### PR TITLE
HW Renderer Screen Fixes

### DIFF
--- a/src/common/math_util.h
+++ b/src/common/math_util.h
@@ -12,7 +12,7 @@ namespace MathUtil
 {
 
 inline bool IntervalsIntersect(unsigned start0, unsigned length0, unsigned start1, unsigned length1) {
-    return (std::max(start0, start1) <= std::min(start0 + length0, start1 + length1));
+    return (std::max(start0, start1) < std::min(start0 + length0, start1 + length1));
 }
 
 template<typename T>

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -652,6 +652,10 @@ void RasterizerOpenGL::SyncDepthTest() {
     const auto& regs = Pica::g_state.regs;
     state.depth.test_enabled = (regs.output_merger.depth_test_enable == 1);
     state.depth.test_func = PicaToGL::CompareFunc(regs.output_merger.depth_test_func);
+    state.color_mask.red_enabled = regs.output_merger.red_enable;
+    state.color_mask.green_enabled = regs.output_merger.green_enable;
+    state.color_mask.blue_enabled = regs.output_merger.blue_enable;
+    state.color_mask.alpha_enabled = regs.output_merger.alpha_enable;
     state.depth.write_mask = regs.output_merger.depth_write_enable ? GL_TRUE : GL_FALSE;
 }
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -793,10 +793,10 @@ void RasterizerOpenGL::ReloadColorBuffer() {
         for (int x = 0; x < fb_color_texture.width; ++x) {
             const u32 coarse_y = y & ~7;
             u32 dst_offset = VideoCore::GetMortonOffset(x, y, bytes_per_pixel) + coarse_y * fb_color_texture.width * bytes_per_pixel;
-            u32 gl_px_idx = (x + y * fb_color_texture.width) * bytes_per_pixel;
+            u32 gl_pixel_index = (x + y * fb_color_texture.width) * bytes_per_pixel;
 
             u8* pixel = color_buffer + dst_offset;
-            memcpy(&temp_fb_color_buffer[gl_px_idx], pixel, bytes_per_pixel);
+            memcpy(&temp_fb_color_buffer[gl_pixel_index], pixel, bytes_per_pixel);
         }
     }
 
@@ -834,11 +834,11 @@ void RasterizerOpenGL::ReloadDepthBuffer() {
             for (int x = 0; x < fb_depth_texture.width; ++x) {
                 const u32 coarse_y = y & ~7;
                 u32 dst_offset = VideoCore::GetMortonOffset(x, y, bytes_per_pixel) + coarse_y * fb_depth_texture.width * bytes_per_pixel;
-                u32 gl_px_idx = (x + y * fb_depth_texture.width);
+                u32 gl_pixel_index = (x + y * fb_depth_texture.width);
 
                 u8* pixel = depth_buffer + dst_offset;
                 u32 depth_stencil = *(u32*)pixel;
-                ((u32*)temp_fb_depth_data)[gl_px_idx] = (depth_stencil << 8) | (depth_stencil >> 24);
+                ((u32*)temp_fb_depth_data)[gl_pixel_index] = (depth_stencil << 8) | (depth_stencil >> 24);
             }
         }
     } else {
@@ -846,10 +846,10 @@ void RasterizerOpenGL::ReloadDepthBuffer() {
             for (int x = 0; x < fb_depth_texture.width; ++x) {
                 const u32 coarse_y = y & ~7;
                 u32 dst_offset = VideoCore::GetMortonOffset(x, y, bytes_per_pixel) + coarse_y * fb_depth_texture.width * bytes_per_pixel;
-                u32 gl_px_idx = (x + y * fb_depth_texture.width) * gl_bpp;
+                u32 gl_pixel_index = (x + y * fb_depth_texture.width) * gl_bpp;
 
                 u8* pixel = depth_buffer + dst_offset;
-                memcpy(&temp_fb_depth_data[gl_px_idx], pixel, bytes_per_pixel);
+                memcpy(&temp_fb_depth_data[gl_pixel_index], pixel, bytes_per_pixel);
             }
         }
     }
@@ -890,10 +890,10 @@ void RasterizerOpenGL::CommitColorBuffer() {
                 for (int x = 0; x < fb_color_texture.width; ++x) {
                     const u32 coarse_y = y & ~7;
                     u32 dst_offset = VideoCore::GetMortonOffset(x, y, bytes_per_pixel) + coarse_y * fb_color_texture.width * bytes_per_pixel;
-                    u32 gl_px_idx = x * bytes_per_pixel + y * fb_color_texture.width * bytes_per_pixel;
+                    u32 gl_pixel_index = x * bytes_per_pixel + y * fb_color_texture.width * bytes_per_pixel;
 
                     u8* pixel = color_buffer + dst_offset;
-                    memcpy(pixel, &temp_gl_color_buffer[gl_px_idx], bytes_per_pixel);
+                    memcpy(pixel, &temp_gl_color_buffer[gl_pixel_index], bytes_per_pixel);
                 }
             }
         }
@@ -930,10 +930,10 @@ void RasterizerOpenGL::CommitDepthBuffer() {
                     for (int x = 0; x < fb_depth_texture.width; ++x) {
                         const u32 coarse_y = y & ~7;
                         u32 dst_offset = VideoCore::GetMortonOffset(x, y, bytes_per_pixel) + coarse_y * fb_depth_texture.width * bytes_per_pixel;
-                        u32 gl_px_idx = (x + y * fb_depth_texture.width);
+                        u32 gl_pixel_index = (x + y * fb_depth_texture.width);
 
                         u8* pixel = depth_buffer + dst_offset;
-                        u32 depth_stencil = ((u32*)temp_gl_depth_data)[gl_px_idx];
+                        u32 depth_stencil = ((u32*)temp_gl_depth_data)[gl_pixel_index];
                         *(u32*)pixel = (depth_stencil >> 8) | (depth_stencil << 24);
                     }
                 }
@@ -942,10 +942,10 @@ void RasterizerOpenGL::CommitDepthBuffer() {
                     for (int x = 0; x < fb_depth_texture.width; ++x) {
                         const u32 coarse_y = y & ~7;
                         u32 dst_offset = VideoCore::GetMortonOffset(x, y, bytes_per_pixel) + coarse_y * fb_depth_texture.width * bytes_per_pixel;
-                        u32 gl_px_idx = (x + y * fb_depth_texture.width) * gl_bpp;
+                        u32 gl_pixel_index = (x + y * fb_depth_texture.width) * gl_bpp;
 
                         u8* pixel = depth_buffer + dst_offset;
-                        memcpy(pixel, &temp_gl_depth_data[gl_px_idx], bytes_per_pixel);
+                        memcpy(pixel, &temp_gl_depth_data[gl_pixel_index], bytes_per_pixel);
                     }
                 }
             }

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -217,7 +217,19 @@ void RasterizerOpenGL::DrawTriangles() {
 
     vertex_batch.clear();
 
-    // TODO: Flush the resource cache at the current depth and color framebuffer addresses for render-to-texture
+    // Flush the resource cache at the current depth and color framebuffer addresses for render-to-texture
+    const auto& regs = Pica::g_state.regs;
+
+    PAddr cur_fb_color_addr = regs.framebuffer.GetColorBufferPhysicalAddress();
+    u32 cur_fb_color_size = Pica::Regs::BytesPerColorPixel(regs.framebuffer.color_format)
+                            * regs.framebuffer.GetWidth() * regs.framebuffer.GetHeight();
+
+    PAddr cur_fb_depth_addr = regs.framebuffer.GetDepthBufferPhysicalAddress();
+    u32 cur_fb_depth_size = Pica::Regs::BytesPerDepthPixel(regs.framebuffer.depth_format)
+                            * regs.framebuffer.GetWidth() * regs.framebuffer.GetHeight();
+
+    res_cache.NotifyFlush(cur_fb_color_addr, cur_fb_color_size);
+    res_cache.NotifyFlush(cur_fb_depth_addr, cur_fb_depth_size);
 }
 
 void RasterizerOpenGL::CommitFramebuffer() {

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -16,6 +16,11 @@ OpenGLState::OpenGLState() {
     depth.test_func = GL_LESS;
     depth.write_mask = GL_TRUE;
 
+    color_mask.red_enabled = GL_TRUE;
+    color_mask.green_enabled = GL_TRUE;
+    color_mask.blue_enabled = GL_TRUE;
+    color_mask.alpha_enabled = GL_TRUE;
+
     stencil.test_enabled = false;
     stencil.test_func = GL_ALWAYS;
     stencil.test_ref = 0;
@@ -75,6 +80,14 @@ void OpenGLState::Apply() {
     // Depth mask
     if (depth.write_mask != cur_state.depth.write_mask) {
         glDepthMask(depth.write_mask);
+    }
+
+    // Color mask
+    if (color_mask.red_enabled != cur_state.color_mask.red_enabled ||
+        color_mask.green_enabled != cur_state.color_mask.green_enabled ||
+        color_mask.blue_enabled != cur_state.color_mask.blue_enabled ||
+        color_mask.alpha_enabled != cur_state.color_mask.alpha_enabled) {
+        glColorMask(color_mask.red_enabled, color_mask.green_enabled, color_mask.blue_enabled, color_mask.alpha_enabled);
     }
 
     // Stencil test

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -84,10 +84,11 @@ void OpenGLState::Apply() {
 
     // Color mask
     if (color_mask.red_enabled != cur_state.color_mask.red_enabled ||
-        color_mask.green_enabled != cur_state.color_mask.green_enabled ||
-        color_mask.blue_enabled != cur_state.color_mask.blue_enabled ||
-        color_mask.alpha_enabled != cur_state.color_mask.alpha_enabled) {
-        glColorMask(color_mask.red_enabled, color_mask.green_enabled, color_mask.blue_enabled, color_mask.alpha_enabled);
+            color_mask.green_enabled != cur_state.color_mask.green_enabled ||
+            color_mask.blue_enabled != cur_state.color_mask.blue_enabled ||
+            color_mask.alpha_enabled != cur_state.color_mask.alpha_enabled) {
+        glColorMask(color_mask.red_enabled, color_mask.green_enabled,
+                    color_mask.blue_enabled, color_mask.alpha_enabled);
     }
 
     // Stencil test
@@ -100,8 +101,8 @@ void OpenGLState::Apply() {
     }
 
     if (stencil.test_func != cur_state.stencil.test_func ||
-        stencil.test_ref != cur_state.stencil.test_ref ||
-        stencil.test_mask != cur_state.stencil.test_mask) {
+            stencil.test_ref != cur_state.stencil.test_ref ||
+            stencil.test_mask != cur_state.stencil.test_mask) {
         glStencilFunc(stencil.test_func, stencil.test_ref, stencil.test_mask);
     }
 
@@ -125,17 +126,19 @@ void OpenGLState::Apply() {
     }
 
     if (blend.color.red != cur_state.blend.color.red ||
-        blend.color.green != cur_state.blend.color.green ||
-        blend.color.blue != cur_state.blend.color.blue ||
-        blend.color.alpha != cur_state.blend.color.alpha) {
-        glBlendColor(blend.color.red, blend.color.green, blend.color.blue, blend.color.alpha);
+            blend.color.green != cur_state.blend.color.green ||
+            blend.color.blue != cur_state.blend.color.blue ||
+            blend.color.alpha != cur_state.blend.color.alpha) {
+        glBlendColor(blend.color.red, blend.color.green,
+                     blend.color.blue, blend.color.alpha);
     }
 
     if (blend.src_rgb_func != cur_state.blend.src_rgb_func ||
-        blend.dst_rgb_func != cur_state.blend.dst_rgb_func ||
-        blend.src_a_func != cur_state.blend.src_a_func ||
-        blend.dst_a_func != cur_state.blend.dst_a_func) {
-        glBlendFuncSeparate(blend.src_rgb_func, blend.dst_rgb_func, blend.src_a_func, blend.dst_a_func);
+            blend.dst_rgb_func != cur_state.blend.dst_rgb_func ||
+            blend.src_a_func != cur_state.blend.src_a_func ||
+            blend.dst_a_func != cur_state.blend.dst_a_func) {
+        glBlendFuncSeparate(blend.src_rgb_func, blend.dst_rgb_func,
+                            blend.src_a_func, blend.dst_a_func);
     }
 
     if (logic_op != cur_state.logic_op) {

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -20,6 +20,13 @@ public:
     } depth;
 
     struct {
+        GLboolean red_enabled;
+        GLboolean green_enabled;
+        GLboolean blue_enabled;
+        GLboolean alpha_enabled;
+    } color_mask; // GL_COLOR_WRITEMASK
+
+    struct {
         bool test_enabled; // GL_STENCIL_TEST
         GLenum test_func; // GL_STENCIL_FUNC
         GLint test_ref; // GL_STENCIL_REF

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -170,6 +170,9 @@ void RendererOpenGL::LoadFBToActiveGLTexture(const GPU::Regs::FramebufferConfig&
                     texture.gl_format, texture.gl_type, framebuffer_data);
 
     glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+
+    state.texture_units[0].texture_2d = 0;
+    state.Apply();
 }
 
 /**
@@ -238,6 +241,9 @@ void RendererOpenGL::InitOpenGLObjects() {
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
     }
+
+    state.texture_units[0].texture_2d = 0;
+    state.Apply();
 
     hw_rasterizer->InitObjects();
 }


### PR DESCRIPTION
A batch of smaller fixes to the hardware renderer.
Addresses issue #814 and some bugs in issue #829
* blargSnes rom rendering fixed
  * glColorMask implemented
* Fewer black screens
  * Depth format handling fixes
  * Textures unbound after done using them
  * Render-to-texture flush
  * Interval intersection math fix
