### PR TITLE
Services/AM: Stubbed am:app::GetNumContentInfos to return 0 results.

### DIFF
--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -38,6 +38,15 @@ void GetTitleIDList(Service::Interface* self) {
     LOG_WARNING(Service_AM, "(STUBBED) Requested %u titles from media type %u", num_titles, media_type);
 }
 
+void GetNumContentInfos(Service::Interface* self) {
+    u32* cmd_buff = Kernel::GetCommandBuffer();
+
+    cmd_buff[1] = RESULT_SUCCESS.raw;
+    cmd_buff[2] = 1; // Number of content infos plus one
+
+    LOG_WARNING(Service_AM, "(STUBBED) called");
+}
+
 void Init() {
     using namespace Kernel;
 

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -37,6 +37,19 @@ void TitleIDListGetTotal(Service::Interface* self);
  */
 void GetTitleIDList(Service::Interface* self);
 
+/**
+ * AM::GetNumContentInfos service function
+ *  Inputs:
+ *      0 : Command header (0x100100C0)
+ *      1 : Unknown
+ *      2 : Unknown
+ *      3 : Unknown
+ *  Outputs:
+ *      1 : Result, 0 on success, otherwise error code
+ *      2 : Number of content infos plus one
+ */
+void GetNumContentInfos(Service::Interface* self);
+
 /// Initialize AM service
 void Init();
 

--- a/src/core/hle/service/am/am_app.cpp
+++ b/src/core/hle/service/am/am_app.cpp
@@ -9,11 +9,19 @@
 namespace Service {
 namespace AM {
 
-// Empty arrays are illegal -- commented out until an entry is added.
-//const Interface::FunctionInfo FunctionTable[] = { };
+const Interface::FunctionInfo FunctionTable[] = {
+    {0x100100C0, GetNumContentInfos, "GetNumContentInfos"},
+    {0x10020104, nullptr, "FindContentInfos"},
+    {0x10030142, nullptr, "ListContentInfos"},
+    {0x10040102, nullptr, "DeleteContents"},
+    {0x10050084, nullptr, "GetDataTitleInfos"},
+    {0x10070102, nullptr, "ListDataTitleTicketInfos"},
+    {0x100900C0, nullptr, "IsDataTitleInUse"},
+    {0x100A0000, nullptr, "IsExternalTitleDatabaseInitialized"},
+};
 
 AM_APP_Interface::AM_APP_Interface() {
-    //Register(FunctionTable);
+    Register(FunctionTable);
 }
 
 } // namespace AM


### PR DESCRIPTION
Named the service functions in am:app as per 3dbrew.

This fixes an illegal read loop in Steel Diver

Related to #961

Pic for reference
![Steel Diver](http://i.imgur.com/IaCNmEo.png)