### PR TITLE
Game list: propely hide on toggling window mode

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -458,6 +458,7 @@ void GMainWindow::ToggleWindowMode() {
         if (emulation_running) {
             render_window->setVisible(true);
             render_window->setFocus();
+            game_list->hide();
         }
 
     } else {


### PR DESCRIPTION
Properly hides the game list upon toggling from external window mode to single window mode. Previously, both the game list and the render window would have been shown at the same time upon toggling.

Fixes #1188 