### PR TITLE
shared_page: stub battery state

### DIFF
--- a/src/core/hle/shared_page.cpp
+++ b/src/core/hle/shared_page.cpp
@@ -6,6 +6,7 @@
 #include <cstring>
 #include <ctime>
 #include "core/core_timing.h"
+#include "core/hle/service/ptm/ptm.h"
 #include "core/hle/shared_page.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -72,6 +73,12 @@ void Init() {
 
     // Some games wait until this value becomes 0x1, before asking running_hw
     shared_page.unknown_value = 0x1;
+
+    // Set to a completely full battery
+    shared_page.battery_state.charge_level.Assign(
+        static_cast<u8>(Service::PTM::ChargeLevels::CompletelyFull));
+    shared_page.battery_state.is_adapter_connected.Assign(1);
+    shared_page.battery_state.is_charging.Assign(1);
 
     update_time_event =
         CoreTiming::RegisterEvent("SharedPage::UpdateTimeCallback", UpdateTimeCallback);

--- a/src/core/hle/shared_page.h
+++ b/src/core/hle/shared_page.h
@@ -10,6 +10,7 @@
  * write access, according to 3dbrew; this is not emulated)
  */
 
+#include "common/bit_field.h"
 #include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "common/swap.h"
@@ -29,6 +30,13 @@ struct DateTime {
 };
 static_assert(sizeof(DateTime) == 0x20, "Datetime size is wrong");
 
+union BatteryState {
+    u8 raw;
+    BitField<0, 1, u8> is_adapter_connected;
+    BitField<1, 1, u8> is_charging;
+    BitField<2, 3, u8> charge_level;
+};
+
 struct SharedPageDef {
     // Most of these names are taken from the 3dbrew page linked above.
     u32_le date_time_counter; // 0
@@ -44,7 +52,7 @@ struct SharedPageDef {
     INSERT_PADDING_BYTES(0x80 - 0x68);   // 68
     float_le sliderstate_3d;             // 80
     u8 ledstate_3d;                      // 84
-    INSERT_PADDING_BYTES(1);             // 85
+    BatteryState battery_state;          // 85
     u8 unknown_value;                    // 86
     INSERT_PADDING_BYTES(0xA0 - 0x87);   // 87
     u64_le menu_title_id;                // A0


### PR DESCRIPTION
We already stubbed the battery state in the PTM service, but there is another API that is more common used by games, which is the shared page. This PR stubbed the battery state in the shared page with the same value as the one in PTM service.