### PR TITLE
Remove ResultVal::MoveFrom

### DIFF
--- a/src/core/hle/kernel/memory.cpp
+++ b/src/core/hle/kernel/memory.cpp
@@ -166,7 +166,7 @@ void HandleSpecialMapping(VMManager& address_space, const AddressMapping& mappin
     auto vma = address_space
                    .MapBackingMemory(mapping.address, target_pointer + offset_into_region,
                                      mapping.size, memory_state)
-                   .MoveFrom();
+                   .Unwrap();
     address_space.Reprotect(vma,
                             mapping.read_only ? VMAPermission::Read : VMAPermission::ReadWrite);
 }
@@ -176,14 +176,14 @@ void MapSharedPages(VMManager& address_space) {
                            .MapBackingMemory(Memory::CONFIG_MEMORY_VADDR,
                                              reinterpret_cast<u8*>(&ConfigMem::config_mem),
                                              Memory::CONFIG_MEMORY_SIZE, MemoryState::Shared)
-                           .MoveFrom();
+                           .Unwrap();
     address_space.Reprotect(cfg_mem_vma, VMAPermission::Read);
 
     auto shared_page_vma = address_space
                                .MapBackingMemory(Memory::SHARED_PAGE_VADDR,
                                                  reinterpret_cast<u8*>(&SharedPage::shared_page),
                                                  Memory::SHARED_PAGE_SIZE, MemoryState::Shared)
-                               .MoveFrom();
+                               .Unwrap();
     address_space.Reprotect(shared_page_vma, VMAPermission::Read);
 }
 

--- a/src/core/hle/kernel/server_session.cpp
+++ b/src/core/hle/kernel/server_session.cpp
@@ -71,7 +71,7 @@ ResultCode ServerSession::HandleSyncRequest() {
 
 ServerSession::SessionPair ServerSession::CreateSessionPair(const std::string& name,
                                                             SharedPtr<ClientPort> port) {
-    auto server_session = ServerSession::Create(name + "_Server").MoveFrom();
+    auto server_session = ServerSession::Create(name + "_Server").Unwrap();
     SharedPtr<ClientSession> client_session(new ClientSession);
     client_session->name = name + "_Client";
 

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -389,7 +389,7 @@ ResultVal<SharedPtr<Thread>> Thread::Create(std::string name, VAddr entry_point,
     thread->wait_objects.clear();
     thread->wait_address = 0;
     thread->name = std::move(name);
-    thread->callback_handle = wakeup_callback_handle_table.Create(thread).MoveFrom();
+    thread->callback_handle = wakeup_callback_handle_table.Create(thread).Unwrap();
     thread->owner_process = g_current_process;
 
     // Find the next available TLS index, and mark it as used
@@ -484,7 +484,7 @@ SharedPtr<Thread> SetupMainThread(u32 entry_point, s32 priority) {
     auto thread_res = Thread::Create("main", entry_point, priority, 0, THREADPROCESSORID_0,
                                      Memory::HEAP_VADDR_END);
 
-    SharedPtr<Thread> thread = thread_res.MoveFrom();
+    SharedPtr<Thread> thread = std::move(thread_res).Unwrap();
 
     thread->context.fpscr =
         FPSCR_DEFAULT_NAN | FPSCR_FLUSH_TO_ZERO | FPSCR_ROUND_TOZERO | FPSCR_IXC; // 0x03C00010

--- a/src/core/hle/kernel/timer.cpp
+++ b/src/core/hle/kernel/timer.cpp
@@ -30,7 +30,7 @@ SharedPtr<Timer> Timer::Create(ResetType reset_type, std::string name) {
     timer->name = std::move(name);
     timer->initial_delay = 0;
     timer->interval_delay = 0;
-    timer->callback_handle = timer_callback_handle_table.Create(timer).MoveFrom();
+    timer->callback_handle = timer_callback_handle_table.Create(timer).Unwrap();
 
     return timer;
 }

--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -398,10 +398,6 @@ public:
         return std::move(**this);
     }
 
-    T&& MoveFrom() {
-        return std::move(Unwrap());
-    }
-
 private:
     // A union is used to allocate the storage for the value, while allowing us to construct and
     // destruct it at will.

--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -388,9 +388,14 @@ public:
     }
 
     /// Asserts that the result succeeded and returns a reference to it.
-    T& Unwrap() {
+    T& Unwrap() & {
         ASSERT_MSG(Succeeded(), "Tried to Unwrap empty ResultVal");
         return **this;
+    }
+
+    T&& Unwrap() && {
+        ASSERT_MSG(Succeeded(), "Tried to Unwrap empty ResultVal");
+        return std::move(**this);
     }
 
     T&& MoveFrom() {

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -55,8 +55,8 @@ void Initialize(Service::Interface* self) {
     u32 flags = rp.Pop<u32>();
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 3);
     rb.Push(RESULT_SUCCESS);
-    rb.PushCopyHandles(Kernel::g_handle_table.Create(notification_event).MoveFrom(),
-                       Kernel::g_handle_table.Create(parameter_event).MoveFrom());
+    rb.PushCopyHandles(Kernel::g_handle_table.Create(notification_event).Unwrap(),
+                       Kernel::g_handle_table.Create(parameter_event).Unwrap());
 
     // TODO(bunnei): Check if these events are cleared every time Initialize is called.
     notification_event->Clear();
@@ -93,7 +93,7 @@ void GetSharedFont(Service::Interface* self) {
     // allocated, the real APT service calculates this address by scanning the entire address space
     // (using svcQueryMemory) and searches for an allocation of the same size as the Shared Font.
     rb.Push(target_address);
-    rb.PushCopyHandles(Kernel::g_handle_table.Create(shared_font_mem).MoveFrom());
+    rb.PushCopyHandles(Kernel::g_handle_table.Create(shared_font_mem).Unwrap());
 }
 
 void NotifyToWait(Service::Interface* self) {
@@ -115,7 +115,7 @@ void GetLockHandle(Service::Interface* self) {
     rb.Push(RESULT_SUCCESS);    // No error
     rb.Push(applet_attributes); // Applet Attributes, this value is passed to Enable.
     rb.Push<u32>(0);            // Least significant bit = power button state
-    Kernel::Handle handle_copy = Kernel::g_handle_table.Create(lock).MoveFrom();
+    Kernel::Handle handle_copy = Kernel::g_handle_table.Create(lock).Unwrap();
     rb.PushCopyHandles(handle_copy);
 
     LOG_WARNING(Service_APT, "(STUBBED) called handle=0x%08X applet_attributes=0x%08X", handle_copy,
@@ -231,7 +231,7 @@ void ReceiveParameter(Service::Interface* self) {
     rb.Push(static_cast<u32>(next_parameter.buffer.size())); // Parameter buffer size
 
     rb.PushMoveHandles((next_parameter.object != nullptr)
-                           ? Kernel::g_handle_table.Create(next_parameter.object).MoveFrom()
+                           ? Kernel::g_handle_table.Create(next_parameter.object).Unwrap()
                            : 0);
     rb.PushStaticBuffer(buffer, static_cast<u32>(next_parameter.buffer.size()), 0);
 
@@ -261,7 +261,7 @@ void GlanceParameter(Service::Interface* self) {
     rb.Push(static_cast<u32>(next_parameter.buffer.size())); // Parameter buffer size
 
     rb.PushCopyHandles((next_parameter.object != nullptr)
-                           ? Kernel::g_handle_table.Create(next_parameter.object).MoveFrom()
+                           ? Kernel::g_handle_table.Create(next_parameter.object).Unwrap()
                            : 0);
     rb.PushStaticBuffer(buffer, static_cast<u32>(next_parameter.buffer.size()), 0);
 

--- a/src/core/hle/service/cam/cam.cpp
+++ b/src/core/hle/service/cam/cam.cpp
@@ -347,7 +347,7 @@ void GetVsyncInterruptEvent(Service::Interface* self) {
         int port = *port_select.begin();
         rb.Push(RESULT_SUCCESS);
         rb.PushCopyHandles(
-            Kernel::g_handle_table.Create(ports[port].vsync_interrupt_event).MoveFrom());
+            Kernel::g_handle_table.Create(ports[port].vsync_interrupt_event).Unwrap());
     } else {
         LOG_ERROR(Service_CAM, "invalid port_select=%u", port_select.m_val);
         rb.Push(ERROR_INVALID_ENUM_VALUE);
@@ -366,7 +366,7 @@ void GetBufferErrorInterruptEvent(Service::Interface* self) {
         int port = *port_select.begin();
         rb.Push(RESULT_SUCCESS);
         rb.PushCopyHandles(
-            Kernel::g_handle_table.Create(ports[port].buffer_error_interrupt_event).MoveFrom());
+            Kernel::g_handle_table.Create(ports[port].buffer_error_interrupt_event).Unwrap());
     } else {
         LOG_ERROR(Service_CAM, "invalid port_select=%u", port_select.m_val);
         rb.Push(ERROR_INVALID_ENUM_VALUE);
@@ -400,7 +400,7 @@ void SetReceiving(Service::Interface* self) {
         }
 
         rb.Push(RESULT_SUCCESS);
-        rb.PushCopyHandles(Kernel::g_handle_table.Create(port.completion_event).MoveFrom());
+        rb.PushCopyHandles(Kernel::g_handle_table.Create(port.completion_event).Unwrap());
     } else {
         LOG_ERROR(Service_CAM, "invalid port_select=%u", port_select.m_val);
         rb.Push(ERROR_INVALID_ENUM_VALUE);

--- a/src/core/hle/service/cecd/cecd.cpp
+++ b/src/core/hle/service/cecd/cecd.cpp
@@ -31,8 +31,8 @@ void GetCecStateAbbreviated(Service::Interface* self) {
 void GetCecInfoEventHandle(Service::Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
-    cmd_buff[1] = RESULT_SUCCESS.raw;                                      // No error
-    cmd_buff[3] = Kernel::g_handle_table.Create(cecinfo_event).MoveFrom(); // Event handle
+    cmd_buff[1] = RESULT_SUCCESS.raw;                                    // No error
+    cmd_buff[3] = Kernel::g_handle_table.Create(cecinfo_event).Unwrap(); // Event handle
 
     LOG_WARNING(Service_CECD, "(STUBBED) called");
 }
@@ -40,8 +40,8 @@ void GetCecInfoEventHandle(Service::Interface* self) {
 void GetChangeStateEventHandle(Service::Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
 
-    cmd_buff[1] = RESULT_SUCCESS.raw;                                           // No error
-    cmd_buff[3] = Kernel::g_handle_table.Create(change_state_event).MoveFrom(); // Event handle
+    cmd_buff[1] = RESULT_SUCCESS.raw;                                         // No error
+    cmd_buff[3] = Kernel::g_handle_table.Create(change_state_event).Unwrap(); // Event handle
 
     LOG_WARNING(Service_CECD, "(STUBBED) called");
 }

--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -406,7 +406,7 @@ ResultCode UpdateConfigNANDSavegame() {
     auto config_result = Service::FS::OpenFileFromArchive(cfg_system_save_data_archive, path, mode);
     ASSERT_MSG(config_result.Succeeded(), "could not open file");
 
-    auto config = config_result.MoveFrom();
+    auto config = std::move(config_result).Unwrap();
     config->backend->Write(0, CONFIG_SAVEFILE_SIZE, 1, cfg_config_file_buffer.data());
 
     return RESULT_SUCCESS;
@@ -560,7 +560,7 @@ ResultCode LoadConfigNANDSaveFile() {
 
     // Read the file if it already exists
     if (config_result.Succeeded()) {
-        auto config = config_result.MoveFrom();
+        auto config = std::move(config_result).Unwrap();
         config->backend->Read(0, CONFIG_SAVEFILE_SIZE, cfg_config_file_buffer.data());
         return RESULT_SUCCESS;
     }

--- a/src/core/hle/service/csnd_snd.cpp
+++ b/src/core/hle/service/csnd_snd.cpp
@@ -51,8 +51,8 @@ static void Initialize(Interface* self) {
 
     cmd_buff[1] = RESULT_SUCCESS.raw;
     cmd_buff[2] = IPC::CopyHandleDesc(2);
-    cmd_buff[3] = Kernel::g_handle_table.Create(mutex).MoveFrom();
-    cmd_buff[4] = Kernel::g_handle_table.Create(shared_memory).MoveFrom();
+    cmd_buff[3] = Kernel::g_handle_table.Create(mutex).Unwrap();
+    cmd_buff[4] = Kernel::g_handle_table.Create(shared_memory).Unwrap();
 
     LOG_WARNING(Service_CSND, "(STUBBED) called");
 }

--- a/src/core/hle/service/dsp_dsp.cpp
+++ b/src/core/hle/service/dsp_dsp.cpp
@@ -168,7 +168,7 @@ static void GetSemaphoreEventHandle(Service::Interface* self) {
     cmd_buff[0] = IPC::MakeHeader(0x16, 1, 2);
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
     // cmd_buff[2] not set
-    cmd_buff[3] = Kernel::g_handle_table.Create(semaphore_event).MoveFrom(); // Event handle
+    cmd_buff[3] = Kernel::g_handle_table.Create(semaphore_event).Unwrap(); // Event handle
 
     LOG_WARNING(Service_DSP, "(STUBBED) called");
 }

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -311,7 +311,7 @@ ResultVal<std::shared_ptr<File>> OpenFileFromArchive(ArchiveHandle archive_handl
     if (backend.Failed())
         return backend.Code();
 
-    auto file = std::shared_ptr<File>(new File(backend.MoveFrom(), path));
+    auto file = std::shared_ptr<File>(new File(std::move(backend).Unwrap(), path));
     return MakeResult<std::shared_ptr<File>>(std::move(file));
 }
 
@@ -401,7 +401,7 @@ ResultVal<std::shared_ptr<Directory>> OpenDirectoryFromArchive(ArchiveHandle arc
     if (backend.Failed())
         return backend.Code();
 
-    auto directory = std::shared_ptr<Directory>(new Directory(backend.MoveFrom(), path));
+    auto directory = std::shared_ptr<Directory>(new Directory(std::move(backend).Unwrap(), path));
     return MakeResult<std::shared_ptr<Directory>>(std::move(directory));
 }
 

--- a/src/core/hle/service/fs/fs_user.cpp
+++ b/src/core/hle/service/fs/fs_user.cpp
@@ -87,7 +87,7 @@ static void OpenFile(Service::Interface* self) {
         file->ClientConnected(std::get<SharedPtr<ServerSession>>(sessions));
 
         rb.PushMoveHandles(
-            Kernel::g_handle_table.Create(std::get<SharedPtr<ClientSession>>(sessions)).MoveFrom());
+            Kernel::g_handle_table.Create(std::get<SharedPtr<ClientSession>>(sessions)).Unwrap());
     } else {
         rb.PushMoveHandles(0);
         LOG_ERROR(Service_FS, "failed to get a handle for file %s", file_path.DebugStr().c_str());
@@ -153,7 +153,7 @@ static void OpenFileDirectly(Service::Interface* self) {
         file->ClientConnected(std::get<SharedPtr<ServerSession>>(sessions));
 
         cmd_buff[3] =
-            Kernel::g_handle_table.Create(std::get<SharedPtr<ClientSession>>(sessions)).MoveFrom();
+            Kernel::g_handle_table.Create(std::get<SharedPtr<ClientSession>>(sessions)).Unwrap();
     } else {
         cmd_buff[3] = 0;
         LOG_ERROR(Service_FS, "failed to get a handle for file %s mode=%u attributes=%u",
@@ -420,7 +420,7 @@ static void OpenDirectory(Service::Interface* self) {
         directory->ClientConnected(std::get<SharedPtr<ServerSession>>(sessions));
 
         cmd_buff[3] =
-            Kernel::g_handle_table.Create(std::get<SharedPtr<ClientSession>>(sessions)).MoveFrom();
+            Kernel::g_handle_table.Create(std::get<SharedPtr<ClientSession>>(sessions)).Unwrap();
     } else {
         LOG_ERROR(Service_FS, "failed to get a handle for directory type=%d size=%d data=%s",
                   dirname_type, dirname_size, dir_path.DebugStr().c_str());

--- a/src/core/hle/service/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp_gpu.cpp
@@ -389,8 +389,8 @@ static void RegisterInterruptRelayQueue(Interface* self) {
     } else {
         cmd_buff[1] = RESULT_SUCCESS.raw;
     }
-    cmd_buff[2] = g_thread_id++;                                             // Thread ID
-    cmd_buff[4] = Kernel::g_handle_table.Create(g_shared_memory).MoveFrom(); // GSP shared memory
+    cmd_buff[2] = g_thread_id++;                                           // Thread ID
+    cmd_buff[4] = Kernel::g_handle_table.Create(g_shared_memory).Unwrap(); // GSP shared memory
 
     g_interrupt_event->Signal(); // TODO(bunnei): Is this correct?
 

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -253,12 +253,12 @@ void GetIPCHandles(Service::Interface* self) {
     cmd_buff[1] = 0;          // No error
     cmd_buff[2] = 0x14000000; // IPC Command Structure translate-header
     // TODO(yuriks): Return error from SendSyncRequest is this fails (part of IPC marshalling)
-    cmd_buff[3] = Kernel::g_handle_table.Create(Service::HID::shared_mem).MoveFrom();
-    cmd_buff[4] = Kernel::g_handle_table.Create(Service::HID::event_pad_or_touch_1).MoveFrom();
-    cmd_buff[5] = Kernel::g_handle_table.Create(Service::HID::event_pad_or_touch_2).MoveFrom();
-    cmd_buff[6] = Kernel::g_handle_table.Create(Service::HID::event_accelerometer).MoveFrom();
-    cmd_buff[7] = Kernel::g_handle_table.Create(Service::HID::event_gyroscope).MoveFrom();
-    cmd_buff[8] = Kernel::g_handle_table.Create(Service::HID::event_debug_pad).MoveFrom();
+    cmd_buff[3] = Kernel::g_handle_table.Create(Service::HID::shared_mem).Unwrap();
+    cmd_buff[4] = Kernel::g_handle_table.Create(Service::HID::event_pad_or_touch_1).Unwrap();
+    cmd_buff[5] = Kernel::g_handle_table.Create(Service::HID::event_pad_or_touch_2).Unwrap();
+    cmd_buff[6] = Kernel::g_handle_table.Create(Service::HID::event_accelerometer).Unwrap();
+    cmd_buff[7] = Kernel::g_handle_table.Create(Service::HID::event_gyroscope).Unwrap();
+    cmd_buff[8] = Kernel::g_handle_table.Create(Service::HID::event_debug_pad).Unwrap();
 }
 
 void EnableAccelerometer(Service::Interface* self) {

--- a/src/core/hle/service/ir/ir_rst.cpp
+++ b/src/core/hle/service/ir/ir_rst.cpp
@@ -145,8 +145,8 @@ static void GetHandles(Interface* self) {
     IPC::RequestParser rp(Kernel::GetCommandBuffer(), 0x01, 0, 0);
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 3);
     rb.Push(RESULT_SUCCESS);
-    rb.PushMoveHandles(Kernel::g_handle_table.Create(Service::IR::shared_memory).MoveFrom(),
-                       Kernel::g_handle_table.Create(Service::IR::update_event).MoveFrom());
+    rb.PushMoveHandles(Kernel::g_handle_table.Create(Service::IR::shared_memory).Unwrap(),
+                       Kernel::g_handle_table.Create(Service::IR::update_event).Unwrap());
 }
 
 /**

--- a/src/core/hle/service/ir/ir_user.cpp
+++ b/src/core/hle/service/ir/ir_user.cpp
@@ -337,7 +337,7 @@ void GetReceiveEvent(Interface* self) {
     IPC::RequestBuilder rb(Kernel::GetCommandBuffer(), 0x0A, 1, 2);
 
     rb.Push(RESULT_SUCCESS);
-    rb.PushCopyHandles(Kernel::g_handle_table.Create(Service::IR::receive_event).MoveFrom());
+    rb.PushCopyHandles(Kernel::g_handle_table.Create(Service::IR::receive_event).Unwrap());
 
     LOG_INFO(Service_IR, "called");
 }
@@ -354,7 +354,7 @@ void GetSendEvent(Interface* self) {
     IPC::RequestBuilder rb(Kernel::GetCommandBuffer(), 0x0B, 1, 2);
 
     rb.Push(RESULT_SUCCESS);
-    rb.PushCopyHandles(Kernel::g_handle_table.Create(Service::IR::send_event).MoveFrom());
+    rb.PushCopyHandles(Kernel::g_handle_table.Create(Service::IR::send_event).Unwrap());
 
     LOG_INFO(Service_IR, "called");
 }
@@ -394,7 +394,7 @@ static void GetConnectionStatusEvent(Interface* self) {
     IPC::RequestBuilder rb(Kernel::GetCommandBuffer(), 0x0C, 1, 2);
 
     rb.Push(RESULT_SUCCESS);
-    rb.PushCopyHandles(Kernel::g_handle_table.Create(Service::IR::conn_status_event).MoveFrom());
+    rb.PushCopyHandles(Kernel::g_handle_table.Create(Service::IR::conn_status_event).Unwrap());
 
     LOG_INFO(Service_IR, "called");
 }

--- a/src/core/hle/service/mic_u.cpp
+++ b/src/core/hle/service/mic_u.cpp
@@ -160,7 +160,7 @@ static void IsSampling(Interface* self) {
 static void GetBufferFullEvent(Interface* self) {
     u32* cmd_buff = Kernel::GetCommandBuffer();
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
-    cmd_buff[3] = Kernel::g_handle_table.Create(buffer_full_event).MoveFrom();
+    cmd_buff[3] = Kernel::g_handle_table.Create(buffer_full_event).Unwrap();
     LOG_WARNING(Service_MIC, "(STUBBED) called");
 }
 

--- a/src/core/hle/service/nfc/nfc.cpp
+++ b/src/core/hle/service/nfc/nfc.cpp
@@ -95,7 +95,7 @@ void GetTagInRangeEvent(Interface* self) {
     cmd_buff[0] = IPC::MakeHeader(0xB, 1, 2);
     cmd_buff[1] = RESULT_SUCCESS.raw;
     cmd_buff[2] = IPC::CopyHandleDesc();
-    cmd_buff[3] = Kernel::g_handle_table.Create(tag_in_range_event).MoveFrom();
+    cmd_buff[3] = Kernel::g_handle_table.Create(tag_in_range_event).Unwrap();
     LOG_WARNING(Service_NFC, "(STUBBED) called");
 }
 
@@ -105,7 +105,7 @@ void GetTagOutOfRangeEvent(Interface* self) {
     cmd_buff[0] = IPC::MakeHeader(0xC, 1, 2);
     cmd_buff[1] = RESULT_SUCCESS.raw;
     cmd_buff[2] = IPC::CopyHandleDesc();
-    cmd_buff[3] = Kernel::g_handle_table.Create(tag_out_of_range_event).MoveFrom();
+    cmd_buff[3] = Kernel::g_handle_table.Create(tag_out_of_range_event).Unwrap();
     LOG_WARNING(Service_NFC, "(STUBBED) called");
 }
 

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -190,7 +190,7 @@ static void InitializeWithVersion(Interface* self) {
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
     rb.Push(RESULT_SUCCESS);
-    rb.PushCopyHandles(Kernel::g_handle_table.Create(connection_status_event).MoveFrom());
+    rb.PushCopyHandles(Kernel::g_handle_table.Create(connection_status_event).Unwrap());
 
     LOG_DEBUG(Service_NWM, "called sharedmem_size=0x%08X, version=0x%08X, sharedmem_handle=0x%08X",
               sharedmem_size, version, sharedmem_handle);
@@ -265,7 +265,7 @@ static void Bind(Interface* self) {
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
 
     rb.Push(RESULT_SUCCESS);
-    rb.PushCopyHandles(Kernel::g_handle_table.Create(event).MoveFrom());
+    rb.PushCopyHandles(Kernel::g_handle_table.Create(event).Unwrap());
 }
 
 /**

--- a/src/core/hle/service/ptm/ptm.cpp
+++ b/src/core/hle/service/ptm/ptm.cpp
@@ -152,7 +152,7 @@ void Init() {
         auto gamecoin_result =
             Service::FS::OpenFileFromArchive(*archive_result, gamecoin_path, open_mode);
         if (gamecoin_result.Succeeded()) {
-            auto gamecoin = gamecoin_result.MoveFrom();
+            auto gamecoin = std::move(gamecoin_result).Unwrap();
             gamecoin->backend->Write(0, sizeof(GameCoin), true,
                                      reinterpret_cast<const u8*>(&default_game_coin));
             gamecoin->backend->Close();

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -207,7 +207,7 @@ void AddService(Interface* interface_) {
     auto server_port =
         SM::g_service_manager
             ->RegisterService(interface_->GetPortName(), interface_->GetMaxSessions())
-            .MoveFrom();
+            .Unwrap();
     server_port->SetHleHandler(std::shared_ptr<Interface>(interface_));
 }
 

--- a/src/core/hle/service/sm/srv.cpp
+++ b/src/core/hle/service/sm/srv.cpp
@@ -113,13 +113,13 @@ void SRV::GetServiceHandle(Kernel::HLERequestContext& ctx) {
                   (*session)->GetObjectId());
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
         rb.Push(session.Code());
-        rb.PushObjects(session.MoveFrom());
+        rb.PushObjects(std::move(session).Unwrap());
     } else if (session.Code() == Kernel::ERR_MAX_CONNECTIONS_REACHED && return_port_on_failure) {
         LOG_WARNING(Service_SRV, "called service=%s -> ERR_MAX_CONNECTIONS_REACHED, *port*=%u",
                     name.c_str(), (*client_port)->GetObjectId());
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
         rb.Push(ERR_MAX_CONNECTIONS_REACHED);
-        rb.PushObjects(client_port.MoveFrom());
+        rb.PushObjects(std::move(client_port).Unwrap());
     } else {
         LOG_ERROR(Service_SRV, "called service=%s -> error 0x%08X", name.c_str(), session.Code());
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);

--- a/src/core/hle/service/y2r_u.cpp
+++ b/src/core/hle/service/y2r_u.cpp
@@ -275,7 +275,7 @@ static void GetTransferEndEvent(Interface* self) {
 
     cmd_buff[0] = IPC::MakeHeader(0xF, 2, 0);
     cmd_buff[1] = RESULT_SUCCESS.raw;
-    cmd_buff[3] = Kernel::g_handle_table.Create(completion_event).MoveFrom();
+    cmd_buff[3] = Kernel::g_handle_table.Create(completion_event).Unwrap();
 
     LOG_DEBUG(Service_Y2R, "called");
 }


### PR DESCRIPTION
It is now 2017 and rvalue qualifiers on `this` are a thing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2790)
<!-- Reviewable:end -->
