### PR TITLE
ShaderJIT: add 16 dummy bytes at the bottom of the stack

### DIFF
--- a/src/video_core/shader/shader_jit_x64_compiler.cpp
+++ b/src/video_core/shader/shader_jit_x64_compiler.cpp
@@ -589,7 +589,7 @@ void JitShader::Compile_RSQ(Instruction instr) {
 void JitShader::Compile_NOP(Instruction instr) {}
 
 void JitShader::Compile_END(Instruction instr) {
-    ABI_PopRegistersAndAdjustStack(*this, ABI_ALL_CALLEE_SAVED, 8);
+    ABI_PopRegistersAndAdjustStack(*this, ABI_ALL_CALLEE_SAVED, 8, 16);
     ret();
 }
 
@@ -841,7 +841,10 @@ void JitShader::Compile(const std::array<u32, 1024>* program_code_,
     FindReturnOffsets();
 
     // The stack pointer is 8 modulo 16 at the entry of a procedure
-    ABI_PushRegistersAndAdjustStack(*this, ABI_ALL_CALLEE_SAVED, 8);
+    // We reserve 16 bytes and assign a dummy value to the first 8 bytes, to catch any potential
+    // return checks (see Compile_Return) that happen in shader main routine.
+    ABI_PushRegistersAndAdjustStack(*this, ABI_ALL_CALLEE_SAVED, 8, 16);
+    mov(qword[rsp + 8], 0xFFFFFFFFFFFFFFFFULL);
 
     mov(SETUP, ABI_PARAM1);
     mov(STATE, ABI_PARAM2);


### PR DESCRIPTION
Fixes #2498, and potentially other shader JIT crash

Here is a recap of what happens in #2498. It is basically many small things happen at the same time:

First, the shader in question is loaded with some leftover code from a previous shader. When compiling the shader, `FindReturnOffsets` scans the code including the leftover, and generates some garbage return offsets, which are function calls in the leftover to the true part of the shader. This is still OK-ish, because we have [the address check on the potential return](https://github.com/citra-emu/citra/blob/master/src/video_core/shader/shader_jit_x64_compiler.cpp#L774), which should prevent the code from returning on a garbage return offsets.

But the bad thing is, the garbage return address is in shader main() routine. During main() execution, when it meets a garbage return, it tries to access `qword[rsp + 8]` check the address, which, because it is in main(), is outside the shader stack, and is in [the callee-saved register we pushed before shader execution](https://github.com/citra-emu/citra/blob/master/src/video_core/shader/shader_jit_x64_compiler.cpp#L844). So now what it will do all depends on the unknown stack value there. If the value doesn't match the address, shader will continue and everything is fine; if the value unfortunately matches the address, shader will do an unexpected return and crash.

In the case of mine, that stack value is caller's r15, according to system-V ABI. What's worse, after yuriks' shader refactor, gcc decides to put [this loop variable](https://github.com/citra-emu/citra/blob/master/src/video_core/command_processor.cpp#L253) in r15. so the crash will be almost for sure to happen because that loop variable iterates over a wide range, and makes it look like a regression.

The solution here is pretty simple: reserve 16 bytes more spaces at the bottom of the stacks, so that any return address check in main() won't access outside shader stack. In the long term we should fix the control flow analysis, but having this fix first is better than nothing.