### PR TITLE
WaitSynchronization: Perform PC modification immediately instead of at thread wakeup

### DIFF
--- a/src/core/hle/hle.cpp
+++ b/src/core/hle/hle.cpp
@@ -23,12 +23,6 @@ namespace HLE {
 void Reschedule(const char *reason) {
     DEBUG_ASSERT_MSG(reason != nullptr && strlen(reason) < 256, "Reschedule: Invalid or too long reason.");
 
-    // TODO(bunnei): It seems that games depend on some CPU execution time elapsing during HLE
-    // routines. This simulates that time by artificially advancing the number of CPU "ticks".
-    // The value was chosen empirically, it seems to work well enough for everything tested, but
-    // is likely not ideal. We should find a more accurate way to simulate timing with HLE.
-    Core::g_app_core->AddTicks(4000);
-
     Core::g_app_core->PrepareReschedule();
 
     reschedule = true;

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -579,11 +579,19 @@ void Reschedule() {
 }
 
 void Thread::SetWaitSynchronizationResult(ResultCode result) {
-    context.cpu_registers[0] = result.raw;
+    if (this == GetCurrentThread()) {
+        Core::g_app_core->SetReg(0, result.raw);
+    } else {
+        context.cpu_registers[0] = result.raw;
+    }
 }
 
 void Thread::SetWaitSynchronizationOutput(s32 output) {
-    context.cpu_registers[1] = output;
+    if (this == GetCurrentThread()) {
+        Core::g_app_core->SetReg(1, output);
+    } else {
+        context.cpu_registers[1] = output;
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -564,8 +564,16 @@ void Reschedule() {
     HLE::DoneRescheduling();
 
     // Don't bother switching to the same thread
-    if (next == cur)
+    if (next == cur) {
+        if (next) {
+            // The status can be THREADSTATUS_READY and not THREADSTATUS_RUNNING as one would expect.
+            // This occurs in the case when an object the thread is waiting on immediately wakes up
+            // the current thread before Reschedule() is called.
+            ASSERT(next->status == THREADSTATUS_RUNNING || next->status == THREADSTATUS_READY);
+            next->status = THREADSTATUS_RUNNING;
+        }
         return;
+    }
 
     if (cur && next) {
         LOG_TRACE(Kernel, "context switch %u -> %u", cur->GetObjectId(), next->GetObjectId());

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -203,7 +203,8 @@ Thread* GetCurrentThread();
 void WaitCurrentThread_Sleep();
 
 /**
- * Waits the current thread from a WaitSynchronization call
+ * Waits the current thread from a WaitSynchronization call.
+ * @note Also steps back the PC one instruction so the previous SVC will be called again on thread wakeup.
  * @param wait_objects Kernel objects that we are waiting on
  * @param wait_set_output If true, set the output parameter on thread wakeup (for WaitSynchronizationN only)
  * @param wait_all If true, wait on all objects before resuming (for WaitSynchronizationN only)

--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -1081,6 +1081,14 @@ MICROPROFILE_DEFINE(Kernel_SVC, "Kernel", "SVC", MP_RGB(70, 200, 70));
 void CallSVC(u32 immediate) {
     MICROPROFILE_SCOPE(Kernel_SVC);
 
+    // TODO(bunnei): It seems that games depend on some CPU execution time elapsing during HLE
+    // routines. This simulates that time by artificially advancing the number of CPU "ticks".
+    // The value was chosen empirically, it seems to work well enough for everything tested, but
+    // is likely not ideal. We should find a more accurate way to simulate timing with HLE.
+    // NOTE(merry): This is performed before service functions are called and not during or after
+    // because the thread-state is well defined at this point in time. (See #1837, #1854, #1868.)
+    Core::g_app_core->AddTicks(4000);
+
     const FunctionDef* info = GetSVCInfo(immediate);
     if (info) {
         if (info->func) {


### PR DESCRIPTION
A possible alternative to #1854 that hopefully makes more sense.

* Perform the PC modification *immediately* so shenanigans can't occur.
* Also added a commit that fixes a bug in `Thread::SetWaitSynchronization{Output,Result}()` I noticed as I was reading related code.

I haven't done testing to see if it fixes the same issues as #1854 does as I don't own many of the games. Ping @wwylele et al.

Thanks to @wwylele for their [investigative work](https://github.com/citra-emu/citra/pull/1854#issuecomment-221836087).