### PR TITLE
Avoid uninitialised in hw renderer + Only sync depth if necessary

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -339,8 +339,11 @@ private:
     /// Syncs the cull mode to match the PICA register
     void SyncCullMode();
 
-    /// Syncs the depth scale and offset to match the PICA registers
-    void SyncDepthModifiers();
+    /// Syncs the depth scale to match the PICA register
+    void SyncDepthScale();
+
+    /// Syncs the depth offset to match the PICA register
+    void SyncDepthOffset();
 
     /// Syncs the blend enabled status to match the PICA register
     void SyncBlendEnabled();

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -413,7 +413,7 @@ private:
         UniformData data;
         bool lut_dirty[6];
         bool dirty;
-    } uniform_block_data;
+    } uniform_block_data = {};
 
     std::array<SamplerInfo, 3> texture_samplers;
     OGLVertexArray vertex_array;
@@ -422,5 +422,5 @@ private:
     OGLFramebuffer framebuffer;
 
     std::array<OGLTexture, 6> lighting_luts;
-    std::array<std::array<GLvec4, 256>, 6> lighting_lut_data;
+    std::array<std::array<GLvec4, 256>, 6> lighting_lut_data{};
 };


### PR DESCRIPTION
The latest bugs have reminded me that I should run valgrind more often.
I then noticed that pretty much every GL state caused 1 uninitalised [sic, valgrind] access.
This PR fixes this by value-initializing those variables.
It's really not that important though because the access is basically: `if (new_value != current_value) { current_value = new_value; dirty = true; }` (the logic still works, it's just not nice to do it).

Furthermore I noticed how different my depth-modifier uniform synced compared to every other uniform sync in gl_rasterizer. This PR fixes that in another commit too.