### PR TITLE
arm: Cleanup.

### DIFF
--- a/src/core/arm/skyeye_common/armdefs.h
+++ b/src/core/arm/skyeye_common/armdefs.h
@@ -395,53 +395,41 @@ So, if lateabtSig=1, then it means Late Abort Model(Base Updated Abort Model)
 #define DIFF_WRITE 0
 
 typedef ARMul_State arm_core_t;
-#define ResetPin NresetSig
-#define FIQPin NfiqSig
-#define IRQPin NirqSig
-#define AbortPin abortSig
-#define TransPin NtransSig
-#define BigEndPin bigendSig
-#define Prog32Pin prog32Sig
-#define Data32Pin data32Sig
-#define LateAbortPin lateabtSig
 
 /***************************************************************************\
 *                        Types of ARM we know about                         *
 \***************************************************************************/
 
-/* The bitflags */
-#define ARM_Fix26_Prop   0x01
-#define ARM_Nexec_Prop   0x02
-#define ARM_Debug_Prop   0x10
-#define ARM_Isync_Prop   ARM_Debug_Prop
-#define ARM_Lock_Prop    0x20
-#define ARM_v4_Prop      0x40
-#define ARM_v5_Prop      0x80
-#define ARM_v6_Prop      0xc0
+enum {
+    ARM_Fix26_Prop  = 0x01,
+    ARM_Nexec_Prop  = 0x02,
+    ARM_Debug_Prop  = 0x10,
+    ARM_Isync_Prop  = ARM_Debug_Prop,
+    ARM_Lock_Prop   = 0x20,
+    ARM_v4_Prop     = 0x40,
+    ARM_v5_Prop     = 0x80,
+    ARM_v6_Prop     = 0xc0,
 
-#define ARM_v5e_Prop     0x100
-#define ARM_XScale_Prop  0x200
-#define ARM_ep9312_Prop  0x400
-#define ARM_iWMMXt_Prop  0x800
-#define ARM_PXA27X_Prop  0x1000
-#define ARM_v7_Prop      0x2000
+    ARM_v5e_Prop    = 0x100,
+    ARM_XScale_Prop = 0x200,
+    ARM_ep9312_Prop = 0x400,
+    ARM_iWMMXt_Prop = 0x800,
+    ARM_PXA27X_Prop = 0x1000,
+    ARM_v7_Prop     = 0x2000,
 
-/* ARM2 family */
-#define ARM2    (ARM_Fix26_Prop)
-#define ARM2as  ARM2
-#define ARM61   ARM2
-#define ARM3    ARM2
+    // ARM2 family
+    ARM2    = ARM_Fix26_Prop,
+    ARM2as  = ARM2,
+    ARM61   = ARM2,
+    ARM3    = ARM2,
 
-#ifdef ARM60            /* previous definition in armopts.h */
-#undef ARM60
-#endif
-
-/* ARM6 family */
-#define ARM6    (ARM_Lock_Prop)
-#define ARM60   ARM6
-#define ARM600  ARM6
-#define ARM610  ARM6
-#define ARM620  ARM6
+    // ARM6 family
+    ARM6    = ARM_Lock_Prop,
+    ARM60   = ARM6,
+    ARM600  = ARM6,
+    ARM610  = ARM6,
+    ARM620  = ARM6
+};
 
 
 /***************************************************************************\
@@ -456,41 +444,44 @@ typedef ARMul_State arm_core_t;
 *                      The hardware vector addresses                        *
 \***************************************************************************/
 
-#define ARMResetV 0L
-#define ARMUndefinedInstrV 4L
-#define ARMSWIV 8L
-#define ARMPrefetchAbortV 12L
-#define ARMDataAbortV 16L
-#define ARMAddrExceptnV 20L
-#define ARMIRQV 24L
-#define ARMFIQV 28L
-#define ARMErrorV 32L        /* This is an offset, not an address ! */
+enum {
+    ARMResetV          = 0,
+    ARMUndefinedInstrV = 4,
+    ARMSWIV            = 8,
+    ARMPrefetchAbortV  = 12,
+    ARMDataAbortV      = 16,
+    ARMAddrExceptnV    = 20,
+    ARMIRQV            = 24,
+    ARMFIQV            = 28,
+    ARMErrorV          = 32, // This is an offset, not an address!
 
-#define ARMul_ResetV ARMResetV
-#define ARMul_UndefinedInstrV ARMUndefinedInstrV
-#define ARMul_SWIV ARMSWIV
-#define ARMul_PrefetchAbortV ARMPrefetchAbortV
-#define ARMul_DataAbortV ARMDataAbortV
-#define ARMul_AddrExceptnV ARMAddrExceptnV
-#define ARMul_IRQV ARMIRQV
-#define ARMul_FIQV ARMFIQV
+    ARMul_ResetV          = ARMResetV,
+    ARMul_UndefinedInstrV = ARMUndefinedInstrV,
+    ARMul_SWIV            = ARMSWIV,
+    ARMul_PrefetchAbortV  = ARMPrefetchAbortV,
+    ARMul_DataAbortV      = ARMDataAbortV,
+    ARMul_AddrExceptnV    = ARMAddrExceptnV,
+    ARMul_IRQV            = ARMIRQV,
+    ARMul_FIQV            = ARMFIQV
+};
 
 /***************************************************************************\
 *                          Mode and Bank Constants                          *
 \***************************************************************************/
 
-#define USER26MODE 0L
-#define FIQ26MODE 1L
-#define IRQ26MODE 2L
-#define SVC26MODE 3L
-#define USER32MODE 16L
-#define FIQ32MODE 17L
-#define IRQ32MODE 18L
-#define SVC32MODE 19L
-#define ABORT32MODE 23L
-#define UNDEF32MODE 27L
-//chy 2006-02-15 add system32 mode
-#define SYSTEM32MODE 31L
+enum {
+    USER26MODE   = 0,
+    FIQ26MODE    = 1,
+    IRQ26MODE    = 2,
+    SVC26MODE    = 3,
+    USER32MODE   = 16,
+    FIQ32MODE    = 17,
+    IRQ32MODE    = 18,
+    SVC32MODE    = 19,
+    ABORT32MODE  = 23,
+    UNDEF32MODE  = 27,
+    SYSTEM32MODE = 31
+};
 
 #define ARM32BITMODE (state->Mode > 3)
 #define ARM26BITMODE (state->Mode <= 3)
@@ -499,14 +490,17 @@ typedef ARMul_State arm_core_t;
 #define ARMul_MODE32BIT ARM32BITMODE
 #define ARMul_MODE26BIT ARM26BITMODE
 
-#define USERBANK 0
-#define FIQBANK 1
-#define IRQBANK 2
-#define SVCBANK 3
-#define ABORTBANK 4
-#define UNDEFBANK 5
-#define DUMMYBANK 6
-#define SYSTEMBANK USERBANK
+enum {
+    USERBANK   = 0,
+    FIQBANK    = 1,
+    IRQBANK    = 2,
+    SVCBANK    = 3,
+    ABORTBANK  = 4,
+    UNDEFBANK  = 5,
+    DUMMYBANK  = 6,
+    SYSTEMBANK = USERBANK
+};
+
 #define BANK_CAN_ACCESS_SPSR(bank)  \
   ((bank) != USERBANK && (bank) != SYSTEMBANK && (bank) != DUMMYBANK)
 
@@ -613,40 +607,44 @@ extern ARMword ARMul_MemAccess(ARMul_State* state, ARMword, ARMword,
 *            Definitons of things in the co-processor interface             *
 \***************************************************************************/
 
-#define ARMul_FIRST 0
-#define ARMul_TRANSFER 1
-#define ARMul_BUSY 2
-#define ARMul_DATA 3
-#define ARMul_INTERRUPT 4
-#define ARMul_DONE 0
-#define ARMul_CANT 1
-#define ARMul_INC 3
+enum {
+    ARMul_FIRST     = 0,
+    ARMul_TRANSFER  = 1,
+    ARMul_BUSY      = 2,
+    ARMul_DATA      = 3,
+    ARMul_INTERRUPT = 4,
+    ARMul_DONE      = 0,
+    ARMul_CANT      = 1,
+    ARMul_INC       = 3
+};
 
-#define ARMul_CP13_R0_FIQ       0x1
-#define ARMul_CP13_R0_IRQ       0x2
-#define ARMul_CP13_R8_PMUS      0x1
+enum {
+    ARMul_CP13_R0_FIQ       = 0x1,
+    ARMul_CP13_R0_IRQ       = 0x2,
+    ARMul_CP13_R8_PMUS      = 0x1,
 
-#define ARMul_CP14_R0_ENABLE    0x0001
-#define ARMul_CP14_R0_CLKRST    0x0004
-#define ARMul_CP14_R0_CCD       0x0008
-#define ARMul_CP14_R0_INTEN0    0x0010
-#define ARMul_CP14_R0_INTEN1    0x0020
-#define ARMul_CP14_R0_INTEN2    0x0040
-#define ARMul_CP14_R0_FLAG0     0x0100
-#define ARMul_CP14_R0_FLAG1     0x0200
-#define ARMul_CP14_R0_FLAG2     0x0400
-#define ARMul_CP14_R10_MOE_IB   0x0004
-#define ARMul_CP14_R10_MOE_DB   0x0008
-#define ARMul_CP14_R10_MOE_BT   0x000c
-#define ARMul_CP15_R1_ENDIAN    0x0080
-#define ARMul_CP15_R1_ALIGN     0x0002
-#define ARMul_CP15_R5_X         0x0400
-#define ARMul_CP15_R5_ST_ALIGN  0x0001
-#define ARMul_CP15_R5_IMPRE     0x0406
-#define ARMul_CP15_R5_MMU_EXCPT 0x0400
-#define ARMul_CP15_DBCON_M      0x0100
-#define ARMul_CP15_DBCON_E1     0x000c
-#define ARMul_CP15_DBCON_E0     0x0003
+    ARMul_CP14_R0_ENABLE    = 0x0001,
+    ARMul_CP14_R0_CLKRST    = 0x0004,
+    ARMul_CP14_R0_CCD       = 0x0008,
+    ARMul_CP14_R0_INTEN0    = 0x0010,
+    ARMul_CP14_R0_INTEN1    = 0x0020,
+    ARMul_CP14_R0_INTEN2    = 0x0040,
+    ARMul_CP14_R0_FLAG0     = 0x0100,
+    ARMul_CP14_R0_FLAG1     = 0x0200,
+    ARMul_CP14_R0_FLAG2     = 0x0400,
+    ARMul_CP14_R10_MOE_IB   = 0x0004,
+    ARMul_CP14_R10_MOE_DB   = 0x0008,
+    ARMul_CP14_R10_MOE_BT   = 0x000c,
+    ARMul_CP15_R1_ENDIAN    = 0x0080,
+    ARMul_CP15_R1_ALIGN     = 0x0002,
+    ARMul_CP15_R5_X         = 0x0400,
+    ARMul_CP15_R5_ST_ALIGN  = 0x0001,
+    ARMul_CP15_R5_IMPRE     = 0x0406,
+    ARMul_CP15_R5_MMU_EXCPT = 0x0400,
+    ARMul_CP15_DBCON_M      = 0x0100,
+    ARMul_CP15_DBCON_E1     = 0x000c,
+    ARMul_CP15_DBCON_E0     = 0x0003
+};
 
 extern unsigned ARMul_CoProInit(ARMul_State* state);
 extern void ARMul_CoProExit(ARMul_State* state);
@@ -675,12 +673,9 @@ extern unsigned ARMul_OSHandleSWI(ARMul_State* state, ARMword number);
 }
 #endif
 
-
 extern ARMword ARMul_OSLastErrorP(ARMul_State* state);
-
 extern ARMword ARMul_Debug(ARMul_State* state, ARMword pc, ARMword instr);
 extern unsigned ARMul_OSException(ARMul_State* state, ARMword vector, ARMword pc);
-extern int rdi_log;
 
 enum ConditionCode {
     EQ = 0,
@@ -729,12 +724,6 @@ enum ConditionCode {
 #define IFFLAGS    state->IFFlags
 #endif //VFLAG
 
-#define FLAG_MASK    0xf0000000
-#define NBIT_SHIFT    31
-#define ZBIT_SHIFT    30
-#define CBIT_SHIFT    29
-#define VBIT_SHIFT    28
-
 #define SKYEYE_OUTREGS(fd) { fprintf ((fd), "R %x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,C %x,S %x,%x,%x,%x,%x,%x,%x,M %x,B %x,E %x,I %x,P %x,T %x,L %x,D %x,",\
                          state->Reg[0],state->Reg[1],state->Reg[2],state->Reg[3], \
                          state->Reg[4],state->Reg[5],state->Reg[6],state->Reg[7], \
@@ -777,14 +766,6 @@ RUn %x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x\n",\
                          state->RegBank[5][8],state->RegBank[5][9],state->RegBank[5][10],state->RegBank[5][11], \
                          state->RegBank[5][12],state->RegBank[5][13],state->RegBank[5][14],state->RegBank[5][15] \
         );}
-
-
-#define SA1110        0x6901b110
-#define SA1100        0x4401a100
-#define PXA250        0x69052100
-#define PXA270        0x69054110
-//#define PXA250      0x69052903
-// 0x69052903;  //PXA250 B1 from intel 278522-001.pdf
 
 extern bool AddOverflow(ARMword, ARMword, ARMword);
 extern bool SubOverflow(ARMword, ARMword, ARMword);

--- a/src/core/arm/skyeye_common/armdefs.h
+++ b/src/core/arm/skyeye_common/armdefs.h
@@ -15,8 +15,7 @@
     along with this program; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA. */
 
-#ifndef _ARMDEFS_H_
-#define _ARMDEFS_H_
+#pragma once
 
 #include <cerrno>
 #include <csignal>
@@ -33,21 +32,6 @@
 #include "core/arm/skyeye_common/armmmu.h"
 #include "core/arm/skyeye_common/skyeye_defs.h"
 
-#if EMU_PLATFORM == PLATFORM_LINUX
-#include <sys/time.h>
-#include <unistd.h>
-#endif
-
-#if 0
-#if 0
-#define DIFF_STATE 1
-#define __FOLLOW_MODE__ 0
-#else
-#define DIFF_STATE 0
-#define __FOLLOW_MODE__ 1
-#endif
-#endif
-
 #ifndef FALSE
 #define FALSE 0
 #define TRUE 1
@@ -58,13 +42,6 @@
 #define LOWHIGH 1
 #define HIGHLOW 2
 
-//#define DBCT_TEST_SPEED
-#define DBCT_TEST_SPEED_SEC    10
-
-#define ARM_BYTE_TYPE         0
-#define ARM_HALFWORD_TYPE     1
-#define ARM_WORD_TYPE         2
-
 //the define of cachetype
 #define NONCACHE  0
 #define DATACACHE  1
@@ -73,18 +50,11 @@
 #define POS(i) ( (~(i)) >> 31 )
 #define NEG(i) ( (i) >> 31 )
 
-#ifndef __STDC__
-typedef char *VoidStar;
-#endif
-
 typedef u64 ARMdword;  // must be 64 bits wide
 typedef u32 ARMword;   // must be 32 bits wide
 typedef u16 ARMhword;  // must be 16 bits wide
 typedef u8 ARMbyte;    // must be 8 bits wide
 typedef struct ARMul_State ARMul_State;
-typedef struct ARMul_io ARMul_io;
-typedef struct ARMul_Energy ARMul_Energy;
-
 
 typedef unsigned ARMul_CPInits(ARMul_State* state);
 typedef unsigned ARMul_CPExits(ARMul_State* state);
@@ -98,65 +68,6 @@ typedef unsigned ARMul_CDPs(ARMul_State* state, unsigned type, ARMword instr);
 typedef unsigned ARMul_CPReads(ARMul_State* state, unsigned reg, ARMword* value);
 typedef unsigned ARMul_CPWrites(ARMul_State* state, unsigned reg, ARMword value);
 
-
-//added by ksh,2004-3-5
-struct ARMul_io
-{
-    ARMword *instr;      // to display the current interrupt state
-    ARMword *net_flag;   // to judge if network is enabled
-    ARMword *net_int;    // netcard interrupt
-
-    //ywc,2004-04-01
-    ARMword *ts_int;
-    ARMword *ts_is_enable;
-    ARMword *ts_addr_begin;
-    ARMword *ts_addr_end;
-    ARMword *ts_buffer;
-};
-
-/* added by ksh,2004-11-26,some energy profiling */
-struct ARMul_Energy
-{
-    int energy_prof;        /* <tktan>  BUG200103282109 : for energy profiling */
-    int enable_func_energy; /* <tktan> BUG200105181702 */
-    char *func_energy;
-    int func_display;       /* <tktan> BUG200103311509 : for function call display */
-    int func_disp_start;    /* <tktan> BUG200104191428 : to start func profiling */
-    char *start_func;       /* <tktan> BUG200104191428 */
-
-    FILE *outfile;          /* <tktan> BUG200105201531 : direct console to file */
-    long long tcycle, pcycle;
-    float t_energy;
-    void *cur_task;         /* <tktan> BUG200103291737 */
-    long long t_mem_cycle, t_idle_cycle, t_uart_cycle;
-    long long p_mem_cycle, p_idle_cycle, p_uart_cycle;
-    long long p_io_update_tcycle;
-    /*record CCCR,to get current core frequency */
-    ARMword cccr;
-};
-#if 0
-#define MAX_BANK 8
-#define MAX_STR  1024
-
-typedef struct mem_bank
-{
-    ARMword (*read_byte) (ARMul_State* state, ARMword addr);
-    void (*write_byte) (ARMul_State* state, ARMword addr, ARMword data);
-    ARMword (*read_halfword) (ARMul_State* state, ARMword addr);
-    void (*write_halfword) (ARMul_State* state, ARMword addr, ARMword data);
-    ARMword (*read_word) (ARMul_State* state, ARMword addr);
-    void (*write_word) (ARMul_State* state, ARMword addr, ARMword data);
-    unsigned int addr, len;
-    char filename[MAX_STR];
-    unsigned type;        //chy 2003-09-21: maybe io,ram,rom
-} mem_bank_t;
-typedef struct
-{
-    int bank_num;
-    int current_num;    /*current num of bank */
-    mem_bank_t mem_banks[MAX_BANK];
-} mem_config_t;
-#endif
 #define VFP_REG_NUM 64
 struct ARMul_State
 {
@@ -196,9 +107,8 @@ struct ARMul_State
     ARMdword Accumulator;
 
     ARMword NFlag, ZFlag, CFlag, VFlag, IFFlags;    /* dummy flags for speed */
-        unsigned long long int icounter, debug_icounter, kernel_icounter;
-        unsigned int shifter_carry_out;
-        //ARMword translate_pc;
+    unsigned long long int icounter, debug_icounter, kernel_icounter;
+    unsigned int shifter_carry_out;
 
     /* add armv6 flags dyf:2010-08-09 */
     ARMword GEFlag, EFlag, AFlag, QFlag;
@@ -226,9 +136,6 @@ struct ARMul_State
     unsigned CanWatch;                      /* set by memory interface if its willing to suffer the
                                                overhead of checking for watchpoints on each memory
                                                access */
-    unsigned int StopHandle;
-
-    char *CommandLine;                      /* Command Line from ARMsd */
 
     ARMul_CPInits *CPInit[16];              /* coprocessor initialisers */
     ARMul_CPExits *CPExit[16];              /* coprocessor finalisers */
@@ -243,10 +150,6 @@ struct ARMul_State
     ARMul_CPWrites *CPWrite[16];            /* Write CP register */
     unsigned char *CPData[16];              /* Coprocessor data */
     unsigned char const *CPRegWords[16];    /* map of coprocessor register sizes */
-
-    unsigned EventSet;                      /* the number of events in the queue */
-    unsigned int Now;                       /* time to the nearest cycle */
-    struct EventNode **EventPtr;            /* the event list */
 
     unsigned Debug;                         /* show instructions as they are executed */
     unsigned NresetSig;                     /* reset the processor */
@@ -300,17 +203,9 @@ So, if lateabtSig=1, then it means Late Abort Model(Base Updated Abort Model)
     ARMword Base;                /* extra hand for base writeback */
     ARMword AbortAddr;           /* to keep track of Prefetch aborts */
 
-    const struct Dbg_HostosInterface *hostif;
-
     int verbose;        /* non-zero means print various messages like the banner */
 
     int mmu_inited;
-    //mem_state_t mem;
-    /*remove io_state to skyeye_mach_*.c files */
-    //io_state_t io;
-    /* point to a interrupt pending register. now for skyeye-ne2k.c
-     * later should move somewhere. e.g machine_config_t*/
-
 
     //chy: 2003-08-11, for different arm core type
     unsigned is_v4;        /* Are we emulating a v4 architecture (or higher) ?  */
@@ -321,44 +216,17 @@ So, if lateabtSig=1, then it means Late Abort Model(Base Updated Abort Model)
     unsigned is_XScale;    /* Are we emulating an XScale architecture ?  */
     unsigned is_iWMMXt;    /* Are we emulating an iWMMXt co-processor ?  */
     unsigned is_ep9312;    /* Are we emulating a Cirrus Maverick co-processor ?  */
-    //chy 2005-09-19
     unsigned is_pxa27x;    /* Are we emulating a Intel PXA27x co-processor ?  */
+
     //chy: seems only used in xscale's CP14
-    unsigned int LastTime; /* Value of last call to ARMul_Time() */
     ARMword CP14R0_CCD;    /* used to count 64 clock cycles with CP14 R0 bit 3 set */
-
-
-    //added by ksh:for handle different machs io 2004-3-5
-    ARMul_io mach_io;
-
-    /*added by ksh,2004-11-26,some energy profiling*/
-    ARMul_Energy energy;
-
-    //teawater add for next_dis 2004.10.27-----------------------
-    int disassemble;
-
-
-    //teawater add for arm2x86 2005.02.15-------------------------------------------
-    u32 trap;
-    u32 tea_break_addr;
-    u32 tea_break_ok;
-    int tea_pc;
 
     //teawater add for arm2x86 2005.07.05-------------------------------------------
     //arm_arm A2-18
-    int abort_model;    //0 Base Restored Abort Model, 1 the Early Abort Model, 2 Base Updated Abort Model 
-
-    //teawater change for return if running tb dirty 2005.07.09---------------------
-    void *tb_now;
-
-
-    //teawater add for record reg value to ./reg.txt 2005.07.10---------------------
-    FILE *tea_reg_fd;
-
+    int abort_model;    //0 Base Restored Abort Model, 1 the Early Abort Model, 2 Base Updated Abort Model
 
     /*added by ksh in 2005-10-1*/
     cpu_config_t *cpu;
-    //mem_config_t *mem_bank;
 
     /* added LPC remap function */
     int vector_remap_flag;
@@ -367,23 +235,12 @@ So, if lateabtSig=1, then it means Late Abort Model(Base Updated Abort Model)
 
     u32 step;
     u32 cycle;
-    int stop_simulator;
-    conf_object_t *dyncom_cpu;
-//teawater add DBCT_TEST_SPEED 2005.10.04---------------------------------------
-#ifdef DBCT_TEST_SPEED
-    uint64_t    instr_count;
-#endif    //DBCT_TEST_SPEED
-//    FILE * state_log;
-//diff log
-//#if DIFF_STATE
-    FILE * state_log;
-//#endif
+
     /* monitored memory for exclusice access */
     ARMword exclusive_tag_array[128];
     /* 1 means exclusive access and 0 means open access */
     ARMword exclusive_access_state;
 
-    memory_space_intf space;    
     u32 CurrInstr;
     u32 last_pc; /* the last pc executed */
     u32 last_instr; /* the last inst executed */
@@ -392,7 +249,6 @@ So, if lateabtSig=1, then it means Late Abort Model(Base Updated Abort Model)
     u32 WritePc[17];
     u32 CurrWrite;
 };
-#define DIFF_WRITE 0
 
 typedef ARMul_State arm_core_t;
 
@@ -519,13 +375,6 @@ extern void ARMul_Reset(ARMul_State* state);
 extern ARMul_State *ARMul_NewState(ARMul_State* state);
 extern ARMword ARMul_DoProg(ARMul_State* state);
 extern ARMword ARMul_DoInstr(ARMul_State* state);
-/***************************************************************************\
-*                Definitons of things for event handling                    *
-\***************************************************************************/
-
-extern void ARMul_ScheduleEvent(ARMul_State* state, unsigned int delay, unsigned(*func) ());
-extern void ARMul_EnvokeEvent(ARMul_State* state);
-extern unsigned int ARMul_Time(ARMul_State* state);
 
 /***************************************************************************\
 *                          Useful support routines                          *
@@ -724,56 +573,12 @@ enum ConditionCode {
 #define IFFLAGS    state->IFFlags
 #endif //VFLAG
 
-#define SKYEYE_OUTREGS(fd) { fprintf ((fd), "R %x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,C %x,S %x,%x,%x,%x,%x,%x,%x,M %x,B %x,E %x,I %x,P %x,T %x,L %x,D %x,",\
-                         state->Reg[0],state->Reg[1],state->Reg[2],state->Reg[3], \
-                         state->Reg[4],state->Reg[5],state->Reg[6],state->Reg[7], \
-                         state->Reg[8],state->Reg[9],state->Reg[10],state->Reg[11], \
-                         state->Reg[12],state->Reg[13],state->Reg[14],state->Reg[15], \
-                         state->Cpsr,   state->Spsr[0], state->Spsr[1], state->Spsr[2],\
-                         state->Spsr[3],state->Spsr[4], state->Spsr[5], state->Spsr[6],\
-                         state->Mode,state->Bank,state->ErrorCode,state->instr,state->pc,\
-                         state->temp,state->loaded,state->decoded);}
-
-#define SKYEYE_OUTMOREREGS(fd) { fprintf ((fd),"\
-RUs %x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,\
-RF  %x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,\
-RI  %x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,\
-RS  %x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,\
-RA  %x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,\
-RUn %x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x,%x\n",\
-                         state->RegBank[0][0],state->RegBank[0][1],state->RegBank[0][2],state->RegBank[0][3], \
-                         state->RegBank[0][4],state->RegBank[0][5],state->RegBank[0][6],state->RegBank[0][7], \
-                         state->RegBank[0][8],state->RegBank[0][9],state->RegBank[0][10],state->RegBank[0][11], \
-                         state->RegBank[0][12],state->RegBank[0][13],state->RegBank[0][14],state->RegBank[0][15], \
-                         state->RegBank[1][0],state->RegBank[1][1],state->RegBank[1][2],state->RegBank[1][3], \
-                         state->RegBank[1][4],state->RegBank[1][5],state->RegBank[1][6],state->RegBank[1][7], \
-                         state->RegBank[1][8],state->RegBank[1][9],state->RegBank[1][10],state->RegBank[1][11], \
-                         state->RegBank[1][12],state->RegBank[1][13],state->RegBank[1][14],state->RegBank[1][15], \
-                         state->RegBank[2][0],state->RegBank[2][1],state->RegBank[2][2],state->RegBank[2][3], \
-                         state->RegBank[2][4],state->RegBank[2][5],state->RegBank[2][6],state->RegBank[2][7], \
-                         state->RegBank[2][8],state->RegBank[2][9],state->RegBank[2][10],state->RegBank[2][11], \
-                         state->RegBank[2][12],state->RegBank[2][13],state->RegBank[2][14],state->RegBank[2][15], \
-                         state->RegBank[3][0],state->RegBank[3][1],state->RegBank[3][2],state->RegBank[3][3], \
-                         state->RegBank[3][4],state->RegBank[3][5],state->RegBank[3][6],state->RegBank[3][7], \
-                         state->RegBank[3][8],state->RegBank[3][9],state->RegBank[3][10],state->RegBank[3][11], \
-                         state->RegBank[3][12],state->RegBank[3][13],state->RegBank[3][14],state->RegBank[3][15], \
-                         state->RegBank[4][0],state->RegBank[4][1],state->RegBank[4][2],state->RegBank[4][3], \
-                         state->RegBank[4][4],state->RegBank[4][5],state->RegBank[4][6],state->RegBank[4][7], \
-                         state->RegBank[4][8],state->RegBank[4][9],state->RegBank[4][10],state->RegBank[4][11], \
-                         state->RegBank[4][12],state->RegBank[4][13],state->RegBank[4][14],state->RegBank[4][15], \
-                         state->RegBank[5][0],state->RegBank[5][1],state->RegBank[5][2],state->RegBank[5][3], \
-                         state->RegBank[5][4],state->RegBank[5][5],state->RegBank[5][6],state->RegBank[5][7], \
-                         state->RegBank[5][8],state->RegBank[5][9],state->RegBank[5][10],state->RegBank[5][11], \
-                         state->RegBank[5][12],state->RegBank[5][13],state->RegBank[5][14],state->RegBank[5][15] \
-        );}
-
 extern bool AddOverflow(ARMword, ARMword, ARMword);
 extern bool SubOverflow(ARMword, ARMword, ARMword);
 
 extern void ARMul_UndefInstr(ARMul_State*, ARMword);
 extern void ARMul_FixCPSR(ARMul_State*, ARMword, ARMword);
 extern void ARMul_FixSPSR(ARMul_State*, ARMword, ARMword);
-extern void ARMul_ConsolePrint(ARMul_State*, const char*, ...);
 extern void ARMul_SelectProcessor(ARMul_State*, unsigned);
 
 extern u32 AddWithCarry(u32, u32, u32, bool*, bool*);
@@ -791,8 +596,3 @@ extern u16 ARMul_UnsignedSaturatedSub16(u16, u16);
 extern u8 ARMul_UnsignedAbsoluteDifference(u8, u8);
 extern u32 ARMul_SignedSatQ(s32, u8, bool*);
 extern u32 ARMul_UnsignedSatQ(s32, u8, bool*);
-
-#define DIFF_LOG 0
-#define SAVE_LOG 0
-
-#endif /* _ARMDEFS_H_ */

--- a/src/core/arm/skyeye_common/armemu.h
+++ b/src/core/arm/skyeye_common/armemu.h
@@ -575,8 +575,6 @@ extern ARMword ARMul_GetPC (ARMul_State *);
 extern ARMword ARMul_GetNextPC (ARMul_State *);
 extern ARMword ARMul_GetR15 (ARMul_State *);
 extern ARMword ARMul_GetCPSR (ARMul_State *);
-extern void ARMul_EnvokeEvent (ARMul_State *);
-extern unsigned int ARMul_Time (ARMul_State *);
 extern void ARMul_NegZero (ARMul_State *, ARMword);
 extern void ARMul_SetPC (ARMul_State *, ARMword);
 extern void ARMul_SetR15 (ARMul_State *, ARMword);
@@ -603,8 +601,7 @@ extern void ARMul_AddCarry (ARMul_State *, ARMword, ARMword, ARMword);
 extern tdstate ARMul_ThumbDecode (ARMul_State *, ARMword, ARMword, ARMword *);
 extern ARMword ARMul_GetReg (ARMul_State *, unsigned, unsigned);
 extern void ARMul_SetReg (ARMul_State *, unsigned, unsigned, ARMword);
-extern void ARMul_ScheduleEvent (ARMul_State *, unsigned int,
-				 unsigned (*)(ARMul_State *));
+
 /* Coprocessor support functions.  */
 extern unsigned ARMul_CoProInit (ARMul_State *);
 extern void ARMul_CoProExit (ARMul_State *);

--- a/src/core/arm/skyeye_common/skyeye_defs.h
+++ b/src/core/arm/skyeye_common/skyeye_defs.h
@@ -1,5 +1,4 @@
-#ifndef CORE_ARM_SKYEYE_DEFS_H_
-#define CORE_ARM_SKYEYE_DEFS_H_
+#pragma once
 
 #include "common/common.h"
 
@@ -8,21 +7,15 @@
 
 typedef struct
 {
-	const char *cpu_arch_name;	/*cpu architecture version name.e.g. armv4t */
-	const char *cpu_name;	/*cpu name. e.g. arm7tdmi or arm720t */
-	u32 cpu_val;	/*CPU value; also call MMU ID or processor id;see
-				   ARM Architecture Reference Manual B2-6 */
-	u32 cpu_mask;	/*cpu_val's mask. */
-	u32 cachetype;	/*this cpu has what kind of cache */
+	const char *cpu_arch_name; /* CPU architecture version name.e.g. armv4t */
+	const char *cpu_name;      /* CPU name. e.g. arm7tdmi or arm720t */
+	u32 cpu_val;               /*CPU value; also call MMU ID or processor id;see
+	                             ARM Architecture Reference Manual B2-6 */
+	u32 cpu_mask;              /* cpu_val's mask. */
+	u32 cachetype;             /* this CPU has what kind of cache */
 } cpu_config_t;
 
-typedef struct conf_object_s{
-	char* objname;
-	void* obj;
-	char* class_name;
-}conf_object_t;
-
-typedef enum{
+typedef enum {
 	/* No exception */
 	No_exp = 0,
 	/* Memory allocation exception */
@@ -44,70 +37,21 @@ typedef enum{
 
 	/* Unknown exception */
 	Unknown_exp
-}exception_t;
+} exception_t;
 
 typedef enum {
 	Align = 0,
 	UnAlign	
-}align_t;
+} align_t;
 
 typedef enum {
 	Little_endian = 0,
 	Big_endian
-}endian_t;
-//typedef int exception_t;
+} endian_t;
 
-typedef enum{
+typedef enum {
 	Phys_addr = 0,
 	Virt_addr
-}addr_type_t;
-
-typedef exception_t(*read_byte_t)(conf_object_t* target, u32 addr, void *buf, size_t count);
-typedef exception_t(*write_byte_t)(conf_object_t* target, u32 addr, const void *buf, size_t count);
-
-typedef struct memory_space{
-	conf_object_t* conf_obj;
-	read_byte_t read;
-	write_byte_t write;
-}memory_space_intf;
-
-
-/*
- * a running instance for a specific archteciture.
- */
-typedef struct generic_arch_s
-{
-	char* arch_name;
-	void (*init) (void);
-	void (*reset) (void);
-	void (*step_once) (void);
-	void (*set_pc)(u32 addr);
-	u32 (*get_pc)(void);
-	u32 (*get_step)(void);
-	//chy 2004-04-15 
-	//int (*ICE_write_byte) (u32 addr, uint8_t v);
-	//int (*ICE_read_byte)(u32 addr, uint8_t *pv);
-	u32 (*get_regval_by_id)(int id);
-	u32 (*get_regnum)(void);
-	char* (*get_regname_by_id)(int id);
-	exception_t (*set_regval_by_id)(int id, u32 value);
-	/*
-	 * read a data by virtual address.
-	 */
-	exception_t (*mmu_read)(short size, u32 addr, u32 * value);
-	/*
-	 * write a data by a virtual address.
-	 */
-	exception_t (*mmu_write)(short size, u32 addr, u32 value);
-	/**
-	 * get a signal from external
-	 */
-	//exception_t (*signal)(interrupt_signal_t* signal);
-
-	endian_t endianess;
-	align_t alignment;
-} generic_arch_t;
+} addr_type_t;
 
 typedef u32 addr_t;
-
-#endif


### PR DESCRIPTION
Removes a lot of unnecessary stuff that's stuffed into the ARMul_State struct. Now it also takes up less space in memory since it gets rid of a few mallocs as well. Will also make removing the armemu interpreter stuff a little easier in the future.