### PR TITLE
Core/Scheduling: Prepare the new priority in the thread queue when svcSetPriority is called

### DIFF
--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -439,6 +439,8 @@ void Thread::SetPriority(s32 priority) {
     // If thread was ready, adjust queues
     if (status == THREADSTATUS_READY)
         ready_queue.move(this, current_priority, priority);
+    else
+        ready_queue.prepare(priority);
 
     nominal_priority = current_priority = priority;
 }


### PR DESCRIPTION
Fixes a crash in swkbd, and could probably fix many other threading bugs

(Sadly it doesn't fix the MoFlex playback bug :( )