### PR TITLE
fixed the override warning

### DIFF
--- a/src/audio_core/sdl2_sink.h
+++ b/src/audio_core/sdl2_sink.h
@@ -22,7 +22,7 @@ public:
     size_t SamplesInQueue() const override;
 
     std::vector<std::string> GetDeviceList() const override;
-    void SetDevice(int device_id);
+    void SetDevice(int device_id) override;
 
 private:
     struct Impl;


### PR DESCRIPTION
```
In file included from citra/src/audio_core/sink_details.cpp:11:
citra/src/./audio_core/sdl2_sink.h:25:10: warning: 'SetDevice' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    void SetDevice(int device_id);
         ^
citra/src/./audio_core/sink.h:39:18: note: overridden virtual function is here
    virtual void SetDevice(int device_id) = 0;
                 ^
```
just adding override to the end of line in sdl2_sink.h made it disappear.