### PR TITLE
Services/FS: Correctly tell the guest app whether a file was correctly opened or not

### DIFF
--- a/src/core/file_sys/disk_archive.cpp
+++ b/src/core/file_sys/disk_archive.cpp
@@ -102,7 +102,7 @@ bool DiskFile::Open() {
     mode_string += "b";
 
     file = Common::make_unique<FileUtil::IOFile>(path, mode_string.c_str());
-    return true;
+    return file->IsOpen();
 }
 
 size_t DiskFile::Read(const u64 offset, const size_t length, u8* buffer) const {


### PR DESCRIPTION
Closes #1067