### PR TITLE
Dyncom/VFP: Do not raise sentinel values as FPSCR exceptions.

### DIFF
--- a/src/core/arm/skyeye_common/vfp/vfpdouble.cpp
+++ b/src/core/arm/skyeye_common/vfp/vfpdouble.cpp
@@ -253,7 +253,7 @@ static u32 vfp_propagate_nan(struct vfp_double* vdd, struct vfp_double* vdn, str
     /*
      * If one was a signalling NAN, raise invalid operation.
      */
-    return tn == VFP_SNAN || tm == VFP_SNAN ? FPSCR_IOC : VFP_NAN_FLAG;
+    return tn == VFP_SNAN || tm == VFP_SNAN ? FPSCR_IOC : 0;
 }
 
 /*

--- a/src/core/arm/skyeye_common/vfp/vfpsingle.cpp
+++ b/src/core/arm/skyeye_common/vfp/vfpsingle.cpp
@@ -257,7 +257,7 @@ static u32 vfp_propagate_nan(struct vfp_single* vsd, struct vfp_single* vsn, str
     /*
      * If one was a signalling NAN, raise invalid operation.
      */
-    return tn == VFP_SNAN || tm == VFP_SNAN ? FPSCR_IOC : VFP_NAN_FLAG;
+    return tn == VFP_SNAN || tm == VFP_SNAN ? FPSCR_IOC : 0;
 }
 
 /*


### PR DESCRIPTION
NaNs are handled inside vfp_*_normaliseround.
This was causing a trap enable bit in the FPSCR to be set when a QNaN was encountered.

Closes #2681

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2691)
<!-- Reviewable:end -->
