### PR TITLE
Fragment lighting: implement lut input 5 (CP) and tangent mapping

### DIFF
--- a/src/video_core/regs_lighting.h
+++ b/src/video_core/regs_lighting.h
@@ -84,7 +84,7 @@ struct LightingRegs {
         NV = 2, // Cosine of the angle between the normal and the view vector
         LN = 3, // Cosine of the angle between the light and the normal vectors
         SP = 4, // Cosine of the angle between the light and the inverse spotlight vectors
-        CP = 5, // TODO: document and implement
+        CP = 5, // Cosine of the angle between the tangent and projection of half-angle vectors
     };
 
     enum class LightingBumpMode : u32 {


### PR DESCRIPTION
[Here](https://gist.github.com/wwylele/f61d6653620bb763ab9dc7a60a9831ce) is my notes when testing these features on 3DS.

[Here](https://github.com/wwylele/ctrhwtest/tree/master/lighting-cp) is a testing program with different bumping modes and lut inputs combined. The bump map this program uses consists of vectors of different directions, length and z-components. With this PR, the only difference between 3DS and citra is in the middle of the cube faces, where the bump map value is exactly (0.0, 0.0, 0.0), using normal map mode, CP input and "renorm" off. In this situation there is actually a divide-by-zero when projecting the vector, and game usually shouldn't have an zero normal vector, so I am not going to fix this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2762)
<!-- Reviewable:end -->
