### PR TITLE
Tell cmake to install the compiled binaries on Linux

### DIFF
--- a/src/citra/CMakeLists.txt
+++ b/src/citra/CMakeLists.txt
@@ -18,4 +18,6 @@ target_link_libraries(citra core common video_core)
 target_link_libraries(citra ${GLFW_LIBRARIES} ${OPENGL_gl_LIBRARY} inih)
 target_link_libraries(citra ${PLATFORM_LIBRARIES})
 
-#install(TARGETS citra RUNTIME DESTINATION ${bindir})
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux|FreeBSD|OpenBSD|NetBSD")
+    install(TARGETS citra RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
+endif()

--- a/src/citra_qt/CMakeLists.txt
+++ b/src/citra_qt/CMakeLists.txt
@@ -73,7 +73,9 @@ target_link_libraries(citra-qt core common video_core qhexedit)
 target_link_libraries(citra-qt ${OPENGL_gl_LIBRARY} ${CITRA_QT_LIBS})
 target_link_libraries(citra-qt ${PLATFORM_LIBRARIES})
 
-#install(TARGETS citra-qt RUNTIME DESTINATION ${bindir})
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux|FreeBSD|OpenBSD|NetBSD")
+    install(TARGETS citra-qt RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
+endif()
 
 if (Qt5_FOUND AND MSVC)
     set(Qt5_DLL_DIR "${Qt5_DIR}/../../../bin")


### PR DESCRIPTION
This will help packaging tremendously, as a `make DESTDIR=… install` will now put every file at their place.

Ideally we should do that on other systems as well, but I don’t know them enough to enable this command there.