### PR TITLE
Fix OSX build warnings about unhandled enumeration values.

### DIFF
--- a/src/citra/citra.cpp
+++ b/src/citra/citra.cpp
@@ -141,6 +141,26 @@ int main(int argc, char** argv) {
     case Core::System::ResultStatus::ErrorLoader:
         LOG_CRITICAL(Frontend, "Failed to load ROM!");
         return -1;
+    case Core::System::ResultStatus::ErrorLoader_ErrorEncrypted:
+        LOG_CRITICAL(Frontend, "The game that you are trying to load must be decrypted before "
+                               "being used with Citra. \n\n For more information on dumping and "
+                               "decrypting games, please refer to: "
+                               "https://citra-emu.org/wiki/Dumping-Game-Cartridges");
+        return -1;
+    case Core::System::ResultStatus::ErrorLoader_ErrorInvalidFormat:
+        LOG_CRITICAL(Frontend, "Error while loading ROM: The ROM format is not supported.");
+        return -1;
+    case Core::System::ResultStatus::ErrorNotInitialized:
+        LOG_CRITICAL(Frontend, "CPUCore not initialized");
+        return -1;
+    case Core::System::ResultStatus::ErrorSystemMode:
+        LOG_CRITICAL(Frontend, "Failed to determine system mode!");
+        return -1;
+    case Core::System::ResultStatus::ErrorVideoCore:
+        LOG_CRITICAL(Frontend, "VideoCore not initialized");
+        return -1;
+    case Core::System::ResultStatus::Success:
+        break; // Expected case
     }
 
     while (emu_window->IsOpen()) {

--- a/src/core/file_sys/archive_extsavedata.cpp
+++ b/src/core/file_sys/archive_extsavedata.cpp
@@ -107,6 +107,8 @@ public:
         case PathParser::NotFound:
             LOG_ERROR(Service_FS, "%s not found", full_path.c_str());
             return ERROR_FILE_NOT_FOUND;
+        case PathParser::FileFound:
+            break; // Expected 'success' case
         }
 
         FileUtil::IOFile file(full_path, "r+b");

--- a/src/core/file_sys/archive_sdmc.cpp
+++ b/src/core/file_sys/archive_sdmc.cpp
@@ -72,6 +72,8 @@ ResultVal<std::unique_ptr<FileBackend>> SDMCArchive::OpenFileBase(const Path& pa
             FileUtil::CreateEmptyFile(full_path);
         }
         break;
+    case PathParser::FileFound:
+        break; // Expected 'success' case
     }
 
     FileUtil::IOFile file(full_path, mode.write_flag ? "r+b" : "rb");
@@ -106,6 +108,8 @@ ResultCode SDMCArchive::DeleteFile(const Path& path) const {
     case PathParser::DirectoryFound:
         LOG_ERROR(Service_FS, "%s is not a file", full_path.c_str());
         return ERROR_UNEXPECTED_FILE_OR_DIRECTORY_SDMC;
+    case PathParser::FileFound:
+        break; // Expected 'success' case
     }
 
     if (FileUtil::Delete(full_path)) {
@@ -154,6 +158,8 @@ static ResultCode DeleteDirectoryHelper(const Path& path, const std::string& mou
     case PathParser::FileFound:
         LOG_ERROR(Service_FS, "Unexpected file in path %s", full_path.c_str());
         return ERROR_UNEXPECTED_FILE_OR_DIRECTORY_SDMC;
+    case PathParser::DirectoryFound:
+        break; // Expected 'success' case
     }
 
     if (deleter(full_path)) {
@@ -197,6 +203,8 @@ ResultCode SDMCArchive::CreateFile(const FileSys::Path& path, u64 size) const {
     case PathParser::FileFound:
         LOG_ERROR(Service_FS, "%s already exists", full_path.c_str());
         return ERROR_ALREADY_EXISTS;
+    case PathParser::NotFound:
+        break; // Expected 'success' case
     }
 
     if (size == 0) {
@@ -238,6 +246,8 @@ ResultCode SDMCArchive::CreateDirectory(const Path& path) const {
     case PathParser::FileFound:
         LOG_ERROR(Service_FS, "%s already exists", full_path.c_str());
         return ERROR_ALREADY_EXISTS;
+    case PathParser::NotFound:
+        break; // Expected 'success' case
     }
 
     if (FileUtil::CreateDir(mount_point + path.AsString())) {
@@ -281,6 +291,8 @@ ResultVal<std::unique_ptr<DirectoryBackend>> SDMCArchive::OpenDirectory(const Pa
     case PathParser::FileInPath:
         LOG_ERROR(Service_FS, "Unexpected file in path %s", full_path.c_str());
         return ERROR_UNEXPECTED_FILE_OR_DIRECTORY_SDMC;
+    case PathParser::DirectoryFound:
+        break; // Expected 'success' case
     }
 
     auto directory = std::make_unique<DiskDirectory>(full_path);

--- a/src/core/file_sys/savedata_archive.cpp
+++ b/src/core/file_sys/savedata_archive.cpp
@@ -57,6 +57,8 @@ ResultVal<std::unique_ptr<FileBackend>> SaveDataArchive::OpenFile(const Path& pa
             FileUtil::CreateEmptyFile(full_path);
         }
         break;
+    case PathParser::FileFound:
+        break; // Expected 'success' case
     }
 
     FileUtil::IOFile file(full_path, mode.write_flag ? "r+b" : "rb");
@@ -91,6 +93,8 @@ ResultCode SaveDataArchive::DeleteFile(const Path& path) const {
     case PathParser::NotFound:
         LOG_ERROR(Service_FS, "File not found %s", full_path.c_str());
         return ERROR_FILE_NOT_FOUND;
+    case PathParser::FileFound:
+        break; // Expected 'success' case
     }
 
     if (FileUtil::Delete(full_path)) {
@@ -139,6 +143,8 @@ static ResultCode DeleteDirectoryHelper(const Path& path, const std::string& mou
     case PathParser::FileFound:
         LOG_ERROR(Service_FS, "Unexpected file or directory %s", full_path.c_str());
         return ERROR_UNEXPECTED_FILE_OR_DIRECTORY;
+    case PathParser::DirectoryFound:
+        break; // Expected 'success' case
     }
 
     if (deleter(full_path)) {
@@ -182,6 +188,8 @@ ResultCode SaveDataArchive::CreateFile(const FileSys::Path& path, u64 size) cons
     case PathParser::FileFound:
         LOG_ERROR(Service_FS, "%s already exists", full_path.c_str());
         return ERROR_FILE_ALREADY_EXISTS;
+    case PathParser::NotFound:
+        break; // Expected 'success' case
     }
 
     if (size == 0) {
@@ -225,6 +233,8 @@ ResultCode SaveDataArchive::CreateDirectory(const Path& path) const {
     case PathParser::FileFound:
         LOG_ERROR(Service_FS, "%s already exists", full_path.c_str());
         return ERROR_DIRECTORY_ALREADY_EXISTS;
+    case PathParser::NotFound:
+        break; // Expected 'success' case
     }
 
     if (FileUtil::CreateDir(mount_point + path.AsString())) {
@@ -269,6 +279,8 @@ ResultVal<std::unique_ptr<DirectoryBackend>> SaveDataArchive::OpenDirectory(
     case PathParser::FileFound:
         LOG_ERROR(Service_FS, "Unexpected file in path %s", full_path.c_str());
         return ERROR_UNEXPECTED_FILE_OR_DIRECTORY;
+    case PathParser::DirectoryFound:
+        break; // Expected 'success' case
     }
 
     auto directory = std::make_unique<DiskDirectory>(full_path);

--- a/src/core/hle/service/err_f.cpp
+++ b/src/core/hle/service/err_f.cpp
@@ -227,6 +227,8 @@ static void ThrowFatalError(Interface* self) {
             LOG_CRITICAL(Service_ERR, "FINST2: 0x%08X",
                          errtype.exception_data.exception_info.fpinst2);
             break;
+        case ExceptionType::Undefined:
+            break; // Not logging exception_info for this case
         }
         LOG_CRITICAL(Service_ERR, "Datetime: %s", GetCurrentSystemTime().c_str());
         break;


### PR DESCRIPTION
Fixes all warnings on OSX builds about unhandled enumeration values on switchs, In addition, I took some time to adds missing control path messages to citra.cpp on rom load.

Fixed warnings:
```
/Users/travis/build/citra-emu/citra/src/core/file_sys/archive_extsavedata.cpp:96:17: warning: enumeration value 'FileFound' not handled in switch [-Wswitch]
/Users/travis/build/citra-emu/citra/src/core/file_sys/archive_sdmc.cpp:54:13: warning: enumeration value 'FileFound' not handled in switch [-Wswitch]
/Users/travis/build/citra-emu/citra/src/core/file_sys/archive_sdmc.cpp:97:13: warning: enumeration value 'FileFound' not handled in switch [-Wswitch]
/Users/travis/build/citra-emu/citra/src/core/file_sys/archive_sdmc.cpp:145:13: warning: enumeration value 'DirectoryFound' not handled in switch [-Wswitch]
/Users/travis/build/citra-emu/citra/src/core/file_sys/archive_sdmc.cpp:186:13: warning: enumeration value 'NotFound' not handled in switch [-Wswitch]
/Users/travis/build/citra-emu/citra/src/core/file_sys/archive_sdmc.cpp:229:13: warning: enumeration value 'NotFound' not handled in switch [-Wswitch]
/Users/travis/build/citra-emu/citra/src/core/file_sys/archive_sdmc.cpp:272:13: warning: enumeration value 'DirectoryFound' not handled in switch [-Wswitch]
/Users/travis/build/citra-emu/citra/src/core/file_sys/savedata_archive.cpp:39:13: warning: enumeration value 'FileFound' not handled in switch [-Wswitch]
/Users/travis/build/citra-emu/citra/src/core/file_sys/savedata_archive.cpp:82:13: warning: enumeration value 'FileFound' not handled in switch [-Wswitch]
/Users/travis/build/citra-emu/citra/src/core/file_sys/savedata_archive.cpp:130:13: warning: enumeration value 'DirectoryFound' not handled in switch [-Wswitch]
/Users/travis/build/citra-emu/citra/src/core/file_sys/savedata_archive.cpp:171:13: warning: enumeration value 'NotFound' not handled in switch [-Wswitch]
/Users/travis/build/citra-emu/citra/src/core/file_sys/savedata_archive.cpp:214:13: warning: enumeration value 'NotFound' not handled in switch [-Wswitch]
/Users/travis/build/citra-emu/citra/src/core/file_sys/savedata_archive.cpp:260:13: warning: enumeration value 'DirectoryFound' not handled in switch [-Wswitch]
/Users/travis/build/citra-emu/citra/src/core/hle/service/err_f.cpp:214:17: warning: enumeration value 'Undefined' not handled in switch [-Wswitch]
/Users/travis/build/citra-emu/citra/src/citra/citra.cpp:137:13: warning: 6 enumeration values not handled in switch: 'Success', 'ErrorNotInitialized', 'ErrorSystemMode'... [-Wswitch]
```

