### PR TITLE
Remove dead gpu_refresh_rate option from the default ini file

### DIFF
--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -33,10 +33,6 @@ pad_cleft =
 pad_cright =
 
 [Core]
-# The refresh rate for the GPU
-# Defaults to 30
-gpu_refresh_rate =
-
 # The applied frameskip amount. Must be a power of two.
 # 0 (default): No frameskip, 1: x2 frameskip, 2: x4 frameskip, 3: x8 frameskip, etc.
 frame_skip =


### PR DESCRIPTION
It got forgotten in d65b42a69abbde2130c77917e7db5722799a6896.