### PR TITLE
Reduce host file name and path logging

### DIFF
--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -691,6 +691,8 @@ const std::string& GetUserPath(const unsigned int DirIDX, const std::string& new
         paths[D_USER_IDX] = GetExeDirectory() + DIR_SEP USERDATA_DIR DIR_SEP;
         if (!FileUtil::IsDirectory(paths[D_USER_IDX])) {
             paths[D_USER_IDX] = AppDataRoamingDirectory() + DIR_SEP EMU_DATA_DIR DIR_SEP;
+        } else {
+            LOG_INFO(Common_Filesystem, "Using the local user directory");
         }
 
         paths[D_CONFIG_IDX] = paths[D_USER_IDX] + CONFIG_DIR DIR_SEP;

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -118,8 +118,7 @@ bool IsDirectory(const std::string& filename) {
 #endif
 
     if (result < 0) {
-        LOG_WARNING(Common_Filesystem, "stat failed on %s: %s", filename.c_str(),
-                    GetLastErrorMsg());
+        LOG_DEBUG(Common_Filesystem, "stat failed on %s: %s", filename.c_str(), GetLastErrorMsg());
         return false;
     }
 
@@ -129,12 +128,12 @@ bool IsDirectory(const std::string& filename) {
 // Deletes a given filename, return true on success
 // Doesn't supports deleting a directory
 bool Delete(const std::string& filename) {
-    LOG_INFO(Common_Filesystem, "file %s", filename.c_str());
+    LOG_TRACE(Common_Filesystem, "file %s", filename.c_str());
 
     // Return true because we care about the file no
     // being there, not the actual delete.
     if (!Exists(filename)) {
-        LOG_WARNING(Common_Filesystem, "%s does not exist", filename.c_str());
+        LOG_DEBUG(Common_Filesystem, "%s does not exist", filename.c_str());
         return true;
     }
 
@@ -169,8 +168,7 @@ bool CreateDir(const std::string& path) {
         return true;
     DWORD error = GetLastError();
     if (error == ERROR_ALREADY_EXISTS) {
-        LOG_WARNING(Common_Filesystem, "CreateDirectory failed on %s: already exists",
-                    path.c_str());
+        LOG_DEBUG(Common_Filesystem, "CreateDirectory failed on %s: already exists", path.c_str());
         return true;
     }
     LOG_ERROR(Common_Filesystem, "CreateDirectory failed on %s: %i", path.c_str(), error);
@@ -182,7 +180,7 @@ bool CreateDir(const std::string& path) {
     int err = errno;
 
     if (err == EEXIST) {
-        LOG_WARNING(Common_Filesystem, "mkdir failed on %s: already exists", path.c_str());
+        LOG_DEBUG(Common_Filesystem, "mkdir failed on %s: already exists", path.c_str());
         return true;
     }
 
@@ -197,7 +195,7 @@ bool CreateFullPath(const std::string& fullPath) {
     LOG_TRACE(Common_Filesystem, "path %s", fullPath.c_str());
 
     if (FileUtil::Exists(fullPath)) {
-        LOG_WARNING(Common_Filesystem, "path exists %s", fullPath.c_str());
+        LOG_DEBUG(Common_Filesystem, "path exists %s", fullPath.c_str());
         return true;
     }
 
@@ -229,7 +227,7 @@ bool CreateFullPath(const std::string& fullPath) {
 
 // Deletes a directory filename, returns true on success
 bool DeleteDir(const std::string& filename) {
-    LOG_INFO(Common_Filesystem, "directory %s", filename.c_str());
+    LOG_TRACE(Common_Filesystem, "directory %s", filename.c_str());
 
     // check if a directory
     if (!FileUtil::IsDirectory(filename)) {

--- a/src/core/file_sys/archive_extsavedata.cpp
+++ b/src/core/file_sys/archive_extsavedata.cpp
@@ -173,7 +173,7 @@ Path ConstructExtDataBinaryPath(u32 media_type, u32 high, u32 low) {
 ArchiveFactory_ExtSaveData::ArchiveFactory_ExtSaveData(const std::string& mount_location,
                                                        bool shared)
     : shared(shared), mount_point(GetExtDataContainerPath(mount_location, shared)) {
-    LOG_INFO(Service_FS, "Directory %s set as base for ExtSaveData.", mount_point.c_str());
+    LOG_DEBUG(Service_FS, "Directory %s set as base for ExtSaveData.", mount_point.c_str());
 }
 
 bool ArchiveFactory_ExtSaveData::Initialize() {

--- a/src/core/file_sys/archive_sdmc.cpp
+++ b/src/core/file_sys/archive_sdmc.cpp
@@ -306,7 +306,7 @@ u64 SDMCArchive::GetFreeBytes() const {
 
 ArchiveFactory_SDMC::ArchiveFactory_SDMC(const std::string& sdmc_directory)
     : sdmc_directory(sdmc_directory) {
-    LOG_INFO(Service_FS, "Directory %s set as SDMC.", sdmc_directory.c_str());
+    LOG_DEBUG(Service_FS, "Directory %s set as SDMC.", sdmc_directory.c_str());
 }
 
 bool ArchiveFactory_SDMC::Initialize() {

--- a/src/core/file_sys/archive_sdmcwriteonly.cpp
+++ b/src/core/file_sys/archive_sdmcwriteonly.cpp
@@ -32,7 +32,7 @@ ResultVal<std::unique_ptr<DirectoryBackend>> SDMCWriteOnlyArchive::OpenDirectory
 
 ArchiveFactory_SDMCWriteOnly::ArchiveFactory_SDMCWriteOnly(const std::string& mount_point)
     : sdmc_directory(mount_point) {
-    LOG_INFO(Service_FS, "Directory %s set as SDMCWriteOnly.", sdmc_directory.c_str());
+    LOG_DEBUG(Service_FS, "Directory %s set as SDMCWriteOnly.", sdmc_directory.c_str());
 }
 
 bool ArchiveFactory_SDMCWriteOnly::Initialize() {

--- a/src/core/file_sys/archive_source_sd_savedata.cpp
+++ b/src/core/file_sys/archive_source_sd_savedata.cpp
@@ -39,7 +39,7 @@ std::string GetSaveDataMetadataPath(const std::string& mount_location, u64 progr
 
 ArchiveSource_SDSaveData::ArchiveSource_SDSaveData(const std::string& sdmc_directory)
     : mount_point(GetSaveDataContainerPath(sdmc_directory)) {
-    LOG_INFO(Service_FS, "Directory %s set as SaveData.", mount_point.c_str());
+    LOG_DEBUG(Service_FS, "Directory %s set as SaveData.", mount_point.c_str());
 }
 
 ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveSource_SDSaveData::Open(u64 program_id) {

--- a/src/core/loader/loader.cpp
+++ b/src/core/loader/loader.cpp
@@ -139,7 +139,7 @@ std::unique_ptr<AppLoader> GetLoader(const std::string& filename) {
             type = filename_type;
     }
 
-    LOG_INFO(Loader, "Loading file %s as %s...", filename.c_str(), GetFileTypeString(type));
+    LOG_DEBUG(Loader, "Loading file %s as %s...", filename.c_str(), GetFileTypeString(type));
 
     return GetFileLoader(std::move(file), type, filename_filename, filename);
 }

--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
+#include <cinttypes>
 #include <cstring>
 #include <memory>
 #include "common/logging/log.h"
@@ -253,7 +254,7 @@ ResultStatus AppLoader_NCCH::LoadExeFS() {
 
     // Skip NCSD header and load first NCCH (NCSD is just a container of NCCH files)...
     if (MakeMagic('N', 'C', 'S', 'D') == ncch_header.magic) {
-        LOG_WARNING(Loader, "Only loading the first (bootable) NCCH within the NCSD file!");
+        LOG_DEBUG(Loader, "Only loading the first (bootable) NCCH within the NCSD file!");
         ncch_offset = 0x4000;
         file.Seek(ncch_offset, SEEK_SET);
         file.ReadBytes(&ncch_header, sizeof(NCCH_Header));
@@ -277,8 +278,8 @@ ResultStatus AppLoader_NCCH::LoadExeFS() {
     priority = exheader_header.arm11_system_local_caps.priority;
     resource_limit_category = exheader_header.arm11_system_local_caps.resource_limit_category;
 
-    LOG_INFO(Loader, "Name:                        %s", exheader_header.codeset_info.name);
-    LOG_INFO(Loader, "Program ID:                  %016llX", ncch_header.program_id);
+    LOG_DEBUG(Loader, "Name:                        %s", exheader_header.codeset_info.name);
+    LOG_DEBUG(Loader, "Program ID:                  %016" PRIX64, ncch_header.program_id);
     LOG_DEBUG(Loader, "Code compressed:             %s", is_compressed ? "yes" : "no");
     LOG_DEBUG(Loader, "Entry point:                 0x%08X", entry_point);
     LOG_DEBUG(Loader, "Code size:                   0x%08X", code_size);
@@ -335,6 +336,8 @@ ResultStatus AppLoader_NCCH::Load() {
     ResultStatus result = LoadExeFS();
     if (result != ResultStatus::Success)
         return result;
+
+    LOG_INFO(Loader, "Program ID: %016" PRIX64, ncch_header.program_id);
 
     is_loaded = true; // Set state to loaded
 


### PR DESCRIPTION
Logging file name and path have several problems:
 - Too verbose and can distract one from finding the actual problem
 - Can contain sensitive personal information (e.g. username) and user can upload the log with it without knowing it.
 - The way a user to name their game file can sometimes lead to misunderstanding about piracy or something.

The aim of this PR is to lower the level of logs that contains file name and path and that is often logged. (generally all <=Warning log are now <=Debug).