### PR TITLE
hwrasterizer: Use proper cached framebuffer addr/size

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -278,8 +278,8 @@ private:
 
     OpenGLState state;
 
-    PAddr last_fb_color_addr;
-    PAddr last_fb_depth_addr;
+    PAddr cached_fb_color_addr;
+    PAddr cached_fb_depth_addr;
 
     // Hardware rasterizer
     std::array<SamplerInfo, 3> texture_samplers;


### PR DESCRIPTION
Fixes the framebuffer sync logic to use the memory region actually 'cached' by the OpenGL framebuffer texture, instead of the current framebuffer registers (which may have changed in the meantime without a framebuffer commit). Fixes #829.