### PR TITLE
CI: Use Qt 5 and GCC 6 on Ubuntu CI builds

### DIFF
--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -11,8 +11,8 @@ fi
 
 #if OS is linux or is not set
 if [ "$TRAVIS_OS_NAME" = "linux" -o -z "$TRAVIS_OS_NAME" ]; then
-    export CC=gcc-5
-    export CXX=g++-5
+    export CC=gcc-6
+    export CXX=g++-6
     export PKG_CONFIG_PATH=$HOME/.local/lib/pkgconfig:$PKG_CONFIG_PATH
 
     mkdir build && cd build

--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -16,7 +16,7 @@ if [ "$TRAVIS_OS_NAME" = "linux" -o -z "$TRAVIS_OS_NAME" ]; then
     export PKG_CONFIG_PATH=$HOME/.local/lib/pkgconfig:$PKG_CONFIG_PATH
 
     mkdir build && cd build
-    cmake -DCITRA_FORCE_QT4=ON ..
+    cmake ..
     make -j4
 
     ctest -VV -C Release

--- a/.travis-deps.sh
+++ b/.travis-deps.sh
@@ -5,8 +5,8 @@ set -x
 
 #if OS is linux or is not set
 if [ "$TRAVIS_OS_NAME" = "linux" -o -z "$TRAVIS_OS_NAME" ]; then
-    export CC=gcc-5
-    export CXX=g++-5
+    export CC=gcc-6
+    export CXX=g++-6
     mkdir -p $HOME/.local
 
     curl -L http://www.cmake.org/files/v3.1/cmake-3.1.0-Linux-i386.tar.gz \

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - gcc-5
-      - g++-5
+      - gcc-6
+      - g++-6
       - qt5-default
       - libqt5opengl5-dev
       - xorg-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,16 @@
-os:
-  - linux
-  - osx
-
 language: cpp
+
+matrix:
+  include:
+    - os: linux
+      sudo: true
+      dist: trusty
+    - os: osx
+      sudo: false
 
 env:
   global:
     - secure: "AXHFIafTmbGDsHD3mUVj5a4I397DQjti/WoqAJGUp2PglxTcc04BwxZ9Z+xLuf5N2Hs5r9ojAJLT8OGxJCLBDXzneQTNSqXbFuYSLbqrEAiIRlA9eRIotWCg+wYcO+5e8MKX+cHVKwiIWasUB21AtCdq6msh6Y3pUshZp212VPg="
-
-sudo: false
 
 addons:
   apt:
@@ -17,6 +19,8 @@ addons:
     packages:
       - gcc-5
       - g++-5
+      - qt5-default
+      - libqt5opengl5-dev
       - xorg-dev
       - lib32stdc++6 # For CMake
       - lftp # To upload builds

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,6 @@ option(CITRA_USE_BUNDLED_SDL2 "Download bundled SDL2 binaries" OFF)
 
 option(ENABLE_QT "Enable the Qt frontend" ON)
 option(CITRA_USE_BUNDLED_QT "Download bundled Qt binaries" OFF)
-option(CITRA_FORCE_QT4 "Use Qt4 even if Qt5 is available." OFF)
 
 if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git/hooks/pre-commit)
     message(STATUS "Copying pre-commit hook")
@@ -201,16 +200,8 @@ if (ENABLE_QT)
         set(QT_PREFIX_HINT)
     endif()
 
-    if (NOT CITRA_FORCE_QT4)
-        find_package(Qt5 COMPONENTS Widgets OpenGL ${QT_PREFIX_HINT})
-        set(CITRA_QT_LIBS Qt5::Widgets Qt5::OpenGL)
-    endif()
-
-    if (CITRA_FORCE_QT4 OR NOT Qt5_FOUND)
-        # Try to fallback to Qt4
-        find_package(Qt4 REQUIRED COMPONENTS QtGui QtOpenGL ${QT_PREFIX_HINT})
-        set(CITRA_QT_LIBS Qt4::QtGui Qt4::QtOpenGL)
-    endif()
+    find_package(Qt5 REQUIRED COMPONENTS Widgets OpenGL ${QT_PREFIX_HINT})
+    set(CITRA_QT_LIBS Qt5::Widgets Qt5::OpenGL)
 endif()
 
 # This function should be passed a list of all files in a target. It will automatically generate


### PR DESCRIPTION
The OSX build already uses Qt 5, so nothing needs to change here for that.

This also bumps the distribution of Ubuntu that we use up from Precise Pangolin (12.04) to Trusty Tahr (14.04). We also finally drop support for Qt 4 variants with this.