### PR TITLE
Mutex/synch fixes

### DIFF
--- a/src/core/hle/kernel/mutex.h
+++ b/src/core/hle/kernel/mutex.h
@@ -30,8 +30,7 @@ public:
     static const HandleType HANDLE_TYPE = HandleType::Mutex;
     HandleType GetHandleType() const override { return HANDLE_TYPE; }
 
-    bool initial_locked;                        ///< Initial lock state when mutex was created
-    bool locked;                                ///< Current locked state
+    int lock_count;                             ///< Number of times the mutex has been acquired
     std::string name;                           ///< Name of mutex (optional)
     SharedPtr<Thread> holding_thread;           ///< Thread that has acquired the mutex
 

--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -144,6 +144,8 @@ static ResultCode WaitSynchronization1(Handle handle, s64 nano_seconds) {
     LOG_TRACE(Kernel_SVC, "called handle=0x%08X(%s:%s), nanoseconds=%lld", handle,
             object->GetTypeName().c_str(), object->GetName().c_str(), nano_seconds);
 
+    HLE::Reschedule(__func__);
+
     // Check for next thread to schedule
     if (object->ShouldWait()) {
 
@@ -152,8 +154,6 @@ static ResultCode WaitSynchronization1(Handle handle, s64 nano_seconds) {
 
         // Create an event to wake the thread up after the specified nanosecond delay has passed
         Kernel::GetCurrentThread()->WakeAfterDelay(nano_seconds);
-
-        HLE::Reschedule(__func__);
 
         // NOTE: output of this SVC will be set later depending on how the thread resumes
         return RESULT_INVALID;
@@ -216,6 +216,8 @@ static ResultCode WaitSynchronizationN(s32* out, Handle* handles, s32 handle_cou
         }
     }
 
+    HLE::Reschedule(__func__);
+
     // If thread should wait, then set its state to waiting and then reschedule...
     if (wait_thread) {
 
@@ -228,8 +230,6 @@ static ResultCode WaitSynchronizationN(s32* out, Handle* handles, s32 handle_cou
 
         // Create an event to wake the thread up after the specified nanosecond delay has passed
         Kernel::GetCurrentThread()->WakeAfterDelay(nano_seconds);
-
-        HLE::Reschedule(__func__);
 
         // NOTE: output of this SVC will be set later depending on how the thread resumes
         return RESULT_INVALID;


### PR DESCRIPTION
WaitSynch SVC should always reschedule, and mutexes can be acquired multiple times. Fixes #521.