### PR TITLE
SOC:U GetSockOpt/SetSockOpt

### DIFF
--- a/src/core/hle/service/soc_u.cpp
+++ b/src/core/hle/service/soc_u.cpp
@@ -729,11 +729,7 @@ static void GetSockOpt(Service::Interface* self) {
     u32 socket_handle = cmd_buffer[1];
     u32 level = cmd_buffer[2];
     u32 optname = cmd_buffer[3];
-#ifdef _WIN32
-    int optlen = (int)cmd_buffer[4];
-#else
     socklen_t optlen = (socklen_t)cmd_buffer[4];
-#endif
 
     // 0x100 = static buffer offset (bytes)
     // + 0x4 = 2nd pointer (u32) position

--- a/src/core/hle/service/soc_u.cpp
+++ b/src/core/hle/service/soc_u.cpp
@@ -729,7 +729,11 @@ static void GetSockOpt(Service::Interface* self) {
     u32 socket_handle = cmd_buffer[1];
     u32 level = cmd_buffer[2];
     u32 optname = cmd_buffer[3];
+#ifdef _WIN32
     int optlen = (int)cmd_buffer[4];
+#else
+    socklen_t optlen = (socklen_t)cmd_buffer[4];
+#endif
 
     // 0x100 = static buffer offset (bytes)
     // + 0x4 = 2nd pointer (u32) position

--- a/src/core/hle/service/soc_u.cpp
+++ b/src/core/hle/service/soc_u.cpp
@@ -729,12 +729,12 @@ static void GetSockOpt(Service::Interface* self) {
     u32 socket_handle = cmd_buffer[1];
     u32 level = cmd_buffer[2];
     u32 optname = cmd_buffer[3];
-    u32 optlen = cmd_buffer[4];
+    int optlen = (int)cmd_buffer[4];
 
     // 0x100 = static buffer offset (bytes)
     // + 0x4 = 2nd pointer (u32) position
     // >> 2  = convert to u32 offset instead of byte offset (cmd_buffer = u32*)
-    u8* optval = Memory::GetPointer(cmd_buffer[0x104 >> 2]);
+    char* optval = reinterpret_cast<char*>(Memory::GetPointer(cmd_buffer[0x104 >> 2]));
 
     int ret = ::getsockopt(socket_handle, level, optname, optval, &optlen);
     int err = 0;
@@ -754,7 +754,7 @@ static void SetSockOpt(Service::Interface* self) {
     u32 level = cmd_buffer[2];
     u32 optname = cmd_buffer[3];
     socklen_t optlen = static_cast<socklen_t>(cmd_buffer[4]);
-    u8 *optval = Memory::GetPointer(cmd_buffer[8]);
+    const char *optval = reinterpret_cast<const char*>(Memory::GetPointer(cmd_buffer[8]));
 
     int ret = static_cast<u32>(::setsockopt(socket_handle, level, optname, optval, optlen));
     int err = 0;

--- a/src/core/hle/service/soc_u.cpp
+++ b/src/core/hle/service/soc_u.cpp
@@ -568,7 +568,7 @@ static void RecvFrom(Service::Interface* self) {
     socklen_t src_addr_len = sizeof(src_addr);
     int ret = ::recvfrom(socket_handle, (char*)output_buff, len, flags, &src_addr, &src_addr_len);
 
-    if (buffer_parameters.output_src_address_buffer != 0 && src_addr_len > 0) {
+    if (ret >= 0 && buffer_parameters.output_src_address_buffer != 0 && src_addr_len > 0) {
         CTRSockAddr* ctr_src_addr = reinterpret_cast<CTRSockAddr*>(Memory::GetPointer(buffer_parameters.output_src_address_buffer));
         *ctr_src_addr = CTRSockAddr::FromPlatform(src_addr);
     }
@@ -736,7 +736,7 @@ static void GetSockOpt(Service::Interface* self) {
     // >> 2  = convert to u32 offset instead of byte offset (cmd_buffer = u32*)
     u8* optval = Memory::GetPointer(cmd_buffer[0x104 >> 2]);
 
-    int ret = ::getsockopt(socket_handle, level, optname, &optval, &optlen);
+    int ret = ::getsockopt(socket_handle, level, optname, optval, &optlen);
     int err = 0;
     if(ret == SOCKET_ERROR_VALUE) {
         err = TranslateError(GET_ERRNO);
@@ -754,11 +754,11 @@ static void SetSockOpt(Service::Interface* self) {
     u32 level = cmd_buffer[2];
     u32 optname = cmd_buffer[3];
     socklen_t optlen = static_cast<socklen_t>(cmd_buffer[4]);
-    void *optval = Memory::GetPointer(cmd_buffer[8]);
+    u8 *optval = Memory::GetPointer(cmd_buffer[8]);
 
     int ret = static_cast<u32>(::setsockopt(socket_handle, level, optname, optval, optlen));
     int err = 0;
-    if(ret == SOCKET_ERROR_VALUE) {
+    if (ret == SOCKET_ERROR_VALUE) {
         err = TranslateError(GET_ERRNO);
     }
 

--- a/src/core/hle/service/soc_u.cpp
+++ b/src/core/hle/service/soc_u.cpp
@@ -738,7 +738,7 @@ static void GetSockOpt(Service::Interface* self) {
 
     int ret = ::getsockopt(socket_handle, level, optname, optval, &optlen);
     int err = 0;
-    if(ret == SOCKET_ERROR_VALUE) {
+    if (ret == SOCKET_ERROR_VALUE) {
         err = TranslateError(GET_ERRNO);
     }
 

--- a/src/core/hle/service/soc_u.cpp
+++ b/src/core/hle/service/soc_u.cpp
@@ -764,7 +764,7 @@ static void GetSockOpt(Service::Interface* self) {
         // 0x100 = static buffer offset (bytes)
         // + 0x4 = 2nd pointer (u32) position
         // >> 2  = convert to u32 offset instead of byte offset (cmd_buffer = u32*)
-        char *optval = reinterpret_cast<char *>(Memory::GetPointer(cmd_buffer[0x104 >> 2]));
+        char* optval = reinterpret_cast<char *>(Memory::GetPointer(cmd_buffer[0x104 >> 2]));
 
         ret = ::getsockopt(socket_handle, level, optname, optval, &optlen);
         err = 0;
@@ -796,7 +796,7 @@ static void SetSockOpt(Service::Interface* self) {
 #endif
     } else {
         socklen_t optlen = static_cast<socklen_t>(cmd_buffer[4]);
-        const char *optval = reinterpret_cast<const char *>(Memory::GetPointer(cmd_buffer[8]));
+        const char* optval = reinterpret_cast<const char *>(Memory::GetPointer(cmd_buffer[8]));
 
         ret = static_cast<u32>(::setsockopt(socket_handle, level, optname, optval, optlen));
         err = 0;


### PR DESCRIPTION
-Implement `GetSockOpt`/`SetSockOpt`
-Fix bug in `RecvFrom` where sending from localhost does not fill in `src_addr`/`src_addr_len` on Linux

`SOC_U::RecvFrom` was crashing due to odd behavior in Linux where `src_addr` was not being filled in, and `src_addr_len` was being set to `0`.  This caused `src_addr.sa_family` to become invalid, failing `CTRSockAddr::FromPlatform`'s assertion that `sa_family` must be `AF_INET`.