### PR TITLE
service: Add mvd and qtm services

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -105,6 +105,8 @@ set(SRCS
             hle/service/ldr_ro/ldr_ro.cpp
             hle/service/ldr_ro/memory_synchronizer.cpp
             hle/service/mic_u.cpp
+            hle/service/mvd/mvd.cpp
+            hle/service/mvd/mvd_std.cpp
             hle/service/ndm/ndm.cpp
             hle/service/ndm/ndm_u.cpp
             hle/service/nfc/nfc.cpp
@@ -124,6 +126,10 @@ set(SRCS
             hle/service/ptm/ptm_play.cpp
             hle/service/ptm/ptm_sysm.cpp
             hle/service/ptm/ptm_u.cpp
+            hle/service/qtm/qtm.cpp
+            hle/service/qtm/qtm_s.cpp
+            hle/service/qtm/qtm_sp.cpp
+            hle/service/qtm/qtm_u.cpp
             hle/service/service.cpp
             hle/service/soc_u.cpp
             hle/service/srv.cpp
@@ -259,6 +265,8 @@ set(HEADERS
             hle/service/ldr_ro/ldr_ro.h
             hle/service/ldr_ro/memory_synchronizer.h
             hle/service/mic_u.h
+            hle/service/mvd/mvd.h
+            hle/service/mvd/mvd_std.h
             hle/service/ndm/ndm.h
             hle/service/ndm/ndm_u.h
             hle/service/nfc/nfc.h
@@ -278,6 +286,10 @@ set(HEADERS
             hle/service/ptm/ptm_play.h
             hle/service/ptm/ptm_sysm.h
             hle/service/ptm/ptm_u.h
+            hle/service/qtm/qtm.h
+            hle/service/qtm/qtm_s.h
+            hle/service/qtm/qtm_sp.h
+            hle/service/qtm/qtm_u.h
             hle/service/service.h
             hle/service/soc_u.h
             hle/service/srv.h

--- a/src/core/hle/service/mvd/mvd.cpp
+++ b/src/core/hle/service/mvd/mvd.cpp
@@ -1,0 +1,17 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/service/mvd/mvd.h"
+#include "core/hle/service/mvd/mvd_std.h"
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace MVD {
+
+void Init() {
+    AddService(new MVD_STD());
+}
+
+} // namespace MVD
+} // namespace Service

--- a/src/core/hle/service/mvd/mvd.h
+++ b/src/core/hle/service/mvd/mvd.h
@@ -1,0 +1,14 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+namespace Service {
+namespace MVD {
+
+/// Initializes all MVD services.
+void Init();
+
+} // namespace MVD
+} // namespace Service

--- a/src/core/hle/service/mvd/mvd_std.cpp
+++ b/src/core/hle/service/mvd/mvd_std.cpp
@@ -1,0 +1,32 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/service/mvd/mvd_std.h"
+
+namespace Service {
+namespace MVD {
+
+const Interface::FunctionInfo FunctionTable[] = {
+    // clang-format off
+    {0x00010082, nullptr, "Initialize"},
+    {0x00020000, nullptr, "Shutdown"},
+    {0x00030300, nullptr, "CalculateWorkBufSize"},
+    {0x000400C0, nullptr, "CalculateImageSize"},
+    {0x00080142, nullptr, "ProcessNALUnit"},
+    {0x00090042, nullptr, "ControlFrameRendering"},
+    {0x000A0000, nullptr, "GetStatus"},
+    {0x000B0000, nullptr, "GetStatusOther"},
+    {0x001D0042, nullptr, "GetConfig"},
+    {0x001E0044, nullptr, "SetConfig"},
+    {0x001F0902, nullptr, "SetOutputBuffer"},
+    {0x00210100, nullptr, "OverrideOutputBuffers"}
+    // clang-format on
+};
+
+MVD_STD::MVD_STD() {
+    Register(FunctionTable);
+}
+
+} // namespace MVD
+} // namespace Service

--- a/src/core/hle/service/mvd/mvd_std.h
+++ b/src/core/hle/service/mvd/mvd_std.h
@@ -1,0 +1,22 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace MVD {
+
+class MVD_STD final : public Interface {
+public:
+    MVD_STD();
+
+    std::string GetPortName() const override {
+        return "mvd:std";
+    }
+};
+
+} // namespace MVD
+} // namespace Service

--- a/src/core/hle/service/qtm/qtm.cpp
+++ b/src/core/hle/service/qtm/qtm.cpp
@@ -1,0 +1,21 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/service/qtm/qtm.h"
+#include "core/hle/service/qtm/qtm_s.h"
+#include "core/hle/service/qtm/qtm_sp.h"
+#include "core/hle/service/qtm/qtm_u.h"
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace QTM {
+
+void Init() {
+    AddService(new QTM_S());
+    AddService(new QTM_SP());
+    AddService(new QTM_U());
+}
+
+} // namespace QTM
+} // namespace Service

--- a/src/core/hle/service/qtm/qtm.h
+++ b/src/core/hle/service/qtm/qtm.h
@@ -1,0 +1,14 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+namespace Service {
+namespace QTM {
+
+/// Initializes all QTM services.
+void Init();
+
+} // namespace QTM
+} // namespace Service

--- a/src/core/hle/service/qtm/qtm_s.cpp
+++ b/src/core/hle/service/qtm/qtm_s.cpp
@@ -1,0 +1,23 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/service/qtm/qtm_s.h"
+
+namespace Service {
+namespace QTM {
+
+const Interface::FunctionInfo FunctionTable[] = {
+    // clang-format off
+    // qtm common commands
+    {0x00010080, nullptr, "GetHeadtrackingInfoRaw"},
+    {0x00020080, nullptr, "GetHeadtrackingInfo"},
+    // clang-format on
+};
+
+QTM_S::QTM_S() {
+    Register(FunctionTable);
+}
+
+} // namespace QTM
+} // namespace Service

--- a/src/core/hle/service/qtm/qtm_s.h
+++ b/src/core/hle/service/qtm/qtm_s.h
@@ -1,0 +1,22 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace QTM {
+
+class QTM_S final : public Interface {
+public:
+    QTM_S();
+
+    std::string GetPortName() const override {
+        return "qtm:s";
+    }
+};
+
+} // namespace QTM
+} // namespace Service

--- a/src/core/hle/service/qtm/qtm_sp.cpp
+++ b/src/core/hle/service/qtm/qtm_sp.cpp
@@ -1,0 +1,23 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/service/qtm/qtm_sp.h"
+
+namespace Service {
+namespace QTM {
+
+const Interface::FunctionInfo FunctionTable[] = {
+    // clang-format off
+    // qtm common commands
+    {0x00010080, nullptr, "GetHeadtrackingInfoRaw"},
+    {0x00020080, nullptr, "GetHeadtrackingInfo"},
+    // clang-format on
+};
+
+QTM_SP::QTM_SP() {
+    Register(FunctionTable);
+}
+
+} // namespace QTM
+} // namespace Service

--- a/src/core/hle/service/qtm/qtm_sp.h
+++ b/src/core/hle/service/qtm/qtm_sp.h
@@ -1,0 +1,22 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace QTM {
+
+class QTM_SP final : public Interface {
+public:
+    QTM_SP();
+
+    std::string GetPortName() const override {
+        return "qtm:sp";
+    }
+};
+
+} // namespace QTM
+} // namespace Service

--- a/src/core/hle/service/qtm/qtm_u.cpp
+++ b/src/core/hle/service/qtm/qtm_u.cpp
@@ -1,0 +1,23 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/service/qtm/qtm_u.h"
+
+namespace Service {
+namespace QTM {
+
+const Interface::FunctionInfo FunctionTable[] = {
+    // clang-format off
+    // qtm common commands
+    {0x00010080, nullptr, "GetHeadtrackingInfoRaw"},
+    {0x00020080, nullptr, "GetHeadtrackingInfo"},
+    // clang-format on
+};
+
+QTM_U::QTM_U() {
+    Register(FunctionTable);
+}
+
+} // namespace QTM
+} // namespace Service

--- a/src/core/hle/service/qtm/qtm_u.h
+++ b/src/core/hle/service/qtm/qtm_u.h
@@ -1,0 +1,22 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace QTM {
+
+class QTM_U final : public Interface {
+public:
+    QTM_U();
+
+    std::string GetPortName() const override {
+        return "qtm:u";
+    }
+};
+
+} // namespace QTM
+} // namespace Service

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -26,6 +26,7 @@
 #include "core/hle/service/ir/ir.h"
 #include "core/hle/service/ldr_ro/ldr_ro.h"
 #include "core/hle/service/mic_u.h"
+#include "core/hle/service/mvd/mvd.h"
 #include "core/hle/service/ndm/ndm.h"
 #include "core/hle/service/news/news.h"
 #include "core/hle/service/nfc/nfc.h"
@@ -34,6 +35,7 @@
 #include "core/hle/service/nwm_uds.h"
 #include "core/hle/service/pm_app.h"
 #include "core/hle/service/ptm/ptm.h"
+#include "core/hle/service/qtm/qtm.h"
 #include "core/hle/service/service.h"
 #include "core/hle/service/soc_u.h"
 #include "core/hle/service/srv.h"
@@ -121,11 +123,13 @@ void Init() {
     FRD::Init();
     HID::Init();
     IR::Init();
+    MVD::Init();
     NDM::Init();
     NEWS::Init();
     NFC::Init();
     NIM::Init();
     PTM::Init();
+    QTM::Init();
 
     AddService(new AC_U::Interface);
     AddService(new ACT_A::Interface);


### PR DESCRIPTION
Adds the two New3DS-only modules.

Just adds the submodules that have any uncovered commands.