### PR TITLE
Implement actual system time

### DIFF
--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -26,7 +26,7 @@
 extern int g_clock_rate_arm11;
 
 inline s64 msToCycles(int ms) {
-    return g_clock_rate_arm11 / 1000 * ms;
+    return (s64)g_clock_rate_arm11 / 1000 * ms;
 }
 
 inline s64 msToCycles(float ms) {

--- a/src/core/hle/shared_page.cpp
+++ b/src/core/hle/shared_page.cpp
@@ -2,8 +2,11 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <chrono>
 #include <cstring>
+#include <ctime>
 
+#include "core/core_timing.h"
 #include "core/hle/shared_page.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -12,6 +15,57 @@ namespace SharedPage {
 
 SharedPageDef shared_page;
 
+static int update_time_event;
+
+/// Gets system time in 3DS format. The epoch is Jan 1900, and the unit is millisecond.
+static u64 GetSystemTime() {
+    auto now = std::chrono::system_clock::now();
+
+    // 3DS system does't allow user to set a time before Jan 1 2000,
+    // so we use it as an auxiliary epoch to calculate the console time.
+    std::tm epoch_tm;
+    epoch_tm.tm_sec = 0;
+    epoch_tm.tm_min = 0;
+    epoch_tm.tm_hour = 0;
+    epoch_tm.tm_mday = 1;
+    epoch_tm.tm_mon = 0;
+    epoch_tm.tm_year = 100;
+    epoch_tm.tm_isdst = 0;
+    auto epoch = std::chrono::system_clock::from_time_t(std::mktime(&epoch_tm));
+
+    // 3DS console time uses Jan 1 1900 as internal epoch,
+    // so we use the milliseconds between 1900 and 2000 as base console time
+    u64 console_time = 3155673600000ULL;
+
+    // Only when system time is after 2000, we set it as 3DS system time
+    if (now > epoch) {
+        console_time += std::chrono::duration_cast<std::chrono::milliseconds>(now - epoch).count();
+    }
+
+    // If the system time is in daylight saving, we give an additional hour to console time
+    std::time_t now_time_t = std::chrono::system_clock::to_time_t(now);
+    std::tm* now_tm = std::localtime(&now_time_t);
+    if (now_tm && now_tm->tm_isdst > 0)
+        console_time += 60 * 60 * 1000;
+
+    return console_time;
+}
+
+static void UpdateTimeCallback(u64 userdata, int cycles_late) {
+    DateTime& date_time = shared_page.date_time_counter % 2 ?
+        shared_page.date_time_0 : shared_page.date_time_1;
+
+    date_time.date_time = GetSystemTime();
+    date_time.update_tick = CoreTiming::GetTicks();
+    date_time.tick_to_second_coefficient = g_clock_rate_arm11;
+    date_time.tick_offset = 0;
+
+    ++shared_page.date_time_counter;
+
+    // system time is updated hourly
+    CoreTiming::ScheduleEvent(msToCycles(60 * 60 * 1000) - cycles_late, update_time_event);
+}
+
 void Init() {
     std::memset(&shared_page, 0, sizeof(shared_page));
 
@@ -19,6 +73,9 @@ void Init() {
 
     // Some games wait until this value becomes 0x1, before asking running_hw
     shared_page.unknown_value = 0x1;
+
+    update_time_event = CoreTiming::RegisterEvent("SharedPage::UpdateTimeCallback", UpdateTimeCallback);
+    CoreTiming::ScheduleEvent(0, update_time_event);
 }
 
 } // namespace

--- a/src/core/hle/shared_page.h
+++ b/src/core/hle/shared_page.h
@@ -25,13 +25,14 @@ namespace SharedPage {
 struct DateTime {
     u64_le date_time;                  // 0
     u64_le update_tick;                // 8
-    INSERT_PADDING_BYTES(0x20 - 0x10); // 10
+    u64_le tick_to_second_coefficient; // 10
+    u64_le tick_offset;                // 18
 };
 static_assert(sizeof(DateTime) == 0x20, "Datetime size is wrong");
 
 struct SharedPageDef {
     // Most of these names are taken from the 3dbrew page linked above.
-    u32_le   date_time_selector;         // 0
+    u32_le   date_time_counter;          // 0
     u8       running_hw;                 // 4
     /// "Microcontroller hardware info"
     u8       mcu_hw_info;                // 5


### PR DESCRIPTION
This implemented synchronizing the system time in the `SharedPage` with actual system time. According to [the reaserch](https://github.com/wwylele/ctrhwtest/tree/master/sharedpage), it is updated every hour on real 3DS. so implemented it the same way here. Also, the name of the first field of `SharedPage` was changed, for its behaviour on real 3DS.

When translating system time to 3DS format, I uses Jan 1, 2000 as an auxiliary epoch, for the following reason:
 - it is a limit in real 3DS settings
 - `epoch = 1970` for `time_t` is not a real standard, and one needs to deal with timezone when using it
 - directly using `epoch = 1900` (real 3DS epoch) may result in invalid values, for it is before `time_t`'s epoch.

There is a known issue: game uses the formula `SharedPage.date_time + (currentSystemTick - SharedPage.update_tick) * tick_to_second_coefficient` (not exactly, needs more RE) to calculate the current time. Because of the slow pace of citra, the time presented in game will be gradually desynchronized with the actual time, and will experience a time jump at the next update. There are other ways to update system time (listed in #1641), but none of them perfectly resolves the problem. I don't think this is a big deal, and it will be automatically resolved when citra runs at full speed in the future.

----
Sorry to @ObsidianX for didn't talk to him before taking over it, but for #1641 hasn't been activated for a month, I assume that it died. Also sorry for me stealing the show in that PR. Anyway we should put an end to this. This less-than-100-line shouldn't take that long.

All research is in the old PR. Tested on Windows and Ubuntu, with different time zone, and with daylight saving on and off. The clock in System Settings App always shows the same time as computer's.