### PR TITLE
Use condition var to properly pause the CPU thread

### DIFF
--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -59,6 +59,9 @@ void EmuThread::run() {
             yieldCurrentThread();
             
             was_active = false;
+        } else {
+            std::unique_lock<std::mutex> lock(running_mutex);
+            running_cv.wait(lock, [this]{ return IsRunning() || stop_run; });
         }
     }
 


### PR DESCRIPTION
Adds support for threaded pausing so citra doesn't spin wait on pause. Fixes #779 