### PR TITLE
GPU/Loaders: Log an error when a loader tries to load from a component beyond the available ones

### DIFF
--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -157,6 +157,8 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
 
                 // TODO: What happens if a loader overwrites a previous one's data?
                 for (unsigned component = 0; component < loader_config.component_count; ++component) {
+                    if (component >= 12)
+                        LOG_ERROR(HW_GPU, "Overflow in the vertex attribute loader %u trying to load component %u", loader, component);
                     u32 attribute_index = loader_config.GetComponent(component);
                     vertex_attribute_sources[attribute_index] = load_address;
                     vertex_attribute_strides[attribute_index] = static_cast<u32>(loader_config.byte_count);


### PR DESCRIPTION
Related to #1170 
None of my games do this but I figured it'd be a good thing to know if it does happen.