### PR TITLE
Travis Build: OS X Startup Crash Fix

### DIFF
--- a/.travis-upload.sh
+++ b/.travis-upload.sh
@@ -78,6 +78,20 @@ if [ "$TRAVIS_BRANCH" = "master" ]; then
             # Debugging info for Travis-CI
             otool -L "citra-qt.app/Contents/Frameworks/$macos_lib.framework/Versions/$QT_VERSION_NUM/$macos_lib"
         done
+        
+        # Make the citra-qt.app application launch a debugging terminal.
+        # Store away the actual binary
+        mv citra-qt.app/Contents/MacOS/citra-qt citra-qt.app/Contents/MacOS/citra-qt-bin
+
+        cat > citra-qt.app/Contents/MacOS/citra-qt <<EOL
+#!/usr/bin/env bash
+cd "\`dirname "\$0"\`"
+chmod +x citra-qt-bin
+open citra-qt-bin
+EOL # Content that will serve as the launching script for citra (within the .app folder)
+
+        # Make the launching script executable
+        chmod +x citra-qt.app/Contents/MacOS/citra-qt
 
     fi
 

--- a/.travis-upload.sh
+++ b/.travis-upload.sh
@@ -107,7 +107,7 @@ if [ "$TRAVIS_BRANCH" = "master" ]; then
 #!/usr/bin/env bash
 cd "\`dirname "\$0"\`"
 chmod +x citra-qt-bin
-open citra-qt-bin "$@"
+open citra-qt-bin --args "$@"
 EOL
         # Content that will serve as the launching script for citra (within the .app folder)
 

--- a/.travis-upload.sh
+++ b/.travis-upload.sh
@@ -107,7 +107,7 @@ if [ "$TRAVIS_BRANCH" = "master" ]; then
 #!/usr/bin/env bash
 cd "\`dirname "\$0"\`"
 chmod +x citra-qt-bin
-open citra-qt-bin --args "$@"
+open citra-qt-bin --args "\$@"
 EOL
         # Content that will serve as the launching script for citra (within the .app folder)
 

--- a/.travis-upload.sh
+++ b/.travis-upload.sh
@@ -23,6 +23,62 @@ if [ "$TRAVIS_BRANCH" = "master" ]; then
 
         # move SDL2 libs into folder for deployment
         dylibbundler -b -x "${REV_NAME}/citra" -cd -d "${REV_NAME}/libs" -p "@executable_path/libs/"
+
+        # Make the changes to make the citra-qt app standalone (i.e. not dependent on the current brew installation).
+        # To do this, the absolute references to each and every QT framework must be re-written to point to the local frameworks (in the Contents/Frameworks folder).
+        # The "install_name_tool" is used to do so.
+
+        # Coreutils is a hack to coerce Homebrew to point to the absolute Cellar path (symlink dereferenced). i.e:
+        # ls -l /usr/local/opt/qt5:: /usr/local/opt/qt5 -> ../Cellar/qt5/5.6.1-1
+        # grealpath ../Cellar/qt5/5.6.1-1:: /usr/local/Cellar/qt5/5.6.1-1
+        brew install coreutils
+
+        # grealpath is located in coreutils, there is no "realpath" for OS X :(
+        QT_BREWS_PATH=$(grealpath "$(brew --prefix qt5)")
+        BREW_PATH=$(brew --prefix)
+        QT_VERSION_NUM=5
+
+        $BREW_PATH/opt/qt5/bin/macdeployqt "citra-qt.app" -executable="citra-qt.app/Contents/MacOS/citra-qt"
+
+        # These are the files that macdeployqt packed into Contents/Frameworks/ - we don't want those, so we replace them.
+        declare -a macos_libs=("QtCore" "QtWidgets" "QtGui" "QtOpenGL" "QtPrintSupport")
+
+        for macos_lib in "${macos_libs[@]}"
+        do
+               # Replace macdeployqt versions of the Frameworks with our own (from /usr/local/opt/qt5/lib/)
+               cp "$BREW_PATH/opt/qt5/lib/$macos_lib.framework/Versions/$QT_VERSION_NUM/$macos_lib" "citra-qt.app/Contents/Frameworks/$macos_lib.framework/Versions/$QT_VERSION_NUM/$macos_lib"
+
+               # Replace references within the embedded Framework files with "internal" versions.
+               for macos_lib2 in "${macos_libs[@]}"
+               do
+                   # Since brew references both the non-symlinked and symlink paths of QT5, it needs to be duplicated.
+                   # /usr/local/Cellar/qt5/5.6.1-1/lib and /usr/local/opt/qt5/lib both resolve to the same files. So the two lines are effectively duplicates when resolved as a path, but as strings, they aren't.
+                   install_name_tool -change $QT_BREWS_PATH/lib/$macos_lib2.framework/Versions/$QT_VERSION_NUM/$macos_lib2 @executable_path/../Frameworks/$macos_lib2.framework/Versions/$QT_VERSION_NUM/$macos_lib2 "citra-qt.app/Contents/Frameworks/$macos_lib.framework/Versions/$QT_VERSION_NUM/$macos_lib"
+                   install_name_tool -change "$BREW_PATH/opt/qt5/lib/$macos_lib2.framework/Versions/$QT_VERSION_NUM/$macos_lib2" @executable_path/../Frameworks/$macos_lib2.framework/Versions/$QT_VERSION_NUM/$macos_lib2 "citra-qt.app/Contents/Frameworks/$macos_lib.framework/Versions/$QT_VERSION_NUM/$macos_lib"
+               done
+        done
+
+        # Handles the "This application failed to start because it could not find or load the Qt platform plugin "cocoa"" which masks itself as the ""
+        # Which manifests itself as "Exception Type:        EXC_CRASH (SIGABRT) Exception Codes:       0x0000000000000000, 0x0000000000000000 Exception Note:        EXC_CORPSE_NOTIFY"
+        # There may be more dylibs needed to be fixed...
+        declare -a macos_plugins=("Plugins/platforms/libqcocoa.dylib")
+
+        for macos_lib in "${macos_plugins[@]}"
+        do
+               install_name_tool -id @executable_path/../$macos_lib "citra-qt.app/Contents/$macos_lib"
+               for macos_lib2 in "${macos_libs[@]}"
+               do
+                   install_name_tool -change $QT_BREWS_PATH/lib/$macos_lib2.framework/Versions/$QT_VERSION_NUM/$macos_lib2 @executable_path/../Frameworks/$macos_lib2.framework/Versions/$QT_VERSION_NUM/$macos_lib2 "citra-qt.app/Contents/$macos_lib"
+                   install_name_tool -change "$BREW_PATH/opt/qt5/lib/$macos_lib2.framework/Versions/$QT_VERSION_NUM/$macos_lib2" @executable_path/../Frameworks/$macos_lib2.framework/Versions/$QT_VERSION_NUM/$macos_lib2 "citra-qt.app/Contents/$macos_lib"
+               done
+        done
+
+        for macos_lib in "${macos_libs[@]}"
+        do
+            # Debugging info for Travis-CI
+            otool -L "citra-qt.app/Contents/Frameworks/$macos_lib.framework/Versions/$QT_VERSION_NUM/$macos_lib"
+        done
+
     fi
 
     # Copy documentation

--- a/.travis-upload.sh
+++ b/.travis-upload.sh
@@ -108,7 +108,8 @@ if [ "$TRAVIS_BRANCH" = "master" ]; then
 cd "\`dirname "\$0"\`"
 chmod +x citra-qt-bin
 open citra-qt-bin
-EOL # Content that will serve as the launching script for citra (within the .app folder)
+EOL
+        # Content that will serve as the launching script for citra (within the .app folder)
 
         # Make the launching script executable
         chmod +x citra-qt.app/Contents/MacOS/citra-qt

--- a/.travis-upload.sh
+++ b/.travis-upload.sh
@@ -101,9 +101,9 @@ if [ "$TRAVIS_BRANCH" = "master" ]; then
 
         # Make the citra-qt.app application launch a debugging terminal.
         # Store away the actual binary
-        mv citra-qt.app/Contents/MacOS/citra-qt citra-qt.app/Contents/MacOS/citra-qt-bin
+        mv ${REV_NAME_ALT}citra-qt.app/Contents/MacOS/citra-qt ${REV_NAME_ALT}citra-qt.app/Contents/MacOS/citra-qt-bin
 
-        cat > citra-qt.app/Contents/MacOS/citra-qt <<EOL
+        cat > ${REV_NAME_ALT}citra-qt.app/Contents/MacOS/citra-qt <<EOL
 #!/usr/bin/env bash
 cd "\`dirname "\$0"\`"
 chmod +x citra-qt-bin
@@ -112,7 +112,7 @@ EOL
         # Content that will serve as the launching script for citra (within the .app folder)
 
         # Make the launching script executable
-        chmod +x citra-qt.app/Contents/MacOS/citra-qt
+        chmod +x ${REV_NAME_ALT}citra-qt.app/Contents/MacOS/citra-qt
 
     fi
 

--- a/.travis-upload.sh
+++ b/.travis-upload.sh
@@ -25,7 +25,8 @@ if [ "$TRAVIS_BRANCH" = "master" ]; then
         dylibbundler -b -x "${REV_NAME}/citra" -cd -d "${REV_NAME}/libs" -p "@executable_path/libs/"
 
         # Make the changes to make the citra-qt app standalone (i.e. not dependent on the current brew installation).
-        # To do this, the absolute references to each and every QT framework must be re-written to point to the local frameworks (in the Contents/Frameworks folder).
+        # To do this, the absolute references to each and every QT framework must be re-written to point to the local frameworks
+        # (in the Contents/Frameworks folder).
         # The "install_name_tool" is used to do so.
 
         # Coreutils is a hack to coerce Homebrew to point to the absolute Cellar path (symlink dereferenced). i.e:
@@ -33,52 +34,71 @@ if [ "$TRAVIS_BRANCH" = "master" ]; then
         # grealpath ../Cellar/qt5/5.6.1-1:: /usr/local/Cellar/qt5/5.6.1-1
         brew install coreutils
 
+        REV_NAME_ALT=$REV_NAME/
         # grealpath is located in coreutils, there is no "realpath" for OS X :(
         QT_BREWS_PATH=$(grealpath "$(brew --prefix qt5)")
         BREW_PATH=$(brew --prefix)
         QT_VERSION_NUM=5
 
-        $BREW_PATH/opt/qt5/bin/macdeployqt "citra-qt.app" -executable="citra-qt.app/Contents/MacOS/citra-qt"
+        $BREW_PATH/opt/qt5/bin/macdeployqt "${REV_NAME_ALT}citra-qt.app" \
+            -executable="${REV_NAME_ALT}citra-qt.app/Contents/MacOS/citra-qt"
 
         # These are the files that macdeployqt packed into Contents/Frameworks/ - we don't want those, so we replace them.
         declare -a macos_libs=("QtCore" "QtWidgets" "QtGui" "QtOpenGL" "QtPrintSupport")
 
         for macos_lib in "${macos_libs[@]}"
         do
-               # Replace macdeployqt versions of the Frameworks with our own (from /usr/local/opt/qt5/lib/)
-               cp "$BREW_PATH/opt/qt5/lib/$macos_lib.framework/Versions/$QT_VERSION_NUM/$macos_lib" "citra-qt.app/Contents/Frameworks/$macos_lib.framework/Versions/$QT_VERSION_NUM/$macos_lib"
+            SC_FRAMEWORK_PART=$macos_lib.framework/Versions/$QT_VERSION_NUM/$macos_lib
+            # Replace macdeployqt versions of the Frameworks with our own (from /usr/local/opt/qt5/lib/)
+            cp "$BREW_PATH/opt/qt5/lib/$SC_FRAMEWORK_PART" "${REV_NAME_ALT}citra-qt.app/Contents/Frameworks/$SC_FRAMEWORK_PART"
 
-               # Replace references within the embedded Framework files with "internal" versions.
-               for macos_lib2 in "${macos_libs[@]}"
-               do
-                   # Since brew references both the non-symlinked and symlink paths of QT5, it needs to be duplicated.
-                   # /usr/local/Cellar/qt5/5.6.1-1/lib and /usr/local/opt/qt5/lib both resolve to the same files. So the two lines are effectively duplicates when resolved as a path, but as strings, they aren't.
-                   install_name_tool -change $QT_BREWS_PATH/lib/$macos_lib2.framework/Versions/$QT_VERSION_NUM/$macos_lib2 @executable_path/../Frameworks/$macos_lib2.framework/Versions/$QT_VERSION_NUM/$macos_lib2 "citra-qt.app/Contents/Frameworks/$macos_lib.framework/Versions/$QT_VERSION_NUM/$macos_lib"
-                   install_name_tool -change "$BREW_PATH/opt/qt5/lib/$macos_lib2.framework/Versions/$QT_VERSION_NUM/$macos_lib2" @executable_path/../Frameworks/$macos_lib2.framework/Versions/$QT_VERSION_NUM/$macos_lib2 "citra-qt.app/Contents/Frameworks/$macos_lib.framework/Versions/$QT_VERSION_NUM/$macos_lib"
-               done
+            # Replace references within the embedded Framework files with "internal" versions.
+            for macos_lib2 in "${macos_libs[@]}"
+            do
+                # Since brew references both the non-symlinked and symlink paths of QT5, it needs to be duplicated.
+                # /usr/local/Cellar/qt5/5.6.1-1/lib and /usr/local/opt/qt5/lib both resolve to the same files.
+                # So the two lines below are effectively duplicates when resolved as a path, but as strings, they aren't.
+                RM_FRAMEWORK_PART=$macos_lib2.framework/Versions/$QT_VERSION_NUM/$macos_lib2
+                install_name_tool -change \
+                    $QT_BREWS_PATH/lib/$RM_FRAMEWORK_PART \
+                    @executable_path/../Frameworks/$RM_FRAMEWORK_PART \
+                    "${REV_NAME_ALT}citra-qt.app/Contents/Frameworks/$SC_FRAMEWORK_PART"
+                install_name_tool -change \
+                    "$BREW_PATH/opt/qt5/lib/$RM_FRAMEWORK_PART" \
+                    @executable_path/../Frameworks/$RM_FRAMEWORK_PART \
+                    "${REV_NAME_ALT}citra-qt.app/Contents/Frameworks/$SC_FRAMEWORK_PART"
+            done
         done
 
-        # Handles the "This application failed to start because it could not find or load the Qt platform plugin "cocoa"" which masks itself as the ""
-        # Which manifests itself as "Exception Type:        EXC_CRASH (SIGABRT) Exception Codes:       0x0000000000000000, 0x0000000000000000 Exception Note:        EXC_CORPSE_NOTIFY"
+        # Handles `This application failed to start because it could not find or load the Qt platform plugin "cocoa"`
+        # Which manifests itself as:
+        # "Exception Type: EXC_CRASH (SIGABRT) | Exception Codes: 0x0000000000000000, 0x0000000000000000 | Exception Note: EXC_CORPSE_NOTIFY"
         # There may be more dylibs needed to be fixed...
         declare -a macos_plugins=("Plugins/platforms/libqcocoa.dylib")
 
         for macos_lib in "${macos_plugins[@]}"
         do
-               install_name_tool -id @executable_path/../$macos_lib "citra-qt.app/Contents/$macos_lib"
-               for macos_lib2 in "${macos_libs[@]}"
-               do
-                   install_name_tool -change $QT_BREWS_PATH/lib/$macos_lib2.framework/Versions/$QT_VERSION_NUM/$macos_lib2 @executable_path/../Frameworks/$macos_lib2.framework/Versions/$QT_VERSION_NUM/$macos_lib2 "citra-qt.app/Contents/$macos_lib"
-                   install_name_tool -change "$BREW_PATH/opt/qt5/lib/$macos_lib2.framework/Versions/$QT_VERSION_NUM/$macos_lib2" @executable_path/../Frameworks/$macos_lib2.framework/Versions/$QT_VERSION_NUM/$macos_lib2 "citra-qt.app/Contents/$macos_lib"
-               done
+            install_name_tool -id @executable_path/../$macos_lib "${REV_NAME_ALT}citra-qt.app/Contents/$macos_lib"
+            for macos_lib2 in "${macos_libs[@]}"
+            do
+                RM_FRAMEWORK_PART=$macos_lib2.framework/Versions/$QT_VERSION_NUM/$macos_lib2
+                install_name_tool -change \
+                    $QT_BREWS_PATH/lib/$RM_FRAMEWORK_PART \
+                    @executable_path/../Frameworks/$RM_FRAMEWORK_PART \
+                    "${REV_NAME_ALT}citra-qt.app/Contents/$macos_lib"
+                install_name_tool -change \
+                    "$BREW_PATH/opt/qt5/lib/$RM_FRAMEWORK_PART" \
+                    @executable_path/../Frameworks/$RM_FRAMEWORK_PART \
+                    "${REV_NAME_ALT}citra-qt.app/Contents/$macos_lib"
+            done
         done
 
         for macos_lib in "${macos_libs[@]}"
         do
             # Debugging info for Travis-CI
-            otool -L "citra-qt.app/Contents/Frameworks/$macos_lib.framework/Versions/$QT_VERSION_NUM/$macos_lib"
+            otool -L "${REV_NAME_ALT}citra-qt.app/Contents/Frameworks/$macos_lib.framework/Versions/$QT_VERSION_NUM/$macos_lib"
         done
-        
+
         # Make the citra-qt.app application launch a debugging terminal.
         # Store away the actual binary
         mv citra-qt.app/Contents/MacOS/citra-qt citra-qt.app/Contents/MacOS/citra-qt-bin

--- a/.travis-upload.sh
+++ b/.travis-upload.sh
@@ -107,7 +107,7 @@ if [ "$TRAVIS_BRANCH" = "master" ]; then
 #!/usr/bin/env bash
 cd "\`dirname "\$0"\`"
 chmod +x citra-qt-bin
-open citra-qt-bin
+open citra-qt-bin "$@"
 EOL
         # Content that will serve as the launching script for citra (within the .app folder)
 


### PR DESCRIPTION
This PR addresses the issue of the nightly builds crashing on OS X #1929 #1932 #1958 #1221 .

So here's a little bit of analysis: the crashes occurred between citra-20160609-7139e63-osx-amd64 and citra-20160610-0c56c9f-osx-amd64. 

Which correspond to these two Travis builds: https://travis-ci.org/citra-emu/citra/jobs/136853816 https://s3.amazonaws.com/archive.travis-ci.org/jobs/136853816/log.txt and https://travis-ci.org/citra-emu/citra/jobs/136414732 https://s3.amazonaws.com/archive.travis-ci.org/jobs/136414732/log.txt.

And these two files: https://builds.citra-emu.org/citra/nightly/osx-amd64/citra-20160609-7139e63-osx-amd64.tar.xz (works) https://builds.citra-emu.org/citra/nightly/osx-amd64/citra-20160610-0c56c9f-osx-amd64.tar.xz (crashes).

The crash error messages addressed have these contents:

```
Exception Type:        EXC_BAD_ACCESS (SIGSEGV)
Exception Codes:       KERN_INVALID_ADDRESS at 0x0000000000000000
Exception Note:        EXC_CORPSE_NOTIFY
```
```
Exception Type:        EXC_CRASH (SIGABRT)
Exception Codes:       0x0000000000000000, 0x0000000000000000
Exception Note:        EXC_CORPSE_NOTIFY
```
```
Exception Type:        EXC_BREAKPOINT (SIGTRAP)
Exception Codes:       0x0000000000000002, 0x0000000000000000
Exception Note:        EXC_CORPSE_NOTIFY
```

```
Dyld Error Message:
  Library not loaded: /usr/local/Cellar/qt5/5.6.1-1/lib/QtWidgets.framework/Versions/5/QtWidgets
  Referenced from: /Volumes/*/citra-20160714-f95d119-osx-amd64 3/citra-qt.app/Contents/Frameworks/QtOpenGL.framework/Versions/5/QtOpenGL
  Reason: image not found
```

The resolution is to change to .travis-upload.sh to rename the references within the binaries in order to make the app “self-contained” - #1902.

This is due to the fact that when you inspect the dylib binaries that the QT .framework folders required, they point to the absolute brew location, and not to the relative path of the app folder.

Here's an example: 

Before:
```
iMac:citra-20160714-f95d119-osx-amd64 3 andy$ otool -L "citra-qt.app/Contents/Frameworks/QtOpenGL.framework/Versions/5/QtOpenGL"
citra-qt.app/Contents/Frameworks/QtOpenGL.framework/Versions/5/QtOpenGL:
	@executable_path/../Frameworks/QtOpenGL.framework/Versions/5/QtOpenGL (compatibility version 5.6.0, current version 5.6.1)
	/usr/local/Cellar/qt5/5.6.1-1/lib/QtWidgets.framework/Versions/5/QtWidgets (compatibility version 5.6.0, current version 5.6.1)
	/usr/local/Cellar/qt5/5.6.1-1/lib/QtGui.framework/Versions/5/QtGui (compatibility version 5.6.0, current version 5.6.1)
	/usr/local/Cellar/qt5/5.6.1-1/lib/QtCore.framework/Versions/5/QtCore (compatibility version 5.6.0, current version 5.6.1)
	/System/Library/Frameworks/DiskArbitration.framework/Versions/A/DiskArbitration (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit (compatibility version 1.0.0, current version 275.0.0)
	/System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/AGL.framework/Versions/A/AGL (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 120.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1213.0.0)
```
After:
```
iMac:citra-20160714-f95d119-osx-amd64 3 andy$ otool -L "citra-qt.app/Contents/Frameworks/QtOpenGL.framework/Versions/5/QtOpenGL"
citra-qt.app/Contents/Frameworks/QtOpenGL.framework/Versions/5/QtOpenGL:
	@executable_path/../Frameworks/QtOpenGL.framework/Versions/5/QtOpenGL (compatibility version 5.6.0, current version 5.6.1)
	@executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtWidgets (compatibility version 5.6.0, current version 5.6.1)
	@executable_path/../Frameworks/QtGui.framework/Versions/5/QtGui (compatibility version 5.6.0, current version 5.6.1)
	@executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore (compatibility version 5.6.0, current version 5.6.1)
	/System/Library/Frameworks/DiskArbitration.framework/Versions/A/DiskArbitration (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/IOKit.framework/Versions/A/IOKit (compatibility version 1.0.0, current version 275.0.0)
	/System/Library/Frameworks/OpenGL.framework/Versions/A/OpenGL (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/AGL.framework/Versions/A/AGL (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 120.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1213.0.0)
```

In short, the absolute path: `/usr/local/Cellar/qt5/5.6.1-1/lib/QtGui.framework/Versions/5/QtGui` gets converted into the relative path: `@executable_path/../Frameworks/QtGui.framework/Versions/5/QtGui`, where `@executable_path` is the location of the citra-qt binary file embedded within the citra-qt.app folder (I believe it points to `citra-qt.app/Contents/MacOS`).

To test that this PR works, you can use the following command to "hide" homebrew's QT: `mv /usr/local/Cellar/qt5/5.6.1-1 /usr/local/Cellar/qt5/5.6.x`, and then run a Travis-built Citra-qt.app Application - https://github.com/extramaster/citra/raw/builds/citra-20160719-909505e-osx-amd64.tar.xz https://github.com/extramaster/citra/raw/builds/citra-20160719-c933995-osx-amd64.tar.xz (it should run even though the homebrew QT has been tampered with, since the references are changed to be relative and contained).

Further references: http://textuploader.com/5edjy https://gist.github.com/tylerhou/b82d32114d66d8140cd15cd51ee00458 https://gist.github.com/JayFoxRox/12bef31635cf0d80ead47794123d3b33#file-can https://discuss.citra-emu.org/d/340-error-message-when-trying-to-run-citra-for-os-x

Also, with this PR, the OS X build now has a direct terminal. #1876 
The gist of it is that the citra-qt.app folder now launches a bash script, which launches the main citra-qt app with a terminal, here it is in action:

![https://gfycat.com/GleefulFearlessCoelacanth](https://giant.gfycat.com/GleefulFearlessCoelacanth.gif)

https://zippy.gfycat.com/GleefulFearlessCoelacanth.mp4

The Travis-CI build above also previews this: https://github.com/extramaster/citra/raw/builds/citra-20160719-c933995-osx-amd64.tar.xz


