### PR TITLE
cecd:u: stub GetCecInfoEventHandle, GetChangeStateEventHandle

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -46,6 +46,7 @@ namespace Log {
         SUB(Service, NIM) \
         SUB(Service, NWM) \
         SUB(Service, CAM) \
+        SUB(Service, CECD) \
         SUB(Service, CFG) \
         SUB(Service, DSP) \
         SUB(Service, HID) \

--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -61,6 +61,7 @@ enum class Class : ClassType {
     Service_NIM,                ///< The NIM (Network interface manager) service
     Service_NWM,                ///< The NWM (Network wlan manager) service
     Service_CAM,                ///< The CAM (Camera) service
+    Service_CECD,               ///< The CECD service
     Service_CFG,                ///< The CFG (Configuration) service
     Service_DSP,                ///< The DSP (DSP control) service
     Service_HID,                ///< The HID (Human interface device) service

--- a/src/core/hle/service/cecd/cecd.cpp
+++ b/src/core/hle/service/cecd/cecd.cpp
@@ -4,6 +4,7 @@
 
 #include "common/logging/log.h"
 
+#include "core/hle/kernel/event.h"
 #include "core/hle/service/service.h"
 #include "core/hle/service/cecd/cecd.h"
 #include "core/hle/service/cecd/cecd_s.h"
@@ -12,14 +13,38 @@
 namespace Service {
 namespace CECD {
 
-void Init() {
-    using namespace Kernel;
+static Kernel::SharedPtr<Kernel::Event> cecinfo_event;
+static Kernel::SharedPtr<Kernel::Event> change_state_event;
 
+void GetCecInfoEventHandle(Service::Interface* self) {
+    u32* cmd_buff = Kernel::GetCommandBuffer();
+
+    cmd_buff[1] = RESULT_SUCCESS.raw; // No error
+    cmd_buff[3] = Kernel::g_handle_table.Create(cecinfo_event).MoveFrom(); // Event handle
+
+    LOG_WARNING(Service_CECD, "(STUBBED) called");
+}
+
+void GetChangeStateEventHandle(Service::Interface* self) {
+    u32* cmd_buff = Kernel::GetCommandBuffer();
+
+    cmd_buff[1] = RESULT_SUCCESS.raw; // No error
+    cmd_buff[3] = Kernel::g_handle_table.Create(change_state_event).MoveFrom(); // Event handle
+
+    LOG_WARNING(Service_CECD, "(STUBBED) called");
+}
+
+void Init() {
     AddService(new CECD_S_Interface);
     AddService(new CECD_U_Interface);
+
+    cecinfo_event = Kernel::Event::Create(Kernel::ResetType::OneShot, "CECD_U::cecinfo_event");
+    change_state_event = Kernel::Event::Create(Kernel::ResetType::OneShot, "CECD_U::change_state_event");
 }
 
 void Shutdown() {
+    cecinfo_event = nullptr;
+    change_state_event = nullptr;
 }
 
 } // namespace CECD

--- a/src/core/hle/service/cecd/cecd.h
+++ b/src/core/hle/service/cecd/cecd.h
@@ -5,7 +5,30 @@
 #pragma once
 
 namespace Service {
+
+class Interface;
+
 namespace CECD {
+
+/**
+ * GetCecInfoEventHandle service function
+ *  Inputs:
+ *      0: 0x000F0000
+ *  Outputs:
+ *      1: ResultCode
+ *      3: Event Handle
+ */
+void GetCecInfoEventHandle(Service::Interface* self);
+
+/**
+ * GetChangeStateEventHandle service function
+ *  Inputs:
+ *      0: 0x00100000
+ *  Outputs:
+ *      1: ResultCode
+ *      3: Event Handle
+ */
+void GetChangeStateEventHandle(Service::Interface* self);
 
 /// Initialize CECD service(s)
 void Init();

--- a/src/core/hle/service/cecd/cecd_u.cpp
+++ b/src/core/hle/service/cecd/cecd_u.cpp
@@ -2,13 +2,16 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "core/hle/service/cecd/cecd.h"
 #include "core/hle/service/cecd/cecd_u.h"
 
 namespace Service {
 namespace CECD {
 
 static const Interface::FunctionInfo FunctionTable[] = {
-    { 0x00120104, nullptr, "ReadSavedData" },
+    {0x000F0000, GetCecInfoEventHandle,     "GetCecInfoEventHandle"},
+    {0x00100000, GetChangeStateEventHandle, "GetChangeStateEventHandle"},
+    {0x00120104, nullptr,                   "ReadSavedData"},
 };
 
 CECD_U_Interface::CECD_U_Interface() {


### PR DESCRIPTION
when games don't get valid event handles, they break with fatal error