### PR TITLE
Loader/NCCH: Log the program ID during loading

### DIFF
--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -255,7 +255,8 @@ ResultStatus AppLoader_NCCH::Load() {
     priority                = exheader_header.arm11_system_local_caps.priority;
     resource_limit_category = exheader_header.arm11_system_local_caps.resource_limit_category;
 
-    LOG_INFO(Loader,  "Name:                         %s"   , exheader_header.codeset_info.name);
+    LOG_INFO(Loader,  "Name:                        %s"    , exheader_header.codeset_info.name);
+    LOG_INFO(Loader,  "Program ID:                  %016X" , ncch_header.program_id);
     LOG_DEBUG(Loader, "Code compressed:             %s"    , is_compressed ? "yes" : "no");
     LOG_DEBUG(Loader, "Entry point:                 0x%08X", entry_point);
     LOG_DEBUG(Loader, "Code size:                   0x%08X", code_size);


### PR DESCRIPTION
This is useful for all sorts of things, but mainly to identify save
folders more easily.