### PR TITLE
GSP::WriteHWRegsWithMask: fix register mask

### DIFF
--- a/src/core/hle/service/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp_gpu.cpp
@@ -149,7 +149,7 @@ static ResultCode WriteHWRegsWithMask(u32 base_address, u32 size_in_bytes, VAddr
                 u32 mask = Memory::Read32(masks_vaddr);
 
                 // Update the current value of the register only for set mask bits
-                reg_value = (reg_value & ~mask) | (data | mask);
+                reg_value = (reg_value & ~mask) | (data & mask);
 
                 WriteSingleHWReg(base_address, reg_value);
 


### PR DESCRIPTION
The formula from decompiling gsp module

fix Citra crash in game **Skylanders - Spyros Adventure**

fix annoying:
```
[   3.738355] HW.GPU <Critical> core\hw\gpu.cpp:GPU::MemoryFill:96: invalid start address 0x00000000
[   3.738736] HW.GPU <Critical> core\hw\gpu.cpp:GPU::MemoryFill:96: invalid start address 0x00000000
```