### PR TITLE
Fix applet includes using iwyu

### DIFF
--- a/src/core/hle/applets/applet.cpp
+++ b/src/core/hle/applets/applet.cpp
@@ -2,12 +2,19 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <cstddef>
+#include <memory>
+#include <type_traits>
+#include <unordered_map>
+
 #include "common/assert.h"
-#include "common/logging/log.h"
+#include "common/common_types.h"
 
 #include "core/core_timing.h"
 #include "core/hle/applets/applet.h"
 #include "core/hle/applets/swkbd.h"
+#include "core/hle/result.h"
+#include "core/hle/service/apt/apt.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/core/hle/applets/applet.h
+++ b/src/core/hle/applets/applet.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include "common/common_types.h"
-#include "core/hle/kernel/kernel.h"
-#include "core/hle/kernel/shared_memory.h"
+#include <memory>
+
+#include "core/hle/result.h"
 #include "core/hle/service/apt/apt.h"
 
 namespace HLE {

--- a/src/core/hle/applets/swkbd.cpp
+++ b/src/core/hle/applets/swkbd.cpp
@@ -2,13 +2,21 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <cstring>
+#include <string>
+
 #include "common/assert.h"
 #include "common/logging/log.h"
 #include "common/string_util.h"
 
 #include "core/hle/applets/swkbd.h"
+#include "core/hle/kernel/kernel.h"
+#include "core/hle/kernel/shared_memory.h"
 #include "core/hle/service/hid/hid.h"
 #include "core/hle/service/gsp_gpu.h"
+#include "core/hle/result.h"
+#include "core/memory.h"
+
 #include "video_core/video_core.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/core/hle/applets/swkbd.h
+++ b/src/core/hle/applets/swkbd.h
@@ -5,9 +5,12 @@
 #pragma once
 
 #include "common/common_types.h"
+#include "common/common_funcs.h"
+
 #include "core/hle/applets/applet.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/shared_memory.h"
+#include "core/hle/result.h"
 #include "core/hle/service/apt/apt.h"
 
 namespace HLE {

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -6,6 +6,7 @@
 
 #include <bitset>
 #include <cstddef>
+#include <memory>
 #include <string>
 
 #include <boost/container/static_vector.hpp>

--- a/src/core/hle/kernel/shared_memory.h
+++ b/src/core/hle/kernel/shared_memory.h
@@ -4,9 +4,12 @@
 
 #pragma once
 
+#include <string>
+
 #include "common/common_types.h"
 
 #include "core/hle/kernel/kernel.h"
+#include "core/hle/result.h"
 
 namespace Kernel {
 

--- a/src/core/hle/service/apt/apt.h
+++ b/src/core/hle/service/apt/apt.h
@@ -4,11 +4,14 @@
 
 #pragma once
 
-#include <array>
-#include "core/hle/result.h"
-#include "core/hle/service/service.h"
+#include "common/common_types.h"
+
+#include "core/hle/kernel/kernel.h"
 
 namespace Service {
+
+class Interface;
+
 namespace APT {
 
 /// Holds information about the parameters used in Send/Glance/ReceiveParameter


### PR DESCRIPTION
`std::shared_ptr` wasn’t included from `<memory>` as it should have.

I also fixed the other includes related to the applet.