### PR TITLE
Fixed game_list focus issue.

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -390,6 +390,7 @@ void GMainWindow::BootGame(const std::string& filename) {
         game_list->hide();
     }
     render_window->show();
+    render_window->setFocus();
 
     emulation_running = true;
     OnStartGame();


### PR DESCRIPTION
*Fixed game_list focus issue.
previously, if we pressed down/up +enter after game started, the game list would load the previous/next game from list. setting focus on render_window fixes this issue.