### PR TITLE
Add basic support for IPC translation for HLE services

### DIFF
--- a/src/core/hle/ipc.h
+++ b/src/core/hle/ipc.h
@@ -44,6 +44,9 @@ inline u32* GetStaticBuffers(const int offset = 0) {
 
 namespace IPC {
 
+/// Size of the command buffer area, in 32-bit words.
+constexpr size_t COMMAND_BUFFER_LENGTH = 0x100 / sizeof(u32);
+
 // These errors are commonly returned by invalid IPC translations, so alias them here for
 // convenience.
 // TODO(yuriks): These will probably go away once translation is implemented inside the kernel.

--- a/src/core/hle/ipc_helpers.h
+++ b/src/core/hle/ipc_helpers.h
@@ -62,6 +62,9 @@ class RequestBuilder : public RequestHelperBase {
 public:
     RequestBuilder(Kernel::HLERequestContext& context, Header command_header)
         : RequestHelperBase(context, command_header) {
+        // From this point we will start overwriting the existing command buffer, so it's safe to
+        // release all previous incoming Object pointers since they won't be usable anymore.
+        context.ClearIncomingObjects();
         cmdbuf[0] = header.raw;
     }
 

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -5,6 +5,7 @@
 #include <boost/range/algorithm_ext/erase.hpp>
 #include "common/assert.h"
 #include "common/common_types.h"
+#include "core/hle/kernel/handle_table.h"
 #include "core/hle/kernel/hle_ipc.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/server_session.h"
@@ -22,5 +23,13 @@ void SessionRequestHandler::ClientDisconnected(SharedPtr<ServerSession> server_s
 }
 
 HLERequestContext::~HLERequestContext() = default;
+
+SharedPtr<Object> HLERequestContext::GetIncomingHandle(Handle id_from_cmdbuf) const {
+    return Kernel::g_handle_table.GetGeneric(id_from_cmdbuf);
+}
+
+Handle HLERequestContext::AddOutgoingHandle(SharedPtr<Object> object) {
+    return Kernel::g_handle_table.Create(object).Unwrap();
+}
 
 } // namespace Kernel

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -35,6 +35,10 @@ u32 HLERequestContext::AddOutgoingHandle(SharedPtr<Object> object) {
     return request_handles.size() - 1;
 }
 
+void HLERequestContext::ClearIncomingObjects() {
+    request_handles.clear();
+}
+
 ResultCode HLERequestContext::PopulateFromIncomingCommandBuffer(const u32_le* src_cmdbuf,
                                                                 Process& src_process,
                                                                 HandleTable& src_table) {

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -7,6 +7,7 @@
 #include <array>
 #include <memory>
 #include <vector>
+#include <boost/container/small_vector.hpp>
 #include "common/common_types.h"
 #include "common/swap.h"
 #include "core/hle/ipc.h"
@@ -127,7 +128,8 @@ private:
 
     std::array<u32, IPC::COMMAND_BUFFER_LENGTH> cmd_buf;
     SharedPtr<ServerSession> session;
-    std::vector<SharedPtr<Object>> request_handles;
+    // TODO(yuriks): Check common usage of this and optimize size accordingly
+    boost::container::small_vector<SharedPtr<Object>, 8> request_handles;
 };
 
 } // namespace Kernel

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -4,8 +4,11 @@
 
 #pragma once
 
+#include <array>
 #include <memory>
 #include <vector>
+#include "common/common_types.h"
+#include "core/hle/ipc.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/server_session.h"
 
@@ -65,8 +68,8 @@ public:
     ~HLERequestContext();
 
     /// Returns a pointer to the IPC command buffer for this request.
-    u32* CommandBuffer() const {
-        return cmd_buf;
+    u32* CommandBuffer() {
+        return cmd_buf.data();
     }
 
     /**
@@ -80,7 +83,7 @@ public:
 private:
     friend class Service::ServiceFrameworkBase;
 
-    u32* cmd_buf = nullptr;
+    std::array<u32, IPC::COMMAND_BUFFER_LENGTH> cmd_buf;
     SharedPtr<ServerSession> session;
 };
 

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -80,6 +80,9 @@ public:
         return session;
     }
 
+    SharedPtr<Object> GetIncomingHandle(Handle id_from_cmdbuf) const;
+    Handle AddOutgoingHandle(SharedPtr<Object> object);
+
 private:
     friend class Service::ServiceFrameworkBase;
 

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <vector>
 #include "common/common_types.h"
+#include "common/swap.h"
 #include "core/hle/ipc.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/server_session.h"
@@ -17,6 +18,9 @@ class ServiceFrameworkBase;
 }
 
 namespace Kernel {
+
+class HandleTable;
+class Process;
 
 /**
  * Interface implemented by HLE Session handlers.
@@ -62,6 +66,20 @@ protected:
  * Class containing information about an in-flight IPC request being handled by an HLE service
  * implementation. Services should avoid using old global APIs (e.g. Kernel::GetCommandBuffer()) and
  * when possible use the APIs in this class to service the request.
+ *
+ * HLE handle protocol
+ * ===================
+ *
+ * To avoid needing HLE services to keep a separate handle table, or having to directly modify the
+ * requester's table, a tweaked protocol is used to receive and send handles in requests. The kernel
+ * will decode the incoming handles into object pointers and insert a id in the buffer where the
+ * handle would normally be. The service then calls GetIncomingHandle() with that id to get the
+ * pointer to the object. Similarly, instead of inserting a handle into the command buffer, the
+ * service calls AddOutgoingHandle() and stores the returned id where the handle would normally go.
+ *
+ * The end result is similar to just giving services their own real handle tables, but since these
+ * ids are local to a specific context, it avoids requiring services to manage handles for objects
+ * across multiple calls and ensuring that unneeded handles are cleaned up.
  */
 class HLERequestContext {
 public:
@@ -80,14 +98,29 @@ public:
         return session;
     }
 
-    SharedPtr<Object> GetIncomingHandle(Handle id_from_cmdbuf) const;
-    Handle AddOutgoingHandle(SharedPtr<Object> object);
+    /**
+     * Resolves a object id from the request command buffer into a pointer to an object. See the
+     * "HLE handle protocol" section in the class documentation for more details.
+     */
+    SharedPtr<Object> GetIncomingHandle(u32 id_from_cmdbuf) const;
+
+    /**
+     * Adds an outgoing object to the response, returning the id which should be used to reference
+     * it. See the "HLE handle protocol" section in the class documentation for more details.
+     */
+    u32 AddOutgoingHandle(SharedPtr<Object> object);
 
 private:
     friend class Service::ServiceFrameworkBase;
 
+    ResultCode PopulateFromIncomingCommandBuffer(const u32_le* src_cmdbuf, Process& src_process,
+                                                 HandleTable& src_table);
+    ResultCode WriteToOutgoingCommandBuffer(u32_le* dst_cmdbuf, Process& dst_process,
+                                            HandleTable& dst_table) const;
+
     std::array<u32, IPC::COMMAND_BUFFER_LENGTH> cmd_buf;
     SharedPtr<ServerSession> session;
+    std::vector<SharedPtr<Object>> request_handles;
 };
 
 } // namespace Kernel

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -110,6 +110,13 @@ public:
      */
     u32 AddOutgoingHandle(SharedPtr<Object> object);
 
+    /**
+     * Discards all Objects from the context, invalidating all ids. This may be called after reading
+     * out all incoming objects, so that the buffer memory can be re-used for outgoing handles, but
+     * this is not required.
+     */
+    void ClearIncomingObjects();
+
 private:
     friend class Service::ServiceFrameworkBase;
 

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -2,9 +2,12 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <algorithm>
 #include <fmt/format.h>
+#include "common/assert.h"
 #include "common/logging/log.h"
 #include "common/string_util.h"
+#include "core/hle/ipc.h"
 #include "core/hle/kernel/client_port.h"
 #include "core/hle/kernel/server_port.h"
 #include "core/hle/kernel/server_session.h"
@@ -160,12 +163,6 @@ void ServiceFrameworkBase::ReportUnimplementedFunction(u32* cmd_buf, const Funct
 void ServiceFrameworkBase::HandleSyncRequest(SharedPtr<ServerSession> server_session) {
     u32* cmd_buf = Kernel::GetCommandBuffer();
 
-    // TODO(yuriks): The kernel should be the one handling this as part of translation after
-    // everything else is migrated
-    Kernel::HLERequestContext context;
-    context.cmd_buf = cmd_buf;
-    context.session = std::move(server_session);
-
     u32 header_code = cmd_buf[0];
     auto itr = handlers.find(header_code);
     const FunctionInfoBase* info = itr == handlers.end() ? nullptr : &itr->second;
@@ -173,9 +170,26 @@ void ServiceFrameworkBase::HandleSyncRequest(SharedPtr<ServerSession> server_ses
         return ReportUnimplementedFunction(cmd_buf, info);
     }
 
+    // TODO(yuriks): The kernel should be the one handling this as part of translation after
+    // everything else is migrated
+    IPC::Header request_header{cmd_buf[0]};
+    size_t request_size =
+        1 + request_header.normal_params_size + request_header.translate_params_size;
+    ASSERT(request_size <= IPC::COMMAND_BUFFER_LENGTH); // TODO(yuriks): Return error
+
+    Kernel::HLERequestContext context;
+    std::copy_n(cmd_buf, request_size, context.cmd_buf.begin());
+    context.session = std::move(server_session);
+
     LOG_TRACE(Service, "%s",
               MakeFunctionString(info->name, GetServiceName().c_str(), cmd_buf).c_str());
     handler_invoker(this, info->handler_callback, context);
+
+    IPC::Header response_header{context.cmd_buf[0]};
+    size_t response_size =
+        1 + response_header.normal_params_size + response_header.translate_params_size;
+    ASSERT(response_size <= IPC::COMMAND_BUFFER_LENGTH);
+    std::copy_n(context.cmd_buf.begin(), response_size, cmd_buf);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Only on ServiceFramework™-based services (aka, just sm/`srv:` for now.) Changes include:
  - Use a separate command buffer copy instead of working directly with the caller's.
  - Make handle lookup/creation the responsibility of the Kernel/Framework

Commits are probably reviewable individually.

Depends on citra-emu/ext-boost#11 for `small_vector`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2774)
<!-- Reviewable:end -->
