### PR TITLE
dyncom: Implement RFE and SRS.

### DIFF
--- a/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
+++ b/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
@@ -2585,7 +2585,23 @@ static ARM_INST_PTR INTERPRETER_TRANSLATE(smulw)(unsigned int inst, int index)
         inst_base->load_r15 = 1;
     return inst_base;
 }
-static ARM_INST_PTR INTERPRETER_TRANSLATE(srs)(unsigned int inst, int index)      { UNIMPLEMENTED_INSTRUCTION("SRS"); }
+
+static ARM_INST_PTR INTERPRETER_TRANSLATE(srs)(unsigned int inst, int index)
+{
+    arm_inst* const inst_base = (arm_inst*)AllocBuffer(sizeof(arm_inst) + sizeof(ldst_inst));
+    ldst_inst* const inst_cream = (ldst_inst*)inst_base->component;
+
+    inst_base->cond     = AL;
+    inst_base->idx      = index;
+    inst_base->br       = NON_BRANCH;
+    inst_base->load_r15 = 0;
+
+    inst_cream->inst     = inst;
+    inst_cream->get_addr = get_calc_addr_op(inst);
+
+    return inst_base;
+}
+
 static ARM_INST_PTR INTERPRETER_TRANSLATE(ssat)(unsigned int inst, int index)
 {
     arm_inst* const inst_base = (arm_inst*)AllocBuffer(sizeof(arm_inst) + sizeof(ssat_inst));
@@ -5963,6 +5979,21 @@ unsigned InterpreterMainLoop(ARMul_State* state) {
     }
 
     SRS_INST:
+    {
+        // SRS is unconditional
+        ldst_inst* const inst_cream = (ldst_inst*)inst_base->component;
+
+        u32 address = 0;
+        inst_cream->get_addr(cpu, inst_cream->inst, address, 1);
+
+        WriteMemory32(cpu, address + 0, cpu->Reg[14]);
+        WriteMemory32(cpu, address + 4, cpu->Spsr_copy);
+
+        cpu->Reg[15] += GET_INST_SIZE(cpu);
+        INC_PC(sizeof(ldst_inst));
+        FETCH_INST;
+        GOTO_NEXT_INST;
+    }
 
     SSAT_INST:
     {


### PR DESCRIPTION
These are system instructions, but they can be easily implemented. Since the dyncom handles banked registers in the background upon mode switching, we don't need to care about handling them explicitly.