### PR TITLE
Qt: Fix UI related warnings and bonus ui file format 

### DIFF
--- a/src/citra_qt/configure_general.ui
+++ b/src/citra_qt/configure_general.ui
@@ -43,26 +43,26 @@
        </layout>
       </widget>
      </item>
-      <item>
-        <widget class="QGroupBox" name="groupBox_2">
-          <property name="title">
-            <string>Performance</string>
-          </property>
-          <layout class="QHBoxLayout" name="horizontalLayout_7">
-            <item>
-              <layout class="QVBoxLayout" name="verticalLayout_5">
-                <item>
-                  <widget class="QCheckBox" name="toggle_cpu_jit">
-                    <property name="text">
-                      <string>Enable CPU JIT</string>
-                    </property>
-                  </widget>
-                </item>
-              </layout>
-            </item>
-          </layout>
-        </widget>
-      </item>
+     <item>
+       <widget class="QGroupBox" name="groupBox_2">
+         <property name="title">
+           <string>Performance</string>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_7">
+           <item>
+             <layout class="QVBoxLayout" name="verticalLayout_5">
+               <item>
+                 <widget class="QCheckBox" name="toggle_cpu_jit">
+                   <property name="text">
+                     <string>Enable CPU JIT</string>
+                   </property>
+                 </widget>
+               </item>
+             </layout>
+           </item>
+         </layout>
+       </widget>
+     </item>
      <item>
       <widget class="QGroupBox" name="groupBox_4">
        <property name="title">

--- a/src/citra_qt/configure_graphics.ui
+++ b/src/citra_qt/configure_graphics.ui
@@ -132,9 +132,9 @@
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout_3">
       <item>
-       <layout class="QVBoxLayout" name="verticalLayout_2">
+       <layout class="QVBoxLayout" name="verticalLayout_4">
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <layout class="QHBoxLayout" name="horizontalLayout_4">
           <item>
            <widget class="QLabel" name="label1">
             <property name="text">

--- a/src/citra_qt/configure_input.ui
+++ b/src/citra_qt/configure_input.ui
@@ -275,7 +275,6 @@
          </layout>
         </item>
        </layout>
-       <zorder></zorder>
       </widget>
      </item>
      <item row="1" column="1">
@@ -521,7 +520,7 @@
         <item row="1" column="1">
          <layout class="QVBoxLayout" name="verticalLayout_28">
           <item>
-           <widget class="QLabel" name="label_34">
+           <widget class="QLabel" name="label_36">
             <property name="text">
              <string>Circle Mod:</string>
             </property>


### PR DESCRIPTION
Warnings fixed:
```
C:\projects\citra\src\citra_qt\configure_graphics.ui : warning : The name 'verticalLayout_2' (QVBoxLayout) is already in use, defaulting to 'verticalLayout_21'. [C:\projects\citra\build\src\citra_qt\citra-qt.vcxproj]
C:\projects\citra\src\citra_qt\configure_graphics.ui : warning : The name 'horizontalLayout_3' (QHBoxLayout) is already in use, defaulting to 'horizontalLayout_31'. 
C:\projects\citra\src\citra_qt\configure_input.ui : warning : The name 'label_34' (QLabel) is already in use, defaulting to 'label_341'. [C:\projects\citra\build\src\citra_qt\citra-qt.vcxproj]
C:\projects\citra\src\citra_qt\configure_input.ui : warning : Z-order assignment: '' is not a valid widget. `
```