### PR TITLE
Fragment lighting: implement geometric factor

### DIFF
--- a/src/video_core/regs_lighting.h
+++ b/src/video_core/regs_lighting.h
@@ -168,6 +168,8 @@ struct LightingRegs {
         union {
             BitField<0, 1, u32> directional;
             BitField<1, 1, u32> two_sided_diffuse; // When disabled, clamp dot-product to 0
+            BitField<2, 1, u32> geometric_factor_0;
+            BitField<3, 1, u32> geometric_factor_1;
         } config;
 
         BitField<0, 20, u32> dist_atten_bias;

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -73,6 +73,8 @@ PicaShaderConfig PicaShaderConfig::BuildFromRegs(const Pica::Regs& regs) {
         state.lighting.light[light_index].num = num;
         state.lighting.light[light_index].directional = light.config.directional != 0;
         state.lighting.light[light_index].two_sided_diffuse = light.config.two_sided_diffuse != 0;
+        state.lighting.light[light_index].geometric_factor_0 = light.config.geometric_factor_0 != 0;
+        state.lighting.light[light_index].geometric_factor_1 = light.config.geometric_factor_1 != 0;
         state.lighting.light[light_index].dist_atten_enable =
             !regs.lighting.IsDistAttenDisabled(num);
         state.lighting.light[light_index].spot_atten_enable =
@@ -518,7 +520,8 @@ static void WriteLighting(std::string& out, const PicaShaderConfig& config) {
            "vec4 specular_sum = vec4(0.0, 0.0, 0.0, 1.0);\n"
            "vec3 light_vector = vec3(0.0);\n"
            "vec3 refl_value = vec3(0.0);\n"
-           "vec3 spot_dir = vec3(0.0);\n;";
+           "vec3 spot_dir = vec3(0.0);\n"
+           "float geo_factor = 1.0;\n";
 
     // Compute fragment normals and tangents
     const std::string pertubation =
@@ -671,6 +674,12 @@ static void WriteLighting(std::string& out, const PicaShaderConfig& config) {
         std::string clamp_highlights =
             lighting.clamp_highlights ? "(dot(light_vector, normal) <= 0.0 ? 0.0 : 1.0)" : "1.0";
 
+        if (light_config.geometric_factor_0 || light_config.geometric_factor_1) {
+            out += "geo_factor = 1 + dot(light_vector, normalize(view));\n"
+                   "geo_factor = geo_factor == 0.0 ? 0.0 : min(0.5 * " +
+                   dot_product + " / geo_factor, 1.0);\n";
+        }
+
         // Specular 0 component
         std::string d0_lut_value = "1.0";
         if (lighting.lut_d0.enable &&
@@ -683,6 +692,9 @@ static void WriteLighting(std::string& out, const PicaShaderConfig& config) {
                            GetLutValue(LightingRegs::LightingSampler::Distribution0, index) + ")";
         }
         std::string specular_0 = "(" + d0_lut_value + " * " + light_src + ".specular_0)";
+        if (light_config.geometric_factor_0) {
+            specular_0 = "(" + specular_0 + " * geo_factor)";
+        }
 
         // If enabled, lookup ReflectRed value, otherwise, 1.0 is used
         if (lighting.lut_rr.enable &&
@@ -738,6 +750,9 @@ static void WriteLighting(std::string& out, const PicaShaderConfig& config) {
         }
         std::string specular_1 =
             "(" + d1_lut_value + " * refl_value * " + light_src + ".specular_1)";
+        if (light_config.geometric_factor_1) {
+            specular_1 = "(" + specular_1 + " * geo_factor)";
+        }
 
         // Fresnel
         if (lighting.lut_fr.enable &&

--- a/src/video_core/renderer_opengl/gl_shader_gen.h
+++ b/src/video_core/renderer_opengl/gl_shader_gen.h
@@ -94,6 +94,8 @@ union PicaShaderConfig {
                 bool two_sided_diffuse;
                 bool dist_atten_enable;
                 bool spot_atten_enable;
+                bool geometric_factor_0;
+                bool geometric_factor_1;
             } light[8];
 
             bool enable;


### PR DESCRIPTION
Reference formula on 3dbrew: http://mathb.in/64694. G0 and G1 are geometric factors

The test result shows that the formula for geometric factors in 3DS is not [the standard Cook-Torrance one](http://ruh.li/images/CookTorranceGeometricAttenuation.png). To get the correct formula, [a testing program](https://github.com/wwylele/ctrhwtest/tree/master/geo_factor) is used. Some assumptions are made when finding the formula:
 - the formula on 3dbrew is correct
 - G only depends on normalized vector N (normal), V (view) and L (light), and can contain half-angle vector H (still depends on V and L)
 - spherical symmetry, as in, rotating N, V and L by the same angle won't change G value 

Based on these assumptions, G value is sampled for different combinations of N, V and L (with two-sided-diffuse on). Because of the symmetry, V and L is confined on the xy plane and are symmetrical about x-axis (so that the potentially used vector H is always (+/-1, 0, 0)). A result of ~65600 samples is [here](https://www.dropbox.com/s/j7cycr7hn9wpuch/geo_factor_big.txt?dl=1). 

The nearest formula found is `G = min(1.0, 0.5 * abs(L * N) / (1 + L * V))`. For the case `1 + L * V == 0` G is set to 0. The overall error of this formula is +/- 0.01, which is negligible considering the measurement is taken by dividing two u8 integer. It is also shown in later tests that G does respect to the two-sided-diffuse bit, which means `abs(L * N)` part is actually `dot_product`.

Fixes the lighting issue of Smash Bros. Probably also fixes other games in #2477 but not tested yet.

Side note: after this PR and the tangent map one, the only known unimplemented feature in lighting is the shadow mapping.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2776)
<!-- Reviewable:end -->
