### PR TITLE
BitField: Make trivially copyable and remove assignment operator.

### DIFF
--- a/src/common/emu_window.cpp
+++ b/src/common/emu_window.cpp
@@ -55,14 +55,14 @@ void EmuWindow::TouchPressed(unsigned framebuffer_x, unsigned framebuffer_y) {
         (framebuffer_layout.bottom_screen.bottom - framebuffer_layout.bottom_screen.top);
 
     touch_pressed = true;
-    pad_state.touch = 1;
+    pad_state.touch.Assign(1);
 }
 
 void EmuWindow::TouchReleased() {
     touch_pressed = false;
     touch_x = 0;
     touch_y = 0;
-    pad_state.touch = 0;
+    pad_state.touch.Assign(0);
 }
 
 void EmuWindow::TouchMoved(unsigned framebuffer_x, unsigned framebuffer_y) {

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -35,7 +35,7 @@ SharedPtr<Process> Process::Create(SharedPtr<CodeSet> code_set) {
 
     process->codeset = std::move(code_set);
     process->flags.raw = 0;
-    process->flags.memory_region = MemoryRegion::APPLICATION;
+    process->flags.memory_region.Assign(MemoryRegion::APPLICATION);
     Memory::InitLegacyAddressSpace(process->vm_manager);
 
     return process;

--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -193,10 +193,10 @@ union ResultCode {
     explicit ResultCode(u32 raw) : raw(raw) {}
     ResultCode(ErrorDescription description_, ErrorModule module_,
             ErrorSummary summary_, ErrorLevel level_) : raw(0) {
-        description = description_;
-        module = module_;
-        summary = summary_;
-        level = level_;
+        description.Assign(description_);
+        module.Assign(module_);
+        summary.Assign(summary_);
+        level.Assign(level_);
     }
 
     ResultCode& operator=(const ResultCode& o) { raw = o.raw; return *this; }

--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -293,8 +293,8 @@ ResultCode DeleteConfigNANDSaveFile() {
 
 ResultCode UpdateConfigNANDSavegame() {
     FileSys::Mode mode = {};
-    mode.write_flag = 1;
-    mode.create_flag = 1;
+    mode.write_flag.Assign(1);
+    mode.create_flag.Assign(1);
 
     FileSys::Path path("config");
 
@@ -405,7 +405,7 @@ void Init() {
 
     FileSys::Path config_path("config");
     FileSys::Mode open_mode = {};
-    open_mode.read_flag = 1;
+    open_mode.read_flag.Assign(1);
 
     auto config_result = Service::FS::OpenFileFromArchive(*archive_result, config_path, open_mode);
 

--- a/src/core/hle/service/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp_gpu.cpp
@@ -347,7 +347,7 @@ void SignalInterrupt(InterruptId interrupt_id) {
             FrameBufferUpdate* info = GetFrameBufferInfo(thread_id, screen_id);
             if (info->is_dirty) {
                 SetBufferSwap(screen_id, info->framebuffer_info[info->index]);
-                info->is_dirty = false;
+                info->is_dirty.Assign(false);
             }
         }
     }
@@ -499,7 +499,7 @@ static void SetLcdForceBlack(Service::Interface* self) {
 
     // Since data is already zeroed, there is no need to explicitly set
     // the color to black (all zero).
-    data.is_enabled = enable_black;
+    data.is_enabled.Assign(enable_black);
 
     LCD::Write(HW::VADDR_LCD + 4 * LCD_REG_INDEX(color_fill_top), data.raw); // Top LCD
     LCD::Write(HW::VADDR_LCD + 4 * LCD_REG_INDEX(color_fill_bottom), data.raw); // Bottom LCD
@@ -521,7 +521,7 @@ static void TriggerCmdReqQueue(Service::Interface* self) {
             ExecuteCommand(command_buffer->commands[i], thread_id);
 
             // Indicates that command has completed
-            command_buffer->number_commands = command_buffer->number_commands - 1;
+            command_buffer->number_commands.Assign(command_buffer->number_commands - 1);
         }
     }
 

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -105,7 +105,7 @@ void Update() {
     bool pressed = false;
 
     std::tie(touch_entry->x, touch_entry->y, pressed) = VideoCore::g_emu_window->GetTouchState();
-    touch_entry->valid = pressed ? 1 : 0;
+    touch_entry->valid.Assign(pressed ? 1 : 0);
 
     // TODO(bunnei): We're not doing anything with offset 0xA8 + 0x18 of HID SharedMemory, which
     // supposedly is "Touch-screen entry, which contains the raw coordinate data prior to being

--- a/src/core/hle/service/ptm/ptm.cpp
+++ b/src/core/hle/service/ptm/ptm.cpp
@@ -110,8 +110,8 @@ void Init() {
 
         FileSys::Path gamecoin_path("gamecoin.dat");
         FileSys::Mode open_mode = {};
-        open_mode.write_flag = 1;
-        open_mode.create_flag = 1;
+        open_mode.write_flag.Assign(1);
+        open_mode.create_flag.Assign(1);
         // Open the file and write the default gamecoin information
         auto gamecoin_result = Service::FS::OpenFileFromArchive(*archive_result, gamecoin_path, open_mode);
         if (gamecoin_result.Succeeded()) {

--- a/src/core/hle/service/soc_u.cpp
+++ b/src/core/hle/service/soc_u.cpp
@@ -178,17 +178,17 @@ struct CTRPollFD {
         static Events TranslateTo3DS(u32 input_event) {
             Events ev = {};
             if (input_event & POLLIN)
-                ev.pollin = 1;
+                ev.pollin.Assign(1);
             if (input_event & POLLPRI)
-                ev.pollpri = 1;
+                ev.pollpri.Assign(1);
             if (input_event & POLLHUP)
-                ev.pollhup = 1;
+                ev.pollhup.Assign(1);
             if (input_event & POLLERR)
-                ev.pollerr = 1;
+                ev.pollerr.Assign(1);
             if (input_event & POLLOUT)
-                ev.pollout = 1;
+                ev.pollout.Assign(1);
             if (input_event & POLLNVAL)
-                ev.pollnval = 1;
+                ev.pollnval.Assign(1);
             return ev;
         }
 

--- a/src/core/hw/gpu.cpp
+++ b/src/core/hw/gpu.cpp
@@ -146,8 +146,8 @@ inline void Write(u32 addr, const T data) {
 
             // Reset "trigger" flag and set the "finish" flag
             // NOTE: This was confirmed to happen on hardware even if "address_start" is zero.
-            config.trigger = 0;
-            config.finished = 1;
+            config.trigger.Assign(0);
+            config.finished.Assign(1);
         }
         break;
     }
@@ -444,16 +444,16 @@ void Init() {
     framebuffer_sub.address_left1  = 0x1848F000;
     framebuffer_sub.address_left2  = 0x184C7800;
 
-    framebuffer_top.width = 240;
-    framebuffer_top.height = 400;
+    framebuffer_top.width.Assign(240);
+    framebuffer_top.height.Assign(400);
     framebuffer_top.stride = 3 * 240;
-    framebuffer_top.color_format = Regs::PixelFormat::RGB8;
+    framebuffer_top.color_format.Assign(Regs::PixelFormat::RGB8);
     framebuffer_top.active_fb = 0;
 
-    framebuffer_sub.width = 240;
-    framebuffer_sub.height = 320;
+    framebuffer_sub.width.Assign(240);
+    framebuffer_sub.height.Assign(320);
     framebuffer_sub.stride = 3 * 240;
-    framebuffer_sub.color_format = Regs::PixelFormat::RGB8;
+    framebuffer_sub.color_format.Assign(Regs::PixelFormat::RGB8);
     framebuffer_sub.active_fb = 0;
 
     last_skip_frame = false;

--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -429,7 +429,7 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
                           uniform.w.ToFloat32());
 
                 // TODO: Verify that this actually modifies the register!
-                uniform_setup.index = uniform_setup.index + 1;
+                uniform_setup.index.Assign(uniform_setup.index + 1);
             }
             break;
         }
@@ -478,7 +478,7 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
             ASSERT_MSG(lut_config.index < 256, "lut_config.index exceeded maximum value of 255!");
 
             g_state.lighting.luts[lut_config.type][lut_config.index].raw = value;
-            lut_config.index = lut_config.index + 1;
+            lut_config.index.Assign(lut_config.index + 1);
             break;
         }
 

--- a/src/video_core/debug_utils/debug_utils.cpp
+++ b/src/video_core/debug_utils/debug_utils.cpp
@@ -201,11 +201,11 @@ void DumpShader(const std::string& filename, const Regs::ShaderConfig& config, c
 
                     if (it == output_info_table.end()) {
                         output_info_table.emplace_back();
-                        output_info_table.back().type = type;
-                        output_info_table.back().component_mask = component_mask;
-                        output_info_table.back().id = i;
+                        output_info_table.back().type.Assign(type);
+                        output_info_table.back().component_mask.Assign(component_mask);
+                        output_info_table.back().id.Assign(i);
                     } else {
-                        it->component_mask = it->component_mask | component_mask;
+                        it->component_mask.Assign(it->component_mask | component_mask);
                     }
                 } catch (const std::out_of_range& ) {
                     DEBUG_ASSERT_MSG(false, "Unknown output attribute mapping");


### PR DESCRIPTION
Making BitField trivially copyable for `memcpy` safety.

Rationale for removing assignment operator:

    11:45 < neobrain_> yeah, I figured a while ago it would be better to move the "intended" usage of BitField towards member
                       functions rather via operator overloading. then it shouldn't be much of a problem anymore
    11:46 < neobrain_> I mean, essentially that's already done, and we should just remove the overloaded operators and replace all
                       usage by explicitly calling Value() and Assign()
    12:54 < merrymage> neobrain_: Something like this?
                       https://github.com/MerryMage/citra/commit/927d7d9da31facd536cf385bcf92f936a9db12d1
    13:20 < neobrain_> merrymage: yes.
    13:21 < neobrain_> although, we probably want to keep around the implicit conversions, since they don't really do any harm.