### PR TITLE
Turn ShaderSetup into a class

### DIFF
--- a/src/citra_qt/debugger/graphics_vertex_shader.cpp
+++ b/src/citra_qt/debugger/graphics_vertex_shader.cpp
@@ -501,7 +501,7 @@ void GraphicsVertexShaderWidget::Reload(bool replace_vertex_data, void* vertex_d
     info.labels.insert({ entry_point, "main" });
 
     // Generate debug information
-    debug_data = Pica::Shader::ProduceDebugInfo(input_vertex, num_attributes, shader_config, shader_setup);
+    debug_data = Pica::g_state.vs.ProduceDebugInfo(input_vertex, num_attributes, shader_config, shader_setup);
 
     // Reload widget state
     for (int attr = 0; attr < num_attributes; ++attr) {

--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -144,12 +144,12 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
                         immediate_attribute_id = 0;
 
                         Shader::UnitState<false> shader_unit;
-                        Shader::Setup();
+                        g_state.vs.Setup();
 
                         // Send to vertex shader
                         if (g_debug_context)
                             g_debug_context->OnEvent(DebugContext::Event::VertexShaderInvocation, static_cast<void*>(&immediate_input));
-                        Shader::OutputVertex output = Shader::Run(shader_unit, immediate_input, regs.vs.num_input_attributes+1);
+                        Shader::OutputVertex output = g_state.vs.Run(shader_unit, immediate_input, regs.vs.num_input_attributes+1);
 
                         // Send to renderer
                         using Pica::Shader::OutputVertex;
@@ -237,7 +237,7 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
             vertex_cache_ids.fill(-1);
 
             Shader::UnitState<false> shader_unit;
-            Shader::Setup();
+            g_state.vs.Setup();
 
             for (unsigned int index = 0; index < regs.num_vertices; ++index)
             {
@@ -274,7 +274,7 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
                     // Send to vertex shader
                     if (g_debug_context)
                         g_debug_context->OnEvent(DebugContext::Event::VertexShaderInvocation, (void*)&input);
-                    output = Shader::Run(shader_unit, input, loader.GetNumTotalAttributes());
+                    output = g_state.vs.Run(shader_unit, input, loader.GetNumTotalAttributes());
 
                     if (is_indexed) {
                         vertex_cache[vertex_cache_pos] = output;

--- a/src/video_core/pica.cpp
+++ b/src/video_core/pica.cpp
@@ -500,7 +500,7 @@ void Init() {
 }
 
 void Shutdown() {
-    Shader::Shutdown();
+    Shader::ClearCache();
 }
 
 template <typename T>

--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -35,7 +35,13 @@ static std::unordered_map<u64, std::unique_ptr<JitShader>> shader_map;
 static const JitShader* jit_shader;
 #endif // ARCHITECTURE_x86_64
 
-void Setup() {
+void ClearCache() {
+#ifdef ARCHITECTURE_x86_64
+    shader_map.clear();
+#endif // ARCHITECTURE_x86_64
+}
+
+void ShaderSetup::Setup() {
 #ifdef ARCHITECTURE_x86_64
     if (VideoCore::g_shader_jit_enabled) {
         u64 cache_key = (Common::ComputeHash64(&g_state.vs.program_code, sizeof(g_state.vs.program_code)) ^
@@ -54,18 +60,12 @@ void Setup() {
 #endif // ARCHITECTURE_x86_64
 }
 
-void Shutdown() {
-#ifdef ARCHITECTURE_x86_64
-    shader_map.clear();
-#endif // ARCHITECTURE_x86_64
-}
+MICROPROFILE_DEFINE(GPU_Shader, "GPU", "Shader", MP_RGB(50, 50, 240));
 
-MICROPROFILE_DEFINE(GPU_VertexShader, "GPU", "Vertex Shader", MP_RGB(50, 50, 240));
-
-OutputVertex Run(UnitState<false>& state, const InputVertex& input, int num_attributes) {
+OutputVertex ShaderSetup::Run(UnitState<false>& state, const InputVertex& input, int num_attributes) {
     auto& config = g_state.regs.vs;
 
-    MICROPROFILE_SCOPE(GPU_VertexShader);
+    MICROPROFILE_SCOPE(GPU_Shader);
 
     state.program_counter = config.main_offset;
     state.debug.max_offset = 0;
@@ -140,7 +140,7 @@ OutputVertex Run(UnitState<false>& state, const InputVertex& input, int num_attr
     return ret;
 }
 
-DebugData<true> ProduceDebugInfo(const InputVertex& input, int num_attributes, const Regs::ShaderConfig& config, const ShaderSetup& setup) {
+DebugData<true> ShaderSetup::ProduceDebugInfo(const InputVertex& input, int num_attributes, const Regs::ShaderConfig& config, const ShaderSetup& setup) {
     UnitState<true> state;
 
     state.program_counter = config.main_offset;


### PR DESCRIPTION
`Setup()` is an objectless function in master and it means that one would have to set up VS or GS before each run which is not suitable due to them being run in alternating pattern (VS is ran a couple of times to generate GS input, then GS runs. The process repeats for each group of vertices until enough GS input data is available again).

Rather than keeping the `Setup()` function in `Shader::` I moved it to a `class ShaderSetup::` (which maintains per shader type state which is not already in the Pica regs) so we can `Setup()` for VS or GS seperately.

I've also decided to rename the `Shutdown()` function to avoid ambiguity and I also kept it out of `ShaderSetup`.
This is more useful because VS and GS should be able to share the same shader cache.
If we would have called `Shutdown()` on either GS or VS it would have affected the other one too.
Also calling a `static ShaderSetup::Shutdown` function feels weird as it's not clear what will happen.

---

This doesn't add anything new. It's mostly cleanup for addition of GS which will happen in future PRs.

---

The code quality in this one is probably bad. I wasn't sure wether to use a `class` or a `struct` for example.
I'd like to remind you that this is part of a larger set of changes for GS.  So please don't ask me to refactor everything.