### PR TITLE
Log the GL driver’s vendor and renderer

### DIFF
--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -376,6 +376,8 @@ void RendererOpenGL::Init() {
     }
 
     LOG_INFO(Render_OpenGL, "GL_VERSION: %s", glGetString(GL_VERSION));
+    LOG_INFO(Render_OpenGL, "GL_VENDOR: %s", glGetString(GL_VENDOR));
+    LOG_INFO(Render_OpenGL, "GL_RENDERER: %s", glGetString(GL_RENDERER));
     InitOpenGLObjects();
 }
 


### PR DESCRIPTION
This helps differentiate the various Mesa drivers, especially hardware and software ones, or in multi-GPU setups.