### PR TITLE
gdbstub: Remove global variable from public interface

### DIFF
--- a/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
+++ b/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
@@ -953,7 +953,7 @@ unsigned InterpreterMainLoop(ARMul_State* cpu) {
 #define GDB_BP_CHECK                                                                               \
     cpu->Cpsr &= ~(1 << 5);                                                                        \
     cpu->Cpsr |= cpu->TFlag << 5;                                                                  \
-    if (GDBStub::g_server_enabled) {                                                               \
+    if (GDBStub::IsServerEnabled()) {                                                              \
         if (GDBStub::IsMemoryBreak() || (breakpoint_data.type != GDBStub::BreakpointType::None &&  \
                                          PC == breakpoint_data.address)) {                         \
             GDBStub::Break();                                                                      \
@@ -1649,7 +1649,7 @@ DISPATCH : {
     }
 
     // Find breakpoint if one exists within the block
-    if (GDBStub::g_server_enabled && GDBStub::IsConnected()) {
+    if (GDBStub::IsConnected()) {
         breakpoint_data =
             GDBStub::GetNextBreakpointFromAddress(cpu->Reg[15], GDBStub::BreakpointType::Execute);
     }

--- a/src/core/arm/skyeye_common/armstate.cpp
+++ b/src/core/arm/skyeye_common/armstate.cpp
@@ -182,7 +182,7 @@ void ARMul_State::ResetMPCoreCP15Registers() {
 }
 
 static void CheckMemoryBreakpoint(u32 address, GDBStub::BreakpointType type) {
-    if (GDBStub::g_server_enabled && GDBStub::CheckBreakpoint(address, type)) {
+    if (GDBStub::IsServerEnabled() && GDBStub::CheckBreakpoint(address, type)) {
         LOG_DEBUG(Debug, "Found memory breakpoint @ %08x", address);
         GDBStub::Break(true);
     }

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -22,7 +22,7 @@ std::unique_ptr<ARM_Interface> g_sys_core; ///< ARM11 system (OS) core
 
 /// Run the core CPU loop
 void RunLoop(int tight_loop) {
-    if (GDBStub::g_server_enabled) {
+    if (GDBStub::IsServerEnabled()) {
         GDBStub::HandlePacket();
 
         // If the loop is halted and we want to step, use a tiny (1) number of instructions to

--- a/src/core/gdbstub/gdbstub.h
+++ b/src/core/gdbstub/gdbstub.h
@@ -5,7 +5,7 @@
 // Originally written by Sven Peter <sven@fail0verflow.com> for anergistic.
 
 #pragma once
-#include <atomic>
+
 #include "common/common_types.h"
 
 namespace GDBStub {
@@ -24,10 +24,6 @@ struct BreakpointAddress {
     BreakpointType type;
 };
 
-/// If set to false, the server will never be started and no gdbstub-related functions will be
-/// executed.
-extern std::atomic<bool> g_server_enabled;
-
 /**
  * Set the port the gdbstub should use to listen for connections.
  *
@@ -36,7 +32,7 @@ extern std::atomic<bool> g_server_enabled;
 void SetServerPort(u16 port);
 
 /**
- * Set the g_server_enabled flag and start or stop the server if possible.
+ * Starts or stops the server if possible.
  *
  * @param status Set the server to enabled or disabled.
  */
@@ -47,6 +43,9 @@ void Init();
 
 /// Stop gdbstub server.
 void Shutdown();
+
+/// Checks if the gdbstub server is enabled.
+bool IsServerEnabled();
 
 /// Returns true if there is an active socket connection.
 bool IsConnected();


### PR DESCRIPTION
Currently, this is only ever queried, so adding a function to check if the server is enabled is more sensible.

If directly modifying this externally is ever desirable, it should be done by adding a function to the interface, rather than exposing implementation details directly.