### PR TITLE
VideoCore: Unify interface to OpenGL and SW rasterizers

### DIFF
--- a/src/core/hle/service/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp_gpu.cpp
@@ -275,7 +275,7 @@ static void FlushDataCache(Service::Interface* self) {
     u32 size    = cmd_buff[2];
     u32 process = cmd_buff[4];
 
-    VideoCore::g_renderer->hw_rasterizer->InvalidateRegion(Memory::VirtualToPhysicalAddress(address), size);
+    VideoCore::g_renderer->rasterizer->InvalidateRegion(Memory::VirtualToPhysicalAddress(address), size);
 
     // TODO(purpasmart96): Verify return header on HW
 
@@ -365,7 +365,7 @@ static void ExecuteCommand(const Command& command, u32 thread_id) {
 
     // GX request DMA - typically used for copying memory from GSP heap to VRAM
     case CommandId::REQUEST_DMA:
-        VideoCore::g_renderer->hw_rasterizer->FlushRegion(Memory::VirtualToPhysicalAddress(command.dma_request.source_address),
+        VideoCore::g_renderer->rasterizer->FlushRegion(Memory::VirtualToPhysicalAddress(command.dma_request.source_address),
                                                             command.dma_request.size);
 
         memcpy(Memory::GetPointer(command.dma_request.dest_address),
@@ -373,7 +373,7 @@ static void ExecuteCommand(const Command& command, u32 thread_id) {
                command.dma_request.size);
         SignalInterrupt(InterruptId::DMA);
 
-        VideoCore::g_renderer->hw_rasterizer->InvalidateRegion(Memory::VirtualToPhysicalAddress(command.dma_request.dest_address),
+        VideoCore::g_renderer->rasterizer->InvalidateRegion(Memory::VirtualToPhysicalAddress(command.dma_request.dest_address),
                                                           command.dma_request.size);
         break;
 
@@ -467,7 +467,7 @@ static void ExecuteCommand(const Command& command, u32 thread_id) {
             if (region.size == 0)
                 break;
 
-            VideoCore::g_renderer->hw_rasterizer->InvalidateRegion(
+            VideoCore::g_renderer->rasterizer->InvalidateRegion(
                 Memory::VirtualToPhysicalAddress(region.address), region.size);
         }
         break;

--- a/src/core/hle/service/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp_gpu.cpp
@@ -275,7 +275,7 @@ static void FlushDataCache(Service::Interface* self) {
     u32 size    = cmd_buff[2];
     u32 process = cmd_buff[4];
 
-    VideoCore::g_renderer->hw_rasterizer->NotifyFlush(Memory::VirtualToPhysicalAddress(address), size);
+    VideoCore::g_renderer->hw_rasterizer->InvalidateRegion(Memory::VirtualToPhysicalAddress(address), size);
 
     // TODO(purpasmart96): Verify return header on HW
 
@@ -365,7 +365,7 @@ static void ExecuteCommand(const Command& command, u32 thread_id) {
 
     // GX request DMA - typically used for copying memory from GSP heap to VRAM
     case CommandId::REQUEST_DMA:
-        VideoCore::g_renderer->hw_rasterizer->NotifyPreRead(Memory::VirtualToPhysicalAddress(command.dma_request.source_address),
+        VideoCore::g_renderer->hw_rasterizer->FlushRegion(Memory::VirtualToPhysicalAddress(command.dma_request.source_address),
                                                             command.dma_request.size);
 
         memcpy(Memory::GetPointer(command.dma_request.dest_address),
@@ -373,7 +373,7 @@ static void ExecuteCommand(const Command& command, u32 thread_id) {
                command.dma_request.size);
         SignalInterrupt(InterruptId::DMA);
 
-        VideoCore::g_renderer->hw_rasterizer->NotifyFlush(Memory::VirtualToPhysicalAddress(command.dma_request.dest_address),
+        VideoCore::g_renderer->hw_rasterizer->InvalidateRegion(Memory::VirtualToPhysicalAddress(command.dma_request.dest_address),
                                                           command.dma_request.size);
         break;
 
@@ -467,7 +467,7 @@ static void ExecuteCommand(const Command& command, u32 thread_id) {
             if (region.size == 0)
                 break;
 
-            VideoCore::g_renderer->hw_rasterizer->NotifyFlush(
+            VideoCore::g_renderer->hw_rasterizer->InvalidateRegion(
                 Memory::VirtualToPhysicalAddress(region.address), region.size);
         }
         break;

--- a/src/core/hle/service/y2r_u.cpp
+++ b/src/core/hle/service/y2r_u.cpp
@@ -267,7 +267,7 @@ static void StartConversion(Service::Interface* self) {
     // dst_image_size would seem to be perfect for this, but it doesn't include the gap :(
     u32 total_output_size = conversion.input_lines *
         (conversion.dst.transfer_unit + conversion.dst.gap);
-    VideoCore::g_renderer->hw_rasterizer->InvalidateRegion(
+    VideoCore::g_renderer->rasterizer->InvalidateRegion(
         Memory::VirtualToPhysicalAddress(conversion.dst.address), total_output_size);
 
     LOG_DEBUG(Service_Y2R, "called");

--- a/src/core/hle/service/y2r_u.cpp
+++ b/src/core/hle/service/y2r_u.cpp
@@ -267,7 +267,7 @@ static void StartConversion(Service::Interface* self) {
     // dst_image_size would seem to be perfect for this, but it doesn't include the gap :(
     u32 total_output_size = conversion.input_lines *
         (conversion.dst.transfer_unit + conversion.dst.gap);
-    VideoCore::g_renderer->hw_rasterizer->NotifyFlush(
+    VideoCore::g_renderer->hw_rasterizer->InvalidateRegion(
         Memory::VirtualToPhysicalAddress(conversion.dst.address), total_output_size);
 
     LOG_DEBUG(Service_Y2R, "called");

--- a/src/core/hw/gpu.cpp
+++ b/src/core/hw/gpu.cpp
@@ -141,7 +141,7 @@ inline void Write(u32 addr, const T data) {
                     GSP_GPU::SignalInterrupt(GSP_GPU::InterruptId::PSC1);
                 }
 
-                VideoCore::g_renderer->hw_rasterizer->NotifyFlush(config.GetStartAddress(), config.GetEndAddress() - config.GetStartAddress());
+                VideoCore::g_renderer->hw_rasterizer->InvalidateRegion(config.GetStartAddress(), config.GetEndAddress() - config.GetStartAddress());
             }
 
             // Reset "trigger" flag and set the "finish" flag
@@ -172,7 +172,7 @@ inline void Write(u32 addr, const T data) {
                 u32 output_gap = config.texture_copy.output_gap * 16;
 
                 size_t contiguous_input_size = config.texture_copy.size / input_width * (input_width + input_gap);
-                VideoCore::g_renderer->hw_rasterizer->NotifyPreRead(config.GetPhysicalInputAddress(), contiguous_input_size);
+                VideoCore::g_renderer->hw_rasterizer->FlushRegion(config.GetPhysicalInputAddress(), contiguous_input_size);
 
                 u32 remaining_size = config.texture_copy.size;
                 u32 remaining_input = input_width;
@@ -205,7 +205,7 @@ inline void Write(u32 addr, const T data) {
                     config.flags);
 
                 size_t contiguous_output_size = config.texture_copy.size / output_width * (output_width + output_gap);
-                VideoCore::g_renderer->hw_rasterizer->NotifyFlush(config.GetPhysicalOutputAddress(), contiguous_output_size);
+                VideoCore::g_renderer->hw_rasterizer->InvalidateRegion(config.GetPhysicalOutputAddress(), contiguous_output_size);
 
                 GSP_GPU::SignalInterrupt(GSP_GPU::InterruptId::PPF);
                 break;
@@ -232,7 +232,7 @@ inline void Write(u32 addr, const T data) {
             u32 input_size = config.input_width * config.input_height * GPU::Regs::BytesPerPixel(config.input_format);
             u32 output_size = output_width * output_height * GPU::Regs::BytesPerPixel(config.output_format);
 
-            VideoCore::g_renderer->hw_rasterizer->NotifyPreRead(config.GetPhysicalInputAddress(), input_size);
+            VideoCore::g_renderer->hw_rasterizer->FlushRegion(config.GetPhysicalInputAddress(), input_size);
 
             for (u32 y = 0; y < output_height; ++y) {
                 for (u32 x = 0; x < output_width; ++x) {
@@ -339,7 +339,7 @@ inline void Write(u32 addr, const T data) {
             g_regs.display_transfer_config.trigger = 0;
             GSP_GPU::SignalInterrupt(GSP_GPU::InterruptId::PPF);
 
-            VideoCore::g_renderer->hw_rasterizer->NotifyFlush(config.GetPhysicalOutputAddress(), output_size);
+            VideoCore::g_renderer->hw_rasterizer->InvalidateRegion(config.GetPhysicalOutputAddress(), output_size);
         }
         break;
     }

--- a/src/core/hw/gpu.cpp
+++ b/src/core/hw/gpu.cpp
@@ -26,7 +26,7 @@
 #include "core/tracer/recorder.h"
 
 #include "video_core/command_processor.h"
-#include "video_core/hwrasterizer_base.h"
+#include "video_core/rasterizer_interface.h"
 #include "video_core/renderer_base.h"
 #include "video_core/utils.h"
 #include "video_core/video_core.h"
@@ -141,7 +141,7 @@ inline void Write(u32 addr, const T data) {
                     GSP_GPU::SignalInterrupt(GSP_GPU::InterruptId::PSC1);
                 }
 
-                VideoCore::g_renderer->hw_rasterizer->InvalidateRegion(config.GetStartAddress(), config.GetEndAddress() - config.GetStartAddress());
+                VideoCore::g_renderer->rasterizer->InvalidateRegion(config.GetStartAddress(), config.GetEndAddress() - config.GetStartAddress());
             }
 
             // Reset "trigger" flag and set the "finish" flag
@@ -172,7 +172,7 @@ inline void Write(u32 addr, const T data) {
                 u32 output_gap = config.texture_copy.output_gap * 16;
 
                 size_t contiguous_input_size = config.texture_copy.size / input_width * (input_width + input_gap);
-                VideoCore::g_renderer->hw_rasterizer->FlushRegion(config.GetPhysicalInputAddress(), contiguous_input_size);
+                VideoCore::g_renderer->rasterizer->FlushRegion(config.GetPhysicalInputAddress(), contiguous_input_size);
 
                 u32 remaining_size = config.texture_copy.size;
                 u32 remaining_input = input_width;
@@ -205,7 +205,7 @@ inline void Write(u32 addr, const T data) {
                     config.flags);
 
                 size_t contiguous_output_size = config.texture_copy.size / output_width * (output_width + output_gap);
-                VideoCore::g_renderer->hw_rasterizer->InvalidateRegion(config.GetPhysicalOutputAddress(), contiguous_output_size);
+                VideoCore::g_renderer->rasterizer->InvalidateRegion(config.GetPhysicalOutputAddress(), contiguous_output_size);
 
                 GSP_GPU::SignalInterrupt(GSP_GPU::InterruptId::PPF);
                 break;
@@ -232,7 +232,7 @@ inline void Write(u32 addr, const T data) {
             u32 input_size = config.input_width * config.input_height * GPU::Regs::BytesPerPixel(config.input_format);
             u32 output_size = output_width * output_height * GPU::Regs::BytesPerPixel(config.output_format);
 
-            VideoCore::g_renderer->hw_rasterizer->FlushRegion(config.GetPhysicalInputAddress(), input_size);
+            VideoCore::g_renderer->rasterizer->FlushRegion(config.GetPhysicalInputAddress(), input_size);
 
             for (u32 y = 0; y < output_height; ++y) {
                 for (u32 x = 0; x < output_width; ++x) {
@@ -339,7 +339,7 @@ inline void Write(u32 addr, const T data) {
             g_regs.display_transfer_config.trigger = 0;
             GSP_GPU::SignalInterrupt(GSP_GPU::InterruptId::PPF);
 
-            VideoCore::g_renderer->hw_rasterizer->InvalidateRegion(config.GetPhysicalOutputAddress(), output_size);
+            VideoCore::g_renderer->rasterizer->InvalidateRegion(config.GetPhysicalOutputAddress(), output_size);
         }
         break;
     }

--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -11,8 +11,10 @@ set(SRCS
             pica.cpp
             primitive_assembly.cpp
             rasterizer.cpp
+            renderer_base.cpp
             shader/shader.cpp
             shader/shader_interpreter.cpp
+            swrasterizer.cpp
             utils.cpp
             video_core.cpp
             )
@@ -30,13 +32,14 @@ set(HEADERS
             clipper.h
             command_processor.h
             gpu_debugger.h
-            hwrasterizer_base.h
             pica.h
             primitive_assembly.h
             rasterizer.h
+            rasterizer_interface.h
             renderer_base.h
             shader/shader.h
             shader/shader_interpreter.h
+            swrasterizer.h
             utils.h
             video_core.h
             )

--- a/src/video_core/clipper.cpp
+++ b/src/video_core/clipper.cpp
@@ -78,7 +78,7 @@ static void InitScreenCoordinates(OutputVertex& vtx)
     vtx.screenpos[2] = viewport.offset_z + vtx.pos.z * inv_w * viewport.zscale;
 }
 
-void ProcessTriangle(OutputVertex &v0, OutputVertex &v1, OutputVertex &v2) {
+void ProcessTriangle(const OutputVertex &v0, const OutputVertex &v1, const OutputVertex &v2) {
     using boost::container::static_vector;
 
     // Clipping a planar n-gon against a plane will remove at least 1 vertex and introduces 2 at

--- a/src/video_core/clipper.h
+++ b/src/video_core/clipper.h
@@ -14,7 +14,7 @@ namespace Clipper {
 
 using Shader::OutputVertex;
 
-void ProcessTriangle(OutputVertex& v0, OutputVertex& v1, OutputVertex& v2);
+void ProcessTriangle(const OutputVertex& v0, const OutputVertex& v1, const OutputVertex& v2);
 
 } // namespace
 

--- a/src/video_core/debug_utils/debug_utils.cpp
+++ b/src/video_core/debug_utils/debug_utils.cpp
@@ -46,10 +46,8 @@ void DebugContext::OnEvent(Event event, void* data) {
     {
         std::unique_lock<std::mutex> lock(breakpoint_mutex);
 
-        if (Settings::values.use_hw_renderer) {
-            // Commit the hardware renderer's framebuffer so it will show on debug widgets
-            VideoCore::g_renderer->hw_rasterizer->FlushFramebuffer();
-        }
+        // Commit the hardware renderer's framebuffer so it will show on debug widgets
+        VideoCore::g_renderer->rasterizer->FlushFramebuffer();
 
         // TODO: Should stop the CPU thread here once we multithread emulation.
 

--- a/src/video_core/debug_utils/debug_utils.cpp
+++ b/src/video_core/debug_utils/debug_utils.cpp
@@ -48,7 +48,7 @@ void DebugContext::OnEvent(Event event, void* data) {
 
         if (Settings::values.use_hw_renderer) {
             // Commit the hardware renderer's framebuffer so it will show on debug widgets
-            VideoCore::g_renderer->hw_rasterizer->CommitFramebuffer();
+            VideoCore::g_renderer->hw_rasterizer->FlushFramebuffer();
         }
 
         // TODO: Should stop the CPU thread here once we multithread emulation.

--- a/src/video_core/hwrasterizer_base.h
+++ b/src/video_core/hwrasterizer_base.h
@@ -32,14 +32,14 @@ public:
     virtual void DrawTriangles() = 0;
 
     /// Commit the rasterizer's framebuffer contents immediately to the current 3DS memory framebuffer
-    virtual void CommitFramebuffer() = 0;
+    virtual void FlushFramebuffer() = 0;
 
     /// Notify rasterizer that the specified PICA register has been changed
     virtual void NotifyPicaRegisterChanged(u32 id) = 0;
 
-    /// Notify rasterizer that the specified 3DS memory region will be read from after this notification
-    virtual void NotifyPreRead(PAddr addr, u32 size) = 0;
+    /// Notify rasterizer that any caches of the specified region should be flushed to 3DS memory.
+    virtual void FlushRegion(PAddr addr, u32 size) = 0;
 
-    /// Notify rasterizer that a 3DS memory region has been changed
-    virtual void NotifyFlush(PAddr addr, u32 size) = 0;
+    /// Notify rasterizer that any caches of the specified region should be discraded and reloaded from 3DS memory.
+    virtual void InvalidateRegion(PAddr addr, u32 size) = 0;
 };

--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -12,10 +12,11 @@ struct OutputVertex;
 }
 }
 
-class HWRasterizer {
+namespace VideoCore {
+
+class RasterizerInterface {
 public:
-    virtual ~HWRasterizer() {
-    }
+    virtual ~RasterizerInterface() {}
 
     /// Initialize API-specific GPU objects
     virtual void InitObjects() = 0;
@@ -43,3 +44,5 @@ public:
     /// Notify rasterizer that any caches of the specified region should be discraded and reloaded from 3DS memory.
     virtual void InvalidateRegion(PAddr addr, u32 size) = 0;
 };
+
+}

--- a/src/video_core/renderer_base.cpp
+++ b/src/video_core/renderer_base.cpp
@@ -1,0 +1,28 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <memory>
+
+#include "common/make_unique.h"
+
+#include "core/settings.h"
+
+#include "video_core/renderer_base.h"
+#include "video_core/video_core.h"
+#include "video_core/swrasterizer.h"
+#include "video_core/renderer_opengl/gl_rasterizer.h"
+
+void RendererBase::RefreshRasterizerSetting() {
+    bool hw_renderer_enabled = VideoCore::g_hw_renderer_enabled;
+    if (rasterizer == nullptr || opengl_rasterizer_active != hw_renderer_enabled) {
+        opengl_rasterizer_active = hw_renderer_enabled;
+
+        if (hw_renderer_enabled) {
+            rasterizer = Common::make_unique<RasterizerOpenGL>();
+        } else {
+            rasterizer = Common::make_unique<VideoCore::SWRasterizer>();
+        }
+        rasterizer->InitObjects();
+    }
+}

--- a/src/video_core/renderer_base.h
+++ b/src/video_core/renderer_base.h
@@ -8,7 +8,7 @@
 
 #include "common/common_types.h"
 
-#include "video_core/hwrasterizer_base.h"
+#include "video_core/rasterizer_interface.h"
 
 class EmuWindow;
 
@@ -54,10 +54,14 @@ public:
         return m_current_frame;
     }
 
-    std::unique_ptr<HWRasterizer> hw_rasterizer;
+    void RefreshRasterizerSetting();
+
+    std::unique_ptr<VideoCore::RasterizerInterface> rasterizer;
 
 protected:
     f32 m_current_fps;              ///< Current framerate, should be set by the renderer
     int m_current_frame;            ///< Current frame, should be set by the renderer
 
+private:
+    bool opengl_rasterizer_active = false;
 };

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -135,7 +135,7 @@ void RasterizerOpenGL::Reset() {
 
     SetShader();
 
-    res_cache.FullFlush();
+    res_cache.InvalidateAll();
 }
 
 void RasterizerOpenGL::AddTriangle(const Pica::Shader::OutputVertex& v0,
@@ -176,8 +176,8 @@ void RasterizerOpenGL::DrawTriangles() {
     u32 cur_fb_depth_size = Pica::Regs::BytesPerDepthPixel(regs.framebuffer.depth_format)
                             * regs.framebuffer.GetWidth() * regs.framebuffer.GetHeight();
 
-    res_cache.NotifyFlush(cur_fb_color_addr, cur_fb_color_size, true);
-    res_cache.NotifyFlush(cur_fb_depth_addr, cur_fb_depth_size, true);
+    res_cache.InvalidateInRange(cur_fb_color_addr, cur_fb_color_size, true);
+    res_cache.InvalidateInRange(cur_fb_depth_addr, cur_fb_depth_size, true);
 }
 
 void RasterizerOpenGL::CommitFramebuffer() {
@@ -328,7 +328,7 @@ void RasterizerOpenGL::NotifyFlush(PAddr addr, u32 size) {
         ReloadDepthBuffer();
 
     // Notify cache of flush in case the region touches a cached resource
-    res_cache.NotifyFlush(addr, size);
+    res_cache.InvalidateInRange(addr, size);
 }
 
 void RasterizerOpenGL::SamplerInfo::Create() {

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -188,9 +188,6 @@ void RasterizerOpenGL::FlushFramebuffer() {
 void RasterizerOpenGL::NotifyPicaRegisterChanged(u32 id) {
     const auto& regs = Pica::g_state.regs;
 
-    if (!Settings::values.use_hw_renderer)
-        return;
-
     switch(id) {
     // Culling
     case PICA_REG_INDEX(cull_mode):
@@ -287,9 +284,6 @@ void RasterizerOpenGL::NotifyPicaRegisterChanged(u32 id) {
 void RasterizerOpenGL::FlushRegion(PAddr addr, u32 size) {
     const auto& regs = Pica::g_state.regs;
 
-    if (!Settings::values.use_hw_renderer)
-        return;
-
     PAddr cur_fb_color_addr = regs.framebuffer.GetColorBufferPhysicalAddress();
     u32 cur_fb_color_size = Pica::Regs::BytesPerColorPixel(regs.framebuffer.color_format)
                             * regs.framebuffer.GetWidth() * regs.framebuffer.GetHeight();
@@ -308,9 +302,6 @@ void RasterizerOpenGL::FlushRegion(PAddr addr, u32 size) {
 
 void RasterizerOpenGL::InvalidateRegion(PAddr addr, u32 size) {
     const auto& regs = Pica::g_state.regs;
-
-    if (!Settings::values.use_hw_renderer)
-        return;
 
     PAddr cur_fb_color_addr = regs.framebuffer.GetColorBufferPhysicalAddress();
     u32 cur_fb_color_size = Pica::Regs::BytesPerColorPixel(regs.framebuffer.color_format)

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -180,7 +180,7 @@ void RasterizerOpenGL::DrawTriangles() {
     res_cache.InvalidateInRange(cur_fb_depth_addr, cur_fb_depth_size, true);
 }
 
-void RasterizerOpenGL::CommitFramebuffer() {
+void RasterizerOpenGL::FlushFramebuffer() {
     CommitColorBuffer();
     CommitDepthBuffer();
 }
@@ -284,7 +284,7 @@ void RasterizerOpenGL::NotifyPicaRegisterChanged(u32 id) {
     }
 }
 
-void RasterizerOpenGL::NotifyPreRead(PAddr addr, u32 size) {
+void RasterizerOpenGL::FlushRegion(PAddr addr, u32 size) {
     const auto& regs = Pica::g_state.regs;
 
     if (!Settings::values.use_hw_renderer)
@@ -306,7 +306,7 @@ void RasterizerOpenGL::NotifyPreRead(PAddr addr, u32 size) {
         CommitDepthBuffer();
 }
 
-void RasterizerOpenGL::NotifyFlush(PAddr addr, u32 size) {
+void RasterizerOpenGL::InvalidateRegion(PAddr addr, u32 size) {
     const auto& regs = Pica::g_state.regs;
 
     if (!Settings::values.use_hw_renderer)

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -123,16 +123,16 @@ public:
     void DrawTriangles() override;
 
     /// Commit the rasterizer's framebuffer contents immediately to the current 3DS memory framebuffer
-    void CommitFramebuffer() override;
+    void FlushFramebuffer() override;
 
     /// Notify rasterizer that the specified PICA register has been changed
     void NotifyPicaRegisterChanged(u32 id) override;
 
     /// Notify rasterizer that the specified 3DS memory region will be read from after this notification
-    void NotifyPreRead(PAddr addr, u32 size) override;
+    void FlushRegion(PAddr addr, u32 size) override;
 
     /// Notify rasterizer that a 3DS memory region has been changed
-    void NotifyFlush(PAddr addr, u32 size) override;
+    void InvalidateRegion(PAddr addr, u32 size) override;
 
     /// OpenGL shader generated for a given Pica register state
     struct PicaShader {

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -14,7 +14,7 @@
 #include "common/hash.h"
 
 #include "video_core/pica.h"
-#include "video_core/hwrasterizer_base.h"
+#include "video_core/rasterizer_interface.h"
 #include "video_core/renderer_opengl/gl_rasterizer_cache.h"
 #include "video_core/renderer_opengl/gl_state.h"
 #include "video_core/shader/shader_interpreter.h"
@@ -102,36 +102,21 @@ struct hash<PicaShaderConfig> {
 
 } // namespace std
 
-class RasterizerOpenGL : public HWRasterizer {
+class RasterizerOpenGL : public VideoCore::RasterizerInterface {
 public:
 
     RasterizerOpenGL();
     ~RasterizerOpenGL() override;
 
-    /// Initialize API-specific GPU objects
     void InitObjects() override;
-
-    /// Reset the rasterizer, such as flushing all caches and updating all state
     void Reset() override;
-
-    /// Queues the primitive formed by the given vertices for rendering
     void AddTriangle(const Pica::Shader::OutputVertex& v0,
                      const Pica::Shader::OutputVertex& v1,
                      const Pica::Shader::OutputVertex& v2) override;
-
-    /// Draw the current batch of triangles
     void DrawTriangles() override;
-
-    /// Commit the rasterizer's framebuffer contents immediately to the current 3DS memory framebuffer
     void FlushFramebuffer() override;
-
-    /// Notify rasterizer that the specified PICA register has been changed
     void NotifyPicaRegisterChanged(u32 id) override;
-
-    /// Notify rasterizer that the specified 3DS memory region will be read from after this notification
     void FlushRegion(PAddr addr, u32 size) override;
-
-    /// Notify rasterizer that a 3DS memory region has been changed
     void InvalidateRegion(PAddr addr, u32 size) override;
 
     /// OpenGL shader generated for a given Pica register state

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -15,7 +15,7 @@
 #include "video_core/renderer_opengl/pica_to_gl.h"
 
 RasterizerCacheOpenGL::~RasterizerCacheOpenGL() {
-    FullFlush();
+    InvalidateAll();
 }
 
 MICROPROFILE_DEFINE(OpenGL_TextureUpload, "OpenGL", "Texture Upload", MP_RGB(128, 64, 192));
@@ -58,8 +58,7 @@ void RasterizerCacheOpenGL::LoadAndBindTexture(OpenGLState &state, unsigned text
     }
 }
 
-void RasterizerCacheOpenGL::NotifyFlush(PAddr addr, u32 size, bool ignore_hash) {
-    // Flush any texture that falls in the flushed region
+void RasterizerCacheOpenGL::InvalidateInRange(PAddr addr, u32 size, bool ignore_hash) {
     // TODO: Optimize by also inserting upper bound (addr + size) of each texture into the same map and also narrow using lower_bound
     auto cache_upper_bound = texture_cache.upper_bound(addr + size);
 
@@ -77,6 +76,6 @@ void RasterizerCacheOpenGL::NotifyFlush(PAddr addr, u32 size, bool ignore_hash) 
     }
 }
 
-void RasterizerCacheOpenGL::FullFlush() {
+void RasterizerCacheOpenGL::InvalidateAll() {
     texture_cache.clear();
 }

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -23,11 +23,11 @@ public:
         LoadAndBindTexture(state, texture_unit, Pica::DebugUtils::TextureInfo::FromPicaRegister(config.config, config.format));
     }
 
-    /// Flush any cached resource that touches the flushed region
-    void NotifyFlush(PAddr addr, u32 size, bool ignore_hash = false);
+    /// Invalidate any cached resource intersecting the specified region.
+    void InvalidateInRange(PAddr addr, u32 size, bool ignore_hash = false);
 
-    /// Flush all cached OpenGL resources tracked by this cache manager
-    void FullFlush();
+    /// Invalidate all cached OpenGL resources tracked by this cache manager
+    void InvalidateAll();
 
 private:
     struct CachedTexture {

--- a/src/video_core/swrasterizer.cpp
+++ b/src/video_core/swrasterizer.cpp
@@ -1,0 +1,16 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "video_core/clipper.h"
+#include "video_core/swrasterizer.h"
+
+namespace VideoCore {
+
+void SWRasterizer::AddTriangle(const Pica::Shader::OutputVertex& v0,
+        const Pica::Shader::OutputVertex& v1,
+        const Pica::Shader::OutputVertex& v2) {
+    Pica::Clipper::ProcessTriangle(v0, v1, v2);
+}
+
+}

--- a/src/video_core/swrasterizer.h
+++ b/src/video_core/swrasterizer.h
@@ -1,0 +1,26 @@
+// Copyright 2015 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "common/common_types.h"
+
+#include "video_core/rasterizer_interface.h"
+
+namespace VideoCore {
+
+class SWRasterizer : public RasterizerInterface {
+    void InitObjects() override {}
+    void Reset() override {}
+    void AddTriangle(const Pica::Shader::OutputVertex& v0,
+            const Pica::Shader::OutputVertex& v1,
+            const Pica::Shader::OutputVertex& v2);
+    void DrawTriangles() override {}
+    void FlushFramebuffer() override {}
+    void NotifyPicaRegisterChanged(u32 id) override {}
+    void FlushRegion(PAddr addr, u32 size) override {}
+    void InvalidateRegion(PAddr addr, u32 size) override {}
+};
+
+}


### PR DESCRIPTION
This removes explicit checks sprinkled all over the codebase to instead just have the SW rasterizer expose an implementation with no-ops for most operations.

Also does a few other cleanups in that interface.