### PR TITLE
swrasterizer: add missing tc0_w attribute processing

### DIFF
--- a/src/video_core/swrasterizer/clipper.cpp
+++ b/src/video_core/swrasterizer/clipper.cpp
@@ -69,13 +69,14 @@ static void InitScreenCoordinates(Vertex& vtx) {
     viewport.offset_y = float24::FromFloat32(static_cast<float>(regs.rasterizer.viewport_corner.y));
 
     float24 inv_w = float24::FromFloat32(1.f) / vtx.pos.w;
-    vtx.color *= inv_w;
-    vtx.view *= inv_w;
+    vtx.pos.w = inv_w;
     vtx.quat *= inv_w;
+    vtx.color *= inv_w;
     vtx.tc0 *= inv_w;
     vtx.tc1 *= inv_w;
+    vtx.tc0_w *= inv_w;
+    vtx.view *= inv_w;
     vtx.tc2 *= inv_w;
-    vtx.pos.w = inv_w;
 
     vtx.screenpos[0] =
         (vtx.pos.x * inv_w + float24::FromFloat32(1.0)) * viewport.halfsize_x + viewport.offset_x;

--- a/src/video_core/swrasterizer/rasterizer.h
+++ b/src/video_core/swrasterizer/rasterizer.h
@@ -23,13 +23,15 @@ struct Vertex : Shader::OutputVertex {
         pos = pos * factor + vtx.pos * (float24::FromFloat32(1) - factor);
 
         // TODO: Should perform perspective correct interpolation here...
+        quat = quat * factor + vtx.quat * (float24::FromFloat32(1) - factor);
+        color = color * factor + vtx.color * (float24::FromFloat32(1) - factor);
         tc0 = tc0 * factor + vtx.tc0 * (float24::FromFloat32(1) - factor);
         tc1 = tc1 * factor + vtx.tc1 * (float24::FromFloat32(1) - factor);
+        tc0_w = tc0_w * factor + vtx.tc0_w * (float24::FromFloat32(1) - factor);
+        view = view * factor + vtx.view * (float24::FromFloat32(1) - factor);
         tc2 = tc2 * factor + vtx.tc2 * (float24::FromFloat32(1) - factor);
 
         screenpos = screenpos * factor + vtx.screenpos * (float24::FromFloat32(1) - factor);
-
-        color = color * factor + vtx.color * (float24::FromFloat32(1) - factor);
     }
 
     // Linear interpolation


### PR DESCRIPTION
Found when I tried to implement TextureCube. This should also affect the implemented Projection2D. Hopefully these are the only two places where `tc0_w` is missing

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2713)
<!-- Reviewable:end -->
