### PR TITLE
Disassembler: ARMv6K instructions

### DIFF
--- a/src/core/arm/disassembler/arm_disasm.h
+++ b/src/core/arm/disassembler/arm_disasm.h
@@ -41,11 +41,13 @@ enum Opcode {
     OP_MSR,
     OP_MUL,
     OP_MVN,
+    OP_NOP,
     OP_ORR,
     OP_PLD,
     OP_RSB,
     OP_RSC,
     OP_SBC,
+    OP_SEV,
     OP_SMLAL,
     OP_SMULL,
     OP_STC,
@@ -63,6 +65,9 @@ enum Opcode {
     OP_TST,
     OP_UMLAL,
     OP_UMULL,
+    OP_WFE,
+    OP_WFI,
+    OP_YIELD,
 
     // Define thumb opcodes
     OP_THUMB_UNDEFINED,
@@ -118,6 +123,7 @@ class ARM_Disasm {
   static Opcode Decode10(uint32_t insn);
   static Opcode Decode11(uint32_t insn);
   static Opcode DecodeMUL(uint32_t insn);
+  static Opcode DecodeMSRImmAndHints(uint32_t insn);
   static Opcode DecodeLDRH(uint32_t insn);
   static Opcode DecodeALU(uint32_t insn);
 
@@ -135,6 +141,7 @@ class ARM_Disasm {
   static std::string DisassembleMUL(Opcode opcode, uint32_t insn);
   static std::string DisassembleMRS(uint32_t insn);
   static std::string DisassembleMSR(uint32_t insn);
+  static std::string DisassembleNoOperands(Opcode opcode, uint32_t insn);
   static std::string DisassemblePLD(uint32_t insn);
   static std::string DisassembleSWI(uint32_t insn);
   static std::string DisassembleSWP(Opcode opcode, uint32_t insn);

--- a/src/core/arm/disassembler/arm_disasm.h
+++ b/src/core/arm/disassembler/arm_disasm.h
@@ -20,6 +20,7 @@ enum Opcode {
     OP_BLX,
     OP_BX,
     OP_CDP,
+    OP_CLREX,
     OP_CLZ,
     OP_CMN,
     OP_CMP,
@@ -29,6 +30,10 @@ enum Opcode {
     OP_LDR,
     OP_LDRB,
     OP_LDRBT,
+    OP_LDREX,
+    OP_LDREXB,
+    OP_LDREXD,
+    OP_LDREXH,
     OP_LDRH,
     OP_LDRSB,
     OP_LDRSH,
@@ -55,6 +60,10 @@ enum Opcode {
     OP_STR,
     OP_STRB,
     OP_STRBT,
+    OP_STREX,
+    OP_STREXB,
+    OP_STREXD,
+    OP_STREXH,
     OP_STRH,
     OP_STRT,
     OP_SUB,
@@ -122,6 +131,7 @@ class ARM_Disasm {
   static Opcode Decode01(uint32_t insn);
   static Opcode Decode10(uint32_t insn);
   static Opcode Decode11(uint32_t insn);
+  static Opcode DecodeSyncPrimitive(uint32_t insn);
   static Opcode DecodeMUL(uint32_t insn);
   static Opcode DecodeMSRImmAndHints(uint32_t insn);
   static Opcode DecodeLDRH(uint32_t insn);
@@ -143,6 +153,7 @@ class ARM_Disasm {
   static std::string DisassembleMSR(uint32_t insn);
   static std::string DisassembleNoOperands(Opcode opcode, uint32_t insn);
   static std::string DisassemblePLD(uint32_t insn);
+  static std::string DisassembleREX(Opcode opcode, uint32_t insn);
   static std::string DisassembleSWI(uint32_t insn);
   static std::string DisassembleSWP(Opcode opcode, uint32_t insn);
 };


### PR DESCRIPTION
Disassemble the following 32-bit ARMv6K hint instructions:

    NOP, SEV, WFI, WFE, YIELD

and the REX instructions:

     LDREX, LDREXB, LDREXD, LDREXH, STREX, STREXB, STREXD, STREXD

None of these instructions have Thumb encodings in the ARMv6K instruction set.