### PR TITLE
Support looping HLE audio

### DIFF
--- a/src/audio_core/hle/source.cpp
+++ b/src/audio_core/hle/source.cpp
@@ -325,9 +325,9 @@ bool Source::DequeueBuffer() {
     }
 
     // the first playthrough starts at play_position, loops start at the beginning of the buffer
-    state.current_buffer_id = buf.buffer_id;
     state.current_sample_number = (!buf.has_played) ? buf.play_position : 0;
     state.next_sample_number = state.current_sample_number;
+    state.current_buffer_id = buf.buffer_id;
     state.buffer_update = buf.from_queue && !buf.has_played;
 
     buf.has_played = true;

--- a/src/audio_core/hle/source.cpp
+++ b/src/audio_core/hle/source.cpp
@@ -180,11 +180,11 @@ void Source::ParseConfig(SourceConfiguration::Configuration& config,
                 state.mono_or_stereo,
                 state.format,
                 false,
-                config.play_position,
+                play_position,
             });
             LOG_TRACE(Audio_DSP, "enqueuing embedded addr=0x%08x len=%u id=%hu start=%u",
                       config.physical_address, config.length, config.buffer_id,
-                      config.play_position.u32());
+                      static_cast<u32>(config.play_position));
         }
     }
 

--- a/src/audio_core/hle/source.cpp
+++ b/src/audio_core/hle/source.cpp
@@ -158,34 +158,40 @@ void Source::ParseConfig(SourceConfiguration::Configuration& config,
                   static_cast<size_t>(state.mono_or_stereo));
     }
 
-    if (config.embedded_buffer_dirty) {
-        config.embedded_buffer_dirty.Assign(0);
-        state.input_queue.emplace(Buffer{
-            config.physical_address,
-            config.length,
-            static_cast<u8>(config.adpcm_ps),
-            {config.adpcm_yn[0], config.adpcm_yn[1]},
-            config.adpcm_dirty.ToBool(),
-            config.is_looping.ToBool(),
-            config.buffer_id,
-            state.mono_or_stereo,
-            state.format,
-            false,
-        });
-        LOG_TRACE(Audio_DSP, "enqueuing embedded addr=0x%08x len=%u id=%hu",
-                  config.physical_address, config.length, config.buffer_id);
+    {
+        u32_dsp play_position = u32_dsp();
+        if (config.play_position_dirty && config.play_position != 0) {
+            config.play_position_dirty.Assign(0);
+            play_position = config.play_position;
+            // play_position applies only to the embedded buffer, and defaults to 0 w/o a dirty bit
+            // This will be the starting sample for the first time the buffer is played.
+        }
+
+        if (config.embedded_buffer_dirty) {
+            config.embedded_buffer_dirty.Assign(0);
+            state.input_queue.emplace(Buffer{
+                config.physical_address,
+                config.length,
+                static_cast<u8>(config.adpcm_ps),
+                {config.adpcm_yn[0], config.adpcm_yn[1]},
+                config.adpcm_dirty.ToBool(),
+                config.is_looping.ToBool(),
+                config.buffer_id,
+                state.mono_or_stereo,
+                state.format,
+                false,
+                config.play_position,
+            });
+            LOG_TRACE(Audio_DSP, "enqueuing embedded addr=0x%08x len=%u id=%hu start=%u",
+                      config.physical_address, config.length, config.buffer_id,
+                      config.play_position.u32());
+        }
     }
 
     if (config.loop_related_dirty && config.loop_related != 0) {
         config.loop_related_dirty.Assign(0);
         LOG_WARNING(Audio_DSP, "Unhandled complex loop with loop_related=0x%08x",
                     static_cast<u32>(config.loop_related));
-    }
-
-    if (config.play_position_dirty && config.play_position != 0) {
-        config.play_position_dirty.Assign(0);
-        LOG_WARNING(Audio_DSP, "Unhandled complex loop with play_position=0x%08x",
-                    static_cast<u32>(config.play_position));
     }
 
     if (config.buffer_queue_dirty) {
@@ -317,8 +323,10 @@ bool Source::DequeueBuffer() {
         break;
     }
 
-    state.current_sample_number = 0;
-    state.next_sample_number = 0;
+    // the first playthrough starts at play_position, loops start at the beginning of the buffer
+    state.current_sample_number = (!buf.has_played) ? buf.play_position : 0;
+    state.next_sample_number = state.current_sample_number;
+
     state.buffer_update = buf.from_queue && !buf.has_played;
     state.current_buffer_id = buf.buffer_id;
 

--- a/src/audio_core/hle/source.h
+++ b/src/audio_core/hle/source.h
@@ -76,6 +76,7 @@ private:
         Format format;
 
         bool from_queue;
+        bool has_played; // = false;
     };
 
     struct BufferOrder {

--- a/src/audio_core/hle/source.h
+++ b/src/audio_core/hle/source.h
@@ -76,7 +76,8 @@ private:
         Format format;
 
         bool from_queue;
-        bool has_played; // = false;
+        u32_dsp play_position; // = 0;
+        bool has_played;       // = false;
     };
 
     struct BufferOrder {


### PR DESCRIPTION
Simple loops to start fixing #2093. This handles all the loops I've seen in commercial games, though the DSP engine can in theory manipulate the way it loops beyond replaying the entire buffer (hence, warnings). 