### PR TITLE
Add immediate mode vertex submission

### DIFF
--- a/src/citra_qt/debugger/graphics_cmdlists.cpp
+++ b/src/citra_qt/debugger/graphics_cmdlists.cpp
@@ -21,6 +21,7 @@
 #include "common/vector_math.h"
 
 #include "video_core/pica.h"
+#include "video_core/pica_state.h"
 #include "video_core/debug_utils/debug_utils.h"
 
 QImage LoadTexture(u8* src, const Pica::DebugUtils::TextureInfo& info) {

--- a/src/citra_qt/debugger/graphics_framebuffer.cpp
+++ b/src/citra_qt/debugger/graphics_framebuffer.cpp
@@ -18,6 +18,7 @@
 #include "core/hw/gpu.h"
 
 #include "video_core/pica.h"
+#include "video_core/pica_state.h"
 #include "video_core/utils.h"
 
 GraphicsFramebufferWidget::GraphicsFramebufferWidget(std::shared_ptr<Pica::DebugContext> debug_context,

--- a/src/citra_qt/debugger/graphics_tracing.cpp
+++ b/src/citra_qt/debugger/graphics_tracing.cpp
@@ -22,7 +22,7 @@
 #include "nihstro/float24.h"
 
 #include "video_core/pica.h"
-
+#include "video_core/pica_state.h"
 
 GraphicsTracingWidget::GraphicsTracingWidget(std::shared_ptr<Pica::DebugContext> debug_context,
                                              QWidget* parent)

--- a/src/citra_qt/debugger/graphics_vertex_shader.cpp
+++ b/src/citra_qt/debugger/graphics_vertex_shader.cpp
@@ -19,6 +19,8 @@
 #include "citra_qt/debugger/graphics_vertex_shader.h"
 #include "citra_qt/util/util.h"
 
+#include "video_core/pica.h"
+#include "video_core/pica_state.h"
 #include "video_core/shader/shader.h"
 
 using nihstro::OpCode;

--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -33,6 +33,7 @@ set(HEADERS
             command_processor.h
             gpu_debugger.h
             pica.h
+            pica_state.h
             pica_types.h
             primitive_assembly.h
             rasterizer.h

--- a/src/video_core/clipper.cpp
+++ b/src/video_core/clipper.cpp
@@ -6,6 +6,7 @@
 
 #include "video_core/clipper.h"
 #include "video_core/pica.h"
+#include "video_core/pica_state.h"
 #include "video_core/rasterizer.h"
 #include "video_core/shader/shader_interpreter.h"
 

--- a/src/video_core/debug_utils/debug_utils.cpp
+++ b/src/video_core/debug_utils/debug_utils.cpp
@@ -28,6 +28,7 @@
 #include "core/settings.h"
 
 #include "video_core/pica.h"
+#include "video_core/pica_state.h"
 #include "video_core/renderer_base.h"
 #include "video_core/utils.h"
 #include "video_core/video_core.h"
@@ -113,7 +114,7 @@ void GeometryDumper::Dump() {
 }
 
 
-void DumpShader(const std::string& filename, const Regs::ShaderConfig& config, const State::ShaderSetup& setup, const Regs::VSOutputAttributes* output_attributes)
+void DumpShader(const std::string& filename, const Regs::ShaderConfig& config, const Shader::ShaderSetup& setup, const Regs::VSOutputAttributes* output_attributes)
 {
     struct StuffToWrite {
         u8* pointer;

--- a/src/video_core/debug_utils/debug_utils.h
+++ b/src/video_core/debug_utils/debug_utils.h
@@ -17,6 +17,7 @@
 #include "core/tracer/recorder.h"
 
 #include "video_core/pica.h"
+#include "video_core/shader/shader.h"
 
 namespace Pica {
 
@@ -182,7 +183,7 @@ private:
 };
 
 void DumpShader(const std::string& filename, const Regs::ShaderConfig& config,
-                const State::ShaderSetup& setup, const Regs::VSOutputAttributes* output_attributes);
+                const Shader::ShaderSetup& setup, const Regs::VSOutputAttributes* output_attributes);
 
 
 // Utility class to log Pica commands.

--- a/src/video_core/pica.cpp
+++ b/src/video_core/pica.cpp
@@ -6,6 +6,7 @@
 #include <unordered_map>
 
 #include "video_core/pica.h"
+#include "video_core/pica_state.h"
 #include "video_core/shader/shader.h"
 
 namespace Pica {

--- a/src/video_core/pica_state.h
+++ b/src/video_core/pica_state.h
@@ -1,0 +1,60 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "video_core/pica.h"
+#include "video_core/primitive_assembly.h"
+#include "video_core/shader/shader.h"
+
+namespace Pica {
+
+/// Struct used to describe current Pica state
+struct State {
+    /// Pica registers
+    Regs regs;
+
+    Shader::ShaderSetup vs;
+    Shader::ShaderSetup gs;
+
+    struct {
+        union LutEntry {
+            // Used for raw access
+            u32 raw;
+
+            // LUT value, encoded as 12-bit fixed point, with 12 fraction bits
+            BitField< 0, 12, u32> value;
+
+            // Used by HW for efficient interpolation, Citra does not use these
+            BitField<12, 12, u32> difference;
+
+            float ToFloat() {
+                return static_cast<float>(value) / 4095.f;
+            }
+        };
+
+        std::array<std::array<LutEntry, 256>, 24> luts;
+    } lighting;
+
+    /// Current Pica command list
+    struct {
+        const u32* head_ptr;
+        const u32* current_ptr;
+        u32 length;
+    } cmd_list;
+
+    /// Struct used to describe immediate mode rendering state
+    struct ImmediateModeState {
+        Shader::InputVertex input;
+        // This is constructed with a dummy triangle topology
+        PrimitiveAssembler<Shader::OutputVertex> primitive_assembler;
+        int attribute_id = 0;
+
+        ImmediateModeState() : primitive_assembler(Regs::TriangleTopology::List) {}
+    } immediate;
+};
+
+extern State g_state; ///< Current Pica state
+
+} // namespace

--- a/src/video_core/primitive_assembly.cpp
+++ b/src/video_core/primitive_assembly.cpp
@@ -53,6 +53,18 @@ void PrimitiveAssembler<VertexType>::SubmitVertex(VertexType& vtx, TriangleHandl
     }
 }
 
+template<typename VertexType>
+void PrimitiveAssembler<VertexType>::Reset() {
+    buffer_index = 0;
+    strip_ready = false;
+}
+
+template<typename VertexType>
+void PrimitiveAssembler<VertexType>::Reconfigure(Regs::TriangleTopology topology) {
+    Reset();
+    this->topology = topology;
+}
+
 // explicitly instantiate use cases
 template
 struct PrimitiveAssembler<Shader::OutputVertex>;

--- a/src/video_core/primitive_assembly.h
+++ b/src/video_core/primitive_assembly.h
@@ -30,6 +30,16 @@ struct PrimitiveAssembler {
      */
     void SubmitVertex(VertexType& vtx, TriangleHandler triangle_handler);
 
+    /**
+     * Resets the internal state of the PrimitiveAssembler.
+     */
+    void Reset();
+
+    /**
+     * Reconfigures the PrimitiveAssembler to use a different triangle topology.
+     */
+    void Reconfigure(Regs::TriangleTopology topology);
+
 private:
     Regs::TriangleTopology topology;
 

--- a/src/video_core/rasterizer.cpp
+++ b/src/video_core/rasterizer.cpp
@@ -15,6 +15,7 @@
 #include "core/hw/gpu.h"
 
 #include "video_core/pica.h"
+#include "video_core/pica_state.h"
 #include "video_core/rasterizer.h"
 #include "video_core/utils.h"
 #include "video_core/debug_utils/debug_utils.h"

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -19,6 +19,7 @@
 #include "core/hw/gpu.h"
 
 #include "video_core/pica.h"
+#include "video_core/pica_state.h"
 #include "video_core/utils.h"
 #include "video_core/renderer_opengl/gl_rasterizer.h"
 #include "video_core/renderer_opengl/gl_shader_gen.h"

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -14,6 +14,7 @@
 #include "common/hash.h"
 
 #include "video_core/pica.h"
+#include "video_core/pica_state.h"
 #include "video_core/rasterizer_interface.h"
 #include "video_core/renderer_opengl/gl_rasterizer_cache.h"
 #include "video_core/renderer_opengl/gl_state.h"

--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -14,6 +14,7 @@
 
 #include "video_core/debug_utils/debug_utils.h"
 #include "video_core/pica.h"
+#include "video_core/pica_state.h"
 #include "video_core/video_core.h"
 
 #include "shader.h"
@@ -145,7 +146,7 @@ OutputVertex Run(UnitState<false>& state, const InputVertex& input, int num_attr
     return ret;
 }
 
-DebugData<true> ProduceDebugInfo(const InputVertex& input, int num_attributes, const Regs::ShaderConfig& config, const State::ShaderSetup& setup) {
+DebugData<true> ProduceDebugInfo(const InputVertex& input, int num_attributes, const Regs::ShaderConfig& config, const ShaderSetup& setup) {
     UnitState<true> state;
 
     state.program_counter = config.main_offset;

--- a/src/video_core/shader/shader.h
+++ b/src/video_core/shader/shader.h
@@ -77,6 +77,22 @@ struct OutputVertex {
 static_assert(std::is_pod<OutputVertex>::value, "Structure is not POD");
 static_assert(sizeof(OutputVertex) == 32 * sizeof(float), "OutputVertex has invalid size");
 
+/// Vertex shader memory
+struct ShaderSetup {
+    struct {
+        // The float uniforms are accessed by the shader JIT using SSE instructions, and are
+        // therefore required to be 16-byte aligned.
+        Math::Vec4<float24> MEMORY_ALIGNED16(f[96]);
+
+        std::array<bool, 16> b;
+        std::array<Math::Vec4<u8>, 4> i;
+    } uniforms;
+
+    Math::Vec4<float24> default_attributes[16];
+
+    std::array<u32, 1024> program_code;
+    std::array<u32, 1024> swizzle_data;
+};
 
 // Helper structure used to keep track of data useful for inspection of shader emulation
 template<bool full_debugging>
@@ -347,7 +363,7 @@ OutputVertex Run(UnitState<false>& state, const InputVertex& input, int num_attr
  * @param setup Setup object for the shader pipeline
  * @return Debug information for this shader with regards to the given vertex
  */
-DebugData<true> ProduceDebugInfo(const InputVertex& input, int num_attributes, const Regs::ShaderConfig& config, const State::ShaderSetup& setup);
+DebugData<true> ProduceDebugInfo(const InputVertex& input, int num_attributes, const Regs::ShaderConfig& config, const ShaderSetup& setup);
 
 } // namespace Shader
 

--- a/src/video_core/shader/shader_interpreter.cpp
+++ b/src/video_core/shader/shader_interpreter.cpp
@@ -7,6 +7,7 @@
 #include <nihstro/shader_bytecode.h>
 
 #include "video_core/pica.h"
+#include "video_core/pica_state.h"
 #include "video_core/shader/shader.h"
 #include "video_core/shader/shader_interpreter.h"
 

--- a/src/video_core/shader/shader_jit_x64.cpp
+++ b/src/video_core/shader/shader_jit_x64.cpp
@@ -11,6 +11,8 @@
 #include "shader.h"
 #include "shader_jit_x64.h"
 
+#include "video_core/pica_state.h"
+
 namespace Pica {
 
 namespace Shader {


### PR DESCRIPTION
This adds support for Immediate Mode Vertex Submission. I have tested this with Mii Maker and [Citro3D's Immediate Mode example](https://github.com/devkitPro/3ds-examples/tree/master/graphics/gpu/immediate).

Triangles are drawn when the PICA GPU Mode register is reset to configuration mode.