### PR TITLE
Fix clang-format lint

### DIFF
--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -17,7 +17,7 @@ if [ "$TRAVIS_OS_NAME" = "linux" ]; then
 
     if [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then
         # Get list of every file modified in this pull request
-        files_to_lint="$(git diff --name-only --diff-filter=ACMRTUXB $TRAVIS_COMMIT_RANGE | grep '^src/[^.]*[.]\(cpp\|h\)$')"
+        files_to_lint="$(git diff --name-only --diff-filter=ACMRTUXB $TRAVIS_COMMIT_RANGE | grep '^src/[^.]*[.]\(cpp\|h\)$' || true)"
     else
         # Check everything for branch pushes
         files_to_lint="$(find src/ -name '*.cpp' -or -name '*.h')"
@@ -27,7 +27,7 @@ if [ "$TRAVIS_OS_NAME" = "linux" ]; then
     set +x
 
     for f in $files_to_lint; do
-        d=$(diff -u "$f" <($CLANG_FORMAT "$f"))
+        d=$(diff -u "$f" <($CLANG_FORMAT "$f") || true)
         if ! [ -z "$d" ]; then
             echo "!!! $f not compliant to coding style, here is the fix:"
             echo "$d"


### PR DESCRIPTION
Fixed:
 - When clang-format found a problem, `diff` would return non-zero which terminated the build, before even print the lint.
 - If a PR didn't change any source code (like this), `git diff ` would return non-zero which terminated the build.