### PR TITLE
Qt: Release all pressed buttons when window focus is lost [rebased]

### DIFF
--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -235,6 +235,11 @@ void GRenderWindow::mouseReleaseEvent(QMouseEvent* event) {
         motion_emu->EndTilt();
 }
 
+void GRenderWindow::focusOutEvent(QFocusEvent* event) {
+    QWidget::focusOutEvent(event);
+    InputCommon::GetKeyboard()->ReleaseAllKeys();
+}
+
 void GRenderWindow::ReloadSetKeymaps() {}
 
 void GRenderWindow::OnClientAreaResized(unsigned width, unsigned height) {

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -240,8 +240,6 @@ void GRenderWindow::focusOutEvent(QFocusEvent* event) {
     InputCommon::GetKeyboard()->ReleaseAllKeys();
 }
 
-void GRenderWindow::ReloadSetKeymaps() {}
-
 void GRenderWindow::OnClientAreaResized(unsigned width, unsigned height) {
     NotifyClientAreaSizeChanged(std::make_pair(width, height));
 }

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -128,6 +128,8 @@ public:
     void mouseMoveEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* event) override;
 
+    void focusOutEvent(QFocusEvent* event) override;
+
     void ReloadSetKeymaps();
 
     void OnClientAreaResized(unsigned width, unsigned height);

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -130,8 +130,6 @@ public:
 
     void focusOutEvent(QFocusEvent* event) override;
 
-    void ReloadSetKeymaps();
-
     void OnClientAreaResized(unsigned width, unsigned height);
 
     void InitRenderTarget();

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -612,7 +612,6 @@ void GMainWindow::OnConfigure() {
     auto result = configureDialog.exec();
     if (result == QDialog::Accepted) {
         configureDialog.applyConfiguration();
-        render_window->ReloadSetKeymaps();
         config->Save();
     }
 }

--- a/src/input_common/keyboard.cpp
+++ b/src/input_common/keyboard.cpp
@@ -53,6 +53,13 @@ public:
         }
     }
 
+    void ChangeAllKeyStatus(bool pressed) {
+        std::lock_guard<std::mutex> guard(mutex);
+        for (const KeyButtonPair& pair : list) {
+            pair.key_button->status.store(pressed);
+        }
+    }
+
 private:
     std::mutex mutex;
     std::list<KeyButtonPair> list;
@@ -77,6 +84,10 @@ void Keyboard::PressKey(int key_code) {
 
 void Keyboard::ReleaseKey(int key_code) {
     key_button_list->ChangeKeyStatus(key_code, false);
+}
+
+void Keyboard::ReleaseAllKeys() {
+    key_button_list->ChangeAllKeyStatus(false);
 }
 
 } // namespace InputCommon

--- a/src/input_common/keyboard.h
+++ b/src/input_common/keyboard.h
@@ -38,6 +38,8 @@ public:
      */
     void ReleaseKey(int key_code);
 
+    void ReleaseAllKeys();
+
 private:
     std::shared_ptr<KeyButtonList> key_button_list;
 };


### PR DESCRIPTION
credit to @Hawkheart for the original PR #2479. This is the rebased version of the same idea on the new input system.

Should fix #2392 

btw I also tested the SDL frontend, which doesn't seem to have this issue on my PC. If anyone finds the same issue in SDL frontend, I can add the same fix to it.