### PR TITLE
Implementation for a configure widget

### DIFF
--- a/src/citra_qt/CMakeLists.txt
+++ b/src/citra_qt/CMakeLists.txt
@@ -17,12 +17,16 @@ set(SRCS
             debugger/profiler.cpp
             debugger/ramview.cpp
             debugger/registers.cpp
-            game_list.cpp
             util/spinbox.cpp
             util/util.cpp
             bootmanager.cpp
+            configure_debug.cpp
+            configure_dialog.cpp
+            configure_general.cpp
+            game_list.cpp
             hotkeys.cpp
             main.cpp
+            ui_settings.cpp
             citra-qt.rc
             Info.plist
             )
@@ -44,12 +48,16 @@ set(HEADERS
             debugger/profiler.h
             debugger/ramview.h
             debugger/registers.h
-            game_list.h
             util/spinbox.h
             util/util.h
             bootmanager.h
+            configure_debug.h
+            configure_dialog.h
+            configure_general.h
+            game_list.h
             hotkeys.h
             main.h
+            ui_settings.h
             version.h
             )
 
@@ -59,6 +67,9 @@ set(UIS
             debugger/disassembler.ui
             debugger/profiler.ui
             debugger/registers.ui
+            configure.ui
+            configure_debug.ui
+            configure_general.ui
             hotkeys.ui
             main.ui
             )

--- a/src/citra_qt/config.cpp
+++ b/src/citra_qt/config.cpp
@@ -82,24 +82,23 @@ void Config::ReadValues() {
     qt_config->beginGroup("Paths");
     UISettings::values.roms_path = qt_config->value("romsPath").toString();
     UISettings::values.symbols_path = qt_config->value("symbolsPath").toString();
-    UISettings::values.gamedir_path = qt_config->value("gameListRootDir", ".").toString();
+    UISettings::values.gamedir = qt_config->value("gameListRootDir", ".").toString();
     UISettings::values.gamedir_deepscan = qt_config->value("gameListDeepScan", false).toBool();
     UISettings::values.recent_files = qt_config->value("recentFiles").toStringList();
     qt_config->endGroup();
 
     qt_config->beginGroup("Shortcuts");
     QStringList groups = qt_config->childGroups();
-    for (auto group : groups)
-    {
+    for (auto group : groups) {
         qt_config->beginGroup(group);
 
         QStringList hotkeys = qt_config->childGroups();
-        for (auto hotkey : hotkeys)
-        {
+        for (auto hotkey : hotkeys) {
             qt_config->beginGroup(hotkey);
-            UISettings::values.shortcuts.push_back(UISettings::Shortcut(group + "/" + hotkey,
-                                                                        UISettings::ContextedShortcut(qt_config->value("KeySeq").toString(),
-                                                                                                      qt_config->value("Context").toInt())));
+            UISettings::values.shortcuts.emplace_back(
+                        UISettings::Shortcut(group + "/" + hotkey,
+                                             UISettings::ContextualShortcut(qt_config->value("KeySeq").toString(),
+                                                                           qt_config->value("Context").toInt())));
             qt_config->endGroup();
         }
 
@@ -109,6 +108,7 @@ void Config::ReadValues() {
 
     UISettings::values.single_window_mode = qt_config->value("singleWindowMode", true).toBool();
     UISettings::values.display_titlebar = qt_config->value("displayTitleBars", true).toBool();
+    UISettings::values.confirm_before_closing = qt_config->value("confirmClose",true).toBool();
     UISettings::values.first_start = qt_config->value("firstStart", true).toBool();
 
     qt_config->endGroup();
@@ -167,14 +167,13 @@ void Config::SaveValues() {
     qt_config->beginGroup("Paths");
     qt_config->setValue("romsPath", UISettings::values.roms_path);
     qt_config->setValue("symbolsPath", UISettings::values.symbols_path);
-    qt_config->setValue("gameListRootDir", UISettings::values.gamedir_path);
+    qt_config->setValue("gameListRootDir", UISettings::values.gamedir);
     qt_config->setValue("gameListDeepScan", UISettings::values.gamedir_deepscan);
     qt_config->setValue("recentFiles", UISettings::values.recent_files);
     qt_config->endGroup();
 
     qt_config->beginGroup("Shortcuts");
-    for (auto shortcut : UISettings::values.shortcuts )
-    {
+    for (auto shortcut : UISettings::values.shortcuts ) {
         qt_config->setValue(shortcut.first + "/KeySeq", shortcut.second.first);
         qt_config->setValue(shortcut.first + "/Context", shortcut.second.second);
     }
@@ -182,6 +181,7 @@ void Config::SaveValues() {
 
     qt_config->setValue("singleWindowMode", UISettings::values.single_window_mode);
     qt_config->setValue("displayTitleBars", UISettings::values.display_titlebar);
+    qt_config->setValue("confirmClose", UISettings::values.confirm_before_closing);
     qt_config->setValue("firstStart", UISettings::values.first_start);
 
     qt_config->endGroup();

--- a/src/citra_qt/config.cpp
+++ b/src/citra_qt/config.cpp
@@ -7,12 +7,12 @@
 #include <QStringList>
 
 #include "citra_qt/config.h"
+#include "citra_qt/ui_settings.h"
 
 #include "common/file_util.h"
 #include "core/settings.h"
 
 Config::Config() {
-
     // TODO: Don't hardcode the path; let the frontend decide where to put the config files.
     qt_config_loc = FileUtil::GetUserPath(D_CONFIG_IDX) + "qt-config.ini";
     FileUtil::CreateFullPath(qt_config_loc);
@@ -67,6 +67,51 @@ void Config::ReadValues() {
     Settings::values.use_gdbstub = qt_config->value("use_gdbstub", false).toBool();
     Settings::values.gdbstub_port = qt_config->value("gdbstub_port", 24689).toInt();
     qt_config->endGroup();
+
+    qt_config->beginGroup("UI");
+
+    qt_config->beginGroup("UILayout");
+    UISettings::values.geometry = qt_config->value("geometry").toByteArray();
+    UISettings::values.state = qt_config->value("state").toByteArray();
+    UISettings::values.renderwindow_geometry = qt_config->value("geometryRenderWindow").toByteArray();
+    UISettings::values.gamelist_header_state = qt_config->value("gameListHeaderState").toByteArray();
+    UISettings::values.microprofile_geometry = qt_config->value("microProfileDialogGeometry").toByteArray();
+    UISettings::values.microprofile_visible = qt_config->value("microProfileDialogVisible", false).toBool();
+    qt_config->endGroup();
+
+    qt_config->beginGroup("Paths");
+    UISettings::values.roms_path = qt_config->value("romsPath").toString();
+    UISettings::values.symbols_path = qt_config->value("symbolsPath").toString();
+    UISettings::values.gamedir_path = qt_config->value("gameListRootDir", ".").toString();
+    UISettings::values.gamedir_deepscan = qt_config->value("gameListDeepScan", false).toBool();
+    UISettings::values.recent_files = qt_config->value("recentFiles").toStringList();
+    qt_config->endGroup();
+
+    qt_config->beginGroup("Shortcuts");
+    QStringList groups = qt_config->childGroups();
+    for (auto group : groups)
+    {
+        qt_config->beginGroup(group);
+
+        QStringList hotkeys = qt_config->childGroups();
+        for (auto hotkey : hotkeys)
+        {
+            qt_config->beginGroup(hotkey);
+            UISettings::values.shortcuts.push_back(UISettings::Shortcut(group + "/" + hotkey,
+                                                                        UISettings::ContextedShortcut(qt_config->value("KeySeq").toString(),
+                                                                                                      qt_config->value("Context").toInt())));
+            qt_config->endGroup();
+        }
+
+        qt_config->endGroup();
+    }
+    qt_config->endGroup();
+
+    UISettings::values.single_window_mode = qt_config->value("singleWindowMode", true).toBool();
+    UISettings::values.display_titlebar = qt_config->value("displayTitleBars", true).toBool();
+    UISettings::values.first_start = qt_config->value("firstStart", true).toBool();
+
+    qt_config->endGroup();
 }
 
 void Config::SaveValues() {
@@ -106,6 +151,39 @@ void Config::SaveValues() {
     qt_config->beginGroup("Debugging");
     qt_config->setValue("use_gdbstub", Settings::values.use_gdbstub);
     qt_config->setValue("gdbstub_port", Settings::values.gdbstub_port);
+    qt_config->endGroup();
+
+    qt_config->beginGroup("UI");
+
+    qt_config->beginGroup("UILayout");
+    qt_config->setValue("geometry", UISettings::values.geometry);
+    qt_config->setValue("state", UISettings::values.state);
+    qt_config->setValue("geometryRenderWindow", UISettings::values.renderwindow_geometry);
+    qt_config->setValue("gameListHeaderState", UISettings::values.gamelist_header_state);
+    qt_config->setValue("microProfileDialogGeometry", UISettings::values.microprofile_geometry);
+    qt_config->setValue("microProfileDialogVisible", UISettings::values.microprofile_visible);
+    qt_config->endGroup();
+
+    qt_config->beginGroup("Paths");
+    qt_config->setValue("romsPath", UISettings::values.roms_path);
+    qt_config->setValue("symbolsPath", UISettings::values.symbols_path);
+    qt_config->setValue("gameListRootDir", UISettings::values.gamedir_path);
+    qt_config->setValue("gameListDeepScan", UISettings::values.gamedir_deepscan);
+    qt_config->setValue("recentFiles", UISettings::values.recent_files);
+    qt_config->endGroup();
+
+    qt_config->beginGroup("Shortcuts");
+    for (auto shortcut : UISettings::values.shortcuts )
+    {
+        qt_config->setValue(shortcut.first + "/KeySeq", shortcut.second.first);
+        qt_config->setValue(shortcut.first + "/Context", shortcut.second.second);
+    }
+    qt_config->endGroup();
+
+    qt_config->setValue("singleWindowMode", UISettings::values.single_window_mode);
+    qt_config->setValue("displayTitleBars", UISettings::values.display_titlebar);
+    qt_config->setValue("firstStart", UISettings::values.first_start);
+
     qt_config->endGroup();
 }
 

--- a/src/citra_qt/configure.ui
+++ b/src/citra_qt/configure.ui
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConfigureDialog</class>
+ <widget class="QDialog" name="ConfigureDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>441</width>
+    <height>401</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>370</width>
+    <height>219</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="minimumSize">
+      <size>
+       <width>371</width>
+       <height>221</height>
+      </size>
+     </property>
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="ConfigureGeneral" name="generalTab">
+      <attribute name="title">
+       <string>General</string>
+      </attribute>
+     </widget>
+     <widget class="QWidget" name="inputTab">
+      <attribute name="title">
+       <string>Input</string>
+      </attribute>
+     </widget>
+     <widget class="ConfigureDebug" name="debugTab">
+      <attribute name="title">
+       <string>Debug</string>
+      </attribute>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ConfigureGeneral</class>
+   <extends>QWidget</extends>
+   <header>configure_general.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ConfigureDebug</class>
+   <extends>QWidget</extends>
+   <header>configure_debug.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ConfigureDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>220</x>
+     <y>380</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>220</x>
+     <y>200</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ConfigureDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>220</x>
+     <y>380</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>220</x>
+     <y>200</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/citra_qt/configure.ui
+++ b/src/citra_qt/configure.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>441</width>
-    <height>401</height>
+    <height>501</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -17,7 +17,7 @@
    </size>
   </property>
   <property name="windowTitle">
-   <string>Dialog</string>
+   <string>Citra Configuration</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/src/citra_qt/configure_debug.cpp
+++ b/src/citra_qt/configure_debug.cpp
@@ -2,12 +2,11 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include "core/core.h"
-#include "core/gdbstub/gdbstub.h" // TODO: can't include gdbstub without core.h
-#include "core/settings.h"
-
-#include "configure_debug.h"
+#include "citra_qt/configure_debug.h"
 #include "ui_configure_debug.h"
+
+#include "core/gdbstub/gdbstub.h"
+#include "core/settings.h"
 
 ConfigureDebug::ConfigureDebug(QWidget *parent) :
     QWidget(parent),
@@ -18,16 +17,16 @@ ConfigureDebug::ConfigureDebug(QWidget *parent) :
 }
 
 ConfigureDebug::~ConfigureDebug() {
-    delete ui;
 }
 
 void ConfigureDebug::setConfiguration() {
-    ui->toogleGDBStub->setChecked(Settings::values.use_gdbstub);
-    ui->GDBPortSpinBox->setValue(Settings::values.gdbstub_port);
+    ui->toogle_gdbstub->setChecked(Settings::values.use_gdbstub);
+    ui->gdbport_spinbox->setEnabled(Settings::values.use_gdbstub);
+    ui->gdbport_spinbox->setValue(Settings::values.gdbstub_port);
 }
 
 void ConfigureDebug::applyConfiguration() {
-    GDBStub::ToggleServer(ui->toogleGDBStub->isChecked());
-    Settings::values.use_gdbstub = ui->toogleGDBStub->isChecked();
-    Settings::values.gdbstub_port = ui->GDBPortSpinBox->value();
+    GDBStub::ToggleServer(ui->toogle_gdbstub->isChecked());
+    Settings::values.use_gdbstub = ui->toogle_gdbstub->isChecked();
+    Settings::values.gdbstub_port = ui->gdbport_spinbox->value();
 }

--- a/src/citra_qt/configure_debug.cpp
+++ b/src/citra_qt/configure_debug.cpp
@@ -1,0 +1,33 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/core.h"
+#include "core/gdbstub/gdbstub.h" // TODO: can't include gdbstub without core.h
+#include "core/settings.h"
+
+#include "configure_debug.h"
+#include "ui_configure_debug.h"
+
+ConfigureDebug::ConfigureDebug(QWidget *parent) :
+    QWidget(parent),
+    ui(new Ui::ConfigureDebug)
+{
+    ui->setupUi(this);
+    this->setConfiguration();
+}
+
+ConfigureDebug::~ConfigureDebug() {
+    delete ui;
+}
+
+void ConfigureDebug::setConfiguration() {
+    ui->toogleGDBStub->setChecked(Settings::values.use_gdbstub);
+    ui->GDBPortSpinBox->setValue(Settings::values.gdbstub_port);
+}
+
+void ConfigureDebug::applyConfiguration() {
+    GDBStub::ToggleServer(ui->toogleGDBStub->isChecked());
+    Settings::values.use_gdbstub = ui->toogleGDBStub->isChecked();
+    Settings::values.gdbstub_port = ui->GDBPortSpinBox->value();
+}

--- a/src/citra_qt/configure_debug.h
+++ b/src/citra_qt/configure_debug.h
@@ -1,0 +1,31 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#ifndef CONFIGURE_DEBUG_H
+#define CONFIGURE_DEBUG_H
+
+#include <QWidget>
+
+namespace Ui {
+class ConfigureDebug;
+}
+
+class ConfigureDebug : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit ConfigureDebug(QWidget *parent = 0);
+    ~ConfigureDebug();
+
+    void applyConfiguration();
+
+private:
+    void setConfiguration();
+
+private:
+    Ui::ConfigureDebug *ui;
+};
+
+#endif // CONFIGURE_DEBUG_H

--- a/src/citra_qt/configure_debug.h
+++ b/src/citra_qt/configure_debug.h
@@ -2,9 +2,9 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#ifndef CONFIGURE_DEBUG_H
-#define CONFIGURE_DEBUG_H
+#pragma once
 
+#include <memory>
 #include <QWidget>
 
 namespace Ui {
@@ -16,7 +16,7 @@ class ConfigureDebug : public QWidget
     Q_OBJECT
 
 public:
-    explicit ConfigureDebug(QWidget *parent = 0);
+    explicit ConfigureDebug(QWidget *parent = nullptr);
     ~ConfigureDebug();
 
     void applyConfiguration();
@@ -25,7 +25,5 @@ private:
     void setConfiguration();
 
 private:
-    Ui::ConfigureDebug *ui;
+    std::unique_ptr<Ui::ConfigureDebug> ui;
 };
-
-#endif // CONFIGURE_DEBUG_H

--- a/src/citra_qt/configure_debug.ui
+++ b/src/citra_qt/configure_debug.ui
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConfigureDebug</class>
+ <widget class="QWidget" name="ConfigureDebug">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QGroupBox" name="groupBox">
+       <property name="title">
+        <string>GDB</string>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_3">
+            <item>
+             <widget class="QCheckBox" name="toogleGDBStub">
+              <property name="text">
+               <string>Enable GDB Stub</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QLabel" name="label">
+              <property name="text">
+               <string>Port:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QSpinBox" name="GDBPortSpinBox">
+              <property name="maximum">
+               <number>65536</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/citra_qt/configure_debug.ui
+++ b/src/citra_qt/configure_debug.ui
@@ -13,54 +13,50 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QVBoxLayout" name="verticalLayout">
+    <layout class="QVBoxLayout" name="verticalLayout_3">
      <item>
       <widget class="QGroupBox" name="groupBox">
        <property name="title">
         <string>GDB</string>
        </property>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <layout class="QVBoxLayout" name="verticalLayout_2">
         <item>
-         <layout class="QVBoxLayout" name="verticalLayout_2">
+         <layout class="QHBoxLayout" name="horizontalLayout_3">
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_3">
-            <item>
-             <widget class="QCheckBox" name="toogleGDBStub">
-              <property name="text">
-               <string>Enable GDB Stub</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QLabel" name="label">
-              <property name="text">
-               <string>Port:</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QSpinBox" name="GDBPortSpinBox">
-              <property name="maximum">
-               <number>65536</number>
-              </property>
-             </widget>
-            </item>
-           </layout>
+           <widget class="QCheckBox" name="toogle_gdbstub">
+            <property name="text">
+             <string>Enable GDB Stub</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Port:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QSpinBox" name="gdbport_spinbox">
+            <property name="maximum">
+             <number>65536</number>
+            </property>
+           </widget>
           </item>
          </layout>
         </item>
@@ -69,8 +65,38 @@
      </item>
     </layout>
    </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
   </layout>
  </widget>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>toogle_gdbstub</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>gdbport_spinbox</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>84</x>
+     <y>157</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>342</x>
+     <y>158</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/src/citra_qt/configure_dialog.cpp
+++ b/src/citra_qt/configure_dialog.cpp
@@ -2,10 +2,10 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include "configure_dialog.h"
+#include "citra_qt/config.h"
+#include "citra_qt/configure_dialog.h"
 #include "ui_configure.h"
 
-#include "config.h"
 
 #include "core/settings.h"
 
@@ -18,15 +18,12 @@ ConfigureDialog::ConfigureDialog(QWidget *parent) :
 }
 
 ConfigureDialog::~ConfigureDialog() {
-    delete ui;
 }
 
 void ConfigureDialog::setConfiguration() {
 }
 
 void ConfigureDialog::applyConfiguration() {
-    Config config;
     ui->generalTab->applyConfiguration();
     ui->debugTab->applyConfiguration();
-    config.Save();
 }

--- a/src/citra_qt/configure_dialog.cpp
+++ b/src/citra_qt/configure_dialog.cpp
@@ -1,0 +1,32 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "configure_dialog.h"
+#include "ui_configure.h"
+
+#include "config.h"
+
+#include "core/settings.h"
+
+ConfigureDialog::ConfigureDialog(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::ConfigureDialog)
+{
+    ui->setupUi(this);
+    this->setConfiguration();
+}
+
+ConfigureDialog::~ConfigureDialog() {
+    delete ui;
+}
+
+void ConfigureDialog::setConfiguration() {
+}
+
+void ConfigureDialog::applyConfiguration() {
+    Config config;
+    ui->generalTab->applyConfiguration();
+    ui->debugTab->applyConfiguration();
+    config.Save();
+}

--- a/src/citra_qt/configure_dialog.h
+++ b/src/citra_qt/configure_dialog.h
@@ -2,9 +2,9 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#ifndef CONFIGURE_DIALOG_H
-#define CONFIGURE_DIALOG_H
+#pragma once
 
+#include <memory>
 #include <QDialog>
 
 namespace Ui {
@@ -16,7 +16,7 @@ class ConfigureDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit ConfigureDialog(QWidget *parent = 0);
+    explicit ConfigureDialog(QWidget *parent = nullptr);
     ~ConfigureDialog();
 
     void applyConfiguration();
@@ -25,7 +25,5 @@ private:
     void setConfiguration();
 
 private:
-    Ui::ConfigureDialog *ui;
+    std::unique_ptr<Ui::ConfigureDialog> ui;
 };
-
-#endif // CONFIGURE_DIALOG_H

--- a/src/citra_qt/configure_dialog.h
+++ b/src/citra_qt/configure_dialog.h
@@ -1,0 +1,31 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#ifndef CONFIGURE_DIALOG_H
+#define CONFIGURE_DIALOG_H
+
+#include <QDialog>
+
+namespace Ui {
+class ConfigureDialog;
+}
+
+class ConfigureDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit ConfigureDialog(QWidget *parent = 0);
+    ~ConfigureDialog();
+
+    void applyConfiguration();
+
+private:
+    void setConfiguration();
+
+private:
+    Ui::ConfigureDialog *ui;
+};
+
+#endif // CONFIGURE_DIALOG_H

--- a/src/citra_qt/configure_general.cpp
+++ b/src/citra_qt/configure_general.cpp
@@ -3,8 +3,8 @@
 // Refer to the license.txt file included.
 
 #include "citra_qt/configure_general.h"
-#include "citra_qt/ui_configure_general.h"
 #include "citra_qt/ui_settings.h"
+#include "ui_configure_general.h"
 
 #include "core/settings.h"
 
@@ -18,23 +18,26 @@ ConfigureGeneral::ConfigureGeneral(QWidget *parent) :
     this->setConfiguration();
 }
 
-ConfigureGeneral::~ConfigureGeneral()
-{
-    delete ui;
+ConfigureGeneral::~ConfigureGeneral() {
 }
 
 void ConfigureGeneral::setConfiguration() {
-    ui->toogleCheckExit->setChecked(UISettings::values.check_closure);
-    ui->toogleHWRenderer->setChecked(Settings::values.use_hw_renderer);
-    ui->toogleShaderJIT->setChecked(Settings::values.use_shader_jit);
+    ui->toogle_deepscan->setChecked(UISettings::values.gamedir_deepscan);
+    ui->toogle_check_exit->setChecked(UISettings::values.confirm_before_closing);
+    ui->region_combobox->setCurrentIndex(Settings::values.region_value);
+    ui->toogle_hw_renderer->setChecked(Settings::values.use_hw_renderer);
+    ui->toogle_shader_jit->setChecked(Settings::values.use_shader_jit);
 }
 
 void ConfigureGeneral::applyConfiguration() {
-    UISettings::values.check_closure = ui->toogleCheckExit->isChecked();
+    UISettings::values.gamedir_deepscan = ui->toogle_deepscan->isChecked();
+    UISettings::values.confirm_before_closing = ui->toogle_check_exit->isChecked();
+
+    Settings::values.region_value = ui->region_combobox->currentIndex();
 
     VideoCore::g_hw_renderer_enabled =
-    Settings::values.use_hw_renderer = ui->toogleHWRenderer->isChecked();
+    Settings::values.use_hw_renderer = ui->toogle_hw_renderer->isChecked();
 
     VideoCore::g_shader_jit_enabled =
-    Settings::values.use_shader_jit = ui->toogleShaderJIT->isChecked();
+    Settings::values.use_shader_jit = ui->toogle_shader_jit->isChecked();
 }

--- a/src/citra_qt/configure_general.cpp
+++ b/src/citra_qt/configure_general.cpp
@@ -1,0 +1,40 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "citra_qt/configure_general.h"
+#include "citra_qt/ui_configure_general.h"
+#include "citra_qt/ui_settings.h"
+
+#include "core/settings.h"
+
+#include "video_core/video_core.h"
+
+ConfigureGeneral::ConfigureGeneral(QWidget *parent) :
+    QWidget(parent),
+    ui(new Ui::ConfigureGeneral)
+{
+    ui->setupUi(this);
+    this->setConfiguration();
+}
+
+ConfigureGeneral::~ConfigureGeneral()
+{
+    delete ui;
+}
+
+void ConfigureGeneral::setConfiguration() {
+    ui->toogleCheckExit->setChecked(UISettings::values.check_closure);
+    ui->toogleHWRenderer->setChecked(Settings::values.use_hw_renderer);
+    ui->toogleShaderJIT->setChecked(Settings::values.use_shader_jit);
+}
+
+void ConfigureGeneral::applyConfiguration() {
+    UISettings::values.check_closure = ui->toogleCheckExit->isChecked();
+
+    VideoCore::g_hw_renderer_enabled =
+    Settings::values.use_hw_renderer = ui->toogleHWRenderer->isChecked();
+
+    VideoCore::g_shader_jit_enabled =
+    Settings::values.use_shader_jit = ui->toogleShaderJIT->isChecked();
+}

--- a/src/citra_qt/configure_general.h
+++ b/src/citra_qt/configure_general.h
@@ -1,0 +1,31 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#ifndef CONFIGURE_GENERAL_H
+#define CONFIGURE_GENERAL_H
+
+#include <QWidget>
+
+namespace Ui {
+class ConfigureGeneral;
+}
+
+class ConfigureGeneral : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit ConfigureGeneral(QWidget *parent = 0);
+    ~ConfigureGeneral();
+
+    void applyConfiguration();
+
+private:
+    void setConfiguration();
+
+private:
+    Ui::ConfigureGeneral *ui;
+};
+
+#endif // CONFIGURE_GENERAL_H

--- a/src/citra_qt/configure_general.h
+++ b/src/citra_qt/configure_general.h
@@ -2,9 +2,9 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#ifndef CONFIGURE_GENERAL_H
-#define CONFIGURE_GENERAL_H
+#pragma once
 
+#include <memory>
 #include <QWidget>
 
 namespace Ui {
@@ -16,7 +16,7 @@ class ConfigureGeneral : public QWidget
     Q_OBJECT
 
 public:
-    explicit ConfigureGeneral(QWidget *parent = 0);
+    explicit ConfigureGeneral(QWidget *parent = nullptr);
     ~ConfigureGeneral();
 
     void applyConfiguration();
@@ -25,7 +25,5 @@ private:
     void setConfiguration();
 
 private:
-    Ui::ConfigureGeneral *ui;
+    std::unique_ptr<Ui::ConfigureGeneral> ui;
 };
-
-#endif // CONFIGURE_GENERAL_H

--- a/src/citra_qt/configure_general.ui
+++ b/src/citra_qt/configure_general.ui
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConfigureGeneral</class>
+ <widget class="QWidget" name="ConfigureGeneral">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>284</width>
+    <height>377</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QGroupBox" name="groupBox">
+       <property name="title">
+        <string>General</string>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <item>
+           <widget class="QCheckBox" name="toogleCheckExit">
+            <property name="text">
+             <string>Confirm exit while emulation is running</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="groupBox_2">
+       <property name="title">
+        <string>Performance</string>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <item>
+           <widget class="QCheckBox" name="toogleHWRenderer">
+            <property name="text">
+             <string>Enable hardware renderer</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="toogleShaderJIT">
+            <property name="text">
+             <string>Enable Shader JIT</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="groupBox_3">
+       <property name="title">
+        <string>Hotkeys</string>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
+        <item>
+         <layout class="QVBoxLayout" name="verticalLayout_4">
+          <item>
+           <widget class="GHotkeysDialog" name="widget" native="true"/>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>GHotkeysDialog</class>
+   <extends>QWidget</extends>
+   <header>hotkeys.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/citra_qt/configure_general.ui
+++ b/src/citra_qt/configure_general.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>284</width>
+    <width>300</width>
     <height>377</height>
    </rect>
   </property>
@@ -25,11 +25,81 @@
         <item>
          <layout class="QVBoxLayout" name="verticalLayout_2">
           <item>
-           <widget class="QCheckBox" name="toogleCheckExit">
+           <widget class="QCheckBox" name="toogle_deepscan">
+            <property name="text">
+             <string>Recursive scan for game folder</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="toogle_check_exit">
             <property name="text">
              <string>Confirm exit while emulation is running</string>
             </property>
            </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="groupBox_4">
+       <property name="title">
+        <string>Emulation</string>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout_5">
+        <item>
+         <layout class="QVBoxLayout" name="verticalLayout_6">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_6">
+            <item>
+             <widget class="QLabel" name="label">
+              <property name="text">
+               <string>Region:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="region_combobox">
+              <item>
+               <property name="text">
+                <string notr="true">JPN</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string notr="true">USA</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string notr="true">EUR</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string notr="true">AUS</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string notr="true">CHN</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string notr="true">KOR</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string notr="true">TWN</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+           </layout>
           </item>
          </layout>
         </item>
@@ -45,16 +115,16 @@
         <item>
          <layout class="QVBoxLayout" name="verticalLayout_3">
           <item>
-           <widget class="QCheckBox" name="toogleHWRenderer">
+           <widget class="QCheckBox" name="toogle_hw_renderer">
             <property name="text">
              <string>Enable hardware renderer</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="toogleShaderJIT">
+           <widget class="QCheckBox" name="toogle_shader_jit">
             <property name="text">
-             <string>Enable Shader JIT</string>
+             <string>Enable shader JIT</string>
             </property>
            </widget>
           </item>

--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -8,6 +8,7 @@
 
 #include "game_list.h"
 #include "game_list_p.h"
+#include "ui_settings.h"
 
 #include "core/loader/loader.h"
 
@@ -100,19 +101,15 @@ void GameList::PopulateAsync(const QString& dir_path, bool deep_scan)
     current_worker = std::move(worker);
 }
 
-void GameList::SaveInterfaceLayout(QSettings& settings)
+void GameList::SaveInterfaceLayout()
 {
-    settings.beginGroup("UILayout");
-    settings.setValue("gameListHeaderState", tree_view->header()->saveState());
-    settings.endGroup();
+    UISettings::values.gamelist_header_state = tree_view->header()->saveState();
 }
 
-void GameList::LoadInterfaceLayout(QSettings& settings)
+void GameList::LoadInterfaceLayout()
 {
     auto header = tree_view->header();
-    settings.beginGroup("UILayout");
-    header->restoreState(settings.value("gameListHeaderState").toByteArray());
-    settings.endGroup();
+    header->restoreState(UISettings::values.gamelist_header_state);
 
     item_model->sort(header->sortIndicatorSection(), header->sortIndicatorOrder());
 }

--- a/src/citra_qt/game_list.h
+++ b/src/citra_qt/game_list.h
@@ -31,8 +31,8 @@ public:
 
     void PopulateAsync(const QString& dir_path, bool deep_scan);
 
-    void SaveInterfaceLayout(QSettings& settings);
-    void LoadInterfaceLayout(QSettings& settings);
+    void SaveInterfaceLayout();
+    void LoadInterfaceLayout();
 
 public slots:
     void AddEntry(QList<QStandardItem*> entry_items);

--- a/src/citra_qt/hotkeys.cpp
+++ b/src/citra_qt/hotkeys.cpp
@@ -94,7 +94,7 @@ QShortcut* GetHotkey(const QString& group, const QString& action, QWidget* widge
 }
 
 
-GHotkeysDialog::GHotkeysDialog(QWidget* parent): QDialog(parent)
+GHotkeysDialog::GHotkeysDialog(QWidget* parent): QWidget(parent)
 {
     ui.setupUi(this);
 

--- a/src/citra_qt/hotkeys.cpp
+++ b/src/citra_qt/hotkeys.cpp
@@ -4,11 +4,12 @@
 
 #include <map>
 
+#include <QtGlobal>
 #include <QKeySequence>
-#include <QSettings>
 #include <QShortcut>
 
 #include "citra_qt/hotkeys.h"
+#include "citra_qt/ui_settings.h"
 
 struct Hotkey
 {
@@ -24,54 +25,38 @@ typedef std::map<QString, HotkeyMap> HotkeyGroupMap;
 
 HotkeyGroupMap hotkey_groups;
 
-void SaveHotkeys(QSettings& settings)
+void SaveHotkeys()
 {
-    settings.beginGroup("Shortcuts");
-
+    UISettings::values.shortcuts.clear();
     for (auto group : hotkey_groups)
     {
-        settings.beginGroup(group.first);
         for (auto hotkey : group.second)
         {
-            settings.beginGroup(hotkey.first);
-            settings.setValue(QString("KeySeq"), hotkey.second.keyseq.toString());
-            settings.setValue(QString("Context"), hotkey.second.context);
-            settings.endGroup();
+            UISettings::values.shortcuts.push_back(UISettings::Shortcut(group.first + "/" + hotkey.first,
+                                                                        UISettings::ContextedShortcut(hotkey.second.keyseq.toString(),
+                                                                                                      hotkey.second.context)));
         }
-        settings.endGroup();
     }
-    settings.endGroup();
 }
 
-void LoadHotkeys(QSettings& settings)
+void LoadHotkeys()
 {
-    settings.beginGroup("Shortcuts");
-
     // Make sure NOT to use a reference here because it would become invalid once we call beginGroup()
-    QStringList groups = settings.childGroups();
-    for (auto group : groups)
+    for (auto shortcut : UISettings::values.shortcuts)
     {
-        settings.beginGroup(group);
+        QStringList cat = shortcut.first.split("/");
+        Q_ASSERT(cat.size() >= 2);
 
-        QStringList hotkeys = settings.childGroups();
-        for (auto hotkey : hotkeys)
+        // RegisterHotkey assigns default keybindings, so use old values as default parameters
+        Hotkey& hk = hotkey_groups[cat[0]][cat[1]];
+        if (!shortcut.second.first.isEmpty())
         {
-            settings.beginGroup(hotkey);
-
-            // RegisterHotkey assigns default keybindings, so use old values as default parameters
-            Hotkey& hk = hotkey_groups[group][hotkey];
-            hk.keyseq = QKeySequence::fromString(settings.value("KeySeq", hk.keyseq.toString()).toString());
-            hk.context = (Qt::ShortcutContext)settings.value("Context", hk.context).toInt();
-            if (hk.shortcut)
-                hk.shortcut->setKey(hk.keyseq);
-
-            settings.endGroup();
+            hk.keyseq = QKeySequence::fromString(shortcut.second.first);
+            hk.context = (Qt::ShortcutContext)shortcut.second.second;
         }
-
-        settings.endGroup();
+        if (hk.shortcut)
+            hk.shortcut->setKey(hk.keyseq);
     }
-
-    settings.endGroup();
 }
 
 void RegisterHotkey(const QString& group, const QString& action, const QKeySequence& default_keyseq, Qt::ShortcutContext default_context)

--- a/src/citra_qt/hotkeys.cpp
+++ b/src/citra_qt/hotkeys.cpp
@@ -32,9 +32,10 @@ void SaveHotkeys()
     {
         for (auto hotkey : group.second)
         {
-            UISettings::values.shortcuts.push_back(UISettings::Shortcut(group.first + "/" + hotkey.first,
-                                                                        UISettings::ContextedShortcut(hotkey.second.keyseq.toString(),
-                                                                                                      hotkey.second.context)));
+            UISettings::values.shortcuts.emplace_back(
+                        UISettings::Shortcut(group.first + "/" + hotkey.first,
+                                             UISettings::ContextualShortcut(hotkey.second.keyseq.toString(),
+                                                                           hotkey.second.context)));
         }
     }
 }

--- a/src/citra_qt/hotkeys.h
+++ b/src/citra_qt/hotkeys.h
@@ -42,7 +42,7 @@ void SaveHotkeys(QSettings& settings);
  */
 void LoadHotkeys(QSettings& settings);
 
-class GHotkeysDialog : public QDialog
+class GHotkeysDialog : public QWidget
 {
     Q_OBJECT
 

--- a/src/citra_qt/hotkeys.h
+++ b/src/citra_qt/hotkeys.h
@@ -33,14 +33,14 @@ QShortcut* GetHotkey(const QString& group, const QString& action, QWidget* widge
  *
  * @note Each hotkey group will be stored a settings group; For each hotkey inside that group, a settings group will be created to store the key sequence and the hotkey context.
  */
-void SaveHotkeys(QSettings& settings);
+void SaveHotkeys();
 
 /**
  * Loads hotkeys from the settings file.
  *
  * @note Yet unregistered hotkeys which are present in the settings will automatically be registered.
  */
-void LoadHotkeys(QSettings& settings);
+void LoadHotkeys();
 
 class GHotkeysDialog : public QWidget
 {

--- a/src/citra_qt/hotkeys.h
+++ b/src/citra_qt/hotkeys.h
@@ -2,6 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#pragma once
+
 #include "ui_hotkeys.h"
 
 class QDialog;

--- a/src/citra_qt/hotkeys.ui
+++ b/src/citra_qt/hotkeys.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>hotkeys</class>
- <widget class="QDialog" name="hotkeys">
+ <widget class="QWidget" name="hotkeys">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -39,51 +39,8 @@
      </column>
     </widget>
    </item>
-   <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok|QDialogButtonBox::Reset</set>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <resources/>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>hotkeys</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>hotkeys</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -17,6 +17,7 @@
 #include "citra_qt/game_list.h"
 #include "citra_qt/hotkeys.h"
 #include "citra_qt/main.h"
+#include "citra_qt/ui_settings.h"
 
 // Debugger
 #include "citra_qt/debugger/callstack.h"
@@ -51,11 +52,9 @@
 
 #include "video_core/video_core.h"
 
-GMainWindow::GMainWindow() : emu_thread(nullptr)
+GMainWindow::GMainWindow() : config(new Config()), emu_thread(nullptr)
 {
     Pica::g_debug_context = Pica::DebugContext::Construct();
-
-    Config config;
 
     ui.setupUi(this);
     statusBar()->hide();
@@ -134,25 +133,21 @@ GMainWindow::GMainWindow() : emu_thread(nullptr)
     setGeometry(x, y, w, h);
 
     // Restore UI state
-    QSettings settings;
+    restoreGeometry(UISettings::values.geometry);
+    restoreState(UISettings::values.state);
+    render_window->restoreGeometry(UISettings::values.renderwindow_geometry);
+    microProfileDialog->restoreGeometry(UISettings::values.microprofile_geometry);
+    microProfileDialog->setVisible(UISettings::values.microprofile_visible);
 
-    settings.beginGroup("UILayout");
-    restoreGeometry(settings.value("geometry").toByteArray());
-    restoreState(settings.value("state").toByteArray());
-    render_window->restoreGeometry(settings.value("geometryRenderWindow").toByteArray());
-    microProfileDialog->restoreGeometry(settings.value("microProfileDialogGeometry").toByteArray());
-    microProfileDialog->setVisible(settings.value("microProfileDialogVisible").toBool());
-    settings.endGroup();
-
-    game_list->LoadInterfaceLayout(settings);
+    game_list->LoadInterfaceLayout();
 
     GDBStub::ToggleServer(Settings::values.use_gdbstub);
     GDBStub::SetServerPort(static_cast<u32>(Settings::values.gdbstub_port));
 
-    ui.action_Single_Window_Mode->setChecked(settings.value("singleWindowMode", true).toBool());
+    ui.action_Single_Window_Mode->setChecked(UISettings::values.single_window_mode);
     ToggleWindowMode();
 
-    ui.actionDisplay_widget_title_bars->setChecked(settings.value("displayTitleBars", true).toBool());
+    ui.actionDisplay_widget_title_bars->setChecked(UISettings::values.display_titlebar);
     OnDisplayTitleBars(ui.actionDisplay_widget_title_bars->isChecked());
 
     // Prepare actions for recent files
@@ -165,12 +160,10 @@ GMainWindow::GMainWindow() : emu_thread(nullptr)
     }
     UpdateRecentFiles();
 
-    confirm_before_closing = settings.value("confirmClose", true).toBool();
-
     // Setup connections
-    connect(game_list, SIGNAL(GameChosen(QString)), this, SLOT(OnGameListLoadFile(QString)));
+    connect(game_list, SIGNAL(GameChosen(QString)), this, SLOT(OnGameListLoadFile(QString)), Qt::DirectConnection);
     connect(ui.action_Configure, SIGNAL(triggered()), this, SLOT(OnConfigure()));
-    connect(ui.action_Load_File, SIGNAL(triggered()), this, SLOT(OnMenuLoadFile()));
+    connect(ui.action_Load_File, SIGNAL(triggered()), this, SLOT(OnMenuLoadFile()),Qt::DirectConnection);
     connect(ui.action_Load_Symbol_Map, SIGNAL(triggered()), this, SLOT(OnMenuLoadSymbolMap()));
     connect(ui.action_Select_Game_List_Root, SIGNAL(triggered()), this, SLOT(OnMenuSelectGameListRoot()));
     connect(ui.action_Start, SIGNAL(triggered()), this, SLOT(OnStartGame()));
@@ -191,7 +184,7 @@ GMainWindow::GMainWindow() : emu_thread(nullptr)
     // Setup hotkeys
     RegisterHotkey("Main Window", "Load File", QKeySequence::Open);
     RegisterHotkey("Main Window", "Start Emulation");
-    LoadHotkeys(settings);
+    LoadHotkeys();
 
     connect(GetHotkey("Main Window", "Load File", this), SIGNAL(activated()), this, SLOT(OnMenuLoadFile()));
     connect(GetHotkey("Main Window", "Start Emulation", this), SIGNAL(activated()), this, SLOT(OnStartGame()));
@@ -201,7 +194,7 @@ GMainWindow::GMainWindow() : emu_thread(nullptr)
 
     show();
 
-    game_list->PopulateAsync(settings.value("gameListRootDir", ".").toString(), settings.value("gameListDeepScan", false).toBool());
+    game_list->PopulateAsync(UISettings::values.gamedir_path, UISettings::values.gamedir_deepscan);
 
     QStringList args = QApplication::arguments();
     if (args.length() >= 2) {
@@ -365,32 +358,24 @@ void GMainWindow::ShutdownGame() {
     emulation_running = false;
 }
 
-void GMainWindow::StoreRecentFile(const std::string& filename)
-{
-    QSettings settings;
-    QStringList recent_files = settings.value("recentFiles").toStringList();
-    recent_files.prepend(QString::fromStdString(filename));
-    recent_files.removeDuplicates();
-    while (recent_files.size() > max_recent_files_item) {
-        recent_files.removeLast();
+void GMainWindow::StoreRecentFile(const std::string& filename) {
+    UISettings::values.recent_files.prepend(QString::fromStdString(filename));
+    UISettings::values.recent_files.removeDuplicates();
+    while (UISettings::values.recent_files.size() > max_recent_files_item) {
+        UISettings::values.recent_files.removeLast();
     }
-
-    settings.setValue("recentFiles", recent_files);
 
     UpdateRecentFiles();
 }
 
 void GMainWindow::UpdateRecentFiles() {
-    QSettings settings;
-    QStringList recent_files = settings.value("recentFiles").toStringList();
-
-    unsigned int num_recent_files = std::min(recent_files.size(), static_cast<int>(max_recent_files_item));
+    unsigned int num_recent_files = std::min(UISettings::values.recent_files.size(), static_cast<int>(max_recent_files_item));
 
     for (unsigned int i = 0; i < num_recent_files; i++) {
-        QString text = QString("&%1. %2").arg(i + 1).arg(QFileInfo(recent_files[i]).fileName());
+        QString text = QString("&%1. %2").arg(i + 1).arg(QFileInfo(UISettings::values.recent_files[i]).fileName());
         actions_recent_files[i]->setText(text);
-        actions_recent_files[i]->setData(recent_files[i]);
-        actions_recent_files[i]->setToolTip(recent_files[i]);
+        actions_recent_files[i]->setData(UISettings::values.recent_files[i]);
+        actions_recent_files[i]->setToolTip(UISettings::values.recent_files[i]);
         actions_recent_files[i]->setVisible(true);
     }
 
@@ -411,36 +396,28 @@ void GMainWindow::OnGameListLoadFile(QString game_path) {
 }
 
 void GMainWindow::OnMenuLoadFile() {
-    QSettings settings;
-    QString rom_path = settings.value("romsPath", QString()).toString();
-
-    QString filename = QFileDialog::getOpenFileName(this, tr("Load File"), rom_path, tr("3DS executable (*.3ds *.3dsx *.elf *.axf *.cci *.cxi)"));
+    QString filename = QFileDialog::getOpenFileName(this, tr("Load File"), UISettings::values.roms_path, tr("3DS executable (*.3ds *.3dsx *.elf *.axf *.cci *.cxi)"));
     if (!filename.isEmpty()) {
-        settings.setValue("romsPath", QFileInfo(filename).path());
+        UISettings::values.roms_path = QFileInfo(filename).path();
 
         BootGame(filename.toLocal8Bit().data());
     }
 }
 
 void GMainWindow::OnMenuLoadSymbolMap() {
-    QSettings settings;
-    QString symbol_path = settings.value("symbolsPath", QString()).toString();
-
-    QString filename = QFileDialog::getOpenFileName(this, tr("Load Symbol Map"), symbol_path, tr("Symbol map (*)"));
+    QString filename = QFileDialog::getOpenFileName(this, tr("Load Symbol Map"), UISettings::values.symbols_path, tr("Symbol map (*)"));
     if (!filename.isEmpty()) {
-        settings.setValue("symbolsPath", QFileInfo(filename).path());
+        UISettings::values.symbols_path = QFileInfo(filename).path();
 
         LoadSymbolMap(filename.toLocal8Bit().data());
     }
 }
 
 void GMainWindow::OnMenuSelectGameListRoot() {
-    QSettings settings;
-
     QString dir_path = QFileDialog::getExistingDirectory(this, tr("Select Directory"));
     if (!dir_path.isEmpty()) {
-        settings.setValue("gameListRootDir", dir_path);
-        game_list->PopulateAsync(dir_path, settings.value("gameListDeepScan").toBool());
+        UISettings::values.gamedir_path = dir_path;
+        game_list->PopulateAsync(dir_path, UISettings::values.gamedir_deepscan);
     }
 }
 
@@ -456,10 +433,7 @@ void GMainWindow::OnMenuRecentFile() {
         // Display an error message and remove the file from the list.
         QMessageBox::information(this, tr("File not found"), tr("File \"%1\" not found").arg(filename));
 
-        QSettings settings;
-        QStringList recent_files = settings.value("recentFiles").toStringList();
-        recent_files.removeOne(filename);
-        settings.setValue("recentFiles", recent_files);
+        UISettings::values.recent_files.removeOne(filename);
         UpdateRecentFiles();
     }
 }
@@ -536,23 +510,18 @@ void GMainWindow::closeEvent(QCloseEvent* event) {
         return;
     }
 
-    // Save window layout
-    QSettings settings(QSettings::IniFormat, QSettings::UserScope, "Citra team", "Citra");
+    UISettings::values.geometry = saveGeometry();
+    UISettings::values.state = saveState();
+    UISettings::values.renderwindow_geometry = render_window->saveGeometry();
+    UISettings::values.microprofile_geometry = microProfileDialog->saveGeometry();
+    UISettings::values.microprofile_visible = microProfileDialog->isVisible();
 
-    settings.beginGroup("UILayout");
-    settings.setValue("geometry", saveGeometry());
-    settings.setValue("state", saveState());
-    settings.setValue("geometryRenderWindow", render_window->saveGeometry());
-    settings.setValue("microProfileDialogGeometry", microProfileDialog->saveGeometry());
-    settings.setValue("microProfileDialogVisible", microProfileDialog->isVisible());
-    settings.endGroup();
+    UISettings::values.single_window_mode = ui.action_Single_Window_Mode->isChecked();
+    UISettings::values.display_titlebar = ui.actionDisplay_widget_title_bars->isChecked();
+    UISettings::values.first_start = false;
 
-    settings.setValue("singleWindowMode", ui.action_Single_Window_Mode->isChecked());
-    settings.setValue("displayTitleBars", ui.actionDisplay_widget_title_bars->isChecked());
-    settings.setValue("firstStart", false);
-    settings.setValue("confirmClose", confirm_before_closing);
-    game_list->SaveInterfaceLayout(settings);
-    SaveHotkeys(settings);
+    game_list->SaveInterfaceLayout();
+    SaveHotkeys();
 
     // Shutdown session if the emu thread is active...
     if (emu_thread != nullptr)
@@ -577,7 +546,6 @@ int main(int argc, char* argv[]) {
     });
 
     // Init settings params
-    QSettings::setDefaultFormat(QSettings::IniFormat);
     QCoreApplication::setOrganizationName("Citra team");
     QCoreApplication::setApplicationName("Citra");
 

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -194,7 +194,7 @@ GMainWindow::GMainWindow() : config(new Config()), emu_thread(nullptr)
 
     show();
 
-    game_list->PopulateAsync(UISettings::values.gamedir_path, UISettings::values.gamedir_deepscan);
+    game_list->PopulateAsync(UISettings::values.gamedir, UISettings::values.gamedir_deepscan);
 
     QStringList args = QApplication::arguments();
     if (args.length() >= 2) {
@@ -416,7 +416,7 @@ void GMainWindow::OnMenuLoadSymbolMap() {
 void GMainWindow::OnMenuSelectGameListRoot() {
     QString dir_path = QFileDialog::getExistingDirectory(this, tr("Select Directory"));
     if (!dir_path.isEmpty()) {
-        UISettings::values.gamedir_path = dir_path;
+        UISettings::values.gamedir = dir_path;
         game_list->PopulateAsync(dir_path, UISettings::values.gamedir_deepscan);
     }
 }
@@ -488,14 +488,15 @@ void GMainWindow::ToggleWindowMode() {
 void GMainWindow::OnConfigure() {
     ConfigureDialog configureDialog(this);
     auto result = configureDialog.exec();
-    if ( result == QDialog::Accepted)
+    if (result == QDialog::Accepted)
     {
         configureDialog.applyConfiguration();
+        config->Save();
     }
 }
 
 bool GMainWindow::ConfirmClose() {
-    if (emu_thread == nullptr || !confirm_before_closing)
+    if (emu_thread == nullptr || !UISettings::values.confirm_before_closing)
         return true;
 
     auto answer = QMessageBox::question(this, tr("Citra"),

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -10,6 +10,7 @@
 
 #include "ui_main.h"
 
+class Config;
 class GameList;
 class GImageInfo;
 class GRenderWindow;
@@ -113,6 +114,8 @@ private:
 
     GRenderWindow* render_window;
     GameList* game_list;
+
+    std::unique_ptr<Config> config;
 
     // Whether emulation is currently running in Citra.
     bool emulation_running = false;

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -104,12 +104,8 @@ private slots:
     /// Called whenever a user selects the "File->Select Game List Root" menu item
     void OnMenuSelectGameListRoot();
     void OnMenuRecentFile();
-    void OnOpenHotkeysDialog();
     void OnConfigure();
     void OnDisplayTitleBars(bool);
-    void SetHardwareRendererEnabled(bool);
-    void SetGdbstubEnabled(bool);
-    void SetShaderJITEnabled(bool);
     void ToggleWindowMode();
 
 private:

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -130,7 +130,6 @@ private:
     GPUCommandListWidget* graphicsCommandsWidget;
 
     QAction* actions_recent_files[max_recent_files_item];
-    bool confirm_before_closing;
 };
 
 #endif // _CITRA_QT_MAIN_HXX_

--- a/src/citra_qt/main.ui
+++ b/src/citra_qt/main.ui
@@ -45,7 +45,7 @@
      <x>0</x>
      <y>0</y>
      <width>1081</width>
-     <height>22</height>
+     <height>19</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">
@@ -73,9 +73,6 @@
     <addaction name="action_Pause"/>
     <addaction name="action_Stop"/>
     <addaction name="separator"/>
-    <addaction name="action_Use_Hardware_Renderer"/>
-    <addaction name="action_Use_Shader_JIT"/>
-    <addaction name="action_Use_Gdbstub"/>
     <addaction name="action_Configure"/>
    </widget>
    <widget class="QMenu" name="menu_View">
@@ -84,7 +81,6 @@
     </property>
     <addaction name="action_Single_Window_Mode"/>
     <addaction name="actionDisplay_widget_title_bars"/>
-    <addaction name="action_Hotkeys"/>
    </widget>
    <widget class="QMenu" name="menu_Help">
     <property name="title">
@@ -150,35 +146,6 @@
     <string>Single Window Mode</string>
    </property>
   </action>
-  <action name="action_Hotkeys">
-   <property name="text">
-    <string>Configure &amp;Hotkeys ...</string>
-   </property>
-  </action>
-  <action name="action_Use_Hardware_Renderer">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Use Hardware Renderer</string>
-   </property>
-  </action>
-  <action name="action_Use_Shader_JIT">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Use Shader JIT</string>
-   </property>
-  </action>
-  <action name="action_Use_Gdbstub">
-    <property name="checkable">
-      <bool>true</bool>
-    </property>
-    <property name="text">
-      <string>Use Gdbstub</string>
-    </property>
-  </action>
   <action name="action_Configure">
    <property name="text">
     <string>Configure ...</string>
@@ -216,22 +183,6 @@
     <hint type="destinationlabel">
      <x>367</x>
      <y>314</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>action_Configure</sender>
-   <signal>triggered()</signal>
-   <receiver>MainWindow</receiver>
-   <slot>OnConfigure()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>-1</x>
-     <y>-1</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>540</x>
-     <y>364</y>
     </hint>
    </hints>
   </connection>

--- a/src/citra_qt/ui_settings.cpp
+++ b/src/citra_qt/ui_settings.cpp
@@ -1,0 +1,11 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "ui_settings.h"
+
+namespace UISettings {
+
+Values values = {};
+
+}

--- a/src/citra_qt/ui_settings.h
+++ b/src/citra_qt/ui_settings.h
@@ -2,8 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#ifndef UISETTINGS_H
-#define UISETTINGS_H
+#pragma once
 
 #include <QByteArray>
 #include <QStringList>
@@ -13,8 +12,8 @@
 
 namespace UISettings {
 
-    typedef std::pair<QString, int> ContextedShortcut;
-    typedef std::pair<QString, ContextedShortcut> Shortcut;
+using ContextualShortcut = std::pair<QString, int> ;
+using Shortcut = std::pair<QString, ContextualShortcut>;
 
 struct Values {
     QByteArray geometry;
@@ -30,19 +29,19 @@ struct Values {
     bool single_window_mode;
     bool display_titlebar;
 
-    bool check_closure;
+    bool confirm_before_closing;
     bool first_start;
 
     QString roms_path;
     QString symbols_path;
-    QString gamedir_path;
+    QString gamedir;
     bool gamedir_deepscan;
     QStringList recent_files;
 
     // Shortcut name <Shortcut, context>
     std::vector<Shortcut> shortcuts;
-} extern values;
+};
+
+extern Values values;
 
 }
-
-#endif // UISETTINGS_H

--- a/src/citra_qt/ui_settings.h
+++ b/src/citra_qt/ui_settings.h
@@ -1,0 +1,16 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#ifndef UISETTINGS_H
+#define UISETTINGS_H
+
+namespace UISettings {
+
+struct Values {
+    bool check_closure;
+} extern values;
+
+}
+
+#endif // UISETTINGS_H

--- a/src/citra_qt/ui_settings.h
+++ b/src/citra_qt/ui_settings.h
@@ -5,10 +5,42 @@
 #ifndef UISETTINGS_H
 #define UISETTINGS_H
 
+#include <QByteArray>
+#include <QStringList>
+#include <QString>
+
+#include <vector>
+
 namespace UISettings {
 
+    typedef std::pair<QString, int> ContextedShortcut;
+    typedef std::pair<QString, ContextedShortcut> Shortcut;
+
 struct Values {
+    QByteArray geometry;
+    QByteArray state;
+
+    QByteArray renderwindow_geometry;
+
+    QByteArray gamelist_header_state;
+
+    QByteArray microprofile_geometry;
+    bool microprofile_visible;
+
+    bool single_window_mode;
+    bool display_titlebar;
+
     bool check_closure;
+    bool first_start;
+
+    QString roms_path;
+    QString symbols_path;
+    QString gamedir_path;
+    bool gamedir_deepscan;
+    QStringList recent_files;
+
+    // Shortcut name <Shortcut, context>
+    std::vector<Shortcut> shortcuts;
 } extern values;
 
 }


### PR DESCRIPTION
I have worked on a new widget to configure Citra:

![citra-configure-dialog](https://cloud.githubusercontent.com/assets/8618754/12538894/e1af5228-c2e5-11e5-93b0-33afcced04e0.png)

There is nothing in "Input" tab since we don't have the input widget yet.

![citra-debug-configuration](https://cloud.githubusercontent.com/assets/8618754/12538903/1cd5e100-c2e6-11e5-86b4-2ea733c45c2e.png)

Additionally, I have centralized all the configuration in Config class. Now, we should have one configure file only.