### PR TITLE
Fix ftoi and disable VFPv3

### DIFF
--- a/src/core/arm/dyncom/arm_dyncom_dec.cpp
+++ b/src/core/arm/dyncom/arm_dyncom_dec.cpp
@@ -422,6 +422,10 @@ ARMDecodeStatus DecodeARMInstruction(u32 instr, s32* idx) {
         n = arm_instruction[i].attribute_value;
         base = 0;
 
+        // 3DS has no VFP3 support
+        if (arm_instruction[i].version == ARMVFP3)
+            continue;
+
         while (n) {
             if (arm_instruction[i].content[base + 1] == 31 && arm_instruction[i].content[base] == 0) {
                 // clrex

--- a/src/core/arm/skyeye_common/vfp/vfpdouble.cpp
+++ b/src/core/arm/skyeye_common/vfp/vfpdouble.cpp
@@ -615,7 +615,7 @@ static u32 vfp_double_ftoui(ARMul_State* state, int sd, int unused, int dm, u32 
 static u32 vfp_double_ftouiz(ARMul_State* state, int sd, int unused, int dm, u32 fpscr)
 {
     LOG_TRACE(Core_ARM11, "In %s", __FUNCTION__);
-    return vfp_double_ftoui(state, sd, unused, dm, FPSCR_ROUND_TOZERO);
+    return vfp_double_ftoui(state, sd, unused, dm, (fpscr & ~FPSCR_RMODE_MASK) | FPSCR_ROUND_TOZERO);
 }
 
 static u32 vfp_double_ftosi(ARMul_State* state, int sd, int unused, int dm, u32 fpscr)
@@ -692,7 +692,7 @@ static u32 vfp_double_ftosi(ARMul_State* state, int sd, int unused, int dm, u32 
 static u32 vfp_double_ftosiz(ARMul_State* state, int dd, int unused, int dm, u32 fpscr)
 {
     LOG_TRACE(Core_ARM11, "In %s", __FUNCTION__);
-    return vfp_double_ftosi(state, dd, unused, dm, FPSCR_ROUND_TOZERO);
+    return vfp_double_ftosi(state, dd, unused, dm, (fpscr & ~FPSCR_RMODE_MASK) | FPSCR_ROUND_TOZERO);
 }
 
 static struct op fops_ext[] = {

--- a/src/core/arm/skyeye_common/vfp/vfpdouble.cpp
+++ b/src/core/arm/skyeye_common/vfp/vfpdouble.cpp
@@ -560,7 +560,7 @@ static u32 vfp_double_ftoui(ARMul_State* state, int sd, int unused, int dm, u32 
     if (vdm.exponent >= 1023 + 32) {
         d = vdm.sign ? 0 : 0xffffffff;
         exceptions = FPSCR_IOC;
-    } else if (vdm.exponent >= 1023 - 1) {
+    } else if (vdm.exponent >= 1023) {
         int shift = 1023 + 63 - vdm.exponent;
         u64 rem, incr = 0;
 
@@ -595,12 +595,20 @@ static u32 vfp_double_ftoui(ARMul_State* state, int sd, int unused, int dm, u32 
     } else {
         d = 0;
         if (vdm.exponent | vdm.significand) {
-            exceptions |= FPSCR_IXC;
-            if (rmode == FPSCR_ROUND_PLUSINF && vdm.sign == 0)
+            if (rmode == FPSCR_ROUND_NEAREST) {
+                if (vdm.exponent >= 1022) {
+                    d = vdm.sign ? 0 : 1;
+                    exceptions |= vdm.sign ? FPSCR_IOC : FPSCR_IXC;
+                } else {
+                    exceptions |= FPSCR_IXC;
+                }
+            } else if (rmode == FPSCR_ROUND_PLUSINF && vdm.sign == 0) {
                 d = 1;
-            else if (rmode == FPSCR_ROUND_MINUSINF && vdm.sign) {
-                d = 0;
-                exceptions |= FPSCR_IOC;
+                exceptions |= FPSCR_IXC;
+            } else if (rmode == FPSCR_ROUND_MINUSINF) {
+                exceptions |= vdm.sign ? FPSCR_IOC : FPSCR_IXC;
+            } else {
+                exceptions |= FPSCR_IXC;
             }
         }
     }
@@ -639,12 +647,12 @@ static u32 vfp_double_ftosi(ARMul_State* state, int sd, int unused, int dm, u32 
     if (tm & VFP_NAN) {
         d = 0;
         exceptions |= FPSCR_IOC;
-    } else if (vdm.exponent >= 1023 + 32) {
+    } else if (vdm.exponent >= 1023 + 31) {
         d = 0x7fffffff;
         if (vdm.sign)
             d = ~d;
         exceptions |= FPSCR_IOC;
-    } else if (vdm.exponent >= 1023 - 1) {
+    } else if (vdm.exponent >= 1023) {
         int shift = 1023 + 63 - vdm.exponent;	/* 58 */
         u64 rem, incr = 0;
 
@@ -675,10 +683,17 @@ static u32 vfp_double_ftosi(ARMul_State* state, int sd, int unused, int dm, u32 
         d = 0;
         if (vdm.exponent | vdm.significand) {
             exceptions |= FPSCR_IXC;
-            if (rmode == FPSCR_ROUND_PLUSINF && vdm.sign == 0)
+            if (rmode == FPSCR_ROUND_NEAREST) {
+                if (vdm.exponent >= 1022) {
+                    d = vdm.sign ? 0xffffffff : 1;
+                } else {
+                    d = 0;
+                }
+            } else if (rmode == FPSCR_ROUND_PLUSINF && vdm.sign == 0) {
                 d = 1;
-            else if (rmode == FPSCR_ROUND_MINUSINF && vdm.sign)
-                d = -1;
+            } else if (rmode == FPSCR_ROUND_MINUSINF && vdm.sign) {
+                d = 0xffffffff;
+            }
         }
     }
 

--- a/src/core/arm/skyeye_common/vfp/vfpsingle.cpp
+++ b/src/core/arm/skyeye_common/vfp/vfpsingle.cpp
@@ -638,7 +638,7 @@ static u32 vfp_single_ftoui(ARMul_State* state, int sd, int unused, s32 m, u32 f
 
 static u32 vfp_single_ftouiz(ARMul_State* state, int sd, int unused, s32 m, u32 fpscr)
 {
-    return vfp_single_ftoui(state, sd, unused, m, FPSCR_ROUND_TOZERO);
+    return vfp_single_ftoui(state, sd, unused, m, (fpscr & ~FPSCR_RMODE_MASK) | FPSCR_ROUND_TOZERO);
 }
 
 static u32 vfp_single_ftosi(ARMul_State* state, int sd, int unused, s32 m, u32 fpscr)
@@ -717,7 +717,7 @@ static u32 vfp_single_ftosi(ARMul_State* state, int sd, int unused, s32 m, u32 f
 
 static u32 vfp_single_ftosiz(ARMul_State* state, int sd, int unused, s32 m, u32 fpscr)
 {
-    return vfp_single_ftosi(state, sd, unused, m, FPSCR_ROUND_TOZERO);
+    return vfp_single_ftosi(state, sd, unused, m, (fpscr & ~FPSCR_RMODE_MASK) | FPSCR_ROUND_TOZERO);
 }
 
 static struct op fops_ext[] = {


### PR DESCRIPTION
This fixes the printf bug (which is actually a bug in "dtoa")
The buggy code is:
```C
ds = (d2.d - 1.5) * 0.289529654602168 + 0.1760912590558 + i * 0.301029995663981;
k = (int) ds;
```
Example values were 0x3ff999999999999a for d2.d (double) and int i = -3.
When ds is -0.6, k would currently be 0x80000000 when 0 is expected (suggested by running dtoa on my x64).

Changing the 2 lines from `if (vdm.exponent >= 1023 - 1)` to just 1023 makes printf work fine (I think?) but I didn't really test it much.
You can find [similar code in qemu](https://github.com/qemu/qemu/blob/master/fpu/softfloat.c#L3126) which also compares using `if ( aExp < 0x3FF )` = `if (!(aExp >= 0x3FF))` = `if (!(aExp >= 1023))`.
There might be some shifting of the mantissa which makes this change incorrect so I'd prefer if someone could look over it.
However, the [single-precision code does it also like this PR suggests](https://github.com/citra-emu/citra/blob/master/src/core/arm/skyeye_common/vfp/vfpsingle.cpp#L587) already.

Fixes #1218 

---

Furthermore the interpreter contains some VFP3 instructions which cause #1483 . This is an entirely different problem but it was found by accident while searching for the other bug.
The idea for this change came from @MerryMage who said it was important that some instructions are ambigious. So I figured that VFP3 might "overwrite" some other instructions.
Information that [3DS only supports VFP2 came from @lioncash ](http://lioncash.github.io/ARMBook/vfp/README.html)
Is this correct or is there any reason for VFP3 code to exist?

Fixes #1483 

---

Tiny change but I'd be happy to split this into 2 seperate commits and give appropiate commit names. Suggestions?