### PR TITLE
audio_core: Tweak audio latency

### DIFF
--- a/src/audio_core/hle/dsp.cpp
+++ b/src/audio_core/hle/dsp.cpp
@@ -105,7 +105,7 @@ static void OutputCurrentFrame(const StereoFrame16& frame) {
         std::vector<s16> stretched_samples = time_stretcher.Process(sink->SamplesInQueue());
         sink->EnqueueSamples(stretched_samples.data(), stretched_samples.size() / 2);
     } else {
-        constexpr size_t maximum_sample_latency = 1024; // about 32 miliseconds
+        constexpr size_t maximum_sample_latency = 2048; // about 64 miliseconds
         if (sink->SamplesInQueue() > maximum_sample_latency) {
             // This can occur if we're running too fast and samples are starting to back up.
             // Just drop the samples.

--- a/src/audio_core/sdl2_sink.cpp
+++ b/src/audio_core/sdl2_sink.cpp
@@ -38,7 +38,7 @@ SDL2Sink::SDL2Sink() : impl(std::make_unique<Impl>()) {
     desired_audiospec.format = AUDIO_S16;
     desired_audiospec.channels = 2;
     desired_audiospec.freq = native_sample_rate;
-    desired_audiospec.samples = 1024;
+    desired_audiospec.samples = 512;
     desired_audiospec.userdata = impl.get();
     desired_audiospec.callback = &Impl::Callback;
 


### PR DESCRIPTION
Fiddling with numbers.

Outputting 1024 samples and dropping samples after 1024 gave pretty much no slack to timing issues.