### PR TITLE
Thread: Correctly set main thread initial stack position

### DIFF
--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -85,7 +85,7 @@ void Process::ParseKernelCaps(const u32* kernel_caps, size_t len) {
 }
 
 void Process::Run(VAddr entry_point, s32 main_thread_priority, u32 stack_size) {
-    Kernel::SetupMainThread(stack_size, entry_point, main_thread_priority);
+    Kernel::SetupMainThread(entry_point, main_thread_priority);
 }
 
 Kernel::Process::Process() {}

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -458,12 +458,12 @@ SharedPtr<Thread> SetupIdleThread() {
     return thread;
 }
 
-SharedPtr<Thread> SetupMainThread(u32 stack_size, u32 entry_point, s32 priority) {
+SharedPtr<Thread> SetupMainThread(u32 entry_point, s32 priority) {
     DEBUG_ASSERT(!GetCurrentThread());
 
     // Initialize new "main" thread
     auto thread_res = Thread::Create("main", entry_point, priority, 0,
-            THREADPROCESSORID_0, Memory::HEAP_VADDR_END - stack_size);
+            THREADPROCESSORID_0, Memory::HEAP_VADDR_END);
 
     SharedPtr<Thread> thread = thread_res.MoveFrom();
 

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -181,12 +181,11 @@ private:
 
 /**
  * Sets up the primary application thread
- * @param stack_size The size of the thread's stack
  * @param entry_point The address at which the thread should start execution
  * @param priority The priority to give the main thread
  * @return A shared pointer to the main thread
  */
-SharedPtr<Thread> SetupMainThread(u32 stack_size, u32 entry_point, s32 priority);
+SharedPtr<Thread> SetupMainThread(u32 entry_point, s32 priority);
 
 /**
  * Reschedules to the next available thread (call after current thread is suspended)


### PR DESCRIPTION
Apparently "top" really means top, and not "bottom" like I seemed to be thinking at the time.