### PR TITLE
Pica/Regs: Correct bit width for blend-equations

### DIFF
--- a/src/video_core/regs_framebuffer.h
+++ b/src/video_core/regs_framebuffer.h
@@ -89,8 +89,8 @@ struct FramebufferRegs {
         };
 
         union {
-            BitField<0, 8, BlendEquation> blend_equation_rgb;
-            BitField<8, 8, BlendEquation> blend_equation_a;
+            BitField<0, 3, BlendEquation> blend_equation_rgb;
+            BitField<8, 3, BlendEquation> blend_equation_a;
 
             BitField<16, 4, BlendFactor> factor_source_rgb;
             BitField<20, 4, BlendFactor> factor_dest_rgb;


### PR DESCRIPTION
(The issue was reported by @emmauss on discord, it was hw-tested by @wwylele based on a hardware-test originally written by me. I'm submitting this on behalf of @wwylele who has enough PRs to worry about)

---

This was an attempt to fix a bug in "Fantasy Life" which reportedly uses blend equation 14 when creating a female character. See #2276 (note that it's [still not fixed by this PR because of this](https://github.com/citra-emu/citra/issues/2276#issuecomment-265439959)).

Blend equation 14 does not exist because the [field which stores the blend equation is only 3 bits wide](https://www.3dbrew.org/wiki/GPU/Internal_Registers#GPUREG_BLEND_FUNC).
This leads to an UNREACHABLE assertion in pica_to_gl.h

This is caused because [the code in master (at the time of writing)](https://github.com/citra-emu/citra/blob/2889372e47624e368df0d0361cb38b8100f047dd/src/video_core/regs_framebuffer.h#L92) uses 8 bits to read the `blend_equation`.

---

[@wwylele wrote a hw-test reusing some of my older hw-test code.](https://github.com/JayFoxRox/3ds-tests/commit/415681e5a22935e9a5079deef103f40a198e68be)

He found that the blend equation does wrap around for value>=8 (i.e. ignore bits 3-7).
So the documentation on 3dbrew is correct.

Additionally he tested blend equation 5, 6, 7: they look the same as 0 (Add).
This is already reflected by our pica_to_gl.h code for the HW-Renderer. However, for equations 5, 6, 7 it will still trigger UNREACHABLE (as we currently assume games to be error-free).
In the SW renderer we only handle values 0, 1, 2, 3, 4. Any other value will be UNIMPLEMENTED.
(Fixing this discrepancy is beyond the scope of this PR though).

I also asked @wwylele wether 5, 6, 7 might not change the internal regs of the GPU at all.
He confirmed this by stepping into 5, 6, 7 from both directions with different step size (so with different valid values before 5, 6, 7): still the same as add.

---

This PR lowers the blend-equation width to 3 bits. We will document the behaviour of mode 5, 6, 7 on 3dbrew.