### PR TITLE
Shader: Implement DPH and DPHI in interpreter/JIT

### DIFF
--- a/src/video_core/shader/shader_interpreter.cpp
+++ b/src/video_core/shader/shader_interpreter.cpp
@@ -197,12 +197,19 @@ void RunInterpreter(UnitState<Debug>& state) {
 
             case OpCode::Id::DP3:
             case OpCode::Id::DP4:
+            case OpCode::Id::DPH:
+            case OpCode::Id::DPHI:
             {
                 Record<DebugDataRecord::SRC1>(state.debug, iteration, src1);
                 Record<DebugDataRecord::SRC2>(state.debug, iteration, src2);
                 Record<DebugDataRecord::DEST_IN>(state.debug, iteration, dest);
+
+                OpCode::Id opcode = instr.opcode.Value().EffectiveOpCode();
+                if (opcode == OpCode::Id::DPH || opcode == OpCode::Id::DPHI)
+                    src1[3] = float24::FromFloat32(1.0f);
+
                 float24 dot = float24::FromFloat32(0.f);
-                int num_components = (instr.opcode.Value() == OpCode::Id::DP3) ? 3 : 4;
+                int num_components = (opcode == OpCode::Id::DP3) ? 3 : 4;
                 for (int i = 0; i < num_components; ++i)
                     dot = dot + src1[i] * src2[i];
 

--- a/src/video_core/shader/shader_jit_x64.h
+++ b/src/video_core/shader/shader_jit_x64.h
@@ -37,6 +37,7 @@ public:
     void Compile_ADD(Instruction instr);
     void Compile_DP3(Instruction instr);
     void Compile_DP4(Instruction instr);
+    void Compile_DPH(Instruction instr);
     void Compile_EX2(Instruction instr);
     void Compile_LG2(Instruction instr);
     void Compile_MUL(Instruction instr);


### PR DESCRIPTION
Implements DPH and DPHI in the interpreter and in the JIT.

-  The JIT implementation could be merged with the DP4 implementation using a few if's statements.
- Tests revealed that the component with w=1 is SRC1 and not SRC2, it is now fixed on 3dbrew.
- Tests are for now available here:
    - DPH: https://github.com/aroulin/3ds-gpu-tests/blob/master/dph-tests/source/main.c
    - DPHI: https://github.com/aroulin/3ds-gpu-tests/blob/master/dphi-tests/source/main.c

I'll work on integrating the tests to https://github.com/citra-emu/hwtests. ~~It might take me a few days to clean/adapt the automated test suite, especially to handle the different shaders compilations and make the test suite generic for different shader instructions.~~

@neobrain is working on a shader test framework so maybe I should wait for it to be ready and then add my tests.

PR history: https://github.com/aroulin/citra/compare/d8908aef6389c83590e5f6fa3a9dc5ea5fe8fced...aroulin:6dfe8d0f45fd4a79ebf078b2c7191872acc84393