### PR TITLE
Shared_memory: Initialize base address to 0x0

### DIFF
--- a/src/core/hle/kernel/shared_memory.cpp
+++ b/src/core/hle/kernel/shared_memory.cpp
@@ -16,6 +16,7 @@ SharedPtr<SharedMemory> SharedMemory::Create(std::string name) {
     SharedPtr<SharedMemory> shared_memory(new SharedMemory);
 
     shared_memory->name = std::move(name);
+    shared_memory->base_address = 0x0;
 
     return shared_memory;
 }


### PR DESCRIPTION
Initialize base_address to 0x0. Instead of leaving it as uninitialized (0xcdcdcdcd) which is out of memory range. This should now identify the unmapped block, rather than reporting bad pointer.