### PR TITLE
Disable Microprofile on Mingw builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,9 @@ if (NOT MSVC)
 
     if (MINGW)
         add_definitions(-DMINGW_HAS_SECURE_API)
+        # Microprofile causes crashes when launching titles on MinGW
+        add_definitions(-DMICROPROFILE_ENABLED=0)
+
         if (MINGW_STATIC_BUILD)
             add_definitions(-DQT_STATICPLUGIN)
             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static")


### PR DESCRIPTION
Microprofile currently has a number of issues on Mingw that (at least, to my eye) would require a major reworking of how it internally works. This PR disables Microprofile on Mingw builds so that they are actually usable.

As of now, Citra (Mingw) crashes when attempting to load a game, with an assertion error @ [externals/microprofile/microprofile.h, line 1177](/citra-emu/citra/tree/master/externals/microprofile/microprofile.h#L1177). Furthermore, much of the timing components of Microprofile do not actually work regardless of this assertion. The rewrite of Microprofile (assuming it fixes this bug) isn't an option at this point due to its lack of a non-web UI.