### PR TITLE
Clean up unaligned 32-bit memory reads

### DIFF
--- a/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
+++ b/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
@@ -4422,12 +4422,7 @@ unsigned InterpreterMainLoop(ARMul_State* state) {
             inst_cream->get_addr(cpu, inst_cream->inst, addr, 1);
 
             unsigned int value = Memory::Read32(addr);
-            if (BIT(CP15_REG(CP15_CONTROL), 22) == 1)
-                cpu->Reg[BITS(inst_cream->inst, 12, 15)] = value;
-            else {
-                value = ROTATE_RIGHT_32(value,(8*(addr&0x3)));
-                cpu->Reg[BITS(inst_cream->inst, 12, 15)] = value;
-            }
+            cpu->Reg[BITS(inst_cream->inst, 12, 15)] = value;
 
             if (BITS(inst_cream->inst, 12, 15) == 15) {
                 // For armv5t, should enter thumb when bits[0] is non-zero.
@@ -4450,12 +4445,7 @@ unsigned InterpreterMainLoop(ARMul_State* state) {
             inst_cream->get_addr(cpu, inst_cream->inst, addr, 1);
 
             unsigned int value = Memory::Read32(addr);
-            if (BIT(CP15_REG(CP15_CONTROL), 22) == 1)
-                cpu->Reg[BITS(inst_cream->inst, 12, 15)] = value;
-            else {
-                value = ROTATE_RIGHT_32(value,(8*(addr&0x3)));
-                cpu->Reg[BITS(inst_cream->inst, 12, 15)] = value;
-            }
+            cpu->Reg[BITS(inst_cream->inst, 12, 15)] = value;
 
             if (BITS(inst_cream->inst, 12, 15) == 15) {
                 // For armv5t, should enter thumb when bits[0] is non-zero.
@@ -4698,11 +4688,6 @@ unsigned InterpreterMainLoop(ARMul_State* state) {
 
             unsigned int value = Memory::Read32(addr);
             cpu->Reg[BITS(inst_cream->inst, 12, 15)] = value;
-
-            if (BIT(CP15_REG(CP15_CONTROL), 22) == 1)
-                cpu->Reg[BITS(inst_cream->inst, 12, 15)] = value;
-            else
-                cpu->Reg[BITS(inst_cream->inst, 12, 15)] = ROTATE_RIGHT_32(value,(8*(addr&0x3))) ;
 
             if (BITS(inst_cream->inst, 12, 15) == 15) {
                 INC_PC(sizeof(ldst_inst));

--- a/src/core/mem_map_funcs.cpp
+++ b/src/core/mem_map_funcs.cpp
@@ -236,30 +236,12 @@ u8 Read8(const VAddr addr) {
 u16 Read16(const VAddr addr) {
     u16_le data = 0;
     Read<u16_le>(data, addr);
-
-    // Check for 16-bit unaligned memory reads...
-    if (addr & 1) {
-        // TODO(bunnei): Implement 16-bit unaligned memory reads
-        LOG_ERROR(HW_Memory, "16-bit unaligned memory reads are not implemented!");
-    }
-
     return (u16)data;
 }
 
 u32 Read32(const VAddr addr) {
     u32_le data = 0;
     Read<u32_le>(data, addr);
-
-    // Check for 32-bit unaligned memory reads...
-    if (addr & 3) {
-        // ARM allows for unaligned memory reads, however older ARM architectures read out memory
-        // from unaligned addresses in a shifted way. Our ARM CPU core (SkyEye) corrects for this,
-        // so therefore expects the memory to be read out in this manner.
-        // TODO(bunnei): Determine if this is necessary - perhaps it is OK to remove this from both
-        // SkyEye and here?
-        int shift = (addr & 3) * 8;
-        data = (data << shift) | (data >> (32 - shift));
-    }
     return (u32)data;
 }
 


### PR DESCRIPTION
SkyEye was apparently written against a memory system that would return unaligned 32-bit reads in a "shifted way". Our Read32 implementation would do the opposite shift, so that the interpreter would end up with the correct value. This assumed that Read32 would only be called with an aligned address, or that if it were called with an unaligned address, the necessary shift would be performed in the interpreter. These changes remove both shifts so that no special behavior is needed for unaligned reads.

Note that the SkyEye interpreter (our interpreter in its current state?) only did this shifting for 32-bit reads. Therefore, we don't need to do anything special for 16-bit reads, and hence the comment was simply removed.