### PR TITLE
Fix attribute mapping in vs debugger

### DIFF
--- a/src/citra_qt/debugger/graphics_vertex_shader.cpp
+++ b/src/citra_qt/debugger/graphics_vertex_shader.cpp
@@ -498,8 +498,8 @@ void GraphicsVertexShaderWidget::Reload(bool replace_vertex_data, void* vertex_d
     // Reload widget state
     for (int attr = 0; attr < num_attributes; ++attr) {
         unsigned source_attr = shader_config.input_register_map.GetRegisterForAttribute(attr);
-        input_data_mapping[source_attr]->setText(QString("-> v%1").arg(attr));
-        input_data_container[source_attr]->setVisible(true);
+        input_data_mapping[attr]->setText(QString("-> v%1").arg(source_attr));
+        input_data_container[attr]->setVisible(true);
     }
     // Only show input attributes which are used as input to the shader
     for (unsigned int attr = num_attributes; attr < 16; ++attr) {


### PR DESCRIPTION
As documented here: https://www.3dbrew.org/wiki/GPU/Internal_Registers#GPUREG_SH_ATTRIBUTES_PERMUTATION_LOW

```
GPUREG_VSH_NUM_ATTR	242	0001	00000004	
GPUREG_VSH_ATTRIBUTES_PERMUTATION_LOW	2bb	1111	00076310	
GPUREG_VSH_ATTRIBUTES_PERMUTATION_HIGH	2bc	1111	00000000	
```

Regs mean: v7=attr4 v6=attr3 v3=attr2 v1=attr1 v0=attr0
Citra would show: v2=attr3 v1=attr1 v0=attr0

(= 3 registers instead 4+1 [because some widgets are hidden by accident] and also mapped the wrong way around ("v2 = attribue 3" instead "v3 = attribute 2"))

This PR fixes this bug.