### PR TITLE
dyncom: Clarify precedence for ternary statements

### DIFF
--- a/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
+++ b/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
@@ -4177,7 +4177,7 @@ unsigned InterpreterMainLoop(ARMul_State* state) {
                 cpu->Reg[14] = (cpu->Reg[15] + GET_INST_SIZE(cpu));
                 cpu->TFlag = 0x1;
                 int signed_int = inst_cream->val.signed_immed_24;
-                signed_int = (signed_int) & 0x800000 ? (0x3F000000 | signed_int) : signed_int;
+                signed_int = (signed_int & 0x800000) ? (0x3F000000 | signed_int) : signed_int;
                 signed_int = signed_int << 2;
                 cpu->Reg[15] = cpu->Reg[15] + 8 + signed_int + (BIT(inst, 24) << 1);
             }

--- a/src/core/arm/skyeye_common/vfp/vfpdouble.cpp
+++ b/src/core/arm/skyeye_common/vfp/vfpdouble.cpp
@@ -1400,7 +1400,7 @@ u32 vfp_double_cpdo(ARMul_State* state, u32 inst, u32 fpscr)
         u32 except;
         char type;
 
-        type = fop->flags & OP_SD ? 's' : 'd';
+        type = (fop->flags & OP_SD) ? 's' : 'd';
         if (op == FOP_EXT)
             pr_debug("VFP: itr%d (%c%u) = op[%u] (d%u)\n",
                      vecitr >> FPSCR_LENGTH_BIT,

--- a/src/core/arm/skyeye_common/vfp/vfpsingle.cpp
+++ b/src/core/arm/skyeye_common/vfp/vfpsingle.cpp
@@ -1290,7 +1290,7 @@ u32 vfp_single_cpdo(ARMul_State* state, u32 inst, u32 fpscr)
         u32 except;
         char type;
 
-        type = fop->flags & OP_DD ? 'd' : 's';
+        type = (fop->flags & OP_DD) ? 'd' : 's';
         if (op == FOP_EXT)
             pr_debug("VFP: itr%d (%c%u) = op[%u] (s%u=%08x)\n",
                      vecitr >> FPSCR_LENGTH_BIT, type, dest, sn,


### PR DESCRIPTION
Gets rid of some warnings on higher warning levels. Also it makes the intent more explicit.