### PR TITLE
Improvements for MRU

### DIFF
--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -60,6 +60,24 @@ private:
     void BootGame(const std::string& filename);
     void ShutdownGame();
 
+    /**
+     * Stores the filename in the recently loaded files list.
+     * The new filename is stored at the beginning of the recently loaded files list.
+     * After inserting the new entry, duplicates are removed meaning that if
+     * this was inserted from \a OnMenuRecentFile(), the entry will be put on top
+     * and remove from its previous position.
+     *
+     * Finally, this function calls \a UpdateRecentFiles() to update the UI.
+     *
+     * @param filename the filename to store
+     */
+    void StoreRecentFile(const QString& filename);
+
+    /**
+     * Updates the recent files menu.
+     * Menu entries are rebuilt from the configuration file.
+     * If there is no entry in the menu, the menu is greyed out.
+     */
     void UpdateRecentFiles();
 
     void closeEvent(QCloseEvent* event) override;


### PR DESCRIPTION
* avoid duplicates
* always put the last file loaded to top of the list

I tried to add tooltips in order to show the fullpath when the mouse is hovering the item, but in fact, tooltips for QAction in QMenu are not shown at all.