### PR TITLE
Common: Work around bug in MSVC2015 standard library

### DIFF
--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -296,14 +296,28 @@ std::string ReplaceAll(std::string result, const std::string& src, const std::st
 
 std::string UTF16ToUTF8(const std::u16string& input)
 {
+#if _MSC_VER >= 1900
+    // Workaround for missing char16_t/char32_t instantiations in MSVC2015
+    std::wstring_convert<std::codecvt_utf8_utf16<__int16>, __int16> convert;
+    std::basic_string<__int16> tmp_buffer(input.cbegin(), input.cend());
+    return convert.to_bytes(tmp_buffer);
+#else
     std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> convert;
     return convert.to_bytes(input);
+#endif
 }
 
 std::u16string UTF8ToUTF16(const std::string& input)
 {
+#if _MSC_VER >= 1900
+    // Workaround for missing char16_t/char32_t instantiations in MSVC2015
+    std::wstring_convert<std::codecvt_utf8_utf16<__int16>, __int16> convert;
+    auto tmp_buffer = convert.from_bytes(input);
+    return std::u16string(tmp_buffer.cbegin(), tmp_buffer.cend());
+#else
     std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> convert;
     return convert.from_bytes(input);
+#endif
 }
 
 static std::string UTF16ToUTF8(const std::wstring& input)


### PR DESCRIPTION
The char16_t/char32_t implementations aren't present in the library and
cause linker errors. This is a known issue that wasn't fixed in VS2015
RTM.