### PR TITLE
common: Minor changes to NonCopyable

### DIFF
--- a/src/common/common_types.h
+++ b/src/common/common_types.h
@@ -53,7 +53,7 @@ typedef u32 PAddr; ///< Represents a pointer in the ARM11 physical address space
 // An inheritable class to disallow the copy constructor and operator= functions
 class NonCopyable {
 protected:
-    NonCopyable() = default;
+    constexpr NonCopyable() = default;
     ~NonCopyable() = default;
 
     NonCopyable(const NonCopyable&) = delete;

--- a/src/common/common_types.h
+++ b/src/common/common_types.h
@@ -56,6 +56,6 @@ protected:
     NonCopyable() = default;
     ~NonCopyable() = default;
 
-    NonCopyable(NonCopyable&) = delete;
-    NonCopyable& operator=(NonCopyable&) = delete;
+    NonCopyable(const NonCopyable&) = delete;
+    NonCopyable& operator=(const NonCopyable&) = delete;
 };


### PR DESCRIPTION
The signature for the copy constructor and copy assignment operators generated by the compiler contain a const reference parameter, so we may as well specify that for consistency.

Also make the default constructor constexpr so it doesn't hamper objects that use it from being constexpr.