### PR TITLE
dyncom: Fix SWPB

### DIFF
--- a/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
+++ b/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
@@ -6267,6 +6267,7 @@ unsigned InterpreterMainLoop(ARMul_State* state) {
             addr = RN;
             unsigned int value = Memory::Read8(addr);
             Memory::Write8(addr, (RM & 0xFF));
+            RD = value;
         }
         cpu->Reg[15] += GET_INST_SIZE(cpu);
         INC_PC(sizeof(swp_inst));


### PR DESCRIPTION
Whoever implemented this forgot to store the read value to the destination register.