### PR TITLE
Pica: Rename VertexLoaded breakpoint to VertexShaderInvocation

### DIFF
--- a/src/citra_qt/debugger/graphics_breakpoints.cpp
+++ b/src/citra_qt/debugger/graphics_breakpoints.cpp
@@ -44,7 +44,7 @@ QVariant BreakPointModel::data(const QModelIndex& index, int role) const
                 { Pica::DebugContext::Event::PicaCommandProcessed, tr("Pica command processed") },
                 { Pica::DebugContext::Event::IncomingPrimitiveBatch, tr("Incoming primitive batch") },
                 { Pica::DebugContext::Event::FinishedPrimitiveBatch, tr("Finished primitive batch") },
-                { Pica::DebugContext::Event::VertexLoaded, tr("Vertex loaded") },
+                { Pica::DebugContext::Event::VertexShaderInvocation, tr("Vertex shader invocation") },
                 { Pica::DebugContext::Event::IncomingDisplayTransfer, tr("Incoming display transfer") },
                 { Pica::DebugContext::Event::GSPCommandProcessed, tr("GSP command processed") },
                 { Pica::DebugContext::Event::BufferSwapped, tr("Buffers swapped") }

--- a/src/citra_qt/debugger/graphics_vertex_shader.cpp
+++ b/src/citra_qt/debugger/graphics_vertex_shader.cpp
@@ -365,7 +365,7 @@ GraphicsVertexShaderWidget::GraphicsVertexShaderWidget(std::shared_ptr< Pica::De
         input_data[i]->setValidator(new QDoubleValidator(input_data[i]));
     }
 
-    breakpoint_warning = new QLabel(tr("(data only available at VertexLoaded breakpoints)"));
+    breakpoint_warning = new QLabel(tr("(data only available at vertex shader invocation breakpoints)"));
 
     // TODO: Add some button for jumping to the shader entry point
 
@@ -454,7 +454,7 @@ GraphicsVertexShaderWidget::GraphicsVertexShaderWidget(std::shared_ptr< Pica::De
 
 void GraphicsVertexShaderWidget::OnBreakPointHit(Pica::DebugContext::Event event, void* data) {
     auto input = static_cast<Pica::Shader::InputVertex*>(data);
-    if (event == Pica::DebugContext::Event::VertexLoaded) {
+    if (event == Pica::DebugContext::Event::VertexShaderInvocation) {
         Reload(true, data);
     } else {
         // No vertex data is retrievable => invalidate currently stored vertex data

--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -146,10 +146,9 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
                         Shader::UnitState<false> shader_unit;
                         Shader::Setup();
 
-                        if (g_debug_context)
-                            g_debug_context->OnEvent(DebugContext::Event::VertexLoaded, static_cast<void*>(&immediate_input));
-
                         // Send to vertex shader
+                        if (g_debug_context)
+                            g_debug_context->OnEvent(DebugContext::Event::VertexShaderInvocation, static_cast<void*>(&immediate_input));
                         Shader::OutputVertex output = Shader::Run(shader_unit, immediate_input, regs.vs.num_input_attributes+1);
 
                         // Send to renderer
@@ -272,10 +271,9 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
                     Shader::InputVertex input;
                     loader.LoadVertex(base_address, index, vertex, input, memory_accesses);
 
-                    if (g_debug_context)
-                        g_debug_context->OnEvent(DebugContext::Event::VertexLoaded, (void*)&input);
-
                     // Send to vertex shader
+                    if (g_debug_context)
+                        g_debug_context->OnEvent(DebugContext::Event::VertexShaderInvocation, (void*)&input);
                     output = Shader::Run(shader_unit, input, loader.GetNumTotalAttributes());
 
                     if (is_indexed) {

--- a/src/video_core/debug_utils/debug_utils.h
+++ b/src/video_core/debug_utils/debug_utils.h
@@ -40,7 +40,7 @@ public:
         PicaCommandProcessed,
         IncomingPrimitiveBatch,
         FinishedPrimitiveBatch,
-        VertexLoaded,
+        VertexShaderInvocation,
         IncomingDisplayTransfer,
         GSPCommandProcessed,
         BufferSwapped,


### PR DESCRIPTION
Another small change to prepare for geometry shaders which will introduce "Geometry shader invocation".

1. Renames the VertexLoaded-events to VertexShaderInvocation ("Vertex shader invocation")
2. Moves the debug events closer to the actual ::Run() of the shader

(The next changes will be larger, I'm aware that these tiny PRs are annoying)