### PR TITLE
Fix mingw64 builds and setup gcc on appveyor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,15 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if (NOT MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-attributes")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+
+    if (MINGW)
+        add_definitions(-DMINGW_HAS_SECURE_API)
+        if (MINGW_STATIC_BUILD)
+            add_definitions(-DQT_STATICPLUGIN)
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static")
+            set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
+        endif()
+    endif()
 else()
     # Silence "deprecation" warnings
     add_definitions(/D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_DEPRECATE /D_SCL_SECURE_NO_WARNINGS)
@@ -166,9 +175,8 @@ IF (APPLE)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -stdlib=libc++")
 ELSEIF(MINGW)
-    # GCC does not support codecvt, so use iconv instead
     # PSAPI is the Process Status API
-    set(PLATFORM_LIBRARIES winmm ws2_32 psapi iconv)
+    set(PLATFORM_LIBRARIES winmm ws2_32 psapi imm32 version)
 
     # WSAPoll functionality doesn't exist before WinNT 6.x (Vista and up)
     add_definitions(-D_WIN32_WINNT=0x0600)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,9 @@
 clone_depth: 5
 
 environment:
+  matrix:
+    - BUILD_TYPE: mingw
+    - BUILD_TYPE: msvc
   BUILD_PASSWORD:
     secure: EXGNlWKJsCtbeImEJ5EP9qrxZ+EqUFfNy+CP61nDOMA=
 
@@ -19,25 +22,63 @@ configuration:
 
 install:
   - git submodule update --init --recursive
+  - ps: >
+        if ($env:BUILD_TYPE -eq 'mingw') {
+          # redirect err to null to prevent warnings from becoming errors
+          # workaround for cyclical dependancies
+          C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S mingw64/mingw-w64-x86_64-freetype mingw64/mingw-w64-x86_64-fontconfig" 2> $null
+          C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S mingw64/mingw-w64-x86_64-cmake mingw64/mingw-w64-x86_64-qt5 mingw64/mingw-w64-x86_64-SDL2" 2> $null
+        }
 
 before_build:
-  - mkdir build
-  - cd build
-  - cmake -G "Visual Studio 14 2015 Win64" -DCITRA_USE_BUNDLED_QT=1 -DCITRA_USE_BUNDLED_SDL2=1 ..
+  - mkdir %BUILD_TYPE%build
+  - cd %BUILD_TYPE%build
+  - ps: >
+        if ($env:BUILD_TYPE -eq 'msvc') {
+          cmake -G "Visual Studio 14 2015 Win64" -DCITRA_USE_BUNDLED_QT=1 -DCITRA_USE_BUNDLED_SDL2=1 ..
+        } else {
+          $old_path = $env:Path
+          # Change path to just include the mingw gcc and *not* sh.exe (which breaks things when using MinGW Makefiles)
+          $env:Path = "C:\msys64\mingw64\bin\;"
+          # make sure error output from this command isn't interpreted as an error in powershell
+          C:\Windows\System32\cmd /c 'C:\msys64\mingw64\bin\cmake -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DQt5_DIR=C:/msys64/mingw64/qt5/lib/cmake/Qt5/ -DSDL2_INCLUDE_DIR=C:/msys64/mingw64/include/SDL2/ -DSDL2_LIBRARY=C:/msys64/mingw64/bin/SDL2.dll .. 2>&1'
+          $env:Path = $old_path
+        }
   - cd ..
 
-build:
-  project: build/citra.sln
-  parallel: true
+build_script:
+  - ps: >
+        if ($env:BUILD_TYPE -eq 'msvc') {
+          # https://www.appveyor.com/docs/build-phase
+          msbuild msvcbuild/citra.sln /maxcpucount /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+        } else {
+          $env:Path = "C:\msys64\mingw64\bin\;" + $env:Path
+          C:\Windows\System32\cmd /c "C:\msys64\mingw64\bin\mingw32-make -C mingwbuild/ -j${env:NUMBER_OF_PROCESSORS} 2>&1"
+        }
 
 test_script:
-  - cd build && ctest -VV -C Release && cd ..
+  - cd %BUILD_TYPE%build && ctest -VV -C Release && cd ..
+
+after_build:
+  - ps: >
+        if ($env:BUILD_TYPE -eq 'mingw') {
+          cmd /c "7z a citra.7z ${env:APPVEYOR_BUILD_FOLDER}\mingwbuild\src\citra\citra.exe ${env:APPVEYOR_BUILD_FOLDER}\mingwbuild\src\citra_qt\citra-qt.exe"
+          cd C:\msys64\mingw64\bin
+          cmd /c "7z a ${env:APPVEYOR_BUILD_FOLDER}\citra.7z Qt5Core.dll Qt5Widgets.dll Qt5Gui.dll Qt5OpenGL.dll"
+          cmd /c "7z a ${env:APPVEYOR_BUILD_FOLDER}\citra.7z libbz2-1.dll libicudt56.dll libicuin56.dll libicuuc56.dll libffi-6.dll libfreetype-6.dll libgcc_s_seh-1.dll libglib-2.0-0.dll libgobject-2.0-0.dll libgraphite2.dll libiconv-2.dll libharfbuzz-0.dll libintl-8.dll libpcre-1.dll libpcre16-0.dll libpng16-16.dll libstdc++-6.dll libwinpthread-1.dll SDL2.dll zlib1.dll"
+          cd C:\msys64\mingw64\share\qt5
+          cmd /c "7z a ${env:APPVEYOR_BUILD_FOLDER}\citra.7z plugins\platforms\qwindows.dll"
+          cd ${env:APPVEYOR_BUILD_FOLDER}
+        }
+
+artifacts:
+  - path: citra.7z
+    name: CitraGCC
 
 on_success:
     # copying the needed QT Dlls is now done post build. See the CMakeLists.txt file in the citra-qt folder
   - ps: >
-        if (!"$env:APPVEYOR_PULL_REQUEST_TITLE" -and ("$env:APPVEYOR_REPO_BRANCH" -eq "master"))
-          {
+        if (!"$env:APPVEYOR_PULL_REQUEST_TITLE" -and ("$env:APPVEYOR_REPO_BRANCH" -eq "master")) {
             $GITDATE = $(git show -s --date=short --format='%ad') -replace "-",""
             $GITREV = $(git show -s --format='%h')
             # Where are these spaces coming from? Regardless, let's remove them
@@ -56,8 +97,6 @@ on_success:
             7z a $BUILD_NAME .\build\bin\release\* .\license.txt .\README.md
             # Do a second archive with only the binaries (excludes dlls) and documentation
             7z a $BUILD_NAME_NOQT .\build\bin\release\*.exe .\license.txt .\README.md
-
-
             # Download WinSCP and upload to server
             choco install winscp.portable
             WinSCP.exe /command `
@@ -68,4 +107,4 @@ on_success:
                 "put $BUILD_NAME_NOQT /citra/nightly/windows-noqt-amd64/" `
                 "put $BUILD_NAME_PDB /citra/nightly/windows-amd64-debugsymbols/" `
                 "exit"
-          }
+        }

--- a/externals/microprofile/microprofile.h
+++ b/externals/microprofile/microprofile.h
@@ -512,7 +512,7 @@ typedef int MpSocket;
 
 #if defined(__APPLE__) || defined(__linux__)
 typedef pthread_t MicroProfileThread;
-#elif defined(_WIN32)
+#elif defined(_MSC_VER)
 typedef HANDLE MicroProfileThread;
 #else
 typedef std::thread* MicroProfileThread;
@@ -921,7 +921,7 @@ void MicroProfileThreadJoin(MicroProfileThread* pThread)
     int r = pthread_join(*pThread, 0);
     MP_ASSERT(r == 0);
 }
-#elif defined(_WIN32)
+#elif defined(_MSC_VER)
 typedef HANDLE MicroProfileThread;
 DWORD _stdcall ThreadTrampoline(void* pFunc)
 {

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -55,6 +55,10 @@
 
 #include "video_core/video_core.h"
 
+#ifdef QT_STATICPLUGIN
+Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
+#endif
+
 GMainWindow::GMainWindow() : config(new Config()), emu_thread(nullptr)
 {
     Pica::g_debug_context = Pica::DebugContext::Construct();

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -13,7 +13,7 @@
 #include "common/logging/log.h"
 #include "common/string_util.h"
 
-#ifdef _MSC_VER
+#ifdef _WIN32
     #include <Windows.h>
     #include <codecvt>
     #include "common/common_funcs.h"
@@ -292,7 +292,7 @@ std::string ReplaceAll(std::string result, const std::string& src, const std::st
     return result;
 }
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 
 std::string UTF16ToUTF8(const std::u16string& input)
 {

--- a/src/core/gdbstub/gdbstub.cpp
+++ b/src/core/gdbstub/gdbstub.cpp
@@ -14,7 +14,7 @@
 #include <map>
 #include <numeric>
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #include <WinSock2.h>
 #include <ws2tcpip.h>
 #include <common/x64/abi.h>


### PR DESCRIPTION
This pr is setup to compile both msvc and gcc builds with appveyor. The gcc builds are uploaded to appveyor as an artifact. I figured its a good enough place to store it for now while we still determine which build is hosted on builds.citra-emu.org and maybe consider other hosting options and still allow people to test out games and stuff with the build. The PR has the ability to build static as well. I put the option as MINGW_STATIC_BUILD, but those commands would probably work just fine for linux as well. (I just doubt anyone on linux wants a static build)

The zip file is not named with the git version because I don't know how that would work with the artifacts. The latest build is hosted here https://ci.appveyor.com/api/projects/bunnei/citra/artifacts/citra.7z Another way to find a mingw build for a certain branch (if this is merged into master) is just browse https://ci.appveyor.com/project/bunnei/citra/history to find the build you want to download 

TODO
- [x] Add license file like the msvc build 
- [x] Figure out what to do with the builds
- [x] Test this out with dynARMic 

Also: I am trying to upstream the changes to microprofile. You can see the PR here https://bitbucket.org/jonasmeyer/microprofile/pull-requests/9/fix-compliation-on-mingw64-on-windows/diff I don't know if I should leave the changes in this PR or just make another PR to update microprofile since updating might break other things.
