### PR TITLE
RasterizerOpenGL: Initialise uniform_block_data

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -421,7 +421,7 @@ private:
         UniformData data;
         bool lut_dirty[6];
         bool dirty;
-    } uniform_block_data;
+    } uniform_block_data = {};
 
     OGLVertexArray vertex_array;
     OGLBuffer vertex_buffer;


### PR DESCRIPTION
When I was doing some debugging with valgrind, this was something that was showing up as being read from when uninitialised. Not sure how important this is (or if this needs to be fixed / there's a better way) but putting this here anyway before I forget.