### PR TITLE
Compile with -Werror

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,8 +64,15 @@ if (NOT DEFINED ARCHITECTURE)
 endif()
 message(STATUS "Target architecture: ${ARCHITECTURE}")
 
+if (NOT CMAKE_GENERATOR STREQUAL Xcode)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
+endif()
+
 if (NOT MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y -Wno-attributes -pthread")
+    # Currently, clang incorrectly throws this warning with enums, see https://llvm.org/bugs/show_bug.cgi?id=16154
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-tautological-constant-out-of-range-compare")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread")
 
     if (ARCHITECTURE_x86_64)
@@ -233,8 +240,8 @@ include_directories(${INI_PREFIX})
 add_subdirectory(${INI_PREFIX})
 
 add_subdirectory(externals/glad)
-include_directories(externals/microprofile)
-include_directories(externals/nihstro/include)
+include_directories(SYSTEM externals/microprofile) # TODO: remove "SYSTEM" and actually fix the warnings upstream
+include_directories(SYSTEM externals/nihstro/include) # TODO: remove "SYSTEM" and actually fix the warnings upstream
 
 if (MSVC)
     add_subdirectory(externals/getopt)

--- a/src/citra_qt/debugger/graphics_framebuffer.cpp
+++ b/src/citra_qt/debugger/graphics_framebuffer.cpp
@@ -346,5 +346,8 @@ u32 GraphicsFramebufferWidget::BytesPerPixel(GraphicsFramebufferWidget::Format f
         case Format::RGBA4:
         case Format::D16:
             return 2;
+        case Format::Unknown:
+            ASSERT_MSG(false, "Unknown frame buffer format.");
+            return 0;
     }
 }

--- a/src/core/gdbstub/gdbstub.cpp
+++ b/src/core/gdbstub/gdbstub.cpp
@@ -55,10 +55,12 @@ const u32 SIGTERM = 15;
 const u32 MSG_WAITALL = 8;
 #endif
 
-const u32 R0_REGISTER = 0;
-const u32 R15_REGISTER = 15;
-const u32 CPSR_REGISTER = 25;
-const u32 FPSCR_REGISTER = 58;
+enum GDBRegister {
+    R0_REGISTER = 0,
+    R15_REGISTER = 15,
+    CPSR_REGISTER = 25,
+    FPSCR_REGISTER = 58
+};
 
 namespace GDBStub {
 

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <cinttypes>
 #include <cstddef>
 #include <system_error>
 #include <type_traits>
@@ -105,7 +106,7 @@ ResultVal<bool> File::SyncRequest() {
                       GetTypeName().c_str(), GetName().c_str(), offset, length, address);
 
             if (offset + length > backend->GetSize()) {
-                LOG_ERROR(Service_FS, "Reading from out of bounds offset=0x%llX length=0x%08X file_size=0x%llX",
+                LOG_ERROR(Service_FS, "Reading from out of bounds offset=0x%" PRIX64 " length=0x%08X file_size=0x%" PRIX64,
                           offset, length, backend->GetSize());
             }
 

--- a/src/core/hle/service/fs/fs_user.cpp
+++ b/src/core/hle/service/fs/fs_user.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <cinttypes>
+
 #include "common/assert.h"
 #include "common/common_types.h"
 #include "common/file_util.h"
@@ -250,7 +252,7 @@ static void CreateFile(Service::Interface* self) {
 
     FileSys::Path file_path(filename_type, filename_size, filename_ptr);
 
-    LOG_DEBUG(Service_FS, "type=%d size=%llu data=%s", filename_type, filename_size, file_path.DebugStr().c_str());
+    LOG_DEBUG(Service_FS, "type=%d size=%" PRIu32 " data=%s", filename_type, filename_size, file_path.DebugStr().c_str());
 
     cmd_buff[1] = CreateFileInArchive(archive_handle, file_path, file_size).raw;
 }

--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
+#include <cinttypes>
 #include <cstring>
 #include <memory>
 
@@ -255,16 +256,16 @@ ResultStatus AppLoader_NCCH::Load() {
     priority                = exheader_header.arm11_system_local_caps.priority;
     resource_limit_category = exheader_header.arm11_system_local_caps.resource_limit_category;
 
-    LOG_INFO(Loader,  "Name:                        %s"    , exheader_header.codeset_info.name);
-    LOG_INFO(Loader,  "Program ID:                  %016X" , ncch_header.program_id);
-    LOG_DEBUG(Loader, "Code compressed:             %s"    , is_compressed ? "yes" : "no");
-    LOG_DEBUG(Loader, "Entry point:                 0x%08X", entry_point);
-    LOG_DEBUG(Loader, "Code size:                   0x%08X", code_size);
-    LOG_DEBUG(Loader, "Stack size:                  0x%08X", stack_size);
-    LOG_DEBUG(Loader, "Bss size:                    0x%08X", bss_size);
-    LOG_DEBUG(Loader, "Core version:                %d"    , core_version);
-    LOG_DEBUG(Loader, "Thread priority:             0x%X"  , priority);
-    LOG_DEBUG(Loader, "Resource limit category:     %d"    , resource_limit_category);
+    LOG_INFO(Loader,  "Name:                        %s"          , exheader_header.codeset_info.name);
+    LOG_INFO(Loader,  "Program ID:                  %016" PRIX64 , ncch_header.program_id);
+    LOG_DEBUG(Loader, "Code compressed:             %s"          , is_compressed ? "yes" : "no");
+    LOG_DEBUG(Loader, "Entry point:                 0x%08X"      , entry_point);
+    LOG_DEBUG(Loader, "Code size:                   0x%08X"      , code_size);
+    LOG_DEBUG(Loader, "Stack size:                  0x%08X"      , stack_size);
+    LOG_DEBUG(Loader, "Bss size:                    0x%08X"      , bss_size);
+    LOG_DEBUG(Loader, "Core version:                %d"          , core_version);
+    LOG_DEBUG(Loader, "Thread priority:             0x%X"        , priority);
+    LOG_DEBUG(Loader, "Resource limit category:     %d"          , resource_limit_category);
 
     if (exheader_header.arm11_system_local_caps.program_id != ncch_header.program_id) {
         LOG_ERROR(Loader, "ExHeader Program ID mismatch: the ROM is probably encrypted.");

--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -737,8 +737,10 @@ struct Regs {
         case LightingSampler::ReflectGreen:
         case LightingSampler::ReflectBlue:
             return (config == LightingConfig::Config4) || (config == LightingConfig::Config5) || (config == LightingConfig::Config7);
+
+        default:
+            return false;
         }
-        return false;
     }
 
     struct {

--- a/src/video_core/rasterizer.cpp
+++ b/src/video_core/rasterizer.cpp
@@ -472,7 +472,11 @@ static void ProcessTriangleInternal(const Shader::OutputVertex& v0,
                 if ((texture.config.wrap_s == Regs::TextureConfig::ClampToBorder && (s < 0 || s >= texture.config.width))
                     || (texture.config.wrap_t == Regs::TextureConfig::ClampToBorder && (t < 0 || t >= texture.config.height))) {
                     auto border_color = texture.config.border_color;
-                    texture_color[i] = { border_color.r, border_color.g, border_color.b, border_color.a };
+                    texture_color[i] = { static_cast<u8>(border_color.r),
+                                         static_cast<u8>(border_color.g),
+                                         static_cast<u8>(border_color.b),
+                                         static_cast<u8>(border_color.a)
+                    };
                 } else {
                     // Textures are laid out from bottom to top, hence we invert the t coordinate.
                     // NOTE: This may not be the right place for the inversion.
@@ -501,8 +505,10 @@ static void ProcessTriangleInternal(const Shader::OutputVertex& v0,
             Math::Vec4<u8> combiner_output;
             Math::Vec4<u8> combiner_buffer = {0, 0, 0, 0};
             Math::Vec4<u8> next_combiner_buffer = {
-                regs.tev_combiner_buffer_color.r, regs.tev_combiner_buffer_color.g,
-                regs.tev_combiner_buffer_color.b, regs.tev_combiner_buffer_color.a
+                static_cast<u8>(regs.tev_combiner_buffer_color.r),
+                static_cast<u8>(regs.tev_combiner_buffer_color.g),
+                static_cast<u8>(regs.tev_combiner_buffer_color.b),
+                static_cast<u8>(regs.tev_combiner_buffer_color.a)
             };
 
             for (unsigned tev_stage_index = 0; tev_stage_index < tev_stages.size(); ++tev_stage_index) {
@@ -537,7 +543,11 @@ static void ProcessTriangleInternal(const Shader::OutputVertex& v0,
                         return combiner_buffer;
 
                     case Source::Constant:
-                        return {tev_stage.const_r, tev_stage.const_g, tev_stage.const_b, tev_stage.const_a};
+                        return { static_cast<u8>(tev_stage.const_r),
+                                 static_cast<u8>(tev_stage.const_g),
+                                 static_cast<u8>(tev_stage.const_b),
+                                 static_cast<u8>(tev_stage.const_a)
+                        };
 
                     case Source::Previous:
                         return combiner_output;


### PR DESCRIPTION
This is a different approach to resolve issue https://github.com/citra-emu/citra/issues/136 than PR https://github.com/citra-emu/citra/pull/1260.

In this PR I add -Werror to the compile flags and fix the warnings I get without more warnings enabled than the default ones. In future PRs I will add more warnings (like -Wall, -Wextra, maybe -Wpedantic and others).

It won't compile until my other PR on nihstro (https://github.com/neobrain/nihstro/pull/46) gets merged, I will add a commit that updates the submodule when (and if) it does.

I tested on an up-to-date archlinux against clang and gcc. I don't know MSVC well so I didn't touch it's flags, but I tested the build in a Windows 8 VM (I don't own a physical Windows machine with a GPU).