### PR TITLE
Add man documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,3 +286,15 @@ if(ENABLE_QT AND UNIX AND NOT APPLE)
     install(FILES "${CMAKE_SOURCE_DIR}/dist/citra.xml"
             DESTINATION "${CMAKE_INSTALL_PREFIX}/share/mime/packages")
 endif()
+
+if(UNIX)
+    if(ENABLE_SDL2)
+        install(FILES "${CMAKE_SOURCE_DIR}/dist/citra.6"
+                DESTINATION "${CMAKE_INSTALL_PREFIX}/share/man/man6")
+    endif()
+
+    if (ENABLE_QT)
+        install(FILES "${CMAKE_SOURCE_DIR}/dist/citra-qt.6"
+                DESTINATION "${CMAKE_INSTALL_PREFIX}/share/man/man6")
+    endif()
+endif()

--- a/dist/citra-qt.6
+++ b/dist/citra-qt.6
@@ -1,0 +1,40 @@
+.Dd November 22 2016
+.Dt citra-qt 6
+.Os
+.Sh NAME
+.Nm Citra-Qt
+.Nd Nintendo 3DS Emulator/Debugger (Qt)
+.Sh SYNOPSIS
+.Nm citra-qt
+.Op Ar file
+.Sh DESCRIPTION
+Citra is an experimental open-source Nintendo 3DS emulator/debugger.
+.Pp
+.Nm citra-qt
+is the Qt implementation.
+.Sh FILES
+.Bl -tag -width Ds
+.It Pa $XDG_DATA_HOME/citra-emu
+Emulator storage.
+.It Pa $XDG_CONFIG_HOME/citra-emu
+Configuration files.
+.El
+.Sh AUTHORS
+This document is made available to you under the CC-BY license.
+.Pp
+Citra is made by a team of volunteers. These contributors are listed
+ at <\fBhttps://github.com/citra-emu/citra/contributors\fR>.
+.Pp
+.Sh SEE ALSO
+.Bl -tag -width Ds
+.It Xr citra 6
+The SDL frontend of the application
+.El
+.Pp
+Resources are available for this project:
+.Bl -tag -width Ds
+.It <\fBhttps://citra-emu.org\fR>
+The main homepage of the project.
+.It <\fBhttps://github.com/citra-emu/citra\fR>
+The main source code repository for the Citra emulator.
+.Pp

--- a/dist/citra.6
+++ b/dist/citra.6
@@ -1,0 +1,49 @@
+.Dd November 22 2016
+.Dt citra 6
+.Os
+.Sh NAME
+.Nm Citra
+.Nd Nintendo 3DS Emulator/Debugger (SDL)
+.Sh SYNOPSIS
+.Nm citra
+.Op Ar options
+.Op Ar file
+.Sh OPTIONS
+.Bl -tag -width Ds
+.It Fl g Ar port , Fl Fl gdbport Ar port
+Starts the GDB stub on the specified port
+.It Fl h , Fl Fl help
+Shows syntax help and exits
+.It Fl v , Fl Fl version
+Describes the installed version and exits
+.Sh DESCRIPTION
+Citra is an experimental open-source Nintendo 3DS emulator/debugger.
+.Pp
+.Nm citra
+is the Simple DirectMedia Layer (SDL) implementation.
+.Sh FILES
+.Bl -tag -width Ds
+.It Pa $XDG_DATA_HOME/citra-emu
+Emulator storage.
+.It Pa $XDG_CONFIG_HOME/citra-emu
+Configuration files.
+.El
+.Sh AUTHORS
+This document is made available to you under the CC-BY license.
+.Pp
+Citra is made by a team of volunteers. These contributors are listed
+ at <\fBhttps://github.com/citra-emu/citra/contributors\fR>.
+.Pp
+.Sh SEE ALSO
+.Bl -tag -width Ds
+.It Xr citra-qt 6
+The Qt frontend of the application
+.El
+.Pp
+Resources are available for this project:
+.Bl -tag -width Ds
+.It <\fBhttps://citra-emu.org\fR>
+The main homepage of the project.
+.It <\fBhttps://github.com/citra-emu/citra\fR>
+The main source code repository for the Citra emulator.
+.Pp


### PR DESCRIPTION
Includes documentation for both both SDL and QT frontends, detailing basic command-line usage and where to find important files/information. This uses mdoc macros to generate its overall layout. Section 6 [(games)](https://linux.die.net/man/) is used for both documentation files, representing games.

This is correctly copied and compressed by man-db when installing using Ubuntu 16.04 when installing Citra via apt/dpkg. It should work on other distributions.

Rendered (for those who don't have access to man):
[citra.6](https://gist.github.com/j-selby/4c4e4c062607a0f50f677ed6500c0ea6)
[citra-qt.6](https://gist.github.com/j-selby/47577d258d616799040b1ed393c05a9b)