### PR TITLE
disassembler: Remove mutable specifier from breakpoints member variable

### DIFF
--- a/src/citra_qt/debugger/disassembler.h
+++ b/src/citra_qt/debugger/disassembler.h
@@ -38,9 +38,7 @@ private:
     unsigned int program_counter;
 
     QModelIndex selection;
-
-    // TODO: Make BreakPoints less crappy (i.e. const-correct) so that this needn't be mutable.
-    mutable BreakPoints breakpoints;
+    BreakPoints breakpoints;
 };
 
 class DisassemblerWidget : public QDockWidget {


### PR DESCRIPTION
Breakpoints has been const correct with regards to what the DisassmblerModel needs for quite a while now.