### PR TITLE
Implement stencil action 2 in SW renderer

### DIFF
--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -431,6 +431,7 @@ struct Regs {
 
     enum class StencilAction : u32 {
         Keep = 0,
+        AndReverse = 2,
         Xor  = 5,
     };
 

--- a/src/video_core/rasterizer.cpp
+++ b/src/video_core/rasterizer.cpp
@@ -221,6 +221,9 @@ static u8 PerformStencilAction(Regs::StencilAction action, u8 dest, u8 ref) {
     case Regs::StencilAction::Keep:
         return dest;
 
+    case Regs::StencilAction::AndReverse:
+        return dest & ~ref;
+
     case Regs::StencilAction::Xor:
         return dest ^ ref;
 


### PR DESCRIPTION
I referenced 3dbrew for this. This PR solely exists as a test to see if it fixes Kingdom Hearts: Dream Drop Distance. I haven't implemented this in the hardware renderer, because the PICA200's stencil operations are really different from the standard in OpenGL and OpenGL ES, and they seem to be completely incompatible.