### PR TITLE
Qt/GPU Breakpoints: Added three more breakpoint types

### DIFF
--- a/src/citra_qt/debugger/graphics_breakpoints.cpp
+++ b/src/citra_qt/debugger/graphics_breakpoints.cpp
@@ -42,11 +42,14 @@ QVariant BreakPointModel::data(const QModelIndex& index, int role) const
         case 0:
         {
             static const std::map<Pica::DebugContext::Event, QString> map = {
-                { Pica::DebugContext::Event::CommandLoaded, tr("Pica command loaded") },
-                { Pica::DebugContext::Event::CommandProcessed, tr("Pica command processed") },
+                { Pica::DebugContext::Event::PicaCommandLoaded, tr("Pica command loaded") },
+                { Pica::DebugContext::Event::PicaCommandProcessed, tr("Pica command processed") },
                 { Pica::DebugContext::Event::IncomingPrimitiveBatch, tr("Incoming primitive batch") },
                 { Pica::DebugContext::Event::FinishedPrimitiveBatch, tr("Finished primitive batch") },
-                { Pica::DebugContext::Event::VertexLoaded, tr("Vertex loaded") }
+                { Pica::DebugContext::Event::VertexLoaded, tr("Vertex loaded") },
+                { Pica::DebugContext::Event::IncomingDisplayTransfer, tr("Incoming display transfer") },
+                { Pica::DebugContext::Event::GSPCommandProcessed, tr("GSP command processed") },
+                { Pica::DebugContext::Event::BufferSwapped, tr("Buffers swapped") }
             };
 
             DEBUG_ASSERT(map.size() == static_cast<size_t>(Pica::DebugContext::Event::NumEvents));

--- a/src/core/hle/service/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp_gpu.cpp
@@ -14,6 +14,7 @@
 #include "core/hw/lcd.h"
 
 #include "video_core/gpu_debugger.h"
+#include "video_core/debug_utils/debug_utils.h"
 #include "video_core/renderer_base.h"
 #include "video_core/video_core.h"
 
@@ -226,6 +227,9 @@ void SetBufferSwap(u32 screen_id, const FrameBufferInfo& info) {
             &info.format);
     WriteHWRegs(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(framebuffer_config[screen_id].active_fb)), 4,
             &info.shown_fb);
+
+    if (Pica::g_debug_context)
+        Pica::g_debug_context->OnEvent(Pica::DebugContext::Event::BufferSwapped, nullptr);
 }
 
 /**
@@ -448,6 +452,9 @@ static void ExecuteCommand(const Command& command, u32 thread_id) {
     default:
         LOG_ERROR(Service_GSP, "unknown command 0x%08X", (int)command.id.Value());
     }
+
+    if (Pica::g_debug_context)
+        Pica::g_debug_context->OnEvent(Pica::DebugContext::Event::GSPCommandProcessed, (void*)&command);
 }
 
 /**

--- a/src/core/hw/gpu.cpp
+++ b/src/core/hw/gpu.cpp
@@ -151,6 +151,10 @@ inline void Write(u32 addr, const T data) {
     {
         const auto& config = g_regs.display_transfer_config;
         if (config.trigger & 1) {
+
+            if (Pica::g_debug_context)
+                Pica::g_debug_context->OnEvent(Pica::DebugContext::Event::IncomingDisplayTransfer, nullptr);
+
             u8* src_pointer = Memory::GetPhysicalPointer(config.GetPhysicalInputAddress());
             u8* dst_pointer = Memory::GetPhysicalPointer(config.GetPhysicalOutputAddress());
 

--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -50,7 +50,7 @@ static inline void WritePicaReg(u32 id, u32 value, u32 mask) {
     regs[id] = (old_value & ~mask) | (value & mask);
 
     if (g_debug_context)
-        g_debug_context->OnEvent(DebugContext::Event::CommandLoaded, reinterpret_cast<void*>(&id));
+        g_debug_context->OnEvent(DebugContext::Event::PicaCommandLoaded, reinterpret_cast<void*>(&id));
 
     DebugUtils::OnPicaRegWrite(id, regs[id]);
 
@@ -428,7 +428,7 @@ static inline void WritePicaReg(u32 id, u32 value, u32 mask) {
     VideoCore::g_renderer->hw_rasterizer->NotifyPicaRegisterChanged(id);
 
     if (g_debug_context)
-        g_debug_context->OnEvent(DebugContext::Event::CommandProcessed, reinterpret_cast<void*>(&id));
+        g_debug_context->OnEvent(DebugContext::Event::PicaCommandProcessed, reinterpret_cast<void*>(&id));
 }
 
 void ProcessCommandList(const u32* list, u32 size) {

--- a/src/video_core/debug_utils/debug_utils.h
+++ b/src/video_core/debug_utils/debug_utils.h
@@ -25,11 +25,14 @@ public:
     enum class Event {
         FirstEvent = 0,
 
-        CommandLoaded = FirstEvent,
-        CommandProcessed,
+        PicaCommandLoaded = FirstEvent,
+        PicaCommandProcessed,
         IncomingPrimitiveBatch,
         FinishedPrimitiveBatch,
         VertexLoaded,
+        IncomingDisplayTransfer,
+        GSPCommandProcessed,
+        BufferSwapped,
 
         NumEvents
     };


### PR DESCRIPTION
* IncomingDisplayTransfer: Triggered just before a display transfer is performed.
* GSPCommandProcessed: Triggered right after a GSP command is processed.
* BufferSwap: Triggered when the buffers flip

As a side note, I suggest dropping the Pica naming from these classes and having them be used for general GPU breakpoints, and then get rid of the GraphicsDebugger class.