### PR TITLE
Pica: Fix DP3 instruction, which wasn't assigning to the w component

### DIFF
--- a/src/video_core/vertex_shader.cpp
+++ b/src/video_core/vertex_shader.cpp
@@ -221,7 +221,7 @@ static void ProcessShaderCode(VertexShaderState& state) {
                 for (int i = 0; i < num_components; ++i)
                     dot = dot + src1[i] * src2[i];
 
-                for (int i = 0; i < num_components; ++i) {
+                for (int i = 0; i < 4; ++i) {
                     if (!swizzle.DestComponentEnabled(i))
                         continue;
 


### PR DESCRIPTION
This fixes the OoT NaN/white/black triangle glitch.