### PR TITLE
AppVeyor: Remove os: unstable

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,3 @@
-# it seems that Qt is only installed by default on unstable os at the moment
-os: unstable
-
 # shallow clone
 clone_depth: 5
 


### PR DESCRIPTION
The default os has Qt now, so there's no need for the unstable os.