### PR TITLE
Kernel/Semaphore: Fixed a regression in semaphore waits.

### DIFF
--- a/src/core/hle/kernel/semaphore.cpp
+++ b/src/core/hle/kernel/semaphore.cpp
@@ -35,7 +35,8 @@ bool Semaphore::ShouldWait(Thread* thread) const {
 }
 
 void Semaphore::Acquire(Thread* thread) {
-    ASSERT_MSG(!ShouldWait(thread), "object unavailable!");
+    if (available_count <= 0)
+        return;
     --available_count;
 }
 


### PR DESCRIPTION
The regression was caused by a missing check in #2260.

The new behavior is consistent with the real kernel.