### PR TITLE
armstate: Zero out the registers on creation

### DIFF
--- a/src/core/arm/skyeye_common/armstate.h
+++ b/src/core/arm/skyeye_common/armstate.h
@@ -193,23 +193,23 @@ public:
         return TFlag ? 2 : 4;
     }
 
-    std::array<u32, 16> Reg;      // The current register file
-    std::array<u32, 2> Reg_usr;
-    std::array<u32, 2> Reg_svc;   // R13_SVC R14_SVC
-    std::array<u32, 2> Reg_abort; // R13_ABORT R14_ABORT
-    std::array<u32, 2> Reg_undef; // R13 UNDEF R14 UNDEF
-    std::array<u32, 2> Reg_irq;   // R13_IRQ R14_IRQ
-    std::array<u32, 7> Reg_firq;  // R8---R14 FIRQ
-    std::array<u32, 7> Spsr;      // The exception psr's
-    std::array<u32, CP15_REGISTER_COUNT> CP15;
+    std::array<u32, 16> Reg{};      // The current register file
+    std::array<u32, 2> Reg_usr{};
+    std::array<u32, 2> Reg_svc{};   // R13_SVC R14_SVC
+    std::array<u32, 2> Reg_abort{}; // R13_ABORT R14_ABORT
+    std::array<u32, 2> Reg_undef{}; // R13 UNDEF R14 UNDEF
+    std::array<u32, 2> Reg_irq{};   // R13_IRQ R14_IRQ
+    std::array<u32, 7> Reg_firq{};  // R8---R14 FIRQ
+    std::array<u32, 7> Spsr{};      // The exception psr's
+    std::array<u32, CP15_REGISTER_COUNT> CP15{};
 
     // FPSID, FPSCR, and FPEXC
-    std::array<u32, VFP_SYSTEM_REGISTER_COUNT> VFP;
+    std::array<u32, VFP_SYSTEM_REGISTER_COUNT> VFP{};
 
     // VFPv2 and VFPv3-D16 has 16 doubleword registers (D0-D16 or S0-S31).
     // VFPv3-D32/ASIMD may have up to 32 doubleword registers (D0-D31),
     // and only 32 singleword registers are accessible (S0-S31).
-    std::array<u32, 64> ExtReg;
+    std::array<u32, 64> ExtReg{};
 
     u32 Emulate; // To start and stop emulation
     u32 Cpsr;    // The current PSR


### PR DESCRIPTION
std::array isn't always guaranteed to explicitly zero out it's contents without an initializer list.