### PR TITLE
APT::GetStartupArgument: force clear startup argument

### DIFF
--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -458,12 +458,16 @@ void GetStartupArgument(Service::Interface* self) {
         return;
     }
 
-    LOG_WARNING(Service_APT, "(stubbed) called startup_argument_type=%u , parameter_size=0x%08x , "
-                             "parameter_value=0x%08x",
-                startup_argument_type, parameter_size, Memory::Read32(cmd_buff[41]));
+    u32 addr = cmd_buff[65];
+    if (addr && parameter_size) {
+        Memory::ZeroBlock(addr, parameter_size);
+    }
+
+    LOG_WARNING(Service_APT, "(stubbed) called startup_argument_type=%u , parameter_size=0x%08x",
+                startup_argument_type, parameter_size);
 
     cmd_buff[1] = RESULT_SUCCESS.raw;
-    cmd_buff[2] = (parameter_size > 0) ? 1 : 0;
+    cmd_buff[2] = 0;
 }
 
 void CheckNew3DSApp(Service::Interface* self) {

--- a/src/core/hle/service/apt/apt.h
+++ b/src/core/hle/service/apt/apt.h
@@ -407,9 +407,11 @@ void CancelLibraryApplet(Service::Interface* self);
  *  Inputs:
  *      1 : Parameter Size (capped to 0x300)
  *      2 : StartupArgumentType
+ *      65 : Output buffer for startup argument
  *  Outputs:
  *      0 : Return header
- *      1 : u8, Exists (0 = does not exist, 1 = exists)
+ *      1 : Result of function, 0 on success, otherwise error code
+ *      2 : u8, Exists (0 = does not exist, 1 = exists)
  */
 void GetStartupArgument(Service::Interface* self);
 


### PR DESCRIPTION
This PR do not provide startup argument for applications at all instead of garbage
Partially fix **Inazuma Eleven 3: won't boot** #2030 (Now it shows LEVEL 5 logo before stuck)