### PR TITLE
svc: Fix compilation with LOG_TRACE enabled

### DIFF
--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -781,7 +781,7 @@ static ResultCode CreateMemoryBlock(Handle* out_handle, u32 addr, u32 size, u32 
 static ResultCode GetSystemInfo(s64* out, u32 type, s32 param) {
     using Kernel::MemoryRegion;
 
-    LOG_TRACE(Kernel_SVC, "called process=0x%08X type=%u param=%d", process_handle, type, param);
+    LOG_TRACE(Kernel_SVC, "called type=%u param=%d", type, param);
 
     switch ((SystemInfoType)type) {
     case SystemInfoType::REGION_MEMORY_USAGE:


### PR DESCRIPTION
another reason why conditional macros outside of determining system specifics is a bad thing.