### PR TITLE
arm: Remove TRUE/FALSE defines

### DIFF
--- a/src/core/arm/interpreter/armcopro.cpp
+++ b/src/core/arm/interpreter/armcopro.cpp
@@ -47,7 +47,7 @@ static unsigned int NoCoPro5W(ARMul_State* state, unsigned int a, ARMword b, ARM
 }
 
 // Install co-processor instruction handlers in this routine.
-unsigned int ARMul_CoProInit(ARMul_State* state)
+void ARMul_CoProInit(ARMul_State* state)
 {
     // Initialise tham all first.
     for (unsigned int i = 0; i < 16; i++)
@@ -71,11 +71,10 @@ unsigned int ARMul_CoProInit(ARMul_State* state)
     // No handlers below here.
 
     // Call all the initialisation routines.
-    for (unsigned int i = 0; i < 16; i++)
+    for (unsigned int i = 0; i < 16; i++) {
         if (state->CPInit[i])
             (state->CPInit[i]) (state);
-
-    return TRUE;
+    }
 }
 
 // Install co-processor finalisation routines in this routine.

--- a/src/core/arm/interpreter/arminit.cpp
+++ b/src/core/arm/interpreter/arminit.cpp
@@ -63,24 +63,22 @@ void ARMul_EmulateInit()
 \***************************************************************************/
 ARMul_State* ARMul_NewState(ARMul_State* state)
 {
-    unsigned i, j;
-
     memset (state, 0, sizeof (ARMul_State));
 
     state->Emulate = RUN;
-    for (i = 0; i < 16; i++) {
+    for (unsigned int i = 0; i < 16; i++) {
         state->Reg[i] = 0;
-        for (j = 0; j < 7; j++)
+        for (unsigned int j = 0; j < 7; j++)
             state->RegBank[j][i] = 0;
     }
-    for (i = 0; i < 7; i++)
+    for (unsigned int i = 0; i < 7; i++)
         state->Spsr[i] = 0;
+
     state->Mode = 0;
 
-    state->Debug = FALSE;
     state->VectorCatch = 0;
-    state->Aborted = FALSE;
-    state->Reseted = FALSE;
+    state->Aborted = false;
+    state->Reseted = false;
     state->Inted = 3;
     state->LastInted = 3;
 

--- a/src/core/arm/skyeye_common/armdefs.h
+++ b/src/core/arm/skyeye_common/armdefs.h
@@ -35,11 +35,6 @@
 #define BITS(s, a, b) ((s << ((sizeof(s) * 8 - 1) - b)) >> (sizeof(s) * 8 - b + a - 1))
 #define BIT(s, n) ((s >> (n)) & 1)
 
-#ifndef FALSE
-#define FALSE 0
-#define TRUE 1
-#endif
-
 #define LOW 0
 #define HIGH 1
 #define LOWHIGH 1
@@ -135,7 +130,6 @@ struct ARMul_State
     unsigned char* CPData[16];              // Coprocessor data
     unsigned char const* CPRegWords[16];    // Map of coprocessor register sizes
 
-    unsigned Debug;                         // Show instructions as they are executed
     unsigned NresetSig;                     // Reset the processor
     unsigned NfiqSig;
     unsigned NirqSig;
@@ -180,12 +174,12 @@ So, if lateabtSig=1, then it means Late Abort Model(Base Updated Abort Model)
 */
     unsigned lateabtSig;
 
-    ARMword Vector;           // Synthesize aborts in cycle modes
-    ARMword Aborted;          // Sticky flag for aborts
-    ARMword Reseted;          // Sticky flag for Reset
+    bool Aborted;             // Sticky flag for aborts
+    bool Reseted;             // Sticky flag for Reset
     ARMword Inted, LastInted; // Sticky flags for interrupts
     ARMword Base;             // Extra hand for base writeback
     ARMword AbortAddr;        // To keep track of Prefetch aborts
+    ARMword Vector;           // Synthesize aborts in cycle modes
 
     // For differentiating ARM core emulaiton.
     bool is_v4;     // Are we emulating a v4 architecture (or higher)?

--- a/src/core/arm/skyeye_common/armemu.h
+++ b/src/core/arm/skyeye_common/armemu.h
@@ -100,10 +100,10 @@ extern ARMword ARMul_ImmedTable[]; // Immediate DP LHS values.
 extern char ARMul_BitList[];       // Number of bits in a byte table.
 
 // Coprocessor support functions.
-extern unsigned ARMul_CoProInit (ARMul_State *);
-extern void ARMul_CoProExit (ARMul_State *);
-extern void ARMul_CoProAttach (ARMul_State *, unsigned, ARMul_CPInits *,
-			       ARMul_CPExits *, ARMul_LDCs *, ARMul_STCs *,
-			       ARMul_MRCs *, ARMul_MCRs *, ARMul_MRRCs *, ARMul_MCRRs *, 
-			       ARMul_CDPs *, ARMul_CPReads *, ARMul_CPWrites *);
-extern void ARMul_CoProDetach (ARMul_State *, unsigned);
+extern void ARMul_CoProInit(ARMul_State*);
+extern void ARMul_CoProExit(ARMul_State*);
+extern void ARMul_CoProAttach(ARMul_State*, unsigned, ARMul_CPInits*,
+                              ARMul_CPExits*, ARMul_LDCs*, ARMul_STCs*,
+                              ARMul_MRCs*, ARMul_MCRs*, ARMul_MRRCs*, ARMul_MCRRs*,
+                              ARMul_CDPs*, ARMul_CPReads*, ARMul_CPWrites*);
+extern void ARMul_CoProDetach(ARMul_State*, unsigned);


### PR DESCRIPTION
- Removed the Debug parameter from ARMul_State since it isn't used.
- Changed ARMul_CoProInit to a void function. It always returned true.