### PR TITLE
Core: Properly configure address space during binary loading

### DIFF
--- a/src/core/file_sys/archive_savedata.cpp
+++ b/src/core/file_sys/archive_savedata.cpp
@@ -37,7 +37,7 @@ ArchiveFactory_SaveData::ArchiveFactory_SaveData(const std::string& sdmc_directo
 }
 
 ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_SaveData::Open(const Path& path) {
-    std::string concrete_mount_point = GetSaveDataPath(mount_point, Kernel::g_current_process->program_id);
+    std::string concrete_mount_point = GetSaveDataPath(mount_point, Kernel::g_current_process->codeset->program_id);
     if (!FileUtil::Exists(concrete_mount_point)) {
         // When a SaveData archive is created for the first time, it is not yet formatted
         // and the save file/directory structure expected by the game has not yet been initialized.
@@ -52,7 +52,7 @@ ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_SaveData::Open(const P
 }
 
 ResultCode ArchiveFactory_SaveData::Format(const Path& path) {
-    std::string concrete_mount_point = GetSaveDataPath(mount_point, Kernel::g_current_process->program_id);
+    std::string concrete_mount_point = GetSaveDataPath(mount_point, Kernel::g_current_process->codeset->program_id);
     FileUtil::DeleteDirRecursively(concrete_mount_point);
     FileUtil::CreateFullPath(concrete_mount_point);
     return RESULT_SUCCESS;

--- a/src/core/hle/kernel/event.cpp
+++ b/src/core/hle/kernel/event.cpp
@@ -21,7 +21,7 @@ SharedPtr<Event> Event::Create(ResetType reset_type, std::string name) {
     SharedPtr<Event> evt(new Event);
 
     evt->signaled = false;
-    evt->reset_type = evt->intitial_reset_type = reset_type;
+    evt->reset_type = reset_type;
     evt->name = std::move(name);
 
     return evt;

--- a/src/core/hle/kernel/event.h
+++ b/src/core/hle/kernel/event.h
@@ -26,7 +26,6 @@ public:
     static const HandleType HANDLE_TYPE = HandleType::Event;
     HandleType GetHandleType() const override { return HANDLE_TYPE; }
 
-    ResetType intitial_reset_type;          ///< ResetType specified at Event initialization
     ResetType reset_type;                   ///< Current ResetType
 
     bool signaled;                          ///< Whether the event has already been signaled

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -47,6 +47,7 @@ enum class HandleType : u32 {
     Semaphore       = 10,
     Timer           = 11,
     ResourceLimit   = 12,
+    CodeSet         = 13,
 };
 
 enum {

--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -35,6 +35,10 @@ VMManager::VMManager() {
     Reset();
 }
 
+VMManager::~VMManager() {
+    Reset();
+}
+
 void VMManager::Reset() {
     vma_map.clear();
 
@@ -128,6 +132,16 @@ void VMManager::Reprotect(VMAHandle vma_handle, VMAPermission new_perms) {
     UpdatePageTableForVMA(vma);
 
     MergeAdjacent(iter);
+}
+
+void VMManager::LogLayout() const {
+    for (const auto& p : vma_map) {
+        const VirtualMemoryArea& vma = p.second;
+        LOG_DEBUG(Kernel, "%08X - %08X  size: %8X %c%c%c", vma.base, vma.base + vma.size, vma.size,
+            (u8)vma.permissions & (u8)VMAPermission::Read    ? 'R' : '-',
+            (u8)vma.permissions & (u8)VMAPermission::Write   ? 'W' : '-',
+            (u8)vma.permissions & (u8)VMAPermission::Execute ? 'X' : '-');
+    }
 }
 
 VMManager::VMAIter VMManager::StripIterConstness(const VMAHandle & iter) {

--- a/src/core/hle/kernel/vm_manager.h
+++ b/src/core/hle/kernel/vm_manager.h
@@ -101,7 +101,7 @@ struct VirtualMemoryArea {
  *  - http://duartes.org/gustavo/blog/post/how-the-kernel-manages-your-memory/
  *  - http://duartes.org/gustavo/blog/post/page-cache-the-affair-between-memory-and-files/
  */
-class VMManager {
+class VMManager final {
     // TODO(yuriks): Make page tables switchable to support multiple VMManagers
 public:
     /**
@@ -121,6 +121,7 @@ public:
     using VMAHandle = decltype(vma_map)::const_iterator;
 
     VMManager();
+    ~VMManager();
 
     /// Clears the address space map, re-initializing with a single free area.
     void Reset();
@@ -167,6 +168,9 @@ public:
 
     /// Changes the permissions of the given VMA.
     void Reprotect(VMAHandle vma, VMAPermission new_perms);
+
+    /// Dumps the address space layout to the log, for debugging
+    void LogLayout() const;
 
 private:
     using VMAIter = decltype(vma_map)::iterator;

--- a/src/core/loader/3dsx.cpp
+++ b/src/core/loader/3dsx.cpp
@@ -116,8 +116,6 @@ static THREEDSX_Error Load3DSXFile(FileUtil::IOFile& file, u32 base_addr)
     loadinfo.seg_sizes[1] = (hdr.rodata_seg_size + 0xFFF) &~0xFFF;
     loadinfo.seg_sizes[2] = (hdr.data_seg_size + 0xFFF) &~0xFFF;
     u32 offsets[2] = { loadinfo.seg_sizes[0], loadinfo.seg_sizes[0] + loadinfo.seg_sizes[1] };
-    u32 data_load_size = (hdr.data_seg_size - hdr.bss_size + 0xFFF) &~0xFFF;
-    u32 bss_load_size = loadinfo.seg_sizes[2] - data_load_size;
     u32 n_reloc_tables = hdr.reloc_hdr_size / 4;
     std::vector<u8> all_mem(loadinfo.seg_sizes[0] + loadinfo.seg_sizes[1] + loadinfo.seg_sizes[2] + 3 * n_reloc_tables);
 
@@ -204,10 +202,9 @@ static THREEDSX_Error Load3DSXFile(FileUtil::IOFile& file, u32 base_addr)
     // Write the data
     memcpy(Memory::GetPointer(base_addr), &all_mem[0], loadinfo.seg_sizes[0] + loadinfo.seg_sizes[1] + loadinfo.seg_sizes[2]);
 
-    LOG_DEBUG(Loader, "CODE:   %u pages\n", loadinfo.seg_sizes[0] / 0x1000);
-    LOG_DEBUG(Loader, "RODATA: %u pages\n", loadinfo.seg_sizes[1] / 0x1000);
-    LOG_DEBUG(Loader, "DATA:   %u pages\n", data_load_size / 0x1000);
-    LOG_DEBUG(Loader, "BSS:    %u pages\n", bss_load_size / 0x1000);
+    LOG_DEBUG(Loader, "code size:   0x%X", loadinfo.seg_sizes[0]);
+    LOG_DEBUG(Loader, "rodata size: 0x%X", loadinfo.seg_sizes[1]);
+    LOG_DEBUG(Loader, "data size:   0x%X (including 0x%X of bss)", loadinfo.seg_sizes[2], hdr.bss_size);
 
     return ERROR_NONE;
 }

--- a/src/core/mem_map.cpp
+++ b/src/core/mem_map.cpp
@@ -32,7 +32,6 @@ struct MemoryArea {
 
 // We don't declare the IO regions in here since its handled by other means.
 static MemoryArea memory_areas[] = {
-    {PROCESS_IMAGE_VADDR, PROCESS_IMAGE_MAX_SIZE, "Process Image"}, // ExeFS:/.code is loaded here
     {HEAP_VADDR,          HEAP_SIZE,              "Heap"},          // Application heap (main memory)
     {SHARED_MEMORY_VADDR, SHARED_MEMORY_SIZE,     "Shared Memory"}, // Shared memory
     {LINEAR_HEAP_VADDR,   LINEAR_HEAP_SIZE,       "Linear Heap"},   // Linear heap (main memory)
@@ -132,13 +131,13 @@ VAddr PhysicalToVirtualAddress(const PAddr addr) {
     return addr | 0x80000000;
 }
 
-// TODO(yuriks): Move this into Process
-static Kernel::VMManager address_space;
-
 void Init() {
-    using namespace Kernel;
-
     InitMemoryMap();
+    LOG_DEBUG(HW_Memory, "initialized OK");
+}
+
+void InitLegacyAddressSpace(Kernel::VMManager& address_space) {
+    using namespace Kernel;
 
     for (MemoryArea& area : memory_areas) {
         auto block = std::make_shared<std::vector<u8>>(area.size);
@@ -152,14 +151,11 @@ void Init() {
     auto shared_page_vma = address_space.MapBackingMemory(SHARED_PAGE_VADDR,
             (u8*)&SharedPage::shared_page, SHARED_PAGE_SIZE, MemoryState::Shared).MoveFrom();
     address_space.Reprotect(shared_page_vma, VMAPermission::Read);
-
-    LOG_DEBUG(HW_Memory, "initialized OK");
 }
 
 void Shutdown() {
     heap_map.clear();
     heap_linear_map.clear();
-    address_space.Reset();
 
     LOG_DEBUG(HW_Memory, "shutdown OK");
 }

--- a/src/core/mem_map.h
+++ b/src/core/mem_map.h
@@ -6,9 +6,14 @@
 
 #include "common/common_types.h"
 
+namespace Kernel {
+class VMManager;
+}
+
 namespace Memory {
 
 void Init();
+void InitLegacyAddressSpace(Kernel::VMManager& address_space);
 void Shutdown();
 
 /**

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -59,14 +59,12 @@ static void MapPages(u32 base, u32 size, u8* memory, PageType type) {
     while (base != end) {
         ASSERT_MSG(base < PageTable::NUM_ENTRIES, "out of range mapping at %08X", base);
 
-        if (current_page_table->attributes[base] != PageType::Unmapped && type != PageType::Unmapped) {
-            LOG_ERROR(HW_Memory, "overlapping memory ranges at %08X", base * PAGE_SIZE);
-        }
         current_page_table->attributes[base] = type;
         current_page_table->pointers[base] = memory;
 
         base += 1;
-        memory += PAGE_SIZE;
+        if (memory != nullptr)
+            memory += PAGE_SIZE;
     }
 }
 


### PR DESCRIPTION
The code now properly configures the process image to match the loaded
binary segments (code, rodata, data) instead of just blindly allocating
a large chunk of dummy memory.