### PR TITLE
HLE: Move SessionRequestHandler from Service:: to Kernel::

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -46,6 +46,7 @@ set(SRCS
             hle/kernel/client_session.cpp
             hle/kernel/event.cpp
             hle/kernel/handle_table.cpp
+            hle/kernel/hle_ipc.cpp
             hle/kernel/kernel.cpp
             hle/kernel/memory.cpp
             hle/kernel/mutex.cpp
@@ -239,6 +240,7 @@ set(HEADERS
             hle/kernel/errors.h
             hle/kernel/event.h
             hle/kernel/handle_table.h
+            hle/kernel/hle_ipc.h
             hle/kernel/kernel.h
             hle/kernel/memory.h
             hle/kernel/mutex.h

--- a/src/core/hle/kernel/client_port.cpp
+++ b/src/core/hle/kernel/client_port.cpp
@@ -6,6 +6,7 @@
 #include "core/hle/kernel/client_port.h"
 #include "core/hle/kernel/client_session.h"
 #include "core/hle/kernel/errors.h"
+#include "core/hle/kernel/hle_ipc.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/server_port.h"
 #include "core/hle/kernel/server_session.h"

--- a/src/core/hle/kernel/client_session.cpp
+++ b/src/core/hle/kernel/client_session.cpp
@@ -5,6 +5,8 @@
 #include "common/assert.h"
 
 #include "core/hle/kernel/client_session.h"
+#include "core/hle/kernel/errors.h"
+#include "core/hle/kernel/hle_ipc.h"
 #include "core/hle/kernel/server_session.h"
 
 namespace Kernel {

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -1,0 +1,22 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <boost/range/algorithm_ext/erase.hpp>
+#include "common/assert.h"
+#include "common/common_types.h"
+#include "core/hle/kernel/hle_ipc.h"
+#include "core/hle/kernel/kernel.h"
+#include "core/hle/kernel/server_session.h"
+
+namespace Kernel {
+
+void SessionRequestHandler::ClientConnected(SharedPtr<ServerSession> server_session) {
+    connected_sessions.push_back(server_session);
+}
+
+void SessionRequestHandler::ClientDisconnected(SharedPtr<ServerSession> server_session) {
+    boost::range::remove_erase(connected_sessions, server_session);
+}
+
+} // namespace Kernel

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -1,0 +1,52 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <vector>
+#include "core/hle/kernel/kernel.h"
+
+namespace Kernel {
+
+class ServerSession;
+
+/**
+ * Interface implemented by HLE Session handlers.
+ * This can be provided to a ServerSession in order to hook into several relevant events
+ * (such as a new connection or a SyncRequest) so they can be implemented in the emulator.
+ */
+class SessionRequestHandler {
+public:
+    /**
+     * Handles a sync request from the emulated application.
+     * @param server_session The ServerSession that was triggered for this sync request,
+     * it should be used to differentiate which client (As in ClientSession) we're answering to.
+     * TODO(Subv): Use a wrapper structure to hold all the information relevant to
+     * this request (ServerSession, Originator thread, Translated command buffer, etc).
+     * @returns ResultCode the result code of the translate operation.
+     */
+    virtual void HandleSyncRequest(Kernel::SharedPtr<Kernel::ServerSession> server_session) = 0;
+
+    /**
+     * Signals that a client has just connected to this HLE handler and keeps the
+     * associated ServerSession alive for the duration of the connection.
+     * @param server_session Owning pointer to the ServerSession associated with the connection.
+     */
+    void ClientConnected(Kernel::SharedPtr<Kernel::ServerSession> server_session);
+
+    /**
+     * Signals that a client has just disconnected from this HLE handler and releases the
+     * associated ServerSession.
+     * @param server_session ServerSession associated with the connection.
+     */
+    void ClientDisconnected(Kernel::SharedPtr<Kernel::ServerSession> server_session);
+
+protected:
+    /// List of sessions that are connected to this handler.
+    /// A ServerSession whose server endpoint is an HLE implementation is kept alive by this list
+    // for the duration of the connection.
+    std::vector<Kernel::SharedPtr<Kernel::ServerSession>> connected_sessions;
+};
+
+} // namespace Kernel

--- a/src/core/hle/kernel/server_port.cpp
+++ b/src/core/hle/kernel/server_port.cpp
@@ -24,8 +24,7 @@ void ServerPort::Acquire(Thread* thread) {
 }
 
 std::tuple<SharedPtr<ServerPort>, SharedPtr<ClientPort>> ServerPort::CreatePortPair(
-    u32 max_sessions, std::string name,
-    std::shared_ptr<Service::SessionRequestHandler> hle_handler) {
+    u32 max_sessions, std::string name, std::shared_ptr<SessionRequestHandler> hle_handler) {
 
     SharedPtr<ServerPort> server_port(new ServerPort);
     SharedPtr<ClientPort> client_port(new ClientPort);

--- a/src/core/hle/kernel/server_port.h
+++ b/src/core/hle/kernel/server_port.h
@@ -11,13 +11,10 @@
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/wait_object.h"
 
-namespace Service {
-class SessionRequestHandler;
-}
-
 namespace Kernel {
 
 class ClientPort;
+class SessionRequestHandler;
 
 class ServerPort final : public WaitObject {
 public:
@@ -31,7 +28,7 @@ public:
      */
     static std::tuple<SharedPtr<ServerPort>, SharedPtr<ClientPort>> CreatePortPair(
         u32 max_sessions, std::string name = "UnknownPort",
-        std::shared_ptr<Service::SessionRequestHandler> hle_handler = nullptr);
+        std::shared_ptr<SessionRequestHandler> hle_handler = nullptr);
 
     std::string GetTypeName() const override {
         return "ServerPort";
@@ -52,7 +49,7 @@ public:
 
     /// This session's HLE request handler template (optional)
     /// ServerSessions created from this port inherit a reference to this handler.
-    std::shared_ptr<Service::SessionRequestHandler> hle_handler;
+    std::shared_ptr<SessionRequestHandler> hle_handler;
 
     bool ShouldWait(Thread* thread) const override;
     void Acquire(Thread* thread) override;

--- a/src/core/hle/kernel/server_session.cpp
+++ b/src/core/hle/kernel/server_session.cpp
@@ -4,8 +4,11 @@
 
 #include <tuple>
 
+#include "core/hle/kernel/client_port.h"
 #include "core/hle/kernel/client_session.h"
+#include "core/hle/kernel/hle_ipc.h"
 #include "core/hle/kernel/server_session.h"
+#include "core/hle/kernel/session.h"
 #include "core/hle/kernel/thread.h"
 
 namespace Kernel {
@@ -26,7 +29,7 @@ ServerSession::~ServerSession() {
 }
 
 ResultVal<SharedPtr<ServerSession>> ServerSession::Create(
-    std::string name, std::shared_ptr<Service::SessionRequestHandler> hle_handler) {
+    std::string name, std::shared_ptr<SessionRequestHandler> hle_handler) {
     SharedPtr<ServerSession> server_session(new ServerSession);
 
     server_session->name = std::move(name);
@@ -69,7 +72,7 @@ ResultCode ServerSession::HandleSyncRequest() {
 }
 
 ServerSession::SessionPair ServerSession::CreateSessionPair(
-    const std::string& name, std::shared_ptr<Service::SessionRequestHandler> hle_handler,
+    const std::string& name, std::shared_ptr<SessionRequestHandler> hle_handler,
     SharedPtr<ClientPort> port) {
 
     auto server_session =

--- a/src/core/hle/kernel/server_session.h
+++ b/src/core/hle/kernel/server_session.h
@@ -12,7 +12,6 @@
 #include "core/hle/kernel/session.h"
 #include "core/hle/kernel/wait_object.h"
 #include "core/hle/result.h"
-#include "core/hle/service/service.h"
 #include "core/memory.h"
 
 namespace Kernel {
@@ -20,6 +19,7 @@ namespace Kernel {
 class ClientSession;
 class ClientPort;
 class ServerSession;
+class SessionRequestHandler;
 class Thread;
 
 /**
@@ -56,7 +56,7 @@ public:
      */
     static SessionPair CreateSessionPair(
         const std::string& name = "Unknown",
-        std::shared_ptr<Service::SessionRequestHandler> hle_handler = nullptr,
+        std::shared_ptr<SessionRequestHandler> hle_handler = nullptr,
         SharedPtr<ClientPort> client_port = nullptr);
 
     /**
@@ -72,7 +72,7 @@ public:
     std::string name;                ///< The name of this session (optional)
     bool signaled;                   ///< Whether there's new data available to this ServerSession
     std::shared_ptr<Session> parent; ///< The parent session, which links to the client endpoint.
-    std::shared_ptr<Service::SessionRequestHandler>
+    std::shared_ptr<SessionRequestHandler>
         hle_handler; ///< This session's HLE request handler (optional)
 
 private:
@@ -87,8 +87,7 @@ private:
      * @return The created server session
      */
     static ResultVal<SharedPtr<ServerSession>> Create(
-        std::string name = "Unknown",
-        std::shared_ptr<Service::SessionRequestHandler> hle_handler = nullptr);
+        std::string name = "Unknown", std::shared_ptr<SessionRequestHandler> hle_handler = nullptr);
 };
 
 /**

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -25,6 +25,7 @@
 #include "core/file_sys/errors.h"
 #include "core/file_sys/file_backend.h"
 #include "core/hle/kernel/client_session.h"
+#include "core/hle/kernel/server_session.h"
 #include "core/hle/result.h"
 #include "core/hle/service/fs/archive.h"
 #include "core/hle/service/fs/fs_user.h"

--- a/src/core/hle/service/fs/archive.h
+++ b/src/core/hle/service/fs/archive.h
@@ -8,7 +8,7 @@
 #include <string>
 #include "common/common_types.h"
 #include "core/file_sys/archive_backend.h"
-#include "core/hle/kernel/server_session.h"
+#include "core/hle/kernel/hle_ipc.h"
 #include "core/hle/result.h"
 
 namespace FileSys {
@@ -43,7 +43,7 @@ enum class MediaType : u32 { NAND = 0, SDMC = 1, GameCard = 2 };
 
 typedef u64 ArchiveHandle;
 
-class File final : public SessionRequestHandler, public std::enable_shared_from_this<File> {
+class File final : public Kernel::SessionRequestHandler, public std::enable_shared_from_this<File> {
 public:
     File(std::unique_ptr<FileSys::FileBackend>&& backend, const FileSys::Path& path);
     ~File();
@@ -60,7 +60,7 @@ protected:
     void HandleSyncRequest(Kernel::SharedPtr<Kernel::ServerSession> server_session) override;
 };
 
-class Directory final : public SessionRequestHandler {
+class Directory final : public Kernel::SessionRequestHandler {
 public:
     Directory(std::unique_ptr<FileSys::DirectoryBackend>&& backend, const FileSys::Path& path);
     ~Directory();

--- a/src/core/hle/service/fs/fs_user.cpp
+++ b/src/core/hle/service/fs/fs_user.cpp
@@ -11,6 +11,7 @@
 #include "core/core.h"
 #include "core/file_sys/errors.h"
 #include "core/hle/kernel/client_session.h"
+#include "core/hle/kernel/server_session.h"
 #include "core/hle/result.h"
 #include "core/hle/service/fs/archive.h"
 #include "core/hle/service/fs/fs_user.h"

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -2,11 +2,10 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <boost/range/algorithm_ext/erase.hpp>
-
 #include "common/logging/log.h"
 #include "common/string_util.h"
 #include "core/hle/kernel/server_port.h"
+#include "core/hle/kernel/server_session.h"
 #include "core/hle/service/ac/ac.h"
 #include "core/hle/service/act/act.h"
 #include "core/hle/service/am/am.h"
@@ -64,16 +63,6 @@ static std::string MakeFunctionString(const char* name, const char* port_name,
         function_string += Common::StringFromFormat(", cmd_buff[%i]=0x%X", i, cmd_buff[i]);
     }
     return function_string;
-}
-
-void SessionRequestHandler::ClientConnected(
-    Kernel::SharedPtr<Kernel::ServerSession> server_session) {
-    connected_sessions.push_back(server_session);
-}
-
-void SessionRequestHandler::ClientDisconnected(
-    Kernel::SharedPtr<Kernel::ServerSession> server_session) {
-    boost::range::remove_erase(connected_sessions, server_session);
 }
 
 Interface::Interface(u32 max_sessions) : max_sessions(max_sessions) {}


### PR DESCRIPTION
Most of the code that works with this is or will be in the kernel, so it's a more appropriate place for it to be.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2752)
<!-- Reviewable:end -->
