### PR TITLE
video_core: Removed unused type alias

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -716,8 +716,6 @@ void RasterizerOpenGL::FlushAndInvalidateRegion(PAddr addr, u32 size) {
 
 bool RasterizerOpenGL::AccelerateDisplayTransfer(const GPU::Regs::DisplayTransferConfig& config) {
     MICROPROFILE_SCOPE(OpenGL_Blits);
-    using PixelFormat = CachedSurface::PixelFormat;
-    using SurfaceType = CachedSurface::SurfaceType;
 
     CachedSurface src_params;
     src_params.addr = config.GetPhysicalInputAddress();

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -172,7 +172,6 @@ bool RasterizerCacheOpenGL::TryBlitSurfaces(CachedSurface* src_surface,
                                             const MathUtil::Rectangle<int>& src_rect,
                                             CachedSurface* dst_surface,
                                             const MathUtil::Rectangle<int>& dst_rect) {
-    using SurfaceType = CachedSurface::SurfaceType;
 
     if (!CachedSurface::CheckFormatsBlittable(src_surface->pixel_format,
                                               dst_surface->pixel_format)) {


### PR DESCRIPTION
(>ლ)
```
/Users/travis/build/citra-emu/citra/src/video_core/renderer_opengl/gl_rasterizer.cpp:719:11: warning: unused type alias 'PixelFormat' [-Wunused-local-typedef]
/Users/travis/build/citra-emu/citra/src/video_core/renderer_opengl/gl_rasterizer.cpp:720:11: warning: unused type alias 'SurfaceType' [-Wunused-local-typedef]
/Users/travis/build/citra-emu/citra/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp:175:11: warning: unused type alias 'SurfaceType' [-Wunused-local-typedef]
```