### PR TITLE
OpenGL: Set shader_dirty on lighting changes

### DIFF
--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -787,23 +787,21 @@ struct Regs {
             LightColor diffuse;     // material.diffuse * light.diffuse
             LightColor ambient;     // material.ambient * light.ambient
 
-            struct {
-                // Encoded as 16-bit floating point
-                union {
-                    BitField< 0, 16, u32> x;
-                    BitField<16, 16, u32> y;
-                };
-                union {
-                    BitField< 0, 16, u32> z;
-                };
-
-                INSERT_PADDING_WORDS(0x3);
-
-                union {
-                    BitField<0, 1, u32> directional;
-                    BitField<1, 1, u32> two_sided_diffuse; // When disabled, clamp dot-product to 0
-                };
+            // Encoded as 16-bit floating point
+            union {
+                BitField< 0, 16, u32> x;
+                BitField<16, 16, u32> y;
             };
+            union {
+                BitField< 0, 16, u32> z;
+            };
+
+            INSERT_PADDING_WORDS(0x3);
+
+            union {
+                BitField<0, 1, u32> directional;
+                BitField<1, 1, u32> two_sided_diffuse; // When disabled, clamp dot-product to 0
+            } config;
 
             BitField<0, 20, u32> dist_atten_bias;
             BitField<0, 20, u32> dist_atten_scale;

--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -824,7 +824,7 @@ struct Regs {
             BitField<27, 1, u32> clamp_highlights;
             BitField<28, 2, LightingBumpMode> bump_mode;
             BitField<30, 1, u32> disable_bump_renorm;
-        };
+        } config0;
 
         union {
             BitField<16, 1, u32> disable_lut_d0;
@@ -845,13 +845,13 @@ struct Regs {
             BitField<29, 1, u32> disable_dist_atten_light_5;
             BitField<30, 1, u32> disable_dist_atten_light_6;
             BitField<31, 1, u32> disable_dist_atten_light_7;
-        };
+        } config1;
 
         bool IsDistAttenDisabled(unsigned index) const {
-            const unsigned disable[] = { disable_dist_atten_light_0, disable_dist_atten_light_1,
-                                         disable_dist_atten_light_2, disable_dist_atten_light_3,
-                                         disable_dist_atten_light_4, disable_dist_atten_light_5,
-                                         disable_dist_atten_light_6, disable_dist_atten_light_7 };
+            const unsigned disable[] = { config1.disable_dist_atten_light_0, config1.disable_dist_atten_light_1,
+                                         config1.disable_dist_atten_light_2, config1.disable_dist_atten_light_3,
+                                         config1.disable_dist_atten_light_4, config1.disable_dist_atten_light_5,
+                                         config1.disable_dist_atten_light_6, config1.disable_dist_atten_light_7 };
             return disable[index] != 0;
         }
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -518,6 +518,58 @@ void RasterizerOpenGL::NotifyPicaRegisterChanged(u32 id) {
         SyncLightPosition(7);
         break;
 
+    // Fragment lighting distance attenuation bias
+    case PICA_REG_INDEX_WORKAROUND(lighting.light[0].dist_atten_bias, 0x014A + 0 * 0x10):
+        SyncLightDistanceAttenuationBias(0);
+        break;
+    case PICA_REG_INDEX_WORKAROUND(lighting.light[1].dist_atten_bias, 0x014A + 1 * 0x10):
+        SyncLightDistanceAttenuationBias(1);
+        break;
+    case PICA_REG_INDEX_WORKAROUND(lighting.light[2].dist_atten_bias, 0x014A + 2 * 0x10):
+        SyncLightDistanceAttenuationBias(2);
+        break;
+    case PICA_REG_INDEX_WORKAROUND(lighting.light[3].dist_atten_bias, 0x014A + 3 * 0x10):
+        SyncLightDistanceAttenuationBias(3);
+        break;
+    case PICA_REG_INDEX_WORKAROUND(lighting.light[4].dist_atten_bias, 0x014A + 4 * 0x10):
+        SyncLightDistanceAttenuationBias(4);
+        break;
+    case PICA_REG_INDEX_WORKAROUND(lighting.light[5].dist_atten_bias, 0x014A + 5 * 0x10):
+        SyncLightDistanceAttenuationBias(5);
+        break;
+    case PICA_REG_INDEX_WORKAROUND(lighting.light[6].dist_atten_bias, 0x014A + 6 * 0x10):
+        SyncLightDistanceAttenuationBias(6);
+        break;
+    case PICA_REG_INDEX_WORKAROUND(lighting.light[7].dist_atten_bias, 0x014A + 7 * 0x10):
+        SyncLightDistanceAttenuationBias(7);
+        break;
+
+    // Fragment lighting distance attenuation scale
+    case PICA_REG_INDEX_WORKAROUND(lighting.light[0].dist_atten_scale, 0x014B + 0 * 0x10):
+        SyncLightDistanceAttenuationScale(0);
+        break;
+    case PICA_REG_INDEX_WORKAROUND(lighting.light[1].dist_atten_scale, 0x014B + 1 * 0x10):
+        SyncLightDistanceAttenuationScale(1);
+        break;
+    case PICA_REG_INDEX_WORKAROUND(lighting.light[2].dist_atten_scale, 0x014B + 2 * 0x10):
+        SyncLightDistanceAttenuationScale(2);
+        break;
+    case PICA_REG_INDEX_WORKAROUND(lighting.light[3].dist_atten_scale, 0x014B + 3 * 0x10):
+        SyncLightDistanceAttenuationScale(3);
+        break;
+    case PICA_REG_INDEX_WORKAROUND(lighting.light[4].dist_atten_scale, 0x014B + 4 * 0x10):
+        SyncLightDistanceAttenuationScale(4);
+        break;
+    case PICA_REG_INDEX_WORKAROUND(lighting.light[5].dist_atten_scale, 0x014B + 5 * 0x10):
+        SyncLightDistanceAttenuationScale(5);
+        break;
+    case PICA_REG_INDEX_WORKAROUND(lighting.light[6].dist_atten_scale, 0x014B + 6 * 0x10):
+        SyncLightDistanceAttenuationScale(6);
+        break;
+    case PICA_REG_INDEX_WORKAROUND(lighting.light[7].dist_atten_scale, 0x014B + 7 * 0x10):
+        SyncLightDistanceAttenuationScale(7);
+        break;
+
     // Fragment lighting global ambient color (emission + ambient * ambient)
     case PICA_REG_INDEX_WORKAROUND(lighting.global_ambient, 0x1c0):
         SyncGlobalAmbient();
@@ -896,6 +948,8 @@ void RasterizerOpenGL::SetShader() {
             SyncLightDiffuse(light_index);
             SyncLightAmbient(light_index);
             SyncLightPosition(light_index);
+            SyncLightDistanceAttenuationBias(light_index);
+            SyncLightDistanceAttenuationScale(light_index);
         }
     }
 }
@@ -1102,6 +1156,24 @@ void RasterizerOpenGL::SyncLightPosition(int light_index) {
 
     if (position != uniform_block_data.data.light_src[light_index].position) {
         uniform_block_data.data.light_src[light_index].position = position;
+        uniform_block_data.dirty = true;
+    }
+}
+
+void RasterizerOpenGL::SyncLightDistanceAttenuationBias(int light_index) {
+    GLfloat dist_atten_bias = Pica::float20::FromRaw(Pica::g_state.regs.lighting.light[light_index].dist_atten_bias).ToFloat32();
+
+    if (dist_atten_bias != uniform_block_data.data.light_src[light_index].dist_atten_bias) {
+        uniform_block_data.data.light_src[light_index].dist_atten_bias = dist_atten_bias;
+        uniform_block_data.dirty = true;
+    }
+}
+
+void RasterizerOpenGL::SyncLightDistanceAttenuationScale(int light_index) {
+    GLfloat dist_atten_scale = Pica::float20::FromRaw(Pica::g_state.regs.lighting.light[light_index].dist_atten_scale).ToFloat32();
+
+    if (dist_atten_scale != uniform_block_data.data.light_src[light_index].dist_atten_scale) {
+        uniform_block_data.data.light_src[light_index].dist_atten_scale = dist_atten_scale;
         uniform_block_data.dirty = true;
     }
 }

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -380,6 +380,17 @@ void RasterizerOpenGL::NotifyPicaRegisterChanged(u32 id) {
         SyncCombinerColor();
         break;
 
+    // Fragment lighting switches
+    case PICA_REG_INDEX(lighting.disable):
+    case PICA_REG_INDEX(lighting.num_lights):
+    case PICA_REG_INDEX(lighting.config0):
+    case PICA_REG_INDEX(lighting.config1):
+    case PICA_REG_INDEX(lighting.abs_lut_input):
+    case PICA_REG_INDEX(lighting.lut_input):
+    case PICA_REG_INDEX(lighting.lut_scale):
+    case PICA_REG_INDEX(lighting.light_enable):
+        break;
+
     // Fragment lighting specular 0 color
     case PICA_REG_INDEX_WORKAROUND(lighting.light[0].specular_0, 0x140 + 0 * 0x10):
         SyncLightSpecular0(0);
@@ -516,6 +527,18 @@ void RasterizerOpenGL::NotifyPicaRegisterChanged(u32 id) {
     case PICA_REG_INDEX_WORKAROUND(lighting.light[7].x, 0x144 + 7 * 0x10):
     case PICA_REG_INDEX_WORKAROUND(lighting.light[7].z, 0x145 + 7 * 0x10):
         SyncLightPosition(7);
+        break;
+
+    // Fragment lighting light source config
+    case PICA_REG_INDEX_WORKAROUND(lighting.light[0].config, 0x149 + 0 * 0x10):
+    case PICA_REG_INDEX_WORKAROUND(lighting.light[1].config, 0x149 + 1 * 0x10):
+    case PICA_REG_INDEX_WORKAROUND(lighting.light[2].config, 0x149 + 2 * 0x10):
+    case PICA_REG_INDEX_WORKAROUND(lighting.light[3].config, 0x149 + 3 * 0x10):
+    case PICA_REG_INDEX_WORKAROUND(lighting.light[4].config, 0x149 + 4 * 0x10):
+    case PICA_REG_INDEX_WORKAROUND(lighting.light[5].config, 0x149 + 5 * 0x10):
+    case PICA_REG_INDEX_WORKAROUND(lighting.light[6].config, 0x149 + 6 * 0x10):
+    case PICA_REG_INDEX_WORKAROUND(lighting.light[7].config, 0x149 + 7 * 0x10):
+        shader_dirty = true;
         break;
 
     // Fragment lighting distance attenuation bias

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -89,8 +89,8 @@ union PicaShaderConfig {
             unsigned num = regs.lighting.light_enable.GetNum(light_index);
             const auto& light = regs.lighting.light[num];
             state.lighting.light[light_index].num = num;
-            state.lighting.light[light_index].directional = light.directional != 0;
-            state.lighting.light[light_index].two_sided_diffuse = light.two_sided_diffuse != 0;
+            state.lighting.light[light_index].directional = light.config.directional != 0;
+            state.lighting.light[light_index].two_sided_diffuse = light.config.two_sided_diffuse != 0;
             state.lighting.light[light_index].dist_atten_enable = !regs.lighting.IsDistAttenDisabled(num);
         }
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -92,8 +92,6 @@ union PicaShaderConfig {
             state.lighting.light[light_index].directional = light.directional != 0;
             state.lighting.light[light_index].two_sided_diffuse = light.two_sided_diffuse != 0;
             state.lighting.light[light_index].dist_atten_enable = !regs.lighting.IsDistAttenDisabled(num);
-            state.lighting.light[light_index].dist_atten_bias = Pica::float20::FromRaw(light.dist_atten_bias).ToFloat32();
-            state.lighting.light[light_index].dist_atten_scale = Pica::float20::FromRaw(light.dist_atten_scale).ToFloat32();
         }
 
         state.lighting.lut_d0.enable = regs.lighting.disable_lut_d0 == 0;
@@ -184,8 +182,6 @@ union PicaShaderConfig {
                 bool directional;
                 bool two_sided_diffuse;
                 bool dist_atten_enable;
-                GLfloat dist_atten_scale;
-                GLfloat dist_atten_bias;
             } light[8];
 
             bool enable;
@@ -316,6 +312,8 @@ private:
         alignas(16) GLvec3 diffuse;
         alignas(16) GLvec3 ambient;
         alignas(16) GLvec3 position;
+        GLfloat dist_atten_bias;
+        GLfloat dist_atten_scale;
     };
 
     /// Uniform structure for the Uniform Buffer Object, all members must be 16-byte aligned
@@ -330,7 +328,7 @@ private:
         LightSrc light_src[8];
     };
 
-    static_assert(sizeof(UniformData) == 0x310, "The size of the UniformData structure has changed, update the structure in the shader");
+    static_assert(sizeof(UniformData) == 0x390, "The size of the UniformData structure has changed, update the structure in the shader");
     static_assert(sizeof(UniformData) < 16384, "UniformData structure must be less than 16kb as per the OpenGL spec");
 
     /// Sets the OpenGL shader in accordance with the current PICA register state
@@ -401,6 +399,12 @@ private:
 
     /// Syncs the specified light's position to match the PICA register
     void SyncLightPosition(int light_index);
+
+    /// Syncs the specified light's distance attenuation bias to match the PICA register
+    void SyncLightDistanceAttenuationBias(int light_index);
+
+    /// Syncs the specified light's distance attenuation scale to match the PICA register
+    void SyncLightDistanceAttenuationScale(int light_index);
 
     OpenGLState state;
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -94,42 +94,42 @@ union PicaShaderConfig {
             state.lighting.light[light_index].dist_atten_enable = !regs.lighting.IsDistAttenDisabled(num);
         }
 
-        state.lighting.lut_d0.enable = regs.lighting.disable_lut_d0 == 0;
+        state.lighting.lut_d0.enable = regs.lighting.config1.disable_lut_d0 == 0;
         state.lighting.lut_d0.abs_input = regs.lighting.abs_lut_input.disable_d0 == 0;
         state.lighting.lut_d0.type = regs.lighting.lut_input.d0.Value();
         state.lighting.lut_d0.scale = regs.lighting.lut_scale.GetScale(regs.lighting.lut_scale.d0);
 
-        state.lighting.lut_d1.enable = regs.lighting.disable_lut_d1 == 0;
+        state.lighting.lut_d1.enable = regs.lighting.config1.disable_lut_d1 == 0;
         state.lighting.lut_d1.abs_input = regs.lighting.abs_lut_input.disable_d1 == 0;
         state.lighting.lut_d1.type = regs.lighting.lut_input.d1.Value();
         state.lighting.lut_d1.scale = regs.lighting.lut_scale.GetScale(regs.lighting.lut_scale.d1);
 
-        state.lighting.lut_fr.enable = regs.lighting.disable_lut_fr == 0;
+        state.lighting.lut_fr.enable = regs.lighting.config1.disable_lut_fr == 0;
         state.lighting.lut_fr.abs_input = regs.lighting.abs_lut_input.disable_fr == 0;
         state.lighting.lut_fr.type = regs.lighting.lut_input.fr.Value();
         state.lighting.lut_fr.scale = regs.lighting.lut_scale.GetScale(regs.lighting.lut_scale.fr);
 
-        state.lighting.lut_rr.enable = regs.lighting.disable_lut_rr == 0;
+        state.lighting.lut_rr.enable = regs.lighting.config1.disable_lut_rr == 0;
         state.lighting.lut_rr.abs_input = regs.lighting.abs_lut_input.disable_rr == 0;
         state.lighting.lut_rr.type = regs.lighting.lut_input.rr.Value();
         state.lighting.lut_rr.scale = regs.lighting.lut_scale.GetScale(regs.lighting.lut_scale.rr);
 
-        state.lighting.lut_rg.enable = regs.lighting.disable_lut_rg == 0;
+        state.lighting.lut_rg.enable = regs.lighting.config1.disable_lut_rg == 0;
         state.lighting.lut_rg.abs_input = regs.lighting.abs_lut_input.disable_rg == 0;
         state.lighting.lut_rg.type = regs.lighting.lut_input.rg.Value();
         state.lighting.lut_rg.scale = regs.lighting.lut_scale.GetScale(regs.lighting.lut_scale.rg);
 
-        state.lighting.lut_rb.enable = regs.lighting.disable_lut_rb == 0;
+        state.lighting.lut_rb.enable = regs.lighting.config1.disable_lut_rb == 0;
         state.lighting.lut_rb.abs_input = regs.lighting.abs_lut_input.disable_rb == 0;
         state.lighting.lut_rb.type = regs.lighting.lut_input.rb.Value();
         state.lighting.lut_rb.scale = regs.lighting.lut_scale.GetScale(regs.lighting.lut_scale.rb);
 
-        state.lighting.config = regs.lighting.config;
-        state.lighting.fresnel_selector = regs.lighting.fresnel_selector;
-        state.lighting.bump_mode = regs.lighting.bump_mode;
-        state.lighting.bump_selector = regs.lighting.bump_selector;
-        state.lighting.bump_renorm = regs.lighting.disable_bump_renorm == 0;
-        state.lighting.clamp_highlights = regs.lighting.clamp_highlights != 0;
+        state.lighting.config = regs.lighting.config0.config;
+        state.lighting.fresnel_selector = regs.lighting.config0.fresnel_selector;
+        state.lighting.bump_mode = regs.lighting.config0.bump_mode;
+        state.lighting.bump_selector = regs.lighting.config0.bump_selector;
+        state.lighting.bump_renorm = regs.lighting.config0.disable_bump_renorm == 0;
+        state.lighting.clamp_highlights = regs.lighting.config0.clamp_highlights != 0;
 
         return res;
     }

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -439,9 +439,7 @@ static void WriteLighting(std::string& out, const PicaShaderConfig& config) {
         // If enabled, compute distance attenuation value
         std::string dist_atten = "1.0";
         if (light_config.dist_atten_enable) {
-            std::string scale = std::to_string(light_config.dist_atten_scale);
-            std::string bias = std::to_string(light_config.dist_atten_bias);
-            std::string index = "(" + scale + " * length(-view - " + light_src + ".position) + " + bias + ")";
+            std::string index = "(" + light_src + ".dist_atten_scale * length(-view - " + light_src + ".position) + " + light_src + ".dist_atten_bias)";
             index = "((clamp(" + index + ", 0.0, FLOAT_255)))";
             const unsigned lut_num = ((unsigned)Regs::LightingSampler::DistanceAttenuation + light_config.num);
             dist_atten = GetLutValue((Regs::LightingSampler)lut_num, index);
@@ -549,6 +547,8 @@ struct LightSrc {
     vec3 diffuse;
     vec3 ambient;
     vec3 position;
+    float dist_atten_bias;
+    float dist_atten_scale;
 };
 
 layout (std140) uniform shader_data {


### PR DESCRIPTION
This should fix #1840 .

Eventually we should get rid of that stupid notify handler thing - it's been a problem way too often.
Also I only looked at the lighting struct in Pica::Regs for this PR, it's possible that more parts of the shader are affected by stuff like this.

It would be nice if someone ( @tfarley ?) could confirm that none of these are used as shader uniform / all of them used in shader code.