### PR TITLE
Shader: Implement SGE, SGEI and SLT in interpreter/JIT

### DIFF
--- a/src/video_core/shader/shader_interpreter.cpp
+++ b/src/video_core/shader/shader_interpreter.cpp
@@ -278,6 +278,20 @@ void RunInterpreter(UnitState<Debug>& state) {
                 break;
             }
 
+            case OpCode::Id::SGE:
+            case OpCode::Id::SGEI:
+                Record<DebugDataRecord::SRC1>(state.debug, iteration, src1);
+                Record<DebugDataRecord::SRC2>(state.debug, iteration, src2);
+                Record<DebugDataRecord::DEST_IN>(state.debug, iteration, dest);
+                for (int i = 0; i < 4; ++i) {
+                    if (!swizzle.DestComponentEnabled(i))
+                        continue;
+
+                    dest[i] = (src1[i] >= src2[i]) ? float24::FromFloat32(1.0f) : float24::FromFloat32(0.0f);
+                }
+                Record<DebugDataRecord::DEST_OUT>(state.debug, iteration, dest);
+                break;
+
             case OpCode::Id::SLT:
             case OpCode::Id::SLTI:
                 Record<DebugDataRecord::SRC1>(state.debug, iteration, src1);

--- a/src/video_core/shader/shader_jit_x64.h
+++ b/src/video_core/shader/shader_jit_x64.h
@@ -40,6 +40,8 @@ public:
     void Compile_EX2(Instruction instr);
     void Compile_LG2(Instruction instr);
     void Compile_MUL(Instruction instr);
+    void Compile_SGE(Instruction instr);
+    void Compile_SLT(Instruction instr);
     void Compile_FLR(Instruction instr);
     void Compile_MAX(Instruction instr);
     void Compile_MIN(Instruction instr);
@@ -47,7 +49,6 @@ public:
     void Compile_RSQ(Instruction instr);
     void Compile_MOVA(Instruction instr);
     void Compile_MOV(Instruction instr);
-    void Compile_SLTI(Instruction instr);
     void Compile_NOP(Instruction instr);
     void Compile_END(Instruction instr);
     void Compile_CALL(Instruction instr);


### PR DESCRIPTION
Implements SGE, SGEI and SLT shader instructions in the interpreter and the JIT.
Simple hardware tests are available here: https://github.com/aroulin/3ds-gpu-tests.