### PR TITLE
IR: separate functions of each port to their own files

### DIFF
--- a/src/core/hle/service/ir/ir.cpp
+++ b/src/core/hle/service/ir/ir.cpp
@@ -2,9 +2,6 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include "core/hle/kernel/event.h"
-#include "core/hle/kernel/kernel.h"
-#include "core/hle/kernel/shared_memory.h"
 #include "core/hle/service/ir/ir.h"
 #include "core/hle/service/ir/ir_rst.h"
 #include "core/hle/service/ir/ir_u.h"
@@ -14,101 +11,18 @@
 namespace Service {
 namespace IR {
 
-static Kernel::SharedPtr<Kernel::Event> handle_event;
-static Kernel::SharedPtr<Kernel::Event> conn_status_event;
-static Kernel::SharedPtr<Kernel::SharedMemory> shared_memory;
-static Kernel::SharedPtr<Kernel::SharedMemory> transfer_shared_memory;
-
-void GetHandles(Service::Interface* self) {
-    u32* cmd_buff = Kernel::GetCommandBuffer();
-
-    cmd_buff[1] = RESULT_SUCCESS.raw;
-    cmd_buff[2] = 0x4000000;
-    cmd_buff[3] = Kernel::g_handle_table.Create(Service::IR::shared_memory).MoveFrom();
-    cmd_buff[4] = Kernel::g_handle_table.Create(Service::IR::handle_event).MoveFrom();
-}
-
-void InitializeIrNopShared(Interface* self) {
-    u32* cmd_buff = Kernel::GetCommandBuffer();
-
-    u32 transfer_buff_size = cmd_buff[1];
-    u32 recv_buff_size = cmd_buff[2];
-    u32 unk1 = cmd_buff[3];
-    u32 send_buff_size = cmd_buff[4];
-    u32 unk2 = cmd_buff[5];
-    u8 baud_rate = cmd_buff[6] & 0xFF;
-    Kernel::Handle handle = cmd_buff[8];
-
-    if (Kernel::g_handle_table.IsValid(handle)) {
-        transfer_shared_memory = Kernel::g_handle_table.Get<Kernel::SharedMemory>(handle);
-        transfer_shared_memory->name = "IR:TransferSharedMemory";
-    }
-
-    cmd_buff[1] = RESULT_SUCCESS.raw;
-
-    LOG_WARNING(Service_IR, "(STUBBED) called, transfer_buff_size=%d, recv_buff_size=%d, "
-                            "unk1=%d, send_buff_size=%d, unk2=%d, baud_rate=%u, handle=0x%08X",
-                transfer_buff_size, recv_buff_size, unk1, send_buff_size, unk2, baud_rate, handle);
-}
-
-void RequireConnection(Interface* self) {
-    u32* cmd_buff = Kernel::GetCommandBuffer();
-
-    conn_status_event->Signal();
-
-    cmd_buff[1] = RESULT_SUCCESS.raw;
-
-    LOG_WARNING(Service_IR, "(STUBBED) called");
-}
-
-void Disconnect(Interface* self) {
-    u32* cmd_buff = Kernel::GetCommandBuffer();
-
-    cmd_buff[1] = RESULT_SUCCESS.raw;
-
-    LOG_WARNING(Service_IR, "(STUBBED) called");
-}
-
-void GetConnectionStatusEvent(Interface* self) {
-    u32* cmd_buff = Kernel::GetCommandBuffer();
-
-    cmd_buff[1] = RESULT_SUCCESS.raw;
-    cmd_buff[3] = Kernel::g_handle_table.Create(Service::IR::conn_status_event).MoveFrom();
-
-    LOG_WARNING(Service_IR, "(STUBBED) called");
-}
-
-void FinalizeIrNop(Interface* self) {
-    u32* cmd_buff = Kernel::GetCommandBuffer();
-
-    cmd_buff[1] = RESULT_SUCCESS.raw;
-
-    LOG_WARNING(Service_IR, "(STUBBED) called");
-}
-
 void Init() {
-    using namespace Kernel;
-
     AddService(new IR_RST_Interface);
     AddService(new IR_U_Interface);
     AddService(new IR_User_Interface);
 
-    using Kernel::MemoryPermission;
-    shared_memory = SharedMemory::Create(nullptr, 0x1000, Kernel::MemoryPermission::ReadWrite,
-                                         Kernel::MemoryPermission::ReadWrite, 0,
-                                         Kernel::MemoryRegion::BASE, "IR:SharedMemory");
-    transfer_shared_memory = nullptr;
-
-    // Create event handle(s)
-    handle_event = Event::Create(ResetType::OneShot, "IR:HandleEvent");
-    conn_status_event = Event::Create(ResetType::OneShot, "IR:ConnectionStatusEvent");
+    InitUser();
+    InitRST();
 }
 
 void Shutdown() {
-    transfer_shared_memory = nullptr;
-    shared_memory = nullptr;
-    handle_event = nullptr;
-    conn_status_event = nullptr;
+    ShutdownUser();
+    ShutdownRST();
 }
 
 } // namespace IR

--- a/src/core/hle/service/ir/ir.h
+++ b/src/core/hle/service/ir/ir.h
@@ -10,63 +10,6 @@ class Interface;
 
 namespace IR {
 
-/**
- * IR::GetHandles service function
- *  Outputs:
- *      1 : Result of function, 0 on success, otherwise error code
- *      2 : Translate header, used by the ARM11-kernel
- *      3 : Shared memory handle
- *      4 : Event handle
- */
-void GetHandles(Interface* self);
-
-/**
- * IR::InitializeIrNopShared service function
- *  Inputs:
- *      1 : Size of transfer buffer
- *      2 : Recv buffer size
- *      3 : unknown
- *      4 : Send buffer size
- *      5 : unknown
- *      6 : BaudRate (u8)
- *      7 : 0
- *      8 : Handle of transfer shared memory
- *  Outputs:
- *      1 : Result of function, 0 on success, otherwise error code
- */
-void InitializeIrNopShared(Interface* self);
-
-/**
- * IR::FinalizeIrNop service function
- *  Outputs:
- *      1 : Result of function, 0 on success, otherwise error code
- */
-void FinalizeIrNop(Interface* self);
-
-/**
- * IR::GetConnectionStatusEvent service function
- *  Outputs:
- *      1 : Result of function, 0 on success, otherwise error code
- *      2 : Connection Status Event handle
- */
-void GetConnectionStatusEvent(Interface* self);
-
-/**
- * IR::Disconnect service function
- *  Outputs:
- *      1 : Result of function, 0 on success, otherwise error code
- */
-void Disconnect(Interface* self);
-
-/**
- * IR::RequireConnection service function
- *  Inputs:
- *      1 : unknown (u8), looks like always 1
- *  Outputs:
- *      1 : Result of function, 0 on success, otherwise error code
- */
-void RequireConnection(Interface* self);
-
 /// Initialize IR service
 void Init();
 

--- a/src/core/hle/service/ir/ir_rst.cpp
+++ b/src/core/hle/service/ir/ir_rst.cpp
@@ -2,11 +2,33 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "core/hle/kernel/event.h"
+#include "core/hle/kernel/shared_memory.h"
 #include "core/hle/service/ir/ir.h"
 #include "core/hle/service/ir/ir_rst.h"
 
 namespace Service {
 namespace IR {
+
+static Kernel::SharedPtr<Kernel::Event> handle_event;
+static Kernel::SharedPtr<Kernel::SharedMemory> shared_memory;
+
+/**
+ * IR::GetHandles service function
+ *  Outputs:
+ *      1 : Result of function, 0 on success, otherwise error code
+ *      2 : Translate header, used by the ARM11-kernel
+ *      3 : Shared memory handle
+ *      4 : Event handle
+ */
+static void GetHandles(Interface* self) {
+    u32* cmd_buff = Kernel::GetCommandBuffer();
+
+    cmd_buff[1] = RESULT_SUCCESS.raw;
+    cmd_buff[2] = 0x4000000;
+    cmd_buff[3] = Kernel::g_handle_table.Create(Service::IR::shared_memory).MoveFrom();
+    cmd_buff[4] = Kernel::g_handle_table.Create(Service::IR::handle_event).MoveFrom();
+}
 
 const Interface::FunctionInfo FunctionTable[] = {
     {0x00010000, GetHandles, "GetHandles"},
@@ -17,6 +39,21 @@ const Interface::FunctionInfo FunctionTable[] = {
 
 IR_RST_Interface::IR_RST_Interface() {
     Register(FunctionTable);
+}
+
+void InitRST() {
+    using namespace Kernel;
+
+    shared_memory =
+        SharedMemory::Create(nullptr, 0x1000, MemoryPermission::ReadWrite,
+                             MemoryPermission::ReadWrite, 0, MemoryRegion::BASE, "IR:SharedMemory");
+
+    handle_event = Event::Create(ResetType::OneShot, "IR:HandleEvent");
+}
+
+void ShutdownRST() {
+    shared_memory = nullptr;
+    handle_event = nullptr;
 }
 
 } // namespace IR

--- a/src/core/hle/service/ir/ir_rst.h
+++ b/src/core/hle/service/ir/ir_rst.h
@@ -18,5 +18,8 @@ public:
     }
 };
 
+void InitRST();
+void ShutdownRST();
+
 } // namespace IR
 } // namespace Service

--- a/src/core/hle/service/ir/ir_user.cpp
+++ b/src/core/hle/service/ir/ir_user.cpp
@@ -2,11 +2,111 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "core/hle/kernel/event.h"
+#include "core/hle/kernel/shared_memory.h"
 #include "core/hle/service/ir/ir.h"
 #include "core/hle/service/ir/ir_user.h"
 
 namespace Service {
 namespace IR {
+
+static Kernel::SharedPtr<Kernel::Event> conn_status_event;
+static Kernel::SharedPtr<Kernel::SharedMemory> transfer_shared_memory;
+
+/**
+ * IR::InitializeIrNopShared service function
+ *  Inputs:
+ *      1 : Size of transfer buffer
+ *      2 : Recv buffer size
+ *      3 : unknown
+ *      4 : Send buffer size
+ *      5 : unknown
+ *      6 : BaudRate (u8)
+ *      7 : 0
+ *      8 : Handle of transfer shared memory
+ *  Outputs:
+ *      1 : Result of function, 0 on success, otherwise error code
+ */
+static void InitializeIrNopShared(Interface* self) {
+    u32* cmd_buff = Kernel::GetCommandBuffer();
+
+    u32 transfer_buff_size = cmd_buff[1];
+    u32 recv_buff_size = cmd_buff[2];
+    u32 unk1 = cmd_buff[3];
+    u32 send_buff_size = cmd_buff[4];
+    u32 unk2 = cmd_buff[5];
+    u8 baud_rate = cmd_buff[6] & 0xFF;
+    Kernel::Handle handle = cmd_buff[8];
+
+    if (Kernel::g_handle_table.IsValid(handle)) {
+        transfer_shared_memory = Kernel::g_handle_table.Get<Kernel::SharedMemory>(handle);
+        transfer_shared_memory->name = "IR:TransferSharedMemory";
+    }
+
+    cmd_buff[1] = RESULT_SUCCESS.raw;
+
+    LOG_WARNING(Service_IR, "(STUBBED) called, transfer_buff_size=%d, recv_buff_size=%d, "
+                            "unk1=%d, send_buff_size=%d, unk2=%d, baud_rate=%u, handle=0x%08X",
+                transfer_buff_size, recv_buff_size, unk1, send_buff_size, unk2, baud_rate, handle);
+}
+
+/**
+ * IR::RequireConnection service function
+ *  Inputs:
+ *      1 : unknown (u8), looks like always 1
+ *  Outputs:
+ *      1 : Result of function, 0 on success, otherwise error code
+ */
+static void RequireConnection(Interface* self) {
+    u32* cmd_buff = Kernel::GetCommandBuffer();
+
+    conn_status_event->Signal();
+
+    cmd_buff[1] = RESULT_SUCCESS.raw;
+
+    LOG_WARNING(Service_IR, "(STUBBED) called");
+}
+
+/**
+ * IR::Disconnect service function
+ *  Outputs:
+ *      1 : Result of function, 0 on success, otherwise error code
+ */
+static void Disconnect(Interface* self) {
+    u32* cmd_buff = Kernel::GetCommandBuffer();
+
+    cmd_buff[1] = RESULT_SUCCESS.raw;
+
+    LOG_WARNING(Service_IR, "(STUBBED) called");
+}
+
+/**
+ * IR::GetConnectionStatusEvent service function
+ *  Outputs:
+ *      1 : Result of function, 0 on success, otherwise error code
+ *      2 : Connection Status Event handle
+ */
+static void GetConnectionStatusEvent(Interface* self) {
+    u32* cmd_buff = Kernel::GetCommandBuffer();
+
+    cmd_buff[1] = RESULT_SUCCESS.raw;
+    cmd_buff[3] = Kernel::g_handle_table.Create(Service::IR::conn_status_event).MoveFrom();
+
+    LOG_WARNING(Service_IR, "(STUBBED) called");
+}
+
+/**
+ * IR::FinalizeIrNop service function
+ *  Outputs:
+ *      1 : Result of function, 0 on success, otherwise error code
+ */
+static void FinalizeIrNop(Interface* self) {
+    u32* cmd_buff = Kernel::GetCommandBuffer();
+
+    cmd_buff[1] = RESULT_SUCCESS.raw;
+
+    LOG_WARNING(Service_IR, "(STUBBED) called");
+}
 
 const Interface::FunctionInfo FunctionTable[] = {
     {0x00010182, nullptr, "InitializeIrNop"},
@@ -39,6 +139,18 @@ const Interface::FunctionInfo FunctionTable[] = {
 
 IR_User_Interface::IR_User_Interface() {
     Register(FunctionTable);
+}
+
+void InitUser() {
+    using namespace Kernel;
+
+    transfer_shared_memory = nullptr;
+    conn_status_event = Event::Create(ResetType::OneShot, "IR:ConnectionStatusEvent");
+}
+
+void ShutdownUser() {
+    transfer_shared_memory = nullptr;
+    conn_status_event = nullptr;
 }
 
 } // namespace IR

--- a/src/core/hle/service/ir/ir_user.h
+++ b/src/core/hle/service/ir/ir_user.h
@@ -18,5 +18,8 @@ public:
     }
 };
 
+void InitUser();
+void ShutdownUser();
+
 } // namespace IR
 } // namespace Service


### PR DESCRIPTION
I am going to make circle pad pro IR implementation, and this is the first step. Just moving code around but not changing anything

Unlike those of other services, The three ports of IR services, "ir:u", "ir:USER" and "ir:rst", expose totally different set of functions and are served for different works: "ir:u" is for low level IR communication; "ir:rst" is for low level handling of new 3DS additional buttons and c-stick (not actually IR related); "ir:USER" is the high level interface above the other two. They don't "share" functions and status, so it makes no sense to put all functions into one file.