### PR TITLE
Add check before closure when emulation is running

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -497,7 +497,25 @@ void GMainWindow::OnConfigure() {
     //GControllerConfigDialog* dialog = new GControllerConfigDialog(controller_ports, this);
 }
 
+bool GMainWindow::ConfirmClose() {
+    if (emu_thread != nullptr) {
+        auto answer = QMessageBox::question(this, tr("Citra"),
+                                            tr("Are you sure you want to close Citra?"),
+                                            QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+
+        if (answer == QMessageBox::No) {
+            return false;
+        }
+    }
+    return true;
+}
+
 void GMainWindow::closeEvent(QCloseEvent* event) {
+    if (!ConfirmClose()) {
+        event->ignore();
+        return;
+    }
+
     // Save window layout
     QSettings settings(QSettings::IniFormat, QSettings::UserScope, "Citra team", "Citra");
 

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -171,6 +171,8 @@ GMainWindow::GMainWindow() : emu_thread(nullptr)
     }
     UpdateRecentFiles();
 
+    confirm_before_closing = settings.value("confirmClose", true).toBool();
+
     // Setup connections
     connect(game_list, SIGNAL(GameChosen(QString)), this, SLOT(OnGameListLoadFile(QString)));
     connect(ui.action_Load_File, SIGNAL(triggered()), this, SLOT(OnMenuLoadFile()));
@@ -498,16 +500,13 @@ void GMainWindow::OnConfigure() {
 }
 
 bool GMainWindow::ConfirmClose() {
-    if (emu_thread != nullptr) {
-        auto answer = QMessageBox::question(this, tr("Citra"),
-                                            tr("Are you sure you want to close Citra?"),
-                                            QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+    if (emu_thread == nullptr || !confirm_before_closing)
+        return true;
 
-        if (answer == QMessageBox::No) {
-            return false;
-        }
-    }
-    return true;
+    auto answer = QMessageBox::question(this, tr("Citra"),
+                                        tr("Are you sure you want to close Citra?"),
+                                        QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+    return answer != QMessageBox::No;
 }
 
 void GMainWindow::closeEvent(QCloseEvent* event) {
@@ -530,6 +529,7 @@ void GMainWindow::closeEvent(QCloseEvent* event) {
     settings.setValue("singleWindowMode", ui.action_Single_Window_Mode->isChecked());
     settings.setValue("displayTitleBars", ui.actionDisplay_widget_title_bars->isChecked());
     settings.setValue("firstStart", false);
+    settings.setValue("confirmClose", confirm_before_closing);
     game_list->SaveInterfaceLayout(settings);
     SaveHotkeys(settings);
 

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -82,6 +82,13 @@ private:
      */
     void UpdateRecentFiles();
 
+    /**
+     * If the emulation is running,
+     * asks the user if he really want to close the emulator
+     *
+     * @return true if the user confirmed
+     */
+    bool ConfirmClose();
     void closeEvent(QCloseEvent* event) override;
 
 private slots:

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -129,6 +129,7 @@ private:
     GPUCommandListWidget* graphicsCommandsWidget;
 
     QAction* actions_recent_files[max_recent_files_item];
+    bool confirm_before_closing;
 };
 
 #endif // _CITRA_QT_MAIN_HXX_


### PR DESCRIPTION
Implementation for #1335

It should also be done for citra-cli (GLFW), but there is no easy way to show a message box using this API.