### PR TITLE
dyncom: Remove unused/unnecessary macros and macro constants

### DIFF
--- a/src/core/arm/dyncom/arm_dyncom_dec.cpp
+++ b/src/core/arm/dyncom/arm_dyncom_dec.cpp
@@ -413,7 +413,7 @@ int decode_arm_instr(uint32_t instr, int32_t *idx) {
                 if (instr != arm_instruction[i].content[base + 2]) {
                     break;
                 }
-            } else if (BITS(arm_instruction[i].content[base], arm_instruction[i].content[base + 1]) != arm_instruction[i].content[base + 2]) {
+            } else if (BITS(instr, arm_instruction[i].content[base], arm_instruction[i].content[base + 1]) != arm_instruction[i].content[base + 2]) {
                 break;
             }
             base += 3;
@@ -429,7 +429,7 @@ int decode_arm_instr(uint32_t instr, int32_t *idx) {
             if (n != 0) {
                 base = 0;
                 while (n) {
-                    if (BITS(arm_exclusion_code[i].content[base], arm_exclusion_code[i].content[base + 1]) != arm_exclusion_code[i].content[base + 2]) {
+                    if (BITS(instr, arm_exclusion_code[i].content[base], arm_exclusion_code[i].content[base + 1]) != arm_exclusion_code[i].content[base + 2]) {
                         break;
                     }
                     base += 3;

--- a/src/core/arm/dyncom/arm_dyncom_dec.h
+++ b/src/core/arm/dyncom/arm_dyncom_dec.h
@@ -4,43 +4,6 @@
 
 #pragma once
 
-#define BITS(a,b)   ((instr >> (a)) & ((1 << (1+(b)-(a)))-1))
-#define BIT(n)      ((instr >> (n)) & 1)
-
-// For MUL instructions
-#define RDHi        ((instr >> 16) & 0xF)
-#define RDLo        ((instr >> 12) & 0xF)
-#define MUL_RD      ((instr >> 16) & 0xF)
-#define MUL_RN      ((instr >> 12) & 0xF)
-#define RS          ((instr >> 8) & 0xF)
-#define RD          ((instr >> 12) & 0xF)
-#define RN          ((instr >> 16) & 0xF)
-#define RM          (instr & 0xF)
-
-// CP15 registers
-#define OPCODE_1    BITS(21, 23)
-#define CRn         BITS(16, 19)
-#define CRm         BITS(0, 3)
-#define OPCODE_2    BITS(5, 7)
-
-#define I           BIT(25)
-#define S           BIT(20)
-
-#define             SHIFT BITS(5,6)
-#define             SHIFT_IMM BITS(7,11)
-#define             IMMH BITS(8,11)
-#define             IMML BITS(0,3)
-
-#define LSPBIT      BIT(24)
-#define LSUBIT      BIT(23)
-#define LSBBIT      BIT(22)
-#define LSWBIT      BIT(21)
-#define LSLBIT      BIT(20)
-#define LSSHBITS    BITS(5,6)
-#define OFFSET12    BITS(0,11)
-#define SBIT        BIT(20)
-#define DESTReg     (BITS (12, 15))
-
 int decode_arm_instr(uint32_t instr, int32_t *idx);
 
 enum DECODE_STATUS {


### PR DESCRIPTION
Should also fix warnings related to macro redefinitions.