### PR TITLE
SVC::WaitSynchronizationN: Reschedule at the end

### DIFF
--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -6,6 +6,7 @@
 
 #include "common/logging/log.h"
 #include "common/microprofile.h"
+#include "common/scope_exit.h"
 #include "common/string_util.h"
 #include "common/symbols.h"
 
@@ -326,9 +327,9 @@ static ResultCode WaitSynchronizationN(s32* out, Handle* handles, s32 handle_cou
         }
     }
 
-    HLE::Reschedule(__func__);
+    SCOPE_EXIT({HLE::Reschedule("WaitSynchronizationN");}); // Reschedule after putting the threads to sleep.
 
-    // If thread should wait, then set its state to waiting and then reschedule...
+    // If thread should wait, then set its state to waiting
     if (wait_thread) {
 
         // Actually wait the current thread on each object if we decided to wait...


### PR DESCRIPTION
Fixes deadlock in an extreme situation:
Say an event A is scheduled to be signaled in 1000 cycles (such event can be GSP event, HID event, etc.). Now thread B calls `WaitSynchronizationN` to wait for A. In our old `WaitSynchronizationN`, the following will happen:
 - B checks A, and finds that it is not signaled;
 - B prepares to sleep (`wait_thread = true;`);
 - calls `HLE::Reschedule()`, where `Core::g_app_core->AddTicks(4000);` steps over A's cycles, and A gets signaled (without any thread waited)
 - Back to `WaitSynchronizationN`, B register itself to wait for A, and sleeps, leaving A in signaled state.
 - If A doesn't get signaled again, B will sleep forever.

The solution is to call `HLE::Reschedule()` at the end of `WaitSynchronizationN` instead, so that event A's state won't change during synchronization.

I found this when playing with #1832, where I gave the camera event a short delay, but caused the camera thread locked.