### PR TITLE
citra-qt: Fixed some Qt errors on initialization

### DIFF
--- a/src/citra_qt/debugger/graphics_framebuffer.cpp
+++ b/src/citra_qt/debugger/graphics_framebuffer.cpp
@@ -160,8 +160,8 @@ void GraphicsFramebufferWidget::OnFramebufferAddressChanged(qint64 new_value)
 
 void GraphicsFramebufferWidget::OnFramebufferWidthChanged(int new_value)
 {
-    if (framebuffer_width != new_value) {
-        framebuffer_width = new_value;
+    if (framebuffer_width != static_cast<unsigned>(new_value)) {
+        framebuffer_width = static_cast<unsigned>(new_value);
 
         framebuffer_source_list->setCurrentIndex(static_cast<int>(Source::Custom));
         emit Update();

--- a/src/citra_qt/debugger/graphics_framebuffer.cpp
+++ b/src/citra_qt/debugger/graphics_framebuffer.cpp
@@ -158,7 +158,7 @@ void GraphicsFramebufferWidget::OnFramebufferAddressChanged(qint64 new_value)
     }
 }
 
-void GraphicsFramebufferWidget::OnFramebufferWidthChanged(unsigned int new_value)
+void GraphicsFramebufferWidget::OnFramebufferWidthChanged(int new_value)
 {
     if (framebuffer_width != new_value) {
         framebuffer_width = new_value;
@@ -168,7 +168,7 @@ void GraphicsFramebufferWidget::OnFramebufferWidthChanged(unsigned int new_value
     }
 }
 
-void GraphicsFramebufferWidget::OnFramebufferHeightChanged(unsigned int new_value)
+void GraphicsFramebufferWidget::OnFramebufferHeightChanged(int new_value)
 {
     if (framebuffer_height != new_value) {
         framebuffer_height = new_value;

--- a/src/citra_qt/debugger/graphics_framebuffer.h
+++ b/src/citra_qt/debugger/graphics_framebuffer.h
@@ -62,8 +62,8 @@ public:
 public slots:
     void OnFramebufferSourceChanged(int new_value);
     void OnFramebufferAddressChanged(qint64 new_value);
-    void OnFramebufferWidthChanged(unsigned int new_value);
-    void OnFramebufferHeightChanged(unsigned int new_value);
+    void OnFramebufferWidthChanged(int new_value);
+    void OnFramebufferHeightChanged(int new_value);
     void OnFramebufferFormatChanged(int new_value);
     void OnUpdate();
 


### PR DESCRIPTION
Fixes two errors from #449
```
QObject::connect: No such slot GraphicsFramebufferWidget::OnFramebufferWidthChanged(int) in ..\..\..\src\citra_qt\debugger\graphics_framebuffer.cpp:87
QObject::connect:  (receiver name: 'PicaFramebuffer')
QObject::connect: No such slot GraphicsFramebufferWidget::OnFramebufferHeightChanged(int) in ..\..\..\src\citra_qt\debugger\graphics_framebuffer.cpp:88 
QObject::connect:  (receiver name: 'PicaFramebuffer')
````

The other error is caused by a connect call on an invalid object, this->windowHandle() returns nullptr in the GRenderWindow constructor, I don't know of a proper way to fix this