### PR TITLE
Update Start menu text to match with the real state of the emulator.

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -263,6 +263,7 @@ void GMainWindow::ShutdownGame() {
 
     // Update the GUI
     ui.action_Start->setEnabled(false);
+    ui.action_Start->setText(tr("Start"));
     ui.action_Pause->setEnabled(false);
     ui.action_Stop->setEnabled(false);
     render_window->hide();
@@ -291,6 +292,8 @@ void GMainWindow::OnStartGame()
     emu_thread->SetRunning(true);
 
     ui.action_Start->setEnabled(false);
+    ui.action_Start->setText(tr("Continue"));
+
     ui.action_Pause->setEnabled(true);
     ui.action_Stop->setEnabled(true);
 }


### PR DESCRIPTION
Small change to update the start menu. With this commit, the start menu is renamed to "Continue" while the emulator is running. In stop function, the start menu text is set back to "Start".