### PR TITLE
Qt: Fix disassembly widget stepping

### DIFF
--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -65,7 +65,7 @@ void EmuThread::run() {
             was_active = false;
         } else {
             std::unique_lock<std::mutex> lock(running_mutex);
-            running_cv.wait(lock, [this]{ return IsRunning() || stop_run; });
+            running_cv.wait(lock, [this]{ return IsRunning() || exec_step || stop_run; });
         }
     }
 

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -35,7 +35,10 @@ public:
      * Steps the emulation thread by a single CPU instruction (if the CPU is not already running)
      * @note This function is thread-safe
      */
-    void ExecStep() { exec_step = true; }
+    void ExecStep() {
+        exec_step = true;
+        running_cv.notify_all();
+    }
 
     /**
      * Sets whether the emulation thread is running or not


### PR DESCRIPTION
Should Fix #923.

Not sure if I need to lock on ```running_mutex``` and even why this lock is needed in first place.