### PR TITLE
Have the ARM interpreter generate callstacks for running applications

### DIFF
--- a/src/citra_qt/debugger/callstack.cpp
+++ b/src/citra_qt/debugger/callstack.cpp
@@ -7,69 +7,27 @@
 #include "citra_qt/debugger/callstack.h"
 
 #include "common/common_types.h"
-#include "common/symbols.h"
 
 #include "core/core.h"
-#include "core/memory.h"
 #include "core/arm/arm_interface.h"
-#include "core/arm/disassembler/arm_disasm.h"
 
 CallstackWidget::CallstackWidget(QWidget* parent): QDockWidget(parent)
 {
     ui.setupUi(this);
 
     callstack_model = new QStandardItemModel(this);
-    callstack_model->setColumnCount(4);
-    callstack_model->setHeaderData(0, Qt::Horizontal, "Stack Pointer");
-    callstack_model->setHeaderData(2, Qt::Horizontal, "Return Address");
-    callstack_model->setHeaderData(1, Qt::Horizontal, "Call Address");
-    callstack_model->setHeaderData(3, Qt::Horizontal, "Function");
+    callstack_model->setColumnCount(1);
+    callstack_model->setHeaderData(0, Qt::Horizontal, "Caller address");
     ui.treeView->setModel(callstack_model);
 }
 
 void CallstackWidget::OnDebugModeEntered()
 {
-    // Stack pointer
-    const u32 sp = Core::g_app_core->GetReg(13);
-
     Clear();
 
-    int counter = 0;
-    for (u32 addr = 0x10000000; addr >= sp; addr -= 4)
-    {
-        const u32 ret_addr = Memory::Read32(addr);
-        const u32 call_addr = ret_addr - 4; //get call address???
-
-        if (Memory::GetPointer(call_addr) == nullptr)
-            break;
-
-        /* TODO (mattvail) clean me, move to debugger interface */
-        u32 insn = Memory::Read32(call_addr);
-        if (ARM_Disasm::Decode(insn) == OP_BL)
-        {
-            std::string name;
-            // ripped from disasm
-            u8 cond = (insn >> 28) & 0xf;
-            u32 i_offset = insn & 0xffffff;
-            // Sign-extend the 24-bit offset
-            if ((i_offset >> 23) & 1)
-                i_offset |= 0xff000000;
-
-            // Pre-compute the left-shift and the prefetch offset
-            i_offset <<= 2;
-            i_offset += 8;
-            const u32 func_addr = call_addr + i_offset;
-
-            callstack_model->setItem(counter, 0, new QStandardItem(QString("0x%1").arg(addr, 8, 16, QLatin1Char('0'))));
-            callstack_model->setItem(counter, 1, new QStandardItem(QString("0x%1").arg(ret_addr, 8, 16, QLatin1Char('0'))));
-            callstack_model->setItem(counter, 2, new QStandardItem(QString("0x%1").arg(call_addr, 8, 16, QLatin1Char('0'))));
-
-            name = Symbols::HasSymbol(func_addr) ? Symbols::GetSymbol(func_addr).name : "unknown";
-            callstack_model->setItem(counter, 3, new QStandardItem(QString("%1_%2").arg(QString::fromStdString(name))
-                .arg(QString("0x%1").arg(func_addr, 8, 16, QLatin1Char('0')))));
-
-            counter++;
-        }
+    std::vector<u32> stack_trace = Core::g_app_core->GetStackTrace();
+    for (auto entry : stack_trace) {
+        callstack_model->setItem(callstack_model->rowCount(), new QStandardItem(QString("0x%1").arg(entry, 8, 16, QLatin1Char('0'))));
     }
 }
 
@@ -80,9 +38,5 @@ void CallstackWidget::OnDebugModeLeft()
 
 void CallstackWidget::Clear()
 {
-    for (int row = 0; row < callstack_model->rowCount(); row++) {
-        for (int column = 0; column < callstack_model->columnCount(); column++) {
-            callstack_model->setItem(row, column, new QStandardItem());
-        }
-    }
+    callstack_model->removeRows(0, callstack_model->rowCount());
 }

--- a/src/core/arm/arm_interface.h
+++ b/src/core/arm/arm_interface.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <vector>
+
 #include "common/common_types.h"
 #include "core/arm/skyeye_common/arm_regformat.h"
 
@@ -110,6 +112,8 @@ public:
      * @param value The value to store into the CP15 register.
      */
     virtual void SetCP15Register(CP15Register reg, u32 value) = 0;
+
+    virtual std::vector<u32> GetStackTrace() const = 0;
 
     /**
      * Advance the CPU core by the specified number of ticks (e.g. to simulate CPU execution time)

--- a/src/core/arm/dyncom/arm_dyncom.h
+++ b/src/core/arm/dyncom/arm_dyncom.h
@@ -33,6 +33,7 @@ public:
     void SetCPSR(u32 cpsr) override;
     u32 GetCP15Register(CP15Register reg) override;
     void SetCP15Register(CP15Register reg, u32 value) override;
+    std::vector<u32> GetStackTrace() const override;
 
     void AddTicks(u64 ticks) override;
 

--- a/src/core/arm/skyeye_common/armstate.h
+++ b/src/core/arm/skyeye_common/armstate.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <array>
+#include <vector>
 #include <unordered_map>
 
 #include "common/common_types.h"
@@ -239,6 +240,7 @@ public:
     // TODO(bunnei): Move this cache to a better place - it should be per codeset (likely per
     // process for our purposes), not per ARMul_State (which tracks CPU core state).
     std::unordered_map<u32, int> instruction_cache;
+    std::vector<u32> stack_trace;
 
 private:
     void ResetMPCoreCP15Registers();

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -5,6 +5,8 @@
 #pragma once
 
 #include <memory>
+#include <vector>
+
 #include "common/common_types.h"
 
 class ARM_Interface;
@@ -22,6 +24,8 @@ struct ThreadContext {
     u32 fpu_registers[64];
     u32 fpscr;
     u32 fpexc;
+
+    std::vector<u32> stack_trace;
 };
 
 extern std::unique_ptr<ARM_Interface> g_app_core; ///< ARM11 application core

--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -411,6 +411,12 @@ static void Break(u8 break_reason) {
     default: reason_str = "UNKNOWN"; break;
     }
     LOG_CRITICAL(Debug_Emulated, "Break reason: %s", reason_str.c_str());
+
+    std::vector<u32> stack_trace = Core::g_app_core->GetStackTrace();
+    for (int i = 0; i < stack_trace.size(); i++) {
+        // Mimic GDB, print stack traces with highest-level procedures displayed first
+        LOG_CRITICAL(Debug_Emulated, "  #%d: 0x%08X", i, stack_trace[stack_trace.size() - 1 - i]);
+    }
 }
 
 /// Used to output a message on a debug hardware unit - does nothing on a retail unit


### PR DESCRIPTION
This fixes the callstack widget (closes #586), although it removes some of its past "features" (which didn't work anyway).

I also changed `svcBreak` to print out a backtrace whenever it is triggered, for easier debugging when the emulated program panics.

CAVEAT: this does incur a minor performance cost, increasing the time spent in dyncom by ~1-2ms. If desired, I can add a CMake variable for disabling populating the callstack during execution.