### PR TITLE
GPU: Use the correct position for the finished bit in memory fills

### DIFF
--- a/src/core/hw/gpu.h
+++ b/src/core/hw/gpu.h
@@ -98,7 +98,7 @@ struct Regs {
             BitField<0, 1, u32> trigger;
 
             // Set to 1 upon completion.
-            BitField<0, 1, u32> finished;
+            BitField<1, 1, u32> finished;
 
             // 0: fill with 16- or 32-bit wide values; 1: fill with 24-bit wide values
             BitField<8, 1, u32> fill_24bit;


### PR DESCRIPTION
It was using the same bit position as the "trigger" bit.