### PR TITLE
vector_math: Add missing member in Vec4's SetZero function

### DIFF
--- a/src/common/vector_math.h
+++ b/src/common/vector_math.h
@@ -447,7 +447,10 @@ public:
 
     void SetZero()
     {
-        x=0; y=0; z=0;
+        x = 0;
+        y = 0;
+        z = 0;
+        w = 0;
     }
 
     // Common alias: RGBA (colors)


### PR DESCRIPTION
Previously Vec4's SetZero would only reset three of its four elements.