### PR TITLE
Add "MinGW" precompile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,10 @@ if (NOT MSVC)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse4.1")
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -msse4.1")
     endif()
+
+    if (MINGW)
+        add_definitions(-DMINGW_HAS_SECURE_API)
+    endif()
 else()
     # Silence "deprecation" warnings
     add_definitions(/D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_DEPRECATE /D_SCL_SECURE_NO_WARNINGS)

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -9,7 +9,6 @@
 #include "common/logging/log.h"
 
 #ifdef _WIN32
-    #include <share.h>
     #include <windows.h>
     #include <shlobj.h> // for SHGetFolderPath
     #include <shellapi.h>
@@ -928,11 +927,7 @@ bool IOFile::Open(const std::string& filename, const char openmode[])
 {
     Close();
 #ifdef _WIN32
-#if defined(__MINGW64__) && !defined(MINGW_HAS_SECURE_API)
-    m_file = _wfsopen(Common::UTF8ToUTF16W(filename).c_str(), Common::UTF8ToUTF16W(openmode).c_str(), SH_DENYNO);
-#else
     _wfopen_s(&m_file, Common::UTF8ToUTF16W(filename).c_str(), Common::UTF8ToUTF16W(openmode).c_str());
-#endif
 #else
     m_file = fopen(filename.c_str(), openmode);
 #endif
@@ -985,16 +980,10 @@ bool IOFile::Flush()
 bool IOFile::Resize(u64 size)
 {
     if (!IsOpen() || 0 !=
-
 #ifdef _WIN32
-#if defined(__MINGW64__) && !defined(MINGW_HAS_SECURE_API)
-        //TDM-GCC64 does not supports _chsize_s ?in <io_s.h>
-        _chsize(_fileno(m_file), size)
-#else
         // ector: _chsize sucks, not 64-bit safe
         // F|RES: changed to _chsize_s. i think it is 64-bit safe
         _chsize_s(_fileno(m_file), size)
-#endif
 #else
         // TODO: handle 64bit and growing
         ftruncate(fileno(m_file), size)

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -928,7 +928,7 @@ bool IOFile::Open(const std::string& filename, const char openmode[])
 {
     Close();
 #ifdef _WIN32
-#if defined(__MINGW64__)
+#if defined(__MINGW64__) && !defined(MINGW_HAS_SECURE_API)
     m_file = _wfsopen(Common::UTF8ToUTF16W(filename).c_str(), Common::UTF8ToUTF16W(openmode).c_str(), SH_DENYNO);
 #else
     _wfopen_s(&m_file, Common::UTF8ToUTF16W(filename).c_str(), Common::UTF8ToUTF16W(openmode).c_str());
@@ -987,7 +987,7 @@ bool IOFile::Resize(u64 size)
     if (!IsOpen() || 0 !=
 
 #ifdef _WIN32
-#if defined(__MINGW64__)
+#if defined(__MINGW64__) && !defined(MINGW_HAS_SECURE_API)
         //TDM-GCC64 does not supports _chsize_s ?in <io_s.h>
         _chsize(_fileno(m_file), size)
 #else

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -929,7 +929,7 @@ bool IOFile::Open(const std::string& filename, const char openmode[])
     Close();
 #ifdef _WIN32
 #if defined(__MINGW64__)
-    m_file = _wfsopen(Common::UTF8ToUTF16W(filename).c_str(), Common::UTF8ToUTF16W(openmode).c_str(),SH_DENYNO);
+    m_file = _wfsopen(Common::UTF8ToUTF16W(filename).c_str(), Common::UTF8ToUTF16W(openmode).c_str(), SH_DENYNO);
 #else
     _wfopen_s(&m_file, Common::UTF8ToUTF16W(filename).c_str(), Common::UTF8ToUTF16W(openmode).c_str());
 #endif

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -52,7 +52,7 @@ bool CharArrayFromFormatV(char* out, int outsize, const char* format, va_list ar
 {
     int writtenCount;
 
-#if defined(_MSC_VER)
+#ifdef _MSC_VER
     // You would think *printf are simple, right? Iterate on each character,
     // if it's a format specifier handle it properly, etc.
     //
@@ -296,7 +296,7 @@ std::string ReplaceAll(std::string result, const std::string& src, const std::st
 
 std::string UTF16ToUTF8(const std::u16string& input)
 {
-#if _MSC_VER >= 1900 || defined(__MINGW64__)
+#if _MSC_VER >= 1900
     // Workaround for missing char16_t/char32_t instantiations in MSVC2015
     std::wstring_convert<std::codecvt_utf8_utf16<__int16>, __int16> convert;
     std::basic_string<__int16> tmp_buffer(input.cbegin(), input.cend());
@@ -309,7 +309,7 @@ std::string UTF16ToUTF8(const std::u16string& input)
 
 std::u16string UTF8ToUTF16(const std::string& input)
 {
-#if _MSC_VER >= 1900 || defined(__MINGW64__)
+#if _MSC_VER >= 1900
     // Workaround for missing char16_t/char32_t instantiations in MSVC2015
     std::wstring_convert<std::codecvt_utf8_utf16<__int16>, __int16> convert;
     auto tmp_buffer = convert.from_bytes(input);

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -324,7 +324,7 @@ static std::wstring CPToUTF16(u32 code_page, const std::string& input)
 {
     auto const size = MultiByteToWideChar(code_page, 0, input.data(), static_cast<int>(input.size()), nullptr, 0);
 
-	std::wstring output;
+    std::wstring output;
     output.resize(size);
 
     if (size == 0 || size != MultiByteToWideChar(code_page, 0, input.data(), static_cast<int>(input.size()), &output[0], static_cast<int>(output.size())))

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -13,7 +13,7 @@
 #include "common/logging/log.h"
 #include "common/string_util.h"
 
-#if defined(_MSC_VER) || __MINGW64__
+#if defined(_MSC_VER) || defined(__MINGW64__)
     #include <Windows.h>
     #include <codecvt>
     #include "common/common_funcs.h"
@@ -52,7 +52,7 @@ bool CharArrayFromFormatV(char* out, int outsize, const char* format, va_list ar
 {
     int writtenCount;
 
-#if defined(_MSC_VER) || !defined(__MINGW64__)
+#if defined(_MSC_VER)
     // You would think *printf are simple, right? Iterate on each character,
     // if it's a format specifier handle it properly, etc.
     //
@@ -292,7 +292,7 @@ std::string ReplaceAll(std::string result, const std::string& src, const std::st
     return result;
 }
 
-#if defined(_MSC_VER) || !__MINGW32__ || __MINGW64__
+#if defined(_MSC_VER) || defined(__MINGW64__)
 
 std::string UTF16ToUTF8(const std::u16string& input)
 {
@@ -323,7 +323,7 @@ std::u16string UTF8ToUTF16(const std::string& input)
 static std::wstring CPToUTF16(u32 code_page, const std::string& input)
 {
     auto const size = MultiByteToWideChar(code_page, 0, input.data(), static_cast<int>(input.size()), nullptr, 0);
-    std::wstring output(size,'\0');
+    std::wstring output;
     output.resize(size);
 
     if (size == 0 || size != MultiByteToWideChar(code_page, 0, input.data(), static_cast<int>(input.size()), &output[0], static_cast<int>(output.size())))

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -13,7 +13,7 @@
 #include "common/logging/log.h"
 #include "common/string_util.h"
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || __MINGW64__
     #include <Windows.h>
     #include <codecvt>
     #include "common/common_funcs.h"
@@ -52,7 +52,7 @@ bool CharArrayFromFormatV(char* out, int outsize, const char* format, va_list ar
 {
     int writtenCount;
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || !defined(__MINGW64__)
     // You would think *printf are simple, right? Iterate on each character,
     // if it's a format specifier handle it properly, etc.
     //
@@ -292,11 +292,11 @@ std::string ReplaceAll(std::string result, const std::string& src, const std::st
     return result;
 }
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || !__MINGW32__ || __MINGW64__
 
 std::string UTF16ToUTF8(const std::u16string& input)
 {
-#if _MSC_VER >= 1900
+#if _MSC_VER >= 1900 && defined(__MINGW64__)
     // Workaround for missing char16_t/char32_t instantiations in MSVC2015
     std::wstring_convert<std::codecvt_utf8_utf16<__int16>, __int16> convert;
     std::basic_string<__int16> tmp_buffer(input.cbegin(), input.cend());
@@ -309,7 +309,7 @@ std::string UTF16ToUTF8(const std::u16string& input)
 
 std::u16string UTF8ToUTF16(const std::string& input)
 {
-#if _MSC_VER >= 1900
+#if _MSC_VER >= 1900 && defined(__MINGW64__)
     // Workaround for missing char16_t/char32_t instantiations in MSVC2015
     std::wstring_convert<std::codecvt_utf8_utf16<__int16>, __int16> convert;
     auto tmp_buffer = convert.from_bytes(input);
@@ -323,13 +323,11 @@ std::u16string UTF8ToUTF16(const std::string& input)
 static std::wstring CPToUTF16(u32 code_page, const std::string& input)
 {
     auto const size = MultiByteToWideChar(code_page, 0, input.data(), static_cast<int>(input.size()), nullptr, 0);
-
-    std::wstring output;
+    std::wstring output(size,'\0');
     output.resize(size);
 
     if (size == 0 || size != MultiByteToWideChar(code_page, 0, input.data(), static_cast<int>(input.size()), &output[0], static_cast<int>(output.size())))
         output.clear();
-
     return output;
 }
 

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -323,11 +323,13 @@ std::u16string UTF8ToUTF16(const std::string& input)
 static std::wstring CPToUTF16(u32 code_page, const std::string& input)
 {
     auto const size = MultiByteToWideChar(code_page, 0, input.data(), static_cast<int>(input.size()), nullptr, 0);
-    std::wstring output;
+    
+	std::wstring output;
     output.resize(size);
 
     if (size == 0 || size != MultiByteToWideChar(code_page, 0, input.data(), static_cast<int>(input.size()), &output[0], static_cast<int>(output.size())))
         output.clear();
+    
     return output;
 }
 

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -323,13 +323,13 @@ std::u16string UTF8ToUTF16(const std::string& input)
 static std::wstring CPToUTF16(u32 code_page, const std::string& input)
 {
     auto const size = MultiByteToWideChar(code_page, 0, input.data(), static_cast<int>(input.size()), nullptr, 0);
-    
+
 	std::wstring output;
     output.resize(size);
 
     if (size == 0 || size != MultiByteToWideChar(code_page, 0, input.data(), static_cast<int>(input.size()), &output[0], static_cast<int>(output.size())))
         output.clear();
-    
+
     return output;
 }
 

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -296,7 +296,7 @@ std::string ReplaceAll(std::string result, const std::string& src, const std::st
 
 std::string UTF16ToUTF8(const std::u16string& input)
 {
-#if _MSC_VER >= 1900 && defined(__MINGW64__)
+#if _MSC_VER >= 1900 || defined(__MINGW64__)
     // Workaround for missing char16_t/char32_t instantiations in MSVC2015
     std::wstring_convert<std::codecvt_utf8_utf16<__int16>, __int16> convert;
     std::basic_string<__int16> tmp_buffer(input.cbegin(), input.cend());
@@ -309,7 +309,7 @@ std::string UTF16ToUTF8(const std::u16string& input)
 
 std::u16string UTF8ToUTF16(const std::string& input)
 {
-#if _MSC_VER >= 1900 && defined(__MINGW64__)
+#if _MSC_VER >= 1900 || defined(__MINGW64__)
     // Workaround for missing char16_t/char32_t instantiations in MSVC2015
     std::wstring_convert<std::codecvt_utf8_utf16<__int16>, __int16> convert;
     auto tmp_buffer = convert.from_bytes(input);

--- a/src/core/gdbstub/gdbstub.cpp
+++ b/src/core/gdbstub/gdbstub.cpp
@@ -14,7 +14,7 @@
 #include <map>
 #include <numeric>
 
-#if defined(_MSC_VER) || defined(__MINGW64__)
+#if defined(_WIN32)
 #include <WinSock2.h>
 #include <ws2tcpip.h>
 #include <common/x64/abi.h>

--- a/src/core/gdbstub/gdbstub.cpp
+++ b/src/core/gdbstub/gdbstub.cpp
@@ -14,7 +14,7 @@
 #include <map>
 #include <numeric>
 
-#if defined(_MSC_VER) || (__MINGW64__)
+#if defined(_MSC_VER) || defined(__MINGW64__)
 #include <WinSock2.h>
 #include <ws2tcpip.h>
 #include <common/x64/abi.h>

--- a/src/core/gdbstub/gdbstub.cpp
+++ b/src/core/gdbstub/gdbstub.cpp
@@ -14,7 +14,7 @@
 #include <map>
 #include <numeric>
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || (__MINGW64__)
 #include <WinSock2.h>
 #include <ws2tcpip.h>
 #include <common/x64/abi.h>


### PR DESCRIPTION
Compiler for mingw64,I don't seem to be able to do more.in TDM-GCC,
1,may need to turn off icov support,construct a libpng library,some errors are external module problems.
2,need Qt64(mingw64)
3,need a SDL2-devel-2.0.4-mingw(need to modify the "CMakeLists.txt" to support SDL2-devel-2.0.4-mingw)
Signed-off-by: yami-hack <yami-hack@foxmail.com>