### PR TITLE
Prevents appveyor from attempting to deploy except on the nightly repo

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,3 +73,4 @@ deploy:
   prerelease: false
   on:
     branch: master
+    appveyor_repo_name: citra-emu/citra-nightly


### PR DESCRIPTION
Appveyor currently errors out when pushing to master because it attempts to upload the artifacts to github, but github rejects the key (as that key is is only for citra-nightly and citra-bleeding-edge)

https://ci.appveyor.com/project/jroweboy/citra/build/1.0.266#L1785 is what the appveyor output looks like on push to master.