### PR TITLE
Pica: Reduce batching errors

### DIFF
--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -409,6 +409,12 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
                                                           range.second, range.first);
             }
 
+            VideoCore::g_renderer->Rasterizer()->DrawTriangles();
+
+            if (g_debug_context) {
+                g_debug_context->OnEvent(DebugContext::Event::FinishedPrimitiveBatch, nullptr);
+            }
+
             break;
         }
 


### PR DESCRIPTION
This ~~gets rid of some damage~~ hides some bugs which were seen after https://github.com/citra-emu/citra/commit/81004211dda74390c02973c37e89215f5ff8829b (bisected and reported by pcmaker - Thanks!)

~~`master` currently merges way too many triangles into one draw call. In MK7 it usually combines particle effects (smoke, coin glitter, speed effects) and HUD rendering. As one batch can only share the same draw state your kart sometimes spits out menu letters from it's exhause pipe and the smoke will look like the HUD item box.
This PR fixes that by reverting some changes from the commit mentioned above.~~
Correction: This might not even be the problem, I'll have to look at the code again

Keep in mind that this is not a perfect solution. All this does is splitting draw calls into seperate batches (like you'd expect). Immediate mode might still cause bad batching - I didn't check!
These are 2 seperate issues though, so I'll create an issue (soon) about possible remaining problems to remind us.

(Also, even if we can batch draw calls for GL we shouldn't do so in debug mode and report each draw call to the debugger)

---

Fixes bugs in MK7 and NSMB2 (#1681). I didn't test much further than that.