### PR TITLE
citra-qt: high-DPI fixes and Retina on OS X

### DIFF
--- a/src/citra_qt/CMakeLists.txt
+++ b/src/citra_qt/CMakeLists.txt
@@ -24,6 +24,7 @@ set(SRCS
             hotkeys.cpp
             main.cpp
             citra-qt.rc
+            Info.plist
             )
 
 set(HEADERS
@@ -72,6 +73,7 @@ endif()
 
 if (APPLE)
     add_executable(citra-qt MACOSX_BUNDLE ${SRCS} ${HEADERS} ${UI_HDRS})
+    set_target_properties(citra-qt PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/Info.plist)
 else()
     add_executable(citra-qt ${SRCS} ${HEADERS} ${UI_HDRS})
 endif()

--- a/src/citra_qt/Info.plist
+++ b/src/citra_qt/Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleGetInfoString</key>
+	<string></string>
+	<key>CFBundleIconFile</key>
+	<string>citra.icns</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.citra-emu.citra</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleLongVersionString</key>
+	<string></string>
+	<key>CFBundleName</key>
+	<string>Citra</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string></string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string></string>
+	<key>CSResourcesFileMapped</key>
+	<true/>
+	<key>LSRequiresCarbon</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string></string>
+</dict>
+</plist>

--- a/src/citra_qt/Info.plist
+++ b/src/citra_qt/Info.plist
@@ -32,5 +32,9 @@
 	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string></string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>NSHighResolutionCapable</key>
+	<string>True</string>
 </dict>
 </plist>

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -111,6 +111,8 @@ public:
     void restoreGeometry(const QByteArray& geometry); // overridden
     QByteArray saveGeometry();  // overridden
 
+    qreal windowPixelRatio();
+
     void closeEvent(QCloseEvent* event) override;
 
     void keyPressEvent(QKeyEvent* event) override;


### PR DESCRIPTION
This PR brings two things:

* **Fix the coordinates of mouse events in high-DPI modes (on all platforms).** Mouse events didn't account for the window DPI.

* **Enable high-DPI UI on OS X.** The OS will render the widgets using the system screen DPI (instead of being locked at @1x resolution).

    For this we have to customize the app manifest file (named `Info.plist` on OS X) — instead of using the default cmake-generated one. This custom app manifest will also enable greater control of the app metadatas on OS X : I already have some code to fix the app icon and improve the app name displayed by the system.

    Apart from the OS X app manifest, no changes are made to the existing high-DPI rendering code already present in Citra.

![standarddpi](https://cloud.githubusercontent.com/assets/179923/9977091/e18f1ee8-5efb-11e5-9915-352fdbdddddf.png)
<img width="618" alt="highdpi" src="https://cloud.githubusercontent.com/assets/179923/9977092/e1a894d6-5efb-11e5-8edd-9b7feb884c46.png">
