### PR TITLE
Fix small UI bugs

### DIFF
--- a/src/citra_qt/configure_audio.cpp
+++ b/src/citra_qt/configure_audio.cpp
@@ -53,7 +53,7 @@ void ConfigureAudio::setConfiguration() {
     ui->audio_device_combo_box->setCurrentIndex(new_device_index);
 }
 
-void ConfigureAudio::applyConfiguration() {
+void ConfigureAudio::applyConfiguration(bool commit_settings_file) {
     Settings::values.sink_id =
         ui->output_sink_combo_box->itemText(ui->output_sink_combo_box->currentIndex())
             .toStdString();
@@ -61,7 +61,9 @@ void ConfigureAudio::applyConfiguration() {
     Settings::values.audio_device_id =
         ui->audio_device_combo_box->itemText(ui->audio_device_combo_box->currentIndex())
             .toStdString();
-    Settings::Apply();
+    if (commit_settings_file) {
+        Settings::Apply();
+    }
 }
 
 void ConfigureAudio::updateAudioDevices(int sink_index) {

--- a/src/citra_qt/configure_audio.h
+++ b/src/citra_qt/configure_audio.h
@@ -18,7 +18,7 @@ public:
     explicit ConfigureAudio(QWidget* parent = nullptr);
     ~ConfigureAudio();
 
-    void applyConfiguration();
+    void applyConfiguration(bool commit_settings_file = true);
 
 public slots:
     void updateAudioDevices(int sink_index);

--- a/src/citra_qt/configure_debug.cpp
+++ b/src/citra_qt/configure_debug.cpp
@@ -19,8 +19,10 @@ void ConfigureDebug::setConfiguration() {
     ui->gdbport_spinbox->setValue(Settings::values.gdbstub_port);
 }
 
-void ConfigureDebug::applyConfiguration() {
+void ConfigureDebug::applyConfiguration(bool commit_settings_file) {
     Settings::values.use_gdbstub = ui->toggle_gdbstub->isChecked();
     Settings::values.gdbstub_port = ui->gdbport_spinbox->value();
-    Settings::Apply();
+    if (commit_settings_file) {
+        Settings::Apply();
+    }
 }

--- a/src/citra_qt/configure_debug.h
+++ b/src/citra_qt/configure_debug.h
@@ -18,7 +18,7 @@ public:
     explicit ConfigureDebug(QWidget* parent = nullptr);
     ~ConfigureDebug();
 
-    void applyConfiguration();
+    void applyConfiguration(bool commit_settings_file = true);
 
 private:
     void setConfiguration();

--- a/src/citra_qt/configure_dialog.cpp
+++ b/src/citra_qt/configure_dialog.cpp
@@ -17,11 +17,15 @@ ConfigureDialog::~ConfigureDialog() {}
 void ConfigureDialog::setConfiguration() {}
 
 void ConfigureDialog::applyConfiguration() {
-    ui->generalTab->applyConfiguration();
-    ui->systemTab->applyConfiguration();
-    ui->inputTab->applyConfiguration();
-    ui->graphicsTab->applyConfiguration();
-    ui->audioTab->applyConfiguration();
-    ui->debugTab->applyConfiguration();
+    // apply each, but don't commit the ini file (and trigger
+    //  associated changes) until the end
+    ui->generalTab->applyConfiguration(false);
+    ui->inputTab->applyConfiguration(false);
+    ui->graphicsTab->applyConfiguration(false);
+    ui->audioTab->applyConfiguration(false);
+    ui->debugTab->applyConfiguration(false);
+
     Settings::Apply();
+    // system settings doesn't actually put settings in the ini file
+    ui->systemTab->applyConfiguration();
 }

--- a/src/citra_qt/configure_general.cpp
+++ b/src/citra_qt/configure_general.cpp
@@ -28,10 +28,12 @@ void ConfigureGeneral::setConfiguration() {
     ui->region_combobox->setCurrentIndex(Settings::values.region_value + 1);
 }
 
-void ConfigureGeneral::applyConfiguration() {
+void ConfigureGeneral::applyConfiguration(bool commit_settings_file) {
     UISettings::values.gamedir_deepscan = ui->toggle_deepscan->isChecked();
     UISettings::values.confirm_before_closing = ui->toggle_check_exit->isChecked();
     Settings::values.region_value = ui->region_combobox->currentIndex() - 1;
     Settings::values.use_cpu_jit = ui->toggle_cpu_jit->isChecked();
-    Settings::Apply();
+    if (commit_settings_file) {
+        Settings::Apply();
+    }
 }

--- a/src/citra_qt/configure_general.h
+++ b/src/citra_qt/configure_general.h
@@ -18,7 +18,7 @@ public:
     explicit ConfigureGeneral(QWidget* parent = nullptr);
     ~ConfigureGeneral();
 
-    void applyConfiguration();
+    void applyConfiguration(bool commit_settings_file = true);
 
 private:
     void setConfiguration();

--- a/src/citra_qt/configure_graphics.cpp
+++ b/src/citra_qt/configure_graphics.cpp
@@ -101,7 +101,7 @@ void ConfigureGraphics::setConfiguration() {
     ui->swap_screen->setChecked(Settings::values.swap_screen);
 }
 
-void ConfigureGraphics::applyConfiguration() {
+void ConfigureGraphics::applyConfiguration(bool commit_settings_file) {
     Settings::values.use_hw_renderer = ui->toggle_hw_renderer->isChecked();
     Settings::values.use_shader_jit = ui->toggle_shader_jit->isChecked();
     Settings::values.resolution_factor =
@@ -111,5 +111,7 @@ void ConfigureGraphics::applyConfiguration() {
     Settings::values.layout_option =
         static_cast<Settings::LayoutOption>(ui->layout_combobox->currentIndex());
     Settings::values.swap_screen = ui->swap_screen->isChecked();
-    Settings::Apply();
+    if (commit_settings_file) {
+        Settings::Apply();
+    }
 }

--- a/src/citra_qt/configure_graphics.h
+++ b/src/citra_qt/configure_graphics.h
@@ -18,7 +18,7 @@ public:
     explicit ConfigureGraphics(QWidget* parent = nullptr);
     ~ConfigureGraphics();
 
-    void applyConfiguration();
+    void applyConfiguration(bool commit = true);
 
 private:
     void setConfiguration();

--- a/src/citra_qt/configure_input.cpp
+++ b/src/citra_qt/configure_input.cpp
@@ -112,13 +112,15 @@ ConfigureInput::ConfigureInput(QWidget* parent)
     ui->buttonCStickRight->setEnabled(false);
 }
 
-void ConfigureInput::applyConfiguration() {
+void ConfigureInput::applyConfiguration(bool commit_settings_file) {
     std::transform(buttons_param.begin(), buttons_param.end(), Settings::values.buttons.begin(),
                    [](const Common::ParamPackage& param) { return param.Serialize(); });
     std::transform(analogs_param.begin(), analogs_param.end(), Settings::values.analogs.begin(),
                    [](const Common::ParamPackage& param) { return param.Serialize(); });
 
-    Settings::Apply();
+    if (commit_settings_file) {
+        Settings::Apply();
+    }
 }
 
 void ConfigureInput::loadConfiguration() {

--- a/src/citra_qt/configure_input.h
+++ b/src/citra_qt/configure_input.h
@@ -30,7 +30,7 @@ public:
     explicit ConfigureInput(QWidget* parent = nullptr);
 
     /// Save all button configurations to settings file
-    void applyConfiguration();
+    void applyConfiguration(bool commit_settings_file = true);
 
 private:
     std::unique_ptr<Ui::ConfigureInput> ui;

--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -73,6 +73,8 @@ void GameList::ValidateEntry(const QModelIndex& item) {
 }
 
 void GameList::DonePopulating() {
+    auto header = tree_view->header();
+    item_model->sort(header->sortIndicatorSection(), header->sortIndicatorOrder());
     tree_view->setEnabled(true);
 }
 

--- a/src/citra_qt/game_list.h
+++ b/src/citra_qt/game_list.h
@@ -33,6 +33,7 @@ public:
 
     void SaveInterfaceLayout();
     void LoadInterfaceLayout();
+    void OnSettingsUpdated();
 
     static const QStringList supported_file_extensions;
 
@@ -54,4 +55,6 @@ private:
     QStandardItemModel* item_model = nullptr;
     GameListWorker* current_worker = nullptr;
     QFileSystemWatcher watcher;
+    QString game_directory;
+    bool recursive;
 };

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -73,8 +73,6 @@ GMainWindow::GMainWindow() : config(new Config()), emu_thread(nullptr) {
                        .arg(Common::g_build_name, Common::g_scm_branch, Common::g_scm_desc));
     show();
 
-    game_list->PopulateAsync(UISettings::values.gamedir, UISettings::values.gamedir_deepscan);
-
     QStringList args = QApplication::arguments();
     if (args.length() >= 2) {
         BootGame(args[1]);
@@ -538,7 +536,7 @@ void GMainWindow::OnMenuSelectGameListRoot() {
     QString dir_path = QFileDialog::getExistingDirectory(this, tr("Select Directory"));
     if (!dir_path.isEmpty()) {
         UISettings::values.gamedir = dir_path;
-        game_list->PopulateAsync(dir_path, UISettings::values.gamedir_deepscan);
+        game_list->OnSettingsUpdated();
     }
 }
 
@@ -612,6 +610,7 @@ void GMainWindow::OnConfigure() {
     auto result = configureDialog.exec();
     if (result == QDialog::Accepted) {
         configureDialog.applyConfiguration();
+        game_list->OnSettingsUpdated();
         config->Save();
     }
 }


### PR DESCRIPTION
Three small UI-related things fixed here. 

 - Sort order is now preserved after auto-refresh
 - Changing settings now triggers a list refresh (for recursive checked/unchecked)
 - The UI dialog now applies its settings exactly once.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2612)
<!-- Reviewable:end -->
