### PR TITLE
Change "user" folder default location to AppData/Roaming/ on Windows systems

### DIFF
--- a/src/common/common_paths.h
+++ b/src/common/common_paths.h
@@ -19,7 +19,7 @@
 #define EMU_DATA_DIR USER_DIR
 #else
 #ifdef _WIN32
-#define EMU_DATA_DIR "Citra Emulator"
+#define EMU_DATA_DIR "Citra"
 #else
 #define EMU_DATA_DIR "citra-emu"
 #endif

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -26,6 +26,9 @@
 #define stat _stat64
 #define fstat _fstat64
 #define fileno _fileno
+// Windows version, at least Vista is required to obtain AppData Path
+#define WINVER 0x0600
+#define _WIN32_WINNT 0x0600
 #else
 #ifdef __APPLE__
 #include <sys/param.h>
@@ -594,6 +597,21 @@ std::string& GetExeDirectory() {
     }
     return exe_path;
 }
+
+std::string& AppDataLocalDirectory() {
+    // Windows Vista or later only
+    static std::string local_path;
+    if (local_path.empty()) {
+        PWSTR pw_local_path = 0;
+        wchar_t* wchar_local_path;
+        SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, NULL, &pw_local_path);
+        wchar_local_path = pw_local_path;
+        local_path = Common::UTF16ToUTF8(wchar_local_path);
+        // Freeing memory
+        CoTaskMemFree(static_cast<void*>(pw_local_path));
+    }
+    return local_path;
+}
 #else
 /**
  * @return The user’s home directory on POSIX systems
@@ -671,6 +689,11 @@ const std::string& GetUserPath(const unsigned int DirIDX, const std::string& new
     if (paths[D_USER_IDX].empty()) {
 #ifdef _WIN32
         paths[D_USER_IDX] = GetExeDirectory() + DIR_SEP USERDATA_DIR DIR_SEP;
+        if (!FileUtil::IsDirectory(paths[D_USER_IDX])) {
+            paths[D_USER_IDX] =
+                AppDataLocalDirectory() + DIR_SEP + EMU_DATA_DIR DIR_SEP USERDATA_DIR DIR_SEP;
+        }
+
         paths[D_CONFIG_IDX] = paths[D_USER_IDX] + CONFIG_DIR DIR_SEP;
         paths[D_CACHE_IDX] = paths[D_USER_IDX] + CACHE_DIR DIR_SEP;
 #else

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -684,8 +684,7 @@ const std::string& GetUserPath(const unsigned int DirIDX, const std::string& new
 #ifdef _WIN32
         paths[D_USER_IDX] = GetExeDirectory() + DIR_SEP USERDATA_DIR DIR_SEP;
         if (!FileUtil::IsDirectory(paths[D_USER_IDX])) {
-            paths[D_USER_IDX] =
-                AppDataRoamingDirectory() + DIR_SEP EMU_DATA_DIR DIR_SEP USERDATA_DIR DIR_SEP;
+            paths[D_USER_IDX] = AppDataRoamingDirectory() + DIR_SEP EMU_DATA_DIR DIR_SEP;
         }
 
         paths[D_CONFIG_IDX] = paths[D_USER_IDX] + CONFIG_DIR DIR_SEP;

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -598,10 +598,10 @@ std::string& GetExeDirectory() {
     return exe_path;
 }
 
-std::string AppDataLocalDirectory() {
+std::string AppDataRoamingDirectory() {
     PWSTR pw_local_path = nullptr;
     // Only supported by Windows Vista or later
-    SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &pw_local_path);
+    SHGetKnownFolderPath(FOLDERID_RoamingAppData, 0, nullptr, &pw_local_path);
     std::string local_path = Common::UTF16ToUTF8(pw_local_path);
     CoTaskMemFree(pw_local_path);
     return local_path;
@@ -685,7 +685,7 @@ const std::string& GetUserPath(const unsigned int DirIDX, const std::string& new
         paths[D_USER_IDX] = GetExeDirectory() + DIR_SEP USERDATA_DIR DIR_SEP;
         if (!FileUtil::IsDirectory(paths[D_USER_IDX])) {
             paths[D_USER_IDX] =
-                AppDataLocalDirectory() + DIR_SEP EMU_DATA_DIR DIR_SEP USERDATA_DIR DIR_SEP;
+                AppDataRoamingDirectory() + DIR_SEP EMU_DATA_DIR DIR_SEP USERDATA_DIR DIR_SEP;
         }
 
         paths[D_CONFIG_IDX] = paths[D_USER_IDX] + CONFIG_DIR DIR_SEP;

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -598,18 +598,12 @@ std::string& GetExeDirectory() {
     return exe_path;
 }
 
-std::string& AppDataLocalDirectory() {
-    // Windows Vista or later only
-    static std::string local_path;
-    if (local_path.empty()) {
-        PWSTR pw_local_path = 0;
-        wchar_t* wchar_local_path;
-        SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, NULL, &pw_local_path);
-        wchar_local_path = pw_local_path;
-        local_path = Common::UTF16ToUTF8(wchar_local_path);
-        // Freeing memory
-        CoTaskMemFree(static_cast<void*>(pw_local_path));
-    }
+std::string AppDataLocalDirectory() {
+    PWSTR pw_local_path = nullptr;
+    // Only supported by Windows Vista or later
+    SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, nullptr, &pw_local_path);
+    std::string local_path = Common::UTF16ToUTF8(pw_local_path);
+    CoTaskMemFree(pw_local_path);
     return local_path;
 }
 #else
@@ -691,7 +685,7 @@ const std::string& GetUserPath(const unsigned int DirIDX, const std::string& new
         paths[D_USER_IDX] = GetExeDirectory() + DIR_SEP USERDATA_DIR DIR_SEP;
         if (!FileUtil::IsDirectory(paths[D_USER_IDX])) {
             paths[D_USER_IDX] =
-                AppDataLocalDirectory() + DIR_SEP + EMU_DATA_DIR DIR_SEP USERDATA_DIR DIR_SEP;
+                AppDataLocalDirectory() + DIR_SEP EMU_DATA_DIR DIR_SEP USERDATA_DIR DIR_SEP;
         }
 
         paths[D_CONFIG_IDX] = paths[D_USER_IDX] + CONFIG_DIR DIR_SEP;

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -154,6 +154,7 @@ std::string GetBundleDirectory();
 
 #ifdef _WIN32
 std::string& GetExeDirectory();
+std::string& AppDataLocalDirectory();
 #endif
 
 size_t WriteStringToFile(bool text_file, const std::string& str, const char* filename);

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -154,7 +154,7 @@ std::string GetBundleDirectory();
 
 #ifdef _WIN32
 std::string& GetExeDirectory();
-std::string AppDataLocalDirectory();
+std::string AppDataRoamingDirectory();
 #endif
 
 size_t WriteStringToFile(bool text_file, const std::string& str, const char* filename);

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -154,7 +154,7 @@ std::string GetBundleDirectory();
 
 #ifdef _WIN32
 std::string& GetExeDirectory();
-std::string& AppDataLocalDirectory();
+std::string AppDataLocalDirectory();
 #endif
 
 size_t WriteStringToFile(bool text_file, const std::string& str, const char* filename);


### PR DESCRIPTION
Hello, this is my first PR, I tried to address #2177 and move the default location of the "user" folder to AppData/Roaming/Citra Emulator/(*).
If there is a "user" folder next to citra executable, that folder will take priority (portable mode).

Configuration changes should be handled with care to avoid problems between different versions.

Also note that SHGetKnownFolderPath works only on Windows Vista and later.

Thanks to @linkmauve for the suggestions he gave me yesterday.

Let me know what you think.

(*) After a bit of discussion we decided for Roaming instead of Local.