### PR TITLE
Kernel/Threading: Warn when a thread can be scheduled in the Syscore (Core 1)

### DIFF
--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -107,6 +107,8 @@ public:
     ProcessFlags flags;
     /// Kernel compatibility version for this process
     u16 kernel_version = 0;
+    /// The default CPU for this process, threads are scheduled on this cpu by default.
+    u8 ideal_processor = 0;
 
     /// The id of this process
     u32 process_id = next_process_id++;

--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -497,6 +497,11 @@ static ResultCode CreateThread(Handle* out_handle, s32 priority, u32 entry_point
         break;
     }
 
+    if (processor_id == THREADPROCESSORID_1 || processor_id == THREADPROCESSORID_ALL ||
+        (processor_id == THREADPROCESSORID_DEFAULT && Kernel::g_current_process->ideal_processor == THREADPROCESSORID_1)) {
+        LOG_WARNING(Kernel_SVC, "Newly created thread is allowed to be run in the SysCore, unimplemented.");
+    }
+
     CASCADE_RESULT(SharedPtr<Thread> thread, Kernel::Thread::Create(
             name, entry_point, priority, arg, processor_id, stack_top));
     CASCADE_RESULT(*out_handle, Kernel::g_handle_table.Create(std::move(thread)));

--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -156,6 +156,9 @@ ResultStatus AppLoader_NCCH::LoadExec() {
         Kernel::g_current_process->resource_limit = Kernel::ResourceLimit::GetForCategory(
             static_cast<Kernel::ResourceLimitCategory>(exheader_header.arm11_system_local_caps.resource_limit_category));
 
+        // Set the default CPU core for this process
+        Kernel::g_current_process->ideal_processor = exheader_header.arm11_system_local_caps.ideal_processor;
+
         // Copy data while converting endianess
         std::array<u32, ARRAY_SIZE(exheader_header.arm11_kernel_caps.descriptors)> kernel_caps;
         std::copy_n(exheader_header.arm11_kernel_caps.descriptors, kernel_caps.size(), begin(kernel_caps));


### PR DESCRIPTION
We do not currently implement any cores other than the AppCore (Core 0).