### PR TITLE
Core: Change default CPU to dyncom.

### DIFF
--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -27,7 +27,7 @@ pad_sleft =
 pad_sright =
 
 [Core]
-cpu_core = ## 0: Interpreter (default), 1: FastInterpreter (experimental)
+cpu_core = ## 0: Interpreter (default), 1: OldInterpreter (may work better, soon to be deprecated)
 gpu_refresh_rate = ## 30 (default)
 frame_skip = ## 0: No frameskip (default), 1 : 2x frameskip, 2 : 4x frameskip, etc.
 

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -53,10 +53,10 @@ int Init() {
     g_sys_core = new ARM_Interpreter();
 
     switch (Settings::values.cpu_core) {
-        case CPU_FastInterpreter:
+        case CPU_Interpreter:
             g_app_core = new ARM_DynCom();
             break;
-        case CPU_Interpreter:
+        case CPU_OldInterpreter:
         default:
             g_app_core = new ARM_Interpreter();
             break;

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -13,7 +13,7 @@ namespace Core {
 
 enum CPUCore {
     CPU_Interpreter,
-    CPU_FastInterpreter
+    CPU_OldInterpreter,
 };
 
 extern ARM_Interface*   g_app_core;     ///< ARM11 application core


### PR DESCRIPTION
Changes the default CPU core from armemu to dyncom. While it's worth keeping armemu around a little while longer (it may work better in some cases, and also to stay in synch with 3dmoo), dyncom is pretty much better in every way now. It implements more instructions, it's faster, cleaner, and is compatible with all titles (that I have tested) that previously booted with armemu (and more). That being said, please test with dyncom, and report any issues if you find something that works better with the old (soon to be deprecated) armemu core.

NOTE: If you previously set your config to use dyncom, you'll need to set cpu_core back to 0 with this PR.