### PR TITLE
Enable RTTI on Windows builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,9 +92,8 @@ else()
     # /Zi - Output debugging information
     # /Zo - enahnced debug info for optimized builds
     set(CMAKE_C_FLAGS   "/W3 /MP /Zi /Zo" CACHE STRING "" FORCE)
-    # /GR- - Disable RTTI
     # /EHsc - C++-only exception handling semantics
-    set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} /GR- /EHsc" CACHE STRING "" FORCE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} /EHsc" CACHE STRING "" FORCE)
 
     # /MDd - Multi-threaded Debug Runtime DLL
     set(CMAKE_C_FLAGS_DEBUG   "/Od /MDd" CACHE STRING "" FORCE)


### PR DESCRIPTION
As per https://github.com/citra-emu/citra/issues/1054.

If I'm not mistaken, RTTI was only disabled on Windows. Please correct me if I missed a gcc/clang compiler switch which disables RTTI currently.