### PR TITLE
GDB stub fixes

### DIFF
--- a/src/citra/citra.cpp
+++ b/src/citra/citra.cpp
@@ -34,25 +34,40 @@
 
 static void PrintHelp()
 {
-    std::cout << "Usage: citra <filename>" << std::endl;
+    std::cout << "Usage: citra [options] <filename>" << std::endl;
+    std::cout << "--help, -h            Display this information" << std::endl;
+    std::cout << "--gdbport, -g number  Enable gdb stub on port number" << std::endl;
 }
 
 /// Application entry point
 int main(int argc, char **argv) {
     int option_index = 0;
+    u32 gdb_port = 0;
+    char *endarg;
     std::string boot_filename;
+
     static struct option long_options[] = {
         { "help", no_argument, 0, 'h' },
+        { "gdbport", required_argument, 0, 'g' },
         { 0, 0, 0, 0 }
     };
 
     while (optind < argc) {
-        char arg = getopt_long(argc, argv, ":h", long_options, &option_index);
+        char arg = getopt_long(argc, argv, ":hg:", long_options, &option_index);
         if (arg != -1) {
             switch (arg) {
             case 'h':
                 PrintHelp();
                 return 0;
+            case 'g':
+                errno = 0;
+                gdb_port = strtoul(optarg, &endarg, 0);
+                if (endarg == optarg) errno = EINVAL;
+                if (errno != 0) {
+                    perror("--gdbport");
+                    exit(1);
+                }
+                break;
             }
         } else {
             boot_filename = argv[optind];
@@ -73,8 +88,10 @@ int main(int argc, char **argv) {
     Config config;
     log_filter.ParseFilterString(Settings::values.log_filter);
 
-    GDBStub::ToggleServer(Settings::values.use_gdbstub);
-    GDBStub::SetServerPort(static_cast<u32>(Settings::values.gdbstub_port));
+    if (gdb_port != 0) {
+        GDBStub::ToggleServer(true);
+        GDBStub::SetServerPort(gdb_port);
+    }
 
     EmuWindow_GLFW* emu_window = new EmuWindow_GLFW;
 

--- a/src/core/gdbstub/gdbstub.cpp
+++ b/src/core/gdbstub/gdbstub.cpp
@@ -491,29 +491,29 @@ static void ReadRegisters() {
     memset(buffer, 0, sizeof(buffer));
 
     u8* bufptr = buffer;
-    for (int i = 0, reg = 0; reg <= FPSCR_REGISTER; i++, reg++) {
-        if (reg <= R15_REGISTER) {
-            IntToGdbHex(bufptr + i * CHAR_BIT, Core::g_app_core->GetReg(reg));
-        } else if (reg == CPSR_REGISTER) {
-            IntToGdbHex(bufptr + i * CHAR_BIT, Core::g_app_core->GetCPSR());
-        } else if (reg == CPSR_REGISTER - 1) {
-            // Dummy FPA register, ignore
-            IntToGdbHex(bufptr + i * CHAR_BIT, 0);
-        } else if (reg < CPSR_REGISTER) {
-            // Dummy FPA registers, ignore
-            IntToGdbHex(bufptr + i * CHAR_BIT, 0);
-            IntToGdbHex(bufptr + (i + 1) * CHAR_BIT, 0);
-            IntToGdbHex(bufptr + (i + 2) * CHAR_BIT, 0);
-            i += 2;
-        } else if (reg > CPSR_REGISTER && reg < FPSCR_REGISTER) {
-            IntToGdbHex(bufptr + i * CHAR_BIT, Core::g_app_core->GetVFPReg(reg - CPSR_REGISTER - 1));
-            IntToGdbHex(bufptr + (i + 1) * CHAR_BIT, 0);
-            i++;
-        } else if (reg == FPSCR_REGISTER) {
-            IntToGdbHex(bufptr + i * CHAR_BIT, Core::g_app_core->GetVFPSystemReg(VFP_FPSCR));
-        }
+
+    for (int reg = 0; reg <= R15_REGISTER; reg++) {
+        IntToGdbHex(bufptr + reg * CHAR_BIT, Core::g_app_core->GetReg(reg));
     }
 
+    bufptr += (16 * CHAR_BIT);
+
+    IntToGdbHex(bufptr, Core::g_app_core->GetCPSR());
+
+// Still getting "Remote 'g' packet reply is too long" from gdb with this
+// Need to figure out how to get gdb to expect vfp registers.
+
+/*
+    bufptr += CHAR_BIT;
+
+    for (int reg = 0; reg <= 31; reg++) {
+        IntToGdbHex(bufptr + reg * CHAR_BIT, Core::g_app_core->GetVFPReg(reg));
+    }
+
+    bufptr += (32 * CHAR_BIT);
+
+    IntToGdbHex(bufptr, Core::g_app_core->GetVFPSystemReg(VFP_FPSCR));
+*/
     SendReply(reinterpret_cast<char*>(buffer));
 }
 


### PR DESCRIPTION
These changes allow the gdb stub to be enabled and configured from the command line which allows for easier integration with IDEs that do source level debugging.

GDB complains Remote 'g' packet reply is too long with this setup because citra is attempting to send float registers it's not expecting, even if I strip out the legacy fpa registers which are no longer used. I'm still attempting to figure out how to get gdb to accept vfp registers.

The Qt build also appears to have problems with gdb communication but these patches don't change that behaviour.