### PR TITLE
GPU/DisplayTransfer: Implemented bit 5 in the transfer flags.

### DIFF
--- a/src/core/hw/gpu.h
+++ b/src/core/hw/gpu.h
@@ -203,6 +203,7 @@ struct Regs {
             BitField< 0, 1, u32> flip_vertically;  // flips input data vertically
             BitField< 1, 1, u32> output_tiled;     // Converts from linear to tiled format
             BitField< 3, 1, u32> raw_copy;         // Copies the data without performing any processing
+            BitField< 5, 1, u32> dont_swizzle;
             BitField< 8, 3, PixelFormat> input_format;
             BitField<12, 3, PixelFormat> output_format;
 


### PR DESCRIPTION
It tells the GPU to not swizzle/de-swizzle the input during the transfer.

Verified with https://github.com/citra-emu/hwtests/pull/36

Closes #853

![llywtxp 1](https://cloud.githubusercontent.com/assets/357072/8769224/9cd2e0e2-2e5d-11e5-927a-1ff015a14eaa.png)
