### PR TITLE
Mutex: Add the calling thread to the waiting list when needed

### DIFF
--- a/src/core/hle/kernel/mutex.cpp
+++ b/src/core/hle/kernel/mutex.cpp
@@ -168,9 +168,9 @@ Handle CreateMutex(bool initial_locked, const std::string& name) {
 ResultVal<bool> Mutex::WaitSynchronization() {
     bool wait = locked;
     if (locked) {
+        waiting_threads.push_back(GetCurrentThreadHandle());
         Kernel::WaitCurrentThread(WAITTYPE_MUTEX, GetHandle());
-    }
-    else {
+    } else {
         // Lock the mutex when the first thread accesses it
         locked = true;
         MutexAcquireLock(this);


### PR DESCRIPTION
This will happen when the mutex is already owned by another thread. Should fix some issues with games being stuck due to waiting threads not being awoken.