### PR TITLE
Decentralize ResultCode

### DIFF
--- a/src/common/bit_field.h
+++ b/src/common/bit_field.h
@@ -121,11 +121,11 @@ private:
     // T is an enumeration. Note that T is wrapped within an enable_if in the
     // former case to workaround compile errors which arise when using
     // std::underlying_type<T>::type directly.
-    typedef typename std::conditional<std::is_enum<T>::value, std::underlying_type<T>,
-                                      std::enable_if<true, T>>::type::type StorageType;
+    using StorageType = typename std::conditional_t<std::is_enum<T>::value, std::underlying_type<T>,
+                                                    std::enable_if<true, T>>::type;
 
     // Unsigned version of StorageType
-    typedef typename std::make_unsigned<StorageType>::type StorageTypeU;
+    using StorageTypeU = std::make_unsigned_t<StorageType>;
 
 public:
     /// Constants to allow limited introspection of fields if needed

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -230,6 +230,7 @@ set(HEADERS
             hle/kernel/address_arbiter.h
             hle/kernel/client_port.h
             hle/kernel/client_session.h
+            hle/kernel/errors.h
             hle/kernel/event.h
             hle/kernel/kernel.h
             hle/kernel/memory.h

--- a/src/core/file_sys/archive_extsavedata.cpp
+++ b/src/core/file_sys/archive_extsavedata.cpp
@@ -38,8 +38,7 @@ public:
     ResultVal<size_t> Write(u64 offset, size_t length, bool flush,
                             const u8* buffer) const override {
         if (offset > size) {
-            return ResultCode(ErrorDescription::FS_WriteBeyondEnd, ErrorModule::FS,
-                              ErrorSummary::InvalidArgument, ErrorLevel::Usage);
+            return ERR_WRITE_BEYOND_END;
         } else if (offset == size) {
             return MakeResult<size_t>(0);
         }
@@ -191,11 +190,9 @@ ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_ExtSaveData::Open(cons
         // TODO(Subv): Verify the archive behavior of SharedExtSaveData compared to ExtSaveData.
         // ExtSaveData seems to return FS_NotFound (120) when the archive doesn't exist.
         if (!shared) {
-            return ResultCode(ErrorDescription::FS_NotFound, ErrorModule::FS,
-                              ErrorSummary::InvalidState, ErrorLevel::Status);
+            return ERR_NOT_FOUND_INVALID_STATE;
         } else {
-            return ResultCode(ErrorDescription::FS_NotFormatted, ErrorModule::FS,
-                              ErrorSummary::InvalidState, ErrorLevel::Status);
+            return ERR_NOT_FORMATTED;
         }
     }
     auto archive = std::make_unique<ExtSaveDataArchive>(fullpath);
@@ -230,8 +227,7 @@ ResultVal<ArchiveFormatInfo> ArchiveFactory_ExtSaveData::GetFormatInfo(const Pat
     if (!file.IsOpen()) {
         LOG_ERROR(Service_FS, "Could not open metadata information for archive");
         // TODO(Subv): Verify error code
-        return ResultCode(ErrorDescription::FS_NotFormatted, ErrorModule::FS,
-                          ErrorSummary::InvalidState, ErrorLevel::Status);
+        return ERR_NOT_FORMATTED;
     }
 
     ArchiveFormatInfo info = {};

--- a/src/core/file_sys/archive_source_sd_savedata.cpp
+++ b/src/core/file_sys/archive_source_sd_savedata.cpp
@@ -6,6 +6,7 @@
 #include "common/logging/log.h"
 #include "common/string_util.h"
 #include "core/file_sys/archive_source_sd_savedata.h"
+#include "core/file_sys/errors.h"
 #include "core/file_sys/savedata_archive.h"
 #include "core/hle/service/fs/archive.h"
 
@@ -49,8 +50,7 @@ ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveSource_SDSaveData::Open(u64 pr
         // save file/directory structure expected by the game has not yet been initialized.
         // Returning the NotFormatted error code will signal the game to provision the SaveData
         // archive with the files and folders that it expects.
-        return ResultCode(ErrorDescription::FS_NotFormatted, ErrorModule::FS,
-                          ErrorSummary::InvalidState, ErrorLevel::Status);
+        return ERR_NOT_FORMATTED;
     }
 
     auto archive = std::make_unique<SaveDataArchive>(std::move(concrete_mount_point));
@@ -81,8 +81,7 @@ ResultVal<ArchiveFormatInfo> ArchiveSource_SDSaveData::GetFormatInfo(u64 program
     if (!file.IsOpen()) {
         LOG_ERROR(Service_FS, "Could not open metadata information for archive");
         // TODO(Subv): Verify error code
-        return ResultCode(ErrorDescription::FS_NotFormatted, ErrorModule::FS,
-                          ErrorSummary::InvalidState, ErrorLevel::Status);
+        return ERR_NOT_FORMATTED;
     }
 
     ArchiveFormatInfo info = {};

--- a/src/core/file_sys/archive_systemsavedata.cpp
+++ b/src/core/file_sys/archive_systemsavedata.cpp
@@ -9,6 +9,7 @@
 #include "common/file_util.h"
 #include "common/string_util.h"
 #include "core/file_sys/archive_systemsavedata.h"
+#include "core/file_sys/errors.h"
 #include "core/file_sys/savedata_archive.h"
 #include "core/hle/service/fs/archive.h"
 
@@ -53,8 +54,7 @@ ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_SystemSaveData::Open(c
     std::string fullpath = GetSystemSaveDataPath(base_path, path);
     if (!FileUtil::Exists(fullpath)) {
         // TODO(Subv): Check error code, this one is probably wrong
-        return ResultCode(ErrorDescription::FS_NotFormatted, ErrorModule::FS,
-                          ErrorSummary::InvalidState, ErrorLevel::Status);
+        return ERR_NOT_FORMATTED;
     }
     auto archive = std::make_unique<SaveDataArchive>(fullpath);
     return MakeResult<std::unique_ptr<ArchiveBackend>>(std::move(archive));

--- a/src/core/file_sys/disk_archive.cpp
+++ b/src/core/file_sys/disk_archive.cpp
@@ -9,6 +9,7 @@
 #include "common/file_util.h"
 #include "common/logging/log.h"
 #include "core/file_sys/disk_archive.h"
+#include "core/file_sys/errors.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // FileSys namespace
@@ -17,8 +18,7 @@ namespace FileSys {
 
 ResultVal<size_t> DiskFile::Read(const u64 offset, const size_t length, u8* buffer) const {
     if (!mode.read_flag)
-        return ResultCode(ErrorDescription::FS_InvalidOpenFlags, ErrorModule::FS,
-                          ErrorSummary::Canceled, ErrorLevel::Status);
+        return ERROR_INVALID_OPEN_FLAGS;
 
     file->Seek(offset, SEEK_SET);
     return MakeResult<size_t>(file->ReadBytes(buffer, length));
@@ -27,8 +27,7 @@ ResultVal<size_t> DiskFile::Read(const u64 offset, const size_t length, u8* buff
 ResultVal<size_t> DiskFile::Write(const u64 offset, const size_t length, const bool flush,
                                   const u8* buffer) const {
     if (!mode.write_flag)
-        return ResultCode(ErrorDescription::FS_InvalidOpenFlags, ErrorModule::FS,
-                          ErrorSummary::Canceled, ErrorLevel::Status);
+        return ERROR_INVALID_OPEN_FLAGS;
 
     file->Seek(offset, SEEK_SET);
     size_t written = file->WriteBytes(buffer, length);

--- a/src/core/file_sys/errors.h
+++ b/src/core/file_sys/errors.h
@@ -2,52 +2,93 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#pragma once
+
 #include "core/hle/result.h"
 
 namespace FileSys {
 
-const ResultCode ERROR_INVALID_PATH(ErrorDescription::FS_InvalidPath, ErrorModule::FS,
-                                    ErrorSummary::InvalidArgument, ErrorLevel::Usage);
-const ResultCode ERROR_UNSUPPORTED_OPEN_FLAGS(ErrorDescription::FS_UnsupportedOpenFlags,
-                                              ErrorModule::FS, ErrorSummary::NotSupported,
-                                              ErrorLevel::Usage);
-const ResultCode ERROR_INVALID_OPEN_FLAGS(ErrorDescription::FS_InvalidOpenFlags, ErrorModule::FS,
-                                          ErrorSummary::Canceled, ErrorLevel::Status);
-const ResultCode ERROR_INVALID_READ_FLAG(ErrorDescription::FS_InvalidReadFlag, ErrorModule::FS,
-                                         ErrorSummary::InvalidArgument, ErrorLevel::Usage);
-const ResultCode ERROR_FILE_NOT_FOUND(ErrorDescription::FS_FileNotFound, ErrorModule::FS,
-                                      ErrorSummary::NotFound, ErrorLevel::Status);
-const ResultCode ERROR_PATH_NOT_FOUND(ErrorDescription::FS_PathNotFound, ErrorModule::FS,
-                                      ErrorSummary::NotFound, ErrorLevel::Status);
-const ResultCode ERROR_NOT_FOUND(ErrorDescription::FS_NotFound, ErrorModule::FS,
-                                 ErrorSummary::NotFound, ErrorLevel::Status);
-const ResultCode ERROR_UNEXPECTED_FILE_OR_DIRECTORY(ErrorDescription::FS_UnexpectedFileOrDirectory,
-                                                    ErrorModule::FS, ErrorSummary::NotSupported,
-                                                    ErrorLevel::Usage);
-const ResultCode ERROR_UNEXPECTED_FILE_OR_DIRECTORY_SDMC(ErrorDescription::FS_NotAFile,
-                                                         ErrorModule::FS, ErrorSummary::Canceled,
-                                                         ErrorLevel::Status);
-const ResultCode ERROR_DIRECTORY_ALREADY_EXISTS(ErrorDescription::FS_DirectoryAlreadyExists,
-                                                ErrorModule::FS, ErrorSummary::NothingHappened,
-                                                ErrorLevel::Status);
-const ResultCode ERROR_FILE_ALREADY_EXISTS(ErrorDescription::FS_FileAlreadyExists, ErrorModule::FS,
-                                           ErrorSummary::NothingHappened, ErrorLevel::Status);
-const ResultCode ERROR_ALREADY_EXISTS(ErrorDescription::FS_AlreadyExists, ErrorModule::FS,
-                                      ErrorSummary::NothingHappened, ErrorLevel::Status);
-const ResultCode ERROR_DIRECTORY_NOT_EMPTY(ErrorDescription::FS_DirectoryNotEmpty, ErrorModule::FS,
-                                           ErrorSummary::Canceled, ErrorLevel::Status);
-const ResultCode ERROR_GAMECARD_NOT_INSERTED(ErrorDescription::FS_GameCardNotInserted,
-                                             ErrorModule::FS, ErrorSummary::NotFound,
-                                             ErrorLevel::Status);
-const ResultCode ERROR_INCORRECT_EXEFS_READ_SIZE(ErrorDescription::FS_IncorrectExeFSReadSize,
-                                                 ErrorModule::FS, ErrorSummary::NotSupported,
-                                                 ErrorLevel::Usage);
-const ResultCode ERROR_ROMFS_NOT_FOUND(ErrorDescription::FS_RomFSNotFound, ErrorModule::FS,
-                                       ErrorSummary::NotFound, ErrorLevel::Status);
-const ResultCode ERROR_COMMAND_NOT_ALLOWED(ErrorDescription::FS_CommandNotAllowed, ErrorModule::FS,
-                                           ErrorSummary::WrongArgument, ErrorLevel::Permanent);
-const ResultCode ERROR_EXEFS_SECTION_NOT_FOUND(ErrorDescription::FS_ExeFSSectionNotFound,
-                                               ErrorModule::FS, ErrorSummary::NotFound,
-                                               ErrorLevel::Status);
+namespace ErrCodes {
+enum {
+    RomFSNotFound = 100,
+    ArchiveNotMounted = 101,
+    FileNotFound = 112,
+    PathNotFound = 113,
+    GameCardNotInserted = 141,
+    NotFound = 120,
+    FileAlreadyExists = 180,
+    DirectoryAlreadyExists = 185,
+    AlreadyExists = 190,
+    InvalidOpenFlags = 230,
+    DirectoryNotEmpty = 240,
+    NotAFile = 250,
+    NotFormatted = 340, ///< This is used by the FS service when creating a SaveData archive
+    ExeFSSectionNotFound = 567,
+    CommandNotAllowed = 630,
+    InvalidReadFlag = 700,
+    InvalidPath = 702,
+    WriteBeyondEnd = 705,
+    UnsupportedOpenFlags = 760,
+    IncorrectExeFSReadSize = 761,
+    UnexpectedFileOrDirectory = 770,
+};
+}
+
+constexpr ResultCode ERROR_INVALID_PATH(ErrCodes::InvalidPath, ErrorModule::FS,
+                                        ErrorSummary::InvalidArgument, ErrorLevel::Usage);
+constexpr ResultCode ERROR_UNSUPPORTED_OPEN_FLAGS(ErrCodes::UnsupportedOpenFlags, ErrorModule::FS,
+                                                  ErrorSummary::NotSupported, ErrorLevel::Usage);
+constexpr ResultCode ERROR_INVALID_OPEN_FLAGS(ErrCodes::InvalidOpenFlags, ErrorModule::FS,
+                                              ErrorSummary::Canceled, ErrorLevel::Status);
+constexpr ResultCode ERROR_INVALID_READ_FLAG(ErrCodes::InvalidReadFlag, ErrorModule::FS,
+                                             ErrorSummary::InvalidArgument, ErrorLevel::Usage);
+constexpr ResultCode ERROR_FILE_NOT_FOUND(ErrCodes::FileNotFound, ErrorModule::FS,
+                                          ErrorSummary::NotFound, ErrorLevel::Status);
+constexpr ResultCode ERROR_PATH_NOT_FOUND(ErrCodes::PathNotFound, ErrorModule::FS,
+                                          ErrorSummary::NotFound, ErrorLevel::Status);
+constexpr ResultCode ERROR_NOT_FOUND(ErrCodes::NotFound, ErrorModule::FS, ErrorSummary::NotFound,
+                                     ErrorLevel::Status);
+constexpr ResultCode ERROR_UNEXPECTED_FILE_OR_DIRECTORY(ErrCodes::UnexpectedFileOrDirectory,
+                                                        ErrorModule::FS, ErrorSummary::NotSupported,
+                                                        ErrorLevel::Usage);
+constexpr ResultCode ERROR_UNEXPECTED_FILE_OR_DIRECTORY_SDMC(ErrCodes::NotAFile, ErrorModule::FS,
+                                                             ErrorSummary::Canceled,
+                                                             ErrorLevel::Status);
+constexpr ResultCode ERROR_DIRECTORY_ALREADY_EXISTS(ErrCodes::DirectoryAlreadyExists,
+                                                    ErrorModule::FS, ErrorSummary::NothingHappened,
+                                                    ErrorLevel::Status);
+constexpr ResultCode ERROR_FILE_ALREADY_EXISTS(ErrCodes::FileAlreadyExists, ErrorModule::FS,
+                                               ErrorSummary::NothingHappened, ErrorLevel::Status);
+constexpr ResultCode ERROR_ALREADY_EXISTS(ErrCodes::AlreadyExists, ErrorModule::FS,
+                                          ErrorSummary::NothingHappened, ErrorLevel::Status);
+constexpr ResultCode ERROR_DIRECTORY_NOT_EMPTY(ErrCodes::DirectoryNotEmpty, ErrorModule::FS,
+                                               ErrorSummary::Canceled, ErrorLevel::Status);
+constexpr ResultCode ERROR_GAMECARD_NOT_INSERTED(ErrCodes::GameCardNotInserted, ErrorModule::FS,
+                                                 ErrorSummary::NotFound, ErrorLevel::Status);
+constexpr ResultCode ERROR_INCORRECT_EXEFS_READ_SIZE(ErrCodes::IncorrectExeFSReadSize,
+                                                     ErrorModule::FS, ErrorSummary::NotSupported,
+                                                     ErrorLevel::Usage);
+constexpr ResultCode ERROR_ROMFS_NOT_FOUND(ErrCodes::RomFSNotFound, ErrorModule::FS,
+                                           ErrorSummary::NotFound, ErrorLevel::Status);
+constexpr ResultCode ERROR_COMMAND_NOT_ALLOWED(ErrCodes::CommandNotAllowed, ErrorModule::FS,
+                                               ErrorSummary::WrongArgument, ErrorLevel::Permanent);
+constexpr ResultCode ERROR_EXEFS_SECTION_NOT_FOUND(ErrCodes::ExeFSSectionNotFound, ErrorModule::FS,
+                                                   ErrorSummary::NotFound, ErrorLevel::Status);
+
+/// Returned when a function is passed an invalid archive handle.
+constexpr ResultCode ERR_INVALID_ARCHIVE_HANDLE(ErrCodes::ArchiveNotMounted, ErrorModule::FS,
+                                                ErrorSummary::NotFound,
+                                                ErrorLevel::Status); // 0xC8804465
+constexpr ResultCode ERR_WRITE_BEYOND_END(ErrCodes::WriteBeyondEnd, ErrorModule::FS,
+                                          ErrorSummary::InvalidArgument, ErrorLevel::Usage);
+
+/**
+ * Variant of ERROR_NOT_FOUND returned in some places in the code. Unknown if these usages are
+ * correct or a bug.
+ */
+constexpr ResultCode ERR_NOT_FOUND_INVALID_STATE(ErrCodes::NotFound, ErrorModule::FS,
+                                                 ErrorSummary::InvalidState, ErrorLevel::Status);
+constexpr ResultCode ERR_NOT_FORMATTED(ErrCodes::NotFormatted, ErrorModule::FS,
+                                       ErrorSummary::InvalidState, ErrorLevel::Status);
 
 } // namespace FileSys

--- a/src/core/hle/function_wrappers.h
+++ b/src/core/hle/function_wrappers.h
@@ -53,7 +53,7 @@ void Wrap() {
     FuncReturn(retval);
 }
 
-template <ResultCode func(u32*, s32, u32, u32, u32, s32)>
+template <ResultCode func(u32*, u32, u32, u32, u32, s32)>
 void Wrap() {
     u32 param_1 = 0;
     u32 retval = func(&param_1, PARAM(0), PARAM(1), PARAM(2), PARAM(3), PARAM(4)).raw;

--- a/src/core/hle/ipc.h
+++ b/src/core/hle/ipc.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "common/common_types.h"
+#include "core/hle/kernel/errors.h"
 #include "core/hle/kernel/thread.h"
 #include "core/memory.h"
 
@@ -42,6 +43,12 @@ inline u32* GetStaticBuffers(const int offset = 0) {
 }
 
 namespace IPC {
+
+// These errors are commonly returned by invalid IPC translations, so alias them here for
+// convenience.
+// TODO(yuriks): These will probably go away once translation is implemented inside the kernel.
+using Kernel::ERR_INVALID_BUFFER_DESCRIPTOR;
+constexpr auto ERR_INVALID_HANDLE = Kernel::ERR_INVALID_HANDLE_OS;
 
 enum DescriptorType : u32 {
     // Buffer related desciptors types (mask : 0x0F)

--- a/src/core/hle/kernel/address_arbiter.cpp
+++ b/src/core/hle/kernel/address_arbiter.cpp
@@ -5,6 +5,7 @@
 #include "common/common_types.h"
 #include "common/logging/log.h"
 #include "core/hle/kernel/address_arbiter.h"
+#include "core/hle/kernel/errors.h"
 #include "core/hle/kernel/thread.h"
 #include "core/memory.h"
 
@@ -74,8 +75,7 @@ ResultCode AddressArbiter::ArbitrateAddress(ArbitrationType type, VAddr address,
 
     default:
         LOG_ERROR(Kernel, "unknown type=%d", type);
-        return ResultCode(ErrorDescription::InvalidEnumValue, ErrorModule::Kernel,
-                          ErrorSummary::WrongArgument, ErrorLevel::Usage);
+        return ERR_INVALID_ENUM_VALUE_FND;
     }
 
     // The calls that use a timeout seem to always return a Timeout error even if they did not put
@@ -83,8 +83,7 @@ ResultCode AddressArbiter::ArbitrateAddress(ArbitrationType type, VAddr address,
     if (type == ArbitrationType::WaitIfLessThanWithTimeout ||
         type == ArbitrationType::DecrementAndWaitIfLessThanWithTimeout) {
 
-        return ResultCode(ErrorDescription::Timeout, ErrorModule::OS, ErrorSummary::StatusChanged,
-                          ErrorLevel::Info);
+        return RESULT_TIMEOUT;
     }
     return RESULT_SUCCESS;
 }

--- a/src/core/hle/kernel/client_port.cpp
+++ b/src/core/hle/kernel/client_port.cpp
@@ -5,6 +5,7 @@
 #include "common/assert.h"
 #include "core/hle/kernel/client_port.h"
 #include "core/hle/kernel/client_session.h"
+#include "core/hle/kernel/errors.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/server_port.h"
 #include "core/hle/kernel/server_session.h"
@@ -19,8 +20,7 @@ ResultVal<SharedPtr<ClientSession>> ClientPort::Connect() {
     // AcceptSession before returning from this call.
 
     if (active_sessions >= max_sessions) {
-        return ResultCode(ErrorDescription::MaxConnectionsReached, ErrorModule::OS,
-                          ErrorSummary::WouldBlock, ErrorLevel::Temporary);
+        return ERR_MAX_CONNECTIONS_REACHED;
     }
     active_sessions++;
 

--- a/src/core/hle/kernel/client_session.cpp
+++ b/src/core/hle/kernel/client_session.cpp
@@ -30,8 +30,7 @@ ResultCode ClientSession::SendSyncRequest() {
     if (parent->server)
         return parent->server->HandleSyncRequest();
 
-    return ResultCode(ErrorDescription::SessionClosedByRemote, ErrorModule::OS,
-                      ErrorSummary::Canceled, ErrorLevel::Status);
+    return ERR_SESSION_CLOSED_BY_REMOTE;
 }
 
 } // namespace

--- a/src/core/hle/kernel/errors.h
+++ b/src/core/hle/kernel/errors.h
@@ -1,0 +1,98 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/result.h"
+
+namespace Kernel {
+
+namespace ErrCodes {
+enum {
+    OutOfHandles = 19,
+    SessionClosedByRemote = 26,
+    PortNameTooLong = 30,
+    WrongPermission = 46,
+    InvalidBufferDescriptor = 48,
+    MaxConnectionsReached = 52,
+};
+}
+
+// WARNING: The kernel is quite inconsistent in it's usage of errors code. Make sure to always
+// double check that the code matches before re-using the constant.
+
+constexpr ResultCode ERR_OUT_OF_HANDLES(ErrCodes::OutOfHandles, ErrorModule::Kernel,
+                                        ErrorSummary::OutOfResource,
+                                        ErrorLevel::Permanent); // 0xD8600413
+constexpr ResultCode ERR_SESSION_CLOSED_BY_REMOTE(ErrCodes::SessionClosedByRemote, ErrorModule::OS,
+                                                  ErrorSummary::Canceled,
+                                                  ErrorLevel::Status); // 0xC920181A
+constexpr ResultCode ERR_PORT_NAME_TOO_LONG(ErrCodes::PortNameTooLong, ErrorModule::OS,
+                                            ErrorSummary::InvalidArgument,
+                                            ErrorLevel::Usage); // 0xE0E0181E
+constexpr ResultCode ERR_WRONG_PERMISSION(ErrCodes::WrongPermission, ErrorModule::OS,
+                                          ErrorSummary::WrongArgument, ErrorLevel::Permanent);
+constexpr ResultCode ERR_INVALID_BUFFER_DESCRIPTOR(ErrCodes::InvalidBufferDescriptor,
+                                                   ErrorModule::OS, ErrorSummary::WrongArgument,
+                                                   ErrorLevel::Permanent);
+constexpr ResultCode ERR_MAX_CONNECTIONS_REACHED(ErrCodes::MaxConnectionsReached, ErrorModule::OS,
+                                                 ErrorSummary::WouldBlock,
+                                                 ErrorLevel::Temporary); // 0xD0401834
+
+constexpr ResultCode ERR_NOT_AUTHORIZED(ErrorDescription::NotAuthorized, ErrorModule::OS,
+                                        ErrorSummary::WrongArgument,
+                                        ErrorLevel::Permanent); // 0xD9001BEA
+constexpr ResultCode ERR_INVALID_ENUM_VALUE(ErrorDescription::InvalidEnumValue, ErrorModule::Kernel,
+                                            ErrorSummary::InvalidArgument,
+                                            ErrorLevel::Permanent); // 0xD8E007ED
+constexpr ResultCode ERR_INVALID_ENUM_VALUE_FND(ErrorDescription::InvalidEnumValue,
+                                                ErrorModule::FND, ErrorSummary::InvalidArgument,
+                                                ErrorLevel::Permanent); // 0xD8E093ED
+constexpr ResultCode ERR_INVALID_COMBINATION(ErrorDescription::InvalidCombination, ErrorModule::OS,
+                                             ErrorSummary::InvalidArgument,
+                                             ErrorLevel::Usage); // 0xE0E01BEE
+constexpr ResultCode ERR_INVALID_COMBINATION_KERNEL(ErrorDescription::InvalidCombination,
+                                                    ErrorModule::Kernel,
+                                                    ErrorSummary::WrongArgument,
+                                                    ErrorLevel::Permanent); // 0xD90007EE
+constexpr ResultCode ERR_MISALIGNED_ADDRESS(ErrorDescription::MisalignedAddress, ErrorModule::OS,
+                                            ErrorSummary::InvalidArgument,
+                                            ErrorLevel::Usage); // 0xE0E01BF1
+constexpr ResultCode ERR_MISALIGNED_SIZE(ErrorDescription::MisalignedSize, ErrorModule::OS,
+                                         ErrorSummary::InvalidArgument,
+                                         ErrorLevel::Usage); // 0xE0E01BF2
+constexpr ResultCode ERR_OUT_OF_MEMORY(ErrorDescription::OutOfMemory, ErrorModule::Kernel,
+                                       ErrorSummary::OutOfResource,
+                                       ErrorLevel::Permanent); // 0xD86007F3
+constexpr ResultCode ERR_NOT_IMPLEMENTED(ErrorDescription::NotImplemented, ErrorModule::OS,
+                                         ErrorSummary::InvalidArgument,
+                                         ErrorLevel::Usage); // 0xE0E01BF4
+constexpr ResultCode ERR_INVALID_ADDRESS(ErrorDescription::InvalidAddress, ErrorModule::OS,
+                                         ErrorSummary::InvalidArgument,
+                                         ErrorLevel::Usage); // 0xE0E01BF5
+constexpr ResultCode ERR_INVALID_ADDRESS_STATE(ErrorDescription::InvalidAddress, ErrorModule::OS,
+                                               ErrorSummary::InvalidState,
+                                               ErrorLevel::Usage); // 0xE0A01BF5
+constexpr ResultCode ERR_INVALID_POINTER(ErrorDescription::InvalidPointer, ErrorModule::Kernel,
+                                         ErrorSummary::InvalidArgument,
+                                         ErrorLevel::Permanent); // 0xD8E007F6
+constexpr ResultCode ERR_INVALID_HANDLE(ErrorDescription::InvalidHandle, ErrorModule::Kernel,
+                                        ErrorSummary::InvalidArgument,
+                                        ErrorLevel::Permanent); // 0xD8E007F7
+/// Alternate code returned instead of ERR_INVALID_HANDLE in some code paths.
+constexpr ResultCode ERR_INVALID_HANDLE_OS(ErrorDescription::InvalidHandle, ErrorModule::OS,
+                                           ErrorSummary::WrongArgument,
+                                           ErrorLevel::Permanent); // 0xD9001BF7
+constexpr ResultCode ERR_NOT_FOUND(ErrorDescription::NotFound, ErrorModule::Kernel,
+                                   ErrorSummary::NotFound, ErrorLevel::Permanent); // 0xD88007FA
+constexpr ResultCode ERR_OUT_OF_RANGE(ErrorDescription::OutOfRange, ErrorModule::OS,
+                                      ErrorSummary::InvalidArgument,
+                                      ErrorLevel::Usage); // 0xE0E01BFD
+constexpr ResultCode ERR_OUT_OF_RANGE_KERNEL(ErrorDescription::OutOfRange, ErrorModule::Kernel,
+                                             ErrorSummary::InvalidArgument,
+                                             ErrorLevel::Permanent); // 0xD8E007FD
+constexpr ResultCode RESULT_TIMEOUT(ErrorDescription::Timeout, ErrorModule::OS,
+                                    ErrorSummary::StatusChanged, ErrorLevel::Info);
+
+} // namespace Kernel

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -6,6 +6,7 @@
 #include "common/assert.h"
 #include "common/logging/log.h"
 #include "core/hle/config_mem.h"
+#include "core/hle/kernel/errors.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/memory.h"
 #include "core/hle/kernel/process.h"

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -19,13 +19,6 @@ using Handle = u32;
 
 class Thread;
 
-// TODO: Verify code
-const ResultCode ERR_OUT_OF_HANDLES(ErrorDescription::OutOfMemory, ErrorModule::Kernel,
-                                    ErrorSummary::OutOfResource, ErrorLevel::Temporary);
-// TOOD: Verify code
-const ResultCode ERR_INVALID_HANDLE(ErrorDescription::InvalidHandle, ErrorModule::Kernel,
-                                    ErrorSummary::InvalidArgument, ErrorLevel::Permanent);
-
 enum KernelHandle : Handle {
     CurrentThread = 0xFFFF8000,
     CurrentProcess = 0xFFFF8001,

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -6,6 +6,7 @@
 #include "common/assert.h"
 #include "common/common_funcs.h"
 #include "common/logging/log.h"
+#include "core/hle/kernel/errors.h"
 #include "core/hle/kernel/memory.h"
 #include "core/hle/kernel/process.h"
 #include "core/hle/kernel/resource_limit.h"

--- a/src/core/hle/kernel/semaphore.cpp
+++ b/src/core/hle/kernel/semaphore.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "common/assert.h"
+#include "core/hle/kernel/errors.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/semaphore.h"
 #include "core/hle/kernel/thread.h"
@@ -16,8 +17,7 @@ ResultVal<SharedPtr<Semaphore>> Semaphore::Create(s32 initial_count, s32 max_cou
                                                   std::string name) {
 
     if (initial_count > max_count)
-        return ResultCode(ErrorDescription::InvalidCombination, ErrorModule::Kernel,
-                          ErrorSummary::WrongArgument, ErrorLevel::Permanent);
+        return ERR_INVALID_COMBINATION_KERNEL;
 
     SharedPtr<Semaphore> semaphore(new Semaphore);
 
@@ -42,8 +42,7 @@ void Semaphore::Acquire(Thread* thread) {
 
 ResultVal<s32> Semaphore::Release(s32 release_count) {
     if (max_count - available_count < release_count)
-        return ResultCode(ErrorDescription::OutOfRange, ErrorModule::Kernel,
-                          ErrorSummary::InvalidArgument, ErrorLevel::Permanent);
+        return ERR_OUT_OF_RANGE_KERNEL;
 
     s32 previous_count = available_count;
     available_count += release_count;

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -57,7 +57,7 @@ public:
      * @param stack_top The address of the thread's stack top
      * @return A shared pointer to the newly created thread
      */
-    static ResultVal<SharedPtr<Thread>> Create(std::string name, VAddr entry_point, s32 priority,
+    static ResultVal<SharedPtr<Thread>> Create(std::string name, VAddr entry_point, u32 priority,
                                                u32 arg, s32 processor_id, VAddr stack_top);
 
     std::string GetName() const override {

--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -4,6 +4,7 @@
 
 #include <iterator>
 #include "common/assert.h"
+#include "core/hle/kernel/errors.h"
 #include "core/hle/kernel/vm_manager.h"
 #include "core/memory.h"
 #include "core/memory_setup.h"

--- a/src/core/hle/kernel/vm_manager.h
+++ b/src/core/hle/kernel/vm_manager.h
@@ -13,14 +13,6 @@
 
 namespace Kernel {
 
-const ResultCode ERR_INVALID_ADDRESS{// 0xE0E01BF5
-                                     ErrorDescription::InvalidAddress, ErrorModule::OS,
-                                     ErrorSummary::InvalidArgument, ErrorLevel::Usage};
-
-const ResultCode ERR_INVALID_ADDRESS_STATE{// 0xE0A01BF5
-                                           ErrorDescription::InvalidAddress, ErrorModule::OS,
-                                           ErrorSummary::InvalidState, ErrorLevel::Usage};
-
 enum class VMAType : u8 {
     /// VMA represents an unmapped region of the address space.
     Free,

--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -21,12 +21,6 @@
 enum class ErrorDescription : u32 {
     Success = 0,
 
-    SessionClosedByRemote = 26,
-    WrongPermission = 46,
-    OS_InvalidBufferDescriptor = 48,
-    MaxConnectionsReached = 52,
-    WrongAddress = 53,
-
     // Codes 1000 and above are considered "well-known" and have common values between all modules.
     InvalidSection = 1000,
     TooLarge = 1001,

--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -13,9 +13,14 @@
 
 // All the constants in this file come from http://3dbrew.org/wiki/Error_codes
 
-/// Detailed description of the error. This listing is likely incomplete.
+/**
+ * Detailed description of the error. Code 0 always means success. Codes 1000 and above are
+ * considered "well-known" and have common values between all modules. The meaning of other codes
+ * vary by module.
+ */
 enum class ErrorDescription : u32 {
     Success = 0,
+
     SessionClosedByRemote = 26,
     WrongPermission = 46,
     OS_InvalidBufferDescriptor = 48,
@@ -45,6 +50,8 @@ enum class ErrorDescription : u32 {
     FS_UnsupportedOpenFlags = 760,
     FS_IncorrectExeFSReadSize = 761,
     FS_UnexpectedFileOrDirectory = 770,
+
+    // Codes 1000 and above are considered "well-known" and have common values between all modules.
     InvalidSection = 1000,
     TooLarge = 1001,
     NotAuthorized = 1002,
@@ -218,7 +225,7 @@ enum class ErrorLevel : u32 {
 union ResultCode {
     u32 raw;
 
-    BitField<0, 10, ErrorDescription> description;
+    BitField<0, 10, u32> description;
     BitField<10, 8, ErrorModule> module;
 
     BitField<21, 6, ErrorSummary> summary;
@@ -230,7 +237,11 @@ union ResultCode {
 
     constexpr explicit ResultCode(u32 raw) : raw(raw) {}
 
-    constexpr ResultCode(ErrorDescription description_, ErrorModule module_, ErrorSummary summary_,
+    constexpr ResultCode(ErrorDescription description, ErrorModule module, ErrorSummary summary,
+                         ErrorLevel level)
+        : ResultCode(static_cast<u32>(description), module, summary, level) {}
+
+    constexpr ResultCode(u32 description_, ErrorModule module_, ErrorSummary summary_,
                          ErrorLevel level_)
         : raw(description.FormatValue(description_) | module.FormatValue(module_) |
               summary.FormatValue(summary_) | level.FormatValue(level_)) {}

--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -26,9 +26,6 @@ enum class ErrorDescription : u32 {
     OS_InvalidBufferDescriptor = 48,
     MaxConnectionsReached = 52,
     WrongAddress = 53,
-    OutofRangeOrMisalignedAddress =
-        513, // TODO(purpasmart): Check if this name fits its actual usage
-    GPU_FirstInitialization = 519,
 
     // Codes 1000 and above are considered "well-known" and have common values between all modules.
     InvalidSection = 1000,

--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -228,45 +228,42 @@ union ResultCode {
     // error
     BitField<31, 1, u32> is_error;
 
-    explicit ResultCode(u32 raw) : raw(raw) {}
-    ResultCode(ErrorDescription description_, ErrorModule module_, ErrorSummary summary_,
-               ErrorLevel level_)
-        : raw(0) {
-        description.Assign(description_);
-        module.Assign(module_);
-        summary.Assign(summary_);
-        level.Assign(level_);
-    }
+    constexpr explicit ResultCode(u32 raw) : raw(raw) {}
 
-    ResultCode& operator=(const ResultCode& o) {
+    constexpr ResultCode(ErrorDescription description_, ErrorModule module_, ErrorSummary summary_,
+                         ErrorLevel level_)
+        : raw(description.FormatValue(description_) | module.FormatValue(module_) |
+              summary.FormatValue(summary_) | level.FormatValue(level_)) {}
+
+    constexpr ResultCode& operator=(const ResultCode& o) {
         raw = o.raw;
         return *this;
     }
 
-    bool IsSuccess() const {
-        return is_error == 0;
+    constexpr bool IsSuccess() const {
+        return is_error.ExtractValue(raw) == 0;
     }
 
-    bool IsError() const {
-        return is_error == 1;
+    constexpr bool IsError() const {
+        return is_error.ExtractValue(raw) == 1;
     }
 };
 
-inline bool operator==(const ResultCode& a, const ResultCode& b) {
+constexpr bool operator==(const ResultCode& a, const ResultCode& b) {
     return a.raw == b.raw;
 }
 
-inline bool operator!=(const ResultCode& a, const ResultCode& b) {
+constexpr bool operator!=(const ResultCode& a, const ResultCode& b) {
     return a.raw != b.raw;
 }
 
 // Convenience functions for creating some common kinds of errors:
 
 /// The default success `ResultCode`.
-const ResultCode RESULT_SUCCESS(0);
+constexpr ResultCode RESULT_SUCCESS(0);
 
 /// Might be returned instead of a dummy success for unimplemented APIs.
-inline ResultCode UnimplementedFunction(ErrorModule module) {
+constexpr ResultCode UnimplementedFunction(ErrorModule module) {
     return ResultCode(ErrorDescription::NotImplemented, module, ErrorSummary::NotSupported,
                       ErrorLevel::Permanent);
 }

--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -26,30 +26,9 @@ enum class ErrorDescription : u32 {
     OS_InvalidBufferDescriptor = 48,
     MaxConnectionsReached = 52,
     WrongAddress = 53,
-    FS_RomFSNotFound = 100,
-    FS_ArchiveNotMounted = 101,
-    FS_FileNotFound = 112,
-    FS_PathNotFound = 113,
-    FS_GameCardNotInserted = 141,
-    FS_NotFound = 120,
-    FS_FileAlreadyExists = 180,
-    FS_DirectoryAlreadyExists = 185,
-    FS_AlreadyExists = 190,
-    FS_InvalidOpenFlags = 230,
-    FS_DirectoryNotEmpty = 240,
-    FS_NotAFile = 250,
-    FS_NotFormatted = 340, ///< This is used by the FS service when creating a SaveData archive
     OutofRangeOrMisalignedAddress =
         513, // TODO(purpasmart): Check if this name fits its actual usage
     GPU_FirstInitialization = 519,
-    FS_ExeFSSectionNotFound = 567,
-    FS_CommandNotAllowed = 630,
-    FS_InvalidReadFlag = 700,
-    FS_InvalidPath = 702,
-    FS_WriteBeyondEnd = 705,
-    FS_UnsupportedOpenFlags = 760,
-    FS_IncorrectExeFSReadSize = 761,
-    FS_UnexpectedFileOrDirectory = 770,
 
     // Codes 1000 and above are considered "well-known" and have common values between all modules.
     InvalidSection = 1000,

--- a/src/core/hle/service/boss/boss.cpp
+++ b/src/core/hle/service/boss/boss.cpp
@@ -24,9 +24,7 @@ void InitializeSession(Service::Interface* self) {
 
     if (translation != IPC::CallingPidDesc()) {
         cmd_buff[0] = IPC::MakeHeader(0, 0x1, 0); // 0x40
-        cmd_buff[1] = ResultCode(ErrorDescription::OS_InvalidBufferDescriptor, ErrorModule::OS,
-                                 ErrorSummary::WrongArgument, ErrorLevel::Permanent)
-                          .raw;
+        cmd_buff[1] = IPC::ERR_INVALID_BUFFER_DESCRIPTOR.raw;
         LOG_ERROR(Service_BOSS, "The translation was invalid, translation=0x%08X", translation);
         return;
     }

--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -11,6 +11,7 @@
 #include "common/string_util.h"
 #include "common/swap.h"
 #include "core/file_sys/archive_systemsavedata.h"
+#include "core/file_sys/errors.h"
 #include "core/file_sys/file_backend.h"
 #include "core/hle/result.h"
 #include "core/hle/service/cfg/cfg.h"
@@ -411,8 +412,7 @@ ResultCode UpdateConfigNANDSavegame() {
 ResultCode FormatConfig() {
     ResultCode res = DeleteConfigNANDSaveFile();
     // The delete command fails if the file doesn't exist, so we have to check that too
-    if (!res.IsSuccess() &&
-        res.description != static_cast<u32>(ErrorDescription::FS_FileNotFound)) {
+    if (!res.IsSuccess() && res != FileSys::ERROR_FILE_NOT_FOUND) {
         return res;
     }
     // Delete the old data
@@ -535,7 +535,7 @@ ResultCode LoadConfigNANDSaveFile() {
         Service::FS::OpenArchive(Service::FS::ArchiveIdCode::SystemSaveData, archive_path);
 
     // If the archive didn't exist, create the files inside
-    if (archive_result.Code().description == static_cast<u32>(ErrorDescription::FS_NotFormatted)) {
+    if (archive_result.Code() == FileSys::ERR_NOT_FORMATTED) {
         // Format the archive to create the directories
         Service::FS::FormatArchive(Service::FS::ArchiveIdCode::SystemSaveData,
                                    FileSys::ArchiveFormatInfo(), archive_path);

--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -411,7 +411,8 @@ ResultCode UpdateConfigNANDSavegame() {
 ResultCode FormatConfig() {
     ResultCode res = DeleteConfigNANDSaveFile();
     // The delete command fails if the file doesn't exist, so we have to check that too
-    if (!res.IsSuccess() && res.description != ErrorDescription::FS_FileNotFound) {
+    if (!res.IsSuccess() &&
+        res.description != static_cast<u32>(ErrorDescription::FS_FileNotFound)) {
         return res;
     }
     // Delete the old data
@@ -534,7 +535,7 @@ ResultCode LoadConfigNANDSaveFile() {
         Service::FS::OpenArchive(Service::FS::ArchiveIdCode::SystemSaveData, archive_path);
 
     // If the archive didn't exist, create the files inside
-    if (archive_result.Code().description == ErrorDescription::FS_NotFormatted) {
+    if (archive_result.Code().description == static_cast<u32>(ErrorDescription::FS_NotFormatted)) {
         // Format the archive to create the directories
         Service::FS::FormatArchive(Service::FS::ArchiveIdCode::SystemSaveData,
                                    FileSys::ArchiveFormatInfo(), archive_path);

--- a/src/core/hle/service/dsp_dsp.cpp
+++ b/src/core/hle/service/dsp_dsp.cpp
@@ -289,9 +289,7 @@ static void WriteProcessPipe(Service::Interface* self) {
                                "size=0x%X, buffer=0x%08X",
                   cmd_buff[3], pipe_index, size, buffer);
         cmd_buff[0] = IPC::MakeHeader(0, 1, 0);
-        cmd_buff[1] = ResultCode(ErrorDescription::OS_InvalidBufferDescriptor, ErrorModule::OS,
-                                 ErrorSummary::WrongArgument, ErrorLevel::Permanent)
-                          .raw;
+        cmd_buff[1] = IPC::ERR_INVALID_BUFFER_DESCRIPTOR.raw;
         return;
     }
 

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -22,6 +22,7 @@
 #include "core/file_sys/archive_sdmcwriteonly.h"
 #include "core/file_sys/archive_systemsavedata.h"
 #include "core/file_sys/directory_backend.h"
+#include "core/file_sys/errors.h"
 #include "core/file_sys/file_backend.h"
 #include "core/hle/kernel/client_session.h"
 #include "core/hle/result.h"
@@ -54,11 +55,6 @@ namespace FS {
 /// Returned when a function is passed an invalid handle.
 const ResultCode ERR_INVALID_HANDLE(ErrorDescription::InvalidHandle, ErrorModule::FS,
                                     ErrorSummary::InvalidArgument, ErrorLevel::Permanent);
-
-/// Returned when a function is passed an invalid archive handle.
-const ResultCode ERR_INVALID_ARCHIVE_HANDLE(ErrorDescription::FS_ArchiveNotMounted, ErrorModule::FS,
-                                            ErrorSummary::NotFound,
-                                            ErrorLevel::Status); // 0xC8804465
 
 // Command to access archive file
 enum class FileCommand : u32 {
@@ -284,7 +280,7 @@ ResultVal<ArchiveHandle> OpenArchive(ArchiveIdCode id_code, FileSys::Path& archi
 
 ResultCode CloseArchive(ArchiveHandle handle) {
     if (handle_map.erase(handle) == 0)
-        return ERR_INVALID_ARCHIVE_HANDLE;
+        return FileSys::ERR_INVALID_ARCHIVE_HANDLE;
     else
         return RESULT_SUCCESS;
 }
@@ -309,7 +305,7 @@ ResultVal<std::shared_ptr<File>> OpenFileFromArchive(ArchiveHandle archive_handl
                                                      const FileSys::Mode mode) {
     ArchiveBackend* archive = GetArchive(archive_handle);
     if (archive == nullptr)
-        return ERR_INVALID_ARCHIVE_HANDLE;
+        return FileSys::ERR_INVALID_ARCHIVE_HANDLE;
 
     auto backend = archive->OpenFile(path, mode);
     if (backend.Failed())
@@ -322,7 +318,7 @@ ResultVal<std::shared_ptr<File>> OpenFileFromArchive(ArchiveHandle archive_handl
 ResultCode DeleteFileFromArchive(ArchiveHandle archive_handle, const FileSys::Path& path) {
     ArchiveBackend* archive = GetArchive(archive_handle);
     if (archive == nullptr)
-        return ERR_INVALID_ARCHIVE_HANDLE;
+        return FileSys::ERR_INVALID_ARCHIVE_HANDLE;
 
     return archive->DeleteFile(path);
 }
@@ -334,7 +330,7 @@ ResultCode RenameFileBetweenArchives(ArchiveHandle src_archive_handle,
     ArchiveBackend* src_archive = GetArchive(src_archive_handle);
     ArchiveBackend* dest_archive = GetArchive(dest_archive_handle);
     if (src_archive == nullptr || dest_archive == nullptr)
-        return ERR_INVALID_ARCHIVE_HANDLE;
+        return FileSys::ERR_INVALID_ARCHIVE_HANDLE;
 
     if (src_archive == dest_archive) {
         return src_archive->RenameFile(src_path, dest_path);
@@ -347,7 +343,7 @@ ResultCode RenameFileBetweenArchives(ArchiveHandle src_archive_handle,
 ResultCode DeleteDirectoryFromArchive(ArchiveHandle archive_handle, const FileSys::Path& path) {
     ArchiveBackend* archive = GetArchive(archive_handle);
     if (archive == nullptr)
-        return ERR_INVALID_ARCHIVE_HANDLE;
+        return FileSys::ERR_INVALID_ARCHIVE_HANDLE;
 
     return archive->DeleteDirectory(path);
 }
@@ -356,7 +352,7 @@ ResultCode DeleteDirectoryRecursivelyFromArchive(ArchiveHandle archive_handle,
                                                  const FileSys::Path& path) {
     ArchiveBackend* archive = GetArchive(archive_handle);
     if (archive == nullptr)
-        return ERR_INVALID_ARCHIVE_HANDLE;
+        return FileSys::ERR_INVALID_ARCHIVE_HANDLE;
 
     return archive->DeleteDirectoryRecursively(path);
 }
@@ -365,7 +361,7 @@ ResultCode CreateFileInArchive(ArchiveHandle archive_handle, const FileSys::Path
                                u64 file_size) {
     ArchiveBackend* archive = GetArchive(archive_handle);
     if (archive == nullptr)
-        return ERR_INVALID_ARCHIVE_HANDLE;
+        return FileSys::ERR_INVALID_ARCHIVE_HANDLE;
 
     return archive->CreateFile(path, file_size);
 }
@@ -373,7 +369,7 @@ ResultCode CreateFileInArchive(ArchiveHandle archive_handle, const FileSys::Path
 ResultCode CreateDirectoryFromArchive(ArchiveHandle archive_handle, const FileSys::Path& path) {
     ArchiveBackend* archive = GetArchive(archive_handle);
     if (archive == nullptr)
-        return ERR_INVALID_ARCHIVE_HANDLE;
+        return FileSys::ERR_INVALID_ARCHIVE_HANDLE;
 
     return archive->CreateDirectory(path);
 }
@@ -385,7 +381,7 @@ ResultCode RenameDirectoryBetweenArchives(ArchiveHandle src_archive_handle,
     ArchiveBackend* src_archive = GetArchive(src_archive_handle);
     ArchiveBackend* dest_archive = GetArchive(dest_archive_handle);
     if (src_archive == nullptr || dest_archive == nullptr)
-        return ERR_INVALID_ARCHIVE_HANDLE;
+        return FileSys::ERR_INVALID_ARCHIVE_HANDLE;
 
     if (src_archive == dest_archive) {
         return src_archive->RenameDirectory(src_path, dest_path);
@@ -399,7 +395,7 @@ ResultVal<std::shared_ptr<Directory>> OpenDirectoryFromArchive(ArchiveHandle arc
                                                                const FileSys::Path& path) {
     ArchiveBackend* archive = GetArchive(archive_handle);
     if (archive == nullptr)
-        return ERR_INVALID_ARCHIVE_HANDLE;
+        return FileSys::ERR_INVALID_ARCHIVE_HANDLE;
 
     auto backend = archive->OpenDirectory(path);
     if (backend.Failed())
@@ -412,7 +408,7 @@ ResultVal<std::shared_ptr<Directory>> OpenDirectoryFromArchive(ArchiveHandle arc
 ResultVal<u64> GetFreeBytesInArchive(ArchiveHandle archive_handle) {
     ArchiveBackend* archive = GetArchive(archive_handle);
     if (archive == nullptr)
-        return ERR_INVALID_ARCHIVE_HANDLE;
+        return FileSys::ERR_INVALID_ARCHIVE_HANDLE;
     return MakeResult<u64>(archive->GetFreeBytes());
 }
 

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -51,11 +51,6 @@ static constexpr Kernel::Handle INVALID_HANDLE{};
 namespace Service {
 namespace FS {
 
-// TODO: Verify code
-/// Returned when a function is passed an invalid handle.
-const ResultCode ERR_INVALID_HANDLE(ErrorDescription::InvalidHandle, ErrorModule::FS,
-                                    ErrorSummary::InvalidArgument, ErrorLevel::Permanent);
-
 // Command to access archive file
 enum class FileCommand : u32 {
     Dummy1 = 0x000100C6,

--- a/src/core/hle/service/fs/fs_user.cpp
+++ b/src/core/hle/service/fs/fs_user.cpp
@@ -801,9 +801,7 @@ static void InitializeWithSdkVersion(Service::Interface* self) {
         cmd_buff[1] = RESULT_SUCCESS.raw;
     } else {
         LOG_ERROR(Service_FS, "ProcessId Header must be 0x20");
-        cmd_buff[1] = ResultCode(ErrorDescription::OS_InvalidBufferDescriptor, ErrorModule::OS,
-                                 ErrorSummary::WrongArgument, ErrorLevel::Permanent)
-                          .raw;
+        cmd_buff[1] = IPC::ERR_INVALID_BUFFER_DESCRIPTOR.raw;
     }
 }
 

--- a/src/core/hle/service/fs/fs_user.cpp
+++ b/src/core/hle/service/fs/fs_user.cpp
@@ -8,6 +8,7 @@
 #include "common/logging/log.h"
 #include "common/scope_exit.h"
 #include "common/string_util.h"
+#include "core/file_sys/errors.h"
 #include "core/hle/kernel/client_session.h"
 #include "core/hle/result.h"
 #include "core/hle/service/fs/archive.h"
@@ -539,9 +540,7 @@ static void FormatSaveData(Service::Interface* self) {
     if (archive_id != FS::ArchiveIdCode::SaveData) {
         LOG_ERROR(Service_FS, "tried to format an archive different than SaveData, %u",
                   static_cast<u32>(archive_id));
-        cmd_buff[1] = ResultCode(ErrorDescription::FS_InvalidPath, ErrorModule::FS,
-                                 ErrorSummary::InvalidArgument, ErrorLevel::Usage)
-                          .raw;
+        cmd_buff[1] = FileSys::ERROR_INVALID_PATH.raw;
         return;
     }
 

--- a/src/core/hle/service/ir/ir_user.cpp
+++ b/src/core/hle/service/ir/ir_user.cpp
@@ -267,8 +267,7 @@ static void InitializeIrNopShared(Interface* self) {
     shared_memory = Kernel::g_handle_table.Get<Kernel::SharedMemory>(handle);
     if (!shared_memory) {
         LOG_CRITICAL(Service_IR, "invalid shared memory handle 0x%08X", handle);
-        rb.Push(ResultCode(ErrorDescription::InvalidHandle, ErrorModule::OS,
-                           ErrorSummary::WrongArgument, ErrorLevel::Permanent));
+        rb.Push(IPC::ERR_INVALID_HANDLE);
         return;
     }
     shared_memory->name = "IR_USER: shared memory";

--- a/src/core/hle/service/ptm/ptm.cpp
+++ b/src/core/hle/service/ptm/ptm.cpp
@@ -134,7 +134,7 @@ void Init() {
     auto archive_result =
         Service::FS::OpenArchive(Service::FS::ArchiveIdCode::SharedExtSaveData, archive_path);
     // If the archive didn't exist, create the files inside
-    if (archive_result.Code().description == ErrorDescription::FS_NotFormatted) {
+    if (archive_result.Code().description == static_cast<u32>(ErrorDescription::FS_NotFormatted)) {
         // Format the archive to create the directories
         Service::FS::FormatArchive(Service::FS::ArchiveIdCode::SharedExtSaveData,
                                    FileSys::ArchiveFormatInfo(), archive_path);

--- a/src/core/hle/service/ptm/ptm.cpp
+++ b/src/core/hle/service/ptm/ptm.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "common/logging/log.h"
+#include "core/file_sys/errors.h"
 #include "core/file_sys/file_backend.h"
 #include "core/hle/service/fs/archive.h"
 #include "core/hle/service/ptm/ptm.h"
@@ -134,7 +135,7 @@ void Init() {
     auto archive_result =
         Service::FS::OpenArchive(Service::FS::ArchiveIdCode::SharedExtSaveData, archive_path);
     // If the archive didn't exist, create the files inside
-    if (archive_result.Code().description == static_cast<u32>(ErrorDescription::FS_NotFormatted)) {
+    if (archive_result.Code() == FileSys::ERR_NOT_FORMATTED) {
         // Format the archive to create the directories
         Service::FS::FormatArchive(Service::FS::ArchiveIdCode::SharedExtSaveData,
                                    FileSys::ArchiveFormatInfo(), archive_path);

--- a/src/core/hle/service/srv.cpp
+++ b/src/core/hle/service/srv.cpp
@@ -30,9 +30,7 @@ static void RegisterClient(Interface* self) {
 
     if (cmd_buff[1] != IPC::CallingPidDesc()) {
         cmd_buff[0] = IPC::MakeHeader(0x0, 0x1, 0); // 0x40
-        cmd_buff[1] = ResultCode(ErrorDescription::OS_InvalidBufferDescriptor, ErrorModule::OS,
-                                 ErrorSummary::WrongArgument, ErrorLevel::Permanent)
-                          .raw;
+        cmd_buff[1] = IPC::ERR_INVALID_BUFFER_DESCRIPTOR.raw;
         return;
     }
     cmd_buff[0] = IPC::MakeHeader(0x1, 0x1, 0); // 0x10040


### PR DESCRIPTION
At some point we noticed that keeping all possible descriptions in a central enum doesn't make much sense. This PR makes the description a mostly free-form integer, and does a general pass of defining result codes in a central location for a few modules.

(God, the kernel is super inconsistent in what error codes they return. It's ridiculous.)

Probably easier to review each commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2716)
<!-- Reviewable:end -->
