### PR TITLE
removed the possibly uneeded cast on values.gdbstub_port

### DIFF
--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -15,7 +15,7 @@ Values values = {};
 
 void Apply() {
 
-    GDBStub::SetServerPort(static_cast<u32>(values.gdbstub_port));
+    GDBStub::SetServerPort(values.gdbstub_port);
     GDBStub::ToggleServer(values.use_gdbstub);
 
     VideoCore::g_hw_renderer_enabled = values.use_hw_renderer;


### PR DESCRIPTION
as far as i could tell this cast is unneeded because [GDBStub::SetServerPort](https://github.com/citra-emu/citra/blob/master/src/core/gdbstub/gdbstub.cpp#L897) takes a u16 and [values.gdbstub_port](https://github.com/citra-emu/citra/blob/master/src/core/settings.h#L116) is already a u16. 