### PR TITLE
Enforce the "no tab, use spaces" policy with a pre-commit hook.

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,2 +1,0 @@
-[core]
-    whitespace = blank-at-eol,trailing-space,tab-in-indent

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,2 @@
+[core]
+    whitespace = blank-at-eol,trailing-space,tab-in-indent

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,13 @@ cmake_minimum_required(VERSION 2.8.11)
 
 project(citra)
 
+if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git/hooks/pre-commit)
+    message(STATUS "Copying pre-commit hook")
+    file(COPY hooks/pre-commit
+        DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/.git/hooks
+        FILE_PERMISSIONS WORLD_EXECUTE )
+endif()
+
 if (NOT MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wno-attributes -pthread")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread")

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+#check the config, in case the user really wants to allow tabs...
+allowtabs=$(git config hooks.allowtabs)
+if [ "$allowtabs" != "true" ] &&
+   git diff --cached | egrep '^\+.*	'
+then
+   cat<<END;
+Error: This commit would contain a tab, which is against this repo's policy.
+END
+  exit 1
+fi
+
+# If there are whitespace errors, print the offending file names and fail.
+if
+# Use git built-in checks for trailing whitespaces
+    ! git diff --check --cached
+then
+   cat<<END;
+Error: This commit would contain trailing spaces, which is against this repo's policy.
+END
+  exit 1
+fi

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,23 +1,24 @@
 #!/bin/sh
 
-#check the config, in case the user really wants to allow tabs...
-allowtabs=$(git config hooks.allowtabs)
-if [ "$allowtabs" != "true" ] &&
-   git diff --cached | egrep '^\+.*	'
-then
-   cat<<END;
-Error: This commit would contain a tab, which is against this repo's policy.
-END
-  exit 1
-fi
+# Enforce citra's whitespace policy
+git config --local core.whitespace tab-in-indent,trailing-space
 
 # If there are whitespace errors, print the offending file names and fail.
-if
-# Use git built-in checks for trailing whitespaces
-    ! git diff --check --cached
-then
-   cat<<END;
-Error: This commit would contain trailing spaces, which is against this repo's policy.
+if ! git diff --cached --check; then
+    cat<<END;
+
+Error: This commit would contain trailing spaces or tabs, which is against this repo's policy.
+Please correct those issues before commiting. (Use 'git diff --check' for more details)
+If you know what you are doing, you can try 'git commit --no-verify' to bypass the check
 END
-  exit 1
+    exit 1
+fi
+
+# Check for tabs, since tab-in-indent catches only those at the beginning of a line
+if git diff --cached | egrep '^\+.*	'; then
+    cat<<END;
+Error: This commit would contain a tab, which is against this repo's policy.
+If you know what you are doing, you can try 'git commit --no-verify' to bypass the check.
+END
+    exit 1
 fi


### PR DESCRIPTION
Enforce the "no tab, use spaces" policy with a pre-commit hook.
This hook is installed through cmake if the user didn't set up any pre-commit hook before (so that we don't override it).

This will also check for trailing spaces