### PR TITLE
appveyor: workaround for unnecesary Xamarin log spam

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,8 @@ install:
   - git submodule update --init --recursive
 
 before_build:
+  # Xamarin log spam workaround
+  - del "C:\Program Files (x86)\MSBuild\14.0\Microsoft.Common.targets\ImportAfter\Xamarin.Common.targets"
   - mkdir build
   - cd build
   - cmake -G "Visual Studio 14 2015 Win64" -DCITRA_USE_BUNDLED_QT=1 -DCITRA_USE_BUNDLED_SDL2=1 ..


### PR DESCRIPTION
There is an issue with AppVeyor and Xamarin log spam since long ago: http://help.appveyor.com/discussions/problems/4569-the-target-_convertpdbfiles-listed-in-a-beforetargets-attribute-at-c-does-not-exist-in-the-project-and-will-be-ignored

We simply don't need that lines (About 56 lines in total) in the log either.