### PR TITLE
Thread: remove the thread from the thread list when exiting

### DIFF
--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -46,7 +46,7 @@ static std::vector<SharedPtr<Thread>> thread_list;
 // Lists only ready thread ids.
 static Common::ThreadQueueList<Thread*, THREADPRIO_LOWEST + 1> ready_queue;
 
-static Thread* current_thread;
+static SharedPtr<Thread> current_thread;
 
 // The first available thread id at startup
 static u32 next_thread_id;
@@ -63,7 +63,7 @@ Thread::Thread() {}
 Thread::~Thread() {}
 
 Thread* GetCurrentThread() {
-    return current_thread;
+    return current_thread.get();
 }
 
 /**
@@ -261,6 +261,13 @@ void WaitCurrentThread_ArbitrateAddress(VAddr wait_address) {
     Thread* thread = GetCurrentThread();
     thread->wait_address = wait_address;
     thread->status = THREADSTATUS_WAIT_ARB;
+}
+
+void ExitCurrentThread() {
+    Thread* thread = GetCurrentThread();
+    thread->Stop();
+    thread_list.erase(std::remove(thread_list.begin(), thread_list.end(), thread),
+                      thread_list.end());
 }
 
 /**

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -253,6 +253,11 @@ void WaitCurrentThread_WaitSynchronization(std::vector<SharedPtr<WaitObject>> wa
 void WaitCurrentThread_ArbitrateAddress(VAddr wait_address);
 
 /**
+ * Stops the current thread and removes it from the thread_list
+ */
+void ExitCurrentThread();
+
+/**
  * Initialize threading
  */
 void ThreadingInit();

--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -584,7 +584,7 @@ static ResultCode CreateThread(Handle* out_handle, s32 priority, u32 entry_point
 static void ExitThread() {
     LOG_TRACE(Kernel_SVC, "called, pc=0x%08X", Core::g_app_core->GetPC());
 
-    Kernel::GetCurrentThread()->Stop();
+    Kernel::ExitCurrentThread();
 }
 
 /// Gets the priority for the specified thread


### PR DESCRIPTION
Currently we leave all dead thread in the `thread_list` and never remove them until exiting the game. This has a significant impact on game that loves to create small threads frequently (such as Pokemon Sun, which creates thousands of threads in 10 minutes). In this case, the `thread_list` grows up quickly and slows down all functions that iterating over the list, as users reported "games slow down after an hour".

I did a profiling on Pokemon running for 40 minutes, with the character standing there without any input. The frame rate drops from 25 FPS at the beginning to 20 FPS at the end. The profiling shows a time difference spending on a function between the beginning and the end:

The first 5 minutes:
![fast](https://cloud.githubusercontent.com/assets/4592895/21286095/3f098906-c453-11e6-85ec-cb10f35b78f8.PNG)

The last 5 minutes:
![slow](https://cloud.githubusercontent.com/assets/4592895/21286097/45559b92-c453-11e6-9f17-1c1f49d6dbb8.PNG)

The profiling results after the change shows no difference in the function between the first and the last 5 minutes.

To avoid use-after-free, I turn `current_thread` into a `SharedPtr`, ~~as well as the return type of `GetCurrentThread`~~. But I am not confident with these changes. Please help me check if the memory management is ok.