### PR TITLE
AudioCore: CurrentRegion() -> ReadRegion(), WriteRegion()

### DIFF
--- a/src/audio_core/audio_core.cpp
+++ b/src/audio_core/audio_core.cpp
@@ -38,10 +38,10 @@ void Init() {
 
 /// Add DSP address spaces to Process's address space.
 void AddAddressSpace(Kernel::VMManager& address_space) {
-    auto r0_vma = address_space.MapBackingMemory(DSP::HLE::region0_base, reinterpret_cast<u8*>(&DSP::HLE::g_region0), sizeof(DSP::HLE::SharedMemory), Kernel::MemoryState::IO).MoveFrom();
+    auto r0_vma = address_space.MapBackingMemory(DSP::HLE::region0_base, reinterpret_cast<u8*>(&DSP::HLE::g_regions[0]), sizeof(DSP::HLE::SharedMemory), Kernel::MemoryState::IO).MoveFrom();
     address_space.Reprotect(r0_vma, Kernel::VMAPermission::ReadWrite);
 
-    auto r1_vma = address_space.MapBackingMemory(DSP::HLE::region1_base, reinterpret_cast<u8*>(&DSP::HLE::g_region1), sizeof(DSP::HLE::SharedMemory), Kernel::MemoryState::IO).MoveFrom();
+    auto r1_vma = address_space.MapBackingMemory(DSP::HLE::region1_base, reinterpret_cast<u8*>(&DSP::HLE::g_regions[1]), sizeof(DSP::HLE::SharedMemory), Kernel::MemoryState::IO).MoveFrom();
     address_space.Reprotect(r1_vma, Kernel::VMAPermission::ReadWrite);
 }
 

--- a/src/audio_core/hle/dsp.h
+++ b/src/audio_core/hle/dsp.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include <type_traits>
 
@@ -30,10 +31,9 @@ namespace HLE {
 struct SharedMemory;
 
 constexpr VAddr region0_base = 0x1FF50000;
-extern SharedMemory g_region0;
-
 constexpr VAddr region1_base = 0x1FF70000;
-extern SharedMemory g_region1;
+
+extern std::array<SharedMemory, 2> g_regions;
 
 /**
  * The DSP is native 16-bit. The DSP also appears to be big-endian. When reading 32-bit numbers from
@@ -534,9 +534,6 @@ void Shutdown();
  * @return Whether an audio interrupt should be triggered this frame.
  */
 bool Tick();
-
-/// Returns a mutable reference to the current region. Current region is selected based on the frame counter.
-SharedMemory& CurrentRegion();
 
 } // namespace HLE
 } // namespace DSP


### PR DESCRIPTION
The DSP and applications read from one region while writing to another.

Replicating this is required for correct behavior.