### PR TITLE
Set object name for the Graphics Debugger

### DIFF
--- a/src/citra_qt/debugger/graphics.cpp
+++ b/src/citra_qt/debugger/graphics.cpp
@@ -72,7 +72,7 @@ void GPUCommandStreamItemModel::OnGXCommandFinishedInternal(int total_command_co
 
 GPUCommandStreamWidget::GPUCommandStreamWidget(QWidget* parent) : QDockWidget(tr("Graphics Debugger"), parent)
 {
-    // TODO: set objectName!
+    setObjectName("GraphicsDebugger");
 
     GPUCommandStreamItemModel* command_model = new GPUCommandStreamItemModel(this);
     g_debugger.RegisterObserver(command_model);


### PR DESCRIPTION
Setting an object name allows for saving the Graphics Debugger's state (i.e., if it's shown and position). This state is restored when restarting the application.

Fixes issue #173 as this was already done for the Pica Command List.