### PR TITLE
Interpreter instruction cache

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SRCS
+            arm/cache/cache.cpp
             arm/disassembler/arm_disasm.cpp
             arm/disassembler/load_symbol_map.cpp
             arm/dyncom/arm_dyncom.cpp
@@ -127,6 +128,7 @@ set(SRCS
 
 set(HEADERS
             arm/arm_interface.h
+            arm/cache/cache.h
             arm/disassembler/arm_disasm.h
             arm/disassembler/load_symbol_map.h
             arm/dyncom/arm_dyncom.h

--- a/src/core/arm/cache/cache.cpp
+++ b/src/core/arm/cache/cache.cpp
@@ -87,11 +87,9 @@ void CacheBase::OnCodeLoad(u32 address, u32 size) {
 }
 
 void CacheBase::OnCodeUnload(u32 address, u32 size) {
-    const u32 end = address + size;
-
     ptr_caches.erase(std::remove_if(ptr_caches.begin(), ptr_caches.end(),
         [&](auto const& cache) {
-            if ((address < cache.addr_end) && (end > cache.addr)) {
+            if ((address < cache.addr_end) && (address + size > cache.addr)) {
                 RemoveRange(cache.addr, cache.addr_end);
                 for (u32 i = cache.addr; i < cache.addr_end; i += Memory::PAGE_SIZE) { page_pointers[i >> Memory::PAGE_BITS] = nullptr; }
                 return true;

--- a/src/core/arm/cache/cache.cpp
+++ b/src/core/arm/cache/cache.cpp
@@ -2,7 +2,6 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include "common/assert.h"
 #include "core/arm/cache/cache.h"
 
 namespace Cache {
@@ -10,20 +9,20 @@ namespace Cache {
 static std::list<CacheBase*> caches;
 
 void RegisterCode(u32 address, u32 size) {
-    for (auto const& cache : caches) {
-        cache->OnCodeLoad(address, size);
+    for (const auto& cache : caches) {
+        cache->cache_fns.code_load(address, size);
     }
 }
 
 void UnregisterCode(u32 address, u32 size) {
-    for (auto const& cache : caches) {
-        cache->OnCodeUnload(address, size);
+    for (const auto& cache : caches) {
+        cache->cache_fns.code_unload(address, size);
     }
 }
 
 void ClearCache() {
-    for (auto const& cache : caches) {
-        cache->Clear();
+    for (const auto& cache : caches) {
+        cache->cache_fns.clear();
     }
 }
 
@@ -35,155 +34,12 @@ static void UnregisterCache(CacheBase* cache) {
     caches.erase(std::remove(caches.begin(), caches.end(), cache), caches.end());
 }
 
-CacheBase::CacheBase(bool index_mode, OnClearCb clearcb) : index_mode(index_mode) {
-    page_pointers.fill(nullptr);
-    Clear();
-    SetClearCallback(clearcb);
+CacheBase::CacheBase(functions fns) : cache_fns(fns) {
     RegisterCache(this);
 }
 
 CacheBase::~CacheBase() {
     UnregisterCache(this);
-}
-
-void CacheBase::Clear() {
-    if (OnClearCallback != nullptr) {
-        OnClearCallback();
-    }
-
-    for (auto& cache : ptr_caches) {
-        cache.data.assign(cache.data.size(), nullptr);
-    }
-
-    if (index_mode) {
-        blocks_pc.assign(MAX_BLOCKS, INVALID_BLOCK);
-        next_block = num_blocks = 0;
-    }
-}
-
-bool CacheBase::RemoveBlock(u32 pc) {
-    void** ptr = page_pointers[pc >> Memory::PAGE_BITS];
-    if (ptr != nullptr) {
-        ptr = &ptr[pc & Memory::PAGE_MASK];
-
-        if (*ptr == nullptr) {
-            return false;
-        }
-
-        if (index_mode) {
-            const u32 id = pointer_to_id(*ptr);
-            ASSERT(blocks_pc[id] == pc);
-
-            blocks_pc[id] = INVALID_BLOCK;
-            if (id < next_block) {
-                next_block = id;
-            }
-            while (num_blocks > 0 && blocks_pc[num_blocks - 1] == INVALID_BLOCK) {
-                --num_blocks;
-            }
-        }
-        *ptr = nullptr;
-        return true;
-    }
-    return false;
-}
-
-bool CacheBase::RemoveRange(u32 start, u32 end) {
-    bool result = false;
-    for (auto& cache : ptr_caches) {
-        for (u32 i = std::max(start, cache.addr); i < std::min(end, cache.addr_end); ++i) {
-            void** ptr = &cache.data[i - cache.addr];
-
-            if (*ptr == nullptr) {
-                continue;
-            }
-
-            if (index_mode) {
-                const u32 id = pointer_to_id(*ptr);
-                ASSERT(blocks_pc[id] == i);
-
-                blocks_pc[id] = INVALID_BLOCK;
-                if (id < next_block) {
-                    next_block = id;
-                }
-                while (num_blocks > 0 && blocks_pc[num_blocks - 1] == INVALID_BLOCK) {
-                    --num_blocks;
-                }
-            }
-            *ptr = nullptr;
-            result = true;
-        }
-    }
-    return result;
-}
-
-void CacheBase::OnCodeLoad(u32 address, u32 size) {
-    const u32 end = address + size;
-
-    // Check there is no overlapping
-    for (auto const& cache : ptr_caches) {
-        ASSERT((address >= cache.addr_end) || (end <= cache.addr));
-    }
-
-    ASSERT((address & Memory::PAGE_MASK) == 0 && (size & Memory::PAGE_MASK) == 0);
-
-    BlockPtrCache cache{ address, address + size };
-    cache.data.assign(size, nullptr);
-
-    for (u32 i = address; i < end; i += Memory::PAGE_SIZE) {
-        page_pointers[i >> Memory::PAGE_BITS] = &cache.data[i - address];
-    }
-    ptr_caches.emplace_back(std::move(cache));
-}
-
-void CacheBase::OnCodeUnload(u32 address, u32 size) {
-    ptr_caches.erase(std::remove_if(ptr_caches.begin(), ptr_caches.end(),
-        [&, this](auto const& cache) {
-            if ((address < cache.addr_end) && (address + size > cache.addr)) {
-                this->RemoveRange(cache.addr, cache.addr_end);
-                for (u32 i = cache.addr; i < cache.addr_end; i += Memory::PAGE_SIZE) {
-                    page_pointers[i >> Memory::PAGE_BITS] = nullptr;
-                }
-                return true;
-            }
-            return false;
-        }),
-        ptr_caches.cend());
-}
-
-void*& CacheBase::GetNewPtr(u32 pc) {
-    DEBUG_ASSERT(!index_mode || next_block == MAX_BLOCKS || ((next_block < MAX_BLOCKS) && blocks_pc[next_block] == INVALID_BLOCK));
-    DEBUG_ASSERT(GetPtr(pc) == nullptr);
-
-    void** page_ptr = page_pointers[pc >> Memory::PAGE_BITS];
-    if (page_ptr == nullptr) {
-        // pc isnt within mapped code
-        OnCodeLoad(pc & ~Memory::PAGE_MASK, Memory::PAGE_SIZE);
-        page_ptr = page_pointers[pc >> Memory::PAGE_BITS];
-    }
-
-    void** block_ptr = &page_ptr[pc & Memory::PAGE_MASK];
-
-    DEBUG_ASSERT(*block_ptr == nullptr);
-
-    if (index_mode) {
-        if (next_block == MAX_BLOCKS) {
-            Clear();
-        }
-
-        blocks_pc[next_block] = pc;
-        *block_ptr = id_to_pointer(next_block);
-
-        do {
-            ++next_block;
-        } while (next_block <= num_blocks && blocks_pc[next_block] != INVALID_BLOCK);
-
-        if (next_block > num_blocks) {
-            num_blocks++;
-        }
-    }
-
-    return *block_ptr;
 }
 
 }

--- a/src/core/arm/cache/cache.cpp
+++ b/src/core/arm/cache/cache.cpp
@@ -7,21 +7,53 @@
 
 namespace Cache {
 
+static std::list<CacheBase*> caches;
+
+void RegisterCode(u32 address, u32 size) {
+    for (auto const& cache : caches) {
+        cache->OnCodeLoad(address, size);
+    }
+}
+
+void UnregisterCode(u32 address, u32 size) {
+    for (auto const& cache : caches) {
+        cache->OnCodeUnload(address, size);
+    }
+}
+
+void ClearCache() {
+    for (auto const& cache : caches) {
+        cache->Clear();
+    }
+}
+
+static void RegisterCache(CacheBase* cache) {
+    caches.push_back(cache);
+}
+
+static void UnregisterCache(CacheBase* cache) {
+    caches.erase(std::remove(caches.begin(), caches.end(), cache), caches.end());
+}
+
 CacheBase::CacheBase(bool index_mode, OnClearCb clearcb) : index_mode(index_mode) {
     page_pointers.fill(nullptr);
     Clear();
     SetClearCallback(clearcb);
-    g_cachemanager.RegisterCache(this);
+    RegisterCache(this);
 }
 
 CacheBase::~CacheBase() {
-    g_cachemanager.UnregisterCache(this);
+    UnregisterCache(this);
 }
 
 void CacheBase::Clear() {
-    if (OnClearCallback != nullptr) OnClearCallback();
+    if (OnClearCallback != nullptr) {
+        OnClearCallback();
+    }
 
-    for (auto& cache : ptr_caches) cache.data.assign(cache.data.size(), nullptr);
+    for (auto& cache : ptr_caches) {
+        cache.data.assign(cache.data.size(), nullptr);
+    }
 
     if (index_mode) {
         blocks_pc.assign(MAX_BLOCKS, INVALID_BLOCK);
@@ -30,18 +62,25 @@ void CacheBase::Clear() {
 }
 
 bool CacheBase::RemoveBlock(u32 pc) {
-    u8** ptr = page_pointers[pc >> Memory::PAGE_BITS];
+    void** ptr = page_pointers[pc >> Memory::PAGE_BITS];
     if (ptr != nullptr) {
         ptr = &ptr[pc & Memory::PAGE_MASK];
-        if (*ptr == nullptr) return false;
+
+        if (*ptr == nullptr) {
+            return false;
+        }
 
         if (index_mode) {
             const u32 id = pointer_to_id(*ptr);
             ASSERT(blocks_pc[id] == pc);
 
             blocks_pc[id] = INVALID_BLOCK;
-            if (id < next_block) next_block = id;
-            while (num_blocks > 0 && blocks_pc[num_blocks - 1] == INVALID_BLOCK) --num_blocks;
+            if (id < next_block) {
+                next_block = id;
+            }
+            while (num_blocks > 0 && blocks_pc[num_blocks - 1] == INVALID_BLOCK) {
+                --num_blocks;
+            }
         }
         *ptr = nullptr;
         return true;
@@ -52,17 +91,24 @@ bool CacheBase::RemoveBlock(u32 pc) {
 bool CacheBase::RemoveRange(u32 start, u32 end) {
     bool result = false;
     for (auto& cache : ptr_caches) {
-        for (int i = std::max(start, cache.addr); i < std::min(end, cache.addr_end); ++i) {
-            u8** ptr = &cache.data[i - cache.addr];
-            if (*ptr == nullptr) continue;
+        for (u32 i = std::max(start, cache.addr); i < std::min(end, cache.addr_end); ++i) {
+            void** ptr = &cache.data[i - cache.addr];
+
+            if (*ptr == nullptr) {
+                continue;
+            }
 
             if (index_mode) {
                 const u32 id = pointer_to_id(*ptr);
                 ASSERT(blocks_pc[id] == i);
 
                 blocks_pc[id] = INVALID_BLOCK;
-                if (id < next_block) next_block = id;
-                while (num_blocks > 0 && blocks_pc[num_blocks - 1] == INVALID_BLOCK) --num_blocks;
+                if (id < next_block) {
+                    next_block = id;
+                }
+                while (num_blocks > 0 && blocks_pc[num_blocks - 1] == INVALID_BLOCK) {
+                    --num_blocks;
+                }
             }
             *ptr = nullptr;
             result = true;
@@ -75,23 +121,29 @@ void CacheBase::OnCodeLoad(u32 address, u32 size) {
     const u32 end = address + size;
 
     // Check there is no overlapping
-    for (auto const& cache : ptr_caches) ASSERT((address >= cache.addr_end) || (end <= cache.addr));
+    for (auto const& cache : ptr_caches) {
+        ASSERT((address >= cache.addr_end) || (end <= cache.addr));
+    }
 
     ASSERT((address & Memory::PAGE_MASK) == 0 && (size & Memory::PAGE_MASK) == 0);
 
     BlockPtrCache cache{ address, address + size };
     cache.data.assign(size, nullptr);
 
-    for (u32 i = address; i < end; i += Memory::PAGE_SIZE) { page_pointers[i >> Memory::PAGE_BITS] = &cache.data[i - address]; }
+    for (u32 i = address; i < end; i += Memory::PAGE_SIZE) {
+        page_pointers[i >> Memory::PAGE_BITS] = &cache.data[i - address];
+    }
     ptr_caches.emplace_back(std::move(cache));
 }
 
 void CacheBase::OnCodeUnload(u32 address, u32 size) {
     ptr_caches.erase(std::remove_if(ptr_caches.begin(), ptr_caches.end(),
-        [&](auto const& cache) {
+        [&, this](auto const& cache) {
             if ((address < cache.addr_end) && (address + size > cache.addr)) {
-                RemoveRange(cache.addr, cache.addr_end);
-                for (u32 i = cache.addr; i < cache.addr_end; i += Memory::PAGE_SIZE) { page_pointers[i >> Memory::PAGE_BITS] = nullptr; }
+                this->RemoveRange(cache.addr, cache.addr_end);
+                for (u32 i = cache.addr; i < cache.addr_end; i += Memory::PAGE_SIZE) {
+                    page_pointers[i >> Memory::PAGE_BITS] = nullptr;
+                }
                 return true;
             }
             return false;
@@ -99,55 +151,39 @@ void CacheBase::OnCodeUnload(u32 address, u32 size) {
         ptr_caches.cend());
 }
 
-u8*& CacheBase::GetNewPtr(u32 pc) {
+void*& CacheBase::GetNewPtr(u32 pc) {
     DEBUG_ASSERT(!index_mode || next_block == MAX_BLOCKS || ((next_block < MAX_BLOCKS) && blocks_pc[next_block] == INVALID_BLOCK));
     DEBUG_ASSERT(GetPtr(pc) == nullptr);
 
-    u8** page_ptr = page_pointers[pc >> Memory::PAGE_BITS];
+    void** page_ptr = page_pointers[pc >> Memory::PAGE_BITS];
     if (page_ptr == nullptr) {
         // pc isnt within mapped code
         OnCodeLoad(pc & ~Memory::PAGE_MASK, Memory::PAGE_SIZE);
         page_ptr = page_pointers[pc >> Memory::PAGE_BITS];
     }
 
-    u8** block_ptr = &page_ptr[pc & Memory::PAGE_MASK];
+    void** block_ptr = &page_ptr[pc & Memory::PAGE_MASK];
 
     DEBUG_ASSERT(*block_ptr == nullptr);
 
     if (index_mode) {
-        if (next_block == MAX_BLOCKS) Clear();
+        if (next_block == MAX_BLOCKS) {
+            Clear();
+        }
 
         blocks_pc[next_block] = pc;
         *block_ptr = id_to_pointer(next_block);
 
-        do ++next_block; while (next_block <= num_blocks && blocks_pc[next_block] != INVALID_BLOCK);
-        if (next_block > num_blocks) num_blocks++;
+        do {
+            ++next_block;
+        } while (next_block <= num_blocks && blocks_pc[next_block] != INVALID_BLOCK);
+
+        if (next_block > num_blocks) {
+            num_blocks++;
+        }
     }
 
     return *block_ptr;
 }
-
-
-void CacheManager::RegisterCode(u32 address, u32 size) const {
-    for (auto const& cache : caches) cache->OnCodeLoad(address, size);
-}
-
-void CacheManager::UnregisterCode(u32 address, u32 size) const {
-    for (auto const& cache : caches) cache->OnCodeUnload(address, size);
-}
-
-void CacheManager::ClearCache() const {
-    for (auto const& cache : caches) cache->Clear();
-}
-
-void CacheManager::RegisterCache(CacheBase* cache) {
-    caches.push_back(cache);
-}
-
-void CacheManager::UnregisterCache(CacheBase* cache) {
-    caches.erase(std::remove(caches.begin(), caches.end(), cache), caches.end());
-}
-
-CacheManager g_cachemanager;
 
 }

--- a/src/core/arm/cache/cache.h
+++ b/src/core/arm/cache/cache.h
@@ -1,0 +1,137 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <functional>
+#include <list>
+#include <vector>
+
+#include "common/assert.h"
+#include "common/common_types.h"
+
+#include "core/memory.h"
+
+namespace Cache {
+
+using OnClearCb = std::function<void()>;
+
+const u32 MAX_BLOCKS = 0x40000;
+const u32 INVALID_BLOCK = 0xFFFFFFFF;
+
+struct BlockPtrCache {
+    u32 addr;
+    u32 addr_end;
+    std::vector<u8*> data;
+};
+
+class CacheBase {
+protected:
+    explicit CacheBase(bool index_mode, OnClearCb clearcb);
+    ~CacheBase();
+
+public:
+    /// Called when the cache needs to reset or Clear() is called
+    void SetClearCallback(OnClearCb cb) { OnClearCallback = cb; }
+
+    /// Clear and call clear callback
+    void Clear();
+    // returns true if block was found, false otherwise
+    bool RemoveBlock(u32 pc);
+    bool RemoveRange(u32 start, u32 end);
+
+    void OnCodeLoad(u32 address, u32 size);
+    void OnCodeUnload(u32 address, u32 size);
+
+protected:
+    u8* GetPtr(u32 pc) const {
+        u8** ptr = page_pointers[pc >> Memory::PAGE_BITS];
+        if (ptr != nullptr) {
+            DEBUG_ASSERT(!index_mode || blocks_pc[pointer_to_id(ptr[pc & Memory::PAGE_MASK])] == pc);
+            return ptr[pc & Memory::PAGE_MASK];
+        }
+        return nullptr;
+    }
+    u8*& GetNewPtr(u32 pc);
+
+    std::function<u8*(u32)> id_to_pointer;
+    std::function<u32(u8*)> pointer_to_id;
+
+private:
+    bool index_mode;
+    OnClearCb OnClearCallback = nullptr;
+
+    std::vector<BlockPtrCache> ptr_caches;
+    std::array<u8**, (1 << (32 - Memory::PAGE_BITS))> page_pointers;
+
+    std::vector<u32> blocks_pc;
+    u32 next_block = 0;
+    u32 num_blocks = 0;
+};
+
+/// Use this if you only need to store a pointer
+template <typename T>
+class PtrCache final : public CacheBase {
+public:
+    explicit PtrCache(OnClearCb clearcb = nullptr) : CacheBase(false, clearcb) {
+        static_assert(std::is_pointer<T>::value, "T must be a pointer");
+    }
+    ~PtrCache() {}
+
+    /// Get cached pointer for PC
+    T FindPtr(u32 pc) { return reinterpret_cast<T>(GetPtr(pc)); }
+
+    /// Get reference of pointer for PC
+    T& GetNewPtr(u32 pc) { return reinterpret_cast<T&>(CacheBase::GetNewPtr(pc)); }
+};
+
+/// Index based cache
+template <typename T>
+class Cache final : public CacheBase {
+public:
+    explicit Cache(OnClearCb clearcb = nullptr) : CacheBase(true, clearcb) {
+        id_to_pointer = [this](u32 id) -> u8* {
+            return reinterpret_cast<u8*>(&blocks[id]);
+        };
+        pointer_to_id = [this](u8* ptr) -> u32 {
+            return static_cast<u32>(reinterpret_cast<T*>(ptr) - &blocks[0]);
+        };
+    }
+    ~Cache() {}
+
+    /// Get block cached for PC
+    T* FindBlock(u32 pc) { return reinterpret_cast<T*>(GetPtr(pc)); }
+
+    /// Allocate block for PC
+    T& GetNewBlock(u32 pc) { return *reinterpret_cast<T*&>(GetNewPtr(pc)); }
+
+private:
+    std::array<T, MAX_BLOCKS> blocks;
+};
+
+class CacheManager {
+public:
+    CacheManager() {}
+    ~CacheManager() {}
+
+    /// Loaders call these when mapping/unmapping code
+    void RegisterCode(u32 address, u32 size) const;
+    void UnregisterCode(u32 address, u32 size = 1) const;
+
+    /// Clear every cache
+    void ClearCache() const;
+
+private:
+    std::list<CacheBase*> caches;
+
+public:
+    void RegisterCache(CacheBase* cache);
+    void UnregisterCache(CacheBase* cache);
+};
+
+extern CacheManager g_cachemanager;
+
+}

--- a/src/core/arm/cache/cache.h
+++ b/src/core/arm/cache/cache.h
@@ -27,19 +27,41 @@ void ClearCache();
 
 using OnClearCb = std::function<void()>;
 
-const u32 MAX_BLOCKS = 0x40000;
-const u32 INVALID_BLOCK = 0xFFFFFFFF;
+constexpr u32 MAX_BLOCKS = 0x40000;
+constexpr u32 INVALID_BLOCK = 0xFFFFFFFF;
 
+template <typename T>
 struct BlockPtrCache {
     u32 addr;
     u32 addr_end;
-    std::vector<void*> data;
+    std::vector<T> data;
 };
 
 class CacheBase {
+public:
+    struct functions {
+        std::function<void(u32, u32)> code_load;
+        std::function<void(u32, u32)> code_unload;
+        std::function<void()> clear;
+    } const cache_fns;
+
 protected:
-    explicit CacheBase(bool index_mode, OnClearCb clearcb);
+    explicit CacheBase(functions fns);
     ~CacheBase();
+};
+
+template <typename T>
+class CacheCommon : CacheBase {
+protected:
+    explicit CacheCommon(bool index_mode, OnClearCb clearcb) : index_mode(index_mode), CacheBase({
+            [this](u32 start, u32 size) { this->OnCodeLoad(start, size); },
+            [this](u32 start, u32 size) { this->OnCodeUnload(start, size); },
+            [this]() { this->Clear(); }}) {
+        static_assert(std::is_pointer<T>::value, "T must be a pointer");
+        Clear();
+        SetClearCallback(clearcb);
+    }
+    ~CacheCommon() {}
 
 public:
     /// Called when the cache needs to reset or Clear() is called
@@ -48,34 +70,165 @@ public:
     }
 
     /// Clear and call clear callback
-    void Clear();
-    // returns true if block was found, false otherwise
-    bool RemoveBlock(u32 pc);
-    bool RemoveRange(u32 start, u32 end);
+    void Clear() {
+        if (OnClearCallback != nullptr) {
+            OnClearCallback();
+        }
 
-    void OnCodeLoad(u32 address, u32 size);
-    void OnCodeUnload(u32 address, u32 size);
+        for (auto& cache : ptr_caches) {
+            cache.data.assign(cache.data.size(), nullptr);
+        }
+
+        if (index_mode) {
+            blocks_pc.assign(MAX_BLOCKS, INVALID_BLOCK);
+            next_block = num_blocks = 0;
+        }
+    }
+
+    /// Returns true if block was found, false otherwise
+    bool RemoveBlock(u32 pc) {
+        T* ptr = page_pointers[pc >> Memory::PAGE_BITS];
+        if (ptr != nullptr) {
+            ptr = &ptr[pc & Memory::PAGE_MASK];
+
+            if (*ptr == nullptr) {
+                return false;
+            }
+
+            if (index_mode) {
+                const u32 id = pointer_to_index(*ptr);
+                ASSERT(blocks_pc[id] == pc);
+
+                blocks_pc[id] = INVALID_BLOCK;
+                next_block = std::min(id, next_block);
+
+                while (num_blocks > 0 && blocks_pc[num_blocks - 1] == INVALID_BLOCK) {
+                    --num_blocks;
+                }
+            }
+            *ptr = nullptr;
+            return true;
+        }
+        return false;
+    }
+
+    /// Returns true if at least one block was found, false otherwise
+    bool RemoveRange(u32 start, u32 end) {
+        bool result = false;
+        for (auto& cache : ptr_caches) {
+            for (u32 i = std::max(start, cache.addr); i < std::min(end, cache.addr_end); ++i) {
+                T* ptr = &cache.data[i - cache.addr];
+
+                if (*ptr == nullptr) {
+                    continue;
+                }
+
+                if (index_mode) {
+                    const u32 id = pointer_to_index(*ptr);
+                    ASSERT(blocks_pc[id] == i);
+
+                    blocks_pc[id] = INVALID_BLOCK;
+                    next_block = std::min(id, next_block);
+
+                    while (num_blocks > 0 && blocks_pc[num_blocks - 1] == INVALID_BLOCK) {
+                        --num_blocks;
+                    }
+                }
+                *ptr = nullptr;
+                result = true;
+            }
+        }
+        return result;
+    }
+
+    void OnCodeLoad(u32 address, u32 size) {
+        // Check there is no overlapping
+        ASSERT(std::none_of(ptr_caches.cbegin(), ptr_caches.cend(),
+            [&](const auto& cache) {
+            return (address < cache.addr_end) && (address + size > cache.addr);
+        }));
+
+        ASSERT((address & Memory::PAGE_MASK) == 0 && (size & Memory::PAGE_MASK) == 0);
+
+        BlockPtrCache<T> cache{ address, address + size };
+        cache.data.assign(size, nullptr);
+
+        for (u32 i = address; i < address + size; i += Memory::PAGE_SIZE) {
+            page_pointers[i >> Memory::PAGE_BITS] = &cache.data[i - address];
+        }
+        ptr_caches.emplace_back(std::move(cache));
+    }
+
+    void OnCodeUnload(u32 address, u32 size) {
+        ptr_caches.erase(std::remove_if(ptr_caches.begin(), ptr_caches.end(),
+            [&, this](const auto& cache) {
+                if ((address < cache.addr_end) && (address + size > cache.addr)) {
+                    this->RemoveRange(cache.addr, cache.addr_end);
+                    for (u32 i = cache.addr; i < cache.addr_end; i += Memory::PAGE_SIZE) {
+                        page_pointers[i >> Memory::PAGE_BITS] = nullptr;
+                    }
+                    return true;
+                }
+                return false;
+            }),
+            ptr_caches.cend());
+    }
 
 protected:
-    void* GetPtr(u32 pc) const {
-        void** ptr = page_pointers[pc >> Memory::PAGE_BITS];
+    T GetPtr(u32 pc) const {
+        T* ptr = page_pointers[pc >> Memory::PAGE_BITS];
         if (ptr != nullptr) {
-            DEBUG_ASSERT(!index_mode || blocks_pc[pointer_to_id(ptr[pc & Memory::PAGE_MASK])] == pc);
-            return ptr[pc & Memory::PAGE_MASK];
+            const T value = ptr[pc & Memory::PAGE_MASK];
+            DEBUG_ASSERT(!index_mode || value == nullptr || blocks_pc[pointer_to_index(ptr[pc & Memory::PAGE_MASK])] == pc);
+            return value;
         }
         return nullptr;
     }
-    void*& GetNewPtr(u32 pc);
 
-    std::function<void*(u32)> id_to_pointer;
-    std::function<u32(void*)> pointer_to_id;
+    T* GetNewPtr(u32 pc) {
+        DEBUG_ASSERT(!index_mode || next_block == MAX_BLOCKS || ((next_block < MAX_BLOCKS) && blocks_pc[next_block] == INVALID_BLOCK));
+        DEBUG_ASSERT(GetPtr(pc) == nullptr);
+
+        T* page_ptr = page_pointers[pc >> Memory::PAGE_BITS];
+        if (page_ptr == nullptr) {
+            // pc isnt within mapped code
+            OnCodeLoad(pc & ~Memory::PAGE_MASK, Memory::PAGE_SIZE);
+            page_ptr = page_pointers[pc >> Memory::PAGE_BITS];
+        }
+
+        T* block_ptr = &page_ptr[pc & Memory::PAGE_MASK];
+
+        DEBUG_ASSERT(!index_mode || *block_ptr == nullptr);
+
+        if (index_mode) {
+            if (next_block == MAX_BLOCKS) {
+                Clear();
+            }
+
+            blocks_pc[next_block] = pc;
+            *block_ptr = index_to_pointer(next_block);
+
+            do {
+                ++next_block;
+            } while (next_block <= num_blocks && blocks_pc[next_block] != INVALID_BLOCK);
+
+            if (next_block > num_blocks) {
+                num_blocks++;
+            }
+        }
+
+        return block_ptr;
+    }
+
+    std::function<T(u32)> index_to_pointer;
+    std::function<u32(T)> pointer_to_index;
 
 private:
-    bool index_mode;
     OnClearCb OnClearCallback = nullptr;
+    const bool index_mode;
 
-    std::vector<BlockPtrCache> ptr_caches;
-    std::array<void**, (1 << (32 - Memory::PAGE_BITS))> page_pointers;
+    std::vector<BlockPtrCache<T>> ptr_caches;
+    std::array<T*, (1 << (32 - Memory::PAGE_BITS))> page_pointers = {};
 
     std::vector<u32> blocks_pc;
     u32 next_block = 0;
@@ -84,49 +237,52 @@ private:
 
 /// Use this if you only need to store a pointer
 template <typename T>
-class PtrCache final : public CacheBase {
+class PtrCache final : public CacheCommon<T> {
 public:
-    explicit PtrCache(OnClearCb clearcb = nullptr) : CacheBase(false, clearcb) {
-        static_assert(std::is_pointer<T>::value, "T must be a pointer");
+    explicit PtrCache(OnClearCb clearcb = nullptr) : CacheCommon<T>(false, clearcb) {
+        static_assert(std::is_pointer<T>::value, "T must be a pointer, use IndexedCache");
     }
     ~PtrCache() {}
 
     /// Get cached pointer for PC
     T GetPtr(u32 pc) {
-        return reinterpret_cast<T>(CacheBase::GetPtr(pc));
+        return CacheCommon<T>::GetPtr(pc);
     }
 
-    /// Get reference of pointer for PC
-    T& GetNewPtr(u32 pc) {
-        return reinterpret_cast<T&>(CacheBase::GetNewPtr(pc));
+    /// Set pointer for PC to value
+    T SetPtr(u32 pc, T value) {
+        return (*CacheCommon<T>::GetNewPtr(pc) = value);
     }
 };
 
 /// Index based cache
 template <typename T>
-class Cache final : public CacheBase {
+class IndexedCache final : public CacheCommon<T*> {
 public:
-    explicit Cache(OnClearCb clearcb = nullptr) : CacheBase(true, clearcb) {
-        id_to_pointer = [this](u32 id) -> void* {
+    explicit IndexedCache(OnClearCb clearcb = nullptr) : CacheCommon<T*>(true, clearcb) {
+
+        static_assert(!std::is_pointer<T>::value, "T can't be a pointer, use PtrCache");
+
+        CacheCommon<T*>::index_to_pointer = [this](u32 id) -> T* {
             return &blocks[id];
         };
-        pointer_to_id = [this](void* ptr) -> u32 {
-            return static_cast<u32>(std::distance(blocks.begin(),
-                std::find_if(blocks.begin(), blocks.end(), [&](auto const& block) {
-                return (reinterpret_cast<T*>(ptr) == &block) ? true : false;
+        CacheCommon<T*>::pointer_to_index = [this](T* ptr) -> u32 {
+            return static_cast<u32>(std::distance(blocks.cbegin(),
+                std::find_if(blocks.cbegin(), blocks.cend(), [&](const T& block) {
+                return (ptr == &block);
             })));
         };
     }
-    ~Cache() {}
+    ~IndexedCache() {}
 
     /// Get block cached for PC
     T* GetBlock(u32 pc) {
-        return reinterpret_cast<T*>(GetPtr(pc));
+        return CacheCommon<T*>::GetPtr(pc);
     }
 
     /// Allocate block for PC
-    T& GetNewBlock(u32 pc) {
-        return *reinterpret_cast<T*&>(GetNewPtr(pc));
+    T* GetNewBlock(u32 pc) {
+        return *CacheCommon<T*>::GetNewPtr(pc);
     }
 
 private:

--- a/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
+++ b/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
@@ -1133,7 +1133,7 @@ struct pkh_inst {
 typedef arm_inst * ARM_INST_PTR;
 
 #define CACHE_BUFFER_SIZE    (64 * 1024 * 2000)
-static char inst_buf[CACHE_BUFFER_SIZE];
+static u8 inst_buf[CACHE_BUFFER_SIZE];
 static int top = 0;
 static inline void *AllocBuffer(unsigned int size) {
     int start = top;
@@ -3900,7 +3900,7 @@ unsigned InterpreterMainLoop(ARMul_State* cpu) {
         // Find the cached instruction cream, otherwise translate it...
         ptr = instr_cache.GetPtr(cpu->Reg[15]);
         if (ptr == nullptr) {
-            ptr = instr_cache.GetNewPtr(cpu->Reg[15]) = reinterpret_cast<u8*>(&inst_buf[top]);
+            ptr = instr_cache.SetPtr(cpu->Reg[15], &inst_buf[top]);
             if (cpu->NumInstrsToExecute != 1) {
                 if (InterpreterTranslateBlock(cpu, cpu->Reg[15]) == FETCH_EXCEPTION)
                     goto END;

--- a/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
+++ b/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
@@ -3893,10 +3893,12 @@ unsigned InterpreterMainLoop(ARMul_State* cpu) {
             cpu->Reg[15] &= 0xfffffffc;
 
         //clear cache if we dont have more than 10kb of buffer remaining
-        if ((top + (10 * 1024)) >= CACHE_BUFFER_SIZE) instr_cache.Clear();
+        if ((top + (10 * 1024)) >= CACHE_BUFFER_SIZE) {
+            instr_cache.Clear();
+        }
 
         // Find the cached instruction cream, otherwise translate it...
-        ptr = instr_cache.FindPtr(cpu->Reg[15]);
+        ptr = instr_cache.GetPtr(cpu->Reg[15]);
         if (ptr == nullptr) {
             ptr = instr_cache.GetNewPtr(cpu->Reg[15]) = reinterpret_cast<u8*>(&inst_buf[top]);
             if (cpu->NumInstrsToExecute != 1) {

--- a/src/core/arm/skyeye_common/armstate.h
+++ b/src/core/arm/skyeye_common/armstate.h
@@ -236,10 +236,6 @@ public:
     unsigned bigendSig;
     unsigned syscallSig;
 
-    // TODO(bunnei): Move this cache to a better place - it should be per codeset (likely per
-    // process for our purposes), not per ARMul_State (which tracks CPU core state).
-    std::unordered_map<u32, int> instruction_cache;
-
 private:
     void ResetMPCoreCP15Registers();
 

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -8,6 +8,7 @@
 #include "common/common_funcs.h"
 #include "common/logging/log.h"
 
+#include "core/arm/cache/cache.h"
 #include "core/hle/kernel/memory.h"
 #include "core/hle/kernel/process.h"
 #include "core/hle/kernel/resource_limit.h"
@@ -119,6 +120,10 @@ void Process::Run(s32 main_thread_priority, u32 stack_size) {
     MapSegment(codeset->code,   VMAPermission::ReadExecute, MemoryState::Code);
     MapSegment(codeset->rodata, VMAPermission::Read,        MemoryState::Code);
     MapSegment(codeset->data,   VMAPermission::ReadWrite,   MemoryState::Private);
+
+    // Map cache
+    Cache::g_cachemanager.UnregisterCode(0, 0xFFFFFFFF);
+    Cache::g_cachemanager.RegisterCode(codeset->code.addr, codeset->code.size);
 
     // Allocate and map stack
     vm_manager.MapMemoryBlock(Memory::HEAP_VADDR_END - stack_size,

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -122,8 +122,8 @@ void Process::Run(s32 main_thread_priority, u32 stack_size) {
     MapSegment(codeset->data,   VMAPermission::ReadWrite,   MemoryState::Private);
 
     // Map cache
-    Cache::g_cachemanager.UnregisterCode(0, 0xFFFFFFFF);
-    Cache::g_cachemanager.RegisterCode(codeset->code.addr, codeset->code.size);
+    Cache::UnregisterCode(0, 0xFFFFFFFF);
+    Cache::RegisterCode(codeset->code.addr, codeset->code.size);
 
     // Allocate and map stack
     vm_manager.MapMemoryBlock(Memory::HEAP_VADDR_END - stack_size,


### PR DESCRIPTION
Profiling showed that the interpreter spent around 10% time doing std::unordered_map lookups for the instruction cache . This PR reduces it to ~2% by caching into vectors instead, in a similar way to Memory::Read (look into page table, check for nullptr then get the data)
It provides a global that allows to clear the cache(s) and un/register codesets that can be useful for CRO
It also fixes MerryMage's jit that suffers the same issue, i have made a separate branch that would support this change