### PR TITLE
Kernel Lifetime Reform Pt. 2

### DIFF
--- a/src/citra_qt/debugger/disassembler.cpp
+++ b/src/citra_qt/debugger/disassembler.cpp
@@ -13,6 +13,7 @@
 #include "core/core.h"
 #include "common/break_points.h"
 #include "common/symbols.h"
+#include "core/arm/arm_interface.h"
 #include "core/arm/skyeye_common/armdefs.h"
 #include "core/arm/disassembler/arm_disasm.h"
 

--- a/src/core/arm/arm_interface.h
+++ b/src/core/arm/arm_interface.h
@@ -7,7 +7,9 @@
 #include "common/common.h"
 #include "common/common_types.h"
 
-#include "core/hle/svc.h"
+namespace Core {
+    struct ThreadContext;
+}
 
 /// Generic ARM11 CPU interface
 class ARM_Interface : NonCopyable {
@@ -87,13 +89,13 @@ public:
      * Saves the current CPU context
      * @param ctx Thread context to save
      */
-    virtual void SaveContext(ThreadContext& ctx) = 0;
+    virtual void SaveContext(Core::ThreadContext& ctx) = 0;
 
     /**
      * Loads a CPU context
      * @param ctx Thread context to load
      */
-    virtual void LoadContext(const ThreadContext& ctx) = 0;
+    virtual void LoadContext(const Core::ThreadContext& ctx) = 0;
 
     /// Prepare core for thread reschedule (if needed to correctly handle state)
     virtual void PrepareReschedule() = 0;

--- a/src/core/arm/dyncom/arm_dyncom.cpp
+++ b/src/core/arm/dyncom/arm_dyncom.cpp
@@ -9,6 +9,7 @@
 #include "core/arm/dyncom/arm_dyncom.h"
 #include "core/arm/dyncom/arm_dyncom_interpreter.h"
 
+#include "core/core.h"
 #include "core/core_timing.h"
 
 const static cpu_config_t s_arm11_cpu_info = {
@@ -94,7 +95,7 @@ void ARM_DynCom::ExecuteInstructions(int num_instructions) {
     AddTicks(ticks_executed);
 }
 
-void ARM_DynCom::SaveContext(ThreadContext& ctx) {
+void ARM_DynCom::SaveContext(Core::ThreadContext& ctx) {
     memcpy(ctx.cpu_registers, state->Reg, sizeof(ctx.cpu_registers));
     memcpy(ctx.fpu_registers, state->ExtReg, sizeof(ctx.fpu_registers));
 
@@ -110,7 +111,7 @@ void ARM_DynCom::SaveContext(ThreadContext& ctx) {
     ctx.mode = state->NextInstr;
 }
 
-void ARM_DynCom::LoadContext(const ThreadContext& ctx) {
+void ARM_DynCom::LoadContext(const Core::ThreadContext& ctx) {
     memcpy(state->Reg, ctx.cpu_registers, sizeof(ctx.cpu_registers));
     memcpy(state->ExtReg, ctx.fpu_registers, sizeof(ctx.fpu_registers));
 

--- a/src/core/arm/dyncom/arm_dyncom.h
+++ b/src/core/arm/dyncom/arm_dyncom.h
@@ -71,13 +71,13 @@ public:
      * Saves the current CPU context
      * @param ctx Thread context to save
      */
-    void SaveContext(ThreadContext& ctx) override;
+    void SaveContext(Core::ThreadContext& ctx) override;
 
     /**
      * Loads a CPU context
      * @param ctx Thread context to load
      */
-    void LoadContext(const ThreadContext& ctx) override;
+    void LoadContext(const Core::ThreadContext& ctx) override;
 
     /// Prepare core for thread reschedule (if needed to correctly handle state)
     void PrepareReschedule() override;

--- a/src/core/arm/interpreter/arm_interpreter.cpp
+++ b/src/core/arm/interpreter/arm_interpreter.cpp
@@ -4,6 +4,8 @@
 
 #include "core/arm/interpreter/arm_interpreter.h"
 
+#include "core/core.h"
+
 const static cpu_config_t arm11_cpu_info = {
     "armv6", "arm11", 0x0007b000, 0x0007f000, NONCACHE
 };
@@ -75,7 +77,7 @@ void ARM_Interpreter::ExecuteInstructions(int num_instructions) {
     ARMul_Emulate32(state);
 }
 
-void ARM_Interpreter::SaveContext(ThreadContext& ctx) {
+void ARM_Interpreter::SaveContext(Core::ThreadContext& ctx) {
     memcpy(ctx.cpu_registers, state->Reg, sizeof(ctx.cpu_registers));
     memcpy(ctx.fpu_registers, state->ExtReg, sizeof(ctx.fpu_registers));
 
@@ -91,7 +93,7 @@ void ARM_Interpreter::SaveContext(ThreadContext& ctx) {
     ctx.mode = state->NextInstr;
 }
 
-void ARM_Interpreter::LoadContext(const ThreadContext& ctx) {
+void ARM_Interpreter::LoadContext(const Core::ThreadContext& ctx) {
     memcpy(state->Reg, ctx.cpu_registers, sizeof(ctx.cpu_registers));
     memcpy(state->ExtReg, ctx.fpu_registers, sizeof(ctx.fpu_registers));
 

--- a/src/core/arm/interpreter/arm_interpreter.h
+++ b/src/core/arm/interpreter/arm_interpreter.h
@@ -70,13 +70,13 @@ public:
      * Saves the current CPU context
      * @param ctx Thread context to save
      */
-    void SaveContext(ThreadContext& ctx) override;
+    void SaveContext(Core::ThreadContext& ctx) override;
 
     /**
      * Loads a CPU context
      * @param ctx Thread context to load
      */
-    void LoadContext(const ThreadContext& ctx) override;
+    void LoadContext(const Core::ThreadContext& ctx) override;
 
     /// Prepare core for thread reschedule (if needed to correctly handle state)
     void PrepareReschedule() override;

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -25,7 +25,7 @@ ARM_Interface*     g_sys_core = nullptr;  ///< ARM11 system (OS) core
 void RunLoop(int tight_loop) {
     // If the current thread is an idle thread, then don't execute instructions,
     // instead advance to the next event and try to yield to the next thread
-    if (Kernel::IsIdleThread(Kernel::GetCurrentThreadHandle())) {
+    if (Kernel::GetCurrentThread()->IsIdle()) {
         LOG_TRACE(Core_ARM11, "Idling");
         CoreTiming::Idle();
         CoreTiming::Advance();

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -8,6 +8,7 @@
 #include "core/core_timing.h"
 
 #include "core/settings.h"
+#include "core/arm/arm_interface.h"
 #include "core/arm/disassembler/arm_disasm.h"
 #include "core/arm/interpreter/arm_interpreter.h"
 #include "core/arm/dyncom/arm_dyncom.h"

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -4,8 +4,9 @@
 
 #pragma once
 
-#include "core/arm/arm_interface.h"
-#include "core/arm/skyeye_common/armdefs.h"
+#include "common/common_types.h"
+
+class ARM_Interface;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -14,6 +15,21 @@ namespace Core {
 enum CPUCore {
     CPU_Interpreter,
     CPU_OldInterpreter,
+};
+
+struct ThreadContext {
+    u32 cpu_registers[13];
+    u32 sp;
+    u32 lr;
+    u32 pc;
+    u32 cpsr;
+    u32 fpu_registers[32];
+    u32 fpscr;
+    u32 fpexc;
+
+    // These are not part of native ThreadContext, but needed by emu
+    u32 reg_15;
+    u32 mode;
 };
 
 extern ARM_Interface*   g_app_core;     ///< ARM11 application core

--- a/src/core/core_timing.cpp
+++ b/src/core/core_timing.cpp
@@ -9,6 +9,8 @@
 
 #include "common/chunk_file.h"
 #include "common/log.h"
+
+#include "core/arm/arm_interface.h"
 #include "core/core.h"
 #include "core/core_timing.h"
 

--- a/src/core/hle/function_wrappers.h
+++ b/src/core/hle/function_wrappers.h
@@ -5,6 +5,8 @@
 #pragma once
 
 #include "common/common_types.h"
+
+#include "core/arm/arm_interface.h"
 #include "core/mem_map.h"
 #include "core/hle/hle.h"
 

--- a/src/core/hle/hle.cpp
+++ b/src/core/hle/hle.cpp
@@ -4,6 +4,7 @@
 
 #include <vector>
 
+#include "core/arm/arm_interface.h"
 #include "core/mem_map.h"
 #include "core/hle/hle.h"
 #include "core/hle/kernel/thread.h"

--- a/src/core/hle/hle.h
+++ b/src/core/hle/hle.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <string>
+
 #include "common/common_types.h"
 #include "core/core.h"
 

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -81,8 +81,7 @@ bool HandleTable::IsValid(Handle handle) const {
 
 Object* HandleTable::GetGeneric(Handle handle) const {
     if (handle == CurrentThread) {
-        // TODO(yuriks) Directly return the pointer once this is possible.
-        handle = GetCurrentThreadHandle();
+        return GetCurrentThread();
     } else if (handle == CurrentProcess) {
         LOG_ERROR(Kernel, "Current process (%08X) pseudo-handle not supported", CurrentProcess);
         return nullptr;

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -14,7 +14,7 @@
 
 namespace Kernel {
 
-Handle g_main_thread = 0;
+Thread* g_main_thread = nullptr;
 HandleTable g_handle_table;
 u64 g_program_id = 0;
 

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -6,6 +6,7 @@
 
 #include "common/common.h"
 
+#include "core/arm/arm_interface.h"
 #include "core/core.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/thread.h"

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -16,6 +16,8 @@ const Handle INVALID_HANDLE = 0;
 
 namespace Kernel {
 
+class Thread;
+
 // TODO: Verify code
 const ResultCode ERR_OUT_OF_HANDLES(ErrorDescription::OutOfMemory, ErrorModule::Kernel,
         ErrorSummary::OutOfResource, ErrorLevel::Temporary);
@@ -190,7 +192,7 @@ private:
 };
 
 extern HandleTable g_handle_table;
-extern Handle g_main_thread;
+extern Thread* g_main_thread;
 
 /// The ID code of the currently running game
 /// TODO(Subv): This variable should not be here, 

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -10,6 +10,7 @@
 #include "common/common.h"
 #include "common/thread_queue_list.h"
 
+#include "core/arm/arm_interface.h"
 #include "core/core.h"
 #include "core/core_timing.h"
 #include "core/hle/hle.h"
@@ -50,7 +51,7 @@ public:
         return MakeResult<bool>(wait);
     }
 
-    ThreadContext context;
+    Core::ThreadContext context;
 
     u32 thread_id;
 
@@ -104,18 +105,18 @@ inline void SetCurrentThread(Thread* t) {
 }
 
 /// Saves the current CPU context
-void SaveContext(ThreadContext& ctx) {
+void SaveContext(Core::ThreadContext& ctx) {
     Core::g_app_core->SaveContext(ctx);
 }
 
 /// Loads a CPU context
-void LoadContext(ThreadContext& ctx) {
+void LoadContext(Core::ThreadContext& ctx) {
     Core::g_app_core->LoadContext(ctx);
 }
 
 /// Resets a thread
 void ResetThread(Thread* t, u32 arg, s32 lowest_priority) {
-    memset(&t->context, 0, sizeof(ThreadContext));
+    memset(&t->context, 0, sizeof(Core::ThreadContext));
 
     t->context.cpu_registers[0] = arg;
     t->context.pc = t->context.reg_15 = t->entry_point;

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -420,7 +420,8 @@ void Reschedule() {
 
         for (Thread* thread : thread_list) {
             LOG_TRACE(Kernel, "\thandle=0x%08X prio=0x%02X, status=0x%08X wait_type=0x%08X wait_handle=0x%08X",
-                thread->GetHandle(), thread->current_priority, thread->status, thread->wait_type, thread->wait_object->GetHandle());
+                thread->GetHandle(), thread->current_priority, thread->status, thread->wait_type,
+                (thread->wait_object ? thread->wait_object->GetHandle() : INVALID_HANDLE));
         }
     }
 }

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -25,23 +25,22 @@ namespace Kernel {
 ResultVal<bool> Thread::WaitSynchronization() {
     const bool wait = status != THREADSTATUS_DORMANT;
     if (wait) {
-        Handle thread = GetCurrentThreadHandle();
+        Thread* thread = GetCurrentThread();
         if (std::find(waiting_threads.begin(), waiting_threads.end(), thread) == waiting_threads.end()) {
             waiting_threads.push_back(thread);
         }
-        WaitCurrentThread(WAITTYPE_THREADEND, this->GetHandle());
+        WaitCurrentThread(WAITTYPE_THREADEND, this);
     }
 
     return MakeResult<bool>(wait);
 }
 
 // Lists all thread ids that aren't deleted/etc.
-static std::vector<Handle> thread_queue;
+static std::vector<Thread*> thread_queue; // TODO(yuriks): Owned
 
 // Lists only ready thread ids.
-static Common::ThreadQueueList<Handle, THREADPRIO_LOWEST+1> thread_ready_queue;
+static Common::ThreadQueueList<Thread*, THREADPRIO_LOWEST+1> thread_ready_queue;
 
-static Handle current_thread_handle;
 static Thread* current_thread;
 
 static const u32 INITIAL_THREAD_ID = 1; ///< The first available thread id at startup
@@ -51,29 +50,8 @@ Thread* GetCurrentThread() {
     return current_thread;
 }
 
-/// Gets the current thread handle
-Handle GetCurrentThreadHandle() {
-    return GetCurrentThread()->GetHandle();
-}
-
-/// Sets the current thread
-inline void SetCurrentThread(Thread* t) {
-    current_thread = t;
-    current_thread_handle = t->GetHandle();
-}
-
-/// Saves the current CPU context
-void SaveContext(Core::ThreadContext& ctx) {
-    Core::g_app_core->SaveContext(ctx);
-}
-
-/// Loads a CPU context
-void LoadContext(Core::ThreadContext& ctx) {
-    Core::g_app_core->LoadContext(ctx);
-}
-
 /// Resets a thread
-void ResetThread(Thread* t, u32 arg, s32 lowest_priority) {
+static void ResetThread(Thread* t, u32 arg, s32 lowest_priority) {
     memset(&t->context, 0, sizeof(Core::ThreadContext));
 
     t->context.cpu_registers[0] = arg;
@@ -90,22 +68,21 @@ void ResetThread(Thread* t, u32 arg, s32 lowest_priority) {
         t->current_priority = t->initial_priority;
     }
     t->wait_type = WAITTYPE_NONE;
-    t->wait_handle = 0;
+    t->wait_object = nullptr;
     t->wait_address = 0;
 }
 
 /// Change a thread to "ready" state
-void ChangeReadyState(Thread* t, bool ready) {
-    Handle handle = t->GetHandle();
+static void ChangeReadyState(Thread* t, bool ready) {
     if (t->IsReady()) {
         if (!ready) {
-            thread_ready_queue.remove(t->current_priority, handle);
+            thread_ready_queue.remove(t->current_priority, t);
         }
     }  else if (ready) {
         if (t->IsRunning()) {
-            thread_ready_queue.push_front(t->current_priority, handle);
+            thread_ready_queue.push_front(t->current_priority, t);
         } else {
-            thread_ready_queue.push_back(t->current_priority, handle);
+            thread_ready_queue.push_back(t->current_priority, t);
         }
         t->status = THREADSTATUS_READY;
     }
@@ -117,43 +94,36 @@ static bool CheckWaitType(const Thread* thread, WaitType type) {
 }
 
 /// Check if a thread is blocking on a specified wait type with a specified handle
-static bool CheckWaitType(const Thread* thread, WaitType type, Handle wait_handle) {
-    return CheckWaitType(thread, type) && (wait_handle == thread->wait_handle);
+static bool CheckWaitType(const Thread* thread, WaitType type, Object* wait_object) {
+    return CheckWaitType(thread, type) && wait_object == thread->wait_object;
 }
 
 /// Check if a thread is blocking on a specified wait type with a specified handle and address
-static bool CheckWaitType(const Thread* thread, WaitType type, Handle wait_handle, VAddr wait_address) {
-    return CheckWaitType(thread, type, wait_handle) && (wait_address == thread->wait_address);
+static bool CheckWaitType(const Thread* thread, WaitType type, Object* wait_object, VAddr wait_address) {
+    return CheckWaitType(thread, type, wait_object) && (wait_address == thread->wait_address);
 }
 
 /// Stops the current thread
-ResultCode StopThread(Handle handle, const char* reason) {
-    Thread* thread = g_handle_table.Get<Thread>(handle);
-    if (thread == nullptr) return InvalidHandle(ErrorModule::Kernel);
-
+void Thread::Stop(const char* reason) {
     // Release all the mutexes that this thread holds
-    ReleaseThreadMutexes(handle);
+    ReleaseThreadMutexes(GetHandle());
 
-    ChangeReadyState(thread, false);
-    thread->status = THREADSTATUS_DORMANT;
-    for (Handle waiting_handle : thread->waiting_threads) {
-        Thread* waiting_thread = g_handle_table.Get<Thread>(waiting_handle);
-
-        if (CheckWaitType(waiting_thread, WAITTYPE_THREADEND, handle))
-            ResumeThreadFromWait(waiting_handle);
+    ChangeReadyState(this, false);
+    status = THREADSTATUS_DORMANT;
+    for (Thread* waiting_thread : waiting_threads) {
+        if (CheckWaitType(waiting_thread, WAITTYPE_THREADEND, this))
+            waiting_thread->ResumeFromWait();
     }
-    thread->waiting_threads.clear();
+    waiting_threads.clear();
 
     // Stopped threads are never waiting.
-    thread->wait_type = WAITTYPE_NONE;
-    thread->wait_handle = 0;
-    thread->wait_address = 0;
-
-    return RESULT_SUCCESS;
+    wait_type = WAITTYPE_NONE;
+    wait_object = nullptr;
+    wait_address = 0;
 }
 
 /// Changes a threads state
-void ChangeThreadState(Thread* t, ThreadStatus new_status) {
+static void ChangeThreadState(Thread* t, ThreadStatus new_status) {
     if (!t || t->status == new_status) {
         return;
     }
@@ -168,14 +138,12 @@ void ChangeThreadState(Thread* t, ThreadStatus new_status) {
 }
 
 /// Arbitrate the highest priority thread that is waiting
-Handle ArbitrateHighestPriorityThread(u32 arbiter, u32 address) {
-    Handle highest_priority_thread = 0;
+Thread* ArbitrateHighestPriorityThread(Object* arbiter, u32 address) {
+    Thread* highest_priority_thread = nullptr;
     s32 priority = THREADPRIO_LOWEST;
 
     // Iterate through threads, find highest priority thread that is waiting to be arbitrated...
-    for (Handle handle : thread_queue) {
-        Thread* thread = g_handle_table.Get<Thread>(handle);
-
+    for (Thread* thread : thread_queue) {
         if (!CheckWaitType(thread, WAITTYPE_ARB, arbiter, address))
             continue;
 
@@ -183,31 +151,31 @@ Handle ArbitrateHighestPriorityThread(u32 arbiter, u32 address) {
             continue; // TODO(yuriks): Thread handle will hang around forever. Should clean up.
 
         if(thread->current_priority <= priority) {
-            highest_priority_thread = handle;
+            highest_priority_thread = thread;
             priority = thread->current_priority;
         }
     }
+
     // If a thread was arbitrated, resume it
-    if (0 != highest_priority_thread)
-        ResumeThreadFromWait(highest_priority_thread);
+    if (nullptr != highest_priority_thread) {
+        highest_priority_thread->ResumeFromWait();
+    }
 
     return highest_priority_thread;
 }
 
 /// Arbitrate all threads currently waiting
-void ArbitrateAllThreads(u32 arbiter, u32 address) {
+void ArbitrateAllThreads(Object* arbiter, u32 address) {
 
     // Iterate through threads, find highest priority thread that is waiting to be arbitrated...
-    for (Handle handle : thread_queue) {
-        Thread* thread = g_handle_table.Get<Thread>(handle);
-
+    for (Thread* thread : thread_queue) {
         if (CheckWaitType(thread, WAITTYPE_ARB, arbiter, address))
-            ResumeThreadFromWait(handle);
+            thread->ResumeFromWait();
     }
 }
 
 /// Calls a thread by marking it as "ready" (note: will not actually execute until current thread yields)
-void CallThread(Thread* t) {
+static void CallThread(Thread* t) {
     // Stop waiting
     if (t->wait_type != WAITTYPE_NONE) {
         t->wait_type = WAITTYPE_NONE;
@@ -216,12 +184,12 @@ void CallThread(Thread* t) {
 }
 
 /// Switches CPU context to that of the specified thread
-void SwitchContext(Thread* t) {
+static void SwitchContext(Thread* t) {
     Thread* cur = GetCurrentThread();
 
     // Save context for current thread
     if (cur) {
-        SaveContext(cur->context);
+        Core::g_app_core->SaveContext(cur->context);
 
         if (cur->IsRunning()) {
             ChangeReadyState(cur, true);
@@ -229,19 +197,19 @@ void SwitchContext(Thread* t) {
     }
     // Load context of new thread
     if (t) {
-        SetCurrentThread(t);
+        current_thread = t;
         ChangeReadyState(t, false);
         t->status = (t->status | THREADSTATUS_RUNNING) & ~THREADSTATUS_READY;
         t->wait_type = WAITTYPE_NONE;
-        LoadContext(t->context);
+        Core::g_app_core->LoadContext(t->context);
     } else {
-        SetCurrentThread(nullptr);
+        current_thread = nullptr;
     }
 }
 
 /// Gets the next thread that is ready to be run by priority
-Thread* NextThread() {
-    Handle next;
+static Thread* NextThread() {
+    Thread* next;
     Thread* cur = GetCurrentThread();
 
     if (cur && cur->IsRunning()) {
@@ -252,18 +220,18 @@ Thread* NextThread() {
     if (next == 0) {
         return nullptr;
     }
-    return Kernel::g_handle_table.Get<Thread>(next);
+    return next;
 }
 
-void WaitCurrentThread(WaitType wait_type, Handle wait_handle) {
+void WaitCurrentThread(WaitType wait_type, Object* wait_object) {
     Thread* thread = GetCurrentThread();
     thread->wait_type = wait_type;
-    thread->wait_handle = wait_handle;
+    thread->wait_object = wait_object;
     ChangeThreadState(thread, ThreadStatus(THREADSTATUS_WAIT | (thread->status & THREADSTATUS_SUSPEND)));
 }
 
-void WaitCurrentThread(WaitType wait_type, Handle wait_handle, VAddr wait_address) {
-    WaitCurrentThread(wait_type, wait_handle);
+void WaitCurrentThread(WaitType wait_type, Object* wait_object, VAddr wait_address) {
+    WaitCurrentThread(wait_type, wait_object);
     GetCurrentThread()->wait_address = wait_address;
 }
 
@@ -279,67 +247,84 @@ static void ThreadWakeupCallback(u64 parameter, int cycles_late) {
         return;
     }
 
-    Kernel::ResumeThreadFromWait(handle);
+    thread->ResumeFromWait();
 }
 
 
-void WakeThreadAfterDelay(Handle handle, s64 nanoseconds) {
+void WakeThreadAfterDelay(Thread* thread, s64 nanoseconds) {
     // Don't schedule a wakeup if the thread wants to wait forever
     if (nanoseconds == -1)
         return;
-
-    Thread* thread = Kernel::g_handle_table.Get<Thread>(handle);
-    if (thread == nullptr) {
-        LOG_ERROR(Kernel, "Thread doesn't exist %u", handle);
-        return;
-    }
+    _dbg_assert_(Kernel, thread != nullptr);
 
     u64 microseconds = nanoseconds / 1000;
-    CoreTiming::ScheduleEvent(usToCycles(microseconds), ThreadWakeupEventType, handle);
+    CoreTiming::ScheduleEvent(usToCycles(microseconds), ThreadWakeupEventType, thread->GetHandle());
 }
 
 /// Resumes a thread from waiting by marking it as "ready"
-void ResumeThreadFromWait(Handle handle) {
-    Thread* thread = Kernel::g_handle_table.Get<Thread>(handle);
-    if (thread) {
-        thread->status &= ~THREADSTATUS_WAIT;
-        thread->wait_handle = 0;
-        thread->wait_type = WAITTYPE_NONE;
-        if (!(thread->status & (THREADSTATUS_WAITSUSPEND | THREADSTATUS_DORMANT | THREADSTATUS_DEAD))) {
-            ChangeReadyState(thread, true);
-        }
+void Thread::ResumeFromWait() {
+    status &= ~THREADSTATUS_WAIT;
+    wait_object = nullptr;
+    wait_type = WAITTYPE_NONE;
+    if (!(status & (THREADSTATUS_WAITSUSPEND | THREADSTATUS_DORMANT | THREADSTATUS_DEAD))) {
+        ChangeReadyState(this, true);
     }
 }
 
 /// Prints the thread queue for debugging purposes
-void DebugThreadQueue() {
+static void DebugThreadQueue() {
     Thread* thread = GetCurrentThread();
     if (!thread) {
         return;
     }
-    LOG_DEBUG(Kernel, "0x%02X 0x%08X (current)", thread->current_priority, GetCurrentThreadHandle());
-    for (u32 i = 0; i < thread_queue.size(); i++) {
-        Handle handle = thread_queue[i];
-        s32 priority = thread_ready_queue.contains(handle);
+    LOG_DEBUG(Kernel, "0x%02X 0x%08X (current)", thread->current_priority, GetCurrentThread()->GetHandle());
+    for (Thread* t : thread_queue) {
+        s32 priority = thread_ready_queue.contains(t);
         if (priority != -1) {
-            LOG_DEBUG(Kernel, "0x%02X 0x%08X", priority, handle);
+            LOG_DEBUG(Kernel, "0x%02X 0x%08X", priority, t->GetHandle());
         }
     }
 }
 
-/// Creates a new thread
-Thread* CreateThread(Handle& handle, const char* name, u32 entry_point, s32 priority,
-    s32 processor_id, u32 stack_top, int stack_size) {
+ResultVal<Thread*> Thread::Create(const char* name, u32 entry_point, s32 priority, u32 arg,
+        s32 processor_id, u32 stack_top, int stack_size) {
+    _dbg_assert_(Kernel, name != nullptr);
 
-    _assert_msg_(KERNEL, (priority >= THREADPRIO_HIGHEST && priority <= THREADPRIO_LOWEST),
-        "priority=%d, outside of allowable range!", priority)
+    if ((u32)stack_size < 0x200) {
+        LOG_ERROR(Kernel, "(name=%s): invalid stack_size=0x%08X", name, stack_size);
+        // TODO: Verify error
+        return ResultCode(ErrorDescription::InvalidSize, ErrorModule::Kernel,
+                ErrorSummary::InvalidArgument, ErrorLevel::Permanent);
+    }
+
+    if (priority < THREADPRIO_HIGHEST || priority > THREADPRIO_LOWEST) {
+        s32 new_priority = CLAMP(priority, THREADPRIO_HIGHEST, THREADPRIO_LOWEST);
+        LOG_WARNING(Kernel_SVC, "(name=%s): invalid priority=%d, clamping to %d",
+            name, priority, new_priority);
+        // TODO(bunnei): Clamping to a valid priority is not necessarily correct behavior... Confirm
+        // validity of this
+        priority = new_priority;
+    }
+
+    if (!Memory::GetPointer(entry_point)) {
+        LOG_ERROR(Kernel_SVC, "(name=%s): invalid entry %08x", name, entry_point);
+        // TODO: Verify error
+        return ResultCode(ErrorDescription::InvalidAddress, ErrorModule::Kernel,
+                ErrorSummary::InvalidArgument, ErrorLevel::Permanent);
+    }
 
     Thread* thread = new Thread;
 
-    // TOOD(yuriks): Fix error reporting
-    handle = Kernel::g_handle_table.Create(thread).ValueOr(INVALID_HANDLE);
+    // TODO(yuriks): Thread requires a handle to be inserted into the various scheduling queues for
+    //               the time being. Create a handle here, it will be copied to the handle field in
+    //               the object and use by the rest of the code. This should be removed when other
+    //               code doesn't rely on the handle anymore.
+    ResultVal<Handle> handle = Kernel::g_handle_table.Create(thread);
+    // TODO(yuriks): Plug memory leak
+    if (handle.Failed())
+        return handle.Code();
 
-    thread_queue.push_back(handle);
+    thread_queue.push_back(thread);
     thread_ready_queue.prepare(priority);
 
     thread->thread_id = next_thread_id++;
@@ -350,69 +335,18 @@ Thread* CreateThread(Handle& handle, const char* name, u32 entry_point, s32 prio
     thread->initial_priority = thread->current_priority = priority;
     thread->processor_id = processor_id;
     thread->wait_type = WAITTYPE_NONE;
-    thread->wait_handle = 0;
+    thread->wait_object = nullptr;
     thread->wait_address = 0;
     thread->name = name;
-
-    return thread;
-}
-
-/// Creates a new thread - wrapper for external user
-Handle CreateThread(const char* name, u32 entry_point, s32 priority, u32 arg, s32 processor_id,
-    u32 stack_top, int stack_size) {
-
-    if (name == nullptr) {
-        LOG_ERROR(Kernel_SVC, "nullptr name");
-        return -1;
-    }
-    if ((u32)stack_size < 0x200) {
-        LOG_ERROR(Kernel_SVC, "(name=%s): invalid stack_size=0x%08X", name,
-            stack_size);
-        return -1;
-    }
-    if (priority < THREADPRIO_HIGHEST || priority > THREADPRIO_LOWEST) {
-        s32 new_priority = CLAMP(priority, THREADPRIO_HIGHEST, THREADPRIO_LOWEST);
-        LOG_WARNING(Kernel_SVC, "(name=%s): invalid priority=%d, clamping to %d",
-            name, priority, new_priority);
-        // TODO(bunnei): Clamping to a valid priority is not necessarily correct behavior... Confirm
-        // validity of this
-        priority = new_priority;
-    }
-    if (!Memory::GetPointer(entry_point)) {
-        LOG_ERROR(Kernel_SVC, "(name=%s): invalid entry %08x", name, entry_point);
-        return -1;
-    }
-    Handle handle;
-    Thread* thread = CreateThread(handle, name, entry_point, priority, processor_id, stack_top,
-        stack_size);
 
     ResetThread(thread, arg, 0);
     CallThread(thread);
 
-    return handle;
-}
-
-/// Get the priority of the thread specified by handle
-ResultVal<u32> GetThreadPriority(const Handle handle) {
-    Thread* thread = g_handle_table.Get<Thread>(handle);
-    if (thread == nullptr) return InvalidHandle(ErrorModule::Kernel);
-
-    return MakeResult<u32>(thread->current_priority);
+    return MakeResult<Thread*>(thread);
 }
 
 /// Set the priority of the thread specified by handle
-ResultCode SetThreadPriority(Handle handle, s32 priority) {
-    Thread* thread = nullptr;
-    if (!handle) {
-        thread = GetCurrentThread(); // TODO(bunnei): Is this correct behavior?
-    } else {
-        thread = g_handle_table.Get<Thread>(handle);
-        if (thread == nullptr) {
-            return InvalidHandle(ErrorModule::Kernel);
-        }
-    }
-    _assert_msg_(KERNEL, (thread != nullptr), "called, but thread is nullptr!");
-
+void Thread::SetPriority(s32 priority) {
     // If priority is invalid, clamp to valid range
     if (priority < THREADPRIO_HIGHEST || priority > THREADPRIO_LOWEST) {
         s32 new_priority = CLAMP(priority, THREADPRIO_HIGHEST, THREADPRIO_LOWEST);
@@ -423,38 +357,39 @@ ResultCode SetThreadPriority(Handle handle, s32 priority) {
     }
 
     // Change thread priority
-    s32 old = thread->current_priority;
-    thread_ready_queue.remove(old, handle);
-    thread->current_priority = priority;
-    thread_ready_queue.prepare(thread->current_priority);
+    s32 old = current_priority;
+    thread_ready_queue.remove(old, this);
+    current_priority = priority;
+    thread_ready_queue.prepare(current_priority);
 
     // Change thread status to "ready" and push to ready queue
-    if (thread->IsRunning()) {
-        thread->status = (thread->status & ~THREADSTATUS_RUNNING) | THREADSTATUS_READY;
+    if (IsRunning()) {
+        status = (status & ~THREADSTATUS_RUNNING) | THREADSTATUS_READY;
     }
-    if (thread->IsReady()) {
-        thread_ready_queue.push_back(thread->current_priority, handle);
+    if (IsReady()) {
+        thread_ready_queue.push_back(current_priority, this);
     }
-
-    return RESULT_SUCCESS;
 }
 
 Handle SetupIdleThread() {
-    Handle handle;
-    Thread* thread = CreateThread(handle, "idle", 0, THREADPRIO_LOWEST, THREADPROCESSORID_0, 0, 0);
+    // We need to pass a few valid values to get around parameter checking in Thread::Create.
+    auto thread_res = Thread::Create("idle", Memory::KERNEL_MEMORY_VADDR, THREADPRIO_LOWEST, 0,
+            THREADPROCESSORID_0, 0, Kernel::DEFAULT_STACK_SIZE);
+    _dbg_assert_(Kernel, thread_res.Succeeded());
+    Thread* thread = *thread_res;
+
     thread->idle = true;
     CallThread(thread);
-    return handle;
+    return thread->GetHandle();
 }
 
-Handle SetupMainThread(s32 priority, int stack_size) {
-    Handle handle;
-
+Thread* SetupMainThread(s32 priority, int stack_size) {
     // Initialize new "main" thread
-    Thread* thread = CreateThread(handle, "main", Core::g_app_core->GetPC(), priority,
+    ResultVal<Thread*> thread_res = Thread::Create("main", Core::g_app_core->GetPC(), priority, 0,
         THREADPROCESSORID_0, Memory::SCRATCHPAD_VADDR_END, stack_size);
-
-    ResetThread(thread, 0, 0);
+    // TODO(yuriks): Propagate error
+    _dbg_assert_(Kernel, thread_res.Succeeded());
+    Thread* thread = *thread_res;
 
     // If running another thread already, set it to "ready" state
     Thread* cur = GetCurrentThread();
@@ -463,11 +398,11 @@ Handle SetupMainThread(s32 priority, int stack_size) {
     }
 
     // Run new "main" thread
-    SetCurrentThread(thread);
+    current_thread = thread;
     thread->status = THREADSTATUS_RUNNING;
-    LoadContext(thread->context);
+    Core::g_app_core->LoadContext(thread->context);
 
-    return handle;
+    return thread;
 }
 
 
@@ -483,32 +418,11 @@ void Reschedule() {
     } else {
         LOG_TRACE(Kernel, "cannot context switch from 0x%08X, no higher priority thread!", prev->GetHandle());
 
-        for (Handle handle : thread_queue) {
-            Thread* thread = g_handle_table.Get<Thread>(handle);
+        for (Thread* thread : thread_queue) {
             LOG_TRACE(Kernel, "\thandle=0x%08X prio=0x%02X, status=0x%08X wait_type=0x%08X wait_handle=0x%08X",
-                thread->GetHandle(), thread->current_priority, thread->status, thread->wait_type, thread->wait_handle);
+                thread->GetHandle(), thread->current_priority, thread->status, thread->wait_type, thread->wait_object->GetHandle());
         }
     }
-}
-
-bool IsIdleThread(Handle handle) {
-    Thread* thread = g_handle_table.Get<Thread>(handle);
-    if (!thread) {
-        LOG_ERROR(Kernel, "Thread not found %u", handle);
-        return false;
-    }
-    return thread->IsIdle();
-}
-
-ResultCode GetThreadId(u32* thread_id, Handle handle) {
-    Thread* thread = g_handle_table.Get<Thread>(handle);
-    if (thread == nullptr)
-        return ResultCode(ErrorDescription::InvalidHandle, ErrorModule::OS, 
-                          ErrorSummary::WrongArgument, ErrorLevel::Permanent);
-
-    *thread_id = thread->thread_id;
-
-    return RESULT_SUCCESS;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -54,6 +54,9 @@ namespace Kernel {
 
 class Thread : public Kernel::Object {
 public:
+    static ResultVal<Thread*> Create(const char* name, u32 entry_point, s32 priority, u32 arg,
+        s32 processor_id, u32 stack_top, int stack_size = Kernel::DEFAULT_STACK_SIZE);
+
     std::string GetName() const override { return name; }
     std::string GetTypeName() const override { return "Thread"; }
 
@@ -68,6 +71,15 @@ public:
     inline bool IsIdle() const { return idle; }
 
     ResultVal<bool> WaitSynchronization() override;
+
+    s32 GetPriority() const { return current_priority; }
+    void SetPriority(s32 priority);
+
+    u32 GetThreadId() const { return thread_id; }
+
+    void Stop(const char* reason);
+    /// Resumes a thread from waiting by marking it as "ready".
+    void ResumeFromWait();
 
     Core::ThreadContext context;
 
@@ -84,10 +96,10 @@ public:
     s32 processor_id;
 
     WaitType wait_type;
-    Handle wait_handle;
+    Object* wait_object;
     VAddr wait_address;
 
-    std::vector<Handle> waiting_threads;
+    std::vector<Thread*> waiting_threads; // TODO(yuriks): Owned
 
     std::string name;
 
@@ -95,79 +107,47 @@ public:
     bool idle = false;
 
 private:
-    // TODO(yuriks) Temporary until the creation logic can be moved into a static function
-    friend Thread* CreateThread(Handle& handle, const char* name, u32 entry_point, s32 priority,
-            s32 processor_id, u32 stack_top, int stack_size);
-
     Thread() = default;
 };
 
-/// Creates a new thread - wrapper for external user
-Handle CreateThread(const char* name, u32 entry_point, s32 priority, u32 arg, s32 processor_id,
-    u32 stack_top, int stack_size=Kernel::DEFAULT_STACK_SIZE);
-
 /// Sets up the primary application thread
-Handle SetupMainThread(s32 priority, int stack_size=Kernel::DEFAULT_STACK_SIZE);
+Thread* SetupMainThread(s32 priority, int stack_size = Kernel::DEFAULT_STACK_SIZE);
 
 /// Reschedules to the next available thread (call after current thread is suspended)
 void Reschedule();
 
-/// Stops the current thread
-ResultCode StopThread(Handle thread, const char* reason);
-
-/**
- * Retrieves the ID of the specified thread handle
- * @param thread_id Will contain the output thread id
- * @param handle Handle to the thread we want
- * @return Whether the function was successful or not
- */
-ResultCode GetThreadId(u32* thread_id, Handle handle);
-
-/// Resumes a thread from waiting by marking it as "ready"
-void ResumeThreadFromWait(Handle handle);
-
 /// Arbitrate the highest priority thread that is waiting
-Handle ArbitrateHighestPriorityThread(u32 arbiter, u32 address);
+Thread* ArbitrateHighestPriorityThread(Object* arbiter, u32 address);
 
 /// Arbitrate all threads currently waiting...
-void ArbitrateAllThreads(u32 arbiter, u32 address);
+void ArbitrateAllThreads(Object* arbiter, u32 address);
 
 /// Gets the current thread
 Thread* GetCurrentThread();
 
-/// Gets the current thread handle
-Handle GetCurrentThreadHandle();
-
 /**
  * Puts the current thread in the wait state for the given type
  * @param wait_type Type of wait
- * @param wait_handle Handle of Kernel object that we are waiting on, defaults to current thread
+ * @param wait_object Kernel object that we are waiting on, defaults to current thread
  */
-void WaitCurrentThread(WaitType wait_type, Handle wait_handle=GetCurrentThreadHandle());
+void WaitCurrentThread(WaitType wait_type, Object* wait_object = GetCurrentThread());
 
 /**
  * Schedules an event to wake up the specified thread after the specified delay.
  * @param handle The thread handle.
  * @param nanoseconds The time this thread will be allowed to sleep for.
  */
-void WakeThreadAfterDelay(Handle handle, s64 nanoseconds);
+void WakeThreadAfterDelay(Thread* thread, s64 nanoseconds);
 
 /**
  * Puts the current thread in the wait state for the given type
  * @param wait_type Type of wait
- * @param wait_handle Handle of Kernel object that we are waiting on, defaults to current thread
+ * @param wait_object Kernel object that we are waiting on
  * @param wait_address Arbitration address used to resume from wait
  */
-void WaitCurrentThread(WaitType wait_type, Handle wait_handle, VAddr wait_address);
+void WaitCurrentThread(WaitType wait_type, Object* wait_object, VAddr wait_address);
 
-/// Put current thread in a wait state - on WaitSynchronization
-void WaitThread_Synchronization();
 
-/// Get the priority of the thread specified by handle
-ResultVal<u32> GetThreadPriority(const Handle handle);
-
-/// Set the priority of the thread specified by handle
-ResultCode SetThreadPriority(Handle handle, s32 priority);
 
 /**
  * Sets up the idle thread, this is a thread that is intended to never execute instructions,
@@ -176,10 +156,6 @@ ResultCode SetThreadPriority(Handle handle, s32 priority);
  * @returns The handle of the idle thread
  */
 Handle SetupIdleThread();
-
-/// Whether the current thread is an idle thread
-bool IsIdleThread(Handle thread);
-
 /// Initialize threading
 void ThreadingInit();
 

--- a/src/core/hle/service/hid_user.cpp
+++ b/src/core/hle/service/hid_user.cpp
@@ -4,6 +4,7 @@
 
 #include "common/log.h"
 
+#include "core/arm/arm_interface.h"
 #include "core/hle/hle.h"
 #include "core/hle/kernel/event.h"
 #include "core/hle/kernel/shared_memory.h"

--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -7,6 +7,7 @@
 #include "common/string_util.h"
 #include "common/symbols.h"
 
+#include "core/arm/arm_interface.h"
 #include "core/mem_map.h"
 
 #include "core/hle/kernel/address_arbiter.h"

--- a/src/core/hle/svc.h
+++ b/src/core/hle/svc.h
@@ -20,21 +20,6 @@ struct PageInfo {
     u32 flags;
 };
 
-struct ThreadContext {
-    u32 cpu_registers[13];
-    u32 sp;
-    u32 lr;
-    u32 pc;
-    u32 cpsr;
-    u32 fpu_registers[32];
-    u32 fpscr;
-    u32 fpexc;
-
-    // These are not part of native ThreadContext, but needed by emu
-    u32 reg_15;
-    u32 mode;
-};
-
 enum ResetType {
     RESETTYPE_ONESHOT,
     RESETTYPE_STICKY,

--- a/src/core/hw/gpu.cpp
+++ b/src/core/hw/gpu.cpp
@@ -4,6 +4,8 @@
 
 #include "common/common_types.h"
 
+#include "core/arm/arm_interface.h"
+
 #include "core/settings.h"
 #include "core/core.h"
 #include "core/mem_map.h"


### PR DESCRIPTION
This is a continuation of #331.

This purges thread.cpp/.h of most of its usages of Handle, replacing them with (for now) raw pointers. In a follow-up PR I will replace these with reference counted pointers, which will provide proper lifetime management. Logically that should've come before this, but it'd be too much work to reverse the order of the two branches now.

After this I'll follow and remove handles from the rest of the Kernel. When that's done we should be good to enable handle duplication and closing.