### PR TITLE
Use std::array<u8,2> instead of u8[2] to fix MSVC build

### DIFF
--- a/src/video_core/texture/etc1.cpp
+++ b/src/video_core/texture/etc1.cpp
@@ -17,7 +17,7 @@ namespace Texture {
 
 namespace {
 
-constexpr std::array<u8[2], 8> etc1_modifier_table = {{
+constexpr std::array<std::array<u8, 2>, 8> etc1_modifier_table = {{
     {2, 8}, {5, 17}, {9, 29}, {13, 42}, {18, 60}, {24, 80}, {33, 106}, {47, 183},
 }};
 


### PR DESCRIPTION
I was getting an error when trying to build with MSVC15 Update3 (a bit weird since appveyor didn't catch the error) as it would somehow decay `u8[2]` into `const u8 *` and couldn't convert it back to` const unsigned char (&)[2]`