### PR TITLE
Dyncom: Correct implementation of STM for R15

### DIFF
--- a/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
+++ b/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
@@ -3228,7 +3228,7 @@ unsigned InterpreterMainLoop(ARMul_State* cpu) {
                     addr += 4;
                 }
                 if (BIT(inst_cream->inst, 15)) {
-                    cpu->WriteMemory32(addr, cpu->Reg_usr[1] + 8);
+                    cpu->WriteMemory32(addr, cpu->Reg[15] + 8);
                 }
             } else {
                 for (int i = 0; i < 15; i++) {
@@ -3243,8 +3243,9 @@ unsigned InterpreterMainLoop(ARMul_State* cpu) {
                 }
 
                 // Check PC reg
-                if (BIT(inst_cream->inst, 15))
-                    cpu->WriteMemory32(addr, cpu->Reg_usr[1] + 8);
+                if (BIT(inst_cream->inst, 15)) {
+                    cpu->WriteMemory32(addr, cpu->Reg[15] + 8);
+                }
             }
         }
         cpu->Reg[15] += cpu->GetInstructionSize();


### PR DESCRIPTION
Related test: https://github.com/MerryMage/3ds-tests/tree/master/stm

`stmfd r13!, {pc}` currently stores the incorrect value to the stack (seems to always be `8`).

Correction for the ~~System~~ STM (User registers) version of the instruction (line 3231) based on manual.