### PR TITLE
core: inline CPU, 132 warnings fixed on GCC

### DIFF
--- a/src/core/core.h
+++ b/src/core/core.h
@@ -115,7 +115,7 @@ private:
     static System s_instance;
 };
 
-static ARM_Interface& CPU() {
+inline ARM_Interface& CPU() {
     return System::GetInstance().CPU();
 }
 


### PR DESCRIPTION
This, should, fix, 132, warnings, on, GCC,  ¯\\_(ツ)_/¯.

They happen to exist due to CPU function being declared static on a `.h` file but don't being used in it's own `.cpp` file.

```
/Users/travis/build/citra-emu/citra/src/core/core.h:118:23: warning: unused function 'CPU' [-Wunused-function]
```

PR by guess & docs all around the net, couldn't find nothing official, open to alternative solutions.

Shortened the build log a bit lol:
![image](https://cloud.githubusercontent.com/assets/9112818/22408553/2f379ab4-e67b-11e6-938d-7d5091919934.png)
