### PR TITLE
Add likely() and unlikely() macros in common_funcs, and use them in GetUserPath().

### DIFF
--- a/src/common/common_funcs.h
+++ b/src/common/common_funcs.h
@@ -29,6 +29,14 @@
     #define FORCE_INLINE inline __attribute__((always_inline))
 #endif
 
+#if defined(__GNUC__)
+    #define likely(x) __builtin_expect(!!(x), 1)
+    #define unlikely(x) __builtin_expect(!!(x), 0)
+#else
+    #define likely(x) (x)
+    #define unlikely(x) (x)
+#endif
+
 #ifndef _MSC_VER
 
 #ifdef ARCHITECTURE_x86_64

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -727,7 +727,7 @@ const std::string& GetUserPath(const unsigned int DirIDX, const std::string &new
     static std::string paths[NUM_PATH_INDICES];
 
     // Set up all paths and files on the first run
-    if (paths[D_USER_IDX].empty())
+    if (unlikely(paths[D_USER_IDX].empty()))
     {
 #ifdef _WIN32
         paths[D_USER_IDX]   = GetExeDirectory() + DIR_SEP USERDATA_DIR DIR_SEP;
@@ -768,7 +768,7 @@ const std::string& GetUserPath(const unsigned int DirIDX, const std::string &new
         paths[F_MAINLOG_IDX]        = paths[D_LOGS_IDX] + MAIN_LOG;
     }
 
-    if (!newPath.empty())
+    if (unlikely(!newPath.empty()))
     {
         if (!FileUtil::IsDirectory(newPath))
         {


### PR DESCRIPTION
This helps with code locality when optimising for the common path.