### PR TITLE
Set fpscr for new threads

### DIFF
--- a/src/core/arm/arm_interface.h
+++ b/src/core/arm/arm_interface.h
@@ -6,6 +6,7 @@
 
 #include "common/common_types.h"
 #include "core/arm/skyeye_common/arm_regformat.h"
+#include "core/arm/skyeye_common/vfp/asm_vfp.h"
 
 namespace Core {
     struct ThreadContext;

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -526,6 +526,8 @@ SharedPtr<Thread> SetupMainThread(u32 entry_point, s32 priority) {
 
     SharedPtr<Thread> thread = thread_res.MoveFrom();
 
+    thread->context.fpscr = FPSCR_DEFAULT_NAN | FPSCR_FLUSH_TO_ZERO | FPSCR_ROUND_TOZERO | FPSCR_IXC; // 0x03C00010
+
     // Run new "main" thread
     SwitchContext(thread.get());
 

--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -502,6 +502,9 @@ static ResultCode CreateThread(Handle* out_handle, s32 priority, u32 entry_point
 
     CASCADE_RESULT(SharedPtr<Thread> thread, Kernel::Thread::Create(
             name, entry_point, priority, arg, processor_id, stack_top));
+
+    thread->context.fpscr = FPSCR_DEFAULT_NAN | FPSCR_FLUSH_TO_ZERO | FPSCR_ROUND_TOZERO; // 0x03C00000
+
     CASCADE_RESULT(*out_handle, Kernel::g_handle_table.Create(std::move(thread)));
 
     LOG_TRACE(Kernel_SVC, "called entrypoint=0x%08X (%s), arg=0x%08X, stacktop=0x%08X, "


### PR DESCRIPTION
~~Improves~~ Fixes #1777 ~~(= does not fix it completly!)~~

~~Doing this in svcCreateThread doesn't work (its too late probably because the thread is already scheduled after creation in the kernel code).
This should really be reset to 0 on CPU level and only set to something else in the Kernel / Service HLE (probably also true for other regs in that function?)~~

I'm stupid, MerryMage is the best :heart: 

---

[HW-Tested using this](https://github.com/JayFoxRox/3ds-tests/commit/3eb17d9e7f4f310ebf1d989a81d11bf36ca2bac0)

Result on actual 3DS (by einstein95):
```
old_fpscr: 0x03C00010
new_fpscr: 0x03C00000
old_fpscr: 0x00000000
new_fpscr: 0x03C00000
old_fpscr: 0x03C00000
new_fpscr: 0x03C00000
old_fpscr: 0x03C00010
new_fpscr: 0x03C00000
```

Citra:
```
old_fpscr: 0x00000000
new_fpscr: 0x00000000
old_fpscr: 0x00000000
new_fpscr: 0x00000000
old_fpscr: 0x03C00000
new_fpscr: 0x00000000
old_fpscr: 0x03C00010
new_fpscr: 0x00000000
```

Citra + this PR:
```
old_fpscr: 0x03C00010
new_fpscr: 0x03C00000
old_fpscr: 0x00000000
new_fpscr: 0x03C00000
old_fpscr: 0x03C00000
new_fpscr: 0x03C00000
old_fpscr: 0x03C00010
new_fpscr: 0x03C00000
```

~~Note that there is still a bug with the first fpscr read from `main()`.
I'm assuming this means that the OS does some other stuff when creating a new process which sets the inexact math bit. We should probably emulate that behaviour but I don't know where.
This is already WAY better than what we currently have because Citra vs 3DS rounding actually causes off-by-one errors on a lot of calculations.~~