### PR TITLE
DOT3_RGB combiner

### DIFF
--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -265,7 +265,7 @@ struct Regs {
             AddSigned       = 3,
             Lerp            = 4,
             Subtract        = 5,
-			Dot3_RGB		= 6,
+            Dot3_RGB		= 6,
             MultiplyThenAdd = 8,
             AddThenMultiply = 9,
         };

--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -265,7 +265,7 @@ struct Regs {
             AddSigned       = 3,
             Lerp            = 4,
             Subtract        = 5,
-            Dot3_RGB		= 6,
+            Dot3_RGB        = 6,
             MultiplyThenAdd = 8,
             AddThenMultiply = 9,
         };

--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -266,6 +266,7 @@ struct Regs {
             Lerp            = 4,
             Subtract        = 5,
             Dot3_RGB        = 6,
+
             MultiplyThenAdd = 8,
             AddThenMultiply = 9,
         };

--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -265,7 +265,7 @@ struct Regs {
             AddSigned       = 3,
             Lerp            = 4,
             Subtract        = 5,
-
+			Dot3_RGB		= 6,
             MultiplyThenAdd = 8,
             AddThenMultiply = 9,
         };

--- a/src/video_core/rasterizer.cpp
+++ b/src/video_core/rasterizer.cpp
@@ -546,8 +546,7 @@ static void ProcessTriangleInternal(const VertexShader::OutputVertex& v0,
                     }
                     case Operation::Dot3_RGB:
                     {
-                        //Not fully accurate
-                        //For hardware tests please check : https://github.com/Lectem/3DS_gpu_tests/tree/DOT3_RGB/
+                        // Not fully accurate
                         int result = ((input[0].r() * 2 - 255) * (input[1].r() * 2 - 255)+128) / 256 +
                                      ((input[0].g() * 2 - 255) * (input[1].g() * 2 - 255)+128) / 256 +
                                      ((input[0].b() * 2 - 255) * (input[1].b() * 2 - 255)+128) / 256;

--- a/src/video_core/rasterizer.cpp
+++ b/src/video_core/rasterizer.cpp
@@ -546,12 +546,15 @@ static void ProcessTriangleInternal(const VertexShader::OutputVertex& v0,
                     }
                     case Operation::Dot3_RGB:
                     {
-                        // Not fully accurate
-                        int result = ((input[0].r() * 2 - 255) * (input[1].r() * 2 - 255)+128) / 256 +
-                                     ((input[0].g() * 2 - 255) * (input[1].g() * 2 - 255)+128) / 256 +
-                                     ((input[0].b() * 2 - 255) * (input[1].b() * 2 - 255)+128) / 256;
-                        result = std::max(0,std::min(255,result));
-                        return{ (u8)result, (u8)result, (u8)result };
+                        // Not fully accurate.
+                        // Worst case scenario seems to yield a +/-3 error
+                        // Some HW results indicate that the per-component computation can't have a higher precision than 1/256,
+                        // while dot3_rgb( (0x80,g0,b0),(0x7F,g1,b1) ) and dot3_rgb( (0x80,g0,b0),(0x80,g1,b1) ) give different results
+                        int result = ((input[0].r() * 2 - 255) * (input[1].r() * 2 - 255) + 128) / 256 +
+                                     ((input[0].g() * 2 - 255) * (input[1].g() * 2 - 255) + 128) / 256 +
+                                     ((input[0].b() * 2 - 255) * (input[1].b() * 2 - 255) + 128) / 256;
+                        result = std::max(0, std::min(255, result));
+                        return { (u8)result, (u8)result, (u8)result };
                     }
                     default:
                         LOG_ERROR(HW_GPU, "Unknown color combiner operation %d\n", (int)op);

--- a/src/video_core/rasterizer.cpp
+++ b/src/video_core/rasterizer.cpp
@@ -544,12 +544,11 @@ static void ProcessTriangleInternal(const VertexShader::OutputVertex& v0,
                         result = (result * input[2].Cast<int>()) / 255;
                         return result.Cast<u8>();
                     }
-					case Operation::Dot3_RGB:
-					{
-						auto result = Math::Dot(input[0], input[1]);
-						return{ result, result, result };
-					}
-
+                    case Operation::Dot3_RGB:
+                    {
+                        auto result = 4 * Math::Dot(input[0] - Math::MakeVec<u8>(127, 127, 127), input[1] - Math::MakeVec<u8>(127, 127, 127));
+                        return{ result, result, result };
+                    }
                     default:
                         LOG_ERROR(HW_GPU, "Unknown color combiner operation %d\n", (int)op);
                         UNIMPLEMENTED();

--- a/src/video_core/rasterizer.cpp
+++ b/src/video_core/rasterizer.cpp
@@ -548,9 +548,9 @@ static void ProcessTriangleInternal(const VertexShader::OutputVertex& v0,
                     {
                         //Not fully accurate
                         //For hardware tests please check : https://github.com/Lectem/3DS_gpu_tests/tree/DOT3_RGB/
-                        int result = ((input[0].r() * 2 - 255) * (input[1].r() * 2 - 255)) / 256 +
-                                     ((input[0].g() * 2 - 255) * (input[1].g() * 2 - 255)) / 256 +
-                                     ((input[0].b() * 2 - 255) * (input[1].b() * 2 - 255)) / 256;
+                        int result = ((input[0].r() * 2 - 255) * (input[1].r() * 2 - 255)+128) / 256 +
+                                     ((input[0].g() * 2 - 255) * (input[1].g() * 2 - 255)+128) / 256 +
+                                     ((input[0].b() * 2 - 255) * (input[1].b() * 2 - 255)+128) / 256;
                         result = std::max(0,std::min(255,result));
                         return{ (u8)result, (u8)result, (u8)result };
                     }

--- a/src/video_core/rasterizer.cpp
+++ b/src/video_core/rasterizer.cpp
@@ -546,7 +546,9 @@ static void ProcessTriangleInternal(const VertexShader::OutputVertex& v0,
                     }
                     case Operation::Dot3_RGB:
                     {
-                        auto result = 4 * Math::Dot(input[0] - Math::MakeVec<u8>(127, 127, 127), input[1] - Math::MakeVec<u8>(127, 127, 127));
+                        //TODO : verify if 0.5 = 127 or 128
+                        auto result = 4 * Math::Dot(input[0] - Math::MakeVec<u8>(128, 128, 128), input[1] - Math::MakeVec<u8>(128, 128, 128));
+                        result = std::max(0,std::min(255,result));
                         return{ result, result, result };
                     }
                     default:

--- a/src/video_core/rasterizer.cpp
+++ b/src/video_core/rasterizer.cpp
@@ -547,7 +547,7 @@ static void ProcessTriangleInternal(const VertexShader::OutputVertex& v0,
                     case Operation::Dot3_RGB:
                     {
                         //TODO : verify if 0.5 = 127 or 128
-                        auto result = 4 * Math::Dot(input[0] - Math::MakeVec<u8>(128, 128, 128), input[1] - Math::MakeVec<u8>(128, 128, 128));
+                        auto result = 4 * Math::Dot(input[0] - Math::MakeVec<u8>(128, 128, 128), input[1] - Math::MakeVec<u8>(128, 128, 128))/255;
                         result = std::max(0,std::min(255,result));
                         return{ result, result, result };
                     }

--- a/src/video_core/rasterizer.cpp
+++ b/src/video_core/rasterizer.cpp
@@ -546,10 +546,13 @@ static void ProcessTriangleInternal(const VertexShader::OutputVertex& v0,
                     }
                     case Operation::Dot3_RGB:
                     {
-                        //TODO : verify if 0.5 = 127 or 128
-                        auto result = 4 * Math::Dot(input[0] - Math::MakeVec<u8>(128, 128, 128), input[1] - Math::MakeVec<u8>(128, 128, 128))/255;
+                        //Not fully accurate
+                        //For hardware tests please check : https://github.com/Lectem/3DS_gpu_tests/tree/DOT3_RGB/
+                        int result = ((input[0].r() * 2 - 255) * (input[1].r() * 2 - 255)) / 256 +
+                                     ((input[0].g() * 2 - 255) * (input[1].g() * 2 - 255)) / 256 +
+                                     ((input[0].b() * 2 - 255) * (input[1].b() * 2 - 255)) / 256;
                         result = std::max(0,std::min(255,result));
-                        return{ result, result, result };
+                        return{ (u8)result, (u8)result, (u8)result };
                     }
                     default:
                         LOG_ERROR(HW_GPU, "Unknown color combiner operation %d\n", (int)op);

--- a/src/video_core/rasterizer.cpp
+++ b/src/video_core/rasterizer.cpp
@@ -544,6 +544,11 @@ static void ProcessTriangleInternal(const VertexShader::OutputVertex& v0,
                         result = (result * input[2].Cast<int>()) / 255;
                         return result.Cast<u8>();
                     }
+					case Operation::Dot3_RGB:
+					{
+						auto result = Math::Dot(input[0], input[1]);
+						return{ result, result, result };
+					}
 
                     default:
                         LOG_ERROR(HW_GPU, "Unknown color combiner operation %d\n", (int)op);


### PR DESCRIPTION
Implemented missing DOT3_RGB texture combiner. However it is not 100% accurate.

The hardware tests are  available at https://github.com/Lectem/3DS_gpu_tests/tree/DOT3_RGB

Sources : 
https://github.com/smealum/ctrulib/blob/2fed2f42411e0cf69e7c61bcae657139ca5cf1b8/libctru/include/3ds/gpu/gpu.h#L193
http://chimera.labs.oreilly.com/books/1234000001814/ch08.html#TextureCombiners


