### PR TITLE
Thread: Prevent waking a thread multiple times.

### DIFF
--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -263,6 +263,9 @@ void WakeThreadAfterDelay(Thread* thread, s64 nanoseconds) {
 
 /// Resumes a thread from waiting by marking it as "ready"
 void Thread::ResumeFromWait() {
+    // Cancel any outstanding wakeup events
+    CoreTiming::UnscheduleEvent(ThreadWakeupEventType, GetHandle());
+
     status &= ~THREADSTATUS_WAIT;
     wait_object = nullptr;
     wait_type = WAITTYPE_NONE;


### PR DESCRIPTION
If a thread was woken up by something, cancel the wakeup timeout.