### PR TITLE
Add helpers to create IPC command buffer headers and descriptors

### DIFF
--- a/src/core/hle/kernel/session.h
+++ b/src/core/hle/kernel/session.h
@@ -8,6 +8,40 @@
 #include "core/hle/kernel/thread.h"
 #include "core/memory.h"
 
+namespace IPC {
+
+inline u32 MakeHeader(u16 command_id, unsigned int regular_params, unsigned int translate_params) {
+    return ((u32)command_id << 16) | (((u32)regular_params & 0x3F) << 6) | (((u32)translate_params & 0x3F) << 0);
+}
+
+inline u32 MoveHandleDesc(unsigned int num_handles = 1) {
+    return 0x0 | ((num_handles - 1) << 26);
+}
+
+inline u32 CopyHandleDesc(unsigned int num_handles = 1) {
+    return 0x10 | ((num_handles - 1) << 26);
+}
+
+inline u32 CallingPidDesc() {
+    return 0x20;
+}
+
+inline u32 StaticBufferDesc(u32 size, unsigned int buffer_id) {
+    return 0x2 | (size << 14) | ((buffer_id & 0xF) << 10);
+}
+
+enum MappedBufferPermissions {
+    R = 2,
+    W = 4,
+    RW = R | W,
+};
+
+inline u32 MappedBufferDesc(u32 size, MappedBufferPermissions perms) {
+    return 0x8 | (size << 4) | (u32)perms;
+}
+
+}
+
 namespace Kernel {
 
 static const int kCommandHeaderOffset = 0x80; ///< Offset into command buffer of header

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -45,7 +45,7 @@ void Initialize(Service::Interface* self) {
     u32 app_id = cmd_buff[1];
     u32 flags  = cmd_buff[2];
 
-    cmd_buff[2] = 0x04000000; // According to 3dbrew, this value should be 0x04000000
+    cmd_buff[2] = IPC::MoveHandleDesc(2);
     cmd_buff[3] = Kernel::g_handle_table.Create(notification_event).MoveFrom();
     cmd_buff[4] = Kernel::g_handle_table.Create(start_event).MoveFrom();
 
@@ -70,11 +70,13 @@ void GetSharedFont(Service::Interface* self) {
         // an easy way to do this, but the copy should be sufficient for now.
         memcpy(Memory::GetPointer(SHARED_FONT_VADDR), shared_font.data(), shared_font.size());
 
-        cmd_buff[0] = 0x00440082;
+        cmd_buff[0] = IPC::MakeHeader(0x44, 2, 2);
         cmd_buff[1] = RESULT_SUCCESS.raw; // No error
         cmd_buff[2] = SHARED_FONT_VADDR;
+        cmd_buff[3] = IPC::MoveHandleDesc();
         cmd_buff[4] = Kernel::g_handle_table.Create(shared_font_mem).MoveFrom();
     } else {
+        cmd_buff[0] = IPC::MakeHeader(0x44, 1, 0);
         cmd_buff[1] = -1; // Generic error (not really possible to verify this on hardware)
         LOG_ERROR(Kernel_SVC, "called, but %s has not been loaded!", SHARED_FONT);
     }

--- a/src/core/hle/service/y2r_u.cpp
+++ b/src/core/hle/service/y2r_u.cpp
@@ -121,7 +121,7 @@ static void SetBlockAlignment(Service::Interface* self) {
 static void SetTransferEndInterrupt(Service::Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
-    cmd_buff[0] = 0x000D0040;
+    cmd_buff[0] = IPC::MakeHeader(0xD, 1, 0);
     cmd_buff[1] = RESULT_SUCCESS.raw;
     LOG_DEBUG(Service_Y2R, "(STUBBED) called");
 }
@@ -279,7 +279,7 @@ static void StartConversion(Service::Interface* self) {
 static void StopConversion(Service::Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
-    cmd_buff[0] = 0x00270040;
+    cmd_buff[0] = IPC::MakeHeader(0x27, 1, 0);
     cmd_buff[1] = RESULT_SUCCESS.raw;
     LOG_DEBUG(Service_Y2R, "called");
 }
@@ -328,7 +328,7 @@ static void SetConversionParams(Service::Interface* self) {
     conversion.alpha = params->alpha;
 
 cleanup:
-    cmd_buff[0] = 0x00290040; // TODO verify
+    cmd_buff[0] = IPC::MakeHeader(0x29, 1, 0);
     cmd_buff[1] = result.raw;
 }
 
@@ -360,7 +360,7 @@ static void DriverInitialize(Service::Interface* self) {
 
     completion_event->Clear();
 
-    cmd_buff[0] = 0x002B0040;
+    cmd_buff[0] = IPC::MakeHeader(0x2B, 1, 0);
     cmd_buff[1] = RESULT_SUCCESS.raw;
     LOG_DEBUG(Service_Y2R, "called");
 }
@@ -368,7 +368,7 @@ static void DriverInitialize(Service::Interface* self) {
 static void DriverFinalize(Service::Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
-    cmd_buff[0] = 0x002C0040;
+    cmd_buff[0] = IPC::MakeHeader(0x2C, 1, 0);
     cmd_buff[1] = RESULT_SUCCESS.raw;
     LOG_DEBUG(Service_Y2R, "called");
 }


### PR DESCRIPTION
This should hopefully encourage people to add these (without using magic numbers) to service returns in the future.