### PR TITLE
Use regular uniform location

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -492,9 +492,10 @@ void RasterizerOpenGL::SetShader() {
         state.Apply();
 
         // Set the texture samplers to correspond to different texture units
-        glUniform1i(PicaShader::Uniform::Texture0, 0);
-        glUniform1i(PicaShader::Uniform::Texture1, 1);
-        glUniform1i(PicaShader::Uniform::Texture2, 2);
+        GLuint uniform_tex = glGetUniformLocation(shader->shader.handle, "tex");
+        glUniform1i(uniform_tex,     0);
+        glUniform1i(uniform_tex + 1, 1);
+        glUniform1i(uniform_tex + 2, 2);
 
         current_shader = shader_cache.emplace(config, std::move(shader)).first->second.get();
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -138,13 +138,6 @@ public:
     struct PicaShader {
         /// OpenGL shader resource
         OGLShader shader;
-
-        /// Fragment shader uniforms
-        enum Uniform : GLuint {
-            Texture0 = 0,
-            Texture1 = 1,
-            Texture2 = 2,
-        };
     };
 
 private:

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -321,8 +321,6 @@ static void WriteTevStage(std::string& out, const PicaShaderConfig& config, unsi
 std::string GenerateFragmentShader(const PicaShaderConfig& config) {
     std::string out = R"(
 #version 330
-#extension GL_ARB_explicit_uniform_location : require
-
 #define NUM_TEV_STAGES 6
 
 in vec4 primary_color;
@@ -338,9 +336,7 @@ layout (std140) uniform shader_data {
 
 )";
 
-    using Uniform = RasterizerOpenGL::PicaShader::Uniform;
-    out += "layout(location = " + std::to_string((int)Uniform::Texture0) + ") uniform sampler2D tex[3];\n";
-
+    out += "uniform sampler2D tex[3];\n";
     out += "void main() {\n";
     out += "vec4 combiner_buffer = tev_combiner_buffer_color;\n";
     out += "vec4 last_tex_env_out = vec4(0.0);\n";


### PR DESCRIPTION
The support for GL_ARB_explicit_uniform_location is decent, but not that good (53% according to http://feedback.wildfiregames.com/report/opengl/feature/GL_ARB_explicit_uniform_location).

Luckily, only a single place uses the explicit uniform location now: the textures uniform. So we can use regular location without much changes.

This fix the shader compilation on Intel HD 4000 (#1222 ; cc @bunnei).

_Disclaimer: I have no idea what I'm doing. But I'm eager for pointers and feedback :)_