### PR TITLE
Move glad initialisation to the frontend

### DIFF
--- a/src/citra/emu_window/emu_window_sdl2.cpp
+++ b/src/citra/emu_window/emu_window_sdl2.cpp
@@ -9,6 +9,8 @@
 #define SDL_MAIN_HANDLED
 #include <SDL.h>
 
+#include <glad/glad.h>
+
 #include "common/key_map.h"
 #include "common/logging/log.h"
 #include "common/scm_rev.h"
@@ -95,6 +97,11 @@ EmuWindow_SDL2::EmuWindow_SDL2() {
 
     if (gl_context == nullptr) {
         LOG_CRITICAL(Frontend, "Failed to create SDL2 GL context! Exiting...");
+        exit(1);
+    }
+
+    if (!gladLoadGLLoader(static_cast<GLADloadproc>(SDL_GL_GetProcAddress))) {
+        LOG_CRITICAL(Frontend, "Failed to initialize GL functions! Exiting...");
         exit(1);
     }
 

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -6,6 +6,9 @@
 #include <memory>
 #include <thread>
 
+#include <glad/glad.h>
+
+#define QT_NO_OPENGL
 #include <QDesktopWidget>
 #include <QtGui>
 #include <QFileDialog>
@@ -239,6 +242,14 @@ bool GMainWindow::InitializeSystem() {
     // Shutdown previous session if the emu thread is still active...
     if (emu_thread != nullptr)
         ShutdownGame();
+
+    render_window->MakeCurrent();
+    if (!gladLoadGL()) {
+        QMessageBox::critical(this, tr("Error while starting Citra!"),
+                              tr("Failed to initialize the video core!\n\n"
+                                 "Please ensure that your GPU supports OpenGL 3.3 and that you have the latest graphics driver."));
+        return false;
+    }
 
     // Initialize the core emulation
     System::Result system_result = System::Init(render_window);

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -473,12 +473,6 @@ static void DebugHandler(GLenum source, GLenum type, GLuint id, GLenum severity,
 bool RendererOpenGL::Init() {
     render_window->MakeCurrent();
 
-    // TODO: Make frontends initialize this, so they can use gladLoadGLLoader with their own loaders
-    if (!gladLoadGL()) {
-        LOG_CRITICAL(Render_OpenGL, "Failed to initialize GL functions! Exiting...");
-        exit(-1);
-    }
-
     if (GLAD_GL_KHR_debug) {
         glEnable(GL_DEBUG_OUTPUT);
         glDebugMessageCallback(DebugHandler, nullptr);


### PR DESCRIPTION
On SDL2 this allows it to use SDL_GL_GetProcAddress() instead of the
default function loader, and fixes a crash when using apitrace with an
EGL context.

On Qt we will need to migrate from QGLWidget to QOpenGLWidget and
QOpenGLContext before we can use gladLoadGLLoader() instead of
gladLoadGL(), since the former doesn’t expose a function loader.