### PR TITLE
AppVeyor: Cache chocolatey packages

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,10 @@ environment:
   BUILD_PASSWORD:
     secure: EXGNlWKJsCtbeImEJ5EP9qrxZ+EqUFfNy+CP61nDOMA=
 
+cache:
+  - C:\ProgramData\chocolatey\bin -> appveyor.yml
+  - C:\ProgramData\chocolatey\lib -> appveyor.yml
+
 os: Visual Studio 2015
 
 platform:


### PR DESCRIPTION
This has been untested and no effort went into this :smiley: 

It has been blatantly stolen from the [AppVeyor docs](https://www.appveyor.com/docs/build-cache/)
It should reduce [problems like the inability to install WinSCP on the CRO merge] (https://ci.appveyor.com/project/bunnei/citra/build/1.0.3782#L1448)

However, I'm not sure if the cache is ever cleaned automaticly. So if WinSCP gets a more serious security update we'll probably have to do something?