### PR TITLE
Config: auto-select region and language

### DIFF
--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -89,7 +89,8 @@ void Config::ReadValues() {
 
     // System
     Settings::values.is_new_3ds = sdl2_config->GetBoolean("System", "is_new_3ds", false);
-    Settings::values.region_value = sdl2_config->GetInteger("System", "region_value", 1);
+    Settings::values.region_value =
+        sdl2_config->GetInteger("System", "region_value", Settings::REGION_VALUE_AUTO_SELECT);
 
     // Miscellaneous
     Settings::values.log_filter = sdl2_config->Get("Miscellaneous", "log_filter", "*:Info");

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -101,7 +101,7 @@ use_virtual_sd =
 is_new_3ds =
 
 # The system region that Citra will use during emulation
-# 0: Japan, 1: USA (default), 2: Europe, 3: Australia, 4: China, 5: Korea, 6: Taiwan
+# -1: Auto-select (default), 0: Japan, 1: USA, 2: Europe, 3: Australia, 4: China, 5: Korea, 6: Taiwan
 region_value =
 
 [Miscellaneous]

--- a/src/citra_qt/config.cpp
+++ b/src/citra_qt/config.cpp
@@ -72,7 +72,8 @@ void Config::ReadValues() {
 
     qt_config->beginGroup("System");
     Settings::values.is_new_3ds = qt_config->value("is_new_3ds", false).toBool();
-    Settings::values.region_value = qt_config->value("region_value", 1).toInt();
+    Settings::values.region_value =
+        qt_config->value("region_value", Settings::REGION_VALUE_AUTO_SELECT).toInt();
     qt_config->endGroup();
 
     qt_config->beginGroup("Miscellaneous");

--- a/src/citra_qt/configure_general.cpp
+++ b/src/citra_qt/configure_general.cpp
@@ -23,13 +23,15 @@ void ConfigureGeneral::setConfiguration() {
     ui->toggle_deepscan->setChecked(UISettings::values.gamedir_deepscan);
     ui->toggle_check_exit->setChecked(UISettings::values.confirm_before_closing);
     ui->toggle_cpu_jit->setChecked(Settings::values.use_cpu_jit);
-    ui->region_combobox->setCurrentIndex(Settings::values.region_value);
+
+    // The first item is "auto-select" with actual value -1, so plus one here will do the trick
+    ui->region_combobox->setCurrentIndex(Settings::values.region_value + 1);
 }
 
 void ConfigureGeneral::applyConfiguration() {
     UISettings::values.gamedir_deepscan = ui->toggle_deepscan->isChecked();
     UISettings::values.confirm_before_closing = ui->toggle_check_exit->isChecked();
-    Settings::values.region_value = ui->region_combobox->currentIndex();
+    Settings::values.region_value = ui->region_combobox->currentIndex() - 1;
     Settings::values.use_cpu_jit = ui->toggle_cpu_jit->isChecked();
     Settings::Apply();
 }

--- a/src/citra_qt/configure_general.ui
+++ b/src/citra_qt/configure_general.ui
@@ -84,6 +84,11 @@
              <widget class="QComboBox" name="region_combobox">
               <item>
                <property name="text">
+                <string>Auto-select</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
                 <string notr="true">JPN</string>
                </property>
               </item>

--- a/src/citra_qt/configure_system.ui
+++ b/src/citra_qt/configure_system.ui
@@ -129,6 +129,9 @@
         </item>
         <item row="2" column="1">
          <widget class="QComboBox" name="combo_language">
+          <property name="toolTip">
+           <string>Note: this can be overridden when region setting is auto-select</string>
+          </property>
           <item>
            <property name="text">
             <string>Japanese (日本語)</string>

--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -114,6 +114,8 @@ static const std::vector<u8> cfg_system_savedata_id = {
     0x00, 0x00, 0x00, 0x00, 0x17, 0x00, 0x01, 0x00,
 };
 
+static u32 preferred_region_code = 0;
+
 void GetCountryCodeString(Service::Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     u32 country_code_id = cmd_buff[1];
@@ -159,11 +161,18 @@ void GetCountryCodeID(Service::Interface* self) {
     cmd_buff[2] = country_code_id;
 }
 
+static u32 GetRegionValue() {
+    if (Settings::values.region_value == Settings::REGION_VALUE_AUTO_SELECT)
+        return preferred_region_code;
+
+    return Settings::values.region_value;
+}
+
 void SecureInfoGetRegion(Service::Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
     cmd_buff[1] = RESULT_SUCCESS.raw;
-    cmd_buff[2] = Settings::values.region_value;
+    cmd_buff[2] = GetRegionValue();
 }
 
 void GenHashConsoleUnique(Service::Interface* self) {
@@ -183,7 +192,7 @@ void GetRegionCanadaUSA(Service::Interface* self) {
     cmd_buff[1] = RESULT_SUCCESS.raw;
 
     u8 canada_or_usa = 1;
-    if (canada_or_usa == Settings::values.region_value) {
+    if (canada_or_usa == GetRegionValue()) {
         cmd_buff[2] = 1;
     } else {
         cmd_buff[2] = 0;
@@ -313,10 +322,47 @@ static ResultVal<void*> GetConfigInfoBlockPointer(u32 block_id, u32 size, u32 fl
     return MakeResult<void*>(pointer);
 }
 
+/// Checks if the language is available in the chosen region, and returns a proper one
+static u8 AdjustLanguageInfoBlock(u32 region, u8 language) {
+    static const std::array<std::vector<u8>, 7> region_languages{{
+        // JPN
+        {LANGUAGE_JP},
+        // USA
+        {LANGUAGE_EN, LANGUAGE_FR, LANGUAGE_ES, LANGUAGE_PT},
+        // EUR
+        {LANGUAGE_EN, LANGUAGE_FR, LANGUAGE_DE, LANGUAGE_IT, LANGUAGE_ES, LANGUAGE_NL, LANGUAGE_PT,
+         LANGUAGE_RU},
+        // AUS
+        {LANGUAGE_EN, LANGUAGE_FR, LANGUAGE_DE, LANGUAGE_IT, LANGUAGE_ES, LANGUAGE_NL, LANGUAGE_PT,
+         LANGUAGE_RU},
+        // CHN
+        {LANGUAGE_ZH},
+        // KOR
+        {LANGUAGE_KO},
+        // TWN
+        {LANGUAGE_TW},
+    }};
+    const auto& available = region_languages[region];
+    if (std::find(available.begin(), available.end(), language) == available.end()) {
+        return available[0];
+    }
+    return language;
+}
+
 ResultCode GetConfigInfoBlock(u32 block_id, u32 size, u32 flag, void* output) {
     void* pointer;
     CASCADE_RESULT(pointer, GetConfigInfoBlockPointer(block_id, size, flag));
     memcpy(output, pointer, size);
+
+    // override the language setting if the region setting is auto
+    if (block_id == LanguageBlockID &&
+        Settings::values.region_value == Settings::REGION_VALUE_AUTO_SELECT) {
+        u8 language;
+        memcpy(&language, output, sizeof(u8));
+        language = AdjustLanguageInfoBlock(preferred_region_code, language);
+        memcpy(output, &language, sizeof(u8));
+    }
+
     return RESULT_SUCCESS;
 }
 
@@ -533,9 +579,16 @@ void Init() {
     AddService(new CFG_U_Interface);
 
     LoadConfigNANDSaveFile();
+
+    preferred_region_code = 0;
 }
 
 void Shutdown() {}
+
+void SetPreferredRegionCode(u32 region_code) {
+    preferred_region_code = region_code;
+    LOG_INFO(Service_CFG, "Preferred region code set to %u", preferred_region_code);
+}
 
 void SetUsername(const std::u16string& name) {
     ASSERT(name.size() <= 10);

--- a/src/core/hle/service/cfg/cfg.h
+++ b/src/core/hle/service/cfg/cfg.h
@@ -282,6 +282,13 @@ void Init();
 /// Shutdown the config service
 void Shutdown();
 
+/**
+ * Set the region code preferred by the game so that CFG will adjust to it when the region setting
+ * is auto.
+ * @param region_code the preferred region code to set
+ */
+void SetPreferredRegionCode(u32 region_code);
+
 // Utilities for frontend to set config data.
 // Note: before calling these functions, LoadConfigNANDSaveFile should be called,
 // and UpdateConfigNANDSavegame should be called after making changes to config data.

--- a/src/core/loader/ncch.h
+++ b/src/core/loader/ncch.h
@@ -250,6 +250,9 @@ private:
      */
     ResultStatus LoadExeFS();
 
+    /// Reads the region lockout info in the SMDH and send it to CFG service
+    void ParseRegionLockoutInfo();
+
     bool is_exefs_loaded = false;
     bool is_compressed = false;
 

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -110,5 +110,9 @@ struct Values {
     u16 gdbstub_port;
 } extern values;
 
+// a special value for Values::region_value indicating that citra will automatically select a region
+// value to fit the region lockout info of the game
+static constexpr int REGION_VALUE_AUTO_SELECT = -1;
+
 void Apply();
 }


### PR DESCRIPTION
Added an option to auto-select region based on game region lockout info. System language will also be override if the region is auto-selected and the chosen language is not available. Also made this option as default value. This aims to reduce false positive caused by selecting a wrong region.

~~I'd like to add a prompt that the system language setting may be overrided. but not sure how to add it (add a tooltip?or make a description bar on the bottom of the configuration dialog?)~~ Added a tooltip