### PR TITLE
Fix OutputDebugString syscall

### DIFF
--- a/src/core/hle/function_wrappers.h
+++ b/src/core/hle/function_wrappers.h
@@ -256,9 +256,9 @@ void Wrap() {
     func(((s64)PARAM(1) << 32) | PARAM(0));
 }
 
-template <void func(const char*)>
+template <void func(const char*, int len)>
 void Wrap() {
-    func((char*)Memory::GetPointer(PARAM(0)));
+    func((char*)Memory::GetPointer(PARAM(0)), PARAM(1));
 }
 
 template <void func(u8)>

--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -467,8 +467,8 @@ static void Break(u8 break_reason) {
 }
 
 /// Used to output a message on a debug hardware unit - does nothing on a retail unit
-static void OutputDebugString(const char* string) {
-    LOG_DEBUG(Debug_Emulated, "%s", string);
+static void OutputDebugString(const char* string, int len) {
+    LOG_DEBUG(Debug_Emulated, "%.*s", len, string);
 }
 
 /// Get resource limit


### PR DESCRIPTION
From libctru:

`Result svcOutputDebugString(const char* str, s32 length);`

I don't know what a real unit would return so I left it void as-is.

Without the length parameter, my shorter debug outputs have the end of previous messages attached to them.