### PR TITLE
Drop framebuffer completeness check.

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -189,10 +189,6 @@ void RasterizerOpenGL::DrawTriangles() {
         GL_DRAW_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_TEXTURE_2D,
         (has_stencil && depth_surface != nullptr) ? depth_surface->texture.handle : 0, 0);
 
-    if (OpenGLState::CheckFBStatus(GL_DRAW_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
-        return;
-    }
-
     // Sync the viewport
     // These registers hold half-width and half-height, so must be multiplied by 2
     GLsizei viewport_width = (GLsizei)Pica::float24::FromRaw(regs.viewport_size_x).ToFloat32() * 2;
@@ -807,10 +803,6 @@ bool RasterizerOpenGL::AccelerateFill(const GPU::Regs::MemoryFillConfig& config)
         glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, 0,
                                0);
 
-        if (OpenGLState::CheckFBStatus(GL_DRAW_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
-            return false;
-        }
-
         GLfloat color_values[4] = {0.0f, 0.0f, 0.0f, 0.0f};
 
         // TODO: Handle additional pixel format and fill value size combinations to accelerate more
@@ -895,10 +887,6 @@ bool RasterizerOpenGL::AccelerateFill(const GPU::Regs::MemoryFillConfig& config)
                                dst_surface->texture.handle, 0);
         glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_TEXTURE_2D, 0, 0);
 
-        if (OpenGLState::CheckFBStatus(GL_DRAW_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
-            return false;
-        }
-
         GLfloat value_float;
         if (dst_surface->pixel_format == CachedSurface::PixelFormat::D16) {
             value_float = config.value_32bit / 65535.0f; // 2^16 - 1
@@ -913,10 +901,6 @@ bool RasterizerOpenGL::AccelerateFill(const GPU::Regs::MemoryFillConfig& config)
         glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, 0, 0);
         glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D,
                                dst_surface->texture.handle, 0);
-
-        if (OpenGLState::CheckFBStatus(GL_DRAW_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
-            return false;
-        }
 
         GLfloat value_float = (config.value_32bit & 0xFFFFFF) / 16777215.0f; // 2^24 - 1
         GLint value_int = (config.value_32bit >> 24);

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -103,7 +103,7 @@ static void MortonCopyPixels(CachedSurface::PixelFormat pixel_format, u32 width,
     }
 }
 
-bool RasterizerCacheOpenGL::BlitTextures(GLuint src_tex, GLuint dst_tex,
+void RasterizerCacheOpenGL::BlitTextures(GLuint src_tex, GLuint dst_tex,
                                          CachedSurface::SurfaceType type,
                                          const MathUtil::Rectangle<int>& src_rect,
                                          const MathUtil::Rectangle<int>& dst_rect) {
@@ -158,21 +158,14 @@ bool RasterizerCacheOpenGL::BlitTextures(GLuint src_tex, GLuint dst_tex,
         buffers = GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT;
     }
 
-    bool can_blit = OpenGLState::CheckFBStatus(GL_READ_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE &&
-                    OpenGLState::CheckFBStatus(GL_DRAW_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE;
-
-    if (can_blit) {
-        glBlitFramebuffer(src_rect.left, src_rect.top, src_rect.right, src_rect.bottom,
-                          dst_rect.left, dst_rect.top, dst_rect.right, dst_rect.bottom, buffers,
-                          buffers == GL_COLOR_BUFFER_BIT ? GL_LINEAR : GL_NEAREST);
-    }
+    glBlitFramebuffer(src_rect.left, src_rect.top, src_rect.right, src_rect.bottom, dst_rect.left,
+                      dst_rect.top, dst_rect.right, dst_rect.bottom, buffers,
+                      buffers == GL_COLOR_BUFFER_BIT ? GL_LINEAR : GL_NEAREST);
 
     // Restore previous framebuffer bindings
     cur_state.draw.read_framebuffer = old_fbs[0];
     cur_state.draw.draw_framebuffer = old_fbs[1];
     cur_state.Apply();
-
-    return can_blit;
 }
 
 bool RasterizerCacheOpenGL::TryBlitSurfaces(CachedSurface* src_surface,
@@ -186,9 +179,9 @@ bool RasterizerCacheOpenGL::TryBlitSurfaces(CachedSurface* src_surface,
         return false;
     }
 
-    return BlitTextures(src_surface->texture.handle, dst_surface->texture.handle,
-                        CachedSurface::GetFormatType(src_surface->pixel_format), src_rect,
-                        dst_rect);
+    BlitTextures(src_surface->texture.handle, dst_surface->texture.handle,
+                 CachedSurface::GetFormatType(src_surface->pixel_format), src_rect, dst_rect);
+    return true;
 }
 
 static void AllocateSurfaceTexture(GLuint texture, CachedSurface::PixelFormat pixel_format,

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -187,7 +187,7 @@ public:
     ~RasterizerCacheOpenGL();
 
     /// Blits one texture to another
-    bool BlitTextures(GLuint src_tex, GLuint dst_tex, CachedSurface::SurfaceType type,
+    void BlitTextures(GLuint src_tex, GLuint dst_tex, CachedSurface::SurfaceType type,
                       const MathUtil::Rectangle<int>& src_rect,
                       const MathUtil::Rectangle<int>& dst_rect);
 

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -232,19 +232,6 @@ void OpenGLState::Apply() const {
     cur_state = *this;
 }
 
-GLenum OpenGLState::CheckFBStatus(GLenum target) {
-    GLenum fb_status = glCheckFramebufferStatus(target);
-    if (fb_status != GL_FRAMEBUFFER_COMPLETE) {
-        const char* fb_description =
-            (target == GL_READ_FRAMEBUFFER ? "READ"
-                                           : (target == GL_DRAW_FRAMEBUFFER ? "DRAW" : "UNK"));
-        LOG_CRITICAL(Render_OpenGL, "OpenGL %s framebuffer check failed, status %X", fb_description,
-                     fb_status);
-    }
-
-    return fb_status;
-}
-
 void OpenGLState::ResetTexture(GLuint handle) {
     for (auto& unit : cur_state.texture_units) {
         if (unit.texture_2d == handle) {

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -90,9 +90,6 @@ public:
     /// Apply this state as the current OpenGL state
     void Apply() const;
 
-    /// Check the status of the current OpenGL read or draw framebuffer configuration
-    static GLenum CheckFBStatus(GLenum target);
-
     /// Resets and unbinds any references to the given resource in the current OpenGL state
     static void ResetTexture(GLuint handle);
     static void ResetSampler(GLuint handle);


### PR DESCRIPTION
This OpenGL call synchronize the worker thread of the nvidia blob.
It can be verified on linux with the __GL_THREADED_OPTIMIZATIONS=1 environment variable.
Those errors should not happen on tested drivers.