### PR TITLE
Revert "Memory: Always flush whole pages from surface cache"

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -357,24 +357,14 @@ void RasterizerMarkRegionCached(PAddr start, u32 size, int count_delta) {
     }
 }
 
-static void RoundToPages(PAddr& start, u32& size) {
-    PAddr start_rounded_down = start & ~PAGE_MASK;
-    PAddr end_rounded_up = ((start + size) + PAGE_MASK) & ~PAGE_MASK;
-
-    start = start_rounded_down;
-    size = end_rounded_up - start_rounded_down;
-}
-
 void RasterizerFlushRegion(PAddr start, u32 size) {
     if (VideoCore::g_renderer != nullptr) {
-        RoundToPages(start, size);
         VideoCore::g_renderer->Rasterizer()->FlushRegion(start, size);
     }
 }
 
 void RasterizerFlushAndInvalidateRegion(PAddr start, u32 size) {
     if (VideoCore::g_renderer != nullptr) {
-        RoundToPages(start, size);
         VideoCore::g_renderer->Rasterizer()->FlushAndInvalidateRegion(start, size);
     }
 }


### PR DESCRIPTION
Reverts citra-emu/citra#2321

This introduced a pretty big performance regression, at least with my game library. It's most pronounced in ZMM w/ GCC (see bleeding edge build 94 - with the change, vs. 99 - without the change). Some of the other games I tested are less affected. Microprofile is broken on GCC, and I just tested this with bleeding edge, so I'm not really sure the exact bottleneck - needs more investigation before we reintroduce the change (or a similar one).

![http://i.imgur.com/KoAHnGU.png](http://i.imgur.com/KoAHnGU.png)