### PR TITLE
HWRasterizer: Lighting Sync + Cleanup

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -874,6 +874,8 @@ void RasterizerOpenGL::SetShader() {
 
         SyncGlobalAmbient();
         for (int light_index = 0; light_index < 8; light_index++) {
+            SyncLightSpecular0(light_index);
+            SyncLightSpecular1(light_index);
             SyncLightDiffuse(light_index);
             SyncLightAmbient(light_index);
             SyncLightPosition(light_index);

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -332,17 +332,23 @@ private:
     /// Syncs the depth test states to match the PICA register
     void SyncDepthTest();
 
-    /// Syncs the TEV constant color to match the PICA register
-    void SyncTevConstColor(int tev_index, const Pica::Regs::TevStageConfig& tev_stage);
-
     /// Syncs the TEV combiner color buffer to match the PICA register
     void SyncCombinerColor();
+
+    /// Syncs the TEV constant color to match the PICA register
+    void SyncTevConstColor(int tev_index, const Pica::Regs::TevStageConfig& tev_stage);
 
     /// Syncs the lighting global ambient color to match the PICA register
     void SyncGlobalAmbient();
 
     /// Syncs the lighting lookup tables
     void SyncLightingLUT(unsigned index);
+
+    /// Syncs the specified light's specular 0 color to match the PICA register
+    void SyncLightSpecular0(int light_index);
+
+    /// Syncs the specified light's specular 1 color to match the PICA register
+    void SyncLightSpecular1(int light_index);
 
     /// Syncs the specified light's diffuse color to match the PICA register
     void SyncLightDiffuse(int light_index);
@@ -352,12 +358,6 @@ private:
 
     /// Syncs the specified light's position to match the PICA register
     void SyncLightPosition(int light_index);
-
-    /// Syncs the specified light's specular 0 color to match the PICA register
-    void SyncLightSpecular0(int light_index);
-
-    /// Syncs the specified light's specular 1 color to match the PICA register
-    void SyncLightSpecular1(int light_index);
 
     OpenGLState state;
 


### PR DESCRIPTION
- Adds missing sync calls for specular light uniforms for new shaders
- Reorders function declarations in header to match definitions in source