### PR TITLE
gsp::gpu: Reset g_thread_id in UnregisterInterruptRelayQueue

### DIFF
--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -26,6 +26,7 @@ enum class ErrorDescription : u32 {
     FS_NotAFile = 250,
     FS_NotFormatted = 340, ///< This is used by the FS service when creating a SaveData archive
     OutofRangeOrMisalignedAddress = 513, // TODO(purpasmart): Check if this name fits its actual usage
+    GPU_FirstInitialization = 519,
     FS_InvalidPath = 702,
     InvalidSection = 1000,
     TooLarge = 1001,

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -450,7 +450,7 @@ static const char* GetType(GLenum type) {
 #undef RET
 }
 
-static void DebugHandler(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length,
+static void APIENTRY DebugHandler(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length,
                          const GLchar* message, const void* user_param) {
     Log::Level level;
     switch (severity) {


### PR DESCRIPTION
Fix https://github.com/citra-emu/citra/issues/1716
All credits to @Phanto-m

Also:
- move the shared memory creation/free to constructor/destructor.
- change result code in RegisterInterruptRelayQueue to  SUCCESS after first initialization (prevent blue screen between UnregisterInterruptRelayQueue/RegisterInterruptRelayQueue)
- change DEBUGPROC callback function signature