### PR TITLE
add config block 0x00170000; remove duplicated content

### DIFF
--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -389,6 +389,10 @@ ResultCode FormatConfig() {
     res = CreateConfigInfoBlk(0x000F0004, sizeof(CONSOLE_MODEL), 0xC, &CONSOLE_MODEL);
     if (!res.IsSuccess()) return res;
 
+    // 0x00170000 - Unknown
+    res = CreateConfigInfoBlk(0x00170000, 0x4, 0xE, zero_buffer);
+    if (!res.IsSuccess()) return res;
+
     // Save the buffer to the file
     res = UpdateConfigNANDSavegame();
     if (!res.IsSuccess())

--- a/src/core/hle/service/cfg/cfg.h
+++ b/src/core/hle/service/cfg/cfg.h
@@ -98,19 +98,6 @@ void GetCountryCodeString(Service::Interface* self);
 void GetCountryCodeID(Service::Interface* self);
 
 /**
- * CFG::GetConfigInfoBlk2 service function
- *  Inputs:
- *      0 : 0x00010082
- *      1 : Size
- *      2 : Block ID
- *      3 : Descriptor for the output buffer
- *      4 : Output buffer pointer
- *  Outputs:
- *      1 : Result of function, 0 on success, otherwise error code
- */
-void GetConfigInfoBlk2(Service::Interface* self);
-
-/**
  * CFG::SecureInfoGetRegion service function
  *  Inputs:
  *      1 : None


### PR DESCRIPTION
An easy patch. Fixes Kirby's Robobot Planet (and maybe some other games) that wants this block. Value (zero) and flag (0xE) is taken from my real console's config savedata.
Edit: please help test #1258, #1486 and #1600.