### PR TITLE
Loader: Implement NCCH encryption check

### DIFF
--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -71,6 +71,7 @@ enum class ResultStatus {
     ErrorNotUsed,
     ErrorAlreadyLoaded,
     ErrorMemoryAllocationFailed,
+    ErrorEncrypted,
 };
 
 static inline u32 MakeMagic(char a, char b, char c, char d) {

--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -266,6 +266,11 @@ ResultStatus AppLoader_NCCH::Load() {
     LOG_DEBUG(Loader, "Thread priority:             0x%X"  , priority);
     LOG_DEBUG(Loader, "Resource limit category:     %d"    , resource_limit_category);
 
+    if (exheader_header.arm11_system_local_caps.program_id != ncch_header.program_id) {
+        LOG_ERROR(Loader, "ExHeader Program ID mismatch: the ROM is probably encrypted.");
+        return ResultStatus::ErrorEncrypted;
+    }
+
     // Read ExeFS...
 
     exefs_offset = ncch_header.exefs_offset * kBlockSize;

--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -128,9 +128,8 @@ ResultStatus AppLoader_NCCH::LoadExec() {
     if (ResultStatus::Success == ReadCode(code)) {
         std::string process_name = Common::StringFromFixedZeroTerminatedBuffer(
                 (const char*)exheader_header.codeset_info.name, 8);
-        u64 program_id = *reinterpret_cast<u64_le const*>(&ncch_header.program_id[0]);
 
-        SharedPtr<CodeSet> codeset = CodeSet::Create(process_name, program_id);
+        SharedPtr<CodeSet> codeset = CodeSet::Create(process_name, ncch_header.program_id);
 
         codeset->code.offset = 0;
         codeset->code.addr = exheader_header.codeset_info.text.address;

--- a/src/core/loader/ncch.h
+++ b/src/core/loader/ncch.h
@@ -17,31 +17,31 @@
 
 struct NCCH_Header {
     u8 signature[0x100];
-    u32 magic;
-    u32 content_size;
+    u32_le magic;
+    u32_le content_size;
     u8 partition_id[8];
-    u16 maker_code;
-    u16 version;
+    u16_le maker_code;
+    u16_le version;
     u8 reserved_0[4];
     u64_le program_id;
     u8 reserved_1[0x10];
     u8 logo_region_hash[0x20];
     u8 product_code[0x10];
     u8 extended_header_hash[0x20];
-    u32 extended_header_size;
+    u32_le extended_header_size;
     u8 reserved_2[4];
     u8 flags[8];
-    u32 plain_region_offset;
-    u32 plain_region_size;
-    u32 logo_region_offset;
-    u32 logo_region_size;
-    u32 exefs_offset;
-    u32 exefs_size;
-    u32 exefs_hash_region_size;
+    u32_le plain_region_offset;
+    u32_le plain_region_size;
+    u32_le logo_region_offset;
+    u32_le logo_region_size;
+    u32_le exefs_offset;
+    u32_le exefs_size;
+    u32_le exefs_hash_region_size;
     u8 reserved_3[4];
-    u32 romfs_offset;
-    u32 romfs_size;
-    u32 romfs_hash_region_size;
+    u32_le romfs_offset;
+    u32_le romfs_size;
+    u32_le romfs_hash_region_size;
     u8 reserved_4[4];
     u8 exefs_super_block_hash[0x20];
     u8 romfs_super_block_hash[0x20];
@@ -110,7 +110,7 @@ struct ExHeader_StorageInfo {
 
 struct ExHeader_ARM11_SystemLocalCaps {
     u64_le program_id;
-    u32 core_version;
+    u32_le core_version;
     u8 reserved_flags[2];
     union {
         u8 flags0;

--- a/src/core/loader/ncch.h
+++ b/src/core/loader/ncch.h
@@ -23,7 +23,7 @@ struct NCCH_Header {
     u16 maker_code;
     u16 version;
     u8 reserved_0[4];
-    u8 program_id[8];
+    u64_le program_id;
     u8 reserved_1[0x10];
     u8 logo_region_hash[0x20];
     u8 product_code[0x10];
@@ -109,7 +109,7 @@ struct ExHeader_StorageInfo {
 };
 
 struct ExHeader_ARM11_SystemLocalCaps {
-    u8 program_id[8];
+    u64_le program_id;
     u32 core_version;
     u8 reserved_flags[2];
     union {


### PR DESCRIPTION
I've implemented a simple encryption check which compares the program IDs in the NCCH header and the extended header to see if the ROM is encrypted. I changed all of the header values to be explicitly little-endian to prevent any surprises if Citra gets ported to a big-endian microwave oven. I also changed the program ID from a uint8 array to a u64_le.

Issue #708 