### PR TITLE
Change "OS X" to "macOS" in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Citra Emulator
 [![Travis CI Build Status](https://travis-ci.org/citra-emu/citra.svg?branch=master)](https://travis-ci.org/citra-emu/citra)
 [![AppVeyor CI Build Status](https://ci.appveyor.com/api/projects/status/sdf1o4kh3g1e68m9?svg=true)](https://ci.appveyor.com/project/bunnei/citra)
 
-Citra is an experimental open-source Nintendo 3DS emulator/debugger written in C++. It is written with portability in mind, with builds actively maintained for Windows, Linux and OS X. Citra only emulates a subset of 3DS hardware, and therefore is generally only useful for running/debugging homebrew applications. At this time, Citra is even able to boot several commercial games! Most of these do not run to a playable state, but we are working every day to advance the project forward.
+Citra is an experimental open-source Nintendo 3DS emulator/debugger written in C++. It is written with portability in mind, with builds actively maintained for Windows, Linux and macOS. Citra only emulates a subset of 3DS hardware, and therefore is generally only useful for running/debugging homebrew applications. At this time, Citra is even able to boot several commercial games! Most of these do not run to a playable state, but we are working every day to advance the project forward.
 
 Citra is licensed under the GPLv2 (or any later version). Refer to the license.txt file included. Please read the [FAQ](https://github.com/citra-emu/citra/wiki/FAQ) before getting started with the project.
 
@@ -23,7 +23,7 @@ If you want to contribute please take a look at the [Contributor's Guide](CONTRI
 
 * __Windows__: [Windows Build](https://github.com/citra-emu/citra/wiki/Building-For-Windows)
 * __Linux__: [Linux Build](https://github.com/citra-emu/citra/wiki/Building-For-Linux)
-* __OSX__: [OS X Build](https://github.com/citra-emu/citra/wiki/Building-For-OS-X)
+* __macOS__: [macOS Build](https://github.com/citra-emu/citra/wiki/Building-for-macOS)
 
 
 ### Support


### PR DESCRIPTION
Change "OS X" to "macOS" as Apple no longer uses the OS X branding as of 10.12. Also update the wiki page link as it broke with the new title.