### PR TITLE
OpenGL: Downgrade GL_DEBUG_SEVERITY_NOTIFICATION to Debug logging level

### DIFF
--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -436,8 +436,6 @@ static void DebugHandler(GLenum source, GLenum type, GLuint id, GLenum severity,
         level = Log::Level::Warning;
         break;
     case GL_DEBUG_SEVERITY_NOTIFICATION:
-        level = Log::Level::Info;
-        break;
     case GL_DEBUG_SEVERITY_LOW:
         level = Log::Level::Debug;
         break;


### PR DESCRIPTION
The nVidia driver is *extremely* spammy on this category, sending a
message on every buffer or texture upload, slowing down the emulator and
making the log useless.