### PR TITLE
Fix read-after-write in SMUAD, SMLAD, SMUSD, SMLSD

### DIFF
--- a/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
+++ b/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
@@ -5527,28 +5527,32 @@ unsigned InterpreterMainLoop(ARMul_State* cpu) {
 
             // SMUAD and SMLAD
             if (BIT(op2, 1) == 0) {
-                RD = (product1 + product2);
+                u32 rd_val = (product1 + product2);
 
                 if (inst_cream->Ra != 15) {
-                    RD += cpu->Reg[inst_cream->Ra];
+                    rd_val += cpu->Reg[inst_cream->Ra];
 
                     if (ARMul_AddOverflowQ(product1 + product2, cpu->Reg[inst_cream->Ra]))
                         cpu->Cpsr |= (1 << 27);
                 }
+
+                RD = rd_val;
 
                 if (ARMul_AddOverflowQ(product1, product2))
                     cpu->Cpsr |= (1 << 27);
             }
             // SMUSD and SMLSD
             else {
-                RD = (product1 - product2);
+                u32 rd_val = (product1 - product2);
 
                 if (inst_cream->Ra != 15) {
-                    RD += cpu->Reg[inst_cream->Ra];
+                    rd_val += cpu->Reg[inst_cream->Ra];
 
                     if (ARMul_AddOverflowQ(product1 - product2, cpu->Reg[inst_cream->Ra]))
                         cpu->Cpsr |= (1 << 27);
                 }
+
+                RD = rd_val;
             }
         }
 


### PR DESCRIPTION
Fixes  #1636  and probably #862 .

There is a read-after-write in SMLAD (etc.) if Rd = Ra.
These [instructions are present in ffmpeg](https://github.com/FFmpeg/FFmpeg/blob/e5920425b02b0feaf45971bf1c8b8abc541f5ae1/libavcodec/arm/vp8dsp_armv6.S#L1522) where this causes bugs.

This PR fixes it.

I've also searched for `RD |=`, `RD +=` etc. in this file (and only this file!) but couldn't find anything. So hopefully it was the only bug of this kind.