### PR TITLE
Fix some MSVC warnings V2 + nihstro update

### DIFF
--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -98,9 +98,9 @@ void EmuWindow::AccelerometerChanged(float x, float y, float z) {
     // TODO(wwylele): do a time stretch as it in GyroscopeChanged
     // The time stretch formula should be like
     // stretched_vector = (raw_vector - gravity) * stretch_ratio + gravity
-    accel_x = x * coef;
-    accel_y = y * coef;
-    accel_z = z * coef;
+    accel_x = static_cast<s16>(x * coef);
+    accel_y = static_cast<s16>(y * coef);
+    accel_z = static_cast<s16>(z * coef);
 }
 
 void EmuWindow::GyroscopeChanged(float x, float y, float z) {
@@ -109,9 +109,9 @@ void EmuWindow::GyroscopeChanged(float x, float y, float z) {
     float stretch =
         FULL_FPS / Common::Profiling::GetTimingResultsAggregator()->GetAggregatedResults().fps;
     std::lock_guard<std::mutex> lock(gyro_mutex);
-    gyro_x = x * coef * stretch;
-    gyro_y = y * coef * stretch;
-    gyro_z = z * coef * stretch;
+    gyro_x = static_cast<s16>(x * coef * stretch);
+    gyro_y = static_cast<s16>(y * coef * stretch);
+    gyro_z = static_cast<s16>(z * coef * stretch);
 }
 
 void EmuWindow::UpdateCurrentFramebufferLayout(unsigned width, unsigned height) {

--- a/src/core/hle/applets/erreula.cpp
+++ b/src/core/hle/applets/erreula.cpp
@@ -31,7 +31,7 @@ ResultCode ErrEula::ReceiveParameter(const Service::APT::MessageParameter& param
     heap_memory = std::make_shared<std::vector<u8>>(capture_info.size);
     // Create a SharedMemory that directly points to this heap block.
     framebuffer_memory = Kernel::SharedMemory::CreateForApplet(
-        heap_memory, 0, heap_memory->size(), MemoryPermission::ReadWrite,
+        heap_memory, 0, static_cast<u32>(heap_memory->size()), MemoryPermission::ReadWrite,
         MemoryPermission::ReadWrite, "ErrEula Memory");
 
     // Send the response message with the newly created SharedMemory

--- a/src/core/hle/applets/mii_selector.cpp
+++ b/src/core/hle/applets/mii_selector.cpp
@@ -39,7 +39,7 @@ ResultCode MiiSelector::ReceiveParameter(const Service::APT::MessageParameter& p
     heap_memory = std::make_shared<std::vector<u8>>(capture_info.size);
     // Create a SharedMemory that directly points to this heap block.
     framebuffer_memory = Kernel::SharedMemory::CreateForApplet(
-        heap_memory, 0, heap_memory->size(), MemoryPermission::ReadWrite,
+        heap_memory, 0, static_cast<u32>(heap_memory->size()), MemoryPermission::ReadWrite,
         MemoryPermission::ReadWrite, "MiiSelector Memory");
 
     // Send the response message with the newly created SharedMemory

--- a/src/core/hle/applets/swkbd.cpp
+++ b/src/core/hle/applets/swkbd.cpp
@@ -42,7 +42,7 @@ ResultCode SoftwareKeyboard::ReceiveParameter(Service::APT::MessageParameter con
     heap_memory = std::make_shared<std::vector<u8>>(capture_info.size);
     // Create a SharedMemory that directly points to this heap block.
     framebuffer_memory = Kernel::SharedMemory::CreateForApplet(
-        heap_memory, 0, heap_memory->size(), MemoryPermission::ReadWrite,
+        heap_memory, 0, static_cast<u32>(heap_memory->size()), MemoryPermission::ReadWrite,
         MemoryPermission::ReadWrite, "SoftwareKeyboard Memory");
 
     // Send the response message with the newly created SharedMemory

--- a/src/core/hle/kernel/shared_memory.cpp
+++ b/src/core/hle/kernel/shared_memory.cpp
@@ -35,7 +35,7 @@ SharedPtr<SharedMemory> SharedMemory::Create(SharedPtr<Process> owner_process, u
                    "Not enough space in region to allocate shared memory!");
 
         shared_memory->backing_block = linheap_memory;
-        shared_memory->backing_block_offset = linheap_memory->size();
+        shared_memory->backing_block_offset = static_cast<u32>(linheap_memory->size());
         // Allocate some memory from the end of the linear heap for this region.
         linheap_memory->insert(linheap_memory->end(), size, 0);
         memory_region->used += size;

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -403,7 +403,7 @@ ResultVal<SharedPtr<Thread>> Thread::Create(std::string name, VAddr entry_point,
                               ErrorSummary::OutOfResource, ErrorLevel::Permanent);
         }
 
-        u32 offset = linheap_memory->size();
+        u32 offset = static_cast<u32>(linheap_memory->size());
 
         // Allocate some memory from the end of the linear heap for this region.
         linheap_memory->insert(linheap_memory->end(), Memory::PAGE_SIZE, 0);
@@ -411,7 +411,7 @@ ResultVal<SharedPtr<Thread>> Thread::Create(std::string name, VAddr entry_point,
         Kernel::g_current_process->linear_heap_used += Memory::PAGE_SIZE;
 
         tls_slots.emplace_back(0); // The page is completely available at the start
-        available_page = tls_slots.size() - 1;
+        available_page = static_cast<u32>(tls_slots.size() - 1);
         available_slot = 0; // Use the first slot in the new page
 
         auto& vm_manager = Kernel::g_current_process->vm_manager;

--- a/src/core/hle/service/dsp_dsp.cpp
+++ b/src/core/hle/service/dsp_dsp.cpp
@@ -139,7 +139,7 @@ static void LoadComponent(Service::Interface* self) {
     Memory::ReadBlock(buffer, component_data.data(), component_data.size());
 
     LOG_INFO(Service_DSP, "Firmware hash: %#" PRIx64,
-             Common::ComputeHash64(component_data.data(), component_data.size()));
+             Common::ComputeHash64(component_data.data(), static_cast<int>(component_data.size())));
     // Some versions of the firmware have the location of DSP structures listed here.
     ASSERT(size > 0x37C);
     LOG_INFO(Service_DSP, "Structures hash: %#" PRIx64,

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -218,7 +218,7 @@ void Directory::HandleSyncRequest(Kernel::SharedPtr<Kernel::ServerSession> serve
         LOG_TRACE(Service_FS, "Read %s: count=%d", GetName().c_str(), count);
 
         // Number of entries actually read
-        u32 read = backend->Read(entries.size(), entries.data());
+        u32 read = backend->Read(static_cast<u32>(entries.size()), entries.data());
         cmd_buff[2] = read;
         Memory::WriteBlock(address, entries.data(), read * sizeof(FileSys::Entry));
         break;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -392,7 +392,7 @@ void ReadBlock(const VAddr src_addr, void* dest_buffer, const size_t size) {
 
     while (remaining_size > 0) {
         const size_t copy_amount = std::min(PAGE_SIZE - page_offset, remaining_size);
-        const VAddr current_vaddr = (page_index << PAGE_BITS) + page_offset;
+        const VAddr current_vaddr = static_cast<VAddr>((page_index << PAGE_BITS) + page_offset);
 
         switch (current_page_table->attributes[page_index]) {
         case PageType::Unmapped: {
@@ -415,7 +415,8 @@ void ReadBlock(const VAddr src_addr, void* dest_buffer, const size_t size) {
             break;
         }
         case PageType::RasterizerCachedMemory: {
-            RasterizerFlushRegion(VirtualToPhysicalAddress(current_vaddr), copy_amount);
+            RasterizerFlushRegion(VirtualToPhysicalAddress(current_vaddr),
+                                  static_cast<u32>(copy_amount));
 
             std::memcpy(dest_buffer, GetPointerFromVMA(current_vaddr), copy_amount);
             break;
@@ -423,7 +424,8 @@ void ReadBlock(const VAddr src_addr, void* dest_buffer, const size_t size) {
         case PageType::RasterizerCachedSpecial: {
             DEBUG_ASSERT(GetMMIOHandler(current_vaddr));
 
-            RasterizerFlushRegion(VirtualToPhysicalAddress(current_vaddr), copy_amount);
+            RasterizerFlushRegion(VirtualToPhysicalAddress(current_vaddr),
+                                  static_cast<u32>(copy_amount));
 
             GetMMIOHandler(current_vaddr)->ReadBlock(current_vaddr, dest_buffer, copy_amount);
             break;
@@ -462,7 +464,7 @@ void WriteBlock(const VAddr dest_addr, const void* src_buffer, const size_t size
 
     while (remaining_size > 0) {
         const size_t copy_amount = std::min(PAGE_SIZE - page_offset, remaining_size);
-        const VAddr current_vaddr = (page_index << PAGE_BITS) + page_offset;
+        const VAddr current_vaddr = static_cast<VAddr>((page_index << PAGE_BITS) + page_offset);
 
         switch (current_page_table->attributes[page_index]) {
         case PageType::Unmapped: {
@@ -486,7 +488,7 @@ void WriteBlock(const VAddr dest_addr, const void* src_buffer, const size_t size
         }
         case PageType::RasterizerCachedMemory: {
             RasterizerFlushAndInvalidateRegion(VirtualToPhysicalAddress(current_vaddr),
-                                               copy_amount);
+                                               static_cast<u32>(copy_amount));
 
             std::memcpy(GetPointerFromVMA(current_vaddr), src_buffer, copy_amount);
             break;
@@ -495,7 +497,7 @@ void WriteBlock(const VAddr dest_addr, const void* src_buffer, const size_t size
             DEBUG_ASSERT(GetMMIOHandler(current_vaddr));
 
             RasterizerFlushAndInvalidateRegion(VirtualToPhysicalAddress(current_vaddr),
-                                               copy_amount);
+                                               static_cast<u32>(copy_amount));
 
             GetMMIOHandler(current_vaddr)->WriteBlock(current_vaddr, src_buffer, copy_amount);
             break;
@@ -520,7 +522,7 @@ void ZeroBlock(const VAddr dest_addr, const size_t size) {
 
     while (remaining_size > 0) {
         const size_t copy_amount = std::min(PAGE_SIZE - page_offset, remaining_size);
-        const VAddr current_vaddr = (page_index << PAGE_BITS) + page_offset;
+        const VAddr current_vaddr = static_cast<VAddr>((page_index << PAGE_BITS) + page_offset);
 
         switch (current_page_table->attributes[page_index]) {
         case PageType::Unmapped: {
@@ -543,7 +545,7 @@ void ZeroBlock(const VAddr dest_addr, const size_t size) {
         }
         case PageType::RasterizerCachedMemory: {
             RasterizerFlushAndInvalidateRegion(VirtualToPhysicalAddress(current_vaddr),
-                                               copy_amount);
+                                               static_cast<u32>(copy_amount));
 
             std::memset(GetPointerFromVMA(current_vaddr), 0, copy_amount);
             break;
@@ -552,7 +554,7 @@ void ZeroBlock(const VAddr dest_addr, const size_t size) {
             DEBUG_ASSERT(GetMMIOHandler(current_vaddr));
 
             RasterizerFlushAndInvalidateRegion(VirtualToPhysicalAddress(current_vaddr),
-                                               copy_amount);
+                                               static_cast<u32>(copy_amount));
 
             GetMMIOHandler(current_vaddr)->WriteBlock(current_vaddr, zeros.data(), copy_amount);
             break;
@@ -574,7 +576,7 @@ void CopyBlock(VAddr dest_addr, VAddr src_addr, const size_t size) {
 
     while (remaining_size > 0) {
         const size_t copy_amount = std::min(PAGE_SIZE - page_offset, remaining_size);
-        const VAddr current_vaddr = (page_index << PAGE_BITS) + page_offset;
+        const VAddr current_vaddr = static_cast<VAddr>((page_index << PAGE_BITS) + page_offset);
 
         switch (current_page_table->attributes[page_index]) {
         case PageType::Unmapped: {
@@ -598,7 +600,8 @@ void CopyBlock(VAddr dest_addr, VAddr src_addr, const size_t size) {
             break;
         }
         case PageType::RasterizerCachedMemory: {
-            RasterizerFlushRegion(VirtualToPhysicalAddress(current_vaddr), copy_amount);
+            RasterizerFlushRegion(VirtualToPhysicalAddress(current_vaddr),
+                                  static_cast<u32>(copy_amount));
 
             WriteBlock(dest_addr, GetPointerFromVMA(current_vaddr), copy_amount);
             break;
@@ -606,7 +609,8 @@ void CopyBlock(VAddr dest_addr, VAddr src_addr, const size_t size) {
         case PageType::RasterizerCachedSpecial: {
             DEBUG_ASSERT(GetMMIOHandler(current_vaddr));
 
-            RasterizerFlushRegion(VirtualToPhysicalAddress(current_vaddr), copy_amount);
+            RasterizerFlushRegion(VirtualToPhysicalAddress(current_vaddr),
+                                  static_cast<u32>(copy_amount));
 
             std::vector<u8> buffer(copy_amount);
             GetMMIOHandler(current_vaddr)->ReadBlock(current_vaddr, buffer.data(), buffer.size());
@@ -619,8 +623,8 @@ void CopyBlock(VAddr dest_addr, VAddr src_addr, const size_t size) {
 
         page_index++;
         page_offset = 0;
-        dest_addr += copy_amount;
-        src_addr += copy_amount;
+        dest_addr += static_cast<VAddr>(copy_amount);
+        src_addr += static_cast<VAddr>(copy_amount);
         remaining_size -= copy_amount;
     }
 }


### PR DESCRIPTION
This PR could be bigger, but I think it's big enough.

Fixed about 30 cast warnings ([C4267](https://msdn.microsoft.com/en-us/library/6kck0s93.aspx) and [C4244](https://msdn.microsoft.com/en-us/library/th7a07tz.aspx))
```
C:\projects\citra\src\core\memory.cpp(395): warning C4267: 'initializing': conversion from 'size_t' to 'VAddr', possible loss of data 
C:\projects\citra\src\core\memory.cpp(395): warning C4267: 'initializing': conversion from 'size_t' to 'const VAddr', possible loss of data
C:\projects\citra\src\core\memory.cpp(418): warning C4267: 'argument': conversion from 'size_t' to 'u32', possible loss of data 
C:\projects\citra\src\core\memory.cpp(426): warning C4267: 'argument': conversion from 'size_t' to 'u32', possible loss of data 
C:\projects\citra\src\core\memory.cpp(465): warning C4267: 'initializing': conversion from 'size_t' to 'VAddr', possible loss of data 
C:\projects\citra\src\core\memory.cpp(465): warning C4267: 'initializing': conversion from 'size_t' to 'const VAddr', possible loss of data
C:\projects\citra\src\core\memory.cpp(489): warning C4267: 'argument': conversion from 'size_t' to 'u32', possible loss of data 
C:\projects\citra\src\core\memory.cpp(498): warning C4267: 'argument': conversion from 'size_t' to 'u32', possible loss of data 
C:\projects\citra\src\core\memory.cpp(523): warning C4267: 'initializing': conversion from 'size_t' to 'VAddr', possible loss of data 
C:\projects\citra\src\core\memory.cpp(523): warning C4267: 'initializing': conversion from 'size_t' to 'const VAddr', possible loss of data
C:\projects\citra\src\core\memory.cpp(546): warning C4267: 'argument': conversion from 'size_t' to 'u32', possible loss of data 
C:\projects\citra\src\core\memory.cpp(555): warning C4267: 'argument': conversion from 'size_t' to 'u32', possible loss of data 
C:\projects\citra\src\core\memory.cpp(577): warning C4267: 'initializing': conversion from 'size_t' to 'VAddr', possible loss of data 
C:\projects\citra\src\core\memory.cpp(577): warning C4267: 'initializing': conversion from 'size_t' to 'const VAddr', possible loss of data
C:\projects\citra\src\core\memory.cpp(601): warning C4267: 'argument': conversion from 'size_t' to 'u32', possible loss of data 
C:\projects\citra\src\core\memory.cpp(609): warning C4267: 'argument': conversion from 'size_t' to 'u32', possible loss of data 
C:\projects\citra\src\core\memory.cpp(622): warning C4267: '+=': conversion from 'size_t' to 'VAddr', possible loss of data
C:\projects\citra\src\core\memory.cpp(623): warning C4267: '+=': conversion from 'size_t' to 'VAddr', possible loss of data
C:\projects\citra\src\core\hle\kernel\thread.cpp(406): warning C4267: 'initializing': conversion from 'size_t' to 'u32', possible loss of data
C:\projects\citra\src\core\hle\kernel\thread.cpp(414): warning C4267: '=': conversion from 'size_t' to 'u32', possible loss of data
C:\projects\citra\src\core\frontend\emu_window.cpp(101): warning C4244: '=': conversion from 'float' to 's16', possible loss of data
C:\projects\citra\src\core\frontend\emu_window.cpp(102): warning C4244: '=': conversion from 'float' to 's16', possible loss of data
C:\projects\citra\src\core\frontend\emu_window.cpp(103): warning C4244: '=': conversion from 'float' to 's16', possible loss of data
C:\projects\citra\src\core\frontend\emu_window.cpp(112): warning C4244: '=': conversion from 'float' to 's16', possible loss of data
C:\projects\citra\src\core\frontend\emu_window.cpp(113): warning C4244: '=': conversion from 'float' to 's16', possible loss of data
C:\projects\citra\src\core\frontend\emu_window.cpp(114): warning C4244: '=': conversion from 'float' to 's16', possible loss of data
C:\projects\citra\src\core\hle\service\dsp_dsp.cpp(142): warning C4267: 'argument': conversion from 'size_t' to 'int', possible loss of data
C:\projects\citra\src\core\hle\service\fs\archive.cpp(221): warning C4267: 'argument': conversion from 'size_t' to 'const u32', possible loss of data
C:\projects\citra\src\core\hle\applets\erreula.cpp(35): warning C4267: 'argument': conversion from 'size_t' to 'u32', possible loss of data
C:\projects\citra\src\core\hle\applets\mii_selector.cpp(43): warning C4267: 'argument': conversion from 'size_t' to 'u32', possible loss of data
C:\projects\citra\src\core\hle\applets\swkbd.cpp(46): warning C4267: 'argument': conversion from 'size_t' to 'u32', possible loss of data
C:\projects\citra\src\core\hle\kernel\shared_memory.cpp(38): warning C4267: '=': conversion from 'size_t' to 'u32', possible loss of data
````

Updated nihstro to latest master, to fix more warnings due to a upstream change I made that got merged recently (https://github.com/neobrain/nihstro/pull/54).
There are about 14 instances of this one:
```
C:\projects\citra\externals\nihstro\include\nihstro\shader_bytecode.h(764): warning C4800: 'unsigned int': forcing value to bool 'true' or 'false' (performance warning)
```
