### PR TITLE
Add static_cast around expressions where the compiler doesn’t deduce the right type

### DIFF
--- a/src/video_core/color.h
+++ b/src/video_core/color.h
@@ -124,7 +124,7 @@ inline u32 DecodeD24(const u8* bytes) {
  * @return Resulting values stored as a Math::Vec2
  */
 inline const Math::Vec2<u32> DecodeD24S8(const u8* bytes) {
-    return { (bytes[2] << 16) | (bytes[1] << 8) | bytes[0], bytes[3] };
+    return { static_cast<u32>((bytes[2] << 16) | (bytes[1] << 8) | bytes[0]), bytes[3] };
 }
 
 /**

--- a/src/video_core/debug_utils/debug_utils.cpp
+++ b/src/video_core/debug_utils/debug_utils.cpp
@@ -322,7 +322,7 @@ const Math::Vec4<u8> LookupTexture(const u8* source, int x, int y, const Texture
     case Regs::TextureFormat::RGBA8:
     {
         auto res = Color::DecodeRGBA8(source + VideoCore::GetMortonOffset(x, y, 4));
-        return { res.r(), res.g(), res.b(), disable_alpha ? 255 : res.a() };
+        return { res.r(), res.g(), res.b(), static_cast<u8>(disable_alpha ? 255 : res.a()) };
     }
 
     case Regs::TextureFormat::RGB8:
@@ -334,7 +334,7 @@ const Math::Vec4<u8> LookupTexture(const u8* source, int x, int y, const Texture
     case Regs::TextureFormat::RGB5A1:
     {
         auto res = Color::DecodeRGB5A1(source + VideoCore::GetMortonOffset(x, y, 2));
-        return { res.r(), res.g(), res.b(), disable_alpha ? 255 : res.a() };
+        return { res.r(), res.g(), res.b(), static_cast<u8>(disable_alpha ? 255 : res.a()) };
     }
 
     case Regs::TextureFormat::RGB565:
@@ -346,7 +346,7 @@ const Math::Vec4<u8> LookupTexture(const u8* source, int x, int y, const Texture
     case Regs::TextureFormat::RGBA4:
     {
         auto res = Color::DecodeRGBA4(source + VideoCore::GetMortonOffset(x, y, 2));
-        return { res.r(), res.g(), res.b(), disable_alpha ? 255 : res.a() };
+        return { res.r(), res.g(), res.b(), static_cast<u8>(disable_alpha ? 255 : res.a()) };
     }
 
     case Regs::TextureFormat::IA8:


### PR DESCRIPTION
This removes a few annoying warnings in VideoCore.