### PR TITLE
dyncom: Pass SVC immediates directly.

### DIFF
--- a/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
+++ b/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
@@ -6248,7 +6248,8 @@ unsigned InterpreterMainLoop(ARMul_State* cpu) {
     SWI_INST:
     {
         if (inst_base->cond == 0xE || CondPassed(cpu, inst_base->cond)) {
-            SVC::CallSVC(Memory::Read32(cpu->Reg[15]));
+            swi_inst* const inst_cream = (swi_inst*)inst_base->component;
+            SVC::CallSVC(inst_cream->num & 0xFFFF);
         }
 
         cpu->Reg[15] += GET_INST_SIZE(cpu);

--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -833,8 +833,7 @@ static const FunctionDef SVC_Table[] = {
 
 Common::Profiling::TimingCategory profiler_svc("SVC Calls");
 
-static const FunctionDef* GetSVCInfo(u32 opcode) {
-    u32 func_num = opcode & 0xFFFFFF; // 8 bits
+static const FunctionDef* GetSVCInfo(u32 func_num) {
     if (func_num >= ARRAY_SIZE(SVC_Table)) {
         LOG_ERROR(Kernel_SVC, "unknown svc=0x%02X", func_num);
         return nullptr;
@@ -842,10 +841,10 @@ static const FunctionDef* GetSVCInfo(u32 opcode) {
     return &SVC_Table[func_num];
 }
 
-void CallSVC(u32 opcode) {
+void CallSVC(u32 immediate) {
     Common::Profiling::ScopeTimer timer_svc(profiler_svc);
 
-    const FunctionDef *info = GetSVCInfo(opcode);
+    const FunctionDef* info = GetSVCInfo(immediate);
     if (info) {
         if (info->func) {
             info->func();

--- a/src/core/hle/svc.h
+++ b/src/core/hle/svc.h
@@ -41,6 +41,6 @@ enum ArbitrationType {
 
 namespace SVC {
 
-void CallSVC(u32 opcode);
+void CallSVC(u32 immediate);
 
 } // namespace


### PR DESCRIPTION
Previously it would just re-read the already decoded instruction and extract the immediate value.