### PR TITLE
AppVeyor: Upload build to Mega upon build completion

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,8 @@ clone_depth: 1
 
 environment:
   QTDIR: C:\Qt\5.4\msvc2013_opengl
+  MEGA_PASSWORD:
+    secure: ozgp54EZj98kcbD/O+Xl5Q==
 
 install:
   - git submodule update --init --recursive
@@ -15,3 +17,27 @@ before_build:
   - cd build
   - cmake ..
   - cd ..
+  
+after_build:
+  # upload the build to Mega
+  - cinst wget -x86
+  - wget -q http://megatools.megous.com/builds/megatools-1.9.94-win64.zip
+    # extract megatools silently. See http://stackoverflow.com/a/11629736/1748450
+  - 7z x megatools-1.9.94-win64.zip | FIND /V "ing  "
+    # copy the qt dlls 
+  - copy C:\Qt\5.4\msvc2013_opengl\bin\icudt53.dll build\bin\debug
+  - copy C:\Qt\5.4\msvc2013_opengl\bin\icuin53.dll build\bin\debug
+  - copy C:\Qt\5.4\msvc2013_opengl\bin\icuuc53.dll build\bin\debug
+  - copy C:\Qt\5.4\msvc2013_opengl\bin\Qt5Cored.dll build\bin\debug
+  - copy C:\Qt\5.4\msvc2013_opengl\bin\Qt5Guid.dll  build\bin\debug
+  - copy C:\Qt\5.4\msvc2013_opengl\bin\Qt5OpenGLd.dll build\bin\debug
+  - copy C:\Qt\5.4\msvc2013_opengl\bin\Qt5Widgetsd.dll  build\bin\debug
+    # delete build craps
+  - del /F /S /Q /A "build\bin\debug\*.ilk"
+  - del /F /S /Q /A "build\bin\debug\*.pdb"
+    # zip up the build folder -> build.7z
+  - 7z a build .\build\bin\debug\*
+    # rename, upload to Mega
+  - cd megatools-1.9.94-win64
+  - node ..\upload_to_mega.js
+  

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,9 +7,9 @@ clone_depth: 1
 environment:
   QTDIR: C:\Qt\5.4\msvc2013_opengl
   MEGA_EMAIL:
-    secure: dLyH/46MKKuCZyozkwwVGCL7nVyX+Cxyo1hVlCUaQDU=
+    secure: rEo9CGAYX87GKTqZCZ9vLCNCNqxO5JLgbERaHF3YJWg=
   MEGA_PASSWORD:
-    secure: ozgp54EZj98kcbD/O+Xl5Q==
+    secure: zE1zmgjS/6GfN/19ROl/O0fVR58svORQ5gdtsxI7J8k=
 
 platform:
   - Win32

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,6 +40,8 @@ after_build:
   - copy C:\Qt\5.4\msvc2013_opengl\bin\Qt5Gui.dll  build\bin\release
   - copy C:\Qt\5.4\msvc2013_opengl\bin\Qt5OpenGL.dll build\bin\release
   - copy C:\Qt\5.4\msvc2013_opengl\bin\Qt5Widgets.dll  build\bin\release
+  - mkdir build\bin\release\platforms\
+  - copy C:\Qt\5.4\msvc2013_opengl\plugins\platforms\qwindows.dll build\bin\release\platforms
     # zip up the build folder -> build.7z
   - 7z a build .\build\bin\release\*
     # rename, upload to Mega

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,9 +6,11 @@ clone_depth: 1
 
 environment:
   QTDIR: C:\Qt\5.4\msvc2013_opengl
+  MEGA_EMAIL:
+    secure: dLyH/46MKKuCZyozkwwVGCL7nVyX+Cxyo1hVlCUaQDU=
   MEGA_PASSWORD:
     secure: ozgp54EZj98kcbD/O+Xl5Q==
-    
+
 platform:
   - Win32
 
@@ -23,7 +25,7 @@ before_build:
   - cd build
   - cmake ..
   - cd ..
-  
+
 after_build:
   # upload the build to Mega
   - cinst wget -x86
@@ -38,12 +40,9 @@ after_build:
   - copy C:\Qt\5.4\msvc2013_opengl\bin\Qt5Gui.dll  build\bin\release
   - copy C:\Qt\5.4\msvc2013_opengl\bin\Qt5OpenGL.dll build\bin\release
   - copy C:\Qt\5.4\msvc2013_opengl\bin\Qt5Widgets.dll  build\bin\release
-    # delete build craps
-  - del /F /S /Q /A "build\bin\release\*.ilk"
-  - del /F /S /Q /A "build\bin\release\*.pdb"
     # zip up the build folder -> build.7z
   - 7z a build .\build\bin\release\*
     # rename, upload to Mega
+  - npm install sanitize-filename
   - cd megatools-1.9.94-win64
   - node ..\upload_to_mega.js
-  

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,12 @@ environment:
   QTDIR: C:\Qt\5.4\msvc2013_opengl
   MEGA_PASSWORD:
     secure: ozgp54EZj98kcbD/O+Xl5Q==
+    
+platform:
+  - Win32
+
+configuration:
+  - Release
 
 install:
   - git submodule update --init --recursive
@@ -25,18 +31,18 @@ after_build:
     # extract megatools silently. See http://stackoverflow.com/a/11629736/1748450
   - 7z x megatools-1.9.94-win64.zip | FIND /V "ing  "
     # copy the qt dlls 
-  - copy C:\Qt\5.4\msvc2013_opengl\bin\icudt53.dll build\bin\debug
-  - copy C:\Qt\5.4\msvc2013_opengl\bin\icuin53.dll build\bin\debug
-  - copy C:\Qt\5.4\msvc2013_opengl\bin\icuuc53.dll build\bin\debug
-  - copy C:\Qt\5.4\msvc2013_opengl\bin\Qt5Cored.dll build\bin\debug
-  - copy C:\Qt\5.4\msvc2013_opengl\bin\Qt5Guid.dll  build\bin\debug
-  - copy C:\Qt\5.4\msvc2013_opengl\bin\Qt5OpenGLd.dll build\bin\debug
-  - copy C:\Qt\5.4\msvc2013_opengl\bin\Qt5Widgetsd.dll  build\bin\debug
+  - copy C:\Qt\5.4\msvc2013_opengl\bin\icudt53.dll build\bin\release
+  - copy C:\Qt\5.4\msvc2013_opengl\bin\icuin53.dll build\bin\release
+  - copy C:\Qt\5.4\msvc2013_opengl\bin\icuuc53.dll build\bin\release
+  - copy C:\Qt\5.4\msvc2013_opengl\bin\Qt5Core.dll build\bin\release
+  - copy C:\Qt\5.4\msvc2013_opengl\bin\Qt5Gui.dll  build\bin\release
+  - copy C:\Qt\5.4\msvc2013_opengl\bin\Qt5OpenGL.dll build\bin\release
+  - copy C:\Qt\5.4\msvc2013_opengl\bin\Qt5Widgets.dll  build\bin\release
     # delete build craps
-  - del /F /S /Q /A "build\bin\debug\*.ilk"
-  - del /F /S /Q /A "build\bin\debug\*.pdb"
+  - del /F /S /Q /A "build\bin\release\*.ilk"
+  - del /F /S /Q /A "build\bin\release\*.pdb"
     # zip up the build folder -> build.7z
-  - 7z a build .\build\bin\debug\*
+  - 7z a build .\build\bin\release\*
     # rename, upload to Mega
   - cd megatools-1.9.94-win64
   - node ..\upload_to_mega.js

--- a/upload_to_mega.js
+++ b/upload_to_mega.js
@@ -1,11 +1,13 @@
 var util = require('util');
 var exec = require('child_process').exec;
+var sanitize = require("sanitize-filename");
 
-var email = 'chin.bimbo@gmail.com';
+var email = process.env.MEGA_EMAIL;
 var password = process.env.MEGA_PASSWORD;
 var sourceFileName = 'build.7z';
 var dstFileName = process.env.APPVEYOR_REPO_COMMIT.substring(0, 8) + " - " + 
                 process.env.APPVEYOR_REPO_COMMIT_MESSAGE.substring(0, 100) + ".7z";
+dstFileName = sanitize(dstFileName);
 
 var cmd = util.format('megaput ../%s --path \"/Root/Citra/Windows/%s\" --username=%s --password=%s --no-progress',
                         sourceFileName,
@@ -13,6 +15,7 @@ var cmd = util.format('megaput ../%s --path \"/Root/Citra/Windows/%s\" --usernam
                         email,
                         password);
 
+// only upload build on master branch, and not on other branches or PRs
 if (process.env.APPVEYOR_REPO_BRANCH == "master") {
     console.log("Uploading file " + dstFileName + " to Mega...");
     exec(cmd, function(error, stdout, stderr) {

--- a/upload_to_mega.js
+++ b/upload_to_mega.js
@@ -1,0 +1,25 @@
+var util = require('util');
+var exec = require('child_process').exec;
+
+var email = 'chin.bimbo@gmail.com';
+var password = process.env.MEGA_PASSWORD;
+var sourceFileName = 'build.7z';
+var dstFileName = process.env.APPVEYOR_REPO_COMMIT.substring(0, 8) + " - " + 
+                process.env.APPVEYOR_REPO_COMMIT_MESSAGE.substring(0, 100) + ".7z";
+
+var cmd = util.format('megaput ../%s --path \"/Root/Citra/Windows/%s\" --username=%s --password=%s --no-progress',
+                        sourceFileName,
+                        dstFileName,
+                        email,
+                        password);
+
+if (process.env.APPVEYOR_REPO_BRANCH == "master") {
+    console.log("Uploading file " + dstFileName + " to Mega...");
+    exec(cmd, function(error, stdout, stderr) {
+        console.log('stdout: ' + stdout);
+        console.log('stderr: ' + stderr);
+        if (error !== null) {
+            console.log('exec error: ' + error);
+        }
+    });            
+}


### PR DESCRIPTION
This PR will upload the build to Mega upon build completion on AppVeyor. Specifically, it will copy over the required Qt dlls to the build folder, remove the junk files, then compress the build folder into a `.7z` file, and upload that file into a Mega folder.

Why Mega? It provides free 50GB storage, no bandwidth limit for upload/download, no wait for download, has the ability to create folders, can share a whole folder, and the interface is nice. [An example](https://mega.co.nz/#F!HR0CzZKZ!fLqLt_7xO7aKqmeVxwkRKQ).

The name of the result file will be

    <first 8 characters of the commit hash> - <first 100 characters of the commit message>.7z

The date of the commit is not included in the file name, since Mega can sort files based on upload date already (see my example folder above)

This will only run on the master branch. It will not run on pull requests or on other branches.

What @bunnei needs to do:

1. Create a Mega account
2. Create a `Citra` folder and a `Windows` folder inside that `Citra` folder. The idea is that later on we will have other folders for osx and Linux.
3. On AppVeyor, encrypt the Mega account password and get a string that looks like this: `ozgp54EZj98kcbD/O+Xl5Q==`. The encrypted string will be decrypted by AppVeyor during the build process, and it can only be decrypted on the original AppVeyor account that created it.
4. Post the email address of the Mega account and the encrypted string of the password here, so I can put it in my PR.
5. Profit


