### PR TITLE
VertexLoader: Minor changes

### DIFF
--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -199,9 +199,8 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
 
             // Processes information about internal vertex attributes to figure out how a vertex is loaded.
             // Later, these can be compiled and cached.
-            VertexLoader loader;
             const u32 base_address = regs.vertex_attributes.GetPhysicalBaseAddress();
-            loader.Setup(regs);
+            VertexLoader loader(regs);
 
             // Load vertices
             bool is_indexed = (id == PICA_REG_INDEX(trigger_draw_indexed));

--- a/src/video_core/vertex_loader.cpp
+++ b/src/video_core/vertex_loader.cpp
@@ -2,8 +2,8 @@
 
 #include <boost/range/algorithm/fill.hpp>
 
-#include "common/assert.h"
 #include "common/alignment.h"
+#include "common/assert.h"
 #include "common/bit_field.h"
 #include "common/common_types.h"
 #include "common/logging/log.h"

--- a/src/video_core/vertex_loader.cpp
+++ b/src/video_core/vertex_loader.cpp
@@ -21,6 +21,8 @@
 namespace Pica {
 
 void VertexLoader::Setup(const Pica::Regs& regs) {
+    ASSERT_MSG(!is_setup, "VertexLoader is not intended to be setup more than once.");
+
     const auto& attribute_config = regs.vertex_attributes;
     num_total_attributes = attribute_config.GetNumTotalAttributes();
 
@@ -60,9 +62,13 @@ void VertexLoader::Setup(const Pica::Regs& regs) {
             }
         }
     }
+
+    is_setup = true;
 }
 
 void VertexLoader::LoadVertex(u32 base_address, int index, int vertex, Shader::InputVertex& input, DebugUtils::MemoryAccessTracker& memory_accesses) {
+    ASSERT_MSG(is_setup, "A VertexLoader needs to be setup before loading vertices.");
+
     for (int i = 0; i < num_total_attributes; ++i) {
         if (vertex_attribute_elements[i] != 0) {
             // Load per-vertex data from the loader arrays

--- a/src/video_core/vertex_loader.h
+++ b/src/video_core/vertex_loader.h
@@ -17,6 +17,11 @@ class InputVertex;
 
 class VertexLoader {
 public:
+    VertexLoader() = default;
+    explicit VertexLoader(const Pica::Regs& regs) {
+        Setup(regs);
+    }
+
     void Setup(const Pica::Regs& regs);
     void LoadVertex(u32 base_address, int index, int vertex, Shader::InputVertex& input, DebugUtils::MemoryAccessTracker& memory_accesses);
 

--- a/src/video_core/vertex_loader.h
+++ b/src/video_core/vertex_loader.h
@@ -28,7 +28,7 @@ private:
     std::array<Regs::VertexAttributeFormat, 16> vertex_attribute_formats;
     std::array<u32, 16> vertex_attribute_elements{};
     std::array<bool, 16> vertex_attribute_is_default;
-    int num_total_attributes;
+    int num_total_attributes = 0;
 };
 
 }  // namespace Pica

--- a/src/video_core/vertex_loader.h
+++ b/src/video_core/vertex_loader.h
@@ -12,7 +12,7 @@ class MemoryAccessTracker;
 }
 
 namespace Shader {
-class InputVertex;
+struct InputVertex;
 }
 
 class VertexLoader {

--- a/src/video_core/vertex_loader.h
+++ b/src/video_core/vertex_loader.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "common/common_types.h"
+#include <array>
 
+#include "common/common_types.h"
 #include "video_core/pica.h"
 
 namespace Pica {
@@ -22,11 +23,11 @@ public:
     int GetNumTotalAttributes() const { return num_total_attributes; }
 
 private:
-    u32 vertex_attribute_sources[16];
-    u32 vertex_attribute_strides[16] = {};
-    Regs::VertexAttributeFormat vertex_attribute_formats[16] = {};
-    u32 vertex_attribute_elements[16] = {};
-    bool vertex_attribute_is_default[16];
+    std::array<u32, 16> vertex_attribute_sources;
+    std::array<u32, 16> vertex_attribute_strides{};
+    std::array<Regs::VertexAttributeFormat, 16> vertex_attribute_formats;
+    std::array<u32, 16> vertex_attribute_elements{};
+    std::array<bool, 16> vertex_attribute_is_default;
     int num_total_attributes;
 };
 

--- a/src/video_core/vertex_loader.h
+++ b/src/video_core/vertex_loader.h
@@ -34,6 +34,7 @@ private:
     std::array<u32, 16> vertex_attribute_elements{};
     std::array<bool, 16> vertex_attribute_is_default;
     int num_total_attributes = 0;
+    bool is_setup = false;
 };
 
 }  // namespace Pica


### PR DESCRIPTION
Superficial things that weren't really necessary to be brought up in the initial PR that introduced it.

cc @hrydgard For one thing I wasn't really certain of. Does it make sense to allow setting up the same VertexLoader more than once (this is likely "probably no", but I just want to make sure)? If it doesn't I can modify the relevant PR to just early return  (or assert) if it's already set up.