### PR TITLE
Use gzip instead of lzma on macOS releases

### DIFF
--- a/.travis-upload.sh
+++ b/.travis-upload.sh
@@ -5,12 +5,14 @@ if [ "$TRAVIS_EVENT_TYPE" = "push" ]&&[ "$TRAVIS_BRANCH" = "master" ]; then
 
     if [ "$TRAVIS_OS_NAME" = "linux" -o -z "$TRAVIS_OS_NAME" ]; then
         REV_NAME="citra-linux-${GITDATE}-${GITREV}"
+        ARCHIVE_NAME="${REV_NAME}.tar.xz"
         mkdir "$REV_NAME"
 
         cp build/src/citra/citra "$REV_NAME"
         cp build/src/citra_qt/citra-qt "$REV_NAME"
     elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
         REV_NAME="citra-osx-${GITDATE}-${GITREV}"
+        ARCHIVE_NAME="${REV_NAME}.tar.gz"
         mkdir "$REV_NAME"
 
         cp build/src/citra/Release/citra "$REV_NAME"
@@ -118,8 +120,7 @@ EOL
     cp license.txt "$REV_NAME"
     cp README.md "$REV_NAME"
 
-    ARCHIVE_NAME="${REV_NAME}.tar.gz"
-    tar -czvf "$ARCHIVE_NAME" "$REV_NAME"
+    tar -cavf "$ARCHIVE_NAME" "$REV_NAME"
 
     # move the compiled archive into the artifacts directory to be uploaded by travis releases
     mv "$ARCHIVE_NAME" artifacts/

--- a/.travis-upload.sh
+++ b/.travis-upload.sh
@@ -118,8 +118,8 @@ EOL
     cp license.txt "$REV_NAME"
     cp README.md "$REV_NAME"
 
-    ARCHIVE_NAME="${REV_NAME}.tar.xz"
-    tar -cJvf "$ARCHIVE_NAME" "$REV_NAME"
+    ARCHIVE_NAME="${REV_NAME}.tar.gz"
+    tar -czvf "$ARCHIVE_NAME" "$REV_NAME"
 
     # move the compiled archive into the artifacts directory to be uploaded by travis releases
     mv "$ARCHIVE_NAME" artifacts/


### PR DESCRIPTION
A common report from macOS users is they can't figure out how to unzip the
program. This will allow them to double click to unzip the archive which
is what users on macOS expect.