### PR TITLE
Fix compilation warnings (part 1)

### DIFF
--- a/src/common/emu_window.cpp
+++ b/src/common/emu_window.cpp
@@ -125,7 +125,6 @@ EmuWindow::FramebufferLayout EmuWindow::FramebufferLayout::DefaultScreenLayout(u
     return res;
 }
 
-void EmuWindow::OnMinimalClientAreaChangeRequest(const std::pair<unsigned,unsigned>& minimal_size) {
+void EmuWindow::OnMinimalClientAreaChangeRequest(const std::pair<unsigned,unsigned>&) {
     // By default, ignore this request and do nothing.
-    (void)minimal_size;
 }

--- a/src/common/emu_window.cpp
+++ b/src/common/emu_window.cpp
@@ -124,3 +124,8 @@ EmuWindow::FramebufferLayout EmuWindow::FramebufferLayout::DefaultScreenLayout(u
 
     return res;
 }
+
+void EmuWindow::OnMinimalClientAreaChangeRequest(const std::pair<unsigned,unsigned>& minimal_size) {
+    // By default, ignore this request and do nothing.
+    (void)minimal_size;
+}

--- a/src/common/emu_window.h
+++ b/src/common/emu_window.h
@@ -195,7 +195,7 @@ private:
      * Handler called when the minimal client area was requested to be changed via SetConfig.
      * For the request to be honored, EmuWindow implementations will usually reimplement this function.
      */
-    virtual void OnMinimalClientAreaChangeRequest(const std::pair<unsigned,unsigned>& minimal_size);
+    virtual void OnMinimalClientAreaChangeRequest(const std::pair<unsigned,unsigned>&);
 
     FramebufferLayout framebuffer_layout; ///< Current framebuffer layout
 

--- a/src/common/emu_window.h
+++ b/src/common/emu_window.h
@@ -195,9 +195,7 @@ private:
      * Handler called when the minimal client area was requested to be changed via SetConfig.
      * For the request to be honored, EmuWindow implementations will usually reimplement this function.
      */
-    virtual void OnMinimalClientAreaChangeRequest(const std::pair<unsigned,unsigned>& minimal_size) {
-        // By default, ignore this request and do nothing.
-    }
+    virtual void OnMinimalClientAreaChangeRequest(const std::pair<unsigned,unsigned>& minimal_size);
 
     FramebufferLayout framebuffer_layout; ///< Current framebuffer layout
 

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -506,7 +506,7 @@ unsigned ScanDirectoryTree(const std::string &directory, FSTEntry& parent_entry)
 
 bool DeleteDirRecursively(const std::string &directory)
 {
-    const static auto callback = [](unsigned* num_entries_out,
+    const static auto callback = [](unsigned*,
                                     const std::string& _directory,
                                     const std::string& virtual_name) -> bool {
         std::string new_path = _directory + DIR_SEP_CHR + virtual_name;

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -470,6 +470,8 @@ bool ForeachDirectoryEntry(unsigned* num_entries_out, const std::string &directo
     // num_entries_out is allowed to be specified nullptr, in which case we shouldn't try to set it
     if (num_entries_out != nullptr)
         *num_entries_out = found_entries;
+
+    return true;
 }
 
 unsigned ScanDirectoryTree(const std::string &directory, FSTEntry& parent_entry)

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -487,7 +487,7 @@ unsigned ScanDirectoryTree(const std::string &directory, FSTEntry& parent_entry)
             entry.isDirectory = true;
             // is a directory, lets go inside
             entry.size = ScanDirectoryTree(entry.physicalName, entry);
-            *num_entries_out += (int)entry.size;
+            *num_entries_out += entry.size;
         } else { // is a file
             entry.isDirectory = false;
             entry.size = GetSize(entry.physicalName);

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -475,11 +475,11 @@ bool ForeachDirectoryEntry(unsigned* num_entries_out, const std::string &directo
 unsigned ScanDirectoryTree(const std::string &directory, FSTEntry& parent_entry)
 {
     const auto callback = [&parent_entry](unsigned* num_entries_out,
-                                          const std::string& directory,
+                                          const std::string& _directory,
                                           const std::string& virtual_name) -> bool {
         FSTEntry entry;
         entry.virtualName = virtual_name;
-        entry.physicalName = directory + DIR_SEP + virtual_name;
+        entry.physicalName = _directory + DIR_SEP + virtual_name;
 
         if (IsDirectory(entry.physicalName)) {
             entry.isDirectory = true;
@@ -505,9 +505,9 @@ unsigned ScanDirectoryTree(const std::string &directory, FSTEntry& parent_entry)
 bool DeleteDirRecursively(const std::string &directory)
 {
     const static auto callback = [](unsigned* num_entries_out,
-                                    const std::string& directory,
+                                    const std::string& _directory,
                                     const std::string& virtual_name) -> bool {
-        std::string new_path = directory + DIR_SEP_CHR + virtual_name;
+        std::string new_path = _directory + DIR_SEP_CHR + virtual_name;
         if (IsDirectory(new_path))
             return DeleteDirRecursively(new_path);
 

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -248,7 +248,7 @@ public:
     void SetHandle(std::FILE* file);
 
     bool Seek(s64 off, int origin);
-    u64 Tell();
+    s64 Tell();
     u64 GetSize();
     bool Resize(u64 size);
     bool Flush();

--- a/src/common/hash.cpp
+++ b/src/common/hash.cpp
@@ -36,7 +36,7 @@ static FORCE_INLINE u64 fmix64(u64 k) {
 // platforms (MurmurHash3_x64_128). It was taken from:
 // https://code.google.com/p/smhasher/source/browse/trunk/MurmurHash3.cpp
 void MurmurHash3_128(const void* key, int len, u32 seed, void* out) {
-    const u8 * data = (const u8*)key;
+    const u8* data = static_cast<const u8*>(key);
     const int nblocks = len / 16;
 
     u64 h1 = seed;
@@ -47,7 +47,7 @@ void MurmurHash3_128(const void* key, int len, u32 seed, void* out) {
 
     // Body
 
-    const u64 * blocks = (const u64 *)(data);
+    const u64* blocks = reinterpret_cast<const u64*>(data);
 
     for (int i = 0; i < nblocks; i++) {
         u64 k1 = getblock64(blocks,i*2+0);
@@ -64,35 +64,36 @@ void MurmurHash3_128(const void* key, int len, u32 seed, void* out) {
 
     // Tail
 
-    const u8 * tail = (const u8*)(data + nblocks*16);
+    const u8* tail = static_cast<const u8*>(data + nblocks*16);
 
     u64 k1 = 0;
     u64 k2 = 0;
 
     switch (len & 15) {
-    case 15: k2 ^= ((u64)tail[14]) << 48;
-    case 14: k2 ^= ((u64)tail[13]) << 40;
-    case 13: k2 ^= ((u64)tail[12]) << 32;
-    case 12: k2 ^= ((u64)tail[11]) << 24;
-    case 11: k2 ^= ((u64)tail[10]) << 16;
-    case 10: k2 ^= ((u64)tail[ 9]) << 8;
-    case  9: k2 ^= ((u64)tail[ 8]) << 0;
+    case 15: k2 ^= static_cast<u64>(tail[14]) << 48;
+    case 14: k2 ^= static_cast<u64>(tail[13]) << 40;
+    case 13: k2 ^= static_cast<u64>(tail[12]) << 32;
+    case 12: k2 ^= static_cast<u64>(tail[11]) << 24;
+    case 11: k2 ^= static_cast<u64>(tail[10]) << 16;
+    case 10: k2 ^= static_cast<u64>(tail[ 9]) << 8;
+    case  9: k2 ^= static_cast<u64>(tail[ 8]) << 0;
         k2 *= c2; k2  = _rotl64(k2,33); k2 *= c1; h2 ^= k2;
 
-    case  8: k1 ^= ((u64)tail[ 7]) << 56;
-    case  7: k1 ^= ((u64)tail[ 6]) << 48;
-    case  6: k1 ^= ((u64)tail[ 5]) << 40;
-    case  5: k1 ^= ((u64)tail[ 4]) << 32;
-    case  4: k1 ^= ((u64)tail[ 3]) << 24;
-    case  3: k1 ^= ((u64)tail[ 2]) << 16;
-    case  2: k1 ^= ((u64)tail[ 1]) << 8;
-    case  1: k1 ^= ((u64)tail[ 0]) << 0;
+    case  8: k1 ^= static_cast<u64>(tail[ 7]) << 56;
+    case  7: k1 ^= static_cast<u64>(tail[ 6]) << 48;
+    case  6: k1 ^= static_cast<u64>(tail[ 5]) << 40;
+    case  5: k1 ^= static_cast<u64>(tail[ 4]) << 32;
+    case  4: k1 ^= static_cast<u64>(tail[ 3]) << 24;
+    case  3: k1 ^= static_cast<u64>(tail[ 2]) << 16;
+    case  2: k1 ^= static_cast<u64>(tail[ 1]) << 8;
+    case  1: k1 ^= static_cast<u64>(tail[ 0]) << 0;
         k1 *= c1; k1  = _rotl64(k1,31); k1 *= c2; h1 ^= k1;
     };
 
     // Finalization
 
-    h1 ^= len; h2 ^= len;
+    h1 ^= static_cast<u64>(len);
+    h2 ^= static_cast<u64>(len);
 
     h1 += h2;
     h2 += h1;
@@ -103,8 +104,8 @@ void MurmurHash3_128(const void* key, int len, u32 seed, void* out) {
     h1 += h2;
     h2 += h1;
 
-    ((u64*)out)[0] = h1;
-    ((u64*)out)[1] = h2;
+    static_cast<u64*>(out)[0] = h1;
+    static_cast<u64*>(out)[1] = h2;
 }
 
 } // namespace Common

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -109,7 +109,7 @@ Entry CreateEntry(Class log_class, Level log_level,
     vsnprintf(formatting_buffer.data(), formatting_buffer.size(), format, args);
     entry.message = std::string(formatting_buffer.data());
 
-    return std::move(entry);
+    return entry;
 }
 
 static Filter* filter = nullptr;

--- a/src/common/logging/filter.h
+++ b/src/common/logging/filter.h
@@ -48,7 +48,7 @@ public:
     bool CheckMessage(Class log_class, Level level) const;
 
 private:
-    std::array<Level, (size_t)Class::Count> class_levels;
+    std::array<Level, static_cast<size_t>(Class::Count)> class_levels;
 };
 
 }

--- a/src/common/memory_util.cpp
+++ b/src/common/memory_util.cpp
@@ -70,7 +70,7 @@ void* AllocateExecutableMemory(size_t size)
     }
 #endif
 
-#if EMU_ARCH_BITS == 64
+#if defined(EMU_ARCH_BITS) && EMU_ARCH_BITS == 64
     if ((u64)ptr >= 0x80000000 && low == true)
         LOG_ERROR(Common_Memory, "Executable memory ended up above 2GB!");
 #endif

--- a/src/common/memory_util.cpp
+++ b/src/common/memory_util.cpp
@@ -25,7 +25,7 @@
 // This is purposely not a full wrapper for virtualalloc/mmap, but it
 // provides exactly the primitive operations that Dolphin needs.
 
-void* AllocateExecutableMemory(size_t size, bool low)
+void* AllocateExecutableMemory(size_t size)
 {
 #if defined(_WIN32)
     void* ptr = VirtualAlloc(nullptr, size, MEM_COMMIT, PAGE_EXECUTE_READWRITE);

--- a/src/common/memory_util.h
+++ b/src/common/memory_util.h
@@ -7,7 +7,7 @@
 #include <cstddef>
 #include <string>
 
-void* AllocateExecutableMemory(size_t size, bool low = true);
+void* AllocateExecutableMemory(size_t size);
 void* AllocateMemoryPages(size_t size);
 void FreeMemoryPages(void* ptr, size_t size);
 void* AllocateAlignedMemory(size_t size,size_t alignment);

--- a/src/common/misc.cpp
+++ b/src/common/misc.cpp
@@ -13,7 +13,7 @@
 #endif
 
 // Neither Android nor OS X support TLS
-#if  defined(__APPLE__) || (ANDROID && __clang__)
+#if  defined(__APPLE__) || (defined(ANDROID) && ANDROID && __clang__)
 #define __thread
 #endif
 

--- a/src/common/misc.cpp
+++ b/src/common/misc.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <cstddef>
+#include "common/common_funcs.h"
 
 #ifdef _WIN32
 #include <windows.h>

--- a/src/common/profiler.cpp
+++ b/src/common/profiler.cpp
@@ -90,10 +90,10 @@ void ProfilingManager::FinishFrame() {
     last_frame_end = now;
 }
 
-TimingResultsAggregator::TimingResultsAggregator(size_t window_size)
-        : max_window_size(window_size), window_size(0) {
-    interframe_times.resize(window_size, Duration::zero());
-    frame_times.resize(window_size, Duration::zero());
+TimingResultsAggregator::TimingResultsAggregator(size_t _window_size)
+        : max_window_size(_window_size), window_size(0) {
+    interframe_times.resize(_window_size, Duration::zero());
+    frame_times.resize(_window_size, Duration::zero());
 }
 
 void TimingResultsAggregator::Clear() {

--- a/src/common/profiler.cpp
+++ b/src/common/profiler.cpp
@@ -59,7 +59,7 @@ unsigned int ProfilingManager::RegisterTimingCategory(TimingCategory* category, 
     info.name = name;
     info.parent = TimingCategoryInfo::NO_PARENT;
 
-    unsigned int id = (unsigned int)timing_categories.size();
+    unsigned int id = static_cast<unsigned int>(timing_categories.size());
     timing_categories.push_back(std::move(info));
 
     return id;
@@ -140,7 +140,7 @@ static AggregatedDuration AggregateField(const std::vector<Duration>& v, size_t 
         result.max = std::max(result.max, value);
     }
     if (len != 0)
-        result.avg /= len;
+        result.avg /= static_cast<const long>(len);
 
     return result;
 }
@@ -177,7 +177,7 @@ ProfilingManager& GetProfilingManager() {
 }
 
 SynchronizedRef<TimingResultsAggregator> GetTimingResultsAggregator() {
-    static SynchronizedWrapper<TimingResultsAggregator> aggregator(30);
+    static SynchronizedWrapper<TimingResultsAggregator> aggregator(static_cast<size_t>(30));
     return SynchronizedRef<TimingResultsAggregator>(aggregator);
 }
 

--- a/src/common/profiler.h
+++ b/src/common/profiler.h
@@ -64,7 +64,7 @@ public:
      */
     Duration GetAccumulatedTime() {
         return Duration(std::atomic_exchange_explicit(
-                &accumulated_duration, (Duration::rep)0,
+                &accumulated_duration, static_cast<Duration::rep>(0),
                 std::memory_order_relaxed));
     }
 

--- a/src/common/profiler.h
+++ b/src/common/profiler.h
@@ -84,7 +84,7 @@ private:
  */
 class Timer {
 public:
-    Timer(TimingCategory& category) : category(category) {
+    Timer(TimingCategory& _category) : category(_category) {
     }
 
     void Start() {

--- a/src/common/profiler_reporting.h
+++ b/src/common/profiler_reporting.h
@@ -14,7 +14,7 @@ namespace Common {
 namespace Profiling {
 
 struct TimingCategoryInfo {
-    static const unsigned int NO_PARENT = -1;
+    static const unsigned int NO_PARENT = std::numeric_limits<unsigned>::max();
 
     TimingCategory* category;
     const char* name;

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -391,8 +391,14 @@ static std::string CodeToUTF8(const char* fromcode, const std::basic_string<T>& 
 
     while (0 != src_bytes)
     {
-        size_t const iconv_result = iconv(conv_desc, (char**)(&src_buffer), &src_bytes,
-            &dst_buffer, &dst_bytes);
+        const char** iconv_inbuff = reinterpret_cast<const char**>(&src_buffer);
+
+        // This const_cast is here because iconv declares its second argument as
+        // "char**" where it should be "const char**" because the only thing
+        // actually modified is the pointer, hence the const_cast.
+        const size_t iconv_result = iconv(conv_desc,
+                                        const_cast<char**>(iconv_inbuff),
+                                        &src_bytes, &dst_buffer, &dst_bytes);
 
         if (static_cast<size_t>(-1) == iconv_result)
         {

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -39,7 +39,7 @@ std::string ToUpper(std::string str) {
 bool AsciiToHex(const char* _szValue, u32& result)
 {
     char *endptr = nullptr;
-    const u32 value = strtoul(_szValue, &endptr, 16);
+    const u32 value = static_cast<u32>(strtoul(_szValue, &endptr, 16));
 
     if (!endptr || *endptr)
         return false;
@@ -81,7 +81,7 @@ bool CharArrayFromFormatV(char* out, int outsize, const char* format, va_list ar
         c_locale = _create_locale(LC_ALL, ".1252");
     writtenCount = _vsnprintf_l(out, outsize, format, c_locale, args);
 #else
-    writtenCount = vsnprintf(out, outsize, format, args);
+    writtenCount = vsnprintf(out, static_cast<size_t>(outsize), format, args);
 #endif
 
     if (writtenCount > 0 && writtenCount < outsize)
@@ -131,7 +131,7 @@ std::string ArrayToString(const u8 *data, u32 size, int line_len, bool spaces)
 
     for (int line = 0; size; ++data, --size)
     {
-        oss << std::setw(2) << (int)*data;
+        oss << std::setw(2) << *data;
 
         if (line_len == ++line)
         {
@@ -266,7 +266,7 @@ void SplitString(const std::string& str, const char delim, std::vector<std::stri
 
 std::string TabsToSpaces(int tab_size, const std::string &in)
 {
-    const std::string spaces(tab_size, ' ');
+    const std::string spaces(static_cast<size_t>(tab_size), ' ');
     std::string out(in);
 
     size_t i = 0;
@@ -369,7 +369,7 @@ static std::string CodeToUTF8(const char* fromcode, const std::basic_string<T>& 
     std::string result;
 
     iconv_t const conv_desc = iconv_open("UTF-8", fromcode);
-    if ((iconv_t)(-1) == conv_desc)
+    if (reinterpret_cast<iconv_t>(-1) == conv_desc)
     {
         LOG_ERROR(Common, "Iconv initialization failure [%s]: %s", fromcode, strerror(errno));
         iconv_close(conv_desc);
@@ -425,7 +425,7 @@ std::u16string UTF8ToUTF16(const std::string& input)
     std::u16string result;
 
     iconv_t const conv_desc = iconv_open("UTF-16LE", "UTF-8");
-    if ((iconv_t)(-1) == conv_desc)
+    if (reinterpret_cast<iconv_t>(-1) == conv_desc)
     {
         LOG_ERROR(Common, "Iconv initialization failure [UTF-8]: %s", strerror(errno));
         iconv_close(conv_desc);
@@ -441,7 +441,7 @@ std::u16string UTF8ToUTF16(const std::string& input)
 
     char* src_buffer = const_cast<char*>(&input[0]);
     size_t src_bytes = in_bytes;
-    char* dst_buffer = (char*)(&out_buffer[0]);
+    char* dst_buffer = reinterpret_cast<char*>(&out_buffer[0]);
     size_t dst_bytes = out_buffer.size();
 
     while (0 != src_bytes)

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -4,6 +4,7 @@
 
 #include <cctype>
 #include <cerrno>
+#include <climits>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>

--- a/src/common/synchronized_wrapper.h
+++ b/src/common/synchronized_wrapper.h
@@ -38,8 +38,8 @@ private:
 template <typename T>
 class SynchronizedRef {
 public:
-    SynchronizedRef(SynchronizedWrapper<T>& wrapper) : wrapper(&wrapper) {
-        wrapper.mutex.lock();
+    SynchronizedRef(SynchronizedWrapper<T>& _wrapper) : wrapper(&_wrapper) {
+        _wrapper.mutex.lock();
     }
 
     SynchronizedRef(SynchronizedRef&) = delete;


### PR DESCRIPTION
I'm compiling with `-Werror`, `-Weverything` and some warnings disabled (see https://github.com/Dettorer/citra/commit/f47d8b846873d760de71d06d8e7eed98cc18cf1b, not in this pull request).

I find `static_cast` are more clear and less dangerous than C-style even on numeric types (they can hide a `const_cast`) but I would understand if you want me to keep them. I would then add `-Wno-old-style-cast` to my compile flags.

I expect this PR to be far from perfect as this is my first one, I will try to fix it and take the remarks into account for the next ones the best as I can!

I took a different, more progressive approach with PR https://github.com/citra-emu/citra/pull/1284. The fixes in this PR are still useful but I will continue developing with the new direction for future PRs.