### PR TITLE
dyncom: Remove warning for SXTAH

### DIFF
--- a/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
+++ b/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
@@ -2905,7 +2905,6 @@ ARM_INST_PTR INTERPRETER_TRANSLATE(sxtb16)(unsigned int inst, int index)
 }
 
 ARM_INST_PTR INTERPRETER_TRANSLATE(sxtah)(unsigned int inst, int index){
-    LOG_WARNING(Core_ARM11, "SXTAH untested");
     arm_inst *inst_base = (arm_inst *)AllocBuffer(sizeof(arm_inst) + sizeof(sxtah_inst));
     sxtah_inst *inst_cream = (sxtah_inst *)inst_base->component;
 


### PR DESCRIPTION
This is tested to work correctly.