### PR TITLE
Mostly complete Gamepad support (keyboard emulation)

### DIFF
--- a/src/citra_qt/CMakeLists.txt
+++ b/src/citra_qt/CMakeLists.txt
@@ -2,6 +2,8 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/CMakeModules)
 
+include_directories(${SDL2_INCLUDE_DIR})
+
 set(SRCS
             config.cpp
             debugger/callstack.cpp

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -9,9 +9,11 @@
 #include <mutex>
 #include <QGLWidget>
 #include <QThread>
+#include <SDL_events.h>	
 #include "common/thread.h"
 #include "core/frontend/emu_window.h"
 #include "core/frontend/motion_emu.h"
+
 
 class QKeyEvent;
 class QScreen;
@@ -110,7 +112,6 @@ public:
     void MakeCurrent() override;
     void DoneCurrent() override;
     void PollEvents() override;
-
     void BackupGeometry();
     void RestoreGeometry();
     void restoreGeometry(const QByteArray& geometry); // overridden
@@ -127,7 +128,12 @@ public:
     void mouseMoveEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* event) override;
 
+    void gamepadButtonEvent(SDL_ControllerButtonEvent* event);
+    void gamepadAxisEvent(SDL_ControllerAxisEvent* event);
+
     void ReloadSetKeymaps() override;
+
+    void GamepadSetMappings();
 
     void OnClientAreaResized(unsigned width, unsigned height);
 
@@ -159,6 +165,12 @@ private:
 
     /// Motion sensors emulation
     std::unique_ptr<Motion::MotionEmu> motion_emu;
+
+    /// Gamepad ID -> Joystick mapping
+    std::vector<SDL_GameController*> gamepad_controllers;
+
+    /// Gamepad button -> keyboard maps
+    std::vector<std::tuple<SDL_GameControllerButton, int>> gamepad_mappings;
 
 protected:
     void showEvent(QShowEvent* event) override;


### PR DESCRIPTION
Hello
In this pull request, I have added in basic gamepad support which emulates key presses. It is pretty rudimentary at the moment, but it is a good functional prototype.

In the future, there will be a new tab inside the Options menu called "Gamepad" (rather like Dolphin's design) which will allow you to bind different buttons and set the deadzones of the sticks.

If you have any changes you would like to see before it gets pulled in I will be happy to make them - this is my first contribution to the project and would like some feedback about code layout and structure so future changes can be seamless 

prasoc