### PR TITLE
Pica: Remove geometry dumper (PICA_DUMP_GEOMETRY)

### DIFF
--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -249,10 +249,6 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
             const u16* index_address_16 = reinterpret_cast<const u16*>(index_address_8);
             bool index_u16 = index_info.format != 0;
 
-#if PICA_DUMP_GEOMETRY
-            DebugUtils::GeometryDumper geometry_dumper;
-            PrimitiveAssembler<DebugUtils::GeometryDumper::Vertex> dumping_primitive_assembler(regs.triangle_topology.Value());
-#endif
             PrimitiveAssembler<Shader::OutputVertex>& primitive_assembler = g_state.primitive_assembler;
 
             if (g_debug_context) {
@@ -388,17 +384,6 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
                     if (g_debug_context)
                         g_debug_context->OnEvent(DebugContext::Event::VertexLoaded, (void*)&input);
 
-#if PICA_DUMP_GEOMETRY
-                    // NOTE: When dumping geometry, we simply assume that the first input attribute
-                    //       corresponds to the position for now.
-                    DebugUtils::GeometryDumper::Vertex dumped_vertex = {
-                        input.attr[0][0].ToFloat32(), input.attr[0][1].ToFloat32(), input.attr[0][2].ToFloat32()
-                    };
-                    using namespace std::placeholders;
-                    dumping_primitive_assembler.SubmitVertex(dumped_vertex,
-                                                             std::bind(&DebugUtils::GeometryDumper::AddTriangle,
-                                                                       &geometry_dumper, _1, _2, _3));
-#endif
                     // Send to vertex shader
                     output = Shader::Run(shader_unit, input, attribute_config.GetNumTotalAttributes());
 
@@ -423,10 +408,6 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
                 g_debug_context->recorder->MemoryAccessed(Memory::GetPhysicalPointer(range.first),
                                                           range.second, range.first);
             }
-
-#if PICA_DUMP_GEOMETRY
-            geometry_dumper.Dump();
-#endif
 
             break;
         }

--- a/src/video_core/debug_utils/debug_utils.cpp
+++ b/src/video_core/debug_utils/debug_utils.cpp
@@ -85,35 +85,6 @@ std::shared_ptr<DebugContext> g_debug_context; // TODO: Get rid of this global
 
 namespace DebugUtils {
 
-void GeometryDumper::AddTriangle(Vertex& v0, Vertex& v1, Vertex& v2) {
-    vertices.push_back(v0);
-    vertices.push_back(v1);
-    vertices.push_back(v2);
-
-    int num_vertices = (int)vertices.size();
-    faces.push_back({{ num_vertices-3, num_vertices-2, num_vertices-1 }});
-}
-
-void GeometryDumper::Dump() {
-    static int index = 0;
-    std::string filename = std::string("geometry_dump") + std::to_string(++index) + ".obj";
-
-    std::ofstream file(filename);
-
-    for (const auto& vertex : vertices) {
-        file << "v " << vertex.pos[0]
-             << " "  << vertex.pos[1]
-             << " "  << vertex.pos[2] << std::endl;
-    }
-
-    for (const Face& face : faces) {
-        file << "f " << 1+face.index[0]
-             << " "  << 1+face.index[1]
-             << " "  << 1+face.index[2] << std::endl;
-    }
-}
-
-
 void DumpShader(const std::string& filename, const Regs::ShaderConfig& config, const Shader::ShaderSetup& setup, const Regs::VSOutputAttributes* output_attributes)
 {
     struct StuffToWrite {

--- a/src/video_core/debug_utils/debug_utils.h
+++ b/src/video_core/debug_utils/debug_utils.h
@@ -158,29 +158,8 @@ extern std::shared_ptr<DebugContext> g_debug_context; // TODO: Get rid of this g
 
 namespace DebugUtils {
 
-#define PICA_DUMP_GEOMETRY 0
 #define PICA_DUMP_TEXTURES 0
 #define PICA_LOG_TEV 0
-
-// Simple utility class for dumping geometry data to an OBJ file
-class GeometryDumper {
-public:
-    struct Vertex {
-        std::array<float,3> pos;
-    };
-
-    void AddTriangle(Vertex& v0, Vertex& v1, Vertex& v2);
-
-    void Dump();
-
-private:
-    struct Face {
-        int index[3];
-    };
-
-    std::vector<Vertex> vertices;
-    std::vector<Face> faces;
-};
 
 void DumpShader(const std::string& filename, const Regs::ShaderConfig& config,
                 const Shader::ShaderSetup& setup, const Regs::VSOutputAttributes* output_attributes);

--- a/src/video_core/primitive_assembly.cpp
+++ b/src/video_core/primitive_assembly.cpp
@@ -68,7 +68,5 @@ void PrimitiveAssembler<VertexType>::Reconfigure(Regs::TriangleTopology topology
 // explicitly instantiate use cases
 template
 struct PrimitiveAssembler<Shader::OutputVertex>;
-template
-struct PrimitiveAssembler<DebugUtils::GeometryDumper::Vertex>;
 
 } // namespace


### PR DESCRIPTION
Resolves #1635 

`grep` for "Dump" and "DUMP_GEOM" found nothing related to this feature anymore.

Use RenderDoc or write your own dumper if you want to dump geometry.
(I'll probably come up with a new dumper at some point as I'm working on an improved shader debugger which fits the bill for this one)