### PR TITLE
Shader JIT Part 2

### DIFF
--- a/src/common/x64/emitter.cpp
+++ b/src/common/x64/emitter.cpp
@@ -531,6 +531,22 @@ void XEmitter::SetJumpTarget(const FixupBranch& branch)
     }
 }
 
+void XEmitter::SetJumpTarget(const FixupBranch& branch, const u8* target)
+{
+    if (branch.type == 0)
+    {
+        s64 distance = (s64)(target - branch.ptr);
+        ASSERT_MSG(distance >= -0x80 && distance < 0x80, "Jump target too far away, needs force5Bytes = true");
+        branch.ptr[-1] = (u8)(s8)distance;
+    }
+    else if (branch.type == 1)
+    {
+        s64 distance = (s64)(target - branch.ptr);
+        ASSERT_MSG(distance >= -0x80000000LL && distance < 0x80000000LL, "Jump target too far away, needs indirect register");
+        ((s32*)branch.ptr)[-1] = (s32)distance;
+    }
+}
+
 //Single byte opcodes
 //There is no PUSHAD/POPAD in 64-bit mode.
 void XEmitter::INT3() {Write8(0xCC);}

--- a/src/common/x64/emitter.cpp
+++ b/src/common/x64/emitter.cpp
@@ -455,6 +455,18 @@ void XEmitter::CALL(const void* fnptr)
     Write32(u32(distance));
 }
 
+FixupBranch XEmitter::CALL()
+{
+    FixupBranch branch;
+    branch.type = 1;
+    branch.ptr = code + 5;
+
+    Write8(0xE8);
+    Write32(0);
+
+    return branch;
+}
+
 FixupBranch XEmitter::J(bool force5bytes)
 {
     FixupBranch branch;

--- a/src/common/x64/emitter.h
+++ b/src/common/x64/emitter.h
@@ -425,6 +425,7 @@ public:
 #undef CALL
 #endif
     void CALL(const void* fnptr);
+    FixupBranch CALL();
     void CALLptr(OpArg arg);
 
     FixupBranch J_CC(CCFlags conditionCode, bool force5bytes = false);

--- a/src/common/x64/emitter.h
+++ b/src/common/x64/emitter.h
@@ -431,6 +431,7 @@ public:
     void J_CC(CCFlags conditionCode, const u8* addr, bool force5Bytes = false);
 
     void SetJumpTarget(const FixupBranch& branch);
+    void SetJumpTarget(const FixupBranch& branch, const u8* target);
 
     void SETcc(CCFlags flag, OpArg dest);
     // Note: CMOV brings small if any benefit on current cpus.

--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -140,7 +140,7 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
                         immediate_attribute_id = 0;
 
                         Shader::UnitState<false> shader_unit;
-                        Shader::Setup(shader_unit);
+                        Shader::Setup();
 
                         if (g_debug_context)
                             g_debug_context->OnEvent(DebugContext::Event::VertexLoaded, static_cast<void*>(&immediate_input));
@@ -300,7 +300,7 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
             vertex_cache_ids.fill(-1);
 
             Shader::UnitState<false> shader_unit;
-            Shader::Setup(shader_unit);
+            Shader::Setup();
 
             for (unsigned int index = 0; index < regs.num_vertices; ++index)
             {

--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -28,15 +28,8 @@ namespace Pica {
 namespace Shader {
 
 #ifdef ARCHITECTURE_x86_64
-static std::unordered_map<u64, CompiledShader*> shader_map;
-static JitCompiler jit;
-static CompiledShader* jit_shader;
-
-static void ClearCache() {
-    shader_map.clear();
-    jit.Clear();
-    LOG_INFO(HW_GPU, "Shader JIT cache cleared");
-}
+static std::unordered_map<u64, std::unique_ptr<JitCompiler>> shader_map;
+static const JitCompiler* jit_shader;
 #endif // ARCHITECTURE_x86_64
 
 void Setup(UnitState<false>& state) {
@@ -48,16 +41,12 @@ void Setup(UnitState<false>& state) {
 
         auto iter = shader_map.find(cache_key);
         if (iter != shader_map.end()) {
-            jit_shader = iter->second;
+            jit_shader = iter->second.get();
         } else {
-            // Check if remaining JIT code space is enough for at least one more (massive) shader
-            if (jit.GetSpaceLeft() < jit_shader_size) {
-                // If not, clear the cache of all previously compiled shaders
-                ClearCache();
-            }
-
-            jit_shader = jit.Compile();
-            shader_map.emplace(cache_key, jit_shader);
+            auto shader = std::make_unique<JitCompiler>();
+            shader->Compile();
+            jit_shader = shader.get();
+            shader_map[cache_key] = std::move(shader);
         }
     }
 #endif // ARCHITECTURE_x86_64
@@ -65,7 +54,7 @@ void Setup(UnitState<false>& state) {
 
 void Shutdown() {
 #ifdef ARCHITECTURE_x86_64
-    ClearCache();
+    shader_map.clear();
 #endif // ARCHITECTURE_x86_64
 }
 
@@ -109,7 +98,7 @@ OutputVertex Run(UnitState<false>& state, const InputVertex& input, int num_attr
 
 #ifdef ARCHITECTURE_x86_64
     if (VideoCore::g_shader_jit_enabled)
-        jit_shader(&state.registers);
+        jit_shader->Run(&state.registers);
     else
         RunInterpreter(state);
 #else

--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -36,8 +36,7 @@ void Setup(UnitState<false>& state) {
 #ifdef ARCHITECTURE_x86_64
     if (VideoCore::g_shader_jit_enabled) {
         u64 cache_key = (Common::ComputeHash64(&g_state.vs.program_code, sizeof(g_state.vs.program_code)) ^
-            Common::ComputeHash64(&g_state.vs.swizzle_data, sizeof(g_state.vs.swizzle_data)) ^
-            g_state.regs.vs.main_offset);
+            Common::ComputeHash64(&g_state.vs.swizzle_data, sizeof(g_state.vs.swizzle_data)));
 
         auto iter = shader_map.find(cache_key);
         if (iter != shader_map.end()) {
@@ -98,7 +97,7 @@ OutputVertex Run(UnitState<false>& state, const InputVertex& input, int num_attr
 
 #ifdef ARCHITECTURE_x86_64
     if (VideoCore::g_shader_jit_enabled)
-        jit_shader->Run(&state.registers);
+        jit_shader->Run(&state.registers, g_state.regs.vs.main_offset);
     else
         RunInterpreter(state);
 #else

--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -32,7 +32,7 @@ static std::unordered_map<u64, std::unique_ptr<JitCompiler>> shader_map;
 static const JitCompiler* jit_shader;
 #endif // ARCHITECTURE_x86_64
 
-void Setup(UnitState<false>& state) {
+void Setup() {
 #ifdef ARCHITECTURE_x86_64
     if (VideoCore::g_shader_jit_enabled) {
         u64 cache_key = (Common::ComputeHash64(&g_state.vs.program_code, sizeof(g_state.vs.program_code)) ^

--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -28,8 +28,8 @@ namespace Pica {
 namespace Shader {
 
 #ifdef ARCHITECTURE_x86_64
-static std::unordered_map<u64, std::unique_ptr<JitCompiler>> shader_map;
-static const JitCompiler* jit_shader;
+static std::unordered_map<u64, std::unique_ptr<JitShader>> shader_map;
+static const JitShader* jit_shader;
 #endif // ARCHITECTURE_x86_64
 
 void Setup() {
@@ -42,7 +42,7 @@ void Setup() {
         if (iter != shader_map.end()) {
             jit_shader = iter->second.get();
         } else {
-            auto shader = std::make_unique<JitCompiler>();
+            auto shader = std::make_unique<JitShader>();
             shader->Compile();
             jit_shader = shader.get();
             shader_map[cache_key] = std::move(shader);

--- a/src/video_core/shader/shader.h
+++ b/src/video_core/shader/shader.h
@@ -339,9 +339,8 @@ struct UnitState {
 /**
  * Performs any shader unit setup that only needs to happen once per shader (as opposed to once per
  * vertex, which would happen within the `Run` function).
- * @param state Shader unit state, must be setup per shader and per shader unit
  */
-void Setup(UnitState<false>& state);
+void Setup();
 
 /// Performs any cleanup when the emulator is shutdown
 void Shutdown();

--- a/src/video_core/shader/shader_jit_x64.cpp
+++ b/src/video_core/shader/shader_jit_x64.cpp
@@ -741,7 +741,9 @@ void JitCompiler::Compile_Block(unsigned end) {
 void JitCompiler::Compile_NextInstr(unsigned* offset) {
     offset_ptr = offset;
 
-    Instruction instr = *(Instruction*)&g_state.vs.program_code[(*offset_ptr)++];
+    Instruction instr;
+    std::memcpy(&instr, &g_state.vs.program_code[(*offset_ptr)++], sizeof(Instruction));
+
     OpCode::Id opcode = instr.opcode.Value();
     auto instr_func = instr_table[static_cast<unsigned>(opcode)];
 

--- a/src/video_core/shader/shader_jit_x64.cpp
+++ b/src/video_core/shader/shader_jit_x64.cpp
@@ -845,6 +845,12 @@ void JitCompiler::Compile() {
         SetJumpTarget(branch.first, code_ptr[branch.second]);
     }
 
+    // Free memory that's no longer needed
+    return_offsets.clear();
+    return_offsets.shrink_to_fit();
+    fixup_branches.clear();
+    fixup_branches.shrink_to_fit();
+
     uintptr_t size = reinterpret_cast<uintptr_t>(GetCodePtr()) - reinterpret_cast<uintptr_t>(program);
     ASSERT_MSG(size <= MAX_SHADER_SIZE, "Compiled a shader that exceeds the allocated size!");
 

--- a/src/video_core/shader/shader_jit_x64.cpp
+++ b/src/video_core/shader/shader_jit_x64.cpp
@@ -677,7 +677,7 @@ void JitCompiler::Compile_MAD(Instruction instr) {
 }
 
 void JitCompiler::Compile_IF(Instruction instr) {
-    RuntimeAssert(instr.flow_control.dest_offset > last_program_counter, "Backwards if-statements not supported");
+    RuntimeAssert(instr.flow_control.dest_offset >= program_counter, "Backwards if-statements not supported");
 
     // Evaluate the "IF" condition
     if (instr.opcode.Value() == OpCode::Id::IFU) {
@@ -708,7 +708,7 @@ void JitCompiler::Compile_IF(Instruction instr) {
 }
 
 void JitCompiler::Compile_LOOP(Instruction instr) {
-    RuntimeAssert(instr.flow_control.dest_offset > last_program_counter, "Backwards loops not supported");
+    RuntimeAssert(instr.flow_control.dest_offset >= program_counter, "Backwards loops not supported");
     RuntimeAssert(!looping, "Nested loops not supported");
 
     looping = true;
@@ -770,8 +770,6 @@ void JitCompiler::Compile_Return() {
 }
 
 void JitCompiler::Compile_NextInstr() {
-    last_program_counter = program_counter;
-
     auto search = return_offsets.find(program_counter);
     if (search != return_offsets.end()) {
         Compile_Return();
@@ -839,7 +837,6 @@ void JitCompiler::Compile() {
     FindReturnOffsets();
 
     // Reset flow control state
-    last_program_counter = 0;
     program_counter = 0;
     looping = false;
     code_ptr.fill(nullptr);

--- a/src/video_core/shader/shader_jit_x64.cpp
+++ b/src/video_core/shader/shader_jit_x64.cpp
@@ -838,9 +838,7 @@ void JitCompiler::Compile() {
     fixup_branches.clear();
 
     // Jump to start of the shader program
-    if (g_state.regs.vs.main_offset != 0) {
-        fixup_branches.push_back({ J(true),  g_state.regs.vs.main_offset });
-    }
+    JMPptr(R(ABI_PARAM2));
 
     // Compile entire program
     Compile_Block(static_cast<unsigned>(g_state.vs.program_code.size()));

--- a/src/video_core/shader/shader_jit_x64.cpp
+++ b/src/video_core/shader/shader_jit_x64.cpp
@@ -151,7 +151,7 @@ static void LogCritical(const char* msg) {
     LOG_CRITICAL(HW_GPU, msg);
 }
 
-void JitShader::RuntimeAssert(bool condition, const char* msg) {
+void JitShader::Compile_Assert(bool condition, const char* msg) {
     if (!condition) {
         ABI_CallFunctionP(reinterpret_cast<const void*>(LogCritical), const_cast<char*>(msg));
     }
@@ -670,7 +670,7 @@ void JitShader::Compile_MAD(Instruction instr) {
 }
 
 void JitShader::Compile_IF(Instruction instr) {
-    RuntimeAssert(instr.flow_control.dest_offset >= program_counter, "Backwards if-statements not supported");
+    Compile_Assert(instr.flow_control.dest_offset >= program_counter, "Backwards if-statements not supported");
 
     // Evaluate the "IF" condition
     if (instr.opcode.Value() == OpCode::Id::IFU) {
@@ -701,8 +701,8 @@ void JitShader::Compile_IF(Instruction instr) {
 }
 
 void JitShader::Compile_LOOP(Instruction instr) {
-    RuntimeAssert(instr.flow_control.dest_offset >= program_counter, "Backwards loops not supported");
-    RuntimeAssert(!looping, "Nested loops not supported");
+    Compile_Assert(instr.flow_control.dest_offset >= program_counter, "Backwards loops not supported");
+    Compile_Assert(!looping, "Nested loops not supported");
 
     looping = true;
 

--- a/src/video_core/shader/shader_jit_x64.cpp
+++ b/src/video_core/shader/shader_jit_x64.cpp
@@ -20,73 +20,73 @@ namespace Shader {
 
 using namespace Gen;
 
-typedef void (JitCompiler::*JitFunction)(Instruction instr);
+typedef void (JitShader::*JitFunction)(Instruction instr);
 
 const JitFunction instr_table[64] = {
-    &JitCompiler::Compile_ADD,      // add
-    &JitCompiler::Compile_DP3,      // dp3
-    &JitCompiler::Compile_DP4,      // dp4
-    &JitCompiler::Compile_DPH,      // dph
+    &JitShader::Compile_ADD,        // add
+    &JitShader::Compile_DP3,        // dp3
+    &JitShader::Compile_DP4,        // dp4
+    &JitShader::Compile_DPH,        // dph
     nullptr,                        // unknown
-    &JitCompiler::Compile_EX2,      // ex2
-    &JitCompiler::Compile_LG2,      // lg2
+    &JitShader::Compile_EX2,        // ex2
+    &JitShader::Compile_LG2,        // lg2
     nullptr,                        // unknown
-    &JitCompiler::Compile_MUL,      // mul
-    &JitCompiler::Compile_SGE,      // sge
-    &JitCompiler::Compile_SLT,      // slt
-    &JitCompiler::Compile_FLR,      // flr
-    &JitCompiler::Compile_MAX,      // max
-    &JitCompiler::Compile_MIN,      // min
-    &JitCompiler::Compile_RCP,      // rcp
-    &JitCompiler::Compile_RSQ,      // rsq
-    nullptr,                        // unknown
-    nullptr,                        // unknown
-    &JitCompiler::Compile_MOVA,     // mova
-    &JitCompiler::Compile_MOV,      // mov
+    &JitShader::Compile_MUL,        // mul
+    &JitShader::Compile_SGE,        // sge
+    &JitShader::Compile_SLT,        // slt
+    &JitShader::Compile_FLR,        // flr
+    &JitShader::Compile_MAX,        // max
+    &JitShader::Compile_MIN,        // min
+    &JitShader::Compile_RCP,        // rcp
+    &JitShader::Compile_RSQ,        // rsq
     nullptr,                        // unknown
     nullptr,                        // unknown
-    nullptr,                        // unknown
-    nullptr,                        // unknown
-    &JitCompiler::Compile_DPH,      // dphi
-    nullptr,                        // unknown
-    &JitCompiler::Compile_SGE,      // sgei
-    &JitCompiler::Compile_SLT,      // slti
+    &JitShader::Compile_MOVA,       // mova
+    &JitShader::Compile_MOV,        // mov
     nullptr,                        // unknown
     nullptr,                        // unknown
     nullptr,                        // unknown
     nullptr,                        // unknown
+    &JitShader::Compile_DPH,        // dphi
     nullptr,                        // unknown
-    &JitCompiler::Compile_NOP,      // nop
-    &JitCompiler::Compile_END,      // end
+    &JitShader::Compile_SGE,        // sgei
+    &JitShader::Compile_SLT,        // slti
+    nullptr,                        // unknown
+    nullptr,                        // unknown
+    nullptr,                        // unknown
+    nullptr,                        // unknown
+    nullptr,                        // unknown
+    &JitShader::Compile_NOP,        // nop
+    &JitShader::Compile_END,        // end
     nullptr,                        // break
-    &JitCompiler::Compile_CALL,     // call
-    &JitCompiler::Compile_CALLC,    // callc
-    &JitCompiler::Compile_CALLU,    // callu
-    &JitCompiler::Compile_IF,       // ifu
-    &JitCompiler::Compile_IF,       // ifc
-    &JitCompiler::Compile_LOOP,     // loop
+    &JitShader::Compile_CALL,       // call
+    &JitShader::Compile_CALLC,      // callc
+    &JitShader::Compile_CALLU,      // callu
+    &JitShader::Compile_IF,         // ifu
+    &JitShader::Compile_IF,         // ifc
+    &JitShader::Compile_LOOP,       // loop
     nullptr,                        // emit
     nullptr,                        // sete
-    &JitCompiler::Compile_JMP,      // jmpc
-    &JitCompiler::Compile_JMP,      // jmpu
-    &JitCompiler::Compile_CMP,      // cmp
-    &JitCompiler::Compile_CMP,      // cmp
-    &JitCompiler::Compile_MAD,      // madi
-    &JitCompiler::Compile_MAD,      // madi
-    &JitCompiler::Compile_MAD,      // madi
-    &JitCompiler::Compile_MAD,      // madi
-    &JitCompiler::Compile_MAD,      // madi
-    &JitCompiler::Compile_MAD,      // madi
-    &JitCompiler::Compile_MAD,      // madi
-    &JitCompiler::Compile_MAD,      // madi
-    &JitCompiler::Compile_MAD,      // mad
-    &JitCompiler::Compile_MAD,      // mad
-    &JitCompiler::Compile_MAD,      // mad
-    &JitCompiler::Compile_MAD,      // mad
-    &JitCompiler::Compile_MAD,      // mad
-    &JitCompiler::Compile_MAD,      // mad
-    &JitCompiler::Compile_MAD,      // mad
-    &JitCompiler::Compile_MAD,      // mad
+    &JitShader::Compile_JMP,        // jmpc
+    &JitShader::Compile_JMP,        // jmpu
+    &JitShader::Compile_CMP,        // cmp
+    &JitShader::Compile_CMP,        // cmp
+    &JitShader::Compile_MAD,        // madi
+    &JitShader::Compile_MAD,        // madi
+    &JitShader::Compile_MAD,        // madi
+    &JitShader::Compile_MAD,        // madi
+    &JitShader::Compile_MAD,        // madi
+    &JitShader::Compile_MAD,        // madi
+    &JitShader::Compile_MAD,        // madi
+    &JitShader::Compile_MAD,        // madi
+    &JitShader::Compile_MAD,        // mad
+    &JitShader::Compile_MAD,        // mad
+    &JitShader::Compile_MAD,        // mad
+    &JitShader::Compile_MAD,        // mad
+    &JitShader::Compile_MAD,        // mad
+    &JitShader::Compile_MAD,        // mad
+    &JitShader::Compile_MAD,        // mad
+    &JitShader::Compile_MAD,        // mad
 };
 
 // The following is used to alias some commonly used registers. Generally, RAX-RDX and XMM0-XMM3 can
@@ -151,7 +151,7 @@ static void LogCritical(const char* msg) {
     LOG_CRITICAL(HW_GPU, msg);
 }
 
-void JitCompiler::RuntimeAssert(bool condition, const char* msg) {
+void JitShader::RuntimeAssert(bool condition, const char* msg) {
     if (!condition) {
         ABI_CallFunctionP(reinterpret_cast<const void*>(LogCritical), const_cast<char*>(msg));
     }
@@ -164,7 +164,7 @@ void JitCompiler::RuntimeAssert(bool condition, const char* msg) {
  * @param src_reg SourceRegister object corresponding to the source register to load
  * @param dest Destination XMM register to store the loaded, swizzled source register
  */
-void JitCompiler::Compile_SwizzleSrc(Instruction instr, unsigned src_num, SourceRegister src_reg, X64Reg dest) {
+void JitShader::Compile_SwizzleSrc(Instruction instr, unsigned src_num, SourceRegister src_reg, X64Reg dest) {
     X64Reg src_ptr;
     size_t src_offset;
 
@@ -236,7 +236,7 @@ void JitCompiler::Compile_SwizzleSrc(Instruction instr, unsigned src_num, Source
     }
 }
 
-void JitCompiler::Compile_DestEnable(Instruction instr,X64Reg src) {
+void JitShader::Compile_DestEnable(Instruction instr,X64Reg src) {
     DestRegister dest;
     unsigned operand_desc_id;
     if (instr.opcode.Value().EffectiveOpCode() == OpCode::Id::MAD ||
@@ -283,7 +283,7 @@ void JitCompiler::Compile_DestEnable(Instruction instr,X64Reg src) {
     }
 }
 
-void JitCompiler::Compile_SanitizedMul(Gen::X64Reg src1, Gen::X64Reg src2, Gen::X64Reg scratch) {
+void JitShader::Compile_SanitizedMul(Gen::X64Reg src1, Gen::X64Reg src2, Gen::X64Reg scratch) {
     MOVAPS(scratch, R(src1));
     CMPPS(scratch, R(src2), CMP_ORD);
 
@@ -296,7 +296,7 @@ void JitCompiler::Compile_SanitizedMul(Gen::X64Reg src1, Gen::X64Reg src2, Gen::
     ANDPS(src1, R(scratch));
 }
 
-void JitCompiler::Compile_EvaluateCondition(Instruction instr) {
+void JitShader::Compile_EvaluateCondition(Instruction instr) {
     // Note: NXOR is used below to check for equality
     switch (instr.flow_control.op) {
     case Instruction::FlowControlType::Or:
@@ -327,23 +327,23 @@ void JitCompiler::Compile_EvaluateCondition(Instruction instr) {
     }
 }
 
-void JitCompiler::Compile_UniformCondition(Instruction instr) {
+void JitShader::Compile_UniformCondition(Instruction instr) {
     int offset = offsetof(decltype(g_state.vs.uniforms), b) + (instr.flow_control.bool_uniform_id * sizeof(bool));
     CMP(sizeof(bool) * 8, MDisp(UNIFORMS, offset), Imm8(0));
 }
 
-BitSet32 JitCompiler::PersistentCallerSavedRegs() {
+BitSet32 JitShader::PersistentCallerSavedRegs() {
     return persistent_regs & ABI_ALL_CALLER_SAVED;
 }
 
-void JitCompiler::Compile_ADD(Instruction instr) {
+void JitShader::Compile_ADD(Instruction instr) {
     Compile_SwizzleSrc(instr, 1, instr.common.src1, SRC1);
     Compile_SwizzleSrc(instr, 2, instr.common.src2, SRC2);
     ADDPS(SRC1, R(SRC2));
     Compile_DestEnable(instr, SRC1);
 }
 
-void JitCompiler::Compile_DP3(Instruction instr) {
+void JitShader::Compile_DP3(Instruction instr) {
     Compile_SwizzleSrc(instr, 1, instr.common.src1, SRC1);
     Compile_SwizzleSrc(instr, 2, instr.common.src2, SRC2);
 
@@ -362,7 +362,7 @@ void JitCompiler::Compile_DP3(Instruction instr) {
     Compile_DestEnable(instr, SRC1);
 }
 
-void JitCompiler::Compile_DP4(Instruction instr) {
+void JitShader::Compile_DP4(Instruction instr) {
     Compile_SwizzleSrc(instr, 1, instr.common.src1, SRC1);
     Compile_SwizzleSrc(instr, 2, instr.common.src2, SRC2);
 
@@ -379,7 +379,7 @@ void JitCompiler::Compile_DP4(Instruction instr) {
     Compile_DestEnable(instr, SRC1);
 }
 
-void JitCompiler::Compile_DPH(Instruction instr) {
+void JitShader::Compile_DPH(Instruction instr) {
     if (instr.opcode.Value().EffectiveOpCode() == OpCode::Id::DPHI) {
         Compile_SwizzleSrc(instr, 1, instr.common.src1i, SRC1);
         Compile_SwizzleSrc(instr, 2, instr.common.src2i, SRC2);
@@ -411,7 +411,7 @@ void JitCompiler::Compile_DPH(Instruction instr) {
     Compile_DestEnable(instr, SRC1);
 }
 
-void JitCompiler::Compile_EX2(Instruction instr) {
+void JitShader::Compile_EX2(Instruction instr) {
     Compile_SwizzleSrc(instr, 1, instr.common.src1, SRC1);
     MOVSS(XMM0, R(SRC1));
 
@@ -424,7 +424,7 @@ void JitCompiler::Compile_EX2(Instruction instr) {
     Compile_DestEnable(instr, SRC1);
 }
 
-void JitCompiler::Compile_LG2(Instruction instr) {
+void JitShader::Compile_LG2(Instruction instr) {
     Compile_SwizzleSrc(instr, 1, instr.common.src1, SRC1);
     MOVSS(XMM0, R(SRC1));
 
@@ -437,14 +437,14 @@ void JitCompiler::Compile_LG2(Instruction instr) {
     Compile_DestEnable(instr, SRC1);
 }
 
-void JitCompiler::Compile_MUL(Instruction instr) {
+void JitShader::Compile_MUL(Instruction instr) {
     Compile_SwizzleSrc(instr, 1, instr.common.src1, SRC1);
     Compile_SwizzleSrc(instr, 2, instr.common.src2, SRC2);
     Compile_SanitizedMul(SRC1, SRC2, SCRATCH);
     Compile_DestEnable(instr, SRC1);
 }
 
-void JitCompiler::Compile_SGE(Instruction instr) {
+void JitShader::Compile_SGE(Instruction instr) {
     if (instr.opcode.Value().EffectiveOpCode() == OpCode::Id::SGEI) {
         Compile_SwizzleSrc(instr, 1, instr.common.src1i, SRC1);
         Compile_SwizzleSrc(instr, 2, instr.common.src2i, SRC2);
@@ -459,7 +459,7 @@ void JitCompiler::Compile_SGE(Instruction instr) {
     Compile_DestEnable(instr, SRC2);
 }
 
-void JitCompiler::Compile_SLT(Instruction instr) {
+void JitShader::Compile_SLT(Instruction instr) {
     if (instr.opcode.Value().EffectiveOpCode() == OpCode::Id::SLTI) {
         Compile_SwizzleSrc(instr, 1, instr.common.src1i, SRC1);
         Compile_SwizzleSrc(instr, 2, instr.common.src2i, SRC2);
@@ -474,7 +474,7 @@ void JitCompiler::Compile_SLT(Instruction instr) {
     Compile_DestEnable(instr, SRC1);
 }
 
-void JitCompiler::Compile_FLR(Instruction instr) {
+void JitShader::Compile_FLR(Instruction instr) {
     Compile_SwizzleSrc(instr, 1, instr.common.src1, SRC1);
 
     if (Common::GetCPUCaps().sse4_1) {
@@ -487,7 +487,7 @@ void JitCompiler::Compile_FLR(Instruction instr) {
     Compile_DestEnable(instr, SRC1);
 }
 
-void JitCompiler::Compile_MAX(Instruction instr) {
+void JitShader::Compile_MAX(Instruction instr) {
     Compile_SwizzleSrc(instr, 1, instr.common.src1, SRC1);
     Compile_SwizzleSrc(instr, 2, instr.common.src2, SRC2);
     // SSE semantics match PICA200 ones: In case of NaN, SRC2 is returned.
@@ -495,7 +495,7 @@ void JitCompiler::Compile_MAX(Instruction instr) {
     Compile_DestEnable(instr, SRC1);
 }
 
-void JitCompiler::Compile_MIN(Instruction instr) {
+void JitShader::Compile_MIN(Instruction instr) {
     Compile_SwizzleSrc(instr, 1, instr.common.src1, SRC1);
     Compile_SwizzleSrc(instr, 2, instr.common.src2, SRC2);
     // SSE semantics match PICA200 ones: In case of NaN, SRC2 is returned.
@@ -503,7 +503,7 @@ void JitCompiler::Compile_MIN(Instruction instr) {
     Compile_DestEnable(instr, SRC1);
 }
 
-void JitCompiler::Compile_MOVA(Instruction instr) {
+void JitShader::Compile_MOVA(Instruction instr) {
     SwizzlePattern swiz = { g_state.vs.swizzle_data[instr.common.operand_desc_id] };
 
     if (!swiz.DestComponentEnabled(0) && !swiz.DestComponentEnabled(1)) {
@@ -548,12 +548,12 @@ void JitCompiler::Compile_MOVA(Instruction instr) {
     }
 }
 
-void JitCompiler::Compile_MOV(Instruction instr) {
+void JitShader::Compile_MOV(Instruction instr) {
     Compile_SwizzleSrc(instr, 1, instr.common.src1, SRC1);
     Compile_DestEnable(instr, SRC1);
 }
 
-void JitCompiler::Compile_RCP(Instruction instr) {
+void JitShader::Compile_RCP(Instruction instr) {
     Compile_SwizzleSrc(instr, 1, instr.common.src1, SRC1);
 
     // TODO(bunnei): RCPSS is a pretty rough approximation, this might cause problems if Pica
@@ -564,7 +564,7 @@ void JitCompiler::Compile_RCP(Instruction instr) {
     Compile_DestEnable(instr, SRC1);
 }
 
-void JitCompiler::Compile_RSQ(Instruction instr) {
+void JitShader::Compile_RSQ(Instruction instr) {
     Compile_SwizzleSrc(instr, 1, instr.common.src1, SRC1);
 
     // TODO(bunnei): RSQRTSS is a pretty rough approximation, this might cause problems if Pica
@@ -575,15 +575,15 @@ void JitCompiler::Compile_RSQ(Instruction instr) {
     Compile_DestEnable(instr, SRC1);
 }
 
-void JitCompiler::Compile_NOP(Instruction instr) {
+void JitShader::Compile_NOP(Instruction instr) {
 }
 
-void JitCompiler::Compile_END(Instruction instr) {
+void JitShader::Compile_END(Instruction instr) {
     ABI_PopRegistersAndAdjustStack(ABI_ALL_CALLEE_SAVED, 8);
     RET();
 }
 
-void JitCompiler::Compile_CALL(Instruction instr) {
+void JitShader::Compile_CALL(Instruction instr) {
     // Push offset of the return
     PUSH(64, Imm32(instr.flow_control.dest_offset + instr.flow_control.num_instructions));
 
@@ -595,21 +595,21 @@ void JitCompiler::Compile_CALL(Instruction instr) {
     ADD(64, R(RSP), Imm32(8));
 }
 
-void JitCompiler::Compile_CALLC(Instruction instr) {
+void JitShader::Compile_CALLC(Instruction instr) {
     Compile_EvaluateCondition(instr);
     FixupBranch b = J_CC(CC_Z, true);
     Compile_CALL(instr);
     SetJumpTarget(b);
 }
 
-void JitCompiler::Compile_CALLU(Instruction instr) {
+void JitShader::Compile_CALLU(Instruction instr) {
     Compile_UniformCondition(instr);
     FixupBranch b = J_CC(CC_Z, true);
     Compile_CALL(instr);
     SetJumpTarget(b);
 }
 
-void JitCompiler::Compile_CMP(Instruction instr) {
+void JitShader::Compile_CMP(Instruction instr) {
     using Op = Instruction::Common::CompareOpType::Op;
     Op op_x = instr.common.compare_op.x;
     Op op_y = instr.common.compare_op.y;
@@ -652,7 +652,7 @@ void JitCompiler::Compile_CMP(Instruction instr) {
     SHR(64, R(COND1), Imm8(63));
 }
 
-void JitCompiler::Compile_MAD(Instruction instr) {
+void JitShader::Compile_MAD(Instruction instr) {
     Compile_SwizzleSrc(instr, 1, instr.mad.src1, SRC1);
 
     if (instr.opcode.Value().EffectiveOpCode() == OpCode::Id::MADI) {
@@ -669,7 +669,7 @@ void JitCompiler::Compile_MAD(Instruction instr) {
     Compile_DestEnable(instr, SRC1);
 }
 
-void JitCompiler::Compile_IF(Instruction instr) {
+void JitShader::Compile_IF(Instruction instr) {
     RuntimeAssert(instr.flow_control.dest_offset >= program_counter, "Backwards if-statements not supported");
 
     // Evaluate the "IF" condition
@@ -700,7 +700,7 @@ void JitCompiler::Compile_IF(Instruction instr) {
     SetJumpTarget(b2);
 }
 
-void JitCompiler::Compile_LOOP(Instruction instr) {
+void JitShader::Compile_LOOP(Instruction instr) {
     RuntimeAssert(instr.flow_control.dest_offset >= program_counter, "Backwards loops not supported");
     RuntimeAssert(!looping, "Nested loops not supported");
 
@@ -728,7 +728,7 @@ void JitCompiler::Compile_LOOP(Instruction instr) {
     looping = false;
 }
 
-void JitCompiler::Compile_JMP(Instruction instr) {
+void JitShader::Compile_JMP(Instruction instr) {
     if (instr.opcode.Value() == OpCode::Id::JMPC)
         Compile_EvaluateCondition(instr);
     else if (instr.opcode.Value() == OpCode::Id::JMPU)
@@ -743,13 +743,13 @@ void JitCompiler::Compile_JMP(Instruction instr) {
     fixup_branches.push_back({ b, instr.flow_control.dest_offset });
 }
 
-void JitCompiler::Compile_Block(unsigned end) {
+void JitShader::Compile_Block(unsigned end) {
     while (program_counter < end) {
         Compile_NextInstr();
     }
 }
 
-void JitCompiler::Compile_Return() {
+void JitShader::Compile_Return() {
     // Peek return offset on the stack and check if we're at that offset
     MOV(64, R(RAX), MDisp(RSP, 8));
     CMP(32, R(RAX), Imm32(program_counter));
@@ -760,7 +760,7 @@ void JitCompiler::Compile_Return() {
     SetJumpTarget(b);
 }
 
-void JitCompiler::Compile_NextInstr() {
+void JitShader::Compile_NextInstr() {
     if (std::binary_search(return_offsets.begin(), return_offsets.end(), program_counter)) {
         Compile_Return();
     }
@@ -783,7 +783,7 @@ void JitCompiler::Compile_NextInstr() {
     }
 }
 
-void JitCompiler::FindReturnOffsets() {
+void JitShader::FindReturnOffsets() {
     return_offsets.clear();
 
     for (size_t offset = 0; offset < g_state.vs.program_code.size(); ++offset) {
@@ -802,7 +802,7 @@ void JitCompiler::FindReturnOffsets() {
     std::sort(return_offsets.begin(), return_offsets.end());
 }
 
-void JitCompiler::Compile() {
+void JitShader::Compile() {
     // Reset flow control state
     program = (CompiledShader*)GetCodePtr();
     program_counter = 0;
@@ -857,7 +857,7 @@ void JitCompiler::Compile() {
     LOG_DEBUG(HW_GPU, "Compiled shader size=%d", size);
 }
 
-JitCompiler::JitCompiler() {
+JitShader::JitShader() {
     AllocCodeSpace(MAX_SHADER_SIZE);
 }
 

--- a/src/video_core/shader/shader_jit_x64.h
+++ b/src/video_core/shader/shader_jit_x64.h
@@ -94,7 +94,7 @@ private:
      * Assertion evaluated at compile-time, but only triggered if executed at runtime.
      * @param msg Message to be logged if the assertion fails.
      */
-    void RuntimeAssert(bool condition, const char* msg);
+    void Compile_Assert(bool condition, const char* msg);
 
     /**
      * Analyzes the entire shader program for `CALL` instructions before emitting any code,

--- a/src/video_core/shader/shader_jit_x64.h
+++ b/src/video_core/shader/shader_jit_x64.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include <set>
 #include <utility>
+#include <vector>
 
 #include <nihstro/shader_bytecode.h>
 
@@ -106,7 +106,7 @@ private:
     std::array<const u8*, 1024> code_ptr;
 
     /// Offsets in code where a return needs to be inserted
-    std::set<unsigned> return_offsets;
+    std::vector<unsigned> return_offsets;
 
     unsigned program_counter = 0;       ///< Offset of the next instruction to decode
     bool looping = false;               ///< True if compiling a loop, used to check for nested loops

--- a/src/video_core/shader/shader_jit_x64.h
+++ b/src/video_core/shader/shader_jit_x64.h
@@ -108,7 +108,6 @@ private:
     /// Offsets in code where a return needs to be inserted
     std::set<unsigned> return_offsets;
 
-    unsigned last_program_counter = 0;  ///< Offset of the most recent instruction decoded
     unsigned program_counter = 0;       ///< Offset of the next instruction to decode
     bool looping = false;               ///< True if compiling a loop, used to check for nested loops
 

--- a/src/video_core/shader/shader_jit_x64.h
+++ b/src/video_core/shader/shader_jit_x64.h
@@ -29,9 +29,9 @@ constexpr size_t MAX_SHADER_SIZE = 1024 * 64;
  * This class implements the shader JIT compiler. It recompiles a Pica shader program into x86_64
  * code that can be executed on the host machine directly.
  */
-class JitCompiler : public Gen::XCodeBlock {
+class JitShader : public Gen::XCodeBlock {
 public:
-    JitCompiler();
+    JitShader();
 
     void Run(void* registers, unsigned offset) const {
         program(registers, code_ptr[offset]);

--- a/src/video_core/shader/shader_jit_x64.h
+++ b/src/video_core/shader/shader_jit_x64.h
@@ -91,6 +91,12 @@ private:
     BitSet32 PersistentCallerSavedRegs();
 
     /**
+     * Assertion evaluated at compile-time, but only triggered if executed at runtime.
+     * @param msg Message to be logged if the assertion fails.
+     */
+    void RuntimeAssert(bool condition, const char* msg);
+
+    /**
      * Analyzes the entire shader program for `CALL` instructions before emitting any code,
      * identifying the locations where a return needs to be inserted.
      */

--- a/src/video_core/shader/shader_jit_x64.h
+++ b/src/video_core/shader/shader_jit_x64.h
@@ -25,8 +25,6 @@ namespace Shader {
 /// Memory allocated for each compiled shader (64Kb)
 constexpr size_t MAX_SHADER_SIZE = 1024 * 64;
 
-using CompiledShader = void(void* registers);
-
 /**
  * This class implements the shader JIT compiler. It recompiles a Pica shader program into x86_64
  * code that can be executed on the host machine directly.
@@ -35,8 +33,8 @@ class JitCompiler : public Gen::XCodeBlock {
 public:
     JitCompiler();
 
-    void Run(void* registers) const {
-        program(registers);
+    void Run(void* registers, unsigned offset) const {
+        program(registers, code_ptr[offset]);
     }
 
     void Compile();
@@ -111,6 +109,7 @@ private:
     /// Branches that need to be fixed up once the entire shader program is compiled
     std::vector<std::pair<Gen::FixupBranch, unsigned>> fixup_branches;
 
+    using CompiledShader = void(void* registers, const u8* start_addr);
     CompiledShader* program = nullptr;
 };
 


### PR DESCRIPTION
Specifically, this is a new and improved implementation of flow control for the shader JIT. Previously, the shader JIT inlined CALL and JMP instructions. This had several issues: 1) Inlining all subroutines resulted in bloated shaders being generated, and 2) JMP to arbitrary addresses (and nested jumps) couldn't be supported.

With these changes, any arbitrary CALL/JMP will now work. Furthermore, this results in pretty constant compiled shader sizes of around ~40kb, so I changed allocation to happen on the fly (preventing cache clearing and recompiling of previously compiled shaders).

The changes in this patch could also be leveraged to support arbitrary (read: wacky) IF and LOOP instructions... But I didn't feel like doing this, particularly because these instructions in the JIT are a bit finicky and are already well vetted, and also AFAIK no game uses IF/LOOP in a way that the JIT didn't already support (mainly: backwards)

Fixes #1293
Fixes #1402