### PR TITLE
FileSys: Fix crash bug in DiskFile exposed by #400

### DIFF
--- a/src/core/file_sys/disk_archive.h
+++ b/src/core/file_sys/disk_archive.h
@@ -56,10 +56,6 @@ public:
     DiskFile();
     DiskFile(const DiskArchive* archive, const Path& path, const Mode mode);
 
-    ~DiskFile() override {
-        Close();
-    }
-
     bool Open() override;
     size_t Read(const u64 offset, const u32 length, u8* buffer) const override;
     size_t Write(const u64 offset, const u32 length, const u32 flush, const u8* buffer) const override;


### PR DESCRIPTION
```
[18:23:24] <yuriks> looks like this is just a dumb bug in DiskFile
[18:23:27] <yuriks> that was masked by the memory leak
[18:24:15] <yuriks> so, if Open fails
[18:24:21] <yuriks> then file is never set, so it's null
[18:24:36] <yuriks> the destructor then doesn't check if file is null before trying to call a method on it
[18:25:28] <yuriks> and on that method, we were leaking the object if the open failed, so the destructor was never being called
```