### PR TITLE
Warn if a new thread is intended to be run on the system CPU core

### DIFF
--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -237,6 +237,11 @@ static Result CreateThread(u32 priority, u32 entry_point, u32 arg, u32 stack_top
         "threadpriority=0x%08X, processorid=0x%08X : created handle=0x%08X", entry_point,
         name.c_str(), arg, stack_top, priority, processor_id, thread);
 
+    if (THREADPROCESSORID_1 == processor_id) {
+        LOG_WARNING(Kernel_SVC,
+            "thread designated for system CPU core (UNIMPLEMENTED) will be run with app core scheduling");
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
Warn if a new thread is intended to be run on the system CPU core until we implement correct scheduling for such a thread.