### PR TITLE
Add common methods to all cfg:* ports

### DIFF
--- a/src/core/hle/service/cfg/cfg_i.cpp
+++ b/src/core/hle/service/cfg/cfg_i.cpp
@@ -9,6 +9,18 @@ namespace Service {
 namespace CFG {
 
 const Interface::FunctionInfo FunctionTable[] = {
+    // cfg common
+    {0x00010082, GetConfigInfoBlk2,                    "GetConfigInfoBlk2"},
+    {0x00020000, SecureInfoGetRegion,                  "SecureInfoGetRegion"},
+    {0x00030040, GenHashConsoleUnique,                 "GenHashConsoleUnique"},
+    {0x00040000, GetRegionCanadaUSA,                   "GetRegionCanadaUSA"},
+    {0x00050000, GetSystemModel,                       "GetSystemModel"},
+    {0x00060000, GetModelNintendo2DS,                  "GetModelNintendo2DS"},
+    {0x00070040, nullptr,                              "WriteToFirstByteCfgSavegame"},
+    {0x00080080, nullptr,                              "GoThroughTable"},
+    {0x00090040, GetCountryCodeString,                 "GetCountryCodeString"},
+    {0x000A0040, GetCountryCodeID,                     "GetCountryCodeID"},
+    // cfg:i
     {0x04010082, GetConfigInfoBlk8,                    "GetConfigInfoBlk8"},
     {0x04020082, nullptr,                              "SetConfigInfoBlk4"},
     {0x04030000, UpdateConfigNANDSavegame,             "UpdateConfigNANDSavegame"},

--- a/src/core/hle/service/cfg/cfg_s.cpp
+++ b/src/core/hle/service/cfg/cfg_s.cpp
@@ -9,10 +9,18 @@ namespace Service {
 namespace CFG {
 
 const Interface::FunctionInfo FunctionTable[] = {
+    // cfg common
     {0x00010082, GetConfigInfoBlk2,                    "GetConfigInfoBlk2"},
     {0x00020000, SecureInfoGetRegion,                  "SecureInfoGetRegion"},
     {0x00030040, GenHashConsoleUnique,                 "GenHashConsoleUnique"},
+    {0x00040000, GetRegionCanadaUSA,                   "GetRegionCanadaUSA"},
     {0x00050000, GetSystemModel,                       "GetSystemModel"},
+    {0x00060000, GetModelNintendo2DS,                  "GetModelNintendo2DS"},
+    {0x00070040, nullptr,                              "WriteToFirstByteCfgSavegame"},
+    {0x00080080, nullptr,                              "GoThroughTable"},
+    {0x00090040, GetCountryCodeString,                 "GetCountryCodeString"},
+    {0x000A0040, GetCountryCodeID,                     "GetCountryCodeID"},
+    // cfg:s
     {0x04010082, GetConfigInfoBlk8,                    "GetConfigInfoBlk8"},
     {0x04020082, nullptr,                              "SetConfigInfoBlk4"},
     {0x04030000, UpdateConfigNANDSavegame,             "UpdateConfigNANDSavegame"},

--- a/src/core/hle/service/cfg/cfg_u.cpp
+++ b/src/core/hle/service/cfg/cfg_u.cpp
@@ -9,6 +9,7 @@ namespace Service {
 namespace CFG {
 
 const Interface::FunctionInfo FunctionTable[] = {
+    // cfg common
     {0x00010082, GetConfigInfoBlk2,     "GetConfigInfoBlk2"},
     {0x00020000, SecureInfoGetRegion,   "SecureInfoGetRegion"},
     {0x00030040, GenHashConsoleUnique,  "GenHashConsoleUnique"},


### PR DESCRIPTION
According to 3dbrew all of the cfg ports share a common set of methods which were previously only implemented in cfg:u.  ctrulib will attempt to connect to the highest privilege port available with the assumption that these shared methods exist across all ports.