### PR TITLE
hook: remove clang-format check

### DIFF
--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -24,20 +24,3 @@ If you know what you are doing, you can try 'git commit --no-verify' to bypass t
 END
     exit 1
 fi
-
-for f in $(git diff --name-only --diff-filter=ACMRTUXB --cached); do
-    if ! echo "$f" | egrep -q "[.](cpp|h)$"; then
-        continue
-    fi
-    if ! echo "$f" | egrep -q "^src/"; then
-        continue
-    fi
-    d=$(clang-format "$f" | diff -u "$f" -)
-    if ! [ -z "$d" ]; then
-        echo "!!! $f not compliant to coding style, here is the fix:"
-        echo "$d"
-        fail=1
-    fi
-done
-
-exit "${fail-0}"


### PR DESCRIPTION
This is constantly causing problems (#2155, #2510 and so on) and is not that useful. We already have format check in CI. 