### PR TITLE
citra-qt: save hardware-rendering and shaders-jit settings

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -443,10 +443,18 @@ void GMainWindow::OnOpenHotkeysDialog() {
 
 void GMainWindow::SetHardwareRendererEnabled(bool enabled) {
     VideoCore::g_hw_renderer_enabled = enabled;
+
+    Config config;
+    Settings::values.use_hw_renderer = enabled;
+    config.Save();
 }
 
 void GMainWindow::SetShaderJITEnabled(bool enabled) {
     VideoCore::g_shader_jit_enabled = enabled;
+
+    Config config;
+    Settings::values.use_shader_jit = enabled;
+    config.Save();
 }
 
 void GMainWindow::ToggleWindowMode() {


### PR DESCRIPTION
Currently the "Use hardware renderer" or "Use Shader JIT" settings aren't persisted across launches when set from the Qt GUI. This PR makes those settings persistent.