### PR TITLE
Dyncom/VFP: Properly pack QNaN values.

### DIFF
--- a/src/core/arm/skyeye_common/vfp/vfpdouble.cpp
+++ b/src/core/arm/skyeye_common/vfp/vfpdouble.cpp
@@ -90,10 +90,12 @@ u32 vfp_double_normaliseround(ARMul_State* state, int dd, struct vfp_double* vd,
 
     vfp_double_dump("pack: in", vd);
 
+    int td = vfp_double_type(vd);
+
     /*
      * Infinities and NaNs are a special case.
      */
-    if (vd->exponent == 2047 && (vd->significand == 0 || exceptions))
+    if (td & (VFP_NAN | VFP_INFINITY))
         goto pack;
 
     /*

--- a/src/core/arm/skyeye_common/vfp/vfpsingle.cpp
+++ b/src/core/arm/skyeye_common/vfp/vfpsingle.cpp
@@ -90,10 +90,12 @@ u32 vfp_single_normaliseround(ARMul_State* state, int sd, struct vfp_single* vs,
 
     vfp_single_dump("pack: in", vs);
 
+    int ts = vfp_single_type(vs);
+
     /*
      * Infinities and NaNs are a special case.
      */
-    if (vs->exponent == 255 && (vs->significand == 0 || exceptions))
+    if (ts & (VFP_NAN | VFP_INFINITY))
         goto pack;
 
     /*


### PR DESCRIPTION
vfp_*_normaliseround was previously converting qnans into numbers, ie, 7fc00000 (qnan) into 7f000000 (1.7014118e+38).

Closes #2680

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2690)
<!-- Reviewable:end -->
