### PR TITLE
Shader: Save caller-saved registers in JIT before a CALL

### DIFF
--- a/src/video_core/shader/shader_jit_x64.h
+++ b/src/video_core/shader/shader_jit_x64.h
@@ -69,6 +69,9 @@ private:
     void Compile_EvaluateCondition(Instruction instr);
     void Compile_UniformCondition(Instruction instr);
 
+    void Compile_PushCallerSavedXMM();
+    void Compile_PopCallerSavedXMM();
+
     /// Pointer to the variable that stores the current Pica code offset. Used to handle nested code blocks.
     unsigned* offset_ptr = nullptr;
 


### PR DESCRIPTION
Caller-saved registers were not saved when calling functions from the shader JIT. We must also save some XMM registers depending on their uses in the JIT and the ABI. 