### PR TITLE
Add appveyor.yml for AppVeyor support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+# it seems that Qt is only installed by default on unstable os at the moment
+os: unstable
+
+# a depth of 50 should be enough (travis uses the same setting)
+clone_depth: 50
+
+environment:
+  QTDIR: C:\Qt\5.4\msvc2013_opengl
+
+install:
+  - git submodule update --init --recursive
+
+before_build:
+  - mkdir build
+  - cd build
+  - cmake ..
+  - cd ..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 # it seems that Qt is only installed by default on unstable os at the moment
 os: unstable
 
-# a depth of 50 should be enough (travis uses the same setting)
-clone_depth: 50
+# shallow clone
+clone_depth: 1
 
 environment:
   QTDIR: C:\Qt\5.4\msvc2013_opengl


### PR DESCRIPTION
This adds the `appveyor.yml` file to enable AppVeyor support. All @bunnei has to do is enable the repository on AppVeyor and we should be all set. [Example output](https://ci.appveyor.com/project/chinhodado/citra/build/1.0.20)