### PR TITLE
Pica: Correct switched S/T texture wrapping registers

### DIFF
--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -132,8 +132,8 @@ struct Regs {
         };
 
         union {
-            BitField< 8, 2, WrapMode> wrap_s;
-            BitField<12, 2, WrapMode> wrap_t;
+            BitField< 8, 2, WrapMode> wrap_t;
+            BitField<12, 2, WrapMode> wrap_s;
         };
 
         INSERT_PADDING_WORDS(0x1);


### PR DESCRIPTION
This was found and hwtested by Lectem in https://github.com/Lectem/3DS_gpu_tests/tree/wrap_modes