### PR TITLE
Kernel Lifetime Reform Pt. 3

### DIFF
--- a/src/core/hle/kernel/address_arbiter.cpp
+++ b/src/core/hle/kernel/address_arbiter.cpp
@@ -30,7 +30,7 @@ public:
 
 /// Arbitrate an address
 ResultCode ArbitrateAddress(Handle handle, ArbitrationType type, u32 address, s32 value) {
-    Object* object = Kernel::g_handle_table.GetGeneric(handle);
+    Object* object = Kernel::g_handle_table.GetGeneric(handle).get();
     if (object == nullptr)
         return InvalidHandle(ErrorModule::Kernel);
 

--- a/src/core/hle/kernel/event.cpp
+++ b/src/core/hle/kernel/event.cpp
@@ -53,7 +53,7 @@ public:
  * @return Result of operation, 0 on success, otherwise error code
  */
 ResultCode SetPermanentLock(Handle handle, const bool permanent_locked) {
-    Event* evt = g_handle_table.Get<Event>(handle);
+    Event* evt = g_handle_table.Get<Event>(handle).get();
     if (evt == nullptr) return InvalidHandle(ErrorModule::Kernel);
 
     evt->permanent_locked = permanent_locked;
@@ -67,7 +67,7 @@ ResultCode SetPermanentLock(Handle handle, const bool permanent_locked) {
  * @return Result of operation, 0 on success, otherwise error code
  */
 ResultCode SetEventLocked(const Handle handle, const bool locked) {
-    Event* evt = g_handle_table.Get<Event>(handle);
+    Event* evt = g_handle_table.Get<Event>(handle).get();
     if (evt == nullptr) return InvalidHandle(ErrorModule::Kernel);
 
     if (!evt->permanent_locked) {
@@ -82,13 +82,13 @@ ResultCode SetEventLocked(const Handle handle, const bool locked) {
  * @return Result of operation, 0 on success, otherwise error code
  */
 ResultCode SignalEvent(const Handle handle) {
-    Event* evt = g_handle_table.Get<Event>(handle);
+    Event* evt = g_handle_table.Get<Event>(handle).get();
     if (evt == nullptr) return InvalidHandle(ErrorModule::Kernel);
 
     // Resume threads waiting for event to signal
     bool event_caught = false;
     for (size_t i = 0; i < evt->waiting_threads.size(); ++i) {
-        Thread* thread = Kernel::g_handle_table.Get<Thread>(evt->waiting_threads[i]);
+        Thread* thread = Kernel::g_handle_table.Get<Thread>(evt->waiting_threads[i]).get();
         if (thread != nullptr)
             thread->ResumeFromWait();
 
@@ -112,7 +112,7 @@ ResultCode SignalEvent(const Handle handle) {
  * @return Result of operation, 0 on success, otherwise error code
  */
 ResultCode ClearEvent(Handle handle) {
-    Event* evt = g_handle_table.Get<Event>(handle);
+    Event* evt = g_handle_table.Get<Event>(handle).get();
     if (evt == nullptr) return InvalidHandle(ErrorModule::Kernel);
 
     if (!evt->permanent_locked) {

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -44,7 +44,8 @@ ResultVal<Handle> HandleTable::Create(Object* obj) {
     objects[slot] = obj;
 
     Handle handle = generation | (slot << 15);
-    obj->handle = handle;
+    if (obj->handle == INVALID_HANDLE)
+        obj->handle = handle;
     return MakeResult<Handle>(handle);
 }
 

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -14,7 +14,7 @@
 
 namespace Kernel {
 
-Thread* g_main_thread = nullptr;
+SharedPtr<Thread> g_main_thread = nullptr;
 HandleTable g_handle_table;
 u64 g_program_id = 0;
 
@@ -23,7 +23,7 @@ HandleTable::HandleTable() {
     Clear();
 }
 
-ResultVal<Handle> HandleTable::Create(Object* obj) {
+ResultVal<Handle> HandleTable::Create(SharedPtr<Object> obj) {
     _dbg_assert_(Kernel, obj != nullptr);
 
     u16 slot = next_free_slot;
@@ -39,23 +39,23 @@ ResultVal<Handle> HandleTable::Create(Object* obj) {
     // CTR-OS doesn't use generation 0, so skip straight to 1.
     if (next_generation >= (1 << 15)) next_generation = 1;
 
-    generations[slot] = generation;
-    intrusive_ptr_add_ref(obj);
-    objects[slot] = obj;
-
     Handle handle = generation | (slot << 15);
     if (obj->handle == INVALID_HANDLE)
         obj->handle = handle;
+
+    generations[slot] = generation;
+    objects[slot] = std::move(obj);
+
     return MakeResult<Handle>(handle);
 }
 
 ResultVal<Handle> HandleTable::Duplicate(Handle handle) {
-    Object* object = GetGeneric(handle);
+    SharedPtr<Object> object = GetGeneric(handle);
     if (object == nullptr) {
         LOG_ERROR(Kernel, "Tried to duplicate invalid handle: %08X", handle);
         return ERR_INVALID_HANDLE;
     }
-    return Create(object);
+    return Create(std::move(object));
 }
 
 ResultCode HandleTable::Close(Handle handle) {
@@ -65,7 +65,6 @@ ResultCode HandleTable::Close(Handle handle) {
     size_t slot = GetSlot(handle);
     u16 generation = GetGeneration(handle);
 
-    intrusive_ptr_release(objects[slot]);
     objects[slot] = nullptr;
 
     generations[generation] = next_free_slot;
@@ -80,7 +79,7 @@ bool HandleTable::IsValid(Handle handle) const {
     return slot < MAX_COUNT && objects[slot] != nullptr && generations[slot] == generation;
 }
 
-Object* HandleTable::GetGeneric(Handle handle) const {
+SharedPtr<Object> HandleTable::GetGeneric(Handle handle) const {
     if (handle == CurrentThread) {
         return GetCurrentThread();
     } else if (handle == CurrentProcess) {
@@ -97,8 +96,6 @@ Object* HandleTable::GetGeneric(Handle handle) const {
 void HandleTable::Clear() {
     for (size_t i = 0; i < MAX_COUNT; ++i) {
         generations[i] = i + 1;
-        if (objects[i] != nullptr)
-            intrusive_ptr_release(objects[i]);
         objects[i] = nullptr;
     }
     next_free_slot = 0;
@@ -126,7 +123,7 @@ bool LoadExec(u32 entry_point) {
     Core::g_app_core->SetPC(entry_point);
 
     // 0x30 is the typical main thread priority I've seen used so far
-    g_main_thread = Kernel::SetupMainThread(0x30);
+    g_main_thread = Kernel::SetupMainThread(0x30, Kernel::DEFAULT_STACK_SIZE);
     // Setup the idle thread
     Kernel::SetupIdleThread();
 

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -52,7 +52,7 @@ class HandleTable;
 
 class Object : NonCopyable {
     friend class HandleTable;
-    u32 handle;
+    u32 handle = INVALID_HANDLE;
 public:
     virtual ~Object() {}
     Handle GetHandle() const { return handle; }

--- a/src/core/hle/kernel/mutex.cpp
+++ b/src/core/hle/kernel/mutex.cpp
@@ -48,7 +48,7 @@ void MutexAcquireLock(Mutex* mutex, Handle thread = GetCurrentThread()->GetHandl
 bool ReleaseMutexForThread(Mutex* mutex, Handle thread_handle) {
     MutexAcquireLock(mutex, thread_handle);
 
-    Thread* thread = Kernel::g_handle_table.Get<Thread>(thread_handle);
+    Thread* thread = Kernel::g_handle_table.Get<Thread>(thread_handle).get();
     if (thread == nullptr) {
         LOG_ERROR(Kernel, "Called with invalid handle: %08X", thread_handle);
         return false;
@@ -94,7 +94,7 @@ void ReleaseThreadMutexes(Handle thread) {
     
     // Release every mutex that the thread holds, and resume execution on the waiting threads
     for (MutexMap::iterator iter = locked.first; iter != locked.second; ++iter) {
-        Mutex* mutex = g_handle_table.Get<Mutex>(iter->second);
+        Mutex* mutex = g_handle_table.Get<Mutex>(iter->second).get();
         ResumeWaitingThread(mutex);
     }
 
@@ -122,7 +122,7 @@ bool ReleaseMutex(Mutex* mutex) {
  * @param handle Handle to mutex to release
  */
 ResultCode ReleaseMutex(Handle handle) {
-    Mutex* mutex = Kernel::g_handle_table.Get<Mutex>(handle);
+    Mutex* mutex = Kernel::g_handle_table.Get<Mutex>(handle).get();
     if (mutex == nullptr) return InvalidHandle(ErrorModule::Kernel);
 
     if (!ReleaseMutex(mutex)) {

--- a/src/core/hle/kernel/semaphore.cpp
+++ b/src/core/hle/kernel/semaphore.cpp
@@ -70,7 +70,7 @@ ResultCode CreateSemaphore(Handle* handle, s32 initial_count,
 }
 
 ResultCode ReleaseSemaphore(s32* count, Handle handle, s32 release_count) {
-    Semaphore* semaphore = g_handle_table.Get<Semaphore>(handle);
+    Semaphore* semaphore = g_handle_table.Get<Semaphore>(handle).get();
     if (semaphore == nullptr)
         return InvalidHandle(ErrorModule::Kernel);
 
@@ -84,7 +84,7 @@ ResultCode ReleaseSemaphore(s32* count, Handle handle, s32 release_count) {
     // Notify some of the threads that the semaphore has been released
     // stop once the semaphore is full again or there are no more waiting threads
     while (!semaphore->waiting_threads.empty() && semaphore->IsAvailable()) {
-        Thread* thread = Kernel::g_handle_table.Get<Thread>(semaphore->waiting_threads.front());
+        Thread* thread = Kernel::g_handle_table.Get<Thread>(semaphore->waiting_threads.front()).get();
         if (thread != nullptr)
             thread->ResumeFromWait();
         semaphore->waiting_threads.pop();

--- a/src/core/hle/kernel/shared_memory.cpp
+++ b/src/core/hle/kernel/shared_memory.cpp
@@ -61,7 +61,7 @@ ResultCode MapSharedMemory(u32 handle, u32 address, MemoryPermission permissions
         return ResultCode(ErrorDescription::InvalidAddress, ErrorModule::Kernel,
                 ErrorSummary::InvalidArgument, ErrorLevel::Permanent);
     }
-    SharedMemory* shared_memory = Kernel::g_handle_table.Get<SharedMemory>(handle);
+    SharedMemory* shared_memory = Kernel::g_handle_table.Get<SharedMemory>(handle).get();
     if (shared_memory == nullptr) return InvalidHandle(ErrorModule::Kernel);
 
     shared_memory->base_address = address;
@@ -72,7 +72,7 @@ ResultCode MapSharedMemory(u32 handle, u32 address, MemoryPermission permissions
 }
 
 ResultVal<u8*> GetSharedMemoryPointer(Handle handle, u32 offset) {
-    SharedMemory* shared_memory = Kernel::g_handle_table.Get<SharedMemory>(handle);
+    SharedMemory* shared_memory = Kernel::g_handle_table.Get<SharedMemory>(handle).get();
     if (shared_memory == nullptr) return InvalidHandle(ErrorModule::Kernel);
 
     if (0 != shared_memory->base_address)

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -54,8 +54,8 @@ namespace Kernel {
 
 class Thread : public Kernel::Object {
 public:
-    static ResultVal<Thread*> Create(const char* name, u32 entry_point, s32 priority, u32 arg,
-        s32 processor_id, u32 stack_top, int stack_size = Kernel::DEFAULT_STACK_SIZE);
+    static ResultVal<SharedPtr<Thread>> Create(std::string name, VAddr entry_point, s32 priority,
+        u32 arg, s32 processor_id, VAddr stack_top, u32 stack_size);
 
     std::string GetName() const override { return name; }
     std::string GetTypeName() const override { return "Thread"; }
@@ -99,7 +99,7 @@ public:
     Object* wait_object;
     VAddr wait_address;
 
-    std::vector<Thread*> waiting_threads; // TODO(yuriks): Owned
+    std::vector<SharedPtr<Thread>> waiting_threads;
 
     std::string name;
 
@@ -111,7 +111,7 @@ private:
 };
 
 /// Sets up the primary application thread
-Thread* SetupMainThread(s32 priority, int stack_size = Kernel::DEFAULT_STACK_SIZE);
+SharedPtr<Thread> SetupMainThread(s32 priority, u32 stack_size);
 
 /// Reschedules to the next available thread (call after current thread is suspended)
 void Reschedule();

--- a/src/core/hle/kernel/timer.cpp
+++ b/src/core/hle/kernel/timer.cpp
@@ -66,7 +66,7 @@ ResultCode CreateTimer(Handle* handle, const ResetType reset_type, const std::st
 }
 
 ResultCode ClearTimer(Handle handle) {
-    Timer* timer = Kernel::g_handle_table.Get<Timer>(handle);
+    SharedPtr<Timer> timer = Kernel::g_handle_table.Get<Timer>(handle);
     
     if (timer == nullptr)
         return InvalidHandle(ErrorModule::Kernel);
@@ -80,7 +80,7 @@ static int TimerCallbackEventType = -1;
 
 /// The timer callback event, called when a timer is fired
 static void TimerCallback(u64 timer_handle, int cycles_late) {
-    Timer* timer = Kernel::g_handle_table.Get<Timer>(timer_handle);
+    SharedPtr<Timer> timer = Kernel::g_handle_table.Get<Timer>(timer_handle);
 
     if (timer == nullptr) {
         LOG_CRITICAL(Kernel, "Callback fired for invalid timer %u", timer_handle);
@@ -93,7 +93,7 @@ static void TimerCallback(u64 timer_handle, int cycles_late) {
 
     // Resume all waiting threads
     for (Handle thread_handle : timer->waiting_threads) {
-        if (Thread* thread = Kernel::g_handle_table.Get<Thread>(thread_handle))
+        if (SharedPtr<Thread> thread = Kernel::g_handle_table.Get<Thread>(thread_handle))
             thread->ResumeFromWait();
     }
 
@@ -111,7 +111,7 @@ static void TimerCallback(u64 timer_handle, int cycles_late) {
 }
 
 ResultCode SetTimer(Handle handle, s64 initial, s64 interval) {
-    Timer* timer = Kernel::g_handle_table.Get<Timer>(handle);
+    SharedPtr<Timer> timer = Kernel::g_handle_table.Get<Timer>(handle);
 
     if (timer == nullptr)
         return InvalidHandle(ErrorModule::Kernel);
@@ -125,7 +125,7 @@ ResultCode SetTimer(Handle handle, s64 initial, s64 interval) {
 }
 
 ResultCode CancelTimer(Handle handle) {
-    Timer* timer = Kernel::g_handle_table.Get<Timer>(handle);
+    SharedPtr<Timer> timer = Kernel::g_handle_table.Get<Timer>(handle);
 
     if (timer == nullptr)
         return InvalidHandle(ErrorModule::Kernel);

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -59,7 +59,8 @@ void Manager::DeleteService(const std::string& port_name) {
 }
 
 Interface* Manager::FetchFromHandle(Handle handle) {
-    return Kernel::g_handle_table.Get<Interface>(handle);
+    // TODO(yuriks): This function is very suspicious and should probably be exterminated.
+    return Kernel::g_handle_table.Get<Interface>(handle).get();
 }
 
 Interface* Manager::FetchFromPortName(const std::string& port_name) {


### PR DESCRIPTION
Follow up to/depends on #444.

This starts using `boost::intrusive_ptr` for managing the lifetime of kernel objects, which will be required as soon as handle closing is enabled, since objects will be able to exist independently of handles then. After this I will continue to work on removing Handles from the other kernel subsystems.