### PR TITLE
Memory: Implemented MMIO

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -250,6 +250,7 @@ set(HEADERS
             tracer/citrace.h
             memory.h
             memory_setup.h
+            mmio.h
             settings.h
             system.h
             )

--- a/src/core/hle/kernel/vm_manager.h
+++ b/src/core/hle/kernel/vm_manager.h
@@ -11,6 +11,7 @@
 #include "common/common_types.h"
 
 #include "core/hle/result.h"
+#include "core/mmio.h"
 
 namespace Kernel {
 
@@ -92,6 +93,7 @@ struct VirtualMemoryArea {
     // Settings for type = MMIO
     /// Physical address of the register area this VMA maps to.
     PAddr paddr = 0;
+    Memory::MMIORegionPointer mmio_handler = nullptr;
 
     /// Tests if this area can be merged to the right with `next`.
     bool CanBeMergedWith(const VirtualMemoryArea& next) const;
@@ -168,8 +170,9 @@ public:
      * @param paddr The physical address where the registers are present.
      * @param size Size of the mapping.
      * @param state MemoryState tag to attach to the VMA.
+     * @param mmio_handler The handler that will implement read and write for this MMIO region.
      */
-    ResultVal<VMAHandle> MapMMIO(VAddr target, PAddr paddr, u32 size, MemoryState state);
+    ResultVal<VMAHandle> MapMMIO(VAddr target, PAddr paddr, u32 size, MemoryState state, Memory::MMIORegionPointer mmio_handler);
 
     /// Unmaps a range of addresses, splitting VMAs as necessary.
     ResultCode UnmapRange(VAddr target, u32 size);

--- a/src/core/memory_setup.h
+++ b/src/core/memory_setup.h
@@ -23,10 +23,11 @@ void MapMemoryRegion(VAddr base, u32 size, u8* target);
 
 /**
  * Maps a region of the emulated process address space as a IO region.
- * @note Currently this can only be used to mark a region as being IO, since actual memory-mapped
- *       IO isn't yet supported.
+ * @param base The address to start mapping at. Must be page-aligned.
+ * @param size The amount of bytes to map. Must be page-aligned.
+ * @param mmio_handler The handler that backs the mapping.
  */
-void MapIoRegion(VAddr base, u32 size);
+void MapIoRegion(VAddr base, u32 size, MMIORegionPointer mmio_handler);
 
 void UnmapRegion(VAddr base, u32 size);
 

--- a/src/core/mmio.h
+++ b/src/core/mmio.h
@@ -1,0 +1,34 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+
+#include "common/common_types.h"
+
+namespace Memory {
+
+/**
+ * Represents a device with memory mapped IO.
+ * A device may be mapped to multiple regions of memory.
+ */
+class MMIORegion {
+public:
+    virtual ~MMIORegion() = default;
+
+    virtual u8 Read8(VAddr addr) = 0;
+    virtual u16 Read16(VAddr addr) = 0;
+    virtual u32 Read32(VAddr addr) = 0;
+    virtual u64 Read64(VAddr addr) = 0;
+
+    virtual void Write8(VAddr addr, u8 data) = 0;
+    virtual void Write16(VAddr addr, u16 data) = 0;
+    virtual void Write32(VAddr addr, u32 data) = 0;
+    virtual void Write64(VAddr addr, u64 data) = 0;
+};
+
+using MMIORegionPointer = std::shared_ptr<MMIORegion>;
+
+};


### PR DESCRIPTION
Intention is for devices that require memory mapped I/O to implement the `MMIORegion` interface which would handle the reads/writes for that memory region.

Intention is for `MapMMIO` calls to go into `InitLegacyAddressSpace`.

Ping @yuriks as I seemed to be implementing something that was on his TODO list.