### PR TITLE
fixup simple type conversions where possible

### DIFF
--- a/src/audio_core/hle/pipe.cpp
+++ b/src/audio_core/hle/pipe.cpp
@@ -36,12 +36,17 @@ std::vector<u8> PipeRead(DspPipe pipe_number, u32 length) {
         return {};
     }
 
+    if (length > UINT16_MAX) { // Can only read at most UINT16_MAX from the pipe
+        LOG_ERROR(Audio_DSP, "length of %u greater than max of %u", length, UINT16_MAX);
+        return {};
+    }
+
     std::vector<u8>& data = pipe_data[pipe_index];
 
     if (length > data.size()) {
         LOG_WARNING(Audio_DSP, "pipe_number = %zu is out of data, application requested read of %u but %zu remain",
                     pipe_index, length, data.size());
-        length = data.size();
+        length = static_cast<u32>(data.size());
     }
 
     if (length == 0)
@@ -94,7 +99,7 @@ static void AudioPipeWriteStructAddresses() {
     };
 
     // Begin with a u16 denoting the number of structs.
-    WriteU16(DspPipe::Audio, struct_addresses.size());
+    WriteU16(DspPipe::Audio, static_cast<u16>(struct_addresses.size()));
     // Then write the struct addresses.
     for (u16 addr : struct_addresses) {
         WriteU16(DspPipe::Audio, addr);

--- a/src/audio_core/hle/pipe.h
+++ b/src/audio_core/hle/pipe.h
@@ -24,10 +24,14 @@ enum class DspPipe {
 constexpr size_t NUM_DSP_PIPE = 8;
 
 /**
- * Read a DSP pipe.
- * @param pipe_number The Pipe ID
- * @param length How much data to request.
- * @return The data read from the pipe. The size of this vector can be less than the length requested.
+ * Reads `length` bytes from the DSP pipe identified with `pipe_number`.
+ * @note Can read up to the maximum value of a u16 in bytes (65,535).
+ * @note IF an error is encoutered with either an invalid `pipe_number` or `length` value, an empty vector will be returned.
+ * @note IF `length` is set to 0, an empty vector will be returned.
+ * @note IF `length` is greater than the amount of data available, this function will only read the available amount.
+ * @param pipe_number a `DspPipe`
+ * @param length the number of bytes to read. The max is 65,535 (max of u16).
+ * @returns a vector of bytes from the specified pipe. On error, will be empty.
  */
 std::vector<u8> PipeRead(DspPipe pipe_number, u32 length);
 

--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -85,7 +85,7 @@ void Config::ReadValues() {
 
     // Debugging
     Settings::values.use_gdbstub = sdl2_config->GetBoolean("Debugging", "use_gdbstub", false);
-    Settings::values.gdbstub_port = sdl2_config->GetInteger("Debugging", "gdbstub_port", 24689);
+    Settings::values.gdbstub_port = static_cast<u16>(sdl2_config->GetInteger("Debugging", "gdbstub_port", 24689));
 }
 
 void Config::Reload() {

--- a/src/citra_qt/debugger/graphics_vertex_shader.cpp
+++ b/src/citra_qt/debugger/graphics_vertex_shader.cpp
@@ -515,7 +515,7 @@ void GraphicsVertexShaderWidget::Reload(bool replace_vertex_data, void* vertex_d
     }
 
     // Initialize debug info text for current cycle count
-    cycle_index->setMaximum(debug_data.records.size() - 1);
+    cycle_index->setMaximum(static_cast<int>(debug_data.records.size() - 1));
     OnCycleIndexChanged(cycle_index->value());
 
     model->endResetModel();

--- a/src/citra_qt/util/util.cpp
+++ b/src/citra_qt/util/util.cpp
@@ -19,7 +19,7 @@ QString ReadableByteSize(qulonglong size) {
     static const std::array<const char*, 6> units = { "B", "KiB", "MiB", "GiB", "TiB", "PiB" };
     if (size == 0)
         return "0";
-    int digit_groups = std::min<int>((int)(std::log10(size) / std::log10(1024)), units.size());
+    int digit_groups = std::min<int>(static_cast<int>(std::log10(size) / std::log10(1024)), static_cast<int>(units.size()));
     return QString("%L1 %2").arg(size / std::pow(1024, digit_groups), 0, 'f', 1)
                             .arg(units[digit_groups]);
 }

--- a/src/core/gdbstub/gdbstub.cpp
+++ b/src/core/gdbstub/gdbstub.cpp
@@ -374,7 +374,7 @@ static void SendReply(const char* reply) {
 
     memset(command_buffer, 0, sizeof(command_buffer));
 
-    command_length = strlen(reply);
+    command_length = static_cast<u32>(strlen(reply));
     if (command_length + 4 > sizeof(command_buffer)) {
         LOG_ERROR(Debug_GDBStub, "command_buffer overflow in SendReply");
         return;
@@ -515,7 +515,7 @@ static bool IsDataAvailable() {
         return false;
     }
 
-    return FD_ISSET(gdbserver_socket, &fd_socket);
+    return FD_ISSET(gdbserver_socket, &fd_socket) != 0;
 }
 
 /// Send requested register to gdb client.
@@ -633,10 +633,10 @@ static void ReadMemory() {
 
     auto start_offset = command_buffer+1;
     auto addr_pos = std::find(start_offset, command_buffer+command_length, ',');
-    PAddr addr = HexToInt(start_offset, addr_pos - start_offset);
+    PAddr addr = HexToInt(start_offset, static_cast<u32>(addr_pos - start_offset));
 
     start_offset = addr_pos+1;
-    u32 len = HexToInt(start_offset, (command_buffer + command_length) - start_offset);
+    u32 len = HexToInt(start_offset, static_cast<u32>((command_buffer + command_length) - start_offset));
 
     LOG_DEBUG(Debug_GDBStub, "gdb: addr: %08x len: %08x\n", addr, len);
 
@@ -658,11 +658,11 @@ static void ReadMemory() {
 static void WriteMemory() {
     auto start_offset = command_buffer+1;
     auto addr_pos = std::find(start_offset, command_buffer+command_length, ',');
-    PAddr addr = HexToInt(start_offset, addr_pos - start_offset);
+    PAddr addr = HexToInt(start_offset, static_cast<u32>(addr_pos - start_offset));
 
     start_offset = addr_pos+1;
     auto len_pos = std::find(start_offset, command_buffer+command_length, ':');
-    u32 len = HexToInt(start_offset, len_pos - start_offset);
+    u32 len = HexToInt(start_offset, static_cast<u32>(len_pos - start_offset));
 
     u8* dst = Memory::GetPointer(addr);
     if (!dst) {
@@ -752,10 +752,10 @@ static void AddBreakpoint() {
 
     auto start_offset = command_buffer+3;
     auto addr_pos = std::find(start_offset, command_buffer+command_length, ',');
-    PAddr addr = HexToInt(start_offset, addr_pos - start_offset);
+    PAddr addr = HexToInt(start_offset, static_cast<u32>(addr_pos - start_offset));
 
     start_offset = addr_pos+1;
-    u32 len = HexToInt(start_offset, (command_buffer + command_length) - start_offset);
+    u32 len = HexToInt(start_offset, static_cast<u32>((command_buffer + command_length) - start_offset));
 
     if (type == BreakpointType::Access) {
         // Access is made up of Read and Write types, so add both breakpoints
@@ -800,10 +800,10 @@ static void RemoveBreakpoint() {
 
     auto start_offset = command_buffer+3;
     auto addr_pos = std::find(start_offset, command_buffer+command_length, ',');
-    PAddr addr = HexToInt(start_offset, addr_pos - start_offset);
+    PAddr addr = HexToInt(start_offset, static_cast<u32>(addr_pos - start_offset));
 
     start_offset = addr_pos+1;
-    u32 len = HexToInt(start_offset, (command_buffer + command_length) - start_offset);
+    u32 len = HexToInt(start_offset, static_cast<u32>((command_buffer + command_length) - start_offset));
 
     if (type == BreakpointType::Access) {
         // Access is made up of Read and Write types, so add both breakpoints

--- a/src/core/hle/service/dsp_dsp.cpp
+++ b/src/core/hle/service/dsp_dsp.cpp
@@ -288,7 +288,7 @@ static void WriteProcessPipe(Service::Interface* self) {
     ASSERT_MSG(Memory::GetPointer(buffer) != nullptr, "Invalid Buffer: pipe=%u, size=0x%X, buffer=0x%08X", pipe_index, size, buffer);
 
     std::vector<u8> message(size);
-    for (size_t i = 0; i < size; i++) {
+    for (u32 i = 0; i < size; i++) {
         message[i] = Memory::Read8(buffer + i);
     }
 
@@ -403,7 +403,7 @@ static void GetPipeReadableSize(Service::Interface* self) {
 
     cmd_buff[0] = IPC::MakeHeader(0xF, 2, 0);
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
-    cmd_buff[2] = DSP::HLE::GetPipeReadableSize(pipe);
+    cmd_buff[2] = static_cast<u32>(DSP::HLE::GetPipeReadableSize(pipe));
 
     LOG_DEBUG(Service_DSP, "pipe=%u, unknown=0x%08X, return cmd_buff[2]=0x%08X", pipe_index, unknown, cmd_buff[2]);
 }

--- a/src/core/hw/gpu.cpp
+++ b/src/core/hw/gpu.cpp
@@ -188,10 +188,10 @@ inline void Write(u32 addr, const T data) {
                     u32 output_gap = config.texture_copy.output_gap * 16;
 
                     size_t contiguous_input_size = config.texture_copy.size / input_width * (input_width + input_gap);
-                    Memory::RasterizerFlushRegion(config.GetPhysicalInputAddress(), contiguous_input_size);
+                    Memory::RasterizerFlushRegion(config.GetPhysicalInputAddress(), static_cast<u32>(contiguous_input_size));
 
                     size_t contiguous_output_size = config.texture_copy.size / output_width * (output_width + output_gap);
-                    Memory::RasterizerFlushAndInvalidateRegion(config.GetPhysicalOutputAddress(), contiguous_output_size);
+                    Memory::RasterizerFlushAndInvalidateRegion(config.GetPhysicalOutputAddress(), static_cast<u32>(contiguous_output_size));
 
                     u32 remaining_size = config.texture_copy.size;
                     u32 remaining_input = input_width;

--- a/src/core/loader/3dsx.cpp
+++ b/src/core/loader/3dsx.cpp
@@ -178,11 +178,11 @@ static THREEDSX_Error Load3DSXFile(FileUtil::IOFile& file, u32 base_addr, Shared
                 for (unsigned current_inprogress = 0; current_inprogress < remaining && pos < end_pos; current_inprogress++) {
                     const auto& table = reloc_table[current_inprogress];
                     LOG_TRACE(Loader, "(t=%d,skip=%u,patch=%u)", current_segment_reloc_table,
-                              (u32)table.skip, (u32)table.patch);
+                              static_cast<u32>(table.skip), static_cast<u32>(table.patch));
                     pos += table.skip;
                     s32 num_patches = table.patch;
                     while (0 < num_patches && pos < end_pos) {
-                        u32 in_addr = (u8*)pos - program_image.data();
+                        u32 in_addr = static_cast<u32>(reinterpret_cast<u8*>(pos) - program_image.data());
                         u32 addr = TranslateAddr(*pos, &loadinfo, offsets);
                         LOG_TRACE(Loader, "Patching %08X <-- rel(%08X,%d) (%08X)",
                                   base_addr + in_addr, addr, current_segment_reloc_table, *pos);
@@ -284,7 +284,7 @@ ResultStatus AppLoader_THREEDSX::ReadRomFS(std::shared_ptr<FileUtil::IOFile>& ro
     // Check if the 3DSX has a RomFS...
     if (hdr.fs_offset != 0) {
         u32 romfs_offset = hdr.fs_offset;
-        u32 romfs_size = file.GetSize() - hdr.fs_offset;
+        u32 romfs_size = static_cast<u32>(file.GetSize()) - hdr.fs_offset;
 
         LOG_DEBUG(Loader, "RomFS offset:           0x%08X", romfs_offset);
         LOG_DEBUG(Loader, "RomFS size:             0x%08X", romfs_size);

--- a/src/core/tracer/recorder.cpp
+++ b/src/core/tracer/recorder.cpp
@@ -26,17 +26,17 @@ void Recorder::Finish(const std::string& filename) {
     // Calculate file offsets
     auto& initial = header.initial_state_offsets;
 
-    initial.gpu_registers_size      = initial_state.gpu_registers.size();
-    initial.lcd_registers_size      = initial_state.lcd_registers.size();
-    initial.pica_registers_size     = initial_state.pica_registers.size();
-    initial.default_attributes_size = initial_state.default_attributes.size();
-    initial.vs_program_binary_size  = initial_state.vs_program_binary.size();
-    initial.vs_swizzle_data_size    = initial_state.vs_swizzle_data.size();
-    initial.vs_float_uniforms_size  = initial_state.vs_float_uniforms.size();
-    initial.gs_program_binary_size  = initial_state.gs_program_binary.size();
-    initial.gs_swizzle_data_size    = initial_state.gs_swizzle_data.size();
-    initial.gs_float_uniforms_size  = initial_state.gs_float_uniforms.size();
-    header.stream_size              = stream.size();
+    initial.gpu_registers_size      = static_cast<u32>(initial_state.gpu_registers.size());
+    initial.lcd_registers_size      = static_cast<u32>(initial_state.lcd_registers.size());
+    initial.pica_registers_size     = static_cast<u32>(initial_state.pica_registers.size());
+    initial.default_attributes_size = static_cast<u32>(initial_state.default_attributes.size());
+    initial.vs_program_binary_size  = static_cast<u32>(initial_state.vs_program_binary.size());
+    initial.vs_swizzle_data_size    = static_cast<u32>(initial_state.vs_swizzle_data.size());
+    initial.vs_float_uniforms_size  = static_cast<u32>(initial_state.vs_float_uniforms.size());
+    initial.gs_program_binary_size  = static_cast<u32>(initial_state.gs_program_binary.size());
+    initial.gs_swizzle_data_size    = static_cast<u32>(initial_state.gs_swizzle_data.size());
+    initial.gs_float_uniforms_size  = static_cast<u32>(initial_state.gs_float_uniforms.size());
+    header.stream_size              = static_cast<u32>(stream.size());
 
     initial.gpu_registers      = sizeof(header);
     initial.lcd_registers      = initial.gpu_registers      + initial.gpu_registers_size * sizeof(u32);
@@ -68,7 +68,7 @@ void Recorder::Finish(const std::string& filename) {
             DEBUG_ASSERT(stream_element.extra_data.size() == 0);
             break;
         }
-        header.stream_offset += stream_element.extra_data.size();
+        header.stream_offset += static_cast<u32>(stream_element.extra_data.size());
     }
 
     try {

--- a/src/video_core/debug_utils/debug_utils.cpp
+++ b/src/video_core/debug_utils/debug_utils.cpp
@@ -208,11 +208,12 @@ void DumpShader(const std::string& filename, const Regs::ShaderConfig& config, c
 
     // TODO: Reduce the amount of binary code written to relevant portions
     dvlp.binary_offset = write_offset - dvlp_offset;
-    dvlp.binary_size_words = setup.program_code.size();
-    QueueForWriting(reinterpret_cast<const u8*>(setup.program_code.data()), setup.program_code.size() * sizeof(u32));
+    dvlp.binary_size_words = static_cast<uint32_t>(setup.program_code.size());
+    QueueForWriting(reinterpret_cast<const u8*>(setup.program_code.data()),
+                    static_cast<u32>(setup.program_code.size()) * sizeof(u32));
 
     dvlp.swizzle_info_offset = write_offset - dvlp_offset;
-    dvlp.swizzle_info_num_entries = setup.swizzle_data.size();
+    dvlp.swizzle_info_num_entries = static_cast<uint32_t>(setup.swizzle_data.size());
     u32 dummy = 0;
     for (unsigned int i = 0; i < setup.swizzle_data.size(); ++i) {
         QueueForWriting(reinterpret_cast<const u8*>(&setup.swizzle_data[i]), sizeof(setup.swizzle_data[i]));
@@ -264,7 +265,7 @@ void DumpShader(const std::string& filename, const Regs::ShaderConfig& config, c
             constant_table.emplace_back(constant);
     }
     dvle.constant_table_offset = write_offset - dvlb.dvle_offset;
-    dvle.constant_table_size = constant_table.size();
+    dvle.constant_table_size = static_cast<uint32_t>(constant_table.size());
     for (const auto& constant : constant_table) {
         QueueForWriting(reinterpret_cast<const u8*>(&constant), sizeof(constant));
     }

--- a/src/video_core/pica_state.h
+++ b/src/video_core/pica_state.h
@@ -56,7 +56,7 @@ struct State {
         // Used to buffer partial vertices for immediate-mode rendering.
         Shader::InputVertex input_vertex;
         // Index of the next attribute to be loaded into `input_vertex`.
-        int current_attribute = 0;
+        u32 current_attribute = 0;
     } immediate;
 
     // This is constructed with a dummy triangle topology

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -93,7 +93,7 @@ RasterizerOpenGL::RasterizerOpenGL() : shader_dirty(true) {
     state.Apply();
 
     for (size_t i = 0; i < lighting_luts.size(); ++i) {
-        glActiveTexture(GL_TEXTURE3 + i);
+        glActiveTexture(static_cast<GLenum>(GL_TEXTURE3 + i));
         glTexImage1D(GL_TEXTURE_1D, 0, GL_RGBA32F, 256, 0, GL_RGBA, GL_FLOAT, nullptr);
         glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
         glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -192,7 +192,7 @@ void RendererOpenGL::LoadFBToScreenInfo(const GPU::Regs::FramebufferConfig& fram
     // only allows rows to have a memory alignement of 4.
     ASSERT(pixel_stride % 4 == 0);
 
-    if (!Rasterizer()->AccelerateDisplay(framebuffer, framebuffer_addr, pixel_stride, screen_info)) {
+    if (!Rasterizer()->AccelerateDisplay(framebuffer, framebuffer_addr, static_cast<u32>(pixel_stride), screen_info)) {
         // Reset the screen info's display texture to its own permanent texture
         screen_info.display_texture = screen_info.texture.resource.handle;
         screen_info.display_texcoords = MathUtil::Rectangle<float>(0.f, 0.f, 1.f, 1.f);


### PR DESCRIPTION
This PR is a step towards fixing all warnings under the MSVC.

There are 3 major classes of warnings that need fixing:
 - implicit type casts where data can be lost
 - code paths where not all branches return
 - comparisons between signed/unsigned values

I only look to fix implicit type casts here, and only for the `citra` project directly. I make no changes to `microprofile` or `nihstro` here.

I'm looking to fix the other classes of warnings in other PRs.