### PR TITLE
Pica/Scissor: Implemented the scissor test.

### DIFF
--- a/src/video_core/pica.cpp
+++ b/src/video_core/pica.cpp
@@ -28,6 +28,7 @@ std::string Regs::GetCommandName(int index) {
         ADD_FIELD(viewport_size_y);
         ADD_FIELD(viewport_depth_range);
         ADD_FIELD(viewport_depth_far_plane);
+        ADD_FIELD(scissor_test);
         ADD_FIELD(viewport_corner);
         ADD_FIELD(texture0_enable);
         ADD_FIELD(texture0);

--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -112,7 +112,36 @@ struct Regs {
         BitField<24, 5, Semantic> map_w;
     } vs_output_attributes[7];
 
-    INSERT_PADDING_WORDS(0x11);
+    INSERT_PADDING_WORDS(0xe);
+
+    enum class ScissorMode : u32 {
+        Disabled = 0,
+        Exclude = 1, // Exclude pixels inside the scissor box
+
+        Include = 3 // Exclude pixels outside the scissor box
+    };
+
+    struct {
+        BitField<0, 2, ScissorMode> mode;
+
+        union {
+            BitField< 0, 16, u32> right;
+            BitField<16, 16, u32> bottom;
+        };
+
+        union {
+            BitField< 0, 16, u32> left;
+            BitField<16, 16, u32> top;
+        };
+
+        u32 GetWidth() const {
+            return left - right + 1;
+        }
+
+        u32 GetHeight() const {
+            return top - bottom + 1;
+        }
+    } scissor_test;
 
     union {
         BitField< 0, 16, u32> x;
@@ -986,6 +1015,7 @@ ASSERT_REG_POSITION(viewport_depth_range, 0x4d);
 ASSERT_REG_POSITION(viewport_depth_far_plane, 0x4e);
 ASSERT_REG_POSITION(vs_output_attributes[0], 0x50);
 ASSERT_REG_POSITION(vs_output_attributes[1], 0x51);
+ASSERT_REG_POSITION(scissor_test, 0x65);
 ASSERT_REG_POSITION(viewport_corner, 0x68);
 ASSERT_REG_POSITION(texture0_enable, 0x80);
 ASSERT_REG_POSITION(texture0, 0x81);

--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -130,16 +130,16 @@ struct Regs {
         };
 
         union {
-            BitField< 0, 16, u32> left;
-            BitField<16, 16, u32> top;
+            BitField< 0, 16, u32> left_minus_1;
+            BitField<16, 16, u32> top_minus_1;
         };
 
-        u32 GetWidth() const {
-            return left - right + 1;
+        u32 GetTop() const {
+            return top_minus_1 + 1;
         }
 
-        u32 GetHeight() const {
-            return top - bottom + 1;
+        u32 GetLeft() const {
+            return left_minus_1 + 1;
         }
     } scissor_test;
 

--- a/src/video_core/rasterizer.cpp
+++ b/src/video_core/rasterizer.cpp
@@ -340,17 +340,17 @@ static void ProcessTriangleInternal(const Shader::OutputVertex& v0,
     u16 max_y = std::max({vtxpos[0].y, vtxpos[1].y, vtxpos[2].y});
 
     // Convert the scissor box coordinates to 12.4 fixed point
-    u16 scissor_width = (u16)(regs.scissor_test.GetWidth() << 4);
-    u16 scissor_height = (u16)(regs.scissor_test.GetHeight() << 4);
-    u16 scissor_x = (u16)(regs.scissor_test.right << 4);
-    u16 scissor_y = (u16)(regs.scissor_test.bottom << 4);
+    u16 scissor_left = (u16)(regs.scissor_test.GetLeft() << 4);
+    u16 scissor_top = (u16)(regs.scissor_test.GetTop() << 4);
+    u16 scissor_right = (u16)(regs.scissor_test.right << 4);
+    u16 scissor_bottom = (u16)(regs.scissor_test.bottom << 4);
 
     if (regs.scissor_test.mode == Regs::ScissorMode::Include) {
         // Calculate the new bounds
-        min_x = std::max(min_x, scissor_x);
-        min_y = std::max(min_y, scissor_y);
-        max_x = std::min(max_x, (u16)(scissor_x + scissor_width));
-        max_y = std::min(max_y, (u16)(scissor_y + scissor_height));
+        min_x = std::max(min_x, scissor_right);
+        min_y = std::max(min_y, scissor_bottom);
+        max_x = std::min(max_x, scissor_left);
+        max_y = std::min(max_y, scissor_top);
     }
 
     min_x &= Fix12P4::IntMask();
@@ -394,8 +394,8 @@ static void ProcessTriangleInternal(const Shader::OutputVertex& v0,
 
             // Do not process the pixel if it's inside the scissor box and the scissor mode is set to Exclude
             if (regs.scissor_test.mode == Regs::ScissorMode::Exclude &&
-                x >= scissor_x && x <= scissor_x + scissor_width &&
-                y >= scissor_y && y <= scissor_y + scissor_height) {
+                x >= scissor_right && x <= scissor_left &&
+                y >= scissor_bottom && y <= scissor_top) {
                 continue;
             }
 

--- a/src/video_core/rasterizer.cpp
+++ b/src/video_core/rasterizer.cpp
@@ -393,10 +393,10 @@ static void ProcessTriangleInternal(const Shader::OutputVertex& v0,
         for (u16 x = min_x + 8; x < max_x; x += 0x10) {
 
             // Do not process the pixel if it's inside the scissor box and the scissor mode is set to Exclude
-            if (regs.scissor_test.mode == Regs::ScissorMode::Exclude) {
-                if (x >= scissor_x && x <= scissor_x + scissor_width &&
-                    y >= scissor_y && y <= scissor_y + scissor_height)
-                    continue;
+            if (regs.scissor_test.mode == Regs::ScissorMode::Exclude &&
+                x >= scissor_x && x <= scissor_x + scissor_width &&
+                y >= scissor_y && y <= scissor_y + scissor_height) {
+                continue;
             }
 
             // Calculate the barycentric coordinates w0, w1 and w2

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -227,7 +227,7 @@ void RasterizerOpenGL::NotifyPicaRegisterChanged(u32 id) {
         state.draw.shader_dirty = true;
         break;
     case PICA_REG_INDEX(scissor_test.right):
-    case PICA_REG_INDEX(scissor_test.left):
+    case PICA_REG_INDEX(scissor_test.left_minus_1):
         SyncScissorTest();
         break;
 
@@ -672,13 +672,13 @@ void RasterizerOpenGL::SyncScissorTest() {
 
     if (uniform_block_data.data.scissor_right != regs.scissor_test.right ||
         uniform_block_data.data.scissor_bottom != regs.scissor_test.bottom ||
-        uniform_block_data.data.scissor_left != regs.scissor_test.left + 1 ||
-        uniform_block_data.data.scissor_top != regs.scissor_test.top + 1) {
+        uniform_block_data.data.scissor_left != regs.scissor_test.GetLeft() ||
+        uniform_block_data.data.scissor_top != regs.scissor_test.GetTop()) {
 
         uniform_block_data.data.scissor_right = regs.scissor_test.right;
         uniform_block_data.data.scissor_bottom = regs.scissor_test.bottom;
-        uniform_block_data.data.scissor_left = regs.scissor_test.left + 1;
-        uniform_block_data.data.scissor_top = regs.scissor_test.top + 1;
+        uniform_block_data.data.scissor_left = regs.scissor_test.GetLeft();
+        uniform_block_data.data.scissor_top = regs.scissor_test.GetTop();
         uniform_block_data.dirty = true;
     }
 }

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -354,12 +354,12 @@ void main() {
 
     // Append the scissor test
     if (config.scissor_test_mode == Regs::ScissorMode::Include || config.scissor_test_mode == Regs::ScissorMode::Exclude) {
-        out += "if (scissor_left <= scissor_right || scissor_top >= scissor_bottom) discard;\n";
+        out += "if (scissor_left <= scissor_right || scissor_top <= scissor_bottom) discard;\n";
         out += "if (";
         // Negate the condition if we have to keep only the pixels outside the scissor box
         if (config.scissor_test_mode == Regs::ScissorMode::Include)
             out += "!";
-        out += "(gl_FragCoord.x >= scissor_right && gl_FragCoord.x <= scissor_left && gl_FragCoord.y >= scissor_top && gl_FragCoord.y <= scissor_bottom)) discard;\n";
+        out += "(gl_FragCoord.x >= scissor_right && gl_FragCoord.x <= scissor_left && gl_FragCoord.y >= scissor_bottom && gl_FragCoord.y <= scissor_top)) discard;\n";
     }
 
     out += "vec4 combiner_buffer = vec4(0.0);\n";

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -346,6 +346,12 @@ uniform sampler2D tex[3];
 void main() {
 )";
 
+    // Do not do any sort of processing if it's obvious we're not going to pass the alpha test
+    if (config.alpha_test_func == Regs::CompareFunc::Never) {
+        out += "discard; }";
+        return out;
+    }
+
     // Append the scissor test
     if (config.scissor_test_mode == Regs::ScissorMode::Include || config.scissor_test_mode == Regs::ScissorMode::Exclude) {
         out += "if (scissor_left <= scissor_right || scissor_top >= scissor_bottom) discard;\n";
@@ -354,12 +360,6 @@ void main() {
         if (config.scissor_test_mode == Regs::ScissorMode::Include)
             out += "!";
         out += "(gl_FragCoord.x >= scissor_right && gl_FragCoord.x <= scissor_left && gl_FragCoord.y >= scissor_top && gl_FragCoord.y <= scissor_bottom)) discard;\n";
-    }
-
-    // Do not do any sort of processing if it's obvious we're not going to pass the alpha test
-    if (config.alpha_test_func == Regs::CompareFunc::Never) {
-        out += "discard; }";
-        return out;
     }
 
     out += "vec4 combiner_buffer = vec4(0.0);\n";


### PR DESCRIPTION
This is based on an earlier work by @neobrain.

It is worth mentioning that the way ctrulib handles scissoring is incorrect, the last two registers are not the size of the scissor rectangle but instead are x+width-1 and y+height-1. This has been verified with homebrew. I will be making a PR to ctrulib later on.