### PR TITLE
Gui: Change title bar to include build name

### DIFF
--- a/src/citra/emu_window/emu_window_sdl2.cpp
+++ b/src/citra/emu_window/emu_window_sdl2.cpp
@@ -79,8 +79,8 @@ EmuWindow_SDL2::EmuWindow_SDL2() {
     SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 8);
     SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 0);
 
-    std::string window_title =
-        Common::StringFromFormat("Citra | %s-%s", Common::g_scm_branch, Common::g_scm_desc);
+    std::string window_title = Common::StringFromFormat("Citra %s| %s-%s ", Common::g_build_name,
+                                                        Common::g_scm_branch, Common::g_scm_desc);
     render_window = SDL_CreateWindow(
         window_title.c_str(),
         SDL_WINDOWPOS_UNDEFINED, // x position

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -101,8 +101,8 @@ private:
 GRenderWindow::GRenderWindow(QWidget* parent, EmuThread* emu_thread)
     : QWidget(parent), child(nullptr), keyboard_id(0), emu_thread(emu_thread) {
 
-    std::string window_title =
-        Common::StringFromFormat("Citra | %s-%s", Common::g_scm_branch, Common::g_scm_desc);
+    std::string window_title = Common::StringFromFormat("Citra %s| %s-%s", Common::g_build_name,
+                                                        Common::g_scm_branch, Common::g_scm_desc);
     setWindowTitle(QString::fromStdString(window_title));
 
     keyboard_id = KeyMap::NewDeviceId();

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -69,7 +69,8 @@ GMainWindow::GMainWindow() : config(new Config()), emu_thread(nullptr) {
     ConnectMenuEvents();
     ConnectWidgetEvents();
 
-    setWindowTitle(QString("Citra | %1-%2").arg(Common::g_scm_branch, Common::g_scm_desc));
+    setWindowTitle(QString("Citra %1| %2-%3")
+                       .arg(Common::g_build_name, Common::g_scm_branch, Common::g_scm_desc));
     show();
 
     game_list->PopulateAsync(UISettings::values.gamedir, UISettings::values.gamedir_deepscan);

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,4 +1,27 @@
 # Generate cpp with Git revision from template
+# Also if this is a CI build, add the build name (ie: Nightly, Bleeding Edge) to the scm_rev file as well
+set(REPO_NAME "")
+if ($ENV{CI})
+  if ($ENV{TRAVIS})
+    set(BUILD_REPOSITORY $ENV{TRAVIS_REPO_SLUG})
+  elseif($ENV{APPVEYOR})
+    set(BUILD_REPOSITORY $ENV{APPVEYOR_REPO_NAME})
+  endif()
+  # regex capture the string nightly or bleeding-edge into CMAKE_MATCH_1
+  string(REGEX MATCH "citra-emu/citra-?(.*)" OUTVAR ${BUILD_REPOSITORY})
+  if (${CMAKE_MATCH_COUNT} GREATER 0)
+    # capitalize the first letter of each word in the repo name.
+    string(REPLACE "-" ";" REPO_NAME_LIST ${CMAKE_MATCH_1})
+    foreach(WORD ${REPO_NAME_LIST})
+      string(SUBSTRING ${WORD} 0 1 FIRST_LETTER)
+      string(SUBSTRING ${WORD} 1 -1 REMAINDER)
+      string(TOUPPER ${FIRST_LETTER} FIRST_LETTER)
+      # this leaves a trailing space on the last word, but we actually want that
+      # because of how its styled in the title bar.
+      set(REPO_NAME "${REPO_NAME}${FIRST_LETTER}${REMAINDER} ")
+    endforeach()
+  endif()
+endif()
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/scm_rev.cpp.in" "${CMAKE_CURRENT_SOURCE_DIR}/scm_rev.cpp" @ONLY)
 
 set(SRCS

--- a/src/common/scm_rev.cpp.in
+++ b/src/common/scm_rev.cpp.in
@@ -7,12 +7,14 @@
 #define GIT_REV      "@GIT_REV@"
 #define GIT_BRANCH   "@GIT_BRANCH@"
 #define GIT_DESC     "@GIT_DESC@"
+#define BUILD_NAME   "@REPO_NAME@"
 
 namespace Common {
 
 const char g_scm_rev[]      = GIT_REV;
 const char g_scm_branch[]   = GIT_BRANCH;
 const char g_scm_desc[]     = GIT_DESC;
+const char g_build_name[]   = BUILD_NAME;
 
 } // namespace
 

--- a/src/common/scm_rev.h
+++ b/src/common/scm_rev.h
@@ -9,5 +9,6 @@ namespace Common {
 extern const char g_scm_rev[];
 extern const char g_scm_branch[];
 extern const char g_scm_desc[];
+extern const char g_build_name[];
 
 } // namespace


### PR DESCRIPTION
A highly requested feature from the citra community moderators. This will hopefully give an "at-a-glance" look at what build each person asking for help is using, so the moderators don't have to search for commits to see if the person they are helping are actually using citra nightly builds. 

Nightly builds now have "Citra nightly" in the titlebar
Bleeding edge builds now have "Citra bleeding edge" in the titlebar
Uploads from CI on the master repo have "Citra master" in the titlebar
Any other build just has "Citra unofficial" in the titlebar