### PR TITLE
pica: use correct register value for shader bool_uniforms

### DIFF
--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -423,7 +423,7 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
     }
 
     case PICA_REG_INDEX(gs.bool_uniforms):
-        WriteUniformBoolReg(g_state.gs, value);
+        WriteUniformBoolReg(g_state.gs, g_state.regs.gs.bool_uniforms.Value());
         break;
 
     case PICA_REG_INDEX_WORKAROUND(gs.int_uniforms[0], 0x281):
@@ -475,7 +475,7 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
     }
 
     case PICA_REG_INDEX(vs.bool_uniforms):
-        WriteUniformBoolReg(g_state.vs, value);
+        WriteUniformBoolReg(g_state.vs, g_state.regs.vs.bool_uniforms.Value());
         break;
 
     case PICA_REG_INDEX_WORKAROUND(vs.int_uniforms[0], 0x2b1):


### PR DESCRIPTION
This fixes a regression from #2695 (bug can be seen in Monster Hunter). The `value` variable is a pitfall， which doesn't contain the current register value if the command comes with a mask.

I also check other use of `value` in command processor, but all of them are used for FIFO registers (lut, shader program code, etc.), which are not likely used with a mask. It would be better if we can figure out if the mask actually have any effects to these registers, but I think we can do this after this quick fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2709)
<!-- Reviewable:end -->
