### PR TITLE
DisassembleMemHalf: actually use width in determining opcode name

### DIFF
--- a/src/core/arm/disassembler/arm_disasm.cpp
+++ b/src/core/arm/disassembler/arm_disasm.cpp
@@ -738,23 +738,23 @@ std::string ARM_Disasm::DisassembleMemHalf(u32 insn)
     if (is_immed) {
         if (is_pre) {
             if (offset == 0) {
-                return Common::StringFromFormat("%s%sh\tr%d, [r%d]", opname, cond_to_str(cond), rd, rn);
+                return Common::StringFromFormat("%s%s%s\tr%d, [r%d]", opname, cond_to_str(cond), width, rd, rn);
             } else {
-                return Common::StringFromFormat("%s%sh\tr%d, [r%d, #%s%u]%s",
-                        opname, cond_to_str(cond), rd, rn, minus, offset, bang);
+                return Common::StringFromFormat("%s%s%s\tr%d, [r%d, #%s%u]%s",
+                        opname, cond_to_str(cond), width, rd, rn, minus, offset, bang);
             }
         } else {
-            return Common::StringFromFormat("%s%sh\tr%d, [r%d], #%s%u",
-                    opname, cond_to_str(cond), rd, rn, minus, offset);
+            return Common::StringFromFormat("%s%s%s\tr%d, [r%d], #%s%u",
+                    opname, cond_to_str(cond), width, rd, rn, minus, offset);
         }
     }
 
     if (is_pre) {
-        return Common::StringFromFormat("%s%sh\tr%d, [r%d, %sr%d]%s",
-                opname, cond_to_str(cond), rd, rn, minus, rm, bang);
+        return Common::StringFromFormat("%s%s%s\tr%d, [r%d, %sr%d]%s",
+                opname, cond_to_str(cond), width, rd, rn, minus, rm, bang);
     } else {
-        return Common::StringFromFormat("%s%sh\tr%d, [r%d], %sr%d",
-                opname, cond_to_str(cond), rd, rn, minus, rm);
+        return Common::StringFromFormat("%s%s%s\tr%d, [r%d], %sr%d",
+                opname, cond_to_str(cond), width, rd, rn, minus, rm);
     }
 }
 


### PR DESCRIPTION
Uhh, I'm like 80% sure that this change is correct? I'm just trying to get my foot in the door, I don't really know what I'm doing yet. Before this pull request, width was not being used at all, and since this function is used for different size opcodes, it wouldn't make sense to just always append h.