### PR TITLE
input_common/sdl: add support for binding button to axis

### DIFF
--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -19,7 +19,13 @@ const char* sdl2_config_file = R"(
 #      - "joystick": the index of the joystick to bind
 #      - "button"(optional): the index of the button to bind
 #      - "hat"(optional): the index of the hat to bind as direction buttons
+#      - "axis"(optional): the index of the axis to bind
 #      - "direction"(only used for hat): the direction name of the hat to bind. Can be "up", "down", "left" or "right"
+#      - "threshould"(only used for axis): a float value in (-1.0, 1.0) which the button is
+#          triggered if the axis value crosses
+#      - "direction"(only used for axis): "+" means the button is triggered when the axis value
+#          is greater than the threshold; "-" means the button is triggered when the axis value
+#          is smaller than the threshold
 button_a=
 button_b=
 button_x=


### PR DESCRIPTION
Controllers like Xbox have left/right triggers that are ideal for binding with 3DS ZL/ZR, but they are exposed via axis API. Also, one may want to bind controller stick (axis API as well) to 3DS D-pad. This resolves the problem of not being able to bind axis to button.

Usage: `button_*="engine:sdl,joystick:*,axis:*,threshold:*,direction:+/-"`. refer to the comment in the code for detail

Here are some example:
Binding controller stick to 3DS D-pad:
```
button_down="engine:sdl,joystick:0,axis:1,threshold:0.5,direction:+"
button_left="engine:sdl,joystick:0,axis:0,threshold:-0.5,direction:-"
button_right="engine:sdl,joystick:0,axis:0,threshold:0.5,direction:+"
button_up="engine:sdl,joystick:0,axis:1,threshold:-0.5,direction:-"
```
Binding Xbox trigger to 3DS ZL/ZR (not confirmed working):
```
button_zl="engine:sdl,joystick:0,axis:8,threshold:0.5,direction:+"
button_zr="engine:sdl,joystick:0,axis:9,threshold:0.5,direction:+"
```