### PR TITLE
Shader: Implement EX2 and LG2 in interpreter/JIT

### DIFF
--- a/src/video_core/shader/shader_interpreter.cpp
+++ b/src/video_core/shader/shader_interpreter.cpp
@@ -334,6 +334,42 @@ void RunInterpreter(UnitState<Debug>& state) {
                 Record<DebugDataRecord::CMP_RESULT>(state.debug, iteration, state.conditional_code);
                 break;
 
+            case OpCode::Id::EX2:
+            {
+                Record<DebugDataRecord::SRC1>(state.debug, iteration, src1);
+                Record<DebugDataRecord::DEST_IN>(state.debug, iteration, dest);
+
+                // EX2 only takes first component exp2 and writes it to all dest components
+                float24 ex2_res = float24::FromFloat32(std::exp2(src1[0].ToFloat32()));
+                for (int i = 0; i < 4; ++i) {
+                    if (!swizzle.DestComponentEnabled(i))
+                        continue;
+
+                    dest[i] = ex2_res;
+                }
+
+                Record<DebugDataRecord::DEST_OUT>(state.debug, iteration, dest);
+                break;
+            }
+
+            case OpCode::Id::LG2:
+            {
+                Record<DebugDataRecord::SRC1>(state.debug, iteration, src1);
+                Record<DebugDataRecord::DEST_IN>(state.debug, iteration, dest);
+
+                // LG2 only takes the first component log2 and writes it to all dest components
+                float24 lg2_res = float24::FromFloat32(std::log2(src1[0].ToFloat32()));
+                for (int i = 0; i < 4; ++i) {
+                    if (!swizzle.DestComponentEnabled(i))
+                        continue;
+
+                    dest[i] = lg2_res;
+                }
+
+                Record<DebugDataRecord::DEST_OUT>(state.debug, iteration, dest);
+                break;
+            }
+
             default:
                 LOG_ERROR(HW_GPU, "Unhandled arithmetic instruction: 0x%02x (%s): 0x%08x",
                           (int)instr.opcode.Value().EffectiveOpCode(), instr.opcode.Value().GetInfo().name, instr.hex);

--- a/src/video_core/shader/shader_jit_x64.cpp
+++ b/src/video_core/shader/shader_jit_x64.cpp
@@ -25,8 +25,8 @@ const JitFunction instr_table[64] = {
     &JitCompiler::Compile_DP4,      // dp4
     nullptr,                        // dph
     nullptr,                        // unknown
-    nullptr,                        // ex2
-    nullptr,                        // lg2
+    &JitCompiler::Compile_EX2,      // ex2
+    &JitCompiler::Compile_LG2,      // lg2
     nullptr,                        // unknown
     &JitCompiler::Compile_MUL,      // mul
     nullptr,                        // lge
@@ -328,6 +328,24 @@ void JitCompiler::Compile_DP4(Instruction instr) {
         ADDPS(SRC1, R(SRC2));
     }
 
+    Compile_DestEnable(instr, SRC1);
+}
+
+void JitCompiler::Compile_EX2(Instruction instr) {
+    Compile_SwizzleSrc(instr, 1, instr.common.src1, SRC1);
+    MOVSS(XMM0, R(SRC1));
+    ABI_CallFunction(reinterpret_cast<const void*>(exp2f));
+    SHUFPS(XMM0, R(XMM0), _MM_SHUFFLE(0, 0, 0, 0));
+    MOVAPS(SRC1, R(XMM0));
+    Compile_DestEnable(instr, SRC1);
+}
+
+void JitCompiler::Compile_LG2(Instruction instr) {
+    Compile_SwizzleSrc(instr, 1, instr.common.src1, SRC1);
+    MOVSS(XMM0, R(SRC1));
+    ABI_CallFunction(reinterpret_cast<const void*>(log2f));
+    SHUFPS(XMM0, R(XMM0), _MM_SHUFFLE(0, 0, 0, 0));
+    MOVAPS(SRC1, R(XMM0));
     Compile_DestEnable(instr, SRC1);
 }
 

--- a/src/video_core/shader/shader_jit_x64.h
+++ b/src/video_core/shader/shader_jit_x64.h
@@ -37,6 +37,8 @@ public:
     void Compile_ADD(Instruction instr);
     void Compile_DP3(Instruction instr);
     void Compile_DP4(Instruction instr);
+    void Compile_EX2(Instruction instr);
+    void Compile_LG2(Instruction instr);
     void Compile_MUL(Instruction instr);
     void Compile_FLR(Instruction instr);
     void Compile_MAX(Instruction instr);


### PR DESCRIPTION
Implements the missing EX2 (exponential base 2) and LG2 (logarithm base 2) shader instructions both in the interpreter and in the JIT.

Using std::exp2 and std::log2 is probably imprecise w.r.t. the hardware. It depends on how the GPU computes floating-points operations internally and if it is still IEEE-754 compliant (despite using very likely 24-bit floating-points internally).

Note that these instructions seem to perform the operation only on the first component and assign the result to all enabled destination's components. Very simple hardware tests to verify this behavior are available here: https://github.com/aroulin/3ds-gpu-tests.

Fixes #1021