### PR TITLE
file_util: fix missing sysdata path

### DIFF
--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -697,9 +697,6 @@ const std::string& GetUserPath(const unsigned int DirIDX, const std::string& new
 
         paths[D_CONFIG_IDX] = paths[D_USER_IDX] + CONFIG_DIR DIR_SEP;
         paths[D_CACHE_IDX] = paths[D_USER_IDX] + CACHE_DIR DIR_SEP;
-        paths[D_SDMC_IDX] = paths[D_USER_IDX] + SDMC_DIR DIR_SEP;
-        paths[D_NAND_IDX] = paths[D_USER_IDX] + NAND_DIR DIR_SEP;
-        paths[D_SYSDATA_IDX] = paths[D_USER_IDX] + SYSDATA_DIR DIR_SEP;
 #else
         if (FileUtil::Exists(ROOT_DIR DIR_SEP USERDATA_DIR)) {
             paths[D_USER_IDX] = ROOT_DIR DIR_SEP USERDATA_DIR DIR_SEP;
@@ -717,6 +714,7 @@ const std::string& GetUserPath(const unsigned int DirIDX, const std::string& new
 #endif
         paths[D_SDMC_IDX] = paths[D_USER_IDX] + SDMC_DIR DIR_SEP;
         paths[D_NAND_IDX] = paths[D_USER_IDX] + NAND_DIR DIR_SEP;
+        paths[D_SYSDATA_IDX] = paths[D_USER_IDX] + SYSDATA_DIR DIR_SEP;
     }
 
     if (!newPath.empty()) {


### PR DESCRIPTION
This is a regression from 707cc66362e613925bbdd0c2abed7959a42decad (#2343). The regression only effects Linux and MacOS version. The sysdata directory was removed, which causes that shared_font can't be found. Also, on the Windows version, sdmc and nand directory are assigned twice.