### PR TITLE
Add Initialize and GenerateRandomData function names to ssl:C

### DIFF
--- a/src/core/hle/service/ssl_c.cpp
+++ b/src/core/hle/service/ssl_c.cpp
@@ -11,8 +11,10 @@
 namespace SSL_C {
 
 const Interface::FunctionInfo FunctionTable[] = {
+    {0x00010002, nullptr,               "Initialize"},
     {0x000200C2, nullptr,               "CreateContext"},
     {0x00050082, nullptr,               "AddTrustedRootCA"},
+    {0x00110042, nullptr,               "GenerateRandomData"},
     {0x00150082, nullptr,               "Read"},
     {0x00170082, nullptr,               "Write"},
 };


### PR DESCRIPTION
Added function names for Initialize and GenerateRandomData in ssl:C (names came from 3dsbrew). Found these functions while testing the game SPEC ~KAN~.