### PR TITLE
Handle invalid `Log::Level::Count`

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cstdio>
 
+#include "common/assert.h"
 #include "common/common_funcs.h" // snprintf compatibility define
 #include "common/logging/backend.h"
 #include "common/logging/filter.h"
@@ -78,8 +79,10 @@ const char* GetLevelName(Level log_level) {
         LVL(Warning);
         LVL(Error);
         LVL(Critical);
+        case Level::Count:
+            ASSERT_MSG(false, "invalid log level");
+            return "Unknown";
     }
-    return "Unknown";
 #undef LVL
 }
 

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -80,8 +80,7 @@ const char* GetLevelName(Level log_level) {
         LVL(Error);
         LVL(Critical);
         case Level::Count:
-            ASSERT_MSG(false, "invalid log level");
-            return "Unknown";
+            UNREACHABLE();
     }
 #undef LVL
 }

--- a/src/common/logging/text_formatter.cpp
+++ b/src/common/logging/text_formatter.cpp
@@ -14,6 +14,7 @@
 #include "common/logging/log.h"
 #include "common/logging/text_formatter.h"
 
+#include "common/assert.h"
 #include "common/common_funcs.h"
 #include "common/string_util.h"
 
@@ -82,6 +83,8 @@ void PrintColoredMessage(const Entry& entry) {
         color = FOREGROUND_RED | FOREGROUND_INTENSITY; break;
     case Level::Critical: // Bright magenta
         color = FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_INTENSITY; break;
+    case Level::Count:
+        ASSERT_MSG(false, "invalid log level"); break;
     }
 
     SetConsoleTextAttribute(console_handle, color);
@@ -101,6 +104,8 @@ void PrintColoredMessage(const Entry& entry) {
         color = ESC "[1;31m"; break;
     case Level::Critical: // Bright magenta
         color = ESC "[1;35m"; break;
+    case Level::Count:
+        ASSERT_MSG(false, "invalid log level"); break;
     }
 
     fputs(color, stderr);

--- a/src/common/logging/text_formatter.cpp
+++ b/src/common/logging/text_formatter.cpp
@@ -84,7 +84,7 @@ void PrintColoredMessage(const Entry& entry) {
     case Level::Critical: // Bright magenta
         color = FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_INTENSITY; break;
     case Level::Count:
-        ASSERT_MSG(false, "invalid log level"); break;
+        UNREACHABLE();
     }
 
     SetConsoleTextAttribute(console_handle, color);
@@ -105,7 +105,7 @@ void PrintColoredMessage(const Entry& entry) {
     case Level::Critical: // Bright magenta
         color = ESC "[1;35m"; break;
     case Level::Count:
-        ASSERT_MSG(false, "invalid log level"); break;
+        UNREACHABLE();
     }
 
     fputs(color, stderr);


### PR DESCRIPTION
Add a case of `Log::Level::Count` to all switch statements that dispatch on `Log::Level`.  The case simply asserts `false` and notes the invalid log level.

This removes a couple warnings under Clang.