### PR TITLE
Try a different encrypted bintray api key for travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ deploy:
   file: "${HOME}/build/${TRAVIS_REPO_SLUG}/.travis.descriptor.json"
   user: citra-emu
   key:
-    secure: "MADIMRKlcr+O2iCmavkbIvUWexopOhnzXuDHKXfGyGY93Im8NCTrbb3tDoLH+bRYQrjNCeaV36ffhpDULU+eH11L4yF5/KY4modEKW4sq3cnAJkm5DUOc/sujlRCwzfjg6NFZGhjxfSlt0ltKRdCKEB/j1vR2GD7d/eQ4diJukQ="
+    secure: "Hdj+/UyDYbvOOXJdlrV0n//t6tAnUqMEy4+Ppb84aF+na4B2hoc+RQ6rfbVXnFE0YKAKJme0J00GVi4JcXViOil2P/wHWxniWBlpz1vHLPT15+p1qi8cPQ0yKMAq9+1kYe6APkHjjsZxHAR6cf1fckI/rPfx/lyuDQOpVq07pJg="

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,10 +33,11 @@ after_build:
   - ps: |
         $GITDATE = $(git show -s --date=short --format='%ad') -replace "-",""
         $GITREV = $(git show -s --format='%h')
+        $GIT_LONG_HASH = $(git rev-parse HEAD)
         # Where are these spaces coming from? Regardless, let's remove them
         $MSVC_BUILD_NAME = "citra-windows-msvc-$GITDATE-$GITREV.zip" -replace " ", ""
         $MSVC_BUILD_PDB = "citra-windows-msvc-$GITDATE-$GITREV-debugsymbols.zip" -replace " ", ""
-        $BINTRAY_VERSION = "nightly-$GITREV" -replace " ", ""
+        $BINTRAY_VERSION = "nightly-$GIT_LONG_HASH" -replace " ", ""
 
         # set the build names as env vars so the artifacts can upload them
         $env:MSVC_BUILD_NAME = $MSVC_BUILD_NAME


### PR DESCRIPTION
Bintray is rejecting the key that travis is sending, so i tried to reencrypt it. If this fails we'll need to wait for bunnei to reencrypt the bintray api key.

I was considering just pushing this to master directly, but I wasn't sure if that would trigger the build bots, so i will just pr it and instamerge this.

Also changes appveyor to upload to a long git hash (since travis is stuck uploading to the full hash name)