### PR TITLE
Dyncom/VFP: Convert denormal outputs into 0 when the FTZ flag is enabled.

### DIFF
--- a/src/core/arm/skyeye_common/vfp/vfpdouble.cpp
+++ b/src/core/arm/skyeye_common/vfp/vfpdouble.cpp
@@ -140,11 +140,9 @@ u32 vfp_double_normaliseround(ARMul_State* state, int dd, struct vfp_double* vd,
 
         if ((type & VFP_DENORMAL) && (fpscr & FPSCR_FLUSH_TO_ZERO)) {
             // Flush denormal to positive 0
-            exponent = 0;
             significand = 0;
 
             vd->sign = 0;
-            vd->exponent = exponent;
             vd->significand = significand;
 
             underflow = 0;

--- a/src/core/arm/skyeye_common/vfp/vfpdouble.cpp
+++ b/src/core/arm/skyeye_common/vfp/vfpdouble.cpp
@@ -135,6 +135,21 @@ u32 vfp_double_normaliseround(ARMul_State* state, int dd, struct vfp_double* vd,
 #endif
         if (!(significand & ((1ULL << (VFP_DOUBLE_LOW_BITS + 1)) - 1)))
             underflow = 0;
+
+        int type = vfp_double_type(vd);
+
+        if ((type & VFP_DENORMAL) && (fpscr & FPSCR_FLUSH_TO_ZERO)) {
+            // Flush denormal to positive 0
+            exponent = 0;
+            significand = 0;
+
+            vd->sign = 0;
+            vd->exponent = exponent;
+            vd->significand = significand;
+
+            underflow = 0;
+            exceptions |= FPSCR_UFC;
+        }
     }
 
     /*

--- a/src/core/arm/skyeye_common/vfp/vfpsingle.cpp
+++ b/src/core/arm/skyeye_common/vfp/vfpsingle.cpp
@@ -138,6 +138,21 @@ u32 vfp_single_normaliseround(ARMul_State* state, int sd, struct vfp_single* vs,
 #endif
         if (!(significand & ((1 << (VFP_SINGLE_LOW_BITS + 1)) - 1)))
             underflow = 0;
+
+        int type = vfp_single_type(vs);
+
+        if ((type & VFP_DENORMAL) && (fpscr & FPSCR_FLUSH_TO_ZERO)) {
+            // Flush denormal to positive 0
+            exponent = 0;
+            significand = 0;
+
+            vs->sign = 0;
+            vs->exponent = exponent;
+            vs->significand = significand;
+
+            underflow = 0;
+            exceptions |= FPSCR_UFC;
+        }
     }
 
     /*

--- a/src/core/arm/skyeye_common/vfp/vfpsingle.cpp
+++ b/src/core/arm/skyeye_common/vfp/vfpsingle.cpp
@@ -143,11 +143,9 @@ u32 vfp_single_normaliseround(ARMul_State* state, int sd, struct vfp_single* vs,
 
         if ((type & VFP_DENORMAL) && (fpscr & FPSCR_FLUSH_TO_ZERO)) {
             // Flush denormal to positive 0
-            exponent = 0;
             significand = 0;
 
             vs->sign = 0;
-            vs->exponent = exponent;
             vs->significand = significand;
 
             underflow = 0;


### PR DESCRIPTION
closes #1990

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2692)
<!-- Reviewable:end -->
