### PR TITLE
OpenGL: Improve accuracy of quaternion interpolation

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -536,8 +536,8 @@ static void WriteLighting(std::string& out, const PicaShaderConfig& config) {
     }
 
     // Rotate the surface-local normal by the interpolated normal quaternion to convert it to
-    // eyespace
-    out += "vec3 normal = normalize(quaternion_rotate(normquat, surface_normal));\n";
+    // eyespace.
+    out += "vec3 normal = quaternion_rotate(normalize(normquat), surface_normal);\n";
 
     // Gets the index into the specified lookup table for specular lighting
     auto GetLutIndex = [&lighting](unsigned light_num, LightingRegs::LightingLutInput input,
@@ -1003,7 +1003,9 @@ uniform sampler1D proctex_diff_lut;
 // Rotate the vector v by the quaternion q
 vec3 quaternion_rotate(vec4 q, vec3 v) {
     return v + 2.0 * cross(q.xyz, cross(q.xyz, v) + q.w * v);
-})";
+}
+
+)";
 
     if (config.state.proctex.enable)
         AppendProcTexSampler(out, config);


### PR DESCRIPTION
Discovered while poking around for #2726.

Current order of operations (rotate then normalize) seems to produce a
lot more distortion than normalizing and then rotating. This makes Citra
results match pretty closesly with hardware, and indicates that hardware
may also be using lerp instead of slerp to interpolate the quaternions.

[Test](https://gist.github.com/yuriks/e5b9fbacbc558587525fb22733a14fa1) results:

System | 70° | 85°
-|-|-
3DS | ![deg70-3ds](https://cloud.githubusercontent.com/assets/341401/26519177/108c9486-4272-11e7-9237-6f1a1006cc9f.png) | ![deg85-3ds](https://cloud.githubusercontent.com/assets/341401/26519178/14e72a6e-4272-11e7-815b-a611ee89fcec.png)
Citra (this PR) | ![deg70-citra-new](https://cloud.githubusercontent.com/assets/341401/26519185/2c10cdd0-4272-11e7-8f3f-fd9c2d5ebc04.png) | ![deg85-citra-new](https://cloud.githubusercontent.com/assets/341401/26519188/30e744d8-4272-11e7-9c1e-80b6949ef17c.png)
Citra (master) | ![deg70-citra-master](https://cloud.githubusercontent.com/assets/341401/26519182/1fb8ead6-4272-11e7-884e-d936e36d427b.png) | ![deg85-citra-master](https://cloud.githubusercontent.com/assets/341401/26519183/23695e0e-4272-11e7-9139-e9cf31c77186.png)

The grey band in the middle is likely caused by our broken LUT interpolation (#2551).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2729)
<!-- Reviewable:end -->
