### PR TITLE
ExtSavedata: Save the icon passed to CreateExtSaveData.

### DIFF
--- a/src/core/file_sys/archive_extsavedata.cpp
+++ b/src/core/file_sys/archive_extsavedata.cpp
@@ -71,7 +71,7 @@ bool ArchiveFactory_ExtSaveData::Initialize() {
 }
 
 ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_ExtSaveData::Open(const Path& path) {
-    std::string fullpath = GetExtSaveDataPath(mount_point, path);
+    std::string fullpath = GetExtSaveDataPath(mount_point, path) + "user/";
     if (!FileUtil::Exists(fullpath)) {
         // TODO(Subv): Check error code, this one is probably wrong
         return ResultCode(ErrorDescription::FS_NotFormatted, ErrorModule::FS,
@@ -82,8 +82,11 @@ ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_ExtSaveData::Open(cons
 }
 
 ResultCode ArchiveFactory_ExtSaveData::Format(const Path& path) {
-    std::string fullpath = GetExtSaveDataPath(mount_point, path);
-    FileUtil::CreateFullPath(fullpath);
+    // These folders are always created with the ExtSaveData
+    std::string user_path = GetExtSaveDataPath(mount_point, path) + "user/";
+    std::string boss_path = GetExtSaveDataPath(mount_point, path) + "boss/";
+    FileUtil::CreateFullPath(user_path);
+    FileUtil::CreateFullPath(boss_path);
     return RESULT_SUCCESS;
 }
 

--- a/src/core/hle/service/fs/archive.h
+++ b/src/core/hle/service/fs/archive.h
@@ -177,9 +177,11 @@ ResultCode FormatArchive(ArchiveIdCode id_code, const FileSys::Path& path = File
  * @param media_type The media type of the archive to create (NAND / SDMC)
  * @param high The high word of the extdata id to create
  * @param low The low word of the extdata id to create
+ * @param icon_buffer VAddr of the SMDH icon for this ExtSaveData
+ * @param icon_size Size of the SMDH icon
  * @return ResultCode 0 on success or the corresponding code on error
  */
-ResultCode CreateExtSaveData(MediaType media_type, u32 high, u32 low);
+ResultCode CreateExtSaveData(MediaType media_type, u32 high, u32 low, VAddr icon_buffer, u32 icon_size);
 
 /**
  * Deletes the SharedExtSaveData archive for the specified extdata ID

--- a/src/core/hle/service/fs/fs_user.cpp
+++ b/src/core/hle/service/fs/fs_user.cpp
@@ -504,9 +504,9 @@ static void FormatThisUserSaveData(Service::Interface* self) {
  *      6 : Unknown
  *      7 : Unknown
  *      8 : Unknown
- *      9 : Unknown
- *      10: Unknown
- *      11: Unknown
+ *      9 : Size of the SMDH icon
+ *      10: (SMDH Size << 4) | 0x0000000A
+ *      11: Pointer to the SMDH icon for the new ExtSaveData
  *  Outputs:
  *      1 : Result of function, 0 on success, otherwise error code
  */
@@ -516,14 +516,16 @@ static void CreateExtSaveData(Service::Interface* self) {
     MediaType media_type = static_cast<MediaType>(cmd_buff[1] & 0xFF);
     u32 save_low = cmd_buff[2];
     u32 save_high = cmd_buff[3];
+    u32 icon_size = cmd_buff[9];
+    VAddr icon_buffer = cmd_buff[11];
 
     LOG_WARNING(Service_FS, "(STUBBED) savedata_high=%08X savedata_low=%08X cmd_buff[3]=%08X "
             "cmd_buff[4]=%08X cmd_buff[5]=%08X cmd_buff[6]=%08X cmd_buff[7]=%08X cmd_buff[8]=%08X "
-            "cmd_buff[9]=%08X cmd_buff[10]=%08X cmd_buff[11]=%08X", save_high, save_low,
-            cmd_buff[3], cmd_buff[4], cmd_buff[5], cmd_buff[6], cmd_buff[7], cmd_buff[8], cmd_buff[9],
-            cmd_buff[10], cmd_buff[11]);
+            "icon_size=%08X icon_descriptor=%08X icon_buffer=%08X", save_high, save_low,
+            cmd_buff[3], cmd_buff[4], cmd_buff[5], cmd_buff[6], cmd_buff[7], cmd_buff[8], icon_size,
+            cmd_buff[10], icon_buffer);
 
-    cmd_buff[1] = CreateExtSaveData(media_type, save_high, save_low).raw;
+    cmd_buff[1] = CreateExtSaveData(media_type, save_high, save_low, icon_buffer, icon_size).raw;
 }
 
 /**


### PR DESCRIPTION
Organize the ExtSaveData folders as they are stored in the console.