### PR TITLE
GPU: Implemented register 0x22A PICA_REG_DRAW_VERTEX_OFFSET

### DIFF
--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -231,7 +231,8 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
 
             for (unsigned int index = 0; index < regs.num_vertices; ++index)
             {
-                unsigned int vertex = is_indexed ? (index_u16 ? index_address_16[index] : index_address_8[index]) : index;
+                // Indexed rendering doesn't use the start offset
+                unsigned int vertex = is_indexed ? (index_u16 ? index_address_16[index] : index_address_8[index]) : (index + regs.vertex_offset);
 
                 // -1 is a common special value used for primitive restart. Since it's unknown if
                 // the PICA supports it, and it would mess up the caching, guard against it here.

--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -757,7 +757,12 @@ struct Regs {
     // Number of vertices to render
     u32 num_vertices;
 
-    INSERT_PADDING_WORDS(0x5);
+    INSERT_PADDING_WORDS(0x1);
+
+    // The index of the first vertex to render
+    u32 vertex_offset;
+
+    INSERT_PADDING_WORDS(0x3);
 
     // These two trigger rendering of triangles
     u32 trigger_draw;


### PR DESCRIPTION
This is the equivalent of the "first" parameter in glDrawArrays, it tells the GPU the vertex index at which to start rendering.

Tested with https://github.com/Subv/3ds-homebrew/tree/master/gpu_draw_arrays_offset