### PR TITLE
Replace std::map with std::array for graphics event breakpoints

### DIFF
--- a/src/citra_qt/debugger/graphics_breakpoints.cpp
+++ b/src/citra_qt/debugger/graphics_breakpoints.cpp
@@ -75,7 +75,7 @@ QVariant BreakPointModel::data(const QModelIndex& index, int role) const
     case Role_IsEnabled:
     {
         auto context = context_weak.lock();
-        return context && context->breakpoints[event].enabled;
+        return context && context->breakpoints[(int)event].enabled;
     }
 
     default:
@@ -110,7 +110,7 @@ bool BreakPointModel::setData(const QModelIndex& index, const QVariant& value, i
         if (!context)
             return false;
 
-        context->breakpoints[event].enabled = value == Qt::Checked;
+        context->breakpoints[(int)event].enabled = value == Qt::Checked;
         QModelIndex changed_index = createIndex(index.row(), 0);
         emit dataChanged(changed_index, changed_index);
         return true;

--- a/src/video_core/debug_utils/debug_utils.cpp
+++ b/src/video_core/debug_utils/debug_utils.cpp
@@ -40,10 +40,7 @@ using nihstro::DVLPHeader;
 
 namespace Pica {
 
-void DebugContext::OnEvent(Event event, void* data) {
-    if (!breakpoints[event].enabled)
-        return;
-
+void DebugContext::DoOnEvent(Event event, void* data) {
     {
         std::unique_lock<std::mutex> lock(breakpoint_mutex);
 

--- a/src/video_core/debug_utils/debug_utils.h
+++ b/src/video_core/debug_utils/debug_utils.h
@@ -114,7 +114,15 @@ public:
      * @param event Event which has happened
      * @param data Optional data pointer (pass nullptr if unused). Needs to remain valid until Resume() is called.
      */
-    void OnEvent(Event event, void* data);
+    void OnEvent(Event event, void* data) {
+        // This check is left in the header to allow the compiler to inline it.
+        if (!breakpoints[(int)event].enabled)
+            return;
+        // For the rest of event handling, call a separate function.
+        DoOnEvent(event, data);
+    }
+
+    void DoOnEvent(Event event, void *data);
 
     /**
      * Resume from the current breakpoint.
@@ -126,12 +134,14 @@ public:
      * Delete all set breakpoints and resume emulation.
      */
     void ClearBreakpoints() {
-        breakpoints.clear();
+        for (auto &bp : breakpoints) {
+            bp.enabled = false;
+        }
         Resume();
     }
 
     // TODO: Evaluate if access to these members should be hidden behind a public interface.
-    std::map<Event, BreakPoint> breakpoints;
+    std::array<BreakPoint, (int)Event::NumEvents> breakpoints;
     Event active_breakpoint;
     bool at_breakpoint = false;
 


### PR DESCRIPTION
And allow the compiler to inline by moving the actual check to the header.

Saves 1%+ in vertex heavy situations as std::map lookups are quite expensive. As Citra was doing one per Pica reg write, that can be replaced with an array lookup, I thought that might be worth fixing.