### PR TITLE
Add option to hide dock widget title bars

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -114,6 +114,9 @@ GMainWindow::GMainWindow()
     ui.action_Single_Window_Mode->setChecked(settings.value("singleWindowMode", true).toBool());
     ToggleWindowMode();
 
+    ui.actionDisplay_widget_title_bars->setChecked(settings.value("displayTitleBars", true).toBool());
+    OnDisplayTitleBars(ui.actionDisplay_widget_title_bars->isChecked());
+
     // Setup connections
     connect(ui.action_Load_File, SIGNAL(triggered()), this, SLOT(OnMenuLoadFile()));
     connect(ui.action_Load_Symbol_Map, SIGNAL(triggered()), this, SLOT(OnMenuLoadSymbolMap()));
@@ -154,6 +157,27 @@ GMainWindow::~GMainWindow()
         delete render_window;
 
     Pica::g_debug_context.reset();
+}
+
+void GMainWindow::OnDisplayTitleBars(bool show)
+{
+    QList<QDockWidget*> widgets = findChildren<QDockWidget*>();
+
+    if (show) {
+        for (QDockWidget* widget: widgets) {
+            QWidget* old = widget->titleBarWidget();
+            widget->setTitleBarWidget(nullptr);
+            if (old != nullptr)
+                delete old;
+        }
+    } else {
+        for (QDockWidget* widget: widgets) {
+            QWidget* old = widget->titleBarWidget();
+            widget->setTitleBarWidget(new QWidget());
+            if (old != nullptr)
+                delete old;
+        }
+    }
 }
 
 void GMainWindow::BootGame(std::string filename)
@@ -259,6 +283,7 @@ void GMainWindow::closeEvent(QCloseEvent* event)
     settings.setValue("state", saveState());
     settings.setValue("geometryRenderWindow", render_window->saveGeometry());
     settings.setValue("singleWindowMode", ui.action_Single_Window_Mode->isChecked());
+    settings.setValue("displayTitleBars", ui.actionDisplay_widget_title_bars->isChecked());
     settings.setValue("firstStart", false);
     SaveHotkeys(settings);
 

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -46,6 +46,7 @@ private slots:
     void OnMenuLoadSymbolMap();
     void OnOpenHotkeysDialog();
     void OnConfigure();
+    void OnDisplayTitleBars(bool);
     void ToggleWindowMode();
 
 private:

--- a/src/citra_qt/main.ui
+++ b/src/citra_qt/main.ui
@@ -32,7 +32,7 @@
      <x>0</x>
      <y>0</y>
      <width>1081</width>
-     <height>20</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">
@@ -59,6 +59,7 @@
      <string>&amp;View</string>
     </property>
     <addaction name="action_Single_Window_Mode"/>
+    <addaction name="actionDisplay_widget_title_bars"/>
     <addaction name="action_Hotkeys"/>
    </widget>
    <widget class="QMenu" name="menu_Help">
@@ -73,17 +74,17 @@
    <addaction name="menu_Help"/>
   </widget>
   <widget class="QStatusBar" name="statusbar"/>
-   <action name="action_Load_File">
-     <property name="text">
-       <string>Load File...</string>
-     </property>
-   </action>
-   <action name="action_Load_Symbol_Map">
-     <property name="text">
-       <string>Load Symbol Map...</string>
-     </property>
-   </action>
-   <action name="action_Exit">
+  <action name="action_Load_File">
+   <property name="text">
+    <string>Load File...</string>
+   </property>
+  </action>
+  <action name="action_Load_Symbol_Map">
+   <property name="text">
+    <string>Load Symbol Map...</string>
+   </property>
+  </action>
+  <action name="action_Exit">
    <property name="text">
     <string>E&amp;xit</string>
    </property>
@@ -101,28 +102,28 @@
     <string>&amp;Pause</string>
    </property>
   </action>
-   <action name="action_Stop">
-     <property name="enabled">
-       <bool>false</bool>
-     </property>
-     <property name="text">
-       <string>&amp;Stop</string>
-     </property>
-   </action>
-   <action name="action_About">
-     <property name="text">
-       <string>About Citra</string>
-     </property>
-   </action>
-   <action name="action_Single_Window_Mode">
-     <property name="checkable">
-       <bool>true</bool>
-     </property>
-     <property name="text">
-       <string>Single Window Mode</string>
-     </property>
-   </action>
-   <action name="action_Hotkeys">
+  <action name="action_Stop">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>&amp;Stop</string>
+   </property>
+  </action>
+  <action name="action_About">
+   <property name="text">
+    <string>About Citra</string>
+   </property>
+  </action>
+  <action name="action_Single_Window_Mode">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Single Window Mode</string>
+   </property>
+  </action>
+  <action name="action_Hotkeys">
    <property name="text">
     <string>Configure &amp;Hotkeys ...</string>
    </property>
@@ -130,6 +131,14 @@
   <action name="action_Configure">
    <property name="text">
     <string>Configure ...</string>
+   </property>
+  </action>
+  <action name="actionDisplay_widget_title_bars">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Display Dock Widget Headers</string>
    </property>
   </action>
  </widget>
@@ -167,8 +176,25 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>actionDisplay_widget_title_bars</sender>
+   <signal>triggered(bool)</signal>
+   <receiver>MainWindow</receiver>
+   <slot>OnDisplayTitleBars(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>540</x>
+     <y>364</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
  <slots>
   <slot>OnConfigure()</slot>
+  <slot>OnDisplayTitleBars(bool)</slot>
  </slots>
 </ui>


### PR DESCRIPTION
If you arranged the widgets in the way you want them already, the title bars really don't accomplish anything and just take away screen space. This adds an option to hide them.