### PR TITLE
Qt: Letter cases and single window mode

### DIFF
--- a/src/citra_qt/debugger/callstack.cpp
+++ b/src/citra_qt/debugger/callstack.cpp
@@ -14,9 +14,9 @@ CallstackWidget::CallstackWidget(QWidget* parent): QDockWidget(parent)
 
     callstack_model = new QStandardItemModel(this);
     callstack_model->setColumnCount(4);
-    callstack_model->setHeaderData(0, Qt::Horizontal, "Stack pointer");
-    callstack_model->setHeaderData(2, Qt::Horizontal, "Return address");
-    callstack_model->setHeaderData(1, Qt::Horizontal, "Call address");
+    callstack_model->setHeaderData(0, Qt::Horizontal, "Stack Pointer");
+    callstack_model->setHeaderData(2, Qt::Horizontal, "Return Address");
+    callstack_model->setHeaderData(1, Qt::Horizontal, "Call Address");
     callstack_model->setHeaderData(3, Qt::Horizontal, "Function");
     ui.treeView->setModel(callstack_model);
 }

--- a/src/citra_qt/debugger/callstack.ui
+++ b/src/citra_qt/debugger/callstack.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Call stack</string>
+   <string>Call Stack</string>
   </property>
   <widget class="QWidget" name="dockWidgetContents">
    <layout class="QVBoxLayout" name="verticalLayout">

--- a/src/citra_qt/debugger/graphics_breakpoints.cpp
+++ b/src/citra_qt/debugger/graphics_breakpoints.cpp
@@ -44,7 +44,7 @@ QVariant BreakPointModel::data(const QModelIndex& index, int role) const
                 { Pica::DebugContext::Event::CommandProcessed, tr("Pica command processed") },
                 { Pica::DebugContext::Event::IncomingPrimitiveBatch, tr("Incoming primitive batch") },
                 { Pica::DebugContext::Event::FinishedPrimitiveBatch, tr("Finished primitive batch") },
-                { Pica::DebugContext::Event::VertexLoaded, tr("Vertex Loaded") }
+                { Pica::DebugContext::Event::VertexLoaded, tr("Vertex loaded") }
             };
 
             _dbg_assert_(Debug_GPU, map.size() == static_cast<size_t>(Pica::DebugContext::Event::NumEvents));

--- a/src/citra_qt/debugger/registers.ui
+++ b/src/citra_qt/debugger/registers.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>ARM registers</string>
+   <string>ARM Registers</string>
   </property>
   <widget class="QWidget" name="dockWidgetContents">
    <layout class="QVBoxLayout" name="verticalLayout">

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -175,13 +175,13 @@ void GMainWindow::BootGame(std::string filename)
 
 void GMainWindow::OnMenuLoadFile()
 {
-    QString filename = QFileDialog::getOpenFileName(this, tr("Load file"), QString(), tr("3DS executable (*.3dsx *.elf *.axf *.bin *.cci *.cxi)"));
+    QString filename = QFileDialog::getOpenFileName(this, tr("Load File"), QString(), tr("3DS executable (*.3dsx *.elf *.axf *.bin *.cci *.cxi)"));
     if (filename.size())
        BootGame(filename.toLatin1().data());
 }
 
 void GMainWindow::OnMenuLoadSymbolMap() {
-    QString filename = QFileDialog::getOpenFileName(this, tr("Load symbol map"), QString(), tr("Symbol map (*)"));
+    QString filename = QFileDialog::getOpenFileName(this, tr("Load Symbol Map"), QString(), tr("Symbol map (*)"));
     if (filename.size())
         LoadSymbolMap(filename.toLatin1().data());
 }

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -107,7 +107,7 @@ GMainWindow::GMainWindow()
     restoreState(settings.value("state").toByteArray());
     render_window->restoreGeometry(settings.value("geometryRenderWindow").toByteArray());
 
-    ui.action_Popout_Window_Mode->setChecked(settings.value("popoutWindowMode", true).toBool());
+    ui.action_Single_Window_Mode->setChecked(settings.value("singleWindowMode", true).toBool());
     ToggleWindowMode();
 
     // Setup connections
@@ -116,7 +116,7 @@ GMainWindow::GMainWindow()
     connect(ui.action_Start, SIGNAL(triggered()), this, SLOT(OnStartGame()));
     connect(ui.action_Pause, SIGNAL(triggered()), this, SLOT(OnPauseGame()));
     connect(ui.action_Stop, SIGNAL(triggered()), this, SLOT(OnStopGame()));
-    connect(ui.action_Popout_Window_Mode, SIGNAL(triggered(bool)), this, SLOT(ToggleWindowMode()));
+    connect(ui.action_Single_Window_Mode, SIGNAL(triggered(bool)), this, SLOT(ToggleWindowMode()));
     connect(ui.action_Hotkeys, SIGNAL(triggered()), this, SLOT(OnOpenHotkeysDialog()));
 
     // BlockingQueuedConnection is important here, it makes sure we've finished refreshing our views before the CPU continues
@@ -223,8 +223,8 @@ void GMainWindow::OnOpenHotkeysDialog()
 
 void GMainWindow::ToggleWindowMode()
 {
-    bool enable = ui.action_Popout_Window_Mode->isChecked();
-    if (enable && render_window->parent() != nullptr)
+    bool enable = ui.action_Single_Window_Mode->isChecked();
+    if (!enable && render_window->parent() != nullptr)
     {
         ui.horizontalLayout->removeWidget(render_window);
         render_window->setParent(nullptr);
@@ -232,7 +232,7 @@ void GMainWindow::ToggleWindowMode()
         render_window->RestoreGeometry();
         render_window->setFocusPolicy(Qt::NoFocus);
     }
-    else if (!enable && render_window->parent() == nullptr)
+    else if (enable && render_window->parent() == nullptr)
     {
         render_window->BackupGeometry();
         ui.horizontalLayout->addWidget(render_window);
@@ -254,7 +254,7 @@ void GMainWindow::closeEvent(QCloseEvent* event)
     settings.setValue("geometry", saveGeometry());
     settings.setValue("state", saveState());
     settings.setValue("geometryRenderWindow", render_window->saveGeometry());
-    settings.setValue("popoutWindowMode", ui.action_Popout_Window_Mode->isChecked());
+    settings.setValue("singleWindowMode", ui.action_Single_Window_Mode->isChecked());
     settings.setValue("firstStart", false);
     SaveHotkeys(settings);
 

--- a/src/citra_qt/main.ui
+++ b/src/citra_qt/main.ui
@@ -75,12 +75,12 @@
   <widget class="QStatusBar" name="statusbar"/>
    <action name="action_Load_File">
      <property name="text">
-       <string>Load file...</string>
+       <string>Load File...</string>
      </property>
    </action>
    <action name="action_Load_Symbol_Map">
      <property name="text">
-       <string>Load symbol map...</string>
+       <string>Load Symbol Map...</string>
      </property>
    </action>
    <action name="action_Exit">

--- a/src/citra_qt/main.ui
+++ b/src/citra_qt/main.ui
@@ -58,7 +58,7 @@
     <property name="title">
      <string>&amp;View</string>
     </property>
-    <addaction name="action_Popout_Window_Mode"/>
+    <addaction name="action_Single_Window_Mode"/>
     <addaction name="action_Hotkeys"/>
    </widget>
    <widget class="QMenu" name="menu_Help">
@@ -114,12 +114,12 @@
        <string>About Citra</string>
      </property>
    </action>
-   <action name="action_Popout_Window_Mode">
+   <action name="action_Single_Window_Mode">
      <property name="checkable">
        <bool>true</bool>
      </property>
      <property name="text">
-       <string>Popout window</string>
+       <string>Single Window Mode</string>
      </property>
    </action>
    <action name="action_Hotkeys">


### PR DESCRIPTION
Change popout mode to "Single Window Mode".

Make letter cases consistent in menus and within widgets. The correct way to use letter cases is of course a matter of opinion, but at least now it's more consistent.