### PR TITLE
Set pause when focus is lost

### DIFF
--- a/src/citra/citra.cpp
+++ b/src/citra/citra.cpp
@@ -150,6 +150,10 @@ int main(int argc, char **argv) {
 
     while (emu_window->IsOpen()) {
         Core::RunLoop();
+
+        // Pause on focus lost
+        if (!emu_window->HasFocus())
+            emu_window->WaitForFocus();
     }
 
     return 0;

--- a/src/citra/emu_window/emu_window_sdl2.cpp
+++ b/src/citra/emu_window/emu_window_sdl2.cpp
@@ -63,16 +63,16 @@ void EmuWindow_SDL2::OnResize() {
 }
 
 void EmuWindow_SDL2::WaitForFocus() {
-    while(!has_focus) {
+    while (!has_focus) {
         SDL_Event event;
         SDL_WaitEvent(&event);
-        if(event.type == SDL_WINDOWEVENT) {
+        if (event.type == SDL_WINDOWEVENT) {
             switch (event.window.event) {
             case SDL_WINDOWEVENT_FOCUS_GAINED:
-                has_focus=true;
+                has_focus = true;
                 break;
             case SDL_WINDOWEVENT_CLOSE:
-                has_focus=true;
+                has_focus = true;
                 is_open = false;
                 break;
             }

--- a/src/citra/emu_window/emu_window_sdl2.cpp
+++ b/src/citra/emu_window/emu_window_sdl2.cpp
@@ -50,12 +50,34 @@ bool EmuWindow_SDL2::IsOpen() const {
     return is_open;
 }
 
+bool EmuWindow_SDL2::HasFocus() const {
+    return has_focus;
+}
+
 void EmuWindow_SDL2::OnResize() {
     int width, height;
 
     SDL_GetWindowSize(render_window, &width, &height);
 
     NotifyFramebufferLayoutChanged(EmuWindow::FramebufferLayout::DefaultScreenLayout(width, height));
+}
+
+void EmuWindow_SDL2::WaitForFocus() {
+    while(!has_focus) {
+        SDL_Event event;
+        SDL_WaitEvent(&event);
+        if(event.type == SDL_WINDOWEVENT) {
+            switch (event.window.event) {
+            case SDL_WINDOWEVENT_FOCUS_GAINED:
+                has_focus=true;
+                break;
+            case SDL_WINDOWEVENT_CLOSE:
+                has_focus=true;
+                is_open = false;
+                break;
+            }
+        }
+    }
 }
 
 EmuWindow_SDL2::EmuWindow_SDL2() {
@@ -135,6 +157,12 @@ void EmuWindow_SDL2::PollEvents() {
             case SDL_WINDOWEVENT_RESTORED:
             case SDL_WINDOWEVENT_MINIMIZED:
                 OnResize();
+                break;
+            case SDL_WINDOWEVENT_FOCUS_GAINED:
+                has_focus = true;
+                break;
+            case SDL_WINDOWEVENT_FOCUS_LOST:
+                has_focus = false;
                 break;
             case SDL_WINDOWEVENT_CLOSE:
                 is_open = false;

--- a/src/citra/emu_window/emu_window_sdl2.h
+++ b/src/citra/emu_window/emu_window_sdl2.h
@@ -58,7 +58,7 @@ private:
     /// Is the window still open?
     bool is_open = true;
 
-    /// Is the window has focus
+    /// Does the window has focus
     bool has_focus = true;
 
     /// Internal SDL2 render window

--- a/src/citra/emu_window/emu_window_sdl2.h
+++ b/src/citra/emu_window/emu_window_sdl2.h
@@ -30,6 +30,12 @@ public:
     /// Whether the window is still open, and a close request hasn't yet been sent
     bool IsOpen() const;
 
+    /// Whether the window has focus
+    bool HasFocus() const;
+
+    /// Wait for the window to gain focus
+    void WaitForFocus();
+
     /// Load keymap from configuration
     void ReloadSetKeymaps() override;
 
@@ -51,6 +57,9 @@ private:
 
     /// Is the window still open?
     bool is_open = true;
+
+    /// Is the window has focus
+    bool has_focus = true;
 
     /// Internal SDL2 render window
     SDL_Window* render_window;

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -137,7 +137,6 @@ GRenderWindow::GRenderWindow(QWidget* parent, EmuThread* emu_thread) :
     NotifyClientAreaSizeChanged(std::pair<unsigned,unsigned>(child->width(), child->height()));
 
     BackupGeometry();
-
 }
 
 void GRenderWindow::moveContext()
@@ -287,11 +286,11 @@ void GRenderWindow::OnMinimalClientAreaChangeRequest(const std::pair<unsigned,un
 }
 
 void GRenderWindow::focusInEvent(QFocusEvent*) {
-    if (emu_thread && UISettings::values.pause_onfocuslost) emit gotFocus();
+    emit focusChanged(true);
 }
 
 void GRenderWindow::focusOutEvent(QFocusEvent*) {
-    if (emu_thread && UISettings::values.pause_onfocuslost) emit lostFocus();
+    emit focusChanged(false);
 }
 
 void GRenderWindow::OnEmulationStarting(EmuThread* emu_thread) {

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -9,6 +9,7 @@
 #endif
 
 #include "citra_qt/bootmanager.h"
+#include "citra_qt/ui_settings.h"
 
 #include "common/key_map.h"
 #include "common/microprofile.h"
@@ -283,6 +284,14 @@ void GRenderWindow::OnClientAreaResized(unsigned width, unsigned height)
 
 void GRenderWindow::OnMinimalClientAreaChangeRequest(const std::pair<unsigned,unsigned>& minimal_size) {
     setMinimumSize(minimal_size.first, minimal_size.second);
+}
+
+void GRenderWindow::focusInEvent(QFocusEvent*) {
+    if (emu_thread && UISettings::values.pause_onfocuslost) emit gotFocus();
+}
+
+void GRenderWindow::focusOutEvent(QFocusEvent*) {
+    if (emu_thread && UISettings::values.pause_onfocuslost) emit lostFocus();
 }
 
 void GRenderWindow::OnEmulationStarting(EmuThread* emu_thread) {

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -136,10 +136,8 @@ public slots:
 signals:
     /// Emitted when the window is closed
     void Closed();
-    /// Emitted when the window got focus
-    void gotFocus();
-    /// Emitted when the window lost focus
-    void lostFocus();
+    /// Emitted when the window focus changed
+    void focusChanged(bool hasFocus);
 
 private:
     void OnMinimalClientAreaChangeRequest(const std::pair<unsigned,unsigned>& minimal_size) override;

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -136,9 +136,25 @@ public slots:
 signals:
     /// Emitted when the window is closed
     void Closed();
+    /// Emitted when the window got focus
+    void gotFocus();
+    /// Emitted when the window lost focus
+    void lostFocus();
 
 private:
     void OnMinimalClientAreaChangeRequest(const std::pair<unsigned,unsigned>& minimal_size) override;
+
+    /**
+     * Capture focus gain to unset pause
+     * @param event
+     */
+    void focusInEvent(QFocusEvent*) override;
+
+    /**
+     * Capture focus lost to set pause
+     * @param event
+     */
+    void focusOutEvent(QFocusEvent*) override;
 
     GGLWidgetInternal* child;
 

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -136,22 +136,16 @@ public slots:
 signals:
     /// Emitted when the window is closed
     void Closed();
-    /// Emitted when the window focus changed
-    void focusChanged(bool hasFocus);
+    /// Emitted when the window focus changes
+    void focusChanged(bool has_focus);
 
 private:
     void OnMinimalClientAreaChangeRequest(const std::pair<unsigned,unsigned>& minimal_size) override;
 
-    /**
-     * Capture focus gain to unset pause
-     * @param event
-     */
+    /// Capture focus gain to unset pause
     void focusInEvent(QFocusEvent*) override;
 
-    /**
-     * Capture focus lost to set pause
-     * @param event
-     */
+    /// Capture focus lost to set pause
     void focusOutEvent(QFocusEvent*) override;
 
     GGLWidgetInternal* child;

--- a/src/citra_qt/config.cpp
+++ b/src/citra_qt/config.cpp
@@ -116,6 +116,7 @@ void Config::ReadValues() {
 
     UISettings::values.single_window_mode = qt_config->value("singleWindowMode", true).toBool();
     UISettings::values.display_titlebar = qt_config->value("displayTitleBars", true).toBool();
+    UISettings::values.pause_onfocuslost = qt_config->value("pauseOnFocusLost",false).toBool();
     UISettings::values.confirm_before_closing = qt_config->value("confirmClose",true).toBool();
     UISettings::values.first_start = qt_config->value("firstStart", true).toBool();
 
@@ -196,6 +197,7 @@ void Config::SaveValues() {
 
     qt_config->setValue("singleWindowMode", UISettings::values.single_window_mode);
     qt_config->setValue("displayTitleBars", UISettings::values.display_titlebar);
+    qt_config->setValue("pauseOnFocusLost", UISettings::values.pause_onfocuslost);
     qt_config->setValue("confirmClose", UISettings::values.confirm_before_closing);
     qt_config->setValue("firstStart", UISettings::values.first_start);
 

--- a/src/citra_qt/config.cpp
+++ b/src/citra_qt/config.cpp
@@ -116,7 +116,7 @@ void Config::ReadValues() {
 
     UISettings::values.single_window_mode = qt_config->value("singleWindowMode", true).toBool();
     UISettings::values.display_titlebar = qt_config->value("displayTitleBars", true).toBool();
-    UISettings::values.pause_onfocuslost = qt_config->value("pauseOnFocusLost",false).toBool();
+    UISettings::values.pause_onfocuslost = qt_config->value("pauseOnFocusLost", false).toBool();
     UISettings::values.confirm_before_closing = qt_config->value("confirmClose",true).toBool();
     UISettings::values.first_start = qt_config->value("firstStart", true).toBool();
 

--- a/src/citra_qt/configure_general.cpp
+++ b/src/citra_qt/configure_general.cpp
@@ -21,6 +21,7 @@ ConfigureGeneral::~ConfigureGeneral() {
 
 void ConfigureGeneral::setConfiguration() {
     ui->toogle_deepscan->setChecked(UISettings::values.gamedir_deepscan);
+    ui->toogle_pause_onfocuslost->setChecked(UISettings::values.pause_onfocuslost);
     ui->toogle_check_exit->setChecked(UISettings::values.confirm_before_closing);
     ui->region_combobox->setCurrentIndex(Settings::values.region_value);
     ui->toogle_hw_renderer->setChecked(Settings::values.use_hw_renderer);
@@ -30,6 +31,7 @@ void ConfigureGeneral::setConfiguration() {
 
 void ConfigureGeneral::applyConfiguration() {
     UISettings::values.gamedir_deepscan = ui->toogle_deepscan->isChecked();
+    UISettings::values.pause_onfocuslost = ui->toogle_pause_onfocuslost->isChecked();
     UISettings::values.confirm_before_closing = ui->toogle_check_exit->isChecked();
     Settings::values.region_value = ui->region_combobox->currentIndex();
     Settings::values.use_hw_renderer = ui->toogle_hw_renderer->isChecked();

--- a/src/citra_qt/configure_general.ui
+++ b/src/citra_qt/configure_general.ui
@@ -32,6 +32,13 @@
            </widget>
           </item>
           <item>
+           <widget class="QCheckBox" name="toogle_pause_onfocuslost">
+            <property name="text">
+             <string>Pause on focus lost</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QCheckBox" name="toogle_check_exit">
             <property name="text">
              <string>Confirm exit while emulation is running</string>

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -186,6 +186,8 @@ GMainWindow::GMainWindow() : config(new Config()), emu_thread(nullptr)
     connect(this, SIGNAL(EmulationStarting(EmuThread*)), graphicsTracingWidget, SLOT(OnEmulationStarting(EmuThread*)));
     connect(this, SIGNAL(EmulationStopping()), graphicsTracingWidget, SLOT(OnEmulationStopping()));
 
+    connect(render_window, SIGNAL(gotFocus()), this, SLOT(OnStartGame()));
+    connect(render_window, SIGNAL(lostFocus()), this, SLOT(OnPauseGame()));
 
     // Setup hotkeys
     RegisterHotkey("Main Window", "Load File", QKeySequence::Open);
@@ -468,6 +470,8 @@ void GMainWindow::OnStartGame() {
 
     ui.action_Pause->setEnabled(true);
     ui.action_Stop->setEnabled(true);
+
+    render_window->setFocus();
 }
 
 void GMainWindow::OnPauseGame() {
@@ -487,7 +491,7 @@ void GMainWindow::ToggleWindowMode() {
         // Render in the main window...
         render_window->BackupGeometry();
         ui.horizontalLayout->addWidget(render_window);
-        render_window->setFocusPolicy(Qt::ClickFocus);
+        render_window->setFocusPolicy(Qt::StrongFocus);
         if (emulation_running) {
             render_window->setVisible(true);
             render_window->setFocus();
@@ -505,6 +509,7 @@ void GMainWindow::ToggleWindowMode() {
             game_list->show();
         }
     }
+    render_window->setFocus();
 }
 
 void GMainWindow::OnConfigure() {

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -489,20 +489,17 @@ void GMainWindow::OnStopGame() {
     ShutdownGame();
 }
 
-void GMainWindow::OnFocusChanged(bool hasFocus) {
+void GMainWindow::OnFocusChanged(bool has_focus) {
     // The focus change does not impact actual emulator state if:
     // - the option is disabled
     // - the emulation is not started
     // - the emulation has been paused through menu
-    if(!UISettings::values.pause_onfocuslost ||
-       !emu_thread ||
-       emulation_paused)
+    if (!UISettings::values.pause_onfocuslost ||
+        !emu_thread ||
+        emulation_paused)
         return;
 
-    if (hasFocus)
-        emu_thread->SetRunning(true);
-    else // focus lost
-        emu_thread->SetRunning(false);
+    emu_thread->SetRunning(has_focus);
 }
 
 void GMainWindow::ToggleWindowMode() {

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -98,6 +98,8 @@ private slots:
     void OnStartGame();
     void OnPauseGame();
     void OnStopGame();
+    /// Called whenever the render window focus is changed
+    void OnFocusChanged(bool hasFocus);
     /// Called whenever a user selects a game in the game list widget.
     void OnGameListLoadFile(QString game_path);
     void OnMenuLoadFile();
@@ -118,6 +120,8 @@ private:
 
     std::unique_ptr<Config> config;
 
+    // Whether emulation has been paused (through menus)
+    bool emulation_paused = false;
     // Whether emulation is currently running in Citra.
     bool emulation_running = false;
     std::unique_ptr<EmuThread> emu_thread;

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -99,7 +99,7 @@ private slots:
     void OnPauseGame();
     void OnStopGame();
     /// Called whenever the render window focus is changed
-    void OnFocusChanged(bool hasFocus);
+    void OnFocusChanged(bool has_focus);
     /// Called whenever a user selects a game in the game list widget.
     void OnGameListLoadFile(QString game_path);
     void OnMenuLoadFile();

--- a/src/citra_qt/ui_settings.h
+++ b/src/citra_qt/ui_settings.h
@@ -29,6 +29,7 @@ struct Values {
     bool single_window_mode;
     bool display_titlebar;
 
+    bool pause_onfocuslost;
     bool confirm_before_closing;
     bool first_start;
 


### PR DESCRIPTION
The feature is disabled by default and can be enabled through the configure widget.
Feature was asked by RavenHome1 in #1495.

![pause_on_focus_lost](https://cloud.githubusercontent.com/assets/8618754/17659267/b93ce738-62d1-11e6-8a7e-db478a97cb55.png)
