### PR TITLE
Kernel: remove object's waiting thread if it is dead

### DIFF
--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -35,7 +35,8 @@ void WaitObject::RemoveWaitingThread(Thread* thread) {
 SharedPtr<Thread> WaitObject::GetHighestPriorityReadyThread() {
     // Remove the threads that are ready or already running from our waitlist
     boost::range::remove_erase_if(waiting_threads, [](const SharedPtr<Thread>& thread) {
-        return thread->status == THREADSTATUS_RUNNING || thread->status == THREADSTATUS_READY;
+        return thread->status == THREADSTATUS_RUNNING || thread->status == THREADSTATUS_READY ||
+               thread->status == THREADSTATUS_DEAD;
     });
 
     // TODO(Subv): This call should be performed inside the loop below to check if an object can be


### PR DESCRIPTION
This is a regression from #2260 . I don't know if this is a proper fix. @Subv if you are going to fix this in a better way, feel free to close this.

The issue itself appears in the following scenery:

A thread calls `WaitSynchN` on two events A and B with `wait_all = false`. Then the events A signals, waking up the thread. The thread then immediately executes to the end and `Stop` itself. Note that because it is in the `wait_all=false` situation, the thread didn't record the objects it was waiting on, therefore it can't remove itself from B's list. Now the thread is in DEAD status, and B signals. B still think the thread is alive, and continue to get it by `GetHighestPriorityReadyThread`. Since the thread is dead and cannot be resumed, it remains in B's list forever, resulting in an infinite loop in `WaitObject::WakeupAllWaitingThreads`