### PR TITLE
Implement stencil testing

### DIFF
--- a/src/citra_qt/debugger/graphics_framebuffer.cpp
+++ b/src/citra_qt/debugger/graphics_framebuffer.cpp
@@ -184,8 +184,32 @@ void GraphicsFramebufferWidget::OnUpdate()
         framebuffer_address = framebuffer.GetColorBufferPhysicalAddress();
         framebuffer_width = framebuffer.GetWidth();
         framebuffer_height = framebuffer.GetHeight();
-        // TODO: It's unknown how this format is actually specified
-        framebuffer_format = Format::RGBA8;
+
+        switch (framebuffer.color_format) {
+        case Pica::Regs::ColorFormat::RGBA8:
+            framebuffer_format = Format::RGBA8;
+            break;
+
+        case Pica::Regs::ColorFormat::RGB8:
+            framebuffer_format = Format::RGB8;
+            break;
+
+        case Pica::Regs::ColorFormat::RGB5A1:
+            framebuffer_format = Format::RGB5A1;
+            break;
+
+        case Pica::Regs::ColorFormat::RGB565:
+            framebuffer_format = Format::RGB565;
+            break;
+
+        case Pica::Regs::ColorFormat::RGBA4:
+            framebuffer_format = Format::RGBA4;
+            break;
+
+        default:
+            framebuffer_format = Format::Unknown;
+            break;
+        }
 
         break;
     }

--- a/src/citra_qt/debugger/graphics_framebuffer.h
+++ b/src/citra_qt/debugger/graphics_framebuffer.h
@@ -35,7 +35,8 @@ class GraphicsFramebufferWidget : public BreakPointObserverDock {
         RGBA4    = 4,
         D16      = 5,
         D24      = 6,
-        D24S8    = 7
+        D24S8    = 7,
+        Unknown  = 8
     };
 
     static u32 BytesPerPixel(Format format);

--- a/src/citra_qt/debugger/graphics_framebuffer.h
+++ b/src/citra_qt/debugger/graphics_framebuffer.h
@@ -35,8 +35,9 @@ class GraphicsFramebufferWidget : public BreakPointObserverDock {
         RGBA4    = 4,
         D16      = 5,
         D24      = 6,
-        D24S8    = 7,
-        Unknown  = 8
+        D24X8    = 7,
+        X24S8    = 8,
+        Unknown  = 9
     };
 
     static u32 BytesPerPixel(Format format);

--- a/src/common/color.h
+++ b/src/common/color.h
@@ -208,7 +208,32 @@ inline void EncodeD24(u32 value, u8* bytes) {
  * @param bytes Pointer where to store the encoded value
  */
 inline void EncodeD24S8(u32 depth, u8 stencil, u8* bytes) {
-    *reinterpret_cast<u32_le*>(bytes) = (stencil << 24) | depth;
+    bytes[0] = depth & 0xFF;
+    bytes[1] = (depth >> 8) & 0xFF;
+    bytes[2] = (depth >> 16) & 0xFF;
+    bytes[3] = stencil;
+}
+
+/**
+ * Encode a 24 bit depth value as D24X8 format (32 bits per pixel with 8 bits unused)
+ * @param depth 24 bit source depth value to encode
+ * @param bytes Pointer where to store the encoded value
+ * @note unused bits will not be modified
+ */
+inline void EncodeD24X8(u32 depth, u8* bytes) {
+    bytes[0] = depth & 0xFF;
+    bytes[1] = (depth >> 8) & 0xFF;
+    bytes[2] = (depth >> 16) & 0xFF;
+}
+
+/**
+ * Encode an 8 bit stencil value as X24S8 format (32 bits per pixel with 24 bits unused)
+ * @param stencil 8 bit source stencil value to encode
+ * @param bytes Pointer where to store the encoded value
+ * @note unused bits will not be modified
+ */
+inline void EncodeX24S8(u8 stencil, u8* bytes) {
+    bytes[3] = stencil;
 }
 
 } // namespace

--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -420,6 +420,11 @@ struct Regs {
         GreaterThanOrEqual = 7,
     };
 
+    enum class StencilAction : u32 {
+        Keep = 0,
+        Xor  = 5,
+    };
+
     struct {
         union {
             // If false, logic blending is used
@@ -454,15 +459,35 @@ struct Regs {
             BitField< 8, 8, u32> ref;
         } alpha_test;
 
-        union {
-            BitField< 0, 1, u32> stencil_test_enable;
-            BitField< 4, 3, CompareFunc> stencil_test_func;
-            BitField< 8, 8, u32> stencil_replacement_value;
-            BitField<16, 8, u32> stencil_reference_value;
-            BitField<24, 8, u32> stencil_mask;
-        } stencil_test;
+        struct {
+            union {
+                // If true, enable stencil testing
+                BitField< 0, 1, u32> enable;
 
-        INSERT_PADDING_WORDS(0x1);
+                // Comparison operation for stencil testing
+                BitField< 4, 3, CompareFunc> func;
+
+                // Value to calculate the new stencil value from
+                BitField< 8, 8, u32> replacement_value;
+
+                // Value to compare against for stencil testing
+                BitField<16, 8, u32> reference_value;
+
+                // Mask to apply on stencil test inputs
+                BitField<24, 8, u32> mask;
+            };
+
+            union {
+                // Action to perform when the stencil test fails
+                BitField< 0, 3, StencilAction> action_stencil_fail;
+
+                // Action to perform when stencil testing passed but depth testing fails
+                BitField< 4, 3, StencilAction> action_depth_fail;
+
+                // Action to perform when both stencil and depth testing pass
+                BitField< 8, 3, StencilAction> action_depth_pass;
+            };
+        } stencil_test;
 
         union {
             BitField< 0, 1, u32> depth_test_enable;
@@ -512,7 +537,7 @@ struct Regs {
     struct {
         INSERT_PADDING_WORDS(0x6);
 
-        DepthFormat depth_format;
+        DepthFormat depth_format; // TODO: Should be a BitField!
         BitField<16, 3, ColorFormat> color_format;
 
         INSERT_PADDING_WORDS(0x4);


### PR DESCRIPTION
Implements basic stencil testing functionality. Also adds two new framebuffer viewing formats: D24X8 and X24S8, each of which spans 32 bits per pixel but only shows the depth and/or stencil values.

The code in this PR was tested against portal3DS, which uses stencil testing to implement "looking through portals". Here's a screenshot showing it in action, as well as the X24S8 framebuffer viewing format (showing that the area covered by a portal is setting a mask for rendering anything beyond the portal).

![stencil testing in action](http://i.imgur.com/pL7wg6A.png) 

Revision history:
* ~~fa770594a29d123ca5612c91603aaf1e13f932be~~
* 5e79706db23a956ea0d6f3e5cc5a57b3a5d86b5e