### PR TITLE
Shader JIT: ifdef out reference to ifdef'd out shader_map

### DIFF
--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -52,7 +52,9 @@ void Setup(UnitState<false>& state) {
 }
 
 void Shutdown() {
+#ifdef ARCHITECTURE_x86_64
     shader_map.clear();
+#endif // ARCHITECTURE_x86_64
 }
 
 static Common::Profiling::TimingCategory shader_category("Vertex Shader");


### PR DESCRIPTION
`shader_map` was only defined on x86 architectures, but was cleared on shutdown
with no `#ifdef` protection. `#ifdef` this out so non-x86_64 architectures can be built.