### PR TITLE
[RFC] Identify games that use procedural textures

### DIFF
--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -44,8 +44,12 @@ void EmuThread::run() {
             if (!was_active)
                 emit DebugModeLeft();
 
-            Core::RunLoop();
-
+            try {
+                Core::RunLoop();
+            } catch (const char* str) {
+                emit UserError(str);
+            }
+            
             was_active = running || exec_step;
             if (!was_active && !stop_run)
                 emit DebugModeEntered();

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -78,6 +78,8 @@ signals:
      * @warning When connecting to this signal from other threads, make sure to specify either Qt::QueuedConnection (invoke slot within the destination object's message thread) or even Qt::BlockingQueuedConnection (additionally block source thread until slot returns)
      */
     void DebugModeLeft();
+
+    void UserError(const char* str);
 };
 
 class GRenderWindow : public QWidget, public EmuWindow

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -219,6 +219,7 @@ void GMainWindow::BootGame(std::string filename) {
     connect(emu_thread.get(), SIGNAL(DebugModeLeft()), disasmWidget, SLOT(OnDebugModeLeft()), Qt::BlockingQueuedConnection);
     connect(emu_thread.get(), SIGNAL(DebugModeLeft()), registersWidget, SLOT(OnDebugModeLeft()), Qt::BlockingQueuedConnection);
     connect(emu_thread.get(), SIGNAL(DebugModeLeft()), callstackWidget, SLOT(OnDebugModeLeft()), Qt::BlockingQueuedConnection);
+    connect(emu_thread.get(), SIGNAL(UserError(const char*)), this, SLOT(OnUserError(const char*)));
 
     // Update the GUI
     registersWidget->OnDebugModeEntered();
@@ -323,6 +324,11 @@ void GMainWindow::ToggleWindowMode() {
 void GMainWindow::OnConfigure()
 {
     //GControllerConfigDialog* dialog = new GControllerConfigDialog(controller_ports, this);
+}
+
+void GMainWindow::OnUserError(const char* str)
+{
+    QMessageBox::information(this, "Error", str);
 }
 
 void GMainWindow::closeEvent(QCloseEvent* event)

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -70,6 +70,7 @@ private slots:
     void OnConfigure();
     void OnDisplayTitleBars(bool);
     void ToggleWindowMode();
+    void OnUserError(const char* str);
 
 private:
     Ui::MainWindow ui;

--- a/src/video_core/rasterizer.cpp
+++ b/src/video_core/rasterizer.cpp
@@ -16,6 +16,8 @@
 #include "vertex_shader.h"
 #include "video_core/utils.h"
 
+extern bool thrown;
+
 namespace Pica {
 
 namespace Rasterizer {
@@ -403,6 +405,13 @@ static void ProcessTriangleInternal(const VertexShader::OutputVertex& v0,
 
                     case Source::Texture2:
                         return texture_color[2];
+
+                    case Source::Texture3:
+                        if (!thrown) {
+                            thrown = true;
+                            throw "Uses procedural textures, tell bunnei!";
+                        }
+                        return{ 255, 0, 255, 255 };
 
                     case Source::PreviousBuffer:
                         return combiner_buffer;

--- a/src/video_core/video_core.cpp
+++ b/src/video_core/video_core.cpp
@@ -14,6 +14,8 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Video Core namespace
 
+bool thrown = false;
+
 namespace VideoCore {
 
 EmuWindow*      g_emu_window    = nullptr;     ///< Frontend emulator window
@@ -25,6 +27,8 @@ void Init(EmuWindow* emu_window) {
     g_renderer = new RendererOpenGL();
     g_renderer->SetWindow(g_emu_window);
     g_renderer->Init();
+
+    thrown = false;
 
     LOG_DEBUG(Render, "initialized OK");
 }


### PR DESCRIPTION
I'm looking for some assistance finding games that use procedural textures for reverse engineering. Developers, please ignore this, I'm not looking for a review. Instead, I'd like for testers that have a lot of games (and/or time to test) to run this branch on their game collections to help me find games that use procedural textures.

If a game tries to use a procedural texture, you'll immediately see the following message box (only once per game):

![image](https://cloud.githubusercontent.com/assets/6956688/7556457/a020b3f6-f73e-11e4-9b50-604035824072.png)

**This will only work with with the Qt GUI.** Furthermore, any triangles that use this texture should appear bright magenta-colored in-game.

Any help is greatly appreciated. Furthermore, any screenshots of where the procedural textures occur (and/or how to reproduce the results) would be helpful. Thanks!
