### PR TITLE
QT: GameList don't attemp to load non-game files

### DIFF
--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <QFileInfo>
 #include <QHeaderView>
 #include <QMenu>
 #include <QThreadPool>
@@ -131,6 +132,14 @@ void GameList::LoadInterfaceLayout() {
     item_model->sort(header->sortIndicatorSection(), header->sortIndicatorOrder());
 }
 
+const QStringList GameList::supported_file_extensions = {"3ds", "3dsx", "elf", "axf",
+                                                         "cci", "cxi",  "app"};
+
+static bool HasSupportedFileExtension(const std::string& file_name) {
+    QFileInfo file = QFileInfo(file_name.c_str());
+    return GameList::supported_file_extensions.contains(file.completeSuffix(), Qt::CaseInsensitive);
+}
+
 void GameListWorker::AddFstEntriesToGameList(const std::string& dir_path, unsigned int recursion) {
     const auto callback = [this, recursion](unsigned* num_entries_out, const std::string& directory,
                                             const std::string& virtual_name) -> bool {
@@ -139,7 +148,7 @@ void GameListWorker::AddFstEntriesToGameList(const std::string& dir_path, unsign
         if (stop_processing)
             return false; // Breaks the callback loop.
 
-        if (!FileUtil::IsDirectory(physical_name)) {
+        if (!FileUtil::IsDirectory(physical_name) && HasSupportedFileExtension(physical_name)) {
             std::unique_ptr<Loader::AppLoader> loader = Loader::GetLoader(physical_name);
             if (!loader)
                 return true;

--- a/src/citra_qt/game_list.h
+++ b/src/citra_qt/game_list.h
@@ -33,6 +33,8 @@ public:
     void SaveInterfaceLayout();
     void LoadInterfaceLayout();
 
+    static const QStringList supported_file_extensions;
+
 signals:
     void GameChosen(QString game_path);
     void ShouldCancelWorker();

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -466,9 +466,14 @@ void GMainWindow::OnGameListOpenSaveFolder(u64 program_id) {
 }
 
 void GMainWindow::OnMenuLoadFile() {
-    QString filename =
-        QFileDialog::getOpenFileName(this, tr("Load File"), UISettings::values.roms_path,
-                                     tr("3DS executable (*.3ds *.3dsx *.elf *.axf *.cci *.cxi)"));
+    QString extensions;
+    for (const auto& piece : game_list->supported_file_extensions)
+        extensions += "*." + piece + " ";
+
+    QString file_filter = tr("3DS executable") + " (" + extensions + ")";
+
+    QString filename = QFileDialog::getOpenFileName(this, tr("Load File"),
+                                                    UISettings::values.roms_path, file_filter);
     if (!filename.isEmpty()) {
         UISettings::values.roms_path = QFileInfo(filename).path();
 


### PR DESCRIPTION
When loading game_list, we are loading all files inside the directory, despite they are any kind of file. This fills the log with a few unnecesary lines regarding the file load of X file, which are of no use at all. With this, we only attemp to load the files we commonly use (The ones we can load through File->Load File...)