### PR TITLE
CMake: Enable VS parallel builds for a good reduction in compile times

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ else()
     # As far as I can tell, there's no way to override the CMake defaults while leaving user
     # changes intact, so we'll just clobber everything and say sorry.
     message(STATUS "Cache compiler flags ignored, please edit CMakeFiles.txt to change the flags.")
+    # /MP - Multi-threaded compilation
     # /MD - Multi-threaded runtime
     # /Ox - Full optimization
     # /Oi - Use intrinsic functions
@@ -24,7 +25,7 @@ else()
     # /GR- - Disable RTTI
     # /GS- - No stack buffer overflow checks
     # /EHsc - C++-only exception handling semantics
-    set(optimization_flags "/MD /Ox /Oi /Oy- /DNDEBUG /GR- /GS- /EHsc")
+    set(optimization_flags "/MP /MD /Ox /Oi /Oy- /DNDEBUG /GR- /GS- /EHsc")
     # /Zi - Output debugging information
     # /Zo - enahnced debug info for optimized builds
     set(CMAKE_C_FLAGS_RELEASE   "${optimization_flags} /Zi" CACHE STRING "" FORCE)


### PR DESCRIPTION
This enables the /MP compiler flag, which parallelizes builds of by
distributing compilation of individual object files across workes
processes, instead of being limited to per-project parallelism.

Reduces the time for a full compile from 72 s to 45 s on my machine.