### PR TITLE
Kernel: Added ClientPort and ServerPort classes, along with svcCreatePort.

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -29,6 +29,7 @@ set(SRCS
             hle/applets/mii_selector.cpp
             hle/applets/swkbd.cpp
             hle/kernel/address_arbiter.cpp
+            hle/kernel/client_port.cpp
             hle/kernel/event.cpp
             hle/kernel/kernel.cpp
             hle/kernel/memory.cpp
@@ -36,6 +37,7 @@ set(SRCS
             hle/kernel/process.cpp
             hle/kernel/resource_limit.cpp
             hle/kernel/semaphore.cpp
+            hle/kernel/server_port.cpp
             hle/kernel/session.cpp
             hle/kernel/shared_memory.cpp
             hle/kernel/thread.cpp
@@ -164,6 +166,7 @@ set(HEADERS
             hle/applets/mii_selector.h
             hle/applets/swkbd.h
             hle/kernel/address_arbiter.h
+            hle/kernel/client_port.h
             hle/kernel/event.h
             hle/kernel/kernel.h
             hle/kernel/memory.h
@@ -171,6 +174,7 @@ set(HEADERS
             hle/kernel/process.h
             hle/kernel/resource_limit.h
             hle/kernel/semaphore.h
+            hle/kernel/server_port.h
             hle/kernel/session.h
             hle/kernel/shared_memory.h
             hle/kernel/thread.h

--- a/src/core/hle/function_wrappers.h
+++ b/src/core/hle/function_wrappers.h
@@ -194,6 +194,16 @@ template<ResultCode func(Handle, u32)> void Wrap() {
     FuncReturn(func(PARAM(0), PARAM(1)).raw);
 }
 
+template<ResultCode func(Handle*, Handle*, const char*, u32)> void Wrap() {
+    Handle param_1 = 0;
+    Handle param_2 = 0;
+    u32 retval = func(&param_1, &param_2, reinterpret_cast<const char*>(Memory::GetPointer(PARAM(2))), PARAM(3)).raw;
+    // The first out parameter is moved into R2 and the second is moved into R1.
+    Core::g_app_core->SetReg(1, param_2);
+    Core::g_app_core->SetReg(2, param_1);
+    FuncReturn(retval);
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Function wrappers that return type u32
 

--- a/src/core/hle/kernel/client_port.cpp
+++ b/src/core/hle/kernel/client_port.cpp
@@ -1,0 +1,16 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "common/assert.h"
+
+#include "core/hle/kernel/client_port.h"
+#include "core/hle/kernel/kernel.h"
+#include "core/hle/kernel/server_port.h"
+
+namespace Kernel {
+
+ClientPort::ClientPort() {}
+ClientPort::~ClientPort() {}
+
+} // namespace

--- a/src/core/hle/kernel/client_port.h
+++ b/src/core/hle/kernel/client_port.h
@@ -1,0 +1,34 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <string>
+
+#include "common/common_types.h"
+
+#include "core/hle/kernel/kernel.h"
+
+namespace Kernel {
+
+class ClientPort : public Object {
+public:
+    friend class ServerPort;
+    std::string GetTypeName() const override { return "ClientPort"; }
+    std::string GetName() const override { return name; }
+
+    static const HandleType HANDLE_TYPE = HandleType::ClientPort;
+    HandleType GetHandleType() const override { return HANDLE_TYPE; }
+
+    SharedPtr<ServerPort> server_port;          ///< ServerPort associated with this client port.
+    u32 max_sessions;                           ///< Maximum number of simultaneous sessions the port can have
+    u32 active_sessions;                        ///< Number of currently open sessions to this port
+    std::string name;                           ///< Name of client port (optional)
+
+protected:
+    ClientPort();
+    ~ClientPort() override;
+};
+
+} // namespace

--- a/src/core/hle/kernel/client_port.h
+++ b/src/core/hle/kernel/client_port.h
@@ -12,6 +12,8 @@
 
 namespace Kernel {
 
+class ServerPort;
+
 class ClientPort : public Object {
 public:
     friend class ServerPort;

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -35,7 +35,7 @@ enum KernelHandle : Handle {
 
 enum class HandleType : u32 {
     Unknown         = 0,
-    ServerPort      = 1,
+
     Session         = 2,
     Event           = 3,
     Mutex           = 4,
@@ -49,6 +49,7 @@ enum class HandleType : u32 {
     ResourceLimit   = 12,
     CodeSet         = 13,
     ClientPort      = 14,
+    ServerPort      = 15,
 };
 
 enum {

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -35,7 +35,7 @@ enum KernelHandle : Handle {
 
 enum class HandleType : u32 {
     Unknown         = 0,
-    Port            = 1,
+    ServerPort      = 1,
     Session         = 2,
     Event           = 3,
     Mutex           = 4,
@@ -48,6 +48,7 @@ enum class HandleType : u32 {
     Timer           = 11,
     ResourceLimit   = 12,
     CodeSet         = 13,
+    ClientPort      = 14,
 };
 
 enum {
@@ -72,6 +73,7 @@ public:
     bool IsWaitable() const {
         switch (GetHandleType()) {
         case HandleType::Session:
+        case HandleType::ServerPort:
         case HandleType::Event:
         case HandleType::Mutex:
         case HandleType::Thread:
@@ -80,13 +82,13 @@ public:
             return true;
 
         case HandleType::Unknown:
-        case HandleType::Port:
         case HandleType::SharedMemory:
         case HandleType::Redirection:
         case HandleType::Process:
         case HandleType::AddressArbiter:
         case HandleType::ResourceLimit:
         case HandleType::CodeSet:
+        case HandleType::ClientPort:
             return false;
         }
     }

--- a/src/core/hle/kernel/server_port.cpp
+++ b/src/core/hle/kernel/server_port.cpp
@@ -2,8 +2,11 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <tuple>
+
 #include "common/assert.h"
 
+#include "core/hle/kernel/client_port.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/server_port.h"
 #include "core/hle/kernel/thread.h"

--- a/src/core/hle/kernel/server_port.cpp
+++ b/src/core/hle/kernel/server_port.cpp
@@ -1,0 +1,38 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "common/assert.h"
+
+#include "core/hle/kernel/kernel.h"
+#include "core/hle/kernel/server_port.h"
+#include "core/hle/kernel/thread.h"
+
+namespace Kernel {
+
+ServerPort::ServerPort() {}
+ServerPort::~ServerPort() {}
+
+bool ServerPort::ShouldWait() {
+    // If there are no pending sessions, we wait until a new one is added.
+    return pending_sessions.size() == 0;
+}
+
+void ServerPort::Acquire() {
+    ASSERT_MSG(!ShouldWait(), "object unavailable!");
+}
+
+std::tuple<SharedPtr<ServerPort>, SharedPtr<ClientPort>> ServerPort::CreatePortPair(u32 max_sessions, std::string name) {
+    SharedPtr<ServerPort> server_port(new ServerPort);
+    SharedPtr<ClientPort> client_port(new ClientPort);
+
+    server_port->name = name + "_Server";
+    client_port->name = name + "_Client";
+    client_port->server_port = server_port;
+    client_port->max_sessions = max_sessions;
+    client_port->active_sessions = 0;
+
+    return std::make_tuple(std::move(server_port), std::move(client_port));
+}
+
+} // namespace

--- a/src/core/hle/kernel/server_port.h
+++ b/src/core/hle/kernel/server_port.h
@@ -1,0 +1,43 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <string>
+
+#include "common/common_types.h"
+
+#include "core/hle/kernel/kernel.h"
+
+namespace Kernel {
+
+class ServerPort final : public WaitObject {
+public:
+    /**
+     * Creates a pair of a ServerPort and an associated ClientPort.
+     * @param max_sessions Maximum number of sessions to the port
+     * @param name Optional name of the ports
+     * @return The created port tuple
+     */
+    static std::tuple<SharedPtr<ServerPort>, SharedPtr<ClientPort>> CreatePortPair(u32 max_sessions, std::string name = "UnknownPort");
+
+    std::string GetTypeName() const override { return "ServerPort"; }
+    std::string GetName() const override { return name; }
+
+    static const HandleType HANDLE_TYPE = HandleType::ServerPort;
+    HandleType GetHandleType() const override { return HANDLE_TYPE; }
+
+    std::string name;                           ///< Name of port (optional)
+
+    std::vector<SharedPtr<WaitObject>> pending_sessions; ///< ServerSessions waiting to be accepted by the port
+
+    bool ShouldWait() override;
+    void Acquire() override;
+
+private:
+    ServerPort();
+    ~ServerPort() override;
+};
+
+} // namespace

--- a/src/core/hle/kernel/server_port.h
+++ b/src/core/hle/kernel/server_port.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <string>
+#include <tuple>
 
 #include "common/common_types.h"
 
@@ -12,10 +13,12 @@
 
 namespace Kernel {
 
+class ClientPort;
+
 class ServerPort final : public WaitObject {
 public:
     /**
-     * Creates a pair of a ServerPort and an associated ClientPort.
+     * Creates a pair of ServerPort and an associated ClientPort.
      * @param max_sessions Maximum number of sessions to the port
      * @param name Optional name of the ports
      * @return The created port tuple


### PR DESCRIPTION
This is part of an ongoing effort to implement support for multiple processes.

For now the goal is to allow applications to register their own services via srv:RegisterService.

See the sequence diagram below to get an overview of how this all fits together.

![ports_sessions_3ds](https://cloud.githubusercontent.com/assets/357072/15455110/e6718830-200f-11e6-9d3c-75afbd8cc064.png)
