### PR TITLE
renderer_opengl: Fix uniform issues with #1253

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -492,10 +492,12 @@ void RasterizerOpenGL::SetShader() {
         state.Apply();
 
         // Set the texture samplers to correspond to different texture units
-        GLuint uniform_tex = glGetUniformLocation(shader->shader.handle, "tex");
-        glUniform1i(uniform_tex,     0);
-        glUniform1i(uniform_tex + 1, 1);
-        glUniform1i(uniform_tex + 2, 2);
+        GLuint uniform_tex = glGetUniformLocation(shader->shader.handle, "tex[0]");
+        if (uniform_tex != -1) { glUniform1i(uniform_tex, 0); }
+        uniform_tex = glGetUniformLocation(shader->shader.handle, "tex[1]");
+        if (uniform_tex != -1) { glUniform1i(uniform_tex, 1); }
+        uniform_tex = glGetUniformLocation(shader->shader.handle, "tex[2]");
+        if (uniform_tex != -1) { glUniform1i(uniform_tex, 2); }
 
         current_shader = shader_cache.emplace(config, std::move(shader)).first->second.get();
 

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -320,7 +320,7 @@ static void WriteTevStage(std::string& out, const PicaShaderConfig& config, unsi
 
 std::string GenerateFragmentShader(const PicaShaderConfig& config) {
     std::string out = R"(
-#version 330
+#version 330 core
 #define NUM_TEV_STAGES 6
 
 in vec4 primary_color;
@@ -362,7 +362,7 @@ layout (std140) uniform shader_data {
 }
 
 std::string GenerateVertexShader() {
-    std::string out = "#version 330\n";
+    std::string out = "#version 330 core\n";
     out += "layout(location = " + std::to_string((int)ATTRIBUTE_POSITION)  + ") in vec4 vert_position;\n";
     out += "layout(location = " + std::to_string((int)ATTRIBUTE_COLOR)     + ") in vec4 vert_color;\n";
     out += "layout(location = " + std::to_string((int)ATTRIBUTE_TEXCOORD0) + ") in vec2 vert_texcoord0;\n";


### PR DESCRIPTION
I hastily merged #1253, which had several issues, including:
* Vertex shader still used fixed uniform positions
 * Furthermore, the corresponding GL extension was not requested
* GL version requested during shader generation was wrong
* GL fragment shader uniforms were being uploaded without checking their validity