### PR TITLE
OpenGL: Fix a double framebuffer completeness checks.

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -140,8 +140,9 @@ void RasterizerOpenGL::InitObjects() {
     }
     state.Apply();
 
-    ASSERT_MSG(glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE,
-               "OpenGL rasterizer framebuffer setup failed, status %X", glCheckFramebufferStatus(GL_FRAMEBUFFER));
+    GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+    ASSERT_MSG(status == GL_FRAMEBUFFER_COMPLETE,
+               "OpenGL rasterizer framebuffer setup failed, status %X", status);
 }
 
 void RasterizerOpenGL::Reset() {
@@ -809,8 +810,9 @@ void RasterizerOpenGL::SyncFramebuffer() {
         ReloadDepthBuffer();
     }
 
-    ASSERT_MSG(glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE,
-               "OpenGL rasterizer framebuffer setup failed, status %X", glCheckFramebufferStatus(GL_FRAMEBUFFER));
+    GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+    ASSERT_MSG(status == GL_FRAMEBUFFER_COMPLETE,
+               "OpenGL rasterizer framebuffer setup failed, status %X", status);
 }
 
 void RasterizerOpenGL::SyncCullMode() {


### PR DESCRIPTION
It was already present elsewhere, and got duplicated in 693cbc1f8ff4b7c01c0f30b871e8301e6867d4c2.