### PR TITLE
VideoCore: #ifdef out some debugging routines

### DIFF
--- a/src/video_core/debug_utils/debug_utils.cpp
+++ b/src/video_core/debug_utils/debug_utils.cpp
@@ -90,10 +90,6 @@ void GeometryDumper::AddTriangle(Vertex& v0, Vertex& v1, Vertex& v2) {
 }
 
 void GeometryDumper::Dump() {
-    // NOTE: Permanently enabling this just trashes the hard disk for no reason.
-    //       Hence, this is currently disabled.
-    return;
-
     static int index = 0;
     std::string filename = std::string("geometry_dump") + std::to_string(++index) + ".obj";
 
@@ -116,10 +112,6 @@ void GeometryDumper::Dump() {
 void DumpShader(const u32* binary_data, u32 binary_size, const u32* swizzle_data, u32 swizzle_size,
                 u32 main_offset, const Regs::VSOutputAttributes* output_attributes)
 {
-    // NOTE: Permanently enabling this just trashes hard disks for no reason.
-    //       Hence, this is currently disabled.
-    return;
-
     struct StuffToWrite {
         u8* pointer;
         u32 size;
@@ -565,10 +557,6 @@ TextureInfo TextureInfo::FromPicaRegister(const Regs::TextureConfig& config,
 }
 
 void DumpTexture(const Pica::Regs::TextureConfig& texture_config, u8* data) {
-    // NOTE: Permanently enabling this just trashes hard disks for no reason.
-    //       Hence, this is currently disabled.
-    return;
-
 #ifndef HAVE_PNG
     return;
 #else

--- a/src/video_core/debug_utils/debug_utils.h
+++ b/src/video_core/debug_utils/debug_utils.h
@@ -157,6 +157,11 @@ extern std::shared_ptr<DebugContext> g_debug_context; // TODO: Get rid of this g
 
 namespace DebugUtils {
 
+#define PICA_DUMP_GEOMETRY 0
+#define PICA_DUMP_SHADERS 0
+#define PICA_DUMP_TEXTURES 0
+#define PICA_LOG_TEV 0
+
 // Simple utility class for dumping geometry data to an OBJ file
 class GeometryDumper {
 public:

--- a/src/video_core/rasterizer.cpp
+++ b/src/video_core/rasterizer.cpp
@@ -462,7 +462,9 @@ static void ProcessTriangleInternal(const VertexShader::OutputVertex& v0,
 
                     // TODO: Apply the min and mag filters to the texture
                     texture_color[i] = DebugUtils::LookupTexture(texture_data, s, t, info);
+#if PICA_DUMP_TEXTURES
                     DebugUtils::DumpTexture(texture.config, texture_data);
+#endif
                 }
             }
 

--- a/src/video_core/vertex_shader.cpp
+++ b/src/video_core/vertex_shader.cpp
@@ -582,9 +582,11 @@ OutputVertex RunShader(const InputVertex& input, int num_attributes, const Regs:
     state.conditional_code[1] = false;
 
     ProcessShaderCode(state);
+#if PICA_DUMP_SHADERS
     DebugUtils::DumpShader(setup.program_code.data(), state.debug.max_offset, setup.swizzle_data.data(),
                            state.debug.max_opdesc_id, config.main_offset,
                            g_state.regs.vs_output_attributes); // TODO: Don't hardcode VS here
+#endif
 
     // Setup output data
     OutputVertex ret;


### PR DESCRIPTION
Some disabled debugging functionality was being called from rendering
routines in VideoCore. Although disabled, many of them still allocated
memory or did some extra work that was enough to show up in a profiler.
Gives a slight (~2ms) speedup.