### PR TITLE
ir: implement circle pad pro

### DIFF
--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -102,14 +102,8 @@ ConfigureInput::ConfigureInput(QWidget* parent)
 
     this->loadConfiguration();
 
-    // TODO(wwylele): enable these when the input emulation for them is implemented
-    ui->buttonZL->setEnabled(false);
-    ui->buttonZR->setEnabled(false);
+    // TODO(wwylele): enable this when we actually emulate it
     ui->buttonHome->setEnabled(false);
-    ui->buttonCStickUp->setEnabled(false);
-    ui->buttonCStickDown->setEnabled(false);
-    ui->buttonCStickLeft->setEnabled(false);
-    ui->buttonCStickRight->setEnabled(false);
 }
 
 void ConfigureInput::applyConfiguration() {

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -109,6 +109,7 @@ set(SRCS
             hle/service/hid/hid_spvr.cpp
             hle/service/hid/hid_user.cpp
             hle/service/http_c.cpp
+            hle/service/ir/extra_hid.cpp
             hle/service/ir/ir.cpp
             hle/service/ir/ir_rst.cpp
             hle/service/ir/ir_u.cpp
@@ -297,6 +298,7 @@ set(HEADERS
             hle/service/hid/hid_spvr.h
             hle/service/hid/hid_user.h
             hle/service/http_c.h
+            hle/service/ir/extra_hid.h
             hle/service/ir/ir.h
             hle/service/ir/ir_rst.h
             hle/service/ir/ir_u.h

--- a/src/core/hle/service/ir/extra_hid.cpp
+++ b/src/core/hle/service/ir/extra_hid.cpp
@@ -1,0 +1,231 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "common/alignment.h"
+#include "common/bit_field.h"
+#include "common/string_util.h"
+#include "core/core_timing.h"
+#include "core/hle/service/ir/extra_hid.h"
+#include "core/settings.h"
+
+namespace Service {
+namespace IR {
+
+enum class RequestID : u8 {
+    /**
+     * ConfigureHIDPolling request
+     * Starts HID input polling, or changes the polling interval if it is already started.
+     *  Inputs:
+     *     byte 0: request ID
+     *     byte 1: polling interval in ms
+     *     byte 2: unknown
+     */
+    ConfigureHIDPolling = 1,
+
+    /**
+     * ReadCalibrationData request
+     * Reads the calibration data stored in circle pad pro.
+     *  Inputs:
+     *     byte 0: request ID
+     *     byte 1: expected response time in ms?
+     *     byte 2-3: data offset (aligned to 0x10)
+     *     byte 4-5: data size (aligned to 0x10)
+     */
+    ReadCalibrationData = 2,
+
+    // TODO(wwylele): there are three more request types (id = 3, 4 and 5)
+};
+
+enum class ResponseID : u8 {
+
+    /**
+     * PollHID response
+     * Sends current HID status
+     *  Output:
+     *     byte 0: response ID
+     *     byte 1-3: Right circle pad position. This three bytes are two little-endian 12-bit
+     *         fields. The first one is for x-axis and the second one is for y-axis.
+     *     byte 4: bit[0:4] battery level; bit[5] ZL button; bit[6] ZR button; bit[7] R button
+     *         Note that for the three button fields, the bit is set when the button is NOT pressed.
+     *     byte 5: unknown
+     */
+    PollHID = 0x10,
+
+    /**
+     * ReadCalibrationData response
+     * Sends the calibration data reads from circle pad pro.
+     *  Output:
+     *     byte 0: resonse ID
+     *     byte 1-2: data offset (aligned to 0x10)
+     *     byte 3-4: data size (aligned to 0x10)
+     *     byte 5-...: calibration data
+     */
+    ReadCalibrationData = 0x11,
+};
+
+ExtraHID::ExtraHID(SendFunc send_func) : IRDevice(send_func) {
+    LoadInputDevices();
+
+    // The data below was retrieved from a New 3DS
+    // TODO(wwylele): this data is probably writable (via request 3?) and thus should be saved to
+    // and loaded from somewhere.
+    calibration_data = std::array<u8, 0x40>{{
+        // 0x00
+        0x00, 0x00, 0x08, 0x80, 0x85, 0xEB, 0x11, 0x3F,
+        // 0x08
+        0x85, 0xEB, 0x11, 0x3F, 0xFF, 0xFF, 0xFF, 0xF5,
+        // 0x10
+        0xFF, 0x00, 0x08, 0x80, 0x85, 0xEB, 0x11, 0x3F,
+        // 0x18
+        0x85, 0xEB, 0x11, 0x3F, 0xFF, 0xFF, 0xFF, 0x65,
+        // 0x20
+        0xFF, 0x00, 0x08, 0x80, 0x85, 0xEB, 0x11, 0x3F,
+        // 0x28
+        0x85, 0xEB, 0x11, 0x3F, 0xFF, 0xFF, 0xFF, 0x65,
+        // 0x30
+        0xFF, 0x00, 0x08, 0x80, 0x85, 0xEB, 0x11, 0x3F,
+        // 0x38
+        0x85, 0xEB, 0x11, 0x3F, 0xFF, 0xFF, 0xFF, 0x65,
+    }};
+
+    hid_polling_callback_id =
+        CoreTiming::RegisterEvent("ExtraHID::SendHIDStatus", [this](u64, int cycles_late) {
+            SendHIDStatus();
+            CoreTiming::ScheduleEvent(msToCycles(hid_period) - cycles_late,
+                                      hid_polling_callback_id);
+        });
+}
+
+ExtraHID::~ExtraHID() {
+    OnDisconnect();
+}
+
+void ExtraHID::OnConnect() {}
+
+void ExtraHID::OnDisconnect() {
+    CoreTiming::UnscheduleEvent(hid_polling_callback_id, 0);
+}
+
+void ExtraHID::HandleConfigureHIDPollingRequest(const std::vector<u8>& request) {
+    if (request.size() != 3) {
+        LOG_ERROR(Service_IR, "Wrong request size (%zu): %s", request.size(),
+                  Common::ArrayToString(request.data(), request.size()).c_str());
+        return;
+    }
+
+    // Change HID input polling interval
+    CoreTiming::UnscheduleEvent(hid_polling_callback_id, 0);
+    hid_period = request[1];
+    CoreTiming::ScheduleEvent(msToCycles(hid_period), hid_polling_callback_id);
+}
+
+void ExtraHID::HandleReadCalibrationDataRequest(const std::vector<u8>& request_buf) {
+    struct ReadCalibrationDataRequest {
+        RequestID request_id;
+        u8 expected_response_time;
+        u16_le offset;
+        u16_le size;
+    };
+    static_assert(sizeof(ReadCalibrationDataRequest) == 6,
+                  "ReadCalibrationDataRequest has wrong size");
+
+    if (request_buf.size() != sizeof(ReadCalibrationDataRequest)) {
+        LOG_ERROR(Service_IR, "Wrong request size (%zu): %s", request_buf.size(),
+                  Common::ArrayToString(request_buf.data(), request_buf.size()).c_str());
+        return;
+    }
+
+    ReadCalibrationDataRequest request;
+    std::memcpy(&request, request_buf.data(), sizeof(request));
+
+    const u16 offset = Common::AlignDown(request.offset, 16);
+    const u16 size = Common::AlignDown(request.size, 16);
+
+    if (offset + size > calibration_data.size()) {
+        LOG_ERROR(Service_IR, "Read beyond the end of calibration data! (offset=%u, size=%u)",
+                  offset, size);
+        return;
+    }
+
+    std::vector<u8> response(5);
+    response[0] = static_cast<u8>(ResponseID::ReadCalibrationData);
+    std::memcpy(&response[1], &request.offset, sizeof(request.offset));
+    std::memcpy(&response[3], &request.size, sizeof(request.size));
+    response.insert(response.end(), calibration_data.begin() + offset,
+                    calibration_data.begin() + offset + size);
+    Send(response);
+}
+
+void ExtraHID::OnReceive(const std::vector<u8>& data) {
+    switch (static_cast<RequestID>(data[0])) {
+    case RequestID::ConfigureHIDPolling:
+        HandleConfigureHIDPollingRequest(data);
+        break;
+    case RequestID::ReadCalibrationData:
+        HandleReadCalibrationDataRequest(data);
+        break;
+    default:
+        LOG_ERROR(Service_IR, "Unknown request: %s",
+                  Common::ArrayToString(data.data(), data.size()).c_str());
+        break;
+    }
+}
+
+void ExtraHID::SendHIDStatus() {
+    if (is_device_reload_pending.exchange(false))
+        LoadInputDevices();
+
+    struct {
+        union {
+            BitField<0, 8, u32_le> header;
+            BitField<8, 12, u32_le> c_stick_x;
+            BitField<20, 12, u32_le> c_stick_y;
+        } c_stick;
+        union {
+            BitField<0, 5, u8> battery_level;
+            BitField<5, 1, u8> zl_not_held;
+            BitField<6, 1, u8> zr_not_held;
+            BitField<7, 1, u8> r_not_held;
+        } buttons;
+        u8 unknown;
+    } response;
+    static_assert(sizeof(response) == 6, "HID status response has wrong size!");
+
+    constexpr int C_STICK_CENTER = 0x800;
+    // TODO(wwylele): this value is not accurately measured. We currently assume that the axis can
+    // take values in the whole range of a 12-bit integer.
+    constexpr int C_STICK_RADIUS = 0x7FF;
+
+    float x, y;
+    std::tie(x, y) = c_stick->GetStatus();
+
+    response.c_stick.header.Assign(static_cast<u8>(ResponseID::PollHID));
+    response.c_stick.c_stick_x.Assign(static_cast<u32>(C_STICK_CENTER + C_STICK_RADIUS * x));
+    response.c_stick.c_stick_y.Assign(static_cast<u32>(C_STICK_CENTER + C_STICK_RADIUS * y));
+    response.buttons.battery_level.Assign(0x1F);
+    response.buttons.zl_not_held.Assign(!zl->GetStatus());
+    response.buttons.zr_not_held.Assign(!zr->GetStatus());
+    response.buttons.r_not_held.Assign(1);
+    response.unknown = 0;
+
+    std::vector<u8> response_buffer(sizeof(response));
+    memcpy(response_buffer.data(), &response, sizeof(response));
+    Send(response_buffer);
+}
+
+void ExtraHID::RequestInputDevicesReload() {
+    is_device_reload_pending.store(true);
+}
+
+void ExtraHID::LoadInputDevices() {
+    zl = Input::CreateDevice<Input::ButtonDevice>(
+        Settings::values.buttons[Settings::NativeButton::ZL]);
+    zr = Input::CreateDevice<Input::ButtonDevice>(
+        Settings::values.buttons[Settings::NativeButton::ZR]);
+    c_stick = Input::CreateDevice<Input::AnalogDevice>(
+        Settings::values.analogs[Settings::NativeAnalog::CStick]);
+}
+
+} // namespace IR
+} // namespace Service

--- a/src/core/hle/service/ir/extra_hid.h
+++ b/src/core/hle/service/ir/extra_hid.h
@@ -1,0 +1,48 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <array>
+#include <atomic>
+#include "core/frontend/input.h"
+#include "core/hle/service/ir/ir_user.h"
+
+namespace Service {
+namespace IR {
+
+/**
+ * An IRDevice emulating Circle Pad Pro or New 3DS additional HID hardware.
+ * This device sends periodic udates at a rate configured by the 3DS, and sends calibration data if
+ * requested.
+ */
+class ExtraHID final : public IRDevice {
+public:
+    explicit ExtraHID(SendFunc send_func);
+    ~ExtraHID();
+
+    void OnConnect() override;
+    void OnDisconnect() override;
+    void OnReceive(const std::vector<u8>& data) override;
+
+    /// Requests input devices reload from current settings. Called when the input settings change.
+    void RequestInputDevicesReload();
+
+private:
+    void SendHIDStatus();
+    void HandleConfigureHIDPollingRequest(const std::vector<u8>& request);
+    void HandleReadCalibrationDataRequest(const std::vector<u8>& request);
+    void LoadInputDevices();
+
+    u8 hid_period;
+    int hid_polling_callback_id;
+    std::array<u8, 0x40> calibration_data;
+    std::unique_ptr<Input::ButtonDevice> zl;
+    std::unique_ptr<Input::ButtonDevice> zr;
+    std::unique_ptr<Input::AnalogDevice> c_stick;
+    std::atomic<bool> is_device_reload_pending;
+};
+
+} // namespace IR
+} // namespace Service

--- a/src/core/hle/service/ir/ir_user.cpp
+++ b/src/core/hle/service/ir/ir_user.cpp
@@ -2,110 +2,481 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <memory>
+#include <boost/crc.hpp>
+#include <boost/optional.hpp>
+#include "common/string_util.h"
+#include "common/swap.h"
 #include "core/hle/kernel/event.h"
 #include "core/hle/kernel/shared_memory.h"
+#include "core/hle/service/ir/extra_hid.h"
 #include "core/hle/service/ir/ir.h"
 #include "core/hle/service/ir/ir_user.h"
 
 namespace Service {
 namespace IR {
 
-static Kernel::SharedPtr<Kernel::Event> conn_status_event;
-static Kernel::SharedPtr<Kernel::SharedMemory> transfer_shared_memory;
+// This is a header that will present in the ir:USER shared memory if it is initialized with
+// InitializeIrNopShared service function. Otherwise the shared memory doesn't have this header if
+// it is initialized with InitializeIrNop service function.
+struct SharedMemoryHeader {
+    u32_le latest_receive_error_result;
+    u32_le latest_send_error_result;
+    // TODO(wwylele): for these fields below, make them enum when the meaning of values is known.
+    u8 connection_status;
+    u8 trying_to_connect_status;
+    u8 connection_role;
+    u8 machine_id;
+    u8 connected;
+    u8 network_id;
+    u8 initialized;
+    u8 unknown;
+
+    // This is not the end of the shared memory. It is followed by a receive buffer and a send
+    // buffer. We handle receive buffer in the BufferManager class. For the send buffer, because
+    // games usually don't access it, we don't emulate it.
+};
+static_assert(sizeof(SharedMemoryHeader) == 16, "SharedMemoryHeader has wrong size!");
+
+/**
+ * A manager of the send/receive buffers in the shared memory. Currently it is only used for the
+ * receive buffer.
+ *
+ * A buffer consists of three parts:
+ *     - BufferInfo: stores available count of packets, and their position in the PacketInfo
+ *         circular queue.
+ *     - PacketInfo circular queue: stores the position of each avaiable packets in the Packet data
+ *         buffer. Each entry is a pair of {offset, size}.
+ *     - Packet data circular buffer: stores the actual data of packets.
+ *
+ * IR packets can be put into and get from the buffer.
+ *
+ * When a new packet is put into the buffer, its data is put into the data circular buffer,
+ * following the end of previous packet data. A new entry is also added to the PacketInfo circular
+ * queue pointing to the added packet data. Then BufferInfo is updated.
+ *
+ * Packets can be released from the other end of the buffer. When releasing a packet, the front
+ * entry in thePacketInfo circular queue is removed, and as a result the corresponding memory in the
+ * data circular buffer is also released. BufferInfo is updated as well.
+ *
+ * The client application usually has a similar manager constructed over the same shared memory
+ * region, performing the same put/get/release operation. This way the client and the service
+ * communicate via a pair of manager of the same buffer.
+ *
+ * TODO(wwylele): implement Get function, which is used by ReceiveIrnop service function.
+ */
+class BufferManager {
+public:
+    BufferManager(Kernel::SharedPtr<Kernel::SharedMemory> shared_memory_, u32 info_offset_,
+                  u32 buffer_offset_, u32 max_packet_count_, u32 buffer_size)
+        : shared_memory(shared_memory_), info_offset(info_offset_), buffer_offset(buffer_offset_),
+          max_packet_count(max_packet_count_),
+          max_data_size(buffer_size - sizeof(PacketInfo) * max_packet_count_) {
+        UpdateBufferInfo();
+    }
+
+    /**
+     * Puts a packet to the head of the buffer.
+     * @params packet The data of the packet to put.
+     * @returns whether the operation is successful.
+     */
+    bool Put(const std::vector<u8>& packet) {
+        if (info.packet_count == max_packet_count)
+            return false;
+
+        u32 write_offset;
+
+        // finds free space offset in data buffer
+        if (info.packet_count == 0) {
+            write_offset = 0;
+            if (packet.size() > max_data_size)
+                return false;
+        } else {
+            const u32 last_index = (info.end_index + max_packet_count - 1) % max_packet_count;
+            const PacketInfo first = GetPacketInfo(info.begin_index);
+            const PacketInfo last = GetPacketInfo(last_index);
+            write_offset = (last.offset + last.size) % max_data_size;
+            const u32 free_space = (first.offset + max_data_size - write_offset) % max_data_size;
+            if (packet.size() > free_space)
+                return false;
+        }
+
+        // writes packet info
+        PacketInfo packet_info{write_offset, static_cast<u32>(packet.size())};
+        SetPacketInfo(info.end_index, packet_info);
+
+        // writes packet data
+        for (size_t i = 0; i < packet.size(); ++i) {
+            *GetDataBufferPointer((write_offset + i) % max_data_size) = packet[i];
+        }
+
+        // updates buffer info
+        info.end_index++;
+        info.end_index %= max_packet_count;
+        info.packet_count++;
+        UpdateBufferInfo();
+        return true;
+    }
+
+    /**
+     * Release packets from the tail of the buffer
+     * @params count Numbers of packets to release.
+     * @returns whether the operation is successful.
+     */
+    bool Release(u32 count) {
+        if (info.packet_count < count)
+            return false;
+
+        info.packet_count -= count;
+        info.begin_index += count;
+        info.begin_index %= max_packet_count;
+        UpdateBufferInfo();
+        return true;
+    }
+
+private:
+    struct BufferInfo {
+        u32_le begin_index;
+        u32_le end_index;
+        u32_le packet_count;
+        u32_le unknown;
+    };
+    static_assert(sizeof(BufferInfo) == 16, "BufferInfo has wrong size!");
+
+    struct PacketInfo {
+        u32_le offset;
+        u32_le size;
+    };
+    static_assert(sizeof(PacketInfo) == 8, "PacketInfo has wrong size!");
+
+    u8* GetPacketInfoPointer(u32 index) {
+        return shared_memory->GetPointer(buffer_offset + sizeof(PacketInfo) * index);
+    }
+
+    void SetPacketInfo(u32 index, const PacketInfo& packet_info) {
+        memcpy(GetPacketInfoPointer(index), &packet_info, sizeof(PacketInfo));
+    }
+
+    PacketInfo GetPacketInfo(u32 index) {
+        PacketInfo packet_info;
+        memcpy(&packet_info, GetPacketInfoPointer(index), sizeof(PacketInfo));
+        return packet_info;
+    }
+
+    u8* GetDataBufferPointer(u32 offset) {
+        return shared_memory->GetPointer(buffer_offset + sizeof(PacketInfo) * max_packet_count +
+                                         offset);
+    }
+
+    void UpdateBufferInfo() {
+        if (info_offset) {
+            memcpy(shared_memory->GetPointer(info_offset), &info, sizeof(info));
+        }
+    }
+
+    BufferInfo info{0, 0, 0, 0};
+    Kernel::SharedPtr<Kernel::SharedMemory> shared_memory;
+    u32 info_offset;
+    u32 buffer_offset;
+    u32 max_packet_count;
+    u32 max_data_size;
+};
+
+static Kernel::SharedPtr<Kernel::Event> conn_status_event, send_event, receive_event;
+static Kernel::SharedPtr<Kernel::SharedMemory> shared_memory;
+static std::unique_ptr<ExtraHID> extra_hid;
+static IRDevice* connected_device;
+static boost::optional<BufferManager> receive_buffer;
+
+/// Wraps the payload into packet and puts it to the receive buffer
+static void PutToReceive(const std::vector<u8>& payload) {
+    LOG_TRACE(Service_IR, "called, data=%s",
+              Common::ArrayToString(payload.data(), payload.size()).c_str());
+    size_t size = payload.size();
+
+    std::vector<u8> packet;
+
+    // Builds packet header. For the format info:
+    // https://www.3dbrew.org/wiki/IRUSER_Shared_Memory#Packet_structure
+
+    // fixed value
+    packet.push_back(0xA5);
+    // destination network ID
+    u8 network_id = *(shared_memory->GetPointer(offsetof(SharedMemoryHeader, network_id)));
+    packet.push_back(network_id);
+
+    // puts the size info.
+    // The highest bit of the first byte is unknown, which is set to zero here. The second highest
+    // bit is a flag that determines whether the size info is in extended form. If the packet size
+    // can be represent within 6 bits, the short form (1 byte) of size info is chosen, the size is
+    // put to the lower bits of this byte, and the flag is clear. If the packet size cannot be
+    // represent within 6 bits, the extended form (2 bytes) is chosen, the lower 8 bits of the size
+    // is put to the second byte, the higher bits of the size is put to the lower bits of the first
+    // byte, and the flag is set. Note that the packet size must be within 14 bits due to this
+    // format restriction, or it will overlap with the flag bit.
+    if (size < 0x40) {
+        packet.push_back(static_cast<u8>(size));
+    } else if (size < 0x4000) {
+        packet.push_back(static_cast<u8>(size >> 8) | 0x40);
+        packet.push_back(static_cast<u8>(size));
+    } else {
+        ASSERT(false);
+    }
+
+    // puts the payload
+    packet.insert(packet.end(), payload.begin(), payload.end());
+
+    // calculates CRC and puts to the end
+    packet.push_back(boost::crc<8, 0x07, 0, 0, false, false>(packet.data(), packet.size()));
+
+    if (receive_buffer->Put(packet)) {
+        receive_event->Signal();
+    } else {
+        LOG_ERROR(Service_IR, "receive buffer is full!");
+    }
+}
 
 /**
  * IR::InitializeIrNopShared service function
+ * Initializes ir:USER service with a user provided shared memory. The shared memory is configured
+ * to shared mode (with SharedMemoryHeader at the beginning of the shared memory).
  *  Inputs:
- *      1 : Size of transfer buffer
+ *      1 : Size of shared memory
  *      2 : Recv buffer size
- *      3 : unknown
+ *      3 : Recv buffer packet count
  *      4 : Send buffer size
- *      5 : unknown
+ *      5 : Send buffer packet count
  *      6 : BaudRate (u8)
- *      7 : 0
- *      8 : Handle of transfer shared memory
+ *      7 : 0 (Handle descriptor)
+ *      8 : Handle of shared memory
  *  Outputs:
  *      1 : Result of function, 0 on success, otherwise error code
  */
 static void InitializeIrNopShared(Interface* self) {
-    u32* cmd_buff = Kernel::GetCommandBuffer();
+    IPC::RequestParser rp(Kernel::GetCommandBuffer(), 0x18, 6, 2);
+    const u32 shared_buff_size = rp.Pop<u32>();
+    const u32 recv_buff_size = rp.Pop<u32>();
+    const u32 recv_buff_packet_count = rp.Pop<u32>();
+    const u32 send_buff_size = rp.Pop<u32>();
+    const u32 send_buff_packet_count = rp.Pop<u32>();
+    const u8 baud_rate = rp.Pop<u8>();
+    const Kernel::Handle handle = rp.PopHandle();
 
-    u32 transfer_buff_size = cmd_buff[1];
-    u32 recv_buff_size = cmd_buff[2];
-    u32 unk1 = cmd_buff[3];
-    u32 send_buff_size = cmd_buff[4];
-    u32 unk2 = cmd_buff[5];
-    u8 baud_rate = cmd_buff[6] & 0xFF;
-    Kernel::Handle handle = cmd_buff[8];
+    IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
 
-    if (Kernel::g_handle_table.IsValid(handle)) {
-        transfer_shared_memory = Kernel::g_handle_table.Get<Kernel::SharedMemory>(handle);
-        transfer_shared_memory->name = "IR:TransferSharedMemory";
+    shared_memory = Kernel::g_handle_table.Get<Kernel::SharedMemory>(handle);
+    if (!shared_memory) {
+        LOG_CRITICAL(Service_IR, "invalid shared memory handle 0x%08X", handle);
+        rb.Push(ResultCode(ErrorDescription::InvalidHandle, ErrorModule::OS,
+                           ErrorSummary::WrongArgument, ErrorLevel::Permanent));
+        return;
     }
+    shared_memory->name = "IR_USER: shared memory";
 
-    cmd_buff[1] = RESULT_SUCCESS.raw;
+    receive_buffer =
+        BufferManager(shared_memory, 0x10, 0x20, recv_buff_packet_count, recv_buff_size);
+    SharedMemoryHeader shared_memory_init{};
+    shared_memory_init.initialized = 1;
+    std::memcpy(shared_memory->GetPointer(), &shared_memory_init, sizeof(SharedMemoryHeader));
 
-    LOG_WARNING(Service_IR, "(STUBBED) called, transfer_buff_size=%d, recv_buff_size=%d, "
-                            "unk1=%d, send_buff_size=%d, unk2=%d, baud_rate=%u, handle=0x%08X",
-                transfer_buff_size, recv_buff_size, unk1, send_buff_size, unk2, baud_rate, handle);
+    rb.Push(RESULT_SUCCESS);
+
+    LOG_INFO(Service_IR, "called, shared_buff_size=%u, recv_buff_size=%u, "
+                         "recv_buff_packet_count=%u, send_buff_size=%u, "
+                         "send_buff_packet_count=%u, baud_rate=%u, handle=0x%08X",
+             shared_buff_size, recv_buff_size, recv_buff_packet_count, send_buff_size,
+             send_buff_packet_count, baud_rate, handle);
 }
 
 /**
  * IR::RequireConnection service function
+ * Searches for an IR device and connects to it. After connecting to the device, applications can
+ * use SendIrNop function, ReceiveIrNop function (or read from the buffer directly) to communicate
+ * with the device.
  *  Inputs:
- *      1 : unknown (u8), looks like always 1
+ *      1 : device ID? always 1 for circle pad pro
  *  Outputs:
  *      1 : Result of function, 0 on success, otherwise error code
  */
 static void RequireConnection(Interface* self) {
-    u32* cmd_buff = Kernel::GetCommandBuffer();
+    IPC::RequestParser rp(Kernel::GetCommandBuffer(), 0x06, 1, 0);
+    const u8 device_id = rp.Pop<u8>();
 
-    conn_status_event->Signal();
+    u8* shared_memory_ptr = shared_memory->GetPointer();
+    if (device_id == 1) {
+        // These values are observed on a New 3DS. The meaning of them is unclear.
+        // TODO (wwylele): should assign network_id a (random?) number
+        shared_memory_ptr[offsetof(SharedMemoryHeader, connection_status)] = 2;
+        shared_memory_ptr[offsetof(SharedMemoryHeader, connection_role)] = 2;
+        shared_memory_ptr[offsetof(SharedMemoryHeader, connected)] = 1;
 
-    cmd_buff[1] = RESULT_SUCCESS.raw;
+        connected_device = extra_hid.get();
+        connected_device->OnConnect();
+        conn_status_event->Signal();
+    } else {
+        LOG_WARNING(Service_IR, "unknown device id %u. Won't connect.", device_id);
+        shared_memory_ptr[offsetof(SharedMemoryHeader, connection_status)] = 1;
+        shared_memory_ptr[offsetof(SharedMemoryHeader, trying_to_connect_status)] = 2;
+    }
 
-    LOG_WARNING(Service_IR, "(STUBBED) called");
+    IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
+    rb.Push(RESULT_SUCCESS);
+
+    LOG_INFO(Service_IR, "called, device_id = %u", device_id);
+}
+
+/**
+ * IR::GetReceiveEvent service function
+ * Gets an event that is signaled when a packet is received from the IR device.
+ *  Outputs:
+ *      1 : Result of function, 0 on success, otherwise error code
+ *      2 : 0 (Handle descriptor)
+ *      3 : Receive event handle
+ */
+void GetReceiveEvent(Interface* self) {
+    IPC::RequestBuilder rb(Kernel::GetCommandBuffer(), 0x0A, 1, 2);
+
+    rb.Push(RESULT_SUCCESS);
+    rb.PushCopyHandles(Kernel::g_handle_table.Create(Service::IR::receive_event).MoveFrom());
+
+    LOG_INFO(Service_IR, "called");
+}
+
+/**
+ * IR::GetSendEvent service function
+ * Gets an event that is signaled when the sending of a packet is complete
+ *  Outputs:
+ *      1 : Result of function, 0 on success, otherwise error code
+ *      2 : 0 (Handle descriptor)
+ *      3 : Send event handle
+ */
+void GetSendEvent(Interface* self) {
+    IPC::RequestBuilder rb(Kernel::GetCommandBuffer(), 0x0B, 1, 2);
+
+    rb.Push(RESULT_SUCCESS);
+    rb.PushCopyHandles(Kernel::g_handle_table.Create(Service::IR::send_event).MoveFrom());
+
+    LOG_INFO(Service_IR, "called");
 }
 
 /**
  * IR::Disconnect service function
+ * Disconnects from the current connected IR device.
  *  Outputs:
  *      1 : Result of function, 0 on success, otherwise error code
  */
 static void Disconnect(Interface* self) {
-    u32* cmd_buff = Kernel::GetCommandBuffer();
+    if (connected_device) {
+        connected_device->OnDisconnect();
+        connected_device = nullptr;
+        conn_status_event->Signal();
+    }
 
-    cmd_buff[1] = RESULT_SUCCESS.raw;
+    u8* shared_memory_ptr = shared_memory->GetPointer();
+    shared_memory_ptr[offsetof(SharedMemoryHeader, connection_status)] = 0;
+    shared_memory_ptr[offsetof(SharedMemoryHeader, connected)] = 0;
 
-    LOG_WARNING(Service_IR, "(STUBBED) called");
+    IPC::RequestBuilder rb(Kernel::GetCommandBuffer(), 0x09, 1, 0);
+    rb.Push(RESULT_SUCCESS);
+
+    LOG_INFO(Service_IR, "called");
 }
 
 /**
  * IR::GetConnectionStatusEvent service function
+ * Gets an event that is signaled when the connection status is changed
  *  Outputs:
  *      1 : Result of function, 0 on success, otherwise error code
- *      2 : Connection Status Event handle
+ *      2 : 0 (Handle descriptor)
+ *      3 : Connection Status Event handle
  */
 static void GetConnectionStatusEvent(Interface* self) {
-    u32* cmd_buff = Kernel::GetCommandBuffer();
+    IPC::RequestBuilder rb(Kernel::GetCommandBuffer(), 0x0C, 1, 2);
 
-    cmd_buff[1] = RESULT_SUCCESS.raw;
-    cmd_buff[3] = Kernel::g_handle_table.Create(Service::IR::conn_status_event).MoveFrom();
+    rb.Push(RESULT_SUCCESS);
+    rb.PushCopyHandles(Kernel::g_handle_table.Create(Service::IR::conn_status_event).MoveFrom());
 
-    LOG_WARNING(Service_IR, "(STUBBED) called");
+    LOG_INFO(Service_IR, "called");
 }
 
 /**
  * IR::FinalizeIrNop service function
+ * Finalize ir:USER service.
  *  Outputs:
  *      1 : Result of function, 0 on success, otherwise error code
  */
 static void FinalizeIrNop(Interface* self) {
-    u32* cmd_buff = Kernel::GetCommandBuffer();
+    if (connected_device) {
+        connected_device->OnDisconnect();
+        connected_device = nullptr;
+    }
 
-    cmd_buff[1] = RESULT_SUCCESS.raw;
+    shared_memory = nullptr;
+    receive_buffer = boost::none;
 
-    LOG_WARNING(Service_IR, "(STUBBED) called");
+    IPC::RequestBuilder rb(Kernel::GetCommandBuffer(), 0x02, 1, 0);
+    rb.Push(RESULT_SUCCESS);
+
+    LOG_INFO(Service_IR, "called");
+}
+
+/**
+ * IR::SendIrNop service function
+ * Sends a packet to the connected IR device
+ *  Inpus:
+ *      1 : Size of data to send
+ *      2 : 2 + (size << 14) (Static buffer descriptor)
+ *      3 : Data buffer address
+ *  Outputs:
+ *      1 : Result of function, 0 on success, otherwise error code
+ */
+static void SendIrNop(Interface* self) {
+    IPC::RequestParser rp(Kernel::GetCommandBuffer(), 0x0D, 1, 2);
+    const u32 size = rp.Pop<u32>();
+    const VAddr address = rp.PopStaticBuffer();
+
+    std::vector<u8> buffer(size);
+    Memory::ReadBlock(address, buffer.data(), size);
+
+    IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
+    if (connected_device) {
+        connected_device->OnReceive(buffer);
+        send_event->Signal();
+        rb.Push(RESULT_SUCCESS);
+    } else {
+        LOG_ERROR(Service_IR, "not connected");
+        rb.Push(ResultCode(static_cast<ErrorDescription>(13), ErrorModule::IR,
+                           ErrorSummary::InvalidState, ErrorLevel::Status));
+    }
+
+    LOG_TRACE(Service_IR, "called, data=%s", Common::ArrayToString(buffer.data(), size).c_str());
+}
+
+/**
+ * IR::ReleaseReceivedData function
+ * Release a specified amount of packet from the receive buffer. This is called after the
+ * application reads received packet from the buffer directly, to release the buffer space for
+ * future packets.
+ *  Inpus:
+ *      1 : Number of packets to release
+ *  Outputs:
+ *      1 : Result of function, 0 on success, otherwise error code
+ */
+static void ReleaseReceivedData(Interface* self) {
+    IPC::RequestParser rp(Kernel::GetCommandBuffer(), 0x19, 1, 0);
+    u32 count = rp.Pop<u32>();
+
+    IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
+
+    if (receive_buffer->Release(count)) {
+        rb.Push(RESULT_SUCCESS);
+    } else {
+        LOG_ERROR(Service_IR, "failed to release %u packets", count);
+        rb.Push(ResultCode(ErrorDescription::NoData, ErrorModule::IR, ErrorSummary::NotFound,
+                           ErrorLevel::Status));
+    }
+
+    LOG_TRACE(Service_IR, "called, count=%u", count);
 }
 
 const Interface::FunctionInfo FunctionTable[] = {
@@ -118,10 +489,10 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x000702C0, nullptr, "AutoConnection"},
     {0x00080000, nullptr, "AnyConnection"},
     {0x00090000, Disconnect, "Disconnect"},
-    {0x000A0000, nullptr, "GetReceiveEvent"},
-    {0x000B0000, nullptr, "GetSendEvent"},
+    {0x000A0000, GetReceiveEvent, "GetReceiveEvent"},
+    {0x000B0000, GetSendEvent, "GetSendEvent"},
     {0x000C0000, GetConnectionStatusEvent, "GetConnectionStatusEvent"},
-    {0x000D0042, nullptr, "SendIrNop"},
+    {0x000D0042, SendIrNop, "SendIrNop"},
     {0x000E0042, nullptr, "SendIrNopLarge"},
     {0x000F0040, nullptr, "ReceiveIrnop"},
     {0x00100042, nullptr, "ReceiveIrnopLarge"},
@@ -133,7 +504,7 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x00160000, nullptr, "GetSendSizeFreeAndUsed"},
     {0x00170000, nullptr, "GetConnectionRole"},
     {0x00180182, InitializeIrNopShared, "InitializeIrNopShared"},
-    {0x00190040, nullptr, "ReleaseReceivedData"},
+    {0x00190040, ReleaseReceivedData, "ReleaseReceivedData"},
     {0x001A0040, nullptr, "SetOwnMachineId"},
 };
 
@@ -144,13 +515,43 @@ IR_User_Interface::IR_User_Interface() {
 void InitUser() {
     using namespace Kernel;
 
-    transfer_shared_memory = nullptr;
+    shared_memory = nullptr;
+
     conn_status_event = Event::Create(ResetType::OneShot, "IR:ConnectionStatusEvent");
+    send_event = Event::Create(ResetType::OneShot, "IR:SendEvent");
+    receive_event = Event::Create(ResetType::OneShot, "IR:ReceiveEvent");
+
+    receive_buffer = boost::none;
+
+    extra_hid = std::make_unique<ExtraHID>(PutToReceive);
+
+    connected_device = nullptr;
 }
 
 void ShutdownUser() {
-    transfer_shared_memory = nullptr;
+    if (connected_device) {
+        connected_device->OnDisconnect();
+        connected_device = nullptr;
+    }
+
+    extra_hid = nullptr;
+    receive_buffer = boost::none;
+    shared_memory = nullptr;
     conn_status_event = nullptr;
+    send_event = nullptr;
+    receive_event = nullptr;
+}
+
+void ReloadInputDevices() {
+    if (extra_hid)
+        extra_hid->RequestInputDevicesReload();
+}
+
+IRDevice::IRDevice(SendFunc send_func_) : send_func(send_func_) {}
+IRDevice::~IRDevice() = default;
+
+void IRDevice::Send(const std::vector<u8>& data) {
+    send_func(data);
 }
 
 } // namespace IR

--- a/src/core/hle/service/ir/ir_user.h
+++ b/src/core/hle/service/ir/ir_user.h
@@ -4,10 +4,40 @@
 
 #pragma once
 
+#include <functional>
 #include "core/hle/service/service.h"
 
 namespace Service {
 namespace IR {
+
+/// An interface representing a device that can communicate with 3DS via ir:USER service
+class IRDevice {
+public:
+    /**
+     * A function object that implements the method to send data to the 3DS, which takes a vector of
+     * data to send.
+     */
+    using SendFunc = std::function<void(const std::vector<u8>& data)>;
+
+    explicit IRDevice(SendFunc send_func);
+    virtual ~IRDevice();
+
+    /// Called when connected with 3DS
+    virtual void OnConnect() = 0;
+
+    /// Called when disconnected from 3DS
+    virtual void OnDisconnect() = 0;
+
+    /// Called when data is received from the 3DS. This is invoked by the ir:USER send function.
+    virtual void OnReceive(const std::vector<u8>& data) = 0;
+
+protected:
+    /// Sends data to the 3DS. The actual sending method is specified in the constructor
+    void Send(const std::vector<u8>& data);
+
+private:
+    const SendFunc send_func;
+};
 
 class IR_User_Interface : public Service::Interface {
 public:
@@ -20,6 +50,9 @@ public:
 
 void InitUser();
 void ShutdownUser();
+
+/// Reload input devices. Used when input configuration changed
+void ReloadInputDevices();
 
 } // namespace IR
 } // namespace Service

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -5,6 +5,7 @@
 #include "audio_core/audio_core.h"
 #include "core/gdbstub/gdbstub.h"
 #include "core/hle/service/hid/hid.h"
+#include "core/hle/service/ir/ir_user.h"
 #include "settings.h"
 #include "video_core/video_core.h"
 
@@ -32,6 +33,7 @@ void Apply() {
     AudioCore::EnableStretching(values.enable_audio_stretching);
 
     Service::HID::ReloadInputDevices();
+    Service::IR::ReloadInputDevices();
 }
 
 } // namespace


### PR DESCRIPTION
Circle pad pro (ZL, ZR and right circle pad) is implemented, along with the minimum set of required ir:USER service functions. For documentation of them please refer to [3dbrew:Circle Pad Pro](https://www.3dbrew.org/wiki/Circle_Pad_Pro) and [3dbrew:IRUSER Shared Memory](https://www.3dbrew.org/wiki/IRUSER_Shared_Memory). 

Some trivial service functions, such as `ReceiveIrnop` and `GetConnectionStatus`, are not implemented, because, from my observation, games usually read data/status directly from the shared memory instead of calling these functions. To minimize the diff, I left them unimplemented. If any games are found using them, I will implement them.

Note on new 3DS input: new 3DS additional HID hardware is mainly handled by ir:rst service, which is not implemented here. However, new 3DS can redirect ir:USER function call to access the additional HID, and most commercial games still uses ir:USER service to access new 3DS additional HID, so this PR should work for them. ir:rst is mostly used by homebrew apps, and is actually more trivial to implement, so I leave it to another PR (not necessary by me)

~~This branch is currently based on my input refactor branch (PR #2497) in order to get a clean input interface to start with (In the current master ZL, ZR and c-stick is mixed into HID service). **Please only review the last commit!**. If this PR get reviewed faster than the input PR, I will rebase this to the master branch. The only expected change at that time is in `ExtraHID::SendHIDStatus`~~