### PR TITLE
GPU/Textures: Fixed ETC texture decoding.

### DIFF
--- a/src/video_core/debug_utils/debug_utils.cpp
+++ b/src/video_core/debug_utils/debug_utils.cpp
@@ -505,7 +505,7 @@ const Math::Vec4<u8> LookupTexture(const u8* source, int x, int y, const Texture
                 }
 
                 // Add modifier
-                unsigned table_index = (x < 2) ? table_index_2.Value() : table_index_1.Value();
+                unsigned table_index = (x < 2) ? table_index_1.Value() : table_index_2.Value();
 
                 static const auto etc1_modifier_table = std::array<std::array<u8, 2>, 8>{{
                     {  2,  8 }, {  5, 17 }, {  9,  29 }, { 13,  42 },


### PR DESCRIPTION
The problem was a typo, coordinates with x < 2 should apparently use the first lookup table whereas our code was using the second table. The fix was taken from 3dmoo's code https://github.com/plutooo/3dmoo/commit/a57d27cabbb598110b518a6c6637e1265e1811b0#diff-db756bba03e234eb3ad60cf015e7d0adR802