### PR TITLE
GPU: Implement TextureCopy-mode display transfers

### DIFF
--- a/src/core/hle/service/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp_gpu.cpp
@@ -418,7 +418,7 @@ static void ExecuteCommand(const Command& command, u32 thread_id) {
 
     case CommandId::SET_DISPLAY_TRANSFER:
     {
-        auto& params = command.image_copy;
+        auto& params = command.display_transfer;
         WriteGPURegister(static_cast<u32>(GPU_REG_INDEX(display_transfer_config.input_address)),
                 Memory::VirtualToPhysicalAddress(params.in_buffer_address) >> 3);
         WriteGPURegister(static_cast<u32>(GPU_REG_INDEX(display_transfer_config.output_address)),
@@ -433,17 +433,22 @@ static void ExecuteCommand(const Command& command, u32 thread_id) {
     // TODO: Check if texture copies are implemented correctly..
     case CommandId::SET_TEXTURE_COPY:
     {
-        auto& params = command.image_copy;
-        WriteGPURegister(static_cast<u32>(GPU_REG_INDEX(display_transfer_config.input_address)),
+        auto& params = command.texture_copy;
+        WriteGPURegister((u32)GPU_REG_INDEX(display_transfer_config.input_address),
                 Memory::VirtualToPhysicalAddress(params.in_buffer_address) >> 3);
-        WriteGPURegister(static_cast<u32>(GPU_REG_INDEX(display_transfer_config.output_address)),
+        WriteGPURegister((u32)GPU_REG_INDEX(display_transfer_config.output_address),
                 Memory::VirtualToPhysicalAddress(params.out_buffer_address) >> 3);
-        WriteGPURegister(static_cast<u32>(GPU_REG_INDEX(display_transfer_config.input_size)), params.in_buffer_size);
-        WriteGPURegister(static_cast<u32>(GPU_REG_INDEX(display_transfer_config.output_size)), params.out_buffer_size);
-        WriteGPURegister(static_cast<u32>(GPU_REG_INDEX(display_transfer_config.flags)), params.flags);
+        WriteGPURegister((u32)GPU_REG_INDEX(display_transfer_config.texture_copy.size),
+                params.size);
+        WriteGPURegister((u32)GPU_REG_INDEX(display_transfer_config.texture_copy.input_size),
+                params.in_width_gap);
+        WriteGPURegister((u32)GPU_REG_INDEX(display_transfer_config.texture_copy.output_size),
+                params.out_width_gap);
+        WriteGPURegister((u32)GPU_REG_INDEX(display_transfer_config.flags),
+                params.flags);
 
-        // TODO: Should this register be set to 1 or should instead its value be OR-ed with 1?
-        WriteGPURegister(static_cast<u32>(GPU_REG_INDEX(display_transfer_config.trigger)), 1);
+        // NOTE: Actual GSP ORs 1 with current register instead of overwriting. Doesn't seem to matter.
+        WriteGPURegister((u32)GPU_REG_INDEX(display_transfer_config.trigger), 1);
         break;
     }
 

--- a/src/core/hle/service/gsp_gpu.h
+++ b/src/core/hle/service/gsp_gpu.h
@@ -127,7 +127,16 @@ struct Command {
             u32 in_buffer_size;
             u32 out_buffer_size;
             u32 flags;
-        } image_copy;
+        } display_transfer;
+
+        struct {
+            u32 in_buffer_address;
+            u32 out_buffer_address;
+            u32 size;
+            u32 in_width_gap;
+            u32 out_width_gap;
+            u32 flags;
+        } texture_copy;
 
         u8 raw_data[0x1C];
     };

--- a/src/core/hw/gpu.h
+++ b/src/core/hw/gpu.h
@@ -201,12 +201,14 @@ struct Regs {
             u32 flags;
 
             BitField< 0, 1, u32> flip_vertically;  // flips input data vertically
-            BitField< 1, 1, u32> output_tiled;     // Converts from linear to tiled format
-            BitField< 3, 1, u32> raw_copy;         // Copies the data without performing any processing
+            BitField< 1, 1, u32> input_linear;     // Converts from linear to tiled format
+            BitField< 2, 1, u32> crop_input_lines;
+            BitField< 3, 1, u32> is_texture_copy;  // Copies the data without performing any processing and respecting texture copy fields
             BitField< 5, 1, u32> dont_swizzle;
             BitField< 8, 3, PixelFormat> input_format;
             BitField<12, 3, PixelFormat> output_format;
-
+            /// Uses some kind of 32x32 block swizzling mode, instead of the usual 8x8 one.
+            BitField<16, 1, u32> block_32; // TODO(yuriks): unimplemented
             BitField<24, 2, ScalingMode> scaling; // Determines the scaling mode of the transfer
         };
 
@@ -214,10 +216,30 @@ struct Regs {
 
         // it seems that writing to this field triggers the display transfer
         u32 trigger;
-    } display_transfer_config;
-    ASSERT_MEMBER_SIZE(display_transfer_config, 0x1c);
 
-    INSERT_PADDING_WORDS(0x331);
+        INSERT_PADDING_WORDS(0x1);
+
+        struct {
+            u32 size;
+
+            union {
+                u32 input_size;
+
+                BitField< 0, 16, u32> input_width;
+                BitField<16, 16, u32> input_gap;
+            };
+
+            union {
+                u32 output_size;
+
+                BitField< 0, 16, u32> output_width;
+                BitField<16, 16, u32> output_gap;
+            };
+        } texture_copy;
+    } display_transfer_config;
+    ASSERT_MEMBER_SIZE(display_transfer_config, 0x2c);
+
+    INSERT_PADDING_WORDS(0x32D);
 
     struct {
         // command list size (in bytes)


### PR DESCRIPTION
Fixes glitchy garbage in Fire Emblem 3D scenes.