### PR TITLE
Rasterizer/Textures: Fixed a bug where the I4 format would get twice the real stride

### DIFF
--- a/src/citra_qt/debugger/graphics_cmdlists.cpp
+++ b/src/citra_qt/debugger/graphics_cmdlists.cpp
@@ -74,7 +74,7 @@ TextureInfoDockWidget::TextureInfoDockWidget(const Pica::DebugUtils::TextureInfo
     format_choice->addItem(tr("I8"));
     format_choice->addItem(tr("A8"));
     format_choice->addItem(tr("IA4"));
-    format_choice->addItem(tr("UNK10"));
+    format_choice->addItem(tr("I4"));
     format_choice->addItem(tr("A4"));
     format_choice->addItem(tr("ETC1"));
     format_choice->addItem(tr("ETC1A4"));

--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -200,6 +200,7 @@ struct Regs {
         case TextureFormat::IA8:
             return 4;
 
+        case TextureFormat::I4:
         case TextureFormat::A4:
             return 1;
 


### PR DESCRIPTION
Also added its name to the texture viewer widget.

Fixes some artifacts in games that use this format, like Crashmo