### PR TITLE
Include the msvc runtime dlls with citra

### DIFF
--- a/src/citra_qt/CMakeLists.txt
+++ b/src/citra_qt/CMakeLists.txt
@@ -121,7 +121,11 @@ if (Qt5_FOUND AND MSVC)
         Qt5Widgets$<$<CONFIG:Debug>:d>.*
     )
     windows_copy_files(citra-qt ${Qt5_PLATFORMS_DIR} ${PLATFORMS} qwindows$<$<CONFIG:Debug>:d>.*)
+    # copy the msvc redistributable dlls to the folder
+    set(MSVC_REDIST_DIR "C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/redist/x64/Microsoft.VC140.CRT")
+    windows_copy_files(citra-qt ${MSVC_REDIST_DIR} ${DLL_DEST} *.dll)
 
+    unset(MSVC_REDIST_DIR)
     unset(Qt5_DLL_DIR)
     unset(Qt5_PLATFORMS_DIR)
     unset(DLL_DEST)


### PR DESCRIPTION
As a potential solution to the "download all the dlls" problem, just include the msvc runtime dlls in the msvc build.

There shouldn't be any issue with licensing really. https://www.visualstudio.com/en-us/downloads/2015-redistribution-vs#visual-c-runtime They are on the list of "okay to redistribute" and the license says that its fine as well https://msdn.microsoft.com/en-us/library/ms235299.aspx

Another solution is to do a silent install as part of the installer, but this patch is much simpler.

Edit: I tested this in a win 10 VM that didn't have the redistributables, and it worked. But further testing is always appreciated.