### PR TITLE
Core: update Kernel Config Memory to latest version (11.2)

### DIFF
--- a/src/core/hle/config_mem.cpp
+++ b/src/core/hle/config_mem.cpp
@@ -14,15 +14,18 @@ ConfigMemDef config_mem;
 void Init() {
     std::memset(&config_mem, 0, sizeof(config_mem));
 
-    config_mem.update_flag = 0; // No update
+    // Values extracted from firmware 11.2.0-35E
+    config_mem.kernel_version_min = 0x34;
+    config_mem.kernel_version_maj = 0x2;
+    config_mem.ns_tid = 0x0004013000008002;
     config_mem.sys_core_ver = 0x2;
     config_mem.unit_info = 0x1; // Bit 0 set for Retail
-    config_mem.prev_firm = 0;
-    config_mem.firm_unk = 0;
-    config_mem.firm_version_rev = 0;
-    config_mem.firm_version_min = 0x40;
+    config_mem.prev_firm = 0x1;
+    config_mem.ctr_sdk_ver = 0x0000F297;
+    config_mem.firm_version_min = 0x34;
     config_mem.firm_version_maj = 0x2;
     config_mem.firm_sys_core_ver = 0x2;
+    config_mem.firm_ctr_sdk_ver = 0x0000F297;
 }
 
 } // namespace


### PR DESCRIPTION
The data from my N3DS with latest firmware