### PR TITLE
Add interactive key rebind tool to SDL2 frontend

### DIFF
--- a/src/citra/CMakeLists.txt
+++ b/src/citra/CMakeLists.txt
@@ -19,7 +19,7 @@ include_directories(${SDL2_INCLUDE_DIR})
 
 add_executable(citra ${SRCS} ${HEADERS})
 target_link_libraries(citra core video_core audio_core common)
-target_link_libraries(citra ${SDL2_LIBRARY} ${OPENGL_gl_LIBRARY} inih glad SDL_Pango)
+target_link_libraries(citra ${SDL2_LIBRARY} ${OPENGL_gl_LIBRARY} inih glad)
 if (MSVC)
     target_link_libraries(citra getopt)
 endif()

--- a/src/citra/CMakeLists.txt
+++ b/src/citra/CMakeLists.txt
@@ -1,11 +1,13 @@
 set(SRCS
             emu_window/emu_window_sdl2.cpp
+            rebind_window/rebind_window_sdl2.cpp
             citra.cpp
             config.cpp
             citra.rc
             )
 set(HEADERS
             emu_window/emu_window_sdl2.h
+            rebind_window/rebind_window_sdl2.h
             config.h
             default_ini.h
             resource.h
@@ -17,7 +19,7 @@ include_directories(${SDL2_INCLUDE_DIR})
 
 add_executable(citra ${SRCS} ${HEADERS})
 target_link_libraries(citra core video_core audio_core common)
-target_link_libraries(citra ${SDL2_LIBRARY} ${OPENGL_gl_LIBRARY} inih glad)
+target_link_libraries(citra ${SDL2_LIBRARY} ${OPENGL_gl_LIBRARY} inih glad SDL_Pango)
 if (MSVC)
     target_link_libraries(citra getopt)
 endif()

--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -12,8 +12,7 @@
 #include "core/settings.h"
 
 Config::Config() {
-    // TODO: Don't hardcode the path; let the frontend decide where to put the
-    // config files.
+    // TODO: Don't hardcode the path; let the frontend decide where to put the config files.
     sdl2_config_loc = FileUtil::GetUserPath(D_CONFIG_IDX) + "sdl2-config.ini";
     sdl2_config = std::make_unique<INIReader>(sdl2_config_loc);
 

--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -12,7 +12,8 @@
 #include "core/settings.h"
 
 Config::Config() {
-    // TODO: Don't hardcode the path; let the frontend decide where to put the config files.
+    // TODO: Don't hardcode the path; let the frontend decide where to put the
+    // config files.
     sdl2_config_loc = FileUtil::GetUserPath(D_CONFIG_IDX) + "sdl2-config.ini";
     sdl2_config = std::make_unique<INIReader>(sdl2_config_loc);
 
@@ -98,6 +99,10 @@ void Config::ReadValues() {
     Settings::values.use_gdbstub = sdl2_config->GetBoolean("Debugging", "use_gdbstub", false);
     Settings::values.gdbstub_port =
         static_cast<u16>(sdl2_config->GetInteger("Debugging", "gdbstub_port", 24689));
+}
+
+const std::string& Config::GetConfigPath() {
+    return sdl2_config_loc;
 }
 
 void Config::Reload() {

--- a/src/citra/config.h
+++ b/src/citra/config.h
@@ -18,5 +18,7 @@ class Config {
 public:
     Config();
 
+    const std::string& GetConfigPath();
+
     void Reload();
 };

--- a/src/citra/rebind_window/rebind_window_sdl2.cpp
+++ b/src/citra/rebind_window/rebind_window_sdl2.cpp
@@ -1,0 +1,130 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+// #include <algorithm>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#define SDL_MAIN_HANDLED
+#include <SDL.h>
+
+#include "citra/rebind_window/rebind_window_sdl2.h"
+// #include "common/key_map.h"
+#include "common/file_util.h"
+#include "common/logging/log.h"
+#include "common/scm_rev.h"
+#include "common/string_util.h"
+// #include "core/hle/service/hid/hid.h"
+#include "citra/config.h"
+#include "core/settings.h"
+// #include "video_core/video_core.h"
+
+const u32 fps = 60;
+const u32 minimum_frame_time = 1000 / fps;
+const int REBIND_WINDOW_WIDTH = 640;
+const int REBIND_WINDOW_HEIGHT = 480;
+
+void RebindWindow_SDL2::OnKeyDown(int key) {
+    const char* key_name = Settings::NativeInput::Mapping[modifying_index];
+    std::string scancode_name = SDL_GetScancodeName(static_cast<SDL_Scancode>(key));
+    std::cout << "Rebound " << key_name << " to " << scancode_name << "." << std::endl;
+    FileUtil::SetINIKey(config_filename, "Controls", key_name, std::to_string(key));
+    is_open = false;
+}
+
+bool RebindWindow_SDL2::IsOpen() const {
+    return is_open;
+}
+
+RebindWindow_SDL2::RebindWindow_SDL2(int modifying_index, const std::string& config_filename)
+    : modifying_index(modifying_index), config_filename(config_filename) {
+    SDL_SetMainReady();
+
+    // Initialize the window
+    if (SDL_Init(SDL_INIT_VIDEO) < 0) {
+        LOG_CRITICAL(Frontend, "Failed to initialize SDL2! Exiting...");
+        exit(1);
+    }
+
+    std::string window_title = Common::StringFromFormat("Citra | %s-%s | Rebinding keys",
+                                                        Common::g_scm_branch, Common::g_scm_desc);
+
+    render_window = SDL_CreateWindow(window_title.c_str(),
+                                     SDL_WINDOWPOS_UNDEFINED, // x position
+                                     SDL_WINDOWPOS_UNDEFINED, // y position
+                                     REBIND_WINDOW_WIDTH, REBIND_WINDOW_HEIGHT, SDL_WINDOW_SHOWN);
+
+    if (render_window == nullptr) {
+        LOG_CRITICAL(Frontend, "Failed to create SDL2 window! Exiting...");
+        exit(1);
+    }
+
+    renderer = SDL_CreateRenderer(render_window, -1, SDL_RENDERER_ACCELERATED);
+
+    if (renderer == nullptr) {
+        LOG_CRITICAL(Frontend, "Failed to create SDL2 renderer! Exiting...");
+        exit(1);
+    }
+}
+
+RebindWindow_SDL2::~RebindWindow_SDL2() {
+    SDL_DestroyRenderer(renderer);
+    SDL_DestroyWindow(render_window);
+    SDL_Quit();
+}
+
+void RebindWindow_SDL2::PollEvents() {
+    SDL_Event event;
+
+    while (SDL_PollEvent(&event) && is_open) {
+        switch (event.type) {
+        case SDL_WINDOWEVENT:
+            if (event.window.event == SDL_WINDOWEVENT_CLOSE) {
+                is_open = false;
+            }
+            break;
+        case SDL_KEYDOWN:
+            OnKeyDown(static_cast<int>(event.key.keysym.scancode));
+            break;
+        case SDL_QUIT:
+            is_open = false;
+            break;
+        }
+    }
+}
+
+void RebindWindow_SDL2::Render() {
+    SDL_SetRenderDrawColor(renderer, 0xff, 0xff, 0xff, 0xff);
+    SDL_RenderClear(renderer);
+    // TODO: Ideally, this window should be an interactive editor, but at the very least,
+    // display some sort of "press a key" text here. This requires a text rendering library
+    // though, see issue #2313.
+}
+
+void RebindWindow_SDL2::Run() {
+    Uint32 last_frame_time = 0;
+    Uint32 frame_time;
+    Uint32 time_delta;
+
+    int current = Settings::values.input_mappings[Settings::NativeInput::All[modifying_index]];
+    std::cout << "Press a key to bind to " << Settings::NativeInput::Mapping[modifying_index]
+              << " (currently " << SDL_GetScancodeName(static_cast<SDL_Scancode>(current)) << ")..."
+              << std::endl;
+
+    while (is_open) {
+        frame_time = SDL_GetTicks();
+
+        PollEvents();
+
+        time_delta = frame_time - last_frame_time;
+        last_frame_time = frame_time;
+
+        Render();
+        SDL_RenderPresent(renderer);
+
+        // Make sure each frame is at least `minimum_frame_time` milliseconds long.
+        Uint32 ms = std::min(minimum_frame_time - (SDL_GetTicks() - frame_time), 0U);
+        SDL_Delay(ms);
+    }
+}

--- a/src/citra/rebind_window/rebind_window_sdl2.h
+++ b/src/citra/rebind_window/rebind_window_sdl2.h
@@ -1,0 +1,50 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <utility>
+#include "common/emu_window.h"
+
+struct SDL_Window;
+
+class RebindWindow_SDL2 {
+public:
+    RebindWindow_SDL2(int modifying_index, const std::string& config_filename);
+    ~RebindWindow_SDL2();
+
+    /// Polls window events
+    void PollEvents();
+
+    /// Run until the window is closed
+    void Run();
+
+    /// Render the keybind editor UI to `renderer`
+    void Render();
+
+    /// Whether the window is still open, and a close request hasn't yet been sent
+    bool IsOpen() const;
+
+    /// Load keymap from configuration
+    void ReloadSetKeymaps();
+
+private:
+    /// Called by PollEvents when a key is pressed.
+    void OnKeyDown(int key);
+
+    /// Which button are we modifying?
+    int modifying_index;
+
+    /// Where is the config file we're modifying?
+    std::string config_filename;
+
+    /// Is the window still open?
+    bool is_open = true;
+
+    /// Internal SDL2 render window
+    SDL_Window* render_window;
+
+    /// Internal SDL2 renderer
+    SDL_Renderer* renderer;
+};

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -170,6 +170,11 @@ size_t ReadFileToString(bool text_file, const char* filename, std::string& str);
 void SplitFilename83(const std::string& filename, std::array<char, 9>& short_name,
                      std::array<char, 4>& extension);
 
+// Set a single key in an INI file at the given path, creating a new key/section
+// if necessary. Overwrites the original file. Returns true on success.
+bool SetINIKey(const std::string& filename, const std::string& section, const std::string& key,
+               const std::string& value);
+
 // simple wrapper for cstdlib file functions to
 // hopefully will make error checking easier
 // and make forgetting an fclose() harder


### PR DESCRIPTION
Solves #111.

This involved writing a slightly messy function that updates an .ini file while keeping its comments and whitespace intact. It seems to do a good job.

This tool isn't *great*, right now -- but issue #2313 prevents me from rendering any text in the SDL window that pops up to prompt the user for a single keypress.

Try running `citra -l` to view the current bindings, `src/citra/citra -r pad_x` to update one of them.