### PR TITLE
Auto-detect original shared_font.bin memory base

### DIFF
--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -81,13 +81,8 @@ void GetSharedFont(Service::Interface* self) {
 
     // The shared font has to be relocated to the new address before being passed to the application.
     VAddr target_address = Memory::PhysicalToVirtualAddress(shared_font_mem->linear_heap_phys_address);
-    // The shared font dumped by 3dsutils (https://github.com/citra-emu/3dsutils) uses this address as base,
-    // so we relocate it from there to our real address.
-    // TODO(Subv): This address is wrong if the shared font is dumped from a n3DS,
-    // we need a way to automatically calculate the original address of the font from the file.
-    static const VAddr SHARED_FONT_VADDR = 0x18000000;
     if (!shared_font_relocated) {
-        BCFNT::RelocateSharedFont(shared_font_mem, SHARED_FONT_VADDR, target_address);
+        BCFNT::RelocateSharedFont(shared_font_mem, target_address);
         shared_font_relocated = true;
     }
     cmd_buff[0] = IPC::MakeHeader(0x44, 2, 2);

--- a/src/core/hle/service/apt/bcfnt/bcfnt.h
+++ b/src/core/hle/service/apt/bcfnt/bcfnt.h
@@ -22,6 +22,11 @@ struct CFNT {
     u32_le num_blocks;
 };
 
+struct SectionHeader {
+    u8 magic[4];
+    u32_le section_size;
+};
+
 struct FINF {
     u8 magic[4];
     u32_le section_size;
@@ -75,12 +80,13 @@ struct CWDH {
 };
 
 /**
- * Relocates the internal addresses of the BCFNT Shared Font to the new base.
+ * Relocates the internal addresses of the BCFNT Shared Font to the new base. The current base will
+ * be auto-detected based on the file headers.
+ *
  * @param shared_font SharedMemory object that contains the Shared Font
- * @param previous_address Previous address at which the offsets in the structure were based.
  * @param new_address New base for the offsets in the structure.
  */
-void RelocateSharedFont(Kernel::SharedPtr<Kernel::SharedMemory> shared_font, VAddr previous_address, VAddr new_address);
+void RelocateSharedFont(Kernel::SharedPtr<Kernel::SharedMemory> shared_font, VAddr new_address);
 
 } // namespace BCFNT
 } // namespace APT


### PR DESCRIPTION
This allows a file dumped from either an o3DS or a n3DS (and potentially even an original unrebased file) to be used.

@endrift Can you test this with your file that didn't work before?