### PR TITLE
Cleanup ShaderSetup (Part 1)

### DIFF
--- a/src/citra_qt/debugger/graphics_tracing.cpp
+++ b/src/citra_qt/debugger/graphics_tracing.cpp
@@ -74,7 +74,7 @@ void GraphicsTracingWidget::StartRecording() {
     std::array<u32, 4 * 16> default_attributes;
     for (unsigned i = 0; i < 16; ++i) {
         for (unsigned comp = 0; comp < 3; ++comp) {
-            default_attributes[4 * i + comp] = nihstro::to_float24(Pica::g_state.vs.default_attributes[i][comp].ToFloat32());
+            default_attributes[4 * i + comp] = nihstro::to_float24(Pica::g_state.vs_default_attributes[i][comp].ToFloat32());
         }
     }
 

--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -128,7 +128,7 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
 
                 // TODO: Verify that this actually modifies the register!
                 if (setup.index < 15) {
-                    g_state.vs.default_attributes[setup.index] = attribute;
+                    g_state.vs_default_attributes[setup.index] = attribute;
                     setup.index++;
                 } else {
                     // Put each attribute into an immediate input buffer.

--- a/src/video_core/pica_state.h
+++ b/src/video_core/pica_state.h
@@ -25,6 +25,8 @@ struct State {
     Shader::ShaderSetup vs;
     Shader::ShaderSetup gs;
 
+    std::array<Math::Vec4<float24>, 16> vs_default_attributes;
+
     struct {
         union LutEntry {
             // Used for raw access

--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -67,7 +67,6 @@ OutputVertex ShaderSetup::Run(UnitState<false>& state, const InputVertex& input,
 
     MICROPROFILE_SCOPE(GPU_Shader);
 
-    state.program_counter = config.main_offset;
     state.debug.max_offset = 0;
     state.debug.max_opdesc_id = 0;
 
@@ -143,7 +142,6 @@ OutputVertex ShaderSetup::Run(UnitState<false>& state, const InputVertex& input,
 DebugData<true> ShaderSetup::ProduceDebugInfo(const InputVertex& input, int num_attributes, const Regs::ShaderConfig& config, const ShaderSetup& setup) {
     UnitState<true> state;
 
-    state.program_counter = config.main_offset;
     state.debug.max_offset = 0;
     state.debug.max_opdesc_id = 0;
 

--- a/src/video_core/shader/shader.h
+++ b/src/video_core/shader/shader.h
@@ -272,28 +272,11 @@ struct UnitState {
     } registers;
     static_assert(std::is_pod<Registers>::value, "Structure is not POD");
 
-    u32 program_counter;
     bool conditional_code[2];
 
     // Two Address registers and one loop counter
     // TODO: How many bits do these actually have?
     s32 address_registers[3];
-
-    enum {
-        INVALID_ADDRESS = 0xFFFFFFFF
-    };
-
-    struct CallStackElement {
-        u32 final_address;  // Address upon which we jump to return_address
-        u32 return_address; // Where to jump when leaving scope
-        u8 repeat_counter;  // How often to repeat until this call stack element is removed
-        u8 loop_increment;  // Which value to add to the loop counter after an iteration
-                            // TODO: Should this be a signed value? Does it even matter?
-        u32 loop_address;   // The address where we'll return to after each loop iteration
-    };
-
-    // TODO: Is there a maximal size for this?
-    boost::container::static_vector<CallStackElement, 16> call_stack;
 
     DebugData<Debug> debug;
 

--- a/src/video_core/shader/shader.h
+++ b/src/video_core/shader/shader.h
@@ -340,8 +340,6 @@ struct ShaderSetup {
         std::array<Math::Vec4<u8>, 4> i;
     } uniforms;
 
-    Math::Vec4<float24> default_attributes[16];
-
     std::array<u32, 1024> program_code;
     std::array<u32, 1024> swizzle_data;
 

--- a/src/video_core/vertex_loader.cpp
+++ b/src/video_core/vertex_loader.cpp
@@ -124,7 +124,7 @@ void VertexLoader::LoadVertex(u32 base_address, int index, int vertex, Shader::I
                 input.attr[i][0].ToFloat32(), input.attr[i][1].ToFloat32(), input.attr[i][2].ToFloat32(), input.attr[i][3].ToFloat32());
         } else if (vertex_attribute_is_default[i]) {
             // Load the default attribute if we're configured to do so
-            input.attr[i] = g_state.vs.default_attributes[i];
+            input.attr[i] = g_state.vs_default_attributes[i];
             LOG_TRACE(HW_GPU, "Loaded default attribute %x for vertex %x (index %x): (%f, %f, %f, %f)",
                 i, vertex, index,
                 input.attr[i][0].ToFloat32(), input.attr[i][1].ToFloat32(),


### PR DESCRIPTION
Another part of my GS branch.

ShaderSetup still stores the fixed per vertex attributes even if that is not directly tied to any specific shader type (VS / GS). Commit moves this into the generic Pica state.

UnitState (which is a helper struct for shader execution) contains state information which is only necessary for the interpreter. Commit moves this into respective functions as local variables.
(One could argue that it's part of the shader unit state, but it's not easily observable from the outside and JIT / Interpreter don't use the same variables, so this was just a memory hog and confusing)

The program_counter is initialized to the VS entry point now which might appear weird because it came from `config` before, however, we always use the VS as config source so this shouldn't break anything.
A later commit will change this back but it will have to change a lot of function signatures so I kept it seperated.

(ftr: There might not be a part 2, this is just broken down from a larger commit which I'll probably split into 2 more commits after this. However I might call the PR differently next time.)

