### PR TITLE
CMake: Fix for QT 5.7 overwriting -std=c++1y flag

### DIFF
--- a/.travis-deps.sh
+++ b/.travis-deps.sh
@@ -9,7 +9,7 @@ if [ "$TRAVIS_OS_NAME" = "linux" -o -z "$TRAVIS_OS_NAME" ]; then
     export CXX=g++-6
     mkdir -p $HOME/.local
 
-    curl -L http://www.cmake.org/files/v3.1/cmake-3.1.0-Linux-i386.tar.gz \
+    curl -L http://www.cmake.org/files/v3.2/cmake-3.2.0-Linux-i386.tar.gz \
         | tar -xz -C $HOME/.local --strip-components=1
 
     (
@@ -21,6 +21,6 @@ if [ "$TRAVIS_OS_NAME" = "linux" -o -z "$TRAVIS_OS_NAME" ]; then
 elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
     brew update > /dev/null # silence the very verbose output
     brew unlink cmake
-    brew install cmake31 qt5 sdl2 dylibbundler
+    brew install cmake qt5 sdl2 dylibbundler
     gem install xcpretty
 fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
-# CMake 3.1 required for Qt5 settings to be applied automatically on
-# dependent libraries and IMPORTED targets.
-cmake_minimum_required(VERSION 3.1)
+# CMake 3.2 required for cmake to know the right flags for CXX standard on OSX
+cmake_minimum_required(VERSION 3.2)
 
 function(download_bundled_external remote_path lib_name prefix_var)
     set(prefix "${CMAKE_BINARY_DIR}/externals/${lib_name}")
@@ -63,8 +62,11 @@ if (NOT DEFINED ARCHITECTURE)
 endif()
 message(STATUS "Target architecture: ${ARCHITECTURE}")
 
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 if (NOT MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y -Wno-attributes")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-attributes")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
 else()
     # Silence "deprecation" warnings


### PR DESCRIPTION
Qt 5.7 added a new check for c++11 compilers (see https://github.com/citra-emu/citra/issues/1931#issuecomment-229549577 for more information) which meant that because citra was setting the c++1y flag directly, cmake assumed that it needed to set c++11 on any target that linked to Qt. This broke the build whenever a c++14 feature was used on targets that linked against Qt. This change specifies that C++14 compilers are required, and it adds the -std=c++14 (or -std=gnu++14 for builds in gcc) flag on every build target.