### PR TITLE
Implement I4 texture format

### DIFF
--- a/src/video_core/debug_utils/debug_utils.cpp
+++ b/src/video_core/debug_utils/debug_utils.cpp
@@ -393,6 +393,17 @@ const Math::Vec4<u8> LookupTexture(const u8* source, int x, int y, const Texture
         }
     }
 
+    case Regs::TextureFormat::I4:
+    {
+        u32 morton_offset = VideoCore::GetMortonOffset(x, y, 1);
+        const u8* source_ptr = source + morton_offset / 2;
+
+        u8 i = (morton_offset % 2) ? ((*source_ptr & 0xF0) >> 4) : (*source_ptr & 0xF);
+        i = Color::Convert4To8(i);
+
+        return { i, i, i, 255 };
+    }
+
     case Regs::TextureFormat::A4:
     {
         u32 morton_offset = VideoCore::GetMortonOffset(x, y, 1);

--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -156,7 +156,7 @@ struct Regs {
         I8           =  7,
         A8           =  8,
         IA4          =  9,
-
+        I4           = 10,
         A4           = 11,
         ETC1         = 12,  // compressed
         ETC1A4       = 13,  // compressed


### PR DESCRIPTION
@neobrain, could you confirm that this is correct?

It's been tested with various different games and fixes different textures, including in Animal Crossing, Kirby Triple Deluxe, and SMB3D.