### PR TITLE
citra-qt: Add support for copying the command list contents to clipboard.

### DIFF
--- a/src/citra_qt/debugger/graphics_cmdlists.h
+++ b/src/citra_qt/debugger/graphics_cmdlists.h
@@ -49,6 +49,8 @@ public slots:
 
     void SetCommandInfo(const QModelIndex&);
 
+    void CopyAllToClipboard();
+
 signals:
     void TracingFinished(const Pica::DebugUtils::PicaTrace&);
 


### PR DESCRIPTION
Title says it all. This is useful for analyzing command lists more efficiently, e.g. by searching for specific commands.