### PR TITLE
CMake: Fix Debug build configuration in MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,32 +22,34 @@ else()
 
     # set up output paths for executable binaries (.exe-files, and .dll-files on DLL-capable platforms)
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-    set(CMAKE_CONFIGURATION_TYPES Debug Release RelWithDebInfo CACHE STRING "" FORCE)
+    set(CMAKE_CONFIGURATION_TYPES Debug Release CACHE STRING "" FORCE)
 
     # Tweak optimization settings
     # As far as I can tell, there's no way to override the CMake defaults while leaving user
     # changes intact, so we'll just clobber everything and say sorry.
     message(STATUS "Cache compiler flags ignored, please edit CMakeLists.txt to change the flags.")
-    # /O2 - Optimization level 2
-    # /Oy- - Don't omit frame pointer
-    # /GR- - Disable RTTI
-    # /GS- - No stack buffer overflow checks
-    # /EHsc - C++-only exception handling semantics
-    set(optimization_flags "/O2 /Oy- /GR- /GS- /EHsc")
+
+    # /W3 - Level 3 warnings
     # /MP - Multi-threaded compilation
     # /Zi - Output debugging information
     # /Zo - enahnced debug info for optimized builds
-    # /MDd - Multi-threaded Debug Runtime DLL
-    set(CMAKE_C_FLAGS_DEBUG   "/MP /MDd /Zi" CACHE STRING "" FORCE)
-    set(CMAKE_CXX_FLAGS_DEBUG "/MP /MDd /Zi" CACHE STRING "" FORCE)
-    # /MD - Multi-threaded runtime DLL
-    set(CMAKE_C_FLAGS_RELEASE   "${optimization_flags} /MP /MD" CACHE STRING "" FORCE)
-    set(CMAKE_CXX_FLAGS_RELEASE "${optimization_flags} /MP /MD" CACHE STRING "" FORCE)
-    set(CMAKE_C_FLAGS_RELWITHDEBINFO   "${optimization_flags} /MP /MD /Zi /Zo" CACHE STRING "" FORCE)
-    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${optimization_flags} /MP /MD /Zi /Zo" CACHE STRING "" FORCE)
+    set(CMAKE_C_FLAGS   "/W3 /MP /Zi /Zo" CACHE STRING "" FORCE)
+    # /GR- - Disable RTTI
+    # /EHsc - C++-only exception handling semantics
+    set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} /GR- /EHsc" CACHE STRING "" FORCE)
 
-    set(CMAKE_EXE_LINKER_FLAGS_DEBUG "/DEBUG" CACHE STRING "" FORCE)
-    set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "/DEBUG" CACHE STRING "" FORCE)
+    # /MDd - Multi-threaded Debug Runtime DLL
+    set(CMAKE_C_FLAGS_DEBUG   "/Od /MDd" CACHE STRING "" FORCE)
+    set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}" CACHE STRING "" FORCE)
+
+    # /O2 - Optimization level 2
+    # /GS- - No stack buffer overflow checks
+    # /MD - Multi-threaded runtime DLL
+    set(CMAKE_C_FLAGS_RELEASE   "/O2 /GS- /MD" CACHE STRING "" FORCE)
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}" CACHE STRING "" FORCE)
+
+    set(CMAKE_EXE_LINKER_FLAGS_DEBUG   "/DEBUG" CACHE STRING "" FORCE)
+    set(CMAKE_EXE_LINKER_FLAGS_RELEASE "/DEBUG" CACHE STRING "" FORCE)
 endif()
 
 add_definitions(-DSINGLETHREADED)


### PR DESCRIPTION
Debug was missing compiler flags, causing MSVC to default it to building
with optimizations enabled (making for a not very useful binary for
actual debugging...). Additionally, the variables were re-organized to
remove some redundancy, the old Release build type was removed, and
RelWithDebInfo was renamed to take its place instead.