### PR TITLE
Fix video_core includes (and dependencies) using include-what-you-use

### DIFF
--- a/src/citra_qt/debugger/graphics_tracing.cpp
+++ b/src/citra_qt/debugger/graphics_tracing.cpp
@@ -2,6 +2,9 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <algorithm>
+#include <array>
+#include <iterator>
 #include <memory>
 
 #include <boost/range/algorithm/copy.hpp>
@@ -18,6 +21,7 @@
 
 #include "core/hw/gpu.h"
 #include "core/hw/lcd.h"
+#include "core/tracer/recorder.h"
 
 #include "nihstro/float24.h"
 

--- a/src/common/bit_field.h
+++ b/src/common/bit_field.h
@@ -186,5 +186,5 @@ private:
 #pragma pack()
 
 #if (__GNUC__ >= 5) || defined(__clang__) || defined(_MSC_VER)
-static_assert(std::is_trivially_copyable<BitField<0, 1, u32>>::value, "BitField must be trivially copyable");
+static_assert(std::is_trivially_copyable<BitField<0, 1, unsigned>>::value, "BitField must be trivially copyable");
 #endif

--- a/src/common/bit_set.h
+++ b/src/common/bit_set.h
@@ -7,6 +7,7 @@
 #include <intrin.h>
 #endif
 #include <initializer_list>
+#include <new>
 #include <type_traits>
 #include "common/common_types.h"
 

--- a/src/common/code_block.h
+++ b/src/common/code_block.h
@@ -4,8 +4,10 @@
 
 #pragma once
 
-#include "common_types.h"
-#include "memory_util.h"
+#include <cstddef>
+
+#include "common/common_types.h"
+#include "common/memory_util.h"
 
 // Everything that needs to generate code should inherit from this.
 // You get memory management for free, plus, you can use all emitter functions without

--- a/src/common/common_funcs.h
+++ b/src/common/common_funcs.h
@@ -4,6 +4,10 @@
 
 #pragma once
 
+#if !defined(ARCHITECTURE_x86_64) && !defined(_M_ARM)
+#include <cstdlib> // for exit
+#endif
+
 #include "common_types.h"
 
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -7,9 +7,9 @@
 #include <array>
 #include <fstream>
 #include <functional>
-#include <cstddef>
 #include <cstdio>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include "common/common_types.h"

--- a/src/common/x64/emitter.h
+++ b/src/common/x64/emitter.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 #include "common/assert.h"
 #include "common/bit_set.h"
 #include "common/common_types.h"

--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <new>
-#include <type_traits>
 #include <utility>
 
 #include "common/assert.h"

--- a/src/core/hle/service/gsp_gpu.h
+++ b/src/core/hle/service/gsp_gpu.h
@@ -10,6 +10,7 @@
 #include "common/bit_field.h"
 #include "common/common_types.h"
 
+#include "core/hle/result.h"
 #include "core/hle/service/service.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/core/hw/lcd.h
+++ b/src/core/hw/lcd.h
@@ -52,8 +52,6 @@ struct Regs {
         return content[index];
     }
 
-#undef ASSERT_MEMBER_SIZE
-
 };
 static_assert(std::is_standard_layout<Regs>::value, "Structure does not use standard layout");
 

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -6,7 +6,8 @@
 
 #include <string>
 #include <array>
-#include <common/file_util.h>
+
+#include "common/common_types.h"
 
 namespace Settings {
 

--- a/src/core/tracer/recorder.h
+++ b/src/core/tracer/recorder.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <string>
 #include <unordered_map>
 #include <vector>
 

--- a/src/video_core/clipper.cpp
+++ b/src/video_core/clipper.cpp
@@ -2,13 +2,24 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <algorithm>
+#include <array>
+#include <cstddef>
+
 #include <boost/container/static_vector.hpp>
+#include <boost/container/vector.hpp>
+
+#include "common/bit_field.h"
+#include "common/common_types.h"
+#include "common/logging/log.h"
+#include "common/vector_math.h"
 
 #include "video_core/clipper.h"
 #include "video_core/pica.h"
 #include "video_core/pica_state.h"
+#include "video_core/pica_types.h"
 #include "video_core/rasterizer.h"
-#include "video_core/shader/shader_interpreter.h"
+#include "video_core/shader/shader.h"
 
 namespace Pica {
 

--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -2,26 +2,32 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <cmath>
-#include <boost/range/algorithm/fill.hpp>
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <utility>
 
-#include "common/alignment.h"
+#include "common/assert.h"
+#include "common/logging/log.h"
 #include "common/microprofile.h"
+#include "common/vector_math.h"
 
-#include "core/settings.h"
 #include "core/hle/service/gsp_gpu.h"
 #include "core/hw/gpu.h"
+#include "core/memory.h"
+#include "core/tracer/recorder.h"
 
-#include "video_core/clipper.h"
 #include "video_core/command_processor.h"
+#include "video_core/debug_utils/debug_utils.h"
 #include "video_core/pica.h"
 #include "video_core/pica_state.h"
+#include "video_core/pica_types.h"
 #include "video_core/primitive_assembly.h"
+#include "video_core/rasterizer_interface.h"
 #include "video_core/renderer_base.h"
-#include "video_core/video_core.h"
-#include "video_core/debug_utils/debug_utils.h"
-#include "video_core/shader/shader_interpreter.h"
+#include "video_core/shader/shader.h"
 #include "video_core/vertex_loader.h"
+#include "video_core/video_core.h"
 
 namespace Pica {
 

--- a/src/video_core/debug_utils/debug_utils.cpp
+++ b/src/video_core/debug_utils/debug_utils.cpp
@@ -4,35 +4,41 @@
 
 #include <algorithm>
 #include <condition_variable>
+#include <cstdint>
 #include <cstring>
 #include <fstream>
-#include <list>
 #include <map>
 #include <mutex>
+#include <stdexcept>
 #include <string>
 
 #ifdef HAVE_PNG
 #include <png.h>
+#include <setjmp.h>
 #endif
 
+#include <nihstro/bit_field.h>
 #include <nihstro/float24.h>
 #include <nihstro/shader_binary.h>
 
 #include "common/assert.h"
+#include "common/bit_field.h"
 #include "common/color.h"
 #include "common/common_types.h"
 #include "common/file_util.h"
+#include "common/logging/log.h"
 #include "common/math_util.h"
 #include "common/vector_math.h"
 
-#include "core/settings.h"
-
+#include "video_core/debug_utils/debug_utils.h"
 #include "video_core/pica.h"
 #include "video_core/pica_state.h"
+#include "video_core/pica_types.h"
+#include "video_core/rasterizer_interface.h"
 #include "video_core/renderer_base.h"
+#include "video_core/shader/shader.h"
 #include "video_core/utils.h"
 #include "video_core/video_core.h"
-#include "video_core/debug_utils/debug_utils.h"
 
 using nihstro::DVLBHeader;
 using nihstro::DVLEHeader;

--- a/src/video_core/debug_utils/debug_utils.h
+++ b/src/video_core/debug_utils/debug_utils.h
@@ -4,22 +4,32 @@
 
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <condition_variable>
+#include <iterator>
 #include <list>
 #include <map>
 #include <memory>
 #include <mutex>
+#include <string>
+#include <utility>
 #include <vector>
 
+#include "common/common_types.h"
 #include "common/vector_math.h"
 
-#include "core/tracer/recorder.h"
-
 #include "video_core/pica.h"
-#include "video_core/shader/shader.h"
+
+namespace CiTrace {
+class Recorder;
+}
 
 namespace Pica {
+
+namespace Shader {
+struct ShaderSetup;
+}
 
 class DebugContext {
 public:

--- a/src/video_core/pica.cpp
+++ b/src/video_core/pica.cpp
@@ -3,10 +3,13 @@
 // Refer to the license.txt file included.
 
 #include <cstring>
+#include <iterator>
 #include <unordered_map>
+#include <utility>
 
 #include "video_core/pica.h"
 #include "video_core/pica_state.h"
+#include "video_core/primitive_assembly.h"
 #include "video_core/shader/shader.h"
 
 namespace Pica {
@@ -480,7 +483,7 @@ std::string Regs::GetCommandName(int index) {
     static std::unordered_map<u32, const char*> map;
 
     if (map.empty()) {
-        map.insert(begin(register_names), end(register_names));
+        map.insert(std::begin(register_names), std::end(register_names));
     }
 
     // Return empty string if no match is found

--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -5,9 +5,12 @@
 #pragma once
 
 #include <array>
-#include <cmath>
 #include <cstddef>
 #include <string>
+
+#ifndef _MSC_VER
+#include <type_traits> // for std::enable_if
+#endif
 
 #include "common/assert.h"
 #include "common/bit_field.h"
@@ -15,8 +18,6 @@
 #include "common/common_types.h"
 #include "common/vector_math.h"
 #include "common/logging/log.h"
-
-#include "pica_types.h"
 
 namespace Pica {
 

--- a/src/video_core/pica_state.h
+++ b/src/video_core/pica_state.h
@@ -4,6 +4,11 @@
 
 #pragma once
 
+#include <array>
+
+#include "common/bit_field.h"
+#include "common/common_types.h"
+
 #include "video_core/pica.h"
 #include "video_core/primitive_assembly.h"
 #include "video_core/shader/shader.h"

--- a/src/video_core/pica_types.h
+++ b/src/video_core/pica_types.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cmath>
 #include <cstring>
 
 #include "common/common_types.h"

--- a/src/video_core/primitive_assembly.cpp
+++ b/src/video_core/primitive_assembly.cpp
@@ -6,8 +6,7 @@
 
 #include "video_core/pica.h"
 #include "video_core/primitive_assembly.h"
-#include "video_core/debug_utils/debug_utils.h"
-#include "video_core/shader/shader_interpreter.h"
+#include "video_core/shader/shader.h"
 
 namespace Pica {
 

--- a/src/video_core/rasterizer.cpp
+++ b/src/video_core/rasterizer.cpp
@@ -3,22 +3,28 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 
+#include "common/assert.h"
+#include "common/bit_field.h"
 #include "common/color.h"
 #include "common/common_types.h"
+#include "common/logging/log.h"
 #include "common/math_util.h"
 #include "common/microprofile.h"
+#include "common/vector_math.h"
 
 #include "core/memory.h"
 #include "core/hw/gpu.h"
 
+#include "video_core/debug_utils/debug_utils.h"
 #include "video_core/pica.h"
 #include "video_core/pica_state.h"
+#include "video_core/pica_types.h"
 #include "video_core/rasterizer.h"
 #include "video_core/utils.h"
-#include "video_core/debug_utils/debug_utils.h"
-#include "video_core/shader/shader_interpreter.h"
+#include "video_core/shader/shader.h"
 
 namespace Pica {
 

--- a/src/video_core/renderer_base.cpp
+++ b/src/video_core/renderer_base.cpp
@@ -2,9 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <atomic>
 #include <memory>
-
-#include "core/settings.h"
 
 #include "video_core/renderer_base.h"
 #include "video_core/video_core.h"

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -2,27 +2,28 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <cstring>
 #include <memory>
+#include <string>
+#include <tuple>
+#include <utility>
 
 #include <glad/glad.h>
 
+#include "common/assert.h"
 #include "common/color.h"
-#include "common/file_util.h"
+#include "common/logging/log.h"
 #include "common/math_util.h"
-#include "common/microprofile.h"
+#include "common/vector_math.h"
 
-#include "core/memory.h"
-#include "core/settings.h"
 #include "core/hw/gpu.h"
 
 #include "video_core/pica.h"
 #include "video_core/pica_state.h"
-#include "video_core/utils.h"
 #include "video_core/renderer_opengl/gl_rasterizer.h"
 #include "video_core/renderer_opengl/gl_shader_gen.h"
 #include "video_core/renderer_opengl/gl_shader_util.h"
 #include "video_core/renderer_opengl/pica_to_gl.h"
+#include "video_core/renderer_opengl/renderer_opengl.h"
 
 static bool IsPassThroughTevStage(const Pica::Regs::TevStageConfig& stage) {
     return (stage.color_op == Pica::Regs::TevStageConfig::Operation::Replace &&

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -4,23 +4,33 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include <cstring>
 #include <memory>
 #include <vector>
 #include <unordered_map>
 
+#include <glad/glad.h>
+
+#include "common/bit_field.h"
 #include "common/common_types.h"
 #include "common/hash.h"
+#include "common/vector_math.h"
+
+#include "core/hw/gpu.h"
 
 #include "video_core/pica.h"
 #include "video_core/pica_state.h"
+#include "video_core/pica_types.h"
 #include "video_core/rasterizer_interface.h"
 #include "video_core/renderer_opengl/gl_rasterizer_cache.h"
+#include "video_core/renderer_opengl/gl_resource_manager.h"
 #include "video_core/renderer_opengl/gl_state.h"
 #include "video_core/renderer_opengl/pica_to_gl.h"
-#include "video_core/renderer_opengl/renderer_opengl.h"
-#include "video_core/shader/shader_interpreter.h"
+#include "video_core/shader/shader.h"
+
+struct ScreenInfo;
 
 /**
  * This struct contains all state used to generate the GLSL shader program that emulates the current

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -2,10 +2,19 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <algorithm>
+#include <atomic>
+#include <cstring>
+#include <iterator>
 #include <unordered_set>
+#include <utility>
+#include <vector>
 
+#include <glad/glad.h>
+
+#include "common/bit_field.h"
 #include "common/emu_window.h"
-#include "common/hash.h"
+#include "common/logging/log.h"
 #include "common/math_util.h"
 #include "common/microprofile.h"
 #include "common/vector_math.h"
@@ -15,7 +24,7 @@
 #include "video_core/debug_utils/debug_utils.h"
 #include "video_core/pica_state.h"
 #include "video_core/renderer_opengl/gl_rasterizer_cache.h"
-#include "video_core/renderer_opengl/pica_to_gl.h"
+#include "video_core/renderer_opengl/gl_state.h"
 #include "video_core/utils.h"
 #include "video_core/video_core.h"
 

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -4,20 +4,26 @@
 
 #pragma once
 
-#include <map>
+#include <array>
 #include <memory>
 #include <set>
+#include <tuple>
 
 #include <boost/icl/interval_map.hpp>
+#include <glad/glad.h>
 
-#include "common/math_util.h"
+#include "common/assert.h"
+#include "common/common_funcs.h"
+#include "common/common_types.h"
 
 #include "core/hw/gpu.h"
 
 #include "video_core/pica.h"
-#include "video_core/debug_utils/debug_utils.h"
 #include "video_core/renderer_opengl/gl_resource_manager.h"
-#include "video_core/renderer_opengl/gl_state.h"
+
+namespace MathUtil {
+template <class T> struct Rectangle;
+}
 
 struct CachedSurface;
 

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -2,9 +2,17 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <array>
+#include <cstddef>
+
+#include "common/assert.h"
+#include "common/bit_field.h"
+#include "common/logging/log.h"
+
 #include "video_core/pica.h"
 #include "video_core/renderer_opengl/gl_rasterizer.h"
 #include "video_core/renderer_opengl/gl_shader_gen.h"
+#include "video_core/renderer_opengl/gl_shader_util.h"
 
 using Pica::Regs;
 using TevStageConfig = Regs::TevStageConfig;

--- a/src/video_core/renderer_opengl/gl_shader_gen.h
+++ b/src/video_core/renderer_opengl/gl_shader_gen.h
@@ -6,7 +6,7 @@
 
 #include <string>
 
-#include "video_core/renderer_opengl/gl_rasterizer.h"
+struct PicaShaderConfig;
 
 namespace GLShader {
 

--- a/src/video_core/renderer_opengl/gl_shader_util.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_util.cpp
@@ -2,8 +2,9 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <algorithm>
 #include <vector>
+
+#include <glad/glad.h>
 
 #include "common/logging/log.h"
 #include "video_core/renderer_opengl/gl_shader_util.h"

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -2,8 +2,11 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include "video_core/pica.h"
-#include "video_core/renderer_opengl/gl_resource_manager.h"
+#include <glad/glad.h>
+
+#include "common/common_funcs.h"
+#include "common/logging/log.h"
+
 #include "video_core/renderer_opengl/gl_state.h"
 
 OpenGLState OpenGLState::cur_state;

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <glad/glad.h>
-#include <memory>
 
 class OpenGLState {
 public:

--- a/src/video_core/renderer_opengl/pica_to_gl.h
+++ b/src/video_core/renderer_opengl/pica_to_gl.h
@@ -4,9 +4,16 @@
 
 #pragma once
 
+#include <array>
+#include <cstddef>
+
 #include <glad/glad.h>
 
+#include "common/assert.h"
+#include "common/bit_field.h"
+#include "common/common_funcs.h"
 #include "common/common_types.h"
+#include "common/logging/log.h"
 
 #include "video_core/pica.h"
 

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -5,23 +5,28 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdlib>
+#include <memory>
+
+#include <glad/glad.h>
 
 #include "common/assert.h"
+#include "common/bit_field.h"
 #include "common/emu_window.h"
 #include "common/logging/log.h"
 #include "common/profiler_reporting.h"
+#include "common/synchronized_wrapper.h"
 
-#include "core/memory.h"
-#include "core/settings.h"
 #include "core/hw/gpu.h"
 #include "core/hw/hw.h"
 #include "core/hw/lcd.h"
+#include "core/memory.h"
+#include "core/settings.h"
+#include "core/tracer/recorder.h"
 
-#include "video_core/video_core.h"
 #include "video_core/debug_utils/debug_utils.h"
-#include "video_core/renderer_opengl/gl_rasterizer.h"
-#include "video_core/renderer_opengl/gl_shader_util.h"
+#include "video_core/rasterizer_interface.h"
 #include "video_core/renderer_opengl/renderer_opengl.h"
+#include "video_core/video_core.h"
 
 static const char vertex_shader[] = R"(
 #version 150 core

--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -8,6 +8,9 @@
 
 #include <glad/glad.h>
 
+#include "common/common_types.h"
+#include "common/math_util.h"
+
 #include "core/hw/gpu.h"
 
 #include "video_core/renderer_base.h"

--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -2,25 +2,29 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <memory>
+#include <atomic>
+#include <cmath>
+#include <cstring>
 #include <unordered_map>
+#include <utility>
 
 #include <boost/range/algorithm/fill.hpp>
 
+#include "common/bit_field.h"
 #include "common/hash.h"
+#include "common/logging/log.h"
 #include "common/microprofile.h"
 
-#include "video_core/debug_utils/debug_utils.h"
 #include "video_core/pica.h"
 #include "video_core/pica_state.h"
-#include "video_core/video_core.h"
-
-#include "shader.h"
-#include "shader_interpreter.h"
+#include "video_core/shader/shader.h"
+#include "video_core/shader/shader_interpreter.h"
 
 #ifdef ARCHITECTURE_x86_64
-#include "shader_jit_x64.h"
+#include "video_core/shader/shader_jit_x64.h"
 #endif // ARCHITECTURE_x86_64
+
+#include "video_core/video_core.h"
 
 namespace Pica {
 

--- a/src/video_core/shader/shader.h
+++ b/src/video_core/shader/shader.h
@@ -4,17 +4,23 @@
 
 #pragma once
 
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <type_traits>
 #include <vector>
 
 #include <boost/container/static_vector.hpp>
 
-#include <nihstro/shader_binary.h>
+#include <nihstro/shader_bytecode.h>
 
+#include "common/assert.h"
 #include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "common/vector_math.h"
 
 #include "video_core/pica.h"
+#include "video_core/pica_types.h"
 
 using nihstro::RegisterType;
 using nihstro::SourceRegister;

--- a/src/video_core/shader/shader_interpreter.cpp
+++ b/src/video_core/shader/shader_interpreter.cpp
@@ -2,12 +2,20 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <algorithm>
+#include <array>
+#include <cmath>
 #include <numeric>
+
 #include <nihstro/shader_bytecode.h>
 
-#include "common/file_util.h"
-#include "video_core/pica.h"
+#include "common/assert.h"
+#include "common/common_types.h"
+#include "common/logging/log.h"
+#include "common/vector_math.h"
+
 #include "video_core/pica_state.h"
+#include "video_core/pica_types.h"
 #include "video_core/shader/shader.h"
 #include "video_core/shader/shader_interpreter.h"
 

--- a/src/video_core/shader/shader_interpreter.h
+++ b/src/video_core/shader/shader_interpreter.h
@@ -4,11 +4,11 @@
 
 #pragma once
 
-#include "video_core/shader/shader.h"
-
 namespace Pica {
 
 namespace Shader {
+
+template <bool Debug> struct UnitState;
 
 template<bool Debug>
 void RunInterpreter(UnitState<Debug>& state);

--- a/src/video_core/shader/shader_jit_x64.cpp
+++ b/src/video_core/shader/shader_jit_x64.cpp
@@ -3,8 +3,15 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
-#include <smmintrin.h>
+#include <cmath>
+#include <cstdint>
+#include <xmmintrin.h>
 
+#include <nihstro/shader_bytecode.h>
+
+#include "common/assert.h"
+#include "common/logging/log.h"
+#include "common/vector_math.h"
 #include "common/x64/abi.h"
 #include "common/x64/cpu_detect.h"
 #include "common/x64/emitter.h"
@@ -13,6 +20,7 @@
 #include "shader_jit_x64.h"
 
 #include "video_core/pica_state.h"
+#include "video_core/pica_types.h"
 
 namespace Pica {
 

--- a/src/video_core/shader/shader_jit_x64.h
+++ b/src/video_core/shader/shader_jit_x64.h
@@ -4,14 +4,17 @@
 
 #pragma once
 
+#include <array>
+#include <cstddef>
 #include <utility>
 #include <vector>
 
 #include <nihstro/shader_bytecode.h>
 
+#include "common/bit_set.h"
+#include "common/common_types.h"
 #include "common/x64/emitter.h"
 
-#include "video_core/pica.h"
 #include "video_core/shader/shader.h"
 
 using nihstro::Instruction;

--- a/src/video_core/swrasterizer.h
+++ b/src/video_core/swrasterizer.h
@@ -8,6 +8,12 @@
 
 #include "video_core/rasterizer_interface.h"
 
+namespace Pica {
+namespace Shader {
+struct OutputVertex;
+}
+}
+
 namespace VideoCore {
 
 class SWRasterizer : public RasterizerInterface {

--- a/src/video_core/utils.h
+++ b/src/video_core/utils.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <string>
-
 #include "common/common_types.h"
 
 namespace VideoCore {

--- a/src/video_core/vertex_loader.cpp
+++ b/src/video_core/vertex_loader.cpp
@@ -1,14 +1,13 @@
-#include <cmath>
-#include <string>
+#include <memory>
 
-#include "boost/range/algorithm/fill.hpp"
+#include <boost/range/algorithm/fill.hpp>
 
 #include "common/assert.h"
 #include "common/alignment.h"
 #include "common/bit_field.h"
-#include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "common/logging/log.h"
+#include "common/vector_math.h"
 
 #include "core/memory.h"
 
@@ -16,6 +15,7 @@
 #include "video_core/pica.h"
 #include "video_core/pica_state.h"
 #include "video_core/pica_types.h"
+#include "video_core/shader/shader.h"
 #include "video_core/vertex_loader.h"
 
 namespace Pica {

--- a/src/video_core/vertex_loader.h
+++ b/src/video_core/vertex_loader.h
@@ -1,13 +1,18 @@
 #pragma once
 
-#include <iterator>
-#include <algorithm>
+#include "common/common_types.h"
 
 #include "video_core/pica.h"
-#include "video_core/shader/shader.h"
-#include "video_core/debug_utils/debug_utils.h"
 
 namespace Pica {
+
+namespace DebugUtils {
+class MemoryAccessTracker;
+}
+
+namespace Shader {
+class InputVertex;
+}
 
 class VertexLoader {
 public:

--- a/src/video_core/video_core.cpp
+++ b/src/video_core/video_core.cpp
@@ -4,11 +4,7 @@
 
 #include <memory>
 
-#include "common/emu_window.h"
 #include "common/logging/log.h"
-
-#include "core/core.h"
-#include "core/settings.h"
 
 #include "video_core/pica.h"
 #include "video_core/renderer_base.h"


### PR DESCRIPTION
This has only be tested on gcc 5.3 and clang 3.7 currently.