### PR TITLE
Check for invalid TextureCopy size when copying

### DIFF
--- a/src/core/hw/gpu.cpp
+++ b/src/core/hw/gpu.cpp
@@ -187,6 +187,14 @@ inline void Write(u32 addr, const T data) {
                     u32 output_width = config.texture_copy.output_width * 16;
                     u32 output_gap = config.texture_copy.output_gap * 16;
 
+                    if (input_width == 0) {
+                        input_width = 1024 * 16;
+                    }
+
+                    if (output_width == 0) {
+                        output_width = 1024 * 16;
+                    }
+
                     size_t contiguous_input_size = config.texture_copy.size / input_width * (input_width + input_gap);
                     Memory::RasterizerFlushRegion(config.GetPhysicalInputAddress(), static_cast<u32>(contiguous_input_size));
 


### PR DESCRIPTION
Fixes #1682, #2005 and likely #1928

This commit implements a check on both the input and output width when copying a texture. While this doesn't fix any potential underlying issues, it does provide the following:
- Proper logging and handling of this behavior
- Allows games which utilize this behavior to execute with no noticeable glitch

Breaking from this new block is required as the loop which follows stalls when attempting to copy a zero-sized texture.