### PR TITLE
Switch to the XDG Base Directory Specification for directory selection

### DIFF
--- a/src/common/common_paths.h
+++ b/src/common/common_paths.h
@@ -25,7 +25,7 @@
     #ifdef USER_DIR
         #define EMU_DATA_DIR USER_DIR
     #else
-        #define EMU_DATA_DIR ".citra-emu"
+        #define EMU_DATA_DIR "citra-emu"
     #endif
 #endif
 


### PR DESCRIPTION
This allows for easily movable and independent configuration and data directories, using standardized paths.
Here is the specification: http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html