### PR TITLE
videocore: Added RG8 texture support

### DIFF
--- a/src/citra_qt/debugger/graphics_cmdlists.cpp
+++ b/src/citra_qt/debugger/graphics_cmdlists.cpp
@@ -73,7 +73,7 @@ TextureInfoDockWidget::TextureInfoDockWidget(const Pica::DebugUtils::TextureInfo
     format_choice->addItem(tr("RGB565"));
     format_choice->addItem(tr("RGBA4"));
     format_choice->addItem(tr("IA8"));
-    format_choice->addItem(tr("UNK6"));
+    format_choice->addItem(tr("RG8"));
     format_choice->addItem(tr("I8"));
     format_choice->addItem(tr("A8"));
     format_choice->addItem(tr("IA4"));

--- a/src/common/color.h
+++ b/src/common/color.h
@@ -69,6 +69,15 @@ inline const Math::Vec4<u8> DecodeRGB8(const u8* bytes) {
 }
 
 /**
+ * Decode a color stored in RG8 (aka HILO8) format
+ * @param bytes Pointer to encoded source color
+ * @return Result color decoded as Math::Vec4<u8>
+ */
+inline const Math::Vec4<u8> DecodeRG8(const u8* bytes) {
+    return { bytes[1], bytes[0], 0, 255 };
+}
+
+/**
  * Decode a color stored in RGB565 format
  * @param bytes Pointer to encoded source color
  * @return Result color decoded as Math::Vec4<u8>
@@ -151,6 +160,15 @@ inline void EncodeRGB8(const Math::Vec4<u8>& color, u8* bytes) {
     bytes[0] = color.b();
 }
 
+/**
+ * Encode a color as RG8 (aka HILO8) format
+ * @param color Source color to encode
+ * @param bytes Destination pointer to store encoded color
+ */
+inline void EncodeRG8(const Math::Vec4<u8>& color, u8* bytes) {
+    bytes[1] = color.r();
+    bytes[0] = color.g();
+}
 /**
  * Encode a color as RGB565 format
  * @param color Source color to encode

--- a/src/video_core/debug_utils/debug_utils.cpp
+++ b/src/video_core/debug_utils/debug_utils.cpp
@@ -359,6 +359,12 @@ const Math::Vec4<u8> LookupTexture(const u8* source, int x, int y, const Texture
         }
     }
 
+    case Regs::TextureFormat::RG8:
+    {
+        auto res = Color::DecodeRG8(source + VideoCore::GetMortonOffset(x, y, 2));
+        return { res.r(), res.g(), 0, 255 };
+    }
+
     case Regs::TextureFormat::I8:
     {
         const u8* source_ptr = source + VideoCore::GetMortonOffset(x, y, 1);

--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -163,7 +163,7 @@ struct Regs {
         RGB565       =  3,
         RGBA4        =  4,
         IA8          =  5,
-
+        RG8          =  6,  ///< @note Also called HILO8 in 3DBrew.
         I8           =  7,
         A8           =  8,
         IA4          =  9,
@@ -204,6 +204,7 @@ struct Regs {
         case TextureFormat::RGB565:
         case TextureFormat::RGBA4:
         case TextureFormat::IA8:
+        case TextureFormat::RG8:
             return 4;
 
         case TextureFormat::I4:


### PR DESCRIPTION
Manual address and rebase of #985.

Verified correct against hardware via hwtest: https://github.com/yuriks/3DS_gpu_tests/tree/hilo8-test