### PR TITLE
Fix missing header

### DIFF
--- a/src/core/gdbstub/gdbstub.h
+++ b/src/core/gdbstub/gdbstub.h
@@ -7,6 +7,8 @@
 #pragma once
 #include <atomic>
 
+#include "common/common_types.h"
+
 namespace GDBStub {
 
 /// Breakpoint Method


### PR DESCRIPTION
gdbstub.h could not be used without including common_types.h as noticed in PR #1368 