### PR TITLE
Search bar for GPU Commands

### DIFF
--- a/src/citra_qt/debugger/graphics_cmdlists.cpp
+++ b/src/citra_qt/debugger/graphics_cmdlists.cpp
@@ -210,7 +210,7 @@ GPUCommandListWidget::GPUCommandListWidget(QWidget* parent)
     connect(list_widget, SIGNAL(doubleClicked(const QModelIndex&)), this,
             SLOT(OnCommandDoubleClicked(const QModelIndex&)));
 
-    connect(search_bar, SIGNAL(textChanged(const QString &)), model, 
+    connect(search_bar, SIGNAL(textChanged(const QString &)), model,
             SLOT(UpdatePicaTrace(const QString &)));
 
     toggle_tracing = new QPushButton(tr("Start Tracing"));

--- a/src/citra_qt/debugger/graphics_cmdlists.cpp
+++ b/src/citra_qt/debugger/graphics_cmdlists.cpp
@@ -226,13 +226,13 @@ GPUCommandListWidget::GPUCommandListWidget(QWidget* parent)
 
     QVBoxLayout* main_layout = new QVBoxLayout;
     main_layout->addWidget(list_widget);
+	main_layout->addWidget(search_bar);
     {
         QHBoxLayout* sub_layout = new QHBoxLayout;
         sub_layout->addWidget(toggle_tracing);
         sub_layout->addWidget(copy_all);
         main_layout->addLayout(sub_layout);
     }
-    main_layout->addWidget(search_bar);
     main_widget->setLayout(main_layout);
 
     setWidget(main_widget);

--- a/src/citra_qt/debugger/graphics_cmdlists.cpp
+++ b/src/citra_qt/debugger/graphics_cmdlists.cpp
@@ -52,7 +52,9 @@ public:
 GPUCommandListModel::GPUCommandListModel(QObject* parent) : QAbstractListModel(parent) {}
 
 int GPUCommandListModel::rowCount(const QModelIndex& parent) const {
-    return static_cast<int>((pica_trace.is_search_corrected ? pica_trace.search_corrected_writes : pica_trace.writes).size());
+    return static_cast<int>(
+        (pica_trace.is_search_corrected ? pica_trace.search_corrected_writes : pica_trace.writes)
+            .size());
 }
 
 int GPUCommandListModel::columnCount(const QModelIndex& parent) const {
@@ -63,7 +65,9 @@ QVariant GPUCommandListModel::data(const QModelIndex& index, int role) const {
     if (!index.isValid())
         return QVariant();
 
-    const auto& write = (pica_trace.is_search_corrected ? pica_trace.search_corrected_writes[index.row()] : pica_trace.writes[index.row()]);
+    const auto& write =
+        (pica_trace.is_search_corrected ? pica_trace.search_corrected_writes[index.row()]
+                                        : pica_trace.writes[index.row()]);
 
     if (role == Qt::DisplayRole) {
         QString content;
@@ -210,8 +214,8 @@ GPUCommandListWidget::GPUCommandListWidget(QWidget* parent)
     connect(list_widget, SIGNAL(doubleClicked(const QModelIndex&)), this,
             SLOT(OnCommandDoubleClicked(const QModelIndex&)));
 
-    connect(search_bar, SIGNAL(textChanged(const QString &)), model,
-            SLOT(UpdatePicaTrace(const QString &)));
+    connect(search_bar, SIGNAL(textChanged(const QString&)), model,
+            SLOT(UpdatePicaTrace(const QString&)));
 
     toggle_tracing = new QPushButton(tr("Start Tracing"));
     QPushButton* copy_all = new QPushButton(tr("Copy All"));
@@ -226,7 +230,7 @@ GPUCommandListWidget::GPUCommandListWidget(QWidget* parent)
 
     QVBoxLayout* main_layout = new QVBoxLayout;
     main_layout->addWidget(list_widget);
-	main_layout->addWidget(search_bar);
+    main_layout->addWidget(search_bar);
     {
         QHBoxLayout* sub_layout = new QHBoxLayout;
         sub_layout->addWidget(toggle_tracing);

--- a/src/citra_qt/debugger/graphics_cmdlists.h
+++ b/src/citra_qt/debugger/graphics_cmdlists.h
@@ -27,10 +27,10 @@ public:
     QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
     QVariant headerData(int section, Qt::Orientation orientation,
                         int role = Qt::DisplayRole) const override;
-    
+
 public slots:
     void OnPicaTraceFinished(const Pica::DebugUtils::PicaTrace& trace);
-    void UpdatePicaTrace(const QString &);
+    void UpdatePicaTrace(const QString&);
 
 private:
     Pica::DebugUtils::PicaTrace pica_trace;

--- a/src/citra_qt/debugger/graphics_cmdlists.h
+++ b/src/citra_qt/debugger/graphics_cmdlists.h
@@ -27,10 +27,10 @@ public:
     QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
     QVariant headerData(int section, Qt::Orientation orientation,
                         int role = Qt::DisplayRole) const override;
-	
+    
 public slots:
     void OnPicaTraceFinished(const Pica::DebugUtils::PicaTrace& trace);
-	void UpdatePicaTrace(const QString &);
+    void UpdatePicaTrace(const QString &);
 
 private:
     Pica::DebugUtils::PicaTrace pica_trace;
@@ -41,15 +41,13 @@ class GPUCommandListWidget : public QDockWidget {
 
 public:
     GPUCommandListWidget(QWidget* parent = nullptr);
-
-	QLineEdit* search_bar;
+    QLineEdit* search_bar;
 
 public slots:
     void OnToggleTracing();
     void OnCommandDoubleClicked(const QModelIndex&);
     void SetCommandInfo(const QModelIndex&);
-
-	void CopyAllToClipboard();
+    void CopyAllToClipboard();
 
 signals:
     void TracingFinished(const Pica::DebugUtils::PicaTrace&);

--- a/src/citra_qt/debugger/graphics_cmdlists.h
+++ b/src/citra_qt/debugger/graphics_cmdlists.h
@@ -27,9 +27,10 @@ public:
     QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
     QVariant headerData(int section, Qt::Orientation orientation,
                         int role = Qt::DisplayRole) const override;
-
+	
 public slots:
     void OnPicaTraceFinished(const Pica::DebugUtils::PicaTrace& trace);
+	void UpdatePicaTrace(const QString &);
 
 private:
     Pica::DebugUtils::PicaTrace pica_trace;
@@ -41,13 +42,14 @@ class GPUCommandListWidget : public QDockWidget {
 public:
     GPUCommandListWidget(QWidget* parent = nullptr);
 
+	QLineEdit* search_bar;
+
 public slots:
     void OnToggleTracing();
     void OnCommandDoubleClicked(const QModelIndex&);
-
     void SetCommandInfo(const QModelIndex&);
 
-    void CopyAllToClipboard();
+	void CopyAllToClipboard();
 
 signals:
     void TracingFinished(const Pica::DebugUtils::PicaTrace&);

--- a/src/video_core/debug_utils/debug_utils.h
+++ b/src/video_core/debug_utils/debug_utils.h
@@ -20,282 +20,282 @@
 #include "video_core/pica.h"
 
 namespace CiTrace {
-    class Recorder;
+class Recorder;
 }
 
 namespace Pica {
 
-    namespace Shader {
-        struct ShaderSetup;
-    }
+namespace Shader {
+struct ShaderSetup;
+}
 
-    class DebugContext {
-    public:
-        enum class Event {
-            FirstEvent = 0,
+class DebugContext {
+public:
+    enum class Event {
+        FirstEvent = 0,
 
-            PicaCommandLoaded = FirstEvent,
-            PicaCommandProcessed,
-            IncomingPrimitiveBatch,
-            FinishedPrimitiveBatch,
-            VertexShaderInvocation,
-            IncomingDisplayTransfer,
-            GSPCommandProcessed,
-            BufferSwapped,
+        PicaCommandLoaded = FirstEvent,
+        PicaCommandProcessed,
+        IncomingPrimitiveBatch,
+        FinishedPrimitiveBatch,
+        VertexShaderInvocation,
+        IncomingDisplayTransfer,
+        GSPCommandProcessed,
+        BufferSwapped,
 
-            NumEvents
-        };
-
-        /**
-        * Inherit from this class to be notified of events registered to some debug context.
-        * Most importantly this is used for our debugger GUI.
-        *
-        * To implement event handling, override the OnPicaBreakPointHit and OnPicaResume methods.
-        * @warning All BreakPointObservers need to be on the same thread to guarantee thread-safe state
-        * access
-        * @todo Evaluate an alternative interface, in which there is only one managing observer and
-        * multiple child observers running (by design) on the same thread.
-        */
-        class BreakPointObserver {
-        public:
-            /// Constructs the object such that it observes events of the given DebugContext.
-            BreakPointObserver(std::shared_ptr<DebugContext> debug_context)
-                : context_weak(debug_context) {
-                std::unique_lock<std::mutex> lock(debug_context->breakpoint_mutex);
-                debug_context->breakpoint_observers.push_back(this);
-            }
-
-            virtual ~BreakPointObserver() {
-                auto context = context_weak.lock();
-                if (context) {
-                    std::unique_lock<std::mutex> lock(context->breakpoint_mutex);
-                    context->breakpoint_observers.remove(this);
-
-                    // If we are the last observer to be destroyed, tell the debugger context that
-                    // it is free to continue. In particular, this is required for a proper Citra
-                    // shutdown, when the emulation thread is waiting at a breakpoint.
-                    if (context->breakpoint_observers.empty())
-                        context->Resume();
-                }
-            }
-
-            /**
-            * Action to perform when a breakpoint was reached.
-            * @param event Type of event which triggered the breakpoint
-            * @param data Optional data pointer (if unused, this is a nullptr)
-            * @note This function will perform nothing unless it is overridden in the child class.
-            */
-            virtual void OnPicaBreakPointHit(Event, void*) {}
-
-            /**
-            * Action to perform when emulation is resumed from a breakpoint.
-            * @note This function will perform nothing unless it is overridden in the child class.
-            */
-            virtual void OnPicaResume() {}
-
-        protected:
-            /**
-            * Weak context pointer. This need not be valid, so when requesting a shared_ptr via
-            * context_weak.lock(), always compare the result against nullptr.
-            */
-            std::weak_ptr<DebugContext> context_weak;
-        };
-
-        /**
-        * Simple structure defining a breakpoint state
-        */
-        struct BreakPoint {
-            bool enabled = false;
-        };
-
-        /**
-        * Static constructor used to create a shared_ptr of a DebugContext.
-        */
-        static std::shared_ptr<DebugContext> Construct() {
-            return std::shared_ptr<DebugContext>(new DebugContext);
-        }
-
-        /**
-        * Used by the emulation core when a given event has happened. If a breakpoint has been set
-        * for this event, OnEvent calls the event handlers of the registered breakpoint observers.
-        * The current thread then is halted until Resume() is called from another thread (or until
-        * emulation is stopped).
-        * @param event Event which has happened
-        * @param data Optional data pointer (pass nullptr if unused). Needs to remain valid until
-        * Resume() is called.
-        */
-        void OnEvent(Event event, void* data) {
-            // This check is left in the header to allow the compiler to inline it.
-            if (!breakpoints[(int)event].enabled)
-                return;
-            // For the rest of event handling, call a separate function.
-            DoOnEvent(event, data);
-        }
-
-        void DoOnEvent(Event event, void* data);
-
-        /**
-        * Resume from the current breakpoint.
-        * @warning Calling this from the same thread that OnEvent was called in will cause a deadlock.
-        * Calling from any other thread is safe.
-        */
-        void Resume();
-
-        /**
-        * Delete all set breakpoints and resume emulation.
-        */
-        void ClearBreakpoints() {
-            for (auto& bp : breakpoints) {
-                bp.enabled = false;
-            }
-            Resume();
-        }
-
-        // TODO: Evaluate if access to these members should be hidden behind a public interface.
-        std::array<BreakPoint, (int)Event::NumEvents> breakpoints;
-        Event active_breakpoint;
-        bool at_breakpoint = false;
-
-        std::shared_ptr<CiTrace::Recorder> recorder = nullptr;
-
-    private:
-        /**
-        * Private default constructor to make sure people always construct this through Construct()
-        * instead.
-        */
-        DebugContext() = default;
-
-        /// Mutex protecting current breakpoint state and the observer list.
-        std::mutex breakpoint_mutex;
-
-        /// Used by OnEvent to wait for resumption.
-        std::condition_variable resume_from_breakpoint;
-
-        /// List of registered observers
-        std::list<BreakPointObserver*> breakpoint_observers;
+        NumEvents
     };
 
-    extern std::shared_ptr<DebugContext> g_debug_context; // TODO: Get rid of this global
+    /**
+    * Inherit from this class to be notified of events registered to some debug context.
+    * Most importantly this is used for our debugger GUI.
+    *
+    * To implement event handling, override the OnPicaBreakPointHit and OnPicaResume methods.
+    * @warning All BreakPointObservers need to be on the same thread to guarantee thread-safe state
+    * access
+    * @todo Evaluate an alternative interface, in which there is only one managing observer and
+    * multiple child observers running (by design) on the same thread.
+    */
+    class BreakPointObserver {
+    public:
+        /// Constructs the object such that it observes events of the given DebugContext.
+        BreakPointObserver(std::shared_ptr<DebugContext> debug_context)
+            : context_weak(debug_context) {
+            std::unique_lock<std::mutex> lock(debug_context->breakpoint_mutex);
+            debug_context->breakpoint_observers.push_back(this);
+        }
 
-    namespace DebugUtils {
+        virtual ~BreakPointObserver() {
+            auto context = context_weak.lock();
+            if (context) {
+                std::unique_lock<std::mutex> lock(context->breakpoint_mutex);
+                context->breakpoint_observers.remove(this);
+
+                // If we are the last observer to be destroyed, tell the debugger context that
+                // it is free to continue. In particular, this is required for a proper Citra
+                // shutdown, when the emulation thread is waiting at a breakpoint.
+                if (context->breakpoint_observers.empty())
+                    context->Resume();
+            }
+        }
+
+        /**
+        * Action to perform when a breakpoint was reached.
+        * @param event Type of event which triggered the breakpoint
+        * @param data Optional data pointer (if unused, this is a nullptr)
+        * @note This function will perform nothing unless it is overridden in the child class.
+        */
+        virtual void OnPicaBreakPointHit(Event, void*) {}
+
+        /**
+        * Action to perform when emulation is resumed from a breakpoint.
+        * @note This function will perform nothing unless it is overridden in the child class.
+        */
+        virtual void OnPicaResume() {}
+
+    protected:
+        /**
+        * Weak context pointer. This need not be valid, so when requesting a shared_ptr via
+        * context_weak.lock(), always compare the result against nullptr.
+        */
+        std::weak_ptr<DebugContext> context_weak;
+    };
+
+    /**
+    * Simple structure defining a breakpoint state
+    */
+    struct BreakPoint {
+        bool enabled = false;
+    };
+
+    /**
+    * Static constructor used to create a shared_ptr of a DebugContext.
+    */
+    static std::shared_ptr<DebugContext> Construct() {
+        return std::shared_ptr<DebugContext>(new DebugContext);
+    }
+
+    /**
+    * Used by the emulation core when a given event has happened. If a breakpoint has been set
+    * for this event, OnEvent calls the event handlers of the registered breakpoint observers.
+    * The current thread then is halted until Resume() is called from another thread (or until
+    * emulation is stopped).
+    * @param event Event which has happened
+    * @param data Optional data pointer (pass nullptr if unused). Needs to remain valid until
+    * Resume() is called.
+    */
+    void OnEvent(Event event, void* data) {
+        // This check is left in the header to allow the compiler to inline it.
+        if (!breakpoints[(int)event].enabled)
+            return;
+        // For the rest of event handling, call a separate function.
+        DoOnEvent(event, data);
+    }
+
+    void DoOnEvent(Event event, void* data);
+
+    /**
+    * Resume from the current breakpoint.
+    * @warning Calling this from the same thread that OnEvent was called in will cause a deadlock.
+    * Calling from any other thread is safe.
+    */
+    void Resume();
+
+    /**
+    * Delete all set breakpoints and resume emulation.
+    */
+    void ClearBreakpoints() {
+        for (auto& bp : breakpoints) {
+            bp.enabled = false;
+        }
+        Resume();
+    }
+
+    // TODO: Evaluate if access to these members should be hidden behind a public interface.
+    std::array<BreakPoint, (int)Event::NumEvents> breakpoints;
+    Event active_breakpoint;
+    bool at_breakpoint = false;
+
+    std::shared_ptr<CiTrace::Recorder> recorder = nullptr;
+
+private:
+    /**
+    * Private default constructor to make sure people always construct this through Construct()
+    * instead.
+    */
+    DebugContext() = default;
+
+    /// Mutex protecting current breakpoint state and the observer list.
+    std::mutex breakpoint_mutex;
+
+    /// Used by OnEvent to wait for resumption.
+    std::condition_variable resume_from_breakpoint;
+
+    /// List of registered observers
+    std::list<BreakPointObserver*> breakpoint_observers;
+};
+
+extern std::shared_ptr<DebugContext> g_debug_context; // TODO: Get rid of this global
+
+namespace DebugUtils {
 
 #define PICA_DUMP_TEXTURES 0
 #define PICA_LOG_TEV 0
 
-        void DumpShader(const std::string& filename, const Regs::ShaderConfig& config,
-            const Shader::ShaderSetup& setup,
-            const Regs::VSOutputAttributes* output_attributes);
+void DumpShader(const std::string& filename, const Regs::ShaderConfig& config,
+                const Shader::ShaderSetup& setup,
+                const Regs::VSOutputAttributes* output_attributes);
 
-        // Utility class to log Pica commands.
-        struct PicaTrace {
-            struct Write {
-                u16 cmd_id;
-                u16 mask;
-                u32 value;
-            };
-            std::vector<Write> writes;
-            std::vector<Write> search_corrected_writes;
-            bool is_search_corrected = false;
+// Utility class to log Pica commands.
+struct PicaTrace {
+    struct Write {
+        u16 cmd_id;
+        u16 mask;
+        u32 value;
+    };
+    std::vector<Write> writes;
+    std::vector<Write> search_corrected_writes;
+    bool is_search_corrected = false;
 
-            void CorrectSearchWrites(std::string search_string) {
-                search_corrected_writes.clear();
+    void CorrectSearchWrites(std::string search_string) {
+        search_corrected_writes.clear();
 
-                if (search_string.size() == 0)
-                    is_search_corrected = false;
-                else
-                    is_search_corrected = true;
+        if (search_string.size() == 0)
+            is_search_corrected = false;
+        else
+            is_search_corrected = true;
 
-                for (int i = 0; i < writes.size(); i++) {
-                    bool is_valid = true;
-                    std::string cmd_name = Pica::Regs::GetCommandName(writes[i].cmd_id);
+        for (int i = 0; i < writes.size(); i++) {
+            bool is_valid = true;
+            std::string cmd_name = Pica::Regs::GetCommandName(writes[i].cmd_id);
 
-                    if (cmd_name.size() < search_string.size())
-                        continue;
+            if (cmd_name.size() < search_string.size())
+                continue;
 
-                    for (int j = 0; j < search_string.size(); j++) {
-                        if (cmd_name.at(j) != search_string.at(j)) {
-                            is_valid = false;
-                            break;
-                        }
-                    }//End of j for-loop
-
-                    if (!is_valid)
-                        continue;
-
-                    search_corrected_writes.push_back(writes[i]);
-                }//End of i for-loop
-            }//End of search filter
-        };
-
-        void StartPicaTracing();
-        bool IsPicaTracing();
-        void OnPicaRegWrite(PicaTrace::Write write);
-        std::unique_ptr<PicaTrace> FinishPicaTracing();
-
-        struct TextureInfo {
-            PAddr physical_address;
-            int width;
-            int height;
-            int stride;
-            Pica::Regs::TextureFormat format;
-
-            static TextureInfo FromPicaRegister(const Pica::Regs::TextureConfig& config,
-                const Pica::Regs::TextureFormat& format);
-        };
-
-        /**
-        * Lookup texel located at the given coordinates and return an RGBA vector of its color.
-        * @param source Source pointer to read data from
-        * @param s,t Texture coordinates to read from
-        * @param info TextureInfo object describing the texture setup
-        * @param disable_alpha This is used for debug widgets which use this method to display textures
-        * without providing a good way to visualize alpha by themselves. If true, this will return 255 for
-        * the alpha component, and either drop the information entirely or store it in an "unused" color
-        * channel.
-        * @todo Eventually we should get rid of the disable_alpha parameter.
-        */
-        const Math::Vec4<u8> LookupTexture(const u8* source, int s, int t, const TextureInfo& info,
-            bool disable_alpha = false);
-
-        void DumpTexture(const Pica::Regs::TextureConfig& texture_config, u8* data);
-
-        std::string GetTevStageConfigColorCombinerString(const Pica::Regs::TevStageConfig& tev_stage);
-        std::string GetTevStageConfigAlphaCombinerString(const Pica::Regs::TevStageConfig& tev_stage);
-
-        /// Dumps the Tev stage config to log at trace level
-        void DumpTevStageConfig(const std::array<Pica::Regs::TevStageConfig, 6>& stages);
-
-        /**
-        * Used in the vertex loader to merge access records. TODO: Investigate if actually useful.
-        */
-        class MemoryAccessTracker {
-            /// Combine overlapping and close ranges
-            void SimplifyRanges() {
-                for (auto it = ranges.begin(); it != ranges.end(); ++it) {
-                    // NOTE: We add 32 to the range end address to make sure "close" ranges are combined,
-                    // too
-                    auto it2 = std::next(it);
-                    while (it2 != ranges.end() && it->first + it->second + 32 >= it2->first) {
-                        it->second = std::max(it->second, it2->first + it2->second - it->first);
-                        it2 = ranges.erase(it2);
-                    }
+            for (int j = 0; j < search_string.size(); j++) {
+                if (cmd_name.at(j) != search_string.at(j)) {
+                    is_valid = false;
+                    break;
                 }
+            } // End of j for-loop
+
+            if (!is_valid)
+                continue;
+
+            search_corrected_writes.push_back(writes[i]);
+        } // End of i for-loop
+    }     // End of search filter
+};
+
+void StartPicaTracing();
+bool IsPicaTracing();
+void OnPicaRegWrite(PicaTrace::Write write);
+std::unique_ptr<PicaTrace> FinishPicaTracing();
+
+struct TextureInfo {
+    PAddr physical_address;
+    int width;
+    int height;
+    int stride;
+    Pica::Regs::TextureFormat format;
+
+    static TextureInfo FromPicaRegister(const Pica::Regs::TextureConfig& config,
+                                        const Pica::Regs::TextureFormat& format);
+};
+
+/**
+* Lookup texel located at the given coordinates and return an RGBA vector of its color.
+* @param source Source pointer to read data from
+* @param s,t Texture coordinates to read from
+* @param info TextureInfo object describing the texture setup
+* @param disable_alpha This is used for debug widgets which use this method to display textures
+* without providing a good way to visualize alpha by themselves. If true, this will return 255 for
+* the alpha component, and either drop the information entirely or store it in an "unused" color
+* channel.
+* @todo Eventually we should get rid of the disable_alpha parameter.
+*/
+const Math::Vec4<u8> LookupTexture(const u8* source, int s, int t, const TextureInfo& info,
+                                   bool disable_alpha = false);
+
+void DumpTexture(const Pica::Regs::TextureConfig& texture_config, u8* data);
+
+std::string GetTevStageConfigColorCombinerString(const Pica::Regs::TevStageConfig& tev_stage);
+std::string GetTevStageConfigAlphaCombinerString(const Pica::Regs::TevStageConfig& tev_stage);
+
+/// Dumps the Tev stage config to log at trace level
+void DumpTevStageConfig(const std::array<Pica::Regs::TevStageConfig, 6>& stages);
+
+/**
+* Used in the vertex loader to merge access records. TODO: Investigate if actually useful.
+*/
+class MemoryAccessTracker {
+    /// Combine overlapping and close ranges
+    void SimplifyRanges() {
+        for (auto it = ranges.begin(); it != ranges.end(); ++it) {
+            // NOTE: We add 32 to the range end address to make sure "close" ranges are combined,
+            // too
+            auto it2 = std::next(it);
+            while (it2 != ranges.end() && it->first + it->second + 32 >= it2->first) {
+                it->second = std::max(it->second, it2->first + it2->second - it->first);
+                it2 = ranges.erase(it2);
             }
+        }
+    }
 
-        public:
-            /// Record a particular memory access in the list
-            void AddAccess(u32 paddr, u32 size) {
-                // Create new range or extend existing one
-                ranges[paddr] = std::max(ranges[paddr], size);
+public:
+    /// Record a particular memory access in the list
+    void AddAccess(u32 paddr, u32 size) {
+        // Create new range or extend existing one
+        ranges[paddr] = std::max(ranges[paddr], size);
 
-                // Simplify ranges...
-                SimplifyRanges();
-            }
+        // Simplify ranges...
+        SimplifyRanges();
+    }
 
-            /// Map of accessed ranges (mapping start address to range size)
-            std::map<u32, u32> ranges;
-        };
+    /// Map of accessed ranges (mapping start address to range size)
+    std::map<u32, u32> ranges;
+};
 
-    } // namespace
+} // namespace
 
 } // namespace

--- a/src/video_core/debug_utils/debug_utils.h
+++ b/src/video_core/debug_utils/debug_utils.h
@@ -20,251 +20,283 @@
 #include "video_core/pica.h"
 
 namespace CiTrace {
-class Recorder;
+	class Recorder;
 }
 
 namespace Pica {
 
-namespace Shader {
-struct ShaderSetup;
-}
+	namespace Shader {
+		struct ShaderSetup;
+	}
 
-class DebugContext {
-public:
-    enum class Event {
-        FirstEvent = 0,
+	class DebugContext {
+	public:
+		enum class Event {
+			FirstEvent = 0,
 
-        PicaCommandLoaded = FirstEvent,
-        PicaCommandProcessed,
-        IncomingPrimitiveBatch,
-        FinishedPrimitiveBatch,
-        VertexShaderInvocation,
-        IncomingDisplayTransfer,
-        GSPCommandProcessed,
-        BufferSwapped,
+			PicaCommandLoaded = FirstEvent,
+			PicaCommandProcessed,
+			IncomingPrimitiveBatch,
+			FinishedPrimitiveBatch,
+			VertexShaderInvocation,
+			IncomingDisplayTransfer,
+			GSPCommandProcessed,
+			BufferSwapped,
 
-        NumEvents
-    };
+			NumEvents
+		};
 
-    /**
-     * Inherit from this class to be notified of events registered to some debug context.
-     * Most importantly this is used for our debugger GUI.
-     *
-     * To implement event handling, override the OnPicaBreakPointHit and OnPicaResume methods.
-     * @warning All BreakPointObservers need to be on the same thread to guarantee thread-safe state
-     * access
-     * @todo Evaluate an alternative interface, in which there is only one managing observer and
-     * multiple child observers running (by design) on the same thread.
-     */
-    class BreakPointObserver {
-    public:
-        /// Constructs the object such that it observes events of the given DebugContext.
-        BreakPointObserver(std::shared_ptr<DebugContext> debug_context)
-            : context_weak(debug_context) {
-            std::unique_lock<std::mutex> lock(debug_context->breakpoint_mutex);
-            debug_context->breakpoint_observers.push_back(this);
-        }
+		/**
+		* Inherit from this class to be notified of events registered to some debug context.
+		* Most importantly this is used for our debugger GUI.
+		*
+		* To implement event handling, override the OnPicaBreakPointHit and OnPicaResume methods.
+		* @warning All BreakPointObservers need to be on the same thread to guarantee thread-safe state
+		* access
+		* @todo Evaluate an alternative interface, in which there is only one managing observer and
+		* multiple child observers running (by design) on the same thread.
+		*/
+		class BreakPointObserver {
+		public:
+			/// Constructs the object such that it observes events of the given DebugContext.
+			BreakPointObserver(std::shared_ptr<DebugContext> debug_context)
+				: context_weak(debug_context) {
+				std::unique_lock<std::mutex> lock(debug_context->breakpoint_mutex);
+				debug_context->breakpoint_observers.push_back(this);
+			}
 
-        virtual ~BreakPointObserver() {
-            auto context = context_weak.lock();
-            if (context) {
-                std::unique_lock<std::mutex> lock(context->breakpoint_mutex);
-                context->breakpoint_observers.remove(this);
+			virtual ~BreakPointObserver() {
+				auto context = context_weak.lock();
+				if (context) {
+					std::unique_lock<std::mutex> lock(context->breakpoint_mutex);
+					context->breakpoint_observers.remove(this);
 
-                // If we are the last observer to be destroyed, tell the debugger context that
-                // it is free to continue. In particular, this is required for a proper Citra
-                // shutdown, when the emulation thread is waiting at a breakpoint.
-                if (context->breakpoint_observers.empty())
-                    context->Resume();
-            }
-        }
+					// If we are the last observer to be destroyed, tell the debugger context that
+					// it is free to continue. In particular, this is required for a proper Citra
+					// shutdown, when the emulation thread is waiting at a breakpoint.
+					if (context->breakpoint_observers.empty())
+						context->Resume();
+				}
+			}
 
-        /**
-         * Action to perform when a breakpoint was reached.
-         * @param event Type of event which triggered the breakpoint
-         * @param data Optional data pointer (if unused, this is a nullptr)
-         * @note This function will perform nothing unless it is overridden in the child class.
-         */
-        virtual void OnPicaBreakPointHit(Event, void*) {}
+			/**
+			* Action to perform when a breakpoint was reached.
+			* @param event Type of event which triggered the breakpoint
+			* @param data Optional data pointer (if unused, this is a nullptr)
+			* @note This function will perform nothing unless it is overridden in the child class.
+			*/
+			virtual void OnPicaBreakPointHit(Event, void*) {}
 
-        /**
-         * Action to perform when emulation is resumed from a breakpoint.
-         * @note This function will perform nothing unless it is overridden in the child class.
-         */
-        virtual void OnPicaResume() {}
+			/**
+			* Action to perform when emulation is resumed from a breakpoint.
+			* @note This function will perform nothing unless it is overridden in the child class.
+			*/
+			virtual void OnPicaResume() {}
 
-    protected:
-        /**
-         * Weak context pointer. This need not be valid, so when requesting a shared_ptr via
-         * context_weak.lock(), always compare the result against nullptr.
-         */
-        std::weak_ptr<DebugContext> context_weak;
-    };
+		protected:
+			/**
+			* Weak context pointer. This need not be valid, so when requesting a shared_ptr via
+			* context_weak.lock(), always compare the result against nullptr.
+			*/
+			std::weak_ptr<DebugContext> context_weak;
+		};
 
-    /**
-     * Simple structure defining a breakpoint state
-     */
-    struct BreakPoint {
-        bool enabled = false;
-    };
+		/**
+		* Simple structure defining a breakpoint state
+		*/
+		struct BreakPoint {
+			bool enabled = false;
+		};
 
-    /**
-     * Static constructor used to create a shared_ptr of a DebugContext.
-     */
-    static std::shared_ptr<DebugContext> Construct() {
-        return std::shared_ptr<DebugContext>(new DebugContext);
-    }
+		/**
+		* Static constructor used to create a shared_ptr of a DebugContext.
+		*/
+		static std::shared_ptr<DebugContext> Construct() {
+			return std::shared_ptr<DebugContext>(new DebugContext);
+		}
 
-    /**
-     * Used by the emulation core when a given event has happened. If a breakpoint has been set
-     * for this event, OnEvent calls the event handlers of the registered breakpoint observers.
-     * The current thread then is halted until Resume() is called from another thread (or until
-     * emulation is stopped).
-     * @param event Event which has happened
-     * @param data Optional data pointer (pass nullptr if unused). Needs to remain valid until
-     * Resume() is called.
-     */
-    void OnEvent(Event event, void* data) {
-        // This check is left in the header to allow the compiler to inline it.
-        if (!breakpoints[(int)event].enabled)
-            return;
-        // For the rest of event handling, call a separate function.
-        DoOnEvent(event, data);
-    }
+		/**
+		* Used by the emulation core when a given event has happened. If a breakpoint has been set
+		* for this event, OnEvent calls the event handlers of the registered breakpoint observers.
+		* The current thread then is halted until Resume() is called from another thread (or until
+		* emulation is stopped).
+		* @param event Event which has happened
+		* @param data Optional data pointer (pass nullptr if unused). Needs to remain valid until
+		* Resume() is called.
+		*/
+		void OnEvent(Event event, void* data) {
+			// This check is left in the header to allow the compiler to inline it.
+			if (!breakpoints[(int)event].enabled)
+				return;
+			// For the rest of event handling, call a separate function.
+			DoOnEvent(event, data);
+		}
 
-    void DoOnEvent(Event event, void* data);
+		void DoOnEvent(Event event, void* data);
 
-    /**
-     * Resume from the current breakpoint.
-     * @warning Calling this from the same thread that OnEvent was called in will cause a deadlock.
-     * Calling from any other thread is safe.
-     */
-    void Resume();
+		/**
+		* Resume from the current breakpoint.
+		* @warning Calling this from the same thread that OnEvent was called in will cause a deadlock.
+		* Calling from any other thread is safe.
+		*/
+		void Resume();
 
-    /**
-     * Delete all set breakpoints and resume emulation.
-     */
-    void ClearBreakpoints() {
-        for (auto& bp : breakpoints) {
-            bp.enabled = false;
-        }
-        Resume();
-    }
+		/**
+		* Delete all set breakpoints and resume emulation.
+		*/
+		void ClearBreakpoints() {
+			for (auto& bp : breakpoints) {
+				bp.enabled = false;
+			}
+			Resume();
+		}
 
-    // TODO: Evaluate if access to these members should be hidden behind a public interface.
-    std::array<BreakPoint, (int)Event::NumEvents> breakpoints;
-    Event active_breakpoint;
-    bool at_breakpoint = false;
+		// TODO: Evaluate if access to these members should be hidden behind a public interface.
+		std::array<BreakPoint, (int)Event::NumEvents> breakpoints;
+		Event active_breakpoint;
+		bool at_breakpoint = false;
 
-    std::shared_ptr<CiTrace::Recorder> recorder = nullptr;
+		std::shared_ptr<CiTrace::Recorder> recorder = nullptr;
 
-private:
-    /**
-     * Private default constructor to make sure people always construct this through Construct()
-     * instead.
-     */
-    DebugContext() = default;
+	private:
+		/**
+		* Private default constructor to make sure people always construct this through Construct()
+		* instead.
+		*/
+		DebugContext() = default;
 
-    /// Mutex protecting current breakpoint state and the observer list.
-    std::mutex breakpoint_mutex;
+		/// Mutex protecting current breakpoint state and the observer list.
+		std::mutex breakpoint_mutex;
 
-    /// Used by OnEvent to wait for resumption.
-    std::condition_variable resume_from_breakpoint;
+		/// Used by OnEvent to wait for resumption.
+		std::condition_variable resume_from_breakpoint;
 
-    /// List of registered observers
-    std::list<BreakPointObserver*> breakpoint_observers;
-};
+		/// List of registered observers
+		std::list<BreakPointObserver*> breakpoint_observers;
+	};
 
-extern std::shared_ptr<DebugContext> g_debug_context; // TODO: Get rid of this global
+	extern std::shared_ptr<DebugContext> g_debug_context; // TODO: Get rid of this global
 
-namespace DebugUtils {
+	namespace DebugUtils {
 
 #define PICA_DUMP_TEXTURES 0
 #define PICA_LOG_TEV 0
 
-void DumpShader(const std::string& filename, const Regs::ShaderConfig& config,
-                const Shader::ShaderSetup& setup,
-                const Regs::VSOutputAttributes* output_attributes);
+		void DumpShader(const std::string& filename, const Regs::ShaderConfig& config,
+			const Shader::ShaderSetup& setup,
+			const Regs::VSOutputAttributes* output_attributes);
 
-// Utility class to log Pica commands.
-struct PicaTrace {
-    struct Write {
-        u16 cmd_id;
-        u16 mask;
-        u32 value;
-    };
-    std::vector<Write> writes;
-};
+		// Utility class to log Pica commands.
+		struct PicaTrace {
+			struct Write {
+				u16 cmd_id;
+				u16 mask;
+				u32 value;
+			};
+			std::vector<Write> writes;
+			std::vector<Write> search_corrected_writes;
+			bool isSearchCorrected = false;
+			void CorrectSearchWrites(std::string search_string) {
 
-void StartPicaTracing();
-bool IsPicaTracing();
-void OnPicaRegWrite(PicaTrace::Write write);
-std::unique_ptr<PicaTrace> FinishPicaTracing();
+				search_corrected_writes.clear();
 
-struct TextureInfo {
-    PAddr physical_address;
-    int width;
-    int height;
-    int stride;
-    Pica::Regs::TextureFormat format;
+				if (search_string.size() == 0)
+					isSearchCorrected = false;
+				else isSearchCorrected = true;
 
-    static TextureInfo FromPicaRegister(const Pica::Regs::TextureConfig& config,
-                                        const Pica::Regs::TextureFormat& format);
-};
+				for (int i = 0; i < writes.size(); i++) {
+					bool isValid = true;
 
-/**
- * Lookup texel located at the given coordinates and return an RGBA vector of its color.
- * @param source Source pointer to read data from
- * @param s,t Texture coordinates to read from
- * @param info TextureInfo object describing the texture setup
- * @param disable_alpha This is used for debug widgets which use this method to display textures
- * without providing a good way to visualize alpha by themselves. If true, this will return 255 for
- * the alpha component, and either drop the information entirely or store it in an "unused" color
- * channel.
- * @todo Eventually we should get rid of the disable_alpha parameter.
- */
-const Math::Vec4<u8> LookupTexture(const u8* source, int s, int t, const TextureInfo& info,
-                                   bool disable_alpha = false);
+					std::string cmdName = Pica::Regs::GetCommandName(writes[i].cmd_id);
 
-void DumpTexture(const Pica::Regs::TextureConfig& texture_config, u8* data);
+					if (cmdName.size() < search_string.size())
+						continue;
 
-std::string GetTevStageConfigColorCombinerString(const Pica::Regs::TevStageConfig& tev_stage);
-std::string GetTevStageConfigAlphaCombinerString(const Pica::Regs::TevStageConfig& tev_stage);
+					for (int j = 0; j < search_string.size(); j++) {
+						if (cmdName.at(j) != search_string.at(j)) {
+							isValid = false;
+							break;
+						}
+					}
 
-/// Dumps the Tev stage config to log at trace level
-void DumpTevStageConfig(const std::array<Pica::Regs::TevStageConfig, 6>& stages);
+					if (!isValid)
+						continue;
 
-/**
- * Used in the vertex loader to merge access records. TODO: Investigate if actually useful.
- */
-class MemoryAccessTracker {
-    /// Combine overlapping and close ranges
-    void SimplifyRanges() {
-        for (auto it = ranges.begin(); it != ranges.end(); ++it) {
-            // NOTE: We add 32 to the range end address to make sure "close" ranges are combined,
-            // too
-            auto it2 = std::next(it);
-            while (it2 != ranges.end() && it->first + it->second + 32 >= it2->first) {
-                it->second = std::max(it->second, it2->first + it2->second - it->first);
-                it2 = ranges.erase(it2);
-            }
-        }
-    }
+					search_corrected_writes.push_back(writes[i]);
+				}
 
-public:
-    /// Record a particular memory access in the list
-    void AddAccess(u32 paddr, u32 size) {
-        // Create new range or extend existing one
-        ranges[paddr] = std::max(ranges[paddr], size);
+			}
+		};
 
-        // Simplify ranges...
-        SimplifyRanges();
-    }
+		void StartPicaTracing();
+		bool IsPicaTracing();
+		void OnPicaRegWrite(PicaTrace::Write write);
+		std::unique_ptr<PicaTrace> FinishPicaTracing();
 
-    /// Map of accessed ranges (mapping start address to range size)
-    std::map<u32, u32> ranges;
-};
+		struct TextureInfo {
+			PAddr physical_address;
+			int width;
+			int height;
+			int stride;
+			Pica::Regs::TextureFormat format;
 
-} // namespace
+			static TextureInfo FromPicaRegister(const Pica::Regs::TextureConfig& config,
+				const Pica::Regs::TextureFormat& format);
+		};
+
+		/**
+		* Lookup texel located at the given coordinates and return an RGBA vector of its color.
+		* @param source Source pointer to read data from
+		* @param s,t Texture coordinates to read from
+		* @param info TextureInfo object describing the texture setup
+		* @param disable_alpha This is used for debug widgets which use this method to display textures
+		* without providing a good way to visualize alpha by themselves. If true, this will return 255 for
+		* the alpha component, and either drop the information entirely or store it in an "unused" color
+		* channel.
+		* @todo Eventually we should get rid of the disable_alpha parameter.
+		*/
+		const Math::Vec4<u8> LookupTexture(const u8* source, int s, int t, const TextureInfo& info,
+			bool disable_alpha = false);
+
+		void DumpTexture(const Pica::Regs::TextureConfig& texture_config, u8* data);
+
+		std::string GetTevStageConfigColorCombinerString(const Pica::Regs::TevStageConfig& tev_stage);
+		std::string GetTevStageConfigAlphaCombinerString(const Pica::Regs::TevStageConfig& tev_stage);
+
+		/// Dumps the Tev stage config to log at trace level
+		void DumpTevStageConfig(const std::array<Pica::Regs::TevStageConfig, 6>& stages);
+
+		/**
+		* Used in the vertex loader to merge access records. TODO: Investigate if actually useful.
+		*/
+		class MemoryAccessTracker {
+			/// Combine overlapping and close ranges
+			void SimplifyRanges() {
+				for (auto it = ranges.begin(); it != ranges.end(); ++it) {
+					// NOTE: We add 32 to the range end address to make sure "close" ranges are combined,
+					// too
+					auto it2 = std::next(it);
+					while (it2 != ranges.end() && it->first + it->second + 32 >= it2->first) {
+						it->second = std::max(it->second, it2->first + it2->second - it->first);
+						it2 = ranges.erase(it2);
+					}
+				}
+			}
+
+		public:
+			/// Record a particular memory access in the list
+			void AddAccess(u32 paddr, u32 size) {
+				// Create new range or extend existing one
+				ranges[paddr] = std::max(ranges[paddr], size);
+
+				// Simplify ranges...
+				SimplifyRanges();
+			}
+
+			/// Map of accessed ranges (mapping start address to range size)
+			std::map<u32, u32> ranges;
+		};
+
+	} // namespace
 
 } // namespace

--- a/src/video_core/debug_utils/debug_utils.h
+++ b/src/video_core/debug_utils/debug_utils.h
@@ -20,283 +20,282 @@
 #include "video_core/pica.h"
 
 namespace CiTrace {
-	class Recorder;
+    class Recorder;
 }
 
 namespace Pica {
 
-	namespace Shader {
-		struct ShaderSetup;
-	}
+    namespace Shader {
+        struct ShaderSetup;
+    }
 
-	class DebugContext {
-	public:
-		enum class Event {
-			FirstEvent = 0,
+    class DebugContext {
+    public:
+        enum class Event {
+            FirstEvent = 0,
 
-			PicaCommandLoaded = FirstEvent,
-			PicaCommandProcessed,
-			IncomingPrimitiveBatch,
-			FinishedPrimitiveBatch,
-			VertexShaderInvocation,
-			IncomingDisplayTransfer,
-			GSPCommandProcessed,
-			BufferSwapped,
+            PicaCommandLoaded = FirstEvent,
+            PicaCommandProcessed,
+            IncomingPrimitiveBatch,
+            FinishedPrimitiveBatch,
+            VertexShaderInvocation,
+            IncomingDisplayTransfer,
+            GSPCommandProcessed,
+            BufferSwapped,
 
-			NumEvents
-		};
+            NumEvents
+        };
 
-		/**
-		* Inherit from this class to be notified of events registered to some debug context.
-		* Most importantly this is used for our debugger GUI.
-		*
-		* To implement event handling, override the OnPicaBreakPointHit and OnPicaResume methods.
-		* @warning All BreakPointObservers need to be on the same thread to guarantee thread-safe state
-		* access
-		* @todo Evaluate an alternative interface, in which there is only one managing observer and
-		* multiple child observers running (by design) on the same thread.
-		*/
-		class BreakPointObserver {
-		public:
-			/// Constructs the object such that it observes events of the given DebugContext.
-			BreakPointObserver(std::shared_ptr<DebugContext> debug_context)
-				: context_weak(debug_context) {
-				std::unique_lock<std::mutex> lock(debug_context->breakpoint_mutex);
-				debug_context->breakpoint_observers.push_back(this);
-			}
+        /**
+        * Inherit from this class to be notified of events registered to some debug context.
+        * Most importantly this is used for our debugger GUI.
+        *
+        * To implement event handling, override the OnPicaBreakPointHit and OnPicaResume methods.
+        * @warning All BreakPointObservers need to be on the same thread to guarantee thread-safe state
+        * access
+        * @todo Evaluate an alternative interface, in which there is only one managing observer and
+        * multiple child observers running (by design) on the same thread.
+        */
+        class BreakPointObserver {
+        public:
+            /// Constructs the object such that it observes events of the given DebugContext.
+            BreakPointObserver(std::shared_ptr<DebugContext> debug_context)
+                : context_weak(debug_context) {
+                std::unique_lock<std::mutex> lock(debug_context->breakpoint_mutex);
+                debug_context->breakpoint_observers.push_back(this);
+            }
 
-			virtual ~BreakPointObserver() {
-				auto context = context_weak.lock();
-				if (context) {
-					std::unique_lock<std::mutex> lock(context->breakpoint_mutex);
-					context->breakpoint_observers.remove(this);
+            virtual ~BreakPointObserver() {
+                auto context = context_weak.lock();
+                if (context) {
+                    std::unique_lock<std::mutex> lock(context->breakpoint_mutex);
+                    context->breakpoint_observers.remove(this);
 
-					// If we are the last observer to be destroyed, tell the debugger context that
-					// it is free to continue. In particular, this is required for a proper Citra
-					// shutdown, when the emulation thread is waiting at a breakpoint.
-					if (context->breakpoint_observers.empty())
-						context->Resume();
-				}
-			}
+                    // If we are the last observer to be destroyed, tell the debugger context that
+                    // it is free to continue. In particular, this is required for a proper Citra
+                    // shutdown, when the emulation thread is waiting at a breakpoint.
+                    if (context->breakpoint_observers.empty())
+                        context->Resume();
+                }
+            }
 
-			/**
-			* Action to perform when a breakpoint was reached.
-			* @param event Type of event which triggered the breakpoint
-			* @param data Optional data pointer (if unused, this is a nullptr)
-			* @note This function will perform nothing unless it is overridden in the child class.
-			*/
-			virtual void OnPicaBreakPointHit(Event, void*) {}
+            /**
+            * Action to perform when a breakpoint was reached.
+            * @param event Type of event which triggered the breakpoint
+            * @param data Optional data pointer (if unused, this is a nullptr)
+            * @note This function will perform nothing unless it is overridden in the child class.
+            */
+            virtual void OnPicaBreakPointHit(Event, void*) {}
 
-			/**
-			* Action to perform when emulation is resumed from a breakpoint.
-			* @note This function will perform nothing unless it is overridden in the child class.
-			*/
-			virtual void OnPicaResume() {}
+            /**
+            * Action to perform when emulation is resumed from a breakpoint.
+            * @note This function will perform nothing unless it is overridden in the child class.
+            */
+            virtual void OnPicaResume() {}
 
-		protected:
-			/**
-			* Weak context pointer. This need not be valid, so when requesting a shared_ptr via
-			* context_weak.lock(), always compare the result against nullptr.
-			*/
-			std::weak_ptr<DebugContext> context_weak;
-		};
+        protected:
+            /**
+            * Weak context pointer. This need not be valid, so when requesting a shared_ptr via
+            * context_weak.lock(), always compare the result against nullptr.
+            */
+            std::weak_ptr<DebugContext> context_weak;
+        };
 
-		/**
-		* Simple structure defining a breakpoint state
-		*/
-		struct BreakPoint {
-			bool enabled = false;
-		};
+        /**
+        * Simple structure defining a breakpoint state
+        */
+        struct BreakPoint {
+            bool enabled = false;
+        };
 
-		/**
-		* Static constructor used to create a shared_ptr of a DebugContext.
-		*/
-		static std::shared_ptr<DebugContext> Construct() {
-			return std::shared_ptr<DebugContext>(new DebugContext);
-		}
+        /**
+        * Static constructor used to create a shared_ptr of a DebugContext.
+        */
+        static std::shared_ptr<DebugContext> Construct() {
+            return std::shared_ptr<DebugContext>(new DebugContext);
+        }
 
-		/**
-		* Used by the emulation core when a given event has happened. If a breakpoint has been set
-		* for this event, OnEvent calls the event handlers of the registered breakpoint observers.
-		* The current thread then is halted until Resume() is called from another thread (or until
-		* emulation is stopped).
-		* @param event Event which has happened
-		* @param data Optional data pointer (pass nullptr if unused). Needs to remain valid until
-		* Resume() is called.
-		*/
-		void OnEvent(Event event, void* data) {
-			// This check is left in the header to allow the compiler to inline it.
-			if (!breakpoints[(int)event].enabled)
-				return;
-			// For the rest of event handling, call a separate function.
-			DoOnEvent(event, data);
-		}
+        /**
+        * Used by the emulation core when a given event has happened. If a breakpoint has been set
+        * for this event, OnEvent calls the event handlers of the registered breakpoint observers.
+        * The current thread then is halted until Resume() is called from another thread (or until
+        * emulation is stopped).
+        * @param event Event which has happened
+        * @param data Optional data pointer (pass nullptr if unused). Needs to remain valid until
+        * Resume() is called.
+        */
+        void OnEvent(Event event, void* data) {
+            // This check is left in the header to allow the compiler to inline it.
+            if (!breakpoints[(int)event].enabled)
+                return;
+            // For the rest of event handling, call a separate function.
+            DoOnEvent(event, data);
+        }
 
-		void DoOnEvent(Event event, void* data);
+        void DoOnEvent(Event event, void* data);
 
-		/**
-		* Resume from the current breakpoint.
-		* @warning Calling this from the same thread that OnEvent was called in will cause a deadlock.
-		* Calling from any other thread is safe.
-		*/
-		void Resume();
+        /**
+        * Resume from the current breakpoint.
+        * @warning Calling this from the same thread that OnEvent was called in will cause a deadlock.
+        * Calling from any other thread is safe.
+        */
+        void Resume();
 
-		/**
-		* Delete all set breakpoints and resume emulation.
-		*/
-		void ClearBreakpoints() {
-			for (auto& bp : breakpoints) {
-				bp.enabled = false;
-			}
-			Resume();
-		}
+        /**
+        * Delete all set breakpoints and resume emulation.
+        */
+        void ClearBreakpoints() {
+            for (auto& bp : breakpoints) {
+                bp.enabled = false;
+            }
+            Resume();
+        }
 
-		// TODO: Evaluate if access to these members should be hidden behind a public interface.
-		std::array<BreakPoint, (int)Event::NumEvents> breakpoints;
-		Event active_breakpoint;
-		bool at_breakpoint = false;
+        // TODO: Evaluate if access to these members should be hidden behind a public interface.
+        std::array<BreakPoint, (int)Event::NumEvents> breakpoints;
+        Event active_breakpoint;
+        bool at_breakpoint = false;
 
-		std::shared_ptr<CiTrace::Recorder> recorder = nullptr;
+        std::shared_ptr<CiTrace::Recorder> recorder = nullptr;
 
-	private:
-		/**
-		* Private default constructor to make sure people always construct this through Construct()
-		* instead.
-		*/
-		DebugContext() = default;
+    private:
+        /**
+        * Private default constructor to make sure people always construct this through Construct()
+        * instead.
+        */
+        DebugContext() = default;
 
-		/// Mutex protecting current breakpoint state and the observer list.
-		std::mutex breakpoint_mutex;
+        /// Mutex protecting current breakpoint state and the observer list.
+        std::mutex breakpoint_mutex;
 
-		/// Used by OnEvent to wait for resumption.
-		std::condition_variable resume_from_breakpoint;
+        /// Used by OnEvent to wait for resumption.
+        std::condition_variable resume_from_breakpoint;
 
-		/// List of registered observers
-		std::list<BreakPointObserver*> breakpoint_observers;
-	};
+        /// List of registered observers
+        std::list<BreakPointObserver*> breakpoint_observers;
+    };
 
-	extern std::shared_ptr<DebugContext> g_debug_context; // TODO: Get rid of this global
+    extern std::shared_ptr<DebugContext> g_debug_context; // TODO: Get rid of this global
 
-	namespace DebugUtils {
+    namespace DebugUtils {
 
 #define PICA_DUMP_TEXTURES 0
 #define PICA_LOG_TEV 0
 
-		void DumpShader(const std::string& filename, const Regs::ShaderConfig& config,
-			const Shader::ShaderSetup& setup,
-			const Regs::VSOutputAttributes* output_attributes);
+        void DumpShader(const std::string& filename, const Regs::ShaderConfig& config,
+            const Shader::ShaderSetup& setup,
+            const Regs::VSOutputAttributes* output_attributes);
 
-		// Utility class to log Pica commands.
-		struct PicaTrace {
-			struct Write {
-				u16 cmd_id;
-				u16 mask;
-				u32 value;
-			};
-			std::vector<Write> writes;
-			std::vector<Write> search_corrected_writes;
-			bool isSearchCorrected = false;
-			void CorrectSearchWrites(std::string search_string) {
+        // Utility class to log Pica commands.
+        struct PicaTrace {
+            struct Write {
+                u16 cmd_id;
+                u16 mask;
+                u32 value;
+            };
+            std::vector<Write> writes;
+            std::vector<Write> search_corrected_writes;
+            bool is_search_corrected = false;
 
-				search_corrected_writes.clear();
+            void CorrectSearchWrites(std::string search_string) {
+                search_corrected_writes.clear();
 
-				if (search_string.size() == 0)
-					isSearchCorrected = false;
-				else isSearchCorrected = true;
+                if (search_string.size() == 0)
+                    is_search_corrected = false;
+                else
+                    is_search_corrected = true;
 
-				for (int i = 0; i < writes.size(); i++) {
-					bool isValid = true;
+                for (int i = 0; i < writes.size(); i++) {
+                    bool is_valid = true;
+                    std::string cmd_name = Pica::Regs::GetCommandName(writes[i].cmd_id);
 
-					std::string cmdName = Pica::Regs::GetCommandName(writes[i].cmd_id);
+                    if (cmd_name.size() < search_string.size())
+                        continue;
 
-					if (cmdName.size() < search_string.size())
-						continue;
+                    for (int j = 0; j < search_string.size(); j++) {
+                        if (cmd_name.at(j) != search_string.at(j)) {
+                            is_valid = false;
+                            break;
+                        }
+                    }//End of j for-loop
 
-					for (int j = 0; j < search_string.size(); j++) {
-						if (cmdName.at(j) != search_string.at(j)) {
-							isValid = false;
-							break;
-						}
-					}
+                    if (!is_valid)
+                        continue;
 
-					if (!isValid)
-						continue;
+                    search_corrected_writes.push_back(writes[i]);
+                }//End of i for-loop
+            }//End of search filter
+        };
 
-					search_corrected_writes.push_back(writes[i]);
-				}
+        void StartPicaTracing();
+        bool IsPicaTracing();
+        void OnPicaRegWrite(PicaTrace::Write write);
+        std::unique_ptr<PicaTrace> FinishPicaTracing();
 
-			}
-		};
+        struct TextureInfo {
+            PAddr physical_address;
+            int width;
+            int height;
+            int stride;
+            Pica::Regs::TextureFormat format;
 
-		void StartPicaTracing();
-		bool IsPicaTracing();
-		void OnPicaRegWrite(PicaTrace::Write write);
-		std::unique_ptr<PicaTrace> FinishPicaTracing();
+            static TextureInfo FromPicaRegister(const Pica::Regs::TextureConfig& config,
+                const Pica::Regs::TextureFormat& format);
+        };
 
-		struct TextureInfo {
-			PAddr physical_address;
-			int width;
-			int height;
-			int stride;
-			Pica::Regs::TextureFormat format;
+        /**
+        * Lookup texel located at the given coordinates and return an RGBA vector of its color.
+        * @param source Source pointer to read data from
+        * @param s,t Texture coordinates to read from
+        * @param info TextureInfo object describing the texture setup
+        * @param disable_alpha This is used for debug widgets which use this method to display textures
+        * without providing a good way to visualize alpha by themselves. If true, this will return 255 for
+        * the alpha component, and either drop the information entirely or store it in an "unused" color
+        * channel.
+        * @todo Eventually we should get rid of the disable_alpha parameter.
+        */
+        const Math::Vec4<u8> LookupTexture(const u8* source, int s, int t, const TextureInfo& info,
+            bool disable_alpha = false);
 
-			static TextureInfo FromPicaRegister(const Pica::Regs::TextureConfig& config,
-				const Pica::Regs::TextureFormat& format);
-		};
+        void DumpTexture(const Pica::Regs::TextureConfig& texture_config, u8* data);
 
-		/**
-		* Lookup texel located at the given coordinates and return an RGBA vector of its color.
-		* @param source Source pointer to read data from
-		* @param s,t Texture coordinates to read from
-		* @param info TextureInfo object describing the texture setup
-		* @param disable_alpha This is used for debug widgets which use this method to display textures
-		* without providing a good way to visualize alpha by themselves. If true, this will return 255 for
-		* the alpha component, and either drop the information entirely or store it in an "unused" color
-		* channel.
-		* @todo Eventually we should get rid of the disable_alpha parameter.
-		*/
-		const Math::Vec4<u8> LookupTexture(const u8* source, int s, int t, const TextureInfo& info,
-			bool disable_alpha = false);
+        std::string GetTevStageConfigColorCombinerString(const Pica::Regs::TevStageConfig& tev_stage);
+        std::string GetTevStageConfigAlphaCombinerString(const Pica::Regs::TevStageConfig& tev_stage);
 
-		void DumpTexture(const Pica::Regs::TextureConfig& texture_config, u8* data);
+        /// Dumps the Tev stage config to log at trace level
+        void DumpTevStageConfig(const std::array<Pica::Regs::TevStageConfig, 6>& stages);
 
-		std::string GetTevStageConfigColorCombinerString(const Pica::Regs::TevStageConfig& tev_stage);
-		std::string GetTevStageConfigAlphaCombinerString(const Pica::Regs::TevStageConfig& tev_stage);
+        /**
+        * Used in the vertex loader to merge access records. TODO: Investigate if actually useful.
+        */
+        class MemoryAccessTracker {
+            /// Combine overlapping and close ranges
+            void SimplifyRanges() {
+                for (auto it = ranges.begin(); it != ranges.end(); ++it) {
+                    // NOTE: We add 32 to the range end address to make sure "close" ranges are combined,
+                    // too
+                    auto it2 = std::next(it);
+                    while (it2 != ranges.end() && it->first + it->second + 32 >= it2->first) {
+                        it->second = std::max(it->second, it2->first + it2->second - it->first);
+                        it2 = ranges.erase(it2);
+                    }
+                }
+            }
 
-		/// Dumps the Tev stage config to log at trace level
-		void DumpTevStageConfig(const std::array<Pica::Regs::TevStageConfig, 6>& stages);
+        public:
+            /// Record a particular memory access in the list
+            void AddAccess(u32 paddr, u32 size) {
+                // Create new range or extend existing one
+                ranges[paddr] = std::max(ranges[paddr], size);
 
-		/**
-		* Used in the vertex loader to merge access records. TODO: Investigate if actually useful.
-		*/
-		class MemoryAccessTracker {
-			/// Combine overlapping and close ranges
-			void SimplifyRanges() {
-				for (auto it = ranges.begin(); it != ranges.end(); ++it) {
-					// NOTE: We add 32 to the range end address to make sure "close" ranges are combined,
-					// too
-					auto it2 = std::next(it);
-					while (it2 != ranges.end() && it->first + it->second + 32 >= it2->first) {
-						it->second = std::max(it->second, it2->first + it2->second - it->first);
-						it2 = ranges.erase(it2);
-					}
-				}
-			}
+                // Simplify ranges...
+                SimplifyRanges();
+            }
 
-		public:
-			/// Record a particular memory access in the list
-			void AddAccess(u32 paddr, u32 size) {
-				// Create new range or extend existing one
-				ranges[paddr] = std::max(ranges[paddr], size);
+            /// Map of accessed ranges (mapping start address to range size)
+            std::map<u32, u32> ranges;
+        };
 
-				// Simplify ranges...
-				SimplifyRanges();
-			}
-
-			/// Map of accessed ranges (mapping start address to range size)
-			std::map<u32, u32> ranges;
-		};
-
-	} // namespace
+    } // namespace
 
 } // namespace


### PR DESCRIPTION
Search bar for the Pica Command List. Just adds a text area that updates the GPU command list with the input from the user. Case-sensitive. Needs optimized, pretty slow, but there's a lot of commands so that may be unavoidable. Spacing should be fixed now, I un-tabbed all my changes.
(As a side note I moved the search bar up above the start/finish/copy trace buttons. Screenshot isn't updated.)

Screenshot of the change in Citra:
![screenshot 28](https://cloud.githubusercontent.com/assets/4676981/19223753/2b56b6be-8e3d-11e6-819b-f9353a303eb5.png)
