### PR TITLE
shader_jit: Fix non-SSE4.1 path where FLR would not truncate

### DIFF
--- a/src/video_core/shader/shader_jit_x64.cpp
+++ b/src/video_core/shader/shader_jit_x64.cpp
@@ -491,7 +491,7 @@ void JitShader::Compile_FLR(Instruction instr) {
     if (Common::GetCPUCaps().sse4_1) {
         ROUNDFLOORPS(SRC1, R(SRC1));
     } else {
-        CVTPS2DQ(SRC1, R(SRC1));
+        CVTTPS2DQ(SRC1, R(SRC1));
         CVTDQ2PS(SRC1, R(SRC1));
     }
 


### PR DESCRIPTION
There was a bug in the fallback path for FLR (Floor shader instruction) which would respect the current rounding mode instead of actually truncating.
As only non-SSE4.1 CPUs were affected by this broken fallback path the issue reports we got were pretty confusing. We should probably add detected CPU features to our log files in the future.

This was responsible for #2209 and #1743 .

I did not check the other fallback paths yet. But I'll make sure to test all paths in any shader-jit issue we'll receive in the future.