### PR TITLE
SVC: Fixed SleepThread

### DIFF
--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -88,6 +88,13 @@ Handle GetCurrentThreadHandle();
 void WaitCurrentThread(WaitType wait_type, Handle wait_handle=GetCurrentThreadHandle());
 
 /**
+ * Schedules an event to wake up the specified thread after the specified delay.
+ * @param handle The thread handle.
+ * @param nanoseconds The time this thread will be allowed to sleep for.
+ */
+void WakeThreadAfterDelay(Handle handle, s64 nanoseconds);
+
+/**
  * Puts the current thread in the wait state for the given type
  * @param wait_type Type of wait
  * @param wait_handle Handle of Kernel object that we are waiting on, defaults to current thread

--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -344,6 +344,10 @@ static void SleepThread(s64 nanoseconds) {
 
     // Sleep current thread and check for next thread to schedule
     Kernel::WaitCurrentThread(WAITTYPE_SLEEP);
+
+    // Create an event to wake the thread up after the specified nanosecond delay has passed
+    Kernel::WakeThreadAfterDelay(Kernel::GetCurrentThreadHandle(), nanoseconds);
+
     HLE::Reschedule(__func__);
 }
 


### PR DESCRIPTION
It will now properly wait the specified number of nanoseconds and then wake up the thread.

Depends on #439