### PR TITLE
Add asio as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "cryptopp"]
     path = externals/cryptopp/cryptopp
     url = https://github.com/weidai11/cryptopp.git
+[submodule "asio"]
+    path = externals/asio
+    url = https://github.com/chriskohlhoff/asio/

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -9,3 +9,6 @@ endif()
 
 add_subdirectory(cryptopp)
 
+add_library(asio INTERFACE)
+target_include_directories(asio INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/asio/asio/include)
+target_compile_definitions(asio INTERFACE -DASIO_STANDALONE=1)


### PR DESCRIPTION
Fixes #Subv pesters random people on IRC to get them to make this extremely minor change instead of writing the 2 lines of code.

As far as I know Subv wants asio added so that soc:u and maybe some other things can use that instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2563)
<!-- Reviewable:end -->
