### PR TITLE
SVC: Advance time when calling GetSystemTick to escape busy-wait loops

### DIFF
--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -755,7 +755,10 @@ static void SleepThread(s64 nanoseconds) {
 
 /// This returns the total CPU ticks elapsed since the CPU was powered-on
 static s64 GetSystemTick() {
-    return (s64)CoreTiming::GetTicks();
+    s64 result = CoreTiming::GetTicks();
+    // Advance time to defeat dumb games (like Cubic Ninja) that busy-wait for the frame to end.
+    Core::g_app_core->AddTicks(150); // Measured time between two calls on a 9.2 o3DS with Ninjhax 1.1b
+    return result;
 }
 
 /// Creates a memory block at the specified address with the specified permissions and size


### PR DESCRIPTION
Cubic Ninja waited for the frame to end by spinning on a loop calling
GetSystemTick while doing nothing else. Since GetSystemTick doesn't
cause a reschedule (which advances time), this meant that very little
emulated time would pass inside that loop, causing the game to spend
most of the frame burning away CPU.