### PR TITLE
Shader: Use constants and proper type casts

### DIFF
--- a/src/video_core/shader/shader.h
+++ b/src/video_core/shader/shader.h
@@ -289,13 +289,13 @@ struct UnitState {
 
     DebugData<Debug> debug;
 
-    static int InputOffset(const SourceRegister& reg) {
+    static size_t InputOffset(const SourceRegister& reg) {
         switch (reg.GetRegisterType()) {
         case RegisterType::Input:
-            return (int)offsetof(UnitState::Registers, input) + reg.GetIndex()*sizeof(Math::Vec4<float24>);
+            return offsetof(UnitState::Registers, input) + reg.GetIndex()*sizeof(Math::Vec4<float24>);
 
         case RegisterType::Temporary:
-            return (int)offsetof(UnitState::Registers, temporary) + reg.GetIndex()*sizeof(Math::Vec4<float24>);
+            return offsetof(UnitState::Registers, temporary) + reg.GetIndex()*sizeof(Math::Vec4<float24>);
 
         default:
             UNREACHABLE();
@@ -303,13 +303,13 @@ struct UnitState {
         }
     }
 
-    static int OutputOffset(const DestRegister& reg) {
+    static size_t OutputOffset(const DestRegister& reg) {
         switch (reg.GetRegisterType()) {
         case RegisterType::Output:
-            return (int)offsetof(UnitState::Registers, output) + reg.GetIndex()*sizeof(Math::Vec4<float24>);
+            return offsetof(UnitState::Registers, output) + reg.GetIndex()*sizeof(Math::Vec4<float24>);
 
         case RegisterType::Temporary:
-            return (int)offsetof(UnitState::Registers, temporary) + reg.GetIndex()*sizeof(Math::Vec4<float24>);
+            return offsetof(UnitState::Registers, temporary) + reg.GetIndex()*sizeof(Math::Vec4<float24>);
 
         default:
             UNREACHABLE();

--- a/src/video_core/shader/shader_jit_x64.cpp
+++ b/src/video_core/shader/shader_jit_x64.cpp
@@ -176,13 +176,13 @@ void JitCompiler::Compile_SwizzleSrc(Instruction instr, unsigned src_num, Source
         if (src_num == offset_src && instr.common.address_register_index != 0) {
             switch (instr.common.address_register_index) {
             case 1: // address offset 1
-                MOVAPS(dest, MComplex(src_ptr, ADDROFFS_REG_0, 1, src_offset_disp));
+                MOVAPS(dest, MComplex(src_ptr, ADDROFFS_REG_0, SCALE_1, src_offset_disp));
                 break;
             case 2: // address offset 2
-                MOVAPS(dest, MComplex(src_ptr, ADDROFFS_REG_1, 1, src_offset_disp));
+                MOVAPS(dest, MComplex(src_ptr, ADDROFFS_REG_1, SCALE_1, src_offset_disp));
                 break;
-            case 3: // adddress offet 3
-                MOVAPS(dest, MComplex(src_ptr, LOOPCOUNT_REG, 1, src_offset_disp));
+            case 3: // address offset 3
+                MOVAPS(dest, MComplex(src_ptr, LOOPCOUNT_REG, SCALE_1, src_offset_disp));
                 break;
             default:
                 UNREACHABLE();


### PR DESCRIPTION
- Change return type of register offsets functions from `int` to `size_t` to decouple them from the signed x64 displacement and adds checks to make sure any needed cast is well-defined.
- Use emitter's SCALE_1 constant.

I think it is clearer to do the distinction between an unsigned register offset a base register block and the x64 displacement which can be signed although this can be argued.
 