### PR TITLE
Small fix to let IDA see target.xml

### DIFF
--- a/src/core/gdbstub/gdbstub.cpp
+++ b/src/core/gdbstub/gdbstub.cpp
@@ -413,7 +413,7 @@ static void HandleQuery() {
 
     if (strcmp(query, "TStatus") == 0) {
         SendReply("T0");
-    } else if (strncmp(query, "Supported:", strlen("Supported:")) == 0) {
+    } else if (strncmp(query, "Supported", strlen("Supported")) == 0) {
         // PacketSize needs to be large enough for target xml
         SendReply("PacketSize=800;qXfer:features:read+");
     } else if (strncmp(query, "Xfer:features:read:target.xml:",


### PR DESCRIPTION
IDA Pro don't add ":" to "qSupported", so, gdbstub don't send back target.xml with register descriptions, and we can't see status bits.
before PR:
![ida3](https://cloud.githubusercontent.com/assets/629437/19816602/b333d6a8-9d50-11e6-828a-64905478d732.png)

after:
![ida4](https://cloud.githubusercontent.com/assets/629437/19816630/bd799436-9d50-11e6-9f62-1e719d7f8182.png)
