### PR TITLE
GL Renderer: Remove erroneous glEnable(GL_TEXTURE_2D) calls

### DIFF
--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -147,19 +147,16 @@ void OpenGLState::Apply() {
 
     // Textures
     for (unsigned texture_index = 0; texture_index < ARRAY_SIZE(texture_units); ++texture_index) {
-        if (texture_units[texture_index].enabled_2d != cur_state.texture_units[texture_index].enabled_2d) {
+        if (texture_units[texture_index].enabled_2d != cur_state.texture_units[texture_index].enabled_2d ||
+            texture_units[texture_index].texture_2d != cur_state.texture_units[texture_index].texture_2d) {
+
             glActiveTexture(GL_TEXTURE0 + texture_index);
 
             if (texture_units[texture_index].enabled_2d) {
-                glEnable(GL_TEXTURE_2D);
+                glBindTexture(GL_TEXTURE_2D, texture_units[texture_index].texture_2d);
             } else {
-                glDisable(GL_TEXTURE_2D);
+                glBindTexture(GL_TEXTURE_2D, 0);
             }
-        }
-
-        if (texture_units[texture_index].texture_2d != cur_state.texture_units[texture_index].texture_2d) {
-            glActiveTexture(GL_TEXTURE0 + texture_index);
-            glBindTexture(GL_TEXTURE_2D, texture_units[texture_index].texture_2d);
         }
     }
 


### PR DESCRIPTION
In OpenGL 3, texturing is always enabled, and this call is invalid.
While it produced no effect in the rest of the execution, it wouldn't
have the intended effect of disabling texturing for that unit. Instead
bind a null texture to the unit.