### PR TITLE
Travis: Remove build uploading

### DIFF
--- a/.travis-upload.sh
+++ b/.travis-upload.sh
@@ -14,7 +14,6 @@ if [ "$TRAVIS_EVENT_TYPE" = "push" ]&&[ "$TRAVIS_BRANCH" = "master" ]; then
         UPLOAD_DIR="/citra/nightly/osx-amd64"
         mkdir "$REV_NAME"
 
-        brew install lftp
         cp build/src/citra/Release/citra "$REV_NAME"
         cp -r build/src/citra_qt/Release/citra-qt.app "$REV_NAME"
 
@@ -122,5 +121,4 @@ EOL
 
     ARCHIVE_NAME="${REV_NAME}.tar.xz"
     tar -cJvf "$ARCHIVE_NAME" "$REV_NAME"
-    lftp -c "open -u citra-builds,$BUILD_PASSWORD sftp://builds.citra-emu.org; set sftp:auto-confirm yes; put -O '$UPLOAD_DIR' '$ARCHIVE_NAME'"
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ addons:
       - libqt5opengl5-dev
       - xorg-dev
       - lib32stdc++6 # For CMake
-      - lftp # To upload builds
       - clang-format-4.0
 
 cache:


### PR DESCRIPTION
@archshift has been MIA for a while, so our builds server is currently
down. Furthermore, uploading is broken in both Linux and macOS:

- The version of lftp in Trusty doesn't support the sftp:auto-confirm
  option, which means that uploading would hang, even if the server
  weren't down. It currently tries to connect forever and fails the
  build with a timeout.
- lftp was removed from Homebrew, so it wasn't being installed on macOS
  and invoking it just failed.