### PR TITLE
OpenGL: Implement color combiner Operation::Dot3_RGB

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -198,6 +198,9 @@ static void AppendColorCombiner(std::string& out, TevStageConfig::Operation oper
     case Operation::AddThenMultiply:
         out += "min(" + variable_name + "[0] + " + variable_name + "[1], vec3(1.0)) * " + variable_name + "[2]";
         break;
+    case Operation::Dot3_RGB:
+        out += "vec3(dot(" + variable_name + "[0] - vec3(0.5), " + variable_name + "[1] - vec3(0.5)) * 4.0)";
+        break;
     default:
         out += "vec3(0.0)";
         LOG_CRITICAL(Render_OpenGL, "Unknown color combiner operation: %u", operation);


### PR DESCRIPTION
This picks up where #1465 left off.

I used [the formula originally posted](https://github.com/citra-emu/citra/pull/1465#issuecomment-193945833) by @JamePeng.
It makes sense, is very similar to what the 3DS-Tested sw-rasterizer by Lectem does (just different precision) and it is also backed by [the GL extension spec.](https://www.opengl.org/registry/specs/ARB/texture_env_dot3.txt).

This does not yet implement Operation::Dot3_RGBA and it doesn't implement the Dot3 operations for the alpha channel either.
For that we have to hardware test wether:
- Color combiner has same operation with Dot3_RGB and Dot3_RGBA?
  - Dot3_RGBA will overwrite alpha combiner result? (GL way according to spec)
- Alpha combiner does the dot() with Dot3_RGBA?
  - Dot3_RGBA will do a correct dot() it without the color combiner in Dot3_RGB mode?
  - Dot3_RGB will crash or what does it do to alpha?
- ... ?

It does not fix any issues (that I'm aware of) because I assume the sample / lib code by Nintendo will do some other things (which don't work properly *yet*) when this is in use.