### PR TITLE
Reimplement circle pad input & add circle pad modifier

### DIFF
--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -49,7 +49,8 @@ static const std::array<int, Settings::NativeInput::NUM_INPUTS> defaults = {
     SDL_SCANCODE_M, SDL_SCANCODE_N, SDL_SCANCODE_B,
     SDL_SCANCODE_T, SDL_SCANCODE_G, SDL_SCANCODE_F, SDL_SCANCODE_H,
     SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, SDL_SCANCODE_LEFT, SDL_SCANCODE_RIGHT,
-    SDL_SCANCODE_I, SDL_SCANCODE_K, SDL_SCANCODE_J, SDL_SCANCODE_L
+    SDL_SCANCODE_I, SDL_SCANCODE_K, SDL_SCANCODE_J, SDL_SCANCODE_L,
+    SDL_SCANCODE_D
 };
 
 void Config::ReadValues() {
@@ -58,6 +59,7 @@ void Config::ReadValues() {
         Settings::values.input_mappings[Settings::NativeInput::All[i]] =
             sdl2_config->GetInteger("Controls", Settings::NativeInput::Mapping[i], defaults[i]);
     }
+    Settings::values.circle_pad_modifier_scale = (float)sdl2_config->GetReal("Controls", "circle_pad_modifier_scale", 0.5);
 
     // Core
     Settings::values.frame_skip = sdl2_config->GetInteger("Core", "frame_skip", 0);

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -31,6 +31,11 @@ pad_cup =
 pad_cdown =
 pad_cleft =
 pad_cright =
+pad_cmodifier =
+
+# The multiplier to the circle pad radius when modifier is pressed.
+# Must be in range of 0.0-1.0. Defaults to 0.5
+circle_pad_modifier_scale =
 
 [Core]
 # The applied frameskip amount. Must be a power of two.

--- a/src/citra_qt/config.cpp
+++ b/src/citra_qt/config.cpp
@@ -27,7 +27,8 @@ static const std::array<QVariant, Settings::NativeInput::NUM_INPUTS> defaults = 
     Qt::Key_M, Qt::Key_N, Qt::Key_B,
     Qt::Key_T, Qt::Key_G, Qt::Key_F, Qt::Key_H,
     Qt::Key_Up, Qt::Key_Down, Qt::Key_Left, Qt::Key_Right,
-    Qt::Key_I, Qt::Key_K, Qt::Key_J, Qt::Key_L
+    Qt::Key_I, Qt::Key_K, Qt::Key_J, Qt::Key_L,
+    Qt::Key_D
 };
 
 void Config::ReadValues() {
@@ -36,6 +37,7 @@ void Config::ReadValues() {
         Settings::values.input_mappings[Settings::NativeInput::All[i]] =
             qt_config->value(QString::fromStdString(Settings::NativeInput::Mapping[i]), defaults[i]).toInt();
     }
+    Settings::values.circle_pad_modifier_scale = qt_config->value("circle_pad_modifier_scale", 0.5).toFloat();
     qt_config->endGroup();
 
     qt_config->beginGroup("Core");
@@ -125,6 +127,7 @@ void Config::SaveValues() {
         qt_config->setValue(QString::fromStdString(Settings::NativeInput::Mapping[i]),
             Settings::values.input_mappings[Settings::NativeInput::All[i]]);
     }
+    qt_config->setValue("circle_pad_modifier_scale", (double)Settings::values.circle_pad_modifier_scale);
     qt_config->endGroup();
 
     qt_config->beginGroup("Core");

--- a/src/common/emu_window.cpp
+++ b/src/common/emu_window.cpp
@@ -12,11 +12,21 @@
 #include "video_core/video_core.h"
 
 void EmuWindow::KeyPressed(KeyMap::HostDeviceKey key) {
-    pad_state.hex |= KeyMap::GetPadKey(key).hex;
+    auto hex = KeyMap::GetPadKey(key).hex;
+    if (hex == Service::HID::PAD_C_MODIFIER.hex) {
+        circle_pad_modifier = true;
+    } else {
+        pad_state.hex |= KeyMap::GetPadKey(key).hex;
+    }
 }
 
 void EmuWindow::KeyReleased(KeyMap::HostDeviceKey key) {
-    pad_state.hex &= ~KeyMap::GetPadKey(key).hex;
+    auto hex = KeyMap::GetPadKey(key).hex;
+    if (hex == Service::HID::PAD_C_MODIFIER.hex) {
+        circle_pad_modifier = false;
+    } else {
+        pad_state.hex &= ~KeyMap::GetPadKey(key).hex;
+    }
 }
 
 /**

--- a/src/common/emu_window.h
+++ b/src/common/emu_window.h
@@ -100,13 +100,45 @@ public:
     void TouchMoved(unsigned framebuffer_x, unsigned framebuffer_y);
 
     /**
-     * Gets the current pad state (which buttons are pressed and the circle pad direction).
+     * Gets the current pad state (which buttons are pressed).
      * @note This should be called by the core emu thread to get a state set by the window thread.
+     * @note The circle pad fields of the returned state are cleared.
+     *         Circle pad should be handled from GetCirclePadState().
      * @todo Fix this function to be thread-safe.
      * @return PadState object indicating the current pad state
      */
     Service::HID::PadState GetPadState() const {
-        return pad_state;
+        auto cleared_pad_state = pad_state;
+        cleared_pad_state.circle_right.Assign(0);
+        cleared_pad_state.circle_left.Assign(0);
+        cleared_pad_state.circle_up.Assign(0);
+        cleared_pad_state.circle_down.Assign(0);
+        return cleared_pad_state;
+    }
+
+    /**
+     * Gets the current cirle pad state.
+     * @note This should be called by the core emu thread to get a state set by the window thread.
+     * @todo Fix this function to be thread-safe.
+     * @return std::tuple of (x, y), where `x` and `y` are the circle pad coordinates
+     */
+    std::tuple<s16, s16> GetCirclePadState() const {
+        const int MAX_CIRCLEPAD_POS = 0x9C; // Max radius for a circle pad position
+        const float SQRT_HALF = 0.707106781;
+        int x = 0, y = 0;
+        if (pad_state.circle_right.ToBool())
+            x += MAX_CIRCLEPAD_POS;
+        if (pad_state.circle_left.ToBool())
+            x -= MAX_CIRCLEPAD_POS;
+        if (pad_state.circle_up.ToBool())
+            y += MAX_CIRCLEPAD_POS;
+        if (pad_state.circle_down.ToBool())
+            y -= MAX_CIRCLEPAD_POS;
+        if (x != 0)
+            y *= SQRT_HALF;
+        if (y != 0)
+            x *= SQRT_HALF;
+        return std::make_tuple<s16, s16>(x, y);
     }
 
     /**

--- a/src/common/emu_window.h
+++ b/src/common/emu_window.h
@@ -138,7 +138,11 @@ public:
             y *= SQRT_HALF;
         if (y != 0)
             x *= SQRT_HALF;
-        return std::make_tuple<s16, s16>(x, y);
+        if (circle_pad_modifier) {
+            x *= Settings::values.circle_pad_modifier_scale;
+            y *= Settings::values.circle_pad_modifier_scale;
+        }
+        return std::make_tuple(x, y);
     }
 
     /**
@@ -233,6 +237,7 @@ protected:
         touch_x = 0;
         touch_y = 0;
         touch_pressed = false;
+        circle_pad_modifier = false;
     }
     virtual ~EmuWindow() {}
 
@@ -298,4 +303,6 @@ private:
     std::tuple<unsigned,unsigned> ClipToTouchScreen(unsigned new_x, unsigned new_y);
 
     Service::HID::PadState pad_state;
+
+    bool circle_pad_modifier;  ///< True if circle pad modifier is currently pressed, otherwise false
 };

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -43,7 +43,8 @@ const std::array<Service::HID::PadState, Settings::NativeInput::NUM_INPUTS> pad_
     Service::HID::PAD_START, Service::HID::PAD_SELECT, Service::HID::PAD_NONE,
     Service::HID::PAD_UP, Service::HID::PAD_DOWN, Service::HID::PAD_LEFT, Service::HID::PAD_RIGHT,
     Service::HID::PAD_CIRCLE_UP, Service::HID::PAD_CIRCLE_DOWN, Service::HID::PAD_CIRCLE_LEFT, Service::HID::PAD_CIRCLE_RIGHT,
-    Service::HID::PAD_C_UP, Service::HID::PAD_C_DOWN, Service::HID::PAD_C_LEFT, Service::HID::PAD_C_RIGHT
+    Service::HID::PAD_C_UP, Service::HID::PAD_C_DOWN, Service::HID::PAD_C_LEFT, Service::HID::PAD_C_RIGHT,
+    Service::HID::PAD_C_MODIFIER , // place holder for circle pad modifier
 }};
 
 void Update() {

--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -215,6 +215,8 @@ const PadState PAD_CIRCLE_LEFT  = {{1u << 29}};
 const PadState PAD_CIRCLE_UP    = {{1u << 30}};
 const PadState PAD_CIRCLE_DOWN  = {{1u << 31}};
 
+const PadState PAD_C_MODIFIER   = {{1u << 23}}; // An intermediate value only used by citra
+
 
 extern const std::array<Service::HID::PadState, Settings::NativeInput::NUM_INPUTS> pad_mapping;
 

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -19,6 +19,7 @@ enum Values {
     DUP, DDOWN, DLEFT, DRIGHT,
     SUP, SDOWN, SLEFT, SRIGHT,
     CUP, CDOWN, CLEFT, CRIGHT,
+    CMODIFIER,
     NUM_INPUTS
 };
 static const std::array<const char*, NUM_INPUTS> Mapping = {{
@@ -27,7 +28,8 @@ static const std::array<const char*, NUM_INPUTS> Mapping = {{
     "pad_start", "pad_select", "pad_home",
     "pad_dup", "pad_ddown", "pad_dleft", "pad_dright",
     "pad_sup", "pad_sdown", "pad_sleft", "pad_sright",
-    "pad_cup", "pad_cdown", "pad_cleft", "pad_cright"
+    "pad_cup", "pad_cdown", "pad_cleft", "pad_cright",
+    "pad_cmodifier"
 }};
 static const std::array<Values, NUM_INPUTS> All = {{
     A, B, X, Y,
@@ -35,7 +37,8 @@ static const std::array<Values, NUM_INPUTS> All = {{
     START, SELECT, HOME,
     DUP, DDOWN, DLEFT, DRIGHT,
     SUP, SDOWN, SLEFT, SRIGHT,
-    CUP, CDOWN, CLEFT, CRIGHT
+    CUP, CDOWN, CLEFT, CRIGHT,
+    CMODIFIER
 }};
 }
 
@@ -43,6 +46,7 @@ static const std::array<Values, NUM_INPUTS> All = {{
 struct Values {
     // Controls
     std::array<int, NativeInput::NUM_INPUTS> input_mappings;
+    float circle_pad_modifier_scale;
 
     // Core
     int frame_skip;


### PR DESCRIPTION
#### Reimplement circle pad
The way we used to handle circle pad input was:
Keyboard input ->[EmuWindow]-> circle pad direction -> [HID] -> make up circle pad position.
Now change it to:
Keyboard input ->[EmuWindow]-> make up circle pad position -> [HID] -> calculate circle pad direction.
(In the future we can also add : controller joystick -> [EmuWindow]-> real circle pad position -> ...)
The position-to-direction algorithm is confirmed by this [hw test](https://github.com/wwylele/ctrhwtest/tree/master/circle_pad). It has an error of +/- 1, but it is hard to test the edge cases on hardware, and I think it is enough for emulation.
Illustrate the circle pad direction threshold:
![circle_pad](https://cloud.githubusercontent.com/assets/4592895/15174898/7d642268-176c-11e6-9cc9-9fdd7c7358ed.PNG)

#### Add circle pad modifier
The word "modifier" is grabbed from Dolphin. (sorry for my poor English. Please help improve if I use it wrongly) When pressing the modifier key (default to D) and circle pad direction key simultaneously, the made up circle pad radius is the max radius multiplied by a scale (default to 0.5) to emulate player gently pushing the circle pad. This is useful, for example, for player to sneak in Pokemon OR/AS.