### PR TITLE
Expose page table to dynarmic for optimized reads and writes to the JIT

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -52,6 +52,7 @@ static Dynarmic::UserCallbacks GetUserCallbacks(ARMul_State* interpeter_state) {
     user_callbacks.MemoryWrite16 = &Memory::Write16;
     user_callbacks.MemoryWrite32 = &Memory::Write32;
     user_callbacks.MemoryWrite64 = &Memory::Write64;
+    user_callbacks.page_table = Memory::GetCurrentPageTablePointers();
     return user_callbacks;
 }
 

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include <string>
 #include "common/common_types.h"
@@ -17,6 +18,7 @@ namespace Memory {
 const u32 PAGE_SIZE = 0x1000;
 const u32 PAGE_MASK = PAGE_SIZE - 1;
 const int PAGE_BITS = 12;
+const size_t PAGE_TABLE_NUM_ENTRIES = 1 << (32 - PAGE_BITS);
 
 /// Physical memory regions as seen from the ARM11
 enum : PAddr {
@@ -166,4 +168,11 @@ void RasterizerFlushRegion(PAddr start, u32 size);
  * Flushes and invalidates any externally cached rasterizer resources touching the given region.
  */
 void RasterizerFlushAndInvalidateRegion(PAddr start, u32 size);
+
+/**
+ * Dynarmic has an optimization to memory accesses when the pointer to the page exists that
+ * can be used by setting up the current page table as a callback. This function is used to
+ * retrieve the current page table for that purpose.
+ */
+std::array<u8*, PAGE_TABLE_NUM_ENTRIES>* GetCurrentPageTablePointers();
 }


### PR DESCRIPTION
Subv commented that this was something left out from the original jit pr. Dynarmic has a fast path for memory access if you expose the memory backing the page table, and will gracefully fall back to calling citra's memory read and writes if the pointer at that addess is null. See here for the implementation: https://github.com/MerryMage/dynarmic/blob/master/src/backend_x64/emit_x64.cpp#L1863

This is just a simple fix that adds a method to return the array that backs the page table's memory.