### PR TITLE
result: Make comparison operators take references

### DIFF
--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -208,11 +208,11 @@ union ResultCode {
     }
 };
 
-inline bool operator==(const ResultCode a, const ResultCode b) {
+inline bool operator==(const ResultCode& a, const ResultCode& b) {
     return a.raw == b.raw;
 }
 
-inline bool operator!=(const ResultCode a, const ResultCode b) {
+inline bool operator!=(const ResultCode& a, const ResultCode& b) {
     return a.raw != b.raw;
 }
 


### PR DESCRIPTION
It's unnecessary to make copies for simple comparisons like this.