### PR TITLE
hle: Get rid of direct global access to g_reschedule

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -52,7 +52,7 @@ void RunLoop(int tight_loop) {
     }
 
     HW::Update();
-    if (HLE::g_reschedule) {
+    if (HLE::RescheduleIsPending()) {
         Kernel::Reschedule();
     }
 }

--- a/src/core/hle/hle.cpp
+++ b/src/core/hle/hle.cpp
@@ -14,9 +14,13 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-namespace HLE {
+namespace {
 
-bool g_reschedule; ///< If true, immediately reschedules the CPU to a new thread
+bool reschedule; ///< If true, immediately reschedules the CPU to a new thread
+
+}
+
+namespace HLE {
 
 void Reschedule(const char *reason) {
     DEBUG_ASSERT_MSG(reason != nullptr && strlen(reason) < 256, "Reschedule: Invalid or too long reason.");
@@ -29,13 +33,21 @@ void Reschedule(const char *reason) {
 
     Core::g_app_core->PrepareReschedule();
 
-    g_reschedule = true;
+    reschedule = true;
+}
+
+bool RescheduleIsPending() {
+    return reschedule;
+}
+
+void DoneRescheduling() {
+    reschedule = false;
 }
 
 void Init() {
     Service::Init();
 
-    g_reschedule = false;
+    reschedule = false;
 
     LOG_DEBUG(Kernel, "initialized OK");
 }

--- a/src/core/hle/hle.h
+++ b/src/core/hle/hle.h
@@ -13,9 +13,9 @@ const Handle INVALID_HANDLE = 0;
 
 namespace HLE {
 
-extern bool g_reschedule;   ///< If true, immediately reschedules the CPU to a new thread
-
 void Reschedule(const char *reason);
+bool RescheduleIsPending();
+void DoneRescheduling();
 
 void Init();
 void Shutdown();

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -483,7 +483,8 @@ void Reschedule() {
 
     Thread* cur = GetCurrentThread();
     Thread* next = PopNextReadyThread();
-    HLE::g_reschedule = false;
+
+    HLE::DoneRescheduling();
 
     // Don't bother switching to the same thread
     if (next == cur)


### PR DESCRIPTION
This shouldn't be directly exposed if there's already a partial API that operates on it.
We can just provide the rest of said API.