### PR TITLE
citra-qt: Use monospace font on Disassembler and ARM Registers

### DIFF
--- a/src/citra_qt/debugger/disassembler.cpp
+++ b/src/citra_qt/debugger/disassembler.cpp
@@ -9,6 +9,8 @@
 #include "../bootmanager.h"
 #include "../hotkeys.h"
 
+#include "../util/util.h"
+
 #include "core/memory.h"
 
 #include "core/core.h"
@@ -16,7 +18,6 @@
 #include "common/symbols.h"
 #include "core/arm/arm_interface.h"
 #include "core/arm/disassembler/arm_disasm.h"
-
 
 DisassemblerModel::DisassemblerModel(QObject* parent) :
     QAbstractListModel(parent), base_address(0), code_size(0), program_counter(0), selection(QModelIndex()) {
@@ -75,6 +76,14 @@ QVariant DisassemblerModel::data(const QModelIndex& index, int role) const {
             else if (address == program_counter)
                 return QBrush(QColor(0xC0, 0xC0, 0xFF));
 
+            break;
+        }
+
+        case Qt::FontRole:
+        {
+            if (index.column() == 0 || index.column() == 1) { // 2 is the symbols column
+                return GetMonospaceFont();
+            }
             break;
         }
 

--- a/src/citra_qt/debugger/registers.cpp
+++ b/src/citra_qt/debugger/registers.cpp
@@ -4,6 +4,8 @@
 
 #include "registers.h"
 
+#include "../util/util.h"
+
 #include "core/core.h"
 #include "core/arm/arm_interface.h"
 
@@ -26,9 +28,32 @@ RegistersWidget::RegistersWidget(QWidget* parent) : QDockWidget(parent) {
         vfp_registers->addChild(child);
     }
 
+    QFont font = GetMonospaceFont();
+
     CreateCPSRChildren();
     CreateVFPSystemRegisterChildren();
 
+    // Set Registers to display in monospace font
+    for (int i = 0; i < core_registers->childCount(); ++i)
+        core_registers->child(i)->setFont(1, font);
+
+    for (int i = 0; i < vfp_registers->childCount(); ++i)
+        vfp_registers->child(i)->setFont(1, font);
+
+    for (int i = 0; i < vfp_system_registers->childCount(); ++i) {
+        vfp_system_registers->child(i)->setFont(1, font);
+        for (int x = 0; x < vfp_system_registers->child(i)->childCount(); ++x) {
+            vfp_system_registers->child(i)->child(x)->setFont(1, font);
+        }
+    }
+    // Set CSPR to display in monospace font
+    cpsr->setFont(1, font);
+    for (int i = 0; i < cpsr->childCount(); ++i) {
+        cpsr->child(i)->setFont(1, font);
+        for (int x = 0; x < cpsr->child(i)->childCount(); ++x) {
+            cpsr->child(i)->child(x)->setFont(1, font);
+        }
+    }
     setEnabled(false);
 }
 


### PR DESCRIPTION
Picked up #156 if order to finish #67. If any other debugger tool should use it, just say it and I'll add it.