### PR TITLE
Frontend: Prevent FileSystemWatcher from blocking UI thread

### DIFF
--- a/src/citra_qt/game_list.h
+++ b/src/citra_qt/game_list.h
@@ -85,10 +85,9 @@ private slots:
 private:
     void AddEntry(const QList<QStandardItem*>& entry_items);
     void ValidateEntry(const QModelIndex& item);
-    void DonePopulating();
+    void DonePopulating(QStringList watch_list);
 
     void PopupContextMenu(const QPoint& menu_location);
-    void UpdateWatcherList(const std::string& path, unsigned int recursion);
     void RefreshGameDirectory();
     bool containsAllWords(QString haystack, QString userinput);
 
@@ -98,5 +97,5 @@ private:
     QTreeView* tree_view = nullptr;
     QStandardItemModel* item_model = nullptr;
     GameListWorker* current_worker = nullptr;
-    QFileSystemWatcher watcher;
+    QFileSystemWatcher* watcher = nullptr;
 };

--- a/src/citra_qt/game_list_p.h
+++ b/src/citra_qt/game_list_p.h
@@ -170,9 +170,15 @@ signals:
      * @param entry_items a list with `QStandardItem`s that make up the columns of the new entry.
      */
     void EntryReady(QList<QStandardItem*> entry_items);
-    void Finished();
+
+    /**
+     * After the worker has traversed the game directory looking for entries, this signal is emmited
+     * with a list of folders that should be watched for changes as well.
+     */
+    void Finished(QStringList watch_list);
 
 private:
+    QStringList watch_list;
     QString dir_path;
     bool deep_scan;
     std::atomic_bool stop_processing;


### PR DESCRIPTION
Instead of tying the QFileSystemWatcher to the GameList and updating in the UI thread, this change moves it to the worker thread. Since it gets deleted and recreated as part of the worker thread, this prevents it from
ever getting used from multiple threads (which is why it was originally done on the UI thread)

macOS users have had issues recently where for some reason their default game list is to some directory where its too large and appears to permanently lock up the main thread.

### Context

The original reason that the `QFileSystemWatcher` was placed on the main thread was because of an odd behavior with sharing a watcher to a different thread. When the watcher was shared to a new thread, and the thread would end, the watcher would emit the `directoryChanged` signal for each of the directories thats its watching. This showed up in the original pull request as a game list refresh on a 30 second interval because that is the default `QThreadPool` timeout after which it would terminate the worker thread. Properly terminating the worker thread after completion caused an endless cycle of `thread creation -> watch dirs -> thread termination -> directoryChanged emitted -> populateAsync called -> thread creation -> ...` 

I have no idea what exactly causes the file watcher to emit the signal for all the directories it was watching on thread exit, but this pull request works around this issue by never moving the watcher to a worker thread in the first place. Instead it always remains a child of the `GameList` and the worker thread will emit a list directories to watch when the worker thread is done.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2669)
<!-- Reviewable:end -->
