### PR TITLE
QT: Remove border around widgets

### DIFF
--- a/src/citra_qt/main.ui
+++ b/src/citra_qt/main.ui
@@ -24,7 +24,20 @@
    <bool>true</bool>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <layout class="QHBoxLayout" name="horizontalLayout"/>
+   <layout class="QHBoxLayout" name="horizontalLayout">
+    <property name="leftMargin">
+     <number>0</number>
+    </property>
+    <property name="topMargin">
+     <number>0</number>
+    </property>
+    <property name="rightMargin">
+     <number>0</number>
+    </property>
+    <property name="bottomMargin">
+     <number>0</number>
+    </property>
+   </layout>
   </widget>
   <widget class="QMenuBar" name="menubar">
    <property name="geometry">
@@ -92,7 +105,7 @@
   </action>
   <action name="action_Start">
    <property name="enabled">
-     <bool>false</bool>
+    <bool>false</bool>
    </property>
    <property name="text">
     <string>&amp;Start</string>


### PR DESCRIPTION
Fixes #815.
Without any extra widgets, it looks like this:
![nowidgets](https://cloud.githubusercontent.com/assets/3057954/7873119/4e846678-056c-11e5-8fb0-cae0175b2a20.png)

And with extra widgets, there is still visible space between different widgets because of the empty space that's part of them:
![widgets](https://cloud.githubusercontent.com/assets/3057954/7873141/79c9fbfe-056c-11e5-9b2f-de85dca1b138.png)
