### PR TITLE
GPU: Fixed the bit 25 in the display transfer flags.

### DIFF
--- a/src/core/hw/gpu.cpp
+++ b/src/core/hw/gpu.cpp
@@ -116,9 +116,15 @@ inline void Write(u32 addr, const T data) {
             u8* src_pointer = Memory::GetPointer(Memory::PhysicalToVirtualAddress(config.GetPhysicalInputAddress()));
             u8* dst_pointer = Memory::GetPointer(Memory::PhysicalToVirtualAddress(config.GetPhysicalOutputAddress()));
 
-            unsigned horizontal_scale = (config.scale_x != 0 || config.scale_xy != 0) ? 2 : 1;
-            unsigned vertical_scale = (config.scale_xy != 0) ? 2 : 1;
-            
+            if (config.scaling > config.ScaleXY) {
+                LOG_CRITICAL(HW_GPU, "Unimplemented display transfer scaling mode %u", config.scaling.Value());
+                UNIMPLEMENTED();
+                break;
+            }
+
+            unsigned horizontal_scale = (config.scaling != config.NoScale) ? 2 : 1;
+            unsigned vertical_scale = (config.scaling == config.ScaleXY) ? 2 : 1;
+
             u32 output_width = config.output_width / horizontal_scale;
             u32 output_height = config.output_height / vertical_scale;
 
@@ -138,7 +144,7 @@ inline void Write(u32 addr, const T data) {
                 break;
             }
 
-            // TODO(Subv): Blend the pixels when horizontal / vertical scaling is enabled, 
+            // TODO(Subv): Implement the box filter when scaling is enabled
             // right now we're just skipping the extra pixels.
             for (u32 y = 0; y < output_height; ++y) {
                 for (u32 x = 0; x < output_width; ++x) {

--- a/src/core/hw/gpu.cpp
+++ b/src/core/hw/gpu.cpp
@@ -116,9 +116,9 @@ inline void Write(u32 addr, const T data) {
             u8* src_pointer = Memory::GetPointer(Memory::PhysicalToVirtualAddress(config.GetPhysicalInputAddress()));
             u8* dst_pointer = Memory::GetPointer(Memory::PhysicalToVirtualAddress(config.GetPhysicalOutputAddress()));
 
-            unsigned horizontal_scale = (config.scale_horizontally != 0) ? 2 : 1;
-            unsigned vertical_scale = (config.scale_vertically != 0) ? 2 : 1;
-
+            unsigned horizontal_scale = (config.scale_x != 0 || config.scale_xy != 0) ? 2 : 1;
+            unsigned vertical_scale = (config.scale_xy != 0) ? 2 : 1;
+            
             u32 output_width = config.output_width / horizontal_scale;
             u32 output_height = config.output_height / vertical_scale;
 

--- a/src/core/hw/gpu.h
+++ b/src/core/hw/gpu.h
@@ -188,6 +188,12 @@ struct Regs {
             BitField<16, 16, u32> input_height;
         };
 
+        enum ScalingMode : u32 {
+            NoScale  = 0,  // Doesn't scale the image
+            ScaleX   = 1,  // Downscales the image in half in the X axis and applies a box filter
+            ScaleXY  = 2,  // Downscales the image in half in both the X and Y axes and applies a box filter
+        };
+
         union {
             u32 flags;
 
@@ -197,8 +203,7 @@ struct Regs {
             BitField< 8, 3, PixelFormat> input_format;
             BitField<12, 3, PixelFormat> output_format;
 
-            BitField<24, 1, u32> scale_x;  // Shrinks the image in half horizontally, blending the extra pixels
-            BitField<25, 1, u32> scale_xy; // Shrinks the image horizontally and vertically, blending the extra pixels
+            BitField<24, 2, ScalingMode> scaling; // Determines the scaling mode of the transfer
         };
 
         INSERT_PADDING_WORDS(0x1);

--- a/src/core/hw/gpu.h
+++ b/src/core/hw/gpu.h
@@ -197,8 +197,8 @@ struct Regs {
             BitField< 8, 3, PixelFormat> input_format;
             BitField<12, 3, PixelFormat> output_format;
 
-            BitField<24, 1, u32> scale_horizontally;
-            BitField<25, 1, u32> scale_vertically;
+            BitField<24, 1, u32> scale_x;  // Shrinks the image in half horizontally, blending the extra pixels
+            BitField<25, 1, u32> scale_xy; // Shrinks the image horizontally and vertically, blending the extra pixels
         };
 
         INSERT_PADDING_WORDS(0x1);


### PR DESCRIPTION
It is used to downscale the input image horizontally and vertically, previously we were only downscaling it vertically so this caused a hard-to-debug memory corruption problem.

This fixes 2048 and possibly other games.
Tests at https://github.com/citra-emu/hwtests/pull/29

Still TODO: Implement the actual box filter when downscaling