### PR TITLE
service: Minor PTM changes

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -123,7 +123,9 @@ set(SRCS
             hle/service/nwm_uds.cpp
             hle/service/pm_app.cpp
             hle/service/ptm/ptm.cpp
+            hle/service/ptm/ptm_gets.cpp
             hle/service/ptm/ptm_play.cpp
+            hle/service/ptm/ptm_sets.cpp
             hle/service/ptm/ptm_sysm.cpp
             hle/service/ptm/ptm_u.cpp
             hle/service/qtm/qtm.cpp
@@ -283,7 +285,9 @@ set(HEADERS
             hle/service/nwm_uds.h
             hle/service/pm_app.h
             hle/service/ptm/ptm.h
+            hle/service/ptm/ptm_gets.h
             hle/service/ptm/ptm_play.h
+            hle/service/ptm/ptm_sets.h
             hle/service/ptm/ptm_sysm.h
             hle/service/ptm/ptm_u.h
             hle/service/qtm/qtm.h

--- a/src/core/hle/service/ptm/ptm.cpp
+++ b/src/core/hle/service/ptm/ptm.cpp
@@ -110,6 +110,7 @@ void CheckNew3DS(Service::Interface* self) {
 void Init() {
     AddService(new PTM_Gets);
     AddService(new PTM_Play);
+    AddService(new PTM_S);
     AddService(new PTM_Sets);
     AddService(new PTM_Sysm);
     AddService(new PTM_U);

--- a/src/core/hle/service/ptm/ptm.cpp
+++ b/src/core/hle/service/ptm/ptm.cpp
@@ -108,11 +108,11 @@ void CheckNew3DS(Service::Interface* self) {
 }
 
 void Init() {
-    AddService(new PTM_Gets());
-    AddService(new PTM_Play_Interface);
-    AddService(new PTM_Sets());
-    AddService(new PTM_Sysm_Interface);
-    AddService(new PTM_U_Interface);
+    AddService(new PTM_Gets);
+    AddService(new PTM_Play);
+    AddService(new PTM_Sets);
+    AddService(new PTM_Sysm);
+    AddService(new PTM_U);
 
     shell_open = true;
     battery_is_charging = true;

--- a/src/core/hle/service/ptm/ptm.cpp
+++ b/src/core/hle/service/ptm/ptm.cpp
@@ -6,7 +6,9 @@
 #include "core/file_sys/file_backend.h"
 #include "core/hle/service/fs/archive.h"
 #include "core/hle/service/ptm/ptm.h"
+#include "core/hle/service/ptm/ptm_gets.h"
 #include "core/hle/service/ptm/ptm_play.h"
+#include "core/hle/service/ptm/ptm_sets.h"
 #include "core/hle/service/ptm/ptm_sysm.h"
 #include "core/hle/service/ptm/ptm_u.h"
 #include "core/hle/service/service.h"
@@ -106,7 +108,9 @@ void CheckNew3DS(Service::Interface* self) {
 }
 
 void Init() {
+    AddService(new PTM_Gets());
     AddService(new PTM_Play_Interface);
+    AddService(new PTM_Sets());
     AddService(new PTM_Sysm_Interface);
     AddService(new PTM_U_Interface);
 

--- a/src/core/hle/service/ptm/ptm_gets.cpp
+++ b/src/core/hle/service/ptm/ptm_gets.cpp
@@ -2,12 +2,30 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "core/hle/service/ptm/ptm.h"
 #include "core/hle/service/ptm/ptm_gets.h"
 
 namespace Service {
 namespace PTM {
 
 const Interface::FunctionInfo FunctionTable[] = {
+    // ptm:u common commands
+    {0x00010002, nullptr, "RegisterAlarmClient"},
+    {0x00020080, nullptr, "SetRtcAlarm"},
+    {0x00030000, nullptr, "GetRtcAlarm"},
+    {0x00040000, nullptr, "CancelRtcAlarm"},
+    {0x00050000, GetAdapterState, "GetAdapterState"},
+    {0x00060000, GetShellState, "GetShellState"},
+    {0x00070000, GetBatteryLevel, "GetBatteryLevel"},
+    {0x00080000, GetBatteryChargeState, "GetBatteryChargeState"},
+    {0x00090000, nullptr, "GetPedometerState"},
+    {0x000A0042, nullptr, "GetStepHistoryEntry"},
+    {0x000B00C2, nullptr, "GetStepHistory"},
+    {0x000C0000, GetTotalStepCount, "GetTotalStepCount"},
+    {0x000D0040, nullptr, "SetPedometerRecordingMode"},
+    {0x000E0000, nullptr, "GetPedometerRecordingMode"},
+    {0x000F0084, nullptr, "GetStepHistoryAll"},
+    // ptm:gets
     {0x04010000, nullptr, "GetSystemTime"},
 };
 

--- a/src/core/hle/service/ptm/ptm_gets.cpp
+++ b/src/core/hle/service/ptm/ptm_gets.cpp
@@ -1,0 +1,19 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/service/ptm/ptm_gets.h"
+
+namespace Service {
+namespace PTM {
+
+const Interface::FunctionInfo FunctionTable[] = {
+    {0x04010000, nullptr, "GetSystemTime"},
+};
+
+PTM_Gets::PTM_Gets() {
+    Register(FunctionTable);
+}
+
+} // namespace PTM
+} // namespace Service

--- a/src/core/hle/service/ptm/ptm_gets.h
+++ b/src/core/hle/service/ptm/ptm_gets.h
@@ -1,0 +1,22 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace PTM {
+
+class PTM_Gets final : public Interface {
+public:
+    PTM_Gets();
+
+    std::string GetPortName() const override {
+        return "ptm:gets";
+    }
+};
+
+} // namespace PTM
+} // namespace Service

--- a/src/core/hle/service/ptm/ptm_play.cpp
+++ b/src/core/hle/service/ptm/ptm_play.cpp
@@ -2,12 +2,30 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "core/hle/service/ptm/ptm.h"
 #include "core/hle/service/ptm/ptm_play.h"
 
 namespace Service {
 namespace PTM {
 
 const Interface::FunctionInfo FunctionTable[] = {
+    // ptm:u common commands
+    {0x00010002, nullptr, "RegisterAlarmClient"},
+    {0x00020080, nullptr, "SetRtcAlarm"},
+    {0x00030000, nullptr, "GetRtcAlarm"},
+    {0x00040000, nullptr, "CancelRtcAlarm"},
+    {0x00050000, GetAdapterState, "GetAdapterState"},
+    {0x00060000, GetShellState, "GetShellState"},
+    {0x00070000, GetBatteryLevel, "GetBatteryLevel"},
+    {0x00080000, GetBatteryChargeState, "GetBatteryChargeState"},
+    {0x00090000, nullptr, "GetPedometerState"},
+    {0x000A0042, nullptr, "GetStepHistoryEntry"},
+    {0x000B00C2, nullptr, "GetStepHistory"},
+    {0x000C0000, GetTotalStepCount, "GetTotalStepCount"},
+    {0x000D0040, nullptr, "SetPedometerRecordingMode"},
+    {0x000E0000, nullptr, "GetPedometerRecordingMode"},
+    {0x000F0084, nullptr, "GetStepHistoryAll"},
+    // ptm:play
     {0x08070082, nullptr, "GetPlayHistory"},
     {0x08080000, nullptr, "GetPlayHistoryStart"},
     {0x08090000, nullptr, "GetPlayHistoryLength"},

--- a/src/core/hle/service/ptm/ptm_play.cpp
+++ b/src/core/hle/service/ptm/ptm_play.cpp
@@ -14,7 +14,7 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x080B0080, nullptr, "CalcPlayHistoryStart"},
 };
 
-PTM_Play_Interface::PTM_Play_Interface() {
+PTM_Play::PTM_Play() {
     Register(FunctionTable);
 }
 

--- a/src/core/hle/service/ptm/ptm_play.h
+++ b/src/core/hle/service/ptm/ptm_play.h
@@ -9,9 +9,9 @@
 namespace Service {
 namespace PTM {
 
-class PTM_Play_Interface : public Service::Interface {
+class PTM_Play final : public Interface {
 public:
-    PTM_Play_Interface();
+    PTM_Play();
 
     std::string GetPortName() const override {
         return "ptm:play";

--- a/src/core/hle/service/ptm/ptm_sets.cpp
+++ b/src/core/hle/service/ptm/ptm_sets.cpp
@@ -8,6 +8,7 @@ namespace Service {
 namespace PTM {
 
 const Interface::FunctionInfo FunctionTable[] = {
+    // Note that this service does not have access to ptm:u's common commands
     {0x00010080, nullptr, "SetSystemTime"},
 };
 

--- a/src/core/hle/service/ptm/ptm_sets.cpp
+++ b/src/core/hle/service/ptm/ptm_sets.cpp
@@ -1,0 +1,19 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/service/ptm/ptm_sets.h"
+
+namespace Service {
+namespace PTM {
+
+const Interface::FunctionInfo FunctionTable[] = {
+    {0x00010080, nullptr, "SetSystemTime"},
+};
+
+PTM_Sets::PTM_Sets() {
+    Register(FunctionTable);
+}
+
+} // namespace PTM
+} // namespace Service

--- a/src/core/hle/service/ptm/ptm_sets.h
+++ b/src/core/hle/service/ptm/ptm_sets.h
@@ -1,0 +1,22 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace PTM {
+
+class PTM_Sets final : public Interface {
+public:
+    PTM_Sets();
+
+    std::string GetPortName() const override {
+        return "ptm:sets";
+    }
+};
+
+} // namespace PTM
+} // namespace Service

--- a/src/core/hle/service/ptm/ptm_sysm.cpp
+++ b/src/core/hle/service/ptm/ptm_sysm.cpp
@@ -59,6 +59,10 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x08180040, nullptr, "ConfigureNew3DSCPU"},
 };
 
+PTM_S::PTM_S() {
+    Register(FunctionTable);
+}
+
 PTM_Sysm::PTM_Sysm() {
     Register(FunctionTable);
 }

--- a/src/core/hle/service/ptm/ptm_sysm.cpp
+++ b/src/core/hle/service/ptm/ptm_sysm.cpp
@@ -9,6 +9,23 @@ namespace Service {
 namespace PTM {
 
 const Interface::FunctionInfo FunctionTable[] = {
+    // ptm:u common commands
+    {0x00010002, nullptr, "RegisterAlarmClient"},
+    {0x00020080, nullptr, "SetRtcAlarm"},
+    {0x00030000, nullptr, "GetRtcAlarm"},
+    {0x00040000, nullptr, "CancelRtcAlarm"},
+    {0x00050000, GetAdapterState, "GetAdapterState"},
+    {0x00060000, GetShellState, "GetShellState"},
+    {0x00070000, GetBatteryLevel, "GetBatteryLevel"},
+    {0x00080000, GetBatteryChargeState, "GetBatteryChargeState"},
+    {0x00090000, nullptr, "GetPedometerState"},
+    {0x000A0042, nullptr, "GetStepHistoryEntry"},
+    {0x000B00C2, nullptr, "GetStepHistory"},
+    {0x000C0000, GetTotalStepCount, "GetTotalStepCount"},
+    {0x000D0040, nullptr, "SetPedometerRecordingMode"},
+    {0x000E0000, nullptr, "GetPedometerRecordingMode"},
+    {0x000F0084, nullptr, "GetStepHistoryAll"},
+    // ptm:sysm
     {0x040100C0, nullptr, "SetRtcAlarmEx"},
     {0x04020042, nullptr, "ReplySleepQuery"},
     {0x04030042, nullptr, "NotifySleepPreparationComplete"},

--- a/src/core/hle/service/ptm/ptm_sysm.cpp
+++ b/src/core/hle/service/ptm/ptm_sysm.cpp
@@ -42,7 +42,7 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x08180040, nullptr, "ConfigureNew3DSCPU"},
 };
 
-PTM_Sysm_Interface::PTM_Sysm_Interface() {
+PTM_Sysm::PTM_Sysm() {
     Register(FunctionTable);
 }
 

--- a/src/core/hle/service/ptm/ptm_sysm.h
+++ b/src/core/hle/service/ptm/ptm_sysm.h
@@ -9,9 +9,9 @@
 namespace Service {
 namespace PTM {
 
-class PTM_Sysm_Interface : public Interface {
+class PTM_Sysm final : public Interface {
 public:
-    PTM_Sysm_Interface();
+    PTM_Sysm();
 
     std::string GetPortName() const override {
         return "ptm:sysm";

--- a/src/core/hle/service/ptm/ptm_sysm.h
+++ b/src/core/hle/service/ptm/ptm_sysm.h
@@ -9,6 +9,15 @@
 namespace Service {
 namespace PTM {
 
+class PTM_S final : public Interface {
+public:
+    PTM_S();
+
+    std::string GetPortName() const override {
+        return "ptm:s";
+    }
+};
+
 class PTM_Sysm final : public Interface {
 public:
     PTM_Sysm();

--- a/src/core/hle/service/ptm/ptm_u.cpp
+++ b/src/core/hle/service/ptm/ptm_u.cpp
@@ -26,7 +26,7 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x000F0084, nullptr, "GetStepHistoryAll"},
 };
 
-PTM_U_Interface::PTM_U_Interface() {
+PTM_U::PTM_U() {
     Register(FunctionTable);
 }
 

--- a/src/core/hle/service/ptm/ptm_u.h
+++ b/src/core/hle/service/ptm/ptm_u.h
@@ -9,9 +9,9 @@
 namespace Service {
 namespace PTM {
 
-class PTM_U_Interface : public Interface {
+class PTM_U final : public Interface {
 public:
-    PTM_U_Interface();
+    PTM_U();
 
     std::string GetPortName() const override {
         return "ptm:u";


### PR DESCRIPTION
So it appears that Nintendo decided to have two services specifically for getting and setting system time because Nintendo.

It also turns out that several other PTM services have access to ptm:u's command set.

ptm:s is also apparently an exact alias for ptm:sysm.

This is based off documentation on 3dbrew, of course.