### PR TITLE
Add BINDIR and MANDIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,8 @@ ELSEIF (WIN32)
     ENDIF (MINGW)
 ELSEIF (CMAKE_SYSTEM_NAME MATCHES "^(Linux|kFreeBSD|GNU|SunOS)$")
     set(PLATFORM_LIBRARIES rt)
+    set(BINDIR ${CMAKE_INSTALL_PREFIX}/bin CACHE PATH "BINDIR")
+    set(MANDIR ${CMAKE_INSTALL_PREFIX}/share/man CACHE PATH "MANDIR")
 ENDIF (APPLE)
 
 # MINGW: GCC does not support codecvt, so use iconv instead
@@ -291,11 +293,11 @@ endif()
 if(UNIX)
     if(ENABLE_SDL2)
         install(FILES "${CMAKE_SOURCE_DIR}/dist/citra.6"
-                DESTINATION "${CMAKE_INSTALL_PREFIX}/share/man/man6")
+                DESTINATION "${MANDIR}/man6")
     endif()
 
     if (ENABLE_QT)
         install(FILES "${CMAKE_SOURCE_DIR}/dist/citra-qt.6"
-                DESTINATION "${CMAKE_INSTALL_PREFIX}/share/man/man6")
+                DESTINATION "${MANDIR}/man6")
     endif()
 endif()

--- a/src/citra/CMakeLists.txt
+++ b/src/citra/CMakeLists.txt
@@ -26,7 +26,7 @@ endif()
 target_link_libraries(citra ${PLATFORM_LIBRARIES} Threads::Threads)
 
 if(UNIX AND NOT APPLE)
-    install(TARGETS citra RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
+    install(TARGETS citra RUNTIME DESTINATION "${BINDIR}")
 endif()
 
 if (MSVC)

--- a/src/citra_qt/CMakeLists.txt
+++ b/src/citra_qt/CMakeLists.txt
@@ -102,7 +102,7 @@ target_link_libraries(citra-qt ${OPENGL_gl_LIBRARY} ${CITRA_QT_LIBS})
 target_link_libraries(citra-qt ${PLATFORM_LIBRARIES} Threads::Threads)
 
 if(UNIX AND NOT APPLE)
-    install(TARGETS citra-qt RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
+    install(TARGETS citra-qt RUNTIME DESTINATION "${BINDIR}")
 endif()
 
 if (MSVC)


### PR DESCRIPTION
This add `BINDIR` and `MANDIR` to the `CMakeLists.txt`. This can be useful on some distros, for example in Slackware man pages are installed in `/usr/man` instead of `/usr/share/man`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2677)
<!-- Reviewable:end -->
