### PR TITLE
Print shaders in case of error

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -1083,7 +1083,9 @@ void RasterizerOpenGL::SetShader() {
         GLint block_size;
         glGetActiveUniformBlockiv(current_shader->shader.handle, block_index,
                                   GL_UNIFORM_BLOCK_DATA_SIZE, &block_size);
-        ASSERT_MSG(block_size == sizeof(UniformData), "Uniform block size did not match!");
+        ASSERT_MSG(block_size == sizeof(UniformData),
+                   "Uniform block size did not match! Got %d, expected %zu",
+                   static_cast<int>(block_size), sizeof(UniformData));
         glUniformBlockBinding(current_shader->shader.handle, block_index, 0);
 
         // Update uniforms

--- a/src/video_core/renderer_opengl/gl_shader_util.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_util.cpp
@@ -4,6 +4,7 @@
 
 #include <vector>
 #include <glad/glad.h>
+#include "common/assert.h"
 #include "common/logging/log.h"
 #include "video_core/renderer_opengl/gl_shader_util.h"
 
@@ -87,6 +88,7 @@ GLuint LoadProgram(const char* vertex_shader, const char* fragment_shader) {
         LOG_ERROR(Render_OpenGL, "Vertex shader:\n%s", vertex_shader);
         LOG_ERROR(Render_OpenGL, "Fragment shader:\n%s", fragment_shader);
     }
+    ASSERT_MSG(result == GL_TRUE, "Shader not linked");
 
     glDeleteShader(vertex_shader_id);
     glDeleteShader(fragment_shader_id);

--- a/src/video_core/renderer_opengl/gl_shader_util.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_util.cpp
@@ -31,7 +31,7 @@ GLuint LoadProgram(const char* vertex_shader, const char* fragment_shader) {
     if (info_log_length > 1) {
         std::vector<char> vertex_shader_error(info_log_length);
         glGetShaderInfoLog(vertex_shader_id, info_log_length, nullptr, &vertex_shader_error[0]);
-        if (result) {
+        if (result == GL_TRUE) {
             LOG_DEBUG(Render_OpenGL, "%s", &vertex_shader_error[0]);
         } else {
             LOG_ERROR(Render_OpenGL, "Error compiling vertex shader:\n%s", &vertex_shader_error[0]);
@@ -51,7 +51,7 @@ GLuint LoadProgram(const char* vertex_shader, const char* fragment_shader) {
     if (info_log_length > 1) {
         std::vector<char> fragment_shader_error(info_log_length);
         glGetShaderInfoLog(fragment_shader_id, info_log_length, nullptr, &fragment_shader_error[0]);
-        if (result) {
+        if (result == GL_TRUE) {
             LOG_DEBUG(Render_OpenGL, "%s", &fragment_shader_error[0]);
         } else {
             LOG_ERROR(Render_OpenGL, "Error compiling fragment shader:\n%s",
@@ -75,11 +75,17 @@ GLuint LoadProgram(const char* vertex_shader, const char* fragment_shader) {
     if (info_log_length > 1) {
         std::vector<char> program_error(info_log_length);
         glGetProgramInfoLog(program_id, info_log_length, nullptr, &program_error[0]);
-        if (result) {
+        if (result == GL_TRUE) {
             LOG_DEBUG(Render_OpenGL, "%s", &program_error[0]);
         } else {
             LOG_ERROR(Render_OpenGL, "Error linking shader:\n%s", &program_error[0]);
         }
+    }
+
+    // If the program linking failed at least one of the shaders was probably bad
+    if (result == GL_FALSE) {
+        LOG_ERROR(Render_OpenGL, "Vertex shader:\n%s", vertex_shader);
+        LOG_ERROR(Render_OpenGL, "Fragment shader:\n%s", fragment_shader);
     }
 
     glDeleteShader(vertex_shader_id);


### PR DESCRIPTION
We recently had a lot of issues with people reporting "Uniform block size did not match!" which usually has one of 3 reasons:

- A broken shader (= compilation fails due to us not having implemented a certain codepath). The block size will be 0.
- Broken code / Alignment issues. This can happen if the last element is not 16 bytes in size (as the spec is unclear wether the block size will be aligned to the next 16 byte block or truncated). The block size will vary a little.
- A broken driver. The block size could vary greatly depending how it intepreted our shader. This should rarely happen.

To show these kind of errors better, the `ASSERT_MSG` was extended to show the expected and received block size.
Additionally the shader source code will be `LOG_ERROR`'d in case of program linking (both shaders will be printed) or shader compilation errors (that particular shader will be printed).