### PR TITLE
Common: Clean up ThreadQueueList

### DIFF
--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -75,7 +75,7 @@ public:
 static std::vector<Handle> thread_queue;
 
 // Lists only ready thread ids.
-static Common::ThreadQueueList<Handle> thread_ready_queue;
+static Common::ThreadQueueList<Handle, THREADPRIO_LOWEST+1> thread_ready_queue;
 
 static Handle current_thread_handle;
 static Thread* current_thread;


### PR DESCRIPTION
Replace all the C-style complicated buffer management with a std::deque.
In addition to making the code easier to understand it also adds support
for non-POD IdTypes.