### PR TITLE
FS: implement DeleteDirectoryRecursively

### DIFF
--- a/src/core/file_sys/archive_backend.h
+++ b/src/core/file_sys/archive_backend.h
@@ -112,6 +112,13 @@ public:
     virtual bool DeleteDirectory(const Path& path) const = 0;
 
     /**
+     * Delete a directory specified by its path and anything under it
+     * @param path Path relative to the archive
+     * @return Whether the directory could be deleted
+     */
+    virtual bool DeleteDirectoryRecursively(const Path& path) const = 0;
+
+    /**
      * Create a file specified by its path
      * @param path Path relative to the Archive
      * @param size The size of the new file, filled with zeroes

--- a/src/core/file_sys/disk_archive.cpp
+++ b/src/core/file_sys/disk_archive.cpp
@@ -51,6 +51,10 @@ bool DiskArchive::DeleteDirectory(const Path& path) const {
     return FileUtil::DeleteDir(mount_point + path.AsString());
 }
 
+bool DiskArchive::DeleteDirectoryRecursively(const Path& path) const {
+    return FileUtil::DeleteDirRecursively(mount_point + path.AsString());
+}
+
 ResultCode DiskArchive::CreateFile(const FileSys::Path& path, u64 size) const {
     std::string full_path = mount_point + path.AsString();
 

--- a/src/core/file_sys/disk_archive.h
+++ b/src/core/file_sys/disk_archive.h
@@ -38,6 +38,7 @@ public:
     ResultCode DeleteFile(const Path& path) const override;
     bool RenameFile(const Path& src_path, const Path& dest_path) const override;
     bool DeleteDirectory(const Path& path) const override;
+    bool DeleteDirectoryRecursively(const Path& path) const override;
     ResultCode CreateFile(const Path& path, u64 size) const override;
     bool CreateDirectory(const Path& path) const override;
     bool RenameDirectory(const Path& src_path, const Path& dest_path) const override;

--- a/src/core/file_sys/ivfc_archive.cpp
+++ b/src/core/file_sys/ivfc_archive.cpp
@@ -43,6 +43,12 @@ bool IVFCArchive::DeleteDirectory(const Path& path) const {
     return false;
 }
 
+bool IVFCArchive::DeleteDirectoryRecursively(const Path& path) const {
+    LOG_CRITICAL(Service_FS, "Attempted to delete a directory from an IVFC archive (%s).",
+                 GetName().c_str());
+    return false;
+}
+
 ResultCode IVFCArchive::CreateFile(const Path& path, u64 size) const {
     LOG_CRITICAL(Service_FS, "Attempted to create a file in an IVFC archive (%s).",
                  GetName().c_str());

--- a/src/core/file_sys/ivfc_archive.h
+++ b/src/core/file_sys/ivfc_archive.h
@@ -37,6 +37,7 @@ public:
     ResultCode DeleteFile(const Path& path) const override;
     bool RenameFile(const Path& src_path, const Path& dest_path) const override;
     bool DeleteDirectory(const Path& path) const override;
+    bool DeleteDirectoryRecursively(const Path& path) const override;
     ResultCode CreateFile(const Path& path, u64 size) const override;
     bool CreateDirectory(const Path& path) const override;
     bool RenameDirectory(const Path& src_path, const Path& dest_path) const override;

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -362,6 +362,18 @@ ResultCode DeleteDirectoryFromArchive(ArchiveHandle archive_handle, const FileSy
                       ErrorSummary::Canceled, ErrorLevel::Status);
 }
 
+ResultCode DeleteDirectoryRecursivelyFromArchive(ArchiveHandle archive_handle,
+                                                 const FileSys::Path& path) {
+    ArchiveBackend* archive = GetArchive(archive_handle);
+    if (archive == nullptr)
+        return ERR_INVALID_ARCHIVE_HANDLE;
+
+    if (archive->DeleteDirectoryRecursively(path))
+        return RESULT_SUCCESS;
+    return ResultCode(ErrorDescription::NoData, ErrorModule::FS, // TODO: verify description
+                      ErrorSummary::Canceled, ErrorLevel::Status);
+}
+
 ResultCode CreateFileInArchive(ArchiveHandle archive_handle, const FileSys::Path& path,
                                u64 file_size) {
     ArchiveBackend* archive = GetArchive(archive_handle);

--- a/src/core/hle/service/fs/archive.h
+++ b/src/core/hle/service/fs/archive.h
@@ -133,6 +133,15 @@ ResultCode RenameFileBetweenArchives(ArchiveHandle src_archive_handle,
 ResultCode DeleteDirectoryFromArchive(ArchiveHandle archive_handle, const FileSys::Path& path);
 
 /**
+ * Delete a Directory and anything under it from an Archive
+ * @param archive_handle Handle to an open Archive object
+ * @param path Path to the Directory inside of the Archive
+ * @return Whether deletion succeeded
+ */
+ResultCode DeleteDirectoryRecursivelyFromArchive(ArchiveHandle archive_handle,
+                                                 const FileSys::Path& path);
+
+/**
  * Create a File in an Archive
  * @param archive_handle Handle to an open Archive object
  * @param path Path to the File inside of the Archive

--- a/src/core/hle/service/fs/fs_user.cpp
+++ b/src/core/hle/service/fs/fs_user.cpp
@@ -64,7 +64,7 @@ static void OpenFile(Service::Interface* self) {
     u32 filename_ptr = cmd_buff[9];
     FileSys::Path file_path(filename_type, filename_size, filename_ptr);
 
-    LOG_DEBUG(Service_FS, "path=%s, mode=%d attrs=%u", file_path.DebugStr().c_str(), mode.hex,
+    LOG_DEBUG(Service_FS, "path=%s, mode=%u attrs=%u", file_path.DebugStr().c_str(), mode.hex,
               attributes);
 
     ResultVal<SharedPtr<File>> file_res = OpenFileFromArchive(archive_handle, file_path, mode);
@@ -112,15 +112,15 @@ static void OpenFileDirectly(Service::Interface* self) {
     FileSys::Path archive_path(archivename_type, archivename_size, archivename_ptr);
     FileSys::Path file_path(filename_type, filename_size, filename_ptr);
 
-    LOG_DEBUG(Service_FS, "archive_id=0x%08X archive_path=%s file_path=%s, mode=%u attributes=%d",
-              archive_id, archive_path.DebugStr().c_str(), file_path.DebugStr().c_str(), mode.hex,
-              attributes);
+    LOG_DEBUG(Service_FS, "archive_id=0x%08X archive_path=%s file_path=%s, mode=%u attributes=%u",
+              static_cast<u32>(archive_id), archive_path.DebugStr().c_str(),
+              file_path.DebugStr().c_str(), mode.hex, attributes);
 
     ResultVal<ArchiveHandle> archive_handle = OpenArchive(archive_id, archive_path);
     if (archive_handle.Failed()) {
         LOG_ERROR(Service_FS,
                   "failed to get a handle for archive archive_id=0x%08X archive_path=%s",
-                  archive_id, archive_path.DebugStr().c_str());
+                  static_cast<u32>(archive_id), archive_path.DebugStr().c_str());
         cmd_buff[1] = archive_handle.Code().raw;
         cmd_buff[3] = 0;
         return;
@@ -133,7 +133,7 @@ static void OpenFileDirectly(Service::Interface* self) {
         cmd_buff[3] = Kernel::g_handle_table.Create(*file_res).MoveFrom();
     } else {
         cmd_buff[3] = 0;
-        LOG_ERROR(Service_FS, "failed to get a handle for file %s mode=%u attributes=%d",
+        LOG_ERROR(Service_FS, "failed to get a handle for file %s mode=%u attributes=%u",
                   file_path.DebugStr().c_str(), mode.hex, attributes);
     }
 }
@@ -159,7 +159,7 @@ static void DeleteFile(Service::Interface* self) {
 
     FileSys::Path file_path(filename_type, filename_size, filename_ptr);
 
-    LOG_DEBUG(Service_FS, "type=%d size=%d data=%s", filename_type, filename_size,
+    LOG_DEBUG(Service_FS, "type=%u size=%u data=%s", static_cast<u32>(filename_type), filename_size,
               file_path.DebugStr().c_str());
 
     cmd_buff[1] = DeleteFileFromArchive(archive_handle, file_path).raw;
@@ -198,9 +198,10 @@ static void RenameFile(Service::Interface* self) {
     FileSys::Path dest_file_path(dest_filename_type, dest_filename_size, dest_filename_ptr);
 
     LOG_DEBUG(Service_FS,
-              "src_type=%d src_size=%d src_data=%s dest_type=%d dest_size=%d dest_data=%s",
-              src_filename_type, src_filename_size, src_file_path.DebugStr().c_str(),
-              dest_filename_type, dest_filename_size, dest_file_path.DebugStr().c_str());
+              "src_type=%u src_size=%u src_data=%s dest_type=%u dest_size=%u dest_data=%s",
+              static_cast<u32>(src_filename_type), src_filename_size,
+              src_file_path.DebugStr().c_str(), static_cast<u32>(dest_filename_type),
+              dest_filename_size, dest_file_path.DebugStr().c_str());
 
     cmd_buff[1] = RenameFileBetweenArchives(src_archive_handle, src_file_path, dest_archive_handle,
                                             dest_file_path)
@@ -228,7 +229,7 @@ static void DeleteDirectory(Service::Interface* self) {
 
     FileSys::Path dir_path(dirname_type, dirname_size, dirname_ptr);
 
-    LOG_DEBUG(Service_FS, "type=%d size=%d data=%s", dirname_type, dirname_size,
+    LOG_DEBUG(Service_FS, "type=%u size=%u data=%s", static_cast<u32>(dirname_type), dirname_size,
               dir_path.DebugStr().c_str());
 
     cmd_buff[1] = DeleteDirectoryFromArchive(archive_handle, dir_path).raw;
@@ -257,7 +258,7 @@ static void DeleteDirectoryRecursively(Service::Interface* self) {
 
     FileSys::Path dir_path(dirname_type, dirname_size, dirname_ptr);
 
-    LOG_DEBUG(Service_FS, "type=%d size=%d data=%s", dirname_type, dirname_size,
+    LOG_DEBUG(Service_FS, "type=%u size=%u data=%s", static_cast<u32>(dirname_type), dirname_size,
               dir_path.DebugStr().c_str());
 
     cmd_buff[1] = DeleteDirectoryRecursivelyFromArchive(archive_handle, dir_path).raw;
@@ -287,7 +288,7 @@ static void CreateFile(Service::Interface* self) {
 
     FileSys::Path file_path(filename_type, filename_size, filename_ptr);
 
-    LOG_DEBUG(Service_FS, "type=%d size=%llu data=%s", filename_type, file_size,
+    LOG_DEBUG(Service_FS, "type=%u size=%llu data=%s", static_cast<u32>(filename_type), file_size,
               file_path.DebugStr().c_str());
 
     cmd_buff[1] = CreateFileInArchive(archive_handle, file_path, file_size).raw;
@@ -314,7 +315,7 @@ static void CreateDirectory(Service::Interface* self) {
 
     FileSys::Path dir_path(dirname_type, dirname_size, dirname_ptr);
 
-    LOG_DEBUG(Service_FS, "type=%d size=%d data=%s", dirname_type, dirname_size,
+    LOG_DEBUG(Service_FS, "type=%u size=%d data=%s", static_cast<u32>(dirname_type), dirname_size,
               dir_path.DebugStr().c_str());
 
     cmd_buff[1] = CreateDirectoryFromArchive(archive_handle, dir_path).raw;
@@ -351,10 +352,10 @@ static void RenameDirectory(Service::Interface* self) {
     FileSys::Path src_dir_path(src_dirname_type, src_dirname_size, src_dirname_ptr);
     FileSys::Path dest_dir_path(dest_dirname_type, dest_dirname_size, dest_dirname_ptr);
 
-    LOG_DEBUG(Service_FS,
-              "src_type=%d src_size=%d src_data=%s dest_type=%d dest_size=%d dest_data=%s",
-              src_dirname_type, src_dirname_size, src_dir_path.DebugStr().c_str(),
-              dest_dirname_type, dest_dirname_size, dest_dir_path.DebugStr().c_str());
+    LOG_DEBUG(
+        Service_FS, "src_type=%u src_size=%u src_data=%s dest_type=%u dest_size=%u dest_data=%s",
+        static_cast<u32>(src_dirname_type), src_dirname_size, src_dir_path.DebugStr().c_str(),
+        static_cast<u32>(dest_dirname_type), dest_dirname_size, dest_dir_path.DebugStr().c_str());
 
     cmd_buff[1] = RenameDirectoryBetweenArchives(src_archive_handle, src_dir_path,
                                                  dest_archive_handle, dest_dir_path)
@@ -384,7 +385,7 @@ static void OpenDirectory(Service::Interface* self) {
 
     FileSys::Path dir_path(dirname_type, dirname_size, dirname_ptr);
 
-    LOG_DEBUG(Service_FS, "type=%d size=%d data=%s", dirname_type, dirname_size,
+    LOG_DEBUG(Service_FS, "type=%u size=%u data=%s", static_cast<u32>(dirname_type), dirname_size,
               dir_path.DebugStr().c_str());
 
     ResultVal<SharedPtr<Directory>> dir_res = OpenDirectoryFromArchive(archive_handle, dir_path);
@@ -419,7 +420,7 @@ static void OpenArchive(Service::Interface* self) {
     u32 archivename_ptr = cmd_buff[5];
     FileSys::Path archive_path(archivename_type, archivename_size, archivename_ptr);
 
-    LOG_DEBUG(Service_FS, "archive_id=0x%08X archive_path=%s", archive_id,
+    LOG_DEBUG(Service_FS, "archive_id=0x%08X archive_path=%s", static_cast<u32>(archive_id),
               archive_path.DebugStr().c_str());
 
     ResultVal<ArchiveHandle> handle = OpenArchive(archive_id, archive_path);
@@ -431,7 +432,7 @@ static void OpenArchive(Service::Interface* self) {
         cmd_buff[2] = cmd_buff[3] = 0;
         LOG_ERROR(Service_FS,
                   "failed to get a handle for archive archive_id=0x%08X archive_path=%s",
-                  archive_id, archive_path.DebugStr().c_str());
+                  static_cast<u32>(archive_id), archive_path.DebugStr().c_str());
     }
 }
 
@@ -514,7 +515,8 @@ static void FormatSaveData(Service::Interface* self) {
     LOG_DEBUG(Service_FS, "archive_path=%s", archive_path.DebugStr().c_str());
 
     if (archive_id != FS::ArchiveIdCode::SaveData) {
-        LOG_ERROR(Service_FS, "tried to format an archive different than SaveData, %u", archive_id);
+        LOG_ERROR(Service_FS, "tried to format an archive different than SaveData, %u",
+                  static_cast<u32>(archive_id));
         cmd_buff[1] = ResultCode(ErrorDescription::FS_InvalidPath, ErrorModule::FS,
                                  ErrorSummary::InvalidArgument, ErrorLevel::Usage)
                           .raw;


### PR DESCRIPTION
Found this unimplemented when writing toys for 3DS file system. So I implemented it, and tested it with my toys against real 3DS.
I plan to clean up all FS error codes in the future, so leave the `// TODO: verify description` for now.