### PR TITLE
Switch context to the same thread if necessary

### DIFF
--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -542,8 +542,12 @@ void Reschedule() {
 
     HLE::DoneRescheduling();
 
-    // Don't bother switching to the same thread
-    if (next == cur)
+    // Don't bother switching to the same thread.
+    // But if the thread was waiting on objects, we still need to switch it
+    // to perform PC modification, change state to RUNNING, etc.
+    // This occurs in the case when an object the thread is waiting on immediately wakes up
+    // the current thread before Reschedule() is called.
+    if (next == cur && (next == nullptr || next->waitsynch_waited == false))
         return;
 
     if (cur && next) {


### PR DESCRIPTION
_Yet another alternative to #1868 and #1854_
#1854 doesn't resolve all related issues (such as #1861), ~~I'd like to close it later~~ closed.
I like the thought of #1868, but it seems that it needs to fix too much stuff, and more issues tend to occur when more changes are made.
So I want a simple, temporary fix to make citra works for most cases, before we rewrite the scheduler (if it is going to be).
The common issue of #1856 and #1861 is that the scheduler doesn't bother switching to the same thread. So the simple fix here is to switch to the same thread if needed (when the thread was waiting on objects), so that it can perform PC modification (causes of `ThrowFatelError` in #1856 and #1861), ~~pop from ready queue~~ change state to RUNNING (= mark the thread popped from ready queue, was an issue in #1868), etc.

@mailwl @JohnGodgames please help test, thanks! (only on this PR, without #1868 or #1854)

Edit:
Fixes  #1856, #1861 and #1866 