### PR TITLE
Apply the logging filter before sending the message to the queue

### DIFF
--- a/src/citra/citra.cpp
+++ b/src/citra/citra.cpp
@@ -22,7 +22,8 @@
 int __cdecl main(int argc, char **argv) {
     std::shared_ptr<Log::Logger> logger = Log::InitGlobalLogger();
     Log::Filter log_filter(Log::Level::Debug);
-    std::thread logging_thread(Log::TextLoggingLoop, logger, &log_filter);
+    Log::SetFilter(&log_filter);
+    std::thread logging_thread(Log::TextLoggingLoop, logger);
     SCOPE_EXIT({
         logger->Close();
         logging_thread.join();

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -310,7 +310,8 @@ int __cdecl main(int argc, char* argv[])
 {
     std::shared_ptr<Log::Logger> logger = Log::InitGlobalLogger();
     Log::Filter log_filter(Log::Level::Info);
-    std::thread logging_thread(Log::TextLoggingLoop, logger, &log_filter);
+    Log::SetFilter(&log_filter);
+    std::thread logging_thread(Log::TextLoggingLoop, logger);
     SCOPE_EXIT({
         logger->Close();
         logging_thread.join();

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -135,9 +135,18 @@ Entry CreateEntry(Class log_class, Level log_level,
     return std::move(entry);
 }
 
+static Filter* filter;
+
+void SetFilter(Filter* new_filter) {
+    filter = new_filter;
+}
+
 void LogMessage(Class log_class, Level log_level,
                 const char* filename, unsigned int line_nr, const char* function,
                 const char* format, ...) {
+    if (!filter->CheckMessage(log_class, log_level))
+        return;
+
     va_list args;
     va_start(args, format);
     Entry entry = CreateEntry(log_class, log_level,

--- a/src/common/logging/backend.h
+++ b/src/common/logging/backend.h
@@ -10,6 +10,7 @@
 
 #include "common/concurrent_ring_buffer.h"
 
+#include "common/logging/filter.h"
 #include "common/logging/log.h"
 
 namespace Log {
@@ -130,5 +131,7 @@ Entry CreateEntry(Class log_class, Level log_level,
                         const char* format, va_list args);
 /// Initializes the default Logger.
 std::shared_ptr<Logger> InitGlobalLogger();
+
+void SetFilter(Filter* filter);
 
 }

--- a/src/common/logging/filter.h
+++ b/src/common/logging/filter.h
@@ -2,6 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#pragma once
+
 #include <array>
 #include <string>
 

--- a/src/common/logging/text_formatter.cpp
+++ b/src/common/logging/text_formatter.cpp
@@ -11,7 +11,6 @@
 #endif
 
 #include "common/logging/backend.h"
-#include "common/logging/filter.h"
 #include "common/logging/log.h"
 #include "common/logging/text_formatter.h"
 
@@ -116,7 +115,7 @@ void PrintColoredMessage(const Entry& entry) {
 #endif
 }
 
-void TextLoggingLoop(std::shared_ptr<Logger> logger, const Filter* filter) {
+void TextLoggingLoop(std::shared_ptr<Logger> logger) {
     std::array<Entry, 256> entry_buffer;
 
     while (true) {
@@ -126,9 +125,7 @@ void TextLoggingLoop(std::shared_ptr<Logger> logger, const Filter* filter) {
         }
         for (size_t i = 0; i < num_entries; ++i) {
             const Entry& entry = entry_buffer[i];
-            if (filter->CheckMessage(entry.log_class, entry.log_level)) {
-                PrintColoredMessage(entry);
-            }
+            PrintColoredMessage(entry);
         }
     }
 }

--- a/src/common/logging/text_formatter.h
+++ b/src/common/logging/text_formatter.h
@@ -11,7 +11,6 @@ namespace Log {
 
 class Logger;
 struct Entry;
-class Filter;
 
 /**
  * Attempts to trim an arbitrary prefix from `path`, leaving only the part starting at `root`. It's
@@ -36,6 +35,6 @@ void PrintColoredMessage(const Entry& entry);
  * Logging loop that repeatedly reads messages from the provided logger and prints them to the
  * console. It is the baseline barebones log outputter.
  */
-void TextLoggingLoop(std::shared_ptr<Logger> logger, const Filter* filter);
+void TextLoggingLoop(std::shared_ptr<Logger> logger);
 
 }


### PR DESCRIPTION
This puts back 3dscraft to its performance level of before logging.