### PR TITLE
DSP_DSP: Remove GetHeadphoneStatus logspam

### DIFF
--- a/src/core/hle/service/dsp_dsp.cpp
+++ b/src/core/hle/service/dsp_dsp.cpp
@@ -440,9 +440,9 @@ static void GetHeadphoneStatus(Service::Interface* self) {
 
     cmd_buff[0] = IPC::MakeHeader(0x1F, 2, 0);
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
-    cmd_buff[2] = 0; // Not using headphones?
+    cmd_buff[2] = 0; // Not using headphones
 
-    LOG_WARNING(Service_DSP, "(STUBBED) called");
+    LOG_DEBUG(Service_DSP, "called");
 }
 
 /**


### PR DESCRIPTION
Downgrade from `WARNING` to `DEBUG` since we don't need to know it's being called x times a second.

May make headphones being inserted a config option in the future.