### PR TITLE
fix #1942 and add a few IPC functions for descriptors

### DIFF
--- a/src/core/hle/kernel/session.h
+++ b/src/core/hle/kernel/session.h
@@ -16,41 +16,129 @@
 
 namespace IPC {
 
-constexpr u32 MakeHeader(u16 command_id, unsigned int regular_params, unsigned int translate_params) {
-    return ((u32)command_id << 16) | (((u32)regular_params & 0x3F) << 6) | (((u32)translate_params & 0x3F) << 0);
+enum DescriptorType : u32 {
+    // Buffer related desciptors types (mask : 0x0F)
+    StaticBuffer = 0x02,
+    PXIBuffer    = 0x04,
+    MappedBuffer = 0x08,
+    // Handle related descriptors types (mask : 0x30, but need to check for buffer related descriptors first )
+    CopyHandle   = 0x00,
+    MoveHandle   = 0x10,
+    CallingPid   = 0x20,
+};
+
+/**
+ * @brief Creates a command header to be used for IPC
+ * @param command_id            ID of the command to create a header for.
+ * @param normal_params         Size of the normal parameters in words. Up to 63.
+ * @param translate_params_size Size of the translate parameters in words. Up to 63.
+ * @return The created IPC header.
+ *
+ * Normal parameters are sent directly to the process while the translate parameters might go through modifications and checks by the kernel.
+ * The translate parameters are described by headers generated with the IPC::*Desc functions.
+ *
+ * @note While #normal_params is equivalent to the number of normal parameters, #translate_params_size includes the size occupied by the translate parameters headers.
+ */
+constexpr u32 MakeHeader(u16 command_id, unsigned int normal_params, unsigned int translate_params_size) {
+    return (u32(command_id) << 16) | ((u32(normal_params) & 0x3F) << 6) | (u32(translate_params_size) & 0x3F);
 }
 
-constexpr u32 MoveHandleDesc(unsigned int num_handles = 1) {
-    return 0x0 | ((num_handles - 1) << 26);
+union Header {
+    u32 raw;
+    BitField< 0, 6, u32> translate_params_size;
+    BitField< 6, 6, u32> normal_params;
+    BitField<16, 16, u32> command_id;
+};
+
+inline Header ParseHeader(u32 header) {
+    return{ header };
 }
 
-constexpr u32 CopyHandleDesc(unsigned int num_handles = 1) {
-    return 0x10 | ((num_handles - 1) << 26);
+constexpr u32 MoveHandleDesc(u32 num_handles = 1) {
+    return MoveHandle | ((num_handles - 1) << 26);
+}
+
+constexpr u32 CopyHandleDesc(u32 num_handles = 1) {
+    return CopyHandle | ((num_handles - 1) << 26);
 }
 
 constexpr u32 CallingPidDesc() {
-    return 0x20;
+    return CallingPid;
 }
 
-constexpr u32 TransferHandleDesc() {
-    return 0x20;
+constexpr bool isHandleDescriptor(u32 descriptor) {
+    return (descriptor & 0xF) == 0x0;
 }
 
-constexpr u32 StaticBufferDesc(u32 size, unsigned int buffer_id) {
-    return 0x2 | (size << 14) | ((buffer_id & 0xF) << 10);
+constexpr u32 HandleNumberFromDesc(u32 handle_descriptor) {
+    return (handle_descriptor >> 26) + 1;
+}
+
+constexpr u32 StaticBufferDesc(u32 size, u8 buffer_id) {
+    return StaticBuffer | (size << 14) | ((buffer_id & 0xF) << 10);
+}
+
+union StaticBufferDescInfo {
+    u32 raw;
+    BitField< 10, 4, u32> buffer_id;
+    BitField< 14, 18, u32> size;
+};
+
+inline StaticBufferDescInfo ParseStaticBufferDesc(const u32 desc) {
+    return{ desc };
+}
+
+/**
+ * @brief Creates a header describing a buffer to be sent over PXI.
+ * @param size         Size of the buffer. Max 0x00FFFFFF.
+ * @param buffer_id    The Id of the buffer. Max 0xF.
+ * @param is_read_only true if the buffer is read-only. If false, the buffer is considered to have read-write access.
+ * @return The created PXI buffer header.
+ *
+ * The next value is a phys-address of a table located in the BASE memregion.
+ */
+inline u32 PXIBufferDesc(u32 size, unsigned buffer_id, bool is_read_only) {
+    u32 type = PXIBuffer;
+    if (is_read_only) type |= 0x2;
+    return  type | (size << 8) | ((buffer_id & 0xF) << 4);
 }
 
 enum MappedBufferPermissions {
-    R = 2,
-    W = 4,
+    R = 1,
+    W = 2,
     RW = R | W,
 };
 
 constexpr u32 MappedBufferDesc(u32 size, MappedBufferPermissions perms) {
-    return 0x8 | (size << 4) | (u32)perms;
+    return MappedBuffer | (size << 4) | (u32(perms) << 1);
 }
 
+union MappedBufferDescInfo {
+    u32 raw;
+    BitField< 4, 28, u32> size;
+    BitField< 1, 2, MappedBufferPermissions> perms;
+};
+
+inline MappedBufferDescInfo ParseMappedBufferDesc(const u32 desc) {
+    return{ desc };
 }
+
+inline DescriptorType GetDescriptorType(u32 descriptor) {
+    // Note: Those checks must be done in this order
+    if (isHandleDescriptor(descriptor))
+        return (DescriptorType)(descriptor & 0x30);
+
+    // handle the fact that the following descriptors can have rights
+    if (descriptor & MappedBuffer)
+        return MappedBuffer;
+
+    if (descriptor & PXIBuffer)
+        return PXIBuffer;
+
+    return StaticBuffer;
+}
+
+} // namespace IPC
 
 namespace Kernel {
 
@@ -64,7 +152,7 @@ static const int kCommandHeaderOffset = 0x80; ///< Offset into command buffer of
  * @param offset Optional offset into command buffer
  * @return Pointer to command buffer
  */
-inline static u32* GetCommandBuffer(const int offset = 0) {
+inline u32* GetCommandBuffer(const int offset = 0) {
     return (u32*)Memory::GetPointer(GetCurrentThread()->GetTLSAddress() + kCommandHeaderOffset + offset);
 }
 

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -53,7 +53,7 @@ void Initialize(Service::Interface* self) {
     u32 app_id = cmd_buff[1];
     u32 flags  = cmd_buff[2];
 
-    cmd_buff[2] = IPC::MoveHandleDesc(2);
+    cmd_buff[2] = IPC::CopyHandleDesc(2);
     cmd_buff[3] = Kernel::g_handle_table.Create(notification_event).MoveFrom();
     cmd_buff[4] = Kernel::g_handle_table.Create(parameter_event).MoveFrom();
 
@@ -96,7 +96,7 @@ void GetSharedFont(Service::Interface* self) {
     // the real APT service calculates this address by scanning the entire address space (using svcQueryMemory)
     // and searches for an allocation of the same size as the Shared Font.
     cmd_buff[2] = target_address;
-    cmd_buff[3] = IPC::MoveHandleDesc();
+    cmd_buff[3] = IPC::CopyHandleDesc();
     cmd_buff[4] = Kernel::g_handle_table.Create(shared_font_mem).MoveFrom();
 }
 

--- a/src/core/hle/service/cam/cam.cpp
+++ b/src/core/hle/service/cam/cam.cpp
@@ -51,7 +51,7 @@ void GetVsyncInterruptEvent(Service::Interface* self) {
 
     cmd_buff[0] = IPC::MakeHeader(0x5, 1, 2);
     cmd_buff[1] = RESULT_SUCCESS.raw;
-    cmd_buff[2] = IPC::MoveHandleDesc();
+    cmd_buff[2] = IPC::CopyHandleDesc();
     cmd_buff[3] = Kernel::g_handle_table.Create(vsync_interrupt_error_event).MoveFrom();
 
     LOG_WARNING(Service_CAM, "(STUBBED) called, port=%d", port);
@@ -64,7 +64,7 @@ void GetBufferErrorInterruptEvent(Service::Interface* self) {
 
     cmd_buff[0] = IPC::MakeHeader(0x6, 1, 2);
     cmd_buff[1] = RESULT_SUCCESS.raw;
-    cmd_buff[2] = IPC::MoveHandleDesc();
+    cmd_buff[2] = IPC::CopyHandleDesc();
     cmd_buff[3] = Kernel::g_handle_table.Create(interrupt_error_event).MoveFrom();
 
     LOG_WARNING(Service_CAM, "(STUBBED) called, port=%d", port);
@@ -85,7 +85,7 @@ void SetReceiving(Service::Interface* self) {
 
     cmd_buff[0] = IPC::MakeHeader(0x7, 1, 2);
     cmd_buff[1] = RESULT_SUCCESS.raw;
-    cmd_buff[2] = IPC::MoveHandleDesc();
+    cmd_buff[2] = IPC::CopyHandleDesc();
     cmd_buff[3] = Kernel::g_handle_table.Create(completion_event).MoveFrom();
 
     LOG_WARNING(Service_CAM, "(STUBBED) called, addr=0x%X, port=%d, image_size=%d, trans_unit=%d",

--- a/src/core/hle/service/csnd_snd.cpp
+++ b/src/core/hle/service/csnd_snd.cpp
@@ -51,7 +51,7 @@ void Initialize(Service::Interface* self) {
     mutex = Kernel::Mutex::Create(false);
 
     cmd_buff[1] = RESULT_SUCCESS.raw;
-    cmd_buff[2] = IPC::MoveHandleDesc(2);
+    cmd_buff[2] = IPC::CopyHandleDesc(2);
     cmd_buff[3] = Kernel::g_handle_table.Create(mutex).MoveFrom();
     cmd_buff[4] = Kernel::g_handle_table.Create(shared_memory).MoveFrom();
 }

--- a/src/core/hle/service/srv.cpp
+++ b/src/core/hle/service/srv.cpp
@@ -57,7 +57,7 @@ static void EnableNotification(Service::Interface* self) {
 
     cmd_buff[0] = IPC::MakeHeader(0x2, 0x1, 0x2); // 0x20042
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
-    cmd_buff[2] = IPC::TransferHandleDesc();
+    cmd_buff[2] = IPC::CopyHandleDesc(1);
     cmd_buff[3] = Kernel::g_handle_table.Create(event_handle).MoveFrom();
     LOG_WARNING(Service_SRV, "(STUBBED) called");
 }


### PR DESCRIPTION
All the MoveHandleDesc and CopyHandleDesc usages were checked on hardware (client side).
TransferHandleDesc has been removed because it was wrong and duplicated CallingPidDesc.

I also added some utilities for a future IPC helper.