### PR TITLE
Set the appropriate locale to get float conversion working using to_string

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <clocale>
 #include <thread>
 
 #include <QDesktopWidget>
@@ -562,6 +563,9 @@ int main(int argc, char* argv[]) {
 
     QApplication::setAttribute(Qt::AA_X11InitThreads);
     QApplication app(argc, argv);
+
+    // Qt changes the locale and causes issues in float conversion using std::to_string() when generating shaders
+    setlocale(LC_ALL, "C");
 
     GMainWindow main_window;
     // After settings have been loaded by GMainWindow, apply the filter


### PR DESCRIPTION
This fixes a bug on Linux (maybe Windows too), on systems where the locale does separate float numbers with ",". Qt through QApplication changes the locale. The new locale affects std::to_string behavior in shaders generation.
The string will be "0,0000" instead of "0.0000" causing numerous problem such as invalid shaders.
My solution is to set back an appropriate locale after QApplication instantiation.