### PR TITLE
Fixing some MSVC warnings

### DIFF
--- a/src/core/hle/service/mic_u.cpp
+++ b/src/core/hle/service/mic_u.cpp
@@ -93,7 +93,7 @@ static void StartSampling(Interface* self) {
     sample_rate = static_cast<SampleRate>(cmd_buff[2] & 0xFF);
     audio_buffer_offset = cmd_buff[3];
     audio_buffer_size = cmd_buff[4];
-    audio_buffer_loop = static_cast<bool>(cmd_buff[5] & 0xFF);
+    audio_buffer_loop = (cmd_buff[5] & 0xFF) != 0;
 
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
     is_sampling = true;
@@ -202,7 +202,7 @@ static void GetGain(Interface* self) {
  */
 static void SetPower(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
-    mic_power = static_cast<bool>(cmd_buff[1] & 0xFF);
+    mic_power = (cmd_buff[1] & 0xFF) != 0;
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
     LOG_WARNING(Service_MIC, "(STUBBED) called, mic_power=%u", mic_power);
 }
@@ -252,7 +252,7 @@ static void SetIirFilterMic(Interface* self) {
  */
 static void SetClamp(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
-    clamp = static_cast<bool>(cmd_buff[1] & 0xFF);
+    clamp = (cmd_buff[1] & 0xFF) != 0;
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
     LOG_WARNING(Service_MIC, "(STUBBED) called, clamp=%u", clamp);
 }
@@ -282,7 +282,7 @@ static void GetClamp(Interface* self) {
  */
 static void SetAllowShellClosed(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
-    allow_shell_closed = static_cast<bool>(cmd_buff[1] & 0xFF);
+    allow_shell_closed = (cmd_buff[1] & 0xFF) != 0;
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
     LOG_WARNING(Service_MIC, "(STUBBED) called, allow_shell_closed=%u", allow_shell_closed);
 }

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -748,7 +748,8 @@ bool RasterizerOpenGL::AccelerateDisplayTransfer(const GPU::Regs::DisplayTransfe
 
     // Adjust the source rectangle to take into account parts of the input lines being cropped
     if (config.input_width > config.output_width) {
-        src_rect.right -= (config.input_width - config.output_width) * src_surface->res_scale_width;
+        src_rect.right -= static_cast<int>((config.input_width - config.output_width) *
+                                           src_surface->res_scale_width);
     }
 
     // Require destination surface to have same resolution scale as source to preserve scaling

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -76,7 +76,7 @@ union PicaShaderConfig {
         }
 
         state.fog_mode = regs.fog_mode;
-        state.fog_flip = regs.fog_flip;
+        state.fog_flip = regs.fog_flip != 0;
 
         state.combiner_buffer_input = regs.tev_combiner_buffer_input.update_mask_rgb.Value() |
                                       regs.tev_combiner_buffer_input.update_mask_a.Value() << 4;

--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -118,7 +118,7 @@ void ShaderSetup::Run(UnitState& state, const InputVertex& input, int num_attrib
     // Setup input register table
     const auto& attribute_register_map = config.input_register_map;
 
-    for (unsigned i = 0; i < num_attributes; i++)
+    for (int i = 0; i < num_attributes; i++)
         state.registers.input[attribute_register_map.GetRegisterForAttribute(i)] = input.attr[i];
 
     state.conditional_code[0] = false;
@@ -146,7 +146,7 @@ DebugData<true> ShaderSetup::ProduceDebugInfo(const InputVertex& input, int num_
     // Setup input register table
     boost::fill(state.registers.input, Math::Vec4<float24>::AssignToAll(float24::Zero()));
     const auto& attribute_register_map = config.input_register_map;
-    for (unsigned i = 0; i < num_attributes; i++)
+    for (int i = 0; i < num_attributes; i++)
         state.registers.input[attribute_register_map.GetRegisterForAttribute(i)] = input.attr[i];
 
     state.conditional_code[0] = false;


### PR DESCRIPTION
I had some fun fixing some warnings on MSVC, included some useless warnings ["by design"](https://msdn.microsoft.com/en-us/library/b6801kcy.aspx)

```
C:\projects\citra\src\core\hle\service\mic_u.cpp(96): warning C4800: 'u32': forcing value to bool 'true' or 'false' (performance warning) 
C:\projects\citra\src\core\hle\service\mic_u.cpp(205): warning C4800: 'u32': forcing value to bool 'true' or 'false' (performance warning) 
C:\projects\citra\src\core\hle\service\mic_u.cpp(255): warning C4800: 'u32': forcing value to bool 'true' or 'false' (performance warning) 
C:\projects\citra\src\core\hle\service\mic_u.cpp(285): warning C4800: 'u32': forcing value to bool 'true' or 'false' (performance warning) 
C:\projects\citra\src\video_core\renderer_opengl\gl_rasterizer.h(79): warning C4800: 'u32': forcing value to bool 'true' or 'false' (performance warning)
C:\projects\citra\src\video_core\renderer_opengl\gl_rasterizer.cpp(751): warning C4244: '-=': conversion from 'float' to 'int', possible loss of data
C:\projects\citra\src\video_core\shader\shader.cpp(121): warning C4018: '<': signed/unsigned mismatch 
C:\projects\citra\src\video_core\shader\shader.cpp(149): warning C4018: '<': signed/unsigned mismatch
```

In addition there is one single upstream change to nihstro https://github.com/neobrain/nihstro/pull/54 which, if merged, should fix more warnings on citra.
