### PR TITLE
Allow the user to set the background clear color during emulation

### DIFF
--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -66,6 +66,11 @@ void Config::ReadValues() {
     Settings::values.gpu_refresh_rate = glfw_config->GetInteger("Core", "gpu_refresh_rate", 30);
     Settings::values.frame_skip = glfw_config->GetInteger("Core", "frame_skip", 0);
 
+    // Renderer
+    Settings::values.bg_red   = (float)glfw_config->GetReal("Renderer", "bg_red",   1.0);
+    Settings::values.bg_green = (float)glfw_config->GetReal("Renderer", "bg_green", 1.0);
+    Settings::values.bg_blue  = (float)glfw_config->GetReal("Renderer", "bg_blue",  1.0);
+
     // Data Storage
     Settings::values.use_virtual_sd = glfw_config->GetBoolean("Data Storage", "use_virtual_sd", true);
 

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -41,6 +41,13 @@ gpu_refresh_rate =
 # 0 (default): No frameskip, 1: x2 frameskip, 2: x4 frameskip, 3: x8 frameskip, etc.
 frame_skip =
 
+[Renderer]
+# The clear color for the renderer. What shows up on the sides of the bottom screen.
+# Must be in range of 0.0-1.0. Defaults to 1.0 for all.
+bg_red =
+bg_blue =
+bg_green =
+
 [Data Storage]
 # Whether to create a virtual SD card.
 # 1 (default): Yes, 0: No

--- a/src/citra_qt/config.cpp
+++ b/src/citra_qt/config.cpp
@@ -53,6 +53,12 @@ void Config::ReadValues() {
     Settings::values.frame_skip = qt_config->value("frame_skip", 0).toInt();
     qt_config->endGroup();
 
+    qt_config->beginGroup("Renderer");
+    Settings::values.bg_red   = qt_config->value("bg_red",   1.0).toFloat();
+    Settings::values.bg_green = qt_config->value("bg_green", 1.0).toFloat();
+    Settings::values.bg_blue  = qt_config->value("bg_blue",  1.0).toFloat();
+    qt_config->endGroup();
+
     qt_config->beginGroup("Data Storage");
     Settings::values.use_virtual_sd = qt_config->value("use_virtual_sd", true).toBool();
     qt_config->endGroup();
@@ -96,6 +102,13 @@ void Config::SaveValues() {
     qt_config->beginGroup("Core");
     qt_config->setValue("gpu_refresh_rate", Settings::values.gpu_refresh_rate);
     qt_config->setValue("frame_skip", Settings::values.frame_skip);
+    qt_config->endGroup();
+
+    qt_config->beginGroup("Renderer");
+    // Cast to double because Qt's written float values are not human-readable
+    qt_config->setValue("bg_red",   (double)Settings::values.bg_red);
+    qt_config->setValue("bg_green", (double)Settings::values.bg_green);
+    qt_config->setValue("bg_blue",  (double)Settings::values.bg_blue);
     qt_config->endGroup();
 
     qt_config->beginGroup("Data Storage");

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -44,6 +44,11 @@ struct Values {
     // System Region
     int region_value;
 
+    // Renderer
+    float bg_red;
+    float bg_green;
+    float bg_blue;
+
     std::string log_filter;
 } extern values;
 

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -6,6 +6,7 @@
 #include "core/hw/hw.h"
 #include "core/hw/lcd.h"
 #include "core/mem_map.h"
+#include "core/settings.h"
 
 #include "common/emu_window.h"
 #include "common/profiler_reporting.h"
@@ -172,7 +173,7 @@ void RendererOpenGL::LoadColorToActiveGLTexture(u8 color_r, u8 color_g, u8 color
  * Initializes the OpenGL state and creates persistent objects.
  */
 void RendererOpenGL::InitOpenGLObjects() {
-    glClearColor(1.0f, 1.0f, 1.0f, 0.0f);
+    glClearColor(Settings::values.bg_red, Settings::values.bg_green, Settings::values.bg_blue, 0.0f);
     glDisable(GL_DEPTH_TEST);
 
     // Link shaders and get variable locations


### PR DESCRIPTION
The background color can be seen at the sides of the bottom screen or when the window is wider than normal.