### PR TITLE
vfp: Change return type of VFPInit from unsigned int to void.

### DIFF
--- a/src/core/arm/skyeye_common/vfp/vfp.cpp
+++ b/src/core/arm/skyeye_common/vfp/vfp.cpp
@@ -26,7 +26,7 @@
 #include "core/arm/skyeye_common/vfp/asm_vfp.h"
 #include "core/arm/skyeye_common/vfp/vfp.h"
 
-unsigned VFPInit(ARMul_State* state)
+void VFPInit(ARMul_State* state)
 {
     state->VFP[VFP_FPSID] = VFP_FPSID_IMPLMEN<<24 | VFP_FPSID_SW<<23 | VFP_FPSID_SUBARCH<<16 |
                             VFP_FPSID_PARTNUM<<8 | VFP_FPSID_VARIANT<<4 | VFP_FPSID_REVISION;
@@ -40,8 +40,6 @@ unsigned VFPInit(ARMul_State* state)
     // ARM11 MPCore feature register values.
     state->VFP[VFP_MVFR0] = 0x11111111;
     state->VFP[VFP_MVFR1] = 0;
-
-    return 0;
 }
 
 void VMOVBRS(ARMul_State* state, ARMword to_arm, ARMword t, ARMword n, ARMword* value)

--- a/src/core/arm/skyeye_common/vfp/vfp.h
+++ b/src/core/arm/skyeye_common/vfp/vfp.h
@@ -26,7 +26,7 @@
 #define CHECK_VFP_ENABLED
 #define CHECK_VFP_CDP_RET vfp_raise_exceptions(cpu, ret, inst_cream->instr, cpu->VFP[VFP_FPSCR]);
 
-unsigned VFPInit(ARMul_State* state);
+void VFPInit(ARMul_State* state);
 
 s32 vfp_get_float(ARMul_State* state, u32 reg);
 void vfp_put_float(ARMul_State* state, s32 val, u32 reg);


### PR DESCRIPTION
This is technically cruft from armemu code, where it took specific function pointer types (where an init routine with a return code was one of them).