### PR TITLE
dyncom: Reset the context into user mode correctly

### DIFF
--- a/src/core/arm/dyncom/arm_dyncom.cpp
+++ b/src/core/arm/dyncom/arm_dyncom.cpp
@@ -93,7 +93,7 @@ void ARM_DynCom::ResetContext(Core::ThreadContext& context, u32 stack_top, u32 e
     context.cpu_registers[0] = arg;
     context.pc = entry_point;
     context.sp = stack_top;
-    context.cpsr = 0x1F | ((entry_point & 1) << 5); // Usermode and THUMB mode
+    context.cpsr = USER32MODE | ((entry_point & 1) << 5); // Usermode and THUMB mode
 }
 
 void ARM_DynCom::SaveContext(Core::ThreadContext& ctx) {


### PR DESCRIPTION
The other mode was system mode.