### PR TITLE
Shader: RCP and RSQ computes only the 1st component

### DIFF
--- a/src/common/x64/emitter.cpp
+++ b/src/common/x64/emitter.cpp
@@ -1535,6 +1535,7 @@ void XEmitter::MAXSS(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0xF3, sseMAX,
 void XEmitter::MAXSD(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0xF2, sseMAX, regOp, arg);}
 void XEmitter::SQRTSS(X64Reg regOp, const OpArg& arg)  {WriteSSEOp(0xF3, sseSQRT, regOp, arg);}
 void XEmitter::SQRTSD(X64Reg regOp, const OpArg& arg)  {WriteSSEOp(0xF2, sseSQRT, regOp, arg);}
+void XEmitter::RCPSS(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0xF3, sseRCP, regOp, arg);}
 void XEmitter::RSQRTSS(X64Reg regOp, const OpArg& arg) {WriteSSEOp(0xF3, sseRSQRT, regOp, arg);}
 
 void XEmitter::ADDPS(X64Reg regOp, const OpArg& arg)   {WriteSSEOp(0x00, sseADD, regOp, arg);}

--- a/src/common/x64/emitter.h
+++ b/src/common/x64/emitter.h
@@ -586,6 +586,7 @@ public:
     void MAXSD(X64Reg regOp, const OpArg& arg);
     void SQRTSS(X64Reg regOp, const OpArg& arg);
     void SQRTSD(X64Reg regOp, const OpArg& arg);
+    void RCPSS(X64Reg regOp, const OpArg& arg);
     void RSQRTSS(X64Reg regOp, const OpArg& arg);
 
     // SSE/SSE2: Floating point bitwise (yes)

--- a/src/video_core/shader/shader_interpreter.cpp
+++ b/src/video_core/shader/shader_interpreter.cpp
@@ -237,7 +237,7 @@ void RunInterpreter(UnitState<Debug>& state) {
             {
                 Record<DebugDataRecord::SRC1>(state.debug, iteration, src1);
                 Record<DebugDataRecord::DEST_IN>(state.debug, iteration, dest);
-                float24 rsq_res = float24::FromFloat32(1.0f / sqrt(src1[0].ToFloat32()));
+                float24 rsq_res = float24::FromFloat32(1.0f / std::sqrt(src1[0].ToFloat32()));
                 for (int i = 0; i < 4; ++i) {
                     if (!swizzle.DestComponentEnabled(i))
                         continue;

--- a/src/video_core/shader/shader_interpreter.cpp
+++ b/src/video_core/shader/shader_interpreter.cpp
@@ -221,13 +221,12 @@ void RunInterpreter(UnitState<Debug>& state) {
             {
                 Record<DebugDataRecord::SRC1>(state.debug, iteration, src1);
                 Record<DebugDataRecord::DEST_IN>(state.debug, iteration, dest);
+                float24 rcp_res = float24::FromFloat32(1.0f / src1[0].ToFloat32());
                 for (int i = 0; i < 4; ++i) {
                     if (!swizzle.DestComponentEnabled(i))
                         continue;
 
-                    // TODO: Be stable against division by zero!
-                    // TODO: I think this might be wrong... we should only use one component here
-                    dest[i] = float24::FromFloat32(1.0f / src1[i].ToFloat32());
+                    dest[i] = rcp_res;
                 }
                 Record<DebugDataRecord::DEST_OUT>(state.debug, iteration, dest);
                 break;
@@ -238,13 +237,12 @@ void RunInterpreter(UnitState<Debug>& state) {
             {
                 Record<DebugDataRecord::SRC1>(state.debug, iteration, src1);
                 Record<DebugDataRecord::DEST_IN>(state.debug, iteration, dest);
+                float24 rsq_res = float24::FromFloat32(1.0f / sqrt(src1[0].ToFloat32()));
                 for (int i = 0; i < 4; ++i) {
                     if (!swizzle.DestComponentEnabled(i))
                         continue;
 
-                    // TODO: Be stable against division by zero!
-                    // TODO: I think this might be wrong... we should only use one component here
-                    dest[i] = float24::FromFloat32(1.0f / sqrt(src1[i].ToFloat32()));
+                    dest[i] = rsq_res;
                 }
                 Record<DebugDataRecord::DEST_OUT>(state.debug, iteration, dest);
                 break;

--- a/src/video_core/shader/shader_jit_x64.cpp
+++ b/src/video_core/shader/shader_jit_x64.cpp
@@ -496,9 +496,10 @@ void JitCompiler::Compile_MOV(Instruction instr) {
 void JitCompiler::Compile_RCP(Instruction instr) {
     Compile_SwizzleSrc(instr, 1, instr.common.src1, SRC1);
 
-    // TODO(bunnei): RCPPS is a pretty rough approximation, this might cause problems if Pica
+    // TODO(bunnei): RCPSS is a pretty rough approximation, this might cause problems if Pica
     // performs this operation more accurately. This should be checked on hardware.
-    RCPPS(SRC1, R(SRC1));
+    RCPSS(SRC1, R(SRC1));
+    SHUFPS(SRC1, R(SRC1), _MM_SHUFFLE(0, 0, 0, 0)); // XYWZ -> XXXX
 
     Compile_DestEnable(instr, SRC1);
 }
@@ -506,9 +507,10 @@ void JitCompiler::Compile_RCP(Instruction instr) {
 void JitCompiler::Compile_RSQ(Instruction instr) {
     Compile_SwizzleSrc(instr, 1, instr.common.src1, SRC1);
 
-    // TODO(bunnei): RSQRTPS is a pretty rough approximation, this might cause problems if Pica
+    // TODO(bunnei): RSQRTSS is a pretty rough approximation, this might cause problems if Pica
     // performs this operation more accurately. This should be checked on hardware.
-    RSQRTPS(SRC1, R(SRC1));
+    RSQRTSS(SRC1, R(SRC1));
+    SHUFPS(SRC1, R(SRC1), _MM_SHUFFLE(0, 0, 0, 0)); // XYWZ -> XXXX
 
     Compile_DestEnable(instr, SRC1);
 }


### PR DESCRIPTION
RCP (RSQ) computes only the source vector's first component reciprocal (reciprocal of square root). It is not surprising as these are transcendental functions typically executed on SFUs.

Confirmed by tests available here:
- https://github.com/aroulin/3ds-gpu-tests/blob/master/rcp-tests/source/main.c
- https://github.com/aroulin/3ds-gpu-tests/blob/master/rsq-tests/source/main.c