### PR TITLE
dyncom: Correct SXTAB16 and SXTB16

### DIFF
--- a/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
+++ b/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
@@ -3928,13 +3928,13 @@ SXTB16_INST : {
         if (inst_cream->Rn == 15) {
             u32 lo = (u32)(s8)rm_val;
             u32 hi = (u32)(s8)(rm_val >> 16);
-            RD = (lo | (hi << 16));
+            RD = (lo & 0xFFFF) | (hi << 16);
         }
         // SXTAB16
         else {
-            u32 lo = (rn_val & 0xFFFF) + (u32)(s8)(rm_val & 0xFF);
-            u32 hi = ((rn_val >> 16) & 0xFFFF) + (u32)(s8)((rm_val >> 16) & 0xFF);
-            RD = (lo | (hi << 16));
+            u32 lo = rn_val + (u32)(s8)(rm_val & 0xFF);
+            u32 hi = (rn_val >> 16) + (u32)(s8)((rm_val >> 16) & 0xFF);
+            RD = (lo & 0xFFFF) | (hi << 16);
         }
     }
 


### PR DESCRIPTION
Incorrect behaviour due to sign extending to 32 bits instead of to 16 bits.

Example:

    sxtb16 r7, r12, ror #24
    with r12 = 0xa2656cc0
    
    expected result in r7: 0x006cffa2
    actual result in r7:   0xffffffa2