### PR TITLE
Use GL_TRUE when setting color_mask

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -875,10 +875,10 @@ bool RasterizerOpenGL::AccelerateFill(const GPU::Regs::MemoryFillConfig& config)
             }
         }
 
-        cur_state.color_mask.red_enabled = true;
-        cur_state.color_mask.green_enabled = true;
-        cur_state.color_mask.blue_enabled = true;
-        cur_state.color_mask.alpha_enabled = true;
+        cur_state.color_mask.red_enabled = GL_TRUE;
+        cur_state.color_mask.green_enabled = GL_TRUE;
+        cur_state.color_mask.blue_enabled = GL_TRUE;
+        cur_state.color_mask.alpha_enabled = GL_TRUE;
         cur_state.Apply();
         glClearBufferfv(GL_COLOR, 0, color_values);
     } else if (dst_type == SurfaceType::Depth) {


### PR DESCRIPTION
See #2219.

I couldn't find any other instances of using true/false when setting a GLboolean / calling a function that takes GLboolean.