### PR TITLE
Fix a few warnings as reported by clang 3.6

### DIFF
--- a/src/citra_qt/debugger/graphics_breakpoints_p.h
+++ b/src/citra_qt/debugger/graphics_breakpoints_p.h
@@ -25,7 +25,7 @@ public:
     QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
     QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
 
-    bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole);
+    bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole) override;
 
 public slots:
     void OnBreakPointHit(Pica::DebugContext::Event event);

--- a/src/citra_qt/debugger/profiler.h
+++ b/src/citra_qt/debugger/profiler.h
@@ -18,7 +18,7 @@ class ProfilerModel : public QAbstractItemModel
 public:
     ProfilerModel(QObject* parent);
 
-    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
+    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
     QModelIndex index(int row, int column, const QModelIndex& parent = QModelIndex()) const override;
     QModelIndex parent(const QModelIndex& child) const override;
     int columnCount(const QModelIndex& parent = QModelIndex()) const override;

--- a/src/citra_qt/util/spinbox.cpp
+++ b/src/citra_qt/util/spinbox.cpp
@@ -29,6 +29,7 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include <cstdlib>
 #include <QLineEdit>
 #include <QRegExpValidator>
 
@@ -206,7 +207,7 @@ QString CSpinBox::TextFromValue()
 {
     return prefix
            + QString(HasSign() ? ((value < 0) ? "-" : "+") : "")
-           + QString("%1").arg(abs(value), num_digits, base, QLatin1Char('0')).toUpper()
+           + QString("%1").arg(std::abs(value), num_digits, base, QLatin1Char('0')).toUpper()
            + suffix;
 }
 

--- a/src/core/arm/dyncom/arm_dyncom.h
+++ b/src/core/arm/dyncom/arm_dyncom.h
@@ -27,7 +27,7 @@ public:
 
     void AddTicks(u64 ticks) override;
 
-    void ResetContext(Core::ThreadContext& context, u32 stack_top, u32 entry_point, u32 arg);
+    void ResetContext(Core::ThreadContext& context, u32 stack_top, u32 entry_point, u32 arg) override;
     void SaveContext(Core::ThreadContext& ctx) override;
     void LoadContext(const Core::ThreadContext& ctx) override;
 

--- a/src/core/arm/skyeye_common/vfp/vfp_helper.h
+++ b/src/core/arm/skyeye_common/vfp/vfp_helper.h
@@ -36,9 +36,6 @@
 #include "common/common_types.h"
 #include "core/arm/skyeye_common/armdefs.h"
 
-#define pr_info //printf
-#define pr_debug //printf
-
 #define do_div(n, base) {n/=base;}
 
 enum : u32 {

--- a/src/core/file_sys/disk_archive.h
+++ b/src/core/file_sys/disk_archive.h
@@ -24,7 +24,7 @@ class DiskArchive : public ArchiveBackend {
 public:
     DiskArchive(const std::string& mount_point_) : mount_point(mount_point_) {}
 
-    virtual std::string GetName() const { return "DiskArchive: " + mount_point; }
+    virtual std::string GetName() const override { return "DiskArchive: " + mount_point; }
 
     std::unique_ptr<FileBackend> OpenFile(const Path& path, const Mode mode) const override;
     bool DeleteFile(const Path& path) const override;

--- a/src/core/hle/kernel/timer.cpp
+++ b/src/core/hle/kernel/timer.cpp
@@ -66,7 +66,7 @@ static void TimerCallback(u64 timer_handle, int cycles_late) {
     SharedPtr<Timer> timer = timer_callback_handle_table.Get<Timer>(static_cast<Handle>(timer_handle));
 
     if (timer == nullptr) {
-        LOG_CRITICAL(Kernel, "Callback fired for invalid timer %08X", timer_handle);
+        LOG_CRITICAL(Kernel, "Callback fired for invalid timer %08lX", timer_handle);
         return;
     }
 


### PR DESCRIPTION
This was just at its default error reporting level.

The remaining warnings are mostly due to UNREACHABLE() not telling it really is unreachable to the compiler.