### PR TITLE
service: Add other DLP services

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -70,7 +70,10 @@ set(SRCS
             hle/service/cfg/cfg_s.cpp
             hle/service/cfg/cfg_u.cpp
             hle/service/csnd_snd.cpp
-            hle/service/dlp_srvr.cpp
+            hle/service/dlp/dlp.cpp
+            hle/service/dlp/dlp_clnt.cpp
+            hle/service/dlp/dlp_fkcl.cpp
+            hle/service/dlp/dlp_srvr.cpp
             hle/service/dsp_dsp.cpp
             hle/service/err_f.cpp
             hle/service/frd/frd.cpp
@@ -206,7 +209,10 @@ set(HEADERS
             hle/service/cfg/cfg_s.h
             hle/service/cfg/cfg_u.h
             hle/service/csnd_snd.h
-            hle/service/dlp_srvr.h
+            hle/service/dlp/dlp.h
+            hle/service/dlp/dlp_clnt.h
+            hle/service/dlp/dlp_fkcl.h
+            hle/service/dlp/dlp_srvr.h
             hle/service/dsp_dsp.h
             hle/service/err_f.h
             hle/service/frd/frd.h

--- a/src/core/hle/service/dlp/dlp.cpp
+++ b/src/core/hle/service/dlp/dlp.cpp
@@ -1,0 +1,24 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/service/service.h"
+#include "core/hle/service/dlp/dlp.h"
+#include "core/hle/service/dlp/dlp_clnt.h"
+#include "core/hle/service/dlp/dlp_fkcl.h"
+#include "core/hle/service/dlp/dlp_srvr.h"
+
+namespace Service {
+namespace DLP {
+
+void Init() {
+    AddService(new DLP_CLNT_Interface);
+    AddService(new DLP_FKCL_Interface);
+    AddService(new DLP_SRVR_Interface);
+}
+
+void Shutdown() {
+}
+
+} // namespace DLP
+} // namespace Service

--- a/src/core/hle/service/dlp/dlp.h
+++ b/src/core/hle/service/dlp/dlp.h
@@ -1,0 +1,15 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+namespace Service {
+namespace DLP {
+
+/// Initializes the DLP services.
+void Init();
+
+/// Shuts down the DLP services.
+void Shutdown();
+
+} // namespace DLP
+} // namespace Service

--- a/src/core/hle/service/dlp/dlp_clnt.cpp
+++ b/src/core/hle/service/dlp/dlp_clnt.cpp
@@ -1,0 +1,20 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/service/dlp/dlp_clnt.h"
+
+namespace Service {
+namespace DLP {
+
+const Interface::FunctionInfo FunctionTable[] = {
+    {0x000100C3, nullptr, "Initialize"},
+    {0x00110000, nullptr, "GetWirelessRebootPassphrase"},
+};
+
+DLP_CLNT_Interface::DLP_CLNT_Interface() {
+    Register(FunctionTable);
+}
+
+} // namespace DLP
+} // namespace Service

--- a/src/core/hle/service/dlp/dlp_clnt.h
+++ b/src/core/hle/service/dlp/dlp_clnt.h
@@ -6,18 +6,17 @@
 
 #include "core/hle/service/service.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace DLP_SRVR
+namespace Service {
+namespace DLP {
 
-namespace DLP_SRVR {
-
-class Interface : public Service::Interface {
+class DLP_CLNT_Interface final : public Interface {
 public:
-    Interface();
+    DLP_CLNT_Interface();
 
     std::string GetPortName() const override {
-        return "dlp:SRVR";
+        return "dlp:CLNT";
     }
 };
 
-} // namespace
+} // namespace DLP
+} // namespace Service

--- a/src/core/hle/service/dlp/dlp_fkcl.cpp
+++ b/src/core/hle/service/dlp/dlp_fkcl.cpp
@@ -1,0 +1,20 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/service/dlp/dlp_fkcl.h"
+
+namespace Service {
+namespace DLP {
+
+const Interface::FunctionInfo FunctionTable[] = {
+    {0x00010083, nullptr, "Initialize"},
+    {0x000F0000, nullptr, "GetWirelessRebootPassphrase"},
+};
+
+DLP_FKCL_Interface::DLP_FKCL_Interface() {
+    Register(FunctionTable);
+}
+
+} // namespace DLP
+} // namespace Service

--- a/src/core/hle/service/dlp/dlp_fkcl.h
+++ b/src/core/hle/service/dlp/dlp_fkcl.h
@@ -1,0 +1,22 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace DLP {
+
+class DLP_FKCL_Interface final : public Interface {
+public:
+    DLP_FKCL_Interface();
+
+    std::string GetPortName() const override {
+        return "dlp:FKCL";
+    }
+};
+
+} // namespace DLP
+} // namespace Service

--- a/src/core/hle/service/dlp/dlp_srvr.cpp
+++ b/src/core/hle/service/dlp/dlp_srvr.cpp
@@ -2,16 +2,15 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "common/common_types.h"
 #include "common/logging/log.h"
-#include "core/hle/hle.h"
-#include "core/hle/service/dlp_srvr.h"
+#include "core/hle/result.h"
+#include "core/hle/service/dlp/dlp_srvr.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Namespace DLP_SRVR
+namespace Service {
+namespace DLP {
 
-namespace DLP_SRVR {
-
-static void unk_0x000E0040(Service::Interface* self) {
+static void unk_0x000E0040(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[1] = RESULT_SUCCESS.raw;
@@ -23,14 +22,13 @@ static void unk_0x000E0040(Service::Interface* self) {
 const Interface::FunctionInfo FunctionTable[] = {
     {0x00010183, nullptr,           "Initialize"},
     {0x00020000, nullptr,           "Finalize"},
+    {0x000800C0, nullptr,           "SendWirelessRebootPassphrase"},
     {0x000E0040, unk_0x000E0040,    "unk_0x000E0040"},
 };
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Interface class
-
-Interface::Interface() {
+DLP_SRVR_Interface::DLP_SRVR_Interface() {
     Register(FunctionTable);
 }
 
-} // namespace
+} // namespace DLP
+} // namespace Service

--- a/src/core/hle/service/dlp/dlp_srvr.h
+++ b/src/core/hle/service/dlp/dlp_srvr.h
@@ -1,0 +1,22 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace DLP {
+
+class DLP_SRVR_Interface final : public Interface {
+public:
+    DLP_SRVR_Interface();
+
+    std::string GetPortName() const override {
+        return "dlp:SRVR";
+    }
+};
+
+} // namespace DLP
+} // namespace Service

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -10,7 +10,6 @@
 #include "core/hle/service/act_a.h"
 #include "core/hle/service/act_u.h"
 #include "core/hle/service/csnd_snd.h"
-#include "core/hle/service/dlp_srvr.h"
 #include "core/hle/service/dsp_dsp.h"
 #include "core/hle/service/err_f.h"
 #include "core/hle/service/gsp_gpu.h"
@@ -31,6 +30,7 @@
 #include "core/hle/service/boss/boss.h"
 #include "core/hle/service/cam/cam.h"
 #include "core/hle/service/cecd/cecd.h"
+#include "core/hle/service/dlp/dlp.h"
 #include "core/hle/service/frd/frd.h"
 #include "core/hle/service/fs/archive.h"
 #include "core/hle/service/cfg/cfg.h"
@@ -111,6 +111,7 @@ void Init() {
     Service::CAM::Init();
     Service::CECD::Init();
     Service::CFG::Init();
+    Service::DLP::Init();
     Service::FRD::Init();
     Service::HID::Init();
     Service::IR::Init();
@@ -123,7 +124,6 @@ void Init() {
     AddService(new ACT_A::Interface);
     AddService(new ACT_U::Interface);
     AddService(new CSND_SND::Interface);
-    AddService(new DLP_SRVR::Interface);
     AddService(new DSP_DSP::Interface);
     AddService(new GSP_GPU::Interface);
     AddService(new GSP_LCD::Interface);
@@ -150,6 +150,7 @@ void Shutdown() {
     Service::IR::Shutdown();
     Service::HID::Shutdown();
     Service::FRD::Shutdown();
+    Service::DLP::Shutdown();
     Service::CFG::Shutdown();
     Service::CECD::Shutdown();
     Service::CAM::Shutdown();


### PR DESCRIPTION
Specifically, dlp::CLNT and dlp::FKCL

Moves all DLP services to their own folder like with other services that contain multiple sub-modules.