### PR TITLE
file_sys: Make a few single-argument constructors explicit

### DIFF
--- a/src/core/file_sys/archive_extsavedata.cpp
+++ b/src/core/file_sys/archive_extsavedata.cpp
@@ -64,7 +64,7 @@ private:
  */
 class ExtSaveDataArchive : public SaveDataArchive {
 public:
-    ExtSaveDataArchive(const std::string& mount_point) : SaveDataArchive(mount_point) {}
+    explicit ExtSaveDataArchive(const std::string& mount_point) : SaveDataArchive(mount_point) {}
 
     std::string GetName() const override {
         return "ExtSaveDataArchive: " + mount_point;

--- a/src/core/file_sys/archive_ncch.h
+++ b/src/core/file_sys/archive_ncch.h
@@ -17,7 +17,7 @@ namespace FileSys {
 /// File system interface to the NCCH archive
 class ArchiveFactory_NCCH final : public ArchiveFactory {
 public:
-    ArchiveFactory_NCCH(const std::string& mount_point);
+    explicit ArchiveFactory_NCCH(const std::string& mount_point);
 
     std::string GetName() const override {
         return "NCCH";

--- a/src/core/file_sys/archive_romfs.h
+++ b/src/core/file_sys/archive_romfs.h
@@ -20,7 +20,7 @@ namespace FileSys {
 /// File system interface to the RomFS archive
 class ArchiveFactory_RomFS final : public ArchiveFactory {
 public:
-    ArchiveFactory_RomFS(Loader::AppLoader& app_loader);
+    explicit ArchiveFactory_RomFS(Loader::AppLoader& app_loader);
 
     std::string GetName() const override {
         return "RomFS";

--- a/src/core/file_sys/archive_sdmc.h
+++ b/src/core/file_sys/archive_sdmc.h
@@ -17,7 +17,7 @@ namespace FileSys {
 /// Archive backend for SDMC archive
 class SDMCArchive : public ArchiveBackend {
 public:
-    SDMCArchive(const std::string& mount_point_) : mount_point(mount_point_) {}
+    explicit SDMCArchive(const std::string& mount_point_) : mount_point(mount_point_) {}
 
     std::string GetName() const override {
         return "SDMCArchive: " + mount_point;
@@ -43,7 +43,7 @@ protected:
 /// File system interface to the SDMC archive
 class ArchiveFactory_SDMC final : public ArchiveFactory {
 public:
-    ArchiveFactory_SDMC(const std::string& mount_point);
+    explicit ArchiveFactory_SDMC(const std::string& mount_point);
 
     /**
      * Initialize the archive.

--- a/src/core/file_sys/archive_sdmcwriteonly.h
+++ b/src/core/file_sys/archive_sdmcwriteonly.h
@@ -19,7 +19,7 @@ namespace FileSys {
  */
 class SDMCWriteOnlyArchive : public SDMCArchive {
 public:
-    SDMCWriteOnlyArchive(const std::string& mount_point) : SDMCArchive(mount_point) {}
+    explicit SDMCWriteOnlyArchive(const std::string& mount_point) : SDMCArchive(mount_point) {}
 
     std::string GetName() const override {
         return "SDMCWriteOnlyArchive: " + mount_point;
@@ -34,7 +34,7 @@ public:
 /// File system interface to the SDMC write-only archive
 class ArchiveFactory_SDMCWriteOnly final : public ArchiveFactory {
 public:
-    ArchiveFactory_SDMCWriteOnly(const std::string& mount_point);
+    explicit ArchiveFactory_SDMCWriteOnly(const std::string& mount_point);
 
     /**
      * Initialize the archive.

--- a/src/core/file_sys/archive_systemsavedata.h
+++ b/src/core/file_sys/archive_systemsavedata.h
@@ -18,7 +18,7 @@ namespace FileSys {
 /// File system interface to the SystemSaveData archive
 class ArchiveFactory_SystemSaveData final : public ArchiveFactory {
 public:
-    ArchiveFactory_SystemSaveData(const std::string& mount_point);
+    explicit ArchiveFactory_SystemSaveData(const std::string& mount_point);
 
     ResultVal<std::unique_ptr<ArchiveBackend>> Open(const Path& path) override;
     ResultCode Format(const Path& path, const FileSys::ArchiveFormatInfo& format_info) override;

--- a/src/core/file_sys/path_parser.h
+++ b/src/core/file_sys/path_parser.h
@@ -17,7 +17,7 @@ namespace FileSys {
  */
 class PathParser {
 public:
-    PathParser(const Path& path);
+    explicit PathParser(const Path& path);
 
     /**
      * Checks if the Path is valid.

--- a/src/core/file_sys/savedata_archive.h
+++ b/src/core/file_sys/savedata_archive.h
@@ -18,7 +18,7 @@ namespace FileSys {
 /// Archive backend for general save data archive type (SaveData and SystemSaveData)
 class SaveDataArchive : public ArchiveBackend {
 public:
-    SaveDataArchive(const std::string& mount_point_) : mount_point(mount_point_) {}
+    explicit SaveDataArchive(const std::string& mount_point_) : mount_point(mount_point_) {}
 
     std::string GetName() const override {
         return "SaveDataArchive: " + mount_point;


### PR DESCRIPTION
Prevents implicit conversions.