### PR TITLE
Add THREADPROCESSORID_ALL on SVC::CreateThread

### DIFF
--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -486,6 +486,7 @@ static ResultCode CreateThread(Handle* out_handle, s32 priority, u32 entry_point
     }
 
     switch (processor_id) {
+    case THREADPROCESSORID_ALL:
     case THREADPROCESSORID_DEFAULT:
     case THREADPROCESSORID_0:
     case THREADPROCESSORID_1:


### PR DESCRIPTION
This allows The legend of legacy to boot. Fixes #1432 