### PR TITLE
Respect vs output map

### DIFF
--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -71,7 +71,7 @@ struct Regs {
     BitField<0, 24, u32> viewport_depth_range; // float24
     BitField<0, 24, u32> viewport_depth_far_plane; // float24
 
-    INSERT_PADDING_WORDS(0x1);
+    BitField<0, 3, u32> vs_output_total;
 
     union VSOutputAttributes {
         // Maps components of output vertex attributes to semantics
@@ -1157,8 +1157,10 @@ struct Regs {
             }
         } input_register_map;
 
-        // OUTMAP_MASK, 0x28E, CODETRANSFER_END
-        INSERT_PADDING_WORDS(0x3);
+        BitField<0, 16, u32> output_mask;
+
+        // 0x28E, CODETRANSFER_END
+        INSERT_PADDING_WORDS(0x2);
 
         struct {
             enum Format : u32

--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -109,15 +109,23 @@ OutputVertex Run(UnitState<false>& state, const InputVertex& input, int num_attr
     OutputVertex ret;
     // TODO(neobrain): Under some circumstances, up to 16 attributes may be output. We need to
     // figure out what those circumstances are and enable the remaining outputs then.
-    for (int i = 0; i < 7; ++i) {
-        const auto& output_register_map = g_state.regs.vs_output_attributes[i]; // TODO: Don't hardcode VS here
+    unsigned index = 0;
+    for (unsigned i = 0; i < 7; ++i) {
+
+        if (index >= g_state.regs.vs_output_total)
+            break;
+
+        if ((g_state.regs.vs.output_mask & (1 << i)) == 0)
+            continue;
+
+        const auto& output_register_map = g_state.regs.vs_output_attributes[index]; // TODO: Don't hardcode VS here
 
         u32 semantics[4] = {
             output_register_map.map_x, output_register_map.map_y,
             output_register_map.map_z, output_register_map.map_w
         };
 
-        for (int comp = 0; comp < 4; ++comp) {
+        for (unsigned comp = 0; comp < 4; ++comp) {
             float24* out = ((float24*)&ret) + semantics[comp];
             if (semantics[comp] != Regs::VSOutputAttributes::INVALID) {
                 *out = state.registers.output[i][comp];
@@ -127,10 +135,12 @@ OutputVertex Run(UnitState<false>& state, const InputVertex& input, int num_attr
                 memset(out, 0, sizeof(*out));
             }
         }
+
+        index++;
     }
 
     // The hardware takes the absolute and saturates vertex colors like this, *before* doing interpolation
-    for (int i = 0; i < 4; ++i) {
+    for (unsigned i = 0; i < 4; ++i) {
         ret.color[i] = float24::FromFloat32(
             std::fmin(std::fabs(ret.color[i].ToFloat32()), 1.0f));
     }


### PR DESCRIPTION
Something along these lines fixes most of #1504

What happens in Digimon?
* vs outmap_total is 5 = 5 output registers used
* vs outmap_mask is 0x2F (you might see where this is going..)
* shader wrote to o0, o1, o2, o3 and o5
* you know where the output semantics for o5 are configured? right.. vs outmap_o4
* said differently: outmap is packed tightly

Therefore I added a second index to count the actual outmap (output_attributes in citra) index.

As the file was already opened I switched the loop indices to unsigned.

I'm not sure about vs_output_total early out and it should be tested on actual HW.
I felt a little safer adding it because I wouldn't want possibly disabled (cause they are not included in output_total) regs overwriting outputs.

![Logo](http://i.imgur.com/XFjnCVS.png)
![Push my buttons](http://i.imgur.com/JX28ANM.png)
![Pushed me hard](http://i.imgur.com/qHaVtLK.png)
![Digimon stuff](http://i.imgur.com/AraiZQZ.png)
![Ash and pikachu](http://i.imgur.com/wna2Fjg.png)
![The dog still has broken eyes](http://i.imgur.com/1prdIqe.png)

I didn't know how to walk in the game as no button seemed to work so I didn't test if the 2D characters appear while talking.
There still seem to be some texturing issues but that's probably a seperate issue.