### PR TITLE
removal of the -1 case in the configure_input switch

### DIFF
--- a/src/citra_qt/configure_input.cpp
+++ b/src/citra_qt/configure_input.cpp
@@ -17,7 +17,6 @@ static QString getKeyName(Qt::Key key_code) {
     case Qt::Key_Alt:
         return QObject::tr("Alt");
     case Qt::Key_Meta:
-    case -1:
         return "";
     default:
         return QKeySequence(key_code).toString();


### PR DESCRIPTION
this case is unneeded because no enumeration value can possibly correspond to it