### PR TITLE
HLE/SVC: Implement UnmapMemoryBlock.

### DIFF
--- a/src/core/hle/function_wrappers.h
+++ b/src/core/hle/function_wrappers.h
@@ -188,6 +188,10 @@ template<ResultCode func(s64*, Handle, u32)> void Wrap() {
     FuncReturn(retval);
 }
 
+template<ResultCode func(Handle, u32)> void Wrap() {
+    FuncReturn(func(PARAM(0), PARAM(1)).raw);
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Function wrappers that return type u32
 

--- a/src/core/hle/kernel/shared_memory.cpp
+++ b/src/core/hle/kernel/shared_memory.cpp
@@ -39,6 +39,12 @@ ResultCode SharedMemory::Map(VAddr address, MemoryPermission permissions,
             ErrorSummary::InvalidArgument, ErrorLevel::Permanent);
     }
 
+    // TODO(Subv): Return E0E01BEE when permissions and other_permissions don't
+    // match what was specified when the memory block was created.
+
+    // TODO(Subv): Return E0E01BEE when address should be 0.
+    // Note: Find out when that's the case.
+
     if (fixed_address != 0) {
          if (address != 0 && address != fixed_address) {
             LOG_ERROR(Kernel, "cannot map id=%u, address=0x%08X name=%s: fixed_addres is 0x%08X!",
@@ -70,6 +76,21 @@ ResultCode SharedMemory::Map(VAddr address, MemoryPermission permissions,
     }
 
     this->base_address = address;
+
+    return RESULT_SUCCESS;
+}
+
+ResultCode SharedMemory::Unmap(VAddr address) {
+    if (base_address == 0) {
+        // TODO(Subv): Verify what actually happens when you want to unmap a memory block that
+        // was originally mapped with address = 0
+        return ResultCode(ErrorDescription::InvalidAddress, ErrorModule::OS, ErrorSummary::InvalidArgument, ErrorLevel::Usage);
+    }
+
+    if (base_address != address)
+        return ResultCode(ErrorDescription::WrongAddress, ErrorModule::OS, ErrorSummary::InvalidState, ErrorLevel::Usage);
+
+    base_address = 0;
 
     return RESULT_SUCCESS;
 }

--- a/src/core/hle/kernel/shared_memory.h
+++ b/src/core/hle/kernel/shared_memory.h
@@ -53,6 +53,13 @@ public:
     ResultCode Map(VAddr address, MemoryPermission permissions, MemoryPermission other_permissions);
 
     /**
+     * Unmaps a shared memory block from the specified address in system memory
+     * @param address Address in system memory where the shared memory block is mapped
+     * @return Result code of the unmap operation
+     */
+    ResultCode Unmap(VAddr address);
+
+    /**
     * Gets a pointer to the shared memory block
     * @param offset Offset from the start of the shared memory block to get pointer
     * @return Pointer to the shared memory block from the specified offset

--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -18,6 +18,7 @@
 /// Detailed description of the error. This listing is likely incomplete.
 enum class ErrorDescription : u32 {
     Success = 0,
+    WrongAddress = 53,
     FS_NotFound = 100,
     FS_NotFormatted = 340, ///< This is used by the FS service when creating a SaveData archive
     InvalidSection = 1000,


### PR DESCRIPTION
This implementation will need to be (almost completely) changed when we implement multiprocess support.

The error codes have been verified in hardware

Closes #1324