### PR TITLE
Frontends: Shutdown core when emulation is stopped

### DIFF
--- a/src/citra/citra.cpp
+++ b/src/citra/citra.cpp
@@ -51,6 +51,8 @@ int __cdecl main(int argc, char **argv) {
         Core::RunLoop();
     }
 
+    System::Shutdown();
+
     delete emu_window;
 
     return 0;

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -13,6 +13,7 @@
 
 #include "core/core.h"
 #include "core/settings.h"
+#include "core/system.h"
 
 #include "video_core/debug_utils/debug_utils.h"
 
@@ -89,6 +90,8 @@ void EmuThread::Stop()
         }
     }
     LOG_INFO(Frontend, "EmuThread stopped");
+
+    System::Shutdown();
 }
 
 


### PR DESCRIPTION
This was causing spurious crashes related to destruction order of objects at shutdown.