### PR TITLE
GPU: Toggle active framebuffer each frame

### DIFF
--- a/src/core/hle/service/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp_gpu.cpp
@@ -291,8 +291,11 @@ static void ExecuteCommand(const Command& command, u32 thread_id) {
         // Update framebuffer information if requested
         for (int screen_id = 0; screen_id < 2; ++screen_id) {
             FrameBufferUpdate* info = GetFrameBufferInfo(thread_id, screen_id);
-            if (info->is_dirty)
+
+            if (info->is_dirty) {
                 SetBufferSwap(screen_id, info->framebuffer_info[info->index]);
+                info->framebuffer_info->active_fb = info->framebuffer_info->active_fb ^ 1;
+            }
 
             info->is_dirty = false;
         }

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -87,8 +87,11 @@ void RendererOpenGL::SwapBuffers() {
  */
 void RendererOpenGL::LoadFBToActiveGLTexture(const GPU::Regs::FramebufferConfig& framebuffer,
                                              const TextureInfo& texture) {
+
+    // TODO: Why are active_fb and the valid framebuffer flipped compared to 3dbrew documentation
+    // and GSP definitions?
     const VAddr framebuffer_vaddr = Memory::PhysicalToVirtualAddress(
-        framebuffer.active_fb == 1 ? framebuffer.address_left2 : framebuffer.address_left1);
+        framebuffer.active_fb == 0 ? framebuffer.address_left2 : framebuffer.address_left1);
 
     LOG_TRACE(Render_OpenGL, "0x%08x bytes from 0x%08x(%dx%d), fmt %x",
         framebuffer.stride * framebuffer.height,


### PR DESCRIPTION
Changed GSP to toggle back and forth between the two framebuffers for each frame. This fixes the flicker seen in some games (e.g. Ocarina of Time 3D, 3DSCraft). It also makes both the top and bottom screens render in synchronization. See below:

![](http://i.imgur.com/36q9ASm.png)