### PR TITLE
VideoCore: Sync state after changing rasterizers

### DIFF
--- a/src/video_core/renderer_base.cpp
+++ b/src/video_core/renderer_base.cpp
@@ -24,5 +24,6 @@ void RendererBase::RefreshRasterizerSetting() {
             rasterizer = Common::make_unique<VideoCore::SWRasterizer>();
         }
         rasterizer->InitObjects();
+        rasterizer->Reset();
     }
 }


### PR DESCRIPTION
This fixes various bugs that appear in the HW rasterizer after switching
between it and the SW one during emulation.