### PR TITLE
Handle `FileType::CIA` in `switch` statements

### DIFF
--- a/src/core/loader/loader.cpp
+++ b/src/core/loader/loader.cpp
@@ -77,6 +77,8 @@ static const char* GetFileTypeString(FileType type) {
         return "NCSD";
     case FileType::CXI:
         return "NCCH";
+    case FileType::CIA:
+        return "CIA";
     case FileType::ELF:
         return "ELF";
     case FileType::THREEDSX:

--- a/src/core/loader/loader.cpp
+++ b/src/core/loader/loader.cpp
@@ -136,6 +136,10 @@ ResultStatus LoadFile(const std::string& filename) {
         break;
     }
 
+    // CIA file format...
+    case FileType::CIA:
+        return ResultStatus::ErrorNotImplemented;
+
     // Error occurred durring IdentifyFile...
     case FileType::Error:
 


### PR DESCRIPTION
Give `FileType::CIA` a string representation and indicate that CIA loading support is unimplemented.

This removes a few warnings under Clang.