### PR TITLE
Remove gpu_refresh_rate configuration option

### DIFF
--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -66,7 +66,6 @@ void Config::ReadValues() {
     Settings::values.pad_cright_key = glfw_config->GetInteger("Controls", "pad_cright", GLFW_KEY_L);
 
     // Core
-    Settings::values.gpu_refresh_rate = glfw_config->GetInteger("Core", "gpu_refresh_rate", 30);
     Settings::values.frame_skip = glfw_config->GetInteger("Core", "frame_skip", 0);
 
     // Renderer

--- a/src/citra_qt/config.cpp
+++ b/src/citra_qt/config.cpp
@@ -49,7 +49,6 @@ void Config::ReadValues() {
     qt_config->endGroup();
 
     qt_config->beginGroup("Core");
-    Settings::values.gpu_refresh_rate = qt_config->value("gpu_refresh_rate", 30).toInt();
     Settings::values.frame_skip = qt_config->value("frame_skip", 0).toInt();
     qt_config->endGroup();
 
@@ -102,7 +101,6 @@ void Config::SaveValues() {
     qt_config->endGroup();
 
     qt_config->beginGroup("Core");
-    qt_config->setValue("gpu_refresh_rate", Settings::values.gpu_refresh_rate);
     qt_config->setValue("frame_skip", Settings::values.frame_skip);
     qt_config->endGroup();
 

--- a/src/core/hw/gpu.cpp
+++ b/src/core/hw/gpu.cpp
@@ -30,8 +30,8 @@ Regs g_regs;
 
 /// True if the current frame was skipped
 bool g_skip_frame;
-/// 268MHz / gpu_refresh_rate frames per second
-static u64 frame_ticks;
+/// 268MHz CPU clocks / 60Hz frames per second
+const u64 frame_ticks = 268123480ull / 60;
 /// Event id for CoreTiming
 static int vblank_event;
 /// Total number of frames drawn
@@ -357,7 +357,6 @@ void Init() {
     framebuffer_sub.color_format = Regs::PixelFormat::RGB8;
     framebuffer_sub.active_fb = 0;
 
-    frame_ticks = 268123480 / Settings::values.gpu_refresh_rate;
     last_skip_frame = false;
     g_skip_frame = false;
     frame_count = 0;

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -35,7 +35,6 @@ struct Values {
     int pad_cright_key;
 
     // Core
-    int gpu_refresh_rate;
     int frame_skip;
 
     // Data Storage


### PR DESCRIPTION
Changing it makes emulation inherently inaccurate. It also had a wrong
default value (30, whereas the real system has a refresh rate of 60 Hz)
which, even if changed, would continue to be used unless people manually
removed it from their config files.