### PR TITLE
Handle invalid `Log::Class`

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -66,8 +66,9 @@ const char* GetLogClassName(Class log_class) {
         ALL_LOG_CLASSES()
 #undef CLS
 #undef SUB
+        case Class::Count:
+            UNREACHABLE();
     }
-    return "Unknown";
 }
 
 const char* GetLevelName(Level log_level) {


### PR DESCRIPTION
Add a case of `Log::Class::Count` to the switch statement that dispatches on `Log::Class`.  The case simply calls the `UNREACHABLE` macro.

Like PR #1018, this removes a warning under Clang.