### PR TITLE
Qt: Release all pressed buttons when window focus is lost

### DIFF
--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -230,6 +230,10 @@ void GRenderWindow::mouseReleaseEvent(QMouseEvent* event) {
         motion_emu->EndTilt();
 }
 
+void GRenderWindow::focusOutEvent(QFocusEvent* event) {
+    KeyMap::ReleaseAllKeys(*this);
+}
+
 void GRenderWindow::ReloadSetKeymaps() {
     KeyMap::ClearKeyMapping(keyboard_id);
     for (int i = 0; i < Settings::NativeInput::NUM_INPUTS; ++i) {

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -231,6 +231,8 @@ void GRenderWindow::mouseReleaseEvent(QMouseEvent* event) {
 }
 
 void GRenderWindow::focusOutEvent(QFocusEvent* event) {
+    QWidget::focusOutEvent(event);
+
     KeyMap::ReleaseAllKeys(*this);
 }
 

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -127,6 +127,8 @@ public:
     void mouseMoveEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* event) override;
 
+    void focusOutEvent(QFocusEvent* event) override;
+
     void ReloadSetKeymaps() override;
 
     void OnClientAreaResized(unsigned width, unsigned height);

--- a/src/core/frontend/key_map.cpp
+++ b/src/core/frontend/key_map.cpp
@@ -149,4 +149,16 @@ void ReleaseKey(EmuWindow& emu_window, HostDeviceKey key) {
         }
     }
 }
+
+void ReleaseAllKeys(EmuWindow& emu_window) {
+    // Release "all" of the buttons.
+    emu_window.ButtonReleased({0xFFFFFFFF});
+
+    circle_pad_up = false;
+    circle_pad_right = false;
+    circle_pad_left = false;
+    circle_pad_right = false;
+    circle_pad_modifier = false;
+    UpdateCirclePad(emu_window);
+}
 }

--- a/src/core/frontend/key_map.h
+++ b/src/core/frontend/key_map.h
@@ -90,4 +90,9 @@ void PressKey(EmuWindow& emu_window, HostDeviceKey key);
  * Maps a key release action and call the corresponding function in EmuWindow
  */
 void ReleaseKey(EmuWindow& emu_window, HostDeviceKey key);
+
+/**
+* Releases all pressed keys and resets the circle pad state to the center.
+*/
+void ReleaseAllKeys(EmuWindow& emu_window);
 }


### PR DESCRIPTION
Currently, if the Citra window loses focus for any reason while a button is being held, no key release will be registered until the user presses and releases the key again.

This commit solves this problem by releasing all keys when window focus is lost.

An alternate solution (if this is not acceptable) could be for the Qt window to keep track of which keys are being held and specifically release those.

(Should fix #2392) 