### PR TITLE
game_list: Add a context menu with "Open Save Location"  option

### DIFF
--- a/src/citra_qt/game_list.h
+++ b/src/citra_qt/game_list.h
@@ -36,11 +36,14 @@ public:
 signals:
     void GameChosen(QString game_path);
     void ShouldCancelWorker();
+    void OpenSaveFolderRequested(u64 program_id);
 
 private:
     void AddEntry(const QList<QStandardItem*>& entry_items);
     void ValidateEntry(const QModelIndex& item);
     void DonePopulating();
+
+    void PopupContextMenu(const QPoint& menu_location);
 
     QTreeView* tree_view = nullptr;
     QStandardItemModel* item_model = nullptr;

--- a/src/citra_qt/game_list_p.h
+++ b/src/citra_qt/game_list_p.h
@@ -71,10 +71,13 @@ class GameListItemPath : public GameListItem {
 public:
     static const int FullPathRole = Qt::UserRole + 1;
     static const int TitleRole = Qt::UserRole + 2;
+    static const int ProgramIdRole = Qt::UserRole + 3;
 
     GameListItemPath() : GameListItem() {}
-    GameListItemPath(const QString& game_path, const std::vector<u8>& smdh_data) : GameListItem() {
+    GameListItemPath(const QString& game_path, const std::vector<u8>& smdh_data, u64 program_id)
+        : GameListItem() {
         setData(game_path, FullPathRole);
+        setData(qulonglong(program_id), ProgramIdRole);
 
         if (!Loader::IsValidSMDH(smdh_data)) {
             // SMDH is not valid, set a default icon

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -105,6 +105,7 @@ private slots:
     void OnStopGame();
     /// Called whenever a user selects a game in the game list widget.
     void OnGameListLoadFile(QString game_path);
+    void OnGameListOpenSaveFolder(u64 program_id);
     void OnMenuLoadFile();
     void OnMenuLoadSymbolMap();
     /// Called whenever a user selects the "File->Select Game List Root" menu item

--- a/src/core/file_sys/archive_source_sd_savedata.cpp
+++ b/src/core/file_sys/archive_source_sd_savedata.cpp
@@ -90,4 +90,9 @@ ResultVal<ArchiveFormatInfo> ArchiveSource_SDSaveData::GetFormatInfo(u64 program
     return MakeResult<ArchiveFormatInfo>(info);
 }
 
+std::string ArchiveSource_SDSaveData::GetSaveDataPathFor(const std::string& mount_point,
+                                                         u64 program_id) {
+    return GetSaveDataPath(GetSaveDataContainerPath(mount_point), program_id);
+}
+
 } // namespace FileSys

--- a/src/core/file_sys/archive_source_sd_savedata.h
+++ b/src/core/file_sys/archive_source_sd_savedata.h
@@ -23,6 +23,8 @@ public:
     ResultCode Format(u64 program_id, const FileSys::ArchiveFormatInfo& format_info);
     ResultVal<ArchiveFormatInfo> GetFormatInfo(u64 program_id) const;
 
+    static std::string GetSaveDataPathFor(const std::string& mount_point, u64 program_id);
+
 private:
     std::string mount_point;
 };

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -144,6 +144,15 @@ public:
     }
 
     /**
+     * Get the program id of the application
+     * @param out_program_id Reference to store program id into
+     * @return ResultStatus result of function
+     */
+    virtual ResultStatus ReadProgramId(u64& out_program_id) {
+        return ResultStatus::ErrorNotImplemented;
+    }
+
+    /**
      * Get the RomFS of the application
      * Since the RomFS can be huge, we return a file reference instead of copying to a buffer
      * @param romfs_file The file containing the RomFS

--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -344,6 +344,18 @@ ResultStatus AppLoader_NCCH::ReadLogo(std::vector<u8>& buffer) {
     return LoadSectionExeFS("logo", buffer);
 }
 
+ResultStatus AppLoader_NCCH::ReadProgramId(u64& out_program_id) {
+    if (!file.IsOpen())
+        return ResultStatus::Error;
+
+    ResultStatus result = LoadExeFS();
+    if (result != ResultStatus::Success)
+        return result;
+
+    out_program_id = ncch_header.program_id;
+    return ResultStatus::Success;
+}
+
 ResultStatus AppLoader_NCCH::ReadRomFS(std::shared_ptr<FileUtil::IOFile>& romfs_file, u64& offset,
                                        u64& size) {
     if (!file.IsOpen())

--- a/src/core/loader/ncch.h
+++ b/src/core/loader/ncch.h
@@ -220,6 +220,13 @@ public:
     ResultStatus ReadLogo(std::vector<u8>& buffer) override;
 
     /**
+     * Get the program id of the application
+     * @param out_program_id Reference to store program id into
+     * @return ResultStatus result of function
+     */
+    ResultStatus ReadProgramId(u64& out_program_id) override;
+
+    /**
      * Get the RomFS of the application
      * @param romfs_file Reference to buffer to store data
      * @param offset     Offset in the file to the RomFS


### PR DESCRIPTION
What changed:
* Added `Loader::GetProgramId`.
* Added static function `ArchiveSource_SDSaveData::GetSaveDataPathFor`.
* Added signal `GameList::OpenSaveFolderRequested`.

Issues that arose:
* The least messy way I could think of to expose a way to get the save data path was to implement a static function.
* I really really wanted to use a `boost::optional<u64>` to represent the `program_id` since not all formats have a program id.

Screenshot:

![20161215-101410](https://cloud.githubusercontent.com/assets/8682882/21220168/8ee937e6-c2af-11e6-8f78-abcab0548ba1.png)