### PR TITLE
AudioCore: Move samples_per_frame and num_sources into hle/common.h

### DIFF
--- a/src/audio_core/audio_core.h
+++ b/src/audio_core/audio_core.h
@@ -10,8 +10,6 @@ class VMManager;
 
 namespace AudioCore {
 
-constexpr int num_sources = 24;
-constexpr int samples_per_frame = 160;     ///< Samples per audio frame at native sample rate
 constexpr int native_sample_rate = 32728;  ///< 32kHz
 
 /// Initialise Audio Core

--- a/src/audio_core/hle/common.h
+++ b/src/audio_core/hle/common.h
@@ -7,18 +7,19 @@
 #include <algorithm>
 #include <array>
 
-#include "audio_core/audio_core.h"
-
 #include "common/common_types.h"
 
 namespace DSP {
 namespace HLE {
 
+constexpr int num_sources = 24;
+constexpr int samples_per_frame = 160;     ///< Samples per audio frame at native sample rate
+
 /// The final output to the speakers is stereo. Preprocessing output in Source is also stereo.
-using StereoFrame16 = std::array<std::array<s16, 2>, AudioCore::samples_per_frame>;
+using StereoFrame16 = std::array<std::array<s16, 2>, samples_per_frame>;
 
 /// The DSP is quadraphonic internally.
-using QuadFrame32   = std::array<std::array<s32, 4>, AudioCore::samples_per_frame>;
+using QuadFrame32   = std::array<std::array<s32, 4>, samples_per_frame>;
 
 /**
  * This performs the filter operation defined by FilterT::ProcessSample on the frame in-place.

--- a/src/audio_core/hle/dsp.h
+++ b/src/audio_core/hle/dsp.h
@@ -7,7 +7,7 @@
 #include <cstddef>
 #include <type_traits>
 
-#include "audio_core/audio_core.h"
+#include "audio_core/hle/common.h"
 
 #include "common/bit_field.h"
 #include "common/common_funcs.h"
@@ -305,7 +305,7 @@ struct SourceConfiguration {
         u16_le buffer_id;
     };
 
-    Configuration config[AudioCore::num_sources];
+    Configuration config[num_sources];
 };
 ASSERT_DSP_STRUCT(SourceConfiguration::Configuration, 192);
 ASSERT_DSP_STRUCT(SourceConfiguration::Configuration::Buffer, 20);
@@ -320,7 +320,7 @@ struct SourceStatus {
         INSERT_PADDING_DSPWORDS(1);
     };
 
-    Status status[AudioCore::num_sources];
+    Status status[num_sources];
 };
 ASSERT_DSP_STRUCT(SourceStatus::Status, 12);
 
@@ -413,7 +413,7 @@ ASSERT_DSP_STRUCT(DspConfiguration::ReverbEffect, 52);
 struct AdpcmCoefficients {
     /// Coefficients are signed fixed point with 11 fractional bits.
     /// Each source has 16 coefficients associated with it.
-    s16_le coeff[AudioCore::num_sources][16];
+    s16_le coeff[num_sources][16];
 };
 ASSERT_DSP_STRUCT(AdpcmCoefficients, 768);
 
@@ -427,7 +427,7 @@ ASSERT_DSP_STRUCT(DspStatus, 32);
 /// Final mixed output in PCM16 stereo format, what you hear out of the speakers.
 /// When the application writes to this region it has no effect.
 struct FinalMixSamples {
-    s16_le pcm16[2 * AudioCore::samples_per_frame];
+    s16_le pcm16[2 * samples_per_frame];
 };
 ASSERT_DSP_STRUCT(FinalMixSamples, 640);
 
@@ -437,7 +437,7 @@ ASSERT_DSP_STRUCT(FinalMixSamples, 640);
 /// Values that exceed s16 range will be clipped by the DSP after further processing.
 struct IntermediateMixSamples {
     struct Samples {
-        s32_le pcm32[4][AudioCore::samples_per_frame]; ///< Little-endian as opposed to DSP middle-endian.
+        s32_le pcm32[4][samples_per_frame]; ///< Little-endian as opposed to DSP middle-endian.
     };
 
     Samples mix1;


### PR DESCRIPTION
Very minor change.

Done so that everything under `src/audio_core/hle` doesn't have to `#include "audio_core/audio_core.h"`.

(Done as it's own PR to not clutter up the others.)