### PR TITLE
ivfc_archive: Fix a printf specifier

### DIFF
--- a/src/core/file_sys/ivfc_archive.cpp
+++ b/src/core/file_sys/ivfc_archive.cpp
@@ -62,7 +62,7 @@ std::unique_ptr<DirectoryBackend> IVFCArchive::OpenDirectory(const Path& path) c
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 size_t IVFCFile::Read(const u64 offset, const size_t length, u8* buffer) const {
-    LOG_TRACE(Service_FS, "called offset=%llu, length=%d", offset, length);
+    LOG_TRACE(Service_FS, "called offset=%llu, length=%zu", offset, length);
     romfs_file->Seek(data_offset + offset, SEEK_SET);
     size_t read_length = (size_t)std::min((u64)length, data_size - offset);
 


### PR DESCRIPTION
Now that MSVC 2015 supports the %z family of specifiers, this can be used.