### PR TITLE
Pica improvements

### DIFF
--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -162,6 +162,25 @@ struct Regs {
         ETC1A4       = 13,  // compressed
     };
 
+    enum class LogicOp : u32 {
+        Clear        =  0,
+        And          =  1,
+        AndReverse   =  2,
+        Copy         =  3,
+        Set          =  4,
+        CopyInverted =  5,
+        NoOp         =  6,
+        Invert       =  7,
+        Nand         =  8,
+        Or           =  9,
+        Nor          = 10,
+        Xor          = 11,
+        Equiv        = 12,
+        AndInverted  = 13,
+        OrReverse    = 14,
+        OrInverted   = 15,
+    };
+
     static unsigned NibblesPerPixel(TextureFormat format) {
         switch (format) {
         case TextureFormat::RGBA8:
@@ -413,12 +432,8 @@ struct Regs {
         } alpha_blending;
 
         union {
-            enum Op {
-                Set = 4,
-            };
-
-            BitField<0, 4, Op> op;
-        } logic_op;
+            BitField<0, 4, LogicOp> logic_op;
+        };
 
         union {
             BitField< 0, 8, u32> r;

--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -240,6 +240,7 @@ struct Regs {
         enum class Source : u32 {
             PrimaryColor           = 0x0,
             PrimaryFragmentColor   = 0x1,
+            SecondaryFragmentColor = 0x2,
 
             Texture0               = 0x3,
             Texture1               = 0x4,

--- a/src/video_core/rasterizer.cpp
+++ b/src/video_core/rasterizer.cpp
@@ -570,6 +570,13 @@ static void ProcessTriangleInternal(const VertexShader::OutputVertex& v0,
                     case Operation::Add:
                         return std::min(255, input[0] + input[1]);
 
+                    case Operation::AddSigned:
+                    {
+                        // TODO(bunnei): Verify that the color conversion from (float) 0.5f to (byte) 128 is correct
+                        auto result = static_cast<int>(input[0]) + static_cast<int>(input[1]) - 128;
+                        return static_cast<u8>(MathUtil::Clamp<int>(result, 0, 255));
+                    }
+
                     case Operation::Lerp:
                         return (input[0] * input[2] + input[1] * (255 - input[2])) / 255;
 

--- a/src/video_core/rasterizer.cpp
+++ b/src/video_core/rasterizer.cpp
@@ -815,10 +815,9 @@ static void ProcessTriangleInternal(const VertexShader::OutputVertex& v0,
                     }
                 };
 
-                using BlendEquation = Regs::BlendEquation;
                 static auto EvaluateBlendEquation = [](const Math::Vec4<u8>& src, const Math::Vec4<u8>& srcfactor,
                                                        const Math::Vec4<u8>& dest, const Math::Vec4<u8>& destfactor,
-                                                       BlendEquation equation) {
+                                                       Regs::BlendEquation equation) {
                     Math::Vec4<int> result;
 
                     auto src_result = (src  *  srcfactor).Cast<int>();

--- a/src/video_core/rasterizer.cpp
+++ b/src/video_core/rasterizer.cpp
@@ -402,10 +402,15 @@ static void ProcessTriangleInternal(const VertexShader::OutputVertex& v0,
 
                 auto GetSource = [&](Source source) -> Math::Vec4<u8> {
                     switch (source) {
-                    // TODO: What's the difference between these two?
                     case Source::PrimaryColor:
+
+                    // HACK: Until we implement fragment lighting, use primary_color
                     case Source::PrimaryFragmentColor:
                         return primary_color;
+
+                    // HACK: Until we implement fragment lighting, use zero
+                    case Source::SecondaryFragmentColor:
+                        return {0, 0, 0, 0};
 
                     case Source::Texture0:
                         return texture_color[0];

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -135,6 +135,7 @@ void RasterizerOpenGL::Reset() {
     SyncBlendFuncs();
     SyncBlendColor();
     SyncAlphaTest();
+    SyncLogicOp();
     SyncStencilTest();
     SyncDepthTest();
 
@@ -247,6 +248,11 @@ void RasterizerOpenGL::NotifyPicaRegisterChanged(u32 id) {
     // Depth test
     case PICA_REG_INDEX(output_merger.depth_test_enable):
         SyncDepthTest();
+        break;
+
+    // Logic op
+    case PICA_REG_INDEX(output_merger.logic_op):
+        SyncLogicOp();
         break;
 
     // TEV stage 0
@@ -631,6 +637,10 @@ void RasterizerOpenGL::SyncAlphaTest() {
     glUniform1i(uniform_alphatest_enabled, regs.output_merger.alpha_test.enable);
     glUniform1i(uniform_alphatest_func, (GLint)regs.output_merger.alpha_test.func.Value());
     glUniform1f(uniform_alphatest_ref, regs.output_merger.alpha_test.ref / 255.0f);
+}
+
+void RasterizerOpenGL::SyncLogicOp() {
+    state.logic_op = PicaToGL::LogicOp(Pica::g_state.regs.output_merger.logic_op);
 }
 
 void RasterizerOpenGL::SyncStencilTest() {

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -125,6 +125,9 @@ private:
     /// Syncs the alpha test states to match the PICA register
     void SyncAlphaTest();
 
+    /// Syncs the logic op states to match the PICA register
+    void SyncLogicOp();
+
     /// Syncs the stencil test states to match the PICA register
     void SyncStencilTest();
 

--- a/src/video_core/renderer_opengl/gl_shaders.h
+++ b/src/video_core/renderer_opengl/gl_shaders.h
@@ -69,15 +69,16 @@ const char g_fragment_shader_hw[] = R"(
 #define NUM_VTX_ATTR 7
 #define NUM_TEV_STAGES 6
 
-#define SOURCE_PRIMARYCOLOR         0x0
-#define SOURCE_PRIMARYFRAGMENTCOLOR 0x1
-#define SOURCE_TEXTURE0             0x3
-#define SOURCE_TEXTURE1             0x4
-#define SOURCE_TEXTURE2             0x5
-#define SOURCE_TEXTURE3             0x6
-#define SOURCE_PREVIOUSBUFFER       0xd
-#define SOURCE_CONSTANT             0xe
-#define SOURCE_PREVIOUS             0xf
+#define SOURCE_PRIMARYCOLOR           0x0
+#define SOURCE_PRIMARYFRAGMENTCOLOR   0x1
+#define SOURCE_SECONDARYFRAGMENTCOLOR 0x2
+#define SOURCE_TEXTURE0               0x3
+#define SOURCE_TEXTURE1               0x4
+#define SOURCE_TEXTURE2               0x5
+#define SOURCE_TEXTURE3               0x6
+#define SOURCE_PREVIOUSBUFFER         0xd
+#define SOURCE_CONSTANT               0xe
+#define SOURCE_PREVIOUS               0xf
 
 #define COLORMODIFIER_SOURCECOLOR         0x0
 #define COLORMODIFIER_ONEMINUSSOURCECOLOR 0x1
@@ -151,8 +152,11 @@ vec4 GetSource(int source) {
     if (source == SOURCE_PRIMARYCOLOR) {
         return o[2];
     } else if (source == SOURCE_PRIMARYFRAGMENTCOLOR) {
-        // HACK: Uses color value, but should really use fragment lighting output
+        // HACK: Until we implement fragment lighting, use primary_color
         return o[2];
+    } else if (source == SOURCE_SECONDARYFRAGMENTCOLOR) {
+        // HACK: Until we implement fragment lighting, use zero
+        return vec4(0.0, 0.0, 0.0, 0.0);
     } else if (source == SOURCE_TEXTURE0) {
         return texture(tex[0], o[3].xy);
     } else if (source == SOURCE_TEXTURE1) {

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -32,6 +32,8 @@ OpenGLState::OpenGLState() {
     blend.color.blue = 0.0f;
     blend.color.alpha = 0.0f;
 
+    logic_op = GL_COPY;
+
     for (auto& texture_unit : texture_units) {
         texture_unit.enabled_2d = false;
         texture_unit.texture_2d = 0;
@@ -99,8 +101,13 @@ void OpenGLState::Apply() {
     if (blend.enabled != cur_state.blend.enabled) {
         if (blend.enabled) {
             glEnable(GL_BLEND);
+
+            cur_state.logic_op = GL_COPY;
+            glLogicOp(cur_state.logic_op);
+            glDisable(GL_COLOR_LOGIC_OP);
         } else {
             glDisable(GL_BLEND);
+            glEnable(GL_COLOR_LOGIC_OP);
         }
     }
 
@@ -116,6 +123,10 @@ void OpenGLState::Apply() {
         blend.src_a_func != cur_state.blend.src_a_func ||
         blend.dst_a_func != cur_state.blend.dst_a_func) {
         glBlendFuncSeparate(blend.src_rgb_func, blend.dst_rgb_func, blend.src_a_func, blend.dst_a_func);
+    }
+
+    if (logic_op != cur_state.logic_op) {
+        glLogicOp(logic_op);
     }
 
     // Textures

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -42,6 +42,8 @@ public:
         } color; // GL_BLEND_COLOR
     } blend;
 
+    GLenum logic_op; // GL_LOGIC_OP_MODE
+
     // 3 texture units - one for each that is used in PICA fragment shader emulation
     struct {
         bool enabled_2d; // GL_TEXTURE_2D

--- a/src/video_core/renderer_opengl/pica_to_gl.h
+++ b/src/video_core/renderer_opengl/pica_to_gl.h
@@ -71,6 +71,37 @@ inline GLenum BlendFunc(Pica::Regs::BlendFactor factor) {
     return blend_func_table[(unsigned)factor];
 }
 
+inline GLenum LogicOp(Pica::Regs::LogicOp op) {
+    static const GLenum logic_op_table[] = {
+        GL_CLEAR,           // Clear
+        GL_AND,             // And
+        GL_AND_REVERSE,     // AndReverse
+        GL_COPY,            // Copy
+        GL_SET,             // Set
+        GL_COPY_INVERTED,   // CopyInverted
+        GL_NOOP,            // NoOp
+        GL_INVERT,          // Invert
+        GL_NAND,            // Nand
+        GL_OR,              // Or
+        GL_NOR,             // Nor
+        GL_XOR,             // Xor
+        GL_EQUIV,           // Equiv
+        GL_AND_INVERTED,    // AndInverted
+        GL_OR_REVERSE,      // OrReverse
+        GL_OR_INVERTED,     // OrInverted
+    };
+
+    // Range check table for input
+    if ((unsigned)op >= ARRAY_SIZE(logic_op_table)) {
+        LOG_CRITICAL(Render_OpenGL, "Unknown logic op %d", op);
+        UNREACHABLE();
+
+        return GL_COPY;
+    }
+
+    return logic_op_table[(unsigned)op];
+}
+
 inline GLenum CompareFunc(Pica::Regs::CompareFunc func) {
     static const GLenum compare_func_table[] = {
         GL_NEVER,    // CompareFunc::Never

--- a/src/video_core/vertex_shader.cpp
+++ b/src/video_core/vertex_shader.cpp
@@ -119,13 +119,13 @@ static void ProcessShaderCode(VertexShaderState& state) {
         switch (instr.opcode.Value().GetInfo().type) {
         case OpCode::Type::Arithmetic:
         {
-            bool is_inverted = 0 != (instr.opcode.Value().GetInfo().subtype & OpCode::Info::SrcInversed);
+            const bool is_inverted = (0 != (instr.opcode.Value().GetInfo().subtype & OpCode::Info::SrcInversed));
 
             const int address_offset = (instr.common.address_register_index == 0)
                                        ? 0 : state.address_registers[instr.common.address_register_index - 1];
 
-            const float24* src1_ = LookupSourceRegister(instr.common.GetSrc1(is_inverted) + address_offset);
-            const float24* src2_ = LookupSourceRegister(instr.common.GetSrc2(is_inverted));
+            const float24* src1_ = LookupSourceRegister(instr.common.GetSrc1(is_inverted) + (!is_inverted * address_offset));
+            const float24* src2_ = LookupSourceRegister(instr.common.GetSrc2(is_inverted) + ( is_inverted * address_offset));
 
             const bool negate_src1 = ((bool)swizzle.negate_src1 != false);
             const bool negate_src2 = ((bool)swizzle.negate_src2 != false);

--- a/src/video_core/vertex_shader.cpp
+++ b/src/video_core/vertex_shader.cpp
@@ -208,6 +208,15 @@ static void ProcessShaderCode(VertexShaderState& state) {
                 }
                 break;
 
+            case OpCode::Id::MIN:
+                for (int i = 0; i < 4; ++i) {
+                    if (!swizzle.DestComponentEnabled(i))
+                        continue;
+
+                    dest[i] = std::min(src1[i], src2[i]);
+                }
+                break;
+
             case OpCode::Id::DP3:
             case OpCode::Id::DP4:
             {

--- a/src/video_core/vertex_shader.cpp
+++ b/src/video_core/vertex_shader.cpp
@@ -120,10 +120,6 @@ static void ProcessShaderCode(VertexShaderState& state) {
         case OpCode::Type::Arithmetic:
         {
             bool is_inverted = 0 != (instr.opcode.Value().GetInfo().subtype & OpCode::Info::SrcInversed);
-            // TODO: We don't really support this properly: For instance, the address register
-            //       offset needs to be applied to SRC2 instead, etc.
-            //       For now, we just abort in this situation.
-            ASSERT_MSG(!is_inverted, "Bad condition...");
 
             const int address_offset = (instr.common.address_register_index == 0)
                                        ? 0 : state.address_registers[instr.common.address_register_index - 1];
@@ -287,6 +283,16 @@ static void ProcessShaderCode(VertexShaderState& state) {
                 }
                 break;
             }
+
+            case OpCode::Id::SLT:
+            case OpCode::Id::SLTI:
+                for (int i = 0; i < 4; ++i) {
+                    if (!swizzle.DestComponentEnabled(i))
+                        continue;
+
+                    dest[i] = (src1[i] < src2[i]) ? float24::FromFloat32(1.0f) : float24::FromFloat32(0.0f);
+                }
+                break;
 
             case OpCode::Id::CMP:
                 for (int i = 0; i < 2; ++i) {


### PR DESCRIPTION
This is a combination of several Pica emulation improvements. All changes have been implemented for both the SW rasterizer and OpenGL rasterizer. I recommend reviewing each commit separately, as they are well separated. This PR implements:
* Pica command buffer execution registers
* Vertex shader MIN, SLT, and SLTI instructions
* Color "logic operation" (same as `glLogicOp`)
* ~~RG8 texture format~~
* AddSigned combiner function for the alpha channel

Here are some results of these features (although I'm sure there are many more, testing welcome!):
![](http://i.imgur.com/RCHE31L.png)![](http://i.imgur.com/AQ8RMYo.png)