### PR TITLE
HID: manages updating itself using correct ticks

### DIFF
--- a/src/core/core_timing.cpp
+++ b/src/core/core_timing.cpp
@@ -13,7 +13,7 @@
 #include "core/core.h"
 #include "core/core_timing.h"
 
-int g_clock_rate_arm11 = 268123480;
+int g_clock_rate_arm11 = BASE_CLOCK_RATE_ARM11;
 
 // is this really necessary?
 #define INITIAL_SLICE_LENGTH 20000

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -21,6 +21,7 @@
 // inside callback:
 //   ScheduleEvent(periodInCycles - cycles_late, callback, "whatever")
 
+constexpr int BASE_CLOCK_RATE_ARM11 = 268123480;
 extern int g_clock_rate_arm11;
 
 inline s64 msToCycles(int ms) {

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -40,9 +40,9 @@ static int accelerometer_update_event;
 static int gyroscope_update_event;
 
 // Updating period for each HID device. These empirical values are measured from a 11.2 3DS.
-constexpr u64 pad_update_ticks = 268123480ull / 234;
-constexpr u64 accelerometer_update_ticks = 268123480ull / 104;
-constexpr u64 gyroscope_update_ticks = 268123480ull / 101;
+constexpr u64 pad_update_ticks = BASE_CLOCK_RATE_ARM11 / 234;
+constexpr u64 accelerometer_update_ticks = BASE_CLOCK_RATE_ARM11 / 104;
+constexpr u64 gyroscope_update_ticks = BASE_CLOCK_RATE_ARM11 / 101;
 
 static PadState GetCirclePadDirectionState(s16 circle_pad_x, s16 circle_pad_y) {
     // 30 degree and 60 degree are angular thresholds for directions

--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -296,9 +296,6 @@ void GetGyroscopeLowRawToDpsCoefficient(Service::Interface* self);
  */
 void GetGyroscopeLowCalibrateParam(Service::Interface* self);
 
-/// Checks for user input updates
-void Update();
-
 /// Initialize HID service
 void Init();
 

--- a/src/core/hw/gpu.cpp
+++ b/src/core/hw/gpu.cpp
@@ -32,7 +32,7 @@ namespace GPU {
 Regs g_regs;
 
 /// 268MHz CPU clocks / 60Hz frames per second
-const u64 frame_ticks = 268123480ull / 60;
+const u64 frame_ticks = BASE_CLOCK_RATE_ARM11 / 60;
 /// Event id for CoreTiming
 static int vblank_event;
 /// Total number of frames drawn

--- a/src/core/hw/gpu.cpp
+++ b/src/core/hw/gpu.cpp
@@ -15,7 +15,6 @@
 #include "common/vector_math.h"
 #include "core/core_timing.h"
 #include "core/hle/service/gsp_gpu.h"
-#include "core/hle/service/hid/hid.h"
 #include "core/hw/gpu.h"
 #include "core/hw/hw.h"
 #include "core/memory.h"
@@ -550,9 +549,6 @@ static void VBlankCallback(u64 userdata, int cycles_late) {
     // two different intervals.
     Service::GSP::SignalInterrupt(Service::GSP::InterruptId::PDC0);
     Service::GSP::SignalInterrupt(Service::GSP::InterruptId::PDC1);
-
-    // Check for user input updates
-    Service::HID::Update();
 
     if (!Settings::values.use_vsync && Settings::values.toggle_framelimit) {
         FrameLimiter();


### PR DESCRIPTION
We should correct this before #2439.

Moved HID updating event from GPU to its own module. Separated three devices updating. Corrected the updating ticks using empirical values.

The ticks values are got from [this test](https://github.com/wwylele/ctrhwtest/tree/master/hid_time_test). Usage: press A to test the updating frequency for each HID event; press X/Y to enable/disable gyroscope/accelerometer
Test result (on a JAP old 3DS):
 - PAD0/1 event updates ~235 times per second with accelerometer disabled, or ~233 times per second with accelerometer enabled.
 - Accelerometer updates ~104 times per second.
 - Gyroscope updates ~101 times per second.

Fixes touch pad not working issue in some games (tested Nintendo Video and Nintendo 3DS Sound)