### PR TITLE
Core: Fixed a crash and removed some unused variables.

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -17,8 +17,6 @@
 
 namespace Core {
 
-static u64         last_ticks = 0;        ///< Last CPU ticks
-static ARM_Disasm* disasm     = nullptr;  ///< ARM disassembler
 ARM_Interface*     g_app_core = nullptr;  ///< ARM11 application core
 ARM_Interface*     g_sys_core = nullptr;  ///< ARM11 system (OS) core
 
@@ -60,7 +58,6 @@ void Stop() {
 int Init() {
     LOG_DEBUG(Core, "initialized OK");
 
-    disasm = new ARM_Disasm();
     g_sys_core = new ARM_Interpreter();
 
     switch (Settings::values.cpu_core) {
@@ -73,13 +70,10 @@ int Init() {
             break;
     }
 
-    last_ticks = Core::g_app_core->GetTicks();
-
     return 0;
 }
 
 void Shutdown() {
-    delete disasm;
     delete g_app_core;
     delete g_sys_core;
 

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -21,11 +21,11 @@ void UpdateState(State state) {
 
 void Init(EmuWindow* emu_window) {
     Core::Init();
+    CoreTiming::Init();
     Memory::Init();
     HW::Init();
     Kernel::Init();
     HLE::Init();
-    CoreTiming::Init();
     VideoCore::Init(emu_window);
 }
 
@@ -38,11 +38,11 @@ void RunLoopUntil(u64 global_cycles) {
 
 void Shutdown() {
     VideoCore::Shutdown();
-    CoreTiming::Shutdown();
     HLE::Shutdown();
     Kernel::Shutdown();
     HW::Shutdown();
     Memory::Shutdown();
+    CoreTiming::Shutdown();
     Core::Shutdown();
 }
 


### PR DESCRIPTION
ARM_Disasm only has static methods, so there's no need to have an instance of it.