### PR TITLE
APT/Applets: Renamed the members of the SignalType enum.

### DIFF
--- a/src/core/hle/applets/erreula.cpp
+++ b/src/core/hle/applets/erreula.cpp
@@ -10,7 +10,7 @@ namespace HLE {
 namespace Applets {
 
 ResultCode ErrEula::ReceiveParameter(const Service::APT::MessageParameter& parameter) {
-    if (parameter.signal != static_cast<u32>(Service::APT::SignalType::LibAppJustStarted)) {
+    if (parameter.signal != static_cast<u32>(Service::APT::SignalType::Request)) {
         LOG_ERROR(Service_APT, "unsupported signal %u", parameter.signal);
         UNIMPLEMENTED();
         // TODO(Subv): Find the right error code
@@ -36,7 +36,7 @@ ResultCode ErrEula::ReceiveParameter(const Service::APT::MessageParameter& param
 
     // Send the response message with the newly created SharedMemory
     Service::APT::MessageParameter result;
-    result.signal = static_cast<u32>(Service::APT::SignalType::LibAppFinished);
+    result.signal = static_cast<u32>(Service::APT::SignalType::Response);
     result.buffer.clear();
     result.destination_id = static_cast<u32>(Service::APT::AppletId::Application);
     result.sender_id = static_cast<u32>(id);
@@ -57,7 +57,7 @@ ResultCode ErrEula::StartImpl(const Service::APT::AppletStartupParameter& parame
     Service::APT::MessageParameter message;
     message.buffer.resize(parameter.buffer.size());
     std::fill(message.buffer.begin(), message.buffer.end(), 0);
-    message.signal = static_cast<u32>(Service::APT::SignalType::LibAppClosed);
+    message.signal = static_cast<u32>(Service::APT::SignalType::WakeupByExit);
     message.destination_id = static_cast<u32>(Service::APT::AppletId::Application);
     message.sender_id = static_cast<u32>(id);
     Service::APT::SendParameter(message);

--- a/src/core/hle/applets/mii_selector.cpp
+++ b/src/core/hle/applets/mii_selector.cpp
@@ -19,7 +19,7 @@ namespace HLE {
 namespace Applets {
 
 ResultCode MiiSelector::ReceiveParameter(const Service::APT::MessageParameter& parameter) {
-    if (parameter.signal != static_cast<u32>(Service::APT::SignalType::LibAppJustStarted)) {
+    if (parameter.signal != static_cast<u32>(Service::APT::SignalType::Request)) {
         LOG_ERROR(Service_APT, "unsupported signal %u", parameter.signal);
         UNIMPLEMENTED();
         // TODO(Subv): Find the right error code
@@ -44,7 +44,7 @@ ResultCode MiiSelector::ReceiveParameter(const Service::APT::MessageParameter& p
 
     // Send the response message with the newly created SharedMemory
     Service::APT::MessageParameter result;
-    result.signal = static_cast<u32>(Service::APT::SignalType::LibAppFinished);
+    result.signal = static_cast<u32>(Service::APT::SignalType::Response);
     result.buffer.clear();
     result.destination_id = static_cast<u32>(Service::APT::AppletId::Application);
     result.sender_id = static_cast<u32>(id);
@@ -73,7 +73,7 @@ ResultCode MiiSelector::StartImpl(const Service::APT::AppletStartupParameter& pa
     Service::APT::MessageParameter message;
     message.buffer.resize(sizeof(MiiResult));
     std::memcpy(message.buffer.data(), &result, message.buffer.size());
-    message.signal = static_cast<u32>(Service::APT::SignalType::LibAppClosed);
+    message.signal = static_cast<u32>(Service::APT::SignalType::WakeupByExit);
     message.destination_id = static_cast<u32>(Service::APT::AppletId::Application);
     message.sender_id = static_cast<u32>(id);
     Service::APT::SendParameter(message);

--- a/src/core/hle/applets/swkbd.cpp
+++ b/src/core/hle/applets/swkbd.cpp
@@ -22,7 +22,7 @@ namespace HLE {
 namespace Applets {
 
 ResultCode SoftwareKeyboard::ReceiveParameter(Service::APT::MessageParameter const& parameter) {
-    if (parameter.signal != static_cast<u32>(Service::APT::SignalType::LibAppJustStarted)) {
+    if (parameter.signal != static_cast<u32>(Service::APT::SignalType::Request)) {
         LOG_ERROR(Service_APT, "unsupported signal %u", parameter.signal);
         UNIMPLEMENTED();
         // TODO(Subv): Find the right error code
@@ -47,7 +47,7 @@ ResultCode SoftwareKeyboard::ReceiveParameter(Service::APT::MessageParameter con
 
     // Send the response message with the newly created SharedMemory
     Service::APT::MessageParameter result;
-    result.signal = static_cast<u32>(Service::APT::SignalType::LibAppFinished);
+    result.signal = static_cast<u32>(Service::APT::SignalType::Response);
     result.buffer.clear();
     result.destination_id = static_cast<u32>(Service::APT::AppletId::Application);
     result.sender_id = static_cast<u32>(id);
@@ -108,7 +108,7 @@ void SoftwareKeyboard::Finalize() {
     Service::APT::MessageParameter message;
     message.buffer.resize(sizeof(SoftwareKeyboardConfig));
     std::memcpy(message.buffer.data(), &config, message.buffer.size());
-    message.signal = static_cast<u32>(Service::APT::SignalType::LibAppClosed);
+    message.signal = static_cast<u32>(Service::APT::SignalType::WakeupByExit);
     message.destination_id = static_cast<u32>(Service::APT::AppletId::Application);
     message.sender_id = static_cast<u32>(id);
     Service::APT::SendParameter(message);

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -523,7 +523,7 @@ void Init() {
     notification_event = Kernel::Event::Create(Kernel::ResetType::OneShot, "APT_U:Notification");
     parameter_event = Kernel::Event::Create(Kernel::ResetType::OneShot, "APT_U:Start");
 
-    next_parameter.signal = static_cast<u32>(SignalType::AppJustStarted);
+    next_parameter.signal = static_cast<u32>(SignalType::Wakeup);
     next_parameter.destination_id = 0x300;
 }
 

--- a/src/core/hle/service/apt/apt.h
+++ b/src/core/hle/service/apt/apt.h
@@ -46,12 +46,23 @@ static_assert(sizeof(CaptureBufferInfo) == 0x20, "CaptureBufferInfo struct has i
 /// Signals used by APT functions
 enum class SignalType : u32 {
     None = 0x0,
-    AppJustStarted = 0x1,
-    LibAppJustStarted = 0x2,
-    LibAppFinished = 0x3,
-    LibAppClosed = 0xA,
-    ReturningToApp = 0xB,
-    ExitingApp = 0xC,
+    Wakeup = 0x1,
+    Request = 0x2,
+    Response = 0x3,
+    Exit = 0x4,
+    Message = 0x5,
+    HomeButtonSingle = 0x6,
+    HomeButtonDouble = 0x7,
+    DspSleep = 0x8,
+    DspWakeup = 0x9,
+    WakeupByExit = 0xA,
+    WakeupByPause = 0xB,
+    WakeupByCancel = 0xC,
+    WakeupByCancelAll = 0xD,
+    WakeupByPowerButtonClick = 0xE,
+    WakeupToJumpHome = 0xF,
+    RequestForSysApplet = 0x10,
+    WakeupToLaunchApplication = 0x11,
 };
 
 /// App Id's used by APT functions


### PR DESCRIPTION
Names now make sense and match 3dbrew.