### PR TITLE
Thread reschedule and MOFLEX fixes

### DIFF
--- a/src/core/hle/kernel/address_arbiter.cpp
+++ b/src/core/hle/kernel/address_arbiter.cpp
@@ -79,6 +79,9 @@ ResultCode AddressArbiter::ArbitrateAddress(ArbitrationType type, VAddr address,
         LOG_ERROR(Kernel, "unknown type=%d", type);
         return ResultCode(ErrorDescription::InvalidEnumValue, ErrorModule::Kernel, ErrorSummary::WrongArgument, ErrorLevel::Usage);
     }
+
+    HLE::Reschedule(__func__);
+
     return RESULT_SUCCESS;
 }
 

--- a/src/core/hle/kernel/event.cpp
+++ b/src/core/hle/kernel/event.cpp
@@ -41,7 +41,10 @@ void Event::Acquire() {
 
 void Event::Signal() {
     signaled = true;
+
     WakeupAllWaitingThreads();
+
+    HLE::Reschedule(__func__);
 }
 
 void Event::Clear() {

--- a/src/core/hle/kernel/mutex.cpp
+++ b/src/core/hle/kernel/mutex.cpp
@@ -94,6 +94,8 @@ void Mutex::Release() {
             ResumeWaitingThread(this);
         }
     }
+
+    HLE::Reschedule(__func__);
 }
 
 } // namespace

--- a/src/core/hle/kernel/semaphore.cpp
+++ b/src/core/hle/kernel/semaphore.cpp
@@ -54,6 +54,8 @@ ResultVal<s32> Semaphore::Release(s32 release_count) {
         Acquire();
     }
 
+    HLE::Reschedule(__func__);
+
     return MakeResult<s32>(previous_count);
 }
 

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -109,6 +109,8 @@ void Thread::Stop() {
     }
 
     Kernel::g_current_process->used_tls_slots[tls_index] = false;
+
+    HLE::Reschedule(__func__);
 }
 
 Thread* ArbitrateHighestPriorityThread(u32 address) {
@@ -232,6 +234,8 @@ static Thread* PopNextReadyThread() {
 void WaitCurrentThread_Sleep() {
     Thread* thread = GetCurrentThread();
     thread->status = THREADSTATUS_WAIT_SLEEP;
+
+    HLE::Reschedule(__func__);
 }
 
 void WaitCurrentThread_WaitSynchronization(std::vector<SharedPtr<WaitObject>> wait_objects, bool wait_set_output, bool wait_all) {
@@ -430,6 +434,8 @@ ResultVal<SharedPtr<Thread>> Thread::Create(std::string name, VAddr entry_point,
 
     ready_queue.push_back(thread->current_priority, thread.get());
     thread->status = THREADSTATUS_READY;
+
+    HLE::Reschedule(__func__);
 
     return MakeResult<SharedPtr<Thread>>(std::move(thread));
 }

--- a/src/core/hle/kernel/timer.cpp
+++ b/src/core/hle/kernel/timer.cpp
@@ -52,10 +52,14 @@ void Timer::Set(s64 initial, s64 interval) {
     u64 initial_microseconds = initial / 1000;
     CoreTiming::ScheduleEvent(usToCycles(initial_microseconds),
             timer_callback_event_type, callback_handle);
+
+    HLE::Reschedule(__func__);
 }
 
 void Timer::Cancel() {
     CoreTiming::UnscheduleEvent(timer_callback_event_type, callback_handle);
+
+    HLE::Reschedule(__func__);
 }
 
 void Timer::Clear() {

--- a/src/core/hle/service/y2r_u.cpp
+++ b/src/core/hle/service/y2r_u.cpp
@@ -43,6 +43,22 @@ static void GetTransferEndEvent(Service::Interface* self) {
     cmd_buff[3] = Kernel::g_handle_table.Create(completion_event).MoveFrom();
 }
 
+/**
+ * Starts a YUV -> RGB conversion
+ */
+static void StartConversion(Service::Interface* self) {
+    u32* cmd_buff = Kernel::GetCommandBuffer();
+
+    // TODO(bunnei): This is hack to indicate to the game that the conversion has immediately
+    // completed, even though it's not actually implemented yet. This fixes games that would
+    // otherwise hang on trying to play moflex videos, which uses the Y2R service.
+    completion_event->Signal();
+
+    LOG_WARNING(Service, "(STUBBED) called, expect blank video (MOFLEX) output!");
+
+    cmd_buff[1] = RESULT_SUCCESS.raw;
+}
+
 const Interface::FunctionInfo FunctionTable[] = {
     {0x00010040, nullptr,                 "SetInputFormat"},
     {0x00030040, nullptr,                 "SetOutputFormat"},
@@ -58,7 +74,7 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x001C0040, nullptr,                 "SetInputLines"},
     {0x00200040, nullptr,                 "SetStandardCoefficient"},
     {0x00220040, nullptr,                 "SetAlpha"},
-    {0x00260000, nullptr,                 "StartConversion"},
+    {0x00260000, StartConversion,         "StartConversion"},
     {0x00270000, nullptr,                 "StopConversion"},
     {0x00280000, IsBusyConversion,        "IsBusyConversion"},
     {0x002A0000, nullptr,                 "PingProcess"},

--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -290,9 +290,6 @@ static ResultCode ArbitrateAddress(Handle handle, u32 address, u32 type, u32 val
     auto res = arbiter->ArbitrateAddress(static_cast<Kernel::ArbitrationType>(type),
                                          address, value, nanoseconds);
 
-    if (res == RESULT_SUCCESS)
-        HLE::Reschedule(__func__);
-
     return res;
 }
 
@@ -399,8 +396,6 @@ static ResultCode CreateThread(Handle* out_handle, s32 priority, u32 entry_point
         "threadpriority=0x%08X, processorid=0x%08X : created handle=0x%08X", entry_point,
         name.c_str(), arg, stack_top, priority, processor_id, *out_handle);
 
-    HLE::Reschedule(__func__);
-
     return RESULT_SUCCESS;
 }
 
@@ -409,7 +404,6 @@ static void ExitThread() {
     LOG_TRACE(Kernel_SVC, "called, pc=0x%08X", Core::g_app_core->GetPC());
 
     Kernel::GetCurrentThread()->Stop();
-    HLE::Reschedule(__func__);
 }
 
 /// Gets the priority for the specified thread
@@ -439,11 +433,9 @@ static ResultCode CreateMutex(Handle* out_handle, u32 initial_locked) {
     SharedPtr<Mutex> mutex = Mutex::Create(initial_locked != 0);
     CASCADE_RESULT(*out_handle, Kernel::g_handle_table.Create(std::move(mutex)));
 
-    HLE::Reschedule(__func__);
-
     LOG_TRACE(Kernel_SVC, "called initial_locked=%s : created handle=0x%08X",
         initial_locked ? "true" : "false", *out_handle);
-    
+
     return RESULT_SUCCESS;
 }
 
@@ -458,8 +450,6 @@ static ResultCode ReleaseMutex(Handle handle) {
         return ERR_INVALID_HANDLE;
 
     mutex->Release();
-
-    HLE::Reschedule(__func__);
 
     return RESULT_SUCCESS;
 }
@@ -528,8 +518,6 @@ static ResultCode ReleaseSemaphore(s32* count, Handle handle, s32 release_count)
 
     CASCADE_RESULT(*count, semaphore->Release(release_count));
 
-    HLE::Reschedule(__func__);
-
     return RESULT_SUCCESS;
 }
 
@@ -568,7 +556,7 @@ static ResultCode SignalEvent(Handle handle) {
         return ERR_INVALID_HANDLE;
 
     evt->Signal();
-    HLE::Reschedule(__func__);
+
     return RESULT_SUCCESS;
 }
 
@@ -623,8 +611,6 @@ static ResultCode SetTimer(Handle handle, s64 initial, s64 interval) {
 
     timer->Set(initial, interval);
 
-    HLE::Reschedule(__func__);
-
     return RESULT_SUCCESS;
 }
 
@@ -640,8 +626,6 @@ static ResultCode CancelTimer(Handle handle) {
 
     timer->Cancel();
 
-    HLE::Reschedule(__func__);
-
     return RESULT_SUCCESS;
 }
 
@@ -654,8 +638,6 @@ static void SleepThread(s64 nanoseconds) {
 
     // Create an event to wake the thread up after the specified nanosecond delay has passed
     Kernel::GetCurrentThread()->WakeAfterDelay(nanoseconds);
-
-    HLE::Reschedule(__func__);
 }
 
 /// This returns the total CPU ticks elapsed since the CPU was powered-on


### PR DESCRIPTION
This is a few fixes to get Zelda: A Link Between Worlds (boots to the menus, but lots of issues), Zelda: Majora's Mask (shows some graphics, still totally broken), and MOFLEX games (Aero Porter, Brunswick Pro Bowling, etc.) to boot (no video output, but it won't hang). The MOFLEX videos will still try to play, but they will appear as a black screen (and could take a while to compete). 

Obligatory Zelda screenshot:

![image](https://cloud.githubusercontent.com/assets/6956688/7716840/17afa4bc-fe66-11e4-85c8-be2fd4d54b7e.png)

Summary of changes:
* Cause a threading reschedule on underlying rescheduling mechanisms, not within the SVCs themselves (e.g. if Citra calls them, but not the game, they should still rechedule)
* Trigger the interrupt signal for Y2R conversions being completed (used for MOFLEX videos), even though they are unimplemented at this time