### PR TITLE
HID: reset acceleroeter and gyroscope index in Init

### DIFF
--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -320,6 +320,8 @@ void Init() {
 
     next_pad_index = 0;
     next_touch_index = 0;
+    next_accelerometer_index = 0;
+    next_gyroscope_index = 0;
 
     // Create event handles
     event_pad_or_touch_1 = Event::Create(ResetType::OneShot, "HID:EventPadOrTouch1");


### PR DESCRIPTION
Forgot to reset this when implementing acceleroeter and gyroscope :stuck_out_tongue: 