### PR TITLE
Fix the build with clang 3.8.

### DIFF
--- a/externals/microprofile/microprofileui.h
+++ b/externals/microprofile/microprofileui.h
@@ -1022,7 +1022,7 @@ void MicroProfileDrawDetailedBars(uint32_t nWidth, uint32_t nHeight, int nBaseY,
             int64_t nBaseTicks = bGpu ? nBaseTicksGpu : nBaseTicksCpu;
             char ThreadName[MicroProfileThreadLog::THREAD_MAX_LEN + 16];
             uint64_t nThreadId = pLog->nThreadId;
-            snprintf(ThreadName, sizeof(ThreadName)-1, "%04llx: %s", nThreadId, &pLog->ThreadName[0] );
+            snprintf(ThreadName, sizeof(ThreadName)-1, "%04lx: %s", nThreadId, &pLog->ThreadName[0] );
             nY += 3;
             uint32_t nThreadColor = -1;
             if(pLog->nThreadId == nContextSwitchHoverThreadAfter || pLog->nThreadId == nContextSwitchHoverThreadBefore)
@@ -1234,7 +1234,7 @@ void MicroProfileDrawDetailedBars(uint32_t nWidth, uint32_t nHeight, int nBaseY,
                 // nThreadId is 32-bit on Windows
                 int nStrLen = snprintf(ThreadName, sizeof(ThreadName)-1, "%04x: %s%s", nThreadId, cLocal, i < nNumThreadsBase ? &S.Pool[i]->ThreadName[0] : MICROPROFILE_THREAD_NAME_FROM_ID(nThreadId) );
 #else
-                int nStrLen = snprintf(ThreadName, sizeof(ThreadName)-1, "%04llx: %s%s", nThreadId, cLocal, i < nNumThreadsBase ? &S.Pool[i]->ThreadName[0] : MICROPROFILE_THREAD_NAME_FROM_ID(nThreadId) );
+                int nStrLen = snprintf(ThreadName, sizeof(ThreadName)-1, "%04lx: %s%s", nThreadId, cLocal, i < nNumThreadsBase ? &S.Pool[i]->ThreadName[0] : MICROPROFILE_THREAD_NAME_FROM_ID(nThreadId) );
 #endif
                 uint32_t nThreadColor = -1;
                 if(nThreadId == nContextSwitchHoverThreadAfter || nThreadId == nContextSwitchHoverThreadBefore)
@@ -1608,7 +1608,7 @@ void MicroProfileDrawBarMetaCountCallback(uint32_t nTimer, uint32_t nIdx, uint64
 {
     uint64_t* pCounters = (uint64_t*)pExtra;
     char sBuffer[SBUF_MAX];
-    int nLen = snprintf(sBuffer, SBUF_MAX-1, "%5llu", pCounters[nTimer]);
+    int nLen = snprintf(sBuffer, SBUF_MAX-1, "%5lu", pCounters[nTimer]);
     MicroProfileDrawText(nX - nLen * (MICROPROFILE_TEXT_WIDTH+1), nY, (uint32_t)-1, sBuffer, nLen);
 }
 

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -42,7 +42,7 @@ void FindContentInfos(Service::Interface* self) {
     am_content_count[media_type] = cmd_buff[4];
 
     cmd_buff[1] = RESULT_SUCCESS.raw;
-    LOG_WARNING(Service_AM, "(STUBBED) media_type=%u, title_id=0x%016llx, content_cound=%u, "
+    LOG_WARNING(Service_AM, "(STUBBED) media_type=%u, title_id=0x%016lx, content_cound=%u, "
                             "content_ids_pointer=0x%08x, content_info_pointer=0x%08x",
                 media_type, title_id, am_content_count[media_type], content_ids_pointer,
                 content_info_pointer);

--- a/src/core/hle/service/boss/boss.cpp
+++ b/src/core/hle/service/boss/boss.cpp
@@ -33,7 +33,7 @@ void InitializeSession(Service::Interface* self) {
     cmd_buff[0] = IPC::MakeHeader(0x1, 0x1, 0);
     cmd_buff[1] = RESULT_SUCCESS.raw;
 
-    LOG_WARNING(Service_BOSS, "(STUBBED) unk_param=0x%016X, translation=0x%08X, unk_param4=0x%08X",
+    LOG_WARNING(Service_BOSS, "(STUBBED) unk_param=0x%016lX, translation=0x%08X, unk_param4=0x%08X",
                 unk_param, translation, unk_param4);
 }
 

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -106,7 +106,7 @@ ResultVal<bool> File::SyncRequest() {
 
         if (offset + length > backend->GetSize()) {
             LOG_ERROR(Service_FS,
-                      "Reading from out of bounds offset=0x%llX length=0x%08X file_size=0x%llX",
+                      "Reading from out of bounds offset=0x%lX length=0x%08X file_size=0x%lX",
                       offset, length, backend->GetSize());
         }
 

--- a/src/core/hle/service/fs/fs_user.cpp
+++ b/src/core/hle/service/fs/fs_user.cpp
@@ -288,7 +288,7 @@ static void CreateFile(Service::Interface* self) {
 
     FileSys::Path file_path(filename_type, filename_size, filename_ptr);
 
-    LOG_DEBUG(Service_FS, "type=%u size=%llu data=%s", static_cast<u32>(filename_type), file_size,
+    LOG_DEBUG(Service_FS, "type=%u size=%lu data=%s", static_cast<u32>(filename_type), file_size,
               file_path.DebugStr().c_str());
 
     cmd_buff[1] = CreateFileInArchive(archive_handle, file_path, file_size).raw;

--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -268,7 +268,7 @@ ResultStatus AppLoader_NCCH::LoadExeFS() {
     resource_limit_category = exheader_header.arm11_system_local_caps.resource_limit_category;
 
     LOG_INFO(Loader, "Name:                        %s", exheader_header.codeset_info.name);
-    LOG_INFO(Loader, "Program ID:                  %016llX", ncch_header.program_id);
+    LOG_INFO(Loader, "Program ID:                  %016lX", ncch_header.program_id);
     LOG_DEBUG(Loader, "Code compressed:             %s", is_compressed ? "yes" : "no");
     LOG_DEBUG(Loader, "Entry point:                 0x%08X", entry_point);
     LOG_DEBUG(Loader, "Code size:                   0x%08X", code_size);


### PR DESCRIPTION
This fixes a bunch of narrowing conversion errors, e.g.:
error: format specifies type 'unsigned long long' but the argument has type
      'u64' (aka 'unsigned long') [-Werror,-Wformat]
