### PR TITLE
Qt/GameList: Use suffix() to parse the file extension

### DIFF
--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -137,7 +137,7 @@ const QStringList GameList::supported_file_extensions = {"3ds", "3dsx", "elf", "
 
 static bool HasSupportedFileExtension(const std::string& file_name) {
     QFileInfo file = QFileInfo(file_name.c_str());
-    return GameList::supported_file_extensions.contains(file.completeSuffix(), Qt::CaseInsensitive);
+    return GameList::supported_file_extensions.contains(file.suffix(), Qt::CaseInsensitive);
 }
 
 void GameListWorker::AddFstEntriesToGameList(const std::string& dir_path, unsigned int recursion) {


### PR DESCRIPTION
completeSuffix returns everything after the first period, which means
that a file such as `foo.bar.3ds` would not get recognized.