### PR TITLE
GPU: Implemented the flip_data (bit 0) bit in display transfers.

### DIFF
--- a/src/core/hw/gpu.h
+++ b/src/core/hw/gpu.h
@@ -191,7 +191,7 @@ struct Regs {
         union {
             u32 flags;
 
-            BitField< 0, 1, u32> flip_data;        // flips input data horizontally (TODO) if true
+            BitField< 0, 1, u32> flip_vertically;  // flips input data vertically
             BitField< 1, 1, u32> output_tiled;     // Converts from linear to tiled format
             BitField< 3, 1, u32> raw_copy;         // Copies the data without performing any processing
             BitField< 8, 3, PixelFormat> input_format;


### PR DESCRIPTION
This is based on information on 3dbrew.

Tested with blargSNES, and this is the output, the top screen is now correctly flipped: http://i.imgur.com/yaoAzLj.png