### PR TITLE
PICA: Use VS config to get immediate mode attribute count

### DIFF
--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -131,14 +131,17 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
 
                     immediate_input.attr[immediate_attribute_id++] = attribute;
 
-                    if (immediate_attribute_id >= attribute_config.GetNumTotalAttributes()) {
+                    if (immediate_attribute_id >= g_state.regs.vs.GetNumTotalAttributes()) {
                         immediate_attribute_id = 0;
 
                         Shader::UnitState<false> shader_unit;
                         Shader::Setup(shader_unit);
 
+                        if (g_debug_context)
+                            g_debug_context->OnEvent(DebugContext::Event::VertexLoaded, (void*)&immediate_input);
+
                         // Send to vertex shader
-                        Shader::OutputVertex output = Shader::Run(shader_unit, immediate_input, attribute_config.GetNumTotalAttributes());
+                        Shader::OutputVertex output = Shader::Run(shader_unit, immediate_input, g_state.regs.vs.GetNumTotalAttributes());
 
                         // Send to renderer
                         using Pica::Shader::OutputVertex;

--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -985,6 +985,7 @@ struct Regs {
             return (id >= 12) || (attribute_mask & (1ULL << id)) != 0;
         }
 
+        // The number of attributes loaded from the vertex buffer
         inline int GetNumTotalAttributes() const {
             return (int)num_extra_attributes+1;
         }
@@ -1123,7 +1124,17 @@ struct Regs {
             BitField<24, 8, u32> w;
         } int_uniforms[4];
 
-        INSERT_PADDING_WORDS(0x5);
+        INSERT_PADDING_WORDS(0x4);
+
+        union {
+            BitField<0, 4, u32> input_vertex_attributes;
+            //TODO: Geometry Shader fields
+        };
+
+        // Number of fixed attributes + loaded from vertex buffer (or immediate buffer) ?
+        inline int GetNumTotalAttributes() const {
+            return (int)input_vertex_attributes+1;
+        }
 
         // Offset to shader program entry point (in words)
         BitField<0, 16, u32> main_offset;
@@ -1292,6 +1303,7 @@ ASSERT_REG_POSITION(triangle_topology, 0x25e);
 ASSERT_REG_POSITION(restart_primitive, 0x25f);
 ASSERT_REG_POSITION(gs, 0x280);
 ASSERT_REG_POSITION(vs, 0x2b0);
+ASSERT_REG_POSITION(vs.input_vertex_attributes, 0x2b9);
 
 #undef ASSERT_REG_POSITION
 #endif // !defined(_MSC_VER)


### PR DESCRIPTION
Fixes Crazy Kangaroo ([Looked like this](http://i.imgur.com/KPT8ixe.png)) - and hopefully more

Needs regression testing (Only with games which use immediate mode!)

**Source of problem:**
`attribute_config.GetNumTotalAttributes()` returns 1 for Crazy Kangaroo (meaning the register has a value of 0). The game uses 3 attributes in the VS (o0, o1, o2), but the game still uploads 4 attributes (= 4 * 3 registers). This was easily observed by looking at the CMD list.

**Possible reason**
I believe `attribute_config.GetNumTotalAttributes()` only indicates how many vertex attributes are loaded from the vertex buffer (= excluding fixed attributes and only when vertex buffers are in use).
\- The newly introduced shader config however should tells us how many attributes in total (= fixed + from buffer) are loaded by the shader. The game configures the VS input register to 3 (= total attributes 4).
There might be another register which sets the immediate attribute output count but I couldn't find it yet (and it would most likely match the VS input value).

Chances are the `attribute_config.GetNumTotalAttributes()` also breaks games which use vertex buffers together with fixed attributes. This PR only changes it for immediate mode as no problems could be confirmed in games using vertex buffers (yet).

This all came from observation. Though [3dbrew also has the shader config register](https://www.3dbrew.org/wiki/GPU/Internal_Registers#GPUREG_SH_INPUTBUFFER_CONFIG).

**Fixed**
![Menu](http://i.imgur.com/jaerlC2.png)
[More screenshots](http://imgur.com/a/iZEj6) (HW renderer has some issues with this game, unrelated to PR)