### PR TITLE
Fix two minor understandability issues in common

### DIFF
--- a/src/common/common_paths.h
+++ b/src/common/common_paths.h
@@ -17,13 +17,12 @@
 
 // The user data dir
 #define ROOT_DIR "."
-#ifdef _WIN32
-    #define USERDATA_DIR "user"
-    #define EMU_DATA_DIR "Citra Emulator"
+#define USERDATA_DIR "user"
+#ifdef USER_DIR
+    #define EMU_DATA_DIR USER_DIR
 #else
-    #define USERDATA_DIR "user"
-    #ifdef USER_DIR
-        #define EMU_DATA_DIR USER_DIR
+    #ifdef _WIN32
+        #define EMU_DATA_DIR "Citra Emulator"
     #else
         #define EMU_DATA_DIR "citra-emu"
     #endif

--- a/src/common/platform.h
+++ b/src/common/platform.h
@@ -83,7 +83,7 @@ inline struct tm* localtime_r(const time_t *clock, struct tm *result) {
 }
 #endif
 
-#else
+#else // EMU_PLATFORM != PLATFORM_WINDOWS
 
 #define EMU_FASTCALL __attribute__((fastcall))
 #define __stdcall
@@ -91,10 +91,6 @@ inline struct tm* localtime_r(const time_t *clock, struct tm *result) {
 
 #define BOOL bool
 #define DWORD u32
-
-#endif
-
-#if EMU_PLATFORM != PLATFORM_WINDOWS
 
 // TODO: Hacks..
 #include <limits.h>


### PR DESCRIPTION
This also adds back the ability to change the name of the default main directory name at compile-time on Windows.