### PR TITLE
Fix filename&path encode problem on Windows

### DIFF
--- a/src/citra_qt/config.cpp
+++ b/src/citra_qt/config.cpp
@@ -16,7 +16,7 @@ Config::Config() {
     // TODO: Don't hardcode the path; let the frontend decide where to put the config files.
     qt_config_loc = FileUtil::GetUserPath(D_CONFIG_IDX) + "qt-config.ini";
     FileUtil::CreateFullPath(qt_config_loc);
-    qt_config = new QSettings(QString::fromLocal8Bit(qt_config_loc.c_str()), QSettings::IniFormat);
+    qt_config = new QSettings(QString::fromStdString(qt_config_loc), QSettings::IniFormat);
 
     Reload();
 }

--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -66,7 +66,7 @@ void GameList::ValidateEntry(const QModelIndex& item)
 
     if (file_path.isEmpty())
         return;
-    std::string std_file_path(file_path.toLocal8Bit());
+    std::string std_file_path(file_path.toStdString());
     if (!FileUtil::Exists(std_file_path) || FileUtil::IsDirectory(std_file_path))
         return;
     emit GameChosen(file_path);
@@ -148,7 +148,7 @@ void GameListWorker::AddFstEntriesToGameList(const std::string& dir_path, bool d
 
             emit EntryReady({
                 new GameListItem(QString::fromStdString(Loader::GetFileTypeString(filetype))),
-                new GameListItemPath(QString::fromLocal8Bit(physical_name.c_str())),
+                new GameListItemPath(QString::fromStdString(physical_name)),
                 new GameListItemSize(FileUtil::GetSize(physical_name)),
             });
         }

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -417,7 +417,7 @@ void GMainWindow::UpdateRecentFiles() {
 }
 
 void GMainWindow::OnGameListLoadFile(QString game_path) {
-    BootGame(game_path.toLocal8Bit().data());
+    BootGame(game_path.toStdString());
 }
 
 void GMainWindow::OnMenuLoadFile() {
@@ -428,7 +428,7 @@ void GMainWindow::OnMenuLoadFile() {
     if (!filename.isEmpty()) {
         settings.setValue("romsPath", QFileInfo(filename).path());
 
-        BootGame(filename.toLocal8Bit().data());
+        BootGame(filename.toStdString());
     }
 }
 
@@ -440,7 +440,7 @@ void GMainWindow::OnMenuLoadSymbolMap() {
     if (!filename.isEmpty()) {
         settings.setValue("symbolsPath", QFileInfo(filename).path());
 
-        LoadSymbolMap(filename.toLocal8Bit().data());
+        LoadSymbolMap(filename.toStdString());
     }
 }
 
@@ -461,7 +461,7 @@ void GMainWindow::OnMenuRecentFile() {
     QString filename = action->data().toString();
     QFileInfo file_info(filename);
     if (file_info.exists()) {
-        BootGame(filename.toLocal8Bit().data());
+        BootGame(filename.toStdString());
     } else {
         // Display an error message and remove the file from the list.
         QMessageBox::information(this, tr("File not found"), tr("File \"%1\" not found").arg(filename));

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -192,7 +192,7 @@ bool CreateFullPath(const std::string &fullPath)
 {
     int panicCounter = 100;
     LOG_TRACE(Common_Filesystem, "path %s", fullPath.c_str());
-    LOG_WARNING(Common_Filesystem, "path %s", fullPath.c_str());
+
     if (FileUtil::Exists(fullPath))
     {
         LOG_WARNING(Common_Filesystem, "path exists %s", fullPath.c_str());

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -320,19 +320,6 @@ std::u16string UTF8ToUTF16(const std::string& input)
 #endif
 }
 
-static std::string UTF16ToUTF8(const std::wstring& input)
-{
-    auto const size = WideCharToMultiByte(CP_UTF8, 0, input.data(), static_cast<int>(input.size()), nullptr, 0, nullptr, nullptr);
-
-    std::string output;
-    output.resize(size);
-
-    if (size == 0 || size != WideCharToMultiByte(CP_UTF8, 0, input.data(), static_cast<int>(input.size()), &output[0], static_cast<int>(output.size()), nullptr, nullptr))
-        output.clear();
-
-    return output;
-}
-
 static std::wstring CPToUTF16(u32 code_page, const std::string& input)
 {
     auto const size = MultiByteToWideChar(code_page, 0, input.data(), static_cast<int>(input.size()), nullptr, 0);
@@ -341,6 +328,19 @@ static std::wstring CPToUTF16(u32 code_page, const std::string& input)
     output.resize(size);
 
     if (size == 0 || size != MultiByteToWideChar(code_page, 0, input.data(), static_cast<int>(input.size()), &output[0], static_cast<int>(output.size())))
+        output.clear();
+
+    return output;
+}
+
+std::string UTF16ToUTF8(const std::wstring& input)
+{
+    auto const size = WideCharToMultiByte(CP_UTF8, 0, input.data(), static_cast<int>(input.size()), nullptr, 0, nullptr, nullptr);
+
+    std::string output;
+    output.resize(size);
+
+    if (size == 0 || size != WideCharToMultiByte(CP_UTF8, 0, input.data(), static_cast<int>(input.size()), &output[0], static_cast<int>(output.size()), nullptr, nullptr))
         output.clear();
 
     return output;

--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -95,7 +95,7 @@ std::string CP1252ToUTF8(const std::string& str);
 std::string SHIFTJISToUTF8(const std::string& str);
 
 #ifdef _WIN32
-
+std::string UTF16ToUTF8(const std::wstring& input);
 std::wstring UTF8ToUTF16W(const std::string& str);
 
 #ifdef _UNICODE


### PR DESCRIPTION
fix #1584 #730 
Use wide version functions for Windows. It fix file name & dir path encode problem.

### Screenshot
![image](https://cloud.githubusercontent.com/assets/7088579/14175147/a9266a5c-f77b-11e5-9218-4530b8f98848.png)

![image](https://cloud.githubusercontent.com/assets/7088579/14175285/a070a980-f77c-11e5-9966-d90bc68c56c9.png)


### Booting with unicode dir path.
`SetConsoleOutputCP(CP_UTF8);` can fix console

![image](https://cloud.githubusercontent.com/assets/7088579/14175187/03b3c4ba-f77c-11e5-94b1-d81810f8be83.png)

![image](https://cloud.githubusercontent.com/assets/7088579/14175219/31fe1550-f77c-11e5-823b-c457aaf12e44.png)

with `SetConsoleOutputCP(CP_UTF8);`

(Consolas)
![image](https://cloud.githubusercontent.com/assets/7088579/14175399/627ffcf6-f77d-11e5-8f3c-88741051a49a.png)

(default font style)
![image](https://cloud.githubusercontent.com/assets/7088579/14175477/bdfb5486-f77d-11e5-858f-d73f3a414bd9.png)

