### PR TITLE
Fix MAD/MADI encoding

### DIFF
--- a/src/citra_qt/debugger/graphics_vertex_shader.cpp
+++ b/src/citra_qt/debugger/graphics_vertex_shader.cpp
@@ -179,9 +179,17 @@ QVariant GraphicsVertexShaderModel::data(const QModelIndex& index, int role) con
                     AlignToColumn(kOutputColumnWidth);
                     print_input(output, src1, swizzle.negate_src1, SelectorToString(swizzle.src1_selector));
                     AlignToColumn(kInputOperandColumnWidth);
-                    print_input(output, src2, swizzle.negate_src2, SelectorToString(swizzle.src2_selector));
+                    if (src_is_inverted) {
+                      print_input(output, src2, swizzle.negate_src2, SelectorToString(swizzle.src2_selector));
+                    } else {
+                      print_input(output, src2, swizzle.negate_src2, SelectorToString(swizzle.src2_selector), true, instr.mad.AddressRegisterName());
+                    }
                     AlignToColumn(kInputOperandColumnWidth);
-                    print_input(output, src3, swizzle.negate_src3, SelectorToString(swizzle.src3_selector));
+                    if (src_is_inverted) {
+                      print_input(output, src3, swizzle.negate_src3, SelectorToString(swizzle.src3_selector), true, instr.mad.AddressRegisterName());
+                    } else {
+                      print_input(output, src3, swizzle.negate_src3, SelectorToString(swizzle.src3_selector));
+                    }
                     AlignToColumn(kInputOperandColumnWidth);
                     break;
                 }

--- a/src/video_core/shader/shader_interpreter.cpp
+++ b/src/video_core/shader/shader_interpreter.cpp
@@ -413,9 +413,12 @@ void RunInterpreter(UnitState<Debug>& state) {
 
                 bool is_inverted = (instr.opcode.Value().EffectiveOpCode() == OpCode::Id::MADI);
 
+                const int address_offset = (instr.mad.address_register_index == 0)
+                                           ? 0 : state.address_registers[instr.mad.address_register_index - 1];
+
                 const float24* src1_ = LookupSourceRegister(instr.mad.GetSrc1(is_inverted));
-                const float24* src2_ = LookupSourceRegister(instr.mad.GetSrc2(is_inverted));
-                const float24* src3_ = LookupSourceRegister(instr.mad.GetSrc3(is_inverted));
+                const float24* src2_ = LookupSourceRegister(instr.mad.GetSrc2(is_inverted) + (!is_inverted * address_offset));
+                const float24* src3_ = LookupSourceRegister(instr.mad.GetSrc3(is_inverted) + ( is_inverted * address_offset));
 
                 const bool negate_src1 = ((bool)swizzle.negate_src1 != false);
                 const bool negate_src2 = ((bool)swizzle.negate_src2 != false);


### PR DESCRIPTION
Fixes https://github.com/citra-emu/citra/issues/974

![interpreter](http://i.imgur.com/JzcHLy5.png)
![shader-jit](http://i.imgur.com/aArUuAn.png)
![debugger](http://i.imgur.com/nAyXX4K.png)

Includes fixes for:

- Interpreter
- Shader JIT
- VS Debugger

My assumption is that MADI will invert src2 and src3, also putting the offset on src3.
~~This is just an educated guess and untested (due to a lack of test code).~~ Confirmed.

I had to change some parts of nihstro (https://github.com/neobrain/nihstro/pull/47) but didn't fix its assembler / disassembler.