### PR TITLE
Core\HLE : Fix Warning

### DIFF
--- a/src/core/hle/function_wrappers.h
+++ b/src/core/hle/function_wrappers.h
@@ -113,7 +113,7 @@ template<ResultCode func(u32)> void Wrap() {
     FuncReturn(func(PARAM(0)).raw);
 }
 
-template<ResultCode func(s64*, u32, u32*, s32)> void Wrap(){
+template<ResultCode func(s64*, u32, u32*, u32)> void Wrap(){
     FuncReturn(func((s64*)Memory::GetPointer(PARAM(0)), PARAM(1), (u32*)Memory::GetPointer(PARAM(2)),
         (s32)PARAM(3)).raw);
 }

--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -333,7 +333,7 @@ static ResultCode GetResourceLimit(Handle* resource_limit, Handle process_handle
 
 /// Get resource limit current values
 static ResultCode GetResourceLimitCurrentValues(s64* values, Handle resource_limit_handle, u32* names,
-    s32 name_count) {
+    u32 name_count) {
     LOG_TRACE(Kernel_SVC, "called resource_limit=%08X, names=%p, name_count=%d",
         resource_limit_handle, names, name_count);
 
@@ -349,7 +349,7 @@ static ResultCode GetResourceLimitCurrentValues(s64* values, Handle resource_lim
 
 /// Get resource limit max values
 static ResultCode GetResourceLimitLimitValues(s64* values, Handle resource_limit_handle, u32* names,
-    s32 name_count) {
+    u32 name_count) {
     LOG_TRACE(Kernel_SVC, "called resource_limit=%08X, names=%p, name_count=%d",
         resource_limit_handle, names, name_count);
 


### PR DESCRIPTION
"signed/unsigned mismatch"

I am unsure of exactly the best way to deal with this but to me it seemed ideal to make the comparison with two variables of the same type.

Of course this does present the unlikely scenario that the variable 'i' could be negative because its no longer unsigned.

Whats the ideal or recommended way to fix this?