### PR TITLE
Travis: Fix OS X build

### DIFF
--- a/.travis-deps.sh
+++ b/.travis-deps.sh
@@ -28,7 +28,6 @@ if [ "$TRAVIS_OS_NAME" = "linux" -o -z "$TRAVIS_OS_NAME" ]; then
     fi
 
 elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
-    brew update > /dev/null # silence the very verbose output
-    brew unlink cmake || true
+    brew update
     brew install cmake qt5 sdl2 dylibbundler
 fi


### PR DESCRIPTION
Probably due to additional Travis caching, cmake is now already
installed when the script runs. This causes the unlink to remove the
symlink to the executable, which is then not re-added by the install
(since it's already installed).