### PR TITLE
Logging backend rewrite to use spdlog

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,6 +28,3 @@
 [submodule "spdlog"]
     path = externals/spdlog
     url = https://github.com/gabime/spdlog.git
-[submodule "fmt"]
-    path = externals/fmt
-    url = https://github.com/fmtlib/fmt

--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "fmt"]
     path = externals/fmt
     url = https://github.com/fmtlib/fmt.git
+[submodule "spdlog"]
+    path = externals/spdlog
+    url = https://github.com/gabime/spdlog.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -28,3 +28,6 @@
 [submodule "spdlog"]
     path = externals/spdlog
     url = https://github.com/gabime/spdlog.git
+[submodule "fmt"]
+    path = externals/fmt
+    url = https://github.com/fmtlib/fmt

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -51,4 +51,5 @@ endif()
 
 # Spdlog
 add_library(spdlog INTERFACE)
+target_compile_definitions(spdlog INTERFACE -DSPDLOG_FMT_EXTERNAL=1)
 target_include_directories(spdlog INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/spdlog/include)

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -48,3 +48,7 @@ if (ARCHITECTURE_x86_64)
     target_include_directories(xbyak INTERFACE ./xbyak/xbyak)
     target_compile_definitions(xbyak INTERFACE XBYAK_NO_OP_NAMES)
 endif()
+
+# Spdlog
+add_library(spdlog INTERFACE)
+target_include_directories(spdlog INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/spdlog/include)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,5 @@
 # Enable modules to include each other's files
 include_directories(.)
-# Include fmtlib so it can be used across the application for logging
-include_directories(../externals/fmt)
 
 add_subdirectory(common)
 add_subdirectory(core)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,7 @@
 # Enable modules to include each other's files
 include_directories(.)
+# Include fmtlib so it can be used across the application for logging
+include_directories(../externals/fmt)
 
 add_subdirectory(common)
 add_subdirectory(core)

--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -27,17 +27,17 @@ bool Config::LoadINI(const std::string& default_contents, bool retry) {
     const char* location = this->sdl2_config_loc.c_str();
     if (sdl2_config->ParseError() < 0) {
         if (retry) {
-            LOG_WARNING(Config, "Failed to load %s. Creating file from defaults...", location);
+            SLOG_WARNING(Config, "Failed to load {}. Creating file from defaults...", location);
             FileUtil::CreateFullPath(location);
             FileUtil::WriteStringToFile(true, default_contents, location);
             sdl2_config = std::make_unique<INIReader>(location); // Reopen file
 
             return LoadINI(default_contents, false);
         }
-        LOG_ERROR(Config, "Failed.");
+        SLOG_ERROR(Config, "Failed.");
         return false;
     }
-    LOG_INFO(Config, "Successfully loaded %s", location);
+    SLOG_INFO(Config, "Successfully loaded {}", location);
     return true;
 }
 

--- a/src/citra/emu_window/emu_window_sdl2.cpp
+++ b/src/citra/emu_window/emu_window_sdl2.cpp
@@ -65,7 +65,7 @@ EmuWindow_SDL2::EmuWindow_SDL2() {
 
     // Initialize the window
     if (SDL_Init(SDL_INIT_VIDEO) < 0) {
-        LOG_CRITICAL(Frontend, "Failed to initialize SDL2! Exiting...");
+        SLOG_CRITICAL(Frontend, "Failed to initialize SDL2! Exiting...");
         exit(1);
     }
 
@@ -88,19 +88,19 @@ EmuWindow_SDL2::EmuWindow_SDL2() {
                          SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
 
     if (render_window == nullptr) {
-        LOG_CRITICAL(Frontend, "Failed to create SDL2 window! Exiting...");
+        SLOG_CRITICAL(Frontend, "Failed to create SDL2 window! Exiting...");
         exit(1);
     }
 
     gl_context = SDL_GL_CreateContext(render_window);
 
     if (gl_context == nullptr) {
-        LOG_CRITICAL(Frontend, "Failed to create SDL2 GL context! Exiting...");
+        SLOG_CRITICAL(Frontend, "Failed to create SDL2 GL context! Exiting...");
         exit(1);
     }
 
     if (!gladLoadGLLoader(static_cast<GLADloadproc>(SDL_GL_GetProcAddress))) {
-        LOG_CRITICAL(Frontend, "Failed to initialize GL functions! Exiting...");
+        SLOG_CRITICAL(Frontend, "Failed to initialize GL functions! Exiting...");
         exit(1);
     }
 

--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -16,7 +16,7 @@
 #include "game_list_p.h"
 #include "ui_settings.h"
 
-REGISTER_LOGGER("Class Name");
+REGISTER_LOGGER("Game List");
 
 GameList::SearchField::KeyReleaseEater::KeyReleaseEater(GameList* gamelist) {
     this->gamelist = gamelist;
@@ -319,7 +319,7 @@ void GameList::PopupContextMenu(const QPoint& menu_location) {
 void GameList::PopulateAsync(const QString& dir_path, bool deep_scan) {
     if (!FileUtil::Exists(dir_path.toStdString()) ||
         !FileUtil::IsDirectory(dir_path.toStdString())) {
-        LOG_ERROR(Frontend, "Could not find game list folder at %s", dir_path.toLocal8Bit().data());
+        SPDLOG_ERROR("Could not find game list folder at {}", dir_path.toLocal8Bit().data());
         search_field->setFilterResult(0, 0);
         return;
     }
@@ -369,7 +369,7 @@ static bool HasSupportedFileExtension(const std::string& file_name) {
 
 void GameList::RefreshGameDirectory() {
     if (!UISettings::values.gamedir.isEmpty() && current_worker != nullptr) {
-        LOG_INFO(Frontend, "Change detected in the games directory. Reloading game list.");
+        SPDLOG_INFO("Change detected in the games directory. Reloading game list.");
         search_field->clear();
         PopulateAsync(UISettings::values.gamedir, UISettings::values.gamedir_deepscan);
     }

--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -16,8 +16,6 @@
 #include "game_list_p.h"
 #include "ui_settings.h"
 
-REGISTER_LOGGER("Game List");
-
 GameList::SearchField::KeyReleaseEater::KeyReleaseEater(GameList* gamelist) {
     this->gamelist = gamelist;
     edit_filter_text_old = "";
@@ -200,7 +198,6 @@ GameList::GameList(GMainWindow* parent) : QWidget{parent} {
     watcher = new QFileSystemWatcher(this);
     connect(watcher, &QFileSystemWatcher::directoryChanged, this, &GameList::RefreshGameDirectory);
 
-    SPDLOG_WARNING("Test! {1} {0}", "world!", "Hello");
     this->main_window = parent;
     layout = new QVBoxLayout;
     tree_view = new QTreeView;
@@ -319,7 +316,8 @@ void GameList::PopupContextMenu(const QPoint& menu_location) {
 void GameList::PopulateAsync(const QString& dir_path, bool deep_scan) {
     if (!FileUtil::Exists(dir_path.toStdString()) ||
         !FileUtil::IsDirectory(dir_path.toStdString())) {
-        SPDLOG_ERROR("Could not find game list folder at {}", dir_path.toLocal8Bit().data());
+        SPDLOG_ERROR(Frontend, "Could not find game list folder at {}",
+                     dir_path.toLocal8Bit().data());
         search_field->setFilterResult(0, 0);
         return;
     }
@@ -369,7 +367,7 @@ static bool HasSupportedFileExtension(const std::string& file_name) {
 
 void GameList::RefreshGameDirectory() {
     if (!UISettings::values.gamedir.isEmpty() && current_worker != nullptr) {
-        SPDLOG_INFO("Change detected in the games directory. Reloading game list.");
+        SPDLOG_INFO(Frontend, "Change detected in the games directory. Reloading game list.");
         search_field->clear();
         PopulateAsync(UISettings::values.gamedir, UISettings::values.gamedir_deepscan);
     }

--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -316,8 +316,8 @@ void GameList::PopupContextMenu(const QPoint& menu_location) {
 void GameList::PopulateAsync(const QString& dir_path, bool deep_scan) {
     if (!FileUtil::Exists(dir_path.toStdString()) ||
         !FileUtil::IsDirectory(dir_path.toStdString())) {
-        SPDLOG_ERROR(Frontend, "Could not find game list folder at {}",
-                     dir_path.toLocal8Bit().data());
+        SLOG_ERROR(Frontend, "Could not find game list folder at {}",
+                   dir_path.toLocal8Bit().data());
         search_field->setFilterResult(0, 0);
         return;
     }
@@ -367,7 +367,7 @@ static bool HasSupportedFileExtension(const std::string& file_name) {
 
 void GameList::RefreshGameDirectory() {
     if (!UISettings::values.gamedir.isEmpty() && current_worker != nullptr) {
-        SPDLOG_INFO(Frontend, "Change detected in the games directory. Reloading game list.");
+        SLOG_INFO(Frontend, "Change detected in the games directory. Reloading game list.");
         search_field->clear();
         PopulateAsync(UISettings::values.gamedir, UISettings::values.gamedir_deepscan);
     }

--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -16,6 +16,8 @@
 #include "game_list_p.h"
 #include "ui_settings.h"
 
+REGISTER_LOGGER("Class Name");
+
 GameList::SearchField::KeyReleaseEater::KeyReleaseEater(GameList* gamelist) {
     this->gamelist = gamelist;
     edit_filter_text_old = "";
@@ -198,6 +200,7 @@ GameList::GameList(GMainWindow* parent) : QWidget{parent} {
     watcher = new QFileSystemWatcher(this);
     connect(watcher, &QFileSystemWatcher::directoryChanged, this, &GameList::RefreshGameDirectory);
 
+    SPDLOG_WARNING("Test! {1} {0}", "world!", "Hello");
     this->main_window = parent;
     layout = new QVBoxLayout;
     tree_view = new QTreeView;

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -48,6 +48,8 @@
 Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
 #endif
 
+REGISTER_LOGGER("Main");
+
 GMainWindow::GMainWindow() : config(new Config()), emu_thread(nullptr) {
     Pica::g_debug_context = Pica::DebugContext::Construct();
     setAcceptDrops(true);
@@ -321,14 +323,13 @@ bool GMainWindow::LoadROM(const QString& filename) {
     if (result != Core::System::ResultStatus::Success) {
         switch (result) {
         case Core::System::ResultStatus::ErrorGetLoader:
-            LOG_CRITICAL(Frontend, "Failed to obtain loader for %s!",
-                         filename.toStdString().c_str());
+            SPDLOG_CRITICAL("Failed to obtain loader for {}!", filename.toStdString());
             QMessageBox::critical(this, tr("Error while loading ROM!"),
                                   tr("The ROM format is not supported."));
             break;
 
         case Core::System::ResultStatus::ErrorSystemMode:
-            LOG_CRITICAL(Frontend, "Failed to load ROM!");
+            SPDLOG_CRITICAL("Failed to load ROM!");
             QMessageBox::critical(this, tr("Error while loading ROM!"),
                                   tr("Could not determine the system mode."));
             break;
@@ -377,7 +378,7 @@ bool GMainWindow::LoadROM(const QString& filename) {
 }
 
 void GMainWindow::BootGame(const QString& filename) {
-    LOG_INFO(Frontend, "Citra starting...");
+    SPDLOG_INFO("Citra starting...");
     StoreRecentFile(filename); // Put the filename on top of the list
 
     if (!LoadROM(filename))
@@ -503,7 +504,7 @@ void GMainWindow::OnGameListOpenSaveFolder(u64 program_id) {
         return;
     }
 
-    LOG_INFO(Frontend, "Opening save data path for program_id=%" PRIu64, program_id);
+    SPDLOG_INFO("Opening save data path for program_id={0:#x}", program_id);
     QDesktopServices::openUrl(QUrl::fromLocalFile(qpath));
 }
 

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -48,8 +48,6 @@
 Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
 #endif
 
-REGISTER_LOGGER("Main");
-
 GMainWindow::GMainWindow() : config(new Config()), emu_thread(nullptr) {
     Pica::g_debug_context = Pica::DebugContext::Construct();
     setAcceptDrops(true);
@@ -323,13 +321,13 @@ bool GMainWindow::LoadROM(const QString& filename) {
     if (result != Core::System::ResultStatus::Success) {
         switch (result) {
         case Core::System::ResultStatus::ErrorGetLoader:
-            SPDLOG_CRITICAL("Failed to obtain loader for {}!", filename.toStdString());
+            SPDLOG_CRITICAL(Frontend, "Failed to obtain loader for {}!", filename.toStdString());
             QMessageBox::critical(this, tr("Error while loading ROM!"),
                                   tr("The ROM format is not supported."));
             break;
 
         case Core::System::ResultStatus::ErrorSystemMode:
-            SPDLOG_CRITICAL("Failed to load ROM!");
+            SPDLOG_CRITICAL(Frontend, "Failed to load ROM!");
             QMessageBox::critical(this, tr("Error while loading ROM!"),
                                   tr("Could not determine the system mode."));
             break;
@@ -378,7 +376,7 @@ bool GMainWindow::LoadROM(const QString& filename) {
 }
 
 void GMainWindow::BootGame(const QString& filename) {
-    SPDLOG_INFO("Citra starting...");
+    SPDLOG_INFO(Frontend, "Citra starting...");
     StoreRecentFile(filename); // Put the filename on top of the list
 
     if (!LoadROM(filename))
@@ -504,7 +502,7 @@ void GMainWindow::OnGameListOpenSaveFolder(u64 program_id) {
         return;
     }
 
-    SPDLOG_INFO("Opening save data path for program_id={0:#x}", program_id);
+    SPDLOG_INFO(Frontend, "Opening save data path for program_id={0:#x}", program_id);
     QDesktopServices::openUrl(QUrl::fromLocalFile(qpath));
 }
 

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -28,9 +28,11 @@ set(SRCS
             break_points.cpp
             file_util.cpp
             hash.cpp
-            logging/filter.cpp
-            logging/text_formatter.cpp
             logging/backend.cpp
+            logging/backend_spdlog.cpp
+            logging/filter.cpp
+            logging/formatter.cpp
+            logging/text_formatter.cpp
             memory_util.cpp
             microprofile.cpp
             misc.cpp
@@ -57,10 +59,12 @@ set(HEADERS
             file_util.h
             hash.h
             linear_disk_cache.h
-            logging/text_formatter.h
-            logging/filter.h
-            logging/log.h
             logging/backend.h
+            logging/backend_spdlog.h
+            logging/filter.h
+            logging/formatter.h
+            logging/log.h
+            logging/text_formatter.h
             math_util.h
             memory_util.h
             microprofile.h

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -95,7 +95,9 @@ endif()
 create_directory_groups(${SRCS} ${HEADERS})
 
 add_library(common STATIC ${SRCS} ${HEADERS})
-target_link_libraries(common PUBLIC Boost::boost microprofile)
+
+target_link_libraries(common PUBLIC Boost::boost microprofile spdlog)
+
 if (ARCHITECTURE_x86_64)
     target_link_libraries(common PRIVATE xbyak)
 endif()

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -99,8 +99,7 @@ endif()
 create_directory_groups(${SRCS} ${HEADERS})
 
 add_library(common STATIC ${SRCS} ${HEADERS})
-
-target_link_libraries(common PUBLIC Boost::boost microprofile spdlog)
+target_link_libraries(common PUBLIC Boost::boost fmt microprofile spdlog)
 
 if (ARCHITECTURE_x86_64)
     target_link_libraries(common PRIVATE xbyak)

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -87,6 +87,7 @@ const char* GetLogClassName(Class log_class) {
 #undef CLS
 #undef SUB
     case Class::Count:
+    default:
         UNREACHABLE();
     }
 }
@@ -103,6 +104,7 @@ const char* GetLevelName(Level log_level) {
         LVL(Error);
         LVL(Critical);
     case Level::Count:
+    default:
         UNREACHABLE();
     }
 #undef LVL

--- a/src/common/logging/backend_spdlog.cpp
+++ b/src/common/logging/backend_spdlog.cpp
@@ -1,14 +1,42 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <array>
+#include <memory>
+#include <vector>
 #include <spdlog/spdlog.h>
 
 #include "common/assert.h"
 #include "common/logging/backend.h"
 #include "common/logging/backend_spdlog.h"
+#include "common/logging/filter.h"
 #include "common/logging/formatter.h"
 #include "common/string_util.h"
 
 namespace Log {
 
-static spdlog::level::level_enum GetLevel(Log::Level log_level) {
+class SpdLogBackend {
+public:
+    SpdLogBackend();
+    ~SpdLogBackend();
+
+    static std::shared_ptr<SpdLogBackend> Instance();
+
+    SpdLogBackend(SpdLogBackend const&) = delete;
+    const SpdLogBackend& operator=(SpdLogBackend const&) = delete;
+
+    using LogArray =
+        std::array<std::shared_ptr<spdlog::logger>, static_cast<u8>(Log::Class::Count)>;
+    const LogArray& GetLoggers() {
+        return loggers;
+    }
+
+private:
+    LogArray loggers;
+};
+
+static spdlog::level::level_enum GetSpdLogLevel(Log::Level log_level) {
     switch (log_level) {
     case Log::Level::Trace:
         return spdlog::level::trace;
@@ -27,8 +55,8 @@ static spdlog::level::level_enum GetLevel(Log::Level log_level) {
     }
 }
 
-SpdLogBackend& SpdLogBackend::Instance() {
-    static SpdLogBackend instance;
+std::shared_ptr<SpdLogBackend> SpdLogBackend::Instance() {
+    static auto instance = std::make_shared<SpdLogBackend>();
     return instance;
 }
 
@@ -36,23 +64,22 @@ SpdLogBackend::SpdLogBackend() {
     // setup the custom citra formatter
     spdlog::set_formatter(std::make_shared<Formatter>());
 
-    std::vector<spdlog::sink_ptr> sinks;
     // Define the sinks to be passed to the loggers
     // true means truncate file
     auto file_sink = std::make_shared<spdlog::sinks::simple_file_sink_mt>("citra_log.txt", true);
 #ifdef _WIN32
     auto color_sink = std::make_shared<spdlog::sinks::wincolor_stderr_sink_mt>();
 #else
-    auto stderr_sink = spdlog::sinks::stderr_sink_mt::instance();
-    auto color_sink = std::make_shared<spdlog::sinks::ansicolor_sink>(stderr_sink);
+    auto color_sink = std::make_shared<spdlog::sinks::ansicolor_stdout_sink_mt>();
 #endif
+    std::vector<spdlog::sink_ptr> sinks;
     sinks.push_back(std::move(file_sink));
     sinks.push_back(std::move(color_sink));
 
     // register all of loggers with spdlog
     for (u8 log_class = 0; log_class != static_cast<u8>(Log::Class::Count); ++log_class) {
-        spdlog::create(GetLogClassName(static_cast<Log::Class>(log_class)), begin(sinks),
-                       end(sinks));
+        loggers[log_class] = spdlog::create(GetLogClassName(static_cast<Log::Class>(log_class)),
+                                            begin(sinks), end(sinks));
     }
 }
 
@@ -62,11 +89,18 @@ SpdLogBackend::~SpdLogBackend() {
 
 void SpdLogImpl(Class log_class, Level log_level, const char* file, int line_num,
                 const char* function, const char* format, fmt::ArgList args) {
-    SpdLogBackend::Instance();
+    auto logger = SpdLogBackend::Instance()->GetLoggers()[static_cast<u8>(log_class)];
     fmt::MemoryWriter formatting_buffer;
     formatting_buffer << Common::TrimSourcePath(file) << ':' << function << ':' << line_num << ": "
                       << format;
-    auto& logger = spdlog::get(GetLogClassName(log_class));
-    logger->log(GetLevel(log_level), formatting_buffer.c_str(), args);
+    logger->log(GetSpdLogLevel(log_level), formatting_buffer.c_str(), args);
+}
+
+void SpdLogSetFilter(Filter* filter) {
+    auto loggers = SpdLogBackend::Instance()->GetLoggers();
+    auto class_level = filter->GetClassLevel();
+    for (u8 log_class = 0; log_class != static_cast<u8>(Log::Class::Count); ++log_class) {
+        loggers[log_class]->set_level(GetSpdLogLevel(class_level[log_class]));
+    }
 }
 }; // namespace Log

--- a/src/common/logging/backend_spdlog.cpp
+++ b/src/common/logging/backend_spdlog.cpp
@@ -1,9 +1,12 @@
 #include <spdlog/spdlog.h>
 
 #include "common/assert.h"
+#include "common/logging/backend.h"
 #include "common/logging/backend_spdlog.h"
 #include "common/logging/formatter.h"
 #include "common/string_util.h"
+
+namespace Log {
 
 static spdlog::level::level_enum GetLevel(Log::Level log_level) {
     switch (log_level) {
@@ -21,14 +24,10 @@ static spdlog::level::level_enum GetLevel(Log::Level log_level) {
         return spdlog::level::critical;
     default:
         UNREACHABLE();
-        break;
     }
-    return spdlog::level::off;
 }
 
-namespace Log {
-
-SpdLogBackend& SpdLogBackend::instance() {
+SpdLogBackend& SpdLogBackend::Instance() {
     static SpdLogBackend instance;
     return instance;
 }
@@ -37,6 +36,7 @@ SpdLogBackend::SpdLogBackend() {
     // setup the custom citra formatter
     spdlog::set_formatter(std::make_shared<Formatter>());
 
+    std::vector<spdlog::sink_ptr> sinks;
     // Define the sinks to be passed to the loggers
     // true means truncate file
     auto file_sink = std::make_shared<spdlog::sinks::simple_file_sink_mt>("citra_log.txt", true);
@@ -46,29 +46,27 @@ SpdLogBackend::SpdLogBackend() {
     auto stderr_sink = spdlog::sinks::stderr_sink_mt::instance();
     auto color_sink = std::make_shared<spdlog::sinks::ansicolor_sink>(stderr_sink);
 #endif
-    sinks.push_back(file_sink);
-    sinks.push_back(color_sink);
+    sinks.push_back(std::move(file_sink));
+    sinks.push_back(std::move(color_sink));
+
+    // register all of loggers with spdlog
+    for (u8 log_class = 0; log_class != static_cast<u8>(Log::Class::Count); ++log_class) {
+        spdlog::create(GetLogClassName(static_cast<Log::Class>(log_class)), begin(sinks),
+                       end(sinks));
+    }
 }
 
 SpdLogBackend::~SpdLogBackend() {
     spdlog::drop_all();
 }
 
-const std::shared_ptr<spdlog::logger>& SpdLogBackend::GetLogger(u32 logger) const {
-    return loggers[logger];
-}
-
-u32 SpdLogBackend::RegisterLogger(const char* class_name) {
-    loggers.push_back(spdlog::create(class_name, sinks.begin(), sinks.end()));
-    return loggers.size() - 1;
-}
-
-void SpdLogImpl(u32 logger, Level log_level, const char* format, fmt::ArgList& args) {
-    auto log = SpdLogBackend::instance().GetLogger(logger);
-    log->log(GetLevel(log_level), format, args);
-}
-
-u32 RegisterLogger(const char* class_name) {
-    return SpdLogBackend::instance().RegisterLogger(class_name);
+void SpdLogImpl(Class log_class, Level log_level, const char* file, int line_num,
+                const char* function, const char* format, fmt::ArgList args) {
+    SpdLogBackend::Instance();
+    fmt::MemoryWriter formatting_buffer;
+    formatting_buffer << Common::TrimSourcePath(file) << ':' << function << ':' << line_num << ": "
+                      << format;
+    auto& logger = spdlog::get(GetLogClassName(log_class));
+    logger->log(GetLevel(log_level), formatting_buffer.c_str(), args);
 }
 }; // namespace Log

--- a/src/common/logging/backend_spdlog.cpp
+++ b/src/common/logging/backend_spdlog.cpp
@@ -8,6 +8,7 @@
 #include <spdlog/spdlog.h>
 
 #include "common/assert.h"
+#include "common/file_util.h"
 #include "common/logging/backend.h"
 #include "common/logging/backend_spdlog.h"
 #include "common/logging/filter.h"
@@ -66,7 +67,8 @@ SpdLogBackend::SpdLogBackend() {
 
     // Define the sinks to be passed to the loggers
     // true means truncate file
-    auto file_sink = std::make_shared<spdlog::sinks::simple_file_sink_mt>("citra_log.txt", true);
+    auto file_sink = std::make_shared<spdlog::sinks::simple_file_sink_mt>(
+        FileUtil::GetUserPath(D_USER_IDX) + "citra_log.txt", true);
 #ifdef _WIN32
     auto color_sink = std::make_shared<spdlog::sinks::wincolor_stderr_sink_mt>();
 #else

--- a/src/common/logging/backend_spdlog.cpp
+++ b/src/common/logging/backend_spdlog.cpp
@@ -79,7 +79,8 @@ SpdLogBackend::SpdLogBackend() {
     sinks.push_back(std::move(color_sink));
 
     // register all of loggers with spdlog
-    for (u8 log_class = 0; log_class != static_cast<u8>(Log::Class::Count); ++log_class) {
+    for (ClassType log_class = 0; log_class != static_cast<ClassType>(Log::Class::Count);
+         ++log_class) {
         loggers[log_class] = spdlog::create(GetLogClassName(static_cast<Log::Class>(log_class)),
                                             begin(sinks), end(sinks));
     }
@@ -101,7 +102,8 @@ void SpdLogImpl(Class log_class, Level log_level, const char* file, int line_num
 void SpdLogSetFilter(Filter* filter) {
     auto loggers = SpdLogBackend::Instance()->GetLoggers();
     auto class_level = filter->GetClassLevel();
-    for (u8 log_class = 0; log_class != static_cast<u8>(Log::Class::Count); ++log_class) {
+    for (ClassType log_class = 0; log_class != static_cast<ClassType>(Log::Class::Count);
+         ++log_class) {
         loggers[log_class]->set_level(GetSpdLogLevel(class_level[log_class]));
     }
 }

--- a/src/common/logging/backend_spdlog.cpp
+++ b/src/common/logging/backend_spdlog.cpp
@@ -72,7 +72,7 @@ SpdLogBackend::SpdLogBackend() {
 #ifdef _WIN32
     auto color_sink = std::make_shared<spdlog::sinks::wincolor_stderr_sink_mt>();
 #else
-    auto color_sink = std::make_shared<spdlog::sinks::ansicolor_stdout_sink_mt>();
+    auto color_sink = std::make_shared<spdlog::sinks::ansicolor_stderr_sink_mt>();
 #endif
     std::vector<spdlog::sink_ptr> sinks;
     sinks.push_back(std::move(file_sink));

--- a/src/common/logging/backend_spdlog.cpp
+++ b/src/common/logging/backend_spdlog.cpp
@@ -1,0 +1,87 @@
+#include "common/assert.h"
+#include "common/logging/backend_spdlog.h"
+#include "common/logging/formatter.h"
+#include "common/string_util.h"
+
+namespace Log {
+
+SpdLogBackend& SpdLogBackend::instance() {
+    static SpdLogBackend instance;
+    return instance;
+}
+
+SpdLogBackend::SpdLogBackend() {
+    // setup the custom citra formatter
+    spdlog::set_formatter(std::make_shared<Formatter>());
+
+    // Define the sinks to be passed to the loggers
+    // true means truncate file
+    auto file_sink = std::make_shared<spdlog::sinks::simple_file_sink_mt>("citra_log.txt", true);
+#ifdef _WIN32
+    auto color_sink = std::make_shared<spdlog::sinks::wincolor_stderr_sink_mt>();
+#else
+    auto stderr_sink = spdlog::sinks::stderr_sink_mt::instance();
+    auto color_sink = std::make_shared<spdlog::sinks::ansicolor_sink>(stderr_sink);
+#endif
+    sinks.push_back(file_sink);
+    sinks.push_back(color_sink);
+}
+
+SpdLogBackend::~SpdLogBackend() {
+    spdlog::drop_all();
+}
+
+const std::shared_ptr<spdlog::logger> SpdLogBackend::GetLogger(u32 logger) const {
+    return loggers[logger];
+}
+
+u32 SpdLogBackend::RegisterLogger(const char* class_name) {
+    loggers.push_back(std::make_shared<spdlog::logger>(class_name, sinks.begin(), sinks.end()));
+    return loggers.size() - 1;
+}
+
+spdlog::level_t GetLevel(Level log_level) {
+    switch (log_level) {
+    case Level::Trace:
+        return spdlog::level::trace;
+    case Level::Debug:
+        return spdlog::level::debug;
+    case Level::Info:
+        return spdlog::level::info;
+    case Level::Warning:
+        return spdlog::level::warn;
+    case Level::Error:
+        return spdlog::level::err;
+    case Level::Critical:
+        return spdlog::level::critical;
+    default:
+        UNREACHABLE();
+        break;
+    }
+    return spdlog::level::off;
+}
+
+template <typename Arg1, typename... Args>
+void SpdLogMessage(u32 logger, Level log_level, const char* filename, unsigned int line_nr,
+                   const char* function, const char* format, const Arg1& arg, const Args&... args) {
+    auto log = SpdLogBackend::instance().GetLogger(logger);
+    fmt::MemoryWriter formatting_buffer;
+    formatting_buffer << Common::TrimSourcePath(filename) << ':' << function << ':' << line_nr
+                      << ": " << format;
+    log->log(GetLevel(log_level), formatting_buffer.c_str(), arg, args...);
+}
+
+template <typename T>
+void SpdLogMessage(u32 logger, Level log_level, const char* filename, unsigned int line_nr,
+                   const char* function, const T& msg) {
+    auto log = SpdLogBackend::instance().GetLogger(logger);
+    fmt::MemoryWriter formatting_buffer;
+    formatting_buffer << Common::TrimSourcePath(filename) << ':' << function << ':' << line_nr
+                      << ": " << msg;
+    log->log(GetLevel(log_level), formatting_buffer.c_str());
+}
+
+u32 RegisterLogger(const char* class_name) {
+    return SpdLogBackend::instance().RegisterLogger(class_name);
+}
+}; // namespace Log

--- a/src/common/logging/backend_spdlog.h
+++ b/src/common/logging/backend_spdlog.h
@@ -1,0 +1,27 @@
+#include <memory>
+#include <vector>
+#include <spdlog/spdlog.h>
+#include "common/logging/log.h"
+
+namespace Log {
+
+class SpdLogBackend {
+public:
+    static SpdLogBackend& instance();
+
+    SpdLogBackend(SpdLogBackend const&) = delete;
+    void operator=(SpdLogBackend const&) = delete;
+
+    u32 RegisterLogger(const char* class_name);
+
+    const std::shared_ptr<spdlog::logger> GetLogger(u32 logger) const;
+
+private:
+    SpdLogBackend();
+
+    ~SpdLogBackend();
+
+    std::vector<std::shared_ptr<spdlog::logger>> loggers;
+    std::vector<spdlog::sink_ptr> sinks;
+};
+} // namespace Log

--- a/src/common/logging/backend_spdlog.h
+++ b/src/common/logging/backend_spdlog.h
@@ -7,21 +7,13 @@ namespace Log {
 
 class SpdLogBackend {
 public:
-    static SpdLogBackend& instance();
+    static SpdLogBackend& Instance();
 
     SpdLogBackend(SpdLogBackend const&) = delete;
-    SpdLogBackend& operator=(SpdLogBackend const&) = delete;
-
-    u32 RegisterLogger(const char* class_name);
-
-    const std::shared_ptr<spdlog::logger>& GetLogger(u32 logger) const;
+    const SpdLogBackend& operator=(SpdLogBackend const&) = delete;
 
 private:
     SpdLogBackend();
-
     ~SpdLogBackend();
-
-    std::vector<std::shared_ptr<spdlog::logger>> loggers;
-    std::vector<spdlog::sink_ptr> sinks;
 };
 } // namespace Log

--- a/src/common/logging/backend_spdlog.h
+++ b/src/common/logging/backend_spdlog.h
@@ -10,11 +10,11 @@ public:
     static SpdLogBackend& instance();
 
     SpdLogBackend(SpdLogBackend const&) = delete;
-    void operator=(SpdLogBackend const&) = delete;
+    SpdLogBackend& operator=(SpdLogBackend const&) = delete;
 
     u32 RegisterLogger(const char* class_name);
 
-    const std::shared_ptr<spdlog::logger> GetLogger(u32 logger) const;
+    const std::shared_ptr<spdlog::logger>& GetLogger(u32 logger) const;
 
 private:
     SpdLogBackend();

--- a/src/common/logging/backend_spdlog.h
+++ b/src/common/logging/backend_spdlog.h
@@ -1,19 +1,11 @@
-#include <memory>
-#include <vector>
-#include <spdlog/spdlog.h>
-#include "common/logging/log.h"
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
 
 namespace Log {
+class Filter;
 
-class SpdLogBackend {
-public:
-    static SpdLogBackend& Instance();
-
-    SpdLogBackend(SpdLogBackend const&) = delete;
-    const SpdLogBackend& operator=(SpdLogBackend const&) = delete;
-
-private:
-    SpdLogBackend();
-    ~SpdLogBackend();
-};
+void SpdLogSetFilter(Filter* filter);
 } // namespace Log

--- a/src/common/logging/filter.cpp
+++ b/src/common/logging/filter.cpp
@@ -21,6 +21,10 @@ void Filter::SetClassLevel(Class log_class, Level level) {
     class_levels[static_cast<size_t>(log_class)] = level;
 }
 
+const std::array<Level, static_cast<size_t>(Class::Count)>& Filter::GetClassLevel() {
+    return class_levels;
+}
+
 void Filter::ParseFilterString(const std::string& filter_str) {
     auto clause_begin = filter_str.cbegin();
     while (clause_begin != filter_str.cend()) {
@@ -94,4 +98,4 @@ bool Filter::ParseFilterRule(const std::string::const_iterator begin,
 bool Filter::CheckMessage(Class log_class, Level level) const {
     return static_cast<u8>(level) >= static_cast<u8>(class_levels[static_cast<size_t>(log_class)]);
 }
-}
+} // namespace Log

--- a/src/common/logging/filter.h
+++ b/src/common/logging/filter.h
@@ -25,6 +25,8 @@ public:
     void ResetAll(Level level);
     /// Sets the minimum level of `log_class` (and not of its subclasses) to `level`.
     void SetClassLevel(Class log_class, Level level);
+    /// Returns the list of levels that each logger is filtered to
+    const std::array<Level, static_cast<size_t>(Class::Count)>& GetClassLevel();
 
     /**
      * Parses a filter string and applies it to this filter.
@@ -50,4 +52,4 @@ public:
 private:
     std::array<Level, (size_t)Class::Count> class_levels;
 };
-}
+} // namespace Log

--- a/src/common/logging/formatter.cpp
+++ b/src/common/logging/formatter.cpp
@@ -1,3 +1,7 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
 #include <chrono>
 #include <string>
 #include "common/assert.h"

--- a/src/common/logging/formatter.cpp
+++ b/src/common/logging/formatter.cpp
@@ -3,11 +3,7 @@
 #include "common/assert.h"
 #include "common/logging/formatter.h"
 
-namespace Log {
-
-Formatter::Formatter() {}
-
-const char* GetLevelName(spdlog::level_t log_level) {
+static const char* GetLevelName(spdlog::level_t log_level) {
     switch (log_level) {
     case spdlog::level::trace:
         return "Trace";
@@ -16,7 +12,7 @@ const char* GetLevelName(spdlog::level_t log_level) {
     case spdlog::level::info:
         return "Info";
     case spdlog::level::warn:
-        return "Warn";
+        return "Warning";
     case spdlog::level::err:
         return "Error";
     case spdlog::level::critical:
@@ -26,6 +22,8 @@ const char* GetLevelName(spdlog::level_t log_level) {
         return "UNREACHABLE";
     }
 }
+
+namespace Log {
 
 void Formatter::format(spdlog::details::log_msg& msg) {
     using std::chrono::steady_clock;

--- a/src/common/logging/formatter.cpp
+++ b/src/common/logging/formatter.cpp
@@ -1,0 +1,48 @@
+#include <chrono>
+#include <string>
+#include "common/assert.h"
+#include "common/logging/formatter.h"
+
+namespace Log {
+
+Formatter::Formatter() {}
+
+const char* GetLevelName(spdlog::level_t log_level) {
+    switch (log_level) {
+    case spdlog::level::trace:
+        return "Trace";
+    case spdlog::level::debug:
+        return "Debug";
+    case spdlog::level::info:
+        return "Info";
+    case spdlog::level::warn:
+        return "Warn";
+    case spdlog::level::err:
+        return "Error";
+    case spdlog::level::critical:
+        return "Critical";
+    default:
+        UNREACHABLE();
+        return "UNREACHABLE";
+    }
+}
+
+void Formatter::format(spdlog::details::log_msg& msg) {
+    using std::chrono::steady_clock;
+    using std::chrono::duration_cast;
+
+    static steady_clock::time_point time_origin = steady_clock::now();
+    auto timestamp = duration_cast<std::chrono::microseconds>(steady_clock::now() - time_origin);
+
+    unsigned int time_seconds = static_cast<unsigned int>(timestamp.count() / 1000000);
+    unsigned int time_fractional = static_cast<unsigned int>(timestamp.count() % 1000000);
+
+    msg.formatted << '[' << fmt::pad(time_seconds, 4, ' ') << '.'
+                  << fmt::pad(time_fractional, 6, '0') << "] ";
+    msg.formatted << *msg.logger_name << " <" << GetLevelName(msg.level) << "> ";
+
+    msg.formatted << fmt::StringRef(msg.raw.data(), msg.raw.size());
+    msg.formatted.write(spdlog::details::os::eol, spdlog::details::os::eol_size);
+}
+
+} // namespace Log

--- a/src/common/logging/formatter.cpp
+++ b/src/common/logging/formatter.cpp
@@ -3,6 +3,8 @@
 #include "common/assert.h"
 #include "common/logging/formatter.h"
 
+namespace Log {
+
 static const char* GetLevelName(spdlog::level_t log_level) {
     switch (log_level) {
     case spdlog::level::trace:
@@ -23,24 +25,22 @@ static const char* GetLevelName(spdlog::level_t log_level) {
     }
 }
 
-namespace Log {
-
 void Formatter::format(spdlog::details::log_msg& msg) {
     using std::chrono::steady_clock;
     using std::chrono::duration_cast;
 
-    static steady_clock::time_point time_origin = steady_clock::now();
+    static const steady_clock::time_point time_origin = steady_clock::now();
     auto timestamp = duration_cast<std::chrono::microseconds>(steady_clock::now() - time_origin);
 
-    unsigned int time_seconds = static_cast<unsigned int>(timestamp.count() / 1000000);
-    unsigned int time_fractional = static_cast<unsigned int>(timestamp.count() % 1000000);
+    const auto time_seconds = timestamp.count() / 1000000;
+    const auto time_fractional = timestamp.count() % 1000000;
 
     msg.formatted << '[' << fmt::pad(time_seconds, 4, ' ') << '.'
                   << fmt::pad(time_fractional, 6, '0') << "] ";
     msg.formatted << *msg.logger_name << " <" << GetLevelName(msg.level) << "> ";
 
     msg.formatted << fmt::StringRef(msg.raw.data(), msg.raw.size());
-    msg.formatted.write(spdlog::details::os::eol, spdlog::details::os::eol_size);
+    msg.formatted << '\n';
 }
 
 } // namespace Log

--- a/src/common/logging/formatter.cpp
+++ b/src/common/logging/formatter.cpp
@@ -9,7 +9,7 @@
 
 namespace Log {
 
-static const char* GetLevelName(spdlog::level_t log_level) {
+static const char* GetLevelName(spdlog::level::level_enum log_level) {
     switch (log_level) {
     case spdlog::level::trace:
         return "Trace";

--- a/src/common/logging/formatter.h
+++ b/src/common/logging/formatter.h
@@ -5,7 +5,7 @@ namespace Log {
 class Formatter : public spdlog::formatter {
 
 public:
-    explicit Formatter();
+    explicit Formatter() = default;
     Formatter(const Formatter&) = delete;
     Formatter& operator=(const Formatter&) = delete;
     void format(spdlog::details::log_msg& msg) override;

--- a/src/common/logging/formatter.h
+++ b/src/common/logging/formatter.h
@@ -1,0 +1,14 @@
+#include <spdlog/spdlog.h>
+
+namespace Log {
+
+class Formatter : public spdlog::formatter {
+
+public:
+    explicit Formatter();
+    Formatter(const Formatter&) = delete;
+    Formatter& operator=(const Formatter&) = delete;
+    void format(spdlog::details::log_msg& msg) override;
+};
+
+} // namespace Log

--- a/src/common/logging/formatter.h
+++ b/src/common/logging/formatter.h
@@ -1,3 +1,9 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
 #include <spdlog/spdlog.h>
 
 namespace Log {

--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -107,9 +107,11 @@ void LogMessage(Class log_class, Level log_level, const char* filename, unsigned
 #endif
     ;
 
+/// Logs a message to the spdlog sinks
 void SpdLogImpl(Class log_class, Level log_level, const char* file, int line_num,
                 const char* function, const char* format, fmt::ArgList args);
 
+/// Macro that creates a variadic template method and wraps the extra arguments into a fmt::ArgList
 FMT_VARIADIC(void, SpdLogImpl, Class, Level, const char*, int, const char*, const char*)
 
 } // namespace Log
@@ -137,25 +139,25 @@ FMT_VARIADIC(void, SpdLogImpl, Class, Level, const char*, int, const char*, cons
 
 // Define the spdlog level macros
 #ifdef _DEBUG
-#define SPDLOG_TRACE(log_class, fmt, ...)                                                          \
-    ::Log::SpdLogMessage(log_class, ::Log::Level::Trace, __FILE__, __LINE__, __func__, fmt,        \
-                         ##__VA_ARGS__)
+#define SLOG_TRACE(log_class, fmt, ...)                                                            \
+    ::Log::SpdLogMessage(::Log::Class::log_class, ::Log::Level::Trace, __FILE__, __LINE__,         \
+                         __func__, fmt, ##__VA_ARGS__)
 #else
-#define SPDLOG_TRACE(log_class, fmt, ...) (void(0))
+#define SLOG_TRACE(log_class, fmt, ...) (void(0))
 #endif
 
-#define SPDLOG_DEBUG(log_class, fmt, ...)                                                          \
+#define SLOG_DEBUG(log_class, fmt, ...)                                                            \
     ::Log::SpdLogImpl(::Log::Class::log_class, ::Log::Level::Debug, __FILE__, __LINE__, __func__,  \
                       fmt, ##__VA_ARGS__)
-#define SPDLOG_INFO(log_class, fmt, ...)                                                           \
+#define SLOG_INFO(log_class, fmt, ...)                                                             \
     ::Log::SpdLogImpl(::Log::Class::log_class, ::Log::Level::Info, __FILE__, __LINE__, __func__,   \
                       fmt, ##__VA_ARGS__)
-#define SPDLOG_WARNING(log_class, fmt, ...)                                                        \
+#define SLOG_WARNING(log_class, fmt, ...)                                                          \
     ::Log::SpdLogImpl(::Log::Class::log_class, ::Log::Level::Warning, __FILE__, __LINE__,          \
                       __func__, fmt, ##__VA_ARGS__)
-#define SPDLOG_ERROR(log_class, fmt, ...)                                                          \
+#define SLOG_ERROR(log_class, fmt, ...)                                                            \
     ::Log::SpdLogImpl(::Log::Class::log_class, ::Log::Level::Error, __FILE__, __LINE__, __func__,  \
                       fmt, ##__VA_ARGS__)
-#define SPDLOG_CRITICAL(log_class, fmt, ...)                                                       \
+#define SLOG_CRITICAL(log_class, fmt, ...)                                                         \
     ::Log::SpdLogImpl(::Log::Class::log_class, ::Log::Level::Critical, __FILE__, __LINE__,         \
                       __func__, fmt, ##__VA_ARGS__)

--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -106,6 +106,15 @@ void LogMessage(Class log_class, Level log_level, const char* filename, unsigned
 #endif
     ;
 
+template <typename Arg1, typename... Args>
+void SpdLogMessage(u32 logger, Level log_level, const char* filename, unsigned int line_nr,
+                   const char* function, const char* format, const Arg1& arg, const Args&... args);
+template <typename T>
+void SpdLogMessage(u32 logger, Level log_level, const char* filename, unsigned int line_nr,
+                   const char* function, const T& msg);
+
+u32 RegisterLogger(const char* class_name);
+
 } // namespace Log
 
 #define LOG_GENERIC(log_class, log_level, ...)                                                     \
@@ -128,3 +137,31 @@ void LogMessage(Class log_class, Level log_level, const char* filename, unsigned
     LOG_GENERIC(::Log::Class::log_class, ::Log::Level::Error, __VA_ARGS__)
 #define LOG_CRITICAL(log_class, ...)                                                               \
     LOG_GENERIC(::Log::Class::log_class, ::Log::Level::Critical, __VA_ARGS__)
+
+// Define the spdlog level macros
+
+#define REGISTER_LOGGER(class_name) static u32 _logger = ::Log::RegisterLogger(class_name)
+
+#ifdef _DEBUG
+#define SPDLOG_TRACE(fmt, ...)                                                                     \
+    ::Log::SpdLogMessage(_logger, ::Log::Level::Trace, __FILE__, __LINE__, __func__, fmt,          \
+                         ##__VA_ARGS__)
+#else
+#define SPDLOG_TRACE(fmt, ...) (void(0))
+#endif
+
+#define SPDLOG_DEBUG(fmt, ...)                                                                     \
+    ::Log::SpdLogMessage(_logger, ::Log::Level::Debug, __FILE__, __LINE__, __func__, fmt,          \
+                         ##__VA_ARGS__)
+#define SPDLOG_INFO(fmt, ...)                                                                      \
+    ::Log::SpdLogMessage(_logger, ::Log::Level::Info, __FILE__, __LINE__, __func__, fmt,           \
+                         ##__VA_ARGS__)
+#define SPDLOG_WARNING(fmt, ...)                                                                   \
+    ::Log::SpdLogMessage(_logger, ::Log::Level::Warning, __FILE__, __LINE__, __func__, fmt,        \
+                         ##__VA_ARGS__)
+#define SPDLOG_ERROR(fmt, ...)                                                                     \
+    ::Log::SpdLogMessage(_logger, ::Log::Level::Error, __FILE__, __LINE__, __func__, fmt,          \
+                         ##__VA_ARGS__)
+#define SPDLOG_CRITICAL(fmt, ...)                                                                  \
+    ::Log::SpdLogMessage(_logger, ::Log::Level::Critical, __FILE__, __LINE__, __func__, fmt,       \
+                         ##__VA_ARGS__)

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -462,4 +462,26 @@ std::string StringFromFixedZeroTerminatedBuffer(const char* buffer, size_t max_l
 
     return std::string(buffer, len);
 }
+
+const char* TrimSourcePath(const char* path, const char* root) {
+    const char* p = path;
+
+    while (*p != '\0') {
+        const char* next_slash = p;
+        while (*next_slash != '\0' && *next_slash != '/' && *next_slash != '\\') {
+            ++next_slash;
+        }
+
+        bool is_src = Common::ComparePartialString(p, next_slash, root);
+        p = next_slash;
+
+        if (*p != '\0') {
+            ++p;
+        }
+        if (is_src) {
+            path = p;
+        }
+    }
+    return path;
+}
 }

--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -134,4 +134,16 @@ bool ComparePartialString(InIt begin, InIt end, const char* other) {
  * NUL-terminated then the string ends at max_len characters.
  */
 std::string StringFromFixedZeroTerminatedBuffer(const char* buffer, size_t max_len);
+
+/**
+ * Attempts to trim an arbitrary prefix from `path`, leaving only the part starting at `root`. It's
+ * intended to be used to strip a system-specific build directory from the `__FILE__` macro,
+ * leaving only the path relative to the sources root.
+ *
+ * @param path The input file path as a null-terminated string
+ * @param root The name of the root source directory as a null-terminated string. Path up to and
+ *             including the last occurrence of this name will be stripped
+ * @return A pointer to the same string passed as `path`, but starting at the trimmed portion
+ */
+const char* TrimSourcePath(const char* path, const char* root = "src");
 }


### PR DESCRIPTION
## Updates since RFC:

* Class based logging is back in. 
* Filter support for the new backend has been added.
* Loggers are stored in an array for fast lookup.
* Macros renamed from `SPDLOG_*` to `SLOG_*` in order to prevent a conflict since `spdlog` already defines `SPDLOG_TRACE` and `SPDLOG_DEBUG` macros... (it doesn't matter really since these names are temporary anyway)
* Several style and bad code fixes.

Thanks for the excellent feedback so far. Please review once more so we can get this merged and get to work on part 2 :)

## Original Description
This is a implementation of the logging rewrite to use spdlog. This was written in conjunction with the feedback in #2646 and tries to address the comments in that proposal.

## TODO List:
- [x] Functional spdlog backend that writes to console and disk.
- [x] Helper macros to enable easy conversion from the old macros.
- [x] Ability to set and change filters. I want to make sure the interface is okay before I start writing glue for filters.
- [ ] Better handling for LOG_TRACE (see #2698)

## Plan of Action

1. Comments, Review Fixes, and Merge this pull request
2. Migrate existing logging statements from the old macros to the new ones. (Can be done in segments when people get bored and are looking for easy contributions)
2.5 Merge any PRs using the old macros in the interim
3. One last sweep for any missing logging that need to be converted. Change them all and remove the old logging system
3.5 Any PRs adding old logging code will need to be rebased.

## Why RFC?

I would like to get a few comments about the interface before I pull this out of RFC in order to make sure that we are comfortable with the new logging code. After I get some feedback, I'll rebase to make the commit messages better. The logging section of this PR includes some sample code, and I've taken a little time to change the few logging statements 

## Implementation details (how to use the new logging)

#### (OBSOLETE) Register a new logger

At the top of each file you intend to use logging in, you will need to use the `REGISTER_LOGGER(name)` macro which will setup a new `spdlog::logger` with that name. This name is similar in function to how the old ClassName works, but since its just a string, its much more flexible. The macro expands to instantiate a new logger and stores a value that will be used to look up the logger in the other logging macros. 

Since the macro registers a global logger, if you need to use the same logger in different files, you can use the `spdlog::get` method to return a handle to the logger you want. (In order to do so, you will need to include the spdlog header in your file, as log.h does not include that)

#### Logging

The new logging macros are almost exactly the same as the old macros, but no longer require the class as that's automatically inferred from the global variable that is created with `REGISTER_LOGGER`. Examples:

```cpp
// All of the old macros are still around, and can be used during the migration process. The new macros are prefixed with S and function the same way.
// The following are valid with the new macros:
SLOG_DEBUG(Frontend, "Testing argument order:");
SLOG_INFO(Renderer, "{1} {0}", "world!", "Hello"); // Prints Hello world!
SLOG_INFO(Frontend, "Hex digit: {0:#x}", 16); // Prints Hex digit: 0x10

SLOG_WARNING(Frontend, "Hi", 't', 15.67); // Compiles and runs, but only prints Hi since its the other arguments are considered part of the formatting arguments (and there are no {} to format into)
SLOG_ERROR(); // doesn't compile as at least 1 argument is required. Fixing this didn't seem important enough
```

The specifiers for formatting can be found on the website for fmtlib http://fmtlib.net/latest/syntax.html

#### Filtering

Filtering is currently implemented, and it works in much the same manner as it does currently.

#### Other details

As an implementation detail, `log.h` now includes `fmt/format.h`, which means if you want to use `fmtlib` directly, its probably already included.

Also this change depends on https://github.com/MerryMage/dynarmic/pull/106 as I'm adding fmt as a static library which is incompatible with fmt-header-only used in dynarmic.

## (OBSOLETE) Design Rationale

#### Goal #1 - Don't increase the compile time 

spdlog is a header only library, and according to the numbers here https://github.com/gabime/spdlog/issues/120#issuecomment-282995233 spdlog greatly increases the compile time. In order to hide spdlog from the rest of the code base, I took care to make sure there were no references to it outside of the backend logging code. In order to handle variadic arguments to the logging call, I generated a `fmt::ArgList` of all of the arguments, but as pointed out in the review, this is an internal method. 

Additionally, the file level static logger (see goal #2) is stored as an index into the vector of loggers, so as to, once again, not include spdlog everywhere. (This could potentially be solved by forward declaring spdlog::logger, or just not storing it on the class and looking up the logger using spdlog's global logger registry, or something i haven't considered yet.)

#### Goal #2 - Remove Logging Classes

This idea came from a conversation with yuriks, where we discussed what could a rewrite of logging provide (and perhaps I misinterpreted how to code the idea up). See the last bullet point here: https://github.com/citra-emu/citra/issues/2646#issuecomment-294379564 and I mentioned this on IRC and had the following conversation: https://pastebin.com/vgw4vbXk I think it would be a good idea to have more flexible logging classes, in order to have more flexible filtering. You currently _can_ add a new logging class for more narrow filtering, but people don't. One eventual goal I have (and was brought up in #2646) is to write a "console" logger for citra-qt (sdl can continue to use stderr) which would allow runtime filtering of logs. Having more flexible class names would allow more specific log filtering.

I agree that my current implementation could use a lot of work, and I will gladly put in the effort to make it work.

(I apologize for not including this rationale from the start.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2707)
<!-- Reviewable:end -->
