### PR TITLE
pica: correct bit field length for some registers

### DIFF
--- a/src/video_core/regs_framebuffer.h
+++ b/src/video_core/regs_framebuffer.h
@@ -211,13 +211,14 @@ struct FramebufferRegs {
             BitField<0, 2, u32> allow_depth_stencil_write; // 0 = disable, else enable
         };
 
-        DepthFormat depth_format; // TODO: Should be a BitField!
+        BitField<0, 2, DepthFormat> depth_format;
+
         BitField<16, 3, ColorFormat> color_format;
 
         INSERT_PADDING_WORDS(0x4);
 
-        u32 depth_buffer_address;
-        u32 color_buffer_address;
+        BitField<0, 28, u32> depth_buffer_address;
+        BitField<0, 28, u32> color_buffer_address;
 
         union {
             // Apparently, the framebuffer width is stored as expected,

--- a/src/video_core/regs_pipeline.h
+++ b/src/video_core/regs_pipeline.h
@@ -22,10 +22,10 @@ struct PipelineRegs {
     };
 
     struct {
-        BitField<0, 29, u32> base_address;
+        BitField<1, 28, u32> base_address;
 
         PAddr GetPhysicalBaseAddress() const {
-            return base_address * 8;
+            return base_address * 16;
         }
 
         // Descriptor for internal vertex attributes
@@ -99,7 +99,7 @@ struct PipelineRegs {
         // This e.g. allows to load different attributes from different memory locations
         struct {
             // Source attribute data offset from the base address
-            u32 data_offset;
+            BitField<0, 28, u32> data_offset;
 
             union {
                 BitField<0, 4, u32> comp0;
@@ -180,6 +180,8 @@ struct PipelineRegs {
         //     kicked off.
         //  2) Games can configure these registers to provide a command list subroutine mechanism.
 
+        // TODO: verify the bit length of these two fields
+        // According to 3dbrew, the bit length of them are 21 and 29, respectively
         BitField<0, 20, u32> size[2]; ///< Size (in bytes / 8) of each channel's command buffer
         BitField<0, 28, u32> addr[2]; ///< Physical address / 8 of each channel's command buffer
         u32 trigger[2]; ///< Triggers execution of the channel's command buffer when written to

--- a/src/video_core/regs_rasterizer.h
+++ b/src/video_core/regs_rasterizer.h
@@ -92,13 +92,13 @@ struct RasterizerRegs {
         BitField<0, 2, ScissorMode> mode;
 
         union {
-            BitField<0, 16, u32> x1;
-            BitField<16, 16, u32> y1;
+            BitField<0, 10, u32> x1;
+            BitField<16, 10, u32> y1;
         };
 
         union {
-            BitField<0, 16, u32> x2;
-            BitField<16, 16, u32> y2;
+            BitField<0, 10, u32> x2;
+            BitField<16, 10, u32> y2;
         };
     } scissor_test;
 

--- a/src/video_core/regs_texturing.h
+++ b/src/video_core/regs_texturing.h
@@ -29,6 +29,11 @@ struct TexturingRegs {
             ClampToBorder = 1,
             Repeat = 2,
             MirroredRepeat = 3,
+            // Mode 4-7 produces some weird result and may be just invalid:
+            // 4: Positive coord: clamp to edge; negative coord: repeat
+            // 5: Positive coord: clamp to border; negative coord: repeat
+            // 6: Repeat
+            // 7: Repeat
         };
 
         enum TextureFilter : u32 {
@@ -45,22 +50,22 @@ struct TexturingRegs {
         } border_color;
 
         union {
-            BitField<0, 16, u32> height;
-            BitField<16, 16, u32> width;
+            BitField<0, 11, u32> height;
+            BitField<16, 11, u32> width;
         };
 
         union {
             BitField<1, 1, TextureFilter> mag_filter;
             BitField<2, 1, TextureFilter> min_filter;
-            BitField<8, 2, WrapMode> wrap_t;
-            BitField<12, 2, WrapMode> wrap_s;
-            BitField<28, 2, TextureType>
-                type; ///< @note Only valid for texture 0 according to 3DBrew.
+            BitField<8, 3, WrapMode> wrap_t;
+            BitField<12, 3, WrapMode> wrap_s;
+            /// @note Only valid for texture 0 according to 3DBrew.
+            BitField<28, 3, TextureType> type;
         };
 
         INSERT_PADDING_WORDS(0x1);
 
-        u32 address;
+        BitField<0, 28, u32> address;
 
         PAddr GetPhysicalAddress() const {
             return address * 8;


### PR DESCRIPTION
I compared the pica register definition in citra with [3dbrew documentation](https://www.3dbrew.org/wiki/GPU/Internal_Registers), and these are all registers that are differ in the bit field length. (except for shader related registers, because I don't want to conflict with ongoing GS change).

~~I haven't done any hardware test yet, and will try to do when I get time. I bring these here first to see if anyone who worked on these registers knows the correct length. Please comment in code if you can confirm if 3dbrew is correct or wrong.~~
All of them are hwtested except for the `pipeline.command_buffer` one. See comments below for test detail. For the `pipeline.command_buffer`, I am not able to do the test, so I dropped a comment there and left the actual code unchanged .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2703)
<!-- Reviewable:end -->
