### PR TITLE
Kernel Lifetime Reform Pt. 4

### DIFF
--- a/src/common/common_funcs.h
+++ b/src/common/common_funcs.h
@@ -31,6 +31,10 @@ template<> struct CompileTimeAssert<true> {};
 
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
 
+/// Textually concatenates two tokens. The double-expansion is required by the C preprocessor.
+#define CONCAT2(x, y) DO_CONCAT2(x, y)
+#define DO_CONCAT2(x, y) x ## y
+
 #ifndef _MSC_VER
 
 #include <errno.h>

--- a/src/common/scope_exit.h
+++ b/src/common/scope_exit.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "common/common_funcs.h"
+
 namespace detail {
     template <typename Func>
     struct ScopeExitHelper {
@@ -34,4 +36,4 @@ namespace detail {
  * }
  * \endcode
  */
-#define SCOPE_EXIT(body) auto scope_exit_helper_##__LINE__ = detail::ScopeExit([&]() body)
+#define SCOPE_EXIT(body) auto CONCAT2(scope_exit_helper_, __LINE__) = detail::ScopeExit([&]() body)

--- a/src/core/hle/function_wrappers.h
+++ b/src/core/hle/function_wrappers.h
@@ -39,10 +39,6 @@ template<ResultCode func(u32, u32, u32, u32)> void Wrap() {
     FuncReturn(func(PARAM(0), PARAM(1), PARAM(2), PARAM(3)).raw);
 }
 
-template<ResultCode func(u32, u32, u32, u32, u32)> void Wrap() {
-    FuncReturn(func(PARAM(0), PARAM(1), PARAM(2), PARAM(3), PARAM(4)).raw);
-}
-
 template<ResultCode func(u32*, u32, u32, u32, u32, u32)> void Wrap(){
     u32 param_1 = 0;
     u32 retval = func(&param_1, PARAM(0), PARAM(1), PARAM(2), PARAM(3), PARAM(4)).raw;

--- a/src/core/hle/function_wrappers.h
+++ b/src/core/hle/function_wrappers.h
@@ -33,114 +33,109 @@ static inline void FuncReturn64(u64 res) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
-// Function wrappers that return type s32
+// Function wrappers that return type ResultCode
 
-template<s32 func(u32, u32, u32, u32)> void Wrap() {
-    FuncReturn(func(PARAM(0), PARAM(1), PARAM(2), PARAM(3)));
+template<ResultCode func(u32, u32, u32, u32)> void Wrap() {
+    FuncReturn(func(PARAM(0), PARAM(1), PARAM(2), PARAM(3)).raw);
 }
 
-template<s32 func(u32, u32, u32, u32, u32)> void Wrap() {
-    FuncReturn(func(PARAM(0), PARAM(1), PARAM(2), PARAM(3), PARAM(4)));
+template<ResultCode func(u32, u32, u32, u32, u32)> void Wrap() {
+    FuncReturn(func(PARAM(0), PARAM(1), PARAM(2), PARAM(3), PARAM(4)).raw);
 }
 
-template<s32 func(u32*, u32, u32, u32, u32, u32)> void Wrap(){
+template<ResultCode func(u32*, u32, u32, u32, u32, u32)> void Wrap(){
     u32 param_1 = 0;
-    u32 retval = func(&param_1, PARAM(0), PARAM(1), PARAM(2), PARAM(3), PARAM(4));
+    u32 retval = func(&param_1, PARAM(0), PARAM(1), PARAM(2), PARAM(3), PARAM(4)).raw;
     Core::g_app_core->SetReg(1, param_1);
     FuncReturn(retval);
 }
 
-template<s32 func(s32*, u32*, s32, bool, s64)> void Wrap() {
+template<ResultCode func(s32*, u32*, s32, bool, s64)> void Wrap() {
     s32 param_1 = 0;
     s32 retval = func(&param_1, (Handle*)Memory::GetPointer(PARAM(1)), (s32)PARAM(2),
-        (PARAM(3) != 0), (((s64)PARAM(4) << 32) | PARAM(0)));
+        (PARAM(3) != 0), (((s64)PARAM(4) << 32) | PARAM(0))).raw;
     Core::g_app_core->SetReg(1, (u32)param_1);
     FuncReturn(retval);
 }
 
-// TODO(bunnei): Is this correct? Probably not - Last parameter looks wrong for ArbitrateAddress
-template<s32 func(u32, u32, u32, u32, s64)> void Wrap() {
-    FuncReturn(func(PARAM(0), PARAM(1), PARAM(2), PARAM(3), (((s64)PARAM(5) << 32) | PARAM(4))));
+template<ResultCode func(u32, u32, u32, u32, s64)> void Wrap() {
+    FuncReturn(func(PARAM(0), PARAM(1), PARAM(2), PARAM(3), (((s64)PARAM(5) << 32) | PARAM(4))).raw);
 }
 
-template<s32 func(u32*)> void Wrap(){
+template<ResultCode func(u32*)> void Wrap(){
     u32 param_1 = 0;
-    u32 retval = func(&param_1);
+    u32 retval = func(&param_1).raw;
     Core::g_app_core->SetReg(1, param_1);
     FuncReturn(retval);
 }
 
-template<s32 func(u32, s64)> void Wrap() {
-    FuncReturn(func(PARAM(0), (((s64)PARAM(3) << 32) | PARAM(2))));
+template<ResultCode func(u32, s64)> void Wrap() {
+    FuncReturn(func(PARAM(0), (((s64)PARAM(3) << 32) | PARAM(2))).raw);
 }
 
-template<s32 func(void*, void*, u32)> void Wrap(){
-    FuncReturn(func(Memory::GetPointer(PARAM(0)), Memory::GetPointer(PARAM(1)), PARAM(2)));
+template<ResultCode func(void*, void*, u32)> void Wrap(){
+    FuncReturn(func(Memory::GetPointer(PARAM(0)), Memory::GetPointer(PARAM(1)), PARAM(2)).raw);
 }
 
-template<s32 func(s32*, u32)> void Wrap(){
+template<ResultCode func(s32*, u32)> void Wrap(){
     s32 param_1 = 0;
-    u32 retval = func(&param_1, PARAM(1));
+    u32 retval = func(&param_1, PARAM(1)).raw;
     Core::g_app_core->SetReg(1, param_1);
     FuncReturn(retval);
 }
 
-template<s32 func(u32, s32)> void Wrap() {
-    FuncReturn(func(PARAM(0), (s32)PARAM(1)));
+template<ResultCode func(u32, s32)> void Wrap() {
+    FuncReturn(func(PARAM(0), (s32)PARAM(1)).raw);
 }
 
-template<s32 func(u32*, u32)> void Wrap(){
+template<ResultCode func(u32*, u32)> void Wrap(){
     u32 param_1 = 0;
-    u32 retval = func(&param_1, PARAM(1));
+    u32 retval = func(&param_1, PARAM(1)).raw;
     Core::g_app_core->SetReg(1, param_1);
     FuncReturn(retval);
 }
 
-template<s32 func(u32)> void Wrap() {
-    FuncReturn(func(PARAM(0)));
+template<ResultCode func(u32)> void Wrap() {
+    FuncReturn(func(PARAM(0)).raw);
 }
 
-template<s32 func(void*)> void Wrap() {
-    FuncReturn(func(Memory::GetPointer(PARAM(0))));
-}
-
-template<s32 func(s64*, u32, void*, s32)> void Wrap(){
+template<ResultCode func(s64*, u32, void*, s32)> void Wrap(){
     FuncReturn(func((s64*)Memory::GetPointer(PARAM(0)), PARAM(1), Memory::GetPointer(PARAM(2)),
-        (s32)PARAM(3)));
+        (s32)PARAM(3)).raw);
 }
 
-template<s32 func(u32*, const char*)> void Wrap() {
+template<ResultCode func(u32*, const char*)> void Wrap() {
     u32 param_1 = 0;
-    u32 retval = func(&param_1, Memory::GetCharPointer(PARAM(1)));
+    u32 retval = func(&param_1, Memory::GetCharPointer(PARAM(1))).raw;
     Core::g_app_core->SetReg(1, param_1);
     FuncReturn(retval);
 }
 
-template<s32 func(u32*, s32, s32)> void Wrap() {
+template<ResultCode func(u32*, s32, s32)> void Wrap() {
     u32 param_1 = 0;
-    u32 retval = func(&param_1, PARAM(1), PARAM(2));
+    u32 retval = func(&param_1, PARAM(1), PARAM(2)).raw;
     Core::g_app_core->SetReg(1, param_1);
     FuncReturn(retval);
 }
 
-template<s32 func(s32*, u32, s32)> void Wrap() {
+template<ResultCode func(s32*, u32, s32)> void Wrap() {
     s32 param_1 = 0;
-    u32 retval = func(&param_1, PARAM(1), PARAM(2));
+    u32 retval = func(&param_1, PARAM(1), PARAM(2)).raw;
     Core::g_app_core->SetReg(1, param_1);
     FuncReturn(retval);
 }
 
-template<s32 func(u32*, u32, u32, u32, u32)> void Wrap() {
+template<ResultCode func(u32*, u32, u32, u32, u32)> void Wrap() {
     u32 param_1 = 0;
-    u32 retval = func(&param_1, PARAM(1), PARAM(2), PARAM(3), PARAM(4));
+    u32 retval = func(&param_1, PARAM(1), PARAM(2), PARAM(3), PARAM(4)).raw;
     Core::g_app_core->SetReg(1, param_1);
     FuncReturn(retval);
 }
 
-template<s32 func(u32, s64, s64)> void Wrap() {
+template<ResultCode func(u32, s64, s64)> void Wrap() {
     s64 param1 = ((u64)PARAM(3) << 32) | PARAM(2);
     s64 param2 = ((u64)PARAM(4) << 32) | PARAM(1);
-    FuncReturn(func(PARAM(0), param1, param2));
+    FuncReturn(func(PARAM(0), param1, param2).raw);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/core/hle/kernel/address_arbiter.cpp
+++ b/src/core/hle/kernel/address_arbiter.cpp
@@ -28,7 +28,6 @@ public:
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-/// Arbitrate an address
 ResultCode ArbitrateAddress(Handle handle, ArbitrationType type, u32 address, s32 value, u64 nanoseconds) {
     AddressArbiter* object = Kernel::g_handle_table.Get<AddressArbiter>(handle).get();
 
@@ -92,8 +91,7 @@ ResultCode ArbitrateAddress(Handle handle, ArbitrationType type, u32 address, s3
     return RESULT_SUCCESS;
 }
 
-/// Create an address arbiter
-AddressArbiter* CreateAddressArbiter(Handle& handle, const std::string& name) {
+static AddressArbiter* CreateAddressArbiter(Handle& handle, const std::string& name) {
     AddressArbiter* address_arbiter = new AddressArbiter;
     // TOOD(yuriks): Fix error reporting
     handle = Kernel::g_handle_table.Create(address_arbiter).ValueOr(INVALID_HANDLE);
@@ -101,7 +99,6 @@ AddressArbiter* CreateAddressArbiter(Handle& handle, const std::string& name) {
     return address_arbiter;
 }
 
-/// Create an address arbiter
 Handle CreateAddressArbiter(const std::string& name) {
     Handle handle;
     CreateAddressArbiter(handle, name);

--- a/src/core/hle/kernel/address_arbiter.cpp
+++ b/src/core/hle/kernel/address_arbiter.cpp
@@ -15,25 +15,18 @@
 
 namespace Kernel {
 
-class AddressArbiter : public Object {
-public:
-    std::string GetTypeName() const override { return "Arbiter"; }
-    std::string GetName() const override { return name; }
+ResultVal<SharedPtr<AddressArbiter>> AddressArbiter::Create(std::string name) {
+    SharedPtr<AddressArbiter> address_arbiter(new AddressArbiter);
+    // TOOD(yuriks): Don't create Handle (see Thread::Create())
+    CASCADE_RESULT(auto unused, Kernel::g_handle_table.Create(address_arbiter));
 
-    static const HandleType HANDLE_TYPE = HandleType::AddressArbiter;
-    HandleType GetHandleType() const override { return HANDLE_TYPE; }
+    address_arbiter->name = std::move(name);
 
-    std::string name;   ///< Name of address arbiter object (optional)
-};
+    return MakeResult<SharedPtr<AddressArbiter>>(std::move(address_arbiter));
+}
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-ResultCode ArbitrateAddress(Handle handle, ArbitrationType type, u32 address, s32 value, u64 nanoseconds) {
-    AddressArbiter* object = Kernel::g_handle_table.Get<AddressArbiter>(handle).get();
-
-    if (object == nullptr)
-        return InvalidHandle(ErrorModule::Kernel);
-
+ResultCode AddressArbiter::ArbitrateAddress(ArbitrationType type, VAddr address, s32 value,
+        u64 nanoseconds) {
     switch (type) {
 
     // Signal thread(s) waiting for arbitrate address...
@@ -89,20 +82,6 @@ ResultCode ArbitrateAddress(Handle handle, ArbitrationType type, u32 address, s3
         return ResultCode(ErrorDescription::InvalidEnumValue, ErrorModule::Kernel, ErrorSummary::WrongArgument, ErrorLevel::Usage);
     }
     return RESULT_SUCCESS;
-}
-
-static AddressArbiter* CreateAddressArbiter(Handle& handle, const std::string& name) {
-    AddressArbiter* address_arbiter = new AddressArbiter;
-    // TOOD(yuriks): Fix error reporting
-    handle = Kernel::g_handle_table.Create(address_arbiter).ValueOr(INVALID_HANDLE);
-    address_arbiter->name = name;
-    return address_arbiter;
-}
-
-Handle CreateAddressArbiter(const std::string& name) {
-    Handle handle;
-    CreateAddressArbiter(handle, name);
-    return handle;
 }
 
 } // namespace Kernel

--- a/src/core/hle/kernel/address_arbiter.h
+++ b/src/core/hle/kernel/address_arbiter.h
@@ -26,8 +26,28 @@ enum class ArbitrationType : u32 {
     DecrementAndWaitIfLessThanWithTimeout,
 };
 
-ResultCode ArbitrateAddress(Handle handle, ArbitrationType type, u32 address, s32 value, u64 nanoseconds);
+class AddressArbiter : public Object {
+public:
+    /**
+     * Creates an address arbiter.
+     *
+     * @param name Optional name used for debugging.
+     * @returns The created AddressArbiter.
+     */
+    static ResultVal<SharedPtr<AddressArbiter>> Create(std::string name = "Unknown");
 
-Handle CreateAddressArbiter(const std::string& name = "Unknown");
+    std::string GetTypeName() const override { return "Arbiter"; }
+    std::string GetName() const override { return name; }
+
+    static const HandleType HANDLE_TYPE = HandleType::AddressArbiter;
+    HandleType GetHandleType() const override { return HANDLE_TYPE; }
+
+    std::string name;   ///< Name of address arbiter object (optional)
+
+    ResultCode ArbitrateAddress(ArbitrationType type, VAddr address, s32 value, u64 nanoseconds);
+
+private:
+    AddressArbiter() = default;
+};
 
 } // namespace FileSys

--- a/src/core/hle/kernel/address_arbiter.h
+++ b/src/core/hle/kernel/address_arbiter.h
@@ -18,7 +18,6 @@
 
 namespace Kernel {
 
-/// Address arbitration types
 enum class ArbitrationType : u32 {
     Signal,
     WaitIfLessThan,
@@ -27,10 +26,8 @@ enum class ArbitrationType : u32 {
     DecrementAndWaitIfLessThanWithTimeout,
 };
 
-/// Arbitrate an address
 ResultCode ArbitrateAddress(Handle handle, ArbitrationType type, u32 address, s32 value, u64 nanoseconds);
 
-/// Create an address arbiter
 Handle CreateAddressArbiter(const std::string& name = "Unknown");
 
 } // namespace FileSys

--- a/src/core/hle/kernel/address_arbiter.h
+++ b/src/core/hle/kernel/address_arbiter.h
@@ -26,7 +26,7 @@ enum class ArbitrationType : u32 {
     DecrementAndWaitIfLessThanWithTimeout,
 };
 
-class AddressArbiter : public Object {
+class AddressArbiter final : public Object {
 public:
     /**
      * Creates an address arbiter.

--- a/src/core/hle/kernel/event.cpp
+++ b/src/core/hle/kernel/event.cpp
@@ -69,7 +69,7 @@ ResultCode ClearEvent(Handle handle) {
  * @param name Optional name of event
  * @return Newly created Event object
  */
-Event* CreateEvent(Handle& handle, const ResetType reset_type, const std::string& name) {
+static Event* CreateEvent(Handle& handle, const ResetType reset_type, const std::string& name) {
     Event* evt = new Event;
 
     // TOOD(yuriks): Fix error reporting

--- a/src/core/hle/kernel/event.h
+++ b/src/core/hle/kernel/event.h
@@ -11,26 +11,35 @@
 
 namespace Kernel {
 
-/**
- * Signals an event
- * @param handle Handle to event to signal
- * @return Result of operation, 0 on success, otherwise error code
- */
-ResultCode SignalEvent(const Handle handle);
+class Event : public WaitObject {
+public:
+    /**
+     * Creates an event
+     * @param reset_type ResetType describing how to create event
+     * @param name Optional name of event
+     */
+    static ResultVal<SharedPtr<Event>> Create(ResetType reset_type, std::string name = "Unknown");
 
-/**
- * Clears an event
- * @param handle Handle to event to clear
- * @return Result of operation, 0 on success, otherwise error code
- */
-ResultCode ClearEvent(Handle handle);
+    std::string GetTypeName() const override { return "Event"; }
+    std::string GetName() const override { return name; }
 
-/**
- * Creates an event
- * @param reset_type ResetType describing how to create event
- * @param name Optional name of event
- * @return Handle to newly created Event object
- */
-Handle CreateEvent(const ResetType reset_type, const std::string& name="Unknown");
+    static const HandleType HANDLE_TYPE = HandleType::Event;
+    HandleType GetHandleType() const override { return HANDLE_TYPE; }
+
+    ResetType intitial_reset_type;          ///< ResetType specified at Event initialization
+    ResetType reset_type;                   ///< Current ResetType
+
+    bool signaled;                          ///< Whether the event has already been signaled
+    std::string name;                       ///< Name of event (optional)
+
+    bool ShouldWait() override;
+    void Acquire() override;
+
+    void Signal();
+    void Clear();
+
+private:
+    Event() = default;
+};
 
 } // namespace

--- a/src/core/hle/kernel/event.h
+++ b/src/core/hle/kernel/event.h
@@ -11,7 +11,7 @@
 
 namespace Kernel {
 
-class Event : public WaitObject {
+class Event final : public WaitObject {
 public:
     /**
      * Creates an event

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -31,7 +31,8 @@ class Thread;
 const ResultCode ERR_OUT_OF_HANDLES(ErrorDescription::OutOfMemory, ErrorModule::Kernel,
         ErrorSummary::OutOfResource, ErrorLevel::Temporary);
 // TOOD: Verify code
-const ResultCode ERR_INVALID_HANDLE = InvalidHandle(ErrorModule::Kernel);
+const ResultCode ERR_INVALID_HANDLE(ErrorDescription::InvalidHandle, ErrorModule::Kernel,
+        ErrorSummary::InvalidArgument, ErrorLevel::Permanent);
 
 enum KernelHandle : Handle {
     CurrentThread   = 0xFFFF8000,

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -16,6 +16,11 @@
 typedef u32 Handle;
 typedef s32 Result;
 
+// TODO: It would be nice to eventually replace these with strong types that prevent accidental
+// conversion between each other.
+typedef u32 VAddr; ///< Represents a pointer in the userspace virtual address space.
+typedef u32 PAddr; ///< Represents a pointer in the ARM11 physical address space.
+
 const Handle INVALID_HANDLE = 0;
 
 namespace Kernel {

--- a/src/core/hle/kernel/mutex.cpp
+++ b/src/core/hle/kernel/mutex.cpp
@@ -13,59 +13,30 @@
 
 namespace Kernel {
 
-class Mutex : public WaitObject {
-public:
-    std::string GetTypeName() const override { return "Mutex"; }
-    std::string GetName() const override { return name; }
-
-    static const HandleType HANDLE_TYPE = HandleType::Mutex;
-    HandleType GetHandleType() const override { return HANDLE_TYPE; }
-
-    bool initial_locked;                        ///< Initial lock state when mutex was created
-    bool locked;                                ///< Current locked state
-    std::string name;                           ///< Name of mutex (optional)
-    SharedPtr<Thread> holding_thread;           ///< Thread that has acquired the mutex
-
-    bool ShouldWait() override;
-    void Acquire() override;
-};
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
 typedef std::multimap<SharedPtr<Thread>, SharedPtr<Mutex>> MutexMap;
 static MutexMap g_mutex_held_locks;
-
-/**
- * Acquires the specified mutex for the specified thread
- * @param mutex Mutex that is to be acquired
- * @param thread Thread that will acquire the mutex
- */
-static void MutexAcquireLock(Mutex* mutex, Thread* thread) {
-    g_mutex_held_locks.insert(std::make_pair(thread, mutex));
-    mutex->holding_thread = thread;
-}
 
 /**
  * Resumes a thread waiting for the specified mutex
  * @param mutex The mutex that some thread is waiting on
  */
 static void ResumeWaitingThread(Mutex* mutex) {
+    // Reset mutex lock thread handle, nothing is waiting
+    mutex->locked = false;
+    mutex->holding_thread = nullptr;
+
     // Find the next waiting thread for the mutex...
     auto next_thread = mutex->WakeupNextThread();
     if (next_thread != nullptr) {
-        MutexAcquireLock(mutex, next_thread);
-    } else {
-        // Reset mutex lock thread handle, nothing is waiting
-        mutex->locked = false;
-        mutex->holding_thread = nullptr;
+        mutex->Acquire(next_thread);
     }
 }
 
 void ReleaseThreadMutexes(Thread* thread) {
-    auto locked = g_mutex_held_locks.equal_range(thread);
+    auto locked_range = g_mutex_held_locks.equal_range(thread);
     
     // Release every mutex that the thread holds, and resume execution on the waiting threads
-    for (auto iter = locked.first; iter != locked.second; ++iter) {
+    for (auto iter = locked_range.first; iter != locked_range.second; ++iter) {
         ResumeWaitingThread(iter->second.get());
     }
 
@@ -73,62 +44,21 @@ void ReleaseThreadMutexes(Thread* thread) {
     g_mutex_held_locks.erase(thread);
 }
 
-static bool ReleaseMutex(Mutex* mutex) {
-    if (mutex->locked) {
-        auto locked = g_mutex_held_locks.equal_range(mutex->holding_thread);
+ResultVal<SharedPtr<Mutex>> Mutex::Create(bool initial_locked, std::string name) {
+    SharedPtr<Mutex> mutex(new Mutex);
+    // TOOD(yuriks): Don't create Handle (see Thread::Create())
+    CASCADE_RESULT(auto unused, Kernel::g_handle_table.Create(mutex));
 
-        for (MutexMap::iterator iter = locked.first; iter != locked.second; ++iter) {
-            if (iter->second == mutex) {
-                g_mutex_held_locks.erase(iter);
-                break;
-            }
-        }
-
-        ResumeWaitingThread(mutex);
-    }
-    return true;
-}
-
-ResultCode ReleaseMutex(Handle handle) {
-    Mutex* mutex = Kernel::g_handle_table.Get<Mutex>(handle).get();
-    if (mutex == nullptr) return InvalidHandle(ErrorModule::Kernel);
-
-    if (!ReleaseMutex(mutex)) {
-        // TODO(yuriks): Verify error code, this one was pulled out of thin air. I'm not even sure
-        // what error condition this is supposed to be signaling.
-        return ResultCode(ErrorDescription::AlreadyDone, ErrorModule::Kernel,
-                ErrorSummary::NothingHappened, ErrorLevel::Temporary);
-    }
-    return RESULT_SUCCESS;
-}
-
-/**
- * Creates a mutex
- * @param handle Reference to handle for the newly created mutex
- * @param initial_locked Specifies if the mutex should be locked initially
- * @param name Optional name of mutex
- * @return Pointer to new Mutex object
- */
-static Mutex* CreateMutex(Handle& handle, bool initial_locked, const std::string& name) {
-    Mutex* mutex = new Mutex;
-    // TODO(yuriks): Fix error reporting
-    handle = Kernel::g_handle_table.Create(mutex).ValueOr(INVALID_HANDLE);
-
-    mutex->locked = mutex->initial_locked = initial_locked;
-    mutex->name = name;
+    mutex->initial_locked = initial_locked;
+    mutex->locked = false;
+    mutex->name = std::move(name);
     mutex->holding_thread = nullptr;
 
     // Acquire mutex with current thread if initialized as locked...
-    if (mutex->locked)
-        MutexAcquireLock(mutex, GetCurrentThread());
+    if (initial_locked)
+        mutex->Acquire();
 
-    return mutex;
-}
-
-Handle CreateMutex(bool initial_locked, const std::string& name) {
-    Handle handle;
-    Mutex* mutex = CreateMutex(handle, initial_locked, name);
-    return handle;
+    return MakeResult<SharedPtr<Mutex>>(mutex);
 }
 
 bool Mutex::ShouldWait() {
@@ -136,9 +66,34 @@ bool Mutex::ShouldWait() {
 }
 
 void Mutex::Acquire() {
+    Acquire(GetCurrentThread());
+}
+
+void Mutex::Acquire(Thread* thread) {
     _assert_msg_(Kernel, !ShouldWait(), "object unavailable!");
+    if (locked)
+        return;
+
     locked = true;
-    MutexAcquireLock(this, GetCurrentThread());
+
+    g_mutex_held_locks.insert(std::make_pair(thread, this));
+    holding_thread = thread;
+}
+
+void Mutex::Release() {
+    if (!locked)
+        return;
+
+    auto locked_range = g_mutex_held_locks.equal_range(holding_thread);
+
+    for (MutexMap::iterator iter = locked_range.first; iter != locked_range.second; ++iter) {
+        if (iter->second == this) {
+            g_mutex_held_locks.erase(iter);
+            break;
+        }
+    }
+
+    ResumeWaitingThread(this);
 }
 
 } // namespace

--- a/src/core/hle/kernel/mutex.h
+++ b/src/core/hle/kernel/mutex.h
@@ -4,25 +4,51 @@
 
 #pragma once
 
+#include <string>
+
 #include "common/common_types.h"
 
 #include "core/hle/kernel/kernel.h"
 
 namespace Kernel {
 
-/**
- * Releases a mutex
- * @param handle Handle to mutex to release
- */
-ResultCode ReleaseMutex(Handle handle);
+class Thread;
 
-/**
- * Creates a mutex
- * @param initial_locked Specifies if the mutex should be locked initially
- * @param name Optional name of mutex
- * @return Handle to newly created object
- */
-Handle CreateMutex(bool initial_locked, const std::string& name="Unknown");
+class Mutex : public WaitObject {
+public:
+    /**
+     * Creates a mutex.
+     * @param initial_locked Specifies if the mutex should be locked initially
+     * @param name Optional name of mutex
+     * @return Pointer to new Mutex object
+     */
+    static ResultVal<SharedPtr<Mutex>> Create(bool initial_locked, std::string name = "Unknown");
+
+    std::string GetTypeName() const override { return "Mutex"; }
+    std::string GetName() const override { return name; }
+
+    static const HandleType HANDLE_TYPE = HandleType::Mutex;
+    HandleType GetHandleType() const override { return HANDLE_TYPE; }
+
+    bool initial_locked;                        ///< Initial lock state when mutex was created
+    bool locked;                                ///< Current locked state
+    std::string name;                           ///< Name of mutex (optional)
+    SharedPtr<Thread> holding_thread;           ///< Thread that has acquired the mutex
+
+    bool ShouldWait() override;
+    void Acquire() override;
+
+    /**
+    * Acquires the specified mutex for the specified thread
+    * @param mutex Mutex that is to be acquired
+    * @param thread Thread that will acquire the mutex
+    */
+    void Acquire(Thread* thread);
+    void Release();
+
+private:
+    Mutex() = default;
+};
 
 /**
  * Releases all the mutexes held by the specified thread

--- a/src/core/hle/kernel/mutex.h
+++ b/src/core/hle/kernel/mutex.h
@@ -14,7 +14,7 @@ namespace Kernel {
 
 class Thread;
 
-class Mutex : public WaitObject {
+class Mutex final : public WaitObject {
 public:
     /**
      * Creates a mutex.

--- a/src/core/hle/kernel/semaphore.h
+++ b/src/core/hle/kernel/semaphore.h
@@ -4,29 +4,50 @@
 
 #pragma once
 
+#include <queue>
+#include <string>
+
 #include "common/common_types.h"
 
 #include "core/hle/kernel/kernel.h"
 
 namespace Kernel {
 
-/**
- * Creates a semaphore.
- * @param handle Pointer to the handle of the newly created object
- * @param initial_count Number of slots reserved for other threads
- * @param max_count Maximum number of slots the semaphore can have
- * @param name Optional name of semaphore
- * @return ResultCode of the error
- */
-ResultCode CreateSemaphore(Handle* handle, s32 initial_count, s32 max_count, const std::string& name = "Unknown");
+class Semaphore : public WaitObject {
+public:
+    /**
+     * Creates a semaphore.
+     * @param handle Pointer to the handle of the newly created object
+     * @param initial_count Number of slots reserved for other threads
+     * @param max_count Maximum number of slots the semaphore can have
+     * @param name Optional name of semaphore
+     * @return The created semaphore
+     */
+    static ResultVal<SharedPtr<Semaphore>> Create(s32 initial_count, s32 max_count,
+            std::string name = "Unknown");
 
-/**
- * Releases a certain number of slots from a semaphore.
- * @param count The number of free slots the semaphore had before this call
- * @param handle The handle of the semaphore to release
- * @param release_count The number of slots to release
- * @return ResultCode of the error
- */
-ResultCode ReleaseSemaphore(s32* count, Handle handle, s32 release_count);
+    std::string GetTypeName() const override { return "Semaphore"; }
+    std::string GetName() const override { return name; }
+
+    static const HandleType HANDLE_TYPE = HandleType::Semaphore;
+    HandleType GetHandleType() const override { return HANDLE_TYPE; }
+
+    s32 max_count;                              ///< Maximum number of simultaneous holders the semaphore can have
+    s32 available_count;                        ///< Number of free slots left in the semaphore
+    std::string name;                           ///< Name of semaphore (optional)
+
+    bool ShouldWait() override;
+    void Acquire() override;
+
+    /**
+     * Releases a certain number of slots from a semaphore.
+     * @param release_count The number of slots to release
+     * @return The number of free slots the semaphore had before this call
+     */
+    ResultVal<s32> Release(s32 release_count);
+
+private:
+    Semaphore() = default;
+};
 
 } // namespace

--- a/src/core/hle/kernel/semaphore.h
+++ b/src/core/hle/kernel/semaphore.h
@@ -13,7 +13,7 @@
 
 namespace Kernel {
 
-class Semaphore : public WaitObject {
+class Semaphore final : public WaitObject {
 public:
     /**
      * Creates a semaphore.

--- a/src/core/hle/kernel/shared_memory.cpp
+++ b/src/core/hle/kernel/shared_memory.cpp
@@ -30,7 +30,7 @@ public:
  * @param name Name of shared memory object
  * @return Pointer to newly created shared memory object
  */
-SharedMemory* CreateSharedMemory(Handle& handle, const std::string& name) {
+static SharedMemory* CreateSharedMemory(Handle& handle, const std::string& name) {
     SharedMemory* shared_memory = new SharedMemory;
     // TOOD(yuriks): Fix error reporting
     handle = Kernel::g_handle_table.Create(shared_memory).ValueOr(INVALID_HANDLE);
@@ -44,14 +44,6 @@ Handle CreateSharedMemory(const std::string& name) {
     return handle;
 }
 
-/**
- * Maps a shared memory block to an address in system memory
- * @param handle Shared memory block handle
- * @param address Address in system memory to map shared memory block to
- * @param permissions Memory block map permissions (specified by SVC field)
- * @param other_permissions Memory block map other permissions (specified by SVC field)
- * @return Result of operation, 0 on success, otherwise error code
- */
 ResultCode MapSharedMemory(u32 handle, u32 address, MemoryPermission permissions,
     MemoryPermission other_permissions) {
 

--- a/src/core/hle/kernel/shared_memory.cpp
+++ b/src/core/hle/kernel/shared_memory.cpp
@@ -9,68 +9,39 @@
 
 namespace Kernel {
 
-class SharedMemory : public Object {
-public:
-    std::string GetTypeName() const override { return "SharedMemory"; }
+ResultVal<SharedPtr<SharedMemory>> SharedMemory::Create(std::string name) {
+    SharedPtr<SharedMemory> shared_memory(new SharedMemory);
 
-    static const HandleType HANDLE_TYPE = HandleType::SharedMemory;
-    HandleType GetHandleType() const override { return HANDLE_TYPE; }
+    // TOOD(yuriks): Don't create Handle (see Thread::Create())
+    CASCADE_RESULT(auto unused, Kernel::g_handle_table.Create(shared_memory));
 
-    u32 base_address;                   ///< Address of shared memory block in RAM
-    MemoryPermission permissions;       ///< Permissions of shared memory block (SVC field)
-    MemoryPermission other_permissions; ///< Other permissions of shared memory block (SVC field)
-    std::string name;                   ///< Name of shared memory object (optional)
-};
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-/**
- * Creates a shared memory object
- * @param handle Handle of newly created shared memory object
- * @param name Name of shared memory object
- * @return Pointer to newly created shared memory object
- */
-static SharedMemory* CreateSharedMemory(Handle& handle, const std::string& name) {
-    SharedMemory* shared_memory = new SharedMemory;
-    // TOOD(yuriks): Fix error reporting
-    handle = Kernel::g_handle_table.Create(shared_memory).ValueOr(INVALID_HANDLE);
-    shared_memory->name = name;
-    return shared_memory;
+    shared_memory->name = std::move(name);
+    return MakeResult<SharedPtr<SharedMemory>>(std::move(shared_memory));
 }
 
-Handle CreateSharedMemory(const std::string& name) {
-    Handle handle;
-    CreateSharedMemory(handle, name);
-    return handle;
-}
-
-ResultCode MapSharedMemory(u32 handle, u32 address, MemoryPermission permissions,
-    MemoryPermission other_permissions) {
+ResultCode SharedMemory::Map(VAddr address, MemoryPermission permissions,
+        MemoryPermission other_permissions) {
 
     if (address < Memory::SHARED_MEMORY_VADDR || address >= Memory::SHARED_MEMORY_VADDR_END) {
-        LOG_ERROR(Kernel_SVC, "cannot map handle=0x%08X, address=0x%08X outside of shared mem bounds!",
-            handle, address);
+        LOG_ERROR(Kernel, "cannot map handle=0x%08X, address=0x%08X outside of shared mem bounds!",
+                GetHandle(), address);
+        // TODO: Verify error code with hardware
         return ResultCode(ErrorDescription::InvalidAddress, ErrorModule::Kernel,
                 ErrorSummary::InvalidArgument, ErrorLevel::Permanent);
     }
-    SharedMemory* shared_memory = Kernel::g_handle_table.Get<SharedMemory>(handle).get();
-    if (shared_memory == nullptr) return InvalidHandle(ErrorModule::Kernel);
 
-    shared_memory->base_address = address;
-    shared_memory->permissions = permissions;
-    shared_memory->other_permissions = other_permissions;
+    base_address = address;
+    permissions = permissions;
+    other_permissions = other_permissions;
 
     return RESULT_SUCCESS;
 }
 
-ResultVal<u8*> GetSharedMemoryPointer(Handle handle, u32 offset) {
-    SharedMemory* shared_memory = Kernel::g_handle_table.Get<SharedMemory>(handle).get();
-    if (shared_memory == nullptr) return InvalidHandle(ErrorModule::Kernel);
+ResultVal<u8*> SharedMemory::GetPointer(u32 offset) {
+    if (base_address != 0)
+        return MakeResult<u8*>(Memory::GetPointer(base_address + offset));
 
-    if (0 != shared_memory->base_address)
-        return MakeResult<u8*>(Memory::GetPointer(shared_memory->base_address + offset));
-
-    LOG_ERROR(Kernel_SVC, "memory block handle=0x%08X not mapped!", handle);
+    LOG_ERROR(Kernel_SVC, "memory block handle=0x%08X not mapped!", GetHandle());
     // TODO(yuriks): Verify error code.
     return ResultCode(ErrorDescription::InvalidAddress, ErrorModule::Kernel,
             ErrorSummary::InvalidState, ErrorLevel::Permanent);

--- a/src/core/hle/kernel/shared_memory.h
+++ b/src/core/hle/kernel/shared_memory.h
@@ -23,7 +23,7 @@ enum class MemoryPermission : u32 {
     DontCare         = (1u << 28)
 };
 
-class SharedMemory : public Object {
+class SharedMemory final : public Object {
 public:
     /**
      * Creates a shared memory object

--- a/src/core/hle/kernel/shared_memory.h
+++ b/src/core/hle/kernel/shared_memory.h
@@ -23,29 +23,41 @@ enum class MemoryPermission : u32 {
     DontCare         = (1u << 28)
 };
 
-/**
- * Creates a shared memory object
- * @param name Optional name of shared memory object
- * @return Handle of newly created shared memory object
- */
-Handle CreateSharedMemory(const std::string& name="Unknown");
+class SharedMemory : public Object {
+public:
+    /**
+     * Creates a shared memory object
+     * @param name Optional object name, used only for debugging purposes.
+     */
+    static ResultVal<SharedPtr<SharedMemory>> Create(std::string name = "Unknown");
 
-/**
- * Maps a shared memory block to an address in system memory
- * @param handle Shared memory block handle
- * @param address Address in system memory to map shared memory block to
- * @param permissions Memory block map permissions (specified by SVC field)
- * @param other_permissions Memory block map other permissions (specified by SVC field)
- */
-ResultCode MapSharedMemory(Handle handle, u32 address, MemoryPermission permissions,
-    MemoryPermission other_permissions);
+    std::string GetTypeName() const override { return "SharedMemory"; }
 
-/**
- * Gets a pointer to the shared memory block
- * @param handle Shared memory block handle
- * @param offset Offset from the start of the shared memory block to get pointer
- * @return Pointer to the shared memory block from the specified offset
- */
-ResultVal<u8*> GetSharedMemoryPointer(Handle handle, u32 offset);
+    static const HandleType HANDLE_TYPE = HandleType::SharedMemory;
+    HandleType GetHandleType() const override { return HANDLE_TYPE; }
+
+    /**
+     * Maps a shared memory block to an address in system memory
+     * @param address Address in system memory to map shared memory block to
+     * @param permissions Memory block map permissions (specified by SVC field)
+     * @param other_permissions Memory block map other permissions (specified by SVC field)
+     */
+    ResultCode Map(VAddr address, MemoryPermission permissions, MemoryPermission other_permissions);
+
+    /**
+    * Gets a pointer to the shared memory block
+    * @param offset Offset from the start of the shared memory block to get pointer
+    * @return Pointer to the shared memory block from the specified offset
+    */
+    ResultVal<u8*> GetPointer(u32 offset = 0);
+
+    VAddr base_address;                   ///< Address of shared memory block in RAM
+    MemoryPermission permissions;       ///< Permissions of shared memory block (SVC field)
+    MemoryPermission other_permissions; ///< Other permissions of shared memory block (SVC field)
+    std::string name;                   ///< Name of shared memory object (optional)
+
+private:
+    SharedMemory() = default;
+};
 
 } // namespace

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -40,7 +40,7 @@ enum ThreadStatus {
 
 namespace Kernel {
 
-class Thread : public WaitObject {
+class Thread final : public WaitObject {
 public:
     static ResultVal<SharedPtr<Thread>> Create(std::string name, VAddr entry_point, s32 priority,
         u32 arg, s32 processor_id, VAddr stack_top, u32 stack_size);
@@ -115,7 +115,6 @@ public:
     bool idle = false;
 
 private:
-
     Thread() = default;
 };
 

--- a/src/core/hle/kernel/timer.cpp
+++ b/src/core/hle/kernel/timer.cpp
@@ -13,75 +13,54 @@
 
 namespace Kernel {
 
-class Timer : public WaitObject {
-public:
-    std::string GetTypeName() const override { return "Timer"; }
-    std::string GetName() const override { return name; }
+/// The event type of the generic timer callback event
+static int timer_callback_event_type = -1;
 
-    static const HandleType HANDLE_TYPE = HandleType::Timer;
-    HandleType GetHandleType() const override { return HANDLE_TYPE; }
-
-    ResetType reset_type;                   ///< The ResetType of this timer
-
-    bool signaled;                          ///< Whether the timer has been signaled or not
-    std::string name;                       ///< Name of timer (optional)
-
-    u64 initial_delay;                      ///< The delay until the timer fires for the first time
-    u64 interval_delay;                     ///< The delay until the timer fires after the first time
-
-    bool ShouldWait() override {
-        return !signaled;
-    }
-
-    void Acquire() override {
-        _assert_msg_(Kernel, !ShouldWait(), "object unavailable!");
-    }
-};
-
-/**
- * Creates a timer.
- * @param handle Reference to handle for the newly created timer
- * @param reset_type ResetType describing how to create timer
- * @param name Optional name of timer
- * @return Newly created Timer object
- */
-static Timer* CreateTimer(Handle& handle, const ResetType reset_type, const std::string& name) {
-    Timer* timer = new Timer;
-
-    handle = Kernel::g_handle_table.Create(timer).ValueOr(INVALID_HANDLE);
+ResultVal<SharedPtr<Timer>> Timer::Create(ResetType reset_type, std::string name) {
+    SharedPtr<Timer> timer(new Timer);
+    // TOOD(yuriks): Don't create Handle (see Thread::Create())
+    CASCADE_RESULT(auto unused, Kernel::g_handle_table.Create(timer));
 
     timer->reset_type = reset_type;
     timer->signaled = false;
-    timer->name = name;
+    timer->name = std::move(name);
     timer->initial_delay = 0;
     timer->interval_delay = 0;
-    return timer;
+    return MakeResult<SharedPtr<Timer>>(timer);
 }
 
-ResultCode CreateTimer(Handle* handle, const ResetType reset_type, const std::string& name) {
-    CreateTimer(*handle, reset_type, name);
-    return RESULT_SUCCESS;
+bool Timer::ShouldWait() {
+    return !signaled;
 }
 
-ResultCode ClearTimer(Handle handle) {
-    SharedPtr<Timer> timer = Kernel::g_handle_table.Get<Timer>(handle);
-    
-    if (timer == nullptr)
-        return InvalidHandle(ErrorModule::Kernel);
-
-    timer->signaled = false;
-    return RESULT_SUCCESS;
+void Timer::Acquire() {
+    _assert_msg_(Kernel, !ShouldWait(), "object unavailable!");
 }
 
-/// The event type of the generic timer callback event
-static int TimerCallbackEventType = -1;
+void Timer::Set(s64 initial, s64 interval) {
+    initial_delay = initial;
+    interval_delay = interval;
+
+    u64 initial_microseconds = initial / 1000;
+    // TODO(yuriks): Figure out a replacement for GetHandle here
+    CoreTiming::ScheduleEvent(usToCycles(initial_microseconds), timer_callback_event_type,
+            GetHandle());
+}
+
+void Timer::Cancel() {
+    CoreTiming::UnscheduleEvent(timer_callback_event_type, GetHandle());
+}
+
+void Timer::Clear() {
+    signaled = false;
+}
 
 /// The timer callback event, called when a timer is fired
 static void TimerCallback(u64 timer_handle, int cycles_late) {
     SharedPtr<Timer> timer = Kernel::g_handle_table.Get<Timer>(timer_handle);
 
     if (timer == nullptr) {
-        LOG_CRITICAL(Kernel, "Callback fired for invalid timer %u", timer_handle);
+        LOG_CRITICAL(Kernel, "Callback fired for invalid timer %08X", timer_handle);
         return;
     }
 
@@ -99,36 +78,12 @@ static void TimerCallback(u64 timer_handle, int cycles_late) {
         // Reschedule the timer with the interval delay
         u64 interval_microseconds = timer->interval_delay / 1000;
         CoreTiming::ScheduleEvent(usToCycles(interval_microseconds) - cycles_late, 
-                TimerCallbackEventType, timer_handle);
+                timer_callback_event_type, timer_handle);
     }
 }
 
-ResultCode SetTimer(Handle handle, s64 initial, s64 interval) {
-    SharedPtr<Timer> timer = Kernel::g_handle_table.Get<Timer>(handle);
-
-    if (timer == nullptr)
-        return InvalidHandle(ErrorModule::Kernel);
-
-    timer->initial_delay = initial;
-    timer->interval_delay = interval;
-
-    u64 initial_microseconds = initial / 1000;
-    CoreTiming::ScheduleEvent(usToCycles(initial_microseconds), TimerCallbackEventType, handle);
-    return RESULT_SUCCESS;
-}
-
-ResultCode CancelTimer(Handle handle) {
-    SharedPtr<Timer> timer = Kernel::g_handle_table.Get<Timer>(handle);
-
-    if (timer == nullptr)
-        return InvalidHandle(ErrorModule::Kernel);
-
-    CoreTiming::UnscheduleEvent(TimerCallbackEventType, handle);
-    return RESULT_SUCCESS;
-}
-
 void TimersInit() {
-    TimerCallbackEventType = CoreTiming::RegisterEvent("TimerCallback", TimerCallback);
+    timer_callback_event_type = CoreTiming::RegisterEvent("TimerCallback", TimerCallback);
 }
 
 void TimersShutdown() {

--- a/src/core/hle/kernel/timer.cpp
+++ b/src/core/hle/kernel/timer.cpp
@@ -45,7 +45,7 @@ public:
  * @param name Optional name of timer
  * @return Newly created Timer object
  */
-Timer* CreateTimer(Handle& handle, const ResetType reset_type, const std::string& name) {
+static Timer* CreateTimer(Handle& handle, const ResetType reset_type, const std::string& name) {
     Timer* timer = new Timer;
 
     handle = Kernel::g_handle_table.Create(timer).ValueOr(INVALID_HANDLE);

--- a/src/core/hle/kernel/timer.h
+++ b/src/core/hle/kernel/timer.h
@@ -11,37 +11,50 @@
 
 namespace Kernel {
 
-/**
- * Cancels a timer
- * @param handle Handle of the timer to cancel
- */
-ResultCode CancelTimer(Handle handle);
+class Timer : public WaitObject {
+public:
+    /**
+     * Creates a timer
+     * @param reset_type ResetType describing how to create the timer
+     * @param name Optional name of timer
+     * @return The created Timer
+     */
+    static ResultVal<SharedPtr<Timer>> Create(ResetType reset_type, std::string name = "Unknown");
 
-/**
- * Starts a timer with the specified initial delay and interval
- * @param handle Handle of the timer to start
- * @param initial Delay until the timer is first fired
- * @param interval Delay until the timer is fired after the first time
- */
-ResultCode SetTimer(Handle handle, s64 initial, s64 interval);
+    std::string GetTypeName() const override { return "Timer"; }
+    std::string GetName() const override { return name; }
 
-/**
- * Clears a timer
- * @param handle Handle of the timer to clear
- */
-ResultCode ClearTimer(Handle handle);
+    static const HandleType HANDLE_TYPE = HandleType::Timer;
+    HandleType GetHandleType() const override { return HANDLE_TYPE; }
 
-/**
- * Creates a timer
- * @param handle Handle to the newly created Timer object
- * @param reset_type ResetType describing how to create the timer
- * @param name Optional name of timer
- * @return ResultCode of the error
- */
-ResultCode CreateTimer(Handle* handle, const ResetType reset_type, const std::string& name="Unknown");
+    ResetType reset_type;                   ///< The ResetType of this timer
+
+    bool signaled;                          ///< Whether the timer has been signaled or not
+    std::string name;                       ///< Name of timer (optional)
+
+    u64 initial_delay;                      ///< The delay until the timer fires for the first time
+    u64 interval_delay;                     ///< The delay until the timer fires after the first time
+
+    bool ShouldWait() override;
+    void Acquire() override;
+
+    /**
+     * Starts the timer, with the specified initial delay and interval.
+     * @param initial Delay until the timer is first fired
+     * @param interval Delay until the timer is fired after the first time
+     */
+    void Set(s64 initial, s64 interval);
+
+    void Cancel();
+    void Clear();
+
+private:
+    Timer() = default;
+};
 
 /// Initializes the required variables for timers
 void TimersInit();
 /// Tears down the timer variables
 void TimersShutdown();
+
 } // namespace

--- a/src/core/hle/kernel/timer.h
+++ b/src/core/hle/kernel/timer.h
@@ -11,7 +11,7 @@
 
 namespace Kernel {
 
-class Timer : public WaitObject {
+class Timer final : public WaitObject {
 public:
     /**
      * Creates a timer

--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -9,8 +9,9 @@
 #include <type_traits>
 #include <utility>
 
-#include "common/common_types.h"
 #include "common/bit_field.h"
+#include "common/common_funcs.h"
+#include "common/common_types.h"
 
 // All the constants in this file come from http://3dbrew.org/wiki/Error_codes
 
@@ -364,6 +365,17 @@ public:
         return !empty() ? *GetPointer() : std::move(value);
     }
 
+    /// Asserts that the result succeeded and returns a reference to it.
+    T& Unwrap() {
+        // TODO(yuriks): Should be a release assert
+        _assert_msg_(Common, Succeeded(), "Tried to Unwrap empty ResultVal");
+        return **this;
+    }
+
+    T&& MoveFrom() {
+        return std::move(Unwrap());
+    }
+
 private:
     typedef typename std::aligned_storage<sizeof(T), std::alignment_of<T>::value>::type StorageType;
 
@@ -400,3 +412,15 @@ template <typename T, typename... Args>
 ResultVal<T> MakeResult(Args&&... args) {
     return ResultVal<T>::WithCode(RESULT_SUCCESS, std::forward<Args>(args)...);
 }
+
+/**
+ * Check for the success of `source` (which must evaluate to a ResultVal). If it succeeds, unwraps
+ * the contained value and assigns it to `target`, which can be either an l-value expression or a
+ * variable declaration. If it fails the return code is returned from the current function. Thus it
+ * can be used to cascade errors out, achieving something akin to exception handling.
+ */
+#define CASCADE_RESULT(target, source) \
+        auto CONCAT2(check_result_L, __LINE__) = source; \
+        if (CONCAT2(check_result_L, __LINE__).Failed()) \
+            return CONCAT2(check_result_L, __LINE__).Code(); \
+        target = std::move(*CONCAT2(check_result_L, __LINE__))

--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -227,11 +227,6 @@ inline ResultCode UnimplementedFunction(ErrorModule module) {
     return ResultCode(ErrorDescription::NotImplemented, module,
             ErrorSummary::NotSupported, ErrorLevel::Permanent);
 }
-/// Returned when a function is passed an invalid handle.
-inline ResultCode InvalidHandle(ErrorModule module) {
-    return ResultCode(ErrorDescription::InvalidHandle, module,
-            ErrorSummary::InvalidArgument, ErrorLevel::Permanent);
-}
 
 /**
  * This is an optional value type. It holds a `ResultCode` and, if that code is a success code,

--- a/src/core/hle/service/apt_s.cpp
+++ b/src/core/hle/service/apt_s.cpp
@@ -10,6 +10,7 @@
 #include "core/hle/kernel/event.h"
 #include "core/hle/kernel/mutex.h"
 #include "core/hle/kernel/shared_memory.h"
+#include "core/hle/kernel/thread.h"
 #include "core/hle/service/apt_s.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -43,6 +43,11 @@ const std::string SDCARD_ID = "00000000000000000000000000000000";
 namespace Service {
 namespace FS {
 
+// TODO: Verify code
+/// Returned when a function is passed an invalid handle.
+const ResultCode ERR_INVALID_HANDLE(ErrorDescription::InvalidHandle, ErrorModule::FS,
+        ErrorSummary::InvalidArgument, ErrorLevel::Permanent);
+
 // Command to access archive file
 enum class FileCommand : u32 {
     Dummy1          = 0x000100C6,
@@ -280,7 +285,7 @@ ResultVal<ArchiveHandle> OpenArchive(ArchiveIdCode id_code, FileSys::Path& archi
 
 ResultCode CloseArchive(ArchiveHandle handle) {
     if (handle_map.erase(handle) == 0)
-        return InvalidHandle(ErrorModule::FS);
+        return ERR_INVALID_HANDLE;
     else
         return RESULT_SUCCESS;
 }
@@ -301,7 +306,7 @@ ResultCode CreateArchive(std::unique_ptr<FileSys::ArchiveBackend>&& backend, Arc
 ResultVal<Handle> OpenFileFromArchive(ArchiveHandle archive_handle, const FileSys::Path& path, const FileSys::Mode mode) {
     Archive* archive = GetArchive(archive_handle);
     if (archive == nullptr)
-        return InvalidHandle(ErrorModule::FS);
+        return ERR_INVALID_HANDLE;
 
     std::unique_ptr<FileSys::FileBackend> backend = archive->backend->OpenFile(path, mode);
     if (backend == nullptr) {
@@ -318,7 +323,7 @@ ResultVal<Handle> OpenFileFromArchive(ArchiveHandle archive_handle, const FileSy
 ResultCode DeleteFileFromArchive(ArchiveHandle archive_handle, const FileSys::Path& path) {
     Archive* archive = GetArchive(archive_handle);
     if (archive == nullptr)
-        return InvalidHandle(ErrorModule::FS);
+        return ERR_INVALID_HANDLE;
 
     if (archive->backend->DeleteFile(path))
         return RESULT_SUCCESS;
@@ -331,7 +336,7 @@ ResultCode RenameFileBetweenArchives(ArchiveHandle src_archive_handle, const Fil
     Archive* src_archive = GetArchive(src_archive_handle);
     Archive* dest_archive = GetArchive(dest_archive_handle);
     if (src_archive == nullptr || dest_archive == nullptr)
-        return InvalidHandle(ErrorModule::FS);
+        return ERR_INVALID_HANDLE;
 
     if (src_archive == dest_archive) {
         if (src_archive->backend->RenameFile(src_path, dest_path))
@@ -350,7 +355,7 @@ ResultCode RenameFileBetweenArchives(ArchiveHandle src_archive_handle, const Fil
 ResultCode DeleteDirectoryFromArchive(ArchiveHandle archive_handle, const FileSys::Path& path) {
     Archive* archive = GetArchive(archive_handle);
     if (archive == nullptr)
-        return InvalidHandle(ErrorModule::FS);
+        return ERR_INVALID_HANDLE;
 
     if (archive->backend->DeleteDirectory(path))
         return RESULT_SUCCESS;
@@ -361,7 +366,7 @@ ResultCode DeleteDirectoryFromArchive(ArchiveHandle archive_handle, const FileSy
 ResultCode CreateFileInArchive(ArchiveHandle archive_handle, const FileSys::Path& path, u32 file_size) {
     Archive* archive = GetArchive(archive_handle);
     if (archive == nullptr)
-        return InvalidHandle(ErrorModule::FS);
+        return ERR_INVALID_HANDLE;
 
     return archive->backend->CreateFile(path, file_size);
 }
@@ -369,7 +374,7 @@ ResultCode CreateFileInArchive(ArchiveHandle archive_handle, const FileSys::Path
 ResultCode CreateDirectoryFromArchive(ArchiveHandle archive_handle, const FileSys::Path& path) {
     Archive* archive = GetArchive(archive_handle);
     if (archive == nullptr)
-        return InvalidHandle(ErrorModule::FS);
+        return ERR_INVALID_HANDLE;
 
     if (archive->backend->CreateDirectory(path))
         return RESULT_SUCCESS;
@@ -382,7 +387,7 @@ ResultCode RenameDirectoryBetweenArchives(ArchiveHandle src_archive_handle, cons
     Archive* src_archive = GetArchive(src_archive_handle);
     Archive* dest_archive = GetArchive(dest_archive_handle);
     if (src_archive == nullptr || dest_archive == nullptr)
-        return InvalidHandle(ErrorModule::FS);
+        return ERR_INVALID_HANDLE;
 
     if (src_archive == dest_archive) {
         if (src_archive->backend->RenameDirectory(src_path, dest_path))
@@ -407,7 +412,7 @@ ResultCode RenameDirectoryBetweenArchives(ArchiveHandle src_archive_handle, cons
 ResultVal<Handle> OpenDirectoryFromArchive(ArchiveHandle archive_handle, const FileSys::Path& path) {
     Archive* archive = GetArchive(archive_handle);
     if (archive == nullptr)
-        return InvalidHandle(ErrorModule::FS);
+        return ERR_INVALID_HANDLE;
 
     std::unique_ptr<FileSys::DirectoryBackend> backend = archive->backend->OpenDirectory(path);
     if (backend == nullptr) {

--- a/src/core/hle/service/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp_gpu.cpp
@@ -23,12 +23,12 @@ GraphicsDebugger g_debugger;
 namespace GSP_GPU {
 
 Handle g_interrupt_event = 0;   ///< Handle to event triggered when GSP interrupt has been signalled
-Handle g_shared_memory = 0;     ///< Handle to GSP shared memorys
+Kernel::SharedPtr<Kernel::SharedMemory> g_shared_memory; ///< GSP shared memoryings
 u32 g_thread_id = 1;            ///< Thread index into interrupt relay queue, 1 is arbitrary
 
 /// Gets a pointer to a thread command buffer in GSP shared memory
 static inline u8* GetCommandBuffer(u32 thread_id) {
-    ResultVal<u8*> ptr = Kernel::GetSharedMemoryPointer(g_shared_memory, 0x800 + (thread_id * sizeof(CommandBuffer)));
+    ResultVal<u8*> ptr = g_shared_memory->GetPointer(0x800 + (thread_id * sizeof(CommandBuffer)));
     return ptr.ValueOr(nullptr);
 }
 
@@ -37,13 +37,13 @@ static inline FrameBufferUpdate* GetFrameBufferInfo(u32 thread_id, u32 screen_in
 
     // For each thread there are two FrameBufferUpdate fields
     u32 offset = 0x200 + (2 * thread_id + screen_index) * sizeof(FrameBufferUpdate);
-    ResultVal<u8*> ptr = Kernel::GetSharedMemoryPointer(g_shared_memory, offset);
+    ResultVal<u8*> ptr = g_shared_memory->GetPointer(offset);
     return reinterpret_cast<FrameBufferUpdate*>(ptr.ValueOr(nullptr));
 }
 
 /// Gets a pointer to the interrupt relay queue for a given thread index
 static inline InterruptRelayQueue* GetInterruptRelayQueue(u32 thread_id) {
-    ResultVal<u8*> ptr = Kernel::GetSharedMemoryPointer(g_shared_memory, sizeof(InterruptRelayQueue) * thread_id);
+    ResultVal<u8*> ptr = g_shared_memory->GetPointer(sizeof(InterruptRelayQueue) * thread_id);
     return reinterpret_cast<InterruptRelayQueue*>(ptr.ValueOr(nullptr));
 }
 
@@ -182,13 +182,15 @@ static void RegisterInterruptRelayQueue(Service::Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     u32 flags = cmd_buff[1];
     g_interrupt_event = cmd_buff[3];
-    g_shared_memory = Kernel::CreateSharedMemory("GSPSharedMem");
+    g_shared_memory = Kernel::SharedMemory::Create("GSPSharedMem").MoveFrom();
 
     _assert_msg_(GSP, (g_interrupt_event != 0), "handle is not valid!");
 
+    Handle shmem_handle = Kernel::g_handle_table.Create(g_shared_memory).MoveFrom();
+
     cmd_buff[1] = 0x2A07; // Value verified by 3dmoo team, purpose unknown, but needed for GSP init
     cmd_buff[2] = g_thread_id++; // Thread ID
-    cmd_buff[4] = g_shared_memory; // GSP shared memory
+    cmd_buff[4] = shmem_handle; // GSP shared memory
 
     Kernel::SignalEvent(g_interrupt_event); // TODO(bunnei): Is this correct?
 }
@@ -204,7 +206,7 @@ void SignalInterrupt(InterruptId interrupt_id) {
         LOG_WARNING(Service_GSP, "cannot synchronize until GSP event has been created!");
         return;
     }
-    if (0 == g_shared_memory) {
+    if (nullptr == g_shared_memory) {
         LOG_WARNING(Service_GSP, "cannot synchronize until GSP shared memory has been created!");
         return;
     }

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -12,7 +12,7 @@
 namespace Service {
 namespace HID {
 
-Handle g_shared_mem = 0;
+Kernel::SharedPtr<Kernel::SharedMemory> g_shared_mem = nullptr;
 
 Handle g_event_pad_or_touch_1 = 0;
 Handle g_event_pad_or_touch_2 = 0;
@@ -30,7 +30,7 @@ static s16 next_circle_y = 0;
  * Gets a pointer to the PadData structure inside HID shared memory
  */
 static inline PadData* GetPadData() {
-    return reinterpret_cast<PadData*>(Kernel::GetSharedMemoryPointer(g_shared_mem, 0).ValueOr(nullptr));
+    return reinterpret_cast<PadData*>(g_shared_mem->GetPointer().ValueOr(nullptr));
 }
 
 /**
@@ -120,7 +120,7 @@ void PadUpdateComplete() {
 }
 
 void HIDInit() {
-    g_shared_mem = Kernel::CreateSharedMemory("HID:SharedMem"); // Create shared memory object
+    g_shared_mem = Kernel::SharedMemory::Create("HID:SharedMem").MoveFrom();
 
     // Create event handles
     g_event_pad_or_touch_1 = Kernel::CreateEvent(RESETTYPE_ONESHOT, "HID:EventPadOrTouch1");

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -14,11 +14,11 @@ namespace HID {
 
 Kernel::SharedPtr<Kernel::SharedMemory> g_shared_mem = nullptr;
 
-Handle g_event_pad_or_touch_1 = 0;
-Handle g_event_pad_or_touch_2 = 0;
-Handle g_event_accelerometer = 0;
-Handle g_event_gyroscope = 0;
-Handle g_event_debug_pad = 0;
+Kernel::SharedPtr<Kernel::Event> g_event_pad_or_touch_1;
+Kernel::SharedPtr<Kernel::Event> g_event_pad_or_touch_2;
+Kernel::SharedPtr<Kernel::Event> g_event_accelerometer;
+Kernel::SharedPtr<Kernel::Event> g_event_gyroscope;
+Kernel::SharedPtr<Kernel::Event> g_event_debug_pad;
 
 // Next Pad state update information
 static PadState next_state = {{0}};
@@ -115,19 +115,21 @@ void PadUpdateComplete() {
     }
     
     // Signal both handles when there's an update to Pad or touch
-    Kernel::SignalEvent(g_event_pad_or_touch_1);
-    Kernel::SignalEvent(g_event_pad_or_touch_2);
+    g_event_pad_or_touch_1->Signal();
+    g_event_pad_or_touch_2->Signal();
 }
 
 void HIDInit() {
-    g_shared_mem = Kernel::SharedMemory::Create("HID:SharedMem").MoveFrom();
+    using namespace Kernel;
+
+    g_shared_mem = SharedMemory::Create("HID:SharedMem").MoveFrom();
 
     // Create event handles
-    g_event_pad_or_touch_1 = Kernel::CreateEvent(RESETTYPE_ONESHOT, "HID:EventPadOrTouch1");
-    g_event_pad_or_touch_2 = Kernel::CreateEvent(RESETTYPE_ONESHOT, "HID:EventPadOrTouch2");
-    g_event_accelerometer = Kernel::CreateEvent(RESETTYPE_ONESHOT, "HID:EventAccelerometer");
-    g_event_gyroscope = Kernel::CreateEvent(RESETTYPE_ONESHOT, "HID:EventGyroscope");
-    g_event_debug_pad = Kernel::CreateEvent(RESETTYPE_ONESHOT, "HID:EventDebugPad");
+    g_event_pad_or_touch_1 = Event::Create(RESETTYPE_ONESHOT, "HID:EventPadOrTouch1").MoveFrom();
+    g_event_pad_or_touch_2 = Event::Create(RESETTYPE_ONESHOT, "HID:EventPadOrTouch2").MoveFrom();
+    g_event_accelerometer  = Event::Create(RESETTYPE_ONESHOT, "HID:EventAccelerometer").MoveFrom();
+    g_event_gyroscope      = Event::Create(RESETTYPE_ONESHOT, "HID:EventGyroscope").MoveFrom();
+    g_event_debug_pad      = Event::Create(RESETTYPE_ONESHOT, "HID:EventDebugPad").MoveFrom();
 }
 
 void HIDShutdown() {

--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -9,11 +9,15 @@
 #include "core/hle/kernel/kernel.h"
 #include "common/bit_field.h"
 
+namespace Kernel {
+    class SharedMemory;
+}
+
 namespace Service {
 namespace HID {
 
 // Handle to shared memory region designated to HID_User service
-extern Handle g_shared_mem;
+extern Kernel::SharedPtr<Kernel::SharedMemory> g_shared_mem;
 
 // Event handles
 extern Handle g_event_pad_or_touch_1;

--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -11,6 +11,7 @@
 
 namespace Kernel {
     class SharedMemory;
+    class Event;
 }
 
 namespace Service {
@@ -20,11 +21,11 @@ namespace HID {
 extern Kernel::SharedPtr<Kernel::SharedMemory> g_shared_mem;
 
 // Event handles
-extern Handle g_event_pad_or_touch_1;
-extern Handle g_event_pad_or_touch_2;
-extern Handle g_event_accelerometer;
-extern Handle g_event_gyroscope;
-extern Handle g_event_debug_pad;
+extern Kernel::SharedPtr<Kernel::Event> g_event_pad_or_touch_1;
+extern Kernel::SharedPtr<Kernel::Event> g_event_pad_or_touch_2;
+extern Kernel::SharedPtr<Kernel::Event> g_event_accelerometer;
+extern Kernel::SharedPtr<Kernel::Event> g_event_gyroscope;
+extern Kernel::SharedPtr<Kernel::Event> g_event_debug_pad;
 
 /**
  * Structure of a Pad controller state.

--- a/src/core/hle/service/hid/hid_user.cpp
+++ b/src/core/hle/service/hid/hid_user.cpp
@@ -5,6 +5,7 @@
 #include "common/log.h"
 
 #include "core/hle/hle.h"
+#include "core/hle/kernel/shared_memory.h"
 #include "core/hle/service/hid/hid.h"
 #include "hid_user.h"
 
@@ -46,7 +47,8 @@ void GetIPCHandles(Service::Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[1] = 0; // No error
-    cmd_buff[3] = Service::HID::g_shared_mem;
+    // TODO(yuriks): Return error from SendSyncRequest is this fails (part of IPC marshalling)
+    cmd_buff[3] = Kernel::g_handle_table.Create(Service::HID::g_shared_mem).MoveFrom();
     cmd_buff[4] = Service::HID::g_event_pad_or_touch_1;
     cmd_buff[5] = Service::HID::g_event_pad_or_touch_2;
     cmd_buff[6] = Service::HID::g_event_accelerometer;

--- a/src/core/hle/service/hid/hid_user.cpp
+++ b/src/core/hle/service/hid/hid_user.cpp
@@ -5,6 +5,7 @@
 #include "common/log.h"
 
 #include "core/hle/hle.h"
+#include "core/hle/kernel/event.h"
 #include "core/hle/kernel/shared_memory.h"
 #include "core/hle/service/hid/hid.h"
 #include "hid_user.h"
@@ -49,11 +50,11 @@ void GetIPCHandles(Service::Interface* self) {
     cmd_buff[1] = 0; // No error
     // TODO(yuriks): Return error from SendSyncRequest is this fails (part of IPC marshalling)
     cmd_buff[3] = Kernel::g_handle_table.Create(Service::HID::g_shared_mem).MoveFrom();
-    cmd_buff[4] = Service::HID::g_event_pad_or_touch_1;
-    cmd_buff[5] = Service::HID::g_event_pad_or_touch_2;
-    cmd_buff[6] = Service::HID::g_event_accelerometer;
-    cmd_buff[7] = Service::HID::g_event_gyroscope;
-    cmd_buff[8] = Service::HID::g_event_debug_pad;
+    cmd_buff[4] = Kernel::g_handle_table.Create(Service::HID::g_event_pad_or_touch_1).MoveFrom();
+    cmd_buff[5] = Kernel::g_handle_table.Create(Service::HID::g_event_pad_or_touch_2).MoveFrom();
+    cmd_buff[6] = Kernel::g_handle_table.Create(Service::HID::g_event_accelerometer).MoveFrom();
+    cmd_buff[7] = Kernel::g_handle_table.Create(Service::HID::g_event_gyroscope).MoveFrom();
+    cmd_buff[8] = Kernel::g_handle_table.Create(Service::HID::g_event_debug_pad).MoveFrom();
 }
 
 const Interface::FunctionInfo FunctionTable[] = {

--- a/src/core/hle/service/srv.cpp
+++ b/src/core/hle/service/srv.cpp
@@ -11,7 +11,7 @@
 
 namespace SRV {
 
-static Handle g_event_handle = 0;
+static Kernel::SharedPtr<Kernel::Event> event_handle;
 
 static void Initialize(Service::Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
@@ -23,11 +23,11 @@ static void GetProcSemaphore(Service::Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     // TODO(bunnei): Change to a semaphore once these have been implemented
-    g_event_handle = Kernel::CreateEvent(RESETTYPE_ONESHOT, "SRV:Event");
-    Kernel::ClearEvent(g_event_handle);
+    event_handle = Kernel::Event::Create(RESETTYPE_ONESHOT, "SRV:Event").MoveFrom();
+    event_handle->Clear();
 
     cmd_buff[1] = 0; // No error
-    cmd_buff[3] = g_event_handle;
+    cmd_buff[3] = Kernel::g_handle_table.Create(event_handle).MoveFrom();
 }
 
 static void GetServiceHandle(Service::Interface* self) {

--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -26,6 +26,7 @@
 // Namespace SVC
 
 using Kernel::SharedPtr;
+using Kernel::ERR_INVALID_HANDLE;
 
 namespace SVC {
 
@@ -71,7 +72,7 @@ static ResultCode MapMemoryBlock(Handle handle, u32 addr, u32 permissions, u32 o
 
     SharedPtr<SharedMemory> shared_memory = Kernel::g_handle_table.Get<SharedMemory>(handle);
     if (shared_memory == nullptr)
-        return InvalidHandle(ErrorModule::Kernel);
+        return ERR_INVALID_HANDLE;
 
     MemoryPermission permissions_type = static_cast<MemoryPermission>(permissions);
     switch (permissions_type) {
@@ -108,7 +109,7 @@ static ResultCode ConnectToPort(Handle* out, const char* port_name) {
 static ResultCode SendSyncRequest(Handle handle) {
     SharedPtr<Kernel::Session> session = Kernel::g_handle_table.Get<Kernel::Session>(handle);
     if (session == nullptr) {
-        return InvalidHandle(ErrorModule::Kernel);
+        return ERR_INVALID_HANDLE;
     }
 
     LOG_TRACE(Kernel_SVC, "called handle=0x%08X(%s)", handle, session->GetName().c_str());
@@ -127,7 +128,7 @@ static ResultCode CloseHandle(Handle handle) {
 static ResultCode WaitSynchronization1(Handle handle, s64 nano_seconds) {
     auto object = Kernel::g_handle_table.GetWaitObject(handle);
     if (object == nullptr)
-        return InvalidHandle(ErrorModule::Kernel);
+        return ERR_INVALID_HANDLE;
 
     LOG_TRACE(Kernel_SVC, "called handle=0x%08X(%s:%s), nanoseconds=%lld", handle,
             object->GetTypeName().c_str(), object->GetName().c_str(), nano_seconds);
@@ -176,7 +177,7 @@ static ResultCode WaitSynchronizationN(s32* out, Handle* handles, s32 handle_cou
         for (int i = 0; i < handle_count; ++i) {
             auto object = Kernel::g_handle_table.GetWaitObject(handles[i]);
             if (object == nullptr)
-                return InvalidHandle(ErrorModule::Kernel);
+                return ERR_INVALID_HANDLE;
 
             // Check if the current thread should wait on this object...
             if (object->ShouldWait()) {
@@ -272,7 +273,7 @@ static ResultCode ArbitrateAddress(Handle handle, u32 address, u32 type, u32 val
 
     SharedPtr<AddressArbiter> arbiter = Kernel::g_handle_table.Get<AddressArbiter>(handle);
     if (arbiter == nullptr)
-        return InvalidHandle(ErrorModule::Kernel);
+        return ERR_INVALID_HANDLE;
 
     return arbiter->ArbitrateAddress(static_cast<Kernel::ArbitrationType>(type),
             address, value, nanoseconds);
@@ -347,7 +348,7 @@ static void ExitThread() {
 static ResultCode GetThreadPriority(s32* priority, Handle handle) {
     const SharedPtr<Kernel::Thread> thread = Kernel::g_handle_table.Get<Kernel::Thread>(handle);
     if (thread == nullptr)
-        return InvalidHandle(ErrorModule::Kernel);
+        return ERR_INVALID_HANDLE;
 
     *priority = thread->GetPriority();
     return RESULT_SUCCESS;
@@ -357,7 +358,7 @@ static ResultCode GetThreadPriority(s32* priority, Handle handle) {
 static ResultCode SetThreadPriority(Handle handle, s32 priority) {
     SharedPtr<Kernel::Thread> thread = Kernel::g_handle_table.Get<Kernel::Thread>(handle);
     if (thread == nullptr)
-        return InvalidHandle(ErrorModule::Kernel);
+        return ERR_INVALID_HANDLE;
 
     thread->SetPriority(priority);
     return RESULT_SUCCESS;
@@ -386,7 +387,7 @@ static ResultCode ReleaseMutex(Handle handle) {
 
     SharedPtr<Mutex> mutex = Kernel::g_handle_table.Get<Mutex>(handle);
     if (mutex == nullptr)
-        return InvalidHandle(ErrorModule::Kernel);
+        return ERR_INVALID_HANDLE;
 
     mutex->Release();
     return RESULT_SUCCESS;
@@ -398,7 +399,7 @@ static ResultCode GetThreadId(u32* thread_id, Handle handle) {
 
     const SharedPtr<Kernel::Thread> thread = Kernel::g_handle_table.Get<Kernel::Thread>(handle);
     if (thread == nullptr)
-        return InvalidHandle(ErrorModule::Kernel);
+        return ERR_INVALID_HANDLE;
 
     *thread_id = thread->GetThreadId();
     return RESULT_SUCCESS;
@@ -430,7 +431,7 @@ static ResultCode ReleaseSemaphore(s32* count, Handle handle, s32 release_count)
 
     SharedPtr<Semaphore> semaphore = Kernel::g_handle_table.Get<Semaphore>(handle);
     if (semaphore == nullptr)
-        return InvalidHandle(ErrorModule::Kernel);
+        return ERR_INVALID_HANDLE;
 
     ResultVal<s32> release_res = semaphore->Release(release_count);
     if (release_res.Failed())
@@ -476,7 +477,7 @@ static ResultCode SignalEvent(Handle handle) {
 
     auto evt = Kernel::g_handle_table.Get<Kernel::Event>(handle);
     if (evt == nullptr)
-        return InvalidHandle(ErrorModule::Kernel);
+        return ERR_INVALID_HANDLE;
 
     evt->Signal();
     HLE::Reschedule(__func__);
@@ -489,7 +490,7 @@ static ResultCode ClearEvent(Handle handle) {
 
     auto evt = Kernel::g_handle_table.Get<Kernel::Event>(handle);
     if (evt == nullptr)
-        return InvalidHandle(ErrorModule::Kernel);
+        return ERR_INVALID_HANDLE;
 
     evt->Clear();
     return RESULT_SUCCESS;
@@ -520,7 +521,7 @@ static ResultCode ClearTimer(Handle handle) {
 
     SharedPtr<Timer> timer = Kernel::g_handle_table.Get<Timer>(handle);
     if (timer == nullptr)
-        return InvalidHandle(ErrorModule::Kernel);
+        return ERR_INVALID_HANDLE;
 
     timer->Clear();
     return RESULT_SUCCESS;
@@ -534,7 +535,7 @@ static ResultCode SetTimer(Handle handle, s64 initial, s64 interval) {
 
     SharedPtr<Timer> timer = Kernel::g_handle_table.Get<Timer>(handle);
     if (timer == nullptr)
-        return InvalidHandle(ErrorModule::Kernel);
+        return ERR_INVALID_HANDLE;
 
     timer->Set(initial, interval);
     return RESULT_SUCCESS;
@@ -548,7 +549,7 @@ static ResultCode CancelTimer(Handle handle) {
 
     SharedPtr<Timer> timer = Kernel::g_handle_table.Get<Timer>(handle);
     if (timer == nullptr)
-        return InvalidHandle(ErrorModule::Kernel);
+        return ERR_INVALID_HANDLE;
 
     timer->Cancel();
     return RESULT_SUCCESS;

--- a/src/core/mem_map.h
+++ b/src/core/mem_map.h
@@ -7,12 +7,9 @@
 #include "common/common.h"
 #include "common/common_types.h"
 
-namespace Memory {
+#include "core/hle/kernel/kernel.h"
 
-// TODO: It would be nice to eventually replace these with strong types that prevent accidental
-// conversion between each other.
-typedef u32 VAddr; ///< Represents a pointer in the ARM11 virtual address space.
-typedef u32 PAddr; ///< Represents a pointer in the physical address space.
+namespace Memory {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -190,7 +187,3 @@ VAddr PhysicalToVirtualAddress(PAddr addr);
 PAddr VirtualToPhysicalAddress(VAddr addr);
 
 } // namespace
-
-// These are used often, so re-export then on the root namespace
-using Memory::VAddr;
-using Memory::PAddr;


### PR DESCRIPTION
This continues #455 by converting the rest of the Kernel objects to not use Handles in their internal APIs. It also features some clean-ups around the code enabled by this.

My next PR will resolve some circular reference issues present between Thread and WaitObject, and then finally enable handle closing and object freeing.

PS: I recommend a commit-per-commit review, since they are pretty well organized.
Also, I didn't have time to test much, so I probably broke many things.