### PR TITLE
Implement standard fog (fog mode 5)

### DIFF
--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -423,6 +423,20 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
             break;
         }
 
+        case PICA_REG_INDEX_WORKAROUND(fog_lut_data[0], 0xe8):
+        case PICA_REG_INDEX_WORKAROUND(fog_lut_data[1], 0xe9):
+        case PICA_REG_INDEX_WORKAROUND(fog_lut_data[2], 0xea):
+        case PICA_REG_INDEX_WORKAROUND(fog_lut_data[3], 0xeb):
+        case PICA_REG_INDEX_WORKAROUND(fog_lut_data[4], 0xec):
+        case PICA_REG_INDEX_WORKAROUND(fog_lut_data[5], 0xed):
+        case PICA_REG_INDEX_WORKAROUND(fog_lut_data[6], 0xee):
+        case PICA_REG_INDEX_WORKAROUND(fog_lut_data[7], 0xef):
+        {
+            g_state.fog.lut[regs.fog_lut_offset % 128].raw = value;
+            regs.fog_lut_offset.Assign(regs.fog_lut_offset + 1);
+            break;
+        }
+
         default:
             break;
     }

--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -401,22 +401,47 @@ struct Regs {
     TevStageConfig tev_stage3;
     INSERT_PADDING_WORDS(0x3);
 
+    enum class FogMode : u32 {
+        None = 0,
+        Fog  = 5,
+        Gas  = 7,
+    };
+
     union {
-        // Tev stages 0-3 write their output to the combiner buffer if the corresponding bit in
-        // these masks are set
-        BitField< 8, 4, u32> update_mask_rgb;
-        BitField<12, 4, u32> update_mask_a;
+        BitField<0, 3, FogMode> fog_mode;
+        BitField<16, 1, u32> fog_flip;
 
-        bool TevStageUpdatesCombinerBufferColor(unsigned stage_index) const {
-            return (stage_index < 4) && (update_mask_rgb & (1 << stage_index));
-        }
+        union {
+            // Tev stages 0-3 write their output to the combiner buffer if the corresponding bit in
+            // these masks are set
+            BitField< 8, 4, u32> update_mask_rgb;
+            BitField<12, 4, u32> update_mask_a;
 
-        bool TevStageUpdatesCombinerBufferAlpha(unsigned stage_index) const {
-            return (stage_index < 4) && (update_mask_a & (1 << stage_index));
-        }
-    } tev_combiner_buffer_input;
+            bool TevStageUpdatesCombinerBufferColor(unsigned stage_index) const {
+                return (stage_index < 4) && (update_mask_rgb & (1 << stage_index));
+            }
 
-    INSERT_PADDING_WORDS(0xf);
+            bool TevStageUpdatesCombinerBufferAlpha(unsigned stage_index) const {
+                return (stage_index < 4) && (update_mask_a & (1 << stage_index));
+            }
+        } tev_combiner_buffer_input;
+    };
+
+    union {
+        u32 raw;
+        BitField< 0, 8, u32> r;
+        BitField< 8, 8, u32> g;
+        BitField<16, 8, u32> b;
+    } fog_color;
+
+    INSERT_PADDING_WORDS(0x4);
+
+    BitField<0, 16, u32> fog_lut_offset;
+
+    INSERT_PADDING_WORDS(0x1);
+
+    u32 fog_lut_data[8];
+
     TevStageConfig tev_stage4;
     INSERT_PADDING_WORDS(0x3);
     TevStageConfig tev_stage5;
@@ -1318,6 +1343,10 @@ ASSERT_REG_POSITION(tev_stage1, 0xc8);
 ASSERT_REG_POSITION(tev_stage2, 0xd0);
 ASSERT_REG_POSITION(tev_stage3, 0xd8);
 ASSERT_REG_POSITION(tev_combiner_buffer_input, 0xe0);
+ASSERT_REG_POSITION(fog_mode, 0xe0);
+ASSERT_REG_POSITION(fog_color, 0xe1);
+ASSERT_REG_POSITION(fog_lut_offset, 0xe6);
+ASSERT_REG_POSITION(fog_lut_data, 0xe8);
 ASSERT_REG_POSITION(tev_stage4, 0xf0);
 ASSERT_REG_POSITION(tev_stage5, 0xf8);
 ASSERT_REG_POSITION(tev_combiner_buffer_color, 0xfd);

--- a/src/video_core/pica_state.h
+++ b/src/video_core/pica_state.h
@@ -33,10 +33,10 @@ struct State {
             u32 raw;
 
             // LUT value, encoded as 12-bit fixed point, with 12 fraction bits
-            BitField< 0, 12, u32> value;
+            BitField< 0, 12, u32> value; // 0.0.12 fixed point
 
             // Used by HW for efficient interpolation, Citra does not use these
-            BitField<12, 12, u32> difference;
+            BitField<12, 12, s32> difference; // 1.0.11 fixed point
 
             float ToFloat() {
                 return static_cast<float>(value) / 4095.f;
@@ -45,6 +45,18 @@ struct State {
 
         std::array<std::array<LutEntry, 256>, 24> luts;
     } lighting;
+
+    struct {
+        union LutEntry {
+            // Used for raw access
+            u32 raw;
+
+            BitField< 0, 13, s32> difference; // 1.1.11 fixed point
+            BitField<13, 11, u32> value; // 0.0.11 fixed point
+        };
+
+        std::array<LutEntry, 128> lut;
+    } fog;
 
     /// Current Pica command list
     struct {

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -316,16 +316,18 @@ private:
         GLfloat dist_atten_scale;
     };
 
-    /// Uniform structure for the Uniform Buffer Object, all members must be 16-byte aligned
+    /// Uniform structure for the Uniform Buffer Object, all vectors must be 16-byte aligned
+    // NOTE: Always keep a vec4 at the end. The GL spec is not clear wether the alignment at
+    //       the end of a uniform block is included in UNIFORM_BLOCK_DATA_SIZE or not.
+    //       Not following that rule will cause problems on some AMD drivers.
     struct UniformData {
-        // A vec4 color for each of the six tev stages
-        GLvec4 const_color[6];
-        GLvec4 tev_combiner_buffer_color;
         GLint alphatest_ref;
         GLfloat depth_scale;
         GLfloat depth_offset;
         alignas(16) GLvec3 lighting_global_ambient;
         LightSrc light_src[8];
+        alignas(16) GLvec4 const_color[6]; // A vec4 color for each of the six tev stages
+        alignas(16) GLvec4 tev_combiner_buffer_color;
     };
 
     static_assert(sizeof(UniformData) == 0x390, "The size of the UniformData structure has changed, update the structure in the shader");

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -76,6 +76,9 @@ union PicaShaderConfig {
             state.tev_stages[i].scales_raw = tev_stage.scales_raw;
         }
 
+        state.fog_mode = regs.fog_mode;
+        state.fog_flip = regs.fog_flip;
+
         state.combiner_buffer_input =
             regs.tev_combiner_buffer_input.update_mask_rgb.Value() |
             regs.tev_combiner_buffer_input.update_mask_a.Value() << 4;
@@ -168,13 +171,14 @@ union PicaShaderConfig {
     };
 
     struct State {
-
         Pica::Regs::CompareFunc alpha_test_func;
         Pica::Regs::TextureConfig::TextureType texture0_type;
         std::array<TevStageConfigRaw, 6> tev_stages;
         u8 combiner_buffer_input;
 
         Pica::Regs::DepthBuffering depthmap_enable;
+        Pica::Regs::FogMode fog_mode;
+        bool fog_flip;
 
         struct {
             struct {
@@ -324,13 +328,14 @@ private:
         GLint alphatest_ref;
         GLfloat depth_scale;
         GLfloat depth_offset;
+        alignas(16) GLvec3 fog_color;
         alignas(16) GLvec3 lighting_global_ambient;
         LightSrc light_src[8];
         alignas(16) GLvec4 const_color[6]; // A vec4 color for each of the six tev stages
         alignas(16) GLvec4 tev_combiner_buffer_color;
     };
 
-    static_assert(sizeof(UniformData) == 0x390, "The size of the UniformData structure has changed, update the structure in the shader");
+    static_assert(sizeof(UniformData) == 0x3A0, "The size of the UniformData structure has changed, update the structure in the shader");
     static_assert(sizeof(UniformData) < 16384, "UniformData structure must be less than 16kb as per the OpenGL spec");
 
     /// Sets the OpenGL shader in accordance with the current PICA register state
@@ -353,6 +358,10 @@ private:
 
     /// Syncs the blend color to match the PICA register
     void SyncBlendColor();
+
+    /// Syncs the fog states to match the PICA register
+    void SyncFogColor();
+    void SyncFogLUT();
 
     /// Syncs the alpha test states to match the PICA register
     void SyncAlphaTest();
@@ -421,6 +430,7 @@ private:
     struct {
         UniformData data;
         bool lut_dirty[6];
+        bool fog_lut_dirty;
         bool dirty;
     } uniform_block_data = {};
 
@@ -432,4 +442,7 @@ private:
 
     std::array<OGLTexture, 6> lighting_luts;
     std::array<std::array<GLvec4, 256>, 6> lighting_lut_data{};
+
+    OGLTexture fog_lut;
+    std::array<GLuint, 128> fog_lut_data{};
 };

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -552,13 +552,13 @@ struct LightSrc {
 };
 
 layout (std140) uniform shader_data {
-    vec4 const_color[NUM_TEV_STAGES];
-    vec4 tev_combiner_buffer_color;
     int alphatest_ref;
     float depth_scale;
     float depth_offset;
     vec3 lighting_global_ambient;
     LightSrc light_src[NUM_LIGHTS];
+    vec4 const_color[NUM_TEV_STAGES];
+    vec4 tev_combiner_buffer_color;
 };
 
 uniform sampler2D tex[3];

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -555,6 +555,7 @@ layout (std140) uniform shader_data {
     int alphatest_ref;
     float depth_scale;
     float depth_offset;
+    vec3 fog_color;
     vec3 lighting_global_ambient;
     LightSrc light_src[NUM_LIGHTS];
     vec4 const_color[NUM_TEV_STAGES];
@@ -563,6 +564,7 @@ layout (std140) uniform shader_data {
 
 uniform sampler2D tex[3];
 uniform sampler1D lut[6];
+uniform usampler1D fog_lut;
 
 // Rotate the vector v by the quaternion q
 vec3 quaternion_rotate(vec4 q, vec3 v) {
@@ -578,6 +580,12 @@ vec4 secondary_fragment_color = vec4(0.0);
     if (state.alpha_test_func == Regs::CompareFunc::Never) {
         out += "discard; }";
         return out;
+    }
+
+    out += "float z_over_w = 1.0 - gl_FragCoord.z * 2.0;\n";
+    out += "float depth = z_over_w * depth_scale + depth_offset;\n";
+    if (state.depthmap_enable == Pica::Regs::DepthBuffering::WBuffering) {
+        out += "depth /= gl_FragCoord.w;\n";
     }
 
     if (state.lighting.enable)
@@ -596,14 +604,30 @@ vec4 secondary_fragment_color = vec4(0.0);
         out += ") discard;\n";
     }
 
-    out += "color = last_tex_env_out;\n";
+    // Append fog combiner
+    if (state.fog_mode == Regs::FogMode::Fog) {
+        // Get index into fog LUT
+        if (state.fog_flip) {
+            out += "float fog_index = (1.0 - depth) * 128.0;\n";
+        } else {
+            out += "float fog_index = depth * 128.0;\n";
+        }
 
-    out += "float z_over_w = 1.0 - gl_FragCoord.z * 2.0;\n";
-    out += "float depth = z_over_w * depth_scale + depth_offset;\n";
-    if (state.depthmap_enable == Pica::Regs::DepthBuffering::WBuffering) {
-        out += "depth /= gl_FragCoord.w;\n";
+        // Generate clamped fog factor from LUT for given fog index
+        out += "float fog_i = clamp(floor(fog_index), 0.0, 127.0);\n";
+        out += "float fog_f = fog_index - fog_i;\n";
+        out += "uint fog_lut_entry = texelFetch(fog_lut, int(fog_i), 0).r;\n";
+        out += "float fog_lut_entry_difference = float(int((fog_lut_entry & 0x1FFFU) << 19U) >> 19);\n"; // Extract signed difference
+        out += "float fog_lut_entry_value = float((fog_lut_entry >> 13U) & 0x7FFU);\n";
+        out += "float fog_factor = (fog_lut_entry_value + fog_lut_entry_difference * fog_f) / 2047.0;\n";
+        out += "fog_factor = clamp(fog_factor, 0.0, 1.0);\n";
+
+        // Blend the fog
+        out += "last_tex_env_out.rgb = mix(fog_color.rgb, last_tex_env_out.rgb, fog_factor);\n";
     }
+
     out += "gl_FragDepth = depth;\n";
+    out += "color = last_tex_env_out;\n";
 
     out += "}";
 

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -58,6 +58,8 @@ OpenGLState::OpenGLState() {
         lut.texture_1d = 0;
     }
 
+    fog_lut.texture_1d = 0;
+
     draw.read_framebuffer = 0;
     draw.draw_framebuffer = 0;
     draw.vertex_array = 0;
@@ -193,6 +195,12 @@ void OpenGLState::Apply() const {
             glActiveTexture(GL_TEXTURE3 + i);
             glBindTexture(GL_TEXTURE_1D, lighting_luts[i].texture_1d);
         }
+    }
+
+    // Fog LUT
+    if (fog_lut.texture_1d != cur_state.fog_lut.texture_1d) {
+        glActiveTexture(GL_TEXTURE9);
+        glBindTexture(GL_TEXTURE_1D, fog_lut.texture_1d);
     }
 
     // Framebuffer

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -68,6 +68,10 @@ public:
     } lighting_luts[6];
 
     struct {
+        GLuint texture_1d; // GL_TEXTURE_BINDING_1D
+    } fog_lut;
+
+    struct {
         GLuint read_framebuffer; // GL_READ_FRAMEBUFFER_BINDING
         GLuint draw_framebuffer; // GL_DRAW_FRAMEBUFFER_BINDING
         GLuint vertex_array; // GL_VERTEX_ARRAY_BINDING


### PR DESCRIPTION
This implements fog mode 5.
(Known fog modes are None = 0; Fog = 5; Gas = 7. `master` treats everything like mode 0)

---

The fog mode is fully implemented in SW rasterizer and HW renderer.
[The fog was hardware tested](https://github.com/JayFoxRox/3ds-tests/tree/6aa1be178d67f115d3f9e3652affaa343dd188b8/fog) (against all logic op modes, blend modes, RGBA write masks, Z-Buffer / W-Buffer, LUT overflows / underflows, LUT index wrapping) and it's been found that this fog mode is like a final-combiner for the R, G, B channels. There is no alpha fog or dual source blending.

The overflow of the fog_lut_offset was confirmed on hardware. I didn't want to change the size of the BitField though because there might be reasons why 3dbrew lists it as 16 bit and we can't read back the actual size of the hardware register.

There are a handful of tiny accuracy problems remaining but we can't solve them until we figure out how exactly the 3DS interpolates the depth etc. I've mentioned this in the SW rasterizer code (HW is inaccurate anyway).

There is only one difference I could find between 3DS fog and this implementation: the fog LUT is cleared to zero in Citra while the 3DS seems to keep random values in it = it's not initialized for the process.
I believe the fog index is still initialized to 0 (somewhere unknown - `FINALIZE` maybe?) because Luigi's Mansion Dark Moon does fog LUT writes (in batches of 128 = fog LUT size) without ever explicitly setting the index (Note that it doesn't ever seem to use fog mode 5 either).

There are no known problems or missing functionality for this fog mode.

---

During development, I was also asked for a "Disable fog" enhancement option in the configuration. 
\- I'll leave that to someone else.
(Fog is often used for graphics effects and gives a sense of scale so I think disabling it would be pretty stupid and not an enhancement. If anybody decides to write such an enhancement they should probably just set a falloff curve for the fog instead so that it can be shifted back slightly)

---

This fixes the OoT fog and more..

Comparison screenshots:

[Citra `master`](http://imgur.com/a/AO6t9):
![Zelda (Citra master)](http://i.imgur.com/wBifF9w.png)

Citra `fog`:
![Zelda (Citra PR)](http://i.imgur.com/sDjgpYJ.png)

[Real console](http://imgur.com/a/jHhA5) (Thanks to @FenrisulfrX):
![Zelda (Console)](http://i.imgur.com/nawyMqT.png)

More Screenshots by @Leo626: [Majora's Mask - Mountain Village](http://imgur.com/a/Mtw3w), [Mario Kart 7 - DK Pass](http://imgur.com/a/TrXaY), [Super Mario 3D Land - S6-5](http://imgur.com/a/ZjF1a). Also regression tested all stages of Kingdom Hearts 3D (with SW / HW renderer) and everything works.

---

Massive thanks to @Leo626 for reporting various major issues during review on my repo.
Also thanks to @wwylele, **Tohka**, @einstein95 and @FenrisulfrX (+ everybody I forgot) who ran the hardware tests for me.