### PR TITLE
Stop defining GCC always_inline attributes as __forceinline

### DIFF
--- a/src/common/bit_field.h
+++ b/src/common/bit_field.h
@@ -141,22 +141,22 @@ public:
     BitField& operator=(const BitField&) = delete;
 #endif
 
-    __forceinline BitField& operator=(T val)
+    FORCE_INLINE BitField& operator=(T val)
     {
         Assign(val);
         return *this;
     }
 
-    __forceinline operator T() const
+    FORCE_INLINE operator T() const
     {
         return Value();
     }
 
-    __forceinline void Assign(const T& value) {
+    FORCE_INLINE void Assign(const T& value) {
         storage = (storage & ~GetMask()) | (((StorageType)value << position) & GetMask());
     }
 
-    __forceinline T Value() const
+    FORCE_INLINE T Value() const
     {
         if (std::numeric_limits<T>::is_signed)
         {
@@ -170,7 +170,7 @@ public:
     }
 
     // TODO: we may want to change this to explicit operator bool() if it's bug-free in VS2015
-    __forceinline bool ToBool() const
+    FORCE_INLINE bool ToBool() const
     {
         return Value() != 0;
     }
@@ -187,7 +187,7 @@ private:
     // Unsigned version of StorageType
     typedef typename std::make_unsigned<StorageType>::type StorageTypeU;
 
-    __forceinline StorageType GetMask() const
+    FORCE_INLINE StorageType GetMask() const
     {
         return (((StorageTypeU)~0) >> (8 * sizeof(T)-bits)) << position;
     }

--- a/src/common/common_funcs.h
+++ b/src/common/common_funcs.h
@@ -20,12 +20,13 @@
 
 #ifdef _WIN32
     // Alignment
+    #define FORCE_INLINE __forceinline
     #define MEMORY_ALIGNED16(x) __declspec(align(16)) x
     #define MEMORY_ALIGNED32(x) __declspec(align(32)) x
     #define MEMORY_ALIGNED64(x) __declspec(align(64)) x
     #define MEMORY_ALIGNED128(x) __declspec(align(128)) x
 #else
-    #define __forceinline inline __attribute__((always_inline))
+    #define FORCE_INLINE inline __attribute__((always_inline))
     #define MEMORY_ALIGNED16(x) __attribute__((aligned(16))) x
     #define MEMORY_ALIGNED32(x) __attribute__((aligned(32))) x
     #define MEMORY_ALIGNED64(x) __attribute__((aligned(64))) x


### PR DESCRIPTION
`__forceinline` is a MSVC extension, which may confuse some people working on the codebase.
Furthermore, the C++ standard dictates that all names which contain adjacent underscores are reserved.