### PR TITLE
gitmodules: citra-emu/soundtouch → citra-emu/ext-soundtouch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 	url = https://github.com/neobrain/nihstro.git
 [submodule "soundtouch"]
 	path = externals/soundtouch
-	url = https://github.com/citra-emu/soundtouch.git
+	url = https://github.com/citra-emu/ext-soundtouch.git


### PR DESCRIPTION
Repo was renamed.