### PR TITLE
Shader debugger improvements

### DIFF
--- a/src/citra_qt/debugger/graphics_vertex_shader.cpp
+++ b/src/citra_qt/debugger/graphics_vertex_shader.cpp
@@ -272,10 +272,9 @@ void GraphicsVertexShaderModel::DumpShader() {
     auto& setup  = Pica::g_state.vs;
     auto& config = Pica::g_state.regs.vs;
 
-    Pica::DebugUtils::DumpShader(setup.program_code.data(), setup.program_code.size(),
-                                 setup.swizzle_data.data(), setup.swizzle_data.size(),
-                                 config.main_offset, Pica::g_state.regs.vs_output_attributes);
+    Pica::DebugUtils::DumpShader(config, setup, Pica::g_state.regs.vs_output_attributes);
 }
+
 GraphicsVertexShaderWidget::GraphicsVertexShaderWidget(std::shared_ptr< Pica::DebugContext > debug_context,
                                                        QWidget* parent)
         : BreakPointObserverDock(debug_context, "Pica Vertex Shader", parent) {

--- a/src/citra_qt/debugger/graphics_vertex_shader.cpp
+++ b/src/citra_qt/debugger/graphics_vertex_shader.cpp
@@ -308,14 +308,14 @@ GraphicsVertexShaderWidget::GraphicsVertexShaderWidget(std::shared_ptr< Pica::De
 
     instruction_description = new QLabel;
 
-    iteration_index = new QSpinBox;
+    cycle_index = new QSpinBox;
 
     connect(this, SIGNAL(SelectCommand(const QModelIndex&, QItemSelectionModel::SelectionFlags)),
             binary_list->selectionModel(), SLOT(select(const QModelIndex&, QItemSelectionModel::SelectionFlags)));
 
     connect(dump_shader, SIGNAL(clicked()), this, SLOT(DumpShader()));
 
-    connect(iteration_index, SIGNAL(valueChanged(int)), this, SLOT(OnIterationIndexChanged(int)));
+    connect(cycle_index, SIGNAL(valueChanged(int)), this, SLOT(OnCycleIndexChanged(int)));
 
     for (unsigned i = 0; i < ARRAY_SIZE(input_data); ++i) {
         connect(input_data[i], SIGNAL(textEdited(const QString&)), input_data_mapper, SLOT(map()));
@@ -364,11 +364,12 @@ GraphicsVertexShaderWidget::GraphicsVertexShaderWidget(std::shared_ptr< Pica::De
     main_layout->addWidget(dump_shader);
     {
         auto sub_layout = new QHBoxLayout;
-        sub_layout->addWidget(new QLabel(tr("Iteration Index:")));
-        sub_layout->addWidget(iteration_index);
+        sub_layout->addWidget(new QLabel(tr("Cycle Index:")));
+        sub_layout->addWidget(cycle_index);
         main_layout->addLayout(sub_layout);
     }
     main_layout->addWidget(instruction_description);
+    main_layout->addStretch();
     main_widget->setLayout(main_layout);
     setWidget(main_widget);
 
@@ -437,9 +438,9 @@ void GraphicsVertexShaderWidget::Reload(bool replace_vertex_data, void* vertex_d
         input_data_container[source_attr]->setVisible(true);
     }
 
-    // Initialize debug info text for current iteration count
-    iteration_index->setMaximum(debug_data.records.size() - 1);
-    OnIterationIndexChanged(iteration_index->value());
+    // Initialize debug info text for current cycle count
+    cycle_index->setMaximum(debug_data.records.size() - 1);
+    OnCycleIndexChanged(cycle_index->value());
 
     model->endResetModel();
 }
@@ -453,7 +454,7 @@ void GraphicsVertexShaderWidget::OnInputAttributeChanged(int index) {
     Reload();
 }
 
-void GraphicsVertexShaderWidget::OnIterationIndexChanged(int index) {
+void GraphicsVertexShaderWidget::OnCycleIndexChanged(int index) {
     QString text;
 
     auto& record = debug_data.records[index];

--- a/src/citra_qt/debugger/graphics_vertex_shader.cpp
+++ b/src/citra_qt/debugger/graphics_vertex_shader.cpp
@@ -130,13 +130,13 @@ QVariant GraphicsVertexShaderModel::data(const QModelIndex& index, int role) con
 
                     print_input_indexed_compact(output, src1, swizzle.negate_src1, swizzle.SelectorToString(false).substr(0,1), instr.common.AddressRegisterName());
                     output << " " << instr.common.compare_op.ToString(instr.common.compare_op.x) << " ";
-                    print_input(output, src2, swizzle.negate_src2, swizzle.SelectorToString(false).substr(0,1));
+                    print_input(output, src2, swizzle.negate_src2, swizzle.SelectorToString(true).substr(0,1));
 
                     output << ", ";
 
                     print_input_indexed_compact(output, src1, swizzle.negate_src1, swizzle.SelectorToString(false).substr(1,1), instr.common.AddressRegisterName());
                     output << " " << instr.common.compare_op.ToString(instr.common.compare_op.y) << " ";
-                    print_input(output, src2, swizzle.negate_src2, swizzle.SelectorToString(false).substr(1,1));
+                    print_input(output, src2, swizzle.negate_src2, swizzle.SelectorToString(true).substr(1,1));
 
                     break;
                 }
@@ -167,7 +167,7 @@ QVariant GraphicsVertexShaderModel::data(const QModelIndex& index, int role) con
                     // TODO: In some cases, the Address Register is used as an index for SRC2 instead of SRC1
                     if (instr.opcode.Value().GetInfo().subtype & OpCode::Info::Src2) {
                         SourceRegister src2 = instr.common.GetSrc2(src_is_inverted);
-                        print_input(output, src2, swizzle.negate_src2, swizzle.SelectorToString(false));
+                        print_input(output, src2, swizzle.negate_src2, swizzle.SelectorToString(true));
                     }
                     break;
                 }

--- a/src/citra_qt/debugger/graphics_vertex_shader.h
+++ b/src/citra_qt/debugger/graphics_vertex_shader.h
@@ -55,10 +55,11 @@ private slots:
 
     void DumpShader();
 
-    /** Reload widget based on the current PICA200 state
-      * @param replace_vertex_data If true, invalidate all current vertex data
-      * @param vertex_data New vertex data to use, as passed to OnBreakPointHit. May be nullptr to specify that no valid vertex data can be retrieved currently. Only used if replace_vertex_data is true.
-      */
+    /**
+     * Reload widget based on the current PICA200 state
+     * @param replace_vertex_data If true, invalidate all current vertex data
+     * @param vertex_data New vertex data to use, as passed to OnBreakPointHit. May be nullptr to specify that no valid vertex data can be retrieved currently. Only used if replace_vertex_data is true.
+     */
     void Reload(bool replace_vertex_data = false, void* vertex_data = nullptr);
 
 
@@ -71,7 +72,7 @@ private:
     QTreeView* binary_list;
     GraphicsVertexShaderModel* model;
 
-    // TODO: Move these into a single struct
+    /// TODO: Move these into a single struct
     std::array<QLineEdit*, 4*16> input_data;  // A text box for each of the 4 components of up to 16 vertex attributes
     std::array<QWidget*, 16> input_data_container; // QWidget containing the QLayout containing each vertex attribute
     std::array<QLabel*, 16> input_data_mapping; // A QLabel denoting the shader input attribute which the vertex attribute maps to

--- a/src/citra_qt/debugger/graphics_vertex_shader.h
+++ b/src/citra_qt/debugger/graphics_vertex_shader.h
@@ -10,11 +10,18 @@
 
 #include "nihstro/parser_shbin.h"
 
+#include "video_core/shader/shader.h"
+
+class QLabel;
+class QSpinBox;
+
+class GraphicsVertexShaderWidget;
+
 class GraphicsVertexShaderModel : public QAbstractItemModel {
     Q_OBJECT
 
 public:
-    GraphicsVertexShaderModel(QObject* parent);
+    GraphicsVertexShaderModel(GraphicsVertexShaderWidget* parent);
 
     QModelIndex index(int row, int column, const QModelIndex& parent = QModelIndex()) const override;
     QModelIndex parent(const QModelIndex& child) const override;
@@ -23,13 +30,10 @@ public:
     QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
     QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
 
-public slots:
-    void OnUpdate();
-
-    void DumpShader();
-
 private:
-    nihstro::ShaderInfo info;
+    GraphicsVertexShaderWidget* par;
+
+    friend class GraphicsVertexShaderWidget;
 };
 
 class GraphicsVertexShaderWidget : public BreakPointObserverDock {
@@ -45,9 +49,41 @@ private slots:
     void OnBreakPointHit(Pica::DebugContext::Event event, void* data) override;
     void OnResumed() override;
 
+    void OnInputAttributeChanged(int index);
+
+    void OnIterationIndexChanged(int index);
+
+    void DumpShader();
+
+    /** Reload widget based on the current PICA200 state
+      * @param replace_vertex_data If true, invalidate all current vertex data
+      * @param vertex_data New vertex data to use, as passed to OnBreakPointHit. May be nullptr to specify that no valid vertex data can be retrieved currently. Only used if replace_vertex_data is true.
+      */
+    void Reload(bool replace_vertex_data = false, void* vertex_data = nullptr);
+
+
 signals:
-    void Update();
+    // Call this to change the current command selection in the disassembly view
+    void SelectCommand(const QModelIndex&, QItemSelectionModel::SelectionFlags);
 
 private:
+    QLabel* instruction_description;
+    QTreeView* binary_list;
+    GraphicsVertexShaderModel* model;
 
+    // TODO: Move these into a single struct
+    std::array<QLineEdit*, 4*16> input_data;  // A text box for each of the 4 components of up to 16 vertex attributes
+    std::array<QWidget*, 16> input_data_container; // QWidget containing the QLayout containing each vertex attribute
+    std::array<QLabel*, 16> input_data_mapping; // A QLabel denoting the shader input attribute which the vertex attribute maps to
+
+    // Text to be shown when input vertex data is not retrievable
+    QLabel* breakpoint_warning;
+
+    QSpinBox* iteration_index;
+
+    nihstro::ShaderInfo info;
+    Pica::Shader::DebugData<true> debug_data;
+    Pica::Shader::InputVertex input_vertex;
+
+    friend class GraphicsVertexShaderModel;
 };

--- a/src/citra_qt/debugger/graphics_vertex_shader.h
+++ b/src/citra_qt/debugger/graphics_vertex_shader.h
@@ -51,7 +51,7 @@ private slots:
 
     void OnInputAttributeChanged(int index);
 
-    void OnIterationIndexChanged(int index);
+    void OnCycleIndexChanged(int index);
 
     void DumpShader();
 
@@ -80,7 +80,7 @@ private:
     // Text to be shown when input vertex data is not retrievable
     QLabel* breakpoint_warning;
 
-    QSpinBox* iteration_index;
+    QSpinBox* cycle_index;
 
     nihstro::ShaderInfo info;
     Pica::Shader::DebugData<true> debug_data;

--- a/src/citra_qt/debugger/graphics_vertex_shader.h
+++ b/src/citra_qt/debugger/graphics_vertex_shader.h
@@ -26,6 +26,8 @@ public:
 public slots:
     void OnUpdate();
 
+    void DumpShader();
+
 private:
     nihstro::ShaderInfo info;
 };

--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -215,7 +215,7 @@ static inline void WritePicaReg(u32 id, u32 value, u32 mask) {
             unsigned int vertex_cache_pos = 0;
             vertex_cache_ids.fill(-1);
 
-            Shader::UnitState shader_unit;
+            Shader::UnitState<false> shader_unit;
             Shader::Setup(shader_unit);
 
             for (unsigned int index = 0; index < regs.num_vertices; ++index)

--- a/src/video_core/debug_utils/debug_utils.cpp
+++ b/src/video_core/debug_utils/debug_utils.cpp
@@ -131,11 +131,14 @@ void DumpShader(const u32* binary_data, u32 binary_size, const u32* swizzle_data
     // into shbin format (separate type and component mask).
     union OutputRegisterInfo {
         enum Type : u64 {
-            POSITION = 0,
-            COLOR = 2,
-            TEXCOORD0 = 3,
-            TEXCOORD1 = 5,
-            TEXCOORD2 = 6,
+            POSITION   = 0,
+            QUATERNION = 1,
+            COLOR      = 2,
+            TEXCOORD0  = 3,
+            TEXCOORD1  = 5,
+            TEXCOORD2  = 6,
+
+            VIEW       = 8,
         };
 
         BitField< 0, 64, u64> hex;
@@ -157,6 +160,10 @@ void DumpShader(const u32* binary_data, u32 binary_size, const u32* swizzle_data
                 { OutputAttributes::POSITION_Y, { OutputRegisterInfo::POSITION, 2} },
                 { OutputAttributes::POSITION_Z, { OutputRegisterInfo::POSITION, 4} },
                 { OutputAttributes::POSITION_W, { OutputRegisterInfo::POSITION, 8} },
+                { OutputAttributes::QUATERNION_X, { OutputRegisterInfo::QUATERNION, 1} },
+                { OutputAttributes::QUATERNION_Y, { OutputRegisterInfo::QUATERNION, 2} },
+                { OutputAttributes::QUATERNION_Z, { OutputRegisterInfo::QUATERNION, 4} },
+                { OutputAttributes::QUATERNION_W, { OutputRegisterInfo::QUATERNION, 8} },
                 { OutputAttributes::COLOR_R, { OutputRegisterInfo::COLOR, 1} },
                 { OutputAttributes::COLOR_G, { OutputRegisterInfo::COLOR, 2} },
                 { OutputAttributes::COLOR_B, { OutputRegisterInfo::COLOR, 4} },
@@ -166,7 +173,10 @@ void DumpShader(const u32* binary_data, u32 binary_size, const u32* swizzle_data
                 { OutputAttributes::TEXCOORD1_U, { OutputRegisterInfo::TEXCOORD1, 1} },
                 { OutputAttributes::TEXCOORD1_V, { OutputRegisterInfo::TEXCOORD1, 2} },
                 { OutputAttributes::TEXCOORD2_U, { OutputRegisterInfo::TEXCOORD2, 1} },
-                { OutputAttributes::TEXCOORD2_V, { OutputRegisterInfo::TEXCOORD2, 2} }
+                { OutputAttributes::TEXCOORD2_V, { OutputRegisterInfo::TEXCOORD2, 2} },
+                { OutputAttributes::VIEW_X, { OutputRegisterInfo::VIEW, 1} },
+                { OutputAttributes::VIEW_Y, { OutputRegisterInfo::VIEW, 2} },
+                { OutputAttributes::VIEW_Z, { OutputRegisterInfo::VIEW, 4} }
             };
 
             for (const auto& semantic : std::vector<OutputAttributes::Semantic>{
@@ -239,6 +249,7 @@ void DumpShader(const u32* binary_data, u32 binary_size, const u32* swizzle_data
 
     // TODO: Create a label table for "main"
 
+    // TODO: Write uniforms as constants
 
     // Write data to file
     static int dump_index = 0;

--- a/src/video_core/debug_utils/debug_utils.cpp
+++ b/src/video_core/debug_utils/debug_utils.cpp
@@ -111,7 +111,7 @@ void GeometryDumper::Dump() {
 }
 
 
-void DumpShader(const Regs::ShaderConfig& config, const State::ShaderSetup& setup, const Regs::VSOutputAttributes* output_attributes)
+void DumpShader(const std::string& filename, const Regs::ShaderConfig& config, const State::ShaderSetup& setup, const Regs::VSOutputAttributes* output_attributes)
 {
     struct StuffToWrite {
         u8* pointer;
@@ -294,7 +294,6 @@ void DumpShader(const Regs::ShaderConfig& config, const State::ShaderSetup& setu
 
     // Write data to file
     static int dump_index = 0;
-    std::string filename = std::string("shader_dump") + std::to_string(++dump_index) + std::string(".shbin");
     std::ofstream file(filename, std::ios_base::out | std::ios_base::binary);
 
     for (auto& chunk : writing_queue) {

--- a/src/video_core/debug_utils/debug_utils.cpp
+++ b/src/video_core/debug_utils/debug_utils.cpp
@@ -14,6 +14,7 @@
 #include <png.h>
 #endif
 
+#include <nihstro/float24.h>
 #include <nihstro/shader_binary.h>
 
 #include "common/assert.h"
@@ -110,8 +111,7 @@ void GeometryDumper::Dump() {
 }
 
 
-void DumpShader(const u32* binary_data, u32 binary_size, const u32* swizzle_data, u32 swizzle_size,
-                u32 main_offset, const Regs::VSOutputAttributes* output_attributes)
+void DumpShader(const Regs::ShaderConfig& config, const State::ShaderSetup& setup, const Regs::VSOutputAttributes* output_attributes)
 {
     struct StuffToWrite {
         u8* pointer;
@@ -231,25 +231,66 @@ void DumpShader(const u32* binary_data, u32 binary_size, const u32* swizzle_data
 
     // TODO: Reduce the amount of binary code written to relevant portions
     dvlp.binary_offset = write_offset - dvlp_offset;
-    dvlp.binary_size_words = binary_size;
-    QueueForWriting((u8*)binary_data, binary_size * sizeof(u32));
+    dvlp.binary_size_words = setup.program_code.size();
+    QueueForWriting((u8*)setup.program_code.data(), setup.program_code.size() * sizeof(u32));
 
     dvlp.swizzle_info_offset = write_offset - dvlp_offset;
-    dvlp.swizzle_info_num_entries = swizzle_size;
+    dvlp.swizzle_info_num_entries = setup.swizzle_data.size();
     u32 dummy = 0;
-    for (unsigned int i = 0; i < swizzle_size; ++i) {
-        QueueForWriting((u8*)&swizzle_data[i], sizeof(swizzle_data[i]));
+    for (unsigned int i = 0; i < setup.swizzle_data.size(); ++i) {
+        QueueForWriting((u8*)&setup.swizzle_data[i], sizeof(setup.swizzle_data[i]));
         QueueForWriting((u8*)&dummy, sizeof(dummy));
     }
 
-    dvle.main_offset_words = main_offset;
+    dvle.main_offset_words = config.main_offset;
     dvle.output_register_table_offset = write_offset - dvlb.dvle_offset;
     dvle.output_register_table_size = static_cast<u32>(output_info_table.size());
     QueueForWriting((u8*)output_info_table.data(), static_cast<u32>(output_info_table.size() * sizeof(OutputRegisterInfo)));
 
     // TODO: Create a label table for "main"
 
-    // TODO: Write uniforms as constants
+    std::vector<nihstro::ConstantInfo> constant_table;
+    for (unsigned i = 0; i < setup.uniforms.b.size(); ++i) {
+        nihstro::ConstantInfo constant;
+        memset(&constant, 0, sizeof(constant));
+        constant.type = nihstro::ConstantInfo::Bool;
+        constant.regid = i;
+        constant.b = setup.uniforms.b[i];
+        constant_table.emplace_back(constant);
+    }
+    for (unsigned i = 0; i < setup.uniforms.i.size(); ++i) {
+        nihstro::ConstantInfo constant;
+        memset(&constant, 0, sizeof(constant));
+        constant.type = nihstro::ConstantInfo::Int;
+        constant.regid = i;
+        constant.i.x = setup.uniforms.i[i].x;
+        constant.i.y = setup.uniforms.i[i].y;
+        constant.i.z = setup.uniforms.i[i].z;
+        constant.i.w = setup.uniforms.i[i].w;
+        constant_table.emplace_back(constant);
+    }
+    for (unsigned i = 0; i < sizeof(setup.uniforms.f) / sizeof(setup.uniforms.f[0]); ++i) {
+        nihstro::ConstantInfo constant;
+        memset(&constant, 0, sizeof(constant));
+        constant.type = nihstro::ConstantInfo::Float;
+        constant.regid = i;
+        constant.f.x = nihstro::to_float24(setup.uniforms.f[i].x.ToFloat32());
+        constant.f.y = nihstro::to_float24(setup.uniforms.f[i].y.ToFloat32());
+        constant.f.z = nihstro::to_float24(setup.uniforms.f[i].z.ToFloat32());
+        constant.f.w = nihstro::to_float24(setup.uniforms.f[i].w.ToFloat32());
+
+        // Store constant if it's different from zero..
+        if (setup.uniforms.f[i].x.ToFloat32() != 0.0 ||
+            setup.uniforms.f[i].y.ToFloat32() != 0.0 ||
+            setup.uniforms.f[i].z.ToFloat32() != 0.0 ||
+            setup.uniforms.f[i].w.ToFloat32() != 0.0)
+            constant_table.emplace_back(constant);
+    }
+    dvle.constant_table_offset = write_offset - dvlb.dvle_offset;
+    dvle.constant_table_size = constant_table.size();
+    for (const auto& constant : constant_table) {
+        QueueForWriting((uint8_t*)&constant, sizeof(constant));
+    }
 
     // Write data to file
     static int dump_index = 0;

--- a/src/video_core/debug_utils/debug_utils.h
+++ b/src/video_core/debug_utils/debug_utils.h
@@ -181,8 +181,7 @@ private:
     std::vector<Face> faces;
 };
 
-void DumpShader(const u32* binary_data, u32 binary_size, const u32* swizzle_data, u32 swizzle_size,
-                u32 main_offset, const Regs::VSOutputAttributes* output_attributes);
+void DumpShader(const Regs::ShaderConfig& config, const State::ShaderSetup& setup, const Regs::VSOutputAttributes* output_attributes);
 
 
 // Utility class to log Pica commands.

--- a/src/video_core/debug_utils/debug_utils.h
+++ b/src/video_core/debug_utils/debug_utils.h
@@ -181,7 +181,8 @@ private:
     std::vector<Face> faces;
 };
 
-void DumpShader(const Regs::ShaderConfig& config, const State::ShaderSetup& setup, const Regs::VSOutputAttributes* output_attributes);
+void DumpShader(const std::string& filename, const Regs::ShaderConfig& config,
+                const State::ShaderSetup& setup, const Regs::VSOutputAttributes* output_attributes);
 
 
 // Utility class to log Pica commands.

--- a/src/video_core/debug_utils/debug_utils.h
+++ b/src/video_core/debug_utils/debug_utils.h
@@ -158,7 +158,6 @@ extern std::shared_ptr<DebugContext> g_debug_context; // TODO: Get rid of this g
 namespace DebugUtils {
 
 #define PICA_DUMP_GEOMETRY 0
-#define PICA_DUMP_SHADERS 0
 #define PICA_DUMP_TEXTURES 0
 #define PICA_LOG_TEV 0
 

--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -80,6 +80,11 @@ struct Regs {
             POSITION_Z   =  2,
             POSITION_W   =  3,
 
+            QUATERNION_X =  4,
+            QUATERNION_Y =  5,
+            QUATERNION_Z =  6,
+            QUATERNION_W =  7,
+
             COLOR_R      =  8,
             COLOR_G      =  9,
             COLOR_B      = 10,
@@ -89,6 +94,12 @@ struct Regs {
             TEXCOORD0_V  = 13,
             TEXCOORD1_U  = 14,
             TEXCOORD1_V  = 15,
+
+            // TODO: Not verified
+            VIEW_X       = 18,
+            VIEW_Y       = 19,
+            VIEW_Z       = 20,
+
             TEXCOORD2_U  = 22,
             TEXCOORD2_V  = 23,
 

--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -96,12 +96,6 @@ OutputVertex Run(UnitState& state, const InputVertex& input, int num_attributes)
     RunInterpreter(state);
 #endif // ARCHITECTURE_x86_64
 
-#if PICA_DUMP_SHADERS
-    DebugUtils::DumpShader(setup.program_code.data(), state.debug.max_offset, setup.swizzle_data.data(),
-        state.debug.max_opdesc_id, config.main_offset,
-        g_state.regs.vs_output_attributes); // TODO: Don't hardcode VS here
-#endif
-
     // Setup output data
     OutputVertex ret;
     // TODO(neobrain): Under some circumstances, up to 16 attributes may be output. We need to

--- a/src/video_core/shader/shader.h
+++ b/src/video_core/shader/shader.h
@@ -4,7 +4,10 @@
 
 #pragma once
 
+#include <vector>
+
 #include <boost/container/static_vector.hpp>
+
 #include <nihstro/shader_binary.h>
 
 #include "common/common_funcs.h"
@@ -72,12 +75,185 @@ struct OutputVertex {
 static_assert(std::is_pod<OutputVertex>::value, "Structure is not POD");
 static_assert(sizeof(OutputVertex) == 32 * sizeof(float), "OutputVertex has invalid size");
 
+
+// Helper structure used to keep track of data useful for inspection of shader emulation
+template<bool full_debugging>
+struct DebugData;
+
+template<>
+struct DebugData<false> {
+    // TODO: Hide these behind and interface and move them to DebugData<true>
+    u32 max_offset; // maximum program counter ever reached
+    u32 max_opdesc_id; // maximum swizzle pattern index ever used
+};
+
+template<>
+struct DebugData<true> {
+    // Records store the input and output operands of a particular instruction.
+    struct Record {
+        enum Type {
+            // Floating point arithmetic operands
+            SRC1         = 0x1,
+            SRC2         = 0x2,
+            SRC3         = 0x4,
+
+            // Initial and final output operand value
+            DEST_IN      = 0x8,
+            DEST_OUT     = 0x10,
+
+            // Current and next instruction offset (in words)
+            CUR_INSTR    = 0x20,
+            NEXT_INSTR   = 0x40,
+
+            // Output address register value
+            ADDR_REG_OUT = 0x80,
+
+            // Result of a comparison instruction
+            CMP_RESULT   = 0x100,
+
+            // Input values for conditional flow control instructions
+            COND_BOOL_IN = 0x200,
+            COND_CMP_IN  = 0x400,
+
+            // Input values for a loop
+            LOOP_INT_IN  = 0x800,
+        };
+
+        Math::Vec4<float24> src1;
+        Math::Vec4<float24> src2;
+        Math::Vec4<float24> src3;
+
+        Math::Vec4<float24> dest_in;
+        Math::Vec4<float24> dest_out;
+
+        s32 address_registers[2];
+        bool conditional_code[2];
+        bool cond_bool;
+        bool cond_cmp[2];
+        Math::Vec4<u8> loop_int;
+
+        u32 instruction_offset;
+        u32 next_instruction;
+
+        // set of enabled fields (as a combination of Type flags)
+        unsigned mask = 0;
+    };
+
+    u32 max_offset; // maximum program counter ever reached
+    u32 max_opdesc_id; // maximum swizzle pattern index ever used
+
+    // List of records for each executed shader instruction
+    std::vector<DebugData<true>::Record> records;
+};
+
+// Type alias for better readability
+using DebugDataRecord = DebugData<true>::Record;
+
+// Helper function to set a DebugData<true>::Record field based on the template enum parameter.
+template<DebugDataRecord::Type type, typename ValueType>
+inline void SetField(DebugDataRecord& record, ValueType value);
+
+template<>
+inline void SetField<DebugDataRecord::SRC1>(DebugDataRecord& record, float24* value) {
+    record.src1.x = value[0];
+    record.src1.y = value[1];
+    record.src1.z = value[2];
+    record.src1.w = value[3];
+}
+
+template<>
+inline void SetField<DebugDataRecord::SRC2>(DebugDataRecord& record, float24* value) {
+    record.src2.x = value[0];
+    record.src2.y = value[1];
+    record.src2.z = value[2];
+    record.src2.w = value[3];
+}
+
+template<>
+inline void SetField<DebugDataRecord::SRC3>(DebugDataRecord& record, float24* value) {
+    record.src3.x = value[0];
+    record.src3.y = value[1];
+    record.src3.z = value[2];
+    record.src3.w = value[3];
+}
+
+template<>
+inline void SetField<DebugDataRecord::DEST_IN>(DebugDataRecord& record, float24* value) {
+    record.dest_in.x = value[0];
+    record.dest_in.y = value[1];
+    record.dest_in.z = value[2];
+    record.dest_in.w = value[3];
+}
+
+template<>
+inline void SetField<DebugDataRecord::DEST_OUT>(DebugDataRecord& record, float24* value) {
+    record.dest_out.x = value[0];
+    record.dest_out.y = value[1];
+    record.dest_out.z = value[2];
+    record.dest_out.w = value[3];
+}
+
+template<>
+inline void SetField<DebugDataRecord::ADDR_REG_OUT>(DebugDataRecord& record, s32* value) {
+    record.address_registers[0] = value[0];
+    record.address_registers[1] = value[1];
+}
+
+template<>
+inline void SetField<DebugDataRecord::CMP_RESULT>(DebugDataRecord& record, bool* value) {
+    record.conditional_code[0] = value[0];
+    record.conditional_code[1] = value[1];
+}
+
+template<>
+inline void SetField<DebugDataRecord::COND_BOOL_IN>(DebugDataRecord& record, bool value) {
+    record.cond_bool = value;
+}
+
+template<>
+inline void SetField<DebugDataRecord::COND_CMP_IN>(DebugDataRecord& record, bool* value) {
+    record.cond_cmp[0] = value[0];
+    record.cond_cmp[1] = value[1];
+}
+
+template<>
+inline void SetField<DebugDataRecord::LOOP_INT_IN>(DebugDataRecord& record, Math::Vec4<u8> value) {
+    record.loop_int = value;
+}
+
+template<>
+inline void SetField<DebugDataRecord::CUR_INSTR>(DebugDataRecord& record, u32 value) {
+    record.instruction_offset = value;
+}
+
+template<>
+inline void SetField<DebugDataRecord::NEXT_INSTR>(DebugDataRecord& record, u32 value) {
+    record.next_instruction = value;
+}
+
+// Helper function to set debug information on the current shader iteration.
+template<DebugDataRecord::Type type, typename ValueType>
+inline void Record(DebugData<false>& debug_data, u32 offset, ValueType value) {
+    // Debugging disabled => nothing to do
+}
+
+template<DebugDataRecord::Type type, typename ValueType>
+inline void Record(DebugData<true>& debug_data, u32 offset, ValueType value) {
+    if (offset >= debug_data.records.size())
+        debug_data.records.resize(offset + 1);
+
+   SetField<type, ValueType>(debug_data.records[offset], value);
+   debug_data.records[offset].mask |= type;
+}
+
+
 /**
  * This structure contains the state information that needs to be unique for a shader unit. The 3DS
  * has four shader units that process shaders in parallel. At the present, Citra only implements a
  * single shader unit that processes all shaders serially. Putting the state information in a struct
  * here will make it easier for us to parallelize the shader processing later.
  */
+template<bool Debug>
 struct UnitState {
     struct Registers {
         // The registers are accessed by the shader JIT using SSE instructions, and are therefore
@@ -111,10 +287,7 @@ struct UnitState {
     // TODO: Is there a maximal size for this?
     boost::container::static_vector<CallStackElement, 16> call_stack;
 
-    struct {
-        u32 max_offset; // maximum program counter ever reached
-        u32 max_opdesc_id; // maximum swizzle pattern index ever used
-    } debug;
+    DebugData<Debug> debug;
 
     static int InputOffset(const SourceRegister& reg) {
         switch (reg.GetRegisterType()) {
@@ -150,7 +323,7 @@ struct UnitState {
  * vertex, which would happen within the `Run` function).
  * @param state Shader unit state, must be setup per shader and per shader unit
  */
-void Setup(UnitState& state);
+void Setup(UnitState<false>& state);
 
 /// Performs any cleanup when the emulator is shutdown
 void Shutdown();
@@ -162,7 +335,17 @@ void Shutdown();
  * @param num_attributes The number of vertex shader attributes
  * @return The output vertex, after having been processed by the vertex shader
  */
-OutputVertex Run(UnitState& state, const InputVertex& input, int num_attributes);
+OutputVertex Run(UnitState<false>& state, const InputVertex& input, int num_attributes);
+
+/**
+ * Produce debug information based on the given shader and input vertex
+ * @param input Input vertex into the shader
+ * @param num_attributes The number of vertex shader attributes
+ * @param config Configuration object for the shader pipeline
+ * @param setup Setup object for the shader pipeline
+ * @return Debug information for this shader with regards to the given vertex
+ */
+DebugData<true> ProduceDebugInfo(const InputVertex& input, int num_attributes, const Regs::ShaderConfig& config, const State::ShaderSetup& setup);
 
 } // namespace Shader
 

--- a/src/video_core/shader/shader_interpreter.h
+++ b/src/video_core/shader/shader_interpreter.h
@@ -12,7 +12,8 @@ namespace Pica {
 
 namespace Shader {
 
-void RunInterpreter(UnitState& state);
+template<bool Debug>
+void RunInterpreter(UnitState<Debug>& state);
 
 } // namespace
 

--- a/src/video_core/shader/shader_jit_x64.cpp
+++ b/src/video_core/shader/shader_jit_x64.cpp
@@ -141,7 +141,7 @@ void JitCompiler::Compile_SwizzleSrc(Instruction instr, unsigned src_num, Source
         src_offset = src_reg.GetIndex() * sizeof(float24) * 4;
     } else {
         src_ptr = REGISTERS;
-        src_offset = UnitState::InputOffset(src_reg);
+        src_offset = UnitState<false>::InputOffset(src_reg);
     }
 
     unsigned operand_desc_id;
@@ -217,11 +217,11 @@ void JitCompiler::Compile_DestEnable(Instruction instr,X64Reg src) {
     // If all components are enabled, write the result to the destination register
     if (swiz.dest_mask == NO_DEST_REG_MASK) {
         // Store dest back to memory
-        MOVAPS(MDisp(REGISTERS, UnitState::OutputOffset(dest)), src);
+        MOVAPS(MDisp(REGISTERS, UnitState<false>::OutputOffset(dest)), src);
 
     } else {
         // Not all components are enabled, so mask the result when storing to the destination register...
-        MOVAPS(SCRATCH, MDisp(REGISTERS, UnitState::OutputOffset(dest)));
+        MOVAPS(SCRATCH, MDisp(REGISTERS, UnitState<false>::OutputOffset(dest)));
 
         if (Common::GetCPUCaps().sse4_1) {
             u8 mask = ((swiz.dest_mask & 1) << 3) | ((swiz.dest_mask & 8) >> 3) | ((swiz.dest_mask & 2) << 1) | ((swiz.dest_mask & 4) >> 1);
@@ -240,7 +240,7 @@ void JitCompiler::Compile_DestEnable(Instruction instr,X64Reg src) {
         }
 
         // Store dest back to memory
-        MOVAPS(MDisp(REGISTERS, UnitState::OutputOffset(dest)), SCRATCH);
+        MOVAPS(MDisp(REGISTERS, UnitState<false>::OutputOffset(dest)), SCRATCH);
     }
 }
 


### PR DESCRIPTION
A number of functional improvements to the shader disassembler (which is now an actual debugger):

* When the emulator halts at a VertexLoaded breakpoint, the vertex attributes are shown in the shader debugger
* Unreached instructions are colored yellow in the shader disassembly
* Shaders can be dumped from the GUI
* More output semantics than before are recognized when dumping shaders
* Each shader interpreter cycle records its inputs and outputs now, so that they can be inspected in the GUI (think of this as stepping through the shader and inspecting data, just that it's all done automatically and you just select a particular "iteration" to analyze in the GUI)

Obligatory screenshot:
![Screenshot of shader debugger GUI](http://i.imgur.com/VKuFSkl.png)

This PR pends on #929 .