### PR TITLE
dyncom: Remove unnecessary enum and typedef

### DIFF
--- a/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
+++ b/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
@@ -3557,7 +3557,7 @@ enum {
     FETCH_FAILURE
 };
 
-static tdstate decode_thumb_instr(ARMul_State* cpu, uint32_t inst, addr_t addr, uint32_t* arm_inst, uint32_t* inst_size, ARM_INST_PTR* ptr_inst_base){
+static tdstate decode_thumb_instr(ARMul_State* cpu, u32 inst, u32 addr, u32* arm_inst, u32* inst_size, ARM_INST_PTR* ptr_inst_base) {
     // Check if in Thumb mode
     tdstate ret = thumb_translate (addr, inst, arm_inst, inst_size);
     if(ret == t_branch){
@@ -3620,7 +3620,7 @@ typedef struct instruction_set_encoding_item ISEITEM;
 
 extern const ISEITEM arm_instruction[];
 
-static int InterpreterTranslate(ARMul_State* cpu, int& bb_start, addr_t addr) {
+static int InterpreterTranslate(ARMul_State* cpu, int& bb_start, u32 addr) {
     Common::Profiling::ScopeTimer timer_decode(profile_decode);
 
     // Decode instruction, get index
@@ -3638,8 +3638,8 @@ static int InterpreterTranslate(ARMul_State* cpu, int& bb_start, addr_t addr) {
     if (cpu->TFlag)
         thumb = THUMB;
 
-    addr_t phys_addr = addr;
-    addr_t pc_start = cpu->Reg[15];
+    u32 phys_addr = addr;
+    u32 pc_start = cpu->Reg[15];
 
     while(ret == NON_BRANCH) {
         inst = Memory::Read32(phys_addr & 0xFFFFFFFC);

--- a/src/core/arm/dyncom/arm_dyncom_run.h
+++ b/src/core/arm/dyncom/arm_dyncom_run.h
@@ -22,31 +22,36 @@
 
 void switch_mode(ARMul_State* core, uint32_t mode);
 
-/* FIXME, we temporarily think thumb instruction is always 16 bit */
+// Note that for the 3DS, a Thumb instruction will only ever be
+// two bytes in size. Thus we don't need to worry about ThumbEE
+// or Thumb-2 where instructions can be 4 bytes in length.
 static inline u32 GET_INST_SIZE(ARMul_State* core) {
     return core->TFlag? 2 : 4;
 }
 
 /**
-* @brief Read R15 and forced R15 to wold align, used address calculation
-*
-* @param core
-* @param Rn
-*
-* @return 
-*/
-static inline addr_t CHECK_READ_REG15_WA(ARMul_State* core, int Rn) {
-    return (Rn == 15)? ((core->Reg[15] & ~0x3) + GET_INST_SIZE(core) * 2) : core->Reg[Rn];
+ * Checks if the PC is being read, and if so, word-aligns it.
+ * Used with address calculations.
+ *
+ * @param core The ARM CPU state instance.
+ * @param Rn   The register being read.
+ *
+ * @return If the PC is being read, then the word-aligned PC value is returned.
+ *         If the PC is not being read, then the value stored in the register is returned.
+ */
+static inline u32 CHECK_READ_REG15_WA(ARMul_State* core, int Rn) {
+    return (Rn == 15) ? ((core->Reg[15] & ~0x3) + GET_INST_SIZE(core) * 2) : core->Reg[Rn];
 }
 
 /**
-* @brief Read R15, used to data processing with pc
-*
-* @param core
-* @param Rn
-*
-* @return 
-*/
+ * Reads the PC. Used for data processing operations that use the PC.
+ *
+ * @param core The ARM CPU state instance.
+ * @param Rn   The register being read.
+ *
+ * @return If the PC is being read, then the incremented PC value is returned.
+ *         If the PC is not being read, then the values stored in the register is returned.
+ */
 static inline u32 CHECK_READ_REG15(ARMul_State* core, int Rn) {
-    return (Rn == 15)? ((core->Reg[15] & ~0x1) + GET_INST_SIZE(core) * 2) : core->Reg[Rn];
+    return (Rn == 15) ? ((core->Reg[15] & ~0x1) + GET_INST_SIZE(core) * 2) : core->Reg[Rn];
 }

--- a/src/core/arm/dyncom/arm_dyncom_thumb.cpp
+++ b/src/core/arm/dyncom/arm_dyncom_thumb.cpp
@@ -13,7 +13,7 @@
 // with the following Thumb instruction held in the high 16-bits.  Passing in two Thumb instructions
 // allows easier simulation of the special dual BL instruction.
 
-tdstate thumb_translate(addr_t addr, uint32_t instr, uint32_t* ainstr, uint32_t* inst_size) {
+tdstate thumb_translate(u32 addr, u32 instr, u32* ainstr, u32* inst_size) {
     tdstate valid = t_uninitialized;
     ARMword tinstr = instr;
 

--- a/src/core/arm/dyncom/arm_dyncom_thumb.h
+++ b/src/core/arm/dyncom/arm_dyncom_thumb.h
@@ -35,9 +35,9 @@ enum tdstate {
     t_uninitialized,
 };
 
-tdstate thumb_translate(addr_t addr, u32 instr, u32* ainstr, u32* inst_size);
+tdstate thumb_translate(u32 addr, u32 instr, u32* ainstr, u32* inst_size);
 
-static inline u32 get_thumb_instr(u32 instr, addr_t pc) {
+static inline u32 get_thumb_instr(u32 instr, u32 pc) {
     u32 tinstr;
     if ((pc & 0x3) != 0)
         tinstr = instr >> 16;

--- a/src/core/arm/skyeye_common/skyeye_defs.h
+++ b/src/core/arm/skyeye_common/skyeye_defs.h
@@ -11,28 +11,3 @@ struct cpu_config_t
     u32 cpu_mask;              // cpu_val's mask.
     u32 cachetype;             // CPU cache type
 };
-
-enum {
-    // No exception
-    No_exp = 0,
-    // Memory allocation exception
-    Malloc_exp,
-    // File open exception
-    File_open_exp,
-    // DLL open exception
-    Dll_open_exp,
-    // Invalid argument exception
-    Invarg_exp,
-    // Invalid module exception
-    Invmod_exp,
-    // wrong format exception for config file parsing
-    Conf_format_exp,
-    // some reference excess the predefiend range. Such as the index out of array range
-    Excess_range_exp,
-    // Can not find the desirable result
-    Not_found_exp,
-    // Unknown exception
-    Unknown_exp
-};
-
-typedef u32 addr_t;


### PR DESCRIPTION
Also fixes descriptions in the process.