### PR TITLE
archive_backend: Remove unnecessary const from return types

### DIFF
--- a/src/core/file_sys/archive_backend.cpp
+++ b/src/core/file_sys/archive_backend.cpp
@@ -43,7 +43,7 @@ Path::Path(LowPathType type, u32 size, u32 pointer) : type(type) {
     }
 }
 
-const std::string Path::DebugStr() const {
+std::string Path::DebugStr() const {
     switch (GetType()) {
     case Invalid:
     default:
@@ -66,7 +66,7 @@ const std::string Path::DebugStr() const {
     }
 }
 
-const std::string Path::AsString() const {
+std::string Path::AsString() const {
     switch (GetType()) {
     case Char:
         return string;
@@ -83,7 +83,7 @@ const std::string Path::AsString() const {
     }
 }
 
-const std::u16string Path::AsU16Str() const {
+std::u16string Path::AsU16Str() const {
     switch (GetType()) {
     case Char:
         return Common::UTF8ToUTF16(string);
@@ -99,7 +99,7 @@ const std::u16string Path::AsU16Str() const {
     }
 }
 
-const std::vector<u8> Path::AsBinary() const {
+std::vector<u8> Path::AsBinary() const {
     switch (GetType()) {
     case Binary:
         return binary;

--- a/src/core/file_sys/archive_backend.h
+++ b/src/core/file_sys/archive_backend.h
@@ -49,11 +49,11 @@ public:
      * Gets the string representation of the path for debugging
      * @return String representation of the path for debugging
      */
-    const std::string DebugStr() const;
+    std::string DebugStr() const;
 
-    const std::string AsString() const;
-    const std::u16string AsU16Str() const;
-    const std::vector<u8> AsBinary() const;
+    std::string AsString() const;
+    std::u16string AsU16Str() const;
+    std::vector<u8> AsBinary() const;
 
 private:
     LowPathType type;


### PR DESCRIPTION
This doesn't return by reference so const isn't really necessary