### PR TITLE
RFC: Move more code into the JIT-ed part of the vertex shaders

### DIFF
--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -34,8 +34,13 @@ static const JitShader* jit_shader;
 void Setup() {
 #ifdef ARCHITECTURE_x86_64
     if (VideoCore::g_shader_jit_enabled) {
-        u64 cache_key = (Common::ComputeHash64(&g_state.vs.program_code, sizeof(g_state.vs.program_code)) ^
-            Common::ComputeHash64(&g_state.vs.swizzle_data, sizeof(g_state.vs.swizzle_data)));
+        auto& config = g_state.regs.vs;
+        const auto& attribute_register_map = config.input_register_map;
+
+        u64 cache_key =
+            Common::ComputeHash64(&g_state.vs.program_code, sizeof(g_state.vs.program_code)) ^
+            Common::ComputeHash64(&g_state.vs.swizzle_data, sizeof(g_state.vs.swizzle_data)) ^
+            Common::ComputeHash64(&attribute_register_map, sizeof(attribute_register_map));
 
         auto iter = shader_map.find(cache_key);
         if (iter != shader_map.end()) {
@@ -68,38 +73,38 @@ OutputVertex Run(UnitState<false>& state, const InputVertex& input, int num_attr
     state.debug.max_opdesc_id = 0;
 
     // Setup input register table
-    const auto& attribute_register_map = config.input_register_map;
-
-    // TODO: Instead of this cumbersome logic, just load the input data directly like
-    // for (int attr = 0; attr < num_attributes; ++attr) { input_attr[0] = state.registers.input[attribute_register_map.attribute0_register]; }
-    if (num_attributes > 0) state.registers.input[attribute_register_map.attribute0_register] = input.attr[0];
-    if (num_attributes > 1) state.registers.input[attribute_register_map.attribute1_register] = input.attr[1];
-    if (num_attributes > 2) state.registers.input[attribute_register_map.attribute2_register] = input.attr[2];
-    if (num_attributes > 3) state.registers.input[attribute_register_map.attribute3_register] = input.attr[3];
-    if (num_attributes > 4) state.registers.input[attribute_register_map.attribute4_register] = input.attr[4];
-    if (num_attributes > 5) state.registers.input[attribute_register_map.attribute5_register] = input.attr[5];
-    if (num_attributes > 6) state.registers.input[attribute_register_map.attribute6_register] = input.attr[6];
-    if (num_attributes > 7) state.registers.input[attribute_register_map.attribute7_register] = input.attr[7];
-    if (num_attributes > 8) state.registers.input[attribute_register_map.attribute8_register] = input.attr[8];
-    if (num_attributes > 9) state.registers.input[attribute_register_map.attribute9_register] = input.attr[9];
-    if (num_attributes > 10) state.registers.input[attribute_register_map.attribute10_register] = input.attr[10];
-    if (num_attributes > 11) state.registers.input[attribute_register_map.attribute11_register] = input.attr[11];
-    if (num_attributes > 12) state.registers.input[attribute_register_map.attribute12_register] = input.attr[12];
-    if (num_attributes > 13) state.registers.input[attribute_register_map.attribute13_register] = input.attr[13];
-    if (num_attributes > 14) state.registers.input[attribute_register_map.attribute14_register] = input.attr[14];
-    if (num_attributes > 15) state.registers.input[attribute_register_map.attribute15_register] = input.attr[15];
 
     state.conditional_code[0] = false;
     state.conditional_code[1] = false;
 
 #ifdef ARCHITECTURE_x86_64
-    if (VideoCore::g_shader_jit_enabled)
-        jit_shader->Run(&state.registers, g_state.regs.vs.main_offset);
-    else
-        RunInterpreter(state);
-#else
-    RunInterpreter(state);
+    if (VideoCore::g_shader_jit_enabled) {
+        jit_shader->Run(&state.registers, &input.attr[0], g_state.regs.vs.main_offset);
+    } else
 #endif // ARCHITECTURE_x86_64
+    {
+        const auto& attribute_register_map = config.input_register_map;
+        // TODO: Instead of this cumbersome logic, just load the input data directly like
+        // for (int attr = 0; attr < num_attributes; ++attr) { input_attr[0] = state.registers.input[attribute_register_map.attribute0_register]; }
+        if (num_attributes > 0) state.registers.input[attribute_register_map.attribute0_register] = input.attr[0];
+        if (num_attributes > 1) state.registers.input[attribute_register_map.attribute1_register] = input.attr[1];
+        if (num_attributes > 2) state.registers.input[attribute_register_map.attribute2_register] = input.attr[2];
+        if (num_attributes > 3) state.registers.input[attribute_register_map.attribute3_register] = input.attr[3];
+        if (num_attributes > 4) state.registers.input[attribute_register_map.attribute4_register] = input.attr[4];
+        if (num_attributes > 5) state.registers.input[attribute_register_map.attribute5_register] = input.attr[5];
+        if (num_attributes > 6) state.registers.input[attribute_register_map.attribute6_register] = input.attr[6];
+        if (num_attributes > 7) state.registers.input[attribute_register_map.attribute7_register] = input.attr[7];
+        if (num_attributes > 8) state.registers.input[attribute_register_map.attribute8_register] = input.attr[8];
+        if (num_attributes > 9) state.registers.input[attribute_register_map.attribute9_register] = input.attr[9];
+        if (num_attributes > 10) state.registers.input[attribute_register_map.attribute10_register] = input.attr[10];
+        if (num_attributes > 11) state.registers.input[attribute_register_map.attribute11_register] = input.attr[11];
+        if (num_attributes > 12) state.registers.input[attribute_register_map.attribute12_register] = input.attr[12];
+        if (num_attributes > 13) state.registers.input[attribute_register_map.attribute13_register] = input.attr[13];
+        if (num_attributes > 14) state.registers.input[attribute_register_map.attribute14_register] = input.attr[14];
+        if (num_attributes > 15) state.registers.input[attribute_register_map.attribute15_register] = input.attr[15];
+
+        RunInterpreter(state);
+    }
 
     // Setup output data
     OutputVertex ret;

--- a/src/video_core/shader/shader_jit_x64.cpp
+++ b/src/video_core/shader/shader_jit_x64.cpp
@@ -94,7 +94,7 @@ const JitFunction instr_table[64] = {
 // purposes, as documented below:
 
 /// Pointer to the uniform memory
-static const X64Reg UNIFORMS = R9;
+static const X64Reg UNIFORMS = R15;
 /// The two 32-bit VS address offset registers set by the MOVA instruction
 static const X64Reg ADDROFFS_REG_0 = R10;
 static const X64Reg ADDROFFS_REG_1 = R11;
@@ -109,7 +109,12 @@ static const X64Reg COND0 = R13;
 /// Result of the previous CMP instruction for the Y-component comparison
 static const X64Reg COND1 = R14;
 /// Pointer to the UnitState instance for the current VS unit
-static const X64Reg REGISTERS = R15;
+static const X64Reg REGISTERS = ABI_PARAM1;
+
+// Clashes with others, but only used in epilogue.
+static const X64Reg ISCRATCH1 = RSI;
+static const X64Reg ISCRATCH2 = RDI;
+
 /// Pointer to the input data. Aliased over LOOPCOUNT as this is before any loops execute.
 static const X64Reg INPUT = RSI;
 /// SIMD scratch register
@@ -825,7 +830,7 @@ void JitShader::Compile() {
     ABI_PushRegistersAndAdjustStack(ABI_ALL_CALLEE_SAVED, 8);
 
     // Prologue: Scatter inputs into registers according to map
-    MOV(PTRBITS, R(REGISTERS), R(ABI_PARAM1));
+    // MOV(PTRBITS, R(REGISTERS), R(ABI_PARAM1));
     MOV(PTRBITS, R(INPUT), R(ABI_PARAM2));
     for (int i = 0; i < num_attributes; i++) {
         MOVAPS(SCRATCH, MDisp(INPUT, i * 16));
@@ -850,7 +855,50 @@ void JitShader::Compile() {
     MOVAPS(NEGBIT, MatR(RAX));
     // Call the start of the shader program.
     CALLptr(R(ABI_PARAM3));
+
     // Alright, back from the program. Now we can do the epilogue.
+    X64Reg OUTPUT = ABI_PARAM4;
+    // TODO(neobrain): Under some circumstances, up to 16 attributes may be output. We need to
+    // figure out what those circumstances are and enable the remaining outputs then.
+    unsigned index = 0;
+    for (unsigned i = 0; i < 7; ++i) {
+        if (index >= g_state.regs.vs_output_total)
+            break;
+
+        if ((g_state.regs.vs.output_mask & (1 << i)) == 0)
+            continue;
+
+        const auto& output_register_map = g_state.regs.vs_output_attributes[index];
+        u32 semantics[4] = {
+            output_register_map.map_x, output_register_map.map_y,
+            output_register_map.map_z, output_register_map.map_w
+        };
+        if (semantics[1] == semantics[0] + 1 && semantics[2] == semantics[1] + 1 && semantics[3] == semantics[2] + 1) {
+            MOVAPS(SCRATCH, MDisp(REGISTERS, UnitState<false>::OutputOffset(i)));
+            MOVAPS(MDisp(OUTPUT, semantics[0] * 4), SCRATCH);
+        } else {
+            for (unsigned comp = 0; comp < 4; ++comp) {
+                int outOffset = semantics[comp] * 4;
+                if (semantics[comp] != Regs::VSOutputAttributes::INVALID) {
+                    MOV(32, R(ISCRATCH1), MDisp(REGISTERS, UnitState<false>::OutputOffset(i) + comp * 4));
+                    MOV(32, MDisp(OUTPUT, outOffset), R(ISCRATCH1));
+                } else {
+                    // Zero output so that attributes which aren't output won't have denormals in them,
+                    // which would slow us down later.
+                    MOV(32, MDisp(OUTPUT, outOffset), Imm32(0));
+                }
+            }
+        }
+        index++;
+    }
+
+    // Saturate/Clamp color, specifically.
+
+    // These effectively do an ABS.
+    MOVAPS(SCRATCH, R(NEGBIT));
+    ANDNPS(SCRATCH, MDisp(OUTPUT, Regs::VSOutputAttributes::Semantic::COLOR_R * 4));
+    // Clamp to 1.0.
+    MINPS(SCRATCH, R(ONE));
 
     ABI_PopRegistersAndAdjustStack(ABI_ALL_CALLEE_SAVED, 8);
     RET();

--- a/src/video_core/shader/shader_jit_x64.h
+++ b/src/video_core/shader/shader_jit_x64.h
@@ -33,8 +33,8 @@ class JitShader : public Gen::XCodeBlock {
 public:
     JitShader();
 
-    void Run(void* registers, const void *input, unsigned offset) const {
-        program(registers, input, code_ptr[offset]);
+    void Run(void* registers, const void *input, unsigned int offset, void *output) const {
+        program(registers, input, code_ptr[offset], output);
     }
 
     void Compile();
@@ -114,7 +114,7 @@ private:
     /// Branches that need to be fixed up once the entire shader program is compiled
     std::vector<std::pair<Gen::FixupBranch, unsigned>> fixup_branches;
 
-    using CompiledShader = void(void* registers, const void *input, const u8* start_addr);
+    using CompiledShader = void(void* registers, const void *input, const u8* start_addr, void *output);
     CompiledShader* program = nullptr;
 };
 

--- a/src/video_core/shader/shader_jit_x64.h
+++ b/src/video_core/shader/shader_jit_x64.h
@@ -33,8 +33,8 @@ class JitShader : public Gen::XCodeBlock {
 public:
     JitShader();
 
-    void Run(void* registers, unsigned offset) const {
-        program(registers, code_ptr[offset]);
+    void Run(void* registers, const void *input, unsigned offset) const {
+        program(registers, input, code_ptr[offset]);
     }
 
     void Compile();
@@ -114,7 +114,7 @@ private:
     /// Branches that need to be fixed up once the entire shader program is compiled
     std::vector<std::pair<Gen::FixupBranch, unsigned>> fixup_branches;
 
-    using CompiledShader = void(void* registers, const u8* start_addr);
+    using CompiledShader = void(void* registers, const void *input, const u8* start_addr);
     CompiledShader* program = nullptr;
 };
 


### PR DESCRIPTION
The shader "prologue" (move from fetched vertex into input registers) and "epilogue" (move from output registers to output vertex struct according to semantics, clamp color value) are now moved into the compiled vertex shader.

Note that in the unlikely case that a game uses multiple different setups for which attribute is used for each input, or which output is used for which semantic, duplicate shaders will be generated. I don't yet have any numbers to see if that's a real issue.

In a quick test, this improves performance by 2-3% in vertex heavy scenes.