### PR TITLE
ptm: create SharedExtSave file before openning it

### DIFF
--- a/src/core/hle/service/ptm/ptm.cpp
+++ b/src/core/hle/service/ptm/ptm.cpp
@@ -134,9 +134,9 @@ void Init() {
         ASSERT_MSG(archive_result.Succeeded(), "Could not open the PTM SharedExtSaveData archive!");
 
         FileSys::Path gamecoin_path("/gamecoin.dat");
+        Service::FS::CreateFileInArchive(*archive_result, gamecoin_path, sizeof(GameCoin));
         FileSys::Mode open_mode = {};
         open_mode.write_flag.Assign(1);
-        open_mode.create_flag.Assign(1);
         // Open the file and write the default gamecoin information
         auto gamecoin_result =
             Service::FS::OpenFileFromArchive(*archive_result, gamecoin_path, open_mode);


### PR DESCRIPTION
This is a leftover from #2132 . 3DS file system doesn't allow opening ExtSave file with create flag, which was corrected in that PR. But the operation in ptm module was not corrected and couldn't create the GameCoin file.