### PR TITLE
OS X: Use dylibbundler to include dylibs required by citra in nightly build

### DIFF
--- a/.travis-deps.sh
+++ b/.travis-deps.sh
@@ -20,6 +20,6 @@ if [ "$TRAVIS_OS_NAME" = "linux" -o -z "$TRAVIS_OS_NAME" ]; then
     )
 elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
     brew update > /dev/null # silence the very verbose output
-    brew install qt5 sdl2
+    brew install qt5 sdl2 dylibbundler
     gem install xcpretty
 fi

--- a/.travis-upload.sh
+++ b/.travis-upload.sh
@@ -20,6 +20,9 @@ if [ "$TRAVIS_BRANCH" = "master" ]; then
 
         # move qt libs into app bundle for deployment
         $(brew --prefix)/opt/qt5/bin/macdeployqt "${REV_NAME}/citra-qt.app"
+
+        # move SDL2 libs into folder for deployment
+        dylibbundler -b -x "${REV_NAME}/citra" -cd -d "${REV_NAME}/libs" -p "@executable_path/libs/"
     fi
 
     ARCHIVE_NAME="${REV_NAME}.tar.xz"


### PR DESCRIPTION
Our nightly builds currently do not include a dylib of SDL2 along in the archive. This requires the user to hunt down and build/install the appropate version of SDL2.

This fixes that by adding the appropriate libraries to the archive using `dylibbundler`. `dylibbundler` also runs `install_name_tool` as appropriate to update the dylib references in the `citra` executable.

This is likely a better solution than #1468 which I originally proposed. Would like someone who actually develops programs for OS X to comment.