### PR TITLE
Protect use of std::is_trivially_copyable to compile with GCC 4.9

### DIFF
--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -192,7 +192,9 @@ public:
     size_t ReadArray(T* data, size_t length)
     {
         static_assert(std::is_standard_layout<T>(), "Given array does not consist of standard layout objects");
+#if (__GNUC__ >= 5) || defined(__clang__) || defined(_MSC_VER)
         static_assert(std::is_trivially_copyable<T>(), "Given array does not consist of trivially copyable objects");
+#endif
 
         if (!IsOpen()) {
             m_good = false;
@@ -210,7 +212,9 @@ public:
     size_t WriteArray(const T* data, size_t length)
     {
         static_assert(std::is_standard_layout<T>(), "Given array does not consist of standard layout objects");
+#if (__GNUC__ >= 5) || defined(__clang__) || defined(_MSC_VER)
         static_assert(std::is_trivially_copyable<T>(), "Given array does not consist of trivially copyable objects");
+#endif
 
         if (!IsOpen()) {
             m_good = false;


### PR DESCRIPTION
The protection was already used in dsp.h so I just added these for other uses of std::is_trivially_copyable. Thanks to this, I can compile citra with my "old" GCC 4.9.