### PR TITLE
Support mingw cross-compilation

### DIFF
--- a/src/citra/citra.cpp
+++ b/src/citra/citra.cpp
@@ -18,7 +18,7 @@
 #endif
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 #include "citra/config.h"

--- a/src/citra/citra.rc
+++ b/src/citra/citra.rc
@@ -5,5 +5,5 @@
 
 // Icon with lowest ID value placed first to ensure application icon
 // remains consistent on all systems.
-GLFW_ICON               ICON                    "..\\..\\dist\\citra.ico"
+GLFW_ICON               ICON                    "../../dist/citra.ico"
 

--- a/src/citra/citra.rc
+++ b/src/citra/citra.rc
@@ -5,5 +5,5 @@
 
 // Icon with lowest ID value placed first to ensure application icon
 // remains consistent on all systems.
-GLFW_ICON               ICON                    "../../dist/citra.ico"
+CITRA_ICON              ICON                    "../../dist/citra.ico"
 

--- a/src/citra_qt/citra-qt.rc
+++ b/src/citra_qt/citra-qt.rc
@@ -5,5 +5,5 @@
 
 // Icon with lowest ID value placed first to ensure application icon
 // remains consistent on all systems.
-IDI_ICON1               ICON                    "../../dist/citra.ico"
+CITRA_ICON              ICON                    "../../dist/citra.ico"
 

--- a/src/citra_qt/citra-qt.rc
+++ b/src/citra_qt/citra-qt.rc
@@ -5,5 +5,5 @@
 
 // Icon with lowest ID value placed first to ensure application icon
 // remains consistent on all systems.
-IDI_ICON1               ICON                    "..\\..\\dist\\citra.ico"
+IDI_ICON1               ICON                    "../../dist/citra.ico"
 

--- a/src/common/bit_set.h
+++ b/src/common/bit_set.h
@@ -16,7 +16,7 @@ namespace Common {
 
 // Helper functions:
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 template <typename T>
 static inline int CountSetBits(T v) {
     // from https://graphics.stanford.edu/~seander/bithacks.html

--- a/src/common/logging/text_formatter.cpp
+++ b/src/common/logging/text_formatter.cpp
@@ -7,7 +7,7 @@
 
 #ifdef _WIN32
 #define WIN32_LEAN_AND_MEAN
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 #include "common/assert.h"

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -14,7 +14,7 @@
 
 #ifdef _WIN32
 #include <codecvt>
-#include <Windows.h>
+#include <windows.h>
 #include "common/common_funcs.h"
 #else
 #include <iconv.h>

--- a/src/common/thread.cpp
+++ b/src/common/thread.cpp
@@ -6,7 +6,7 @@
 #ifdef __APPLE__
 #include <mach/mach.h>
 #elif defined(_WIN32)
-#include <Windows.h>
+#include <windows.h>
 #else
 #if defined(__Bitrig__) || defined(__DragonFly__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <pthread_np.h>

--- a/src/common/timer.cpp
+++ b/src/common/timer.cpp
@@ -4,7 +4,8 @@
 
 #include <time.h>
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
+// windows.h needs to be included before other windows headers
 #include <mmsystem.h>
 #include <sys/timeb.h>
 #else

--- a/src/core/gdbstub/gdbstub.cpp
+++ b/src/core/gdbstub/gdbstub.cpp
@@ -15,7 +15,8 @@
 #include <fcntl.h>
 
 #ifdef _WIN32
-#include <WinSock2.h>
+#include <winsock2.h>
+// winsock2.h needs to be included first to prevent winsock.h being included by other includes
 #include <common/x64/abi.h>
 #include <io.h>
 #include <iphlpapi.h>

--- a/src/core/gdbstub/gdbstub.cpp
+++ b/src/core/gdbstub/gdbstub.cpp
@@ -17,7 +17,6 @@
 #ifdef _WIN32
 #include <winsock2.h>
 // winsock2.h needs to be included first to prevent winsock.h being included by other includes
-#include <common/x64/abi.h>
 #include <io.h>
 #include <iphlpapi.h>
 #include <ws2tcpip.h>


### PR DESCRIPTION
This involves 3 kind of changes:

- Lowercase spelling for includes (`Windows.h` and `WinSock2.h`)
- Use of gcc intrinsics (Old check was for `_WIN32`, not the compiler)
- Use of forward slashes as path seperator (present in *.rc files, used for exe icon path)

Additionally I decided to update the icon name in the rc files.
One was kind of arbritrary, the other one referenced GLFW which we aren't even using anymore.

---

This currently does not pack SDL2 or Qt5 dependencies properly (which is done conditionally for MSVC builds). I intend to do this in a follow-up PR as we still have various Qt version checks which I'd like to remove anyway (as chances are very slim we'll ever support Qt4 or below again).
It's also not a cross-compile issue, but rather a lack in the original mingw support.