### PR TITLE
GPU/PrimitiveAssembler: Fixed drawing triangle fans.

### DIFF
--- a/src/video_core/primitive_assembly.cpp
+++ b/src/video_core/primitive_assembly.cpp
@@ -39,13 +39,12 @@ void PrimitiveAssembler<VertexType>::SubmitVertex(VertexType& vtx, TriangleHandl
 
             buffer[buffer_index] = vtx;
 
-            if (topology == Regs::TriangleTopology::Strip) {
-                strip_ready |= (buffer_index == 1);
+            strip_ready |= (buffer_index == 1);
+
+            if (topology == Regs::TriangleTopology::Strip)
                 buffer_index = !buffer_index;
-            } else if (topology == Regs::TriangleTopology::Fan) {
+            else if (topology == Regs::TriangleTopology::Fan)
                 buffer_index = 1;
-                strip_ready = true;
-            }
             break;
 
         default:


### PR DESCRIPTION
It was skipping the second vertex assignment and using uninitialized garbage when assembling the corresponding triangle.

Fixes the sf2dlib sample.