### PR TITLE
ConfigMem: Set the app memory to be 96MB instead of the default 64MB

### DIFF
--- a/src/core/hle/config_mem.cpp
+++ b/src/core/hle/config_mem.cpp
@@ -65,9 +65,9 @@ void Init() {
     config_mem.sys_core_ver = 0x2;
     config_mem.unit_info = 0x1; // Bit 0 set for Retail
     config_mem.prev_firm = 0;
-    config_mem.app_mem_type = 0; // Defualt app mem type
+    config_mem.app_mem_type = 0x2; // Default app mem type is 0
     config_mem.unit_info = 0x1; // Bit 0 set for Retail
-    config_mem.app_mem_alloc = 0x04000000; // Default app memory size is 64MB
+    config_mem.app_mem_alloc = 0x06000000; // Set to 96MB, since some games use more than the default (64MB)
     config_mem.base_mem_alloc = 0x01400000; // Default base memory is 20MB
     config_mem.sys_mem_alloc = Memory::FCRAM_SIZE - (config_mem.app_mem_alloc + config_mem.base_mem_alloc);
     config_mem.firm_unk = 0;


### PR DESCRIPTION
Since we aren't emulating the actual firmware, games that would use more then 64MB would crash. Because on the real 3ds, the firmware would change its Config Memory to comply with the game's memory resources.
Pokemon Gates to Affinity no longer crashes at boot, and you can almost get in game.