### PR TITLE
Fixes for #1711 and other compilation errors.

### DIFF
--- a/.travis-deps.sh
+++ b/.travis-deps.sh
@@ -9,7 +9,7 @@ if [ "$TRAVIS_OS_NAME" = "linux" -o -z "$TRAVIS_OS_NAME" ]; then
     export CXX=g++-5
     mkdir -p $HOME/.local
 
-    curl -L http://www.cmake.org/files/v2.8/cmake-2.8.11-Linux-i386.tar.gz \
+    curl -L http://www.cmake.org/files/v3.1/cmake-3.1.0-Linux-i386.tar.gz \
         | tar -xz -C $HOME/.local --strip-components=1
 
     (
@@ -20,6 +20,7 @@ if [ "$TRAVIS_OS_NAME" = "linux" -o -z "$TRAVIS_OS_NAME" ]; then
     )
 elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
     brew update > /dev/null # silence the very verbose output
-    brew install qt5 sdl2 dylibbundler
+    brew unlink cmake
+    brew install cmake31 qt5 sdl2 dylibbundler
     gem install xcpretty
 fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-# CMake 2.8.11 required for Qt5 settings to be applied automatically on
-# dependent libraries.
-cmake_minimum_required(VERSION 2.8.11)
+# CMake 3.1 required for Qt5 settings to be applied automatically on
+# dependent libraries and IMPORTED targets.
+cmake_minimum_required(VERSION 3.1)
 
 function(download_bundled_external remote_path lib_name prefix_var)
     set(prefix "${CMAKE_BINARY_DIR}/externals/${lib_name}")
@@ -135,6 +135,8 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/externals/cmake-modules")
 find_package(OpenGL REQUIRED)
 include_directories(${OPENGL_INCLUDE_DIR})
 
+# Prefer the -pthread flag on Linux.
+set (THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
 if (ENABLE_SDL2)

--- a/src/citra/CMakeLists.txt
+++ b/src/citra/CMakeLists.txt
@@ -21,7 +21,7 @@ target_link_libraries(citra ${SDL2_LIBRARY} ${OPENGL_gl_LIBRARY} inih glad)
 if (MSVC)
     target_link_libraries(citra getopt)
 endif()
-target_link_libraries(citra ${PLATFORM_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(citra ${PLATFORM_LIBRARIES} Threads::Threads)
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux|FreeBSD|OpenBSD|NetBSD")
     install(TARGETS citra RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")

--- a/src/common/assert.h
+++ b/src/common/assert.h
@@ -39,7 +39,7 @@ static void assert_noinline_call(const Fn& fn) {
     }); } while (0)
 
 #define UNREACHABLE() ASSERT_MSG(false, "Unreachable code!")
-#define UNREACHABLE_MSG(_a_, ...) ASSERT_MSG(false, _a_, __VA_ARGS__)
+#define UNREACHABLE_MSG(...) ASSERT_MSG(false, __VA_ARGS__)
 
 #ifdef _DEBUG
 #define DEBUG_ASSERT(_a_) ASSERT(_a_)

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -43,7 +43,7 @@ void FindContentInfos(Service::Interface* self) {
     am_content_count[media_type] = cmd_buff[4];
 
     cmd_buff[1] = RESULT_SUCCESS.raw;
-    LOG_WARNING(Service_AM, "(STUBBED) media_type=%u, title_id=0x%016lx, content_cound=%u, content_ids_pointer=0x%08x, content_info_pointer=0x%08x",
+    LOG_WARNING(Service_AM, "(STUBBED) media_type=%u, title_id=0x%016llx, content_cound=%u, content_ids_pointer=0x%08x, content_info_pointer=0x%08x",
                 media_type, title_id, am_content_count[media_type], content_ids_pointer, content_info_pointer);
 }
 

--- a/src/video_core/shader/shader_jit_x64.cpp
+++ b/src/video_core/shader/shader_jit_x64.cpp
@@ -795,6 +795,8 @@ void JitShader::FindReturnOffsets() {
         case OpCode::Id::CALLU:
             return_offsets.push_back(instr.flow_control.dest_offset + instr.flow_control.num_instructions);
             break;
+        default:
+            break;
         }
     }
 

--- a/src/video_core/shader/shader_jit_x64.cpp
+++ b/src/video_core/shader/shader_jit_x64.cpp
@@ -856,7 +856,7 @@ void JitShader::Compile() {
     uintptr_t size = reinterpret_cast<uintptr_t>(GetCodePtr()) - reinterpret_cast<uintptr_t>(program);
     ASSERT_MSG(size <= MAX_SHADER_SIZE, "Compiled a shader that exceeds the allocated size!");
 
-    LOG_DEBUG(HW_GPU, "Compiled shader size=%d", size);
+    LOG_DEBUG(HW_GPU, "Compiled shader size=%lu", size);
 }
 
 JitShader::JitShader() {

--- a/src/video_core/shader/shader_jit_x64.cpp
+++ b/src/video_core/shader/shader_jit_x64.cpp
@@ -148,7 +148,7 @@ static Instruction GetVertexShaderInstruction(size_t offset) {
 }
 
 static void LogCritical(const char* msg) {
-    LOG_CRITICAL(HW_GPU, msg);
+    LOG_CRITICAL(HW_GPU, "%s", msg);
 }
 
 void JitShader::Compile_Assert(bool condition, const char* msg) {


### PR DESCRIPTION
The big change is moving to CMake 3.1. Other changes
fix compiler errors noticed on Clang 3.9 / OSX.

Fixes #1711 