### PR TITLE
DSP: dsp::DSP semaphore indicates completion of audio frame config

### DIFF
--- a/src/audio_core/audio_core.cpp
+++ b/src/audio_core/audio_core.cpp
@@ -24,11 +24,12 @@ static constexpr u64 audio_frame_ticks = 1310252ull; ///< Units: ARM11 cycles
 
 static void AudioTickCallback(u64 /*userdata*/, int cycles_late) {
     if (DSP::HLE::Tick()) {
-        // TODO(merry): Signal all the other interrupts as appropriate.
         DSP_DSP::SignalPipeInterrupt(DSP::HLE::DspPipe::Audio);
-        // HACK(merry): Added to prevent regressions. Will remove soon.
-        DSP_DSP::SignalPipeInterrupt(DSP::HLE::DspPipe::Binary);
     }
+
+    // TODO(merry): Signal all the other interrupts as appropriate.
+    // HACK(merry): Added to prevent regressions. Will remove soon.
+    DSP_DSP::SignalPipeInterrupt(DSP::HLE::DspPipe::Binary);
 
     // Reschedule recurrent event
     CoreTiming::ScheduleEvent(audio_frame_ticks - cycles_late, tick_event);

--- a/src/core/hle/service/dsp_dsp.cpp
+++ b/src/core/hle/service/dsp_dsp.cpp
@@ -89,6 +89,14 @@ void SignalPipeInterrupt(DspPipe pipe) {
     interrupt_events.Signal(InterruptType::Pipe, pipe);
 }
 
+void ResetSemaphore() {
+    semaphore_event->Clear();
+}
+
+bool IsSemaphoreSignalled() {
+    return semaphore_event->signaled;
+}
+
 /**
  * DSP_DSP::ConvertProcessAddressFromDspDram service function
  *  Inputs:

--- a/src/core/hle/service/dsp_dsp.h
+++ b/src/core/hle/service/dsp_dsp.h
@@ -35,4 +35,10 @@ public:
  */
 void SignalPipeInterrupt(DSP::HLE::DspPipe pipe);
 
+/// Reset the dsp::DSP semaphore.
+void ResetSemaphore();
+
+/// Has the dsp::DSP semaphore been signalled?
+bool IsSemaphoreSignalled();
+
 } // namespace DSP_DSP


### PR DESCRIPTION
How synchronisation between the emulated application and the DSP occurs:

1. DSP firmware signals audio-pipe interrupt. This indicates it's ready to receive a frame.
2. Application writes to shared memory region.
3. Application signals the semaphore.
4. DSP firmware does processing.
5. goto 1

On actual hardware Step 4 may take longer than ~5 ms which may result in skipped frames; this is not implemented here.