### PR TITLE
arm: Set the A bit on reset.

### DIFF
--- a/src/core/arm/skyeye_common/armemu.h
+++ b/src/core/arm/skyeye_common/armemu.h
@@ -35,7 +35,7 @@ enum : u32 {
 
     // Masks for groups of bits in the APSR.
     MODEBITS = 0x1F,
-    INTBITS  = 0xC0,
+    INTBITS  = 0x1C0,
 };
 
 // Different ways to start the next instruction.


### PR DESCRIPTION
This enum value is ORed against in ARMul_Reset (and used to refer to all interrupt bits in the CPSR). So simply updating this is enough because the A bit is an interrupt bit.