### PR TITLE
Replace OnCpuStepped signal

### DIFF
--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -81,12 +81,18 @@ private:
 
 signals:
     /**
-     * Emitted when CPU when we've finished processing a single Gekko instruction
+     * Emitted when the CPU has halted execution
      *
-     * @warning This will only be emitted when the CPU is not running (SetCpuRunning(false))
      * @warning When connecting to this signal from other threads, make sure to specify either Qt::QueuedConnection (invoke slot within the destination object's message thread) or even Qt::BlockingQueuedConnection (additionally block source thread until slot returns)
      */
-    void CPUStepped();
+    void DebugModeEntered();
+    
+    /**
+     * Emitted right before the CPU continues execution
+     *
+     * @warning When connecting to this signal from other threads, make sure to specify either Qt::QueuedConnection (invoke slot within the destination object's message thread) or even Qt::BlockingQueuedConnection (additionally block source thread until slot returns)
+     */
+    void DebugModeLeft();
 };
 
 class GRenderWindow : public QWidget, public EmuWindow

--- a/src/citra_qt/debugger/callstack.cpp
+++ b/src/citra_qt/debugger/callstack.cpp
@@ -25,7 +25,7 @@ CallstackWidget::CallstackWidget(QWidget* parent): QDockWidget(parent)
     ui.treeView->setModel(callstack_model);
 }
 
-void CallstackWidget::OnCPUStepped()
+void CallstackWidget::OnDebugModeEntered()
 {
     ARM_Disasm* disasm = new ARM_Disasm();
     ARM_Interface* app_core = Core::g_app_core;
@@ -67,4 +67,9 @@ void CallstackWidget::OnCPUStepped()
             counter++;
         }
     }
+}
+
+void CallstackWidget::OnDebugModeLeft()
+{
+
 }

--- a/src/citra_qt/debugger/callstack.h
+++ b/src/citra_qt/debugger/callstack.h
@@ -15,7 +15,8 @@ public:
     CallstackWidget(QWidget* parent = 0);
 
 public slots:
-    void OnCPUStepped();
+    void OnDebugModeEntered();
+    void OnDebugModeLeft();
 
 private:
     Ui::CallStack ui;

--- a/src/citra_qt/debugger/disassembler.cpp
+++ b/src/citra_qt/debugger/disassembler.cpp
@@ -234,7 +234,7 @@ void DisassemblerWidget::OnToggleStartStop()
     emu_thread.SetCpuRunning(!emu_thread.IsCpuRunning());
 }
 
-void DisassemblerWidget::OnCPUStepped()
+void DisassemblerWidget::OnDebugModeEntered()
 {
     ARMword next_instr = Core::g_app_core->GetPC();
 
@@ -249,6 +249,11 @@ void DisassemblerWidget::OnCPUStepped()
     QModelIndex model_index = model->IndexFromAbsoluteAddress(next_instr);
     disasm_ui.treeView->scrollTo(model_index);
     disasm_ui.treeView->selectionModel()->setCurrentIndex(model_index, QItemSelectionModel::SelectCurrent | QItemSelectionModel::Rows);
+}
+
+void DisassemblerWidget::OnDebugModeLeft()
+{
+
 }
 
 int DisassemblerWidget::SelectedRow()

--- a/src/citra_qt/debugger/disassembler.h
+++ b/src/citra_qt/debugger/disassembler.h
@@ -61,7 +61,8 @@ public slots:
     void OnPause();
     void OnToggleStartStop();
 
-    void OnCPUStepped();
+    void OnDebugModeEntered();
+    void OnDebugModeLeft();
 
 private:
     // returns -1 if no row is selected

--- a/src/citra_qt/debugger/registers.cpp
+++ b/src/citra_qt/debugger/registers.cpp
@@ -41,7 +41,7 @@ RegistersWidget::RegistersWidget(QWidget* parent) : QDockWidget(parent)
     CSPR->addChild(new QTreeWidgetItem(QStringList("N")));
 }
 
-void RegistersWidget::OnCPUStepped()
+void RegistersWidget::OnDebugModeEntered()
 {
     ARM_Interface* app_core = Core::g_app_core;
 
@@ -64,4 +64,9 @@ void RegistersWidget::OnCPUStepped()
     CSPR->child(12)->setText(1, QString("%1").arg((app_core->GetCPSR() >> 29) & 0x1));  // C - Carry/Borrow/Extend
     CSPR->child(13)->setText(1, QString("%1").arg((app_core->GetCPSR() >> 30) & 0x1));  // Z - Zero
     CSPR->child(14)->setText(1, QString("%1").arg((app_core->GetCPSR() >> 31) & 0x1));  // N - Negative/Less than
+}
+
+void RegistersWidget::OnDebugModeLeft()
+{
+
 }

--- a/src/citra_qt/debugger/registers.h
+++ b/src/citra_qt/debugger/registers.h
@@ -17,7 +17,8 @@ public:
     RegistersWidget(QWidget* parent = NULL);
 
 public slots:
-    void OnCPUStepped();
+    void OnDebugModeEntered();
+    void OnDebugModeLeft();
 
 private:
     Ui::ARMRegisters cpu_regs_ui;

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -124,9 +124,13 @@ GMainWindow::GMainWindow()
     connect(ui.action_Hotkeys, SIGNAL(triggered()), this, SLOT(OnOpenHotkeysDialog()));
 
     // BlockingQueuedConnection is important here, it makes sure we've finished refreshing our views before the CPU continues
-    connect(&render_window->GetEmuThread(), SIGNAL(CPUStepped()), disasmWidget, SLOT(OnCPUStepped()), Qt::BlockingQueuedConnection);
-    connect(&render_window->GetEmuThread(), SIGNAL(CPUStepped()), registersWidget, SLOT(OnCPUStepped()), Qt::BlockingQueuedConnection);
-    connect(&render_window->GetEmuThread(), SIGNAL(CPUStepped()), callstackWidget, SLOT(OnCPUStepped()), Qt::BlockingQueuedConnection);
+    connect(&render_window->GetEmuThread(), SIGNAL(DebugModeEntered()), disasmWidget, SLOT(OnDebugModeEntered()), Qt::BlockingQueuedConnection);
+    connect(&render_window->GetEmuThread(), SIGNAL(DebugModeEntered()), registersWidget, SLOT(OnDebugModeEntered()), Qt::BlockingQueuedConnection);
+    connect(&render_window->GetEmuThread(), SIGNAL(DebugModeEntered()), callstackWidget, SLOT(OnDebugModeEntered()), Qt::BlockingQueuedConnection);
+    
+    connect(&render_window->GetEmuThread(), SIGNAL(DebugModeLeft()), disasmWidget, SLOT(OnDebugModeLeft()), Qt::BlockingQueuedConnection);
+    connect(&render_window->GetEmuThread(), SIGNAL(DebugModeLeft()), registersWidget, SLOT(OnDebugModeLeft()), Qt::BlockingQueuedConnection);
+    connect(&render_window->GetEmuThread(), SIGNAL(DebugModeLeft()), callstackWidget, SLOT(OnDebugModeLeft()), Qt::BlockingQueuedConnection);
 
     // Setup hotkeys
     RegisterHotkey("Main Window", "Load File", QKeySequence::Open);
@@ -167,8 +171,8 @@ void GMainWindow::BootGame(std::string filename)
     }
 
     disasmWidget->Init();
-    registersWidget->OnCPUStepped();
-    callstackWidget->OnCPUStepped();
+    registersWidget->OnDebugModeEntered();
+    callstackWidget->OnDebugModeEntered();
 
     render_window->GetEmuThread().SetFilename(filename);
     render_window->GetEmuThread().start();


### PR DESCRIPTION
This replaces it by two signals to note when execution stopped and when it continues. It makes more sense like this from a debugging point of view. This also causes the widgets to update immediately after the execution was paused, and not only after the first step.

It's probably best if someone reviewed it a bit.