### PR TITLE
PICA: Fix viewport offset

### DIFF
--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -117,8 +117,8 @@ struct Regs {
     INSERT_PADDING_WORDS(0x11);
 
     union {
-        BitField< 0, 16, u32> x;
-        BitField<16, 16, u32> y;
+        BitField< 0, 10, s32> x;
+        BitField<16, 10, s32> y;
     } viewport_corner;
 
     INSERT_PADDING_WORDS(0x17);


### PR DESCRIPTION
Turns out the viewport offset is 10 bit signed.


Game is Digimon World ReDigtize Decode. Previously didn't render Agumon in the load / save menu.

3DS (Image by Romsstar)
![On 3DS](http://abload.de/img/top_0006irus9.png)

Currently crashes on Citra (Addressed in #1518 ) or doesn't draw Agumon with hw renderer.

Fixed (SW Renderer only):
![This PR](http://i.imgur.com/Nehwi35.png)

HW rendering has other issues with this title so only SW rendering was used to test this.
3dbrew already said that it was 10 bit but it was still wrong about signedness. I've already changed it there to reflect these findings from Digimon.