### PR TITLE
cfg: add config block 0x00090000

### DIFF
--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -45,7 +45,8 @@ static_assert(sizeof(SaveFileConfig) == 0x455C,
 enum ConfigBlockID {
     StereoCameraSettingsBlockID = 0x00050005,
     SoundOutputModeBlockID = 0x00070001,
-    ConsoleUniqueIDBlockID = 0x00090001,
+    ConsoleUniqueID1BlockID = 0x00090000,
+    ConsoleUniqueID2BlockID = 0x00090001,
     UsernameBlockID = 0x000A0000,
     BirthdayBlockID = 0x000A0001,
     LanguageBlockID = 0x000A0002,
@@ -409,7 +410,12 @@ ResultCode FormatConfig() {
     if (!res.IsSuccess())
         return res;
 
-    res = CreateConfigInfoBlk(ConsoleUniqueIDBlockID, sizeof(CONSOLE_UNIQUE_ID), 0xE,
+    res = CreateConfigInfoBlk(ConsoleUniqueID1BlockID, sizeof(CONSOLE_UNIQUE_ID), 0xE,
+                              &CONSOLE_UNIQUE_ID);
+    if (!res.IsSuccess())
+        return res;
+
+    res = CreateConfigInfoBlk(ConsoleUniqueID2BlockID, sizeof(CONSOLE_UNIQUE_ID), 0xE,
                               &CONSOLE_UNIQUE_ID);
     if (!res.IsSuccess())
         return res;


### PR DESCRIPTION
This is found needed by Pokemon games, which also causes a freeze at intro in Pokemon Sun/Moon:
```
[ 723.289812] Service.CFG <Error> core/hle/service/cfg/cfg.cpp:GetConfigInfoBlockPointer:285: Config block 0x90000 with flags 2 and size 8 was not found
```

From observation of a config file dumped from my 3DS, 0x90000 and 0x90001 blocks has exactly the same size(8), flags(0xE) and contents, so my theory is these two blocks are duplicated from the same data. Needs to confirm.

One need to remove the pre-existing config file to test this.