### PR TITLE
Remove superfluous std::move in return std::move(local_var)

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -117,7 +117,7 @@ Entry CreateEntry(Class log_class, Level log_level,
     vsnprintf(formatting_buffer.data(), formatting_buffer.size(), format, args);
     entry.message = std::string(formatting_buffer.data());
 
-    return std::move(entry);
+    return entry;
 }
 
 static Filter* filter = nullptr;

--- a/src/video_core/debug_utils/debug_utils.cpp
+++ b/src/video_core/debug_utils/debug_utils.cpp
@@ -328,7 +328,7 @@ std::unique_ptr<PicaTrace> FinishPicaTracing()
     std::lock_guard<std::mutex> lock(pica_trace_mutex);
     std::unique_ptr<PicaTrace> ret(std::move(pica_trace));
 
-    return std::move(ret);
+    return ret;
 }
 
 const Math::Vec4<u8> LookupTexture(const u8* source, int x, int y, const TextureInfo& info, bool disable_alpha) {


### PR DESCRIPTION
The r-value overload already gets selected, and the `std::move` technically inhibits copy elision.