### PR TITLE
Fix thumb ADR instruction alignment

### DIFF
--- a/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
+++ b/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
@@ -3955,9 +3955,7 @@ unsigned InterpreterMainLoop(ARMul_State* cpu) {
         if (inst_base->cond == ConditionCode::AL || CondPassed(cpu, inst_base->cond)) {
             add_inst* const inst_cream = (add_inst*)inst_base->component;
 
-            u32 rn_val = RN;
-            if (inst_cream->Rn == 15)
-                rn_val += 2 * cpu->GetInstructionSize();
+            u32 rn_val = CHECK_READ_REG15_WA(cpu, inst_cream->Rn);
 
             bool carry;
             bool overflow;
@@ -6167,9 +6165,7 @@ unsigned InterpreterMainLoop(ARMul_State* cpu) {
         if (inst_base->cond == ConditionCode::AL || CondPassed(cpu, inst_base->cond)) {
             sub_inst* const inst_cream = (sub_inst*)inst_base->component;
 
-            u32 rn_val = RN;
-            if (inst_cream->Rn == 15)
-                rn_val += 2 * cpu->GetInstructionSize();
+            u32 rn_val = CHECK_READ_REG15_WA(cpu, inst_cream->Rn);
 
             bool carry;
             bool overflow;


### PR DESCRIPTION
Only one instruction fixed, not sure if another pc-based instructions must be aligned, too.

PR fixes the game **Conception 2: Children of the Seven Stars**