### PR TITLE
Common/Log: get rid repeated log entries

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -147,6 +147,15 @@ void LogMessage(Class log_class, Level log_level, const char* filename, unsigned
     Entry entry = CreateEntry(log_class, log_level, filename, line_nr, function, format, args);
     va_end(args);
 
+    static Entry prev_entry{};
+    if (entry == prev_entry) {
+        prev_entry.count++;
+        prev_entry.timestamp = entry.timestamp;
+        return;
+    }
+    if (prev_entry.count != 0)
+        PrintColoredMessage(prev_entry);
     PrintColoredMessage(entry);
+    prev_entry = std::move(entry);
 }
-}
+} // namespace Log

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -151,6 +151,10 @@ void LogMessage(Class log_class, Level log_level, const char* filename, unsigned
     if (entry == prev_entry) {
         prev_entry.count++;
         prev_entry.timestamp = entry.timestamp;
+        if (prev_entry.count == 100) {
+            PrintColoredMessage(prev_entry);
+            prev_entry.count = 0;
+        }
         return;
     }
     if (prev_entry.count != 0)

--- a/src/common/logging/backend.h
+++ b/src/common/logging/backend.h
@@ -7,7 +7,6 @@
 #include <chrono>
 #include <cstdarg>
 #include <string>
-#include <utility>
 #include "common/logging/log.h"
 
 namespace Log {
@@ -24,12 +23,18 @@ struct Entry {
     Level log_level;
     std::string location;
     std::string message;
+    u32 count{0};
 
     Entry() = default;
     Entry(Entry&& o) = default;
 
     Entry& operator=(Entry&& o) = default;
 };
+
+inline bool operator==(const Entry& lhs, const Entry& rhs) {
+    return (lhs.log_class == rhs.log_class) && (lhs.log_level == rhs.log_level) &&
+           (lhs.location == rhs.location) && (lhs.message == rhs.message);
+}
 
 /**
  * Returns the name of the passed log class as a C-string. Subclasses are separated by periods
@@ -47,4 +52,4 @@ Entry CreateEntry(Class log_class, Level log_level, const char* filename, unsign
                   const char* function, const char* format, va_list args);
 
 void SetFilter(Filter* filter);
-}
+} // namespace Log

--- a/src/common/logging/text_formatter.cpp
+++ b/src/common/logging/text_formatter.cpp
@@ -49,8 +49,15 @@ void FormatLogMessage(const Entry& entry, char* out_text, size_t text_len) {
     const char* class_name = GetLogClassName(entry.log_class);
     const char* level_name = GetLevelName(entry.log_level);
 
-    snprintf(out_text, text_len, "[%4u.%06u] %s <%s> %s: %s", time_seconds, time_fractional,
-             class_name, level_name, TrimSourcePath(entry.location.c_str()), entry.message.c_str());
+    if (entry.count < 2) {
+        snprintf(out_text, text_len, "[%4u.%06u] %s <%s> %s: %s", time_seconds, time_fractional,
+                 class_name, level_name, TrimSourcePath(entry.location.c_str()),
+                 entry.message.c_str());
+    } else {
+        snprintf(out_text, text_len, "[%4u.%06u] %s <%s> %s: %s (repeats %d times)", time_seconds,
+                 time_fractional, class_name, level_name, TrimSourcePath(entry.location.c_str()),
+                 entry.message.c_str(), entry.count);
+    }
 }
 
 void PrintMessage(const Entry& entry) {


### PR DESCRIPTION
idea from #2522

example of optimized log:

> [   8.244176] Service.Y2R <Warning> core\hle\service\y2r_u.cpp:Service::Y2R::SetTransferEndInterrupt:248: (STUBBED) called
> [   8.244176] Service.Y2R <Warning> core\hle\service\y2r_u.cpp:Service::Y2R::SetTransferEndInterrupt:248: (STUBBED) called (repeats 287 times)
...
> [  17.753575] Service <Error> core\hle\service\service.cpp:Service::Interface::HandleSyncRequest:95: unknown / unimplemented function 'InvalidateDCache': port=dsp::DSP, cmd_buff[1]=0x94AC80, cmd_buff[2]=0x4000, cmd_buff[3]=0x0, cmd_buff[4]=0xFFFF8001
> [  17.753575] Service <Error> core\hle\service\service.cpp:Service::Interface::HandleSyncRequest:95: unknown / unimplemented function 'InvalidateDCache': port=dsp::DSP, cmd_buff[1]=0x94AC80, cmd_buff[2]=0x4000, cmd_buff[3]=0x0, cmd_buff[4]=0xFFFF8001 (repeats 10 times)