### PR TITLE
citra-qt: Trim recently used files list to size when insterting new item

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -297,6 +297,10 @@ void GMainWindow::StoreRecentFile(const QString& filename)
     QStringList recent_files = settings.value("recentFiles").toStringList();
     recent_files.prepend(filename);
     recent_files.removeDuplicates();
+    while (recent_files.size() > max_recent_files_item) {
+        recent_files.removeLast();
+    }
+
     settings.setValue("recentFiles", recent_files);
 
     UpdateRecentFiles();


### PR DESCRIPTION
Even though they weren't visible in the UI, old entries would never be removed from the list and would be stored in the config file across sessions.