### PR TITLE
 Threads: Use a dummy idle thread when no other are ready. 

### DIFF
--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -124,6 +124,8 @@ bool LoadExec(u32 entry_point) {
 
     // 0x30 is the typical main thread priority I've seen used so far
     g_main_thread = Kernel::SetupMainThread(0x30);
+    // Setup the idle thread
+    Kernel::SetupIdleThread();
 
     return true;
 }

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -104,6 +104,17 @@ ResultVal<u32> GetThreadPriority(const Handle handle);
 /// Set the priority of the thread specified by handle
 ResultCode SetThreadPriority(Handle handle, s32 priority);
 
+/**
+ * Sets up the idle thread, this is a thread that is intended to never execute instructions,
+ * only to advance the timing. It is scheduled when there are no other ready threads in the thread queue
+ * and will try to yield on every call.
+ * @returns The handle of the idle thread
+ */
+Handle SetupIdleThread();
+
+/// Whether the current thread is an idle thread
+bool IsIdleThread(Handle thread);
+
 /// Initialize threading
 void ThreadingInit();
 


### PR DESCRIPTION
This thread will not actually execute instructions, it will only advance the timing/events and try to yield immediately to the next ready thread, if there aren't any ready threads then it will be rescheduled and start its job again.

Closes #430
Depends on #425 

Some benches: http://tinyurl.com/m5on5tq
Some more benches: https://gist.github.com/Subv/aeaf84943721c3c22fba