### PR TITLE
UXTB16: Avoid undefined behaviour (shift past width)

### DIFF
--- a/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
+++ b/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
@@ -6854,18 +6854,20 @@ unsigned InterpreterMainLoop(ARMul_State* cpu) {
             uxtab_inst* const inst_cream = (uxtab_inst*)inst_base->component;
 
             const u8 rn_idx = inst_cream->Rn;
-            const u32 rm_val = RM;
             const u32 rotation = inst_cream->rotate * 8;
-            const u32 rotated_rm = ((rm_val << (32 - rotation)) | (rm_val >> rotation));
+            u32 rm_val = RM;
+
+            if (rotation)
+                rm_val = ((rm_val << (32 - rotation)) | (rm_val >> rotation));
 
             // UXTB16, otherwise UXTAB16
             if (rn_idx == 15) {
-                RD = rotated_rm & 0x00FF00FF;
+                RD = rm_val & 0x00FF00FF;
             } else {
                 const u32 rn_val = RN;
-                const u8 lo_rotated = (rotated_rm & 0xFF);
+                const u8 lo_rotated = (rm_val & 0xFF);
                 const u16 lo_result = (rn_val & 0xFFFF) + (u16)lo_rotated;
-                const u8 hi_rotated = (rotated_rm >> 16) & 0xFF;
+                const u8 hi_rotated = (rm_val >> 16) & 0xFF;
                 const u16 hi_result = (rn_val >> 16) + (u16)hi_rotated;
 
                 RD = ((hi_result << 16) | (lo_result & 0xFFFF));


### PR DESCRIPTION
`rotation` could be zero here.

Solution already [used in SXTB16](https://github.com/citra-emu/citra/blob/master/src/core/arm/dyncom/arm_dyncom_interpreter.cpp#L6259)

---

Edit: We (#citra-dev) noticed this is an ongoing problem in this file, hidden by `ROTATE_RIGHT` and `ROTATE_LEFT` macros. I have an ugly fix but I'd rather not extend this PR as I already have too many PRs to maintain.