### PR TITLE
Service/CFG: Add additional blocks to default save data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ if (NOT MSVC)
     endif()
 else()
     # Silence "deprecation" warnings
-    add_definitions(/D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_DEPRECATE)
+    add_definitions(/D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_DEPRECATE /D_SCL_SECURE_NO_WARNINGS)
     # Avoid windows.h junk
     add_definitions(/DNOMINMAX)
 

--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -332,7 +332,7 @@ ResultCode FormatConfig() {
     if (!res.IsSuccess()) return res;
     res = CreateConfigInfoBlk(0x000A0000, sizeof(CONSOLE_USERNAME_BLOCK), 0xE, &CONSOLE_USERNAME_BLOCK);
     if (!res.IsSuccess()) return res;
-    res = CreateConfigInfoBlk(0x000A0002, sizeof(CONSOLE_LANGUAGE), 0xA, &CONSOLE_LANGUAGE);
+    res = CreateConfigInfoBlk(0x000A0002, sizeof(CONSOLE_LANGUAGE), 0xE, &CONSOLE_LANGUAGE);
     if (!res.IsSuccess()) return res;
     res = CreateConfigInfoBlk(0x000B0000, sizeof(COUNTRY_INFO), 0xE, &COUNTRY_INFO);
     if (!res.IsSuccess()) return res;
@@ -364,7 +364,7 @@ ResultCode FormatConfig() {
     res = CreateConfigInfoBlk(0x000D0000, 0x4, 0xE, zero_buffer);
     if (!res.IsSuccess()) return res;
 
-    res = CreateConfigInfoBlk(0x000F0004, sizeof(CONSOLE_MODEL), 0x8, &CONSOLE_MODEL);
+    res = CreateConfigInfoBlk(0x000F0004, sizeof(CONSOLE_MODEL), 0xC, &CONSOLE_MODEL);
     if (!res.IsSuccess()) return res;
 
     // Save the buffer to the file

--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -318,6 +318,12 @@ ResultCode FormatConfig() {
     config->data_entries_offset = 0x455C;
 
     // Insert the default blocks
+    u8 zero_buffer[0xC0] = {};
+
+    // 0x00030001 - Unknown
+    res = CreateConfigInfoBlk(0x00030001, 0x8, 0xE, zero_buffer);
+    if (!res.IsSuccess()) return res;
+
     res = CreateConfigInfoBlk(0x00050005, sizeof(STEREO_CAMERA_SETTINGS), 0xE, STEREO_CAMERA_SETTINGS.data());
     if (!res.IsSuccess()) return res;
     res = CreateConfigInfoBlk(0x00070001, sizeof(SOUND_OUTPUT_MODE), 0xE, &SOUND_OUTPUT_MODE);
@@ -330,6 +336,34 @@ ResultCode FormatConfig() {
     if (!res.IsSuccess()) return res;
     res = CreateConfigInfoBlk(0x000B0000, sizeof(COUNTRY_INFO), 0xE, &COUNTRY_INFO);
     if (!res.IsSuccess()) return res;
+
+    char16_t country_name_buffer[16][0x40] = {};
+    for (size_t i = 0; i < 16; ++i) {
+        auto size = Common::UTF8ToUTF16("Gensokyo").copy(country_name_buffer[i], 0x40);
+    }
+    // 0x000B0001 - Localized names for the profile Country
+    res = CreateConfigInfoBlk(0x000B0001, sizeof(country_name_buffer), 0xE, country_name_buffer);
+    if (!res.IsSuccess()) return res;
+    // 0x000B0002 - Localized names for the profile State/Province
+    res = CreateConfigInfoBlk(0x000B0002, sizeof(country_name_buffer), 0xE, country_name_buffer);
+    if (!res.IsSuccess()) return res;
+
+    // 0x000B0003 - Unknown, related to country/address (zip code?)
+    res = CreateConfigInfoBlk(0x000B0003, 0x4, 0xE, zero_buffer);
+    if (!res.IsSuccess()) return res;
+
+    // 0x000C0000 - Unknown
+    res = CreateConfigInfoBlk(0x000C0000, 0xC0, 0xE, zero_buffer);
+    if (!res.IsSuccess()) return res;
+
+    // 0x000C0001 - Unknown
+    res = CreateConfigInfoBlk(0x000C0001, 0x14, 0xE, zero_buffer);
+    if (!res.IsSuccess()) return res;
+
+    // 0x000D0000 - Accepted EULA version
+    res = CreateConfigInfoBlk(0x000D0000, 0x4, 0xE, zero_buffer);
+    if (!res.IsSuccess()) return res;
+
     res = CreateConfigInfoBlk(0x000F0004, sizeof(CONSOLE_MODEL), 0x8, &CONSOLE_MODEL);
     if (!res.IsSuccess()) return res;
 

--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -332,6 +332,12 @@ ResultCode FormatConfig() {
     if (!res.IsSuccess()) return res;
     res = CreateConfigInfoBlk(0x000A0000, sizeof(CONSOLE_USERNAME_BLOCK), 0xE, &CONSOLE_USERNAME_BLOCK);
     if (!res.IsSuccess()) return res;
+
+    // 0x000A0001 - Profile birthday
+    const u8 profile_birthday[2] = {3, 25}; // March 25th, 2014
+    res = CreateConfigInfoBlk(0x000A0001, sizeof(profile_birthday), 0xE, profile_birthday);
+    if (!res.IsSuccess()) return res;
+
     res = CreateConfigInfoBlk(0x000A0002, sizeof(CONSOLE_LANGUAGE), 0xE, &CONSOLE_LANGUAGE);
     if (!res.IsSuccess()) return res;
     res = CreateConfigInfoBlk(0x000B0000, sizeof(COUNTRY_INFO), 0xE, &COUNTRY_INFO);

--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -212,7 +212,7 @@ ResultCode GetConfigInfoBlock(u32 block_id, u32 size, u32 flag, u8* output) {
     return RESULT_SUCCESS;
 }
 
-ResultCode CreateConfigInfoBlk(u32 block_id, u16 size, u16 flags, const u8* data) {
+ResultCode CreateConfigInfoBlk(u32 block_id, u16 size, u16 flags, const void* data) {
     SaveFileConfig* config = reinterpret_cast<SaveFileConfig*>(cfg_config_file_buffer.data());
     if (config->total_entries >= CONFIG_FILE_MAX_BLOCK_ENTRIES)
         return ResultCode(-1); // TODO(Subv): Find the right error code
@@ -277,33 +277,23 @@ ResultCode FormatConfig() {
     SaveFileConfig* config = reinterpret_cast<SaveFileConfig*>(cfg_config_file_buffer.data());
     // This value is hardcoded, taken from 3dbrew, verified by hardware, it's always the same value
     config->data_entries_offset = 0x455C;
+
     // Insert the default blocks
-    res = CreateConfigInfoBlk(0x00050005, sizeof(STEREO_CAMERA_SETTINGS), 0xE,
-                              reinterpret_cast<const u8*>(STEREO_CAMERA_SETTINGS.data()));
-    if (!res.IsSuccess())
-        return res;
-    res = CreateConfigInfoBlk(0x00090001, sizeof(CONSOLE_UNIQUE_ID), 0xE,
-                              reinterpret_cast<const u8*>(&CONSOLE_UNIQUE_ID));
-    if (!res.IsSuccess())
-        return res;
-    res = CreateConfigInfoBlk(0x000F0004, sizeof(CONSOLE_MODEL), 0x8,
-                              reinterpret_cast<const u8*>(&CONSOLE_MODEL));
-    if (!res.IsSuccess())
-        return res;
-    res = CreateConfigInfoBlk(0x000A0002, sizeof(CONSOLE_LANGUAGE), 0xA, &CONSOLE_LANGUAGE);
-    if (!res.IsSuccess())
-        return res;
+    res = CreateConfigInfoBlk(0x00050005, sizeof(STEREO_CAMERA_SETTINGS), 0xE, STEREO_CAMERA_SETTINGS.data());
+    if (!res.IsSuccess()) return res;
     res = CreateConfigInfoBlk(0x00070001, sizeof(SOUND_OUTPUT_MODE), 0xE, &SOUND_OUTPUT_MODE);
-    if (!res.IsSuccess())
-        return res;
-    res = CreateConfigInfoBlk(0x000B0000, sizeof(COUNTRY_INFO), 0xE,
-                              reinterpret_cast<const u8*>(&COUNTRY_INFO));
-    if (!res.IsSuccess())
-        return res;
-    res = CreateConfigInfoBlk(0x000A0000, sizeof(CONSOLE_USERNAME_BLOCK), 0xE,
-                              reinterpret_cast<const u8*>(&CONSOLE_USERNAME_BLOCK));
-    if (!res.IsSuccess())
-        return res;
+    if (!res.IsSuccess()) return res;
+    res = CreateConfigInfoBlk(0x00090001, sizeof(CONSOLE_UNIQUE_ID), 0xE, &CONSOLE_UNIQUE_ID);
+    if (!res.IsSuccess()) return res;
+    res = CreateConfigInfoBlk(0x000A0000, sizeof(CONSOLE_USERNAME_BLOCK), 0xE, &CONSOLE_USERNAME_BLOCK);
+    if (!res.IsSuccess()) return res;
+    res = CreateConfigInfoBlk(0x000A0002, sizeof(CONSOLE_LANGUAGE), 0xA, &CONSOLE_LANGUAGE);
+    if (!res.IsSuccess()) return res;
+    res = CreateConfigInfoBlk(0x000B0000, sizeof(COUNTRY_INFO), 0xE, &COUNTRY_INFO);
+    if (!res.IsSuccess()) return res;
+    res = CreateConfigInfoBlk(0x000F0004, sizeof(CONSOLE_MODEL), 0x8, &CONSOLE_MODEL);
+    if (!res.IsSuccess()) return res;
+
     // Save the buffer to the file
     res = UpdateConfigNANDSavegame();
     if (!res.IsSuccess())

--- a/src/core/hle/service/cfg/cfg.h
+++ b/src/core/hle/service/cfg/cfg.h
@@ -204,59 +204,6 @@ void UpdateConfigNANDSavegame(Service::Interface* self);
  */
 void FormatConfig(Service::Interface* self);
 
-/// The maximum number of block entries that can exist in the config file
-static const u32 CONFIG_FILE_MAX_BLOCK_ENTRIES = 1479;
-
-/**
-* The header of the config savedata file,
-* contains information about the blocks in the file
-*/
-struct SaveFileConfig {
-    u16 total_entries;                        ///< The total number of set entries in the config file
-    u16 data_entries_offset;                  ///< The offset where the data for the blocks start, this is hardcoded to 0x455C as per hardware
-    SaveConfigBlockEntry block_entries[CONFIG_FILE_MAX_BLOCK_ENTRIES]; ///< The block headers, the maximum possible value is 1479 as per hardware
-    u32 unknown;                              ///< This field is unknown, possibly padding, 0 has been observed in hardware
-};
-static_assert(sizeof(SaveFileConfig) == 0x455C, "The SaveFileConfig header must be exactly 0x455C bytes");
-
-struct UsernameBlock {
-    char16_t username[10]; ///< Exactly 20 bytes long, padded with zeros at the end if necessary
-    u32 zero;
-    u32 ng_word;
-};
-static_assert(sizeof(UsernameBlock) == 0x1C, "Size of UsernameBlock must be 0x1C");
-
-struct ConsoleModelInfo {
-    u8 model;       ///< The console model (3DS, 2DS, etc)
-    u8 unknown[3];  ///< Unknown data
-};
-static_assert(sizeof(ConsoleModelInfo) == 4, "ConsoleModelInfo must be exactly 4 bytes");
-
-struct ConsoleCountryInfo {
-    u8 unknown[3];   ///< Unknown data
-    u8 country_code; ///< The country code of the console
-};
-static_assert(sizeof(ConsoleCountryInfo) == 4, "ConsoleCountryInfo must be exactly 4 bytes");
-
-extern const u64 CFG_SAVE_ID;
-extern const u64 CONSOLE_UNIQUE_ID;
-extern const ConsoleModelInfo CONSOLE_MODEL;
-extern const u8 CONSOLE_LANGUAGE;
-extern const char CONSOLE_USERNAME[0x14];
-/// This will be initialized in the Interface constructor, and will be used when creating the block
-extern UsernameBlock CONSOLE_USERNAME_BLOCK;
-/// TODO(Subv): Find out what this actually is
-extern const u8 SOUND_OUTPUT_MODE;
-extern const u8 UNITED_STATES_COUNTRY_ID;
-/// TODO(Subv): Find what the other bytes are
-extern const ConsoleCountryInfo COUNTRY_INFO;
-extern const std::array<float, 8> STEREO_CAMERA_SETTINGS;
-
-static_assert(sizeof(STEREO_CAMERA_SETTINGS) == 0x20, "STEREO_CAMERA_SETTINGS must be exactly 0x20 bytes");
-static_assert(sizeof(CONSOLE_UNIQUE_ID) == 8, "CONSOLE_UNIQUE_ID must be exactly 8 bytes");
-static_assert(sizeof(CONSOLE_LANGUAGE) == 1, "CONSOLE_LANGUAGE must be exactly 1 byte");
-static_assert(sizeof(SOUND_OUTPUT_MODE) == 1, "SOUND_OUTPUT_MODE must be exactly 1 byte");
-
 /**
  * Reads a block with the specified id and flag from the Config savegame buffer
  * and writes the output to output.

--- a/src/core/hle/service/cfg/cfg.h
+++ b/src/core/hle/service/cfg/cfg.h
@@ -278,7 +278,7 @@ ResultCode GetConfigInfoBlock(u32 block_id, u32 size, u32 flag, u8* output);
  * @param data A pointer containing the data we will write to the new block
  * @returns ResultCode indicating the result of the operation, 0 on success
  */
-ResultCode CreateConfigInfoBlk(u32 block_id, u16 size, u16 flags, const u8* data);
+ResultCode CreateConfigInfoBlk(u32 block_id, u16 size, u16 flags, const void* data);
 
 /**
  * Deletes the config savegame file from the filesystem, the buffer in memory is not affected

--- a/src/core/hle/service/cfg/cfg.h
+++ b/src/core/hle/service/cfg/cfg.h
@@ -42,7 +42,7 @@ struct SaveConfigBlockEntry {
 };
 
 // TODO(Link Mauve): use a constexpr once MSVC starts supporting it.
-#define C(code) ((code)[0] | ((code)[1] << 8))
+#define C(code) (u16)((code)[0] | ((code)[1] << 8))
 
 static const std::array<u16, 187> country_codes = {
     0,       C("JP"), 0,       0,       0,       0,       0,       0,       // 0-7


### PR DESCRIPTION
These blocks are required by various games to boot. (Including ALBW, Fire Emblem, and more.)

**NOTE:** You will have to delete your existing save at `user/nand/data/00000000000000000000000000000000/sysdata/00010017/00000000/config` in order for these changes to take effect.