### PR TITLE
Shader JIT: Fix float to integer rounding in MOVA

### DIFF
--- a/src/video_core/shader/shader_jit_x64.cpp
+++ b/src/video_core/shader/shader_jit_x64.cpp
@@ -485,8 +485,8 @@ void JitCompiler::Compile_MOVA(Instruction instr) {
 
     Compile_SwizzleSrc(instr, 1, instr.common.src1, SRC1);
 
-    // Convert floats to integers (only care about X and Y components)
-    CVTPS2DQ(SRC1, R(SRC1));
+    // Convert floats to integers using truncation (only care about X and Y components)
+    CVTTPS2DQ(SRC1, R(SRC1));
 
     // Get result
     MOVQ_xmm(R(RAX), SRC1);


### PR DESCRIPTION
MOVA converts new address register values from floats to integers **using truncation**.
- specified here http://3dbrew.org/wiki/Shader_Instruction_Set#Instructions
- I validated this behavior on hardware: https://github.com/aroulin/3ds-gpu-tests/blob/master/mova-tests/source/main.c

This fixes an issue in The Legend of Zelda: A Link Between Worlds where the UI boxes were not drawn
in the main menu screen.

Before (with the shader JIT): 
![albw_before](https://cloud.githubusercontent.com/assets/5475997/9521791/3a517de2-4cd1-11e5-8fce-fadfede0e9b4.png)

After (with the shader JIT and the shader interpreter):

![albw_after](https://cloud.githubusercontent.com/assets/5475997/9521809/543569c6-4cd1-11e5-8910-18732b8f561c.png)