### PR TITLE
Check clang-format during pre-commit

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -25,6 +25,13 @@ END
     exit 1
 fi
 
+if ! hash "clang-format" 2> /dev/null; then
+    cat<<END
+Error: You must have clang-format installed on your system for codestyle checking purposes.
+END
+    exit 1
+fi
+
 for f in $(git diff --name-only --diff-filter=ACMRTUXB --cached); do
     if ! echo "$f" | egrep -q "[.](cpp|h)$"; then
         continue


### PR DESCRIPTION
Users who do not have clang-format installed were not able to push commits. This patch gives
better feedback to the developer by explicitely telling the user to install the package.

Tracked-On: https://github.com/citra-emu/citra/issues/2155