### PR TITLE
Fix for Issue #449 Qt errors on startup.

### DIFF
--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -168,10 +168,6 @@ GRenderWindow::GRenderWindow(QWidget* parent) : QWidget(parent), emu_thread(this
     NotifyClientAreaSizeChanged(std::pair<unsigned,unsigned>(child->width(), child->height()));
 
     BackupGeometry();
-
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-    connect(this->windowHandle(), SIGNAL(screenChanged(QScreen*)), this, SLOT(OnFramebufferSizeChanged()));
-#endif
 }
 
 void GRenderWindow::moveContext()

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -331,3 +331,11 @@ void GRenderWindow::OnClientAreaResized(unsigned width, unsigned height)
 void GRenderWindow::OnMinimalClientAreaChangeRequest(const std::pair<unsigned,unsigned>& minimal_size) {
     setMinimumSize(minimal_size.first, minimal_size.second);
 }
+
+void GRenderWindow::showEvent(QShowEvent * event) {
+    QWidget::showEvent(event);
+
+    #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+        connect(this->windowHandle(), SIGNAL(screenChanged(QScreen*)), this, SLOT(OnFramebufferSizeChanged()));
+    #endif
+}

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -145,4 +145,7 @@ private:
 
     /// Device id of keyboard for use with KeyMap
     int keyboard_id;
+
+protected:
+    void showEvent(QShowEvent * event) override;
 };

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -132,7 +132,7 @@ public:
 public slots:
     void moveContext();  // overridden
 
-	void OnFramebufferSizeChanged();
+    void OnFramebufferSizeChanged();
 
 private:
     void OnMinimalClientAreaChangeRequest(const std::pair<unsigned,unsigned>& minimal_size) override;

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -128,11 +128,11 @@ public:
     void ReloadSetKeymaps() override;
 
     void OnClientAreaResized(unsigned width, unsigned height);
-
-    void OnFramebufferSizeChanged();
-
+	
 public slots:
     void moveContext();  // overridden
+
+	void OnFramebufferSizeChanged();
 
 private:
     void OnMinimalClientAreaChangeRequest(const std::pair<unsigned,unsigned>& minimal_size) override;

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -160,6 +160,10 @@ GMainWindow::GMainWindow()
 
     show();
 
+	#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+		connect(render_window->windowHandle(), SIGNAL(screenChanged(QScreen*)), render_window, SLOT(OnFramebufferSizeChanged()));
+	#endif
+
     QStringList args = QApplication::arguments();
     if (args.length() >= 2) {
         BootGame(args[1].toStdString());

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -159,11 +159,7 @@ GMainWindow::GMainWindow()
     setWindowTitle(window_title.c_str());
 
     show();
-
-    #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-        connect(render_window->windowHandle(), SIGNAL(screenChanged(QScreen*)), render_window, SLOT(OnFramebufferSizeChanged()));
-    #endif
-
+    
     QStringList args = QApplication::arguments();
     if (args.length() >= 2) {
         BootGame(args[1].toStdString());

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -160,9 +160,9 @@ GMainWindow::GMainWindow()
 
     show();
 
-	#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-		connect(render_window->windowHandle(), SIGNAL(screenChanged(QScreen*)), render_window, SLOT(OnFramebufferSizeChanged()));
-	#endif
+    #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+        connect(render_window->windowHandle(), SIGNAL(screenChanged(QScreen*)), render_window, SLOT(OnFramebufferSizeChanged()));
+    #endif
 
     QStringList args = QApplication::arguments();
     if (args.length() >= 2) {


### PR DESCRIPTION
windowHandle() is not initialized until the Window is shown. Moved the slot connect to main.cpp file after show(). Had to change the OnFramebufferSizeChanged(); to a slot.