### PR TITLE
Common: Get rid of alignment macros

### DIFF
--- a/src/common/common_funcs.h
+++ b/src/common/common_funcs.h
@@ -18,19 +18,11 @@
 #define INSERT_PADDING_BYTES(num_bytes) u8 CONCAT2(pad, __LINE__)[(num_bytes)]
 #define INSERT_PADDING_WORDS(num_words) u32 CONCAT2(pad, __LINE__)[(num_words)]
 
+// Inlining
 #ifdef _WIN32
-    // Alignment
     #define FORCE_INLINE __forceinline
-    #define MEMORY_ALIGNED16(x) __declspec(align(16)) x
-    #define MEMORY_ALIGNED32(x) __declspec(align(32)) x
-    #define MEMORY_ALIGNED64(x) __declspec(align(64)) x
-    #define MEMORY_ALIGNED128(x) __declspec(align(128)) x
 #else
     #define FORCE_INLINE inline __attribute__((always_inline))
-    #define MEMORY_ALIGNED16(x) __attribute__((aligned(16))) x
-    #define MEMORY_ALIGNED32(x) __attribute__((aligned(32))) x
-    #define MEMORY_ALIGNED64(x) __attribute__((aligned(64))) x
-    #define MEMORY_ALIGNED128(x) __attribute__((aligned(128))) x
 #endif
 
 #ifndef _MSC_VER

--- a/src/video_core/shader/shader.h
+++ b/src/video_core/shader/shader.h
@@ -82,7 +82,7 @@ struct ShaderSetup {
     struct {
         // The float uniforms are accessed by the shader JIT using SSE instructions, and are
         // therefore required to be 16-byte aligned.
-        Math::Vec4<float24> MEMORY_ALIGNED16(f[96]);
+        alignas(16) Math::Vec4<float24> f[96];
 
         std::array<bool, 16> b;
         std::array<Math::Vec4<u8>, 4> i;
@@ -276,9 +276,9 @@ struct UnitState {
     struct Registers {
         // The registers are accessed by the shader JIT using SSE instructions, and are therefore
         // required to be 16-byte aligned.
-        Math::Vec4<float24> MEMORY_ALIGNED16(input[16]);
-        Math::Vec4<float24> MEMORY_ALIGNED16(output[16]);
-        Math::Vec4<float24> MEMORY_ALIGNED16(temporary[16]);
+        alignas(16) Math::Vec4<float24> input[16];
+        alignas(16) Math::Vec4<float24> output[16];
+        alignas(16) Math::Vec4<float24> temporary[16];
     } registers;
     static_assert(std::is_pod<Registers>::value, "Structure is not POD");
 


### PR DESCRIPTION
The GL rasterizer already uses alignas, so we may as well move everything over.