### PR TITLE
EmuWindow: Fixed a reference to a temporary variable

### DIFF
--- a/src/common/emu_window.h
+++ b/src/common/emu_window.h
@@ -110,7 +110,7 @@ public:
      * @return std::tuple of (x, y, pressed) where `x` and `y` are the touch coordinates and
      *         `pressed` is true if the touch screen is currently being pressed
      */
-    const std::tuple<u16, u16, bool>& GetTouchState() const {
+    const std::tuple<u16, u16, bool> GetTouchState() const {
         return std::make_tuple(touch_x, touch_y, touch_pressed);
     }
 


### PR DESCRIPTION
 in EmuWindow::GetTouchState()