### PR TITLE
Shaders: Use UBOs instead of individual uniforms in the generated frag shaders

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -329,13 +329,17 @@ in vec4 primary_color;
 in vec2 texcoord[3];
 
 out vec4 color;
+
+layout (std140) uniform shader_data {
+    vec4 const_color[NUM_TEV_STAGES];
+    vec4 tev_combiner_buffer_color;
+    int alphatest_ref;
+};
+
 )";
 
     using Uniform = RasterizerOpenGL::PicaShader::Uniform;
-    out += "layout(location = " + std::to_string((int)Uniform::AlphaTestRef) + ") uniform int alphatest_ref;\n";
-    out += "layout(location = " + std::to_string((int)Uniform::TevConstColors) + ") uniform vec4 const_color[NUM_TEV_STAGES];\n";
     out += "layout(location = " + std::to_string((int)Uniform::Texture0) + ") uniform sampler2D tex[3];\n";
-    out += "layout(location = " + std::to_string((int)Uniform::TevCombinerBufferColor) + ") uniform vec4 tev_combiner_buffer_color;\n";
 
     out += "void main() {\n";
     out += "vec4 combiner_buffer = tev_combiner_buffer_color;\n";

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -180,6 +180,11 @@ void OpenGLState::Apply() {
         glBindBuffer(GL_ARRAY_BUFFER, draw.vertex_buffer);
     }
 
+    // Uniform buffer
+    if (draw.uniform_buffer != cur_state.draw.uniform_buffer) {
+        glBindBuffer(GL_UNIFORM_BUFFER, draw.uniform_buffer);
+    }
+
     // Shader program
     if (draw.shader_program != cur_state.draw.shader_program) {
         glUseProgram(draw.shader_program);
@@ -213,6 +218,9 @@ void OpenGLState::ResetProgram(GLuint id) {
 void OpenGLState::ResetBuffer(GLuint id) {
     if (cur_state.draw.vertex_buffer == id) {
         cur_state.draw.vertex_buffer = 0;
+    }
+    if (cur_state.draw.uniform_buffer == id) {
+        cur_state.draw.uniform_buffer = 0;
     }
 }
 

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -64,6 +64,7 @@ public:
         GLuint framebuffer; // GL_DRAW_FRAMEBUFFER_BINDING
         GLuint vertex_array; // GL_VERTEX_ARRAY_BINDING
         GLuint vertex_buffer; // GL_ARRAY_BUFFER_BINDING
+        GLuint uniform_buffer; // GL_UNIFORM_BUFFER_BINDING
         GLuint shader_program; // GL_CURRENT_PROGRAM
         bool shader_dirty;
     } draw;

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -256,6 +256,7 @@ void RendererOpenGL::InitOpenGLObjects() {
 
     state.draw.vertex_array = vertex_array_handle;
     state.draw.vertex_buffer = vertex_buffer_handle;
+    state.draw.uniform_buffer = 0;
     state.Apply();
 
     // Attach vertex data to VAO


### PR DESCRIPTION
Uniform Buffer Objects allow us to upload all our uniforms in a single OpenGL call instead of multiple ones.

This increases performance a little bit.