### PR TITLE
Clean-up mem_map constants and fix framebuffer translation errors

### DIFF
--- a/src/core/hle/service/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp_gpu.cpp
@@ -204,16 +204,18 @@ static void ReadHWRegs(Service::Interface* self) {
 
 static void SetBufferSwap(u32 screen_id, const FrameBufferInfo& info) {
     u32 base_address = 0x400000;
+    PAddr phys_address_left = Memory::VirtualToPhysicalAddress(info.address_left);
+    PAddr phys_address_right = Memory::VirtualToPhysicalAddress(info.address_right);
     if (info.active_fb == 0) {
         WriteHWRegs(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(framebuffer_config[screen_id].address_left1)), 4, 
-                &info.address_left);
+                &phys_address_left);
         WriteHWRegs(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(framebuffer_config[screen_id].address_right1)), 4, 
-                &info.address_right);
+                &phys_address_right);
     } else {
         WriteHWRegs(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(framebuffer_config[screen_id].address_left2)), 4, 
-                &info.address_left);
+                &phys_address_left);
         WriteHWRegs(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(framebuffer_config[screen_id].address_right2)), 4, 
-                &info.address_right);
+                &phys_address_right);
     }
     WriteHWRegs(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(framebuffer_config[screen_id].stride)), 4, 
             &info.stride);

--- a/src/core/mem_map.h
+++ b/src/core/mem_map.h
@@ -27,10 +27,16 @@ enum : u32 {
     MPCORE_PRIV_PADDR_END       = (MPCORE_PRIV_PADDR + MPCORE_PRIV_SIZE),
 
     FCRAM_SIZE                  = 0x08000000,   ///< FCRAM size
-    FCRAM_PADDR                 = 0x20000000,                       ///< FCRAM physical address
-    FCRAM_PADDR_END             = (FCRAM_PADDR + FCRAM_SIZE),       ///< FCRAM end of physical space
-    FCRAM_VADDR                 = 0x08000000,                       ///< FCRAM virtual address
-    FCRAM_VADDR_END             = (FCRAM_VADDR + FCRAM_SIZE),       ///< FCRAM end of virtual space
+    FCRAM_PADDR                 = 0x20000000,   ///< FCRAM physical address
+    FCRAM_PADDR_END             = (FCRAM_PADDR + FCRAM_SIZE),
+
+    HEAP_SIZE                   = FCRAM_SIZE,   ///< Application heap size
+    HEAP_VADDR                  = 0x08000000,
+    HEAP_VADDR_END              = (HEAP_VADDR + HEAP_SIZE),
+
+    HEAP_LINEAR_SIZE            = FCRAM_SIZE,
+    HEAP_LINEAR_VADDR           = 0x14000000,
+    HEAP_LINEAR_VADDR_END       = (HEAP_LINEAR_VADDR + HEAP_LINEAR_SIZE),
     
     AXI_WRAM_SIZE               = 0x00080000,   ///< AXI WRAM size
     AXI_WRAM_PADDR              = 0x1FF80000,   ///< AXI WRAM physical address
@@ -64,18 +70,6 @@ enum : u32 {
     SYSTEM_MEMORY_SIZE          = 0x02C00000,   ///< 44MB
     SYSTEM_MEMORY_VADDR         = 0x04000000,
     SYSTEM_MEMORY_VADDR_END     = (SYSTEM_MEMORY_VADDR + SYSTEM_MEMORY_SIZE),
-
-    HEAP_SIZE                   = FCRAM_SIZE,   ///< Application heap size
-    //HEAP_PADDR                  = HEAP_GSP_SIZE,
-    //HEAP_PADDR_END              = (HEAP_PADDR + HEAP_SIZE),
-    HEAP_VADDR                  = 0x08000000,
-    HEAP_VADDR_END              = (HEAP_VADDR + HEAP_SIZE),
-
-    HEAP_LINEAR_SIZE            = 0x08000000,   ///< Linear heap size... TODO: Define correctly?
-    HEAP_LINEAR_VADDR           = 0x14000000,
-    HEAP_LINEAR_VADDR_END       = (HEAP_LINEAR_VADDR + HEAP_LINEAR_SIZE),
-    HEAP_LINEAR_PADDR           = 0x00000000,
-    HEAP_LINEAR_PADDR_END       = (HEAP_LINEAR_PADDR + HEAP_LINEAR_SIZE),
 
     HARDWARE_IO_SIZE            = 0x01000000,
     HARDWARE_IO_PADDR           = 0x10000000,                       ///< IO physical address start

--- a/src/core/mem_map_funcs.cpp
+++ b/src/core/mem_map_funcs.cpp
@@ -23,10 +23,12 @@ VAddr PhysicalToVirtualAddress(const PAddr addr) {
     // to virtual address translations here. This is quite hacky, but necessary until we implement
     // proper MMU emulation.
     // TODO: Screw it, I'll let bunnei figure out how to do this properly.
-    if ((addr >= VRAM_PADDR) && (addr < VRAM_PADDR_END)) {
+    if (addr == 0) {
+        return 0;
+    } else if ((addr >= VRAM_PADDR) && (addr < VRAM_PADDR_END)) {
         return addr - VRAM_PADDR + VRAM_VADDR;
-    }else if ((addr >= FCRAM_PADDR) && (addr < FCRAM_PADDR_END)) {
-        return addr - FCRAM_PADDR + FCRAM_VADDR;
+    } else if ((addr >= FCRAM_PADDR) && (addr < FCRAM_PADDR_END)) {
+        return addr - FCRAM_PADDR + HEAP_LINEAR_VADDR;
     }
 
     LOG_ERROR(HW_Memory, "Unknown physical address @ 0x%08x", addr);
@@ -39,10 +41,12 @@ PAddr VirtualToPhysicalAddress(const VAddr addr) {
     // to virtual address translations here. This is quite hacky, but necessary until we implement
     // proper MMU emulation.
     // TODO: Screw it, I'll let bunnei figure out how to do this properly.
-    if ((addr >= VRAM_VADDR) && (addr < VRAM_VADDR_END)) {
-        return addr - 0x07000000;
-    } else if ((addr >= FCRAM_VADDR) && (addr < FCRAM_VADDR_END)) {
-        return addr - FCRAM_VADDR + FCRAM_PADDR;
+    if (addr == 0) {
+        return 0;
+    } else if ((addr >= VRAM_VADDR) && (addr < VRAM_VADDR_END)) {
+        return addr - VRAM_VADDR + VRAM_PADDR;
+    } else if ((addr >= HEAP_LINEAR_VADDR) && (addr < HEAP_LINEAR_VADDR_END)) {
+        return addr - HEAP_LINEAR_VADDR + FCRAM_PADDR;
     }
 
     LOG_ERROR(HW_Memory, "Unknown virtual address @ 0x%08x", addr);


### PR DESCRIPTION
This gets rid of spurious error messages like these:
```
[  18.481601] HW.Memory <Error> core\mem_map_funcs.cpp:Memory::VirtualToPhysicalAddress:48: Unknown virtual address @ 0x14189c70
[  18.481601] HW.Memory <Error> core\mem_map_funcs.cpp:Memory::PhysicalToVirtualAddress:32: Unknown physical address @ 0x14189c70
[  18.558621] HW.Memory <Error> core\mem_map_funcs.cpp:Memory::VirtualToPhysicalAddress:48: Unknown virtual address @ 0x14046520
[  18.558621] HW.Memory <Error> core\mem_map_funcs.cpp:Memory::PhysicalToVirtualAddress:32: Unknown physical address @ 0x14046520
```