### PR TITLE
gl_rasterizer_cache: Cache textures based on hash in addition to address.

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -231,8 +231,8 @@ void RasterizerOpenGL::DrawTriangles() {
     u32 cur_fb_depth_size = Pica::Regs::BytesPerDepthPixel(regs.framebuffer.depth_format)
                             * regs.framebuffer.GetWidth() * regs.framebuffer.GetHeight();
 
-    res_cache.NotifyFlush(cur_fb_color_addr, cur_fb_color_size);
-    res_cache.NotifyFlush(cur_fb_depth_addr, cur_fb_depth_size);
+    res_cache.NotifyFlush(cur_fb_color_addr, cur_fb_color_size, true);
+    res_cache.NotifyFlush(cur_fb_depth_addr, cur_fb_depth_size, true);
 }
 
 void RasterizerOpenGL::CommitFramebuffer() {

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -19,7 +19,7 @@ public:
     void LoadAndBindTexture(OpenGLState &state, unsigned texture_unit, const Pica::Regs::FullTextureConfig& config);
 
     /// Flush any cached resource that touches the flushed region
-    void NotifyFlush(PAddr addr, u32 size);
+    void NotifyFlush(PAddr addr, u32 size, bool ignore_hash = false);
 
     /// Flush all cached OpenGL resources tracked by this cache manager
     void FullFlush();
@@ -30,6 +30,8 @@ private:
         GLuint width;
         GLuint height;
         u32 size;
+        u64 hash;
+        PAddr addr;
     };
 
     std::map<PAddr, std::unique_ptr<CachedTexture>> texture_cache;


### PR DESCRIPTION
This hugely reduces the number of texture uploads in some games (e.g. ZMM, where it results in a pretty significant overall performance boost).

Before:
![](http://i.imgur.com/Zm08vl0.jpg)

After:
![](http://i.imgur.com/UWYoo5A.jpg)