### PR TITLE
Core: reset cpu_core in Shutdown to make IsPoweredOn work properly

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -159,6 +159,7 @@ void System::Shutdown() {
     Kernel::Shutdown();
     HW::Shutdown();
     CoreTiming::Shutdown();
+    cpu_core.reset();
 
     LOG_DEBUG(Core, "Shutdown OK");
 }


### PR DESCRIPTION
Yet another regression from #2343 (232ef55c1a13552e5ba8b72d61d1d072f5851598, issue #2373). `cpu_core` doesn't get reset when shutting down, causing `IsPoweredOn(){return cpu_core != nullptr;}` not working properly. I kind of want to restore the old `bool is_powered_on;` method, but not sure.

_Three regressions from one PR is ridiculous._