### PR TITLE
core: Add missing #pragma once directives where applicable

### DIFF
--- a/src/core/arm/dyncom/arm_dyncom_trans.h
+++ b/src/core/arm/dyncom/arm_dyncom_trans.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <cstddef>
 #include "common/common_types.h"
 

--- a/src/core/hle/service/dlp/dlp.h
+++ b/src/core/hle/service/dlp/dlp.h
@@ -2,6 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#pragma once
+
 namespace Service {
 namespace DLP {
 

--- a/src/core/hle/service/srv.h
+++ b/src/core/hle/service/srv.h
@@ -2,6 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#pragma once
+
 #include "core/hle/service/service.h"
 
 namespace Service {


### PR DESCRIPTION
Three more files missing header guards.