### PR TITLE
Add deploy to bintray for builds to master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,12 @@ doc-build/
 
 # Generated source files
 src/common/scm_rev.cpp
+.travis.descriptor.json
 
 # Project/editor files
 *.swp
 .idea/
+.vscode/
 
 # *nix related
 # Common convention for backup or temporary files

--- a/.travis-upload.sh
+++ b/.travis-upload.sh
@@ -1,17 +1,16 @@
 if [ "$TRAVIS_EVENT_TYPE" = "push" ]&&[ "$TRAVIS_BRANCH" = "master" ]; then
     GITDATE="`git show -s --date=short --format='%ad' | sed 's/-//g'`"
     GITREV="`git show -s --format='%h'`"
+    mkdir -p artifacts
 
     if [ "$TRAVIS_OS_NAME" = "linux" -o -z "$TRAVIS_OS_NAME" ]; then
-        REV_NAME="citra-${GITDATE}-${GITREV}-linux-amd64"
-        UPLOAD_DIR="/citra/nightly/linux-amd64"
+        REV_NAME="citra-linux-${GITDATE}-${GITREV}"
         mkdir "$REV_NAME"
 
         cp build/src/citra/citra "$REV_NAME"
         cp build/src/citra_qt/citra-qt "$REV_NAME"
     elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
-        REV_NAME="citra-${GITDATE}-${GITREV}-osx-amd64"
-        UPLOAD_DIR="/citra/nightly/osx-amd64"
+        REV_NAME="citra-osx-${GITDATE}-${GITREV}"
         mkdir "$REV_NAME"
 
         cp build/src/citra/Release/citra "$REV_NAME"
@@ -121,4 +120,7 @@ EOL
 
     ARCHIVE_NAME="${REV_NAME}.tar.xz"
     tar -cJvf "$ARCHIVE_NAME" "$REV_NAME"
+
+    # move the compiled archive into the artifacts directory to be uploaded by travis releases
+    mv "$ARCHIVE_NAME" artifacts/
 fi

--- a/.travis.descriptor.json.in
+++ b/.travis.descriptor.json.in
@@ -1,0 +1,23 @@
+{
+    "package": {
+        "name": "nightly",
+        "repo": "citra",
+        "subject": "citra-emu",
+        "desc": "Build created on @BUILD_DATE@",
+        "website_url": "www.citra-emu.org",
+        "public_download_numbers": false,
+        "public_stats": false
+    },
+    "version": {
+        "name": "nightly",
+        "released": "@BUILD_DATE@",
+        "gpgSign": false
+    },
+    "files": [
+        {
+            "includePattern": "artifacts/(.*\\.tar.xz)",
+            "uploadPattern": "$1"
+        }
+    ],
+    "publish": true
+}

--- a/.travis.descriptor.json.in
+++ b/.travis.descriptor.json.in
@@ -9,7 +9,7 @@
         "public_stats": false
     },
     "version": {
-        "name": "nightly",
+        "name": "nightly-@GIT_REV@",
         "released": "@BUILD_DATE@",
         "gpgSign": false
     },

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: cpp
-
 matrix:
   include:
     - os: linux
@@ -8,10 +7,6 @@ matrix:
     - os: osx
       sudo: false
       osx_image: xcode7.3
-
-env:
-  global:
-    - secure: "AXHFIafTmbGDsHD3mUVj5a4I397DQjti/WoqAJGUp2PglxTcc04BwxZ9Z+xLuf5N2Hs5r9ojAJLT8OGxJCLBDXzneQTNSqXbFuYSLbqrEAiIRlA9eRIotWCg+wYcO+5e8MKX+cHVKwiIWasUB21AtCdq6msh6Y3pUshZp212VPg="
 
 addons:
   apt:
@@ -27,8 +22,15 @@ addons:
 
 cache:
   directories:
-    - $HOME/.local
+    - "$HOME/.local"
 
-install: ./.travis-deps.sh
-script: ./.travis-build.sh
-after_success: ./.travis-upload.sh
+install: "./.travis-deps.sh"
+script: "./.travis-build.sh"
+after_success: "./.travis-upload.sh"
+
+deploy:
+  provider: bintray
+  file: "${HOME}/build/${TRAVIS_REPO_SLUG}/.travis.descriptor.json"
+  user: citra-emu
+  key:
+    secure: "MADIMRKlcr+O2iCmavkbIvUWexopOhnzXuDHKXfGyGY93Im8NCTrbb3tDoLH+bRYQrjNCeaV36ffhpDULU+eH11L4yF5/KY4modEKW4sq3cnAJkm5DUOc/sujlRCwzfjg6NFZGhjxfSlt0ltKRdCKEB/j1vR2GD7d/eQ4diJukQ="

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,6 +253,11 @@ get_git_head_revision(GIT_REF_SPEC GIT_REV)
 git_describe(GIT_DESC --always --long --dirty)
 git_branch_name(GIT_BRANCH)
 
+# configure the bintray travis release json
+string(TIMESTAMP BUILD_DATE "%Y-%m-%d")
+configure_file("${CMAKE_SOURCE_DIR}/.travis.descriptor.json.in" "${CMAKE_SOURCE_DIR}/.travis.descriptor.json" @ONLY)
+unset(BUILD_DATE)
+
 set(INI_PREFIX "${CMAKE_CURRENT_SOURCE_DIR}/externals/inih")
 include_directories(${INI_PREFIX})
 add_subdirectory(${INI_PREFIX})

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,10 +36,12 @@ after_build:
         # Where are these spaces coming from? Regardless, let's remove them
         $MSVC_BUILD_NAME = "citra-windows-msvc-$GITDATE-$GITREV.zip" -replace " ", ""
         $MSVC_BUILD_PDB = "citra-windows-msvc-$GITDATE-$GITREV-debugsymbols.zip" -replace " ", ""
+        $BINTRAY_VERSION = "nightly-$GITREV" -replace " ", ""
 
         # set the build names as env vars so the artifacts can upload them
         $env:MSVC_BUILD_NAME = $MSVC_BUILD_NAME
         $env:MSVC_BUILD_PDB = $MSVC_BUILD_PDB
+        $env:BINTRAY_VERSION = $BINTRAY_VERSION
 
         7z a -tzip $MSVC_BUILD_PDB .\build\bin\release\*.pdb
         rm .\build\bin\release\*.pdb
@@ -64,7 +66,7 @@ deploy:
   subject: citra-emu
   repo: citra
   package: nightly
-  version: nightly
+  version: $(BINTRAY_VERSION)
   publish: true
   on:
     branch: master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,8 @@
 # shallow clone
-clone_depth: 5
+clone_depth: 10
 
-environment:
-  BUILD_PASSWORD:
-    secure: EXGNlWKJsCtbeImEJ5EP9qrxZ+EqUFfNy+CP61nDOMA=
+# don't build on tag
+skip_tags: true
 
 cache:
   - C:\ProgramData\chocolatey\bin -> appveyor.yml
@@ -30,42 +29,42 @@ build:
   project: build/citra.sln
   parallel: true
 
+after_build:
+  - ps: |
+        $GITDATE = $(git show -s --date=short --format='%ad') -replace "-",""
+        $GITREV = $(git show -s --format='%h')
+        # Where are these spaces coming from? Regardless, let's remove them
+        $MSVC_BUILD_NAME = "citra-windows-msvc-$GITDATE-$GITREV.zip" -replace " ", ""
+        $MSVC_BUILD_PDB = "citra-windows-msvc-$GITDATE-$GITREV-debugsymbols.zip" -replace " ", ""
+
+        # set the build names as env vars so the artifacts can upload them
+        $env:MSVC_BUILD_NAME = $MSVC_BUILD_NAME
+        $env:MSVC_BUILD_PDB = $MSVC_BUILD_PDB
+
+        7z a -tzip $MSVC_BUILD_PDB .\build\bin\release\*.pdb
+        rm .\build\bin\release\*.pdb
+        7z a -tzip $MSVC_BUILD_NAME .\build\bin\release\* .\license.txt .\README.md
+
 test_script:
   - cd build && ctest -VV -C Release && cd ..
 
-on_success:
-    # copying the needed QT Dlls is now done post build. See the CMakeLists.txt file in the citra-qt folder
-  - ps: >
-        if (!"$env:APPVEYOR_PULL_REQUEST_TITLE" -and ("$env:APPVEYOR_REPO_BRANCH" -eq "master"))
-          {
-            $GITDATE = $(git show -s --date=short --format='%ad') -replace "-",""
-            $GITREV = $(git show -s --format='%h')
-            # Where are these spaces coming from? Regardless, let's remove them
-            $BUILD_NAME = "citra-${GITDATE}-${GITREV}-windows-amd64.7z" -replace " ",""
-            $BUILD_NAME_PDB = "citra-${GITDATE}-${GITREV}-windows-amd64-debugsymbols.7z" -replace " ",""
-            $BUILD_NAME_NOQT = "citra-noqt-${GITDATE}-${GITREV}-windows-amd64.7z" -replace " ",""
+artifacts:
+  - path: $(MSVC_BUILD_NAME)
+    name: msvcbuild
+    type: zip
+  - path: $(MSVC_BUILD_PDB)
+    name: msvcdebug
+    type: zip
 
-            # Remove unnecessary files
-            rm .\build\bin\release\*tests*
-
-            # Put the pdb files in a separate archive and remove them from the main download
-            7z a $BUILD_NAME_PDB .\build\bin\release\*.pdb
-            rm .\build\bin\release\*.pdb
-
-            # Zip up the build folder and documentation
-            7z a $BUILD_NAME .\build\bin\release\* .\license.txt .\README.md
-            # Do a second archive with only the binaries (excludes dlls) and documentation
-            7z a $BUILD_NAME_NOQT .\build\bin\release\*.exe .\license.txt .\README.md
-
-
-            # Download WinSCP and upload to server
-            choco install winscp.portable
-            WinSCP.exe /command `
-                "option batch abort" `
-                "option confirm off" `
-                "open sftp://citra-builds:${env:BUILD_PASSWORD}@builds.citra-emu.org -hostkey=*" `
-                "put $BUILD_NAME /citra/nightly/windows-amd64/" `
-                "put $BUILD_NAME_NOQT /citra/nightly/windows-noqt-amd64/" `
-                "put $BUILD_NAME_PDB /citra/nightly/windows-amd64-debugsymbols/" `
-                "exit"
-          }
+deploy:
+- provider: BinTray
+  username: citra-emu
+  api_key:
+    secure: qaZZfXp5Vv9xw5EmCxKLhGnNYhiNMDCdP84l0+h6HetfmvFlvHxyohWEVokLjl7d
+  subject: citra-emu
+  repo: citra
+  package: nightly
+  version: nightly
+  publish: true
+  on:
+    branch: master


### PR DESCRIPTION
In an effort to get nightly builds back online, I went and found two providers for nightly builds. The first is bintray, a site that has an OSS plan with 1TiB bandwidth and both travis and appveyor can upload to it directly. Additionally, I got permission to upload to fosshub as well, which can provide us upwards of 5TiB a month, but they do not use any deploy scripts to upload (so no changes for this pr), and I will be working directly with the fosshub account in order to get the nightly builds hosted on there as well. 

### Needs attention -
One thing to note with this PR, I have added Appveyor artifacts, meaning each pull request will be built and stored in Appveyor. There is some argument about whether we should somehow disable this as it poses a security concern if someone submits a malicious PR and tricks people into downloading the autocompiled version. The upside to having artifacts is if someone needs to test a specfic PR on windows, they can just download a compiled version at master + PR, instead of cloning and merging and building. It may be possible to only generate artifacts on push to master, so if that change is decided on, I will update this PR and remove the per PR artifact.