### PR TITLE
citra-qt: Improve pica command list widget (add mask, fix some issues)

### DIFF
--- a/src/citra_qt/debugger/graphics_cmdlists.cpp
+++ b/src/citra_qt/debugger/graphics_cmdlists.cpp
@@ -300,7 +300,9 @@ GPUCommandListWidget::GPUCommandListWidget(QWidget* parent) : QDockWidget(tr("Pi
 
     list_widget = new QTreeView;
     list_widget->setModel(model);
-    list_widget->setFont(QFont("monospace"));
+    QFont font("monospace");
+    font.setStyleHint(QFont::Monospace); // Automatic fallback to a monospace font on on platforms without a font called "monospace"
+    list_widget->setFont(font);
     list_widget->setRootIsDecorated(false);
     list_widget->setUniformRowHeights(true);
 

--- a/src/citra_qt/debugger/graphics_cmdlists.cpp
+++ b/src/citra_qt/debugger/graphics_cmdlists.cpp
@@ -262,7 +262,7 @@ void GPUCommandListWidget::OnCommandDoubleClicked(const QModelIndex& index) {
 }
 
 void GPUCommandListWidget::SetCommandInfo(const QModelIndex& index) {
-    QWidget* new_info_widget;
+    QWidget* new_info_widget = nullptr;
 
     const unsigned int command_id = list_widget->model()->data(index, GPUCommandListModel::CommandIdRole).toUInt();
     if (COMMAND_IN_RANGE(command_id, texture0) ||
@@ -283,14 +283,15 @@ void GPUCommandListWidget::SetCommandInfo(const QModelIndex& index) {
         auto info = Pica::DebugUtils::TextureInfo::FromPicaRegister(config, format);
         u8* src = Memory::GetPhysicalPointer(config.GetPhysicalAddress());
         new_info_widget = new TextureInfoWidget(src, info);
-    } else {
-        new_info_widget = new QWidget;
     }
-
-    widget()->layout()->removeWidget(command_info_widget);
-    delete command_info_widget;
-    widget()->layout()->addWidget(new_info_widget);
-    command_info_widget = new_info_widget;
+    if (command_info_widget) {
+        delete command_info_widget;
+        command_info_widget = nullptr;
+    }
+    if (new_info_widget) {
+        widget()->layout()->addWidget(new_info_widget);
+        command_info_widget = new_info_widget;
+    }
 }
 #undef COMMAND_IN_RANGE
 
@@ -328,7 +329,7 @@ GPUCommandListWidget::GPUCommandListWidget(QWidget* parent) : QDockWidget(tr("Pi
 
     connect(copy_all, SIGNAL(clicked()), this, SLOT(CopyAllToClipboard()));
 
-    command_info_widget = new QWidget;
+    command_info_widget = nullptr;
 
     QVBoxLayout* main_layout = new QVBoxLayout;
     main_layout->addWidget(list_widget);
@@ -338,7 +339,6 @@ GPUCommandListWidget::GPUCommandListWidget(QWidget* parent) : QDockWidget(tr("Pi
         sub_layout->addWidget(copy_all);
         main_layout->addLayout(sub_layout);
     }
-    main_layout->addWidget(command_info_widget);
     main_widget->setLayout(main_layout);
 
     setWidget(main_widget);

--- a/src/citra_qt/debugger/graphics_cmdlists.cpp
+++ b/src/citra_qt/debugger/graphics_cmdlists.cpp
@@ -175,29 +175,29 @@ int GPUCommandListModel::rowCount(const QModelIndex& parent) const {
 }
 
 int GPUCommandListModel::columnCount(const QModelIndex& parent) const {
-    return 3;
+    return 4;
 }
 
 QVariant GPUCommandListModel::data(const QModelIndex& index, int role) const {
     if (!index.isValid())
         return QVariant();
 
-    const auto& writes = pica_trace.writes;
-    const Pica::CommandProcessor::CommandHeader cmd{writes[index.row()].Id()};
-    const u32 val{writes[index.row()].Value()};
+    const auto& write = pica_trace.writes[index.row()];
 
     if (role == Qt::DisplayRole) {
         QString content;
         switch ( index.column() ) {
         case 0:
-            return QString::fromLatin1(Pica::Regs::GetCommandName(cmd.cmd_id).c_str());
+            return QString::fromLatin1(Pica::Regs::GetCommandName(write.cmd_id).c_str());
         case 1:
-            return QString("%1").arg(cmd.cmd_id, 3, 16, QLatin1Char('0'));
+            return QString("%1").arg(write.cmd_id, 3, 16, QLatin1Char('0'));
         case 2:
-            return QString("%1").arg(val, 8, 16, QLatin1Char('0'));
+            return QString("%1").arg(write.mask, 4, 2, QLatin1Char('0'));
+        case 3:
+            return QString("%1").arg(write.value, 8, 16, QLatin1Char('0'));
         }
     } else if (role == CommandIdRole) {
-        return QVariant::fromValue<int>(cmd.cmd_id.Value());
+        return QVariant::fromValue<int>(write.cmd_id);
     }
 
     return QVariant();
@@ -213,6 +213,8 @@ QVariant GPUCommandListModel::headerData(int section, Qt::Orientation orientatio
         case 1:
             return tr("Register");
         case 2:
+            return tr("Mask");
+        case 3:
             return tr("New Value");
         }
 

--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -35,7 +35,15 @@ static u32 default_attr_write_buffer[3];
 
 Common::Profiling::TimingCategory category_drawing("Drawing");
 
-static inline void WritePicaReg(u32 id, u32 value, u32 mask) {
+// Expand a 4-bit mask to 4-byte mask, e.g. 0b0101 -> 0x00FF00FF
+static const u32 expand_bits_to_bytes[] = {
+    0x00000000, 0x000000ff, 0x0000ff00, 0x0000ffff,
+    0x00ff0000, 0x00ff00ff, 0x00ffff00, 0x00ffffff,
+    0xff000000, 0xff0000ff, 0xff00ff00, 0xff00ffff,
+    0xffff0000, 0xffff00ff, 0xffffff00, 0xffffffff
+};
+
+static void WritePicaReg(u32 id, u32 value, u32 mask) {
     auto& regs = g_state.regs;
 
     if (id >= regs.NumIds())
@@ -47,12 +55,15 @@ static inline void WritePicaReg(u32 id, u32 value, u32 mask) {
 
     // TODO: Figure out how register masking acts on e.g. vs.uniform_setup.set_value
     u32 old_value = regs[id];
-    regs[id] = (old_value & ~mask) | (value & mask);
+
+    const u32 write_mask = expand_bits_to_bytes[mask];
+
+    regs[id] = (old_value & ~write_mask) | (value & write_mask);
+
+    DebugUtils::OnPicaRegWrite({ (u16)id, (u16)mask, regs[id] });
 
     if (g_debug_context)
         g_debug_context->OnEvent(DebugContext::Event::PicaCommandLoaded, reinterpret_cast<void*>(&id));
-
-    DebugUtils::OnPicaRegWrite(id, regs[id]);
 
     switch(id) {
         // Trigger IRQ
@@ -436,13 +447,6 @@ void ProcessCommandList(const u32* list, u32 size) {
     g_state.cmd_list.length = size / sizeof(u32);
 
     while (g_state.cmd_list.current_ptr < g_state.cmd_list.head_ptr + g_state.cmd_list.length) {
-        // Expand a 4-bit mask to 4-byte mask, e.g. 0b0101 -> 0x00FF00FF
-        static const u32 expand_bits_to_bytes[] = {
-            0x00000000, 0x000000ff, 0x0000ff00, 0x0000ffff,
-            0x00ff0000, 0x00ff00ff, 0x00ffff00, 0x00ffffff,
-            0xff000000, 0xff0000ff, 0xff00ff00, 0xff00ffff,
-            0xffff0000, 0xffff00ff, 0xffffff00, 0xffffffff
-        };
 
         // Align read pointer to 8 bytes
         if ((g_state.cmd_list.head_ptr - g_state.cmd_list.current_ptr) % 2 != 0)
@@ -450,14 +454,13 @@ void ProcessCommandList(const u32* list, u32 size) {
 
         u32 value = *g_state.cmd_list.current_ptr++;
         const CommandHeader header = { *g_state.cmd_list.current_ptr++ };
-        const u32 write_mask = expand_bits_to_bytes[header.parameter_mask];
         u32 cmd = header.cmd_id;
 
-        WritePicaReg(cmd, value, write_mask);
+        WritePicaReg(cmd, value, header.parameter_mask);
 
         for (unsigned i = 0; i < header.extra_data_length; ++i) {
             u32 cmd = header.cmd_id + (header.group_commands ? i + 1 : 0);
-            WritePicaReg(cmd, *g_state.cmd_list.current_ptr++, write_mask);
+            WritePicaReg(cmd, *g_state.cmd_list.current_ptr++, header.parameter_mask);
          }
     }
 }

--- a/src/video_core/debug_utils/debug_utils.cpp
+++ b/src/video_core/debug_utils/debug_utils.cpp
@@ -280,7 +280,7 @@ bool IsPicaTracing()
     return is_pica_tracing != 0;
 }
 
-void OnPicaRegWrite(u32 id, u32 value)
+void OnPicaRegWrite(PicaTrace::Write write)
 {
     // Double check for is_pica_tracing to avoid pointless locking overhead
     if (!is_pica_tracing)
@@ -291,7 +291,7 @@ void OnPicaRegWrite(u32 id, u32 value)
     if (!is_pica_tracing)
         return;
 
-    pica_trace->writes.emplace_back(id, value);
+    pica_trace->writes.push_back(write);
 }
 
 std::unique_ptr<PicaTrace> FinishPicaTracing()

--- a/src/video_core/debug_utils/debug_utils.h
+++ b/src/video_core/debug_utils/debug_utils.h
@@ -183,21 +183,17 @@ void DumpShader(const u32* binary_data, u32 binary_size, const u32* swizzle_data
 
 // Utility class to log Pica commands.
 struct PicaTrace {
-    struct Write : public std::pair<u32,u32> {
-        Write(u32 id, u32 value) : std::pair<u32,u32>(id, value) {}
-
-        u32& Id() { return first; }
-        const u32& Id() const { return first; }
-
-        u32& Value() { return second; }
-        const u32& Value() const { return second; }
+    struct Write {
+        u16 cmd_id;
+        u16 mask;
+        u32 value;
     };
     std::vector<Write> writes;
 };
 
 void StartPicaTracing();
 bool IsPicaTracing();
-void OnPicaRegWrite(u32 id, u32 value);
+void OnPicaRegWrite(PicaTrace::Write write);
 std::unique_ptr<PicaTrace> FinishPicaTracing();
 
 struct TextureInfo {


### PR DESCRIPTION
The monospace font was not being used on Windows, this has been fixed.
I added the mask and moved its expansion into WritePicaReg.
A widget was created to replace the previous one every single time a row was selected, which caused some slowdowns. No widget is now created if not needed.