### PR TITLE
VideoCore: Eliminate an unnecessary copy in the drawcall loop

### DIFF
--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -251,7 +251,6 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
             ASSERT(vertex != -1);
 
             bool vertex_cache_hit = false;
-            Shader::OutputRegisters output_registers;
 
             if (is_indexed) {
                 if (g_debug_context && Pica::g_debug_context->recorder) {
@@ -279,10 +278,9 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
                     g_debug_context->OnEvent(DebugContext::Event::VertexShaderInvocation,
                                              (void*)&input);
                 g_state.vs.Run(shader_unit, input, loader.GetNumTotalAttributes());
-                output_registers = shader_unit.output_registers;
 
                 // Retrieve vertex from register data
-                output_vertex = output_registers.ToVertex(regs.vs);
+                output_vertex = shader_unit.output_registers.ToVertex(regs.vs);
 
                 if (is_indexed) {
                     vertex_cache[vertex_cache_pos] = output_vertex;

--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -25,7 +25,7 @@ namespace Pica {
 
 namespace Shader {
 
-OutputVertex OutputRegisters::ToVertex(const Regs::ShaderConfig& config) {
+OutputVertex OutputRegisters::ToVertex(const Regs::ShaderConfig& config) const {
     // Setup output data
     OutputVertex ret;
     // TODO(neobrain): Under some circumstances, up to 16 attributes may be output. We need to

--- a/src/video_core/shader/shader.h
+++ b/src/video_core/shader/shader.h
@@ -85,7 +85,7 @@ struct OutputRegisters {
 
     alignas(16) Math::Vec4<float24> value[16];
 
-    OutputVertex ToVertex(const Regs::ShaderConfig& config);
+    OutputVertex ToVertex(const Regs::ShaderConfig& config) const;
 };
 static_assert(std::is_pod<OutputRegisters>::value, "Structure is not POD");
 


### PR DESCRIPTION
This does, in fact, remove instructions from the code, but I haven't checked if it's actually discernibly faster.