### PR TITLE
Crash on MacOS 10.12 because Memory::GetPhysicalPointer return NULL

### DIFF
--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -222,7 +222,8 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
                     continue;
 
                 u8* texture_data = Memory::GetPhysicalPointer(texture.config.GetPhysicalAddress());
-                if (texture_data == NULL) {
+                if (texture_data == nullptr) {
+                    LOG_ERROR(HW_GPU, "Texture's data at index %d is null", i);
                     return;
                 }
                 if (g_debug_context && Pica::g_debug_context->recorder)

--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -222,6 +222,9 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
                     continue;
 
                 u8* texture_data = Memory::GetPhysicalPointer(texture.config.GetPhysicalAddress());
+                if (texture_data == NULL) {
+                    return;
+                }
                 if (g_debug_context && Pica::g_debug_context->recorder)
                     g_debug_context->recorder->MemoryAccessed(
                         texture_data, Pica::Regs::NibblesPerPixel(texture.format) *


### PR DESCRIPTION
Please review and test.