### PR TITLE
citra-qt: Separate UI layout state in a separate section of the config

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -130,11 +130,14 @@ GMainWindow::GMainWindow() : emu_thread(nullptr)
 
     // Restore UI state
     QSettings settings;
+
+    settings.beginGroup("UILayout");
     restoreGeometry(settings.value("geometry").toByteArray());
     restoreState(settings.value("state").toByteArray());
     render_window->restoreGeometry(settings.value("geometryRenderWindow").toByteArray());
     microProfileDialog->restoreGeometry(settings.value("microProfileDialogGeometry").toByteArray());
     microProfileDialog->setVisible(settings.value("microProfileDialogVisible").toBool());
+    settings.endGroup();
 
     ui.action_Use_Hardware_Renderer->setChecked(Settings::values.use_hw_renderer);
     SetHardwareRendererEnabled(ui.action_Use_Hardware_Renderer->isChecked());
@@ -435,11 +438,15 @@ void GMainWindow::OnConfigure() {
 void GMainWindow::closeEvent(QCloseEvent* event) {
     // Save window layout
     QSettings settings(QSettings::IniFormat, QSettings::UserScope, "Citra team", "Citra");
+
+    settings.beginGroup("UILayout");
     settings.setValue("geometry", saveGeometry());
     settings.setValue("state", saveState());
     settings.setValue("geometryRenderWindow", render_window->saveGeometry());
     settings.setValue("microProfileDialogGeometry", microProfileDialog->saveGeometry());
     settings.setValue("microProfileDialogVisible", microProfileDialog->isVisible());
+    settings.endGroup();
+
     settings.setValue("singleWindowMode", ui.action_Single_Window_Mode->isChecked());
     settings.setValue("displayTitleBars", ui.actionDisplay_widget_title_bars->isChecked());
     settings.setValue("firstStart", false);


### PR DESCRIPTION
Closes #1113