### PR TITLE
Reorganize the ndm service path for implement dummy function

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -42,6 +42,7 @@ namespace Log {
         SUB(Service, AM) \
         SUB(Service, PTM) \
         SUB(Service, LDR) \
+        SUB(Service, NDM) \
         SUB(Service, NIM) \
         SUB(Service, NWM) \
         SUB(Service, CAM) \

--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -57,6 +57,7 @@ enum class Class : ClassType {
     Service_AM,                 ///< The AM (Application manager) service
     Service_PTM,                ///< The PTM (Power status & misc.) service
     Service_LDR,                ///< The LDR (3ds dll loader) service
+    Service_NDM,                ///< The NDM (Network daemon manager) service
     Service_NIM,                ///< The NIM (Network interface manager) service
     Service_NWM,                ///< The NWM (Network wlan manager) service
     Service_CAM,                ///< The CAM (Camera) service

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -87,7 +87,8 @@ set(SRCS
             hle/service/ir/ir_user.cpp
             hle/service/ldr_ro.cpp
             hle/service/mic_u.cpp
-            hle/service/ndm_u.cpp
+            hle/service/ndm/ndm.cpp
+            hle/service/ndm/ndm_u.cpp
             hle/service/news/news.cpp
             hle/service/news/news_s.cpp
             hle/service/news/news_u.cpp
@@ -218,7 +219,8 @@ set(HEADERS
             hle/service/ir/ir_user.h
             hle/service/ldr_ro.h
             hle/service/mic_u.h
-            hle/service/ndm_u.h
+            hle/service/ndm/ndm.h
+            hle/service/ndm/ndm_u.h
             hle/service/news/news.h
             hle/service/news/news_s.h
             hle/service/news/news_u.h

--- a/src/core/hle/service/ndm/ndm.cpp
+++ b/src/core/hle/service/ndm/ndm.cpp
@@ -1,0 +1,47 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "common/common_types.h"
+#include "common/logging/log.h"
+#include "core/hle/service/service.h"
+#include "core/hle/service/ndm/ndm.h"
+#include "core/hle/service/ndm/ndm_u.h"
+
+namespace Service {
+namespace NDM {
+
+void SuspendDaemons(Service::Interface* self) {
+    u32* cmd_buff = Kernel::GetCommandBuffer();
+
+    LOG_WARNING(Service_NDM, "(STUBBED) bit_mask=0x%08X ", cmd_buff[1]);
+
+    cmd_buff[1] = RESULT_SUCCESS.raw; // No error
+}
+
+void ResumeDaemons(Service::Interface* self) {
+    u32* cmd_buff = Kernel::GetCommandBuffer();
+
+    LOG_WARNING(Service_NDM, "(STUBBED) bit_mask=0x%08X ", cmd_buff[1]);
+
+    cmd_buff[1] = RESULT_SUCCESS.raw; // No error
+}
+
+void OverrideDefaultDaemons(Service::Interface* self) {
+    u32* cmd_buff = Kernel::GetCommandBuffer();
+
+    LOG_WARNING(Service_NDM, "(STUBBED) bit_mask=0x%08X ", cmd_buff[1]);
+
+    cmd_buff[1] = RESULT_SUCCESS.raw; // No error
+}
+
+void Init() {
+    AddService(new NDM_U_Interface);
+}
+
+void Shutdown() {
+
+}
+
+}// namespace NDM
+}// namespace Service

--- a/src/core/hle/service/ndm/ndm.h
+++ b/src/core/hle/service/ndm/ndm.h
@@ -1,0 +1,52 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "common/common_types.h"
+
+namespace Service {
+
+class Interface;
+
+namespace NDM {
+
+/**
+ *  SuspendDaemons
+ *  Inputs:
+ *      0 : Command header (0x00020082)
+ *      1 : Daemon bit mask
+ *  Outputs:
+ *      1 : Result, 0 on success, otherwise error code
+ */
+void SuspendDaemons(Service::Interface* self);
+
+/**
+ *  ResumeDaemons
+ *  Inputs:
+ *      0 : Command header (0x00020082)
+ *      1 : Daemon bit mask
+ *  Outputs:
+ *      1 : Result, 0 on success, otherwise error code
+ */
+void ResumeDaemons(Service::Interface* self);
+
+/**
+ *  OverrideDefaultDaemons
+ *  Inputs:
+ *      0 : Command header (0x00020082)
+ *      1 : Daemon bit mask
+ *  Outputs:
+ *      1 : Result, 0 on success, otherwise error code
+ */
+void OverrideDefaultDaemons(Service::Interface* self);
+
+/// Initialize NDM service
+void Init();
+
+/// Shutdown NDM service
+void Shutdown();
+
+}// namespace NDM
+}// namespace Service

--- a/src/core/hle/service/ndm/ndm_u.cpp
+++ b/src/core/hle/service/ndm/ndm_u.cpp
@@ -2,12 +2,11 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include "core/hle/service/ndm_u.h"
+#include "core/hle/service/ndm/ndm.h"
+#include "core/hle/service/ndm/ndm_u.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace NDM_U
-
-namespace NDM_U {
+namespace Service {
+namespace NDM {
 
 const Interface::FunctionInfo FunctionTable[] = {
     {0x00010042, nullptr,                 "EnterExclusiveState"},
@@ -15,8 +14,8 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x00030000, nullptr,                 "QueryExclusiveMode"},
     {0x00040002, nullptr,                 "LockState"},
     {0x00050002, nullptr,                 "UnlockState"},
-    {0x00060040, nullptr,                 "SuspendDaemons"},
-    {0x00070040, nullptr,                 "ResumeDaemons"},
+    {0x00060040, SuspendDaemons,          "SuspendDaemons"},
+    {0x00070040, ResumeDaemons,           "ResumeDaemons"},
     {0x00080040, nullptr,                 "DisableWifiUsage"},
     {0x00090000, nullptr,                 "EnableWifiUsage"},
     {0x000A0000, nullptr,                 "GetCurrentState"},
@@ -29,17 +28,15 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x00110000, nullptr,                 "GetScanInterval"},
     {0x00120040, nullptr,                 "SetRetryInterval"},
     {0x00130000, nullptr,                 "GetRetryInterval"},
-    {0x00140040, nullptr,                 "OverrideDefaultDaemons"},
+    {0x00140040, OverrideDefaultDaemons,  "OverrideDefaultDaemons"},
     {0x00150000, nullptr,                 "ResetDefaultDaemons"},
     {0x00160000, nullptr,                 "GetDefaultDaemons"},
     {0x00170000, nullptr,                 "ClearHalfAwakeMacFilter"},
 };
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Interface class
-
-Interface::Interface() {
+NDM_U_Interface::NDM_U_Interface() {
     Register(FunctionTable);
 }
 
-} // namespace
+} // namespace NDM
+} // namespace Service

--- a/src/core/hle/service/ndm/ndm_u.h
+++ b/src/core/hle/service/ndm/ndm_u.h
@@ -6,20 +6,17 @@
 
 #include "core/hle/service/service.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace NDM
+namespace Service {
+namespace NDM {
 
-// No idea what this is
-
-namespace NDM_U {
-
-class Interface : public Service::Interface {
+class NDM_U_Interface : public Service::Interface {
 public:
-    Interface();
+    NDM_U_Interface();
 
     std::string GetPortName() const override {
         return "ndm:u";
     }
 };
 
-} // namespace
+} // namespace NDM
+} // namespace Service

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -16,7 +16,6 @@
 #include "core/hle/service/http_c.h"
 #include "core/hle/service/ldr_ro.h"
 #include "core/hle/service/mic_u.h"
-#include "core/hle/service/ndm_u.h"
 #include "core/hle/service/ns_s.h"
 #include "core/hle/service/nwm_uds.h"
 #include "core/hle/service/pm_app.h"
@@ -35,6 +34,7 @@
 #include "core/hle/service/cfg/cfg.h"
 #include "core/hle/service/hid/hid.h"
 #include "core/hle/service/ir/ir.h"
+#include "core/hle/service/ndm/ndm.h"
 #include "core/hle/service/news/news.h"
 #include "core/hle/service/nim/nim.h"
 #include "core/hle/service/ptm/ptm.h"
@@ -114,6 +114,7 @@ void Init() {
     Service::HID::Init();
     Service::IR::Init();
     Service::NEWS::Init();
+    Service::NDM::Init();
     Service::NIM::Init();
     Service::PTM::Init();
 
@@ -126,7 +127,6 @@ void Init() {
     AddService(new HTTP_C::Interface);
     AddService(new LDR_RO::Interface);
     AddService(new MIC_U::Interface);
-    AddService(new NDM_U::Interface);
     AddService(new NS_S::Interface);
     AddService(new NWM_UDS::Interface);
     AddService(new PM_APP::Interface);
@@ -141,6 +141,7 @@ void Init() {
 void Shutdown() {
 
     Service::PTM::Shutdown();
+    Service::NDM::Shutdown();
     Service::NIM::Shutdown();
     Service::NEWS::Shutdown();
     Service::IR::Shutdown();


### PR DESCRIPTION
SuspendDaemons , ResumeDaemons , OverrideDefaultDaemons

The NDM file move to /core/hle/service/ndm/ now!

Signed-off-by: JamePeng <jame_peng@sina.com>