### PR TITLE
hwrasterizer: Use depth offset

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -126,6 +126,7 @@ void RasterizerOpenGL::InitObjects() {
 
 void RasterizerOpenGL::Reset() {
     SyncCullMode();
+    SyncDepthModifiers();
     SyncBlendEnabled();
     SyncBlendFuncs();
     SyncBlendColor();
@@ -192,6 +193,12 @@ void RasterizerOpenGL::NotifyPicaRegisterChanged(u32 id) {
     // Culling
     case PICA_REG_INDEX(cull_mode):
         SyncCullMode();
+        break;
+
+    // Depth modifiers
+    case PICA_REG_INDEX(viewport_depth_range):
+    case PICA_REG_INDEX(viewport_depth_far_plane):
+        SyncDepthModifiers();
         break;
 
     // Blending
@@ -600,6 +607,15 @@ void RasterizerOpenGL::SyncCullMode() {
         UNIMPLEMENTED();
         break;
     }
+}
+
+void RasterizerOpenGL::SyncDepthModifiers() {
+    float depth_scale = -Pica::float24::FromRawFloat24(Pica::g_state.regs.viewport_depth_range).ToFloat32();
+    float depth_offset = Pica::float24::FromRawFloat24(Pica::g_state.regs.viewport_depth_far_plane).ToFloat32() / 2.0f;
+
+    // TODO: Implement scale modifier
+    uniform_block_data.data.depth_offset = depth_offset;
+    uniform_block_data.dirty = true;
 }
 
 void RasterizerOpenGL::SyncBlendEnabled() {

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -197,7 +197,8 @@ private:
         std::array<GLfloat, 4> const_color[6];
         std::array<GLfloat, 4> tev_combiner_buffer_color;
         GLint alphatest_ref;
-        INSERT_PADDING_BYTES(12);
+        GLfloat depth_offset;
+        INSERT_PADDING_BYTES(8);
     };
 
     static_assert(sizeof(UniformData) == 0x80, "The size of the UniformData structure has changed, update the structure in the shader");
@@ -217,6 +218,9 @@ private:
 
     /// Syncs the cull mode to match the PICA register
     void SyncCullMode();
+
+    /// Syncs the depth scale and offset to match the PICA registers
+    void SyncDepthModifiers();
 
     /// Syncs the blend enabled status to match the PICA register
     void SyncBlendEnabled();

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -334,6 +334,7 @@ layout (std140) uniform shader_data {
     vec4 const_color[NUM_TEV_STAGES];
     vec4 tev_combiner_buffer_color;
     int alphatest_ref;
+    float depth_offset;
 };
 
 uniform sampler2D tex[3];
@@ -360,7 +361,8 @@ void main() {
         out += ") discard;\n";
     }
 
-    out += "color = last_tex_env_out;\n}";
+    out += "color = last_tex_env_out;\n";
+    out += "gl_FragDepth = gl_FragCoord.z + depth_offset;\n}";
 
     return out;
 }


### PR DESCRIPTION
Uses offsets in the hardware renderer fragment shader to emulate depth near plane + polygon offsets. Should fix z-fighting as in #1150 including ALBW along with making the "inner" sub in the Sub Wars title screen consistent with the software renderer.