### PR TITLE
emitter: Remove pointer casts

### DIFF
--- a/src/common/x64/emitter.cpp
+++ b/src/common/x64/emitter.cpp
@@ -109,6 +109,29 @@ u8 *XEmitter::GetWritableCodePtr()
     return code;
 }
 
+void XEmitter::Write8(u8 value)
+{
+    *code++ = value;
+}
+
+void XEmitter::Write16(u16 value)
+{
+    std::memcpy(code, &value, sizeof(u16));
+    code += sizeof(u16);
+}
+
+void XEmitter::Write32(u32 value)
+{
+    std::memcpy(code, &value, sizeof(u32));
+    code += sizeof(u32);
+}
+
+void XEmitter::Write64(u64 value)
+{
+    std::memcpy(code, &value, sizeof(u64));
+    code += sizeof(u64);
+}
+
 void XEmitter::ReserveCodeSpace(int bytes)
 {
     for (int i = 0; i < bytes; i++)

--- a/src/common/x64/emitter.h
+++ b/src/common/x64/emitter.h
@@ -359,10 +359,10 @@ private:
     void ABI_CalculateFrameSize(u32 mask, size_t rsp_alignment, size_t needed_frame_size, size_t* shadowp, size_t* subtractionp, size_t* xmm_offsetp);
 
 protected:
-    void Write8(u8 value)   {*code++ = value;}
-    void Write16(u16 value) {*(u16*)code = (value); code += 2;}
-    void Write32(u32 value) {*(u32*)code = (value); code += 4;}
-    void Write64(u64 value) {*(u64*)code = (value); code += 8;}
+    void Write8(u8 value);
+    void Write16(u16 value);
+    void Write32(u32 value);
+    void Write64(u64 value);
 
 public:
     XEmitter() { code = nullptr; flags_locked = false; }


### PR DESCRIPTION
This should also technically silence a few ubsan warnings if used when the shader JIT is running.