### PR TITLE
AppVeyor: Remove submodule checkout depth

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ configuration:
   - Release
 
 install:
-  - git submodule update --init --recursive --depth 20
+  - git submodule update --init --recursive
 
 before_build:
   - mkdir build


### PR DESCRIPTION
This avoid intermittent build failures due to a commit not being
reachable using a fixed depth, at the expense of longer checkout times.