### PR TITLE
Travis: Use a stable version of clang-format

### DIFF
--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -12,7 +12,7 @@ fi
 # Only run clang-format on Linux because we don't have 4.0 on OS X images
 if [ "$TRAVIS_OS_NAME" = "linux" ]; then
     # Default clang-format points to default 3.5 version one
-    CLANG_FORMAT=clang-format-4.0
+    CLANG_FORMAT=clang-format-3.9
     $CLANG_FORMAT --version
 
     if [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then

--- a/.travis-deps.sh
+++ b/.travis-deps.sh
@@ -27,6 +27,13 @@ if [ "$TRAVIS_OS_NAME" = "linux" -o -z "$TRAVIS_OS_NAME" ]; then
         echo "Using cached SDL2"
     fi
 
+    export DEBIAN_FRONTEND=noninteractive
+    # Amazing placebo security
+    curl http://apt.llvm.org/llvm-snapshot.gpg.key | sudo -E apt-key add -
+    sudo -E add-apt-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main"
+    sudo -E apt-get -yq update
+    sudo -E apt-get -yq install clang-format-3.9
+
 elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
     brew update
     brew install qt5 sdl2 dylibbundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: cpp
 matrix:
   include:
     - os: linux
-      sudo: true
+      sudo: required
       dist: trusty
     - os: osx
       sudo: false
@@ -17,7 +17,6 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - llvm-toolchain-precise
     packages:
       - gcc-6
       - g++-6
@@ -25,7 +24,6 @@ addons:
       - libqt5opengl5-dev
       - xorg-dev
       - lib32stdc++6 # For CMake
-      - clang-format-4.0
 
 cache:
   directories:

--- a/src/video_core/pica.h
+++ b/src/video_core/pica.h
@@ -40,7 +40,7 @@ namespace Pica {
 //       field offset. Otherwise, the compiler will fail to compile this code.
 #define PICA_REG_INDEX_WORKAROUND(field_name, backup_workaround_index)                             \
     ((typename std::enable_if<backup_workaround_index == PICA_REG_INDEX(field_name),               \
-                              size_t>::type) PICA_REG_INDEX(field_name))
+                              size_t>::type)PICA_REG_INDEX(field_name))
 #endif // _MSC_VER
 
 struct Regs {


### PR DESCRIPTION
We were using a SVN version of clang-format (due to the stable repo not being whitelisted by travis) which may change randomly and break our formatting/build. Changed to manually install a stable version using sudo.