### PR TITLE
dyncom: Handle modifying the APSR via an MRC instruction

### DIFF
--- a/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
+++ b/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
@@ -4696,18 +4696,15 @@ unsigned InterpreterMainLoop(ARMul_State* cpu) {
         if (inst_base->cond == ConditionCode::AL || CondPassed(cpu, inst_base->cond)) {
             mrc_inst* inst_cream = (mrc_inst*)inst_base->component;
 
-            unsigned int inst = inst_cream->inst;
-            if (inst_cream->Rd == 15) {
-                DEBUG_MSG;
-            }
-            if (inst_cream->inst == 0xeef04a10) {
-                // Undefined instruction fmrx
-                RD = 0x20000000;
-                CITRA_IGNORE_EXIT(-1);
-                goto END;
-            } else {
-                if (inst_cream->cp_num == 15)
-                     RD = cpu->ReadCP15Register(CRn, OPCODE_1, CRm, OPCODE_2);
+            if (inst_cream->cp_num == 15) {
+                const uint32_t value = cpu->ReadCP15Register(CRn, OPCODE_1, CRm, OPCODE_2);
+
+                if (inst_cream->Rd == 15) {
+                    cpu->Cpsr = (cpu->Cpsr & ~0xF0000000) | (value & 0xF0000000);
+                    LOAD_NZCVT;
+                } else {
+                    RD = value;
+                }
             }
         }
         cpu->Reg[15] += cpu->GetInstructionSize();


### PR DESCRIPTION
For example, you can nonsensically do:

```cpp
uint32_t thread_value = 0;
uint32_t cpsr_prev = 0;
uint32_t cpsr_after = 0;

asm volatile (
    "MRS %[cpsr_prev], APSR\n"
    "MRC p15, 0, %[thread_out], c13, c0, 3\n"
    "MRC p15, 0, APSR_nzcv, c13, c0, 3\n"
    "MRS %[cpsr_after], APSR\n"
    : [thread_out]"=r"(thread_value), [cpsr_prev]"=r"(cpsr_prev), [cpsr_after]"=r"(cpsr_after)
);

printf("Thread URO: 0x%08X\n", thread_value);
printf("CPSR Prev : 0x%08X\n", cpsr_prev);
printf("CPSR After: 0x%08X\n", cpsr_after);
```

and have it work on the 3DS.