### PR TITLE
Prepare Pica registers for Geometry Shaders

### DIFF
--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -422,6 +422,58 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
         break;
     }
 
+    case PICA_REG_INDEX(gs.bool_uniforms):
+        WriteUniformBoolReg(g_state.gs, value);
+        break;
+
+    case PICA_REG_INDEX_WORKAROUND(gs.int_uniforms[0], 0x281):
+    case PICA_REG_INDEX_WORKAROUND(gs.int_uniforms[1], 0x282):
+    case PICA_REG_INDEX_WORKAROUND(gs.int_uniforms[2], 0x283):
+    case PICA_REG_INDEX_WORKAROUND(gs.int_uniforms[3], 0x284): {
+        unsigned index = (id - PICA_REG_INDEX_WORKAROUND(gs.int_uniforms[0], 0x281));
+        auto values = regs.gs.int_uniforms[index];
+        WriteUniformIntReg(g_state.gs, index,
+                           Math::Vec4<u8>(values.x, values.y, values.z, values.w));
+        break;
+    }
+
+    case PICA_REG_INDEX_WORKAROUND(gs.uniform_setup.set_value[0], 0x291):
+    case PICA_REG_INDEX_WORKAROUND(gs.uniform_setup.set_value[1], 0x292):
+    case PICA_REG_INDEX_WORKAROUND(gs.uniform_setup.set_value[2], 0x293):
+    case PICA_REG_INDEX_WORKAROUND(gs.uniform_setup.set_value[3], 0x294):
+    case PICA_REG_INDEX_WORKAROUND(gs.uniform_setup.set_value[4], 0x295):
+    case PICA_REG_INDEX_WORKAROUND(gs.uniform_setup.set_value[5], 0x296):
+    case PICA_REG_INDEX_WORKAROUND(gs.uniform_setup.set_value[6], 0x297):
+    case PICA_REG_INDEX_WORKAROUND(gs.uniform_setup.set_value[7], 0x298): {
+        WriteUniformFloatReg(g_state.regs.gs, g_state.gs, gs_float_regs_counter,
+                             gs_uniform_write_buffer, value);
+        break;
+    }
+
+    case PICA_REG_INDEX_WORKAROUND(gs.program.set_word[0], 0x29c):
+    case PICA_REG_INDEX_WORKAROUND(gs.program.set_word[1], 0x29d):
+    case PICA_REG_INDEX_WORKAROUND(gs.program.set_word[2], 0x29e):
+    case PICA_REG_INDEX_WORKAROUND(gs.program.set_word[3], 0x29f):
+    case PICA_REG_INDEX_WORKAROUND(gs.program.set_word[4], 0x2a0):
+    case PICA_REG_INDEX_WORKAROUND(gs.program.set_word[5], 0x2a1):
+    case PICA_REG_INDEX_WORKAROUND(gs.program.set_word[6], 0x2a2):
+    case PICA_REG_INDEX_WORKAROUND(gs.program.set_word[7], 0x2a3): {
+        WriteProgramCode(g_state.regs.gs, g_state.gs, 4096, value);
+        break;
+    }
+
+    case PICA_REG_INDEX_WORKAROUND(gs.swizzle_patterns.set_word[0], 0x2a6):
+    case PICA_REG_INDEX_WORKAROUND(gs.swizzle_patterns.set_word[1], 0x2a7):
+    case PICA_REG_INDEX_WORKAROUND(gs.swizzle_patterns.set_word[2], 0x2a8):
+    case PICA_REG_INDEX_WORKAROUND(gs.swizzle_patterns.set_word[3], 0x2a9):
+    case PICA_REG_INDEX_WORKAROUND(gs.swizzle_patterns.set_word[4], 0x2aa):
+    case PICA_REG_INDEX_WORKAROUND(gs.swizzle_patterns.set_word[5], 0x2ab):
+    case PICA_REG_INDEX_WORKAROUND(gs.swizzle_patterns.set_word[6], 0x2ac):
+    case PICA_REG_INDEX_WORKAROUND(gs.swizzle_patterns.set_word[7], 0x2ad): {
+        WriteSwizzlePatterns(g_state.regs.gs, g_state.gs, value);
+        break;
+    }
+
     case PICA_REG_INDEX(vs.bool_uniforms):
         WriteUniformBoolReg(g_state.vs, value);
         break;

--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -32,12 +32,13 @@ namespace Pica {
 
 namespace CommandProcessor {
 
-static int float_regs_counter = 0;
+static int vs_float_regs_counter = 0;
+static u32 vs_uniform_write_buffer[4];
 
-static u32 uniform_write_buffer[4];
+static int gs_float_regs_counter = 0;
+static u32 gs_uniform_write_buffer[4];
 
 static int default_attr_counter = 0;
-
 static u32 default_attr_write_buffer[3];
 
 // Expand a 4-bit mask to 4-byte mask, e.g. 0b0101 -> 0x00FF00FF
@@ -47,6 +48,97 @@ static const u32 expand_bits_to_bytes[] = {
 };
 
 MICROPROFILE_DEFINE(GPU_Drawing, "GPU", "Drawing", MP_RGB(50, 50, 240));
+
+static const char* GetShaderSetupTypeName(Shader::ShaderSetup& setup) {
+    if (&setup == &g_state.vs) {
+        return "vertex shader";
+    }
+    if (&setup == &g_state.gs) {
+        return "geometry shader";
+    }
+    return "unknown shader";
+}
+
+static void WriteUniformBoolReg(Shader::ShaderSetup& setup, u32 value) {
+    for (unsigned i = 0; i < setup.uniforms.b.size(); ++i)
+        setup.uniforms.b[i] = (value & (1 << i)) != 0;
+}
+
+static void WriteUniformIntReg(Shader::ShaderSetup& setup, unsigned index,
+                               const Math::Vec4<u8>& values) {
+    ASSERT(index < setup.uniforms.i.size());
+    setup.uniforms.i[index] = values;
+    LOG_TRACE(HW_GPU, "Set %s integer uniform %d to %02x %02x %02x %02x",
+              GetShaderSetupTypeName(setup), index, values.x, values.y, values.z, values.w);
+}
+
+static void WriteUniformFloatReg(ShaderRegs& config, Shader::ShaderSetup& setup,
+                                 int& float_regs_counter, u32 uniform_write_buffer[4], u32 value) {
+    auto& uniform_setup = config.uniform_setup;
+
+    // TODO: Does actual hardware indeed keep an intermediate buffer or does
+    //       it directly write the values?
+    uniform_write_buffer[float_regs_counter++] = value;
+
+    // Uniforms are written in a packed format such that four float24 values are encoded in
+    // three 32-bit numbers. We write to internal memory once a full such vector is
+    // written.
+    if ((float_regs_counter >= 4 && uniform_setup.IsFloat32()) ||
+        (float_regs_counter >= 3 && !uniform_setup.IsFloat32())) {
+        float_regs_counter = 0;
+
+        auto& uniform = setup.uniforms.f[uniform_setup.index];
+
+        if (uniform_setup.index >= 96) {
+            LOG_ERROR(HW_GPU, "Invalid %s float uniform index %d", GetShaderSetupTypeName(setup),
+                      (int)uniform_setup.index);
+        } else {
+
+            // NOTE: The destination component order indeed is "backwards"
+            if (uniform_setup.IsFloat32()) {
+                for (auto i : {0, 1, 2, 3})
+                    uniform[3 - i] = float24::FromFloat32(*(float*)(&uniform_write_buffer[i]));
+            } else {
+                // TODO: Untested
+                uniform.w = float24::FromRaw(uniform_write_buffer[0] >> 8);
+                uniform.z = float24::FromRaw(((uniform_write_buffer[0] & 0xFF) << 16) |
+                                             ((uniform_write_buffer[1] >> 16) & 0xFFFF));
+                uniform.y = float24::FromRaw(((uniform_write_buffer[1] & 0xFFFF) << 8) |
+                                             ((uniform_write_buffer[2] >> 24) & 0xFF));
+                uniform.x = float24::FromRaw(uniform_write_buffer[2] & 0xFFFFFF);
+            }
+
+            LOG_TRACE(HW_GPU, "Set %s float uniform %x to (%f %f %f %f)",
+                      GetShaderSetupTypeName(setup), (int)uniform_setup.index,
+                      uniform.x.ToFloat32(), uniform.y.ToFloat32(), uniform.z.ToFloat32(),
+                      uniform.w.ToFloat32());
+
+            // TODO: Verify that this actually modifies the register!
+            uniform_setup.index.Assign(uniform_setup.index + 1);
+        }
+    }
+}
+
+static void WriteProgramCode(ShaderRegs& config, Shader::ShaderSetup& setup,
+                             unsigned max_program_code_length, u32 value) {
+    if (config.program.offset >= max_program_code_length) {
+        LOG_ERROR(HW_GPU, "Invalid %s program offset %d", GetShaderSetupTypeName(setup),
+                  (int)config.program.offset);
+    } else {
+        setup.program_code[config.program.offset] = value;
+        config.program.offset++;
+    }
+}
+
+static void WriteSwizzlePatterns(ShaderRegs& config, Shader::ShaderSetup& setup, u32 value) {
+    if (config.swizzle_patterns.offset >= setup.swizzle_data.size()) {
+        LOG_ERROR(HW_GPU, "Invalid %s swizzle pattern offset %d", GetShaderSetupTypeName(setup),
+                  (int)config.swizzle_patterns.offset);
+    } else {
+        setup.swizzle_data[config.swizzle_patterns.offset] = value;
+        config.swizzle_patterns.offset++;
+    }
+}
 
 static void WritePicaReg(u32 id, u32 value, u32 mask) {
     auto& regs = g_state.regs;
@@ -331,20 +423,17 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
     }
 
     case PICA_REG_INDEX(vs.bool_uniforms):
-        for (unsigned i = 0; i < 16; ++i)
-            g_state.vs.uniforms.b[i] = (regs.vs.bool_uniforms.Value() & (1 << i)) != 0;
-
+        WriteUniformBoolReg(g_state.vs, value);
         break;
 
     case PICA_REG_INDEX_WORKAROUND(vs.int_uniforms[0], 0x2b1):
     case PICA_REG_INDEX_WORKAROUND(vs.int_uniforms[1], 0x2b2):
     case PICA_REG_INDEX_WORKAROUND(vs.int_uniforms[2], 0x2b3):
     case PICA_REG_INDEX_WORKAROUND(vs.int_uniforms[3], 0x2b4): {
-        int index = (id - PICA_REG_INDEX_WORKAROUND(vs.int_uniforms[0], 0x2b1));
+        unsigned index = (id - PICA_REG_INDEX_WORKAROUND(vs.int_uniforms[0], 0x2b1));
         auto values = regs.vs.int_uniforms[index];
-        g_state.vs.uniforms.i[index] = Math::Vec4<u8>(values.x, values.y, values.z, values.w);
-        LOG_TRACE(HW_GPU, "Set integer uniform %d to %02x %02x %02x %02x", index, values.x.Value(),
-                  values.y.Value(), values.z.Value(), values.w.Value());
+        WriteUniformIntReg(g_state.vs, index,
+                           Math::Vec4<u8>(values.x, values.y, values.z, values.w));
         break;
     }
 
@@ -356,51 +445,11 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
     case PICA_REG_INDEX_WORKAROUND(vs.uniform_setup.set_value[5], 0x2c6):
     case PICA_REG_INDEX_WORKAROUND(vs.uniform_setup.set_value[6], 0x2c7):
     case PICA_REG_INDEX_WORKAROUND(vs.uniform_setup.set_value[7], 0x2c8): {
-        auto& uniform_setup = regs.vs.uniform_setup;
-
-        // TODO: Does actual hardware indeed keep an intermediate buffer or does
-        //       it directly write the values?
-        uniform_write_buffer[float_regs_counter++] = value;
-
-        // Uniforms are written in a packed format such that four float24 values are encoded in
-        // three 32-bit numbers. We write to internal memory once a full such vector is
-        // written.
-        if ((float_regs_counter >= 4 && uniform_setup.IsFloat32()) ||
-            (float_regs_counter >= 3 && !uniform_setup.IsFloat32())) {
-            float_regs_counter = 0;
-
-            auto& uniform = g_state.vs.uniforms.f[uniform_setup.index];
-
-            if (uniform_setup.index > 95) {
-                LOG_ERROR(HW_GPU, "Invalid VS uniform index %d", (int)uniform_setup.index);
-                break;
-            }
-
-            // NOTE: The destination component order indeed is "backwards"
-            if (uniform_setup.IsFloat32()) {
-                for (auto i : {0, 1, 2, 3})
-                    uniform[3 - i] = float24::FromFloat32(*(float*)(&uniform_write_buffer[i]));
-            } else {
-                // TODO: Untested
-                uniform.w = float24::FromRaw(uniform_write_buffer[0] >> 8);
-                uniform.z = float24::FromRaw(((uniform_write_buffer[0] & 0xFF) << 16) |
-                                             ((uniform_write_buffer[1] >> 16) & 0xFFFF));
-                uniform.y = float24::FromRaw(((uniform_write_buffer[1] & 0xFFFF) << 8) |
-                                             ((uniform_write_buffer[2] >> 24) & 0xFF));
-                uniform.x = float24::FromRaw(uniform_write_buffer[2] & 0xFFFFFF);
-            }
-
-            LOG_TRACE(HW_GPU, "Set uniform %x to (%f %f %f %f)", (int)uniform_setup.index,
-                      uniform.x.ToFloat32(), uniform.y.ToFloat32(), uniform.z.ToFloat32(),
-                      uniform.w.ToFloat32());
-
-            // TODO: Verify that this actually modifies the register!
-            uniform_setup.index.Assign(uniform_setup.index + 1);
-        }
+        WriteUniformFloatReg(g_state.regs.vs, g_state.vs, vs_float_regs_counter,
+                             vs_uniform_write_buffer, value);
         break;
     }
 
-    // Load shader program code
     case PICA_REG_INDEX_WORKAROUND(vs.program.set_word[0], 0x2cc):
     case PICA_REG_INDEX_WORKAROUND(vs.program.set_word[1], 0x2cd):
     case PICA_REG_INDEX_WORKAROUND(vs.program.set_word[2], 0x2ce):
@@ -409,12 +458,10 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
     case PICA_REG_INDEX_WORKAROUND(vs.program.set_word[5], 0x2d1):
     case PICA_REG_INDEX_WORKAROUND(vs.program.set_word[6], 0x2d2):
     case PICA_REG_INDEX_WORKAROUND(vs.program.set_word[7], 0x2d3): {
-        g_state.vs.program_code[regs.vs.program.offset] = value;
-        regs.vs.program.offset++;
+        WriteProgramCode(g_state.regs.vs, g_state.vs, 512, value);
         break;
     }
 
-    // Load swizzle pattern data
     case PICA_REG_INDEX_WORKAROUND(vs.swizzle_patterns.set_word[0], 0x2d6):
     case PICA_REG_INDEX_WORKAROUND(vs.swizzle_patterns.set_word[1], 0x2d7):
     case PICA_REG_INDEX_WORKAROUND(vs.swizzle_patterns.set_word[2], 0x2d8):
@@ -423,8 +470,7 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
     case PICA_REG_INDEX_WORKAROUND(vs.swizzle_patterns.set_word[5], 0x2db):
     case PICA_REG_INDEX_WORKAROUND(vs.swizzle_patterns.set_word[6], 0x2dc):
     case PICA_REG_INDEX_WORKAROUND(vs.swizzle_patterns.set_word[7], 0x2dd): {
-        g_state.vs.swizzle_data[regs.vs.swizzle_patterns.offset] = value;
-        regs.vs.swizzle_patterns.offset++;
+        WriteSwizzlePatterns(g_state.regs.vs, g_state.vs, value);
         break;
     }
 

--- a/src/video_core/shader/shader.h
+++ b/src/video_core/shader/shader.h
@@ -24,6 +24,9 @@ namespace Pica {
 
 namespace Shader {
 
+constexpr unsigned MAX_PROGRAM_CODE_LENGTH = 4096;
+constexpr unsigned MAX_SWIZZLE_DATA_LENGTH = 4096;
+
 struct AttributeBuffer {
     alignas(16) Math::Vec4<float24> attr[16];
 };
@@ -144,8 +147,8 @@ struct ShaderSetup {
         return offsetof(ShaderSetup, uniforms.i) + index * sizeof(Math::Vec4<u8>);
     }
 
-    std::array<u32, 1024> program_code;
-    std::array<u32, 1024> swizzle_data;
+    std::array<u32, MAX_PROGRAM_CODE_LENGTH> program_code;
+    std::array<u32, MAX_SWIZZLE_DATA_LENGTH> swizzle_data;
 
     /// Data private to ShaderEngines
     struct EngineData {

--- a/src/video_core/shader/shader_interpreter.cpp
+++ b/src/video_core/shader/shader_interpreter.cpp
@@ -653,7 +653,7 @@ static void RunInterpreter(const ShaderSetup& setup, UnitState& state, DebugData
 }
 
 void InterpreterEngine::SetupBatch(ShaderSetup& setup, unsigned int entry_point) {
-    ASSERT(entry_point < 1024);
+    ASSERT(entry_point < MAX_PROGRAM_CODE_LENGTH);
     setup.engine_data.entry_point = entry_point;
 }
 

--- a/src/video_core/shader/shader_jit_x64.cpp
+++ b/src/video_core/shader/shader_jit_x64.cpp
@@ -15,7 +15,7 @@ JitX64Engine::JitX64Engine() = default;
 JitX64Engine::~JitX64Engine() = default;
 
 void JitX64Engine::SetupBatch(ShaderSetup& setup, unsigned int entry_point) {
-    ASSERT(entry_point < 1024);
+    ASSERT(entry_point < MAX_PROGRAM_CODE_LENGTH);
     setup.engine_data.entry_point = entry_point;
 
     u64 code_hash = Common::ComputeHash64(&setup.program_code, sizeof(setup.program_code));

--- a/src/video_core/shader/shader_jit_x64_compiler.cpp
+++ b/src/video_core/shader/shader_jit_x64_compiler.cpp
@@ -834,8 +834,8 @@ void JitShader::FindReturnOffsets() {
     std::sort(return_offsets.begin(), return_offsets.end());
 }
 
-void JitShader::Compile(const std::array<u32, 1024>* program_code_,
-                        const std::array<u32, 1024>* swizzle_data_) {
+void JitShader::Compile(const std::array<u32, MAX_PROGRAM_CODE_LENGTH>* program_code_,
+                        const std::array<u32, MAX_SWIZZLE_DATA_LENGTH>* swizzle_data_) {
     program_code = program_code_;
     swizzle_data = swizzle_data_;
 

--- a/src/video_core/shader/shader_jit_x64_compiler.h
+++ b/src/video_core/shader/shader_jit_x64_compiler.h
@@ -22,8 +22,8 @@ namespace Pica {
 
 namespace Shader {
 
-/// Memory allocated for each compiled shader (64Kb)
-constexpr size_t MAX_SHADER_SIZE = 1024 * 64;
+/// Memory allocated for each compiled shader
+constexpr size_t MAX_SHADER_SIZE = MAX_PROGRAM_CODE_LENGTH * 64;
 
 /**
  * This class implements the shader JIT compiler. It recompiles a Pica shader program into x86_64
@@ -37,8 +37,8 @@ public:
         program(&setup, &state, instruction_labels[offset].getAddress());
     }
 
-    void Compile(const std::array<u32, 1024>* program_code,
-                 const std::array<u32, 1024>* swizzle_data);
+    void Compile(const std::array<u32, MAX_PROGRAM_CODE_LENGTH>* program_code,
+                 const std::array<u32, MAX_SWIZZLE_DATA_LENGTH>* swizzle_data);
 
     void Compile_ADD(Instruction instr);
     void Compile_DP3(Instruction instr);
@@ -104,11 +104,11 @@ private:
      */
     void FindReturnOffsets();
 
-    const std::array<u32, 1024>* program_code = nullptr;
-    const std::array<u32, 1024>* swizzle_data = nullptr;
+    const std::array<u32, MAX_PROGRAM_CODE_LENGTH>* program_code = nullptr;
+    const std::array<u32, MAX_SWIZZLE_DATA_LENGTH>* swizzle_data = nullptr;
 
     /// Mapping of Pica VS instructions to pointers in the emitted code
-    std::array<Xbyak::Label, 1024> instruction_labels;
+    std::array<Xbyak::Label, MAX_PROGRAM_CODE_LENGTH> instruction_labels;
 
     /// Offsets in code where a return needs to be inserted
     std::vector<unsigned> return_offsets;


### PR DESCRIPTION
This code is part of the geometry shader (GS) implementation written by me which is based on work by @ds84182 .

This PR shouldn't change any behaviour currently (except maybe for cases where GS is active, but those are bugged anyway). It merely prepares the registers for GS.
I'd recommend inclusion in bleeding-edge to figure out if there are any issues.
However, this went through a larger refactor shortly before creating this PR, so review / testing should be done first.

Review per commit; see commit description too.

---

### Notes:

* The limit for VS (Vertex Shaders) appears to be 512 program words (compared to 4096 for GS). We should probably introduce a template parameter or something to handle these differences between VS / GS structure. However, that's beyond the scope of this PR. I can create an issue for this.

* [`vsh_com_mode`](https://3dbrew.org/wiki/GPU/Internal_Registers#GPUREG_VSH_COM_MODE) will later (next PR) be indicating if GS will use the same shader data (uniform / program / swizzle data) as VS.
It is not yet known if this influences writes (the functions introduced in this commit) OR reads (in the interpreter and jit).
We also don't know wether the shader data is per shader mode (VS / GS) or per shader-unit (4 units, only one of which is able to run GS).
However, this should be easy to change in the future if the current implementation is wrong (handling it on read = not doing extra work in functions introduced by this PR).
*We need a couple of hardware tests to understand how exactly the shader data is uploaded. However, I vote for accepting this for now, and refactoring later (once hardware tests have been done).*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2695)
<!-- Reviewable:end -->
