### PR TITLE
CMake: Add missing library required by Linux for compiling glad

### DIFF
--- a/externals/glad/CMakeLists.txt
+++ b/externals/glad/CMakeLists.txt
@@ -9,3 +9,6 @@ set(HEADERS
 create_directory_groups(${SRCS} ${HEADERS})
 add_library(glad STATIC ${SRCS} ${HEADERS})
 target_include_directories(glad PUBLIC "include/")
+if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
+    target_link_libraries(glad dl)
+endif()


### PR DESCRIPTION
Closes #1108 and closes #1109 