### PR TITLE
OpenGL: Check for framebuffer completeness

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -808,6 +808,9 @@ void RasterizerOpenGL::SyncFramebuffer() {
 
         ReloadDepthBuffer();
     }
+
+    ASSERT_MSG(glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE,
+               "OpenGL rasterizer framebuffer setup failed, status %X", glCheckFramebufferStatus(GL_FRAMEBUFFER));
 }
 
 void RasterizerOpenGL::SyncCullMode() {


### PR DESCRIPTION
Work around [this mesa bug](https://bugs.freedesktop.org/show_bug.cgi?id=94148). It's also the sane thing to do anyway.

I'm not sure if ASSERT_MSG() is meant to catch errors which should be presentable to the user or wether it should be a debugging aid (absent from release builds). - Probably worth another issue.
This line however was copied from elsewhere in the same file so.. insta-merge?