### PR TITLE
skyeye: Remove duplicate typedefs

### DIFF
--- a/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
+++ b/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
@@ -1079,7 +1079,7 @@ typedef struct _cdp_inst {
     unsigned int cp_num;
     unsigned int opcode_2;
     unsigned int CRm;
-    uint32 inst;
+    unsigned int inst;
 }cdp_inst;
 
 typedef struct _uxtb_inst {
@@ -3458,7 +3458,7 @@ static tdstate decode_thumb_instr(arm_processor *cpu, uint32_t inst, addr_t addr
     tdstate ret = thumb_translate (addr, inst, arm_inst, inst_size);
     if(ret == t_branch){
         // TODO: FIXME, endian should be judged
-        uint32 tinstr;
+        u32 tinstr;
         if((addr & 0x3) != 0)
             tinstr = inst >> 16;
         else
@@ -3471,7 +3471,7 @@ static tdstate decode_thumb_instr(arm_processor *cpu, uint32_t inst, addr_t addr
         case 26:
         case 27:
             if (((tinstr & 0x0F00) != 0x0E00) && ((tinstr & 0x0F00) != 0x0F00)){
-                uint32 cond = (tinstr & 0x0F00) >> 8;
+                u32 cond = (tinstr & 0x0F00) >> 8;
                 inst_index = table_length - 4;
                 *ptr_inst_base = arm_instruction_trans[inst_index](tinstr, inst_index);
             } else {
@@ -6625,7 +6625,7 @@ unsigned InterpreterMainLoop(ARMul_State* state) {
     BLX_1_THUMB:
     {
         // BLX 1 for armv5t and above
-        uint32 tmp = cpu->Reg[15];
+        u32 tmp = cpu->Reg[15];
         blx_1_thumb *inst_cream = (blx_1_thumb *)inst_base->component;
         cpu->Reg[15] = (cpu->Reg[14] + inst_cream->imm) & 0xFFFFFFFC;
         cpu->Reg[14] = ((tmp + 2) | 1);

--- a/src/core/arm/dyncom/arm_dyncom_run.h
+++ b/src/core/arm/dyncom/arm_dyncom_run.h
@@ -24,8 +24,8 @@
 void switch_mode(arm_core_t *core, uint32_t mode);
 
 /* FIXME, we temporarily think thumb instruction is always 16 bit */
-static inline uint32 GET_INST_SIZE(arm_core_t* core){
-	return core->TFlag? 2 : 4;
+static inline u32 GET_INST_SIZE(arm_core_t* core) {
+    return core->TFlag? 2 : 4;
 }
 
 /**
@@ -36,8 +36,8 @@ static inline uint32 GET_INST_SIZE(arm_core_t* core){
 *
 * @return 
 */
-static inline addr_t CHECK_READ_REG15_WA(arm_core_t* core, int Rn){
-	return (Rn == 15)? ((core->Reg[15] & ~0x3) + GET_INST_SIZE(core) * 2) : core->Reg[Rn];
+static inline addr_t CHECK_READ_REG15_WA(arm_core_t* core, int Rn) {
+    return (Rn == 15)? ((core->Reg[15] & ~0x3) + GET_INST_SIZE(core) * 2) : core->Reg[Rn];
 }
 
 /**
@@ -48,8 +48,8 @@ static inline addr_t CHECK_READ_REG15_WA(arm_core_t* core, int Rn){
 *
 * @return 
 */
-static inline uint32 CHECK_READ_REG15(arm_core_t* core, int Rn){
-	return (Rn == 15)? ((core->Reg[15] & ~0x1) + GET_INST_SIZE(core) * 2) : core->Reg[Rn];
+static inline u32 CHECK_READ_REG15(arm_core_t* core, int Rn) {
+    return (Rn == 15)? ((core->Reg[15] & ~0x1) + GET_INST_SIZE(core) * 2) : core->Reg[Rn];
 }
 
 #endif

--- a/src/core/arm/dyncom/arm_dyncom_thumb.h
+++ b/src/core/arm/dyncom/arm_dyncom_thumb.h
@@ -37,10 +37,10 @@ enum tdstate {
     t_uninitialized,
 };
 
-tdstate
-thumb_translate(addr_t addr, uint32_t instr, uint32_t* ainstr, uint32_t* inst_size);
-static inline uint32 get_thumb_instr(uint32 instr, addr_t pc){
-    uint32 tinstr;
+tdstate thumb_translate(addr_t addr, u32 instr, u32* ainstr, u32* inst_size);
+
+static inline u32 get_thumb_instr(u32 instr, addr_t pc) {
+    u32 tinstr;
     if ((pc & 0x3) != 0)
         tinstr = instr >> 16;
     else

--- a/src/core/arm/skyeye_common/skyeye_types.h
+++ b/src/core/arm/skyeye_common/skyeye_types.h
@@ -22,34 +22,10 @@
  * 12/16/2006   Michael.Kang  <blackfin.kang@gmail.com>
  */
 
-#ifndef __SKYEYE_TYPES_H
-#define __SKYEYE_TYPES_H
+#pragma once
 
-#include <stdint.h>
-
-/*default machine word length */
-
-#ifndef __BEOS__
-/* To avoid the type conflict with the qemu */
-#ifndef QEMU
-typedef uint8_t uint8;
-typedef uint16_t uint16;
-typedef uint32_t uint32;
-typedef uint64_t uint64;
-
-typedef int8_t sint8;
-typedef int16_t sint16;
-typedef int32_t sint32;
-typedef int64_t sint64;
-#endif
+#include <cstdint>
 
 typedef uint32_t address_t;
-typedef uint32_t uinteger_t;
-typedef int32_t integer_t;
-
 typedef uint32_t physical_address_t;
-typedef uint32_t generic_address_t; 
-
-#endif
-
-#endif
+typedef uint32_t generic_address_t;


### PR DESCRIPTION
citra already has its own typedefs like this.