### PR TITLE
Remove the unused and commented GetThemeDir prototype from FileUtil

### DIFF
--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -116,9 +116,6 @@ bool SetCurrentDir(const std::string &directory);
 // directory. To be used in "multi-user" mode (that is, installed).
 const std::string& GetUserPath(const unsigned int DirIDX, const std::string &newPath="");
 
-// probably doesn't belong here
-//std::string GetThemeDir(const std::string& theme_name);
-
 // Returns the path to where the sys file are
 std::string GetSysDirectory();
 


### PR DESCRIPTION
This is a followup from #920.