### PR TITLE
Remove the -msse4.1 on ¬MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,11 +66,6 @@ message(STATUS "Target architecture: ${ARCHITECTURE}")
 if (NOT MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++1y -Wno-attributes")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
-
-    if (ARCHITECTURE_x86_64)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse4.1")
-        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -msse4.1")
-    endif()
 else()
     # Silence "deprecation" warnings
     add_definitions(/D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_DEPRECATE /D_SCL_SECURE_NO_WARNINGS)


### PR DESCRIPTION
This option makes the generated binary crash with an illegal
instruction when the target CPU doesn’t support the SSE4.1 extension
(see #1968), with no noticeable performance increase compared to a
generic build.