### PR TITLE
ptm: Use boolean instead of integral value

### DIFF
--- a/src/core/hle/service/ptm/ptm.cpp
+++ b/src/core/hle/service/ptm/ptm.cpp
@@ -137,7 +137,7 @@ void Init() {
             Service::FS::OpenFileFromArchive(*archive_result, gamecoin_path, open_mode);
         if (gamecoin_result.Succeeded()) {
             auto gamecoin = gamecoin_result.MoveFrom();
-            gamecoin->backend->Write(0, sizeof(GameCoin), 1,
+            gamecoin->backend->Write(0, sizeof(GameCoin), true,
                                      reinterpret_cast<const u8*>(&default_game_coin));
             gamecoin->backend->Close();
         }


### PR DESCRIPTION
The third parameter of Write is actually a bool type, not an int.