### PR TITLE
Fix Qt string encode problem on Windows

### DIFF
--- a/src/citra_qt/config.cpp
+++ b/src/citra_qt/config.cpp
@@ -16,7 +16,7 @@ Config::Config() {
     // TODO: Don't hardcode the path; let the frontend decide where to put the config files.
     qt_config_loc = FileUtil::GetUserPath(D_CONFIG_IDX) + "qt-config.ini";
     FileUtil::CreateFullPath(qt_config_loc);
-    qt_config = new QSettings(QString::fromStdString(qt_config_loc), QSettings::IniFormat);
+    qt_config = new QSettings(QString::fromLocal8Bit(qt_config_loc.c_str()), QSettings::IniFormat);
 
     Reload();
 }

--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -66,7 +66,7 @@ void GameList::ValidateEntry(const QModelIndex& item)
 
     if (file_path.isEmpty())
         return;
-    std::string std_file_path = file_path.toStdString();
+    std::string std_file_path = file_path.toLocal8Bit();
     if (!FileUtil::Exists(std_file_path) || FileUtil::IsDirectory(std_file_path))
         return;
     emit GameChosen(file_path);
@@ -148,7 +148,7 @@ void GameListWorker::AddFstEntriesToGameList(const std::string& dir_path, bool d
 
             emit EntryReady({
                 new GameListItem(QString::fromStdString(Loader::GetFileTypeString(filetype))),
-                new GameListItemPath(QString::fromStdString(physical_name)),
+                new GameListItemPath(QString::fromLocal8Bit(physical_name.c_str())),
                 new GameListItemSize(FileUtil::GetSize(physical_name)),
             });
         }


### PR DESCRIPTION
On Windows10 with codepage 950

Before (can not open that game)
![image](https://cloud.githubusercontent.com/assets/7088579/13853628/89a0e718-eca2-11e5-8ebb-593be5fd3934.png)

After (it is fine)
![image](https://cloud.githubusercontent.com/assets/7088579/13853701/e88ab272-eca2-11e5-815f-7871e6cf3f61.png)

**But it just a temporary fix! **


There are more problems with [here](https://github.com/citra-emu/citra/blob/master/src/common/file_util.cpp#L444)


Citra use FindFirstFileA / FindNextFileA as default ,but these functions can not correctly handle filename. for example : 

There are some file names
```
ゲーム.cci (Japanese)
경기.cci (Korean)
游戏.cci  (Simplified Chinese)
遊戲.cci  (Traditional Chinese) (local environment)
game.cci (English)
```

![image](https://cloud.githubusercontent.com/assets/7088579/13854258/89d9a80c-eca5-11e5-94a5-48eae2c2053c.png)
![image](https://cloud.githubusercontent.com/assets/7088579/13854282/a4fa8b10-eca5-11e5-9168-71a166015f2e.png)

Only 遊戲.cci & game.cci are correctly loaded. 
`ゲーム.cci`  with UTF-8 
`e3 82 b2 e3 83 bc e3 83 a0 2e 63 63 69`


dump ffd.cFileName got
`3f 3f 3f 2e 63 63 69`

and it cause error and output `core\loader\loader.cpp:Loader::IdentifyFile:49: Failed to load file ./???.cci`
![image](https://cloud.githubusercontent.com/assets/7088579/13855073/9da4b42c-eca9-11e5-8ee9-6bc6770d2eb1.png)

I can keep trying to solve it.