### PR TITLE
Qt/GPU Breakpoints: Changed the widget to have a checkbox next to each bp type

### DIFF
--- a/src/citra_qt/debugger/graphics_breakpoints.h
+++ b/src/citra_qt/debugger/graphics_breakpoints.h
@@ -31,10 +31,9 @@ public:
 
 public slots:
     void OnBreakPointHit(Pica::DebugContext::Event event, void* data);
+    void OnItemDoubleClicked(const QModelIndex&);
     void OnResumeRequested();
     void OnResumed();
-    void OnBreakpointSelectionChanged(const QModelIndex&);
-    void OnToggleBreakpointEnabled();
 
 signals:
     void Resumed();
@@ -42,11 +41,8 @@ signals:
     void BreakPointsChanged(const QModelIndex& topLeft, const QModelIndex& bottomRight);
 
 private:
-    void UpdateToggleBreakpointButton(const QModelIndex& index);
-
     QLabel* status_text;
     QPushButton* resume_button;
-    QPushButton* toggle_breakpoint_button;
 
     BreakPointModel* breakpoint_model;
     QTreeView* breakpoint_list;

--- a/src/citra_qt/debugger/graphics_breakpoints_p.h
+++ b/src/citra_qt/debugger/graphics_breakpoints_p.h
@@ -23,7 +23,7 @@ public:
     int columnCount(const QModelIndex& parent = QModelIndex()) const override;
     int rowCount(const QModelIndex& parent = QModelIndex()) const override;
     QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
-    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+    Qt::ItemFlags flags(const QModelIndex &index) const;
 
     bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole) override;
 


### PR DESCRIPTION
Changed it so that we don't have to select and click the Enable button when enabling/disabling a breakpoint, now it is done via a checkbox next to the breakpoint's name.

Removed the now redundant Enable button and second column of the list.
The QTreeView's headers are now hidden, seeing how we don't need them anymore.

Pic
![Pic](http://i.imgur.com/9Nadg8e.png)