### PR TITLE
Rasterizer: Don't draw outside of framebuffer (re-open)

### DIFF
--- a/src/video_core/rasterizer.cpp
+++ b/src/video_core/rasterizer.cpp
@@ -290,6 +290,14 @@ struct Fix12P4 {
         return static_cast<u16>(val & FracMask());
     }
 
+    Fix12P4 Ceil() const {
+        return FromRaw(static_cast<s16>(val + FracMask())).Floor();
+    }
+
+    Fix12P4 Floor() const {
+        return FromRaw(static_cast<s16>(val & IntMask()));
+    }
+
     operator s16() const {
         return val;
     }
@@ -387,11 +395,10 @@ static void ProcessTriangleInternal(const Shader::OutputVertex& v0,
 
     // TODO: Proper scissor rect test!
 
-    Fix12P4 frac = Fix12P4::FromInt(0, Fix12P4::FracMask());
-    min_x = Fix12P4::FromInt(min_x.Int(), 0);
-    min_y = Fix12P4::FromInt(min_y.Int(), 0);
-    max_x = Fix12P4::FromInt((max_x + frac).Int());
-    max_y = Fix12P4::FromInt((max_y + frac).Int());
+    min_x = min_x.Floor();
+    min_y = min_y.Floor();
+    max_x = max_x.Ceil();
+    max_y = max_y.Ceil();
 
     // Keep pixels inside framebuffer
     min_x = std::max(min_x, Fix12P4::Zero());

--- a/src/video_core/rasterizer.cpp
+++ b/src/video_core/rasterizer.cpp
@@ -344,6 +344,7 @@ static void ProcessTriangleInternal(const Shader::OutputVertex& v0,
 {
     const auto& regs = g_state.regs;
     const auto& framebuffer = regs.framebuffer;
+    const auto& output_merger = regs.output_merger;
     MICROPROFILE_SCOPE(GPU_Rasterization);
 
     // vertex positions in rasterizer coordinates
@@ -424,8 +425,8 @@ static void ProcessTriangleInternal(const Shader::OutputVertex& v0,
     auto textures = regs.GetTextures();
     auto tev_stages = regs.GetTevStages();
 
-    bool stencil_action_enable = g_state.regs.output_merger.stencil_test.enable && framebuffer.depth_format == Regs::DepthFormat::D24S8;
-    const auto stencil_test = g_state.regs.output_merger.stencil_test;
+    bool stencil_action_enable = output_merger.stencil_test.enable && framebuffer.depth_format == Regs::DepthFormat::D24S8;
+    const auto stencil_test = output_merger.stencil_test;
 
     // Enter rasterization loop, starting at the center of the topleft bounding box corner.
     // TODO: Not sure if looping through x first might be faster
@@ -841,7 +842,6 @@ static void ProcessTriangleInternal(const Shader::OutputVertex& v0,
                 }
             }
 
-            const auto& output_merger = regs.output_merger;
             // TODO: Does alpha testing happen before or after stencil?
             if (output_merger.alpha_test.enable) {
                 bool pass = false;


### PR DESCRIPTION
I'm re-opening this one as a new PR because apparently GitHub can't re-open force pushed PRs.. Find the original PR here #1518 

This fixes #1633 and probably more.
- I've changed the commit for better performance and tried to make the code a bit cleaner.
- Now uses s16 instead of u16 to move viewport near center of our integer range
  (u16 came from PPSSPP but the PSP uses a 4096 x 4096 coordinate space and the viewport is usually located near the center (2048, 2048) whereas 3DS viewport offsets are usually near (0,0). This meant the slightest negative offset would underflow the rasterizer coords)

Not much testing was done with `s16` but the math makes sense to me. I also changed all `>> 4` to `/ 16` because the C spec (didn't actually verify with C++) says shifting negative numbers is implementation defined.
(The current framebuffer check makes it impossible to have negative x or y in the rasterizer loop but I still thought it would be a good idea to keep the same coordinate system (and types))

As the framebuffer ownership test required `regs.framebuffer` I decided to put it in a variable (like SetDepth etc.) and also changed the rasterizer function elsewhere to reflect this. Tell me if I should leave the old code instead or even remove the variable altogether (from the new code).
