### PR TITLE
Rename git submodules, so they are more easily accessible from external tools

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
-[submodule "externals/inih/inih"]
+[submodule "inih"]
 	path = externals/inih/inih
 	url = https://github.com/svn2github/inih
-[submodule "externals/boost"]
+[submodule "boost"]
 	path = externals/boost
 	url = https://github.com/citra-emu/ext-boost.git
-[submodule "externals/nihstro"]
+[submodule "nihstro"]
 	path = externals/nihstro
 	url = https://github.com/neobrain/nihstro.git


### PR DESCRIPTION
`git config submodule.<submodule>.url some/local/path` can now directly define where to find the submodule.