### PR TITLE
Video Core: Add vertex loader cache

### DIFF
--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -63,6 +63,7 @@ set(HEADERS
             texture/texture_decode.h
             utils.h
             vertex_loader.h
+            vertex_loader_base.h
             video_core.h
             )
 

--- a/src/video_core/regs_pipeline.h
+++ b/src/video_core/regs_pipeline.h
@@ -21,7 +21,7 @@ struct PipelineRegs {
         FLOAT = 3,
     };
 
-    struct {
+    struct VertexAttributes {
         BitField<1, 28, u32> base_address;
 
         PAddr GetPhysicalBaseAddress() const {

--- a/src/video_core/vertex_loader.cpp
+++ b/src/video_core/vertex_loader.cpp
@@ -16,10 +16,7 @@
 
 namespace Pica {
 
-void VertexLoader::Setup(const PipelineRegs& regs) {
-    ASSERT_MSG(!is_setup, "VertexLoader is not intended to be setup more than once.");
-
-    const auto& attribute_config = regs.vertex_attributes;
+VertexLoader::VertexLoader(const PipelineRegs::VertexAttributes& attribute_config) {
     num_total_attributes = attribute_config.GetNumTotalAttributes();
 
     boost::fill(vertex_attribute_sources, 0xdeadbeef);
@@ -66,15 +63,11 @@ void VertexLoader::Setup(const PipelineRegs& regs) {
             }
         }
     }
-
-    is_setup = true;
 }
 
 void VertexLoader::LoadVertex(u32 base_address, int index, int vertex,
                               Shader::AttributeBuffer& input,
                               DebugUtils::MemoryAccessTracker& memory_accesses) {
-    ASSERT_MSG(is_setup, "A VertexLoader needs to be setup before loading vertices.");
-
     for (int i = 0; i < num_total_attributes; ++i) {
         if (vertex_attribute_elements[i] != 0) {
             // Load per-vertex data from the loader arrays

--- a/src/video_core/vertex_loader.h
+++ b/src/video_core/vertex_loader.h
@@ -3,6 +3,7 @@
 #include <array>
 #include "common/common_types.h"
 #include "video_core/regs_pipeline.h"
+#include "video_core/vertex_loader_base.h"
 
 namespace Pica {
 
@@ -14,16 +15,11 @@ namespace Shader {
 struct AttributeBuffer;
 }
 
-class VertexLoader {
+class VertexLoader : public VertexLoaderBase {
 public:
-    VertexLoader() = default;
-    explicit VertexLoader(const PipelineRegs& regs) {
-        Setup(regs);
-    }
-
-    void Setup(const PipelineRegs& regs);
+    explicit VertexLoader(const PipelineRegs::VertexAttributes& vertex_attributes);
     void LoadVertex(u32 base_address, int index, int vertex, Shader::AttributeBuffer& input,
-                    DebugUtils::MemoryAccessTracker& memory_accesses);
+                    DebugUtils::MemoryAccessTracker& memory_accesses) override;
 
     int GetNumTotalAttributes() const {
         return num_total_attributes;
@@ -36,7 +32,6 @@ private:
     std::array<u32, 16> vertex_attribute_elements{};
     std::array<bool, 16> vertex_attribute_is_default;
     int num_total_attributes = 0;
-    bool is_setup = false;
 };
 
 } // namespace Pica

--- a/src/video_core/vertex_loader_base.h
+++ b/src/video_core/vertex_loader_base.h
@@ -1,0 +1,32 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+
+#include "common/common_types.h"
+#include "common/hash.h"
+
+namespace Pica {
+namespace DebugUtils {
+class MemoryAccessTracker;
+}
+
+namespace Shader {
+struct AttributeBuffer;
+}
+
+class VertexLoaderBase {
+public:
+    virtual void LoadVertex(u32 base_address, int index, int vertex, Shader::AttributeBuffer& input,
+                            DebugUtils::MemoryAccessTracker& memory_accesses) = 0;
+};
+
+using VertexLoaderCache = std::unordered_map<u64, std::unique_ptr<VertexLoaderBase>>;
+
+static VertexLoaderCache vertex_loader_cache;
+
+} // namespace Pica


### PR DESCRIPTION
## Description

Adds a vertex loader cache. The code is similar to the shader JIT cache.

## Rationale

Before adding a vertex loader JIT, we should have a cache to store the vertex loaders so we don't need to regenerate them all the time.

## Performance

In my testing, this has no affect on performance. If anything, I'd imagine it might be slower if the cache lookup is more than the penalty for generating new vertex loaders, but I tested all of my games and the frametime didn't change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2764)
<!-- Reviewable:end -->
