### PR TITLE
Qt: Shutdown emulation session only if EmuThread exists.

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -337,7 +337,9 @@ void GMainWindow::closeEvent(QCloseEvent* event)
     settings.setValue("firstStart", false);
     SaveHotkeys(settings);
 
-    ShutdownGame();
+    // Shutdown session if the emu thread is active...
+    if (emu_thread != nullptr)
+        ShutdownGame();
 
     render_window->close();
 


### PR DESCRIPTION
Fixes #737