### PR TITLE
Fix recursive scanning of directories

### DIFF
--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -120,11 +120,9 @@ void GameList::LoadInterfaceLayout()
 
 void GameListWorker::AddFstEntriesToGameList(const std::string& dir_path, unsigned int recursion)
 {
-    const auto callback = [&](unsigned* num_entries_out,
-                              const std::string& directory,
-                              const std::string& virtual_name,
-                              unsigned int recursion) -> bool {
-
+    const auto callback = [this, recursion](unsigned* num_entries_out,
+                                            const std::string& directory,
+                                            const std::string& virtual_name) -> bool {
         std::string physical_name = directory + DIR_SEP + virtual_name;
 
         if (stop_processing)

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -105,13 +105,11 @@ bool CreateEmptyFile(const std::string &filename);
  * @param num_entries_out to be assigned by the callable with the number of iterated directory entries, never null
  * @param directory the path to the enclosing directory
  * @param virtual_name the entry name, without any preceding directory info
- * @param recursion Number of children directory to read before giving up
  * @return whether handling the entry succeeded
  */
 using DirectoryEntryCallable = std::function<bool(unsigned* num_entries_out,
                                                  const std::string& directory,
-                                                 const std::string& virtual_name,
-                                                 unsigned int recursion)>;
+                                                 const std::string& virtual_name)>;
 
 /**
  * Scans a directory, calling the callback for each file/directory contained within.
@@ -119,10 +117,9 @@ using DirectoryEntryCallable = std::function<bool(unsigned* num_entries_out,
  * @param num_entries_out assigned by the function with the number of iterated directory entries, can be null
  * @param directory the directory to scan
  * @param callback The callback which will be called for each entry
- * @param recursion Number of children directories to read before giving up
  * @return whether scanning the directory succeeded
  */
-bool ForeachDirectoryEntry(unsigned* num_entries_out, const std::string &directory, DirectoryEntryCallable callback, unsigned int recursion = 0);
+bool ForeachDirectoryEntry(unsigned* num_entries_out, const std::string &directory, DirectoryEntryCallable callback);
 
 /**
  * Scans the directory tree, storing the results.


### PR DESCRIPTION
ForeachDirectoryEntry didn't actually do anything with the `recursive`
parameter, and the corresponding callback parameter was shadowing the
actual recursion counters in the user functions.