### PR TITLE
Common: Fix MicroProfile compilation in MSVC2015

### DIFF
--- a/src/common/microprofile.h
+++ b/src/common/microprofile.h
@@ -11,6 +11,11 @@
 #define MICROPROFILE_CONTEXT_SWITCH_TRACE 0
 #define MICROPROFILE_PER_THREAD_BUFFER_SIZE (2048<<12) // 8 MB
 
+#ifdef _WIN32
+// This isn't defined by the standard library in MSVC2015
+typedef void* HANDLE;
+#endif
+
 #include <microprofile.h>
 
 #define MP_RGB(r, g, b) ((r) << 16 | (g) << 8 | (b) << 0)


### PR DESCRIPTION
This typedef happened to be defined through a include path in the standard libraries in 2013, but isn't anymore in 2015. Ideally I'll upstream the fix, but this will do until then.