### PR TITLE
Fix Travis build issue on mac

### DIFF
--- a/.travis-deps.sh
+++ b/.travis-deps.sh
@@ -29,5 +29,5 @@ if [ "$TRAVIS_OS_NAME" = "linux" -o -z "$TRAVIS_OS_NAME" ]; then
 
 elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
     brew update
-    brew install cmake qt5 sdl2 dylibbundler
+    brew install qt5 sdl2 dylibbundler
 fi


### PR DESCRIPTION
Removes cmake from the install list. Cmake now up to date on the new travis mac image meaning brew install cmake would throw an error. Doing `--force` means force reinstalling it every build, and ignoring error codes means that you potentially will miss other build breaking errors that could occur at this phase.