### PR TITLE
gdbstub: E0 should be E00

### DIFF
--- a/src/core/gdbstub/gdbstub.cpp
+++ b/src/core/gdbstub/gdbstub.cpp
@@ -646,7 +646,7 @@ static void ReadMemory() {
 
     u8* data = Memory::GetPointer(addr);
     if (!data) {
-        return SendReply("E0");
+        return SendReply("E00");
     }
 
     MemToGdbHex(reply, data, len);


### PR DESCRIPTION
Fixes issues with IDA and probably other debuggers. If an invalid virtual address was accessed, it would continue attempting to access it because it never saw an error and did not receive it's data in full.