### PR TITLE
swrasterizer: implemented TextureCube

### DIFF
--- a/src/video_core/swrasterizer/rasterizer.cpp
+++ b/src/video_core/swrasterizer/rasterizer.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <tuple>
 #include "common/assert.h"
 #include "common/bit_field.h"
 #include "common/color.h"
@@ -69,6 +70,49 @@ static int SignedArea(const Math::Vec2<Fix12P4>& vtx1, const Math::Vec2<Fix12P4>
     // TODO: There is a very small chance this will overflow for sizeof(int) == 4
     return Math::Cross(vec1, vec2).z;
 };
+
+/// Convert a 3D vector for cube map coordinates to 2D texture coordinates along with the face name
+static std::tuple<float24, float24, PAddr> ConvertCubeCoord(float24 u, float24 v, float24 w,
+                                                            const TexturingRegs& regs) {
+    const float abs_u = std::abs(u.ToFloat32());
+    const float abs_v = std::abs(v.ToFloat32());
+    const float abs_w = std::abs(w.ToFloat32());
+    float24 x, y, z;
+    PAddr addr;
+    if (abs_u > abs_v && abs_u > abs_w) {
+        if (u > float24::FromFloat32(0)) {
+            addr = regs.GetCubePhysicalAddress(TexturingRegs::CubeFace::PositiveX);
+            y = -v;
+        } else {
+            addr = regs.GetCubePhysicalAddress(TexturingRegs::CubeFace::NegativeX);
+            y = v;
+        }
+        x = -w;
+        z = u;
+    } else if (abs_v > abs_w) {
+        if (v > float24::FromFloat32(0)) {
+            addr = regs.GetCubePhysicalAddress(TexturingRegs::CubeFace::PositiveY);
+            x = u;
+        } else {
+            addr = regs.GetCubePhysicalAddress(TexturingRegs::CubeFace::NegativeY);
+            x = -u;
+        }
+        y = w;
+        z = v;
+    } else {
+        if (w > float24::FromFloat32(0)) {
+            addr = regs.GetCubePhysicalAddress(TexturingRegs::CubeFace::PositiveZ);
+            y = -v;
+        } else {
+            addr = regs.GetCubePhysicalAddress(TexturingRegs::CubeFace::NegativeZ);
+            y = v;
+        }
+        x = u;
+        z = w;
+    }
+    const float24 half = float24::FromFloat32(0.5f);
+    return std::make_tuple(x / z * half + half, y / z * half + half, addr);
+}
 
 MICROPROFILE_DEFINE(GPU_Rasterization, "GPU", "Rasterization", MP_RGB(50, 50, 240));
 
@@ -284,10 +328,16 @@ static void ProcessTriangleInternal(const Vertex& v0, const Vertex& v1, const Ve
 
                 // Only unit 0 respects the texturing type (according to 3DBrew)
                 // TODO: Refactor so cubemaps and shadowmaps can be handled
+                PAddr texture_address = texture.config.GetPhysicalAddress();
                 if (i == 0) {
                     switch (texture.config.type) {
                     case TexturingRegs::TextureConfig::Texture2D:
                         break;
+                    case TexturingRegs::TextureConfig::TextureCube: {
+                        auto w = GetInterpolatedAttribute(v0.tc0_w, v1.tc0_w, v2.tc0_w);
+                        std::tie(u, v, texture_address) = ConvertCubeCoord(u, v, w, regs.texturing);
+                        break;
+                    }
                     case TexturingRegs::TextureConfig::Projection2D: {
                         auto tc0_w = GetInterpolatedAttribute(v0.tc0_w, v1.tc0_w, v2.tc0_w);
                         u /= tc0_w;
@@ -322,8 +372,7 @@ static void ProcessTriangleInternal(const Vertex& v0, const Vertex& v1, const Ve
                     t = texture.config.height - 1 -
                         GetWrappedTexCoord(texture.config.wrap_t, t, texture.config.height);
 
-                    u8* texture_data =
-                        Memory::GetPhysicalPointer(texture.config.GetPhysicalAddress());
+                    const u8* texture_data = Memory::GetPhysicalPointer(texture_address);
                     auto info =
                         Texture::TextureInfo::FromPicaRegister(texture.config, texture.format);
 


### PR DESCRIPTION
Currently only implemented in the software renderer, not in gl one. I have some questions regarding to this implementation and incoming gl implementation:
 - `// TODO: Refactor so cubemaps and shadowmaps can be handled` what kind of refactor is preferred here?
 - When implementing in gl, should gl's cube mapping be used, or we store them in 6 texture2D and manually convert the coordinates?

And [here](https://www.dropbox.com/s/l6zzmkiw4gh1eoq/texture_box.zip?dl=1) is a testing program

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2721)
<!-- Reviewable:end -->
