### PR TITLE
OpenGL State Tracker Immediacy

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -91,7 +91,7 @@ RasterizerOpenGL::RasterizerOpenGL() : shader_dirty(true) {
     for (size_t i = 0; i < lighting_luts.size(); ++i) {
         lighting_luts[i].Create();
         state.SetActiveTextureUnit(GL_TEXTURE3 + i);
-        state.SetLUTTexture1D(lighting_luts[i].handle);
+        state.SetTexture1D(lighting_luts[i].handle);
         glTexImage1D(GL_TEXTURE_1D, 0, GL_RGBA32F, 256, 0, GL_RGBA, GL_FLOAT, nullptr);
         glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
         glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
@@ -166,7 +166,7 @@ void RasterizerOpenGL::DrawTriangles() {
     bool has_stencil = regs.framebuffer.depth_format == Pica::Regs::DepthFormat::D24S8;
     glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_TEXTURE_2D, (has_stencil && depth_surface != nullptr) ? depth_surface->texture.handle : 0, 0);
 
-    if (OpenGLState::CheckFBStatus(GL_DRAW_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+    if (OpenGLState::CheckBoundFBStatus(GL_DRAW_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
         return;
     }
 
@@ -616,13 +616,12 @@ bool RasterizerOpenGL::AccelerateFill(const GPU::Regs::MemoryFillConfig& config)
     utility_state.MakeCurrent();
 
     utility_state.SetDrawFramebuffer(framebuffer.handle);
-    // TODO: When scissor test is implemented, need to disable scissor test in the state here so Clear call isn't affected
 
     if (dst_type == SurfaceType::Color || dst_type == SurfaceType::Texture) {
         glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, dst_surface->texture.handle, 0);
         glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, 0, 0);
 
-        if (OpenGLState::CheckFBStatus(GL_DRAW_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+        if (OpenGLState::CheckBoundFBStatus(GL_DRAW_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
             old_state->MakeCurrent();
             return false;
         }
@@ -707,7 +706,7 @@ bool RasterizerOpenGL::AccelerateFill(const GPU::Regs::MemoryFillConfig& config)
         glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, dst_surface->texture.handle, 0);
         glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_TEXTURE_2D, 0, 0);
 
-        if (OpenGLState::CheckFBStatus(GL_DRAW_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+        if (OpenGLState::CheckBoundFBStatus(GL_DRAW_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
             old_state->MakeCurrent();
             return false;
         }
@@ -725,7 +724,7 @@ bool RasterizerOpenGL::AccelerateFill(const GPU::Regs::MemoryFillConfig& config)
         glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, 0, 0);
         glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, dst_surface->texture.handle, 0);
 
-        if (OpenGLState::CheckFBStatus(GL_DRAW_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+        if (OpenGLState::CheckBoundFBStatus(GL_DRAW_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
             old_state->MakeCurrent();
             return false;
         }

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -351,7 +351,6 @@ private:
     void SyncLightPosition(int light_index);
 
     OpenGLState state;
-    OpenGLState utility_state;
 
     RasterizerCacheOpenGL res_cache;
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -351,6 +351,7 @@ private:
     void SyncLightPosition(int light_index);
 
     OpenGLState state;
+    OpenGLState utility_state;
 
     RasterizerCacheOpenGL res_cache;
 

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -6,6 +6,7 @@
 #include <atomic>
 #include <cstring>
 #include <iterator>
+#include <tuple>
 #include <unordered_set>
 #include <utility>
 #include <vector>

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -105,17 +105,15 @@ static void MortonCopyPixels(CachedSurface::PixelFormat pixel_format, u32 width,
 bool RasterizerCacheOpenGL::BlitTextures(GLuint src_tex, GLuint dst_tex, CachedSurface::SurfaceType type, const MathUtil::Rectangle<int>& src_rect, const MathUtil::Rectangle<int>& dst_rect) {
     using SurfaceType = CachedSurface::SurfaceType;
 
-    OpenGLState cur_state = OpenGLState::GetCurState();
+    OpenGLState* old_state = OpenGLState::GetCurrentState();
+    utility_state.MakeCurrent();
 
     // Make sure textures aren't bound to texture units, since going to bind them to framebuffer components
     OpenGLState::ResetTexture(src_tex);
     OpenGLState::ResetTexture(dst_tex);
 
-    // Keep track of previous framebuffer bindings
-    GLuint old_fbs[2] = { cur_state.draw.read_framebuffer, cur_state.draw.draw_framebuffer };
-    cur_state.draw.read_framebuffer = transfer_framebuffers[0].handle;
-    cur_state.draw.draw_framebuffer = transfer_framebuffers[1].handle;
-    cur_state.Apply();
+    utility_state.SetReadFramebuffer(transfer_framebuffers[0].handle);
+    utility_state.SetDrawFramebuffer(transfer_framebuffers[1].handle);
 
     u32 buffers = 0;
 
@@ -148,10 +146,12 @@ bool RasterizerCacheOpenGL::BlitTextures(GLuint src_tex, GLuint dst_tex, CachedS
     }
 
     if (OpenGLState::CheckFBStatus(GL_READ_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+        old_state->MakeCurrent();
         return false;
     }
 
     if (OpenGLState::CheckFBStatus(GL_DRAW_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+        old_state->MakeCurrent();
         return false;
     }
 
@@ -159,10 +159,7 @@ bool RasterizerCacheOpenGL::BlitTextures(GLuint src_tex, GLuint dst_tex, CachedS
                       dst_rect.left, dst_rect.top, dst_rect.right, dst_rect.bottom,
                       buffers, buffers == GL_COLOR_BUFFER_BIT ? GL_LINEAR : GL_NEAREST);
 
-    // Restore previous framebuffer bindings
-    cur_state.draw.read_framebuffer = old_fbs[0];
-    cur_state.draw.draw_framebuffer = old_fbs[1];
-    cur_state.Apply();
+    old_state->MakeCurrent();
 
     return true;
 }
@@ -177,17 +174,15 @@ bool RasterizerCacheOpenGL::TryBlitSurfaces(CachedSurface* src_surface, const Ma
     return BlitTextures(src_surface->texture.handle, dst_surface->texture.handle, CachedSurface::GetFormatType(src_surface->pixel_format), src_rect, dst_rect);
 }
 
-static void AllocateSurfaceTexture(GLuint texture, CachedSurface::PixelFormat pixel_format, u32 width, u32 height) {
+void RasterizerCacheOpenGL::AllocateSurfaceTexture(GLuint texture, CachedSurface::PixelFormat pixel_format, u32 width, u32 height) {
     // Allocate an uninitialized texture of appropriate size and format for the surface
     using SurfaceType = CachedSurface::SurfaceType;
 
-    OpenGLState cur_state = OpenGLState::GetCurState();
+    OpenGLState* old_state = OpenGLState::GetCurrentState();
+    utility_state.MakeCurrent();
 
-    // Keep track of previous texture bindings
-    GLuint old_tex = cur_state.texture_units[0].texture_2d;
-    cur_state.texture_units[0].texture_2d = texture;
-    cur_state.Apply();
-    glActiveTexture(GL_TEXTURE0);
+    utility_state.SetActiveTextureUnit(GL_TEXTURE0);
+    utility_state.SetTexture2D(texture);
 
     SurfaceType type = CachedSurface::GetFormatType(pixel_format);
 
@@ -211,9 +206,7 @@ static void AllocateSurfaceTexture(GLuint texture, CachedSurface::PixelFormat pi
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-    // Restore previous texture bindings
-    cur_state.texture_units[0].texture_2d = old_tex;
-    cur_state.Apply();
+    old_state->MakeCurrent();
 }
 
 MICROPROFILE_DEFINE(OpenGL_SurfaceUpload, "OpenGL", "Surface Upload", MP_RGB(128, 64, 192));
@@ -295,12 +288,11 @@ CachedSurface* RasterizerCacheOpenGL::GetSurface(const CachedSurface& params, bo
         Memory::RasterizerFlushRegion(params.addr, params_size);
 
         // Load data from memory to the new surface
-        OpenGLState cur_state = OpenGLState::GetCurState();
+        OpenGLState* old_state = OpenGLState::GetCurrentState();
+        utility_state.MakeCurrent();
 
-        GLuint old_tex = cur_state.texture_units[0].texture_2d;
-        cur_state.texture_units[0].texture_2d = new_surface->texture.handle;
-        cur_state.Apply();
-        glActiveTexture(GL_TEXTURE0);
+        utility_state.SetActiveTextureUnit(GL_TEXTURE0);
+        utility_state.SetTexture2D(new_surface->texture.handle);
 
         glPixelStorei(GL_UNPACK_ROW_LENGTH, (GLint)new_surface->stride);
         if (!new_surface->is_tiled) {
@@ -375,8 +367,6 @@ CachedSurface* RasterizerCacheOpenGL::GetSurface(const CachedSurface& params, bo
             new_surface->texture.Release();
             new_surface->texture.handle = scaled_texture.handle;
             scaled_texture.handle = 0;
-            cur_state.texture_units[0].texture_2d = new_surface->texture.handle;
-            cur_state.Apply();
         }
 
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
@@ -384,8 +374,7 @@ CachedSurface* RasterizerCacheOpenGL::GetSurface(const CachedSurface& params, bo
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-        cur_state.texture_units[0].texture_2d = old_tex;
-        cur_state.Apply();
+        old_state->MakeCurrent();
     }
 
     Memory::RasterizerMarkRegionCached(new_surface->addr, new_surface->size, 1);
@@ -607,8 +596,8 @@ void RasterizerCacheOpenGL::FlushSurface(CachedSurface* surface) {
         return;
     }
 
-    OpenGLState cur_state = OpenGLState::GetCurState();
-    GLuint old_tex = cur_state.texture_units[0].texture_2d;
+    OpenGLState* old_state = OpenGLState::GetCurrentState();
+    utility_state.MakeCurrent();
 
     OGLTexture unscaled_tex;
     GLuint texture_to_flush = surface->texture.handle;
@@ -625,9 +614,8 @@ void RasterizerCacheOpenGL::FlushSurface(CachedSurface* surface) {
         texture_to_flush = unscaled_tex.handle;
     }
 
-    cur_state.texture_units[0].texture_2d = texture_to_flush;
-    cur_state.Apply();
-    glActiveTexture(GL_TEXTURE0);
+    utility_state.SetActiveTextureUnit(GL_TEXTURE0);
+    utility_state.SetTexture2D(texture_to_flush);
 
     glPixelStorei(GL_PACK_ROW_LENGTH, (GLint)surface->stride);
     if (!surface->is_tiled) {
@@ -676,8 +664,7 @@ void RasterizerCacheOpenGL::FlushSurface(CachedSurface* surface) {
 
     surface->dirty = false;
 
-    cur_state.texture_units[0].texture_2d = old_tex;
-    cur_state.Apply();
+    old_state->MakeCurrent();
 }
 
 void RasterizerCacheOpenGL::FlushRegion(PAddr addr, u32 size, const CachedSurface* skip_surface, bool invalidate) {

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -145,12 +145,12 @@ bool RasterizerCacheOpenGL::BlitTextures(GLuint src_tex, GLuint dst_tex, CachedS
         buffers = GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT;
     }
 
-    if (OpenGLState::CheckFBStatus(GL_READ_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+    if (OpenGLState::CheckBoundFBStatus(GL_READ_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
         old_state->MakeCurrent();
         return false;
     }
 
-    if (OpenGLState::CheckFBStatus(GL_DRAW_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
+    if (OpenGLState::CheckBoundFBStatus(GL_DRAW_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
         old_state->MakeCurrent();
         return false;
     }

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -217,6 +217,10 @@ public:
     void FlushAll();
 
 private:
+    void AllocateSurfaceTexture(GLuint texture, CachedSurface::PixelFormat pixel_format, u32 width, u32 height);
+
+    OpenGLState utility_state;
+
     SurfaceCache surface_cache;
     OGLFramebuffer transfer_framebuffers[2];
 };

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -219,8 +219,6 @@ public:
 private:
     void AllocateSurfaceTexture(GLuint texture, CachedSurface::PixelFormat pixel_format, u32 width, u32 height);
 
-    OpenGLState utility_state;
-
     SurfaceCache surface_cache;
     OGLFramebuffer transfer_framebuffers[2];
 };

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -9,7 +9,8 @@
 
 #include "video_core/renderer_opengl/gl_state.h"
 
-OpenGLState OpenGLState::cur_state;
+static OpenGLState default_state;
+OpenGLState* OpenGLState::cur_state = &default_state;
 
 OpenGLState::OpenGLState() {
     // These all match default OpenGL values
@@ -56,6 +57,8 @@ OpenGLState::OpenGLState() {
         lut.texture_1d = 0;
     }
 
+    active_texture_unit = GL_TEXTURE0;
+
     draw.read_framebuffer = 0;
     draw.draw_framebuffer = 0;
     draw.vertex_array = 0;
@@ -64,159 +67,290 @@ OpenGLState::OpenGLState() {
     draw.shader_program = 0;
 }
 
-void OpenGLState::Apply() const {
-    // Culling
-    if (cull.enabled != cur_state.cull.enabled) {
-        if (cull.enabled) {
+OpenGLState* OpenGLState::GetCurrentState() {
+    return cur_state;
+}
+
+void OpenGLState::SetCullEnabled(bool n_enabled) {
+    if (n_enabled != cur_state->cull.enabled) {
+        if (n_enabled) {
             glEnable(GL_CULL_FACE);
         } else {
             glDisable(GL_CULL_FACE);
         }
     }
+    cull.enabled = n_enabled;
+}
 
-    if (cull.mode != cur_state.cull.mode) {
-        glCullFace(cull.mode);
+void OpenGLState::SetCullMode(GLenum n_mode) {
+    if (n_mode != cur_state->cull.mode) {
+        glCullFace(n_mode);
     }
+    cull.mode = n_mode;
+}
 
-    if (cull.front_face != cur_state.cull.front_face) {
-        glFrontFace(cull.front_face);
+void OpenGLState::SetCullFrontFace(GLenum n_front_face) {
+    if (n_front_face != cur_state->cull.front_face) {
+        glFrontFace(n_front_face);
     }
+    cull.front_face = n_front_face;
+}
 
-    // Depth test
-    if (depth.test_enabled != cur_state.depth.test_enabled) {
-        if (depth.test_enabled) {
+void OpenGLState::SetDepthTestEnabled(bool n_test_enabled) {
+    if (n_test_enabled != cur_state->depth.test_enabled) {
+        if (n_test_enabled) {
             glEnable(GL_DEPTH_TEST);
         } else {
             glDisable(GL_DEPTH_TEST);
         }
     }
+    depth.test_enabled = n_test_enabled;
+}
 
-    if (depth.test_func != cur_state.depth.test_func) {
-        glDepthFunc(depth.test_func);
+void OpenGLState::SetDepthFunc(GLenum n_test_func) {
+    if (n_test_func != cur_state->depth.test_func) {
+        glDepthFunc(n_test_func);
     }
+    depth.test_func = n_test_func;
+}
 
-    // Depth mask
-    if (depth.write_mask != cur_state.depth.write_mask) {
-        glDepthMask(depth.write_mask);
+void OpenGLState::SetDepthWriteMask(GLboolean n_write_mask) {
+    if (n_write_mask != cur_state->depth.write_mask) {
+        glDepthMask(n_write_mask);
     }
+    depth.write_mask = n_write_mask;
+}
 
-    // Color mask
-    if (color_mask.red_enabled != cur_state.color_mask.red_enabled ||
-            color_mask.green_enabled != cur_state.color_mask.green_enabled ||
-            color_mask.blue_enabled != cur_state.color_mask.blue_enabled ||
-            color_mask.alpha_enabled != cur_state.color_mask.alpha_enabled) {
-        glColorMask(color_mask.red_enabled, color_mask.green_enabled,
-                    color_mask.blue_enabled, color_mask.alpha_enabled);
+void OpenGLState::SetColorMask(GLboolean n_red_enabled, GLboolean n_green_enabled, GLboolean n_blue_enabled, GLboolean n_alpha_enabled) {
+    if (n_red_enabled != cur_state->color_mask.red_enabled ||
+            n_green_enabled != cur_state->color_mask.green_enabled ||
+            n_blue_enabled != cur_state->color_mask.blue_enabled ||
+            n_alpha_enabled != cur_state->color_mask.alpha_enabled) {
+        glColorMask(n_red_enabled, n_green_enabled,
+                    n_blue_enabled, n_alpha_enabled);
     }
+    color_mask.red_enabled = n_red_enabled;
+    color_mask.green_enabled = n_green_enabled;
+    color_mask.blue_enabled = n_blue_enabled;
+    color_mask.alpha_enabled = n_alpha_enabled;
+}
 
-    // Stencil test
-    if (stencil.test_enabled != cur_state.stencil.test_enabled) {
-        if (stencil.test_enabled) {
+void OpenGLState::SetStencilTestEnabled(bool n_test_enabled) {
+    if (n_test_enabled != cur_state->stencil.test_enabled) {
+        if (n_test_enabled) {
             glEnable(GL_STENCIL_TEST);
         } else {
             glDisable(GL_STENCIL_TEST);
         }
     }
+    stencil.test_enabled = n_test_enabled;
+}
 
-    if (stencil.test_func != cur_state.stencil.test_func ||
-            stencil.test_ref != cur_state.stencil.test_ref ||
-            stencil.test_mask != cur_state.stencil.test_mask) {
-        glStencilFunc(stencil.test_func, stencil.test_ref, stencil.test_mask);
+void OpenGLState::SetStencilFunc(GLenum n_test_func, GLint n_test_ref, GLuint n_test_mask) {
+    if (n_test_func != cur_state->stencil.test_func ||
+            n_test_ref != cur_state->stencil.test_ref ||
+            n_test_mask != cur_state->stencil.test_mask) {
+        glStencilFunc(n_test_func, n_test_ref, n_test_mask);
     }
+    stencil.test_func = n_test_func;
+    stencil.test_ref = n_test_ref;
+    stencil.test_mask = n_test_mask;
+}
 
-    if (stencil.action_depth_fail != cur_state.stencil.action_depth_fail ||
-            stencil.action_depth_pass != cur_state.stencil.action_depth_pass ||
-            stencil.action_stencil_fail != cur_state.stencil.action_stencil_fail) {
-        glStencilOp(stencil.action_stencil_fail, stencil.action_depth_fail, stencil.action_depth_pass);
+void OpenGLState::SetStencilOp(GLenum n_action_stencil_fail, GLenum n_action_depth_fail, GLenum n_action_depth_pass) {
+    if (n_action_stencil_fail != cur_state->stencil.action_depth_fail ||
+            n_action_depth_fail != cur_state->stencil.action_depth_pass ||
+            n_action_depth_pass != cur_state->stencil.action_stencil_fail) {
+        glStencilOp(n_action_stencil_fail, n_action_depth_fail, n_action_depth_pass);
     }
+    stencil.action_depth_fail = n_action_stencil_fail;
+    stencil.action_depth_pass = n_action_depth_fail;
+    stencil.action_stencil_fail = n_action_depth_pass;
+}
 
-    // Stencil mask
-    if (stencil.write_mask != cur_state.stencil.write_mask) {
-        glStencilMask(stencil.write_mask);
+void OpenGLState::SetStencilWriteMask(GLuint n_write_mask) {
+    if (n_write_mask != cur_state->stencil.write_mask) {
+        glStencilMask(n_write_mask);
     }
+    stencil.write_mask = n_write_mask;
+}
 
-    // Blending
-    if (blend.enabled != cur_state.blend.enabled) {
-        if (blend.enabled) {
+void OpenGLState::SetBlendEnabled(bool n_enabled) {
+    if (n_enabled != cur_state->blend.enabled) {
+        if (n_enabled) {
             glEnable(GL_BLEND);
 
-            cur_state.logic_op = GL_COPY;
-            glLogicOp(cur_state.logic_op);
+            SetLogicOp(GL_COPY);
             glDisable(GL_COLOR_LOGIC_OP);
         } else {
             glDisable(GL_BLEND);
             glEnable(GL_COLOR_LOGIC_OP);
         }
     }
+    blend.enabled = n_enabled;
+}
 
-    if (blend.color.red != cur_state.blend.color.red ||
-            blend.color.green != cur_state.blend.color.green ||
-            blend.color.blue != cur_state.blend.color.blue ||
-            blend.color.alpha != cur_state.blend.color.alpha) {
-        glBlendColor(blend.color.red, blend.color.green,
-                     blend.color.blue, blend.color.alpha);
+void OpenGLState::SetBlendFunc(GLenum n_src_rgb_func, GLenum n_dst_rgb_func, GLenum n_src_a_func, GLenum n_dst_a_func) {
+    if (n_src_rgb_func != cur_state->blend.src_rgb_func ||
+            n_dst_rgb_func != cur_state->blend.dst_rgb_func ||
+            n_src_a_func != cur_state->blend.src_a_func ||
+            n_dst_a_func != cur_state->blend.dst_a_func) {
+        glBlendFuncSeparate(n_src_rgb_func, n_dst_rgb_func,
+                            n_src_a_func, n_dst_a_func);
+    }
+    blend.src_rgb_func = n_src_rgb_func;
+    blend.dst_rgb_func = n_dst_rgb_func;
+    blend.src_a_func = n_src_a_func;
+    blend.dst_a_func = n_dst_a_func;
+}
+
+void OpenGLState::SetBlendColor(GLclampf n_red, GLclampf n_green, GLclampf n_blue, GLclampf n_alpha) {
+    if (n_red != cur_state->blend.color.red ||
+            n_green != cur_state->blend.color.green ||
+            n_blue != cur_state->blend.color.blue ||
+            n_alpha != cur_state->blend.color.alpha) {
+        glBlendColor(n_red, n_green,
+                     n_blue, n_alpha);
+    }
+    blend.color.red = n_red;
+    blend.color.green = n_green;
+    blend.color.blue = n_blue;
+    blend.color.alpha = n_alpha;
+}
+
+void OpenGLState::SetLogicOp(GLenum n_logic_op) {
+    if (n_logic_op != cur_state->logic_op) {
+        glLogicOp(n_logic_op);
+    }
+    logic_op = n_logic_op;
+}
+
+void OpenGLState::SetTexture2D(GLuint n_texture_2d) {
+    unsigned unit_index = active_texture_unit - GL_TEXTURE0;
+    ASSERT(unit_index < ARRAY_SIZE(texture_units));
+
+    if (n_texture_2d != cur_state->texture_units[unit_index].texture_2d) {
+        glBindTexture(GL_TEXTURE_2D, n_texture_2d);
+    }
+    texture_units[unit_index].texture_2d = n_texture_2d;
+}
+
+void OpenGLState::SetSampler(GLuint n_sampler) {
+    unsigned unit_index = active_texture_unit - GL_TEXTURE0;
+    ASSERT(unit_index < ARRAY_SIZE(texture_units));
+
+    if (n_sampler != cur_state->texture_units[unit_index].sampler) {
+        glBindSampler(unit_index, n_sampler);
+    }
+    texture_units[unit_index].sampler = n_sampler;
+}
+
+void OpenGLState::SetLUTTexture1D(GLuint n_texture_1d) {
+    unsigned unit_index = active_texture_unit - GL_TEXTURE3;
+    ASSERT(unit_index < ARRAY_SIZE(lighting_luts));
+
+    if (n_texture_1d != cur_state->lighting_luts[unit_index].texture_1d) {
+        glBindTexture(GL_TEXTURE_1D, n_texture_1d);
+    }
+    lighting_luts[unit_index].texture_1d = n_texture_1d;
+}
+
+void OpenGLState::SetActiveTextureUnit(GLenum n_active_texture_unit) {
+    if (n_active_texture_unit != cur_state->active_texture_unit) {
+        glActiveTexture(n_active_texture_unit);
+    }
+    active_texture_unit = n_active_texture_unit;
+}
+
+void OpenGLState::SetReadFramebuffer(GLuint n_read_framebuffer) {
+    if (n_read_framebuffer != cur_state->draw.read_framebuffer) {
+        glBindFramebuffer(GL_READ_FRAMEBUFFER, n_read_framebuffer);
+    }
+    draw.read_framebuffer = n_read_framebuffer;
+}
+
+void OpenGLState::SetDrawFramebuffer(GLuint n_draw_framebuffer) {
+    if (n_draw_framebuffer != cur_state->draw.draw_framebuffer) {
+        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, n_draw_framebuffer);
+    }
+    draw.draw_framebuffer = n_draw_framebuffer;
+}
+
+void OpenGLState::SetVertexArray(GLuint n_vertex_array) {
+    if (n_vertex_array != cur_state->draw.vertex_array) {
+        glBindVertexArray(n_vertex_array);
+    }
+    draw.vertex_array = n_vertex_array;
+}
+
+void OpenGLState::SetVertexBuffer(GLuint n_vertex_buffer) {
+    if (n_vertex_buffer != cur_state->draw.vertex_buffer) {
+        glBindBuffer(GL_ARRAY_BUFFER, n_vertex_buffer);
+    }
+    draw.vertex_buffer = n_vertex_buffer;
+}
+
+void OpenGLState::SetUniformBuffer(GLuint n_uniform_buffer) {
+    if (n_uniform_buffer != cur_state->draw.uniform_buffer) {
+        glBindBuffer(GL_UNIFORM_BUFFER, n_uniform_buffer);
+    }
+    draw.uniform_buffer = n_uniform_buffer;
+}
+
+void OpenGLState::SetShaderProgram(GLuint n_shader_program) {
+    if (n_shader_program != cur_state->draw.shader_program) {
+        glUseProgram(n_shader_program);
+    }
+    draw.shader_program = n_shader_program;
+}
+
+void OpenGLState::MakeCurrent() {
+    if (cur_state == this) {
+        return;
     }
 
-    if (blend.src_rgb_func != cur_state.blend.src_rgb_func ||
-            blend.dst_rgb_func != cur_state.blend.dst_rgb_func ||
-            blend.src_a_func != cur_state.blend.src_a_func ||
-            blend.dst_a_func != cur_state.blend.dst_a_func) {
-        glBlendFuncSeparate(blend.src_rgb_func, blend.dst_rgb_func,
-                            blend.src_a_func, blend.dst_a_func);
-    }
+    SetCullEnabled(cull.enabled);
+    SetCullMode(cull.mode);
+    SetCullFrontFace(cull.front_face);
 
-    if (logic_op != cur_state.logic_op) {
-        glLogicOp(logic_op);
-    }
+    SetDepthTestEnabled(depth.test_enabled);
+    SetDepthFunc(depth.test_func);
+    SetDepthWriteMask(depth.write_mask);
 
-    // Textures
+    SetColorMask(color_mask.red_enabled, color_mask.green_enabled, color_mask.blue_enabled, color_mask.alpha_enabled);
+
+    SetStencilTestEnabled(stencil.test_enabled);
+    SetStencilFunc(stencil.test_func, stencil.test_ref, stencil.test_mask);
+    SetStencilOp(stencil.action_stencil_fail, stencil.action_depth_fail, stencil.action_depth_pass);
+    SetStencilWriteMask(stencil.write_mask);
+
+    SetBlendEnabled(blend.enabled);
+    SetBlendFunc(blend.src_rgb_func, blend.dst_rgb_func, blend.src_a_func, blend.dst_a_func);
+    SetBlendColor(blend.color.red, blend.color.green, blend.color.blue, blend.color.alpha);
+
+    SetLogicOp(logic_op);
+
     for (unsigned i = 0; i < ARRAY_SIZE(texture_units); ++i) {
-        if (texture_units[i].texture_2d != cur_state.texture_units[i].texture_2d) {
-            glActiveTexture(GL_TEXTURE0 + i);
-            glBindTexture(GL_TEXTURE_2D, texture_units[i].texture_2d);
-        }
-        if (texture_units[i].sampler != cur_state.texture_units[i].sampler) {
-            glBindSampler(i, texture_units[i].sampler);
-        }
+        SetActiveTextureUnit(GL_TEXTURE0 + i);
+        SetTexture2D(texture_units[i].texture_2d);
+        SetSampler(texture_units[i].sampler);
     }
 
-    // Lighting LUTs
     for (unsigned i = 0; i < ARRAY_SIZE(lighting_luts); ++i) {
-        if (lighting_luts[i].texture_1d != cur_state.lighting_luts[i].texture_1d) {
-            glActiveTexture(GL_TEXTURE3 + i);
-            glBindTexture(GL_TEXTURE_1D, lighting_luts[i].texture_1d);
-        }
+        SetActiveTextureUnit(GL_TEXTURE3 + i);
+        SetLUTTexture1D(lighting_luts[i].texture_1d);
     }
 
-    // Framebuffer
-    if (draw.read_framebuffer != cur_state.draw.read_framebuffer) {
-        glBindFramebuffer(GL_READ_FRAMEBUFFER, draw.read_framebuffer);
-    }
-    if (draw.draw_framebuffer != cur_state.draw.draw_framebuffer) {
-        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, draw.draw_framebuffer);
-    }
+    SetActiveTextureUnit(active_texture_unit);
 
-    // Vertex array
-    if (draw.vertex_array != cur_state.draw.vertex_array) {
-        glBindVertexArray(draw.vertex_array);
-    }
+    SetReadFramebuffer(draw.read_framebuffer);
+    SetDrawFramebuffer(draw.draw_framebuffer);
+    SetVertexArray(draw.vertex_array);
+    SetVertexBuffer(draw.vertex_buffer);
+    SetUniformBuffer(draw.uniform_buffer);
+    SetShaderProgram(draw.shader_program);
 
-    // Vertex buffer
-    if (draw.vertex_buffer != cur_state.draw.vertex_buffer) {
-        glBindBuffer(GL_ARRAY_BUFFER, draw.vertex_buffer);
-    }
-
-    // Uniform buffer
-    if (draw.uniform_buffer != cur_state.draw.uniform_buffer) {
-        glBindBuffer(GL_UNIFORM_BUFFER, draw.uniform_buffer);
-    }
-
-    // Shader program
-    if (draw.shader_program != cur_state.draw.shader_program) {
-        glUseProgram(draw.shader_program);
-    }
-
-    cur_state = *this;
+    cur_state = this;
 }
 
 GLenum OpenGLState::CheckFBStatus(GLenum target) {
@@ -230,47 +364,55 @@ GLenum OpenGLState::CheckFBStatus(GLenum target) {
 }
 
 void OpenGLState::ResetTexture(GLuint handle) {
-    for (auto& unit : cur_state.texture_units) {
-        if (unit.texture_2d == handle) {
-            unit.texture_2d = 0;
+    for (unsigned i = 0; i < ARRAY_SIZE(texture_units); ++i) {
+        if (cur_state->texture_units[i].texture_2d == handle) {
+            cur_state->SetActiveTextureUnit(GL_TEXTURE0 + i);
+            cur_state->SetTexture2D(0);
+        }
+    }
+    for (unsigned i = 0; i < ARRAY_SIZE(lighting_luts); ++i) {
+        if (cur_state->lighting_luts[i].texture_1d == handle) {
+            cur_state->SetActiveTextureUnit(GL_TEXTURE3 + i);
+            cur_state->SetLUTTexture1D(0);
         }
     }
 }
 
 void OpenGLState::ResetSampler(GLuint handle) {
-    for (auto& unit : cur_state.texture_units) {
-        if (unit.sampler == handle) {
-            unit.sampler = 0;
+    for (unsigned i = 0; i < ARRAY_SIZE(texture_units); ++i) {
+        if (cur_state->texture_units[i].texture_2d == handle) {
+            cur_state->SetActiveTextureUnit(GL_TEXTURE0 + i);
+            cur_state->SetSampler(0);
         }
     }
 }
 
 void OpenGLState::ResetProgram(GLuint handle) {
-    if (cur_state.draw.shader_program == handle) {
-        cur_state.draw.shader_program = 0;
+    if (cur_state->draw.shader_program == handle) {
+        cur_state->SetShaderProgram(0);
     }
 }
 
 void OpenGLState::ResetBuffer(GLuint handle) {
-    if (cur_state.draw.vertex_buffer == handle) {
-        cur_state.draw.vertex_buffer = 0;
+    if (cur_state->draw.vertex_buffer == handle) {
+        cur_state->SetVertexBuffer(0);
     }
-    if (cur_state.draw.uniform_buffer == handle) {
-        cur_state.draw.uniform_buffer = 0;
+    if (cur_state->draw.uniform_buffer == handle) {
+        cur_state->SetUniformBuffer(0);
     }
 }
 
 void OpenGLState::ResetVertexArray(GLuint handle) {
-    if (cur_state.draw.vertex_array == handle) {
-        cur_state.draw.vertex_array = 0;
+    if (cur_state->draw.vertex_array == handle) {
+        cur_state->SetVertexArray(0);
     }
 }
 
 void OpenGLState::ResetFramebuffer(GLuint handle) {
-    if (cur_state.draw.read_framebuffer == handle) {
-        cur_state.draw.read_framebuffer = 0;
+    if (cur_state->draw.read_framebuffer == handle) {
+        cur_state->SetReadFramebuffer(0);
     }
-    if (cur_state.draw.draw_framebuffer == handle) {
-        cur_state.draw.draw_framebuffer = 0;
+    if (cur_state->draw.draw_framebuffer == handle) {
+        cur_state->SetDrawFramebuffer(0);
     }
 }

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -82,26 +82,26 @@ void OpenGLState::MakeCurrent() {
         return;
     }
 
-    SetCullEnabled(cull.enabled);
-    SetCullMode(cull.mode);
-    SetCullFrontFace(cull.front_face);
+    SetCullEnabled(GetCullEnabled());
+    SetCullMode(GetCullMode());
+    SetCullFrontFace(GetCullFrontFace());
 
-    SetDepthTestEnabled(depth.test_enabled);
-    SetDepthFunc(depth.test_func);
-    SetDepthWriteMask(depth.write_mask);
+    SetDepthTestEnabled(GetDepthTestEnabled());
+    SetDepthFunc(GetDepthFunc());
+    SetDepthWriteMask(GetDepthWriteMask());
 
-    SetColorMask(color_mask.red_enabled, color_mask.green_enabled, color_mask.blue_enabled, color_mask.alpha_enabled);
+    SetColorMask(GetColorMask());
 
-    SetStencilTestEnabled(stencil.test_enabled);
-    SetStencilFunc(stencil.test_func, stencil.test_ref, stencil.test_mask);
-    SetStencilOp(stencil.action_stencil_fail, stencil.action_depth_fail, stencil.action_depth_pass);
-    SetStencilWriteMask(stencil.write_mask);
+    SetStencilTestEnabled(GetStencilTestEnabled());
+    SetStencilFunc(GetStencilFunc());
+    SetStencilOp(GetStencilOp());
+    SetStencilWriteMask(GetStencilWriteMask());
 
-    SetBlendEnabled(blend.enabled);
-    SetBlendFunc(blend.src_rgb_func, blend.dst_rgb_func, blend.src_a_func, blend.dst_a_func);
-    SetBlendColor(blend.color.red, blend.color.green, blend.color.blue, blend.color.alpha);
+    SetBlendEnabled(GetBlendEnabled());
+    SetBlendFunc(GetBlendFunc());
+    SetBlendColor(GetBlendColor());
 
-    SetLogicOp(logic_op);
+    SetLogicOp(GetLogicOp());
 
     GLenum prev_active_texture_unit = active_texture_unit;
     for (unsigned i = 0; i < ARRAY_SIZE(texture_units); ++i) {
@@ -114,14 +114,14 @@ void OpenGLState::MakeCurrent() {
     active_texture_unit = prev_active_texture_unit;
     glActiveTexture(cur_state->active_texture_unit);
 
-    SetActiveTextureUnit(active_texture_unit);
+    SetActiveTextureUnit(GetActiveTextureUnit());
 
-    SetReadFramebuffer(draw.read_framebuffer);
-    SetDrawFramebuffer(draw.draw_framebuffer);
-    SetVertexArray(draw.vertex_array);
-    SetVertexBuffer(draw.vertex_buffer);
-    SetUniformBuffer(draw.uniform_buffer);
-    SetShaderProgram(draw.shader_program);
+    SetReadFramebuffer(GetReadFramebuffer());
+    SetDrawFramebuffer(GetDrawFramebuffer());
+    SetVertexArray(GetVertexArray());
+    SetVertexBuffer(GetVertexBuffer());
+    SetUniformBuffer(GetUniformBuffer());
+    SetShaderProgram(GetShaderProgram());
 
     cur_state = this;
 }
@@ -176,7 +176,10 @@ void OpenGLState::SetDepthWriteMask(GLboolean n_write_mask) {
     depth.write_mask = n_write_mask;
 }
 
-void OpenGLState::SetColorMask(GLboolean n_red_enabled, GLboolean n_green_enabled, GLboolean n_blue_enabled, GLboolean n_alpha_enabled) {
+void OpenGLState::SetColorMask(std::tuple<GLboolean, GLboolean, GLboolean, GLboolean> n_rgba_enabled) {
+    GLboolean n_red_enabled, n_green_enabled, n_blue_enabled, n_alpha_enabled;
+    std::tie(n_red_enabled, n_green_enabled, n_blue_enabled, n_alpha_enabled) = n_rgba_enabled;
+
     if (n_red_enabled != cur_state->color_mask.red_enabled ||
             n_green_enabled != cur_state->color_mask.green_enabled ||
             n_blue_enabled != cur_state->color_mask.blue_enabled ||
@@ -201,7 +204,11 @@ void OpenGLState::SetStencilTestEnabled(bool n_test_enabled) {
     stencil.test_enabled = n_test_enabled;
 }
 
-void OpenGLState::SetStencilFunc(GLenum n_test_func, GLint n_test_ref, GLuint n_test_mask) {
+void OpenGLState::SetStencilFunc(std::tuple<GLenum, GLint, GLint> n_funcs) {
+    GLenum n_test_func;
+    GLint n_test_ref, n_test_mask;
+    std::tie(n_test_func, n_test_ref, n_test_mask) = n_funcs;
+
     if (n_test_func != cur_state->stencil.test_func ||
             n_test_ref != cur_state->stencil.test_ref ||
             n_test_mask != cur_state->stencil.test_mask) {
@@ -212,7 +219,10 @@ void OpenGLState::SetStencilFunc(GLenum n_test_func, GLint n_test_ref, GLuint n_
     stencil.test_mask = n_test_mask;
 }
 
-void OpenGLState::SetStencilOp(GLenum n_action_stencil_fail, GLenum n_action_depth_fail, GLenum n_action_depth_pass) {
+void OpenGLState::SetStencilOp(std::tuple<GLenum, GLenum, GLenum> n_actions) {
+    GLenum n_action_stencil_fail, n_action_depth_fail, n_action_depth_pass;
+    std::tie(n_action_stencil_fail, n_action_depth_fail, n_action_depth_pass) = n_actions;
+
     if (n_action_stencil_fail != cur_state->stencil.action_stencil_fail ||
             n_action_depth_fail != cur_state->stencil.action_depth_fail ||
             n_action_depth_pass != cur_state->stencil.action_depth_pass) {
@@ -245,7 +255,10 @@ void OpenGLState::SetBlendEnabled(bool n_enabled) {
     blend.enabled = n_enabled;
 }
 
-void OpenGLState::SetBlendFunc(GLenum n_src_rgb_func, GLenum n_dst_rgb_func, GLenum n_src_a_func, GLenum n_dst_a_func) {
+void OpenGLState::SetBlendFunc(std::tuple<GLenum, GLenum, GLenum, GLenum> n_funcs) {
+    GLenum n_src_rgb_func, n_dst_rgb_func, n_src_a_func, n_dst_a_func;
+    std::tie(n_src_rgb_func, n_dst_rgb_func, n_src_a_func, n_dst_a_func) = n_funcs;
+
     if (n_src_rgb_func != cur_state->blend.src_rgb_func ||
             n_dst_rgb_func != cur_state->blend.dst_rgb_func ||
             n_src_a_func != cur_state->blend.src_a_func ||
@@ -259,7 +272,10 @@ void OpenGLState::SetBlendFunc(GLenum n_src_rgb_func, GLenum n_dst_rgb_func, GLe
     blend.dst_a_func = n_dst_a_func;
 }
 
-void OpenGLState::SetBlendColor(GLclampf n_red, GLclampf n_green, GLclampf n_blue, GLclampf n_alpha) {
+void OpenGLState::SetBlendColor(std::tuple<GLclampf, GLclampf, GLclampf, GLclampf> n_color) {
+    GLclampf n_red, n_green, n_blue, n_alpha;
+    std::tie(n_red, n_green, n_blue, n_alpha) = n_color;
+
     if (n_red != cur_state->blend.color.red ||
             n_green != cur_state->blend.color.green ||
             n_blue != cur_state->blend.color.blue ||
@@ -476,4 +492,32 @@ GLenum OpenGLState::CheckBoundFBStatus(GLenum target) {
     }
 
     return fb_status;
+}
+
+OpenGLState OpenGLState::ApplyTransferState(GLuint src_tex, GLuint read_framebuffer, GLuint dst_tex, GLuint draw_framebuffer) {
+    OpenGLState old_state = *cur_state;
+
+    cur_state->SetColorMask(std::make_tuple<>(true, true, true, true));
+    cur_state->SetDepthWriteMask(true);
+    cur_state->SetStencilWriteMask(true);
+    if (src_tex != 0) {
+        cur_state->ResetTexture(src_tex);
+    }
+    cur_state->SetReadFramebuffer(read_framebuffer);
+    if (dst_tex != 0) {
+        cur_state->ResetTexture(dst_tex);
+    }
+    cur_state->SetDrawFramebuffer(draw_framebuffer);
+
+    return old_state;
+}
+
+void OpenGLState::UndoTransferState(OpenGLState &old_state) {
+    cur_state->SetColorMask(old_state.GetColorMask());
+    cur_state->SetDepthWriteMask(old_state.GetDepthWriteMask());
+    cur_state->SetStencilWriteMask(old_state.GetStencilWriteMask());
+    cur_state->SetReadFramebuffer(old_state.GetReadFramebuffer());
+    cur_state->SetDrawFramebuffer(old_state.GetDrawFramebuffer());
+
+    // NOTE: Textures that were reset in ApplyTransferState() are NOT restored
 }

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -3,6 +3,8 @@
 // Refer to the license.txt file included.
 
 #include <set>
+#include <tuple>
+
 #include <glad/glad.h>
 
 #include "common/assert.h"

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -9,6 +9,7 @@
 class OpenGLState {
 public:
     OpenGLState();
+    ~OpenGLState();
 
     /// Get a pointer to the currently bound state tracker object
     static OpenGLState* GetCurrentState();
@@ -51,7 +52,7 @@ public:
     void SetUniformBuffer(GLuint n_uniform_buffer);
     void SetShaderProgram(GLuint n_shader_program);
 
-    /// Resets and unbinds any references to the given resource in the current OpenGL state
+    /// Resets and unbinds any references to the given resource across all existing states
     static void ResetTexture(GLuint handle);
     static void ResetSampler(GLuint handle);
     static void ResetProgram(GLuint handle);
@@ -127,6 +128,4 @@ private:
         GLuint uniform_buffer; // GL_UNIFORM_BUFFER_BINDING
         GLuint shader_program; // GL_CURRENT_PROGRAM
     } draw;
-
-    static OpenGLState* cur_state;
 };

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -10,22 +10,13 @@ class OpenGLState {
 public:
     OpenGLState();
 
+    /// Get a pointer to the currently bound state tracker object
     static OpenGLState* GetCurrentState();
 
     /// Apply this state as the current OpenGL state
     void MakeCurrent();
 
-    /// Check the status of the current OpenGL read or draw framebuffer configuration
-    static GLenum CheckFBStatus(GLenum target);
-
-    /// Resets and unbinds any references to the given resource in the current OpenGL state
-    static void ResetTexture(GLuint handle);
-    static void ResetSampler(GLuint handle);
-    static void ResetProgram(GLuint handle);
-    static void ResetBuffer(GLuint handle);
-    static void ResetVertexArray(GLuint handle);
-    static void ResetFramebuffer(GLuint handle);
-
+    /// Setter functions for OpenGL state
     void SetCullEnabled(bool n_enabled);
     void SetCullMode(GLenum n_mode);
     void SetCullFrontFace(GLenum n_front_face);
@@ -47,10 +38,9 @@ public:
 
     void SetLogicOp(GLenum n_logic_op);
 
+    void SetTexture1D(GLuint n_texture_1d);
     void SetTexture2D(GLuint n_texture_2d);
     void SetSampler(GLuint n_sampler);
-
-    void SetLUTTexture1D(GLuint n_texture_1d);
 
     void SetActiveTextureUnit(GLenum n_active_texture_unit);
 
@@ -60,6 +50,17 @@ public:
     void SetVertexBuffer(GLuint n_vertex_buffer);
     void SetUniformBuffer(GLuint n_uniform_buffer);
     void SetShaderProgram(GLuint n_shader_program);
+
+    /// Resets and unbinds any references to the given resource in the current OpenGL state
+    static void ResetTexture(GLuint handle);
+    static void ResetSampler(GLuint handle);
+    static void ResetProgram(GLuint handle);
+    static void ResetBuffer(GLuint handle);
+    static void ResetVertexArray(GLuint handle);
+    static void ResetFramebuffer(GLuint handle);
+
+    /// Check the status of the currently bound OpenGL read or draw framebuffer configuration
+    static GLenum CheckBoundFBStatus(GLenum target);
 
 private:
     struct {
@@ -111,13 +112,10 @@ private:
 
     // 3 texture units - one for each that is used in PICA fragment shader emulation
     struct {
+        GLuint texture_1d; // GL_TEXTURE_BINDING_1D
         GLuint texture_2d; // GL_TEXTURE_BINDING_2D
         GLuint sampler; // GL_SAMPLER_BINDING
-    } texture_units[3];
-
-    struct {
-        GLuint texture_1d; // GL_TEXTURE_BINDING_1D
-    } lighting_luts[6];
+    } texture_units[9];
 
     GLenum active_texture_unit; // GL_ACTIVE_TEXTURE
 

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -17,39 +17,74 @@ public:
     /// Apply this state as the current OpenGL state
     void MakeCurrent();
 
-    /// Setter functions for OpenGL state
+    /// Getter and setter functions for OpenGL state
+    inline bool GetCullEnabled() { return cull.enabled; }
     void SetCullEnabled(bool n_enabled);
+    inline GLenum GetCullMode() { return cull.mode; }
     void SetCullMode(GLenum n_mode);
+    inline GLenum GetCullFrontFace() { return cull.front_face; }
     void SetCullFrontFace(GLenum n_front_face);
 
+    inline bool GetDepthTestEnabled() { return depth.test_enabled; }
     void SetDepthTestEnabled(bool n_test_enabled);
+    inline GLenum GetDepthFunc() { return depth.test_func; }
     void SetDepthFunc(GLenum n_test_func);
+    inline GLboolean GetDepthWriteMask() { return depth.write_mask; }
     void SetDepthWriteMask(GLboolean n_write_mask);
 
-    void SetColorMask(GLboolean n_red_enabled, GLboolean n_green_enabled, GLboolean n_blue_enabled, GLboolean n_alpha_enabled);
+    inline std::tuple<GLboolean, GLboolean, GLboolean, GLboolean> GetColorMask() {
+        return std::make_tuple(color_mask.red_enabled, color_mask.green_enabled, color_mask.blue_enabled, color_mask.alpha_enabled);
+    }
+    void SetColorMask(std::tuple<GLboolean, GLboolean, GLboolean, GLboolean> n_rgba_enabled);
 
+    inline bool GetStencilTestEnabled() { return stencil.test_enabled; }
     void SetStencilTestEnabled(bool n_test_enabled);
-    void SetStencilFunc(GLenum n_test_func, GLint n_test_ref, GLuint n_test_mask);
-    void SetStencilOp(GLenum n_action_stencil_fail, GLenum n_action_depth_fail, GLenum n_action_depth_pass);
+    inline std::tuple<GLenum, GLint, GLint> GetStencilFunc() {
+        return std::make_tuple(stencil.test_func, stencil.test_ref, stencil.test_mask);
+    }
+    void SetStencilFunc(std::tuple<GLenum, GLint, GLint> n_funcs);
+    inline std::tuple<GLenum, GLenum, GLenum> GetStencilOp() {
+        return std::make_tuple(stencil.action_stencil_fail, stencil.action_depth_fail, stencil.action_depth_pass);
+    }
+    void SetStencilOp(std::tuple<GLenum, GLenum, GLenum> n_actions);
+    inline GLuint GetStencilWriteMask() { return stencil.write_mask; }
     void SetStencilWriteMask(GLuint n_write_mask);
 
+    inline bool GetBlendEnabled() { return blend.enabled; }
     void SetBlendEnabled(bool n_enabled);
-    void SetBlendFunc(GLenum n_src_rgb_func, GLenum n_dst_rgb_func, GLenum n_src_a_func, GLenum n_dst_a_func);
-    void SetBlendColor(GLclampf n_red, GLclampf n_green, GLclampf n_blue, GLclampf n_alpha);
+    inline std::tuple<GLenum, GLenum, GLenum, GLenum> GetBlendFunc() {
+        return std::make_tuple(blend.src_rgb_func, blend.dst_rgb_func, blend.src_a_func, blend.dst_a_func);
+    }
+    void SetBlendFunc(std::tuple<GLenum, GLenum, GLenum, GLenum> n_funcs);
+    inline std::tuple<GLclampf, GLclampf, GLclampf, GLclampf> GetBlendColor() {
+        return std::make_tuple(blend.color.red, blend.color.green, blend.color.blue, blend.color.alpha);
+    }
+    void SetBlendColor(std::tuple<GLclampf, GLclampf, GLclampf, GLclampf> n_color);
 
+    inline GLenum GetLogicOp() { return logic_op; }
     void SetLogicOp(GLenum n_logic_op);
 
+    inline GLuint GetTexture1D() { return texture_units[active_texture_unit - GL_TEXTURE0].texture_1d; }
     void SetTexture1D(GLuint n_texture_1d);
+    inline GLuint GetTexture2D() { return texture_units[active_texture_unit - GL_TEXTURE0].texture_2d; }
     void SetTexture2D(GLuint n_texture_2d);
+    inline GLuint GetSampler() { return texture_units[active_texture_unit - GL_TEXTURE0].sampler; }
     void SetSampler(GLuint n_sampler);
 
+    inline GLenum GetActiveTextureUnit() { return active_texture_unit; }
     void SetActiveTextureUnit(GLenum n_active_texture_unit);
 
+    inline GLuint GetReadFramebuffer() { return draw.read_framebuffer; }
     void SetReadFramebuffer(GLuint n_read_framebuffer);
+    inline GLuint GetDrawFramebuffer() { return draw.draw_framebuffer; }
     void SetDrawFramebuffer(GLuint n_draw_framebuffer);
+    inline GLuint GetVertexArray() { return draw.vertex_array; }
     void SetVertexArray(GLuint n_vertex_array);
+    inline GLuint GetVertexBuffer() { return draw.vertex_buffer; }
     void SetVertexBuffer(GLuint n_vertex_buffer);
+    inline GLuint GetUniformBuffer() { return draw.uniform_buffer; }
     void SetUniformBuffer(GLuint n_uniform_buffer);
+    inline GLuint GetShaderProgram() { return draw.shader_program; }
     void SetShaderProgram(GLuint n_shader_program);
 
     /// Resets and unbinds any references to the given resource across all existing states
@@ -62,6 +97,12 @@ public:
 
     /// Check the status of the currently bound OpenGL read or draw framebuffer configuration
     static GLenum CheckBoundFBStatus(GLenum target);
+
+    /// Manipulates the current state to prepare for pixel transfer, and returns a copy of the old state
+    static OpenGLState ApplyTransferState(GLuint src_tex, GLuint read_framebuffer, GLuint dst_tex, GLuint draw_framebuffer);
+
+    /// Returns the old state before transfer state changes were made
+    static void UndoTransferState(OpenGLState &old_state);
 
 private:
     struct {

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -8,6 +8,60 @@
 
 class OpenGLState {
 public:
+    OpenGLState();
+
+    static OpenGLState* GetCurrentState();
+
+    /// Apply this state as the current OpenGL state
+    void MakeCurrent();
+
+    /// Check the status of the current OpenGL read or draw framebuffer configuration
+    static GLenum CheckFBStatus(GLenum target);
+
+    /// Resets and unbinds any references to the given resource in the current OpenGL state
+    static void ResetTexture(GLuint handle);
+    static void ResetSampler(GLuint handle);
+    static void ResetProgram(GLuint handle);
+    static void ResetBuffer(GLuint handle);
+    static void ResetVertexArray(GLuint handle);
+    static void ResetFramebuffer(GLuint handle);
+
+    void SetCullEnabled(bool n_enabled);
+    void SetCullMode(GLenum n_mode);
+    void SetCullFrontFace(GLenum n_front_face);
+
+    void SetDepthTestEnabled(bool n_test_enabled);
+    void SetDepthFunc(GLenum n_test_func);
+    void SetDepthWriteMask(GLboolean n_write_mask);
+
+    void SetColorMask(GLboolean n_red_enabled, GLboolean n_green_enabled, GLboolean n_blue_enabled, GLboolean n_alpha_enabled);
+
+    void SetStencilTestEnabled(bool n_test_enabled);
+    void SetStencilFunc(GLenum n_test_func, GLint n_test_ref, GLuint n_test_mask);
+    void SetStencilOp(GLenum n_action_stencil_fail, GLenum n_action_depth_fail, GLenum n_action_depth_pass);
+    void SetStencilWriteMask(GLuint n_write_mask);
+
+    void SetBlendEnabled(bool n_enabled);
+    void SetBlendFunc(GLenum n_src_rgb_func, GLenum n_dst_rgb_func, GLenum n_src_a_func, GLenum n_dst_a_func);
+    void SetBlendColor(GLclampf n_red, GLclampf n_green, GLclampf n_blue, GLclampf n_alpha);
+
+    void SetLogicOp(GLenum n_logic_op);
+
+    void SetTexture2D(GLuint n_texture_2d);
+    void SetSampler(GLuint n_sampler);
+
+    void SetLUTTexture1D(GLuint n_texture_1d);
+
+    void SetActiveTextureUnit(GLenum n_active_texture_unit);
+
+    void SetReadFramebuffer(GLuint n_read_framebuffer);
+    void SetDrawFramebuffer(GLuint n_draw_framebuffer);
+    void SetVertexArray(GLuint n_vertex_array);
+    void SetVertexBuffer(GLuint n_vertex_buffer);
+    void SetUniformBuffer(GLuint n_uniform_buffer);
+    void SetShaderProgram(GLuint n_shader_program);
+
+private:
     struct {
         bool enabled; // GL_CULL_FACE
         GLenum mode; // GL_CULL_FACE_MODE
@@ -32,10 +86,10 @@ public:
         GLenum test_func; // GL_STENCIL_FUNC
         GLint test_ref; // GL_STENCIL_REF
         GLuint test_mask; // GL_STENCIL_VALUE_MASK
-        GLuint write_mask; // GL_STENCIL_WRITEMASK
         GLenum action_stencil_fail; // GL_STENCIL_FAIL
         GLenum action_depth_fail; // GL_STENCIL_PASS_DEPTH_FAIL
         GLenum action_depth_pass; // GL_STENCIL_PASS_DEPTH_PASS
+        GLuint write_mask; // GL_STENCIL_WRITEMASK
     } stencil;
 
     struct {
@@ -65,6 +119,8 @@ public:
         GLuint texture_1d; // GL_TEXTURE_BINDING_1D
     } lighting_luts[6];
 
+    GLenum active_texture_unit; // GL_ACTIVE_TEXTURE
+
     struct {
         GLuint read_framebuffer; // GL_READ_FRAMEBUFFER_BINDING
         GLuint draw_framebuffer; // GL_DRAW_FRAMEBUFFER_BINDING
@@ -74,27 +130,5 @@ public:
         GLuint shader_program; // GL_CURRENT_PROGRAM
     } draw;
 
-    OpenGLState();
-
-    /// Get the currently active OpenGL state
-    static const OpenGLState& GetCurState() {
-        return cur_state;
-    }
-
-    /// Apply this state as the current OpenGL state
-    void Apply() const;
-
-    /// Check the status of the current OpenGL read or draw framebuffer configuration
-    static GLenum CheckFBStatus(GLenum target);
-
-    /// Resets and unbinds any references to the given resource in the current OpenGL state
-    static void ResetTexture(GLuint handle);
-    static void ResetSampler(GLuint handle);
-    static void ResetProgram(GLuint handle);
-    static void ResetBuffer(GLuint handle);
-    static void ResetVertexArray(GLuint handle);
-    static void ResetFramebuffer(GLuint handle);
-
-private:
-    static OpenGLState cur_state;
+    static OpenGLState* cur_state;
 };

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <tuple>
+
 #include <glad/glad.h>
 
 class OpenGLState {

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -108,6 +108,7 @@ RendererOpenGL::~RendererOpenGL() {
 
 /// Swap buffers (render frame)
 void RendererOpenGL::SwapBuffers() {
+    OpenGLState* old_state = OpenGLState::GetCurrentState();
     state.MakeCurrent();
 
     for (int i : {0, 1}) {
@@ -156,6 +157,8 @@ void RendererOpenGL::SwapBuffers() {
     render_window->SwapBuffers();
 
     profiler.BeginFrame();
+
+    old_state->MakeCurrent();
 
     RefreshRasterizerSetting();
 


### PR DESCRIPTION
This is one thought I had for making the state tracker a bit easier/less error prone to use by making it more immediate, and I'm wondering what people think of this as a possibility. I'm definitely open to other suggestions (even ones that involve killing the state tracker somehow) but at the least I have been finding its current incarnation a little too messy for my tastes.

**Main arguments for actually having a state tracker in the first place:**
- Automatically avoids setting redundant state.
- It allows the OpenGL frontend renderer and backend rasterizer to co-exist in the same context without polluting each others' state (less effort to keep consistent).
- It allows for chunks of code to be able to get to a clean/personal state easily without polluting the renderer/rasterizer.
  - i.e. for the rasterizer cache and OpenGL framebuffer blits in general, you don't want a lot of the state that the rasterizer has set (like color/depth/stencil mask, bound framebuffers, etc.), yet you don't want to trash the rasterizer's state as it would then need to be re-set by the rasterizer anyway. The state tracker provides an easier API to replace and restore entire states with minimal state switching calls.
- Could theoretically be helpful as a debugging aid - nice to be able to inspect the current state in-debugger without apitrace or its ilk.

**The changes are:**

Before:
- All state was expressed as public variables of the tracker object.
- Apply() was the only way to actually apply the changes to state variables, which would check each and every state variable for change and make the corresponding OpenGL call if so.

After:
- State changes are broken out into individual setter functions.
- Each setter function immediately makes the state change, so careful placement of Apply() is no longer necessary.
  - (i.e. before, had to be sure to call Apply() _after_ binding a texture but _before_ glTex*() operations)
- Each setter function checks only the state that was changed.
  - This avoids checking all state as in the old Apply(). Assumes:
  - (#state variables \* #Apply calls) > (#state changes + #state variables \* #MakeCurrent calls).
- Apply() has conceptually been transformed into MakeCurrent() which essentially just calls every state setter function with the state tracker's current value for that state - for wholesale switching between trackers.
