### PR TITLE
Only check src/ directory for whitespace errors in the pre-commit hook

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -3,8 +3,10 @@
 # Enforce citra's whitespace policy
 git config --local core.whitespace tab-in-indent,trailing-space
 
+paths_to_check="src/ CMakeLists.txt"
+
 # If there are whitespace errors, print the offending file names and fail.
-if ! git diff --cached --check; then
+if ! git diff --cached --check -- $paths_to_check ; then
     cat<<END;
 
 Error: This commit would contain trailing spaces or tabs, which is against this repo's policy.
@@ -15,7 +17,7 @@ END
 fi
 
 # Check for tabs, since tab-in-indent catches only those at the beginning of a line
-if git diff --cached | egrep '^\+.*	'; then
+if git diff --cached -- $paths_to_check | egrep '^\+.*	'; then
     cat<<END;
 Error: This commit would contain a tab, which is against this repo's policy.
 If you know what you are doing, you can try 'git commit --no-verify' to bypass the check.


### PR DESCRIPTION
This allows importing of external libraries into externals/ without
having to reformat them. Unfortunately it also allows whitespace to be
introduced in files like the root CMakeLists.txt, but that is a small
downside compared to the tradeoff.