### PR TITLE
HID: add missing header

### DIFF
--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <cmath>
+
 #include "common/logging/log.h"
 #include "common/emu_window.h"
 


### PR DESCRIPTION
#1789 is causing error on clang build (Why it passed the build in the PR ? :confused: ) , also on gcc 6.1 as @linkmauve said.

>[ 66%] /home/travis/build/citra-emu/citra/src/core/hle/service/hid/hid.cpp: In function ‘Service::HID::PadState Service::HID::GetCirclePadDirectionState(s16, s16)’:
>
/home/travis/build/citra-emu/citra/src/core/hle/service/hid/hid.cpp:47:75: error: call of overloaded ‘abs(float)’ is ambiguous
