### PR TITLE
Services: Stubbed many low level services

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -60,12 +60,32 @@ set(SRCS
             hle/service/hid/hid_spvr.cpp
             hle/service/gsp_lcd.cpp
             hle/service/http_c.cpp
+            hle/service/i2c/i2c.cpp
+            hle/service/i2c/i2c_cam.cpp
+            hle/service/i2c/i2c_deb.cpp
+            hle/service/i2c/i2c_eep.cpp
+            hle/service/i2c/i2c_hid.cpp
+            hle/service/i2c/i2c_ir.cpp
+            hle/service/i2c/i2c_lcd.cpp
+            hle/service/i2c/i2c_mcu.cpp
+            hle/service/i2c/i2c_nfc.cpp
+            hle/service/i2c/i2c_qtm.cpp
             hle/service/ir/ir.cpp
             hle/service/ir/ir_rst.cpp
             hle/service/ir/ir_u.cpp
             hle/service/ir/ir_user.cpp
             hle/service/ldr_ro.cpp
             hle/service/mic_u.cpp
+            hle/service/mcu/mcu.cpp
+            hle/service/mcu/mcu_cam.cpp
+            hle/service/mcu/mcu_cdc.cpp
+            hle/service/mcu/mcu_gpu.cpp
+            hle/service/mcu/mcu_hid.cpp
+            hle/service/mcu/mcu_hwc.cpp
+            hle/service/mcu/mcu_nwm.cpp
+            hle/service/mcu/mcu_pls.cpp
+            hle/service/mcu/mcu_rtc.cpp
+            hle/service/mcu/mcu_snd.cpp
             hle/service/ndm_u.cpp
             hle/service/news_s.cpp
             hle/service/news_u.cpp
@@ -73,10 +93,17 @@ set(SRCS
             hle/service/nim_u.cpp
             hle/service/ns_s.cpp
             hle/service/nwm_uds.cpp
+            hle/service/pdn/pdn.cpp
+            hle/service/pdn/pdn_c.cpp
+            hle/service/pdn/pdn_d.cpp
+            hle/service/pdn/pdn_g.cpp
+            hle/service/pdn/pdn_i.cpp
+            hle/service/pdn/pdn_s.cpp
             hle/service/pm_app.cpp
             hle/service/ptm/ptm.cpp
             hle/service/ptm/ptm_play.cpp
             hle/service/ptm/ptm_u.cpp
+            hle/service/ptm/ptm_s.cpp
             hle/service/ptm/ptm_sysm.cpp
             hle/service/service.cpp
             hle/service/soc_u.cpp
@@ -171,12 +198,32 @@ set(HEADERS
             hle/service/hid/hid_user.h
             hle/service/gsp_lcd.h
             hle/service/http_c.h
+            hle/service/i2c/i2c.h
+            hle/service/i2c/i2c_cam.h
+            hle/service/i2c/i2c_deb.h
+            hle/service/i2c/i2c_eep.h
+            hle/service/i2c/i2c_hid.h
+            hle/service/i2c/i2c_ir.h
+            hle/service/i2c/i2c_lcd.h
+            hle/service/i2c/i2c_mcu.h
+            hle/service/i2c/i2c_nfc.h
+            hle/service/i2c/i2c_qtm.h
             hle/service/ir/ir.h
             hle/service/ir/ir_rst.h
             hle/service/ir/ir_u.h
             hle/service/ir/ir_user.h
             hle/service/ldr_ro.h
             hle/service/mic_u.h
+            hle/service/mcu/mcu.cpp
+            hle/service/mcu/mcu_cam.h
+            hle/service/mcu/mcu_cdc.h
+            hle/service/mcu/mcu_gpu.h
+            hle/service/mcu/mcu_hid.h
+            hle/service/mcu/mcu_hwc.h
+            hle/service/mcu/mcu_nwm.h
+            hle/service/mcu/mcu_pls.h
+            hle/service/mcu/mcu_rtc.h
+            hle/service/mcu/mcu_snd.h
             hle/service/ndm_u.h
             hle/service/news_s.h
             hle/service/news_u.h
@@ -184,10 +231,17 @@ set(HEADERS
             hle/service/nim_u.h
             hle/service/ns_s.h
             hle/service/nwm_uds.h
+            hle/service/pdn/pdn.h
+            hle/service/pdn/pdn_c.h
+            hle/service/pdn/pdn_d.h
+            hle/service/pdn/pdn_g.h
+            hle/service/pdn/pdn_i.h
+            hle/service/pdn/pdn_s.h
             hle/service/pm_app.h
             hle/service/ptm/ptm.h
             hle/service/ptm/ptm_play.h
             hle/service/ptm/ptm_u.h
+            hle/service/ptm/ptm_s.h
             hle/service/ptm/ptm_sysm.h
             hle/service/service.h
             hle/service/soc_u.h

--- a/src/core/hle/service/fs/fs_user.cpp
+++ b/src/core/hle/service/fs/fs_user.cpp
@@ -647,7 +647,7 @@ static void SetPriority(Service::Interface* self) {
 
     cmd_buff[1] = RESULT_SUCCESS.raw;
 
-    LOG_DEBUG(Service_FS, "called priority=0x%08X", priority);
+    LOG_DEBUG(Service_FS, "called priority=0x%X", priority);
 }
 
 /**
@@ -666,7 +666,7 @@ static void GetPriority(Service::Interface* self) {
     cmd_buff[1] = RESULT_SUCCESS.raw;
     cmd_buff[2] = priority;
 
-    LOG_DEBUG(Service_FS, "called priority=0x%08X", priority);
+    LOG_DEBUG(Service_FS, "called priority=0x%X", priority);
 }
 
 const Interface::FunctionInfo FunctionTable[] = {

--- a/src/core/hle/service/i2c/i2c.cpp
+++ b/src/core/hle/service/i2c/i2c.cpp
@@ -1,0 +1,43 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/service/service.h"
+#include "core/hle/service/i2c/i2c.h"
+#include "core/hle/service/i2c/i2c_cam.h"
+#include "core/hle/service/i2c/i2c_deb.h"
+#include "core/hle/service/i2c/i2c_eep.h"
+#include "core/hle/service/i2c/i2c_hid.h"
+#include "core/hle/service/i2c/i2c_ir.h"
+#include "core/hle/service/i2c/i2c_lcd.h"
+#include "core/hle/service/i2c/i2c_mcu.h"
+#include "core/hle/service/i2c/i2c_nfc.h"
+#include "core/hle/service/i2c/i2c_qtm.h"
+
+#include "core/hle/kernel/event.h"
+#include "core/hle/kernel/shared_memory.h"
+#include "core/hle/hle.h"
+
+namespace Service {
+namespace I2C {
+
+void Init() {
+    using namespace Kernel;
+
+    AddService(new I2C_CAM_Interface);
+    AddService(new I2C_DEB_Interface);
+    AddService(new I2C_EEP_Interface);
+    AddService(new I2C_HID_Interface);
+    AddService(new I2C_IR_Interface);
+    AddService(new I2C_LCD_Interface);
+    AddService(new I2C_MCU_Interface);
+    AddService(new I2C_NFC_Interface);
+    AddService(new I2C_QTM_Interface);
+}
+
+void Shutdown() {
+}
+
+} // namespace I2C
+
+} // namespace Service

--- a/src/core/hle/service/i2c/i2c.h
+++ b/src/core/hle/service/i2c/i2c.h
@@ -1,0 +1,20 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/kernel/kernel.h"
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace I2C {
+
+/// Initialize I2C service(s)
+void Init();
+
+/// Shutdown I2C service(s)
+void Shutdown();
+
+} // namespace I2C
+} // namespace Service

--- a/src/core/hle/service/i2c/i2c_cam.cpp
+++ b/src/core/hle/service/i2c/i2c_cam.cpp
@@ -1,0 +1,33 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/hle.h"
+#include "core/hle/service/i2c/i2c.h"
+#include "core/hle/service/i2c/i2c_cam.h"
+
+namespace Service {
+namespace I2C {
+
+const Interface::FunctionInfo FunctionTable[] = {
+    {0x00010100, nullptr,                    "SetRegisterBits8"},
+    {0x000300C0, nullptr,                    "DisableRegisterBits8"},
+    {0x00040102, nullptr,                    "MultiSetRegisterBits16"},
+    {0x000800C2, nullptr,                    "MultiWriteRegister16"},
+    {0x000B00C2, nullptr,                    "WriteRegister1Buffer8"},
+    {0x000C00C2, nullptr,                    "WriteRegisterBuffer16"},
+    {0x000D00C0, nullptr,                    "WriteRegister2Buffer8"},
+    {0x000E00C2, nullptr,                    "WriteRegister3Buffer8"},
+    {0x001100C2, nullptr,                    "ReadRegisterBuffer"},
+    {0x001200C2, nullptr,                    "WriteRegisterBuffer"},
+    {0x00130040, nullptr,                    "ReadDeviceRaw8"},
+    {0x00140082, nullptr,                    "WriteDeviceRaw"},
+    {0x00150080, nullptr,                    "ReadDeviceRaw"},
+};
+
+I2C_CAM_Interface::I2C_CAM_Interface() {
+    Register(FunctionTable);
+}
+    
+} // namespace I2C
+} // namespace Service

--- a/src/core/hle/service/i2c/i2c_cam.h
+++ b/src/core/hle/service/i2c/i2c_cam.h
@@ -1,0 +1,22 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace I2C {
+
+class I2C_CAM_Interface : public Service::Interface {
+public:
+    I2C_CAM_Interface();
+
+    std::string GetPortName() const override {
+        return "i2c::CAM";
+    }
+};
+
+} // namespace I2C
+} // namespace Service

--- a/src/core/hle/service/i2c/i2c_deb.cpp
+++ b/src/core/hle/service/i2c/i2c_deb.cpp
@@ -1,0 +1,33 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/hle.h"
+#include "core/hle/service/i2c/i2c.h"
+#include "core/hle/service/i2c/i2c_deb.h"
+
+namespace Service {
+namespace I2C {
+
+const Interface::FunctionInfo FunctionTable[] = {
+    {0x00010100, nullptr,                    "SetRegisterBits8"},
+    {0x000300C0, nullptr,                    "DisableRegisterBits8"},
+    {0x00040102, nullptr,                    "MultiSetRegisterBits16"},
+    {0x000800C2, nullptr,                    "MultiWriteRegister16"},
+    {0x000B00C2, nullptr,                    "WriteRegister1Buffer8"},
+    {0x000C00C2, nullptr,                    "WriteRegisterBuffer16"},
+    {0x000D00C0, nullptr,                    "WriteRegister2Buffer8"},
+    {0x000E00C2, nullptr,                    "WriteRegister3Buffer8"},
+    {0x001100C2, nullptr,                    "ReadRegisterBuffer"},
+    {0x001200C2, nullptr,                    "WriteRegisterBuffer"},
+    {0x00130040, nullptr,                    "ReadDeviceRaw8"},
+    {0x00140082, nullptr,                    "WriteDeviceRaw"},
+    {0x00150080, nullptr,                    "ReadDeviceRaw"},
+};
+
+I2C_DEB_Interface::I2C_DEB_Interface() {
+    Register(FunctionTable);
+}
+    
+} // namespace I2C
+} // namespace Service

--- a/src/core/hle/service/i2c/i2c_deb.h
+++ b/src/core/hle/service/i2c/i2c_deb.h
@@ -1,0 +1,22 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace I2C {
+
+class I2C_DEB_Interface : public Service::Interface {
+public:
+    I2C_DEB_Interface();
+
+    std::string GetPortName() const override {
+        return "i2c::DEB";
+    }
+};
+
+} // namespace I2C
+} // namespace Service

--- a/src/core/hle/service/i2c/i2c_eep.cpp
+++ b/src/core/hle/service/i2c/i2c_eep.cpp
@@ -1,0 +1,33 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/hle.h"
+#include "core/hle/service/i2c/i2c.h"
+#include "core/hle/service/i2c/i2c_eep.h"
+
+namespace Service {
+namespace I2C {
+
+const Interface::FunctionInfo FunctionTable[] = {
+    {0x00010100, nullptr,                    "SetRegisterBits8"},
+    {0x000300C0, nullptr,                    "DisableRegisterBits8"},
+    {0x00040102, nullptr,                    "MultiSetRegisterBits16"},
+    {0x000800C2, nullptr,                    "MultiWriteRegister16"},
+    {0x000B00C2, nullptr,                    "WriteRegister1Buffer8"},
+    {0x000C00C2, nullptr,                    "WriteRegisterBuffer16"},
+    {0x000D00C0, nullptr,                    "WriteRegister2Buffer8"},
+    {0x000E00C2, nullptr,                    "WriteRegister3Buffer8"},
+    {0x001100C2, nullptr,                    "ReadRegisterBuffer"},
+    {0x001200C2, nullptr,                    "WriteRegisterBuffer"},
+    {0x00130040, nullptr,                    "ReadDeviceRaw8"},
+    {0x00140082, nullptr,                    "WriteDeviceRaw"},
+    {0x00150080, nullptr,                    "ReadDeviceRaw"},
+};
+
+I2C_EEP_Interface::I2C_EEP_Interface() {
+    Register(FunctionTable);
+}
+    
+} // namespace I2C
+} // namespace Service

--- a/src/core/hle/service/i2c/i2c_eep.h
+++ b/src/core/hle/service/i2c/i2c_eep.h
@@ -1,0 +1,22 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace I2C {
+
+class I2C_EEP_Interface : public Service::Interface {
+public:
+    I2C_EEP_Interface();
+
+    std::string GetPortName() const override {
+        return "i2c::EEP";
+    }
+};
+
+} // namespace I2C
+} // namespace Service

--- a/src/core/hle/service/i2c/i2c_hid.cpp
+++ b/src/core/hle/service/i2c/i2c_hid.cpp
@@ -1,0 +1,33 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/hle.h"
+#include "core/hle/service/i2c/i2c.h"
+#include "core/hle/service/i2c/i2c_hid.h"
+
+namespace Service {
+namespace I2C {
+
+const Interface::FunctionInfo FunctionTable[] = {
+    {0x00010100, nullptr,                    "SetRegisterBits8"},
+    {0x000300C0, nullptr,                    "DisableRegisterBits8"},
+    {0x00040102, nullptr,                    "MultiSetRegisterBits16"},
+    {0x000800C2, nullptr,                    "MultiWriteRegister16"},
+    {0x000B00C2, nullptr,                    "WriteRegister1Buffer8"},
+    {0x000C00C2, nullptr,                    "WriteRegisterBuffer16"},
+    {0x000D00C0, nullptr,                    "WriteRegister2Buffer8"},
+    {0x000E00C2, nullptr,                    "WriteRegister3Buffer8"},
+    {0x001100C2, nullptr,                    "ReadRegisterBuffer"},
+    {0x001200C2, nullptr,                    "WriteRegisterBuffer"},
+    {0x00130040, nullptr,                    "ReadDeviceRaw8"},
+    {0x00140082, nullptr,                    "WriteDeviceRaw"},
+    {0x00150080, nullptr,                    "ReadDeviceRaw"},
+};
+
+I2C_HID_Interface::I2C_HID_Interface() {
+    Register(FunctionTable);
+}
+    
+} // namespace I2C
+} // namespace Service

--- a/src/core/hle/service/i2c/i2c_hid.h
+++ b/src/core/hle/service/i2c/i2c_hid.h
@@ -1,0 +1,22 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace I2C {
+
+class I2C_HID_Interface : public Service::Interface {
+public:
+    I2C_HID_Interface();
+
+    std::string GetPortName() const override {
+        return "i2c::HID";
+    }
+};
+
+} // namespace I2C
+} // namespace Service

--- a/src/core/hle/service/i2c/i2c_ir.cpp
+++ b/src/core/hle/service/i2c/i2c_ir.cpp
@@ -1,0 +1,33 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/hle.h"
+#include "core/hle/service/i2c/i2c.h"
+#include "core/hle/service/i2c/i2c_ir.h"
+
+namespace Service {
+namespace I2C {
+
+const Interface::FunctionInfo FunctionTable[] = {
+    {0x00010100, nullptr,                    "SetRegisterBits8"},
+    {0x000300C0, nullptr,                    "DisableRegisterBits8"},
+    {0x00040102, nullptr,                    "MultiSetRegisterBits16"},
+    {0x000800C2, nullptr,                    "MultiWriteRegister16"},
+    {0x000B00C2, nullptr,                    "WriteRegister1Buffer8"},
+    {0x000C00C2, nullptr,                    "WriteRegisterBuffer16"},
+    {0x000D00C0, nullptr,                    "WriteRegister2Buffer8"},
+    {0x000E00C2, nullptr,                    "WriteRegister3Buffer8"},
+    {0x001100C2, nullptr,                    "ReadRegisterBuffer"},
+    {0x001200C2, nullptr,                    "WriteRegisterBuffer"},
+    {0x00130040, nullptr,                    "ReadDeviceRaw8"},
+    {0x00140082, nullptr,                    "WriteDeviceRaw"},
+    {0x00150080, nullptr,                    "ReadDeviceRaw"},
+};
+
+I2C_IR_Interface::I2C_IR_Interface() {
+    Register(FunctionTable);
+}
+    
+} // namespace I2C
+} // namespace Service

--- a/src/core/hle/service/i2c/i2c_ir.h
+++ b/src/core/hle/service/i2c/i2c_ir.h
@@ -1,0 +1,22 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace I2C {
+
+class I2C_IR_Interface : public Service::Interface {
+public:
+    I2C_IR_Interface();
+
+    std::string GetPortName() const override {
+        return "i2c::IR";
+    }
+};
+
+} // namespace I2C
+} // namespace Service

--- a/src/core/hle/service/i2c/i2c_lcd.cpp
+++ b/src/core/hle/service/i2c/i2c_lcd.cpp
@@ -1,0 +1,33 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/hle.h"
+#include "core/hle/service/i2c/i2c.h"
+#include "core/hle/service/i2c/i2c_lcd.h"
+
+namespace Service {
+namespace I2C {
+
+const Interface::FunctionInfo FunctionTable[] = {
+    {0x00010100, nullptr,                    "SetRegisterBits8"},
+    {0x000300C0, nullptr,                    "DisableRegisterBits8"},
+    {0x00040102, nullptr,                    "MultiSetRegisterBits16"},
+    {0x000800C2, nullptr,                    "MultiWriteRegister16"},
+    {0x000B00C2, nullptr,                    "WriteRegister1Buffer8"},
+    {0x000C00C2, nullptr,                    "WriteRegisterBuffer16"},
+    {0x000D00C0, nullptr,                    "WriteRegister2Buffer8"},
+    {0x000E00C2, nullptr,                    "WriteRegister3Buffer8"},
+    {0x001100C2, nullptr,                    "ReadRegisterBuffer"},
+    {0x001200C2, nullptr,                    "WriteRegisterBuffer"},
+    {0x00130040, nullptr,                    "ReadDeviceRaw8"},
+    {0x00140082, nullptr,                    "WriteDeviceRaw"},
+    {0x00150080, nullptr,                    "ReadDeviceRaw"},
+};
+
+I2C_LCD_Interface::I2C_LCD_Interface() {
+    Register(FunctionTable);
+}
+    
+} // namespace I2C
+} // namespace Service

--- a/src/core/hle/service/i2c/i2c_lcd.h
+++ b/src/core/hle/service/i2c/i2c_lcd.h
@@ -1,0 +1,22 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace I2C {
+
+class I2C_LCD_Interface : public Service::Interface {
+public:
+    I2C_LCD_Interface();
+
+    std::string GetPortName() const override {
+        return "i2c::LCD";
+    }
+};
+
+} // namespace I2C
+} // namespace Service

--- a/src/core/hle/service/i2c/i2c_mcu.cpp
+++ b/src/core/hle/service/i2c/i2c_mcu.cpp
@@ -1,0 +1,33 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/hle.h"
+#include "core/hle/service/i2c/i2c.h"
+#include "core/hle/service/i2c/i2c_mcu.h"
+
+namespace Service {
+namespace I2C {
+
+const Interface::FunctionInfo FunctionTable[] = {
+    {0x00010100, nullptr,                    "SetRegisterBits8"},
+    {0x000300C0, nullptr,                    "DisableRegisterBits8"},
+    {0x00040102, nullptr,                    "MultiSetRegisterBits16"},
+    {0x000800C2, nullptr,                    "MultiWriteRegister16"},
+    {0x000B00C2, nullptr,                    "WriteRegister1Buffer8"},
+    {0x000C00C2, nullptr,                    "WriteRegisterBuffer16"},
+    {0x000D00C0, nullptr,                    "WriteRegister2Buffer8"},
+    {0x000E00C2, nullptr,                    "WriteRegister3Buffer8"},
+    {0x001100C2, nullptr,                    "ReadRegisterBuffer"},
+    {0x001200C2, nullptr,                    "WriteRegisterBuffer"},
+    {0x00130040, nullptr,                    "ReadDeviceRaw8"},
+    {0x00140082, nullptr,                    "WriteDeviceRaw"},
+    {0x00150080, nullptr,                    "ReadDeviceRaw"},
+};
+
+I2C_MCU_Interface::I2C_MCU_Interface() {
+    Register(FunctionTable);
+}
+    
+} // namespace I2C
+} // namespace Service

--- a/src/core/hle/service/i2c/i2c_mcu.h
+++ b/src/core/hle/service/i2c/i2c_mcu.h
@@ -1,0 +1,22 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace I2C {
+
+class I2C_MCU_Interface : public Service::Interface {
+public:
+    I2C_MCU_Interface();
+
+    std::string GetPortName() const override {
+        return "i2c::MCU";
+    }
+};
+
+} // namespace I2C
+} // namespace Service

--- a/src/core/hle/service/i2c/i2c_nfc.cpp
+++ b/src/core/hle/service/i2c/i2c_nfc.cpp
@@ -1,0 +1,33 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/hle.h"
+#include "core/hle/service/i2c/i2c.h"
+#include "core/hle/service/i2c/i2c_nfc.h"
+
+namespace Service {
+namespace I2C {
+
+const Interface::FunctionInfo FunctionTable[] = {
+    {0x00010100, nullptr,                    "SetRegisterBits8"},
+    {0x000300C0, nullptr,                    "DisableRegisterBits8"},
+    {0x00040102, nullptr,                    "MultiSetRegisterBits16"},
+    {0x000800C2, nullptr,                    "MultiWriteRegister16"},
+    {0x000B00C2, nullptr,                    "WriteRegister1Buffer8"},
+    {0x000C00C2, nullptr,                    "WriteRegisterBuffer16"},
+    {0x000D00C0, nullptr,                    "WriteRegister2Buffer8"},
+    {0x000E00C2, nullptr,                    "WriteRegister3Buffer8"},
+    {0x001100C2, nullptr,                    "ReadRegisterBuffer"},
+    {0x001200C2, nullptr,                    "WriteRegisterBuffer"},
+    {0x00130040, nullptr,                    "ReadDeviceRaw8"},
+    {0x00140082, nullptr,                    "WriteDeviceRaw"},
+    {0x00150080, nullptr,                    "ReadDeviceRaw"},
+};
+
+I2C_NFC_Interface::I2C_NFC_Interface() {
+    Register(FunctionTable);
+}
+    
+} // namespace I2C
+} // namespace Service

--- a/src/core/hle/service/i2c/i2c_nfc.h
+++ b/src/core/hle/service/i2c/i2c_nfc.h
@@ -1,0 +1,22 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace I2C {
+
+class I2C_NFC_Interface : public Service::Interface {
+public:
+    I2C_NFC_Interface();
+
+    std::string GetPortName() const override {
+        return "i2c::NFC";
+    }
+};
+
+} // namespace I2C
+} // namespace Service

--- a/src/core/hle/service/i2c/i2c_qtm.cpp
+++ b/src/core/hle/service/i2c/i2c_qtm.cpp
@@ -1,0 +1,33 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/hle.h"
+#include "core/hle/service/i2c/i2c.h"
+#include "core/hle/service/i2c/i2c_qtm.h"
+
+namespace Service {
+namespace I2C {
+
+const Interface::FunctionInfo FunctionTable[] = {
+    {0x00010100, nullptr,                    "SetRegisterBits8"},
+    {0x000300C0, nullptr,                    "DisableRegisterBits8"},
+    {0x00040102, nullptr,                    "MultiSetRegisterBits16"},
+    {0x000800C2, nullptr,                    "MultiWriteRegister16"},
+    {0x000B00C2, nullptr,                    "WriteRegister1Buffer8"},
+    {0x000C00C2, nullptr,                    "WriteRegisterBuffer16"},
+    {0x000D00C0, nullptr,                    "WriteRegister2Buffer8"},
+    {0x000E00C2, nullptr,                    "WriteRegister3Buffer8"},
+    {0x001100C2, nullptr,                    "ReadRegisterBuffer"},
+    {0x001200C2, nullptr,                    "WriteRegisterBuffer"},
+    {0x00130040, nullptr,                    "ReadDeviceRaw8"},
+    {0x00140082, nullptr,                    "WriteDeviceRaw"},
+    {0x00150080, nullptr,                    "ReadDeviceRaw"},
+};
+
+I2C_QTM_Interface::I2C_QTM_Interface() {
+    Register(FunctionTable);
+}
+    
+} // namespace I2C
+} // namespace Service

--- a/src/core/hle/service/i2c/i2c_qtm.h
+++ b/src/core/hle/service/i2c/i2c_qtm.h
@@ -1,0 +1,22 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace I2C {
+
+class I2C_QTM_Interface : public Service::Interface {
+public:
+    I2C_QTM_Interface();
+
+    std::string GetPortName() const override {
+        return "i2c::QTM";
+    }
+};
+
+} // namespace I2C
+} // namespace Service

--- a/src/core/hle/service/mcu/mcu.cpp
+++ b/src/core/hle/service/mcu/mcu.cpp
@@ -1,0 +1,43 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/service/service.h"
+#include "core/hle/service/mcu/mcu.h"
+#include "core/hle/service/mcu/mcu_cam.h"
+#include "core/hle/service/mcu/mcu_cdc.h"
+#include "core/hle/service/mcu/mcu_gpu.h"
+#include "core/hle/service/mcu/mcu_hid.h"
+#include "core/hle/service/mcu/mcu_hwc.h"
+#include "core/hle/service/mcu/mcu_nwm.h"
+#include "core/hle/service/mcu/mcu_pls.h"
+#include "core/hle/service/mcu/mcu_rtc.h"
+#include "core/hle/service/mcu/mcu_snd.h"
+
+#include "core/hle/kernel/event.h"
+#include "core/hle/kernel/shared_memory.h"
+#include "core/hle/hle.h"
+
+namespace Service {
+namespace MCU {
+
+void Init() {
+    using namespace Kernel;
+
+    AddService(new MCU_CAM_Interface);
+    AddService(new MCU_CDC_Interface);
+    AddService(new MCU_GPU_Interface);
+    AddService(new MCU_HID_Interface);
+    AddService(new MCU_HWC_Interface);
+    AddService(new MCU_NWM_Interface);
+    AddService(new MCU_PLS_Interface);
+    AddService(new MCU_RTC_Interface);
+    AddService(new MCU_SND_Interface);
+}
+
+void Shutdown() {
+}
+
+} // namespace MCU
+
+} // namespace Service

--- a/src/core/hle/service/mcu/mcu.h
+++ b/src/core/hle/service/mcu/mcu.h
@@ -1,0 +1,20 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/kernel/kernel.h"
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace MCU {
+
+/// Initialize MCU service(s)
+void Init();
+
+/// Shutdown MCU service(s)
+void Shutdown();
+
+} // namespace MCU
+} // namespace Service

--- a/src/core/hle/service/mcu/mcu_cam.cpp
+++ b/src/core/hle/service/mcu/mcu_cam.cpp
@@ -1,0 +1,20 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/hle.h"
+#include "core/hle/service/mcu/mcu.h"
+#include "core/hle/service/mcu/mcu_cam.h"
+
+namespace Service {
+namespace MCU {
+
+// Empty arrays are illegal -- commented out until an entry is added.
+//const Interface::FunctionInfo FunctionTable[] = {};
+
+MCU_CAM_Interface::MCU_CAM_Interface() {
+    //Register(FunctionTable);
+}
+
+} // namespace MCU
+} // namespace Service

--- a/src/core/hle/service/mcu/mcu_cam.h
+++ b/src/core/hle/service/mcu/mcu_cam.h
@@ -1,0 +1,22 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace MCU {
+
+class MCU_CAM_Interface : public Service::Interface {
+public:
+    MCU_CAM_Interface();
+
+    std::string GetPortName() const override {
+        return "mcu::CAM";
+    }
+};
+
+} // namespace MCU
+} // namespace Service

--- a/src/core/hle/service/mcu/mcu_cdc.cpp
+++ b/src/core/hle/service/mcu/mcu_cdc.cpp
@@ -1,0 +1,20 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/hle.h"
+#include "core/hle/service/mcu/mcu.h"
+#include "core/hle/service/mcu/mcu_cdc.h"
+
+namespace Service {
+namespace MCU {
+
+// Empty arrays are illegal -- commented out until an entry is added.
+//const Interface::FunctionInfo FunctionTable[] = {};
+
+MCU_CDC_Interface::MCU_CDC_Interface() {
+    //Register(FunctionTable);
+}
+    
+} // namespace MCU
+} // namespace Service

--- a/src/core/hle/service/mcu/mcu_cdc.h
+++ b/src/core/hle/service/mcu/mcu_cdc.h
@@ -1,0 +1,22 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace MCU {
+
+class MCU_CDC_Interface : public Service::Interface {
+public:
+    MCU_CDC_Interface();
+
+    std::string GetPortName() const override {
+        return "mcu::CDC";
+    }
+};
+
+} // namespace MCU
+} // namespace Service

--- a/src/core/hle/service/mcu/mcu_gpu.cpp
+++ b/src/core/hle/service/mcu/mcu_gpu.cpp
@@ -1,0 +1,20 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/hle.h"
+#include "core/hle/service/mcu/mcu.h"
+#include "core/hle/service/mcu/mcu_gpu.h"
+
+namespace Service {
+namespace MCU {
+
+// Empty arrays are illegal -- commented out until an entry is added.
+//const Interface::FunctionInfo FunctionTable[] = {};
+
+MCU_GPU_Interface::MCU_GPU_Interface() {
+    //Register(FunctionTable);
+}
+
+} // namespace MCU
+} // namespace Service

--- a/src/core/hle/service/mcu/mcu_gpu.h
+++ b/src/core/hle/service/mcu/mcu_gpu.h
@@ -1,0 +1,22 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace MCU {
+
+class MCU_GPU_Interface : public Service::Interface {
+public:
+    MCU_GPU_Interface();
+
+    std::string GetPortName() const override {
+        return "mcu::GPU";
+    }
+};
+
+} // namespace MCU
+} // namespace Service

--- a/src/core/hle/service/mcu/mcu_hid.cpp
+++ b/src/core/hle/service/mcu/mcu_hid.cpp
@@ -1,0 +1,21 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/hle.h"
+#include "core/hle/service/mcu/mcu.h"
+#include "core/hle/service/mcu/mcu_hid.h"
+
+namespace Service {
+namespace MCU {
+
+const Interface::FunctionInfo FunctionTable[] = {
+    {0x000E0000, nullptr,                    "GetSoundVolume"},
+};
+
+MCU_HID_Interface::MCU_HID_Interface() {
+    Register(FunctionTable);
+}
+
+} // namespace MCU
+} // namespace Service

--- a/src/core/hle/service/mcu/mcu_hid.h
+++ b/src/core/hle/service/mcu/mcu_hid.h
@@ -1,0 +1,22 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace MCU {
+
+class MCU_HID_Interface : public Service::Interface {
+public:
+    MCU_HID_Interface();
+
+    std::string GetPortName() const override {
+        return "mcu::HID";
+    }
+};
+
+} // namespace MCU
+} // namespace Service

--- a/src/core/hle/service/mcu/mcu_hwc.cpp
+++ b/src/core/hle/service/mcu/mcu_hwc.cpp
@@ -1,0 +1,21 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/hle.h"
+#include "core/hle/service/mcu/mcu.h"
+#include "core/hle/service/mcu/mcu_hwc.h"
+
+namespace Service {
+namespace MCU {
+
+const Interface::FunctionInfo FunctionTable[] = {
+    {0x000A0640, nullptr,                    "SetInfoLEDPattern"},
+};
+
+MCU_HWC_Interface::MCU_HWC_Interface() {
+    Register(FunctionTable);
+}
+
+} // namespace MCU
+} // namespace Service

--- a/src/core/hle/service/mcu/mcu_hwc.h
+++ b/src/core/hle/service/mcu/mcu_hwc.h
@@ -1,0 +1,22 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace MCU {
+
+class MCU_HWC_Interface : public Service::Interface {
+public:
+    MCU_HWC_Interface();
+
+    std::string GetPortName() const override {
+        return "mcu::HWC";
+    }
+};
+
+} // namespace MCU
+} // namespace Service

--- a/src/core/hle/service/mcu/mcu_nwm.cpp
+++ b/src/core/hle/service/mcu/mcu_nwm.cpp
@@ -1,0 +1,20 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/hle.h"
+#include "core/hle/service/mcu/mcu.h"
+#include "core/hle/service/mcu/mcu_nwm.h"
+
+namespace Service {
+namespace MCU {
+
+// Empty arrays are illegal -- commented out until an entry is added.
+//const Interface::FunctionInfo FunctionTable[] = {};
+
+MCU_NWM_Interface::MCU_NWM_Interface() {
+    //Register(FunctionTable);
+}
+
+} // namespace MCU
+} // namespace Service

--- a/src/core/hle/service/mcu/mcu_nwm.h
+++ b/src/core/hle/service/mcu/mcu_nwm.h
@@ -1,0 +1,22 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace MCU {
+
+class MCU_NWM_Interface : public Service::Interface {
+public:
+    MCU_NWM_Interface();
+
+    std::string GetPortName() const override {
+        return "mcu::NWM";
+    }
+};
+
+} // namespace MCU
+} // namespace Service

--- a/src/core/hle/service/mcu/mcu_pls.cpp
+++ b/src/core/hle/service/mcu/mcu_pls.cpp
@@ -1,0 +1,20 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/hle.h"
+#include "core/hle/service/mcu/mcu.h"
+#include "core/hle/service/mcu/mcu_pls.h"
+
+namespace Service {
+namespace MCU {
+
+// Empty arrays are illegal -- commented out until an entry is added.
+//const Interface::FunctionInfo FunctionTable[] = {};
+
+MCU_PLS_Interface::MCU_PLS_Interface() {
+    //Register(FunctionTable);
+}
+
+} // namespace MCU
+} // namespace Service

--- a/src/core/hle/service/mcu/mcu_pls.h
+++ b/src/core/hle/service/mcu/mcu_pls.h
@@ -1,0 +1,22 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace MCU {
+
+class MCU_PLS_Interface : public Service::Interface {
+public:
+    MCU_PLS_Interface();
+
+    std::string GetPortName() const override {
+        return "mcu::PLS";
+    }
+};
+
+} // namespace MCU
+} // namespace Service

--- a/src/core/hle/service/mcu/mcu_rtc.cpp
+++ b/src/core/hle/service/mcu/mcu_rtc.cpp
@@ -1,0 +1,31 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/hle.h"
+#include "core/hle/service/mcu/mcu.h"
+#include "core/hle/service/mcu/mcu_rtc.h"
+
+namespace Service {
+namespace MCU {
+
+const Interface::FunctionInfo FunctionTable[] = {
+    {0x001F0040, nullptr,                    "SetPedometerRecordingMode"},
+    {0x00200000, nullptr,                    "GetPedometerState"},
+    {0x002A0000, nullptr,                    "GetShellState"},
+    {0x002B0000, nullptr,                    "GetAdapterState"},
+    {0x002C0000, nullptr,                    "GetBatteryChargeState"},
+    {0x002D0000, nullptr,                    "GetBatteryLevel"},
+    {0x003B0640, nullptr,                    "SetInfoLEDPattern"},
+    {0x003C0040, nullptr,                    "SetInfoLEDPatternHeader"},
+    {0x003D0000, nullptr,                    "GetInfoLEDStatus"},
+    {0x00420040, nullptr,                    "SetBatteryEmptyLEDPattern"},
+    {0x00520000, nullptr,                    "IsLegacyPowerOff"},
+};
+
+MCU_RTC_Interface::MCU_RTC_Interface() {
+    Register(FunctionTable);
+}
+
+} // namespace MCU
+} // namespace Service

--- a/src/core/hle/service/mcu/mcu_rtc.h
+++ b/src/core/hle/service/mcu/mcu_rtc.h
@@ -1,0 +1,22 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace MCU {
+
+class MCU_RTC_Interface : public Service::Interface {
+public:
+    MCU_RTC_Interface();
+
+    std::string GetPortName() const override {
+        return "mcu::RTC";
+    }
+};
+
+} // namespace MCU
+} // namespace Service

--- a/src/core/hle/service/mcu/mcu_snd.cpp
+++ b/src/core/hle/service/mcu/mcu_snd.cpp
@@ -1,0 +1,20 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/hle.h"
+#include "core/hle/service/mcu/mcu.h"
+#include "core/hle/service/mcu/mcu_snd.h"
+
+namespace Service {
+namespace MCU {
+
+// Empty arrays are illegal -- commented out until an entry is added.
+//const Interface::FunctionInfo FunctionTable[] = {};
+
+MCU_SND_Interface::MCU_SND_Interface() {
+    //Register(FunctionTable);
+}
+
+} // namespace MCU
+} // namespace Service

--- a/src/core/hle/service/mcu/mcu_snd.h
+++ b/src/core/hle/service/mcu/mcu_snd.h
@@ -1,0 +1,22 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace MCU {
+
+class MCU_SND_Interface : public Service::Interface {
+public:
+    MCU_SND_Interface();
+
+    std::string GetPortName() const override {
+        return "mcu::SND";
+    }
+};
+
+} // namespace MCU
+} // namespace Service

--- a/src/core/hle/service/pdn/pdn.cpp
+++ b/src/core/hle/service/pdn/pdn.cpp
@@ -1,0 +1,35 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/service/service.h"
+#include "core/hle/service/pdn/pdn.h"
+#include "core/hle/service/pdn/pdn_c.h"
+#include "core/hle/service/pdn/pdn_d.h"
+#include "core/hle/service/pdn/pdn_g.h"
+#include "core/hle/service/pdn/pdn_i.h"
+#include "core/hle/service/pdn/pdn_s.h"
+
+#include "core/hle/kernel/event.h"
+#include "core/hle/kernel/shared_memory.h"
+#include "core/hle/hle.h"
+
+namespace Service {
+namespace PDN {
+
+void Init() {
+    using namespace Kernel;
+
+    AddService(new PDN_C_Interface);
+    AddService(new PDN_D_Interface);
+    AddService(new PDN_G_Interface);
+    AddService(new PDN_I_Interface);
+    AddService(new PDN_S_Interface);
+}
+
+void Shutdown() {
+}
+
+} // namespace PDN
+
+} // namespace Service

--- a/src/core/hle/service/pdn/pdn.h
+++ b/src/core/hle/service/pdn/pdn.h
@@ -1,0 +1,20 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/kernel/kernel.h"
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace PDN {
+
+/// Initialize PDN service(s)
+void Init();
+
+/// Shutdown PDN service(s)
+void Shutdown();
+
+} // namespace PDN
+} // namespace Service

--- a/src/core/hle/service/pdn/pdn_c.cpp
+++ b/src/core/hle/service/pdn/pdn_c.cpp
@@ -1,0 +1,22 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/hle.h"
+#include "core/hle/service/pdn/pdn.h"
+#include "core/hle/service/pdn/pdn_c.h"
+
+namespace Service {
+namespace PDN {
+
+const Interface::FunctionInfo FunctionTable[] = {
+    {0x00010040, nullptr,                    "CameraPowerControl_cmd1"},
+    {0x00020000, nullptr,                    "CameraPowerControl_cmd2"},
+};
+
+PDN_C_Interface::PDN_C_Interface() {
+    Register(FunctionTable);
+}
+    
+} // namespace PDN
+} // namespace Service

--- a/src/core/hle/service/pdn/pdn_c.h
+++ b/src/core/hle/service/pdn/pdn_c.h
@@ -1,0 +1,22 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace PDN {
+
+class PDN_C_Interface : public Service::Interface {
+public:
+    PDN_C_Interface();
+
+    std::string GetPortName() const override {
+        return "pdn:c";
+    }
+};
+
+} // namespace PDN
+} // namespace Service

--- a/src/core/hle/service/pdn/pdn_d.cpp
+++ b/src/core/hle/service/pdn/pdn_d.cpp
@@ -1,0 +1,21 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/hle.h"
+#include "core/hle/service/pdn/pdn.h"
+#include "core/hle/service/pdn/pdn_d.h"
+
+namespace Service {
+namespace PDN {
+
+const Interface::FunctionInfo FunctionTable[] = {
+    {0x000100C0, nullptr,                    "DSPPowerControl_cmd1"},
+};
+
+PDN_D_Interface::PDN_D_Interface() {
+    Register(FunctionTable);
+}
+    
+} // namespace PDN
+} // namespace Service

--- a/src/core/hle/service/pdn/pdn_d.h
+++ b/src/core/hle/service/pdn/pdn_d.h
@@ -1,0 +1,22 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace PDN {
+
+class PDN_D_Interface : public Service::Interface {
+public:
+    PDN_D_Interface();
+
+    std::string GetPortName() const override {
+        return "pdn:d";
+    }
+};
+
+} // namespace PDN
+} // namespace Service

--- a/src/core/hle/service/pdn/pdn_g.cpp
+++ b/src/core/hle/service/pdn/pdn_g.cpp
@@ -1,0 +1,21 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/hle.h"
+#include "core/hle/service/pdn/pdn.h"
+#include "core/hle/service/pdn/pdn_g.h"
+
+namespace Service {
+namespace PDN {
+
+const Interface::FunctionInfo FunctionTable[] = {
+    {0x000100C0, nullptr,                    "GPUPowerControl_cmd1"},
+};
+
+PDN_G_Interface::PDN_G_Interface() {
+    Register(FunctionTable);
+}
+    
+} // namespace PDN
+} // namespace Service

--- a/src/core/hle/service/pdn/pdn_g.h
+++ b/src/core/hle/service/pdn/pdn_g.h
@@ -1,0 +1,22 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace PDN {
+
+class PDN_G_Interface : public Service::Interface {
+public:
+    PDN_G_Interface();
+
+    std::string GetPortName() const override {
+        return "pdn:g";
+    }
+};
+
+} // namespace PDN
+} // namespace Service

--- a/src/core/hle/service/pdn/pdn_i.cpp
+++ b/src/core/hle/service/pdn/pdn_i.cpp
@@ -1,0 +1,20 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/hle.h"
+#include "core/hle/service/pdn/pdn.h"
+#include "core/hle/service/pdn/pdn_i.h"
+
+namespace Service {
+namespace PDN {
+
+// Empty arrays are illegal -- commented out until an entry is added.
+//const Interface::FunctionInfo FunctionTable[] = {};
+
+PDN_I_Interface::PDN_I_Interface() {
+    //Register(FunctionTable);
+}
+    
+} // namespace PDN
+} // namespace Service

--- a/src/core/hle/service/pdn/pdn_i.h
+++ b/src/core/hle/service/pdn/pdn_i.h
@@ -1,0 +1,22 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace PDN {
+
+class PDN_I_Interface : public Service::Interface {
+public:
+    PDN_I_Interface();
+
+    std::string GetPortName() const override {
+        return "pdn:i";
+    }
+};
+
+} // namespace PDN
+} // namespace Service

--- a/src/core/hle/service/pdn/pdn_s.cpp
+++ b/src/core/hle/service/pdn/pdn_s.cpp
@@ -1,0 +1,20 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/hle.h"
+#include "core/hle/service/pdn/pdn.h"
+#include "core/hle/service/pdn/pdn_s.h"
+
+namespace Service {
+namespace PDN {
+
+// Empty arrays are illegal -- commented out until an entry is added.
+//const Interface::FunctionInfo FunctionTable[] = {};
+
+PDN_S_Interface::PDN_S_Interface() {
+    //Register(FunctionTable);
+}
+    
+} // namespace PDN
+} // namespace Service

--- a/src/core/hle/service/pdn/pdn_s.h
+++ b/src/core/hle/service/pdn/pdn_s.h
@@ -1,0 +1,22 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace PDN {
+
+class PDN_S_Interface : public Service::Interface {
+public:
+    PDN_S_Interface();
+
+    std::string GetPortName() const override {
+        return "pdn:s";
+    }
+};
+
+} // namespace PDN
+} // namespace Service

--- a/src/core/hle/service/ptm/ptm.cpp
+++ b/src/core/hle/service/ptm/ptm.cpp
@@ -6,6 +6,7 @@
 #include "core/hle/service/fs/archive.h"
 #include "core/hle/service/ptm/ptm.h"
 #include "core/hle/service/ptm/ptm_play.h"
+#include "core/hle/service/ptm/ptm_s.h"
 #include "core/hle/service/ptm/ptm_sysm.h"
 #include "core/hle/service/ptm/ptm_u.h"
 
@@ -22,24 +23,61 @@ static bool shell_open = true;
 
 static bool battery_is_charging = true;
 
-u32 GetAdapterState() {
+void GetAdapterState(Service::Interface* self) {
+    u32* cmd_buff = Kernel::GetCommandBuffer();
+
     // TODO(purpasmart96): This function is only a stub,
     // it returns a valid result without implementing full functionality.
-    return battery_is_charging ? 1 : 0;
+
+    cmd_buff[1] = RESULT_SUCCESS.raw;
+    cmd_buff[2] = battery_is_charging ? 1 : 0;
+
+    LOG_WARNING(Service_PTM, "(STUBBED) called");
 }
 
-u32 GetShellState() {
-    return shell_open ? 1 : 0;
+void GetShellState(Service::Interface* self) {
+    u32* cmd_buff = Kernel::GetCommandBuffer();
+
+    cmd_buff[1] = RESULT_SUCCESS.raw;
+    cmd_buff[2] = shell_open ? 1 : 0;
 }
 
-ChargeLevels GetBatteryLevel() {
+void GetBatteryLevel(Service::Interface* self) {
+    u32* cmd_buff = Kernel::GetCommandBuffer();
+
     // TODO(purpasmart96): This function is only a stub,
     // it returns a valid result without implementing full functionality.
-    return ChargeLevels::CompletelyFull; // Set to a completely full battery
+
+    cmd_buff[1] = RESULT_SUCCESS.raw;
+    cmd_buff[2] = static_cast<u32>(ChargeLevels::CompletelyFull); // Set to a completely full battery
+
+    LOG_WARNING(Service_PTM, "(STUBBED) called");
+}
+
+void GetBatteryChargeState(Service::Interface* self) {
+    u32* cmd_buff = Kernel::GetCommandBuffer();
+
+    // TODO(purpasmart96): This function is only a stub,
+    // it returns a valid result without implementing full functionality.
+
+    cmd_buff[1] = RESULT_SUCCESS.raw;
+    cmd_buff[2] = battery_is_charging ? 1 : 0;
+
+    LOG_WARNING(Service_PTM, "(STUBBED) called");
+}
+
+void IsLegacyPowerOff(Service::Interface* self) {
+    u32* cmd_buff = Kernel::GetCommandBuffer();
+
+    cmd_buff[1] = RESULT_SUCCESS.raw;
+    cmd_buff[2] = 0;
+
+    LOG_WARNING(Service_PTM, "(STUBBED) called");
 }
 
 void Init() {
     AddService(new PTM_Play_Interface);
+    AddService(new PTM_S_Interface);
     AddService(new PTM_Sysm_Interface);
     AddService(new PTM_U_Interface);
 

--- a/src/core/hle/service/ptm/ptm.h
+++ b/src/core/hle/service/ptm/ptm.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include "core/hle/service/service.h"
 #include "core/hle/result.h"
 
 namespace Service {
@@ -41,19 +42,38 @@ struct GameCoin {
  * that controls another part of the HW.
  * @returns 1 if the battery is charging, and 0 otherwise.
  */
-u32 GetAdapterState();
+void GetAdapterState(Interface* self);
 
 /**
  * Returns whether the 3DS's physical shell casing is open or closed
  * @returns 1 if the shell is open, and 0 if otherwise
  */
-u32 GetShellState();
+void GetShellState(Interface* self);
 
 /**
- * Get the current battery's charge level.
- * @returns The battery's charge level.
+  * PTM::GetBatteryLevel service function
+  *  Outputs:
+  *      1 : Result of function, 0 on success, otherwise error code
+  *      2 : Battery level, 5 = completely full battery, 4 = mostly full battery,
+  *          3 = half full battery, 2 =  low battery, 1 = critical battery.
+  */
+void GetBatteryLevel(Interface* self);
+
+/**
+  * PTM::GetBatteryChargeState service function
+  *  Outputs:
+  *      1 : Result of function, 0 on success, otherwise error code
+  *      2 : Output of function, 0 = not charging, 1 = charging.
+  */
+void GetBatteryChargeState(Interface* self);
+
+/**
+ * Returns whether the system is powering off (?)
+ *   Outputs:
+ *     1: Result code, 0 on success, otherwise error code
+ *     2: Whether the system is going through a power off
  */
-ChargeLevels GetBatteryLevel();
+void IsLegacyPowerOff(Interface* self);
 
 /// Initialize the PTM service
 void Init();

--- a/src/core/hle/service/ptm/ptm_play.cpp
+++ b/src/core/hle/service/ptm/ptm_play.cpp
@@ -9,10 +9,10 @@ namespace Service {
 namespace PTM {
 
 const Interface::FunctionInfo FunctionTable[] = {
-    { 0x08070082, nullptr,               "GetPlayHistory" },
-    { 0x08080000, nullptr,               "GetPlayHistoryStart" },
-    { 0x08090000, nullptr,               "GetPlayHistoryLength" },
-    { 0x080B0080, nullptr,               "CalcPlayHistoryStart" },
+    {0x08070082, nullptr,               "GetPlayHistory"},
+    {0x08080000, nullptr,               "GetPlayHistoryStart"},
+    {0x08090000, nullptr,               "GetPlayHistoryLength"},
+    {0x080B0080, nullptr,               "CalcPlayHistoryStart"},
 };
 
 PTM_Play_Interface::PTM_Play_Interface() {

--- a/src/core/hle/service/ptm/ptm_s.cpp
+++ b/src/core/hle/service/ptm/ptm_s.cpp
@@ -4,7 +4,7 @@
 
 #include "core/hle/hle.h"
 #include "core/hle/service/ptm/ptm.h"
-#include "core/hle/service/ptm/ptm_sysm.h"
+#include "core/hle/service/ptm/ptm_s.h"
 
 namespace Service {
 namespace PTM {
@@ -42,7 +42,7 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x08140000, nullptr,             "GetLegacyJumpProhibitedFlag"}
 };
 
-PTM_Sysm_Interface::PTM_Sysm_Interface() {
+PTM_S_Interface::PTM_S_Interface() {
     Register(FunctionTable);
 }
 

--- a/src/core/hle/service/ptm/ptm_s.h
+++ b/src/core/hle/service/ptm/ptm_s.h
@@ -1,0 +1,22 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace PTM {
+
+class PTM_S_Interface : public Interface {
+public:
+    PTM_S_Interface();
+
+    std::string GetPortName() const override {
+        return "ptm:s";
+    }
+};
+
+} // namespace PTM
+} // namespace Service

--- a/src/core/hle/service/ptm/ptm_u.cpp
+++ b/src/core/hle/service/ptm/ptm_u.cpp
@@ -11,68 +11,6 @@
 namespace Service {
 namespace PTM {
 
-/**
- * PTM_U::GetAdapterState service function
- *  Outputs:
- *      1 : Result of function, 0 on success, otherwise error code
- *      2 : Output of function, 0 = not charging, 1 = charging.
- */
-static void GetAdapterState(Service::Interface* self) {
-    u32* cmd_buff = Kernel::GetCommandBuffer();
-
-    cmd_buff[1] = RESULT_SUCCESS.raw;
-    cmd_buff[2] = GetAdapterState();
-
-    LOG_WARNING(Service_PTM, "(STUBBED) called");
-}
-
-/*
- * PTM_User::GetShellState service function.
- *  Outputs:
- *      1 : Result of function, 0 on success, otherwise error code
- *      2 : Whether the 3DS's physical shell casing is open (1) or closed (0)
- */
-static void GetShellState(Service::Interface* self) {
-    u32* cmd_buff = Kernel::GetCommandBuffer();
-
-    cmd_buff[1] = RESULT_SUCCESS.raw;
-    cmd_buff[2] = GetShellState();
-}
-
-/**
- * PTM_U::GetBatteryLevel service function
- *  Outputs:
- *      1 : Result of function, 0 on success, otherwise error code
- *      2 : Battery level, 5 = completely full battery, 4 = mostly full battery,
- *          3 = half full battery, 2 =  low battery, 1 = critical battery.
- */
-static void GetBatteryLevel(Service::Interface* self) {
-    u32* cmd_buff = Kernel::GetCommandBuffer();
-
-    cmd_buff[1] = RESULT_SUCCESS.raw;
-    cmd_buff[2] = static_cast<u32>(GetBatteryLevel());
-
-    LOG_WARNING(Service_PTM, "(STUBBED) called");
-}
-
-/**
- * PTM_U::GetBatteryChargeState service function
- *  Outputs:
- *      1 : Result of function, 0 on success, otherwise error code
- *      2 : Output of function, 0 = not charging, 1 = charging.
- */
-static void GetBatteryChargeState(Service::Interface* self) {
-    u32* cmd_buff = Kernel::GetCommandBuffer();
-
-    // TODO(purpasmart96): This function is only a stub,
-    // it returns a valid result without implementing full functionality.
-
-    cmd_buff[1] = RESULT_SUCCESS.raw;
-    cmd_buff[2] = GetAdapterState();
-
-    LOG_WARNING(Service_PTM, "(STUBBED) called");
-}
-
 const Interface::FunctionInfo FunctionTable[] = {
     {0x00010002, nullptr,               "RegisterAlarmClient"},
     {0x00020080, nullptr,               "SetRtcAlarm"},

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -43,7 +43,10 @@
 #include "core/hle/service/fs/archive.h"
 #include "core/hle/service/cfg/cfg.h"
 #include "core/hle/service/hid/hid.h"
+#include "core/hle/service/i2c/i2c.h"
 #include "core/hle/service/ir/ir.h"
+#include "core/hle/service/mcu/mcu.h"
+#include "core/hle/service/pdn/pdn.h"
 #include "core/hle/service/ptm/ptm.h"
 
 namespace Service {
@@ -113,9 +116,12 @@ void Init() {
     Service::FS::ArchiveInit();
     Service::CFG::Init();
     Service::APT::Init();
+    Service::PDN::Init();
     Service::PTM::Init();
     Service::HID::Init();
+    Service::I2C::Init();
     Service::IR::Init();
+    Service::MCU::Init();
 
     AddService(new AC_U::Interface);
     AddService(new ACT_U::Interface);
@@ -153,9 +159,12 @@ void Init() {
 
 /// Shutdown ServiceManager
 void Shutdown() {
+    Service::MCU::Shutdown();
     Service::IR::Shutdown();
+    Service::I2C::Shutdown();
     Service::HID::Shutdown();
     Service::PTM::Shutdown();
+    Service::PDN::Shutdown();
     Service::APT::Shutdown();
     Service::CFG::Shutdown();
     Service::FS::ArchiveShutdown();


### PR DESCRIPTION
I also made the PTM services have the same format as the  HID, APT, IR services as well.
These low level services are used by the the by the core service modules, which can  be dumped from the 3ds and can be run as ncch's. Not useful to games, but useful for getting low level service command headers and stuff that utilized in the future. 