### PR TITLE
Fix WaitSynchronization

### DIFF
--- a/src/core/hle/kernel/address_arbiter.cpp
+++ b/src/core/hle/kernel/address_arbiter.cpp
@@ -15,7 +15,7 @@
 
 namespace Kernel {
 
-class AddressArbiter : public Object {
+class AddressArbiter : public WaitObject {
 public:
     std::string GetTypeName() const override { return "Arbiter"; }
     std::string GetName() const override { return name; }
@@ -30,7 +30,8 @@ public:
 
 /// Arbitrate an address
 ResultCode ArbitrateAddress(Handle handle, ArbitrationType type, u32 address, s32 value, u64 nanoseconds) {
-    Object* object = Kernel::g_handle_table.GetGeneric(handle).get();
+    WaitObject* object = static_cast<WaitObject*>(Kernel::g_handle_table.GetGeneric(handle).get());
+
     if (object == nullptr)
         return InvalidHandle(ErrorModule::Kernel);
 

--- a/src/core/hle/kernel/address_arbiter.cpp
+++ b/src/core/hle/kernel/address_arbiter.cpp
@@ -52,13 +52,13 @@ ResultCode ArbitrateAddress(Handle handle, ArbitrationType type, u32 address, s3
     // Wait current thread (acquire the arbiter)...
     case ArbitrationType::WaitIfLessThan:
         if ((s32)Memory::Read32(address) <= value) {
-            Kernel::WaitCurrentThread(WAITTYPE_ARB, object, address);
+            Kernel::WaitCurrentThread_ArbitrateAddress(object, address);
             HLE::Reschedule(__func__);
         }
         break;
     case ArbitrationType::WaitIfLessThanWithTimeout:
         if ((s32)Memory::Read32(address) <= value) {
-            Kernel::WaitCurrentThread(WAITTYPE_ARB, object, address);
+            Kernel::WaitCurrentThread_ArbitrateAddress(object, address);
             Kernel::WakeThreadAfterDelay(GetCurrentThread(), nanoseconds);
             HLE::Reschedule(__func__);
         }
@@ -68,7 +68,7 @@ ResultCode ArbitrateAddress(Handle handle, ArbitrationType type, u32 address, s3
         s32 memory_value = Memory::Read32(address) - 1;
         Memory::Write32(address, memory_value);
         if (memory_value <= value) {
-            Kernel::WaitCurrentThread(WAITTYPE_ARB, object, address);
+            Kernel::WaitCurrentThread_ArbitrateAddress(object, address);
             HLE::Reschedule(__func__);
         }
         break;
@@ -78,7 +78,7 @@ ResultCode ArbitrateAddress(Handle handle, ArbitrationType type, u32 address, s3
         s32 memory_value = Memory::Read32(address) - 1;
         Memory::Write32(address, memory_value);
         if (memory_value <= value) {
-            Kernel::WaitCurrentThread(WAITTYPE_ARB, object, address);
+            Kernel::WaitCurrentThread_ArbitrateAddress(object, address);
             Kernel::WakeThreadAfterDelay(GetCurrentThread(), nanoseconds);
             HLE::Reschedule(__func__);
         }

--- a/src/core/hle/kernel/address_arbiter.cpp
+++ b/src/core/hle/kernel/address_arbiter.cpp
@@ -15,7 +15,7 @@
 
 namespace Kernel {
 
-class AddressArbiter : public WaitObject {
+class AddressArbiter : public Object {
 public:
     std::string GetTypeName() const override { return "Arbiter"; }
     std::string GetName() const override { return name; }
@@ -30,7 +30,7 @@ public:
 
 /// Arbitrate an address
 ResultCode ArbitrateAddress(Handle handle, ArbitrationType type, u32 address, s32 value, u64 nanoseconds) {
-    WaitObject* object = static_cast<WaitObject*>(Kernel::g_handle_table.GetGeneric(handle).get());
+    AddressArbiter* object = Kernel::g_handle_table.Get<AddressArbiter>(handle).get();
 
     if (object == nullptr)
         return InvalidHandle(ErrorModule::Kernel);
@@ -41,24 +41,24 @@ ResultCode ArbitrateAddress(Handle handle, ArbitrationType type, u32 address, s3
     case ArbitrationType::Signal:
         // Negative value means resume all threads
         if (value < 0) {
-            ArbitrateAllThreads(object, address);
+            ArbitrateAllThreads(address);
         } else {
             // Resume first N threads
             for(int i = 0; i < value; i++)
-                ArbitrateHighestPriorityThread(object, address);
+                ArbitrateHighestPriorityThread(address);
         }
         break;
 
     // Wait current thread (acquire the arbiter)...
     case ArbitrationType::WaitIfLessThan:
         if ((s32)Memory::Read32(address) <= value) {
-            Kernel::WaitCurrentThread_ArbitrateAddress(object, address);
+            Kernel::WaitCurrentThread_ArbitrateAddress(address);
             HLE::Reschedule(__func__);
         }
         break;
     case ArbitrationType::WaitIfLessThanWithTimeout:
         if ((s32)Memory::Read32(address) <= value) {
-            Kernel::WaitCurrentThread_ArbitrateAddress(object, address);
+            Kernel::WaitCurrentThread_ArbitrateAddress(address);
             Kernel::WakeThreadAfterDelay(GetCurrentThread(), nanoseconds);
             HLE::Reschedule(__func__);
         }
@@ -68,7 +68,7 @@ ResultCode ArbitrateAddress(Handle handle, ArbitrationType type, u32 address, s3
         s32 memory_value = Memory::Read32(address) - 1;
         Memory::Write32(address, memory_value);
         if (memory_value <= value) {
-            Kernel::WaitCurrentThread_ArbitrateAddress(object, address);
+            Kernel::WaitCurrentThread_ArbitrateAddress(address);
             HLE::Reschedule(__func__);
         }
         break;
@@ -78,7 +78,7 @@ ResultCode ArbitrateAddress(Handle handle, ArbitrationType type, u32 address, s3
         s32 memory_value = Memory::Read32(address) - 1;
         Memory::Write32(address, memory_value);
         if (memory_value <= value) {
-            Kernel::WaitCurrentThread_ArbitrateAddress(object, address);
+            Kernel::WaitCurrentThread_ArbitrateAddress(address);
             Kernel::WakeThreadAfterDelay(GetCurrentThread(), nanoseconds);
             HLE::Reschedule(__func__);
         }

--- a/src/core/hle/kernel/event.cpp
+++ b/src/core/hle/kernel/event.cpp
@@ -28,13 +28,8 @@ public:
     bool signaled;                          ///< Whether the event has already been signaled
     std::string name;                       ///< Name of event (optional)
 
-    ResultVal<bool> Wait(bool wait_thread) override {
-        bool wait = !signaled;
-        if (wait && wait_thread) {
-            AddWaitingThread(GetCurrentThread());
-            Kernel::WaitCurrentThread_WaitSynchronization(WAITTYPE_EVENT, this);
-        }
-        return MakeResult<bool>(wait);
+    ResultVal<bool> Wait() override {
+        return MakeResult<bool>(!signaled);
     }
 
     ResultVal<bool> Acquire() override {

--- a/src/core/hle/kernel/event.cpp
+++ b/src/core/hle/kernel/event.cpp
@@ -28,16 +28,16 @@ public:
     bool signaled;                          ///< Whether the event has already been signaled
     std::string name;                       ///< Name of event (optional)
 
-    ResultVal<bool> ShouldWait() override {
-        return MakeResult<bool>(!signaled);
+    bool ShouldWait() override {
+        return !signaled;
     }
 
-    ResultVal<bool> Acquire() override {
+    void Acquire() override {
+        _assert_msg_(Kernel, !ShouldWait(), "object unavailable!");
+
         // Release the event if it's not sticky...
         if (reset_type != RESETTYPE_STICKY)
             signaled = false;
-
-        return MakeResult<bool>(true);
     }
 };
 

--- a/src/core/hle/kernel/event.cpp
+++ b/src/core/hle/kernel/event.cpp
@@ -47,7 +47,7 @@ ResultCode SignalEvent(const Handle handle) {
         return InvalidHandle(ErrorModule::Kernel);
 
     evt->signaled = true;
-    evt->ReleaseAllWaitingThreads();
+    evt->WakeupAllWaitingThreads();
 
     return RESULT_SUCCESS;
 }

--- a/src/core/hle/kernel/event.cpp
+++ b/src/core/hle/kernel/event.cpp
@@ -28,13 +28,17 @@ public:
     bool signaled;                          ///< Whether the event has already been signaled
     std::string name;                       ///< Name of event (optional)
 
-    ResultVal<bool> WaitSynchronization(unsigned index) override {
+    ResultVal<bool> Wait(unsigned index) override {
         bool wait = !signaled;
         if (wait) {
             AddWaitingThread(GetCurrentThread());
             Kernel::WaitCurrentThread_WaitSynchronization(WAITTYPE_EVENT, this, index);
         }
         return MakeResult<bool>(wait);
+    }
+
+    ResultVal<bool> Acquire() override {
+        return MakeResult<bool>(true);
     }
 };
 

--- a/src/core/hle/kernel/event.cpp
+++ b/src/core/hle/kernel/event.cpp
@@ -28,11 +28,11 @@ public:
     bool signaled;                          ///< Whether the event has already been signaled
     std::string name;                       ///< Name of event (optional)
 
-    ResultVal<bool> WaitSynchronization() override {
+    ResultVal<bool> WaitSynchronization(unsigned index) override {
         bool wait = !signaled;
         if (wait) {
             AddWaitingThread(GetCurrentThread());
-            Kernel::WaitCurrentThread(WAITTYPE_EVENT, this);
+            Kernel::WaitCurrentThread_WaitSynchronization(WAITTYPE_EVENT, this, index);
         }
         return MakeResult<bool>(wait);
     }

--- a/src/core/hle/kernel/event.cpp
+++ b/src/core/hle/kernel/event.cpp
@@ -33,6 +33,10 @@ public:
     }
 
     ResultVal<bool> Acquire() override {
+        // Release the event if it's not sticky...
+        if (reset_type != RESETTYPE_STICKY)
+            signaled = false;
+
         return MakeResult<bool>(true);
     }
 };

--- a/src/core/hle/kernel/event.cpp
+++ b/src/core/hle/kernel/event.cpp
@@ -25,66 +25,36 @@ public:
     ResetType intitial_reset_type;          ///< ResetType specified at Event initialization
     ResetType reset_type;                   ///< Current ResetType
 
-    bool locked;                            ///< Event signal wait
+    bool signaled;                          ///< Whether the event has already been signaled
     std::string name;                       ///< Name of event (optional)
 
     ResultVal<bool> WaitSynchronization() override {
-        bool wait = locked;
-        if (locked) {
+        bool wait = !signaled;
+        if (wait) {
             AddWaitingThread(GetCurrentThread());
             Kernel::WaitCurrentThread(WAITTYPE_EVENT, this);
-        }
-        if (reset_type != RESETTYPE_STICKY) {
-            locked = true;
         }
         return MakeResult<bool>(wait);
     }
 };
 
-/**
- * Changes whether an event is locked or not
- * @param handle Handle to event to change
- * @param locked Boolean locked value to set event
- * @return Result of operation, 0 on success, otherwise error code
- */
-ResultCode SetEventLocked(const Handle handle, const bool locked) {
-    Event* evt = g_handle_table.Get<Event>(handle).get();
-    if (evt == nullptr) return InvalidHandle(ErrorModule::Kernel);
-
-    evt->locked = locked;
-
-    return RESULT_SUCCESS;
-}
-
-/**
- * Signals an event
- * @param handle Handle to event to signal
- * @return Result of operation, 0 on success, otherwise error code
- */
 ResultCode SignalEvent(const Handle handle) {
     Event* evt = g_handle_table.Get<Event>(handle).get();
-    if (evt == nullptr) return InvalidHandle(ErrorModule::Kernel);
+    if (evt == nullptr)
+        return InvalidHandle(ErrorModule::Kernel);
 
-    // If any thread is signalled awake by this event, assume the event was "caught" and reset
-    // the event. This will result in the next thread waiting on the event to block. Otherwise,
-    // the event will not be reset, and the next thread to call WaitSynchronization on it will
-    // not block. Not sure if this is correct behavior, but it seems to work.
-    // TODO(bunnei): Test how this works on hardware
-    evt->locked = evt->ResumeAllWaitingThreads();
+    evt->signaled = true;
+    evt->ReleaseAllWaitingThreads();
 
     return RESULT_SUCCESS;
 }
 
-/**
- * Clears an event
- * @param handle Handle to event to clear
- * @return Result of operation, 0 on success, otherwise error code
- */
 ResultCode ClearEvent(Handle handle) {
     Event* evt = g_handle_table.Get<Event>(handle).get();
-    if (evt == nullptr) return InvalidHandle(ErrorModule::Kernel);
+    if (evt == nullptr)
+        return InvalidHandle(ErrorModule::Kernel);
 
-    evt->locked = true;
+    evt->signaled = false;
 
     return RESULT_SUCCESS;
 }
@@ -102,19 +72,13 @@ Event* CreateEvent(Handle& handle, const ResetType reset_type, const std::string
     // TOOD(yuriks): Fix error reporting
     handle = Kernel::g_handle_table.Create(evt).ValueOr(INVALID_HANDLE);
 
-    evt->locked = true;
+    evt->signaled = false;
     evt->reset_type = evt->intitial_reset_type = reset_type;
     evt->name = name;
 
     return evt;
 }
 
-/**
- * Creates an event
- * @param reset_type ResetType describing how to create event
- * @param name Optional name of event
- * @return Handle to newly created Event object
- */
 Handle CreateEvent(const ResetType reset_type, const std::string& name) {
     Handle handle;
     Event* evt = CreateEvent(handle, reset_type, name);

--- a/src/core/hle/kernel/event.cpp
+++ b/src/core/hle/kernel/event.cpp
@@ -28,11 +28,11 @@ public:
     bool signaled;                          ///< Whether the event has already been signaled
     std::string name;                       ///< Name of event (optional)
 
-    ResultVal<bool> Wait(unsigned index) override {
+    ResultVal<bool> Wait(bool wait_thread) override {
         bool wait = !signaled;
-        if (wait) {
+        if (wait && wait_thread) {
             AddWaitingThread(GetCurrentThread());
-            Kernel::WaitCurrentThread_WaitSynchronization(WAITTYPE_EVENT, this, index);
+            Kernel::WaitCurrentThread_WaitSynchronization(WAITTYPE_EVENT, this);
         }
         return MakeResult<bool>(wait);
     }

--- a/src/core/hle/kernel/event.cpp
+++ b/src/core/hle/kernel/event.cpp
@@ -28,7 +28,7 @@ public:
     bool signaled;                          ///< Whether the event has already been signaled
     std::string name;                       ///< Name of event (optional)
 
-    ResultVal<bool> Wait() override {
+    ResultVal<bool> ShouldWait() override {
         return MakeResult<bool>(!signaled);
     }
 

--- a/src/core/hle/kernel/event.h
+++ b/src/core/hle/kernel/event.h
@@ -19,13 +19,6 @@ namespace Kernel {
 ResultCode SetEventLocked(const Handle handle, const bool locked);
 
 /**
- * Hackish function to set an events permanent lock state, used to pass through synch blocks
- * @param handle Handle to event to change
- * @param permanent_locked Boolean permanent locked value to set event
- */
-ResultCode SetPermanentLock(Handle handle, const bool permanent_locked);
-
-/**
  * Signals an event
  * @param handle Handle to event to signal
  */

--- a/src/core/hle/kernel/event.h
+++ b/src/core/hle/kernel/event.h
@@ -12,21 +12,16 @@
 namespace Kernel {
 
 /**
- * Changes whether an event is locked or not
- * @param handle Handle to event to change
- * @param locked Boolean locked value to set event
- */
-ResultCode SetEventLocked(const Handle handle, const bool locked);
-
-/**
  * Signals an event
  * @param handle Handle to event to signal
+ * @return Result of operation, 0 on success, otherwise error code
  */
 ResultCode SignalEvent(const Handle handle);
 
 /**
  * Clears an event
  * @param handle Handle to event to clear
+ * @return Result of operation, 0 on success, otherwise error code
  */
 ResultCode ClearEvent(Handle handle);
 

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -36,7 +36,7 @@ Thread* WaitObject::ReleaseNextThread() {
 
     auto next_thread = waiting_threads.front();
 
-    next_thread->ReleaseFromWait(this);
+    next_thread->ReleaseWaitObject(this);
     waiting_threads.erase(waiting_threads.begin());
 
     return next_thread.get();

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -19,13 +19,20 @@ HandleTable g_handle_table;
 u64 g_program_id = 0;
 
 void WaitObject::AddWaitingThread(Thread* thread) {
-    if (std::find(waiting_threads.begin(), waiting_threads.end(), thread) == waiting_threads.end()) {
+    auto itr = std::find(waiting_threads.begin(), waiting_threads.end(), thread);
+    if (itr == waiting_threads.end())
         waiting_threads.push_back(thread);
-    }
+}
+
+void WaitObject::RemoveWaitingThread(Thread* thread) {
+    auto itr = std::find(waiting_threads.begin(), waiting_threads.end(), thread);
+    if (itr != waiting_threads.end())
+        waiting_threads.erase(itr);
 }
 
 Thread* WaitObject::ResumeNextThread() {
-    if (waiting_threads.empty()) return nullptr;
+    if (waiting_threads.empty())
+        return nullptr;
 
     auto next_thread = waiting_threads.front();
 

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -42,13 +42,15 @@ Thread* WaitObject::ReleaseNextThread() {
     return next_thread.get();
 }
 
-void WaitObject::ReleaseAllWaitingThreads() {
+void WaitObject::WakeupAllWaitingThreads() {
     auto waiting_threads_copy = waiting_threads;
 
+    // We use a copy because ReleaseWaitObject will remove the thread from this object's
+    // waiting_threads list
     for (auto thread : waiting_threads_copy)
         thread->ReleaseWaitObject(this);
 
-    waiting_threads.clear();
+    _assert_msg_(Kernel, waiting_threads.empty(), "failed to awaken all waiting threads!");
 }
 
 HandleTable::HandleTable() {

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -30,7 +30,7 @@ void WaitObject::RemoveWaitingThread(Thread* thread) {
         waiting_threads.erase(itr);
 }
 
-Thread* WaitObject::ReleaseNextThread() {
+Thread* WaitObject::WakeupNextThread() {
     if (waiting_threads.empty())
         return nullptr;
 

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -30,13 +30,13 @@ void WaitObject::RemoveWaitingThread(Thread* thread) {
         waiting_threads.erase(itr);
 }
 
-Thread* WaitObject::ResumeNextThread() {
+Thread* WaitObject::ReleaseNextThread() {
     if (waiting_threads.empty())
         return nullptr;
 
     auto next_thread = waiting_threads.front();
 
-    next_thread->ResumeFromWait();
+    next_thread->ReleaseFromWait(this);
     waiting_threads.erase(waiting_threads.begin());
 
     return next_thread.get();

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -35,9 +35,9 @@ Thread* WaitObject::ReleaseNextThread() {
         return nullptr;
 
     auto next_thread = waiting_threads.front();
+    waiting_threads.erase(waiting_threads.begin());
 
     next_thread->ReleaseWaitObject(this);
-    waiting_threads.erase(waiting_threads.begin());
 
     return next_thread.get();
 }

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -39,7 +39,7 @@ Thread* WaitObject::ReleaseNextThread() {
 
     next_thread->ReleaseWaitObject(this);
 
-    return next_thread.get();
+    return next_thread;
 }
 
 void WaitObject::WakeupAllWaitingThreads() {

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -65,18 +65,18 @@ public:
     virtual Kernel::HandleType GetHandleType() const = 0;
 
     /**
-     * Wait the current thread for kernel object to synchronize.
-     * @param index Index of wait object (only applies to WaitSynchronizationN)
-     * @return True if the current thread should wait as a result of the wait
+     * Check if this object is available, (optionally) wait the current thread if not
+     * @param wait_thread If true, wait the current thread if this object is unavailable
+     * @return True if the current thread should wait due to this object being unavailable
      */
-    virtual ResultVal<bool> Wait(unsigned index = 0) {
+    virtual ResultVal<bool> Wait(bool wait_thread) {
         LOG_ERROR(Kernel, "(UNIMPLEMENTED)");
         return UnimplementedFunction(ErrorModule::Kernel);
     }
 
     /**
-     * Acquire/lock the kernel object if it is available
-     * @return True if we were able to acquire the kernel object, otherwise false
+     * Acquire/lock the this object if it is available
+     * @return True if we were able to acquire this object, otherwise false
      */
     virtual ResultVal<bool> Acquire() {
         LOG_ERROR(Kernel, "(UNIMPLEMENTED)");

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -71,6 +71,7 @@ public:
      */
     bool IsWaitable() const {
         switch (GetHandleType()) {
+        case HandleType::Session:
         case HandleType::Event:
         case HandleType::Mutex:
         case HandleType::Thread:

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -105,7 +105,13 @@ public:
     void AddWaitingThread(Thread* thread);
 
     /**
-     * Resumes the next thread waiting on this object
+     * Removes a thread from waiting on this object (e.g. if it was resumed already)
+     * @param thread Pointer to thread to remove
+     */
+    void RemoveWaitingThread(Thread* thead);
+
+    /**
+     * Resumes (and removes) the next thread waiting on this object
      * @return Pointer to the thread that was resumed, nullptr if no threads are waiting
      */
     Thread* ResumeNextThread();

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -66,9 +66,10 @@ public:
 
     /**
      * Wait for kernel object to synchronize.
+     * @param index Index of wait object (only applies to WaitSynchronizationN)
      * @return True if the current thread should wait as a result of the wait
      */
-    virtual ResultVal<bool> WaitSynchronization() {
+    virtual ResultVal<bool> WaitSynchronization(unsigned index=0) {
         LOG_ERROR(Kernel, "(UNIMPLEMENTED)");
         return UnimplementedFunction(ErrorModule::Kernel);
     }
@@ -111,10 +112,10 @@ public:
     void RemoveWaitingThread(Thread* thead);
 
     /**
-     * Resumes (and removes) the next thread waiting on this object
+     * Releases (and removes) the next thread waiting on this object
      * @return Pointer to the thread that was resumed, nullptr if no threads are waiting
      */
-    Thread* ResumeNextThread();
+    Thread* ReleaseNextThread();
 
     /// Releases all threads waiting on this object
     void ReleaseAllWaitingThreads();

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -65,11 +65,10 @@ public:
     virtual Kernel::HandleType GetHandleType() const = 0;
 
     /**
-     * Check if this object is available, (optionally) wait the current thread if not
-     * @param wait_thread If true, wait the current thread if this object is unavailable
+     * Check if this object is available
      * @return True if the current thread should wait due to this object being unavailable
      */
-    virtual ResultVal<bool> Wait(bool wait_thread) {
+    virtual ResultVal<bool> Wait() {
         LOG_ERROR(Kernel, "(UNIMPLEMENTED)");
         return UnimplementedFunction(ErrorModule::Kernel);
     }

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -8,6 +8,8 @@
 
 #include <array>
 #include <string>
+#include <vector>
+
 #include "common/common.h"
 #include "core/hle/result.h"
 
@@ -91,6 +93,29 @@ inline void intrusive_ptr_release(Object* object) {
 
 template <typename T>
 using SharedPtr = boost::intrusive_ptr<T>;
+
+/// Class that represents a Kernel object that a thread can be waiting on
+class WaitObject : public Object {
+public:
+
+    /**
+     * Add a thread to wait on this object
+     * @param thread Pointer to thread to add
+     */
+    void AddWaitingThread(Thread* thread);
+
+    /**
+     * Resumes the next thread waiting on this object
+     * @return Pointer to the thread that was resumed, nullptr if no threads are waiting
+     */
+    Thread* ResumeNextThread();
+
+    /// Releases all threads waiting on this object
+    void ReleaseAllWaitingThreads();
+
+private:
+    std::vector<Thread*> waiting_threads; ///< Threads waiting for this object to become available
+};
 
 /**
  * This class allows the creation of Handles, which are references to objects that can be tested

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -138,13 +138,13 @@ public:
     void RemoveWaitingThread(Thread* thead);
 
     /**
-     * Releases (and removes) the next thread waiting on this object
+     * Wake up the next thread waiting on this object
      * @return Pointer to the thread that was resumed, nullptr if no threads are waiting
      */
-    Thread* ReleaseNextThread();
+    Thread* WakeupNextThread();
 
-    /// Releases all threads waiting on this object
-    void ReleaseAllWaitingThreads();
+    /// Wake up all threads waiting on this object
+    void WakeupAllWaitingThreads();
 
 private:
     std::vector<Thread*> waiting_threads; ///< Threads waiting for this object to become available

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -65,11 +65,20 @@ public:
     virtual Kernel::HandleType GetHandleType() const = 0;
 
     /**
-     * Wait for kernel object to synchronize.
+     * Wait the current thread for kernel object to synchronize.
      * @param index Index of wait object (only applies to WaitSynchronizationN)
      * @return True if the current thread should wait as a result of the wait
      */
-    virtual ResultVal<bool> WaitSynchronization(unsigned index=0) {
+    virtual ResultVal<bool> Wait(unsigned index = 0) {
+        LOG_ERROR(Kernel, "(UNIMPLEMENTED)");
+        return UnimplementedFunction(ErrorModule::Kernel);
+    }
+
+    /**
+     * Acquire/lock the kernel object if it is available
+     * @return True if we were able to acquire the kernel object, otherwise false
+     */
+    virtual ResultVal<bool> Acquire() {
         LOG_ERROR(Kernel, "(UNIMPLEMENTED)");
         return UnimplementedFunction(ErrorModule::Kernel);
     }

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -120,13 +120,10 @@ public:
      * Check if the current thread should wait until the object is available
      * @return True if the current thread should wait due to this object being unavailable
      */
-    virtual ResultVal<bool> ShouldWait() = 0;
+    virtual bool ShouldWait() = 0;
 
-    /**
-     * Acquire/lock the object if it is available
-     * @return True if we were able to acquire this object, otherwise false
-     */
-    virtual ResultVal<bool> Acquire() = 0;
+    /// Acquire/lock the object if it is available
+    virtual void Acquire() = 0;
 
     /**
      * Add a thread to wait on this object

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -117,22 +117,16 @@ class WaitObject : public Object {
 public:
 
     /**
-     * Check if this object is available
+     * Check if the current thread should wait until the object is available
      * @return True if the current thread should wait due to this object being unavailable
      */
-    virtual ResultVal<bool> Wait() {
-        LOG_ERROR(Kernel, "(UNIMPLEMENTED)");
-        return UnimplementedFunction(ErrorModule::Kernel);
-    }
+    virtual ResultVal<bool> ShouldWait() = 0;
 
     /**
-     * Acquire/lock the this object if it is available
+     * Acquire/lock the object if it is available
      * @return True if we were able to acquire this object, otherwise false
      */
-    virtual ResultVal<bool> Acquire() {
-        LOG_ERROR(Kernel, "(UNIMPLEMENTED)");
-        return UnimplementedFunction(ErrorModule::Kernel);
-    }
+    virtual ResultVal<bool> Acquire() = 0;
 
     /**
      * Add a thread to wait on this object

--- a/src/core/hle/kernel/mutex.cpp
+++ b/src/core/hle/kernel/mutex.cpp
@@ -26,7 +26,7 @@ public:
     Handle lock_thread;                         ///< Handle to thread that currently has mutex
     std::string name;                           ///< Name of mutex (optional)
 
-    ResultVal<bool> Wait(unsigned index) override;
+    ResultVal<bool> Wait(bool wait_thread) override;
     ResultVal<bool> Acquire() override;
 };
 
@@ -156,10 +156,10 @@ Handle CreateMutex(bool initial_locked, const std::string& name) {
     return handle;
 }
 
-ResultVal<bool> Mutex::Wait(unsigned index) {
-    if (locked) {
+ResultVal<bool> Mutex::Wait(bool wait_thread) {
+    if (locked && wait_thread) {
         AddWaitingThread(GetCurrentThread());
-        Kernel::WaitCurrentThread_WaitSynchronization(WAITTYPE_MUTEX, this, index);
+        Kernel::WaitCurrentThread_WaitSynchronization(WAITTYPE_MUTEX, this);
     }
 
     return MakeResult<bool>(locked);

--- a/src/core/hle/kernel/mutex.cpp
+++ b/src/core/hle/kernel/mutex.cpp
@@ -27,7 +27,7 @@ public:
     std::string name;                           ///< Name of mutex (optional)
     SharedPtr<Thread> current_thread;           ///< Thread that has acquired the mutex
 
-    ResultVal<bool> Wait() override;
+    ResultVal<bool> ShouldWait() override;
     ResultVal<bool> Acquire() override;
 };
 
@@ -159,7 +159,7 @@ Handle CreateMutex(bool initial_locked, const std::string& name) {
     return handle;
 }
 
-ResultVal<bool> Mutex::Wait() {
+ResultVal<bool> Mutex::ShouldWait() {
     return MakeResult<bool>(locked && (current_thread != GetCurrentThread()));
 }
 

--- a/src/core/hle/kernel/mutex.cpp
+++ b/src/core/hle/kernel/mutex.cpp
@@ -26,7 +26,7 @@ public:
     Handle lock_thread;                         ///< Handle to thread that currently has mutex
     std::string name;                           ///< Name of mutex (optional)
 
-    ResultVal<bool> Wait(bool wait_thread) override;
+    ResultVal<bool> Wait() override;
     ResultVal<bool> Acquire() override;
 };
 
@@ -156,12 +156,7 @@ Handle CreateMutex(bool initial_locked, const std::string& name) {
     return handle;
 }
 
-ResultVal<bool> Mutex::Wait(bool wait_thread) {
-    if (locked && wait_thread) {
-        AddWaitingThread(GetCurrentThread());
-        Kernel::WaitCurrentThread_WaitSynchronization(WAITTYPE_MUTEX, this);
-    }
-
+ResultVal<bool> Mutex::Wait() {
     return MakeResult<bool>(locked);
 }
 

--- a/src/core/hle/kernel/mutex.cpp
+++ b/src/core/hle/kernel/mutex.cpp
@@ -53,7 +53,7 @@ void MutexAcquireLock(Mutex* mutex, Handle thread = GetCurrentThread()->GetHandl
  */
 void ResumeWaitingThread(Mutex* mutex) {
     // Find the next waiting thread for the mutex...
-    auto next_thread = mutex->ReleaseNextThread();
+    auto next_thread = mutex->WakeupNextThread();
     if (next_thread != nullptr) {
         MutexAcquireLock(mutex, next_thread->GetHandle());
     } else {

--- a/src/core/hle/kernel/mutex.cpp
+++ b/src/core/hle/kernel/mutex.cpp
@@ -27,8 +27,8 @@ public:
     std::string name;                           ///< Name of mutex (optional)
     SharedPtr<Thread> current_thread;           ///< Thread that has acquired the mutex
 
-    ResultVal<bool> ShouldWait() override;
-    ResultVal<bool> Acquire() override;
+    bool ShouldWait() override;
+    void Acquire() override;
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -159,20 +159,14 @@ Handle CreateMutex(bool initial_locked, const std::string& name) {
     return handle;
 }
 
-ResultVal<bool> Mutex::ShouldWait() {
-    return MakeResult<bool>(locked && (current_thread != GetCurrentThread()));
+bool Mutex::ShouldWait() {
+    return locked && current_thread != GetCurrentThread();
 }
 
-ResultVal<bool> Mutex::Acquire() {
-    bool res = false;
-
-    if (!locked) {
-        // Lock the mutex when the first thread accesses it
-        locked = true;
-        res = true;
-        MutexAcquireLock(this);
-    }
-
-    return MakeResult<bool>(res);
+void Mutex::Acquire() {
+    _assert_msg_(Kernel, !ShouldWait(), "object unavailable!");
+    locked = true;
+    MutexAcquireLock(this);
 }
+
 } // namespace

--- a/src/core/hle/kernel/mutex.h
+++ b/src/core/hle/kernel/mutex.h
@@ -28,6 +28,6 @@ Handle CreateMutex(bool initial_locked, const std::string& name="Unknown");
  * Releases all the mutexes held by the specified thread
  * @param thread Thread that is holding the mutexes
  */
-void ReleaseThreadMutexes(Handle thread);
+void ReleaseThreadMutexes(Thread* thread);
 
 } // namespace

--- a/src/core/hle/kernel/semaphore.cpp
+++ b/src/core/hle/kernel/semaphore.cpp
@@ -32,15 +32,8 @@ public:
         return available_count > 0;
     }
 
-    ResultVal<bool> Wait(bool wait_thread) override {
-        bool wait = !IsAvailable();
-
-        if (wait && wait_thread) {
-            Kernel::WaitCurrentThread_WaitSynchronization(WAITTYPE_SEMA, this);
-            AddWaitingThread(GetCurrentThread());
-        }
-
-        return MakeResult<bool>(wait);
+    ResultVal<bool> Wait() override {
+        return MakeResult<bool>(!IsAvailable());
     }
 
     ResultVal<bool> Acquire() override {

--- a/src/core/hle/kernel/semaphore.cpp
+++ b/src/core/hle/kernel/semaphore.cpp
@@ -70,7 +70,7 @@ ResultCode ReleaseSemaphore(s32* count, Handle handle, s32 release_count) {
 
     // Notify some of the threads that the semaphore has been released
     // stop once the semaphore is full again or there are no more waiting threads
-    while (!semaphore->ShouldWait() && semaphore->ReleaseNextThread() != nullptr) {
+    while (!semaphore->ShouldWait() && semaphore->WakeupNextThread() != nullptr) {
         semaphore->Acquire();
     }
 

--- a/src/core/hle/kernel/semaphore.cpp
+++ b/src/core/hle/kernel/semaphore.cpp
@@ -32,11 +32,11 @@ public:
         return available_count > 0;
     }
 
-    ResultVal<bool> Wait(unsigned index) override {
+    ResultVal<bool> Wait(bool wait_thread) override {
         bool wait = !IsAvailable();
 
-        if (wait) {
-            Kernel::WaitCurrentThread_WaitSynchronization(WAITTYPE_SEMA, this, index);
+        if (wait && wait_thread) {
+            Kernel::WaitCurrentThread_WaitSynchronization(WAITTYPE_SEMA, this);
             AddWaitingThread(GetCurrentThread());
         }
 

--- a/src/core/hle/kernel/semaphore.cpp
+++ b/src/core/hle/kernel/semaphore.cpp
@@ -32,11 +32,11 @@ public:
         return available_count > 0;
     }
 
-    ResultVal<bool> WaitSynchronization() override {
+    ResultVal<bool> WaitSynchronization(unsigned index) override {
         bool wait = !IsAvailable();
 
         if (wait) {
-            Kernel::WaitCurrentThread(WAITTYPE_SEMA, this);
+            Kernel::WaitCurrentThread_WaitSynchronization(WAITTYPE_SEMA, this, index);
             AddWaitingThread(GetCurrentThread());
         } else {
             --available_count;
@@ -82,7 +82,7 @@ ResultCode ReleaseSemaphore(s32* count, Handle handle, s32 release_count) {
 
     // Notify some of the threads that the semaphore has been released
     // stop once the semaphore is full again or there are no more waiting threads
-    while (semaphore->IsAvailable() && semaphore->ResumeNextThread() != nullptr) {
+    while (semaphore->IsAvailable() && semaphore->ReleaseNextThread() != nullptr) {
         --semaphore->available_count;
     }
 

--- a/src/core/hle/kernel/semaphore.cpp
+++ b/src/core/hle/kernel/semaphore.cpp
@@ -32,7 +32,7 @@ public:
         return available_count > 0;
     }
 
-    ResultVal<bool> Wait() override {
+    ResultVal<bool> ShouldWait() override {
         return MakeResult<bool>(!IsAvailable());
     }
 

--- a/src/core/hle/kernel/semaphore.cpp
+++ b/src/core/hle/kernel/semaphore.cpp
@@ -32,17 +32,26 @@ public:
         return available_count > 0;
     }
 
-    ResultVal<bool> WaitSynchronization(unsigned index) override {
+    ResultVal<bool> Wait(unsigned index) override {
         bool wait = !IsAvailable();
 
         if (wait) {
             Kernel::WaitCurrentThread_WaitSynchronization(WAITTYPE_SEMA, this, index);
             AddWaitingThread(GetCurrentThread());
-        } else {
-            --available_count;
         }
 
         return MakeResult<bool>(wait);
+    }
+
+    ResultVal<bool> Acquire() override {
+        bool res = false;
+
+        if (IsAvailable()) {
+            --available_count;
+            res = true;
+        }
+
+        return MakeResult<bool>(res);
     }
 };
 

--- a/src/core/hle/kernel/session.h
+++ b/src/core/hle/kernel/session.h
@@ -41,7 +41,7 @@ inline static u32* GetCommandBuffer(const int offset=0) {
  * CTR-OS so that IPC calls can be optionally handled by the real implementations of processes, as
  * opposed to HLE simulations.
  */
-class Session : public Object {
+class Session : public WaitObject {
 public:
     std::string GetTypeName() const override { return "Session"; }
 
@@ -53,6 +53,12 @@ public:
      * aren't supported yet.
      */
     virtual ResultVal<bool> SyncRequest() = 0;
+
+    ResultVal<bool> Wait() override {
+        // TODO(bunnei): This function exists to satisfy a hardware test with a Session object
+        // passed into WaitSynchronization. Not sure if it's possible for this to ever be false?
+        return MakeResult<bool>(true);
+    }
 };
 
 }

--- a/src/core/hle/kernel/session.h
+++ b/src/core/hle/kernel/session.h
@@ -54,10 +54,15 @@ public:
      */
     virtual ResultVal<bool> SyncRequest() = 0;
 
-    ResultVal<bool> Wait() override {
-        // TODO(bunnei): This function exists to satisfy a hardware test with a Session object
-        // passed into WaitSynchronization. Not sure if it's possible for this to ever be false?
+    // TODO(bunnei): These functions exist to satisfy a hardware test with a Session object
+    // passed into WaitSynchronization. Figure out the meaning of them.
+
+    ResultVal<bool> ShouldWait() override {
         return MakeResult<bool>(true);
+    }
+
+    ResultVal<bool> Acquire() override {
+        return MakeResult<bool>(false);
     }
 };
 

--- a/src/core/hle/kernel/session.h
+++ b/src/core/hle/kernel/session.h
@@ -57,12 +57,12 @@ public:
     // TODO(bunnei): These functions exist to satisfy a hardware test with a Session object
     // passed into WaitSynchronization. Figure out the meaning of them.
 
-    ResultVal<bool> ShouldWait() override {
-        return MakeResult<bool>(true);
+    bool ShouldWait() override {
+        return true;
     }
 
-    ResultVal<bool> Acquire() override {
-        return MakeResult<bool>(false);
+    void Acquire() override {
+        _assert_msg_(Kernel, !ShouldWait(), "object unavailable!");
     }
 };
 

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -22,7 +22,7 @@
 
 namespace Kernel {
 
-ResultVal<bool> Thread::WaitSynchronization(unsigned index) {
+ResultVal<bool> Thread::Wait(unsigned index) {
     const bool wait = status != THREADSTATUS_DORMANT;
     if (wait) {
         AddWaitingThread(GetCurrentThread());
@@ -30,6 +30,10 @@ ResultVal<bool> Thread::WaitSynchronization(unsigned index) {
     }
 
     return MakeResult<bool>(wait);
+}
+
+ResultVal<bool> Thread::Acquire() {
+    return MakeResult<bool>(true);
 }
 
 // Lists all thread ids that aren't deleted/etc.

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -22,7 +22,7 @@
 
 namespace Kernel {
 
-ResultVal<bool> Thread::Wait() {
+ResultVal<bool> Thread::ShouldWait() {
     return MakeResult<bool>(status != THREADSTATUS_DORMANT);
 }
 
@@ -269,7 +269,7 @@ void Thread::ReleaseWaitObject(WaitObject* wait_object) {
 
     // Iterate through all waiting objects to check availability...
     for (auto itr = wait_objects.begin(); itr != wait_objects.end(); ++itr) {
-        auto res = (*itr)->Wait();
+        auto res = (*itr)->ShouldWait();
 
         if (*res && res.Succeeded())
             wait_all_failed = true;

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -85,10 +85,11 @@ static void ChangeReadyState(Thread* t, bool ready) {
 
 /// Check if a thread is waiting on a the specified wait object
 static bool CheckWait_WaitObject(const Thread* thread, WaitObject* wait_object) {
-    for (auto itr = thread->wait_objects.begin(); itr != thread->wait_objects.end(); ++itr) {
-        if (*itr == wait_object)
-            return (thread->IsWaiting());
-    }
+    auto itr = std::find(thread->wait_objects.begin(), thread->wait_objects.end(), wait_object);
+
+    if (itr != thread->wait_objects.end())
+        return thread->IsWaiting();
+
     return false;
 }
 

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -210,7 +210,7 @@ void WaitCurrentThread_Sleep() {
     ChangeThreadState(thread, ThreadStatus(THREADSTATUS_WAIT | (thread->status & THREADSTATUS_SUSPEND)));
 }
 
-void WaitCurrentThread_WaitSynchronization(WaitObject* wait_object, bool wait_all) {
+void WaitCurrentThread_WaitSynchronization(SharedPtr<WaitObject> wait_object, bool wait_all) {
     Thread* thread = GetCurrentThread();
     thread->wait_all = wait_all;
     thread->wait_address = 0;

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -100,7 +100,7 @@ static bool CheckWait_AddressArbiter(const Thread* thread, VAddr wait_address) {
 /// Stops the current thread
 void Thread::Stop(const char* reason) {
     // Release all the mutexes that this thread holds
-    ReleaseThreadMutexes(GetHandle());
+    ReleaseThreadMutexes(this);
 
     ChangeReadyState(this, false);
     status = THREADSTATUS_DORMANT;

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -104,7 +104,7 @@ void Thread::Stop(const char* reason) {
 
     ChangeReadyState(this, false);
     status = THREADSTATUS_DORMANT;
-    ReleaseAllWaitingThreads();
+    WakeupAllWaitingThreads();
 
     // Stopped threads are never waiting.
     wait_objects.clear();

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -22,12 +22,12 @@
 
 namespace Kernel {
 
-ResultVal<bool> Thread::ShouldWait() {
-    return MakeResult<bool>(status != THREADSTATUS_DORMANT);
+bool Thread::ShouldWait() {
+    return status != THREADSTATUS_DORMANT;
 }
 
-ResultVal<bool> Thread::Acquire() {
-    return MakeResult<bool>(true);
+void Thread::Acquire() {
+    _assert_msg_(Kernel, !ShouldWait(), "object unavailable!");
 }
 
 // Lists all thread ids that aren't deleted/etc.
@@ -269,9 +269,7 @@ void Thread::ReleaseWaitObject(WaitObject* wait_object) {
 
     // Iterate through all waiting objects to check availability...
     for (auto itr = wait_objects.begin(); itr != wait_objects.end(); ++itr) {
-        auto res = (*itr)->ShouldWait();
-
-        if (*res && res.Succeeded())
+        if ((*itr)->ShouldWait())
             wait_all_failed = true;
 
         // The output should be the last index of wait_object

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -58,7 +58,7 @@ public:
     inline bool IsSuspended() const { return (status & THREADSTATUS_SUSPEND) != 0; }
     inline bool IsIdle() const { return idle; }
 
-    ResultVal<bool> Wait() override;
+    ResultVal<bool> ShouldWait() override;
     ResultVal<bool> Acquire() override;
 
     s32 GetPriority() const { return current_priority; }

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -136,7 +136,7 @@ void WaitCurrentThread_Sleep();
  * @param wait_object Kernel object that we are waiting on
  * @param wait_all If true, wait on all objects before resuming (for WaitSynchronizationN only)
  */
-void WaitCurrentThread_WaitSynchronization(WaitObject* wait_object, bool wait_all=false);
+void WaitCurrentThread_WaitSynchronization(SharedPtr<WaitObject> wait_object, bool wait_all = false);
 
 /**
  * Waits the current thread from an ArbitrateAddress call

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -96,7 +96,7 @@ public:
     s32 processor_id;
 
     WaitType wait_type;
-    Object* wait_object;
+    std::vector<SharedPtr<WaitObject>> wait_objects;
     VAddr wait_address;
 
     std::string name;
@@ -128,7 +128,7 @@ Thread* GetCurrentThread();
  * @param wait_type Type of wait
  * @param wait_object Kernel object that we are waiting on, defaults to current thread
  */
-void WaitCurrentThread(WaitType wait_type, Object* wait_object = GetCurrentThread());
+void WaitCurrentThread(WaitType wait_type, WaitObject* wait_object = GetCurrentThread());
 
 /**
  * Schedules an event to wake up the specified thread after the specified delay.
@@ -143,7 +143,7 @@ void WakeThreadAfterDelay(Thread* thread, s64 nanoseconds);
  * @param wait_object Kernel object that we are waiting on
  * @param wait_address Arbitration address used to resume from wait
  */
-void WaitCurrentThread(WaitType wait_type, Object* wait_object, VAddr wait_address);
+void WaitCurrentThread(WaitType wait_type, WaitObject* wait_object, VAddr wait_address);
 
 
 

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -70,7 +70,8 @@ public:
     inline bool IsSuspended() const { return (status & THREADSTATUS_SUSPEND) != 0; }
     inline bool IsIdle() const { return idle; }
 
-    ResultVal<bool> WaitSynchronization(unsigned index) override;
+    ResultVal<bool> Wait(unsigned index) override;
+    ResultVal<bool> Acquire() override;
 
     s32 GetPriority() const { return current_priority; }
     void SetPriority(s32 priority);

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -58,8 +58,8 @@ public:
     inline bool IsSuspended() const { return (status & THREADSTATUS_SUSPEND) != 0; }
     inline bool IsIdle() const { return idle; }
 
-    ResultVal<bool> ShouldWait() override;
-    ResultVal<bool> Acquire() override;
+    bool ShouldWait() override;
+    void Acquire() override;
 
     s32 GetPriority() const { return current_priority; }
     void SetPriority(s32 priority);

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -69,10 +69,10 @@ public:
     void Stop(const char* reason);
     
     /**
-     * Release an object from the thread's wait list
-     * @param wait_object WaitObject to release from the thread's wait list
+     * Release an acquired wait object
+     * @param wait_object WaitObject to release
      */
-    void ReleaseFromWait(WaitObject* wait_object);
+    void ReleaseWaitObject(WaitObject* wait_object);
 
     /// Resumes a thread from waiting by marking it as "ready"
     void ResumeFromWait();
@@ -120,16 +120,16 @@ SharedPtr<Thread> SetupMainThread(s32 priority, u32 stack_size);
 void Reschedule();
 
 /// Arbitrate the highest priority thread that is waiting
-Thread* ArbitrateHighestPriorityThread(WaitObject* arbiter, u32 address);
+Thread* ArbitrateHighestPriorityThread(u32 address);
 
 /// Arbitrate all threads currently waiting...
-void ArbitrateAllThreads(WaitObject* arbiter, u32 address);
+void ArbitrateAllThreads(u32 address);
 
 /// Gets the current thread
 Thread* GetCurrentThread();
 
-/// Waits the current thread
-void WaitCurrentThread();
+/// Waits the current thread on a sleep
+void WaitCurrentThread_Sleep();
 
 /**
  * Waits the current thread from a WaitSynchronization call
@@ -140,10 +140,9 @@ void WaitCurrentThread_WaitSynchronization(WaitObject* wait_object, bool wait_al
 
 /**
  * Waits the current thread from an ArbitrateAddress call
- * @param wait_object Kernel object that we are waiting on
  * @param wait_address Arbitration address used to resume from wait
  */
-void WaitCurrentThread_ArbitrateAddress(WaitObject* wait_object, VAddr wait_address);
+void WaitCurrentThread_ArbitrateAddress(VAddr wait_address);
 
 /**
  * Schedules an event to wake up the specified thread after the specified delay.

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -52,7 +52,7 @@ enum WaitType {
 
 namespace Kernel {
 
-class Thread : public Kernel::Object {
+class Thread : public WaitObject {
 public:
     static ResultVal<SharedPtr<Thread>> Create(std::string name, VAddr entry_point, s32 priority,
         u32 arg, s32 processor_id, VAddr stack_top, u32 stack_size);
@@ -98,8 +98,6 @@ public:
     WaitType wait_type;
     Object* wait_object;
     VAddr wait_address;
-
-    std::vector<SharedPtr<Thread>> waiting_threads;
 
     std::string name;
 

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -70,7 +70,7 @@ public:
     inline bool IsSuspended() const { return (status & THREADSTATUS_SUSPEND) != 0; }
     inline bool IsIdle() const { return idle; }
 
-    ResultVal<bool> Wait(unsigned index) override;
+    ResultVal<bool> Wait(bool wait_thread) override;
     ResultVal<bool> Acquire() override;
 
     s32 GetPriority() const { return current_priority; }
@@ -117,7 +117,7 @@ public:
     s32 processor_id;
 
     WaitType wait_type;
-    std::vector<std::pair<SharedPtr<WaitObject>, unsigned>> wait_objects;
+    std::vector<SharedPtr<WaitObject>> wait_objects;
     VAddr wait_address;
 
     std::string name;

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -78,11 +78,16 @@ public:
     void ResumeFromWait();
 
     /**
-     * Sets the output values after the thread awakens from WaitSynchronization
-     * @param return_val Value returned
-     * @param out_val Value to set to the output parameter
+     * Sets the result after the thread awakens (from either WaitSynchronization SVC)
+     * @param result Value to set to the returned result
      */
-    void SetReturnValue(ResultCode return_val, s32 out_val);
+    void SetWaitSynchronizationResult(ResultCode result);
+
+    /**
+     * Sets the output parameter value after the thread awakens (from WaitSynchronizationN SVC only)
+     * @param output Value to set to the output parameter
+     */
+    void SetWaitSynchronizationOutput(s32 output);
 
     Core::ThreadContext context;
 
@@ -100,8 +105,9 @@ public:
 
     std::vector<SharedPtr<WaitObject>> wait_objects; ///< Objects that the thread is waiting on
 
-    VAddr wait_address; ///< If waiting on an AddressArbiter, this is the arbitration address 
-    bool wait_all;      ///< True if the thread is waiting on all objects before resuming
+    VAddr wait_address;     ///< If waiting on an AddressArbiter, this is the arbitration address
+    bool wait_all;          ///< True if the thread is waiting on all objects before resuming
+    bool wait_set_output;   ///< True if the output parameter should be set on thread wakeup
 
     std::string name;
 
@@ -134,9 +140,10 @@ void WaitCurrentThread_Sleep();
 /**
  * Waits the current thread from a WaitSynchronization call
  * @param wait_object Kernel object that we are waiting on
+ * @param wait_set_output If true, set the output parameter on thread wakeup (for WaitSynchronizationN only)
  * @param wait_all If true, wait on all objects before resuming (for WaitSynchronizationN only)
  */
-void WaitCurrentThread_WaitSynchronization(SharedPtr<WaitObject> wait_object, bool wait_all = false);
+void WaitCurrentThread_WaitSynchronization(SharedPtr<WaitObject> wait_object, bool wait_set_output, bool wait_all);
 
 /**
  * Waits the current thread from an ArbitrateAddress call

--- a/src/core/hle/kernel/timer.cpp
+++ b/src/core/hle/kernel/timer.cpp
@@ -29,13 +29,8 @@ public:
     u64 initial_delay;                      ///< The delay until the timer fires for the first time
     u64 interval_delay;                     ///< The delay until the timer fires after the first time
 
-    ResultVal<bool> Wait(bool wait_thread) override {
-        bool wait = !signaled;
-        if (wait && wait_thread) {
-            AddWaitingThread(GetCurrentThread());
-            Kernel::WaitCurrentThread_WaitSynchronization(WAITTYPE_TIMER, this);
-        }
-        return MakeResult<bool>(wait);
+    ResultVal<bool> Wait() override {
+        return MakeResult<bool>(!signaled);
     }
 
     ResultVal<bool> Acquire() override {

--- a/src/core/hle/kernel/timer.cpp
+++ b/src/core/hle/kernel/timer.cpp
@@ -29,7 +29,7 @@ public:
     u64 initial_delay;                      ///< The delay until the timer fires for the first time
     u64 interval_delay;                     ///< The delay until the timer fires after the first time
 
-    ResultVal<bool> Wait() override {
+    ResultVal<bool> ShouldWait() override {
         return MakeResult<bool>(!signaled);
     }
 

--- a/src/core/hle/kernel/timer.cpp
+++ b/src/core/hle/kernel/timer.cpp
@@ -29,13 +29,17 @@ public:
     u64 initial_delay;                      ///< The delay until the timer fires for the first time
     u64 interval_delay;                     ///< The delay until the timer fires after the first time
 
-    ResultVal<bool> WaitSynchronization(unsigned index) override {
+    ResultVal<bool> Wait(unsigned index) override {
         bool wait = !signaled;
         if (wait) {
             AddWaitingThread(GetCurrentThread());
             Kernel::WaitCurrentThread_WaitSynchronization(WAITTYPE_TIMER, this, index);
         }
         return MakeResult<bool>(wait);
+    }
+
+    ResultVal<bool> Acquire() override {
+        return MakeResult<bool>(true);
     }
 };
 

--- a/src/core/hle/kernel/timer.cpp
+++ b/src/core/hle/kernel/timer.cpp
@@ -90,7 +90,7 @@ static void TimerCallback(u64 timer_handle, int cycles_late) {
     timer->signaled = true;
 
     // Resume all waiting threads
-    timer->ReleaseAllWaitingThreads();
+    timer->WakeupAllWaitingThreads();
 
     if (timer->reset_type == RESETTYPE_ONESHOT)
         timer->signaled = false;

--- a/src/core/hle/kernel/timer.cpp
+++ b/src/core/hle/kernel/timer.cpp
@@ -29,11 +29,11 @@ public:
     u64 initial_delay;                      ///< The delay until the timer fires for the first time
     u64 interval_delay;                     ///< The delay until the timer fires after the first time
 
-    ResultVal<bool> WaitSynchronization() override {
+    ResultVal<bool> WaitSynchronization(unsigned index) override {
         bool wait = !signaled;
         if (wait) {
             AddWaitingThread(GetCurrentThread());
-            Kernel::WaitCurrentThread(WAITTYPE_TIMER, this);
+            Kernel::WaitCurrentThread_WaitSynchronization(WAITTYPE_TIMER, this, index);
         }
         return MakeResult<bool>(wait);
     }
@@ -91,7 +91,7 @@ static void TimerCallback(u64 timer_handle, int cycles_late) {
     timer->signaled = true;
 
     // Resume all waiting threads
-    timer->ResumeAllWaitingThreads();
+    timer->ReleaseAllWaitingThreads();
 
     if (timer->reset_type == RESETTYPE_ONESHOT)
         timer->signaled = false;

--- a/src/core/hle/kernel/timer.cpp
+++ b/src/core/hle/kernel/timer.cpp
@@ -29,12 +29,12 @@ public:
     u64 initial_delay;                      ///< The delay until the timer fires for the first time
     u64 interval_delay;                     ///< The delay until the timer fires after the first time
 
-    ResultVal<bool> ShouldWait() override {
-        return MakeResult<bool>(!signaled);
+    bool ShouldWait() override {
+        return !signaled;
     }
 
-    ResultVal<bool> Acquire() override {
-        return MakeResult<bool>(true);
+    void Acquire() override {
+        _assert_msg_(Kernel, !ShouldWait(), "object unavailable!");
     }
 };
 

--- a/src/core/hle/kernel/timer.cpp
+++ b/src/core/hle/kernel/timer.cpp
@@ -29,11 +29,11 @@ public:
     u64 initial_delay;                      ///< The delay until the timer fires for the first time
     u64 interval_delay;                     ///< The delay until the timer fires after the first time
 
-    ResultVal<bool> Wait(unsigned index) override {
+    ResultVal<bool> Wait(bool wait_thread) override {
         bool wait = !signaled;
-        if (wait) {
+        if (wait && wait_thread) {
             AddWaitingThread(GetCurrentThread());
-            Kernel::WaitCurrentThread_WaitSynchronization(WAITTYPE_TIMER, this, index);
+            Kernel::WaitCurrentThread_WaitSynchronization(WAITTYPE_TIMER, this);
         }
         return MakeResult<bool>(wait);
     }

--- a/src/core/hle/service/apt_u.cpp
+++ b/src/core/hle/service/apt_u.cpp
@@ -50,8 +50,8 @@ void Initialize(Service::Interface* self) {
     cmd_buff[3] = notification_event_handle;
     cmd_buff[4] = pause_event_handle;
 
-    Kernel::SetEventLocked(notification_event_handle, true);
-    Kernel::SetEventLocked(pause_event_handle, false); // Fire start event
+    Kernel::ClearEvent(notification_event_handle);
+    Kernel::SignalEvent(pause_event_handle); // Fire start event
 
     _assert_msg_(KERNEL, (0 != lock_handle), "Cannot initialize without lock");
     Kernel::ReleaseMutex(lock_handle);

--- a/src/core/hle/service/srv.cpp
+++ b/src/core/hle/service/srv.cpp
@@ -24,7 +24,7 @@ static void GetProcSemaphore(Service::Interface* self) {
 
     // TODO(bunnei): Change to a semaphore once these have been implemented
     g_event_handle = Kernel::CreateEvent(RESETTYPE_ONESHOT, "SRV:Event");
-    Kernel::SetEventLocked(g_event_handle, false);
+    Kernel::ClearEvent(g_event_handle);
 
     cmd_buff[1] = 0; // No error
     cmd_buff[3] = g_event_handle;

--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -105,7 +105,7 @@ static Result SendSyncRequest(Handle handle) {
 
     ResultVal<bool> wait = session->SyncRequest();
     if (wait.Succeeded() && *wait) {
-        Kernel::WaitCurrentThread(); // TODO(bunnei): Is this correct?
+        Kernel::WaitCurrentThread_Sleep(); // TODO(bunnei): Is this correct?
     }
 
     return wait.Code().raw;
@@ -196,7 +196,7 @@ static Result WaitSynchronizationN(s32* out, Handle* handles, s32 handle_count, 
         // NOTE: This should deadlock the current thread if no timeout was specified
         if (!wait_all) {
             wait_thread = true;
-            Kernel::WaitCurrentThread();
+            Kernel::WaitCurrentThread_Sleep();
         }
     }
 
@@ -450,7 +450,7 @@ static void SleepThread(s64 nanoseconds) {
     LOG_TRACE(Kernel_SVC, "called nanoseconds=%lld", nanoseconds);
 
     // Sleep current thread and check for next thread to schedule
-    Kernel::WaitCurrentThread();
+    Kernel::WaitCurrentThread_Sleep();
 
     // Create an event to wake the thread up after the specified nanosecond delay has passed
     Kernel::WakeThreadAfterDelay(Kernel::GetCurrentThread(), nanoseconds);

--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -115,7 +115,7 @@ static Result CloseHandle(Handle handle) {
 
 /// Wait for a handle to synchronize, timeout after the specified nanoseconds
 static Result WaitSynchronization1(Handle handle, s64 nano_seconds) {
-    Kernel::WaitObject* object = static_cast<Kernel::WaitObject*>(Kernel::g_handle_table.GetGeneric(handle).get());
+    auto object = Kernel::g_handle_table.GetWaitObject(handle);
     if (object == nullptr)
         return InvalidHandle(ErrorModule::Kernel).raw;
 
@@ -163,7 +163,7 @@ static Result WaitSynchronizationN(s32* out, Handle* handles, s32 handle_count, 
     if (handle_count != 0) {
         bool selected = false; // True once an object has been selected
         for (int i = 0; i < handle_count; ++i) {
-            Kernel::WaitObject* object = static_cast<Kernel::WaitObject*>(Kernel::g_handle_table.GetGeneric(handles[i]).get());
+            auto object = Kernel::g_handle_table.GetWaitObject(handles[i]);
             if (object == nullptr)
                 return InvalidHandle(ErrorModule::Kernel).raw;
 

--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -148,8 +148,12 @@ static Result WaitSynchronizationN(s32* out, Handle* handles, s32 handle_count, 
     bool wait_all_succeeded = false;
     int handle_index = 0;
 
-    // If handles were passed in, iterate through them and wait/acquire the objects as needed
-    if (handle_count > 0) {
+    // Negative handle_count is invalid
+    if (handle_count < 0)
+        return ResultCode(ErrorDescription::OutOfRange, ErrorModule::OS, ErrorSummary::InvalidArgument, ErrorLevel::Usage).raw;
+
+    // If handle_count is non-zero, iterate through them and wait/acquire the objects as needed
+    if (handle_count != 0) {
         while (handle_index < handle_count) {
             SharedPtr<Kernel::Object> object = Kernel::g_handle_table.GetGeneric(handles[handle_index]);
             if (object == nullptr)
@@ -172,7 +176,7 @@ static Result WaitSynchronizationN(s32* out, Handle* handles, s32 handle_count, 
 
             handle_index++;
         }
-    }else {
+    } else {
         // If no handles were passed in, put the thread to sleep only when wait_all=false
         // NOTE: This is supposed to deadlock if no timeout was specified
         if (!wait_all) {

--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -103,12 +103,7 @@ static Result SendSyncRequest(Handle handle) {
 
     LOG_TRACE(Kernel_SVC, "called handle=0x%08X(%s)", handle, session->GetName().c_str());
 
-    ResultVal<bool> wait = session->SyncRequest();
-    if (wait.Succeeded() && *wait) {
-        Kernel::WaitCurrentThread_Sleep(); // TODO(bunnei): Is this correct?
-    }
-
-    return wait.Code().raw;
+    return session->SyncRequest().Code().raw;
 }
 
 /// Close a handle

--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -126,7 +126,7 @@ static Result WaitSynchronization1(Handle handle, s64 nano_seconds) {
     if (object->ShouldWait()) {
 
         object->AddWaitingThread(Kernel::GetCurrentThread());
-        Kernel::WaitCurrentThread_WaitSynchronization(object);
+        Kernel::WaitCurrentThread_WaitSynchronization(object, false, false);
 
         // Create an event to wake the thread up after the specified nanosecond delay has passed
         Kernel::WakeThreadAfterDelay(Kernel::GetCurrentThread(), nano_seconds);
@@ -187,7 +187,7 @@ static Result WaitSynchronizationN(s32* out, Handle* handles, s32 handle_count, 
         // NOTE: This should deadlock the current thread if no timeout was specified
         if (!wait_all) {
             wait_thread = true;
-            Kernel::WaitCurrentThread_Sleep();
+            Kernel::WaitCurrentThread_WaitSynchronization(nullptr, true, wait_all);
         }
     }
 
@@ -198,7 +198,7 @@ static Result WaitSynchronizationN(s32* out, Handle* handles, s32 handle_count, 
         for (int i = 0; i < handle_count; ++i) {
             auto object = Kernel::g_handle_table.GetWaitObject(handles[i]);
             object->AddWaitingThread(Kernel::GetCurrentThread());
-            Kernel::WaitCurrentThread_WaitSynchronization(object, wait_all);
+            Kernel::WaitCurrentThread_WaitSynchronization(object, true, wait_all);
         }
 
         // Create an event to wake the thread up after the specified nanosecond delay has passed

--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -122,7 +122,7 @@ static Result WaitSynchronization1(Handle handle, s64 nano_seconds) {
     LOG_TRACE(Kernel_SVC, "called handle=0x%08X(%s:%s), nanoseconds=%lld", handle,
             object->GetTypeName().c_str(), object->GetName().c_str(), nano_seconds);
 
-    ResultVal<bool> wait = object->Wait();
+    ResultVal<bool> wait = object->ShouldWait();
 
     // Check for next thread to schedule
     if (wait.Succeeded() && *wait) {
@@ -167,7 +167,7 @@ static Result WaitSynchronizationN(s32* out, Handle* handles, s32 handle_count, 
             if (object == nullptr)
                 return InvalidHandle(ErrorModule::Kernel).raw;
 
-            ResultVal<bool> wait = object->Wait();
+            ResultVal<bool> wait = object->ShouldWait();
 
             // Check if the current thread should wait on this object...
             if (wait.Succeeded() && *wait) {

--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -148,6 +148,10 @@ static Result WaitSynchronizationN(s32* out, Handle* handles, s32 handle_count, 
     bool wait_all_succeeded = false;
     int handle_index = 0;
 
+    // Handles pointer is invalid
+    if (handles == nullptr)
+        return ResultCode(ErrorDescription::InvalidPointer, ErrorModule::Kernel, ErrorSummary::InvalidArgument, ErrorLevel::Permanent).raw;
+
     // Negative handle_count is invalid
     if (handle_count < 0)
         return ResultCode(ErrorDescription::OutOfRange, ErrorModule::OS, ErrorSummary::InvalidArgument, ErrorLevel::Usage).raw;

--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -122,10 +122,8 @@ static Result WaitSynchronization1(Handle handle, s64 nano_seconds) {
     LOG_TRACE(Kernel_SVC, "called handle=0x%08X(%s:%s), nanoseconds=%lld", handle,
             object->GetTypeName().c_str(), object->GetName().c_str(), nano_seconds);
 
-    ResultVal<bool> wait = object->ShouldWait();
-
     // Check for next thread to schedule
-    if (wait.Succeeded() && *wait) {
+    if (object->ShouldWait()) {
 
         object->AddWaitingThread(Kernel::GetCurrentThread());
         Kernel::WaitCurrentThread_WaitSynchronization(object);
@@ -138,7 +136,7 @@ static Result WaitSynchronization1(Handle handle, s64 nano_seconds) {
         object->Acquire();
     }
 
-    return wait.Code().raw;
+    return RESULT_SUCCESS.raw;
 }
 
 /// Wait for the given handles to synchronize, timeout after the specified nanoseconds
@@ -167,10 +165,8 @@ static Result WaitSynchronizationN(s32* out, Handle* handles, s32 handle_count, 
             if (object == nullptr)
                 return InvalidHandle(ErrorModule::Kernel).raw;
 
-            ResultVal<bool> wait = object->ShouldWait();
-
             // Check if the current thread should wait on this object...
-            if (wait.Succeeded() && *wait) {
+            if (object->ShouldWait()) {
 
                 // Check we are waiting on all objects...
                 if (wait_all)

--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -405,6 +405,7 @@ static Result DuplicateHandle(Handle* out, Handle handle) {
 /// Signals an event
 static Result SignalEvent(Handle evt) {
     LOG_TRACE(Kernel_SVC, "called event=0x%08X", evt);
+    HLE::Reschedule(__func__);
     return Kernel::SignalEvent(evt).raw;
 }
 


### PR DESCRIPTION
Complete rewrite of WaitSynchronization1/WaitSynchronizationN. Basically, with our previous implementation, WaitSynchronizationN was entirely broken (this PR fixes #469). This required some pretty massive refactoring, which actually greatly simplified a lot of code. This is a very large change, so I would appreciate a pretty in-depth code review (especially for silly C++ mistakes), as well as extensive testing. However, my usual test suite of homebrew and retail works fine. I also wrote a quite extensive addition to hwtests to validate my implementation (that of which now passes), and as such I'm fairly confident that the implementations of these functions are now pretty sufficiently correct (PR for hwtests to follow once I clean it up). Please let me know if you have any interesting ideas for test cases that might break this implementation :) A quick overview of changes:
* Created a WaitObject type for Kernel objects that can wait the current thread via WaitSynchronization, and changed relevant Kernel objects to inherit from it
* Got rid of WaitType's (legacy code from PPSSPP that made no sense here)
* Split up object's WaitSynchronization method into Wait and Aquire methods
* Implemented WaitSynchronizationN with wait_all=true
* Implemented WaitSynchronizationN with wait_all=false (i.e. "select")
* Implemented timeouts with WaitSynchronizationN
* Fixed output values for WaitSynchronizationN if the current thread waited
* Fixed a bug in Mutex
* Fixed several bugs in Event
* ...I'm sure many more things

EDIT: Please don't review commit by commit, some design decisions changed over time :( And sorry, I'm very likely not going to redo the commit history just for this.