### PR TITLE
Create a random console_unique_id

### DIFF
--- a/src/citra_qt/configuration/configure_system.cpp
+++ b/src/citra_qt/configuration/configure_system.cpp
@@ -77,7 +77,7 @@ void ConfigureSystem::ReadSystemSettings() {
     ui->combo_sound->setCurrentIndex(sound_index);
 
     // set the console id
-    u64_le console_id = Service::CFG::GetConsoleUniqueId();
+    u64 console_id = Service::CFG::GetConsoleUniqueId();
     ui->label_console_id->setText("Console ID: 0x" + QString::number(console_id, 16).toUpper());
 }
 
@@ -159,8 +159,8 @@ void ConfigureSystem::refreshConsoleID() {
                                   QMessageBox::No | QMessageBox::Yes);
     if (reply == QMessageBox::No)
         return;
-    u32_le random_number;
-    u64_le console_id;
+    u32 random_number;
+    u64 console_id;
     Service::CFG::GenerateConsoleUniqueId(random_number, console_id);
     Service::CFG::SetConsoleUniqueId(random_number, console_id);
     Service::CFG::UpdateConfigNANDSavegame();

--- a/src/citra_qt/configuration/configure_system.cpp
+++ b/src/citra_qt/configuration/configure_system.cpp
@@ -75,6 +75,10 @@ void ConfigureSystem::ReadSystemSettings() {
     // set sound output mode
     sound_index = Service::CFG::GetSoundOutputMode();
     ui->combo_sound->setCurrentIndex(sound_index);
+
+    // set the console id
+    u64_le console_id = Service::CFG::GetConsoleUniqueId();
+    ui->label_console_id->setText("Console ID: 0x" + QString::number(console_id, 16).toUpper());
 }
 
 void ConfigureSystem::applyConfiguration() {
@@ -149,7 +153,8 @@ void ConfigureSystem::refreshConsoleID() {
     QMessageBox::StandardButton reply;
     QString warning_text = tr("This will replace your current virtual 3DS with a new one. "
                               "Your current virtual 3DS will not be recoverable. "
-                              "This might have unexpected effects in games. Continue?");
+                              "This might have unexpected effects in games. This might fail, "
+                              "if you use an outdated config savegame. Continue?");
     reply = QMessageBox::critical(this, tr("Warning"), warning_text,
                                   QMessageBox::No | QMessageBox::Yes);
     if (reply == QMessageBox::No)
@@ -157,15 +162,7 @@ void ConfigureSystem::refreshConsoleID() {
     u32_le random_number;
     u64_le console_id;
     Service::CFG::GenerateConsoleUniqueId(random_number, console_id);
-    ResultCode res = Service::CFG::SetConsoleUniqueId(random_number, console_id);
-    if (res != RESULT_SUCCESS) {
-        QMessageBox::critical(this, tr("Failure"), tr("Failed to set a new console ID"),
-                              QMessageBox::Ok);
-        return;
-    }
+    Service::CFG::SetConsoleUniqueId(random_number, console_id);
     Service::CFG::UpdateConfigNANDSavegame();
-    QMessageBox::information(this, tr("New Console ID"),
-                             tr("Your new unique console ID is 0x") +
-                                 QString::number(console_id, 16).toUpper(),
-                             QMessageBox::Ok);
+    ui->label_console_id->setText("Console ID: 0x" + QString::number(console_id, 16).toUpper());
 }

--- a/src/citra_qt/configuration/configure_system.cpp
+++ b/src/citra_qt/configuration/configure_system.cpp
@@ -17,6 +17,7 @@ ConfigureSystem::ConfigureSystem(QWidget* parent) : QWidget(parent), ui(new Ui::
     ui->setupUi(this);
     connect(ui->combo_birthmonth, SIGNAL(currentIndexChanged(int)),
             SLOT(updateBirthdayComboBox(int)));
+    connect(ui->button_refresh_console_id, SIGNAL(clicked()), this, SLOT(refreshConsoleID()));
 
     this->setConfiguration();
 }

--- a/src/citra_qt/configuration/configure_system.cpp
+++ b/src/citra_qt/configuration/configure_system.cpp
@@ -140,3 +140,8 @@ void ConfigureSystem::updateBirthdayComboBox(int birthmonth_index) {
     // restore the day selection
     ui->combo_birthday->setCurrentIndex(birthday_index);
 }
+
+void ConfigureSystem::refreshConsoleID() {
+    Service::CFG::GenerateConsoleUniqueId();
+    Service::CFG::UpdateConfigNANDSavegame();
+}

--- a/src/citra_qt/configuration/configure_system.cpp
+++ b/src/citra_qt/configuration/configure_system.cpp
@@ -147,11 +147,11 @@ void ConfigureSystem::updateBirthdayComboBox(int birthmonth_index) {
 
 void ConfigureSystem::refreshConsoleID() {
     QMessageBox::StandardButton reply;
-    reply = QMessageBox::critical(
-        this, tr("Warning"),
-        tr("This is an advanced feature. Some of your games might lose their saves. Only "
-           "continue, if you know what you are doing. Do you want to continue?"),
-        QMessageBox::Abort | QMessageBox::Yes);
+    reply = QMessageBox::critical(this, tr("Warning"),
+                                  tr("This will replace your virtual 3DS with a new one. Your "
+                                     "current 3DS will not be recoverable. "
+                                     "This might have unexpected effects in games. Continue?"),
+                                  QMessageBox::Abort | QMessageBox::Yes);
     if (reply == QMessageBox::Abort)
         return;
     Service::CFG::GenerateConsoleUniqueId();

--- a/src/citra_qt/configuration/configure_system.h
+++ b/src/citra_qt/configuration/configure_system.h
@@ -23,6 +23,7 @@ public:
 
 public slots:
     void updateBirthdayComboBox(int birthmonth_index);
+    void refreshConsoleID();
 
 private:
     void ReadSystemSettings();

--- a/src/citra_qt/configuration/configure_system.ui
+++ b/src/citra_qt/configuration/configure_system.ui
@@ -267,12 +267,5 @@
   </layout>
  </widget>
  <resources/>
- <connections>
-  <connection>
-   <sender>button_refresh_console_id</sender>
-   <signal>clicked()</signal>
-   <receiver>ConfigureSystem</receiver>
-   <slot>refreshConsoleID()</slot>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/src/citra_qt/configuration/configure_system.ui
+++ b/src/citra_qt/configuration/configure_system.ui
@@ -221,7 +221,7 @@
          </widget>
         </item>
         <item row="4" column="1">
-         <widget class="QPushButton" name="button_refresh_console_id">
+         <widget class="QPushButton" name="button_regenerate_console_id">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -232,7 +232,7 @@
            <enum>Qt::RightToLeft</enum>
           </property>
           <property name="text">
-           <string>Refresh Console ID</string>
+           <string>Generate new console ID</string>
           </property>
          </widget>
         </item>

--- a/src/citra_qt/configuration/configure_system.ui
+++ b/src/citra_qt/configuration/configure_system.ui
@@ -220,6 +220,22 @@
           </item>
          </widget>
         </item>
+        <item row="4" column="1">
+         <widget class="QPushButton" name="button_refresh_console_id">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="layoutDirection">
+           <enum>Qt::RightToLeft</enum>
+          </property>
+          <property name="text">
+           <string>Refresh Console ID</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </widget>
      </item>
@@ -251,5 +267,12 @@
   </layout>
  </widget>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>button_refresh_console_id</sender>
+   <signal>clicked()</signal>
+   <receiver>ConfigureSystem</receiver>
+   <slot>refreshConsoleID()</slot>
+  </connection>
+ </connections>
 </ui>

--- a/src/citra_qt/configuration/configure_system.ui
+++ b/src/citra_qt/configuration/configure_system.ui
@@ -220,6 +220,13 @@
           </item>
          </widget>
         </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="label_console_id">
+          <property name="text">
+           <string>Console ID:</string>
+          </property>
+         </widget>
+        </item>
         <item row="4" column="1">
          <widget class="QPushButton" name="button_regenerate_console_id">
           <property name="sizePolicy">
@@ -232,7 +239,7 @@
            <enum>Qt::RightToLeft</enum>
           </property>
           <property name="text">
-           <string>Generate new console ID</string>
+           <string>Regenerate</string>
           </property>
          </widget>
         </item>

--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -671,19 +671,15 @@ SoundOutputMode GetSoundOutputMode() {
 
 void GenerateConsoleUniqueId(u32& random_number, u64& console_id) {
     CryptoPP::AutoSeededRandomPool rng;
-    u32_le random_number_le = rng.GenerateWord32(0, 0xFFFF);
+    random_number = rng.GenerateWord32(0, 0xFFFF);
     u64_le local_friend_code_seed;
     rng.GenerateBlock(reinterpret_cast<byte*>(&local_friend_code_seed),
                       sizeof(local_friend_code_seed));
-    u64_le console_id_le =
-        (local_friend_code_seed & 0x3FFFFFFFF) | (static_cast<u64_le>(random_number_le) << 48);
-
-    random_number = random_number_le;
-    console_id = console_id_le;
+    console_id =
+        (local_friend_code_seed & 0x3FFFFFFFF) | (static_cast<u64_le>(random_number) << 48);
 }
 
 ResultCode SetConsoleUniqueId(u32 random_number, u64 console_id) {
-    u32_le random_number_le = random_number;
     u64_le console_id_le = console_id;
     ResultCode res =
         SetConfigInfoBlock(ConsoleUniqueID1BlockID, sizeof(console_id_le), 0xE, &console_id_le);
@@ -694,6 +690,7 @@ ResultCode SetConsoleUniqueId(u32 random_number, u64 console_id) {
     if (!res.IsSuccess())
         return res;
 
+    u32_le random_number_le = random_number;
     res = SetConfigInfoBlock(ConsoleUniqueID3BlockID, sizeof(random_number_le), 0xE,
                              &random_number_le);
     if (!res.IsSuccess())

--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -669,37 +669,43 @@ SoundOutputMode GetSoundOutputMode() {
     return static_cast<SoundOutputMode>(block);
 }
 
-void GenerateConsoleUniqueId(u32_le& random_number, u64_le& console_id) {
+void GenerateConsoleUniqueId(u32& random_number, u64& console_id) {
     CryptoPP::AutoSeededRandomPool rng;
-    random_number = rng.GenerateWord32(0, 0xFFFF);
+    u32_le random_number_le = rng.GenerateWord32(0, 0xFFFF);
     u64_le local_friend_code_seed;
     rng.GenerateBlock(reinterpret_cast<byte*>(&local_friend_code_seed),
                       sizeof(local_friend_code_seed));
-    console_id =
-        (local_friend_code_seed & 0x3FFFFFFFF) | (static_cast<u64_le>(random_number) << 48);
+    u64_le console_id_le =
+        (local_friend_code_seed & 0x3FFFFFFFF) | (static_cast<u64_le>(random_number_le) << 48);
+
+    random_number = random_number_le;
+    console_id = console_id_le;
 }
 
-ResultCode SetConsoleUniqueId(u32_le random_number, u64_le console_id) {
+ResultCode SetConsoleUniqueId(u32 random_number, u64 console_id) {
+    u32_le random_number_le = random_number;
+    u64_le console_id_le = console_id;
     ResultCode res =
-        SetConfigInfoBlock(ConsoleUniqueID1BlockID, sizeof(console_id), 0xE, &console_id);
+        SetConfigInfoBlock(ConsoleUniqueID1BlockID, sizeof(console_id_le), 0xE, &console_id_le);
     if (!res.IsSuccess())
         return res;
 
-    res = SetConfigInfoBlock(ConsoleUniqueID2BlockID, sizeof(console_id), 0xE, &console_id);
+    res = SetConfigInfoBlock(ConsoleUniqueID2BlockID, sizeof(console_id_le), 0xE, &console_id_le);
     if (!res.IsSuccess())
         return res;
 
-    res = SetConfigInfoBlock(ConsoleUniqueID3BlockID, sizeof(random_number), 0xE, &random_number);
+    res = SetConfigInfoBlock(ConsoleUniqueID3BlockID, sizeof(random_number_le), 0xE,
+                             &random_number_le);
     if (!res.IsSuccess())
         return res;
 
     return RESULT_SUCCESS;
 }
 
-u64_le GetConsoleUniqueId() {
-    u64 console_id;
-    GetConfigInfoBlock(ConsoleUniqueID2BlockID, sizeof(console_id), 0xE, &console_id);
-    return console_id;
+u64 GetConsoleUniqueId() {
+    u64_le console_id_le;
+    GetConfigInfoBlock(ConsoleUniqueID2BlockID, sizeof(console_id_le), 0xE, &console_id_le);
+    return console_id_le;
 }
 
 } // namespace CFG

--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -439,18 +439,22 @@ ResultCode FormatConfig() {
     if (!res.IsSuccess())
         return res;
 
-    u32_le random_number;
-    u64_le console_id;
+    u32 random_number;
+    u64 console_id;
     GenerateConsoleUniqueId(random_number, console_id);
-    res = CreateConfigInfoBlk(ConsoleUniqueID1BlockID, sizeof(console_id), 0xE, &console_id);
+
+    u64_le console_id_le = console_id;
+    res = CreateConfigInfoBlk(ConsoleUniqueID1BlockID, sizeof(console_id_le), 0xE, &console_id_le);
     if (!res.IsSuccess())
         return res;
 
-    res = CreateConfigInfoBlk(ConsoleUniqueID2BlockID, sizeof(console_id), 0xE, &console_id);
+    res = CreateConfigInfoBlk(ConsoleUniqueID2BlockID, sizeof(console_id_le), 0xE, &console_id_le);
     if (!res.IsSuccess())
         return res;
 
-    res = CreateConfigInfoBlk(ConsoleUniqueID3BlockID, sizeof(random_number), 0xE, &random_number);
+    u32_le random_number_le = random_number;
+    res = CreateConfigInfoBlk(ConsoleUniqueID3BlockID, sizeof(random_number_le), 0xE,
+                              &random_number_le);
     if (!res.IsSuccess())
         return res;
 
@@ -675,8 +679,7 @@ void GenerateConsoleUniqueId(u32& random_number, u64& console_id) {
     u64_le local_friend_code_seed;
     rng.GenerateBlock(reinterpret_cast<byte*>(&local_friend_code_seed),
                       sizeof(local_friend_code_seed));
-    console_id =
-        (local_friend_code_seed & 0x3FFFFFFFF) | (static_cast<u64_le>(random_number) << 48);
+    console_id = (local_friend_code_seed & 0x3FFFFFFFF) | (static_cast<u64>(random_number) << 48);
 }
 
 ResultCode SetConsoleUniqueId(u32 random_number, u64 console_id) {

--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -4,8 +4,8 @@
 
 #include <algorithm>
 #include <array>
-#include <cryptopp/sha.h>
 #include <random>
+#include <cryptopp/sha.h>
 #include "common/file_util.h"
 #include "common/logging/log.h"
 #include "common/string_util.h"

--- a/src/core/hle/service/cfg/cfg.h
+++ b/src/core/hle/service/cfg/cfg.h
@@ -342,5 +342,10 @@ void SetSoundOutputMode(SoundOutputMode mode);
  */
 SoundOutputMode GetSoundOutputMode();
 
+/**
+ * Generates and sets a new random console unique id.
+ */
+void GenerateConsoleUniqueId();
+
 } // namespace CFG
 } // namespace Service

--- a/src/core/hle/service/cfg/cfg.h
+++ b/src/core/hle/service/cfg/cfg.h
@@ -344,8 +344,15 @@ SoundOutputMode GetSoundOutputMode();
 
 /**
  * Generates and sets a new random console unique id.
+ * @returns ResultCode indicating the result of the operation, 0 on success
  */
-void GenerateConsoleUniqueId();
+ResultCode GenerateConsoleUniqueId();
+
+/**
+ * Gets the console unique id from config savegame.
+ * @returns the console unique id
+ */
+u64 GetConsoleUniqueId();
 
 } // namespace CFG
 } // namespace Service

--- a/src/core/hle/service/cfg/cfg.h
+++ b/src/core/hle/service/cfg/cfg.h
@@ -343,10 +343,19 @@ void SetSoundOutputMode(SoundOutputMode mode);
 SoundOutputMode GetSoundOutputMode();
 
 /**
- * Generates and sets a new random console unique id.
- * @returns ResultCode indicating the result of the operation, 0 on success
+ * Generates a new random console unique id.
+ * @param random_number a random generated 16bit number stored at 0x90002, used for generating the
+ * console_id
+ * @param console_id the randomly created console id
  */
-ResultCode GenerateConsoleUniqueId();
+void GenerateConsoleUniqueId(u32& random_number, u64& console_id);
+
+/**
+ * Sets the random_number and the  console unique id in the config savegame.
+ * @param random_number the random_number to set
+ * @param console_id the console id to set
+ */
+ResultCode SetConsoleUniqueId(u32 random_number, u64 console_id);
 
 /**
  * Gets the console unique id from config savegame.


### PR DESCRIPTION
This will allow that each citra gets its own console_unique_id and gets rid of the hardcoded 0xDEADC0DE.

It will create a random console_unique_id when the config savegame is created.
To also have to ability to change the console_unique_id without formatting the complete config savegame a button was added to the system config dialog which allows to generate a new random console_unique_id.
<img width="487" alt="system config dialog with new refresh console id button" src="https://cloud.githubusercontent.com/assets/26032316/25100392/31cd65c0-23b0-11e7-8e67-5199efa5191d.png">
One minor draw back is that this won't allow to set the console_unique_id manually. But most users won't ever need to set it manually, and those i need to set it, should know how to edit the savegame. On the other side adding a textbox for that in the ui, seemed way to much for a feature used that rarely.