### PR TITLE
Implement fragment lighting in the sw renderer.

### DIFF
--- a/src/common/quaternion.h
+++ b/src/common/quaternion.h
@@ -30,6 +30,11 @@ public:
         return {xyz * other.w + other.xyz * w + Cross(xyz, other.xyz),
                 w * other.w - Dot(xyz, other.xyz)};
     }
+
+    Quaternion<T> Normalized() const {
+        T length = std::sqrt(xyz.Length2() + w * w);
+        return {xyz / length, w / length};
+    }
 };
 
 template <typename T>

--- a/src/common/vector_math.h
+++ b/src/common/vector_math.h
@@ -462,7 +462,7 @@ public:
         z -= other.z;
         w -= other.w;
     }
-    template <typename Q = T, class = typename std::enable_if<std::is_signed<Q>::value>::type>
+    template <typename Q = T>
     Vec4<decltype(-T{})> operator-() const {
         return MakeVec(-x, -y, -z, -w);
     }

--- a/src/video_core/pica_state.h
+++ b/src/video_core/pica_state.h
@@ -79,7 +79,7 @@ struct State {
         std::array<ColorDifferenceEntry, 256> color_diff_table;
     } proctex;
 
-    struct {
+    struct Lighting {
         union LutEntry {
             // Used for raw access
             u32 raw;

--- a/src/video_core/swrasterizer/clipper.cpp
+++ b/src/video_core/swrasterizer/clipper.cpp
@@ -95,6 +95,17 @@ void ProcessTriangle(const OutputVertex& v0, const OutputVertex& v1, const Outpu
     static const size_t MAX_VERTICES = 9;
     static_vector<Vertex, MAX_VERTICES> buffer_a = {v0, v1, v2};
     static_vector<Vertex, MAX_VERTICES> buffer_b;
+
+    auto FlipQuaternionIfOpposite = [](auto& a, const auto& b) {
+        if (Math::Dot(a, b) < float24::Zero())
+            a = -a;
+    };
+
+    // Flip the quaternions if they are opposite to prevent interpolating them over the wrong
+    // direction.
+    FlipQuaternionIfOpposite(buffer_a[1].quat, buffer_a[0].quat);
+    FlipQuaternionIfOpposite(buffer_a[2].quat, buffer_a[0].quat);
+
     auto* output_list = &buffer_a;
     auto* input_list = &buffer_b;
 

--- a/src/video_core/swrasterizer/rasterizer.cpp
+++ b/src/video_core/swrasterizer/rasterizer.cpp
@@ -117,7 +117,9 @@ static std::tuple<float24, float24, PAddr> ConvertCubeCoord(float24 u, float24 v
 
 
 float LookupLightingLut(size_t lut_index, float index) {
-    unsigned index_i = static_cast<unsigned>(MathUtil::Clamp(floor(index * 256), 0.0f, 1.0f));
+    index *= 256;
+
+    unsigned index_i = static_cast<unsigned>(MathUtil::Clamp(floor(index), 0.0f, 255.0f));
 
     float index_f = index - index_i;
 
@@ -126,7 +128,7 @@ float LookupLightingLut(size_t lut_index, float index) {
     float lut_value = g_state.lighting.luts[lut_index][index_i].ToFloat();
     float lut_diff = g_state.lighting.luts[lut_index][index_i].DiffToFloat();
 
-    return lut_value + lut_diff * index_f;
+    return lut_value + lut_diff * index_f / 256.f;
 }
 
 std::tuple<Math::Vec4<u8>, Math::Vec4<u8>> ComputeFragmentsColors(const Math::Quaternion<float>& normquat, const Math::Vec3<float>& view) {

--- a/src/video_core/swrasterizer/rasterizer.cpp
+++ b/src/video_core/swrasterizer/rasterizer.cpp
@@ -132,9 +132,6 @@ std::tuple<Math::Vec4<u8>, Math::Vec4<u8>> ComputeFragmentsColors(
     const Pica::LightingRegs& lighting, const Math::Quaternion<float>& normquat,
     const Math::Vec3<float>& view) {
 
-    if (lighting.disable)
-        return {Math::MakeVec<u8>(0, 0, 0, 0), Math::MakeVec<u8>(0, 0, 0, 0)};
-
     // TODO(Subv): Bump mapping
     Math::Vec3<float> surface_normal = {0.0f, 0.0f, 1.0f};
 
@@ -728,11 +725,13 @@ static void ProcessTriangleInternal(const Vertex& v0, const Vertex& v1, const Ve
                 regs.texturing.tev_combiner_buffer_color.a,
             };
 
-            Math::Vec4<u8> primary_fragment_color;
-            Math::Vec4<u8> secondary_fragment_color;
+            Math::Vec4<u8> primary_fragment_color = {0, 0, 0, 0};
+            Math::Vec4<u8> secondary_fragment_color = {0, 0, 0, 0};
 
-            std::tie(primary_fragment_color, secondary_fragment_color) =
-                ComputeFragmentsColors(g_state.regs.lighting, normquat, fragment_position);
+            if (!g_state.regs.lighting.disable) {
+                std::tie(primary_fragment_color, secondary_fragment_color) =
+                    ComputeFragmentsColors(g_state.regs.lighting, normquat, fragment_position);
+            }
 
             for (unsigned tev_stage_index = 0; tev_stage_index < tev_stages.size();
                  ++tev_stage_index) {

--- a/src/video_core/swrasterizer/rasterizer.cpp
+++ b/src/video_core/swrasterizer/rasterizer.cpp
@@ -125,11 +125,12 @@ float LookupLightingLut(size_t lut_index, u8 index, float delta) {
     return lut_value + lut_diff * delta;
 }
 
-std::tuple<Math::Vec4<u8>, Math::Vec4<u8>> ComputeFragmentsColors(const Math::Quaternion<float>& normquat, const Math::Vec3<float>& view) {
+std::tuple<Math::Vec4<u8>, Math::Vec4<u8>> ComputeFragmentsColors(
+    const Math::Quaternion<float>& normquat, const Math::Vec3<float>& view) {
     const auto& lighting = g_state.regs.lighting;
 
     if (lighting.disable)
-        return {{}, {}};
+        return {Math::MakeVec<u8>(0, 0, 0, 0), Math::MakeVec<u8>(0, 0, 0, 0)};
 
     // TODO(Subv): Bump mapping
     Math::Vec3<float> surface_normal = {0.0f, 0.0f, 1.0f};
@@ -151,7 +152,9 @@ std::tuple<Math::Vec4<u8>, Math::Vec4<u8>> ComputeFragmentsColors(const Math::Qu
         unsigned num = lighting.light_enable.GetNum(light_index);
         const auto& light_config = g_state.regs.lighting.light[num];
 
-        Math::Vec3<float> position = {float16::FromRaw(light_config.x).ToFloat32(), float16::FromRaw(light_config.y).ToFloat32(), float16::FromRaw(light_config.z).ToFloat32()};
+        Math::Vec3<float> position = {float16::FromRaw(light_config.x).ToFloat32(),
+                                      float16::FromRaw(light_config.y).ToFloat32(),
+                                      float16::FromRaw(light_config.z).ToFloat32()};
 
         if (light_config.config.directional)
             light_vector = position;
@@ -173,11 +176,13 @@ std::tuple<Math::Vec4<u8>, Math::Vec4<u8>> ComputeFragmentsColors(const Math::Qu
             auto distance = (-view - position).Length();
             float scale = Pica::float20::FromRaw(light_config.dist_atten_scale).ToFloat32();
             float bias = Pica::float20::FromRaw(light_config.dist_atten_scale).ToFloat32();
-            size_t lut = static_cast<size_t>(LightingRegs::LightingSampler::DistanceAttenuation) + num;
+            size_t lut =
+                static_cast<size_t>(LightingRegs::LightingSampler::DistanceAttenuation) + num;
 
             float sample_loc = scale * distance + bias;
 
-            u8 lutindex = MathUtil::Clamp(std::floor(sample_loc * 256.f), 0.0f, 255.0f);
+            u8 lutindex =
+                static_cast<u8>(MathUtil::Clamp(std::floor(sample_loc * 256.f), 0.0f, 255.0f));
             float delta = sample_loc * 256 - lutindex;
             dist_atten = LookupLightingLut(lut, lutindex, delta);
         }
@@ -192,7 +197,7 @@ std::tuple<Math::Vec4<u8>, Math::Vec4<u8>> ComputeFragmentsColors(const Math::Qu
         }
 
         auto GetLutIndex = [&](unsigned num, LightingRegs::LightingLutInput input,
-                              bool abs) -> std::tuple<u8, float> {
+                               bool abs) -> std::tuple<u8, float> {
 
             Math::Vec3<float> norm_view = view.Normalized();
             Math::Vec3<float> half_angle = (norm_view + light_vector).Normalized();
@@ -216,7 +221,7 @@ std::tuple<Math::Vec4<u8>, Math::Vec4<u8>> ComputeFragmentsColors(const Math::Qu
                 break;
 
             default:
-                LOG_CRITICAL(HW_GPU, "Unknown lighting LUT input %d\n", (int)input);
+                LOG_CRITICAL(HW_GPU, "Unknown lighting LUT input %u\n", static_cast<u32>(input));
                 UNIMPLEMENTED();
                 result = 0.f;
             }
@@ -227,14 +232,15 @@ std::tuple<Math::Vec4<u8>, Math::Vec4<u8>> ComputeFragmentsColors(const Math::Qu
                 else
                     result = std::max(result, 0.0f);
 
-                u8 lutindex = MathUtil::Clamp(std::floor(result * 256.f), 0.0f, 255.0f);
+                float flr = std::floor(result * 256.f);
+                u8 lutindex = static_cast<u8>(MathUtil::Clamp(flr, 0.0f, 255.0f));
                 float delta = result * 256 - lutindex;
-                return { lutindex, delta };
+                return {lutindex, delta};
             } else {
                 float flr = std::floor(result * 128.f);
-                s8 tmpi = MathUtil::Clamp(flr, -128.0f, 127.0f);
-                float delta = result * 128.f - tmpi;
-                return { tmpi & 0xFF, delta };
+                s8 lutindex = static_cast<u8>(MathUtil::Clamp(flr, -128.0f, 127.0f));
+                float delta = result * 128.f - lutindex;
+                return {static_cast<u8>(lutindex), delta};
             }
         };
 
@@ -247,11 +253,15 @@ std::tuple<Math::Vec4<u8>, Math::Vec4<u8>> ComputeFragmentsColors(const Math::Qu
             // Lookup specular "distribution 0" LUT value
             u8 index;
             float delta;
-            std::tie(index, delta) = GetLutIndex(num, lighting.lut_input.d0.Value(), lighting.abs_lut_input.disable_d0 == 0);
+            std::tie(index, delta) = GetLutIndex(num, lighting.lut_input.d0.Value(),
+                                                 lighting.abs_lut_input.disable_d0 == 0);
 
             float scale = lighting.lut_scale.GetScale(lighting.lut_scale.d0);
 
-            d0_lut_value = scale * LookupLightingLut(static_cast<size_t>(LightingRegs::LightingSampler::Distribution0), index, delta);
+            d0_lut_value =
+                scale *
+                LookupLightingLut(static_cast<size_t>(LightingRegs::LightingSampler::Distribution0),
+                                  index, delta);
         }
 
         Math::Vec3<float> specular_0 = d0_lut_value * light_config.specular_0.ToVec3f();
@@ -263,11 +273,15 @@ std::tuple<Math::Vec4<u8>, Math::Vec4<u8>> ComputeFragmentsColors(const Math::Qu
 
             u8 index;
             float delta;
-            std::tie(index, delta) = GetLutIndex(num, lighting.lut_input.rr, lighting.abs_lut_input.disable_rr == 0);
+            std::tie(index, delta) =
+                GetLutIndex(num, lighting.lut_input.rr, lighting.abs_lut_input.disable_rr == 0);
 
             float scale = lighting.lut_scale.GetScale(lighting.lut_scale.rr);
 
-            refl_value.x = scale * LookupLightingLut(static_cast<size_t>(LightingRegs::LightingSampler::ReflectRed), index, delta);
+            refl_value.x =
+                scale *
+                LookupLightingLut(static_cast<size_t>(LightingRegs::LightingSampler::ReflectRed),
+                                  index, delta);
         } else {
             refl_value.x = 1.0f;
         }
@@ -279,11 +293,15 @@ std::tuple<Math::Vec4<u8>, Math::Vec4<u8>> ComputeFragmentsColors(const Math::Qu
 
             u8 index;
             float delta;
-            std::tie(index, delta) = GetLutIndex(num, lighting.lut_input.rg, lighting.abs_lut_input.disable_rg == 0);
+            std::tie(index, delta) =
+                GetLutIndex(num, lighting.lut_input.rg, lighting.abs_lut_input.disable_rg == 0);
 
             float scale = lighting.lut_scale.GetScale(lighting.lut_scale.rg);
 
-            refl_value.y = scale * LookupLightingLut(static_cast<size_t>(LightingRegs::LightingSampler::ReflectGreen), index, delta);
+            refl_value.y =
+                scale *
+                LookupLightingLut(static_cast<size_t>(LightingRegs::LightingSampler::ReflectGreen),
+                                  index, delta);
         } else {
             refl_value.y = refl_value.x;
         }
@@ -295,11 +313,15 @@ std::tuple<Math::Vec4<u8>, Math::Vec4<u8>> ComputeFragmentsColors(const Math::Qu
 
             u8 index;
             float delta;
-            std::tie(index, delta) = GetLutIndex(num, lighting.lut_input.rb, lighting.abs_lut_input.disable_rb == 0);
+            std::tie(index, delta) =
+                GetLutIndex(num, lighting.lut_input.rb, lighting.abs_lut_input.disable_rb == 0);
 
             float scale = lighting.lut_scale.GetScale(lighting.lut_scale.rb);
 
-            refl_value.z = scale * LookupLightingLut(static_cast<size_t>(LightingRegs::LightingSampler::ReflectBlue), index, delta);
+            refl_value.z =
+                scale *
+                LookupLightingLut(static_cast<size_t>(LightingRegs::LightingSampler::ReflectBlue),
+                                  index, delta);
         } else {
             refl_value.z = refl_value.x;
         }
@@ -312,54 +334,72 @@ std::tuple<Math::Vec4<u8>, Math::Vec4<u8>> ComputeFragmentsColors(const Math::Qu
             // Lookup specular "distribution 1" LUT value
             u8 index;
             float delta;
-            std::tie(index, delta) = GetLutIndex(num, lighting.lut_input.d1.Value(), lighting.abs_lut_input.disable_d1 == 0);
+            std::tie(index, delta) = GetLutIndex(num, lighting.lut_input.d1.Value(),
+                                                 lighting.abs_lut_input.disable_d1 == 0);
 
             float scale = lighting.lut_scale.GetScale(lighting.lut_scale.d1);
 
-            d1_lut_value = scale * LookupLightingLut(static_cast<size_t>(LightingRegs::LightingSampler::Distribution1), index, delta);
+            d1_lut_value =
+                scale *
+                LookupLightingLut(static_cast<size_t>(LightingRegs::LightingSampler::Distribution1),
+                                  index, delta);
         }
 
-        Math::Vec3<float> specular_1 = d1_lut_value * refl_value * light_config.specular_1.ToVec3f();
+        Math::Vec3<float> specular_1 =
+            d1_lut_value * refl_value * light_config.specular_1.ToVec3f();
 
         if (lighting.config1.disable_lut_fr == 0 &&
-            LightingRegs::IsLightingSamplerSupported(
-                lighting.config0.config, LightingRegs::LightingSampler::Fresnel)) {
+            LightingRegs::IsLightingSamplerSupported(lighting.config0.config,
+                                                     LightingRegs::LightingSampler::Fresnel)) {
 
             // Lookup fresnel LUT value
             u8 index;
             float delta;
-            std::tie(index, delta) = GetLutIndex(num, lighting.lut_input.fr.Value(), lighting.abs_lut_input.disable_fr == 0);
+            std::tie(index, delta) = GetLutIndex(num, lighting.lut_input.fr.Value(),
+                                                 lighting.abs_lut_input.disable_fr == 0);
 
             float scale = lighting.lut_scale.GetScale(lighting.lut_scale.fr);
 
-            float lut_value = scale * LookupLightingLut(static_cast<size_t>(LightingRegs::LightingSampler::Fresnel), index, delta);
+            float lut_value =
+                scale *
+                LookupLightingLut(static_cast<size_t>(LightingRegs::LightingSampler::Fresnel),
+                                  index, delta);
 
-            // Enabled for difffuse lighting alpha component
-            if (lighting.config0.fresnel_selector == LightingRegs::LightingFresnelSelector::PrimaryAlpha ||
+            // Enabled for diffuse lighting alpha component
+            if (lighting.config0.fresnel_selector ==
+                    LightingRegs::LightingFresnelSelector::PrimaryAlpha ||
                 lighting.config0.fresnel_selector == LightingRegs::LightingFresnelSelector::Both) {
                 diffuse_sum.a() *= lut_value;
             }
 
             // Enabled for the specular lighting alpha component
             if (lighting.config0.fresnel_selector ==
-                LightingRegs::LightingFresnelSelector::SecondaryAlpha ||
+                    LightingRegs::LightingFresnelSelector::SecondaryAlpha ||
                 lighting.config0.fresnel_selector == LightingRegs::LightingFresnelSelector::Both) {
                 specular_sum.a() *= lut_value;
             }
         }
 
-
-        auto diffuse = light_config.diffuse.ToVec3f() * dot_product + light_config.ambient.ToVec3f();
+        auto diffuse =
+            light_config.diffuse.ToVec3f() * dot_product + light_config.ambient.ToVec3f();
         diffuse_sum += Math::MakeVec(diffuse * dist_atten, 0.0f);
 
-        specular_sum += Math::MakeVec((specular_0 + specular_1) * clamp_highlights * dist_atten, 0.f);
+        specular_sum +=
+            Math::MakeVec((specular_0 + specular_1) * clamp_highlights * dist_atten, 0.f);
     }
 
     diffuse_sum += Math::MakeVec(lighting.global_ambient.ToVec3f(), 0.0f);
-    return {
-        Math::MakeVec<float>(MathUtil::Clamp(diffuse_sum.x, 0.0f, 1.0f) * 255, MathUtil::Clamp(diffuse_sum.y, 0.0f, 1.0f) * 255, MathUtil::Clamp(diffuse_sum.z, 0.0f, 1.0f) * 255, MathUtil::Clamp(diffuse_sum.w, 0.0f, 1.0f) * 255).Cast<u8>(),
-        Math::MakeVec<float>(MathUtil::Clamp(specular_sum.x, 0.0f, 1.0f) * 255, MathUtil::Clamp(specular_sum.y, 0.0f, 1.0f) * 255, MathUtil::Clamp(specular_sum.z, 0.0f, 1.0f) * 255, MathUtil::Clamp(specular_sum.w, 0.0f, 1.0f) * 255).Cast<u8>()
-    };
+
+    return {Math::MakeVec<float>(MathUtil::Clamp(diffuse_sum.x, 0.0f, 1.0f) * 255,
+                                 MathUtil::Clamp(diffuse_sum.y, 0.0f, 1.0f) * 255,
+                                 MathUtil::Clamp(diffuse_sum.z, 0.0f, 1.0f) * 255,
+                                 MathUtil::Clamp(diffuse_sum.w, 0.0f, 1.0f) * 255)
+                .Cast<u8>(),
+            Math::MakeVec<float>(MathUtil::Clamp(specular_sum.x, 0.0f, 1.0f) * 255,
+                                 MathUtil::Clamp(specular_sum.y, 0.0f, 1.0f) * 255,
+                                 MathUtil::Clamp(specular_sum.z, 0.0f, 1.0f) * 255,
+                                 MathUtil::Clamp(specular_sum.w, 0.0f, 1.0f) * 255)
+                .Cast<u8>()};
 }
 
 MICROPROFILE_DEFINE(GPU_Rasterization, "GPU", "Rasterization", MP_RGB(50, 50, 240));
@@ -554,19 +594,16 @@ static void ProcessTriangleInternal(const Vertex& v0, const Vertex& v1, const Ve
             };
 
             Math::Quaternion<float> normquat{
-                {
-                    GetInterpolatedAttribute(v0.quat.x, v1.quat.x, v2.quat.x).ToFloat32(),
-                    GetInterpolatedAttribute(v0.quat.y, v1.quat.y, v2.quat.y).ToFloat32(),
-                    GetInterpolatedAttribute(v0.quat.z, v1.quat.z, v2.quat.z).ToFloat32()
-                },
+                {GetInterpolatedAttribute(v0.quat.x, v1.quat.x, v2.quat.x).ToFloat32(),
+                 GetInterpolatedAttribute(v0.quat.y, v1.quat.y, v2.quat.y).ToFloat32(),
+                 GetInterpolatedAttribute(v0.quat.z, v1.quat.z, v2.quat.z).ToFloat32()},
                 GetInterpolatedAttribute(v0.quat.w, v1.quat.w, v2.quat.w).ToFloat32(),
             };
 
             Math::Vec3<float> fragment_position{
                 GetInterpolatedAttribute(v0.view.x, v1.view.x, v2.view.x).ToFloat32(),
                 GetInterpolatedAttribute(v0.view.y, v1.view.y, v2.view.y).ToFloat32(),
-                GetInterpolatedAttribute(v0.view.z, v1.view.z, v2.view.z).ToFloat32()
-            };
+                GetInterpolatedAttribute(v0.view.z, v1.view.z, v2.view.z).ToFloat32()};
 
             Math::Vec2<float24> uv[3];
             uv[0].u() = GetInterpolatedAttribute(v0.tc0.u(), v1.tc0.u(), v2.tc0.u());
@@ -685,7 +722,8 @@ static void ProcessTriangleInternal(const Vertex& v0, const Vertex& v1, const Ve
             Math::Vec4<u8> primary_fragment_color;
             Math::Vec4<u8> secondary_fragment_color;
 
-            std::tie(primary_fragment_color, secondary_fragment_color) = ComputeFragmentsColors(normquat, fragment_position);
+            std::tie(primary_fragment_color, secondary_fragment_color) =
+                ComputeFragmentsColors(normquat, fragment_position);
 
             for (unsigned tev_stage_index = 0; tev_stage_index < tev_stages.size();
                  ++tev_stage_index) {

--- a/src/video_core/swrasterizer/rasterizer.cpp
+++ b/src/video_core/swrasterizer/rasterizer.cpp
@@ -175,12 +175,11 @@ std::tuple<Math::Vec4<u8>, Math::Vec4<u8>> ComputeFragmentsColors(
         if (!lighting.IsDistAttenDisabled(num)) {
             auto distance = (-view - position).Length();
             float scale = Pica::float20::FromRaw(light_config.dist_atten_scale).ToFloat32();
-            float dist_aten_bias =
-                Pica::float20::FromRaw(light_config.dist_atten_scale).ToFloat32();
+            float bias = Pica::float20::FromRaw(light_config.dist_atten_bias).ToFloat32();
             size_t lut =
                 static_cast<size_t>(LightingRegs::LightingSampler::DistanceAttenuation) + num;
 
-            float sample_loc = scale * distance + dist_aten_bias;
+            float sample_loc = scale * distance + bias;
 
             u8 lutindex =
                 static_cast<u8>(MathUtil::Clamp(std::floor(sample_loc * 256.f), 0.0f, 255.0f));

--- a/src/video_core/swrasterizer/rasterizer.cpp
+++ b/src/video_core/swrasterizer/rasterizer.cpp
@@ -129,8 +129,8 @@ static float LookupLightingLut(const Pica::State::Lighting& lighting, size_t lut
 }
 
 std::tuple<Math::Vec4<u8>, Math::Vec4<u8>> ComputeFragmentsColors(
-    const Math::Quaternion<float>& normquat, const Math::Vec3<float>& view) {
-    const auto& lighting = g_state.regs.lighting;
+    const Pica::LightingRegs& lighting, const Math::Quaternion<float>& normquat,
+    const Math::Vec3<float>& view) {
 
     if (lighting.disable)
         return {Math::MakeVec<u8>(0, 0, 0, 0), Math::MakeVec<u8>(0, 0, 0, 0)};
@@ -732,7 +732,7 @@ static void ProcessTriangleInternal(const Vertex& v0, const Vertex& v1, const Ve
             Math::Vec4<u8> secondary_fragment_color;
 
             std::tie(primary_fragment_color, secondary_fragment_color) =
-                ComputeFragmentsColors(normquat, fragment_position);
+                ComputeFragmentsColors(g_state.regs.lighting, normquat, fragment_position);
 
             for (unsigned tev_stage_index = 0; tev_stage_index < tev_stages.size();
                  ++tev_stage_index) {

--- a/src/video_core/swrasterizer/rasterizer.cpp
+++ b/src/video_core/swrasterizer/rasterizer.cpp
@@ -115,12 +115,15 @@ static std::tuple<float24, float24, PAddr> ConvertCubeCoord(float24 u, float24 v
     return std::make_tuple(x / z * half + half, y / z * half + half, addr);
 }
 
-float LookupLightingLut(size_t lut_index, u8 index, float delta) {
-    ASSERT_MSG(lut_index < g_state.lighting.luts.size(), "Out of range lut");
-    ASSERT_MSG(index < g_state.lighting.luts[0].size(), "Out of range index");
+static float LookupLightingLut(const Pica::State::Lighting& lighting, size_t lut_index, u8 index,
+                        float delta) {
+    ASSERT_MSG(lut_index < lighting.luts.size(), "Out of range lut");
+    ASSERT_MSG(index < lighting.luts[0].size(), "Out of range index");
 
-    float lut_value = g_state.lighting.luts[lut_index][index].ToFloat();
-    float lut_diff = g_state.lighting.luts[lut_index][index].DiffToFloat();
+    const auto& lut = lighting.luts[lut_index][index];
+
+    float lut_value = lut.ToFloat();
+    float lut_diff = lut.DiffToFloat();
 
     return lut_value + lut_diff * delta;
 }
@@ -184,7 +187,7 @@ std::tuple<Math::Vec4<u8>, Math::Vec4<u8>> ComputeFragmentsColors(
             u8 lutindex =
                 static_cast<u8>(MathUtil::Clamp(std::floor(sample_loc * 256.f), 0.0f, 255.0f));
             float delta = sample_loc * 256 - lutindex;
-            dist_atten = LookupLightingLut(lut, lutindex, delta);
+            dist_atten = LookupLightingLut(g_state.lighting, lut, lutindex, delta);
         }
 
         float clamp_highlights = 1.0f;
@@ -260,7 +263,8 @@ std::tuple<Math::Vec4<u8>, Math::Vec4<u8>> ComputeFragmentsColors(
 
             d0_lut_value =
                 scale *
-                LookupLightingLut(static_cast<size_t>(LightingRegs::LightingSampler::Distribution0),
+                LookupLightingLut(g_state.lighting,
+                                  static_cast<size_t>(LightingRegs::LightingSampler::Distribution0),
                                   index, delta);
         }
 
@@ -280,7 +284,8 @@ std::tuple<Math::Vec4<u8>, Math::Vec4<u8>> ComputeFragmentsColors(
 
             refl_value.x =
                 scale *
-                LookupLightingLut(static_cast<size_t>(LightingRegs::LightingSampler::ReflectRed),
+                LookupLightingLut(g_state.lighting,
+                                  static_cast<size_t>(LightingRegs::LightingSampler::ReflectRed),
                                   index, delta);
         } else {
             refl_value.x = 1.0f;
@@ -300,7 +305,8 @@ std::tuple<Math::Vec4<u8>, Math::Vec4<u8>> ComputeFragmentsColors(
 
             refl_value.y =
                 scale *
-                LookupLightingLut(static_cast<size_t>(LightingRegs::LightingSampler::ReflectGreen),
+                LookupLightingLut(g_state.lighting,
+                                  static_cast<size_t>(LightingRegs::LightingSampler::ReflectGreen),
                                   index, delta);
         } else {
             refl_value.y = refl_value.x;
@@ -320,7 +326,8 @@ std::tuple<Math::Vec4<u8>, Math::Vec4<u8>> ComputeFragmentsColors(
 
             refl_value.z =
                 scale *
-                LookupLightingLut(static_cast<size_t>(LightingRegs::LightingSampler::ReflectBlue),
+                LookupLightingLut(g_state.lighting,
+                                  static_cast<size_t>(LightingRegs::LightingSampler::ReflectBlue),
                                   index, delta);
         } else {
             refl_value.z = refl_value.x;
@@ -341,7 +348,8 @@ std::tuple<Math::Vec4<u8>, Math::Vec4<u8>> ComputeFragmentsColors(
 
             d1_lut_value =
                 scale *
-                LookupLightingLut(static_cast<size_t>(LightingRegs::LightingSampler::Distribution1),
+                LookupLightingLut(g_state.lighting,
+                                  static_cast<size_t>(LightingRegs::LightingSampler::Distribution1),
                                   index, delta);
         }
 
@@ -362,7 +370,8 @@ std::tuple<Math::Vec4<u8>, Math::Vec4<u8>> ComputeFragmentsColors(
 
             float lut_value =
                 scale *
-                LookupLightingLut(static_cast<size_t>(LightingRegs::LightingSampler::Fresnel),
+                LookupLightingLut(g_state.lighting,
+                                  static_cast<size_t>(LightingRegs::LightingSampler::Fresnel),
                                   index, delta);
 
             // Enabled for diffuse lighting alpha component

--- a/src/video_core/swrasterizer/rasterizer.cpp
+++ b/src/video_core/swrasterizer/rasterizer.cpp
@@ -362,13 +362,6 @@ std::tuple<Math::Vec4<u8>, Math::Vec4<u8>> ComputeFragmentsColors(const Math::Qu
     };
 }
 
-static bool AreQuaternionsOpposite(Math::Vec4<Pica::float24> qa, Math::Vec4<Pica::float24> qb) {
-    Math::Vec4f a{ qa.x.ToFloat32(), qa.y.ToFloat32(), qa.z.ToFloat32(), qa.w.ToFloat32() };
-    Math::Vec4f b{ qb.x.ToFloat32(), qb.y.ToFloat32(), qb.z.ToFloat32(), qb.w.ToFloat32() };
-
-    return (Math::Dot(a, b) < 0.f);
-}
-
 MICROPROFILE_DEFINE(GPU_Rasterization, "GPU", "Rasterization", MP_RGB(50, 50, 240));
 
 /**
@@ -461,15 +454,6 @@ static void ProcessTriangleInternal(const Vertex& v0, const Vertex& v1, const Ve
         IsRightSideOrFlatBottomEdge(vtxpos[1].xy(), vtxpos[2].xy(), vtxpos[0].xy()) ? -1 : 0;
     int bias2 =
         IsRightSideOrFlatBottomEdge(vtxpos[2].xy(), vtxpos[0].xy(), vtxpos[1].xy()) ? -1 : 0;
-
-    // Flip the quaternions if they are opposite to prevent interpolating them over the wrong direction.
-    auto v1_quat = v1.quat;
-    auto v2_quat = v2.quat;
-
-    if (AreQuaternionsOpposite(v0.quat, v1.quat))
-        v1_quat = v1_quat * float24::FromFloat32(-1.0f);
-    if (AreQuaternionsOpposite(v0.quat, v2.quat))
-        v2_quat = v2_quat * float24::FromFloat32(-1.0f);
 
     auto w_inverse = Math::MakeVec(v0.pos.w, v1.pos.w, v2.pos.w);
 
@@ -571,11 +555,11 @@ static void ProcessTriangleInternal(const Vertex& v0, const Vertex& v1, const Ve
 
             Math::Quaternion<float> normquat{
                 {
-                    GetInterpolatedAttribute(v0.quat.x, v1_quat.x, v2_quat.x).ToFloat32(),
-                    GetInterpolatedAttribute(v0.quat.y, v1_quat.y, v2_quat.y).ToFloat32(),
-                    GetInterpolatedAttribute(v0.quat.z, v1_quat.z, v2_quat.z).ToFloat32()
+                    GetInterpolatedAttribute(v0.quat.x, v1.quat.x, v2.quat.x).ToFloat32(),
+                    GetInterpolatedAttribute(v0.quat.y, v1.quat.y, v2.quat.y).ToFloat32(),
+                    GetInterpolatedAttribute(v0.quat.z, v1.quat.z, v2.quat.z).ToFloat32()
                 },
-                GetInterpolatedAttribute(v0.quat.w, v1_quat.w, v2_quat.w).ToFloat32(),
+                GetInterpolatedAttribute(v0.quat.w, v1.quat.w, v2.quat.w).ToFloat32(),
             };
 
             Math::Vec3<float> fragment_position{

--- a/src/video_core/swrasterizer/rasterizer.cpp
+++ b/src/video_core/swrasterizer/rasterizer.cpp
@@ -177,9 +177,9 @@ std::tuple<Math::Vec4<u8>, Math::Vec4<u8>> ComputeFragmentsColors(const Math::Qu
 
             float sample_loc = scale * distance + bias;
 
-            u8 lutindex = MathUtil::Clamp(floorf(sample_loc * 256.f), 0.0f, 255.0f);
+            u8 lutindex = MathUtil::Clamp(std::floor(sample_loc * 256.f), 0.0f, 255.0f);
             float delta = sample_loc * 256 - lutindex;
-            dist_atten = LookupLightingLut(lut, lutindex, delta / 256.f);
+            dist_atten = LookupLightingLut(lut, lutindex, delta);
         }
 
         float clamp_highlights = 1.0f;
@@ -227,13 +227,14 @@ std::tuple<Math::Vec4<u8>, Math::Vec4<u8>> ComputeFragmentsColors(const Math::Qu
                 else
                     result = std::max(result, 0.0f);
 
-                u8 lutindex = MathUtil::Clamp(floorf(result * 256.f), 0.0f, 255.0f);
+                u8 lutindex = MathUtil::Clamp(std::floor(result * 256.f), 0.0f, 255.0f);
                 float delta = result * 256 - lutindex;
-                return { lutindex, delta / 256.f };
+                return { lutindex, delta };
             } else {
-                u8 tmpi = MathUtil::Clamp(floorf(result * 128.f), 0.0f, 127.0f);
+                float flr = std::floor(result * 128.f);
+                s8 tmpi = MathUtil::Clamp(flr, -128.0f, 127.0f);
                 float delta = result * 128.f - tmpi;
-                return { tmpi & 0xFF, delta / 128.f };
+                return { tmpi & 0xFF, delta };
             }
         };
 


### PR DESCRIPTION
The code in the hw renderer was used as a base.

Bump mapping is **not** yet implemented.

This implementation does use the difference values in the lighting LUTs instead of always doing linear interpolation.

The differences between the sw renderer and the hw renderer are now fewer.

Here are some screenshots:

Super Mario 3D Land:
![](http://i.imgur.com/PvtJ9r9.png)

Image from hw for reference:

![](https://i.imgur.com/FZvqOrD.png)


Kirby Triple Deluxe:

![](https://cdn.discordapp.com/attachments/242442830486700045/322835487066685451/unknown.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2766)
<!-- Reviewable:end -->
