### PR TITLE
Qt graphics configure & V-Sync option

### DIFF
--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -71,6 +71,7 @@ void Config::ReadValues() {
     Settings::values.use_hw_renderer = sdl2_config->GetBoolean("Renderer", "use_hw_renderer", true);
     Settings::values.use_shader_jit = sdl2_config->GetBoolean("Renderer", "use_shader_jit", true);
     Settings::values.use_scaled_resolution = sdl2_config->GetBoolean("Renderer", "use_scaled_resolution", false);
+    Settings::values.use_vsync = sdl2_config->GetBoolean("Renderer", "use_vsync", false);
 
     Settings::values.bg_red   = (float)sdl2_config->GetReal("Renderer", "bg_red",   1.0);
     Settings::values.bg_green = (float)sdl2_config->GetReal("Renderer", "bg_green", 1.0);

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -55,6 +55,10 @@ use_shader_jit =
 # 0 (default): Native, 1: Scaled
 use_scaled_resolution =
 
+# Whether to enable V-Sync (caps the framerate at 60FPS) or not.
+# 0 (default): Off, 1: On
+use_vsync =
+
 # The clear color for the renderer. What shows up on the sides of the bottom screen.
 # Must be in range of 0.0-1.0. Defaults to 1.0 for all.
 bg_red =

--- a/src/citra/emu_window/emu_window_sdl2.cpp
+++ b/src/citra/emu_window/emu_window_sdl2.cpp
@@ -108,6 +108,7 @@ EmuWindow_SDL2::EmuWindow_SDL2() {
     OnResize();
     OnMinimalClientAreaChangeRequest(GetActiveConfig().min_client_area_size);
     SDL_PumpEvents();
+    SDL_GL_SetSwapInterval(Settings::values.use_vsync);
 
     DoneCurrent();
 }

--- a/src/citra_qt/CMakeLists.txt
+++ b/src/citra_qt/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SRCS
             configure_debug.cpp
             configure_dialog.cpp
             configure_general.cpp
+            configure_graphics.cpp
             configure_system.cpp
             configure_input.cpp
             game_list.cpp
@@ -54,6 +55,7 @@ set(HEADERS
             configure_debug.h
             configure_dialog.h
             configure_general.h
+            configure_graphics.h
             configure_system.h
             configure_input.h
             game_list.h
@@ -73,6 +75,7 @@ set(UIS
             configure_audio.ui
             configure_debug.ui
             configure_general.ui
+            configure_graphics.ui
             configure_system.ui
             configure_input.ui
             hotkeys.ui

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -107,37 +107,13 @@ private:
 };
 
 GRenderWindow::GRenderWindow(QWidget* parent, EmuThread* emu_thread) :
-    QWidget(parent), keyboard_id(0), emu_thread(emu_thread) {
+    QWidget(parent), keyboard_id(0), emu_thread(emu_thread), child(nullptr) {
 
     std::string window_title = Common::StringFromFormat("Citra | %s-%s", Common::g_scm_branch, Common::g_scm_desc);
     setWindowTitle(QString::fromStdString(window_title));
 
     keyboard_id = KeyMap::NewDeviceId();
     ReloadSetKeymaps();
-
-    // TODO: One of these flags might be interesting: WA_OpaquePaintEvent, WA_NoBackground, WA_DontShowOnScreen, WA_DeleteOnClose
-    QGLFormat fmt;
-    fmt.setVersion(3,3);
-    fmt.setProfile(QGLFormat::CoreProfile);
-    fmt.setSwapInterval(VideoCore::g_vsync_enabled);
-    // Requests a forward-compatible context, which is required to get a 3.2+ context on OS X
-    fmt.setOption(QGL::NoDeprecatedFunctions);
-
-    child = new GGLWidgetInternal(fmt, this);
-    QBoxLayout* layout = new QHBoxLayout(this);
-
-    resize(VideoCore::kScreenTopWidth, VideoCore::kScreenTopHeight + VideoCore::kScreenBottomHeight);
-    layout->addWidget(child);
-    layout->setMargin(0);
-    setLayout(layout);
-
-    OnMinimalClientAreaChangeRequest(GetActiveConfig().min_client_area_size);
-
-    OnFramebufferSizeChanged();
-    NotifyClientAreaSizeChanged(std::pair<unsigned,unsigned>(child->width(), child->height()));
-
-    BackupGeometry();
-
 }
 
 void GRenderWindow::moveContext()
@@ -280,6 +256,40 @@ void GRenderWindow::ReloadSetKeymaps()
 void GRenderWindow::OnClientAreaResized(unsigned width, unsigned height)
 {
     NotifyClientAreaSizeChanged(std::make_pair(width, height));
+}
+
+void GRenderWindow::InitRenderTarget() {
+    if (child) {
+        delete child;
+    }
+
+    if (layout()) {
+        delete layout();
+    }
+
+    // TODO: One of these flags might be interesting: WA_OpaquePaintEvent, WA_NoBackground, WA_DontShowOnScreen, WA_DeleteOnClose
+    QGLFormat fmt;
+    fmt.setVersion(3, 3);
+    fmt.setProfile(QGLFormat::CoreProfile);
+    fmt.setSwapInterval(Settings::values.use_vsync);
+
+    // Requests a forward-compatible context, which is required to get a 3.2+ context on OS X
+    fmt.setOption(QGL::NoDeprecatedFunctions);
+
+    child = new GGLWidgetInternal(fmt, this);
+    QBoxLayout* layout = new QHBoxLayout(this);
+
+    resize(VideoCore::kScreenTopWidth, VideoCore::kScreenTopHeight + VideoCore::kScreenBottomHeight);
+    layout->addWidget(child);
+    layout->setMargin(0);
+    setLayout(layout);
+
+    OnMinimalClientAreaChangeRequest(GetActiveConfig().min_client_area_size);
+
+    OnFramebufferSizeChanged();
+    NotifyClientAreaSizeChanged(std::pair<unsigned, unsigned>(child->width(), child->height()));
+
+    BackupGeometry();
 }
 
 void GRenderWindow::OnMinimalClientAreaChangeRequest(const std::pair<unsigned,unsigned>& minimal_size) {

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -119,6 +119,7 @@ GRenderWindow::GRenderWindow(QWidget* parent, EmuThread* emu_thread) :
     QGLFormat fmt;
     fmt.setVersion(3,3);
     fmt.setProfile(QGLFormat::CoreProfile);
+    fmt.setSwapInterval(VideoCore::g_vsync_enabled);
     // Requests a forward-compatible context, which is required to get a 3.2+ context on OS X
     fmt.setOption(QGL::NoDeprecatedFunctions);
 

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -126,6 +126,8 @@ public:
 
     void OnClientAreaResized(unsigned width, unsigned height);
 
+    void InitRenderTarget();
+
 public slots:
     void moveContext();  // overridden
 

--- a/src/citra_qt/config.cpp
+++ b/src/citra_qt/config.cpp
@@ -48,6 +48,7 @@ void Config::ReadValues() {
     Settings::values.use_hw_renderer = qt_config->value("use_hw_renderer", true).toBool();
     Settings::values.use_shader_jit = qt_config->value("use_shader_jit", true).toBool();
     Settings::values.use_scaled_resolution = qt_config->value("use_scaled_resolution", false).toBool();
+    Settings::values.use_vsync = qt_config->value("use_vsync", false).toBool();
 
     Settings::values.bg_red   = qt_config->value("bg_red",   1.0).toFloat();
     Settings::values.bg_green = qt_config->value("bg_green", 1.0).toFloat();
@@ -139,6 +140,7 @@ void Config::SaveValues() {
     qt_config->setValue("use_hw_renderer", Settings::values.use_hw_renderer);
     qt_config->setValue("use_shader_jit", Settings::values.use_shader_jit);
     qt_config->setValue("use_scaled_resolution", Settings::values.use_scaled_resolution);
+    qt_config->setValue("use_vsync", Settings::values.use_vsync);
 
     // Cast to double because Qt's written float values are not human-readable
     qt_config->setValue("bg_red",   (double)Settings::values.bg_red);

--- a/src/citra_qt/configure.ui
+++ b/src/citra_qt/configure.ui
@@ -34,11 +34,16 @@
        <string>Input</string>
       </attribute>
      </widget>
-      <widget class="ConfigureAudio" name="audioTab">
+      <widget class="ConfigureGraphics" name="graphicsTab">
         <attribute name="title">
-          <string>Audio</string>
+          <string>Graphics</string>
         </attribute>
       </widget>
+     <widget class="ConfigureAudio" name="audioTab">
+       <attribute name="title">
+         <string>Audio</string>
+       </attribute>
+     </widget>
      <widget class="ConfigureDebug" name="debugTab">
       <attribute name="title">
        <string>Debug</string>
@@ -80,12 +85,18 @@
    <header>configure_debug.h</header>
    <container>1</container>
   </customwidget>
-   <customwidget>
-     <class>ConfigureInput</class>
-     <extends>QWidget</extends>
-     <header>configure_input.h</header>
-     <container>1</container>
-   </customwidget>
+  <customwidget>
+   <class>ConfigureInput</class>
+   <extends>QWidget</extends>
+   <header>configure_input.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ConfigureGraphics</class>
+   <extends>QWidget</extends>
+   <header>configure_graphics.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <resources/>
  <connections>

--- a/src/citra_qt/configure_debug.cpp
+++ b/src/citra_qt/configure_debug.cpp
@@ -19,13 +19,13 @@ ConfigureDebug::~ConfigureDebug() {
 }
 
 void ConfigureDebug::setConfiguration() {
-    ui->toogle_gdbstub->setChecked(Settings::values.use_gdbstub);
+    ui->toggle_gdbstub->setChecked(Settings::values.use_gdbstub);
     ui->gdbport_spinbox->setEnabled(Settings::values.use_gdbstub);
     ui->gdbport_spinbox->setValue(Settings::values.gdbstub_port);
 }
 
 void ConfigureDebug::applyConfiguration() {
-    Settings::values.use_gdbstub = ui->toogle_gdbstub->isChecked();
+    Settings::values.use_gdbstub = ui->toggle_gdbstub->isChecked();
     Settings::values.gdbstub_port = ui->gdbport_spinbox->value();
     Settings::Apply();
 }

--- a/src/citra_qt/configure_debug.ui
+++ b/src/citra_qt/configure_debug.ui
@@ -25,7 +25,7 @@
         <item>
          <layout class="QHBoxLayout" name="horizontalLayout_3">
           <item>
-           <widget class="QCheckBox" name="toogle_gdbstub">
+           <widget class="QCheckBox" name="toggle_gdbstub">
             <property name="text">
              <string>Enable GDB Stub</string>
             </property>
@@ -83,7 +83,7 @@
  <resources/>
  <connections>
   <connection>
-   <sender>toogle_gdbstub</sender>
+   <sender>toggle_gdbstub</sender>
    <signal>toggled(bool)</signal>
    <receiver>gdbport_spinbox</receiver>
    <slot>setEnabled(bool)</slot>

--- a/src/citra_qt/configure_dialog.cpp
+++ b/src/citra_qt/configure_dialog.cpp
@@ -31,6 +31,7 @@ void ConfigureDialog::applyConfiguration() {
     ui->generalTab->applyConfiguration();
     ui->systemTab->applyConfiguration();
     ui->inputTab->applyConfiguration();
+    ui->graphicsTab->applyConfiguration();
     ui->audioTab->applyConfiguration();
     ui->debugTab->applyConfiguration();
 }

--- a/src/citra_qt/configure_general.cpp
+++ b/src/citra_qt/configure_general.cpp
@@ -23,17 +23,11 @@ void ConfigureGeneral::setConfiguration() {
     ui->toogle_deepscan->setChecked(UISettings::values.gamedir_deepscan);
     ui->toogle_check_exit->setChecked(UISettings::values.confirm_before_closing);
     ui->region_combobox->setCurrentIndex(Settings::values.region_value);
-    ui->toogle_hw_renderer->setChecked(Settings::values.use_hw_renderer);
-    ui->toogle_shader_jit->setChecked(Settings::values.use_shader_jit);
-    ui->toogle_scaled_resolution->setChecked(Settings::values.use_scaled_resolution);
 }
 
 void ConfigureGeneral::applyConfiguration() {
     UISettings::values.gamedir_deepscan = ui->toogle_deepscan->isChecked();
     UISettings::values.confirm_before_closing = ui->toogle_check_exit->isChecked();
     Settings::values.region_value = ui->region_combobox->currentIndex();
-    Settings::values.use_hw_renderer = ui->toogle_hw_renderer->isChecked();
-    Settings::values.use_shader_jit = ui->toogle_shader_jit->isChecked();
-    Settings::values.use_scaled_resolution = ui->toogle_scaled_resolution->isChecked();
     Settings::Apply();
 }

--- a/src/citra_qt/configure_general.cpp
+++ b/src/citra_qt/configure_general.cpp
@@ -20,14 +20,14 @@ ConfigureGeneral::~ConfigureGeneral() {
 }
 
 void ConfigureGeneral::setConfiguration() {
-    ui->toogle_deepscan->setChecked(UISettings::values.gamedir_deepscan);
-    ui->toogle_check_exit->setChecked(UISettings::values.confirm_before_closing);
+    ui->toggle_deepscan->setChecked(UISettings::values.gamedir_deepscan);
+    ui->toggle_check_exit->setChecked(UISettings::values.confirm_before_closing);
     ui->region_combobox->setCurrentIndex(Settings::values.region_value);
 }
 
 void ConfigureGeneral::applyConfiguration() {
-    UISettings::values.gamedir_deepscan = ui->toogle_deepscan->isChecked();
-    UISettings::values.confirm_before_closing = ui->toogle_check_exit->isChecked();
+    UISettings::values.gamedir_deepscan = ui->toggle_deepscan->isChecked();
+    UISettings::values.confirm_before_closing = ui->toggle_check_exit->isChecked();
     Settings::values.region_value = ui->region_combobox->currentIndex();
     Settings::Apply();
 }

--- a/src/citra_qt/configure_general.ui
+++ b/src/citra_qt/configure_general.ui
@@ -107,40 +107,6 @@
       </widget>
      </item>
      <item>
-      <widget class="QGroupBox" name="groupBox_2">
-       <property name="title">
-        <string>Performance</string>
-       </property>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
-        <item>
-         <layout class="QVBoxLayout" name="verticalLayout_3">
-          <item>
-           <widget class="QCheckBox" name="toogle_hw_renderer">
-            <property name="text">
-             <string>Enable hardware renderer</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="toogle_shader_jit">
-            <property name="text">
-             <string>Enable shader JIT</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="toogle_scaled_resolution">
-            <property name="text">
-             <string>Enable scaled resolution</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
       <widget class="QGroupBox" name="groupBox_3">
        <property name="title">
         <string>Hotkeys</string>

--- a/src/citra_qt/configure_general.ui
+++ b/src/citra_qt/configure_general.ui
@@ -25,14 +25,14 @@
         <item>
          <layout class="QVBoxLayout" name="verticalLayout_2">
           <item>
-           <widget class="QCheckBox" name="toogle_deepscan">
+           <widget class="QCheckBox" name="toggle_deepscan">
             <property name="text">
              <string>Recursive scan for game folder</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="toogle_check_exit">
+           <widget class="QCheckBox" name="toggle_check_exit">
             <property name="text">
              <string>Confirm exit while emulation is running</string>
             </property>

--- a/src/citra_qt/configure_graphics.cpp
+++ b/src/citra_qt/configure_graphics.cpp
@@ -22,11 +22,12 @@ void ConfigureGraphics::setConfiguration() {
     ui->toogle_hw_renderer->setChecked(Settings::values.use_hw_renderer);
     ui->toogle_shader_jit->setChecked(Settings::values.use_shader_jit);
     ui->toogle_scaled_resolution->setChecked(Settings::values.use_scaled_resolution);
+    ui->toogle_vsync->setChecked(Settings::values.use_vsync);
 }
 
 void ConfigureGraphics::applyConfiguration() {
     Settings::values.use_hw_renderer = ui->toogle_hw_renderer->isChecked();
     Settings::values.use_shader_jit = ui->toogle_shader_jit->isChecked();
-    Settings::values.use_scaled_resolution = ui->toogle_scaled_resolution->isChecked();
+    Settings::values.use_vsync = ui->toogle_vsync->isChecked();
     Settings::Apply();
 }

--- a/src/citra_qt/configure_graphics.cpp
+++ b/src/citra_qt/configure_graphics.cpp
@@ -1,0 +1,32 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "citra_qt/configure_graphics.h"
+#include "ui_configure_graphics.h"
+
+#include "core/settings.h"
+
+ConfigureGraphics::ConfigureGraphics(QWidget *parent) :
+    QWidget(parent),
+    ui(new Ui::ConfigureGraphics)
+{
+    ui->setupUi(this);
+    this->setConfiguration();
+}
+
+ConfigureGraphics::~ConfigureGraphics() {
+}
+
+void ConfigureGraphics::setConfiguration() {
+    ui->toogle_hw_renderer->setChecked(Settings::values.use_hw_renderer);
+    ui->toogle_shader_jit->setChecked(Settings::values.use_shader_jit);
+    ui->toogle_scaled_resolution->setChecked(Settings::values.use_scaled_resolution);
+}
+
+void ConfigureGraphics::applyConfiguration() {
+    Settings::values.use_hw_renderer = ui->toogle_hw_renderer->isChecked();
+    Settings::values.use_shader_jit = ui->toogle_shader_jit->isChecked();
+    Settings::values.use_scaled_resolution = ui->toogle_scaled_resolution->isChecked();
+    Settings::Apply();
+}

--- a/src/citra_qt/configure_graphics.cpp
+++ b/src/citra_qt/configure_graphics.cpp
@@ -6,6 +6,7 @@
 #include "ui_configure_graphics.h"
 
 #include "core/settings.h"
+#include "core/system.h"
 
 ConfigureGraphics::ConfigureGraphics(QWidget *parent) :
     QWidget(parent),
@@ -13,6 +14,8 @@ ConfigureGraphics::ConfigureGraphics(QWidget *parent) :
 {
     ui->setupUi(this);
     this->setConfiguration();
+
+    ui->toogle_vsync->setEnabled(!System::IsPoweredOn());
 }
 
 ConfigureGraphics::~ConfigureGraphics() {
@@ -28,6 +31,7 @@ void ConfigureGraphics::setConfiguration() {
 void ConfigureGraphics::applyConfiguration() {
     Settings::values.use_hw_renderer = ui->toogle_hw_renderer->isChecked();
     Settings::values.use_shader_jit = ui->toogle_shader_jit->isChecked();
+    Settings::values.use_scaled_resolution = ui->toogle_scaled_resolution->isChecked();
     Settings::values.use_vsync = ui->toogle_vsync->isChecked();
     Settings::Apply();
 }

--- a/src/citra_qt/configure_graphics.cpp
+++ b/src/citra_qt/configure_graphics.cpp
@@ -15,23 +15,23 @@ ConfigureGraphics::ConfigureGraphics(QWidget *parent) :
     ui->setupUi(this);
     this->setConfiguration();
 
-    ui->toogle_vsync->setEnabled(!System::IsPoweredOn());
+    ui->toggle_vsync->setEnabled(!System::IsPoweredOn());
 }
 
 ConfigureGraphics::~ConfigureGraphics() {
 }
 
 void ConfigureGraphics::setConfiguration() {
-    ui->toogle_hw_renderer->setChecked(Settings::values.use_hw_renderer);
-    ui->toogle_shader_jit->setChecked(Settings::values.use_shader_jit);
-    ui->toogle_scaled_resolution->setChecked(Settings::values.use_scaled_resolution);
-    ui->toogle_vsync->setChecked(Settings::values.use_vsync);
+    ui->toggle_hw_renderer->setChecked(Settings::values.use_hw_renderer);
+    ui->toggle_shader_jit->setChecked(Settings::values.use_shader_jit);
+    ui->toggle_scaled_resolution->setChecked(Settings::values.use_scaled_resolution);
+    ui->toggle_vsync->setChecked(Settings::values.use_vsync);
 }
 
 void ConfigureGraphics::applyConfiguration() {
-    Settings::values.use_hw_renderer = ui->toogle_hw_renderer->isChecked();
-    Settings::values.use_shader_jit = ui->toogle_shader_jit->isChecked();
-    Settings::values.use_scaled_resolution = ui->toogle_scaled_resolution->isChecked();
-    Settings::values.use_vsync = ui->toogle_vsync->isChecked();
+    Settings::values.use_hw_renderer = ui->toggle_hw_renderer->isChecked();
+    Settings::values.use_shader_jit = ui->toggle_shader_jit->isChecked();
+    Settings::values.use_scaled_resolution = ui->toggle_scaled_resolution->isChecked();
+    Settings::values.use_vsync = ui->toggle_vsync->isChecked();
     Settings::Apply();
 }

--- a/src/citra_qt/configure_graphics.h
+++ b/src/citra_qt/configure_graphics.h
@@ -1,0 +1,29 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include <QWidget>
+
+namespace Ui {
+class ConfigureGraphics;
+}
+
+class ConfigureGraphics : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit ConfigureGraphics(QWidget *parent = nullptr);
+    ~ConfigureGraphics();
+
+    void applyConfiguration();
+
+private:
+    void setConfiguration();
+
+private:
+    std::unique_ptr<Ui::ConfigureGraphics> ui;
+};

--- a/src/citra_qt/configure_graphics.ui
+++ b/src/citra_qt/configure_graphics.ui
@@ -43,6 +43,13 @@
              </property>
            </widget>
          </item>
+         <item>
+           <widget class="QCheckBox" name="toogle_vsync">
+             <property name="text">
+               <string>Enable V-Sync</string>
+             </property>
+           </widget>
+         </item>
        </layout>
       </widget>
      </item>

--- a/src/citra_qt/configure_graphics.ui
+++ b/src/citra_qt/configure_graphics.ui
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConfigureGraphics</class>
+ <widget class="QWidget" name="ConfigureGraphics">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout_3">
+     <item>
+      <widget class="QGroupBox" name="groupBox">
+       <property name="title">
+        <string>Graphics</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+         <item>
+           <widget class="QCheckBox" name="toogle_hw_renderer">
+             <property name="text">
+               <string>Enable hardware renderer</string>
+             </property>
+           </widget>
+         </item>
+         <item>
+           <widget class="QCheckBox" name="toogle_shader_jit">
+             <property name="text">
+               <string>Enable shader JIT</string>
+             </property>
+           </widget>
+         </item>
+         <item>
+           <widget class="QCheckBox" name="toogle_scaled_resolution">
+             <property name="text">
+               <string>Enable scaled resolution</string>
+             </property>
+           </widget>
+         </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>toogle_gdbstub</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>gdbport_spinbox</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>84</x>
+     <y>157</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>342</x>
+     <y>158</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/citra_qt/configure_graphics.ui
+++ b/src/citra_qt/configure_graphics.ui
@@ -23,28 +23,28 @@
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_2">
          <item>
-           <widget class="QCheckBox" name="toogle_hw_renderer">
+           <widget class="QCheckBox" name="toggle_hw_renderer">
              <property name="text">
                <string>Enable hardware renderer</string>
              </property>
            </widget>
          </item>
          <item>
-           <widget class="QCheckBox" name="toogle_shader_jit">
+           <widget class="QCheckBox" name="toggle_shader_jit">
              <property name="text">
                <string>Enable shader JIT</string>
              </property>
            </widget>
          </item>
          <item>
-           <widget class="QCheckBox" name="toogle_scaled_resolution">
+           <widget class="QCheckBox" name="toggle_scaled_resolution">
              <property name="text">
                <string>Enable scaled resolution</string>
              </property>
            </widget>
          </item>
          <item>
-           <widget class="QCheckBox" name="toogle_vsync">
+           <widget class="QCheckBox" name="toggle_vsync">
              <property name="text">
                <string>Enable V-Sync</string>
              </property>
@@ -73,7 +73,7 @@
  <resources/>
  <connections>
   <connection>
-   <sender>toogle_gdbstub</sender>
+   <sender>toggle_gdbstub</sender>
    <signal>toggled(bool)</signal>
    <receiver>gdbport_spinbox</receiver>
    <slot>setEnabled(bool)</slot>

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -243,7 +243,9 @@ bool GMainWindow::InitializeSystem() {
     if (emu_thread != nullptr)
         ShutdownGame();
 
+    render_window->InitRenderTarget();
     render_window->MakeCurrent();
+
     if (!gladLoadGL()) {
         QMessageBox::critical(this, tr("Error while starting Citra!"),
                               tr("Failed to initialize the video core!\n\n"

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -72,6 +72,7 @@ struct Values {
     bool use_hw_renderer;
     bool use_shader_jit;
     bool use_scaled_resolution;
+    bool use_vsync;
 
     float bg_red;
     float bg_green;

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -17,6 +17,8 @@
 
 namespace System {
 
+static bool is_powered_on{ false };
+
 Result Init(EmuWindow* emu_window) {
     Core::Init();
     CoreTiming::Init();
@@ -30,7 +32,13 @@ Result Init(EmuWindow* emu_window) {
     AudioCore::Init();
     GDBStub::Init();
 
+    is_powered_on = true;
+
     return Result::Success;
+}
+
+bool IsPoweredOn() {
+    return is_powered_on;
 }
 
 void Shutdown() {
@@ -42,6 +50,8 @@ void Shutdown() {
     HW::Shutdown();
     CoreTiming::Shutdown();
     Core::Shutdown();
+
+    is_powered_on = false;
 }
 
 } // namespace

--- a/src/core/system.h
+++ b/src/core/system.h
@@ -16,6 +16,7 @@ enum class Result {
 };
 
 Result Init(EmuWindow* emu_window);
+bool IsPoweredOn();
 void Shutdown();
 
 }

--- a/src/video_core/video_core.cpp
+++ b/src/video_core/video_core.cpp
@@ -22,6 +22,7 @@ std::unique_ptr<RendererBase> g_renderer;             ///< Renderer plugin
 std::atomic<bool> g_hw_renderer_enabled;
 std::atomic<bool> g_shader_jit_enabled;
 std::atomic<bool> g_scaled_resolution_enabled;
+std::atomic<bool> g_vsync_enabled;
 
 /// Initialize the video core
 bool Init(EmuWindow* emu_window) {


### PR DESCRIPTION
Adds a new tab to the Qt Configuration UI for graphics settings, and moves relevant settings there. Also adds a setting to enable V-Sync, mostly just as a quick & easy frame limiter until we have a better solution. Obligatory screenshot:

![](http://i.imgur.com/0nC627y.png)