### PR TITLE
Remove x86 specifics

### DIFF
--- a/src/common/common_types.h
+++ b/src/common/common_types.h
@@ -26,6 +26,7 @@
 
 #include <cmath>
 #include <cstdint>
+#include <cstdlib>
 
 typedef std::uint8_t  u8;  ///< 8-bit unsigned byte
 typedef std::uint16_t u16; ///< 16-bit unsigned short
@@ -83,8 +84,8 @@ public:
     int x1_;    ///< Rect bottom left X-coordinate
     int y1_;    ///< Rect bottom right Y-coordinate
 
-    inline u32 width() const { return abs(x1_ - x0_); }
-    inline u32 height() const { return abs(y1_ - y0_); }
+    inline u32 width() const { return std::abs(x1_ - x0_); }
+    inline u32 height() const { return std::abs(y1_ - y0_); }
 
     inline bool operator == (const Rect& val) const {
         return (x0_ == val.x0_ && y0_ == val.y0_ && x1_ == val.x1_ && y1_ == val.y1_);

--- a/src/common/common_types.h
+++ b/src/common/common_types.h
@@ -26,7 +26,6 @@
 
 #include <cmath>
 #include <cstdint>
-#include <xmmintrin.h> // data_types__m128.cpp
 
 typedef std::uint8_t  u8;  ///< 8-bit unsigned byte
 typedef std::uint16_t u16; ///< 16-bit unsigned short
@@ -65,16 +64,6 @@ union t64 {
     s32 _s32[2];            ///< 32-bit signed int(s)
     u16 _u16[4];            ///< 16-bit unsigned shorts(s)
     u8  _u8[8];             ///< 8-bit unsigned char(s)
-};
-
-/// Union for fast 128-bit type casting
-union t128 {
-    struct
-    {
-        t64 ps0;            ///< 64-bit paired single 0
-        t64 ps1;            ///< 64-bit paired single 1
-    };
-    __m128  a;              ///< 128-bit floating point (__m128 maps to the XMM[0-7] registers)
 };
 
 namespace Common {


### PR DESCRIPTION
Those two small changes make Citra able to compile on ARM, as long as _M_GENERIC is defined.

The only remaining uses of x86 code are for the Crash() function used here and there, and for the CRC32 hash function, which we don’t use at all and which isn’t implemented for any CPU that doesn’t have SSE4.2.