### PR TITLE
CMake: Fix Info.plist template for citra_qt/OSX

### DIFF
--- a/src/citra_qt/Info.plist
+++ b/src/citra_qt/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleExecutable</key>
-	<string>$(EXECUTABLE_NAME)</string>
+	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleGetInfoString</key>
 	<string></string>
 	<key>CFBundleIconFile</key>


### PR DESCRIPTION
The Info.plist template incorrectly uses parentheses instead of curly braces,
which means that building the .app bundle using regular 'make' results in the
variable not being replaced, and hence the app bundle won't start because the
executable name is incorrect.

This commit fixes this issue.