### PR TITLE
Timers: Immediately signal the timer if it was started with an initial value of 0

### DIFF
--- a/src/core/hle/kernel/timer.h
+++ b/src/core/hle/kernel/timer.h
@@ -54,6 +54,14 @@ public:
     void Cancel();
     void Clear();
 
+    /**
+     * Signals the timer, waking up any waiting threads and rescheduling it
+     * for the next interval.
+     * This method should not be called from outside the timer callback handler,
+     * lest multiple callback events get scheduled.
+     */
+    void Signal(int cycles_late);
+
 private:
     Timer();
     ~Timer() override;

--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -837,6 +837,11 @@ static ResultCode SetTimer(Kernel::Handle handle, s64 initial, s64 interval) {
 
     LOG_TRACE(Kernel_SVC, "called timer=0x%08X", handle);
 
+    if (initial < 0 || interval < 0) {
+        return ResultCode(ErrorDescription::OutOfRange, ErrorModule::Kernel,
+                          ErrorSummary::InvalidArgument, ErrorLevel::Permanent);
+    }
+
     SharedPtr<Timer> timer = Kernel::g_handle_table.Get<Timer>(handle);
     if (timer == nullptr)
         return ERR_INVALID_HANDLE;


### PR DESCRIPTION
Also added some error checking in the SetTimer svc.

Huge thanks to @TuxSH for spotting these deficiencies.

Please note that the timer_callback_handle_table HandleTable is currently a source of memory leaks due to Timer objects never reaching 0 references. (ping @yuriks )