### PR TITLE
Disable warning for Cryptopp

### DIFF
--- a/externals/cryptopp/CMakeLists.txt
+++ b/externals/cryptopp/CMakeLists.txt
@@ -44,6 +44,13 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "Intel")
     add_definitions(-wd68 -wd186 -wd279 -wd327 -wd161 -wd3180)
 endif()
 
+#disable warning for external libraries
+if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+	set( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} /W0" )
+else()
+	set( CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -w" )
+endif()
+
 # Endianness
 TEST_BIG_ENDIAN(IS_BIG_ENDIAN)
 if(IS_BIG_ENDIAN)


### PR DESCRIPTION
Add CXX_FLAGS /W0 or -w, to suppress compiler warning in cryptopp component

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2758)
<!-- Reviewable:end -->
