### PR TITLE
Video core: Fix pixelation/blockiness in textures.

### DIFF
--- a/src/video_core/debug_utils/debug_utils.cpp
+++ b/src/video_core/debug_utils/debug_utils.cpp
@@ -333,9 +333,9 @@ const Math::Vec4<u8> LookupTexture(const u8* source, int x, int y, const Texture
     // Interleave the lower 3 bits of each coordinate to get the intra-block offsets, which are
     // arranged in a Z-order curve. More details on the bit manipulation at:
     // https://fgiesen.wordpress.com/2009/12/13/decoding-morton-codes/
-    unsigned int i = (x | (y << 8)) & 0x0707; // ---- -210
-    i = (i ^ (i << 2)) & 0x1313;              // ---2 --10
-    i = (i ^ (i << 1)) & 0x1515;              // ---2 -1-0
+    unsigned int i = (x & 7) | ((y & 7) << 8); // ---- -210
+    i = (i ^ (i << 2)) & 0x1313;               // ---2 --10
+    i = (i ^ (i << 1)) & 0x1515;               // ---2 -1-0
     i = (i | (i >> 7)) & 0x3F;
 
     if (info.format != Regs::TextureFormat::ETC1 &&


### PR DESCRIPTION
This was caused during morton decoding by me not masking the bits of
each coordinate before merging them, so the bits from x could set bits
in y if it was >255.