### PR TITLE
New service framework

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -385,4 +385,4 @@ set(HEADERS
 create_directory_groups(${SRCS} ${HEADERS})
 add_library(core STATIC ${SRCS} ${HEADERS})
 target_link_libraries(core PUBLIC common PRIVATE audio_core video_core)
-target_link_libraries(core PUBLIC Boost::boost PRIVATE cryptopp dynarmic)
+target_link_libraries(core PUBLIC Boost::boost PRIVATE cryptopp dynarmic fmt)

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -21,4 +21,6 @@ void SessionRequestHandler::ClientDisconnected(SharedPtr<ServerSession> server_s
     boost::range::remove_erase(connected_sessions, server_session);
 }
 
+HLERequestContext::~HLERequestContext() = default;
+
 } // namespace Kernel

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -7,10 +7,13 @@
 #include <memory>
 #include <vector>
 #include "core/hle/kernel/kernel.h"
+#include "core/hle/kernel/server_session.h"
+
+namespace Service {
+class ServiceFrameworkBase;
+}
 
 namespace Kernel {
-
-class ServerSession;
 
 /**
  * Interface implemented by HLE Session handlers.
@@ -50,6 +53,35 @@ protected:
     /// A ServerSession whose server endpoint is an HLE implementation is kept alive by this list
     // for the duration of the connection.
     std::vector<SharedPtr<ServerSession>> connected_sessions;
+};
+
+/**
+ * Class containing information about an in-flight IPC request being handled by an HLE service
+ * implementation. Services should avoid using old global APIs (e.g. Kernel::GetCommandBuffer()) and
+ * when possible use the APIs in this class to service the request.
+ */
+class HLERequestContext {
+public:
+    ~HLERequestContext();
+
+    /// Returns a pointer to the IPC command buffer for this request.
+    u32* CommandBuffer() const {
+        return cmd_buf;
+    }
+
+    /**
+     * Returns the session through which this request was made. This can be used as a map key to
+     * access per-client data on services.
+     */
+    SharedPtr<ServerSession> Session() const {
+        return session;
+    }
+
+private:
+    friend class Service::ServiceFrameworkBase;
+
+    u32* cmd_buf = nullptr;
+    SharedPtr<ServerSession> session;
 };
 
 } // namespace Kernel

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -19,6 +19,8 @@ class ServerSession;
  */
 class SessionRequestHandler : public std::enable_shared_from_this<SessionRequestHandler> {
 public:
+    virtual ~SessionRequestHandler() = default;
+
     /**
      * Handles a sync request from the emulated application.
      * @param server_session The ServerSession that was triggered for this sync request,
@@ -27,27 +29,27 @@ public:
      * this request (ServerSession, Originator thread, Translated command buffer, etc).
      * @returns ResultCode the result code of the translate operation.
      */
-    virtual void HandleSyncRequest(Kernel::SharedPtr<Kernel::ServerSession> server_session) = 0;
+    virtual void HandleSyncRequest(SharedPtr<ServerSession> server_session) = 0;
 
     /**
      * Signals that a client has just connected to this HLE handler and keeps the
      * associated ServerSession alive for the duration of the connection.
      * @param server_session Owning pointer to the ServerSession associated with the connection.
      */
-    void ClientConnected(Kernel::SharedPtr<Kernel::ServerSession> server_session);
+    void ClientConnected(SharedPtr<ServerSession> server_session);
 
     /**
      * Signals that a client has just disconnected from this HLE handler and releases the
      * associated ServerSession.
      * @param server_session ServerSession associated with the connection.
      */
-    void ClientDisconnected(Kernel::SharedPtr<Kernel::ServerSession> server_session);
+    void ClientDisconnected(SharedPtr<ServerSession> server_session);
 
 protected:
     /// List of sessions that are connected to this handler.
     /// A ServerSession whose server endpoint is an HLE implementation is kept alive by this list
     // for the duration of the connection.
-    std::vector<Kernel::SharedPtr<Kernel::ServerSession>> connected_sessions;
+    std::vector<SharedPtr<ServerSession>> connected_sessions;
 };
 
 } // namespace Kernel

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -53,7 +53,7 @@ using Kernel::SharedPtr;
 
 namespace Service {
 
-std::unordered_map<std::string, Kernel::SharedPtr<Kernel::ClientPort>> g_kernel_named_ports;
+std::unordered_map<std::string, SharedPtr<ClientPort>> g_kernel_named_ports;
 
 /**
  * Creates a function string for logging, complete with the name (or header code, depending
@@ -75,7 +75,7 @@ static std::string MakeFunctionString(const char* name, const char* port_name,
 Interface::Interface(u32 max_sessions) : max_sessions(max_sessions) {}
 Interface::~Interface() = default;
 
-void Interface::HandleSyncRequest(Kernel::SharedPtr<Kernel::ServerSession> server_session) {
+void Interface::HandleSyncRequest(SharedPtr<ServerSession> server_session) {
     // TODO(Subv): Make use of the server_session in the HLE service handlers to distinguish which
     // session triggered each command.
 
@@ -187,10 +187,10 @@ void AddNamedPort(std::string name, SharedPtr<ClientPort> port) {
 }
 
 static void AddNamedPort(Interface* interface_) {
-    Kernel::SharedPtr<Kernel::ServerPort> server_port;
-    Kernel::SharedPtr<Kernel::ClientPort> client_port;
+    SharedPtr<ServerPort> server_port;
+    SharedPtr<ClientPort> client_port;
     std::tie(server_port, client_port) =
-        Kernel::ServerPort::CreatePortPair(interface_->GetMaxSessions(), interface_->GetPortName());
+        ServerPort::CreatePortPair(interface_->GetMaxSessions(), interface_->GetPortName());
 
     server_port->SetHleHandler(std::shared_ptr<Interface>(interface_));
     AddNamedPort(interface_->GetPortName(), std::move(client_port));

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -206,8 +206,9 @@ void AddService(Interface* interface_) {
 
 /// Initialize ServiceManager
 void Init() {
-    SM::g_service_manager = std::make_unique<SM::ServiceManager>();
-    AddNamedPort(new SM::SRV);
+    SM::g_service_manager = std::make_shared<SM::ServiceManager>();
+    SM::ServiceManager::InstallInterfaces(SM::g_service_manager);
+
     AddNamedPort(new ERR::ERR_F);
 
     FS::ArchiveInit();

--- a/src/core/hle/service/sm/sm.cpp
+++ b/src/core/hle/service/sm/sm.cpp
@@ -3,11 +3,13 @@
 // Refer to the license.txt file included.
 
 #include <tuple>
+#include "common/assert.h"
 #include "core/hle/kernel/client_port.h"
 #include "core/hle/kernel/client_session.h"
 #include "core/hle/kernel/server_port.h"
 #include "core/hle/result.h"
 #include "core/hle/service/sm/sm.h"
+#include "core/hle/service/sm/srv.h"
 
 namespace Service {
 namespace SM {
@@ -22,6 +24,14 @@ static ResultCode ValidateServiceName(const std::string& name) {
     return RESULT_SUCCESS;
 }
 
+void ServiceManager::InstallInterfaces(std::shared_ptr<ServiceManager> self) {
+    ASSERT(self->srv_interface.expired());
+
+    auto srv = std::make_shared<SRV>(self);
+    srv->InstallAsNamedPort();
+    self->srv_interface = srv;
+}
+
 ResultVal<Kernel::SharedPtr<Kernel::ServerPort>> ServiceManager::RegisterService(
     std::string name, unsigned int max_sessions) {
 
@@ -30,7 +40,7 @@ ResultVal<Kernel::SharedPtr<Kernel::ServerPort>> ServiceManager::RegisterService
     Kernel::SharedPtr<Kernel::ClientPort> client_port;
     std::tie(server_port, client_port) = Kernel::ServerPort::CreatePortPair(max_sessions, name);
 
-    registered_services.emplace(name, std::move(client_port));
+    registered_services.emplace(std::move(name), std::move(client_port));
     return MakeResult<Kernel::SharedPtr<Kernel::ServerPort>>(std::move(server_port));
 }
 
@@ -53,7 +63,7 @@ ResultVal<Kernel::SharedPtr<Kernel::ClientSession>> ServiceManager::ConnectToSer
     return client_port->Connect();
 }
 
-std::unique_ptr<ServiceManager> g_service_manager;
+std::shared_ptr<ServiceManager> g_service_manager;
 
 } // namespace SM
 } // namespace Service

--- a/src/core/hle/service/sm/sm.h
+++ b/src/core/hle/service/sm/sm.h
@@ -20,6 +20,8 @@ class SessionRequestHandler;
 namespace Service {
 namespace SM {
 
+class SRV;
+
 constexpr ResultCode ERR_SERVICE_NOT_REGISTERED(1, ErrorModule::SRV, ErrorSummary::WouldBlock,
                                                 ErrorLevel::Temporary); // 0xD0406401
 constexpr ResultCode ERR_MAX_CONNECTIONS_REACHED(2, ErrorModule::SRV, ErrorSummary::WouldBlock,
@@ -33,17 +35,21 @@ constexpr ResultCode ERR_NAME_CONTAINS_NUL(7, ErrorModule::SRV, ErrorSummary::Wr
 
 class ServiceManager {
 public:
+    static void InstallInterfaces(std::shared_ptr<ServiceManager> self);
+
     ResultVal<Kernel::SharedPtr<Kernel::ServerPort>> RegisterService(std::string name,
                                                                      unsigned int max_sessions);
     ResultVal<Kernel::SharedPtr<Kernel::ClientPort>> GetServicePort(const std::string& name);
     ResultVal<Kernel::SharedPtr<Kernel::ClientSession>> ConnectToService(const std::string& name);
 
 private:
-    /// Map of services registered with the "srv:" service, retrieved using GetServiceHandle.
+    std::weak_ptr<SRV> srv_interface;
+
+    /// Map of registered services, retrieved using GetServicePort or ConnectToService.
     std::unordered_map<std::string, Kernel::SharedPtr<Kernel::ClientPort>> registered_services;
 };
 
-extern std::unique_ptr<ServiceManager> g_service_manager;
+extern std::shared_ptr<ServiceManager> g_service_manager;
 
 } // namespace SM
 } // namespace Service

--- a/src/core/hle/service/sm/srv.h
+++ b/src/core/hle/service/sm/srv.h
@@ -4,21 +4,33 @@
 
 #pragma once
 
-#include <string>
+#include "core/hle/kernel/kernel.h"
 #include "core/hle/service/service.h"
+
+namespace Kernel {
+class HLERequestContext;
+class Semaphore;
+}
 
 namespace Service {
 namespace SM {
 
 /// Interface to "srv:" service
-class SRV final : public Interface {
+class SRV final : public ServiceFramework<SRV> {
 public:
-    SRV();
-    ~SRV() override;
+    explicit SRV(std::shared_ptr<ServiceManager> service_manager);
+    ~SRV();
 
-    std::string GetPortName() const override {
-        return "srv:";
-    }
+private:
+    void RegisterClient(Kernel::HLERequestContext& ctx);
+    void EnableNotification(Kernel::HLERequestContext& ctx);
+    void GetServiceHandle(Kernel::HLERequestContext& ctx);
+    void Subscribe(Kernel::HLERequestContext& ctx);
+    void Unsubscribe(Kernel::HLERequestContext& ctx);
+    void PublishToSubscriber(Kernel::HLERequestContext& ctx);
+
+    std::shared_ptr<ServiceManager> service_manager;
+    Kernel::SharedPtr<Kernel::Semaphore> notification_semaphore;
 };
 
 } // namespace SM


### PR DESCRIPTION
From the main commit's description:

> The old "Interface" class had a few problems such as using free
> functions (Which didn't allow you to write the service handler as if it
> were a regular class.) which weren't very extensible. (Only received one
> parameter with a pointer to the Interface object.)
> 
> The new ServiceFramework aims to solve these problems by working with
> member functions and passing a generic context struct as parameter. This
> struct can be extended in the future without having to update all
> existing service implementations.

Please hold off on actually migrating stuff to this new framework for now. I have some other API changes planned/half-implemented which, while backwards compatible, should save a lot of work when writing handlers, so it's probably better to wait for them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2756)
<!-- Reviewable:end -->
