### PR TITLE
Create a second Windows archive with only the binaries

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,8 +33,11 @@ after_build:
             $GITREV = $(git show -s --format='%h')
             # Where are these spaces coming from? Regardless, let's remove them
             $BUILD_NAME = "citra-${GITDATE}-${GITREV}-windows-amd64.7z" -replace " ",""
+            $BUILD_NAME_NOQT = "citra-noqt-${GITDATE}-${GITREV}-windows-amd64.7z" -replace " ",""
             # Zip up the build folder
             7z a $BUILD_NAME .\build\bin\release\*
+            # Do a second archive with only the binaries
+            7z a $BUILD_NAME_NOQT .\build\bin\release\*.exe
 
             # Download winscp
             Invoke-WebRequest "http://hivelocity.dl.sourceforge.net/project/winscp/WinSCP/5.7/winscp570.zip" -OutFile "winscp570.zip"
@@ -46,5 +49,6 @@ after_build:
                 "option confirm off" `
                 "open sftp://citra-builds:${env:BUILD_PASSWORD}@builds.citra-emu.org -hostkey=*" `
                 "put $BUILD_NAME /citra/nightly/windows-amd64/" `
+                "put $BUILD_NAME_NOQT /citra/nightly/windows-noqt-amd64/" `
                 "exit"
           }


### PR DESCRIPTION
This will help people who don’t have much bandwidth to download only what they want, and not the Qt dll again and again.

It is put in an hidden directory by default, in order to not confuse normal users who do need the Qt dll.