### PR TITLE
CMakeFiles: Compile as C++14

### DIFF
--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -11,8 +11,8 @@ fi
 
 #if OS is linux or is not set
 if [ "$TRAVIS_OS_NAME" = "linux" -o -z "$TRAVIS_OS_NAME" ]; then
-    export CC=gcc-4.9
-    export CXX=g++-4.9
+    export CC=gcc-5
+    export CXX=g++-5
     export PKG_CONFIG_PATH=$HOME/.local/lib/pkgconfig:$PKG_CONFIG_PATH
 
     mkdir build && cd build

--- a/.travis-deps.sh
+++ b/.travis-deps.sh
@@ -5,8 +5,8 @@ set -x
 
 #if OS is linux or is not set
 if [ "$TRAVIS_OS_NAME" = "linux" -o -z "$TRAVIS_OS_NAME" ]; then
-    export CC=gcc-4.9
-    export CXX=g++-4.9
+    export CC=gcc-5
+    export CXX=g++-5
     mkdir -p $HOME/.local
 
     curl -L http://www.cmake.org/files/v2.8/cmake-2.8.11-Linux-i386.tar.gz \

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - gcc-4.9
-      - g++-4.9
+      - gcc-5
+      - g++-5
       - xorg-dev
       - lib32stdc++6 # For CMake
       - lftp # To upload builds

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ endif()
 message(STATUS "Target architecture: ${ARCHITECTURE}")
 
 if (NOT MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wno-attributes -pthread")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y -Wno-attributes -pthread")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread")
 
     if (ARCHITECTURE_x86_64)


### PR DESCRIPTION
Quite overdue

As Travis CI devs are continually dedicated to providing only the most up-to-date compiler tools, they use vitrual environments containing Mac OS X 10.9 with XCode 6.1 (LLVM 3.5) and Ubuntu Trusty with the blazingly up-to-date GCC 4.9. So we cannot use the regular `-std=c++14` switch. So we need to use `-std=c++1y` (the name of C++14 when it didn't have a concrete date).