### PR TITLE
Qt: Rename configuration folder (Breaks configuration, see description)

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -480,7 +480,7 @@ void GMainWindow::OnConfigure() {
 
 void GMainWindow::closeEvent(QCloseEvent* event) {
     // Save window layout
-    QSettings settings(QSettings::IniFormat, QSettings::UserScope, "Citra team", "Citra");
+    QSettings settings(QSettings::IniFormat, QSettings::UserScope, "Citra", "Citra");
 
     settings.beginGroup("UILayout");
     settings.setValue("geometry", saveGeometry());
@@ -520,7 +520,7 @@ int main(int argc, char* argv[]) {
 
     // Init settings params
     QSettings::setDefaultFormat(QSettings::IniFormat);
-    QCoreApplication::setOrganizationName("Citra team");
+    QCoreApplication::setOrganizationName("Citra");
     QCoreApplication::setApplicationName("Citra");
 
     QApplication::setAttribute(Qt::AA_X11InitThreads);


### PR DESCRIPTION
The folder in %appdata% or ~/.local/share with Citra.ini in it is currently called "Citra team". This is inconsistent with the naming scheme generally used in these locations. I have renamed the folder to "Citra" to better reflect its purpose.

Instructions for migration:

You'll have to rename the "Citra team" directory to "Citra". This can be found in %appdata% on Windows, or in ~/.local/share on Linux.