### PR TITLE
Handle service registrations using sm/srv

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -156,8 +156,8 @@ set(SRCS
             hle/service/qtm/qtm_sp.cpp
             hle/service/qtm/qtm_u.cpp
             hle/service/service.cpp
+            hle/service/sm/srv.cpp
             hle/service/soc_u.cpp
-            hle/service/srv.cpp
             hle/service/ssl_c.cpp
             hle/service/y2r_u.cpp
             hle/shared_page.cpp
@@ -352,8 +352,8 @@ set(HEADERS
             hle/service/qtm/qtm_sp.h
             hle/service/qtm/qtm_u.h
             hle/service/service.h
+            hle/service/sm/srv.h
             hle/service/soc_u.h
-            hle/service/srv.h
             hle/service/ssl_c.h
             hle/service/y2r_u.h
             hle/shared_page.h

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -46,6 +46,7 @@ set(SRCS
             hle/kernel/client_session.cpp
             hle/kernel/event.cpp
             hle/kernel/handle_table.cpp
+            hle/kernel/hle_ipc.cpp
             hle/kernel/kernel.cpp
             hle/kernel/memory.cpp
             hle/kernel/mutex.cpp
@@ -239,6 +240,7 @@ set(HEADERS
             hle/kernel/errors.h
             hle/kernel/event.h
             hle/kernel/handle_table.h
+            hle/kernel/hle_ipc.h
             hle/kernel/kernel.h
             hle/kernel/memory.h
             hle/kernel/mutex.h

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -156,6 +156,7 @@ set(SRCS
             hle/service/qtm/qtm_sp.cpp
             hle/service/qtm/qtm_u.cpp
             hle/service/service.cpp
+            hle/service/sm/sm.cpp
             hle/service/sm/srv.cpp
             hle/service/soc_u.cpp
             hle/service/ssl_c.cpp
@@ -352,6 +353,7 @@ set(HEADERS
             hle/service/qtm/qtm_sp.h
             hle/service/qtm/qtm_u.h
             hle/service/service.h
+            hle/service/sm/sm.h
             hle/service/sm/srv.h
             hle/service/soc_u.h
             hle/service/ssl_c.h

--- a/src/core/hle/kernel/client_port.cpp
+++ b/src/core/hle/kernel/client_port.cpp
@@ -6,6 +6,7 @@
 #include "core/hle/kernel/client_port.h"
 #include "core/hle/kernel/client_session.h"
 #include "core/hle/kernel/errors.h"
+#include "core/hle/kernel/hle_ipc.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/server_port.h"
 #include "core/hle/kernel/server_session.h"

--- a/src/core/hle/kernel/client_port.cpp
+++ b/src/core/hle/kernel/client_port.cpp
@@ -26,20 +26,17 @@ ResultVal<SharedPtr<ClientSession>> ClientPort::Connect() {
     active_sessions++;
 
     // Create a new session pair, let the created sessions inherit the parent port's HLE handler.
-    auto sessions =
-        ServerSession::CreateSessionPair(server_port->GetName(), server_port->hle_handler, this);
-    auto client_session = std::get<SharedPtr<ClientSession>>(sessions);
-    auto server_session = std::get<SharedPtr<ServerSession>>(sessions);
+    auto sessions = ServerSession::CreateSessionPair(server_port->GetName(), this);
 
     if (server_port->hle_handler)
-        server_port->hle_handler->ClientConnected(server_session);
+        server_port->hle_handler->ClientConnected(std::get<SharedPtr<ServerSession>>(sessions));
     else
-        server_port->pending_sessions.push_back(std::move(server_session));
+        server_port->pending_sessions.push_back(std::get<SharedPtr<ServerSession>>(sessions));
 
     // Wake the threads waiting on the ServerPort
     server_port->WakeupAllWaitingThreads();
 
-    return MakeResult<SharedPtr<ClientSession>>(std::move(client_session));
+    return MakeResult(std::get<SharedPtr<ClientSession>>(sessions));
 }
 
 } // namespace

--- a/src/core/hle/kernel/client_session.cpp
+++ b/src/core/hle/kernel/client_session.cpp
@@ -5,6 +5,8 @@
 #include "common/assert.h"
 
 #include "core/hle/kernel/client_session.h"
+#include "core/hle/kernel/errors.h"
+#include "core/hle/kernel/hle_ipc.h"
 #include "core/hle/kernel/server_session.h"
 
 namespace Kernel {

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -12,10 +12,12 @@
 namespace Kernel {
 
 void SessionRequestHandler::ClientConnected(SharedPtr<ServerSession> server_session) {
+    server_session->SetHleHandler(shared_from_this());
     connected_sessions.push_back(server_session);
 }
 
 void SessionRequestHandler::ClientDisconnected(SharedPtr<ServerSession> server_session) {
+    server_session->SetHleHandler(nullptr);
     boost::range::remove_erase(connected_sessions, server_session);
 }
 

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -1,0 +1,22 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <boost/range/algorithm_ext/erase.hpp>
+#include "common/assert.h"
+#include "common/common_types.h"
+#include "core/hle/kernel/hle_ipc.h"
+#include "core/hle/kernel/kernel.h"
+#include "core/hle/kernel/server_session.h"
+
+namespace Kernel {
+
+void SessionRequestHandler::ClientConnected(SharedPtr<ServerSession> server_session) {
+    connected_sessions.push_back(server_session);
+}
+
+void SessionRequestHandler::ClientDisconnected(SharedPtr<ServerSession> server_session) {
+    boost::range::remove_erase(connected_sessions, server_session);
+}
+
+} // namespace Kernel

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -1,0 +1,52 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <vector>
+#include "core/hle/kernel/kernel.h"
+
+namespace Kernel {
+
+class ServerSession;
+
+/**
+ * Interface implemented by HLE Session handlers.
+ * This can be provided to a ServerSession in order to hook into several relevant events
+ * (such as a new connection or a SyncRequest) so they can be implemented in the emulator.
+ */
+class SessionRequestHandler {
+public:
+    /**
+     * Handles a sync request from the emulated application.
+     * @param server_session The ServerSession that was triggered for this sync request,
+     * it should be used to differentiate which client (As in ClientSession) we're answering to.
+     * TODO(Subv): Use a wrapper structure to hold all the information relevant to
+     * this request (ServerSession, Originator thread, Translated command buffer, etc).
+     * @returns ResultCode the result code of the translate operation.
+     */
+    virtual void HandleSyncRequest(Kernel::SharedPtr<Kernel::ServerSession> server_session) = 0;
+
+    /**
+     * Signals that a client has just connected to this HLE handler and keeps the
+     * associated ServerSession alive for the duration of the connection.
+     * @param server_session Owning pointer to the ServerSession associated with the connection.
+     */
+    void ClientConnected(Kernel::SharedPtr<Kernel::ServerSession> server_session);
+
+    /**
+     * Signals that a client has just disconnected from this HLE handler and releases the
+     * associated ServerSession.
+     * @param server_session ServerSession associated with the connection.
+     */
+    void ClientDisconnected(Kernel::SharedPtr<Kernel::ServerSession> server_session);
+
+protected:
+    /// List of sessions that are connected to this handler.
+    /// A ServerSession whose server endpoint is an HLE implementation is kept alive by this list
+    // for the duration of the connection.
+    std::vector<Kernel::SharedPtr<Kernel::ServerSession>> connected_sessions;
+};
+
+} // namespace Kernel

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <memory>
 #include <vector>
 #include "core/hle/kernel/kernel.h"
 
@@ -16,7 +17,7 @@ class ServerSession;
  * This can be provided to a ServerSession in order to hook into several relevant events
  * (such as a new connection or a SyncRequest) so they can be implemented in the emulator.
  */
-class SessionRequestHandler {
+class SessionRequestHandler : public std::enable_shared_from_this<SessionRequestHandler> {
 public:
     /**
      * Handles a sync request from the emulated application.

--- a/src/core/hle/kernel/server_port.cpp
+++ b/src/core/hle/kernel/server_port.cpp
@@ -24,13 +24,12 @@ void ServerPort::Acquire(Thread* thread) {
 }
 
 std::tuple<SharedPtr<ServerPort>, SharedPtr<ClientPort>> ServerPort::CreatePortPair(
-    u32 max_sessions, std::string name, std::shared_ptr<SessionRequestHandler> hle_handler) {
+    u32 max_sessions, std::string name) {
 
     SharedPtr<ServerPort> server_port(new ServerPort);
     SharedPtr<ClientPort> client_port(new ClientPort);
 
     server_port->name = name + "_Server";
-    server_port->hle_handler = std::move(hle_handler);
     client_port->name = name + "_Client";
     client_port->server_port = server_port;
     client_port->max_sessions = max_sessions;

--- a/src/core/hle/kernel/server_port.cpp
+++ b/src/core/hle/kernel/server_port.cpp
@@ -24,8 +24,7 @@ void ServerPort::Acquire(Thread* thread) {
 }
 
 std::tuple<SharedPtr<ServerPort>, SharedPtr<ClientPort>> ServerPort::CreatePortPair(
-    u32 max_sessions, std::string name,
-    std::shared_ptr<Service::SessionRequestHandler> hle_handler) {
+    u32 max_sessions, std::string name, std::shared_ptr<SessionRequestHandler> hle_handler) {
 
     SharedPtr<ServerPort> server_port(new ServerPort);
     SharedPtr<ClientPort> client_port(new ClientPort);

--- a/src/core/hle/kernel/server_port.h
+++ b/src/core/hle/kernel/server_port.h
@@ -20,15 +20,13 @@ class ServerPort final : public WaitObject {
 public:
     /**
      * Creates a pair of ServerPort and an associated ClientPort.
+     *
      * @param max_sessions Maximum number of sessions to the port
      * @param name Optional name of the ports
-     * @param hle_handler Optional HLE handler template for the port,
-     * ServerSessions crated from this port will inherit a reference to this handler.
      * @return The created port tuple
      */
     static std::tuple<SharedPtr<ServerPort>, SharedPtr<ClientPort>> CreatePortPair(
-        u32 max_sessions, std::string name = "UnknownPort",
-        std::shared_ptr<SessionRequestHandler> hle_handler = nullptr);
+        u32 max_sessions, std::string name = "UnknownPort");
 
     std::string GetTypeName() const override {
         return "ServerPort";
@@ -40,6 +38,14 @@ public:
     static const HandleType HANDLE_TYPE = HandleType::ServerPort;
     HandleType GetHandleType() const override {
         return HANDLE_TYPE;
+    }
+
+    /**
+     * Sets the HLE handler template for the port. ServerSessions crated by connecting to this port
+     * will inherit a reference to this handler.
+     */
+    void SetHleHandler(std::shared_ptr<SessionRequestHandler> hle_handler_) {
+        hle_handler = std::move(hle_handler_);
     }
 
     std::string name; ///< Name of port (optional)

--- a/src/core/hle/kernel/server_port.h
+++ b/src/core/hle/kernel/server_port.h
@@ -11,13 +11,10 @@
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/wait_object.h"
 
-namespace Service {
-class SessionRequestHandler;
-}
-
 namespace Kernel {
 
 class ClientPort;
+class SessionRequestHandler;
 
 class ServerPort final : public WaitObject {
 public:
@@ -31,7 +28,7 @@ public:
      */
     static std::tuple<SharedPtr<ServerPort>, SharedPtr<ClientPort>> CreatePortPair(
         u32 max_sessions, std::string name = "UnknownPort",
-        std::shared_ptr<Service::SessionRequestHandler> hle_handler = nullptr);
+        std::shared_ptr<SessionRequestHandler> hle_handler = nullptr);
 
     std::string GetTypeName() const override {
         return "ServerPort";
@@ -52,7 +49,7 @@ public:
 
     /// This session's HLE request handler template (optional)
     /// ServerSessions created from this port inherit a reference to this handler.
-    std::shared_ptr<Service::SessionRequestHandler> hle_handler;
+    std::shared_ptr<SessionRequestHandler> hle_handler;
 
     bool ShouldWait(Thread* thread) const override;
     void Acquire(Thread* thread) override;

--- a/src/core/hle/kernel/server_session.cpp
+++ b/src/core/hle/kernel/server_session.cpp
@@ -4,8 +4,11 @@
 
 #include <tuple>
 
+#include "core/hle/kernel/client_port.h"
 #include "core/hle/kernel/client_session.h"
+#include "core/hle/kernel/hle_ipc.h"
 #include "core/hle/kernel/server_session.h"
+#include "core/hle/kernel/session.h"
 #include "core/hle/kernel/thread.h"
 
 namespace Kernel {
@@ -26,7 +29,7 @@ ServerSession::~ServerSession() {
 }
 
 ResultVal<SharedPtr<ServerSession>> ServerSession::Create(
-    std::string name, std::shared_ptr<Service::SessionRequestHandler> hle_handler) {
+    std::string name, std::shared_ptr<SessionRequestHandler> hle_handler) {
     SharedPtr<ServerSession> server_session(new ServerSession);
 
     server_session->name = std::move(name);
@@ -69,7 +72,7 @@ ResultCode ServerSession::HandleSyncRequest() {
 }
 
 ServerSession::SessionPair ServerSession::CreateSessionPair(
-    const std::string& name, std::shared_ptr<Service::SessionRequestHandler> hle_handler,
+    const std::string& name, std::shared_ptr<SessionRequestHandler> hle_handler,
     SharedPtr<ClientPort> port) {
 
     auto server_session =

--- a/src/core/hle/kernel/server_session.cpp
+++ b/src/core/hle/kernel/server_session.cpp
@@ -28,16 +28,14 @@ ServerSession::~ServerSession() {
     parent->server = nullptr;
 }
 
-ResultVal<SharedPtr<ServerSession>> ServerSession::Create(
-    std::string name, std::shared_ptr<SessionRequestHandler> hle_handler) {
+ResultVal<SharedPtr<ServerSession>> ServerSession::Create(std::string name) {
     SharedPtr<ServerSession> server_session(new ServerSession);
 
     server_session->name = std::move(name);
     server_session->signaled = false;
-    server_session->hle_handler = std::move(hle_handler);
     server_session->parent = nullptr;
 
-    return MakeResult<SharedPtr<ServerSession>>(std::move(server_session));
+    return MakeResult(std::move(server_session));
 }
 
 bool ServerSession::ShouldWait(Thread* thread) const {
@@ -71,13 +69,9 @@ ResultCode ServerSession::HandleSyncRequest() {
     return RESULT_SUCCESS;
 }
 
-ServerSession::SessionPair ServerSession::CreateSessionPair(
-    const std::string& name, std::shared_ptr<SessionRequestHandler> hle_handler,
-    SharedPtr<ClientPort> port) {
-
-    auto server_session =
-        ServerSession::Create(name + "_Server", std::move(hle_handler)).MoveFrom();
-
+ServerSession::SessionPair ServerSession::CreateSessionPair(const std::string& name,
+                                                            SharedPtr<ClientPort> port) {
+    auto server_session = ServerSession::Create(name + "_Server").MoveFrom();
     SharedPtr<ClientSession> client_session(new ClientSession);
     client_session->name = name + "_Client";
 

--- a/src/core/hle/kernel/server_session.h
+++ b/src/core/hle/kernel/server_session.h
@@ -50,14 +50,20 @@ public:
     /**
      * Creates a pair of ServerSession and an associated ClientSession.
      * @param name        Optional name of the ports.
-     * @param hle_handler Optional HLE handler for this server session.
      * @param client_port Optional The ClientPort that spawned this session.
      * @return The created session tuple
      */
-    static SessionPair CreateSessionPair(
-        const std::string& name = "Unknown",
-        std::shared_ptr<SessionRequestHandler> hle_handler = nullptr,
-        SharedPtr<ClientPort> client_port = nullptr);
+    static SessionPair CreateSessionPair(const std::string& name = "Unknown",
+                                         SharedPtr<ClientPort> client_port = nullptr);
+
+    /**
+     * Sets the HLE handler for the session. This handler will be called to service IPC requests
+     * instead of the regular IPC machinery. (The regular IPC machinery is currently not
+     * implemented.)
+     */
+    void SetHleHandler(std::shared_ptr<SessionRequestHandler> hle_handler_) {
+        hle_handler = std::move(hle_handler_);
+    }
 
     /**
      * Handle a sync request from the emulated application.
@@ -83,11 +89,9 @@ private:
      * Creates a server session. The server session can have an optional HLE handler,
      * which will be invoked to handle the IPC requests that this session receives.
      * @param name Optional name of the server session.
-     * @param hle_handler Optional HLE handler for this server session.
      * @return The created server session
      */
-    static ResultVal<SharedPtr<ServerSession>> Create(
-        std::string name = "Unknown", std::shared_ptr<SessionRequestHandler> hle_handler = nullptr);
+    static ResultVal<SharedPtr<ServerSession>> Create(std::string name = "Unknown");
 };
 
 /**

--- a/src/core/hle/kernel/server_session.h
+++ b/src/core/hle/kernel/server_session.h
@@ -12,7 +12,6 @@
 #include "core/hle/kernel/session.h"
 #include "core/hle/kernel/wait_object.h"
 #include "core/hle/result.h"
-#include "core/hle/service/service.h"
 #include "core/memory.h"
 
 namespace Kernel {
@@ -20,6 +19,7 @@ namespace Kernel {
 class ClientSession;
 class ClientPort;
 class ServerSession;
+class SessionRequestHandler;
 class Thread;
 
 /**
@@ -56,7 +56,7 @@ public:
      */
     static SessionPair CreateSessionPair(
         const std::string& name = "Unknown",
-        std::shared_ptr<Service::SessionRequestHandler> hle_handler = nullptr,
+        std::shared_ptr<SessionRequestHandler> hle_handler = nullptr,
         SharedPtr<ClientPort> client_port = nullptr);
 
     /**
@@ -72,7 +72,7 @@ public:
     std::string name;                ///< The name of this session (optional)
     bool signaled;                   ///< Whether there's new data available to this ServerSession
     std::shared_ptr<Session> parent; ///< The parent session, which links to the client endpoint.
-    std::shared_ptr<Service::SessionRequestHandler>
+    std::shared_ptr<SessionRequestHandler>
         hle_handler; ///< This session's HLE request handler (optional)
 
 private:
@@ -87,8 +87,7 @@ private:
      * @return The created server session
      */
     static ResultVal<SharedPtr<ServerSession>> Create(
-        std::string name = "Unknown",
-        std::shared_ptr<Service::SessionRequestHandler> hle_handler = nullptr);
+        std::string name = "Unknown", std::shared_ptr<SessionRequestHandler> hle_handler = nullptr);
 };
 
 /**

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -25,6 +25,7 @@
 #include "core/file_sys/errors.h"
 #include "core/file_sys/file_backend.h"
 #include "core/hle/kernel/client_session.h"
+#include "core/hle/kernel/server_session.h"
 #include "core/hle/result.h"
 #include "core/hle/service/fs/archive.h"
 #include "core/hle/service/fs/fs_user.h"

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -84,6 +84,10 @@ File::File(std::unique_ptr<FileSys::FileBackend>&& backend, const FileSys::Path&
 File::~File() {}
 
 void File::HandleSyncRequest(Kernel::SharedPtr<Kernel::ServerSession> server_session) {
+    using Kernel::ClientSession;
+    using Kernel::ServerSession;
+    using Kernel::SharedPtr;
+
     u32* cmd_buff = Kernel::GetCommandBuffer();
     FileCommand cmd = static_cast<FileCommand>(cmd_buff[0]);
     switch (cmd) {
@@ -162,10 +166,9 @@ void File::HandleSyncRequest(Kernel::SharedPtr<Kernel::ServerSession> server_ses
 
     case FileCommand::OpenLinkFile: {
         LOG_WARNING(Service_FS, "(STUBBED) File command OpenLinkFile %s", GetName().c_str());
-        auto sessions = Kernel::ServerSession::CreateSessionPair(GetName(), shared_from_this());
-        ClientConnected(std::get<Kernel::SharedPtr<Kernel::ServerSession>>(sessions));
-        cmd_buff[3] = Kernel::g_handle_table
-                          .Create(std::get<Kernel::SharedPtr<Kernel::ClientSession>>(sessions))
+        auto sessions = ServerSession::CreateSessionPair(GetName());
+        ClientConnected(std::get<SharedPtr<ServerSession>>(sessions));
+        cmd_buff[3] = Kernel::g_handle_table.Create(std::get<SharedPtr<ClientSession>>(sessions))
                           .ValueOr(INVALID_HANDLE);
         break;
     }

--- a/src/core/hle/service/fs/archive.h
+++ b/src/core/hle/service/fs/archive.h
@@ -43,7 +43,7 @@ enum class MediaType : u32 { NAND = 0, SDMC = 1, GameCard = 2 };
 
 typedef u64 ArchiveHandle;
 
-class File final : public Kernel::SessionRequestHandler, public std::enable_shared_from_this<File> {
+class File final : public Kernel::SessionRequestHandler {
 public:
     File(std::unique_ptr<FileSys::FileBackend>&& backend, const FileSys::Path& path);
     ~File();

--- a/src/core/hle/service/fs/archive.h
+++ b/src/core/hle/service/fs/archive.h
@@ -8,7 +8,7 @@
 #include <string>
 #include "common/common_types.h"
 #include "core/file_sys/archive_backend.h"
-#include "core/hle/kernel/server_session.h"
+#include "core/hle/kernel/hle_ipc.h"
 #include "core/hle/result.h"
 
 namespace FileSys {
@@ -43,7 +43,7 @@ enum class MediaType : u32 { NAND = 0, SDMC = 1, GameCard = 2 };
 
 typedef u64 ArchiveHandle;
 
-class File final : public SessionRequestHandler, public std::enable_shared_from_this<File> {
+class File final : public Kernel::SessionRequestHandler, public std::enable_shared_from_this<File> {
 public:
     File(std::unique_ptr<FileSys::FileBackend>&& backend, const FileSys::Path& path);
     ~File();
@@ -60,7 +60,7 @@ protected:
     void HandleSyncRequest(Kernel::SharedPtr<Kernel::ServerSession> server_session) override;
 };
 
-class Directory final : public SessionRequestHandler {
+class Directory final : public Kernel::SessionRequestHandler {
 public:
     Directory(std::unique_ptr<FileSys::DirectoryBackend>&& backend, const FileSys::Path& path);
     ~Directory();

--- a/src/core/hle/service/fs/fs_user.cpp
+++ b/src/core/hle/service/fs/fs_user.cpp
@@ -11,6 +11,7 @@
 #include "core/core.h"
 #include "core/file_sys/errors.h"
 #include "core/hle/kernel/client_session.h"
+#include "core/hle/kernel/server_session.h"
 #include "core/hle/result.h"
 #include "core/hle/service/fs/archive.h"
 #include "core/hle/service/fs/fs_user.h"

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -2,11 +2,10 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <boost/range/algorithm_ext/erase.hpp>
-
 #include "common/logging/log.h"
 #include "common/string_util.h"
 #include "core/hle/kernel/server_port.h"
+#include "core/hle/kernel/server_session.h"
 #include "core/hle/service/ac/ac.h"
 #include "core/hle/service/act/act.h"
 #include "core/hle/service/am/am.h"
@@ -64,16 +63,6 @@ static std::string MakeFunctionString(const char* name, const char* port_name,
         function_string += Common::StringFromFormat(", cmd_buff[%i]=0x%X", i, cmd_buff[i]);
     }
     return function_string;
-}
-
-void SessionRequestHandler::ClientConnected(
-    Kernel::SharedPtr<Kernel::ServerSession> server_session) {
-    connected_sessions.push_back(server_session);
-}
-
-void SessionRequestHandler::ClientDisconnected(
-    Kernel::SharedPtr<Kernel::ServerSession> server_session) {
-    boost::range::remove_erase(connected_sessions, server_session);
 }
 
 Interface::Interface(u32 max_sessions) : max_sessions(max_sessions) {}

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -105,18 +105,22 @@ void Interface::Register(const FunctionInfo* functions, size_t n) {
 // Module interface
 
 static void AddNamedPort(Interface* interface_) {
-    auto ports =
-        Kernel::ServerPort::CreatePortPair(interface_->GetMaxSessions(), interface_->GetPortName(),
-                                           std::shared_ptr<Interface>(interface_));
-    auto client_port = std::get<Kernel::SharedPtr<Kernel::ClientPort>>(ports);
+    Kernel::SharedPtr<Kernel::ServerPort> server_port;
+    Kernel::SharedPtr<Kernel::ClientPort> client_port;
+    std::tie(server_port, client_port) =
+        Kernel::ServerPort::CreatePortPair(interface_->GetMaxSessions(), interface_->GetPortName());
+
+    server_port->SetHleHandler(std::shared_ptr<Interface>(interface_));
     g_kernel_named_ports.emplace(interface_->GetPortName(), std::move(client_port));
 }
 
 void AddService(Interface* interface_) {
-    auto ports =
-        Kernel::ServerPort::CreatePortPair(interface_->GetMaxSessions(), interface_->GetPortName(),
-                                           std::shared_ptr<Interface>(interface_));
-    auto client_port = std::get<Kernel::SharedPtr<Kernel::ClientPort>>(ports);
+    Kernel::SharedPtr<Kernel::ServerPort> server_port;
+    Kernel::SharedPtr<Kernel::ClientPort> client_port;
+    std::tie(server_port, client_port) =
+        Kernel::ServerPort::CreatePortPair(interface_->GetMaxSessions(), interface_->GetPortName());
+
+    server_port->SetHleHandler(std::shared_ptr<Interface>(interface_));
     g_srv_services.emplace(interface_->GetPortName(), std::move(client_port));
 }
 

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -38,8 +38,8 @@
 #include "core/hle/service/ptm/ptm.h"
 #include "core/hle/service/qtm/qtm.h"
 #include "core/hle/service/service.h"
+#include "core/hle/service/sm/srv.h"
 #include "core/hle/service/soc_u.h"
-#include "core/hle/service/srv.h"
 #include "core/hle/service/ssl_c.h"
 #include "core/hle/service/y2r_u.h"
 
@@ -126,7 +126,7 @@ void AddService(Interface* interface_) {
 
 /// Initialize ServiceManager
 void Init() {
-    AddNamedPort(new SRV::SRV);
+    AddNamedPort(new SM::SRV);
     AddNamedPort(new ERR::ERR_F);
 
     FS::ArchiveInit();

--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -107,8 +107,6 @@ void Shutdown();
 
 /// Map of named ports managed by the kernel, which can be retrieved using the ConnectToPort SVC.
 extern std::unordered_map<std::string, Kernel::SharedPtr<Kernel::ClientPort>> g_kernel_named_ports;
-/// Map of services registered with the "srv:" service, retrieved using GetServiceHandle.
-extern std::unordered_map<std::string, Kernel::SharedPtr<Kernel::ClientPort>> g_srv_services;
 
 /// Adds a service to the services table
 void AddService(Interface* interface_);

--- a/src/core/hle/service/sm/sm.cpp
+++ b/src/core/hle/service/sm/sm.cpp
@@ -1,0 +1,58 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <tuple>
+#include "core/hle/kernel/client_session.h"
+#include "core/hle/kernel/server_port.h"
+#include "core/hle/result.h"
+#include "core/hle/service/sm/sm.h"
+
+namespace Service {
+namespace SM {
+
+static ResultCode ValidateServiceName(const std::string& name) {
+    if (name.size() <= 0 || name.size() > 8) {
+        return ERR_INVALID_NAME_SIZE;
+    }
+    if (name.find('\0') != std::string::npos) {
+        return ERR_NAME_CONTAINS_NUL;
+    }
+    return RESULT_SUCCESS;
+}
+
+ResultVal<Kernel::SharedPtr<Kernel::ServerPort>> ServiceManager::RegisterService(
+    std::string name, unsigned int max_sessions) {
+
+    CASCADE_CODE(ValidateServiceName(name));
+    Kernel::SharedPtr<Kernel::ServerPort> server_port;
+    Kernel::SharedPtr<Kernel::ClientPort> client_port;
+    std::tie(server_port, client_port) = Kernel::ServerPort::CreatePortPair(max_sessions, name);
+
+    registered_services.emplace(name, std::move(client_port));
+    return MakeResult<Kernel::SharedPtr<Kernel::ServerPort>>(std::move(server_port));
+}
+
+ResultVal<Kernel::SharedPtr<Kernel::ClientPort>> ServiceManager::GetServicePort(
+    const std::string& name) {
+
+    CASCADE_CODE(ValidateServiceName(name));
+    auto it = registered_services.find(name);
+    if (it == registered_services.end()) {
+        return ERR_SERVICE_NOT_REGISTERED;
+    }
+
+    return MakeResult<Kernel::SharedPtr<Kernel::ClientPort>>(it->second);
+}
+
+ResultVal<Kernel::SharedPtr<Kernel::ClientSession>> ServiceManager::ConnectToService(
+    const std::string& name) {
+
+    CASCADE_RESULT(auto client_port, GetServicePort(name));
+    return client_port->Connect();
+}
+
+std::unique_ptr<ServiceManager> g_service_manager;
+
+} // namespace SM
+} // namespace Service

--- a/src/core/hle/service/sm/sm.h
+++ b/src/core/hle/service/sm/sm.h
@@ -1,0 +1,49 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include "core/hle/kernel/kernel.h"
+#include "core/hle/result.h"
+#include "core/hle/service/service.h"
+
+namespace Kernel {
+class ClientPort;
+class ClientSession;
+class ServerPort;
+class SessionRequestHandler;
+} // namespace Kernel
+
+namespace Service {
+namespace SM {
+
+constexpr ResultCode ERR_SERVICE_NOT_REGISTERED(1, ErrorModule::SRV, ErrorSummary::WouldBlock,
+                                                ErrorLevel::Temporary); // 0xD0406401
+constexpr ResultCode ERR_MAX_CONNECTIONS_REACHED(2, ErrorModule::SRV, ErrorSummary::WouldBlock,
+                                                 ErrorLevel::Temporary); // 0xD0406402
+constexpr ResultCode ERR_INVALID_NAME_SIZE(5, ErrorModule::SRV, ErrorSummary::WrongArgument,
+                                           ErrorLevel::Permanent); // 0xD9006405
+constexpr ResultCode ERR_ACCESS_DENIED(6, ErrorModule::SRV, ErrorSummary::InvalidArgument,
+                                       ErrorLevel::Permanent); // 0xD8E06406
+constexpr ResultCode ERR_NAME_CONTAINS_NUL(7, ErrorModule::SRV, ErrorSummary::WrongArgument,
+                                           ErrorLevel::Permanent); // 0xD9006407
+
+class ServiceManager {
+public:
+    ResultVal<Kernel::SharedPtr<Kernel::ServerPort>> RegisterService(std::string name,
+                                                                     unsigned int max_sessions);
+    ResultVal<Kernel::SharedPtr<Kernel::ClientPort>> GetServicePort(const std::string& name);
+    ResultVal<Kernel::SharedPtr<Kernel::ClientSession>> ConnectToService(const std::string& name);
+
+private:
+    /// Map of services registered with the "srv:" service, retrieved using GetServiceHandle.
+    std::unordered_map<std::string, Kernel::SharedPtr<Kernel::ClientPort>> registered_services;
+};
+
+extern std::unique_ptr<ServiceManager> g_service_manager;
+
+} // namespace SM
+} // namespace Service

--- a/src/core/hle/service/sm/srv.cpp
+++ b/src/core/hle/service/sm/srv.cpp
@@ -9,10 +9,10 @@
 #include "core/hle/kernel/client_session.h"
 #include "core/hle/kernel/event.h"
 #include "core/hle/kernel/server_session.h"
-#include "core/hle/service/srv.h"
+#include "core/hle/service/sm/srv.h"
 
 namespace Service {
-namespace SRV {
+namespace SM {
 
 static Kernel::SharedPtr<Kernel::Event> event_handle;
 
@@ -184,5 +184,5 @@ SRV::~SRV() {
     event_handle = nullptr;
 }
 
-} // namespace SRV
+} // namespace SM
 } // namespace Service

--- a/src/core/hle/service/sm/srv.h
+++ b/src/core/hle/service/sm/srv.h
@@ -4,10 +4,11 @@
 
 #pragma once
 
+#include <string>
 #include "core/hle/service/service.h"
 
 namespace Service {
-namespace SRV {
+namespace SM {
 
 /// Interface to "srv:" service
 class SRV final : public Interface {
@@ -20,5 +21,5 @@ public:
     }
 };
 
-} // namespace SRV
+} // namespace SM
 } // namespace Service


### PR DESCRIPTION
Depends on:
 - [x] #2752 HLE: Move SessionRequestHandler from Service:: to Kernel::
 - [ ] #2753 Add SetHleHandler to ServerPort/ServerSession

Moves the srv/sm implementation to a sub-directory and tasks it with handling service registrations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2754)
<!-- Reviewable:end -->
