### PR TITLE
Fix svcWaitSynch to correctly acquire wait objects

### DIFF
--- a/src/core/hle/kernel/event.cpp
+++ b/src/core/hle/kernel/event.cpp
@@ -41,10 +41,7 @@ void Event::Acquire() {
 
 void Event::Signal() {
     signaled = true;
-
     WakeupAllWaitingThreads();
-
-    HLE::Reschedule(__func__);
 }
 
 void Event::Clear() {

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -32,27 +32,13 @@ void WaitObject::RemoveWaitingThread(Thread* thread) {
         waiting_threads.erase(itr);
 }
 
-SharedPtr<Thread> WaitObject::WakeupNextThread() {
-    if (waiting_threads.empty())
-        return nullptr;
-
-    auto next_thread = std::move(waiting_threads.front());
-    waiting_threads.erase(waiting_threads.begin());
-
-    next_thread->ReleaseWaitObject(this);
-
-    return next_thread;
-}
-
 void WaitObject::WakeupAllWaitingThreads() {
-    auto waiting_threads_copy = waiting_threads;
+    for (auto thread : waiting_threads)
+        thread->ResumeFromWait();
 
-    // We use a copy because ReleaseWaitObject will remove the thread from this object's
-    // waiting_threads list
-    for (auto thread : waiting_threads_copy)
-        thread->ReleaseWaitObject(this);
+    waiting_threads.clear();
 
-    ASSERT_MSG(waiting_threads.empty(), "failed to awaken all waiting threads!");
+    HLE::Reschedule(__func__);
 }
 
 HandleTable::HandleTable() {

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -140,12 +140,6 @@ public:
      */
     void RemoveWaitingThread(Thread* thread);
 
-    /**
-     * Wake up the next thread waiting on this object
-     * @return Pointer to the thread that was resumed, nullptr if no threads are waiting
-     */
-    SharedPtr<Thread> WakeupNextThread();
-
     /// Wake up all threads waiting on this object
     void WakeupAllWaitingThreads();
 

--- a/src/core/hle/kernel/mutex.cpp
+++ b/src/core/hle/kernel/mutex.cpp
@@ -23,12 +23,7 @@ static void ResumeWaitingThread(Mutex* mutex) {
     // Reset mutex lock thread handle, nothing is waiting
     mutex->lock_count = 0;
     mutex->holding_thread = nullptr;
-
-    // Find the next waiting thread for the mutex...
-    auto next_thread = mutex->WakeupNextThread();
-    if (next_thread != nullptr) {
-        mutex->Acquire(next_thread);
-    }
+    mutex->WakeupAllWaitingThreads();
 }
 
 void ReleaseThreadMutexes(Thread* thread) {
@@ -94,8 +89,6 @@ void Mutex::Release() {
             ResumeWaitingThread(this);
         }
     }
-
-    HLE::Reschedule(__func__);
 }
 
 } // namespace

--- a/src/core/hle/kernel/semaphore.cpp
+++ b/src/core/hle/kernel/semaphore.cpp
@@ -48,13 +48,7 @@ ResultVal<s32> Semaphore::Release(s32 release_count) {
     s32 previous_count = available_count;
     available_count += release_count;
 
-    // Notify some of the threads that the semaphore has been released
-    // stop once the semaphore is full again or there are no more waiting threads
-    while (!ShouldWait() && WakeupNextThread() != nullptr) {
-        Acquire();
-    }
-
-    HLE::Reschedule(__func__);
+    WakeupAllWaitingThreads();
 
     return MakeResult<s32>(previous_count);
 }

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -96,12 +96,6 @@ public:
     u32 GetThreadId() const { return thread_id; }
 
     /**
-     * Release an acquired wait object
-     * @param wait_object WaitObject to release
-     */
-    void ReleaseWaitObject(WaitObject* wait_object);
-
-    /**
      * Resumes a thread from waiting
      */
     void ResumeFromWait();
@@ -152,6 +146,8 @@ public:
 
     s32 tls_index; ///< Index of the Thread Local Storage of the thread
 
+    bool waitsynch_waited; ///< Set to true if the last svcWaitSynch call caused the thread to wait
+
     /// Mutexes currently held by this thread, which will be released when it exits.
     boost::container::flat_set<SharedPtr<Mutex>> held_mutexes;
 
@@ -163,12 +159,12 @@ public:
 
     std::string name;
 
+    /// Handle used as userdata to reference this object when inserting into the CoreTiming queue.
+    Handle callback_handle;
+
 private:
     Thread();
     ~Thread() override;
-
-    /// Handle used as userdata to reference this object when inserting into the CoreTiming queue.
-    Handle callback_handle;
 };
 
 /**

--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -40,9 +40,6 @@ const ResultCode ERR_NOT_FOUND(ErrorDescription::NotFound, ErrorModule::Kernel,
 const ResultCode ERR_PORT_NAME_TOO_LONG(ErrorDescription(30), ErrorModule::OS,
         ErrorSummary::InvalidArgument, ErrorLevel::Usage); // 0xE0E0181E
 
-/// An invalid result code that is meant to be overwritten when a thread resumes from waiting
-const ResultCode RESULT_INVALID(0xDEADC0DE);
-
 enum ControlMemoryOperation {
     MEMORY_OPERATION_HEAP       = 0x00000003,
     MEMORY_OPERATION_GSP_HEAP   = 0x00010003,
@@ -143,6 +140,10 @@ static ResultCode CloseHandle(Handle handle) {
 /// Wait for a handle to synchronize, timeout after the specified nanoseconds
 static ResultCode WaitSynchronization1(Handle handle, s64 nano_seconds) {
     auto object = Kernel::g_handle_table.GetWaitObject(handle);
+    Kernel::Thread* thread = Kernel::GetCurrentThread();
+
+    thread->waitsynch_waited = false;
+
     if (object == nullptr)
         return ERR_INVALID_HANDLE;
 
@@ -154,14 +155,14 @@ static ResultCode WaitSynchronization1(Handle handle, s64 nano_seconds) {
     // Check for next thread to schedule
     if (object->ShouldWait()) {
 
-        object->AddWaitingThread(Kernel::GetCurrentThread());
+        object->AddWaitingThread(thread);
         Kernel::WaitCurrentThread_WaitSynchronization({ object }, false, false);
 
         // Create an event to wake the thread up after the specified nanosecond delay has passed
-        Kernel::GetCurrentThread()->WakeAfterDelay(nano_seconds);
+        thread->WakeAfterDelay(nano_seconds);
 
         // NOTE: output of this SVC will be set later depending on how the thread resumes
-        return RESULT_INVALID;
+        return HLE::RESULT_INVALID;
     }
 
     object->Acquire();
@@ -173,6 +174,9 @@ static ResultCode WaitSynchronization1(Handle handle, s64 nano_seconds) {
 static ResultCode WaitSynchronizationN(s32* out, Handle* handles, s32 handle_count, bool wait_all, s64 nano_seconds) {
     bool wait_thread = !wait_all;
     int handle_index = 0;
+    Kernel::Thread* thread = Kernel::GetCurrentThread();
+    bool was_waiting = thread->waitsynch_waited;
+    thread->waitsynch_waited = false;
 
     // Check if 'handles' is invalid
     if (handles == nullptr)
@@ -190,6 +194,9 @@ static ResultCode WaitSynchronizationN(s32* out, Handle* handles, s32 handle_cou
     // necessary
     if (handle_count != 0) {
         bool selected = false; // True once an object has been selected
+
+        Kernel::SharedPtr<Kernel::WaitObject> wait_object;
+
         for (int i = 0; i < handle_count; ++i) {
             auto object = Kernel::g_handle_table.GetWaitObject(handles[i]);
             if (object == nullptr)
@@ -204,10 +211,11 @@ static ResultCode WaitSynchronizationN(s32* out, Handle* handles, s32 handle_cou
                     wait_thread = true;
             } else {
                 // Do not wait on this object, check if this object should be selected...
-                if (!wait_all && !selected) {
+                if (!wait_all && (!selected || (wait_object == object && was_waiting))) {
                     // Do not wait the thread
                     wait_thread = false;
                     handle_index = i;
+                    wait_object = object;
                     selected = true;
                 }
             }
@@ -241,7 +249,7 @@ static ResultCode WaitSynchronizationN(s32* out, Handle* handles, s32 handle_cou
         Kernel::GetCurrentThread()->WakeAfterDelay(nano_seconds);
 
         // NOTE: output of this SVC will be set later depending on how the thread resumes
-        return RESULT_INVALID;
+        return HLE::RESULT_INVALID;
     }
 
     // Acquire objects if we did not wait...
@@ -261,7 +269,7 @@ static ResultCode WaitSynchronizationN(s32* out, Handle* handles, s32 handle_cou
 
     // TODO(bunnei): If 'wait_all' is true, this is probably wrong. However, real hardware does
     // not seem to set it to any meaningful value.
-    *out = wait_all ? 0 : handle_index;
+    *out = handle_count != 0 ? (wait_all ? -1 : handle_index) : 0;
 
     return RESULT_SUCCESS;
 }


### PR DESCRIPTION
This changes how we emulate svcWaitSynch to ensure that wait objects are always acquired by the right thread. My solution with this PR is to always call the SVC when a thread is awoken until conditions are satisfied for it to continue. A side-effect of this is that threads will often be scheduled that are not actually able to run, resulting in unnecessary context switches (this could result in a hopefully minor performance hit). This is because when a wait_object becomes available, all waiting threads will be awoken, so whichever don't acquire the resource will still be scheduled then rescheduled. However, this actually makes our code much simpler/cleaner, as we can get rid of all the state management cruft trying to "predict" the next best thread to run. This fixes #432. I suspect it will fix a lot of games, although I don't own enough games to verify this claim.

Mario Kart 7 now will go in game (NOTE: needs a few other patches that aren't mainline yet):

![image](https://cloud.githubusercontent.com/assets/6956688/8028141/bf237012-0d74-11e5-9d30-90d37074cf8f.png)