### PR TITLE
Fix/mask crash in shader debugger in Mii Maker

### DIFF
--- a/src/common/vector_math.h
+++ b/src/common/vector_math.h
@@ -60,7 +60,6 @@ public:
     }
 
     Vec2() = default;
-    Vec2(const T a[2]) : x(a[0]), y(a[1]) {}
     Vec2(const T& _x, const T& _y) : x(_x), y(_y) {}
 
     template <typename T2>
@@ -199,7 +198,6 @@ public:
     }
 
     Vec3() = default;
-    Vec3(const T a[3]) : x(a[0]), y(a[1]), z(a[2]) {}
     Vec3(const T& _x, const T& _y, const T& _z) : x(_x), y(_y), z(_z) {}
 
     template <typename T2>
@@ -405,7 +403,6 @@ public:
     }
 
     Vec4() = default;
-    Vec4(const T a[4]) : x(a[0]), y(a[1]), z(a[2]), w(a[3]) {}
     Vec4(const T& _x, const T& _y, const T& _z, const T& _w) : x(_x), y(_y), z(_z), w(_w) {}
 
     template <typename T2>

--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -146,10 +146,8 @@ DebugData<true> ShaderSetup::ProduceDebugInfo(const InputVertex& input, int num_
     state.debug.max_opdesc_id = 0;
 
     // Setup input register table
+    boost::fill(state.registers.input, Math::Vec4<float24>::AssignToAll(float24::Zero()));
     const auto& attribute_register_map = config.input_register_map;
-    float24 dummy_register;
-    boost::fill(state.registers.input, &dummy_register);
-
     for (unsigned i = 0; i < num_attributes; i++)
         state.registers.input[attribute_register_map.GetRegisterForAttribute(i)] = input.attr[i];
 

--- a/src/video_core/shader/shader_interpreter.cpp
+++ b/src/video_core/shader/shader_interpreter.cpp
@@ -116,32 +116,36 @@ void RunInterpreter(const ShaderSetup& setup, UnitState<Debug>& state, unsigned 
                     : state.address_registers[instr.common.address_register_index - 1];
 
             const float24* src1_ = LookupSourceRegister(instr.common.GetSrc1(is_inverted) +
-                                                        (!is_inverted * address_offset));
+                                                        (is_inverted ? 0 : address_offset));
             const float24* src2_ = LookupSourceRegister(instr.common.GetSrc2(is_inverted) +
-                                                        (is_inverted * address_offset));
+                                                        (is_inverted ? address_offset : 0));
 
             const bool negate_src1 = ((bool)swizzle.negate_src1 != false);
             const bool negate_src2 = ((bool)swizzle.negate_src2 != false);
 
             float24 src1[4] = {
-                src1_[(int)swizzle.GetSelectorSrc1(0)], src1_[(int)swizzle.GetSelectorSrc1(1)],
-                src1_[(int)swizzle.GetSelectorSrc1(2)], src1_[(int)swizzle.GetSelectorSrc1(3)],
+                src1_[(int)swizzle.src1_selector_0.Value()],
+                src1_[(int)swizzle.src1_selector_1.Value()],
+                src1_[(int)swizzle.src1_selector_2.Value()],
+                src1_[(int)swizzle.src1_selector_3.Value()],
             };
             if (negate_src1) {
-                src1[0] = src1[0] * float24::FromFloat32(-1);
-                src1[1] = src1[1] * float24::FromFloat32(-1);
-                src1[2] = src1[2] * float24::FromFloat32(-1);
-                src1[3] = src1[3] * float24::FromFloat32(-1);
+                src1[0] = -src1[0];
+                src1[1] = -src1[1];
+                src1[2] = -src1[2];
+                src1[3] = -src1[3];
             }
             float24 src2[4] = {
-                src2_[(int)swizzle.GetSelectorSrc2(0)], src2_[(int)swizzle.GetSelectorSrc2(1)],
-                src2_[(int)swizzle.GetSelectorSrc2(2)], src2_[(int)swizzle.GetSelectorSrc2(3)],
+                src2_[(int)swizzle.src2_selector_0.Value()],
+                src2_[(int)swizzle.src2_selector_1.Value()],
+                src2_[(int)swizzle.src2_selector_2.Value()],
+                src2_[(int)swizzle.src2_selector_3.Value()],
             };
             if (negate_src2) {
-                src2[0] = src2[0] * float24::FromFloat32(-1);
-                src2[1] = src2[1] * float24::FromFloat32(-1);
-                src2[2] = src2[2] * float24::FromFloat32(-1);
-                src2[3] = src2[3] * float24::FromFloat32(-1);
+                src2[0] = -src2[0];
+                src2[1] = -src2[1];
+                src2[2] = -src2[2];
+                src2[3] = -src2[3];
             }
 
             float24* dest =
@@ -451,34 +455,40 @@ void RunInterpreter(const ShaderSetup& setup, UnitState<Debug>& state, unsigned 
                 const bool negate_src3 = ((bool)swizzle.negate_src3 != false);
 
                 float24 src1[4] = {
-                    src1_[(int)swizzle.GetSelectorSrc1(0)], src1_[(int)swizzle.GetSelectorSrc1(1)],
-                    src1_[(int)swizzle.GetSelectorSrc1(2)], src1_[(int)swizzle.GetSelectorSrc1(3)],
+                    src1_[(int)swizzle.src1_selector_0.Value()],
+                    src1_[(int)swizzle.src1_selector_1.Value()],
+                    src1_[(int)swizzle.src1_selector_2.Value()],
+                    src1_[(int)swizzle.src1_selector_3.Value()],
                 };
                 if (negate_src1) {
-                    src1[0] = src1[0] * float24::FromFloat32(-1);
-                    src1[1] = src1[1] * float24::FromFloat32(-1);
-                    src1[2] = src1[2] * float24::FromFloat32(-1);
-                    src1[3] = src1[3] * float24::FromFloat32(-1);
+                    src1[0] = -src1[0];
+                    src1[1] = -src1[1];
+                    src1[2] = -src1[2];
+                    src1[3] = -src1[3];
                 }
                 float24 src2[4] = {
-                    src2_[(int)swizzle.GetSelectorSrc2(0)], src2_[(int)swizzle.GetSelectorSrc2(1)],
-                    src2_[(int)swizzle.GetSelectorSrc2(2)], src2_[(int)swizzle.GetSelectorSrc2(3)],
+                    src2_[(int)swizzle.src2_selector_0.Value()],
+                    src2_[(int)swizzle.src2_selector_1.Value()],
+                    src2_[(int)swizzle.src2_selector_2.Value()],
+                    src2_[(int)swizzle.src2_selector_3.Value()],
                 };
                 if (negate_src2) {
-                    src2[0] = src2[0] * float24::FromFloat32(-1);
-                    src2[1] = src2[1] * float24::FromFloat32(-1);
-                    src2[2] = src2[2] * float24::FromFloat32(-1);
-                    src2[3] = src2[3] * float24::FromFloat32(-1);
+                    src2[0] = -src2[0];
+                    src2[1] = -src2[1];
+                    src2[2] = -src2[2];
+                    src2[3] = -src2[3];
                 }
                 float24 src3[4] = {
-                    src3_[(int)swizzle.GetSelectorSrc3(0)], src3_[(int)swizzle.GetSelectorSrc3(1)],
-                    src3_[(int)swizzle.GetSelectorSrc3(2)], src3_[(int)swizzle.GetSelectorSrc3(3)],
+                    src3_[(int)swizzle.src3_selector_0.Value()],
+                    src3_[(int)swizzle.src3_selector_1.Value()],
+                    src3_[(int)swizzle.src3_selector_2.Value()],
+                    src3_[(int)swizzle.src3_selector_3.Value()],
                 };
                 if (negate_src3) {
-                    src3[0] = src3[0] * float24::FromFloat32(-1);
-                    src3[1] = src3[1] * float24::FromFloat32(-1);
-                    src3[2] = src3[2] * float24::FromFloat32(-1);
-                    src3[3] = src3[3] * float24::FromFloat32(-1);
+                    src3[0] = -src3[0];
+                    src3[1] = -src3[1];
+                    src3[2] = -src3[2];
+                    src3[3] = -src3[3];
                 }
 
                 float24* dest =


### PR DESCRIPTION
Stopping on a GPU breakpoint at certain points of Mii Maker causes a crash in the vertex shader interpreter as it tries to produce debug info using bogus vertex data. This fixes a bug which happens to stop triggering the crash, though the root causes (the debug info is generated even without valid vertex/shader data and the interpreter doesn't do proper bounds checks of data generated by the shader) remain.