### PR TITLE
PICA: Alignment happens locally in vertex

### DIFF
--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -200,7 +200,7 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
             for (int loader = 0; loader < 12; ++loader) {
                 const auto& loader_config = attribute_config.attribute_loaders[loader];
 
-                u32 load_address = base_address + loader_config.data_offset;
+                u32 offset = 0;
 
                 // TODO: What happens if a loader overwrites a previous one's data?
                 for (unsigned component = 0; component < loader_config.component_count; ++component) {
@@ -212,17 +212,17 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
                     u32 attribute_index = loader_config.GetComponent(component);
                     if (attribute_index < 12) {
                         int element_size = attribute_config.GetElementSizeInBytes(attribute_index);
-                        load_address = Common::AlignUp(load_address, element_size);
-                        vertex_attribute_sources[attribute_index] = load_address;
+                        offset = Common::AlignUp(offset, element_size);
+                        vertex_attribute_sources[attribute_index] = base_address + loader_config.data_offset + offset;
                         vertex_attribute_strides[attribute_index] = static_cast<u32>(loader_config.byte_count);
                         vertex_attribute_formats[attribute_index] = attribute_config.GetFormat(attribute_index);
                         vertex_attribute_elements[attribute_index] = attribute_config.GetNumElements(attribute_index);
                         vertex_attribute_element_size[attribute_index] = element_size;
-                        load_address += attribute_config.GetStride(attribute_index);
+                        offset += attribute_config.GetStride(attribute_index);
                     } else if (attribute_index < 16) {
                         // Attribute ids 12, 13, 14 and 15 signify 4, 8, 12 and 16-byte paddings, respectively
-                        load_address = Common::AlignUp(load_address, 4);
-                        load_address += (attribute_index - 11) * 4;
+                        offset = Common::AlignUp(offset, 4);
+                        offset += (attribute_index - 11) * 4;
                     } else {
                         UNREACHABLE(); // This is truly unreachable due to the number of bits for each component
                     }


### PR DESCRIPTION
pcmaker informed me about a [regression with "Thor - Thunder of Gods"](http://i.imgur.com/IcbBtoj.jpg) since #1496.
As @yuriks and me hw-tested the aligment this came as a surprise.

I had a lot of trouble debugging this issue because the alignment looked fine while debugging it. Then I noticed that my debug code tested the alignment by aligning locally in each vertex (load_address = 0 for testing), while Citra was doing it globally because load_address can be unaligned.
The hw-test we did also only ever used aligned buffers so we never hit this case. (Sorry!)

This PR makes the alignment local to each vertex. It fixes the Thor regression, Super Smash Bros also still works. I didn't test any other games yet.

With the assumption that alignment happens to avoid accessing multiple words from RAM it would be insanely weird if PICA works as in this PR.. (as each local vertex could still be unaligned in RAM, so the align is not really necessary for the hw and only fills up bandwidth).

I could also imagine the Thor regression being caused by a memory allocator bug in Citra which might not return aligned addresses to the game. So this should be tested on hardware to be certain, however, even if that is the case this code will still work (but it wouldn't be as clear that alignment happens globally due to RAM access, instead it would suggest local alignment).

So try this PR and if it breaks even more I'll have to rethink the whole alignment thing (again).
\- If it works fine we'll just make another cross in the long list we shall call "PITA200 is being weird again" and merge this.