### PR TITLE
citra-qt: Adjust initializer list order

### DIFF
--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -94,7 +94,7 @@ private:
 };
 
 GRenderWindow::GRenderWindow(QWidget* parent, EmuThread* emu_thread) :
-    QWidget(parent), emu_thread(emu_thread), keyboard_id(0) {
+    QWidget(parent), keyboard_id(0), emu_thread(emu_thread) {
 
     std::string window_title = Common::StringFromFormat("Citra | %s-%s", Common::g_scm_branch, Common::g_scm_desc);
     setWindowTitle(QString::fromStdString(window_title));

--- a/src/citra_qt/debugger/disassembler.cpp
+++ b/src/citra_qt/debugger/disassembler.cpp
@@ -159,7 +159,7 @@ void DisassemblerModel::SetNextInstruction(unsigned int address) {
 }
 
 DisassemblerWidget::DisassemblerWidget(QWidget* parent, EmuThread* emu_thread) :
-    QDockWidget(parent), emu_thread(emu_thread), base_addr(0) {
+    QDockWidget(parent), base_addr(0), emu_thread(emu_thread) {
 
     disasm_ui.setupUi(this);
 


### PR DESCRIPTION
Silences two warnings