### PR TITLE
Shader: Implement "invert condition" feature of IFU instruction

### DIFF
--- a/src/video_core/shader/shader_interpreter.cpp
+++ b/src/video_core/shader/shader_interpreter.cpp
@@ -515,7 +515,8 @@ void RunInterpreter(UnitState<Debug>& state) {
 
             case OpCode::Id::JMPU:
                 Record<DebugDataRecord::COND_BOOL_IN>(state.debug, iteration, uniforms.b[instr.flow_control.bool_uniform_id]);
-                if (uniforms.b[instr.flow_control.bool_uniform_id]) {
+
+                if (uniforms.b[instr.flow_control.bool_uniform_id] == !(instr.flow_control.num_instructions & 1)) {
                     state.program_counter = instr.flow_control.dest_offset - 1;
                 }
                 break;

--- a/src/video_core/shader/shader_jit_x64.cpp
+++ b/src/video_core/shader/shader_jit_x64.cpp
@@ -710,7 +710,9 @@ void JitCompiler::Compile_JMP(Instruction instr) {
     else
         UNREACHABLE();
 
-    FixupBranch b = J_CC(CC_NZ, true);
+    bool inverted_condition = (instr.opcode.Value() == OpCode::Id::JMPU) &&
+        (instr.flow_control.num_instructions & 1);
+    FixupBranch b = J_CC(inverted_condition ? CC_Z : CC_NZ, true);
 
     Compile_Block(instr.flow_control.dest_offset);
 


### PR DESCRIPTION
If the bit 0 of the JMPU instruction is set, then the jump condition
will be inverted. That is, a jump will happen when the boolean is false
instead of when it is true.

Fixes normals in lots of stuff for #1264