### PR TITLE
HLE/Applets: Use the correct size for the framebuffer SharedMemory

### DIFF
--- a/src/core/hle/applets/mii_selector.h
+++ b/src/core/hle/applets/mii_selector.h
@@ -18,15 +18,15 @@ namespace Applets {
 
 class MiiSelector final : public Applet {
 public:
-    MiiSelector(Service::APT::AppletId id);
+    MiiSelector(Service::APT::AppletId id) : Applet(id), started(false) { }
 
     ResultCode ReceiveParameter(const Service::APT::MessageParameter& parameter) override;
     ResultCode StartImpl(const Service::APT::AppletStartupParameter& parameter) override;
     void Update() override;
     bool IsRunning() const override { return started; }
 
-    /// TODO(Subv): Find out what this is actually used for.
-    /// It is believed that the application stores the current screen image here.
+    /// This SharedMemory will be created when we receive the LibAppJustStarted message.
+    /// It holds the framebuffer info retrieved by the application with GSPGPU::ImportDisplayCaptureInfo
     Kernel::SharedPtr<Kernel::SharedMemory> framebuffer_memory;
 
     /// Whether this applet is currently running instead of the host application or not.

--- a/src/core/hle/applets/swkbd.cpp
+++ b/src/core/hle/applets/swkbd.cpp
@@ -24,13 +24,6 @@
 namespace HLE {
 namespace Applets {
 
-SoftwareKeyboard::SoftwareKeyboard(Service::APT::AppletId id) : Applet(id), started(false) {
-    // Create the SharedMemory that will hold the framebuffer data
-    // TODO(Subv): What size should we use here?
-    using Kernel::MemoryPermission;
-    framebuffer_memory = Kernel::SharedMemory::Create(0x1000, MemoryPermission::ReadWrite, MemoryPermission::ReadWrite, "SoftwareKeyboard Memory");
-}
-
 ResultCode SoftwareKeyboard::ReceiveParameter(Service::APT::MessageParameter const& parameter) {
     if (parameter.signal != static_cast<u32>(Service::APT::SignalType::LibAppJustStarted)) {
         LOG_ERROR(Service_APT, "unsupported signal %u", parameter.signal);
@@ -39,8 +32,19 @@ ResultCode SoftwareKeyboard::ReceiveParameter(Service::APT::MessageParameter con
         return ResultCode(-1);
     }
 
+    // The LibAppJustStarted message contains a buffer with the size of the framebuffer shared memory.
+    // Create the SharedMemory that will hold the framebuffer data
+    Service::APT::CaptureBufferInfo capture_info;
+    ASSERT(sizeof(capture_info) == parameter.buffer_size);
+
+    memcpy(&capture_info, parameter.data, sizeof(capture_info));
+
+    using Kernel::MemoryPermission;
+    framebuffer_memory = Kernel::SharedMemory::Create(capture_info.size, MemoryPermission::ReadWrite,
+                                                      MemoryPermission::ReadWrite, "SoftwareKeyboard Memory");
+
+    // Send the response message with the newly created SharedMemory
     Service::APT::MessageParameter result;
-    // The buffer passed in parameter contains the data returned by GSPGPU::ImportDisplayCaptureInfo
     result.signal = static_cast<u32>(Service::APT::SignalType::LibAppFinished);
     result.data = nullptr;
     result.buffer_size = 0;

--- a/src/core/hle/applets/swkbd.h
+++ b/src/core/hle/applets/swkbd.h
@@ -53,8 +53,7 @@ static_assert(sizeof(SoftwareKeyboardConfig) == 0x400, "Software Keyboard Config
 
 class SoftwareKeyboard final : public Applet {
 public:
-    SoftwareKeyboard(Service::APT::AppletId id);
-    ~SoftwareKeyboard() {}
+    SoftwareKeyboard(Service::APT::AppletId id) : Applet(id), started(false) { }
 
     ResultCode ReceiveParameter(const Service::APT::MessageParameter& parameter) override;
     ResultCode StartImpl(const Service::APT::AppletStartupParameter& parameter) override;
@@ -72,8 +71,8 @@ public:
      */
     void Finalize();
 
-    /// TODO(Subv): Find out what this is actually used for.
-    /// It is believed that the application stores the current screen image here.
+    /// This SharedMemory will be created when we receive the LibAppJustStarted message.
+    /// It holds the framebuffer info retrieved by the application with GSPGPU::ImportDisplayCaptureInfo
     Kernel::SharedPtr<Kernel::SharedMemory> framebuffer_memory;
 
     /// SharedMemory where the output text will be stored

--- a/src/core/hle/service/apt/apt.h
+++ b/src/core/hle/service/apt/apt.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "common/common_types.h"
+#include "common/swap.h"
 
 #include "core/hle/kernel/kernel.h"
 
@@ -30,6 +31,20 @@ struct AppletStartupParameter {
     Kernel::SharedPtr<Kernel::Object> object = nullptr;
     u8* data = nullptr;
 };
+
+/// Used by the application to pass information about the current framebuffer to applets.
+struct CaptureBufferInfo {
+    u32_le size;
+    u8 is_3d;
+    INSERT_PADDING_BYTES(0x3); // Padding for alignment
+    u32_le top_screen_left_offset;
+    u32_le top_screen_right_offset;
+    u32_le top_screen_format;
+    u32_le bottom_screen_left_offset;
+    u32_le bottom_screen_right_offset;
+    u32_le bottom_screen_format;
+};
+static_assert(sizeof(CaptureBufferInfo) == 0x20, "CaptureBufferInfo struct has incorrect size");
 
 /// Signals used by APT functions
 enum class SignalType : u32 {


### PR DESCRIPTION
This is preliminary work for a fix we need in #1689