### PR TITLE
build with visual studio 2015

### DIFF
--- a/src/common/common_funcs.h
+++ b/src/common/common_funcs.h
@@ -69,8 +69,10 @@ inline u64 _rotr64(u64 x, unsigned int shift){
 }
 
 #else // _MSC_VER
-    // Function Cross-Compatibility
-    #define snprintf _snprintf
+    #if (_MSC_VER < 1900)
+        // Function Cross-Compatibility
+        #define snprintf _snprintf
+    #endif
 
     // Locale Cross-Compatibility
     #define locale_t _locale_t


### PR DESCRIPTION
this prepares citra to be build with Visual Studio 2015.

There is still [a linker error](https://gist.githubusercontent.com/Apology11/c99fe8a3f51cbf587503/raw/76d66f8befa1ec24a48a69cf92bdb0ddd620d2bb/gistfile1.txt), but as far as I´ve read this is a problem [tracked by microsoft](http://stackoverflow.com/questions/30765256/linker-error-using-vs-2015-rc-cant-find-symbol-related-to-stdcodecvt).