### PR TITLE
citra-qt: save path for recent files loaded

### DIFF
--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -24,6 +24,8 @@ class GMainWindow : public QMainWindow
 {
     Q_OBJECT
 
+    static const int max_recent_files_item = 10; ///< Max number of recently loaded items to keep track
+
     // TODO: Make use of this!
     enum {
         UI_IDLE,
@@ -58,6 +60,8 @@ private:
     void BootGame(const std::string& filename);
     void ShutdownGame();
 
+    void UpdateRecentFiles();
+
     void closeEvent(QCloseEvent* event) override;
 
 private slots:
@@ -66,6 +70,7 @@ private slots:
     void OnStopGame();
     void OnMenuLoadFile();
     void OnMenuLoadSymbolMap();
+    void OnMenuRecentFile();
     void OnOpenHotkeysDialog();
     void OnConfigure();
     void OnDisplayTitleBars(bool);
@@ -85,6 +90,8 @@ private:
     CallstackWidget* callstackWidget;
     GPUCommandStreamWidget* graphicsWidget;
     GPUCommandListWidget* graphicsCommandsWidget;
+
+    QAction* actions_recent_files[max_recent_files_item];
 };
 
 #endif // _CITRA_QT_MAIN_HXX_

--- a/src/citra_qt/main.ui
+++ b/src/citra_qt/main.ui
@@ -52,8 +52,15 @@
     <property name="title">
      <string>&amp;File</string>
     </property>
+    <widget class="QMenu" name="menu_recent_files">
+     <property name="title">
+      <string>Recent Files</string>
+     </property>
+    </widget>
     <addaction name="action_Load_File"/>
     <addaction name="action_Load_Symbol_Map"/>
+    <addaction name="separator"/>
+    <addaction name="menu_recent_files"/>
     <addaction name="separator"/>
     <addaction name="action_Exit"/>
    </widget>


### PR DESCRIPTION
I propose to save the path to files recently loaded (symbols and roms).

I am not sure how to avoid the new variables in the class. I think, I am forced to add the QSignalMapper. About the list of paths, I could avoid it, using QSettings, but it would make the code more complicated.
