### PR TITLE
Lighting LUT Quickfix

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -293,7 +293,7 @@ static void AppendAlphaTestCondition(std::string& out, Regs::CompareFunc func) {
     case CompareFunc::GreaterThanOrEqual: {
         static const char* op[] = {"!=", "==", ">=", ">", "<=", "<"};
         unsigned index = (unsigned)func - (unsigned)CompareFunc::Equal;
-        out += "int(last_tex_env_out.a * 255.0f) " + std::string(op[index]) + " alphatest_ref";
+        out += "int(last_tex_env_out.a * 255.0) " + std::string(op[index]) + " alphatest_ref";
         break;
     }
 
@@ -422,7 +422,7 @@ static void WriteLighting(std::string& out, const PicaShaderConfig& config) {
         if (abs) {
             // LUT index is in the range of (0.0, 1.0)
             index = lighting.light[light_num].two_sided_diffuse ? "abs(" + index + ")"
-                                                                : "max(" + index + ", 0.f)";
+                                                                : "max(" + index + ", 0.0)";
         } else {
             // LUT index is in the range of (-1.0, 1.0)
             index = "((" + index + " < 0) ? " + index + " + 2.0 : " + index + ") / 2.0";
@@ -577,7 +577,6 @@ std::string GenerateFragmentShader(const PicaShaderConfig& config) {
 #version 330 core
 #define NUM_TEV_STAGES 6
 #define NUM_LIGHTS 8
-#define LIGHTING_LUT_SIZE 256
 
 // Texture coordinate offsets and scales
 #define OFFSET_256 (0.5 / 256.0)


### PR DESCRIPTION
This fixes the broken lighting in Zelda: ALBW (As reported by Migue via Discord).

**Broken (master):**
![Broken](http://i.imgur.com/HqPuIAm.png)

**Fixed (this PR):**
![Fixed](http://i.imgur.com/V6iD7bH.png)

---

The error is caused by a wrapping of the texture in `LUT[4]` (`GL_TEXTURE_7`) where the red channel (so `texture(LUT[4], index)[0])` will be a ramp from 0.0 to 1.0 accross its width of 256 pixels.
Hence turning samples at texcoord 0.0 into the value 0.5 (average of 0.0 (left border) and 1.0 (right border)).

Note that this also removes the scaling with `255.0/256.0` (`FLOAT_255`) because I'm not sure what it was supposed to do (as offsetting from 0.0 wasn't done and scaling would have to be done using: *stupidme* check what yuriks wrote below for the proper formula).
All of the clamping has been moved into the texture object now which means we can simplify the shader slightly.

Aside from that, this PR removes some ugly float suffixes and implicit conversions in GLSL.
The whole shader_gen deserves a rewrite, but that is a seperate issue.

---

@degasus pointed out that glTexSubImage1D is probably a lot worse than buffer textures.
So in the future, we should be rewriting the whole LUT (lighting and fog) upload code.
This would also give us the option to adapt a better interpolation like the fog LUT already does (albeit being very slow / stupid in GLSL in the case of the fog LUT).
However, I consider that a seperate issue. So this quickfix will have to do for now.
