### PR TITLE
Don't yield execution in SleepThread(0) if there are no available threads to run

### DIFF
--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -556,6 +556,10 @@ SharedPtr<Thread> SetupMainThread(u32 entry_point, s32 priority) {
     return thread;
 }
 
+bool HaveReadyThreads() {
+    return ready_queue.get_first() != nullptr;
+}
+
 void Reschedule() {
     PriorityBoostStarvedThreads();
 

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -219,6 +219,11 @@ private:
 SharedPtr<Thread> SetupMainThread(u32 entry_point, s32 priority);
 
 /**
+ * Returns whether there are any threads that are ready to run.
+ */
+bool HaveReadyThreads();
+
+/**
  * Reschedules to the next available thread (call after current thread is suspended)
  */
 void Reschedule();

--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -849,6 +849,11 @@ static ResultCode CancelTimer(Kernel::Handle handle) {
 static void SleepThread(s64 nanoseconds) {
     LOG_TRACE(Kernel_SVC, "called nanoseconds=%lld", nanoseconds);
 
+    // Don't attempt to yield execution if there are no available threads to run,
+    // this way we avoid a useless reschedule to the idle thread.
+    if (nanoseconds == 0 && !Kernel::HaveReadyThreads())
+        return;
+
     // Sleep current thread and check for next thread to schedule
     Kernel::WaitCurrentThread_Sleep();
 


### PR DESCRIPTION
With this we avoid an useless temporary deschedule of the current thread.

Closes #2383