### PR TITLE
x64: Proper stack alignment in shader JIT function calls

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -24,6 +24,7 @@ set(SRCS
 set(HEADERS
             assert.h
             bit_field.h
+            bit_set.h
             break_points.h
             chunk_file.h
             code_block.h

--- a/src/common/bit_set.h
+++ b/src/common/bit_set.h
@@ -1,0 +1,189 @@
+// This file is under the public domain.
+
+#pragma once
+
+#include <cstddef>
+#ifdef _WIN32
+#include <intrin.h>
+#endif
+#include <initializer_list>
+#include <type_traits>
+#include "common/common_types.h"
+
+// namespace avoids conflict with OS X Carbon; don't use BitSet<T> directly
+namespace Common {
+
+// Helper functions:
+
+#ifdef _WIN32
+template <typename T>
+static inline int CountSetBits(T v)
+{
+    // from https://graphics.stanford.edu/~seander/bithacks.html
+    // GCC has this built in, but MSVC's intrinsic will only emit the actual
+    // POPCNT instruction, which we're not depending on
+    v = v - ((v >> 1) & (T)~(T)0/3);
+    v = (v & (T)~(T)0/15*3) + ((v >> 2) & (T)~(T)0/15*3);
+    v = (v + (v >> 4)) & (T)~(T)0/255*15;
+    return (T)(v * ((T)~(T)0/255)) >> (sizeof(T) - 1) * 8;
+}
+static inline int LeastSignificantSetBit(u8 val)
+{
+    unsigned long index;
+    _BitScanForward(&index, val);
+    return (int)index;
+}
+static inline int LeastSignificantSetBit(u16 val)
+{
+    unsigned long index;
+    _BitScanForward(&index, val);
+    return (int)index;
+}
+static inline int LeastSignificantSetBit(u32 val)
+{
+    unsigned long index;
+    _BitScanForward(&index, val);
+    return (int)index;
+}
+static inline int LeastSignificantSetBit(u64 val)
+{
+    unsigned long index;
+    _BitScanForward64(&index, val);
+    return (int)index;
+}
+#else
+static inline int CountSetBits(u8 val) { return __builtin_popcount(val); }
+static inline int CountSetBits(u16 val) { return __builtin_popcount(val); }
+static inline int CountSetBits(u32 val) { return __builtin_popcount(val); }
+static inline int CountSetBits(u64 val) { return __builtin_popcountll(val); }
+static inline int LeastSignificantSetBit(u8 val) { return __builtin_ctz(val); }
+static inline int LeastSignificantSetBit(u16 val) { return __builtin_ctz(val); }
+static inline int LeastSignificantSetBit(u32 val) { return __builtin_ctz(val); }
+static inline int LeastSignificantSetBit(u64 val) { return __builtin_ctzll(val); }
+#endif
+
+// Similar to std::bitset, this is a class which encapsulates a bitset, i.e.
+// using the set bits of an integer to represent a set of integers.  Like that
+// class, it acts like an array of bools:
+//     BitSet32 bs;
+//     bs[1] = true;
+// but also like the underlying integer ([0] = least significant bit):
+//     BitSet32 bs2 = ...;
+//     bs = (bs ^ bs2) & BitSet32(0xffff);
+// The following additional functionality is provided:
+// - Construction using an initializer list.
+//     BitSet bs { 1, 2, 4, 8 };
+// - Efficiently iterating through the set bits:
+//     for (int i : bs)
+//         [i is the *index* of a set bit]
+//   (This uses the appropriate CPU instruction to find the next set bit in one
+//   operation.)
+// - Counting set bits using .Count() - see comment on that method.
+
+// TODO: use constexpr when MSVC gets out of the Dark Ages
+
+template <typename IntTy>
+class BitSet
+{
+    static_assert(!std::is_signed<IntTy>::value, "BitSet should not be used with signed types");
+public:
+    // A reference to a particular bit, returned from operator[].
+    class Ref
+    {
+    public:
+        Ref(Ref&& other) : m_bs(other.m_bs), m_mask(other.m_mask) {}
+        Ref(BitSet* bs, IntTy mask) : m_bs(bs), m_mask(mask) {}
+        operator bool() const { return (m_bs->m_val & m_mask) != 0; }
+        bool operator=(bool set)
+        {
+            m_bs->m_val = (m_bs->m_val & ~m_mask) | (set ? m_mask : 0);
+            return set;
+        }
+    private:
+        BitSet* m_bs;
+        IntTy m_mask;
+    };
+
+    // A STL-like iterator is required to be able to use range-based for loops.
+    class Iterator
+    {
+    public:
+        Iterator(const Iterator& other) : m_val(other.m_val), m_bit(other.m_bit) {}
+        Iterator(IntTy val, int bit) : m_val(val), m_bit(bit) {}
+        Iterator& operator=(Iterator other) { new (this) Iterator(other); return *this; }
+        int operator*() { return m_bit; }
+        Iterator& operator++()
+        {
+            if (m_val == 0)
+            {
+                m_bit = -1;
+            }
+            else
+            {
+                int bit = LeastSignificantSetBit(m_val);
+                m_val &= ~(1 << bit);
+                m_bit = bit;
+            }
+            return *this;
+        }
+        Iterator operator++(int _)
+        {
+            Iterator other(*this);
+            ++*this;
+            return other;
+        }
+        bool operator==(Iterator other) const { return m_bit == other.m_bit; }
+        bool operator!=(Iterator other) const { return m_bit != other.m_bit; }
+    private:
+        IntTy m_val;
+        int m_bit;
+    };
+
+    BitSet() : m_val(0) {}
+    explicit BitSet(IntTy val) : m_val(val) {}
+    BitSet(std::initializer_list<int> init)
+    {
+        m_val = 0;
+        for (int bit : init)
+            m_val |= (IntTy)1 << bit;
+    }
+
+    static BitSet AllTrue(size_t count)
+    {
+        return BitSet(count == sizeof(IntTy)*8 ? ~(IntTy)0 : (((IntTy)1 << count) - 1));
+    }
+
+    Ref operator[](size_t bit) { return Ref(this, (IntTy)1 << bit); }
+    const Ref operator[](size_t bit) const { return (*const_cast<BitSet*>(this))[bit]; }
+    bool operator==(BitSet other) const { return m_val == other.m_val; }
+    bool operator!=(BitSet other) const { return m_val != other.m_val; }
+    bool operator<(BitSet other) const { return m_val < other.m_val; }
+    bool operator>(BitSet other) const { return m_val > other.m_val; }
+    BitSet operator|(BitSet other) const { return BitSet(m_val | other.m_val); }
+    BitSet operator&(BitSet other) const { return BitSet(m_val & other.m_val); }
+    BitSet operator^(BitSet other) const { return BitSet(m_val ^ other.m_val); }
+    BitSet operator~() const { return BitSet(~m_val); }
+    BitSet& operator|=(BitSet other) { return *this = *this | other; }
+    BitSet& operator&=(BitSet other) { return *this = *this & other; }
+    BitSet& operator^=(BitSet other) { return *this = *this ^ other; }
+    operator u32() = delete;
+    operator bool() { return m_val != 0; }
+
+    // Warning: Even though on modern CPUs this is a single fast instruction,
+    // Dolphin's official builds do not currently assume POPCNT support on x86,
+    // so slower explicit bit twiddling is generated.  Still should generally
+    // be faster than a loop.
+    unsigned int Count() const { return CountSetBits(m_val); }
+
+    Iterator begin() const { Iterator it(m_val, 0); return ++it; }
+    Iterator end() const { return Iterator(m_val, -1); }
+
+    IntTy m_val;
+};
+
+} // Common
+
+typedef Common::BitSet<u8> BitSet8;
+typedef Common::BitSet<u16> BitSet16;
+typedef Common::BitSet<u32> BitSet32;
+typedef Common::BitSet<u64> BitSet64;

--- a/src/video_core/shader/shader_jit_x64.cpp
+++ b/src/video_core/shader/shader_jit_x64.cpp
@@ -122,6 +122,14 @@ static const X64Reg ONE = XMM14;
 /// Constant vector of [-0.f, -0.f, -0.f, -0.f], used to efficiently negate a vector with XOR
 static const X64Reg NEGBIT = XMM15;
 
+// State registers that must not be modified by external functions calls
+// Scratch registers, e.g., SRC1 and SCRATCH, have to be saved on the side if needed
+static const BitSet32 persistent_regs = {
+    UNIFORMS, REGISTERS, // Pointers to register blocks
+    ADDROFFS_REG_0, ADDROFFS_REG_1, LOOPCOUNT_REG, COND0, COND1, // Cached registers
+    ONE+16, NEGBIT+16, // Constants
+};
+
 /// Raw constant for the source register selector that indicates no swizzling is performed
 static const u8 NO_SRC_REG_SWIZZLE = 0x1b;
 /// Raw constant for the destination register enable mask that indicates all components are enabled
@@ -295,20 +303,8 @@ void JitCompiler::Compile_UniformCondition(Instruction instr) {
     CMP(sizeof(bool) * 8, MDisp(UNIFORMS, offset), Imm8(0));
 }
 
-void JitCompiler::Compile_PushCallerSavedXMM() {
-#ifndef _WIN32
-    SUB(64, R(RSP), Imm8(2 * 16));
-    MOVUPS(MDisp(RSP, 16), ONE);
-    MOVUPS(MDisp(RSP, 0), NEGBIT);
-#endif
-}
-
-void JitCompiler::Compile_PopCallerSavedXMM() {
-#ifndef _WIN32
-    MOVUPS(NEGBIT, MDisp(RSP, 0));
-    MOVUPS(ONE, MDisp(RSP, 16));
-    ADD(64, R(RSP), Imm8(2 * 16));
-#endif
+BitSet32 JitCompiler::PersistentCallerSavedRegs() {
+    return persistent_regs & ABI_ALL_CALLER_SAVED;
 }
 
 void JitCompiler::Compile_ADD(Instruction instr) {
@@ -390,12 +386,9 @@ void JitCompiler::Compile_EX2(Instruction instr) {
     Compile_SwizzleSrc(instr, 1, instr.common.src1, SRC1);
     MOVSS(XMM0, R(SRC1));
 
-    // The following will actually break the stack alignment
-    ABI_PushAllCallerSavedRegsAndAdjustStack();
-    Compile_PushCallerSavedXMM();
+    ABI_PushRegistersAndAdjustStack(PersistentCallerSavedRegs(), 0);
     ABI_CallFunction(reinterpret_cast<const void*>(exp2f));
-    Compile_PopCallerSavedXMM();
-    ABI_PopAllCallerSavedRegsAndAdjustStack();
+    ABI_PopRegistersAndAdjustStack(PersistentCallerSavedRegs(), 0);
 
     SHUFPS(XMM0, R(XMM0), _MM_SHUFFLE(0, 0, 0, 0));
     MOVAPS(SRC1, R(XMM0));
@@ -406,12 +399,9 @@ void JitCompiler::Compile_LG2(Instruction instr) {
     Compile_SwizzleSrc(instr, 1, instr.common.src1, SRC1);
     MOVSS(XMM0, R(SRC1));
 
-    // The following will actually break the stack alignment
-    ABI_PushAllCallerSavedRegsAndAdjustStack();
-    Compile_PushCallerSavedXMM();
+    ABI_PushRegistersAndAdjustStack(PersistentCallerSavedRegs(), 0);
     ABI_CallFunction(reinterpret_cast<const void*>(log2f));
-    Compile_PopCallerSavedXMM();
-    ABI_PopAllCallerSavedRegsAndAdjustStack();
+    ABI_PopRegistersAndAdjustStack(PersistentCallerSavedRegs(), 0);
 
     SHUFPS(XMM0, R(XMM0), _MM_SHUFFLE(0, 0, 0, 0));
     MOVAPS(SRC1, R(XMM0));
@@ -560,7 +550,7 @@ void JitCompiler::Compile_NOP(Instruction instr) {
 }
 
 void JitCompiler::Compile_END(Instruction instr) {
-    ABI_PopAllCalleeSavedRegsAndAdjustStack();
+    ABI_PopRegistersAndAdjustStack(ABI_ALL_CALLEE_SAVED, 8);
     RET();
 }
 
@@ -755,7 +745,8 @@ CompiledShader* JitCompiler::Compile() {
     const auto& code = g_state.vs.program_code;
     unsigned offset = g_state.regs.vs.main_offset;
 
-    ABI_PushAllCalleeSavedRegsAndAdjustStack();
+    // The stack pointer is 8 modulo 16 at the entry of a procedure
+    ABI_PushRegistersAndAdjustStack(ABI_ALL_CALLEE_SAVED, 8);
 
     MOV(PTRBITS, R(REGISTERS), R(ABI_PARAM1));
     MOV(PTRBITS, R(UNIFORMS), ImmPtr(&g_state.vs.uniforms));

--- a/src/video_core/shader/shader_jit_x64.h
+++ b/src/video_core/shader/shader_jit_x64.h
@@ -77,8 +77,7 @@ private:
     void Compile_EvaluateCondition(Instruction instr);
     void Compile_UniformCondition(Instruction instr);
 
-    void Compile_PushCallerSavedXMM();
-    void Compile_PopCallerSavedXMM();
+    BitSet32 PersistentCallerSavedRegs();
 
     /// Pointer to the variable that stores the current Pica code offset. Used to handle nested code blocks.
     unsigned* offset_ptr = nullptr;


### PR DESCRIPTION
Fixes misaligned stack when calling external functions from the shader JIT. Both the Win64 and the System V ABIs require a 16-byte aligned stack when calling a function.

[Agner's Calling Conventions 5. Stack Alignment](http://www.agner.org/optimize/calling_conventions.pdf)
    
    The 64 bit systems keep the stack aligned by 16. The stack word size
    is 8 bytes, but the stack must be aligned by 16 before any call instruction.
    Consequently, the value of the stack pointer is always 8 modulo 16 at
    the entry of a procedure.

[System V ABI 3.2.2 The Stack Frame](http://www.x86-64.org/documentation/abi.pdf):

    […], the value (%rsp + 8) is always a multiple of 16 when control 
    is transferred to the function entry point.

[Win64 Software Conventions](https://msdn.microsoft.com/en-us/library/ew5tede7.aspx):

    The stack will always be maintained 16-byte aligned, except 
    within the prolog (for example, after the return address is pushed)

External functions are for the time being only used to emulate EX2 and LG2 instructions and these might be replaced in a near future with inline approximations. Nevertheless, it is certainly still useful to have a clean stack alignment system (and maybe geometry shader instructions will use external interpreter functions as a first step).

The list of registers to save is for now static. The next enhancement would be to have a register caching system that, additionally to cache registers, would keep track of which registers are currently in use and have to be saved.

The problem is fixed by using Dolphin's `ABI_{Push,Pop}RegistersAndAdjustStack` instead of `ABI_{Push,Pop}All{Caller,Callee}SavedRegsAndAdjustStack`. Dolphin's code is x64-only therefore the remaining x86 bits are removed from the ABI files.

Previous functions `ABI_{Push,Pop}All{Caller,Callee}SavedRegsAndAdjustStack` are removed because of multiple problems. One is that they don't make sure the stack is aligned as they just push **a hard-coded odd number of registers**. This can be misleading, for example the following will break the stack alignment:

    // Function entry: stack pointer misaligned
    ABI_PushAllCalleeSavedRegsAndAdjustStack();
    // OK stack pointer is aligned
    
    // [...]
    
    // later we want to call a function so need to save caller-saved register
    ABI_PushAllCallerSavedRegsAndAdjustStack();
    // stack pointer is misaligned now !
    CALL(myfunc); // calling with misaligned stack

Example of a misaligned stack when emulating the EX2 shader instruction by calling `std::exp2` 
![misaligned_ex2_call](https://cloud.githubusercontent.com/assets/5475997/9566176/3f7b83d2-4efa-11e5-9aff-9ea9b0c2e470.png)