### PR TITLE
Rasterizer/Memfill: Set the correct stencil write mask when clearing the stencil buffer.

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -893,7 +893,7 @@ bool RasterizerOpenGL::AccelerateFill(const GPU::Regs::MemoryFillConfig& config)
             value_float = config.value_32bit / 16777215.0f; // 2^24 - 1
         }
 
-        cur_state.depth.write_mask = true;
+        cur_state.depth.write_mask = GL_TRUE;
         cur_state.Apply();
         glClearBufferfv(GL_DEPTH, 0, &value_float);
     } else if (dst_type == SurfaceType::DepthStencil) {
@@ -908,7 +908,7 @@ bool RasterizerOpenGL::AccelerateFill(const GPU::Regs::MemoryFillConfig& config)
         GLfloat value_float = (config.value_32bit & 0xFFFFFF) / 16777215.0f; // 2^24 - 1
         GLint value_int = (config.value_32bit >> 24);
 
-        cur_state.depth.write_mask = true;
+        cur_state.depth.write_mask = GL_TRUE;
         cur_state.stencil.write_mask = 0xFF;
         cur_state.Apply();
         glClearBufferfi(GL_DEPTH_STENCIL, 0, value_float, value_int);

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -909,7 +909,7 @@ bool RasterizerOpenGL::AccelerateFill(const GPU::Regs::MemoryFillConfig& config)
         GLint value_int = (config.value_32bit >> 24);
 
         cur_state.depth.write_mask = true;
-        cur_state.stencil.write_mask = true;
+        cur_state.stencil.write_mask = 0xFF;
         cur_state.Apply();
         glClearBufferfi(GL_DEPTH_STENCIL, 0, value_float, value_int);
     }

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -27,8 +27,8 @@ OpenGLState::OpenGLState() {
     stencil.test_enabled = false;
     stencil.test_func = GL_ALWAYS;
     stencil.test_ref = 0;
-    stencil.test_mask = -1;
-    stencil.write_mask = -1;
+    stencil.test_mask = 0xFF;
+    stencil.write_mask = 0xFF;
     stencil.action_depth_fail = GL_KEEP;
     stencil.action_depth_pass = GL_KEEP;
     stencil.action_stencil_fail = GL_KEEP;


### PR DESCRIPTION
This fixes the lingering outlines in Pokemon and other games.