### PR TITLE
Align attribute components

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SRCS
             )
 
 set(HEADERS
+            alignment.h
             assert.h
             bit_field.h
             bit_set.h

--- a/src/common/alignment.h
+++ b/src/common/alignment.h
@@ -1,0 +1,22 @@
+// This file is under the public domain.
+
+#pragma once
+
+#include <cstddef>
+#include <type_traits>
+
+namespace Common {
+
+template <typename T>
+constexpr T AlignUp(T value, size_t size) {
+    static_assert(std::is_unsigned<T>::value, "T must be an unsigned value.");
+    return static_cast<T>(value + (size - value % size) % size);
+}
+
+template <typename T>
+constexpr T AlignDown(T value, size_t size) {
+    static_assert(std::is_unsigned<T>::value, "T must be an unsigned value.");
+    return static_cast<T>(value - value % size);
+}
+
+} // namespace Common

--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <boost/range/algorithm/fill.hpp>
 
+#include "common/alignment.h"
 #include "common/microprofile.h"
 #include "common/profiler.h"
 
@@ -210,14 +211,17 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
 
                     u32 attribute_index = loader_config.GetComponent(component);
                     if (attribute_index < 12) {
+                        int element_size = attribute_config.GetElementSizeInBytes(attribute_index);
+                        load_address = Common::AlignUp(load_address, element_size);
                         vertex_attribute_sources[attribute_index] = load_address;
                         vertex_attribute_strides[attribute_index] = static_cast<u32>(loader_config.byte_count);
                         vertex_attribute_formats[attribute_index] = attribute_config.GetFormat(attribute_index);
                         vertex_attribute_elements[attribute_index] = attribute_config.GetNumElements(attribute_index);
-                        vertex_attribute_element_size[attribute_index] = attribute_config.GetElementSizeInBytes(attribute_index);
+                        vertex_attribute_element_size[attribute_index] = element_size;
                         load_address += attribute_config.GetStride(attribute_index);
                     } else if (attribute_index < 16) {
                         // Attribute ids 12, 13, 14 and 15 signify 4, 8, 12 and 16-byte paddings, respectively
+                        load_address = Common::AlignUp(load_address, 4);
                         load_address += (attribute_index - 11) * 4;
                     } else {
                         UNREACHABLE(); // This is truly unreachable due to the number of bits for each component


### PR DESCRIPTION
Fixes #1488 and possible a good chunk of others.

Not tested against real hw, not documented on 3dbrew but very very very likely.
Not sure yet wether each component or just each attribute vec is aligned.

Example (Super Smash Bros Demo Characters) of problematic uploads in current master:

Outline:

```
v0.z [Vertex 206], format 0x2, base 0x18201B00, stride 18, element size: 2: 3192.000000
v1.x [Vertex 206], format 0x0, base 0x18201B06, stride 18, element size: 1: -43.000000
v1.y [Vertex 206], format 0x0, base 0x18201B06, stride 18, element size: 1: -118.000000
v1.z [Vertex 206], format 0x0, base 0x18201B06, stride 18, element size: 1: -6.000000
v2.x [Vertex 206], format 0x1, base 0x18201B09, stride 18, element size: 1: 141.000000
v2.y [Vertex 206], format 0x1, base 0x18201B09, stride 18, element size: 1: 83.000000
v2.z [Vertex 206], format 0x1, base 0x18201B09, stride 18, element size: 1: 46.000000
v2.w [Vertex 206], format 0x1, base 0x18201B09, stride 18, element size: 1: 255.000000
v3.x [Vertex 206], format 0x1, base 0x18201B0D, stride 18, element size: 1: 4.000000
v3.y [Vertex 206], format 0x1, base 0x18201B0D, stride 18, element size: 1: 8.000000
v4.x [Vertex 206], format 0x1, base 0x18201B0F, stride 18, element size: 1: 30.000000
v4.y [Vertex 206], format 0x1, base 0x18201B0F, stride 18, element size: 1: 70.000000
```

(v3 are bone indices, v4 are bone weights (30+70 = 100))

Actual model:

```
v0.z [Vertex 234], format 0x2, base 0x1820CCA0, stride 18, element size: 2: 3192.000000
v1.x [Vertex 234], format 0x0, base 0x1820CCA6, stride 18, element size: 1: 43.000000
v1.y [Vertex 234], format 0x0, base 0x1820CCA6, stride 18, element size: 1: 118.000000
v1.z [Vertex 234], format 0x0, base 0x1820CCA6, stride 18, element size: 1: 6.000000
v2.x [Vertex 234], format 0x2, base 0x1820CCA9, stride 18, element size: 2: 18432.000000 << alignment breaks here
v2.y [Vertex 234], format 0x2, base 0x1820CCA9, stride 18, element size: 2: -19443.000000
v3.x [Vertex 234], format 0x1, base 0x1820CCAD, stride 18, element size: 1: 79.000000
v3.y [Vertex 234], format 0x1, base 0x1820CCAD, stride 18, element size: 1: 4.000000
v4.x [Vertex 234], format 0x1, base 0x1820CCAF, stride 18, element size: 1: 8.000000
v4.y [Vertex 234], format 0x1, base 0x1820CCAF, stride 18, element size: 1: 30.000000
```

(v3 are bone indices: index 79?! WTF.. v4 bone weights: 8+30 = 38 WTF..)


Fixed:

![Mario](http://i.imgur.com/l70AxvX.png)
![That yellow pokemon thingy..](http://i.imgur.com/ShSMhl8.png)
![That orange dude who is in games which I don't like](http://i.imgur.com/oMpXa9M.png)