### PR TITLE
vfp: Handle accesses to FPINST/FPINST2 system registers.

### DIFF
--- a/src/core/arm/skyeye_common/arm_regformat.h
+++ b/src/core/arm/skyeye_common/arm_regformat.h
@@ -59,6 +59,8 @@ enum {
     VFP_FPSID,
     VFP_FPSCR,
     VFP_FPEXC,
+    VFP_FPINST,
+    VFP_FPINST2,
     VFP_MVFR0,
     VFP_MVFR1,
 

--- a/src/core/arm/skyeye_common/vfp/vfp.cpp
+++ b/src/core/arm/skyeye_common/vfp/vfp.cpp
@@ -33,23 +33,15 @@ unsigned VFPInit(ARMul_State* state)
     state->VFP[VFP_FPEXC] = 0;
     state->VFP[VFP_FPSCR] = 0;
 
+    // ARM11 MPCore instruction register reset values.
+    state->VFP[VFP_FPINST]  = 0xEE000A00;
+    state->VFP[VFP_FPINST2] = 0;
+
     // ARM11 MPCore feature register values.
     state->VFP[VFP_MVFR0] = 0x11111111;
     state->VFP[VFP_MVFR1] = 0;
 
     return 0;
-}
-
-void VMSR(ARMul_State* state, ARMword reg, ARMword Rt)
-{
-    if (reg == 1)
-    {
-        state->VFP[VFP_FPSCR] = state->Reg[Rt];
-    }
-    else if (reg == 8)
-    {
-        state->VFP[VFP_FPEXC] = state->Reg[Rt];
-    }
 }
 
 void VMOVBRS(ARMul_State* state, ARMword to_arm, ARMword t, ARMword n, ARMword* value)

--- a/src/core/arm/skyeye_common/vfp/vfp.h
+++ b/src/core/arm/skyeye_common/vfp/vfp.h
@@ -36,10 +36,8 @@ void vfp_raise_exceptions(ARMul_State* state, u32 exceptions, u32 inst, u32 fpsc
 u32 vfp_single_cpdo(ARMul_State* state, u32 inst, u32 fpscr);
 u32 vfp_double_cpdo(ARMul_State* state, u32 inst, u32 fpscr);
 
-void VMSR(ARMul_State* state, ARMword reg, ARMword Rt);
 void VMOVBRS(ARMul_State* state, ARMword to_arm, ARMword t, ARMword n, ARMword* value);
 void VMOVBRRD(ARMul_State* state, ARMword to_arm, ARMword t, ARMword t2, ARMword n, ARMword* value1, ARMword* value2);
 void VMOVBRRSS(ARMul_State* state, ARMword to_arm, ARMword t, ARMword t2, ARMword n, ARMword* value1, ARMword* value2);
 void VMOVI(ARMul_State* state, ARMword single, ARMword d, ARMword imm);
 void VMOVR(ARMul_State* state, ARMword single, ARMword d, ARMword imm);
-


### PR DESCRIPTION
Also has a side-benefit of correcting access to the FPEXC register. Only privileged mode stuff. No userland changes.