### PR TITLE
Unbreak QT-only build after 75ee2f8c6702

### DIFF
--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -13,6 +13,6 @@ include_directories(../../externals/catch/single_include/)
 
 add_executable(tests ${SRCS} ${HEADERS})
 target_link_libraries(tests core video_core audio_core common)
-target_link_libraries(tests ${PLATFORM_LIBRARIES})
+target_link_libraries(tests ${PLATFORM_LIBRARIES} Threads::Threads)
 
 add_test(NAME tests COMMAND $<TARGET_FILE:tests>)


### PR DESCRIPTION
```
$ (cmake -DENABLE_SDL2:BOOL=false /path/to/citra; gmake)
[...]
[ 85%] Linking CXX executable tests
../common/libcommon.a(microprofile.cpp.o): In function `MicroProfileThreadStart(pthread**, void* (*)(void*))':
src/common/microprofile.cpp:(.text+0x41): undefined reference to `pthread_create'
c++: error: linker command failed with exit code 1 (use -v to see invocation)
```