### PR TITLE
Better looking status bar under Linux Ubuntu

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -115,6 +115,7 @@ void GMainWindow::InitializeWidgets() {
         statusBar()->addPermanentWidget(label);
     }
     statusBar()->setVisible(true);
+    setStyleSheet("QStatusBar::item{border: none;}");
 }
 
 void GMainWindow::InitializeDebugWidgets() {

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -115,7 +115,6 @@ void GMainWindow::InitializeWidgets() {
         statusBar()->addPermanentWidget(label);
     }
     statusBar()->setVisible(true);
-	setStyleSheet("QStatusBar::item{border: none;}");
 }
 
 void GMainWindow::InitializeDebugWidgets() {

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -115,6 +115,7 @@ void GMainWindow::InitializeWidgets() {
         statusBar()->addPermanentWidget(label);
     }
     statusBar()->setVisible(true);
+	setStyleSheet("QStatusBar::item{border: none;}");
 }
 
 void GMainWindow::InitializeDebugWidgets() {


### PR DESCRIPTION
This commit will remove the inner border on the status bar cells under Linux.
I undid the first commit to replace the tab with spaces.

![screenshot from 2017-04-12 16-06-49](https://cloud.githubusercontent.com/assets/25939765/24983145/2e77b57a-1f9a-11e7-90bd-a20ef2a4826c.png)
