### PR TITLE
Misc. GPU vertex loading fixes

### DIFF
--- a/src/video_core/vertex_shader.cpp
+++ b/src/video_core/vertex_shader.cpp
@@ -610,6 +610,12 @@ OutputVertex RunShader(const InputVertex& input, int num_attributes, const Regs:
         }
     }
 
+    // The hardware takes the absolute and saturates vertex colors like this, *before* doing interpolation
+    for (int i = 0; i < 4; ++i) {
+        ret.color[i] = float24::FromFloat32(
+            std::fmin(std::fabs(ret.color[i].ToFloat32()), 1.0f));
+    }
+
     LOG_TRACE(Render_Software, "Output vertex: pos (%.2f, %.2f, %.2f, %.2f), col(%.2f, %.2f, %.2f, %.2f), tc0(%.2f, %.2f)",
         ret.pos.x.ToFloat32(), ret.pos.y.ToFloat32(), ret.pos.z.ToFloat32(), ret.pos.w.ToFloat32(),
         ret.color.x.ToFloat32(), ret.color.y.ToFloat32(), ret.color.z.ToFloat32(), ret.color.w.ToFloat32(),


### PR DESCRIPTION
Two small GPU fixes. See individual commit messages for more info.

Notably, one of them fixes the UI in Fire Emblem, which is now playable:

![fire_emblem](https://cloud.githubusercontent.com/assets/341401/8794556/0bd147ec-2f5b-11e5-9544-35fd840c5b01.png)

Test homebrew at:
 - https://github.com/yuriks/3DS_gpu_tests/tree/color-clamping
 - https://github.com/yuriks/3DS_gpu_tests/tree/vertex-loading