### PR TITLE
Appveyor: Restore working directory after test_script

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ build:
   parallel: true
 
 test_script:
-  - cd build && ctest -VV -C Release
+  - cd build && ctest -VV -C Release && cd ..
 
 on_success:
     # copying the needed QT Dlls is now done post build. See the CMakeLists.txt file in the citra-qt folder


### PR DESCRIPTION
`on_success` script breaks because `test_script` changes the current working directory