### PR TITLE
Video core: Fix A4 texture decoding

### DIFF
--- a/src/video_core/debug_utils/debug_utils.cpp
+++ b/src/video_core/debug_utils/debug_utils.cpp
@@ -436,9 +436,9 @@ const Math::Vec4<u8> LookupTexture(const u8* source, int x, int y, const Texture
 
     case Regs::TextureFormat::A4:
     {
-        const u8* source_ptr = source + offset / 2 + i / 2;
+        const u8* source_ptr = source + (offset + i) / 2;
 
-        u8 a = (coarse_x % 2) ? ((*source_ptr)&0xF) : (((*source_ptr) & 0xF0) >> 4);
+        u8 a = (i % 2) ? ((*source_ptr & 0xF0) >> 4) : (*source_ptr & 0xF);
         a = Color::Convert4To8(a);
 
         if (disable_alpha) {


### PR DESCRIPTION
It was trying to take the LSB from `coarse_x`, which would always be 0
and thus would always return the same texel from each byte. To add
insult to the injury, the conditional was actually the wrong way around
too.

Fixes blocky text in OoT.