### PR TITLE
Common: Remove the BIT macro

### DIFF
--- a/src/common/common_funcs.h
+++ b/src/common/common_funcs.h
@@ -15,8 +15,6 @@
 #define b32(x)  (b16(x) | (b16(x) >>16) )
 #define ROUND_UP_POW2(x)    (b32(x - 1) + 1)
 
-#define BIT(x) (1U << (x))
-
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
 
 /// Textually concatenates two tokens. The double-expansion is required by the C preprocessor.

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -62,8 +62,8 @@ void Process::ParseKernelCaps(const u32* kernel_caps, size_t len) {
             AddressMapping mapping;
             mapping.address = descriptor << 12;
             mapping.size = (end_desc << 12) - mapping.address;
-            mapping.writable = descriptor & BIT(20);
-            mapping.unk_flag = end_desc & BIT(20);
+            mapping.writable = descriptor & (1 << 20);
+            mapping.unk_flag = end_desc & (1 << 20);
 
             address_mappings.push_back(mapping);
         } else if ((type & 0xFFF) == 0xFFE) { // 0x000F


### PR DESCRIPTION
When the macro was introduced in 326ec51261299e48de97592631c02523da9c8118
it wasn't noticed that it conflicted in name with a heavily used macro
inside of dyncom. This causes some compiler warnings. Since it's only
lightly used, it was opted to simply remove the new macro.