### PR TITLE
Fixed the gpu command list size when creating CiTraces.

### DIFF
--- a/src/core/hw/gpu.cpp
+++ b/src/core/hw/gpu.cpp
@@ -476,8 +476,8 @@ inline void Write(u32 addr, const T data) {
             u32* buffer = (u32*)Memory::GetPhysicalPointer(config.GetPhysicalAddress());
 
             if (Pica::g_debug_context && Pica::g_debug_context->recorder) {
-                Pica::g_debug_context->recorder->MemoryAccessed(
-                    (u8*)buffer, config.size * sizeof(u32), config.GetPhysicalAddress());
+                Pica::g_debug_context->recorder->MemoryAccessed((u8*)buffer, config.size,
+                                                                config.GetPhysicalAddress());
             }
 
             Pica::CommandProcessor::ProcessCommandList(buffer, config.size);


### PR DESCRIPTION
We were writing 4 times as much data, and thus reading (and writing) garbage to the linear heap when replaying the traces with the citrace player.