### PR TITLE
Revert "Travis: Enable caching of dependencies"

### DIFF
--- a/.travis-deps.sh
+++ b/.travis-deps.sh
@@ -24,8 +24,6 @@ if [ "$TRAVIS_OS_NAME" = linux -o -z "$TRAVIS_OS_NAME" ]; then
     curl http://www.cmake.org/files/v2.8/cmake-2.8.11-Linux-i386.tar.gz \
         | sudo tar -xz -C /usr/local --strip-components=1
 elif [ "$TRAVIS_OS_NAME" = osx ]; then
-    export HOMEBREW_CACHE="$PWD/.homebrew-cache"
-    mkdir -p "$HOMEBREW_CACHE"
     brew tap homebrew/versions
     brew install qt5 glfw3 pkgconfig
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,6 @@ os:
 
 language: cpp
 
-cache:
-  apt: true
-  directories:
-    - .homebrew-cache
-
 before_install:
  - sh .travis-deps.sh
 


### PR DESCRIPTION
Caching won't work on our repository, I explained the reason on the [PR](https://github.com/citra-emu/citra/pull/319) page:

>This won't work. According to Travis:

>>The features described here are currently only available for private repositories on travis-ci.com and our new container-based infrastructure

>If we want to use caching without paid Travis account, we would need to move to Travis's new container-based infrastructure, which would require sudo: false, which means we can't use sudo, which is no good for our linux build.