### PR TITLE
Immediate-mode improvements

### DIFF
--- a/src/video_core/pica.cpp
+++ b/src/video_core/pica.cpp
@@ -493,12 +493,25 @@ std::string Regs::GetCommandName(int index) {
 }
 
 void Init() {
+    g_state.Reset();
 }
 
 void Shutdown() {
     Shader::Shutdown();
+}
 
-    memset(&g_state, 0, sizeof(State));
+template <typename T>
+void Zero(T& o) {
+    memset(&o, 0, sizeof(o));
+}
+
+void State::Reset() {
+    Zero(regs);
+    Zero(vs);
+    Zero(gs);
+    Zero(cmd_list);
+    Zero(immediate);
+    primitive_assembler.Reconfigure(Regs::TriangleTopology::List);
 }
 
 }

--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -1123,7 +1123,12 @@ struct Regs {
             BitField<24, 8, u32> w;
         } int_uniforms[4];
 
-        INSERT_PADDING_WORDS(0x5);
+        INSERT_PADDING_WORDS(0x4);
+
+        union {
+            // Number of input attributes to shader unit - 1
+            BitField<0, 4, u32> num_input_attributes;
+        };
 
         // Offset to shader program entry point (in words)
         BitField<0, 16, u32> main_offset;

--- a/src/video_core/pica_state.h
+++ b/src/video_core/pica_state.h
@@ -12,6 +12,8 @@ namespace Pica {
 
 /// Struct used to describe current Pica state
 struct State {
+    void Reset();
+
     /// Pica registers
     Regs regs;
 
@@ -46,13 +48,14 @@ struct State {
 
     /// Struct used to describe immediate mode rendering state
     struct ImmediateModeState {
-        Shader::InputVertex input;
-        // This is constructed with a dummy triangle topology
-        PrimitiveAssembler<Shader::OutputVertex> primitive_assembler;
-        int attribute_id = 0;
-
-        ImmediateModeState() : primitive_assembler(Regs::TriangleTopology::List) {}
+        // Used to buffer partial vertices for immediate-mode rendering.
+        Shader::InputVertex input_vertex;
+        // Index of the next attribute to be loaded into `input_vertex`.
+        int current_attribute = 0;
     } immediate;
+
+    // This is constructed with a dummy triangle topology
+    PrimitiveAssembler<Shader::OutputVertex> primitive_assembler;
 };
 
 extern State g_state; ///< Current Pica state

--- a/src/video_core/primitive_assembly.h
+++ b/src/video_core/primitive_assembly.h
@@ -20,7 +20,7 @@ struct PrimitiveAssembler {
                                                VertexType& v1,
                                                VertexType& v2)>;
 
-    PrimitiveAssembler(Regs::TriangleTopology topology);
+    PrimitiveAssembler(Regs::TriangleTopology topology = Regs::TriangleTopology::List);
 
     /*
      * Queues a vertex, builds primitives from the vertex queue according to the given

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -190,6 +190,9 @@ void RasterizerOpenGL::AddTriangle(const Pica::Shader::OutputVertex& v0,
 }
 
 void RasterizerOpenGL::DrawTriangles() {
+    if (vertex_batch.empty())
+        return;
+
     SyncFramebuffer();
     SyncDrawState();
 


### PR DESCRIPTION
This fixes some issues I missed when reviewing #1394 and also forward-ports some extra features from my old branch:
  - Unifies some duplicated code paths between immediate mode and batch vertex draws.
  - Fixes initialization of the PicaState struct to not memset over PrimitiveAssembler.
  - Adds support for primitive restart.
  - Tweaks and moves a few things around to more closely match behavior from the hardware with unusual register values and command sequences.

cc @ds84182 