### PR TITLE
Core/Memory: Add TLS support for creating up to 300 threads

### DIFF
--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -74,6 +74,9 @@ public:
     /// The id of this process
     u32 process_id = next_process_id++;
 
+    /// Bitmask of the used TLS slots
+    std::bitset<300> used_tls_slots;
+
     /**
      * Parses a list of kernel capability descriptors (as found in the ExHeader) and applies them
      * to this process.

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -107,6 +107,8 @@ void Thread::Stop() {
     for (auto& wait_object : wait_objects) {
         wait_object->RemoveWaitingThread(this);
     }
+
+    Kernel::g_current_process->used_tls_slots[tls_index] = false;
 }
 
 Thread* ArbitrateHighestPriorityThread(u32 address) {
@@ -404,12 +406,19 @@ ResultVal<SharedPtr<Thread>> Thread::Create(std::string name, VAddr entry_point,
     thread->name = std::move(name);
     thread->callback_handle = wakeup_callback_handle_table.Create(thread).MoveFrom();
     thread->owner_process = g_current_process;
+    thread->tls_index = -1;
 
-    VAddr tls_address = Memory::TLS_AREA_VADDR + (thread->thread_id - 1) * 0x200;
+    // Find the next available TLS index, and mark it as used
+    auto& used_tls_slots = Kernel::g_current_process->used_tls_slots;
+    for (unsigned int i = 0; i < used_tls_slots.size(); ++i) {
+        if (used_tls_slots[i] == false) {
+            thread->tls_index = i;
+            used_tls_slots[i] = true;
+            break;
+        }
+    }
 
-    ASSERT_MSG(tls_address < Memory::TLS_AREA_VADDR_END, "Too many threads");
-
-    thread->tls_address = tls_address;
+    ASSERT_MSG(thread->tls_index != -1, "Out of TLS space");
 
     // TODO(peachum): move to ScheduleThread() when scheduler is added so selected core is used
     // to initialize the context
@@ -505,7 +514,7 @@ void Thread::SetWaitSynchronizationOutput(s32 output) {
 }
 
 VAddr Thread::GetTLSAddress() const {
-    return tls_address;
+    return Memory::TLS_AREA_VADDR + tls_index * 0x200;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -157,7 +157,7 @@ public:
 
     s32 processor_id;
 
-    VAddr tls_address; ///< Address of the Thread Local Storage of the thread
+    s32 tls_index; ///< Index of the Thread Local Storage of the thread
 
     /// Mutexes currently held by this thread, which will be released when it exits.
     boost::container::flat_set<SharedPtr<Mutex>> held_mutexes;

--- a/src/core/mem_map.h
+++ b/src/core/mem_map.h
@@ -94,10 +94,12 @@ enum : VAddr {
     SHARED_PAGE_SIZE      = 0x00001000,
     SHARED_PAGE_VADDR_END = SHARED_PAGE_VADDR + SHARED_PAGE_SIZE,
 
-    // TODO(yuriks): The exact location and size of this area is uncomfirmed.
+    // TODO(yuriks): The size of this area is dynamic, the kernel grows
+    // it as more and more threads are created. For now we'll just use a 
+    // hardcoded value.
     /// Area where TLS (Thread-Local Storage) buffers are allocated.
-    TLS_AREA_VADDR     = 0x1FFA0000,
-    TLS_AREA_SIZE      = 0x00002000, // Each TLS buffer is 0x200 bytes, allows for 16 threads
+    TLS_AREA_VADDR     = 0x1FF82000,
+    TLS_AREA_SIZE      = 0x00030000, // Each TLS buffer is 0x200 bytes, allows for 300 threads
     TLS_AREA_VADDR_END = TLS_AREA_VADDR + TLS_AREA_SIZE,
 };
 


### PR DESCRIPTION
The real kernel autogrows the TLS area as more threads are created, up to an unknown limit, but for our purposes this will suffice for now.
This fixes #743 