### PR TITLE
shared_memory: Fix assignments in SharedMemory::Map

### DIFF
--- a/src/core/hle/kernel/shared_memory.cpp
+++ b/src/core/hle/kernel/shared_memory.cpp
@@ -30,9 +30,9 @@ ResultCode SharedMemory::Map(VAddr address, MemoryPermission permissions,
                 ErrorSummary::InvalidArgument, ErrorLevel::Permanent);
     }
 
-    base_address = address;
-    permissions = permissions;
-    other_permissions = other_permissions;
+    this->base_address = address;
+    this->permissions = permissions;
+    this->other_permissions = other_permissions;
 
     return RESULT_SUCCESS;
 }

--- a/src/core/hle/kernel/shared_memory.h
+++ b/src/core/hle/kernel/shared_memory.h
@@ -51,7 +51,7 @@ public:
     */
     ResultVal<u8*> GetPointer(u32 offset = 0);
 
-    VAddr base_address;                   ///< Address of shared memory block in RAM
+    VAddr base_address;                 ///< Address of shared memory block in RAM
     MemoryPermission permissions;       ///< Permissions of shared memory block (SVC field)
     MemoryPermission other_permissions; ///< Other permissions of shared memory block (SVC field)
     std::string name;                   ///< Name of shared memory object (optional)


### PR DESCRIPTION
added `this->` to `base_address` for side-by-side consistency.