### PR TITLE
ResourceLimit handles shouldn’t be waitable

### DIFF
--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -85,10 +85,9 @@ public:
         case HandleType::Redirection:
         case HandleType::Process:
         case HandleType::AddressArbiter:
+        case HandleType::ResourceLimit:
             return false;
         }
-
-        return false;
     }
 
 public:


### PR DESCRIPTION
This fixes a warning, and will error the next time another handle type is added.