### PR TITLE
video_core: silence unused-local-typedef boost related warnings on GCC

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -8,7 +8,14 @@
 #include <memory>
 #include <set>
 #include <tuple>
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-local-typedef"
+#endif
 #include <boost/icl/interval_map.hpp>
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 #include <glad/glad.h>
 #include "common/assert.h"
 #include "common/common_funcs.h"


### PR DESCRIPTION
This are some boost related warnings, so, since we can't change the code directly neither fix it, I chose to do this, in addition: [Boost Warnings Guidelines](https://svn.boost.org/trac/boost/wiki/Guidelines/WarningsGuidelines)

I chose to do it this way, and don't add the `-Wno-unused-local-typedefs` to the flags, because we have other warnings of this type, that are not boost related.

Silenced warnings:
```
/usr/local/include/boost/icl/concept/interval.hpp:110:60: warning: unused typedef 'domain_type' [-Wunused-local-typedef]
/usr/local/include/boost/icl/concept/interval.hpp:111:60: warning: unused typedef 'domain_compare' [-Wunused-local-typedef]
/usr/local/include/boost/icl/concept/interval.hpp:124:60: warning: unused typedef 'domain_compare' [-Wunused-local-typedef]
/usr/local/include/boost/icl/concept/interval.hpp:123:60: warning: unused typedef 'domain_type' [-Wunused-local-typedef]
/usr/local/include/boost/icl/concept/interval.hpp:179:60: warning: unused typedef 'domain_type' [-Wunused-local-typedef]
/usr/local/include/boost/icl/concept/interval.hpp:180:60: warning: unused typedef 'domain_compare' [-Wunused-local-typedef]
/usr/local/include/boost/icl/concept/interval.hpp:196:60: warning: unused typedef 'domain_type' [-Wunused-local-typedef]
/usr/local/include/boost/icl/concept/interval.hpp:197:60: warning: unused typedef 'domain_compare' [-Wunused-local-typedef]
/usr/local/include/boost/icl/concept/interval.hpp:290:60: warning: unused typedef 'domain_type' [-Wunused-local-typedef]
/usr/local/include/boost/icl/concept/interval.hpp:291:60: warning: unused typedef 'domain_compare' [-Wunused-local-typedef]
/usr/local/include/boost/icl/concept/interval.hpp:323:60: warning: unused typedef 'domain_compare' [-Wunused-local-typedef]
/usr/local/include/boost/icl/concept/interval.hpp:322:60: warning: unused typedef 'domain_type' [-Wunused-local-typedef]
/usr/local/include/boost/icl/concept/interval.hpp:419:60: warning: unused typedef 'domain_type' [-Wunused-local-typedef]
/usr/local/include/boost/icl/concept/interval.hpp:420:60: warning: unused typedef 'domain_compare' [-Wunused-local-typedef]
/usr/local/include/boost/icl/concept/interval.hpp:431:60: warning: unused typedef 'domain_type' [-Wunused-local-typedef]
/usr/local/include/boost/icl/concept/interval.hpp:432:60: warning: unused typedef 'domain_compare' [-Wunused-local-typedef]
```