### PR TITLE
Update homebrew before building, which no longer uses SourceForge

### DIFF
--- a/.travis-deps.sh
+++ b/.travis-deps.sh
@@ -24,7 +24,7 @@ if [ "$TRAVIS_OS_NAME" = "linux" -o -z "$TRAVIS_OS_NAME" ]; then
     )
 
 elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
-    brew tap homebrew/versions
+    brew update > /dev/null # silence the very verbose output
     brew install qt5 glfw3 pkgconfig
     gem install xcpretty
 fi


### PR DESCRIPTION
Also removes the `brew tap` command, which is irrelevant now that Travis taps `homebrew/versions` by default.