### PR TITLE
Thread priority and scheduler improvements

### DIFF
--- a/src/common/thread_queue_list.h
+++ b/src/common/thread_queue_list.h
@@ -40,6 +40,18 @@ struct ThreadQueueList {
         return -1;
     }
 
+    T get_first() {
+        Queue *cur = first;
+        while (cur != nullptr) {
+            if (!cur->data.empty()) {
+                return cur->data.front();
+            }
+            cur = cur->next_nonempty;
+        }
+
+        return T();
+    }
+
     T pop_first() {
         Queue *cur = first;
         while (cur != nullptr) {
@@ -77,6 +89,12 @@ struct ThreadQueueList {
     void push_back(Priority priority, const T& thread_id) {
         Queue *cur = &queues[priority];
         cur->data.push_back(thread_id);
+    }
+
+    void move(const T& thread_id, Priority old_priority, Priority new_priority) {
+        remove(old_priority, thread_id);
+        prepare(new_priority);
+        push_back(new_priority, thread_id);
     }
 
     void remove(Priority priority, const T& thread_id) {

--- a/src/core/hle/function_wrappers.h
+++ b/src/core/hle/function_wrappers.h
@@ -46,6 +46,13 @@ template<ResultCode func(u32*, u32, u32, u32, u32, u32)> void Wrap(){
     FuncReturn(retval);
 }
 
+template<ResultCode func(u32*, s32, u32, u32, u32, s32)> void Wrap() {
+    u32 param_1 = 0;
+    u32 retval = func(&param_1, PARAM(0), PARAM(1), PARAM(2), PARAM(3), PARAM(4)).raw;
+    Core::g_app_core->SetReg(1, param_1);
+    FuncReturn(retval);
+}
+
 template<ResultCode func(s32*, u32*, s32, bool, s64)> void Wrap() {
     s32 param_1 = 0;
     s32 retval = func(&param_1, (Handle*)Memory::GetPointer(PARAM(1)), (s32)PARAM(2),

--- a/src/core/hle/kernel/address_arbiter.cpp
+++ b/src/core/hle/kernel/address_arbiter.cpp
@@ -46,14 +46,12 @@ ResultCode AddressArbiter::ArbitrateAddress(ArbitrationType type, VAddr address,
     case ArbitrationType::WaitIfLessThan:
         if ((s32)Memory::Read32(address) <= value) {
             Kernel::WaitCurrentThread_ArbitrateAddress(address);
-            HLE::Reschedule(__func__);
         }
         break;
     case ArbitrationType::WaitIfLessThanWithTimeout:
         if ((s32)Memory::Read32(address) <= value) {
             Kernel::WaitCurrentThread_ArbitrateAddress(address);
             GetCurrentThread()->WakeAfterDelay(nanoseconds);
-            HLE::Reschedule(__func__);
         }
         break;
     case ArbitrationType::DecrementAndWaitIfLessThan:
@@ -62,7 +60,6 @@ ResultCode AddressArbiter::ArbitrateAddress(ArbitrationType type, VAddr address,
         Memory::Write32(address, memory_value);
         if (memory_value <= value) {
             Kernel::WaitCurrentThread_ArbitrateAddress(address);
-            HLE::Reschedule(__func__);
         }
         break;
     }
@@ -73,7 +70,6 @@ ResultCode AddressArbiter::ArbitrateAddress(ArbitrationType type, VAddr address,
         if (memory_value <= value) {
             Kernel::WaitCurrentThread_ArbitrateAddress(address);
             GetCurrentThread()->WakeAfterDelay(nanoseconds);
-            HLE::Reschedule(__func__);
         }
         break;
     }

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -154,7 +154,7 @@ void Shutdown() {
  */
 bool LoadExec(u32 entry_point) {
     // 0x30 is the typical main thread priority I've seen used so far
-    g_main_thread = Kernel::SetupMainThread(Kernel::DEFAULT_STACK_SIZE, entry_point, 0x30);
+    g_main_thread = Kernel::SetupMainThread(Kernel::DEFAULT_STACK_SIZE, entry_point, THREADPRIO_DEFAULT);
 
     return true;
 }

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -140,6 +140,29 @@ void ArbitrateAllThreads(u32 address) {
     }
 }
 
+/// Boost low priority threads (temporarily) that have been starved
+static void PriorityBoostStarvedThreads() {
+    u64 current_ticks = CoreTiming::GetTicks();
+
+    for (auto& thread : thread_list) {
+        // TODO(bunnei): Threads that have been waiting to be scheduled for `boost_ticks` (or
+        // longer) will have their priority temporarily adjusted to 1 higher than the highest
+        // priority thread to prevent thread starvation. This general behavior has been verified
+        // on hardware. However, this is almost certainly not perfect, and the real CTR OS scheduler
+        // should probably be reversed to verify this.
+
+        const u64 boost_timeout = 2000000;  // Boost threads that have been ready for > this long
+
+        u64 delta = current_ticks - thread->last_running_ticks;
+
+        if (thread->status == THREADSTATUS_READY && delta > boost_timeout && !thread->idle) {
+            const s32 boost_priority = std::max(ready_queue.get_first()->current_priority - 1, 0);
+            ready_queue.move(thread, thread->current_priority, boost_priority);
+            thread->current_priority = boost_priority;
+        }
+    }
+}
+
 /** 
  * Switches the CPU's active thread context to that of the specified thread
  * @param new_thread The thread to switch to
@@ -151,6 +174,7 @@ static void SwitchContext(Thread* new_thread) {
 
     // Save context for previous thread
     if (previous_thread) {
+        previous_thread->last_running_ticks = CoreTiming::GetTicks();
         Core::g_app_core->SaveContext(previous_thread->context);
 
         if (previous_thread->status == THREADSTATUS_RUNNING) {
@@ -167,6 +191,9 @@ static void SwitchContext(Thread* new_thread) {
 
         ready_queue.remove(new_thread->current_priority, new_thread);
         new_thread->status = THREADSTATUS_RUNNING;
+
+        // Restores thread to its nominal priority if it has been temporarily changed
+        new_thread->current_priority = new_thread->nominal_priority;
 
         Core::g_app_core->LoadContext(new_thread->context);
     } else {
@@ -364,7 +391,8 @@ ResultVal<SharedPtr<Thread>> Thread::Create(std::string name, VAddr entry_point,
     thread->status = THREADSTATUS_DORMANT;
     thread->entry_point = entry_point;
     thread->stack_top = stack_top;
-    thread->initial_priority = thread->current_priority = priority;
+    thread->nominal_priority = thread->current_priority = priority;
+    thread->last_running_ticks = CoreTiming::GetTicks();
     thread->processor_id = processor_id;
     thread->wait_set_output = false;
     thread->wait_all = false;
@@ -400,18 +428,11 @@ static void ClampPriority(const Thread* thread, s32* priority) {
 void Thread::SetPriority(s32 priority) {
     ClampPriority(this, &priority);
 
-    if (current_priority == priority) {
-        return;
-    }
+    // If thread was ready, adjust queues
+    if (status == THREADSTATUS_READY)
+        ready_queue.move(this, current_priority, priority);
 
-    if (status == THREADSTATUS_READY) {
-        // If thread was ready, adjust queues
-        ready_queue.remove(current_priority, this);
-        ready_queue.prepare(priority);
-        ready_queue.push_back(priority, this);
-    }
-    
-    current_priority = priority;
+    nominal_priority = current_priority = priority;
 }
 
 SharedPtr<Thread> SetupIdleThread() {
@@ -440,6 +461,9 @@ SharedPtr<Thread> SetupMainThread(u32 stack_size, u32 entry_point, s32 priority)
 
 void Reschedule() {
     Thread* prev = GetCurrentThread();
+
+    PriorityBoostStarvedThreads();
+
     Thread* next = PopNextReadyThread();
     HLE::g_reschedule = false;
 

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -156,9 +156,8 @@ static void PriorityBoostStarvedThreads() {
         u64 delta = current_ticks - thread->last_running_ticks;
 
         if (thread->status == THREADSTATUS_READY && delta > boost_timeout && !thread->idle) {
-            const s32 boost_priority = std::max(ready_queue.get_first()->current_priority - 1, 0);
-            ready_queue.move(thread, thread->current_priority, boost_priority);
-            thread->current_priority = boost_priority;
+            const s32 priority = std::max(ready_queue.get_first()->current_priority - 1, 0);
+            thread->BoostPriority(priority);
         }
     }
 }
@@ -433,6 +432,11 @@ void Thread::SetPriority(s32 priority) {
         ready_queue.move(this, current_priority, priority);
 
     nominal_priority = current_priority = priority;
+}
+
+void Thread::BoostPriority(s32 priority) {
+    ready_queue.move(this, current_priority, priority);
+    current_priority = priority;
 }
 
 SharedPtr<Thread> SetupIdleThread() {

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -90,6 +90,12 @@ public:
     void SetPriority(s32 priority);
 
     /**
+     * Temporarily boosts the thread's priority until the next time it is scheduled
+     * @param priority The new priority
+     */
+    void BoostPriority(s32 priority);
+
+    /**
      * Gets the thread's thread ID
      * @return The thread's ID
      */

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -17,16 +17,19 @@
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/result.h"
 
-enum ThreadPriority {
-    THREADPRIO_HIGHEST      = 0x0,  ///< Highest thread priority
-    THREADPRIO_DEFAULT      = 0x30, ///< Default thread priority for userland apps
-    THREADPRIO_LOWEST       = 0x3F, ///< Lowest thread priority
+enum ThreadPriority : s32{
+    THREADPRIO_HIGHEST          = 0,  ///< Highest thread priority
+    THREADPRIO_USERLAND_MAX     = 24, ///< Highest thread priority for userland apps
+    THREADPRIO_DEFAULT          = 48, ///< Default thread priority for userland apps
+    THREADPRIO_LOWEST           = 63, ///< Lowest thread priority
 };
 
-enum ThreadProcessorId {
-    THREADPROCESSORID_0     = 0xFFFFFFFE,   ///< Enables core appcode
-    THREADPROCESSORID_1     = 0xFFFFFFFD,   ///< Enables core syscore
-    THREADPROCESSORID_ALL   = 0xFFFFFFFC,   ///< Enables both cores
+enum ThreadProcessorId : s32 {
+    THREADPROCESSORID_DEFAULT   = -2, ///< Run thread on default core specified by exheader
+    THREADPROCESSORID_ALL       = -1, ///< Run thread on either core
+    THREADPROCESSORID_0         =  0, ///< Run thread on core 0 (AppCore)
+    THREADPROCESSORID_1         =  1, ///< Run thread on core 1 (SysCore)
+    THREADPROCESSORID_MAX       =  2, ///< Processor ID must be less than this
 };
 
 enum ThreadStatus {
@@ -134,8 +137,10 @@ public:
     u32 entry_point;
     u32 stack_top;
 
-    s32 initial_priority;
-    s32 current_priority;
+    s32 nominal_priority;   ///< Nominal thread priority, as set by the emulated application
+    s32 current_priority;   ///< Current thread priority, can be temporarily changed
+
+    u64 last_running_ticks; ///< CPU tick when thread was last running
 
     s32 processor_id;
 

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -18,10 +18,9 @@
 #include "core/hle/result.h"
 
 enum ThreadPriority {
-    THREADPRIO_HIGHEST      = 0,    ///< Highest thread priority
-    THREADPRIO_DEFAULT      = 16,   ///< Default thread priority for userland apps
-    THREADPRIO_LOW          = 31,   ///< Low range of thread priority for userland apps
-    THREADPRIO_LOWEST       = 63,   ///< Thread priority max checked by svcCreateThread
+    THREADPRIO_HIGHEST      = 0x0,  ///< Highest thread priority
+    THREADPRIO_DEFAULT      = 0x30, ///< Default thread priority for userland apps
+    THREADPRIO_LOWEST       = 0x3F, ///< Lowest thread priority
 };
 
 enum ThreadProcessorId {

--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -336,6 +336,8 @@ static ResultCode CreateThread(u32* out_handle, u32 priority, u32 entry_point, u
             "thread designated for system CPU core (UNIMPLEMENTED) will be run with app core scheduling");
     }
 
+    HLE::Reschedule(__func__);
+
     return RESULT_SUCCESS;
 }
 

--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -338,9 +338,15 @@ static ResultCode CreateThread(Handle* out_handle, s32 priority, u32 entry_point
                           ErrorSummary::InvalidArgument, ErrorLevel::Usage);
     }
 
-    if (processor_id > THREADPROCESSORID_MAX) {
-        return ResultCode(ErrorDescription::OutOfRange, ErrorModule::Kernel,
-                          ErrorSummary::InvalidArgument, ErrorLevel::Permanent);
+    switch (processor_id) {
+    case THREADPROCESSORID_DEFAULT:
+    case THREADPROCESSORID_0:
+    case THREADPROCESSORID_1:
+        break;
+    default:
+        // TODO(bunnei): Implement support for other processor IDs
+        ASSERT_MSG(false, "Unsupported thread processor ID: %d", processor_id);
+        break;
     }
 
     CASCADE_RESULT(SharedPtr<Thread> thread, Kernel::Thread::Create(


### PR DESCRIPTION
Adds support for priority boosting for starved threads, priority inheritance for mutexes, some additional (verified) error codes on svcCreateThread, and some additional bug fixes/improvements. I've written some hardware tests that I'll publish at a later time that verify these changes. Some outstanding things for my next PR:
* Identify any other scenarios (other than a mutex wait) that might cause priority inheritance (and implement)
* Implement kernel reschedule on other SVCs as appropriate
* RE other error codes that are used and implement