### PR TITLE
Service/NFC: stub GetTagInRangeEvent

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -45,6 +45,7 @@ namespace Log {
     SUB(Service, LDR)                                                                              \
     SUB(Service, MIC)                                                                              \
     SUB(Service, NDM)                                                                              \
+    SUB(Service, NFC)                                                                              \
     SUB(Service, NIM)                                                                              \
     SUB(Service, NWM)                                                                              \
     SUB(Service, CAM)                                                                              \

--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -62,6 +62,7 @@ enum class Class : ClassType {
     Service_LDR,       ///< The LDR (3ds dll loader) service
     Service_MIC,       ///< The MIC (Microphone) service
     Service_NDM,       ///< The NDM (Network daemon manager) service
+    Service_NFC,       ///< The NFC service
     Service_NIM,       ///< The NIM (Network interface manager) service
     Service_NWM,       ///< The NWM (Network wlan manager) service
     Service_CAM,       ///< The CAM (Camera) service

--- a/src/core/hle/service/nfc/nfc.cpp
+++ b/src/core/hle/service/nfc/nfc.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "core/hle/kernel/event.h"
 #include "core/hle/service/nfc/nfc.h"
 #include "core/hle/service/nfc/nfc_m.h"
 #include "core/hle/service/nfc/nfc_u.h"
@@ -9,9 +10,28 @@
 namespace Service {
 namespace NFC {
 
+static Kernel::SharedPtr<Kernel::Event> tag_in_range_event;
+
+void GetTagInRangeEvent(Interface* self) {
+    u32* cmd_buff = Kernel::GetCommandBuffer();
+
+    cmd_buff[0] = IPC::MakeHeader(0xB, 1, 2);
+    cmd_buff[1] = RESULT_SUCCESS.raw;
+    cmd_buff[2] = IPC::CopyHandleDesc();
+    cmd_buff[3] = Kernel::g_handle_table.Create(tag_in_range_event).MoveFrom();
+    LOG_WARNING(Service_NFC, "(STUBBED) called");
+}
+
 void Init() {
     AddService(new NFC_M());
     AddService(new NFC_U());
+
+    tag_in_range_event =
+        Kernel::Event::Create(Kernel::ResetType::OneShot, "NFC::tag_in_range_event");
+}
+
+void Shutdown() {
+    tag_in_range_event = nullptr;
 }
 
 } // namespace NFC

--- a/src/core/hle/service/nfc/nfc.h
+++ b/src/core/hle/service/nfc/nfc.h
@@ -5,10 +5,27 @@
 #pragma once
 
 namespace Service {
+
+class Interface;
+
 namespace NFC {
+
+/**
+ * NFC::GetTagInRangeEvent service function
+ *  Inputs:
+ *      0 : Header code [0x000B0000]
+ *  Outputs:
+ *      1 : Result of function, 0 on success, otherwise error code
+ *      2 : Copy handle descriptor
+ *      3 : Event Handle
+ */
+void GetTagInRangeEvent(Interface* self);
 
 /// Initialize all NFC services.
 void Init();
+
+/// Shutdown all NFC services.
+void Shutdown();
 
 } // namespace NFC
 } // namespace Service

--- a/src/core/hle/service/nfc/nfc_m.cpp
+++ b/src/core/hle/service/nfc/nfc_m.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "core/hle/service/nfc/nfc.h"
 #include "core/hle/service/nfc/nfc_m.h"
 
 namespace Service {
@@ -19,6 +20,7 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x00070000, nullptr, "LoadAmiiboData"},
     {0x00080000, nullptr, "ResetTagScanState"},
     {0x00090002, nullptr, "UpdateStoredAmiiboData"},
+    {0x000B0000, GetTagInRangeEvent, "GetTagInRangeEvent"},
     {0x000D0000, nullptr, "GetTagState"},
     {0x000F0000, nullptr, "CommunicationGetStatus"},
     {0x00100000, nullptr, "GetTagInfo2"},

--- a/src/core/hle/service/nfc/nfc_u.cpp
+++ b/src/core/hle/service/nfc/nfc_u.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "core/hle/service/nfc/nfc.h"
 #include "core/hle/service/nfc/nfc_u.h"
 
 namespace Service {
@@ -18,6 +19,7 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x00070000, nullptr, "LoadAmiiboData"},
     {0x00080000, nullptr, "ResetTagScanState"},
     {0x00090002, nullptr, "UpdateStoredAmiiboData"},
+    {0x000B0000, GetTagInRangeEvent, "GetTagInRangeEvent"},
     {0x000D0000, nullptr, "GetTagState"},
     {0x000F0000, nullptr, "CommunicationGetStatus"},
     {0x00100000, nullptr, "GetTagInfo2"},

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -178,6 +178,7 @@ void Init() {
 /// Shutdown ServiceManager
 void Shutdown() {
     PTM::Shutdown();
+    NFC::Shutdown();
     NIM::Shutdown();
     NEWS::Shutdown();
     NDM::Shutdown();


### PR DESCRIPTION
This PR mostly for pass Fatal Error in game **Mini-Mario & Friends - amiibo Challenge** (no amiibo emulating, so, no way to pass amiibo scanning)
