### PR TITLE
travis: Update to XCode 7.3.1

### DIFF
--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -23,11 +23,12 @@ if [ "$TRAVIS_OS_NAME" = "linux" -o -z "$TRAVIS_OS_NAME" ]; then
 elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
     set -o pipefail
 
+    export MACOSX_DEPLOYMENT_TARGET=10.9
     export Qt5_DIR=$(brew --prefix)/opt/qt5
 
     mkdir build && cd build
     cmake .. -GXcode
-    xcodebuild -configuration Release | xcpretty -c
+    xcodebuild -configuration Release
 
     ctest -VV -C Release
 fi

--- a/.travis-deps.sh
+++ b/.travis-deps.sh
@@ -20,7 +20,6 @@ if [ "$TRAVIS_OS_NAME" = "linux" -o -z "$TRAVIS_OS_NAME" ]; then
     )
 elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
     brew update > /dev/null # silence the very verbose output
-    brew unlink cmake
+    brew unlink cmake || true
     brew install cmake qt5 sdl2 dylibbundler
-    gem install xcpretty
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ matrix:
       dist: trusty
     - os: osx
       sudo: false
+      osx_image: xcode7.3
 
 env:
   global:


### PR DESCRIPTION
Xcode 7.3.1 provides a compiler with better C++14 support compared to [Xcode 6.1](https://docs.travis-ci.com/user/languages/objective-c/#Supported-OS-X-iOS-SDK-versions) which Travis uses by default.

Had to remove `xcpretty` (log prettyfier) because the version of Ruby provided on these images was segfaulting!

I've set `MACOSX_DEPLOYMENT_TARGET=10.9` so we're still producing a OS X 10.9 compatible build despite using a 10.11 build machine.