### PR TITLE
Common: Add proper macros to test for architecture pointer size

### DIFF
--- a/src/common/common_funcs.h
+++ b/src/common/common_funcs.h
@@ -34,13 +34,6 @@
     #define MEMORY_ALIGNED64(x) __declspec(align(64)) x
     #define MEMORY_ALIGNED128(x) __declspec(align(128)) x
 #else
-    // Windows compatibility
-    #ifdef _LP64
-        #define _M_X64 1
-    #else
-        #define _M_IX86 1
-    #endif
-
     #define __forceinline inline __attribute__((always_inline))
     #define MEMORY_ALIGNED16(x) __attribute__((aligned(16))) x
     #define MEMORY_ALIGNED32(x) __attribute__((aligned(32))) x

--- a/src/common/hash.cpp
+++ b/src/common/hash.cpp
@@ -103,7 +103,7 @@ u32 HashEctor(const u8* ptr, int length)
 }
 
 
-#ifdef _M_X64
+#if EMU_ARCH_BITS == 64
 
 //-----------------------------------------------------------------------------
 // Block read - if your platform needs to do endian-swapping or can only

--- a/src/common/mem_arena.cpp
+++ b/src/common/mem_arena.cpp
@@ -20,6 +20,7 @@
 #include "common/logging/log.h"
 #include "common/mem_arena.h"
 #include "common/memory_util.h"
+#include "common/platform.h"
 #include "common/string_util.h"
 
 #ifndef _WIN32
@@ -198,7 +199,7 @@ void MemArena::ReleaseView(void* view, size_t size)
 
 u8* MemArena::Find4GBBase()
 {
-#ifdef _M_X64
+#if EMU_ARCH_BITS == 64
 #ifdef _WIN32
     // 64 bit
     u8* base = (u8*)VirtualAlloc(0, 0xE1000000, MEM_RESERVE, PAGE_READWRITE);
@@ -269,7 +270,7 @@ static bool Memory_TryBase(u8 *base, const MemoryView *views, int num_views, u32
             if (!*view.out_ptr_low)
                 goto bail;
         }
-#ifdef _M_X64
+#if EMU_ARCH_BITS == 64
         *view.out_ptr = (u8*)arena->CreateView(
             position, view.size, base + view.virtual_address);
 #else
@@ -305,7 +306,7 @@ bail:
         }
         if (*views[j].out_ptr)
         {
-#ifdef _M_X64
+#if EMU_ARCH_BITS == 64
             arena->ReleaseView(*views[j].out_ptr, views[j].size);
 #else
             if (!(views[j].flags & MV_MIRROR_PREVIOUS))
@@ -336,7 +337,7 @@ u8 *MemoryMap_Setup(const MemoryView *views, int num_views, u32 flags, MemArena 
     arena->GrabLowMemSpace(total_mem);
 
     // Now, create views in high memory where there's plenty of space.
-#ifdef _M_X64
+#if EMU_ARCH_BITS == 64
     u8 *base = MemArena::Find4GBBase();
     // This really shouldn't fail - in 64-bit, there will always be enough
     // address space.

--- a/src/common/memory_util.cpp
+++ b/src/common/memory_util.cpp
@@ -71,7 +71,7 @@ void* AllocateExecutableMemory(size_t size, bool low)
     }
 #endif
 
-#if defined(_M_X64)
+#if EMU_ARCH_BITS == 64
     if ((u64)ptr >= 0x80000000 && low == true)
         LOG_ERROR(Common_Memory, "Executable memory ended up above 2GB!");
 #endif

--- a/src/common/platform.h
+++ b/src/common/platform.h
@@ -57,10 +57,10 @@
 
 #endif
 
-#if defined(__x86_64__) || defined(_M_X64) || defined(__alpha__) || defined(__ia64__)
-#define EMU_ARCHITECTURE_X64
-#else
-#define EMU_ARCHITECTURE_X86
+#if defined(__x86_64__) || defined(_M_X64) || defined(__aarch64__)
+    #define EMU_ARCH_BITS 64
+#elif defined(__i386) || defined(_M_IX86) || defined(__arm__) || defined(_M_ARM)
+    #define EMU_ARCH_BITS 32
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The old system of just defining macros available in some other platform
was susceptible to silently using the wrong code if you forgot to
include a particular header. This fixes a crash on non-Windows platforms
introduced by e1fbac3ca13d37d2625c11d30cfdece4327b446b.