### PR TITLE
Replace standard uint*_t and int*_t with CommonTypes’ u* and s* types

### DIFF
--- a/src/citra_qt/debugger/callstack.cpp
+++ b/src/citra_qt/debugger/callstack.cpp
@@ -4,12 +4,14 @@
 
 #include <QStandardItemModel>
 
+#include "common/common_types.h"
+#include "common/symbols.h"
+
 #include "callstack.h"
 
 #include "core/core.h"
 #include "core/arm/arm_interface.h"
 #include "core/memory.h"
-#include "common/symbols.h"
 #include "core/arm/disassembler/arm_disasm.h"
 
 CallstackWidget::CallstackWidget(QWidget* parent): QDockWidget(parent)
@@ -49,8 +51,8 @@ void CallstackWidget::OnDebugModeEntered()
         {
             std::string name;
             // ripped from disasm
-            uint8_t cond = (insn >> 28) & 0xf;
-            uint32_t i_offset = insn & 0xffffff;
+            u8 cond = (insn >> 28) & 0xf;
+            u32 i_offset = insn & 0xffffff;
             // Sign-extend the 24-bit offset
             if ((i_offset >> 23) & 1)
                 i_offset |= 0xff000000;

--- a/src/citra_qt/debugger/graphics_tracing.cpp
+++ b/src/citra_qt/debugger/graphics_tracing.cpp
@@ -14,6 +14,8 @@
 
 #include <boost/range/algorithm/copy.hpp>
 
+#include "common/common_types.h"
+
 #include "core/hw/gpu.h"
 #include "core/hw/lcd.h"
 
@@ -66,14 +68,14 @@ void GraphicsTracingWidget::StartRecording() {
 
     // Encode floating point numbers to 24-bit values
     // TODO: Drop this explicit conversion once we store float24 values bit-correctly internally.
-    std::array<uint32_t, 4 * 16> default_attributes;
+    std::array<u32, 4 * 16> default_attributes;
     for (unsigned i = 0; i < 16; ++i) {
         for (unsigned comp = 0; comp < 3; ++comp) {
             default_attributes[4 * i + comp] = nihstro::to_float24(Pica::g_state.vs.default_attributes[i][comp].ToFloat32());
         }
     }
 
-    std::array<uint32_t, 4 * 96> vs_float_uniforms;
+    std::array<u32, 4 * 96> vs_float_uniforms;
     for (unsigned i = 0; i < 96; ++i)
         for (unsigned comp = 0; comp < 3; ++comp)
             vs_float_uniforms[4 * i + comp] = nihstro::to_float24(Pica::g_state.vs.uniforms.f[i][comp].ToFloat32());

--- a/src/core/arm/disassembler/arm_disasm.h
+++ b/src/core/arm/disassembler/arm_disasm.h
@@ -2,8 +2,9 @@
 
 #pragma once
 
-#include <cstdint>
 #include <string>
+
+#include "common/common_types.h"
 
 // Note: this list of opcodes must match the list used to initialize
 // the opflags[] array in opcode.cpp.
@@ -191,48 +192,48 @@ enum Opcode {
 
 class ARM_Disasm {
  public:
-  static std::string Disassemble(uint32_t addr, uint32_t insn);
-  static Opcode Decode(uint32_t insn);
+  static std::string Disassemble(u32 addr, u32 insn);
+  static Opcode Decode(u32 insn);
 
  private:
-  static Opcode Decode00(uint32_t insn);
-  static Opcode Decode01(uint32_t insn);
-  static Opcode Decode10(uint32_t insn);
-  static Opcode Decode11(uint32_t insn);
-  static Opcode DecodeSyncPrimitive(uint32_t insn);
-  static Opcode DecodeParallelAddSub(uint32_t insn);
-  static Opcode DecodePackingSaturationReversal(uint32_t insn);
-  static Opcode DecodeMUL(uint32_t insn);
-  static Opcode DecodeMSRImmAndHints(uint32_t insn);
-  static Opcode DecodeMediaMulDiv(uint32_t insn);
-  static Opcode DecodeMedia(uint32_t insn);
-  static Opcode DecodeLDRH(uint32_t insn);
-  static Opcode DecodeALU(uint32_t insn);
+  static Opcode Decode00(u32 insn);
+  static Opcode Decode01(u32 insn);
+  static Opcode Decode10(u32 insn);
+  static Opcode Decode11(u32 insn);
+  static Opcode DecodeSyncPrimitive(u32 insn);
+  static Opcode DecodeParallelAddSub(u32 insn);
+  static Opcode DecodePackingSaturationReversal(u32 insn);
+  static Opcode DecodeMUL(u32 insn);
+  static Opcode DecodeMSRImmAndHints(u32 insn);
+  static Opcode DecodeMediaMulDiv(u32 insn);
+  static Opcode DecodeMedia(u32 insn);
+  static Opcode DecodeLDRH(u32 insn);
+  static Opcode DecodeALU(u32 insn);
 
-  static std::string DisassembleALU(Opcode opcode, uint32_t insn);
-  static std::string DisassembleBranch(uint32_t addr, Opcode opcode, uint32_t insn);
-  static std::string DisassembleBX(uint32_t insn);
-  static std::string DisassembleBKPT(uint32_t insn);
-  static std::string DisassembleCLZ(uint32_t insn);
-  static std::string DisassembleMediaMulDiv(Opcode opcode, uint32_t insn);
-  static std::string DisassembleMemblock(Opcode opcode, uint32_t insn);
-  static std::string DisassembleMem(uint32_t insn);
-  static std::string DisassembleMemHalf(uint32_t insn);
-  static std::string DisassembleMCR(Opcode opcode, uint32_t insn);
-  static std::string DisassembleMLA(Opcode opcode, uint32_t insn);
-  static std::string DisassembleUMLAL(Opcode opcode, uint32_t insn);
-  static std::string DisassembleMUL(Opcode opcode, uint32_t insn);
-  static std::string DisassembleMRS(uint32_t insn);
-  static std::string DisassembleMSR(uint32_t insn);
-  static std::string DisassembleNoOperands(Opcode opcode, uint32_t insn);
-  static std::string DisassembleParallelAddSub(Opcode opcode, uint32_t insn);
-  static std::string DisassemblePKH(uint32_t insn);
-  static std::string DisassemblePLD(uint32_t insn);
-  static std::string DisassembleREV(Opcode opcode, uint32_t insn);
-  static std::string DisassembleREX(Opcode opcode, uint32_t insn);
-  static std::string DisassembleSAT(Opcode opcode, uint32_t insn);
-  static std::string DisassembleSEL(uint32_t insn);
-  static std::string DisassembleSWI(uint32_t insn);
-  static std::string DisassembleSWP(Opcode opcode, uint32_t insn);
-  static std::string DisassembleXT(Opcode opcode, uint32_t insn);
+  static std::string DisassembleALU(Opcode opcode, u32 insn);
+  static std::string DisassembleBranch(u32 addr, Opcode opcode, u32 insn);
+  static std::string DisassembleBX(u32 insn);
+  static std::string DisassembleBKPT(u32 insn);
+  static std::string DisassembleCLZ(u32 insn);
+  static std::string DisassembleMediaMulDiv(Opcode opcode, u32 insn);
+  static std::string DisassembleMemblock(Opcode opcode, u32 insn);
+  static std::string DisassembleMem(u32 insn);
+  static std::string DisassembleMemHalf(u32 insn);
+  static std::string DisassembleMCR(Opcode opcode, u32 insn);
+  static std::string DisassembleMLA(Opcode opcode, u32 insn);
+  static std::string DisassembleUMLAL(Opcode opcode, u32 insn);
+  static std::string DisassembleMUL(Opcode opcode, u32 insn);
+  static std::string DisassembleMRS(u32 insn);
+  static std::string DisassembleMSR(u32 insn);
+  static std::string DisassembleNoOperands(Opcode opcode, u32 insn);
+  static std::string DisassembleParallelAddSub(Opcode opcode, u32 insn);
+  static std::string DisassemblePKH(u32 insn);
+  static std::string DisassemblePLD(u32 insn);
+  static std::string DisassembleREV(Opcode opcode, u32 insn);
+  static std::string DisassembleREX(Opcode opcode, u32 insn);
+  static std::string DisassembleSAT(Opcode opcode, u32 insn);
+  static std::string DisassembleSEL(u32 insn);
+  static std::string DisassembleSWI(u32 insn);
+  static std::string DisassembleSWP(Opcode opcode, u32 insn);
+  static std::string DisassembleXT(Opcode opcode, u32 insn);
 };

--- a/src/core/arm/skyeye_common/vfp/vfp.cpp
+++ b/src/core/arm/skyeye_common/vfp/vfp.cpp
@@ -21,6 +21,7 @@
 /* Note: this file handles interface with arm core and vfp registers */
 
 #include "common/common_funcs.h"
+#include "common/common_types.h"
 #include "common/logging/log.h"
 
 #include "core/arm/skyeye_common/armstate.h"
@@ -110,30 +111,30 @@ void VMOVR(ARMul_State* state, u32 single, u32 d, u32 m)
 }
 
 /* Miscellaneous functions */
-int32_t vfp_get_float(ARMul_State* state, unsigned int reg)
+s32 vfp_get_float(ARMul_State* state, unsigned int reg)
 {
     LOG_TRACE(Core_ARM11, "VFP get float: s%d=[%08x]\n", reg, state->ExtReg[reg]);
     return state->ExtReg[reg];
 }
 
-void vfp_put_float(ARMul_State* state, int32_t val, unsigned int reg)
+void vfp_put_float(ARMul_State* state, s32 val, unsigned int reg)
 {
     LOG_TRACE(Core_ARM11, "VFP put float: s%d <= [%08x]\n", reg, val);
     state->ExtReg[reg] = val;
 }
 
-uint64_t vfp_get_double(ARMul_State* state, unsigned int reg)
+u64 vfp_get_double(ARMul_State* state, unsigned int reg)
 {
-    uint64_t result = ((uint64_t) state->ExtReg[reg*2+1])<<32 | state->ExtReg[reg*2];
+    u64 result = ((u64) state->ExtReg[reg*2+1])<<32 | state->ExtReg[reg*2];
     LOG_TRACE(Core_ARM11, "VFP get double: s[%d-%d]=[%016llx]\n", reg * 2 + 1, reg * 2, result);
     return result;
 }
 
-void vfp_put_double(ARMul_State* state, uint64_t val, unsigned int reg)
+void vfp_put_double(ARMul_State* state, u64 val, unsigned int reg)
 {
-    LOG_TRACE(Core_ARM11, "VFP put double: s[%d-%d] <= [%08x-%08x]\n", reg * 2 + 1, reg * 2, (uint32_t)(val >> 32), (uint32_t)(val & 0xffffffff));
-    state->ExtReg[reg*2] = (uint32_t) (val & 0xffffffff);
-    state->ExtReg[reg*2+1] = (uint32_t) (val>>32);
+    LOG_TRACE(Core_ARM11, "VFP put double: s[%d-%d] <= [%08x-%08x]\n", reg * 2 + 1, reg * 2, (u32)(val >> 32), (u32)(val & 0xffffffff));
+    state->ExtReg[reg*2] = (u32) (val & 0xffffffff);
+    state->ExtReg[reg*2+1] = (u32) (val>>32);
 }
 
 /*

--- a/src/core/tracer/citrace.h
+++ b/src/core/tracer/citrace.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <cstdint>
+#include "common/common_types.h"
 
 namespace CiTrace {
 
@@ -17,38 +17,38 @@ struct CTHeader {
         return "CiTr";
     }
 
-    static uint32_t ExpectedVersion() {
+    static u32 ExpectedVersion() {
         return 1;
     }
 
     char magic[4];
-    uint32_t version;
-    uint32_t header_size;
+    u32 version;
+    u32 header_size;
 
     struct {
         // NOTE: Register range sizes are technically hardware-constants, but the actual limits
         // aren't known. Hence we store the presumed limits along the offsets.
-        // Sizes are given in uint32_t units.
-        uint32_t gpu_registers;
-        uint32_t gpu_registers_size;
-        uint32_t lcd_registers;
-        uint32_t lcd_registers_size;
-        uint32_t pica_registers;
-        uint32_t pica_registers_size;
-        uint32_t default_attributes;
-        uint32_t default_attributes_size;
-        uint32_t vs_program_binary;
-        uint32_t vs_program_binary_size;
-        uint32_t vs_swizzle_data;
-        uint32_t vs_swizzle_data_size;
-        uint32_t vs_float_uniforms;
-        uint32_t vs_float_uniforms_size;
-        uint32_t gs_program_binary;
-        uint32_t gs_program_binary_size;
-        uint32_t gs_swizzle_data;
-        uint32_t gs_swizzle_data_size;
-        uint32_t gs_float_uniforms;
-        uint32_t gs_float_uniforms_size;
+        // Sizes are given in u32 units.
+        u32 gpu_registers;
+        u32 gpu_registers_size;
+        u32 lcd_registers;
+        u32 lcd_registers_size;
+        u32 pica_registers;
+        u32 pica_registers_size;
+        u32 default_attributes;
+        u32 default_attributes_size;
+        u32 vs_program_binary;
+        u32 vs_program_binary_size;
+        u32 vs_swizzle_data;
+        u32 vs_swizzle_data_size;
+        u32 vs_float_uniforms;
+        u32 vs_float_uniforms_size;
+        u32 gs_program_binary;
+        u32 gs_program_binary_size;
+        u32 gs_swizzle_data;
+        u32 gs_swizzle_data_size;
+        u32 gs_float_uniforms;
+        u32 gs_float_uniforms_size;
 
         // Other things we might want to store here:
         // - Initial framebuffer data, maybe even a full copy of FCRAM/VRAM
@@ -56,27 +56,27 @@ struct CTHeader {
         // - Lookup tables for procedural textures
     } initial_state_offsets;
 
-    uint32_t stream_offset;
-    uint32_t stream_size;
+    u32 stream_offset;
+    u32 stream_size;
 };
 
-enum CTStreamElementType : uint32_t {
+enum CTStreamElementType : u32 {
     FrameMarker   = 0xE1,
     MemoryLoad    = 0xE2,
     RegisterWrite = 0xE3,
 };
 
 struct CTMemoryLoad {
-    uint32_t file_offset;
-    uint32_t size;
-    uint32_t physical_address;
-    uint32_t pad;
+    u32 file_offset;
+    u32 size;
+    u32 physical_address;
+    u32 pad;
 };
 
 struct CTRegisterWrite {
-    uint32_t physical_address;
+    u32 physical_address;
 
-    enum : uint32_t {
+    enum : u32 {
         SIZE_8  = 0xD1,
         SIZE_16 = 0xD2,
         SIZE_32 = 0xD3,
@@ -84,7 +84,7 @@ struct CTRegisterWrite {
     } size;
 
     // TODO: Make it clearer which bits of this member are used for sizes other than 32 bits
-    uint64_t value;
+    u64 value;
 };
 
 struct CTStreamElement {

--- a/src/video_core/debug_utils/debug_utils.cpp
+++ b/src/video_core/debug_utils/debug_utils.cpp
@@ -18,6 +18,7 @@
 
 #include "common/assert.h"
 #include "common/color.h"
+#include "common/common_types.h"
 #include "common/file_util.h"
 #include "common/math_util.h"
 #include "common/vector_math.h"
@@ -233,7 +234,7 @@ void DumpShader(const u32* binary_data, u32 binary_size, const u32* swizzle_data
 
     dvle.main_offset_words = main_offset;
     dvle.output_register_table_offset = write_offset - dvlb.dvle_offset;
-    dvle.output_register_table_size = static_cast<uint32_t>(output_info_table.size());
+    dvle.output_register_table_size = static_cast<u32>(output_info_table.size());
     QueueForWriting((u8*)output_info_table.data(), static_cast<u32>(output_info_table.size() * sizeof(OutputRegisterInfo)));
 
     // TODO: Create a label table for "main"


### PR DESCRIPTION
The ARM core was ridden with those, but there was also an occurence in the CitraQt debugger.

This commit is purely stylistic, there is no change in behaviour.