### PR TITLE
GPU: Implemented bits 3 and 1 from the display transfer flags.

### DIFF
--- a/src/core/hw/gpu.cpp
+++ b/src/core/hw/gpu.cpp
@@ -18,9 +18,9 @@
 #include "core/hw/gpu.h"
 
 #include "video_core/command_processor.h"
+#include "video_core/utils.h"
 #include "video_core/video_core.h"
 #include <video_core/color.h>
-
 
 namespace GPU {
 
@@ -116,24 +116,64 @@ inline void Write(u32 addr, const T data) {
             u8* source_pointer = Memory::GetPointer(Memory::PhysicalToVirtualAddress(config.GetPhysicalInputAddress()));
             u8* dest_pointer = Memory::GetPointer(Memory::PhysicalToVirtualAddress(config.GetPhysicalOutputAddress()));
 
-            // Cheap emulation of horizontal scaling: Just skip each second pixel of the
-            // input framebuffer. We keep track of this in the pixel_skip variable.
-            unsigned pixel_skip = (config.scale_horizontally != 0) ? 2 : 1;
+            unsigned horizontal_scale = (config.scale_horizontally != 0) ? 2 : 1;
+            unsigned vertical_scale = (config.scale_vertically != 0) ? 2 : 1;
 
-            u32 output_width = config.output_width / pixel_skip;
+            u32 output_width = config.output_width / horizontal_scale;
+            u32 output_height = config.output_height / vertical_scale;
 
-            for (u32 y = 0; y < config.output_height; ++y) {
-                // TODO: Why does the register seem to hold twice the framebuffer width?
+            if (config.raw_copy) {
+                // Raw copies do not perform color conversion nor tiled->linear / linear->tiled conversions
+                // TODO(Subv): Verify if raw copies perform scaling
+                memcpy(dest_pointer, source_pointer, config.output_width * config.output_height * 
+                        GPU::Regs::BytesPerPixel(config.output_format));
+                
+                LOG_TRACE(HW_GPU, "DisplayTriggerTransfer: 0x%08x bytes from 0x%08x(%ux%u)-> 0x%08x(%ux%u), flags 0x%08X, Raw copy",
+                    config.output_height * output_width * GPU::Regs::BytesPerPixel(config.output_format),
+                    config.GetPhysicalInputAddress(), config.input_width.Value(), config.input_height.Value(),
+                    config.GetPhysicalOutputAddress(), config.output_width.Value(), config.output_height.Value(),
+                    config.output_format.Value(), config.flags);
 
+                GSP_GPU::SignalInterrupt(GSP_GPU::InterruptId::PPF);
+                break;
+            }
+
+            // TODO(Subv): Blend the pixels when horizontal / vertical scaling is enabled, 
+            // right now we're just skipping the extra pixels.
+            for (u32 y = 0; y < output_height; ++y) {
                 for (u32 x = 0; x < output_width; ++x) {
                     struct {
                         int r, g, b, a;
                     } source_color = { 0, 0, 0, 0 };
 
+                    u32 scaled_x = x * horizontal_scale;
+                    u32 scaled_y = y * vertical_scale;
+
+                    u32 dst_bytes_per_pixel = GPU::Regs::BytesPerPixel(config.output_format);
+                    u32 src_bytes_per_pixel = GPU::Regs::BytesPerPixel(config.input_format);
+                    u32 src_offset;
+                    u32 dst_offset;
+
+                    if (config.output_tiled) {
+                        // Interpret the input as linear and the output as tiled
+                        u32 coarse_y = y & ~7;
+                        u32 stride = output_width * dst_bytes_per_pixel;
+
+                        src_offset = (scaled_x + scaled_y * config.input_width) * src_bytes_per_pixel;
+                        dst_offset = VideoCore::GetMortonOffset(x, y, dst_bytes_per_pixel) + coarse_y * stride;
+                    } else {
+                        // Interpret the input as tiled and the output as linear
+                        u32 coarse_y = scaled_y & ~7;
+                        u32 stride = config.input_width * src_bytes_per_pixel;
+
+                        src_offset = VideoCore::GetMortonOffset(scaled_x, scaled_y, src_bytes_per_pixel) + coarse_y * stride;
+                        dst_offset = (x + y * output_width) * dst_bytes_per_pixel;
+                    }
+
                     switch (config.input_format) {
                     case Regs::PixelFormat::RGBA8:
                     {
-                        u8* srcptr = source_pointer + (x * pixel_skip + y * config.input_width) * 4;
+                        u8* srcptr = source_pointer + src_offset;
                         source_color.r = srcptr[3]; // red
                         source_color.g = srcptr[2]; // green
                         source_color.b = srcptr[1]; // blue
@@ -143,7 +183,7 @@ inline void Write(u32 addr, const T data) {
 
                     case Regs::PixelFormat::RGB5A1:
                     {
-                        u16 srcval = *(u16*)(source_pointer + x * 4 * pixel_skip + y * config.input_width * 4 * pixel_skip);
+                        u16 srcval = *(u16*)(source_pointer + src_offset);
                         source_color.r = Color::Convert5To8((srcval >> 11) & 0x1F); // red
                         source_color.g = Color::Convert5To8((srcval >>  6) & 0x1F); // green
                         source_color.b = Color::Convert5To8((srcval >>  1) & 0x1F); // blue
@@ -153,7 +193,7 @@ inline void Write(u32 addr, const T data) {
 
                     case Regs::PixelFormat::RGBA4:
                     {
-                        u16 srcval = *(u16*)(source_pointer + x * 4 * pixel_skip + y * config.input_width * 4 * pixel_skip);
+                        u16 srcval = *(u16*)(source_pointer + src_offset);
                         source_color.r = Color::Convert4To8((srcval >> 12) & 0xF); // red
                         source_color.g = Color::Convert4To8((srcval >>  8) & 0xF); // green
                         source_color.b = Color::Convert4To8((srcval >>  4) & 0xF); // blue
@@ -169,7 +209,7 @@ inline void Write(u32 addr, const T data) {
                     switch (config.output_format) {
                     case Regs::PixelFormat::RGBA8:
                     {
-                        u8* dstptr = dest_pointer + (x * pixel_skip + y * config.output_width) * 4;
+                        u8* dstptr = dest_pointer + dst_offset;
                         dstptr[3] = source_color.r;
                         dstptr[2] = source_color.g;
                         dstptr[1] = source_color.b;
@@ -179,7 +219,7 @@ inline void Write(u32 addr, const T data) {
 
                     case Regs::PixelFormat::RGB8:
                     {
-                        u8* dstptr = dest_pointer + (x + y * output_width) * 3;
+                        u8* dstptr = dest_pointer + dst_offset;
                         dstptr[2] = source_color.r; // red
                         dstptr[1] = source_color.g; // green
                         dstptr[0] = source_color.b; // blue
@@ -188,7 +228,7 @@ inline void Write(u32 addr, const T data) {
 
                     case Regs::PixelFormat::RGB5A1:
                     {
-                        u16* dstptr = (u16*)(dest_pointer + x * 2 + y * config.output_width * 2);
+                        u16* dstptr = (u16*)(dest_pointer + dst_offset);
                         *dstptr = ((source_color.r >> 3) << 11) | ((source_color.g >> 3) << 6)
                                 | ((source_color.b >> 3) <<  1) | ( source_color.a >> 7);
                         break;
@@ -196,7 +236,7 @@ inline void Write(u32 addr, const T data) {
 
                     case Regs::PixelFormat::RGBA4:
                     {
-                        u16* dstptr = (u16*)(dest_pointer + x * 2 + y * config.output_width * 2);
+                        u16* dstptr = (u16*)(dest_pointer + dst_offset);
                         *dstptr = ((source_color.r >> 4) << 12) | ((source_color.g >> 4) << 8)
                                 | ((source_color.b >> 4) <<  4) | ( source_color.a >> 4);
                         break;
@@ -209,11 +249,11 @@ inline void Write(u32 addr, const T data) {
                 }
             }
 
-            LOG_TRACE(HW_GPU, "DisplayTriggerTransfer: 0x%08x bytes from 0x%08x(%ux%u)-> 0x%08x(%ux%u), dst format %x",
-                      config.output_height * output_width * 4,
-                      config.GetPhysicalInputAddress(), (u32)config.input_width, (u32)config.input_height,
-                      config.GetPhysicalOutputAddress(), (u32)output_width, (u32)config.output_height,
-                      config.output_format.Value());
+            LOG_TRACE(HW_GPU, "DisplayTriggerTransfer: 0x%08x bytes from 0x%08x(%ux%u)-> 0x%08x(%ux%u), dst format %x, flags 0x%08X",
+                      config.output_height * output_width * GPU::Regs::BytesPerPixel(config.output_format),
+                      config.GetPhysicalInputAddress(), config.input_width.Value(), config.input_height.Value(),
+                      config.GetPhysicalOutputAddress(), output_width, output_height,
+                      config.output_format.Value(), config.flags);
 
             GSP_GPU::SignalInterrupt(GSP_GPU::InterruptId::PPF);
         }

--- a/src/core/hw/gpu.h
+++ b/src/core/hw/gpu.h
@@ -192,12 +192,13 @@ struct Regs {
             u32 flags;
 
             BitField< 0, 1, u32> flip_data;        // flips input data horizontally (TODO) if true
+            BitField< 1, 1, u32> output_tiled;     // Converts from linear to tiled format
+            BitField< 3, 1, u32> raw_copy;         // Copies the data without performing any processing
             BitField< 8, 3, PixelFormat> input_format;
             BitField<12, 3, PixelFormat> output_format;
-            BitField<16, 1, u32> output_tiled;     // stores output in a tiled format
 
-            // TODO: Not really sure if this actually scales, or even resizes at all.
             BitField<24, 1, u32> scale_horizontally;
+            BitField<25, 1, u32> scale_vertically;
         };
 
         INSERT_PADDING_WORDS(0x1);

--- a/src/video_core/utils.h
+++ b/src/video_core/utils.h
@@ -35,4 +35,54 @@ struct TGAHeader {
  */
 void DumpTGA(std::string filename, short width, short height, u8* raw_data);
 
+/**
+ * Interleave the lower 3 bits of each coordinate to get the intra-block offsets, which are
+ * arranged in a Z-order curve. More details on the bit manipulation at:
+ * https://fgiesen.wordpress.com/2009/12/13/decoding-morton-codes/
+ */
+static inline u32 MortonInterleave(u32 x, u32 y) {
+    u32 i = (x & 7) | ((y & 7) << 8); // ---- -210
+    i = (i ^ (i << 2)) & 0x1313;      // ---2 --10
+    i = (i ^ (i << 1)) & 0x1515;      // ---2 -1-0
+    i = (i | (i >> 7)) & 0x3F;
+    return i;
+}
+
+/**
+ * Calculates the offset of the position of the pixel in Morton order
+ */
+static inline u32 GetMortonOffset(u32 x, u32 y, u32 bytes_per_pixel) {
+    // Images are split into 8x8 tiles. Each tile is composed of four 4x4 subtiles each
+    // of which is composed of four 2x2 subtiles each of which is composed of four texels.
+    // Each structure is embedded into the next-bigger one in a diagonal pattern, e.g.
+    // texels are laid out in a 2x2 subtile like this:
+    // 2 3
+    // 0 1
+    //
+    // The full 8x8 tile has the texels arranged like this:
+    //
+    // 42 43 46 47 58 59 62 63
+    // 40 41 44 45 56 57 60 61
+    // 34 35 38 39 50 51 54 55
+    // 32 33 36 37 48 49 52 53
+    // 10 11 14 15 26 27 30 31
+    // 08 09 12 13 24 25 28 29
+    // 02 03 06 07 18 19 22 23
+    // 00 01 04 05 16 17 20 21
+    //
+    // This pattern is what's called Z-order curve, or Morton order.
+
+    const unsigned int block_width = 8;
+    const unsigned int block_height = 8;
+
+    const unsigned int coarse_x = x & ~7;
+    const unsigned int coarse_y = y & ~7;
+
+    u32 i = VideoCore::MortonInterleave(x, y);
+
+    const unsigned int offset = coarse_x * block_height;
+
+    return (i + offset) * bytes_per_pixel;
+}
+
 } // namespace


### PR DESCRIPTION
Bit 3 is used to specify a raw copy, where no processing is done to the data, seems to behave exactly as a DMA.
Bit 1 is used to specify whether to convert from a tiled format to a linear format or viceversa.

Verified with hwtests