### PR TITLE
Switch ComputeHash64 len param to size_t instead of int

### DIFF
--- a/src/common/hash.cpp
+++ b/src/common/hash.cpp
@@ -16,7 +16,7 @@ namespace Common {
 
 // Block read - if your platform needs to do endian-swapping or can only handle aligned reads, do
 // the conversion here
-static FORCE_INLINE u64 getblock64(const u64* p, int i) {
+static FORCE_INLINE u64 getblock64(const u64* p, size_t i) {
     return p[i];
 }
 
@@ -34,9 +34,9 @@ static FORCE_INLINE u64 fmix64(u64 k) {
 // This is the 128-bit variant of the MurmurHash3 hash function that is targeted for 64-bit
 // platforms (MurmurHash3_x64_128). It was taken from:
 // https://code.google.com/p/smhasher/source/browse/trunk/MurmurHash3.cpp
-void MurmurHash3_128(const void* key, int len, u32 seed, void* out) {
+void MurmurHash3_128(const void* key, size_t len, u32 seed, void* out) {
     const u8* data = (const u8*)key;
-    const int nblocks = len / 16;
+    const size_t nblocks = len / 16;
 
     u64 h1 = seed;
     u64 h2 = seed;
@@ -48,7 +48,7 @@ void MurmurHash3_128(const void* key, int len, u32 seed, void* out) {
 
     const u64* blocks = (const u64*)(data);
 
-    for (int i = 0; i < nblocks; i++) {
+    for (size_t i = 0; i < nblocks; i++) {
         u64 k1 = getblock64(blocks, i * 2 + 0);
         u64 k2 = getblock64(blocks, i * 2 + 1);
 

--- a/src/common/hash.h
+++ b/src/common/hash.h
@@ -8,7 +8,7 @@
 
 namespace Common {
 
-void MurmurHash3_128(const void* key, int len, u32 seed, void* out);
+void MurmurHash3_128(const void* key, size_t len, u32 seed, void* out);
 
 /**
  * Computes a 64-bit hash over the specified block of data
@@ -16,7 +16,7 @@ void MurmurHash3_128(const void* key, int len, u32 seed, void* out);
  * @param len Length of data (in bytes) to compute hash over
  * @returns 64-bit hash value that was computed over the data block
  */
-static inline u64 ComputeHash64(const void* data, int len) {
+static inline u64 ComputeHash64(const void* data, size_t len) {
     u64 res[2];
     MurmurHash3_128(data, len, 0, res);
     return res[0];

--- a/src/common/hash.h
+++ b/src/common/hash.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include "common/common_types.h"
 
 namespace Common {


### PR DESCRIPTION
Bisected from #2471 

Switch ComputeHash64 len param to size_t instead of int.

Fixes following warning on MSVC:

```
C:\projects\citra\src\core\hle\service\dsp_dsp.cpp(142): warning C4267: 'argument': conversion from 'size_t' to 'int', possible loss of data
```