### PR TITLE
Memory: Remove most usages of GetPointer

### DIFF
--- a/src/citra_qt/debugger/callstack.cpp
+++ b/src/citra_qt/debugger/callstack.cpp
@@ -37,10 +37,13 @@ void CallstackWidget::OnDebugModeEntered()
     int counter = 0;
     for (u32 addr = 0x10000000; addr >= sp; addr -= 4)
     {
+        if (!Memory::IsValidVirtualAddress(addr))
+            break;
+
         const u32 ret_addr = Memory::Read32(addr);
         const u32 call_addr = ret_addr - 4; //get call address???
 
-        if (Memory::GetPointer(call_addr) == nullptr)
+        if (!Memory::IsValidVirtualAddress(call_addr))
             break;
 
         /* TODO (mattvail) clean me, move to debugger interface */

--- a/src/core/file_sys/archive_backend.cpp
+++ b/src/core/file_sys/archive_backend.cpp
@@ -19,22 +19,22 @@ Path::Path(LowPathType type, u32 size, u32 pointer) : type(type) {
     switch (type) {
     case Binary:
     {
-        u8* data = Memory::GetPointer(pointer);
-        binary = std::vector<u8>(data, data + size);
+        binary.resize(size);
+        Memory::ReadBlock(pointer, binary.data(), binary.size());
         break;
     }
 
     case Char:
     {
-        const char* data = reinterpret_cast<const char*>(Memory::GetPointer(pointer));
-        string = std::string(data, size - 1); // Data is always null-terminated.
+        string.resize(size - 1); // Data is always null-terminated.
+        Memory::ReadBlock(pointer, &string[0], string.size());
         break;
     }
 
     case Wchar:
     {
-        const char16_t* data = reinterpret_cast<const char16_t*>(Memory::GetPointer(pointer));
-        u16str = std::u16string(data, size/2 - 1); // Data is always null-terminated.
+        u16str.resize(size / 2 - 1); // Data is always null-terminated.
+        Memory::ReadBlock(pointer, &u16str[0], u16str.size() * sizeof(char16_t));
         break;
     }
 

--- a/src/core/hle/applets/mii_selector.h
+++ b/src/core/hle/applets/mii_selector.h
@@ -24,7 +24,7 @@ struct MiiConfig {
     u8  unk_004;
     INSERT_PADDING_BYTES(3);
     u16 unk_008;
-    INSERT_PADDING_BYTES(0x8C - 0xA);
+    INSERT_PADDING_BYTES(0x82);
     u8  unk_08C;
     INSERT_PADDING_BYTES(3);
     u16 unk_090;
@@ -75,6 +75,8 @@ public:
 
     /// Whether this applet is currently running instead of the host application or not.
     bool started;
+
+    MiiConfig config;
 };
 
 }

--- a/src/core/hle/applets/swkbd.cpp
+++ b/src/core/hle/applets/swkbd.cpp
@@ -35,9 +35,9 @@ ResultCode SoftwareKeyboard::ReceiveParameter(Service::APT::MessageParameter con
     // The LibAppJustStarted message contains a buffer with the size of the framebuffer shared memory.
     // Create the SharedMemory that will hold the framebuffer data
     Service::APT::CaptureBufferInfo capture_info;
-    ASSERT(sizeof(capture_info) == parameter.buffer_size);
+    ASSERT(sizeof(capture_info) == parameter.buffer.size());
 
-    memcpy(&capture_info, parameter.data, sizeof(capture_info));
+    memcpy(&capture_info, parameter.buffer.data(), sizeof(capture_info));
 
     using Kernel::MemoryPermission;
     // Allocate a heap block of the required size for this applet.
@@ -50,8 +50,7 @@ ResultCode SoftwareKeyboard::ReceiveParameter(Service::APT::MessageParameter con
     // Send the response message with the newly created SharedMemory
     Service::APT::MessageParameter result;
     result.signal = static_cast<u32>(Service::APT::SignalType::LibAppFinished);
-    result.data = nullptr;
-    result.buffer_size = 0;
+    result.buffer.clear();
     result.destination_id = static_cast<u32>(Service::APT::AppletId::Application);
     result.sender_id = static_cast<u32>(id);
     result.object = framebuffer_memory;
@@ -61,9 +60,9 @@ ResultCode SoftwareKeyboard::ReceiveParameter(Service::APT::MessageParameter con
 }
 
 ResultCode SoftwareKeyboard::StartImpl(Service::APT::AppletStartupParameter const& parameter) {
-    ASSERT_MSG(parameter.buffer_size == sizeof(config), "The size of the parameter (SoftwareKeyboardConfig) is wrong");
+    ASSERT_MSG(parameter.buffer.size() == sizeof(config), "The size of the parameter (SoftwareKeyboardConfig) is wrong");
 
-    memcpy(&config, parameter.data, parameter.buffer_size);
+    memcpy(&config, parameter.buffer.data(), parameter.buffer.size());
     text_memory = boost::static_pointer_cast<Kernel::SharedMemory, Kernel::Object>(parameter.object);
 
     // TODO(Subv): Verify if this is the correct behavior
@@ -107,8 +106,8 @@ void SoftwareKeyboard::DrawScreenKeyboard() {
 void SoftwareKeyboard::Finalize() {
     // Let the application know that we're closing
     Service::APT::MessageParameter message;
-    message.buffer_size = sizeof(SoftwareKeyboardConfig);
-    message.data = reinterpret_cast<u8*>(&config);
+    message.buffer.resize(sizeof(SoftwareKeyboardConfig));
+    std::memcpy(message.buffer.data(), &config, message.buffer.size());
     message.signal = static_cast<u32>(Service::APT::SignalType::LibAppClosed);
     message.destination_id = static_cast<u32>(Service::APT::AppletId::Application);
     message.sender_id = static_cast<u32>(id);

--- a/src/core/hle/applets/swkbd.cpp
+++ b/src/core/hle/applets/swkbd.cpp
@@ -99,7 +99,7 @@ void SoftwareKeyboard::DrawScreenKeyboard() {
     auto info = bottom_screen->framebuffer_info[bottom_screen->index];
 
     // TODO(Subv): Draw the HLE keyboard, for now just zero-fill the framebuffer
-    memset(Memory::GetPointer(info.address_left), 0, info.stride * 320);
+    Memory::ZeroBlock(info.address_left, info.stride * 320);
 
     GSP_GPU::SetBufferSwap(1, info);
 }

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -403,7 +403,7 @@ ResultVal<SharedPtr<Thread>> Thread::Create(std::string name, VAddr entry_point,
         priority = new_priority;
     }
 
-    if (!Memory::GetPointer(entry_point)) {
+    if (!Memory::IsValidVirtualAddress(entry_point)) {
         LOG_ERROR(Kernel_SVC, "(name=%s): invalid entry %08x", name.c_str(), entry_point);
         // TODO: Verify error
         return ResultCode(ErrorDescription::InvalidAddress, ErrorModule::Kernel,

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -176,12 +176,12 @@ void SendParameter(Service::Interface* self) {
     }
 
     MessageParameter param;
-    param.buffer_size = buffer_size;
     param.destination_id = dst_app_id;
     param.sender_id = src_app_id;
     param.object = Kernel::g_handle_table.GetGeneric(handle);
     param.signal = signal_type;
-    param.data = Memory::GetPointer(buffer);
+    param.buffer.resize(buffer_size);
+    Memory::ReadBlock(buffer, param.buffer.data(), param.buffer.size());
 
     cmd_buff[1] = dest_applet->ReceiveParameter(param).raw;
 
@@ -199,16 +199,15 @@ void ReceiveParameter(Service::Interface* self) {
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
     cmd_buff[2] = next_parameter.sender_id;
     cmd_buff[3] = next_parameter.signal; // Signal type
-    cmd_buff[4] = next_parameter.buffer_size; // Parameter buffer size
+    cmd_buff[4] = next_parameter.buffer.size(); // Parameter buffer size
     cmd_buff[5] = 0x10;
     cmd_buff[6] = 0;
     if (next_parameter.object != nullptr)
         cmd_buff[6] = Kernel::g_handle_table.Create(next_parameter.object).MoveFrom();
-    cmd_buff[7] = (next_parameter.buffer_size << 14) | 2;
+    cmd_buff[7] = (next_parameter.buffer.size() << 14) | 2;
     cmd_buff[8] = buffer;
 
-    if (next_parameter.data)
-        memcpy(Memory::GetPointer(buffer), next_parameter.data, std::min(buffer_size, next_parameter.buffer_size));
+    Memory::WriteBlock(buffer, next_parameter.buffer.data(), next_parameter.buffer.size());
 
     LOG_WARNING(Service_APT, "called app_id=0x%08X, buffer_size=0x%08X", app_id, buffer_size);
 }
@@ -222,16 +221,15 @@ void GlanceParameter(Service::Interface* self) {
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
     cmd_buff[2] = next_parameter.sender_id;
     cmd_buff[3] = next_parameter.signal; // Signal type
-    cmd_buff[4] = next_parameter.buffer_size; // Parameter buffer size
+    cmd_buff[4] = next_parameter.buffer.size(); // Parameter buffer size
     cmd_buff[5] = 0x10;
     cmd_buff[6] = 0;
     if (next_parameter.object != nullptr)
         cmd_buff[6] = Kernel::g_handle_table.Create(next_parameter.object).MoveFrom();
-    cmd_buff[7] = (next_parameter.buffer_size << 14) | 2;
+    cmd_buff[7] = (next_parameter.buffer.size() << 14) | 2;
     cmd_buff[8] = buffer;
 
-    if (next_parameter.data)
-        memcpy(Memory::GetPointer(buffer), next_parameter.data, std::min(buffer_size, next_parameter.buffer_size));
+    Memory::WriteBlock(buffer, next_parameter.buffer.data(), std::min(static_cast<size_t>(buffer_size), next_parameter.buffer.size()));
 
     LOG_WARNING(Service_APT, "called app_id=0x%08X, buffer_size=0x%08X", app_id, buffer_size);
 }
@@ -365,10 +363,13 @@ void StartLibraryApplet(Service::Interface* self) {
         return;
     }
 
+    size_t buffer_size = cmd_buff[2];
+    VAddr buffer_addr = cmd_buff[6];
+
     AppletStartupParameter parameter;
-    parameter.buffer_size = cmd_buff[2];
     parameter.object = Kernel::g_handle_table.GetGeneric(cmd_buff[4]);
-    parameter.data = Memory::GetPointer(cmd_buff[6]);
+    parameter.buffer.resize(buffer_size);
+    Memory::ReadBlock(buffer_addr, parameter.buffer.data(), parameter.buffer.size());
 
     cmd_buff[1] = applet->Start(parameter).raw;
 }

--- a/src/core/hle/service/apt/apt.h
+++ b/src/core/hle/service/apt/apt.h
@@ -20,16 +20,14 @@ struct MessageParameter {
     u32 sender_id = 0;
     u32 destination_id = 0;
     u32 signal = 0;
-    u32 buffer_size = 0;
     Kernel::SharedPtr<Kernel::Object> object = nullptr;
-    u8* data = nullptr;
+    std::vector<u8> buffer;
 };
 
 /// Holds information about the parameters used in StartLibraryApplet
 struct AppletStartupParameter {
-    u32 buffer_size = 0;
     Kernel::SharedPtr<Kernel::Object> object = nullptr;
-    u8* data = nullptr;
+    std::vector<u8> buffer;
 };
 
 /// Used by the application to pass information about the current framebuffer to applets.

--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -191,28 +191,32 @@ void GetConfigInfoBlk2(Service::Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     u32 size = cmd_buff[1];
     u32 block_id = cmd_buff[2];
-    u8* data_pointer = Memory::GetPointer(cmd_buff[4]);
+    VAddr data_pointer = cmd_buff[4];
 
-    if (data_pointer == nullptr) {
+    if (!Memory::IsValidVirtualAddress(data_pointer)) {
         cmd_buff[1] = -1; // TODO(Subv): Find the right error code
         return;
     }
 
-    cmd_buff[1] = Service::CFG::GetConfigInfoBlock(block_id, size, 0x2, data_pointer).raw;
+    std::vector<u8> data(size);
+    cmd_buff[1] = Service::CFG::GetConfigInfoBlock(block_id, size, 0x2, data.data()).raw;
+    Memory::WriteBlock(data_pointer, data.data(), data.size());
 }
 
 void GetConfigInfoBlk8(Service::Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     u32 size = cmd_buff[1];
     u32 block_id = cmd_buff[2];
-    u8* data_pointer = Memory::GetPointer(cmd_buff[4]);
+    VAddr data_pointer = cmd_buff[4];
 
-    if (data_pointer == nullptr) {
+    if (!Memory::IsValidVirtualAddress(data_pointer)) {
         cmd_buff[1] = -1; // TODO(Subv): Find the right error code
         return;
     }
 
-    cmd_buff[1] = Service::CFG::GetConfigInfoBlock(block_id, size, 0x8, data_pointer).raw;
+    std::vector<u8> data(size);
+    cmd_buff[1] = Service::CFG::GetConfigInfoBlock(block_id, size, 0x8, data.data()).raw;
+    Memory::WriteBlock(data_pointer, data.data(), data.size());
 }
 
 void UpdateConfigNANDSavegame(Service::Interface* self) {

--- a/src/core/hle/service/frd/frd.cpp
+++ b/src/core/hle/service/frd/frd.cpp
@@ -23,7 +23,7 @@ void GetMyPresence(Service::Interface* self) {
 
     ASSERT(shifted_out_size == ((sizeof(MyPresence) << 14) | 2));
 
-    Memory::WriteBlock(my_presence_addr, reinterpret_cast<const u8*>(&my_presence), sizeof(MyPresence));
+    Memory::WriteBlock(my_presence_addr, &my_presence, sizeof(MyPresence));
 
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
 
@@ -39,8 +39,7 @@ void GetFriendKeyList(Service::Interface* self) {
 
     FriendKey zero_key = {};
     for (u32 i = 0; i < frd_count; ++i) {
-        Memory::WriteBlock(frd_key_addr + i * sizeof(FriendKey),
-                           reinterpret_cast<const u8*>(&zero_key), sizeof(FriendKey));
+        Memory::WriteBlock(frd_key_addr + i * sizeof(FriendKey), &zero_key, sizeof(FriendKey));
     }
 
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
@@ -58,8 +57,7 @@ void GetFriendProfile(Service::Interface* self) {
 
     Profile zero_profile = {};
     for (u32 i = 0; i < count; ++i) {
-        Memory::WriteBlock(profiles_addr + i * sizeof(Profile),
-            reinterpret_cast<const u8*>(&zero_profile), sizeof(Profile));
+        Memory::WriteBlock(profiles_addr + i * sizeof(Profile), &zero_profile, sizeof(Profile));
     }
 
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
@@ -88,7 +86,7 @@ void GetMyFriendKey(Service::Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
-    Memory::WriteBlock(cmd_buff[2], reinterpret_cast<const u8*>(&my_friend_key), sizeof(FriendKey));
+    Memory::WriteBlock(cmd_buff[2], &my_friend_key, sizeof(FriendKey));
     LOG_WARNING(Service_FRD, "(STUBBED) called");
 }
 

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -116,7 +116,6 @@ ResultVal<bool> File::SyncRequest() {
             }
             Memory::WriteBlock(address, data.data(), *read);
             cmd_buff[2] = static_cast<u32>(*read);
-            Memory::RasterizerFlushAndInvalidateRegion(Memory::VirtualToPhysicalAddress(address), length);
             break;
         }
 

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -108,11 +108,13 @@ ResultVal<bool> File::SyncRequest() {
                           offset, length, backend->GetSize());
             }
 
-            ResultVal<size_t> read = backend->Read(offset, length, Memory::GetPointer(address));
+            std::vector<u8> data(length);
+            ResultVal<size_t> read = backend->Read(offset, data.size(), data.data());
             if (read.Failed()) {
                 cmd_buff[1] = read.Code().raw;
                 return read.Code();
             }
+            Memory::WriteBlock(address, data.data(), *read);
             cmd_buff[2] = static_cast<u32>(*read);
             Memory::RasterizerFlushAndInvalidateRegion(Memory::VirtualToPhysicalAddress(address), length);
             break;
@@ -128,7 +130,9 @@ ResultVal<bool> File::SyncRequest() {
             LOG_TRACE(Service_FS, "Write %s %s: offset=0x%llx length=%d address=0x%x, flush=0x%x",
                       GetTypeName().c_str(), GetName().c_str(), offset, length, address, flush);
 
-            ResultVal<size_t> written = backend->Write(offset, length, flush != 0, Memory::GetPointer(address));
+            std::vector<u8> data(length);
+            Memory::ReadBlock(address, data.data(), data.size());
+            ResultVal<size_t> written = backend->Write(offset, data.size(), flush != 0, data.data());
             if (written.Failed()) {
                 cmd_buff[1] = written.Code().raw;
                 return written.Code();
@@ -216,12 +220,14 @@ ResultVal<bool> Directory::SyncRequest() {
         {
             u32 count = cmd_buff[1];
             u32 address = cmd_buff[3];
-            auto entries = reinterpret_cast<FileSys::Entry*>(Memory::GetPointer(address));
+            std::vector<FileSys::Entry> entries(count);
             LOG_TRACE(Service_FS, "Read %s %s: count=%d",
                 GetTypeName().c_str(), GetName().c_str(), count);
 
             // Number of entries actually read
-            cmd_buff[2] = backend->Read(count, entries);
+            u32 read = backend->Read(entries.size(), entries.data());
+            cmd_buff[2] = read;
+            Memory::WriteBlock(address, entries.data(), read * sizeof(FileSys::Entry));
             break;
         }
 
@@ -456,11 +462,12 @@ ResultCode CreateExtSaveData(MediaType media_type, u32 high, u32 low, VAddr icon
     if (result.IsError())
         return result;
 
-    u8* smdh_icon = Memory::GetPointer(icon_buffer);
-    if (!smdh_icon)
+    if (!Memory::IsValidVirtualAddress(icon_buffer))
         return ResultCode(-1); // TODO(Subv): Find the right error code
 
-    ext_savedata->WriteIcon(path, smdh_icon, icon_size);
+    std::vector<u8> smdh_icon(icon_size);
+    Memory::ReadBlock(icon_buffer, smdh_icon.data(), smdh_icon.size());
+    ext_savedata->WriteIcon(path, smdh_icon.data(), smdh_icon.size());
     return RESULT_SUCCESS;
 }
 

--- a/src/core/hle/service/soc_u.cpp
+++ b/src/core/hle/service/soc_u.cpp
@@ -373,14 +373,18 @@ static void Bind(Service::Interface* self) {
     u32* cmd_buffer = Kernel::GetCommandBuffer();
     u32 socket_handle = cmd_buffer[1];
     u32 len = cmd_buffer[2];
-    CTRSockAddr* ctr_sock_addr = reinterpret_cast<CTRSockAddr*>(Memory::GetPointer(cmd_buffer[6]));
 
-    if (ctr_sock_addr == nullptr) {
+    // Virtual address of the sock_addr structure
+    VAddr sock_addr_addr = cmd_buffer[6];
+    if (!Memory::IsValidVirtualAddress(sock_addr_addr)) {
         cmd_buffer[1] = -1; // TODO(Subv): Correct code
         return;
     }
 
-    sockaddr sock_addr = CTRSockAddr::ToPlatform(*ctr_sock_addr);
+    CTRSockAddr ctr_sock_addr;
+    Memory::ReadBlock(sock_addr_addr, reinterpret_cast<u8*>(&ctr_sock_addr), sizeof(CTRSockAddr));
+
+    sockaddr sock_addr = CTRSockAddr::ToPlatform(ctr_sock_addr);
 
     int res = ::bind(socket_handle, &sock_addr, std::max<u32>(sizeof(sock_addr), len));
 
@@ -496,7 +500,7 @@ static void Accept(Service::Interface* self) {
         result = TranslateError(GET_ERRNO);
     } else {
         CTRSockAddr ctr_addr = CTRSockAddr::FromPlatform(addr);
-        Memory::WriteBlock(cmd_buffer[0x104 >> 2], (const u8*)&ctr_addr, max_addr_len);
+        Memory::WriteBlock(cmd_buffer[0x104 >> 2], &ctr_addr, sizeof(ctr_addr));
     }
 
     cmd_buffer[0] = IPC::MakeHeader(4, 2, 2);
@@ -547,20 +551,31 @@ static void SendTo(Service::Interface* self) {
     u32 flags = cmd_buffer[3];
     u32 addr_len = cmd_buffer[4];
 
-    u8* input_buff = Memory::GetPointer(cmd_buffer[8]);
-    CTRSockAddr* ctr_dest_addr = reinterpret_cast<CTRSockAddr*>(Memory::GetPointer(cmd_buffer[10]));
-
-    if (ctr_dest_addr == nullptr) {
+    VAddr input_buff_address = cmd_buffer[8];
+    if (!Memory::IsValidVirtualAddress(input_buff_address)) {
         cmd_buffer[1] = -1; // TODO(Subv): Find the right error code
         return;
     }
 
+    // Memory address of the dest_addr structure
+    VAddr dest_addr_addr = cmd_buffer[10];
+    if (!Memory::IsValidVirtualAddress(dest_addr_addr)) {
+        cmd_buffer[1] = -1; // TODO(Subv): Find the right error code
+        return;
+    }
+
+    std::vector<u8> input_buff(len);
+    Memory::ReadBlock(input_buff_address, input_buff.data(), input_buff.size());
+
+    CTRSockAddr ctr_dest_addr;
+    Memory::ReadBlock(dest_addr_addr, reinterpret_cast<u8*>(&ctr_dest_addr), sizeof(ctr_dest_addr));
+
     int ret = -1;
     if (addr_len > 0) {
-        sockaddr dest_addr = CTRSockAddr::ToPlatform(*ctr_dest_addr);
-        ret = ::sendto(socket_handle, (const char*)input_buff, len, flags, &dest_addr, sizeof(dest_addr));
+        sockaddr dest_addr = CTRSockAddr::ToPlatform(ctr_dest_addr);
+        ret = ::sendto(socket_handle, reinterpret_cast<const char*>(input_buff.data()), len, flags, &dest_addr, sizeof(dest_addr));
     } else {
-        ret = ::sendto(socket_handle, (const char*)input_buff, len, flags, nullptr, 0);
+        ret = ::sendto(socket_handle, reinterpret_cast<const char*>(input_buff.data()), len, flags, nullptr, 0);
     }
 
     int result = 0;
@@ -591,14 +606,24 @@ static void RecvFrom(Service::Interface* self) {
 
     std::memcpy(&buffer_parameters, &cmd_buffer[64], sizeof(buffer_parameters));
 
-    u8* output_buff = Memory::GetPointer(buffer_parameters.output_buffer_addr);
+    if (!Memory::IsValidVirtualAddress(buffer_parameters.output_buffer_addr)) {
+        cmd_buffer[1] = -1; // TODO(Subv): Find the right error code
+        return;
+    }
+
+    if (!Memory::IsValidVirtualAddress(buffer_parameters.output_src_address_buffer)) {
+        cmd_buffer[1] = -1; // TODO(Subv): Find the right error code
+        return;
+    }
+
+    std::vector<u8> output_buff(len);
     sockaddr src_addr;
     socklen_t src_addr_len = sizeof(src_addr);
-    int ret = ::recvfrom(socket_handle, (char*)output_buff, len, flags, &src_addr, &src_addr_len);
+    int ret = ::recvfrom(socket_handle, reinterpret_cast<char*>(output_buff.data()), len, flags, &src_addr, &src_addr_len);
 
     if (ret >= 0 && buffer_parameters.output_src_address_buffer != 0 && src_addr_len > 0) {
-        CTRSockAddr* ctr_src_addr = reinterpret_cast<CTRSockAddr*>(Memory::GetPointer(buffer_parameters.output_src_address_buffer));
-        *ctr_src_addr = CTRSockAddr::FromPlatform(src_addr);
+        CTRSockAddr ctr_src_addr = CTRSockAddr::FromPlatform(src_addr);
+        Memory::WriteBlock(buffer_parameters.output_src_address_buffer, reinterpret_cast<u8*>(&ctr_src_addr), sizeof(ctr_src_addr));
     }
 
     int result = 0;
@@ -606,6 +631,9 @@ static void RecvFrom(Service::Interface* self) {
     if (ret == SOCKET_ERROR_VALUE) {
         result = TranslateError(GET_ERRNO);
         total_received = 0;
+    } else {
+        // Write only the data we received to avoid overwriting parts of the buffer with zeros
+        Memory::WriteBlock(buffer_parameters.output_buffer_addr, output_buff.data(), total_received);
     }
 
     cmd_buffer[1] = result;
@@ -617,18 +645,28 @@ static void Poll(Service::Interface* self) {
     u32* cmd_buffer = Kernel::GetCommandBuffer();
     u32 nfds = cmd_buffer[1];
     int timeout = cmd_buffer[2];
-    CTRPollFD* input_fds = reinterpret_cast<CTRPollFD*>(Memory::GetPointer(cmd_buffer[6]));
-    CTRPollFD* output_fds = reinterpret_cast<CTRPollFD*>(Memory::GetPointer(cmd_buffer[0x104 >> 2]));
+
+    VAddr input_fds_addr = cmd_buffer[6];
+    VAddr output_fds_addr = cmd_buffer[0x104 >> 2];
+    if (!Memory::IsValidVirtualAddress(input_fds_addr) || !Memory::IsValidVirtualAddress(output_fds_addr)) {
+        cmd_buffer[1] = -1; // TODO(Subv): Find correct error code.
+        return;
+    }
+
+    std::vector<CTRPollFD> ctr_fds(nfds);
+    Memory::ReadBlock(input_fds_addr, reinterpret_cast<u8*>(ctr_fds.data()), nfds * sizeof(CTRPollFD));
 
     // The 3ds_pollfd and the pollfd structures may be different (Windows/Linux have different sizes)
     // so we have to copy the data
     std::vector<pollfd> platform_pollfd(nfds);
-    std::transform(input_fds, input_fds + nfds, platform_pollfd.begin(), CTRPollFD::ToPlatform);
+    std::transform(ctr_fds.begin(), ctr_fds.end(), platform_pollfd.begin(), CTRPollFD::ToPlatform);
 
     const int ret = ::poll(platform_pollfd.data(), nfds, timeout);
 
     // Now update the output pollfd structure
-    std::transform(platform_pollfd.begin(), platform_pollfd.end(), output_fds, CTRPollFD::FromPlatform);
+    std::transform(platform_pollfd.begin(), platform_pollfd.end(), ctr_fds.begin(), CTRPollFD::FromPlatform);
+
+    Memory::WriteBlock(output_fds_addr, reinterpret_cast<u8*>(ctr_fds.data()), nfds * sizeof(CTRPollFD));
 
     int result = 0;
     if (ret == SOCKET_ERROR_VALUE)
@@ -643,14 +681,16 @@ static void GetSockName(Service::Interface* self) {
     u32 socket_handle = cmd_buffer[1];
     socklen_t ctr_len = cmd_buffer[2];
 
-    CTRSockAddr* ctr_dest_addr = reinterpret_cast<CTRSockAddr*>(Memory::GetPointer(cmd_buffer[0x104 >> 2]));
+    // Memory address of the ctr_dest_addr structure
+    VAddr ctr_dest_addr_addr = cmd_buffer[0x104 >> 2];
 
     sockaddr dest_addr;
     socklen_t dest_addr_len = sizeof(dest_addr);
     int ret = ::getsockname(socket_handle, &dest_addr, &dest_addr_len);
 
-    if (ctr_dest_addr != nullptr) {
-        *ctr_dest_addr = CTRSockAddr::FromPlatform(dest_addr);
+    if (ctr_dest_addr_addr != 0 && Memory::IsValidVirtualAddress(ctr_dest_addr_addr)) {
+        CTRSockAddr ctr_dest_addr = CTRSockAddr::FromPlatform(dest_addr);
+        Memory::WriteBlock(ctr_dest_addr_addr, reinterpret_cast<u8*>(&ctr_dest_addr), sizeof(ctr_dest_addr));
     } else {
         cmd_buffer[1] = -1; // TODO(Subv): Verify error
         return;
@@ -682,14 +722,16 @@ static void GetPeerName(Service::Interface* self) {
     u32 socket_handle = cmd_buffer[1];
     socklen_t len = cmd_buffer[2];
 
-    CTRSockAddr* ctr_dest_addr = reinterpret_cast<CTRSockAddr*>(Memory::GetPointer(cmd_buffer[0x104 >> 2]));
+    // Memory address of the ctr_dest_addr structure
+    VAddr ctr_dest_addr_addr = cmd_buffer[0x104 >> 2];
 
     sockaddr dest_addr;
     socklen_t dest_addr_len = sizeof(dest_addr);
     int ret = ::getpeername(socket_handle, &dest_addr, &dest_addr_len);
 
-    if (ctr_dest_addr != nullptr) {
-        *ctr_dest_addr = CTRSockAddr::FromPlatform(dest_addr);
+    if (ctr_dest_addr_addr != 0 && Memory::IsValidVirtualAddress(ctr_dest_addr_addr)) {
+        CTRSockAddr ctr_dest_addr = CTRSockAddr::FromPlatform(dest_addr);
+        Memory::WriteBlock(ctr_dest_addr_addr, reinterpret_cast<u8*>(&ctr_dest_addr), sizeof(ctr_dest_addr));
     } else {
         cmd_buffer[1] = -1;
         return;
@@ -711,13 +753,17 @@ static void Connect(Service::Interface* self) {
     u32 socket_handle = cmd_buffer[1];
     socklen_t len = cmd_buffer[2];
 
-    CTRSockAddr* ctr_input_addr = reinterpret_cast<CTRSockAddr*>(Memory::GetPointer(cmd_buffer[6]));
-    if (ctr_input_addr == nullptr) {
+    // Memory address of the ctr_input_addr structure
+    VAddr ctr_input_addr_addr = cmd_buffer[6];
+    if (!Memory::IsValidVirtualAddress(ctr_input_addr_addr)) {
         cmd_buffer[1] = -1; // TODO(Subv): Verify error
         return;
     }
 
-    sockaddr input_addr = CTRSockAddr::ToPlatform(*ctr_input_addr);
+    CTRSockAddr ctr_input_addr;
+    Memory::ReadBlock(ctr_input_addr_addr, reinterpret_cast<u8*>(&ctr_input_addr), sizeof(ctr_input_addr));
+
+    sockaddr input_addr = CTRSockAddr::ToPlatform(ctr_input_addr);
     int ret = ::connect(socket_handle, &input_addr, sizeof(input_addr));
     int result = 0;
     if (ret != 0)

--- a/src/core/hle/service/soc_u.cpp
+++ b/src/core/hle/service/soc_u.cpp
@@ -568,7 +568,7 @@ static void SendTo(Service::Interface* self) {
     Memory::ReadBlock(input_buff_address, input_buff.data(), input_buff.size());
 
     CTRSockAddr ctr_dest_addr;
-    Memory::ReadBlock(dest_addr_addr, reinterpret_cast<u8*>(&ctr_dest_addr), sizeof(ctr_dest_addr));
+    Memory::ReadBlock(dest_addr_addr, &ctr_dest_addr, sizeof(ctr_dest_addr));
 
     int ret = -1;
     if (addr_len > 0) {
@@ -623,7 +623,7 @@ static void RecvFrom(Service::Interface* self) {
 
     if (ret >= 0 && buffer_parameters.output_src_address_buffer != 0 && src_addr_len > 0) {
         CTRSockAddr ctr_src_addr = CTRSockAddr::FromPlatform(src_addr);
-        Memory::WriteBlock(buffer_parameters.output_src_address_buffer, reinterpret_cast<u8*>(&ctr_src_addr), sizeof(ctr_src_addr));
+        Memory::WriteBlock(buffer_parameters.output_src_address_buffer, &ctr_src_addr, sizeof(ctr_src_addr));
     }
 
     int result = 0;
@@ -654,7 +654,7 @@ static void Poll(Service::Interface* self) {
     }
 
     std::vector<CTRPollFD> ctr_fds(nfds);
-    Memory::ReadBlock(input_fds_addr, reinterpret_cast<u8*>(ctr_fds.data()), nfds * sizeof(CTRPollFD));
+    Memory::ReadBlock(input_fds_addr, ctr_fds.data(), nfds * sizeof(CTRPollFD));
 
     // The 3ds_pollfd and the pollfd structures may be different (Windows/Linux have different sizes)
     // so we have to copy the data
@@ -666,7 +666,7 @@ static void Poll(Service::Interface* self) {
     // Now update the output pollfd structure
     std::transform(platform_pollfd.begin(), platform_pollfd.end(), ctr_fds.begin(), CTRPollFD::FromPlatform);
 
-    Memory::WriteBlock(output_fds_addr, reinterpret_cast<u8*>(ctr_fds.data()), nfds * sizeof(CTRPollFD));
+    Memory::WriteBlock(output_fds_addr, ctr_fds.data(), nfds * sizeof(CTRPollFD));
 
     int result = 0;
     if (ret == SOCKET_ERROR_VALUE)
@@ -690,7 +690,7 @@ static void GetSockName(Service::Interface* self) {
 
     if (ctr_dest_addr_addr != 0 && Memory::IsValidVirtualAddress(ctr_dest_addr_addr)) {
         CTRSockAddr ctr_dest_addr = CTRSockAddr::FromPlatform(dest_addr);
-        Memory::WriteBlock(ctr_dest_addr_addr, reinterpret_cast<u8*>(&ctr_dest_addr), sizeof(ctr_dest_addr));
+        Memory::WriteBlock(ctr_dest_addr_addr, &ctr_dest_addr, sizeof(ctr_dest_addr));
     } else {
         cmd_buffer[1] = -1; // TODO(Subv): Verify error
         return;
@@ -731,7 +731,7 @@ static void GetPeerName(Service::Interface* self) {
 
     if (ctr_dest_addr_addr != 0 && Memory::IsValidVirtualAddress(ctr_dest_addr_addr)) {
         CTRSockAddr ctr_dest_addr = CTRSockAddr::FromPlatform(dest_addr);
-        Memory::WriteBlock(ctr_dest_addr_addr, reinterpret_cast<u8*>(&ctr_dest_addr), sizeof(ctr_dest_addr));
+        Memory::WriteBlock(ctr_dest_addr_addr, &ctr_dest_addr, sizeof(ctr_dest_addr));
     } else {
         cmd_buffer[1] = -1;
         return;
@@ -761,7 +761,7 @@ static void Connect(Service::Interface* self) {
     }
 
     CTRSockAddr ctr_input_addr;
-    Memory::ReadBlock(ctr_input_addr_addr, reinterpret_cast<u8*>(&ctr_input_addr), sizeof(ctr_input_addr));
+    Memory::ReadBlock(ctr_input_addr_addr, &ctr_input_addr, sizeof(ctr_input_addr));
 
     sockaddr input_addr = CTRSockAddr::ToPlatform(ctr_input_addr);
     int ret = ::connect(socket_handle, &input_addr, sizeof(input_addr));

--- a/src/core/hle/service/ssl_c.cpp
+++ b/src/core/hle/service/ssl_c.cpp
@@ -31,7 +31,6 @@ static void GenerateRandomData(Service::Interface* self) {
 
     u32 size = cmd_buff[1];
     VAddr address = cmd_buff[3];
-    u8* output_buff = Memory::GetPointer(address);
 
     // Fill the output buffer with random data.
     u32 data = 0;
@@ -44,13 +43,13 @@ static void GenerateRandomData(Service::Interface* self) {
 
         if (size > 4) {
             // Use up the entire 4 bytes of the random data for as long as possible
-            *(u32*)(output_buff + i) = data;
+            Memory::Write32(address + i, data);
             i += 4;
         } else if (size == 2) {
-            *(u16*)(output_buff + i) = (u16)(data & 0xffff);
+            Memory::Write16(address + i, static_cast<u16>(data & 0xffff));
             i += 2;
         } else {
-            *(u8*)(output_buff + i) = (u8)(data & 0xff);
+            Memory::Write8(address + i, static_cast<u8>(data & 0xff));
             i++;
         }
     }

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -364,7 +364,7 @@ u64 Read64(const VAddr addr) {
     return Read<u64_le>(addr);
 }
 
-void ReadBlock(const VAddr src_addr, u8* dest_buffer, const size_t size) {
+void ReadBlock(const VAddr src_addr, void* dest_buffer, const size_t size) {
     size_t remaining_size = size;
     size_t page_index = src_addr >> PAGE_BITS;
     size_t page_offset = src_addr & PAGE_MASK;
@@ -398,7 +398,7 @@ void ReadBlock(const VAddr src_addr, u8* dest_buffer, const size_t size) {
 
         page_index++;
         page_offset = 0;
-        dest_buffer += copy_amount;
+        dest_buffer = static_cast<u8*>(dest_buffer) + copy_amount;
         remaining_size -= copy_amount;
     }
 }
@@ -419,7 +419,7 @@ void Write64(const VAddr addr, const u64 data) {
     Write<u64_le>(addr, data);
 }
 
-void WriteBlock(const VAddr dest_addr, const u8* src_buffer, const size_t size) {
+void WriteBlock(const VAddr dest_addr, const void* src_buffer, const size_t size) {
     size_t remaining_size = size;
     size_t page_index = dest_addr >> PAGE_BITS;
     size_t page_offset = dest_addr & PAGE_MASK;
@@ -452,7 +452,7 @@ void WriteBlock(const VAddr dest_addr, const u8* src_buffer, const size_t size) 
 
         page_index++;
         page_offset = 0;
-        src_buffer += copy_amount;
+        src_buffer = static_cast<const u8*>(src_buffer) + copy_amount;
         remaining_size -= copy_amount;
     }
 }

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -123,8 +123,8 @@ void Write16(VAddr addr, u16 data);
 void Write32(VAddr addr, u32 data);
 void Write64(VAddr addr, u64 data);
 
-void ReadBlock(const VAddr src_addr, u8* dest_buffer, size_t size);
-void WriteBlock(const VAddr dest_addr, const u8* src_buffer, size_t size);
+void ReadBlock(const VAddr src_addr, void* dest_buffer, size_t size);
+void WriteBlock(const VAddr dest_addr, const void* src_buffer, size_t size);
 void ZeroBlock(const VAddr dest_addr, const size_t size);
 void CopyBlock(VAddr dest_addr, VAddr src_addr, size_t size);
 

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -118,15 +118,15 @@ u16 Read16(VAddr addr);
 u32 Read32(VAddr addr);
 u64 Read64(VAddr addr);
 
-void ReadBlock(const VAddr src_addr, u8* dest_buffer, size_t size);
-
 void Write8(VAddr addr, u8 data);
 void Write16(VAddr addr, u16 data);
 void Write32(VAddr addr, u32 data);
 void Write64(VAddr addr, u64 data);
 
+void ReadBlock(const VAddr src_addr, u8* dest_buffer, size_t size);
 void WriteBlock(const VAddr dest_addr, const u8* src_buffer, size_t size);
 void ZeroBlock(const VAddr dest_addr, const size_t size);
+void CopyBlock(VAddr dest_addr, VAddr src_addr, size_t size);
 
 u8* GetPointer(VAddr virtual_address);
 

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -118,12 +118,14 @@ u16 Read16(VAddr addr);
 u32 Read32(VAddr addr);
 u64 Read64(VAddr addr);
 
+void ReadBlock(const VAddr src_addr, u8* dest_buffer, size_t size);
+
 void Write8(VAddr addr, u8 data);
 void Write16(VAddr addr, u16 data);
 void Write32(VAddr addr, u32 data);
 void Write64(VAddr addr, u64 data);
 
-void WriteBlock(VAddr addr, const u8* data, size_t size);
+void WriteBlock(const VAddr dest_addr, const u8* src_buffer, size_t size);
 
 u8* GetPointer(VAddr virtual_address);
 

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -110,6 +110,9 @@ enum : VAddr {
     NEW_LINEAR_HEAP_VADDR_END = NEW_LINEAR_HEAP_VADDR + NEW_LINEAR_HEAP_SIZE,
 };
 
+bool IsValidVirtualAddress(const VAddr addr);
+bool IsValidPhysicalAddress(const PAddr addr);
+
 u8 Read8(VAddr addr);
 u16 Read16(VAddr addr);
 u32 Read32(VAddr addr);

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -126,6 +126,7 @@ void Write32(VAddr addr, u32 data);
 void Write64(VAddr addr, u64 data);
 
 void WriteBlock(const VAddr dest_addr, const u8* src_buffer, size_t size);
+void ZeroBlock(const VAddr dest_addr, const size_t size);
 
 u8* GetPointer(VAddr virtual_address);
 

--- a/src/core/mmio.h
+++ b/src/core/mmio.h
@@ -18,6 +18,8 @@ class MMIORegion {
 public:
     virtual ~MMIORegion() = default;
 
+    virtual bool IsValidAddress(VAddr addr) = 0;
+
     virtual u8 Read8(VAddr addr) = 0;
     virtual u16 Read16(VAddr addr) = 0;
     virtual u32 Read32(VAddr addr) = 0;

--- a/src/core/mmio.h
+++ b/src/core/mmio.h
@@ -25,14 +25,14 @@ public:
     virtual u32 Read32(VAddr addr) = 0;
     virtual u64 Read64(VAddr addr) = 0;
 
-    virtual bool ReadBlock(VAddr src_addr, u8* dest_buffer, size_t size) = 0;
+    virtual bool ReadBlock(VAddr src_addr, void* dest_buffer, size_t size) = 0;
 
     virtual void Write8(VAddr addr, u8 data) = 0;
     virtual void Write16(VAddr addr, u16 data) = 0;
     virtual void Write32(VAddr addr, u32 data) = 0;
     virtual void Write64(VAddr addr, u64 data) = 0;
 
-    virtual bool WriteBlock(VAddr dest_addr, const u8* src_buffer, size_t size) = 0;
+    virtual bool WriteBlock(VAddr dest_addr, const void* src_buffer, size_t size) = 0;
 };
 
 using MMIORegionPointer = std::shared_ptr<MMIORegion>;

--- a/src/core/mmio.h
+++ b/src/core/mmio.h
@@ -25,10 +25,14 @@ public:
     virtual u32 Read32(VAddr addr) = 0;
     virtual u64 Read64(VAddr addr) = 0;
 
+    virtual bool ReadBlock(VAddr src_addr, u8* dest_buffer, size_t size) = 0;
+
     virtual void Write8(VAddr addr, u8 data) = 0;
     virtual void Write16(VAddr addr, u16 data) = 0;
     virtual void Write32(VAddr addr, u32 data) = 0;
     virtual void Write64(VAddr addr, u64 data) = 0;
+
+    virtual bool WriteBlock(VAddr dest_addr, const u8* src_buffer, size_t size) = 0;
 };
 
 using MMIORegionPointer = std::shared_ptr<MMIORegion>;


### PR DESCRIPTION
Most usages were replaced by the new functions Memory::ReadBlock and Memory::WriteBlock, which take into account segmentation of memory pages.

There are 14 usages of GetPointer left, down from the 54 usages we had before.
Original work by @MerryMage.