### PR TITLE
OpenGL: Avoid error on unsupported lighting LUT

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -400,6 +400,7 @@ static void WriteLighting(std::string& out, const PicaShaderConfig& config) {
         default:
             LOG_CRITICAL(HW_GPU, "Unknown lighting LUT input %d\n", (int)input);
             UNIMPLEMENTED();
+            index = "0.0";
             break;
         }
 


### PR DESCRIPTION
Apparently kids these days don't know how to code.
This error came up so often on the forums that I felt like it was easier to finally push my ~~fix~~ workaround for it, instead of telling them what to do again (which usually resulted in more questions).

---

Essentially all this does is add a dummy zero constant into the shader in case of an unimplemented branch (which still gives a critical log error).
This avoids generating invalid shaders which would stop execution due to the uniform block size mismatch.

IIRC there is a similar case elsewhere in that code but I don't remember exactly. If the error comes up on the forums again I'll be here with a follow-up PR.

---

This shouldn't really change anything aside from preventing a ~~crash~~ failed assertion on entering World 1-1 in Super Mario 3D Land. I've [mentioned said error here](https://github.com/citra-emu/citra/issues/1981#issuecomment-235861835). I'm not sure if #1981 is about this crash though.