### PR TITLE
Services/Loader: Use more sensible log formats for certain functions along with more info being logged.

### DIFF
--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -53,12 +53,12 @@ ResultCode GetConfigInfoBlock(u32 block_id, u32 size, u32 flag, u8* output) {
         });
 
     if (itr == std::end(config->block_entries)) {
-        LOG_ERROR(Service_CFG, "Config block %u with flags %u was not found", block_id, flag);
+        LOG_ERROR(Service_CFG, "Config block 0x%X with flags %u and size %u was not found", block_id, flag, size);
         return ResultCode(ErrorDescription::NotFound, ErrorModule::Config, ErrorSummary::WrongArgument, ErrorLevel::Permanent);
     }
 
     if (itr->size != size) {
-        LOG_ERROR(Service_CFG, "Invalid size %u for config block %u with flags %u", size, block_id, flag);
+        LOG_ERROR(Service_CFG, "Invalid size %u for config block 0x%X with flags %u", size, block_id, flag);
         return ResultCode(ErrorDescription::InvalidSize, ErrorModule::Config, ErrorSummary::WrongArgument, ErrorLevel::Permanent);
     }
 

--- a/src/core/hle/service/dsp_dsp.cpp
+++ b/src/core/hle/service/dsp_dsp.cpp
@@ -42,7 +42,7 @@ static void ConvertProcessAddressFromDspDram(Service::Interface* self) {
     cmd_buff[1] = 0; // No error
     cmd_buff[2] = (addr << 1) + (Memory::DSP_MEMORY_VADDR + 0x40000);
 
-    LOG_WARNING(Service_DSP, "(STUBBED) called with address %u", addr);
+    LOG_WARNING(Service_DSP, "(STUBBED) called with address 0x%08X", addr);
 }
 
 /**
@@ -60,12 +60,19 @@ static void ConvertProcessAddressFromDspDram(Service::Interface* self) {
 static void LoadComponent(Service::Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
+    u32 size       = cmd_buff[1];
+    u32 unk1       = cmd_buff[2];
+    u32 unk2       = cmd_buff[3];
+    u32 new_size   = cmd_buff[4];
+    u32 buffer     = cmd_buff[5];
+
     cmd_buff[1] = 0; // No error
     cmd_buff[2] = 1; // Pretend that we actually loaded the DSP firmware
 
     // TODO(bunnei): Implement real DSP firmware loading
 
-    LOG_WARNING(Service_DSP, "(STUBBED) called");
+    LOG_WARNING(Service_DSP, "(STUBBED) called size=0x%X, unk1=0x%08X, unk2=0x%08X, new_size=0x%X, buffer=0x%08X",
+                size, unk1, unk2, new_size, buffer);
 }
 
 /**
@@ -106,7 +113,7 @@ static void FlushDataCache(Service::Interface* self) {
 
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
 
-    LOG_DEBUG(Service_DSP, "(STUBBED) called address=0x%08X, size=0x%08X, process=0x%08X",
+    LOG_DEBUG(Service_DSP, "(STUBBED) called address=0x%08X, size=0x%X, process=0x%08X",
               address, size, process);
 }
 
@@ -122,6 +129,10 @@ static void FlushDataCache(Service::Interface* self) {
 static void RegisterInterruptEvents(Service::Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
+    u32 param0 = cmd_buff[1];
+    u32 param1 = cmd_buff[2];
+    u32 event_handle = cmd_buff[4];
+
     auto evt = Kernel::g_handle_table.Get<Kernel::Event>(cmd_buff[4]);
     if (evt != nullptr) {
         interrupt_event = evt;
@@ -133,7 +144,7 @@ static void RegisterInterruptEvents(Service::Interface* self) {
         cmd_buff[1] = -1;
     }
 
-    LOG_WARNING(Service_DSP, "(STUBBED) called");
+    LOG_WARNING(Service_DSP, "(STUBBED) called param0=%u, param1=%u, event_handle=0x%08X", param0, param1, event_handle);
 }
 
 /**
@@ -174,7 +185,7 @@ static void WriteProcessPipe(Service::Interface* self) {
 
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
 
-    LOG_WARNING(Service_DSP, "(STUBBED) called number=%u, size=0x%08X, new_size=0x%08X, buffer=0x%08X",
+    LOG_WARNING(Service_DSP, "(STUBBED) called number=%u, size=0x%X, new_size=0x%X, buffer=0x%08X",
                 number, size, new_size, buffer);
 }
 
@@ -192,6 +203,8 @@ static void WriteProcessPipe(Service::Interface* self) {
 static void ReadPipeIfPossible(Service::Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
+    u32 unk1 = cmd_buff[1];
+    u32 unk2 = cmd_buff[2];
     u32 size = cmd_buff[3] & 0xFFFF;// Lower 16 bits are size
     VAddr addr = cmd_buff[0x41];
 
@@ -217,7 +230,8 @@ static void ReadPipeIfPossible(Service::Interface* self) {
     cmd_buff[1] = 0; // No error
     cmd_buff[2] = (read_pipe_count - initial_size) * sizeof(u16);
 
-    LOG_WARNING(Service_DSP, "(STUBBED) called size=0x%08X, buffer=0x%08X", size, addr);
+    LOG_WARNING(Service_DSP, "(STUBBED) called unk1=0x%08X, unk2=0x%08X, size=0x%X, buffer=0x%08X",
+                unk1, unk2, size, addr);
 }
 
 /**

--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -198,20 +198,33 @@ ResultStatus AppLoader_NCCH::Load() {
     if (file->ReadBytes(&exheader_header, sizeof(ExHeader_Header)) != sizeof(ExHeader_Header))
         return ResultStatus::Error;
 
-    is_compressed = (exheader_header.codeset_info.flags.flag & 1) == 1;
-    entry_point = exheader_header.codeset_info.text.address;
+    is_compressed           = (exheader_header.codeset_info.flags.flag & 1) == 1;
+    entry_point             = exheader_header.codeset_info.text.address;
+    code_size               = exheader_header.codeset_info.text.code_size;
+    stack_size              = exheader_header.codeset_info.stack_size;
+    bss_size                = exheader_header.codeset_info.bss_size;
+    core_version            = exheader_header.arm11_system_local_caps.core_version;
+    priority                = exheader_header.arm11_system_local_caps.priority;
+    resource_limit_category = exheader_header.arm11_system_local_caps.resource_limit_category;
 
-    LOG_INFO(Loader, "Name:            %s", exheader_header.codeset_info.name);
-    LOG_DEBUG(Loader, "Code compressed: %s", is_compressed ? "yes" : "no");
-    LOG_DEBUG(Loader, "Entry point:     0x%08X", entry_point);
+    LOG_INFO(Loader,  "Name:                         %s"   , exheader_header.codeset_info.name);
+    LOG_DEBUG(Loader, "Code compressed:             %s"    , is_compressed ? "yes" : "no");
+    LOG_DEBUG(Loader, "Entry point:                 0x%08X", entry_point);
+    LOG_DEBUG(Loader, "Code size:                   0x%08X", code_size);
+    LOG_DEBUG(Loader, "Stack size:                  0x%08X", stack_size);
+    LOG_DEBUG(Loader, "Bss size:                    0x%08X", bss_size);
+    LOG_DEBUG(Loader, "Core version:                %d"    , core_version);
+    LOG_DEBUG(Loader, "Thread priority:             0x%X"  , priority);
+    LOG_DEBUG(Loader, "Resource limit descriptor:   0x%08X", exheader_header.arm11_system_local_caps.resource_limit_descriptor);
+    LOG_DEBUG(Loader, "Resource limit category:     %d"    , resource_limit_category);
 
     // Read ExeFS...
 
     exefs_offset = ncch_header.exefs_offset * kBlockSize;
     u32 exefs_size = ncch_header.exefs_size * kBlockSize;
 
-    LOG_DEBUG(Loader, "ExeFS offset:    0x%08X", exefs_offset);
-    LOG_DEBUG(Loader, "ExeFS size:      0x%08X", exefs_size);
+    LOG_DEBUG(Loader, "ExeFS offset:                0x%08X", exefs_offset);
+    LOG_DEBUG(Loader, "ExeFS size:                  0x%08X", exefs_size);
 
     file->Seek(exefs_offset + ncch_offset, SEEK_SET);
     if (file->ReadBytes(&exefs_header, sizeof(ExeFs_Header)) != sizeof(ExeFs_Header))
@@ -247,8 +260,8 @@ ResultStatus AppLoader_NCCH::ReadRomFS(std::vector<u8>& buffer) const {
         u32 romfs_offset = ncch_offset + (ncch_header.romfs_offset * kBlockSize) + 0x1000;
         u32 romfs_size = (ncch_header.romfs_size * kBlockSize) - 0x1000;
 
-        LOG_DEBUG(Loader, "RomFS offset:    0x%08X", romfs_offset);
-        LOG_DEBUG(Loader, "RomFS size:      0x%08X", romfs_size);
+        LOG_DEBUG(Loader, "RomFS offset:           0x%08X", romfs_offset);
+        LOG_DEBUG(Loader, "RomFS size:             0x%08X", romfs_size);
 
         buffer.resize(romfs_size);
 

--- a/src/core/loader/ncch.h
+++ b/src/core/loader/ncch.h
@@ -43,6 +43,8 @@ struct NCCH_Header {
     u8 romfs_super_block_hash[0x20];
 };
 
+static_assert(sizeof(NCCH_Header) == 0x200, "NCCH header structure size is wrong");
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // ExeFS (executable file system) headers
 
@@ -77,11 +79,11 @@ struct ExHeader_CodeSetInfo {
     u8 name[8];
     ExHeader_SystemInfoFlags flags;
     ExHeader_CodeSegmentInfo text;
-    u8 stacksize[4];
+    u32 stack_size;
     ExHeader_CodeSegmentInfo ro;
     u8 reserved[4];
     ExHeader_CodeSegmentInfo data;
-    u8 bsssize[4];
+    u32 bss_size;
 };
 
 struct ExHeader_DependencyList{
@@ -107,9 +109,9 @@ struct ExHeader_ARM11_SystemLocalCaps{
     u32 core_version;
     u8 flags[3];
     u8 priority;
-    u8 resource_limit_descriptor[0x16][2];
+    u8 resource_limit_descriptor[0x10][2];
     ExHeader_StorageInfo storage_info;
-    u8 service_access_control[0x32][8];
+    u8 service_access_control[0x20][8];
     u8 ex_service_access_control[0x2][8];
     u8 reserved[0xf];
     u8 resource_limit_category;
@@ -140,6 +142,8 @@ struct ExHeader_Header{
         ExHeader_ARM9_AccessControl arm9_access_control;
     } access_desc;
 };
+
+static_assert(sizeof(ExHeader_Header) == 0x800, "ExHeader structure size is wrong");
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Loader namespace
@@ -224,6 +228,12 @@ private:
     bool            is_compressed = false;
 
     u32             entry_point = 0;
+    u32             code_size = 0;
+    u32             stack_size = 0;
+    u32             bss_size = 0;
+    u32             core_version = 0;
+    u8              priority = 0;
+    u8              resource_limit_category = 0;
     u32             ncch_offset = 0; // Offset to NCCH header, can be 0 or after NCSD header
     u32             exefs_offset = 0;
 


### PR DESCRIPTION
Also fixed a  bug in the exheader, since some values on 3dbrew were using the  decimal format for some of the types instead of hex resulting in a invalid size for the exheader, to make sure this doesn't happen again I added a static assert for the exheader and for the ncch header, I also decided that logging some of the exheader values(like the stack size, bss size, etc.) would provide somewhat useful debug info.