### PR TITLE
OpenGL: Take cached viewport sub-rect into account for scissor

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -393,9 +393,6 @@ private:
     /// Syncs the depth test states to match the PICA register
     void SyncDepthTest();
 
-    /// Syncs the scissor test state to match the PICA register
-    void SyncScissorTest();
-
     /// Syncs the TEV combiner color buffer to match the PICA register
     void SyncCombinerColor();
 

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -645,11 +645,10 @@ vec4 secondary_fragment_color = vec4(0.0);
         // Negate the condition if we have to keep only the pixels outside the scissor box
         if (state.scissor_test_mode == Regs::ScissorMode::Include)
             out += "!";
-        // x2,y2 have +1 added to cover the entire pixel area
-        out += "(gl_FragCoord.x >= scissor_x1 * framebuffer_scale.x && "
-               "gl_FragCoord.y >= scissor_y1 * framebuffer_scale.y && "
-               "gl_FragCoord.x < (scissor_x2 + 1) * framebuffer_scale.x && "
-               "gl_FragCoord.y < (scissor_y2 + 1) * framebuffer_scale.y)) discard;\n";
+        out += "(gl_FragCoord.x >= scissor_x1 && "
+               "gl_FragCoord.y >= scissor_y1 && "
+               "gl_FragCoord.x < scissor_x2 && "
+               "gl_FragCoord.y < scissor_y2)) discard;\n";
     }
 
     out += "float z_over_w = 1.0 - gl_FragCoord.z * 2.0;\n";


### PR DESCRIPTION
Fixes #1938