### PR TITLE
 HID: Proper Signal Interrupts for EnableAccelerometer & EnableGyroscopeLow along  with a stub for GetSoundVolume

### DIFF
--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -114,6 +114,7 @@ void GetIPCHandles(Service::Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[1] = 0; // No error
+    cmd_buff[2] = 0x14000000; // IPC Command Structure translate-header
     // TODO(yuriks): Return error from SendSyncRequest is this fails (part of IPC marshalling)
     cmd_buff[3] = Kernel::g_handle_table.Create(Service::HID::shared_mem).MoveFrom();
     cmd_buff[4] = Kernel::g_handle_table.Create(Service::HID::event_pad_or_touch_1).MoveFrom();
@@ -121,6 +122,37 @@ void GetIPCHandles(Service::Interface* self) {
     cmd_buff[6] = Kernel::g_handle_table.Create(Service::HID::event_accelerometer).MoveFrom();
     cmd_buff[7] = Kernel::g_handle_table.Create(Service::HID::event_gyroscope).MoveFrom();
     cmd_buff[8] = Kernel::g_handle_table.Create(Service::HID::event_debug_pad).MoveFrom();
+}
+
+void EnableAccelerometer(Service::Interface* self) {
+    u32* cmd_buff = Kernel::GetCommandBuffer();
+
+    event_accelerometer->Signal();
+
+    cmd_buff[1] = RESULT_SUCCESS.raw;
+
+    LOG_WARNING(Service_HID, "(STUBBED) called");
+}
+
+void EnableGyroscopeLow(Service::Interface* self) {
+    u32* cmd_buff = Kernel::GetCommandBuffer();
+
+    event_gyroscope->Signal();
+
+    cmd_buff[1] = RESULT_SUCCESS.raw;
+
+    LOG_WARNING(Service_HID, "(STUBBED) called");
+}
+
+void GetSoundVolume(Service::Interface* self) {
+    u32* cmd_buff = Kernel::GetCommandBuffer();
+
+    const u8 volume = 0x3F; // TODO(purpasmart): Find out if this is the max value for the volume
+
+    cmd_buff[1] = RESULT_SUCCESS.raw;
+    cmd_buff[2] = volume;
+
+    LOG_WARNING(Service_HID, "(STUBBED) called");
 }
 
 void HIDInit() {

--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -161,7 +161,7 @@ const PadState PAD_CIRCLE_DOWN  = {{1u << 31}};
  *      None
  *  Outputs:
  *      1 : Result of function, 0 on success, otherwise error code
- *      2 : Unused
+ *      2 : IPC Command Structure translate-header
  *      3 : Handle to HID_User shared memory
  *      4 : Event signaled by HID_User
  *      5 : Event signaled by HID_User
@@ -170,6 +170,34 @@ const PadState PAD_CIRCLE_DOWN  = {{1u << 31}};
  *      8 : Event signaled by HID_User
  */
 void GetIPCHandles(Interface* self);
+
+/**
+ * HID::EnableAccelerometer service function
+ *  Inputs:
+ *      None
+ *  Outputs:
+ *      1 : Result of function, 0 on success, otherwise error code
+ */
+void EnableAccelerometer(Interface* self);
+
+/**
+ * HID::EnableGyroscopeLow service function
+ *  Inputs:
+ *      None
+ *  Outputs:
+ *      1 : Result of function, 0 on success, otherwise error code
+ */
+void EnableGyroscopeLow(Interface* self);
+
+/**
+ * HID::GetSoundVolume service function
+ *  Inputs:
+ *      None
+ *  Outputs:
+ *      1 : Result of function, 0 on success, otherwise error code
+ *      2 : u8 output value
+ */
+void GetSoundVolume(Interface* self);
 
 /// Checks for user input updates
 void HIDUpdate();

--- a/src/core/hle/service/hid/hid_spvr.cpp
+++ b/src/core/hle/service/hid/hid_spvr.cpp
@@ -13,13 +13,13 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x000A0000, GetIPCHandles,              "GetIPCHandles"},
     {0x000B0000, nullptr,                    "StartAnalogStickCalibration"},
     {0x000E0000, nullptr,                    "GetAnalogStickCalibrateParam"},
-    {0x00110000, nullptr,                    "EnableAccelerometer"},
+    {0x00110000, EnableAccelerometer,        "EnableAccelerometer"},
     {0x00120000, nullptr,                    "DisableAccelerometer"},
-    {0x00130000, nullptr,                    "EnableGyroscopeLow"},
+    {0x00130000, EnableGyroscopeLow,         "EnableGyroscopeLow"},
     {0x00140000, nullptr,                    "DisableGyroscopeLow"},
     {0x00150000, nullptr,                    "GetGyroscopeLowRawToDpsCoefficient"},
     {0x00160000, nullptr,                    "GetGyroscopeLowCalibrateParam"},
-    {0x00170000, nullptr,                    "GetSoundVolume"},
+    {0x00170000, GetSoundVolume,             "GetSoundVolume"},
 };
 
 HID_SPVR_Interface::HID_SPVR_Interface() {

--- a/src/core/hle/service/hid/hid_user.cpp
+++ b/src/core/hle/service/hid/hid_user.cpp
@@ -10,14 +10,14 @@ namespace Service {
 namespace HID {
 
 const Interface::FunctionInfo FunctionTable[] = {
-    {0x000A0000, GetIPCHandles, "GetIPCHandles"},
-    {0x00110000, nullptr,       "EnableAccelerometer"},
-    {0x00120000, nullptr,       "DisableAccelerometer"},
-    {0x00130000, nullptr,       "EnableGyroscopeLow"},
-    {0x00140000, nullptr,       "DisableGyroscopeLow"},
-    {0x00150000, nullptr,       "GetGyroscopeLowRawToDpsCoefficient"},
-    {0x00160000, nullptr,       "GetGyroscopeLowCalibrateParam"},
-    {0x00170000, nullptr,       "GetSoundVolume"},
+    {0x000A0000, GetIPCHandles,             "GetIPCHandles"},
+    {0x00110000, EnableAccelerometer,       "EnableAccelerometer"},
+    {0x00120000, nullptr,                   "DisableAccelerometer"},
+    {0x00130000, EnableGyroscopeLow,        "EnableGyroscopeLow"},
+    {0x00140000, nullptr,                   "DisableGyroscopeLow"},
+    {0x00150000, nullptr,                   "GetGyroscopeLowRawToDpsCoefficient"},
+    {0x00160000, nullptr,                   "GetGyroscopeLowCalibrateParam"},
+    {0x00170000, GetSoundVolume,            "GetSoundVolume"},
 };
 
 HID_U_Interface::HID_U_Interface() {


### PR DESCRIPTION
This fixes the freeze when pressing the ocarina on the touch pad in OoT.