### PR TITLE
PICA: Implement scissor test

### DIFF
--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -115,7 +115,36 @@ struct Regs {
         BitField<24, 5, Semantic> map_w;
     } vs_output_attributes[7];
 
-    INSERT_PADDING_WORDS(0x11);
+    INSERT_PADDING_WORDS(0xe);
+
+    enum class ScissorMode : u32 {
+        Disabled = 0,
+        Exclude = 1, // Exclude pixels inside the scissor box
+
+        Include = 3 // Exclude pixels outside the scissor box
+    };
+
+    struct {
+        BitField<0, 2, ScissorMode> mode;
+
+        union {
+            BitField< 0, 16, u32> right;
+            BitField<16, 16, u32> bottom;
+        };
+
+        union {
+            BitField< 0, 16, u32> left_minus_1;
+            BitField<16, 16, u32> top_minus_1;
+        };
+
+        u32 GetTop() const {
+            return top_minus_1 + 1;
+        }
+
+        u32 GetLeft() const {
+            return left_minus_1 + 1;
+        }
+    } scissor_test;
 
     union {
         BitField< 0, 10, s32> x;
@@ -1328,6 +1357,7 @@ ASSERT_REG_POSITION(viewport_depth_range, 0x4d);
 ASSERT_REG_POSITION(viewport_depth_near_plane, 0x4e);
 ASSERT_REG_POSITION(vs_output_attributes[0], 0x50);
 ASSERT_REG_POSITION(vs_output_attributes[1], 0x51);
+ASSERT_REG_POSITION(scissor_test, 0x65);
 ASSERT_REG_POSITION(viewport_corner, 0x68);
 ASSERT_REG_POSITION(depthmap_enable, 0x6D);
 ASSERT_REG_POSITION(texture0_enable, 0x80);

--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -128,22 +128,14 @@ struct Regs {
         BitField<0, 2, ScissorMode> mode;
 
         union {
-            BitField< 0, 16, u32> right;
-            BitField<16, 16, u32> bottom;
+            BitField< 0, 16, u32> x1;
+            BitField<16, 16, u32> y1;
         };
 
         union {
-            BitField< 0, 16, u32> left_minus_1;
-            BitField<16, 16, u32> top_minus_1;
+            BitField< 0, 16, u32> x2;
+            BitField<16, 16, u32> y2;
         };
-
-        u32 GetTop() const {
-            return top_minus_1 + 1;
-        }
-
-        u32 GetLeft() const {
-            return left_minus_1 + 1;
-        }
     } scissor_test;
 
     union {

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -196,6 +196,14 @@ void RasterizerOpenGL::DrawTriangles() {
                (GLint)(rect.bottom + regs.viewport_corner.y * color_surface->res_scale_height),
                (GLsizei)(viewport_width * color_surface->res_scale_width), (GLsizei)(viewport_height * color_surface->res_scale_height));
 
+    if (uniform_block_data.data.framebuffer_scale[0] != color_surface->res_scale_width ||
+        uniform_block_data.data.framebuffer_scale[1] != color_surface->res_scale_height) {
+
+        uniform_block_data.data.framebuffer_scale[0] = color_surface->res_scale_width;
+        uniform_block_data.data.framebuffer_scale[1] = color_surface->res_scale_height;
+        uniform_block_data.dirty = true;
+    }
+
     // Sync and bind the texture surfaces
     const auto pica_textures = regs.GetTextures();
     for (unsigned texture_index = 0; texture_index < pica_textures.size(); ++texture_index) {

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -357,8 +357,8 @@ void RasterizerOpenGL::NotifyPicaRegisterChanged(u32 id) {
     case PICA_REG_INDEX(scissor_test.mode):
         shader_dirty = true;
         break;
-    case PICA_REG_INDEX(scissor_test.right):
-    case PICA_REG_INDEX(scissor_test.left_minus_1):
+    case PICA_REG_INDEX(scissor_test.x1): // and y1
+    case PICA_REG_INDEX(scissor_test.x2): // and y2
         SyncScissorTest();
         break;
 
@@ -1179,15 +1179,15 @@ void RasterizerOpenGL::SyncDepthTest() {
 void RasterizerOpenGL::SyncScissorTest() {
     const auto& regs = Pica::g_state.regs;
 
-    if (uniform_block_data.data.scissor_right != regs.scissor_test.right ||
-        uniform_block_data.data.scissor_bottom != regs.scissor_test.bottom ||
-        uniform_block_data.data.scissor_left != regs.scissor_test.GetLeft() ||
-        uniform_block_data.data.scissor_top != regs.scissor_test.GetTop()) {
+    if (uniform_block_data.data.scissor_x1 != regs.scissor_test.x1 ||
+        uniform_block_data.data.scissor_y1 != regs.scissor_test.y1 ||
+        uniform_block_data.data.scissor_x2 != regs.scissor_test.x2 ||
+        uniform_block_data.data.scissor_y2 != regs.scissor_test.y2) {
 
-        uniform_block_data.data.scissor_right = regs.scissor_test.right;
-        uniform_block_data.data.scissor_bottom = regs.scissor_test.bottom;
-        uniform_block_data.data.scissor_left = regs.scissor_test.GetLeft();
-        uniform_block_data.data.scissor_top = regs.scissor_test.GetTop();
+        uniform_block_data.data.scissor_x1 = regs.scissor_test.x1;
+        uniform_block_data.data.scissor_y1 = regs.scissor_test.y1;
+        uniform_block_data.data.scissor_x2 = regs.scissor_test.x2;
+        uniform_block_data.data.scissor_y2 = regs.scissor_test.y2;
         uniform_block_data.dirty = true;
     }
 }

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -353,6 +353,15 @@ void RasterizerOpenGL::NotifyPicaRegisterChanged(u32 id) {
         SyncColorWriteMask();
         break;
 
+    // Scissor test
+    case PICA_REG_INDEX(scissor_test.mode):
+        shader_dirty = true;
+        break;
+    case PICA_REG_INDEX(scissor_test.right):
+    case PICA_REG_INDEX(scissor_test.left_minus_1):
+        SyncScissorTest();
+        break;
+
     // Logic op
     case PICA_REG_INDEX(output_merger.logic_op):
         SyncLogicOp();
@@ -1002,6 +1011,7 @@ void RasterizerOpenGL::SetShader() {
         SyncDepthOffset();
         SyncAlphaTest();
         SyncCombinerColor();
+        SyncScissorTest();
         auto& tev_stages = Pica::g_state.regs.GetTevStages();
         for (int index = 0; index < tev_stages.size(); ++index)
             SyncTevConstColor(index, tev_stages[index]);
@@ -1164,6 +1174,22 @@ void RasterizerOpenGL::SyncDepthTest() {
                                regs.output_merger.depth_write_enable == 1;
     state.depth.test_func = regs.output_merger.depth_test_enable == 1 ?
                             PicaToGL::CompareFunc(regs.output_merger.depth_test_func) : GL_ALWAYS;
+}
+
+void RasterizerOpenGL::SyncScissorTest() {
+    const auto& regs = Pica::g_state.regs;
+
+    if (uniform_block_data.data.scissor_right != regs.scissor_test.right ||
+        uniform_block_data.data.scissor_bottom != regs.scissor_test.bottom ||
+        uniform_block_data.data.scissor_left != regs.scissor_test.GetLeft() ||
+        uniform_block_data.data.scissor_top != regs.scissor_test.GetTop()) {
+
+        uniform_block_data.data.scissor_right = regs.scissor_test.right;
+        uniform_block_data.data.scissor_bottom = regs.scissor_test.bottom;
+        uniform_block_data.data.scissor_left = regs.scissor_test.GetLeft();
+        uniform_block_data.data.scissor_top = regs.scissor_test.GetTop();
+        uniform_block_data.dirty = true;
+    }
 }
 
 void RasterizerOpenGL::SyncCombinerColor() {

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -56,6 +56,8 @@ union PicaShaderConfig {
 
         const auto& regs = Pica::g_state.regs;
 
+        state.scissor_test_mode = regs.scissor_test.mode;
+
         state.depthmap_enable = regs.depthmap_enable;
 
         state.alpha_test_func = regs.output_merger.alpha_test.enable ?
@@ -172,6 +174,7 @@ union PicaShaderConfig {
 
     struct State {
         Pica::Regs::CompareFunc alpha_test_func;
+        Pica::Regs::ScissorMode scissor_test_mode;
         Pica::Regs::TextureConfig::TextureType texture0_type;
         std::array<TevStageConfigRaw, 6> tev_stages;
         u8 combiner_buffer_input;
@@ -328,6 +331,10 @@ private:
         GLint alphatest_ref;
         GLfloat depth_scale;
         GLfloat depth_offset;
+        GLint scissor_right;
+        GLint scissor_bottom;
+        GLint scissor_left;
+        GLint scissor_top;
         alignas(16) GLvec3 fog_color;
         alignas(16) GLvec3 lighting_global_ambient;
         LightSrc light_src[8];
@@ -335,7 +342,7 @@ private:
         alignas(16) GLvec4 tev_combiner_buffer_color;
     };
 
-    static_assert(sizeof(UniformData) == 0x3A0, "The size of the UniformData structure has changed, update the structure in the shader");
+    static_assert(sizeof(UniformData) == 0x3B0, "The size of the UniformData structure has changed, update the structure in the shader");
     static_assert(sizeof(UniformData) < 16384, "UniformData structure must be less than 16kb as per the OpenGL spec");
 
     /// Sets the OpenGL shader in accordance with the current PICA register state
@@ -383,6 +390,9 @@ private:
 
     /// Syncs the depth test states to match the PICA register
     void SyncDepthTest();
+
+    /// Syncs the scissor test state to match the PICA register
+    void SyncScissorTest();
 
     /// Syncs the TEV combiner color buffer to match the PICA register
     void SyncCombinerColor();

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -331,10 +331,10 @@ private:
         GLint alphatest_ref;
         GLfloat depth_scale;
         GLfloat depth_offset;
-        GLint scissor_right;
-        GLint scissor_bottom;
-        GLint scissor_left;
-        GLint scissor_top;
+        GLint scissor_x1;
+        GLint scissor_y1;
+        GLint scissor_x2;
+        GLint scissor_y2;
         alignas(16) GLvec3 fog_color;
         alignas(16) GLvec3 lighting_global_ambient;
         LightSrc light_src[8];

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -328,6 +328,7 @@ private:
     //       the end of a uniform block is included in UNIFORM_BLOCK_DATA_SIZE or not.
     //       Not following that rule will cause problems on some AMD drivers.
     struct UniformData {
+        alignas(8) GLvec2 framebuffer_scale;
         GLint alphatest_ref;
         GLfloat depth_scale;
         GLfloat depth_offset;
@@ -342,7 +343,7 @@ private:
         alignas(16) GLvec4 tev_combiner_buffer_color;
     };
 
-    static_assert(sizeof(UniformData) == 0x3B0, "The size of the UniformData structure has changed, update the structure in the shader");
+    static_assert(sizeof(UniformData) == 0x3C0, "The size of the UniformData structure has changed, update the structure in the shader");
     static_assert(sizeof(UniformData) < 16384, "UniformData structure must be less than 16kb as per the OpenGL spec");
 
     /// Sets the OpenGL shader in accordance with the current PICA register state

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -554,6 +554,7 @@ struct LightSrc {
 };
 
 layout (std140) uniform shader_data {
+    vec2 framebuffer_scale;
     int alphatest_ref;
     float depth_scale;
     float depth_offset;
@@ -595,8 +596,10 @@ vec4 secondary_fragment_color = vec4(0.0);
         if (state.scissor_test_mode == Regs::ScissorMode::Include)
             out += "!";
         // x2,y2 have +1 added to cover the entire pixel area
-        out += "(gl_FragCoord.x >= scissor_x1 && gl_FragCoord.x < scissor_x2 + 1 && "
-                "gl_FragCoord.y >= scissor_y1 && gl_FragCoord.y < scissor_y2 + 1)) discard;\n";
+        out += "(gl_FragCoord.x >= scissor_x1 * framebuffer_scale.x && "
+                "gl_FragCoord.y >= scissor_y1 * framebuffer_scale.y && "
+                "gl_FragCoord.x < (scissor_x2 + 1) * framebuffer_scale.x && "
+                "gl_FragCoord.y < (scissor_y2 + 1) * framebuffer_scale.y)) discard;\n";
     }
 
     out += "float z_over_w = 1.0 - gl_FragCoord.z * 2.0;\n";

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -557,10 +557,10 @@ layout (std140) uniform shader_data {
     int alphatest_ref;
     float depth_scale;
     float depth_offset;
-    int scissor_right;
-    int scissor_bottom;
-    int scissor_left;
-    int scissor_top;
+    int scissor_x1;
+    int scissor_y1;
+    int scissor_x2;
+    int scissor_y2;
     vec3 fog_color;
     vec3 lighting_global_ambient;
     LightSrc light_src[NUM_LIGHTS];
@@ -589,13 +589,14 @@ vec4 secondary_fragment_color = vec4(0.0);
     }
 
     // Append the scissor test
-    if (state.scissor_test_mode == Regs::ScissorMode::Include || state.scissor_test_mode == Regs::ScissorMode::Exclude) {
-        out += "if (scissor_left <= scissor_right || scissor_top <= scissor_bottom) discard;\n";
+    if (state.scissor_test_mode != Regs::ScissorMode::Disabled) {
         out += "if (";
         // Negate the condition if we have to keep only the pixels outside the scissor box
         if (state.scissor_test_mode == Regs::ScissorMode::Include)
             out += "!";
-        out += "(gl_FragCoord.x >= scissor_right && gl_FragCoord.x <= scissor_left && gl_FragCoord.y >= scissor_bottom && gl_FragCoord.y <= scissor_top)) discard;\n";
+        // x2,y2 have +1 added to cover the entire pixel area
+        out += "(gl_FragCoord.x >= scissor_x1 && gl_FragCoord.x < scissor_x2 + 1 && "
+                "gl_FragCoord.y >= scissor_y1 && gl_FragCoord.y < scissor_y2 + 1)) discard;\n";
     }
 
     out += "float z_over_w = 1.0 - gl_FragCoord.z * 2.0;\n";

--- a/src/video_core/renderer_opengl/pica_to_gl.h
+++ b/src/video_core/renderer_opengl/pica_to_gl.h
@@ -17,6 +17,7 @@
 
 #include "video_core/pica.h"
 
+using GLvec2 = std::array<GLfloat, 2>;
 using GLvec3 = std::array<GLfloat, 3>;
 using GLvec4 = std::array<GLfloat, 4>;
 


### PR DESCRIPTION
Nuff' said.

More efficient implementations that use glScissor or multiple rectangles in the swrast can be done later.