### PR TITLE
Set accepted EULA version to maximum in config

### DIFF
--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -383,7 +383,8 @@ ResultCode FormatConfig() {
     if (!res.IsSuccess()) return res;
 
     // 0x000D0000 - Accepted EULA version
-    res = CreateConfigInfoBlk(0x000D0000, 0x4, 0xE, zero_buffer);
+    u32 eula_version = 0xFFFF; // max possible EULA version
+    res = CreateConfigInfoBlk(0x000D0000, 0x4, 0xE, &eula_version);
     if (!res.IsSuccess()) return res;
 
     res = CreateConfigInfoBlk(0x000F0004, sizeof(CONSOLE_MODEL), 0xC, &CONSOLE_MODEL);


### PR DESCRIPTION
to get it working, need to remove config file user\nand\data\00000000000000000000000000000000\sysdata\00010017\00000000\config

This PR helps to skip showing ErrEULA applet in some games, for example, #1606, but may be reason for huge regression in games compatibility, because of eula agree games starts to use a lot of unimplemented functions, related to network (AC, CECD).

so, this PR just for test, very uncomplete, to find out how to implement it in right way