### PR TITLE
Settings: Fix saving wrong values for input configuration

### DIFF
--- a/src/citra_qt/config.cpp
+++ b/src/citra_qt/config.cpp
@@ -66,7 +66,8 @@ void Config::ReadValues() {
 void Config::SaveValues() {
     qt_config->beginGroup("Controls");
     for (int i = 0; i < Settings::NativeInput::NUM_INPUTS; ++i) {
-        qt_config->setValue(QString::fromStdString(Settings::NativeInput::Mapping[i]), Settings::NativeInput::All[i]);
+        qt_config->setValue(QString::fromStdString(Settings::NativeInput::Mapping[i]),
+            Settings::values.input_mappings[Settings::NativeInput::All[i]]);
     }
     qt_config->endGroup();
 


### PR DESCRIPTION
There was a mistake in #873 where the values that get saved are just the index of the buttons, not the key mapped to the buttons.