### PR TITLE
CitraQt: Apply config at startup

### DIFF
--- a/src/citra/citra.cpp
+++ b/src/citra/citra.cpp
@@ -93,13 +93,12 @@ int main(int argc, char **argv) {
 
     log_filter.ParseFilterString(Settings::values.log_filter);
 
-    GDBStub::ToggleServer(use_gdbstub);
-    GDBStub::SetServerPort(gdb_port);
+    // Apply the command line arguments
+    Settings::values.gdbstub_port = gdb_port;
+    Settings::values.use_gdbstub = use_gdbstub;
+    Settings::Apply();
 
     std::unique_ptr<EmuWindow_SDL2> emu_window = std::make_unique<EmuWindow_SDL2>();
-
-    VideoCore::g_hw_renderer_enabled = Settings::values.use_hw_renderer;
-    VideoCore::g_shader_jit_enabled = Settings::values.use_shader_jit;
 
     System::Init(emu_window.get());
     SCOPE_EXIT({ System::Shutdown(); });

--- a/src/citra_qt/config.cpp
+++ b/src/citra_qt/config.cpp
@@ -189,6 +189,7 @@ void Config::SaveValues() {
 
 void Config::Reload() {
     ReadValues();
+    Settings::Apply();
 }
 
 void Config::Save() {

--- a/src/citra_qt/configure_debug.cpp
+++ b/src/citra_qt/configure_debug.cpp
@@ -5,7 +5,6 @@
 #include "citra_qt/configure_debug.h"
 #include "ui_configure_debug.h"
 
-#include "core/gdbstub/gdbstub.h"
 #include "core/settings.h"
 
 ConfigureDebug::ConfigureDebug(QWidget *parent) :
@@ -26,7 +25,7 @@ void ConfigureDebug::setConfiguration() {
 }
 
 void ConfigureDebug::applyConfiguration() {
-    GDBStub::ToggleServer(ui->toogle_gdbstub->isChecked());
     Settings::values.use_gdbstub = ui->toogle_gdbstub->isChecked();
     Settings::values.gdbstub_port = ui->gdbport_spinbox->value();
+    Settings::Apply();
 }

--- a/src/citra_qt/configure_general.cpp
+++ b/src/citra_qt/configure_general.cpp
@@ -8,8 +8,6 @@
 
 #include "core/settings.h"
 
-#include "video_core/video_core.h"
-
 ConfigureGeneral::ConfigureGeneral(QWidget *parent) :
     QWidget(parent),
     ui(new Ui::ConfigureGeneral)
@@ -32,12 +30,8 @@ void ConfigureGeneral::setConfiguration() {
 void ConfigureGeneral::applyConfiguration() {
     UISettings::values.gamedir_deepscan = ui->toogle_deepscan->isChecked();
     UISettings::values.confirm_before_closing = ui->toogle_check_exit->isChecked();
-
     Settings::values.region_value = ui->region_combobox->currentIndex();
-
-    VideoCore::g_hw_renderer_enabled =
     Settings::values.use_hw_renderer = ui->toogle_hw_renderer->isChecked();
-
-    VideoCore::g_shader_jit_enabled =
     Settings::values.use_shader_jit = ui->toogle_shader_jit->isChecked();
+    Settings::Apply();
 }

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -141,9 +141,6 @@ GMainWindow::GMainWindow() : config(new Config()), emu_thread(nullptr)
 
     game_list->LoadInterfaceLayout();
 
-    GDBStub::ToggleServer(Settings::values.use_gdbstub);
-    GDBStub::SetServerPort(static_cast<u32>(Settings::values.gdbstub_port));
-
     ui.action_Single_Window_Mode->setChecked(UISettings::values.single_window_mode);
     ToggleWindowMode();
 

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -4,8 +4,22 @@
 
 #include "settings.h"
 
+#include "core/gdbstub/gdbstub.h"
+
+#include "video_core/video_core.h"
+
 namespace Settings {
 
 Values values = {};
 
+void Apply() {
+
+    GDBStub::SetServerPort(static_cast<u32>(values.gdbstub_port));
+    GDBStub::ToggleServer(values.use_gdbstub);
+
+    VideoCore::g_hw_renderer_enabled = values.use_hw_renderer;
+    VideoCore::g_shader_jit_enabled = values.use_shader_jit;
+
 }
+
+} // namespace

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -67,4 +67,6 @@ struct Values {
     u16 gdbstub_port;
 } extern values;
 
+void Apply();
+
 }


### PR DESCRIPTION
This is a quick-and-dirty hack (mostly untested too).

`master` doesn't load config with CitraQt at the moment so no matter what your settings say: you are starting with SW Rasterizer (and maybe also interpreter?). It also means you can't trust the config dialog because that claims you are running with HW Rendering.

it's probably not smart to do it this way but `master` is currently broken so we need a fix.

I also ordered the GDB calls because I'm pretty sure enabling the server will open a socket on the *previously* specified port. I'm not sure if GDB can even change the port while the server is running?