### PR TITLE
Qt: fix birthday combo box updating

### DIFF
--- a/src/citra_qt/configure_system.cpp
+++ b/src/citra_qt/configure_system.cpp
@@ -18,9 +18,9 @@ ConfigureSystem::ConfigureSystem(QWidget *parent) :
     QWidget(parent),
     ui(new Ui::ConfigureSystem) {
     ui->setupUi(this);
-    this->setConfiguration();
-
     connect(ui->combo_birthmonth, SIGNAL(currentIndexChanged(int)), SLOT(updateBirthdayComboBox(int)));
+
+    this->setConfiguration();
 }
 
 ConfigureSystem::~ConfigureSystem() {
@@ -60,6 +60,7 @@ void ConfigureSystem::ReadSystemSettings() {
     // set birthday
     std::tie(birthmonth, birthday) = Service::CFG::GetBirthday();
     ui->combo_birthmonth->setCurrentIndex(birthmonth - 1);
+    updateBirthdayComboBox(birthmonth - 1); // explicitly update it because the signal from setCurrentIndex is not reliable
     ui->combo_birthday->setCurrentIndex(birthday - 1);
 
     // set system language


### PR DESCRIPTION
Fix a bug in #2044 and a hidden bug long ago (Sorry!). ~~The birthday combo box didn't get filled properly because the signal-slot connection was performed after reading system setting data. Now the connection is moved to the ui file. the code order is changed. Also explicitly update the combo box in `ReadSystemSetting` because `setCurrentIndex` won't always emit `currentIndexChanged` - if `setCurrentIndex` sets the same index as it was (in this case, if the birthday is in January), `currentIndexChanged` won't be emitted.~~

The old bug: when the birthday is in January, `setCurrentIndex` in `ReadSystemSetting` won't emit `currentIndexChanged` because the index doesn't actually get changed, resulting birthday combo box unfilled.

Bug in #2044, the `ReadSystemSetting` call moves before the connecting, and `setCurrentIndex` will never fill the birthday combo box.

Solution: just explicitly call the updating funcion.

In addition, switched the order of connection and `ReadSystemSetting` call
>[yuriks] wwylele: I think it's good for code cleanliness to call the connect before calling the initialize function anyway