### PR TITLE
gl_rasterizer: fix lighting LUT interpolation

### DIFF
--- a/src/video_core/pica_state.h
+++ b/src/video_core/pica_state.h
@@ -87,11 +87,17 @@ struct State {
             // LUT value, encoded as 12-bit fixed point, with 12 fraction bits
             BitField<0, 12, u32> value; // 0.0.12 fixed point
 
-            // Used by HW for efficient interpolation, Citra does not use these
-            BitField<12, 12, s32> difference; // 1.0.11 fixed point
+            // Used for efficient interpolation.
+            BitField<12, 11, u32> difference; // 0.0.11 fixed point
+            BitField<23, 1, u32> neg_difference;
 
-            float ToFloat() {
+            float ToFloat() const {
                 return static_cast<float>(value) / 4095.f;
+            }
+
+            float DiffToFloat() const {
+                float diff = static_cast<float>(difference) / 2047.f;
+                return neg_difference ? -diff : diff;
             }
         };
 

--- a/src/video_core/regs_lighting.h
+++ b/src/video_core/regs_lighting.h
@@ -26,6 +26,8 @@ struct LightingRegs {
         DistanceAttenuation = 16,
     };
 
+    static constexpr unsigned NumLightingSampler = 24;
+
     static LightingSampler SpotlightAttenuationSampler(unsigned index) {
         return static_cast<LightingSampler>(
             static_cast<unsigned>(LightingSampler::SpotlightAttenuation) + index);

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -1183,7 +1183,7 @@ void RasterizerOpenGL::SetShader() {
         state.Apply();
 
         // Set the texture samplers to correspond to different texture units
-        GLuint uniform_tex = glGetUniformLocation(shader->shader.handle, "tex[0]");
+        GLint uniform_tex = glGetUniformLocation(shader->shader.handle, "tex[0]");
         if (uniform_tex != -1) {
             glUniform1i(uniform_tex, TextureUnits::PicaTexture(0).id);
         }
@@ -1197,40 +1197,40 @@ void RasterizerOpenGL::SetShader() {
         }
 
         // Set the texture samplers to correspond to different lookup table texture units
-        GLuint uniform_lut = glGetUniformLocation(shader->shader.handle, "lighting_lut");
+        GLint uniform_lut = glGetUniformLocation(shader->shader.handle, "lighting_lut");
         if (uniform_lut != -1) {
             glUniform1i(uniform_lut, TextureUnits::LightingLUT.id);
         }
 
-        GLuint uniform_fog_lut = glGetUniformLocation(shader->shader.handle, "fog_lut");
+        GLint uniform_fog_lut = glGetUniformLocation(shader->shader.handle, "fog_lut");
         if (uniform_fog_lut != -1) {
             glUniform1i(uniform_fog_lut, TextureUnits::FogLUT.id);
         }
 
-        GLuint uniform_proctex_noise_lut =
+        GLint uniform_proctex_noise_lut =
             glGetUniformLocation(shader->shader.handle, "proctex_noise_lut");
         if (uniform_proctex_noise_lut != -1) {
             glUniform1i(uniform_proctex_noise_lut, TextureUnits::ProcTexNoiseLUT.id);
         }
 
-        GLuint uniform_proctex_color_map =
+        GLint uniform_proctex_color_map =
             glGetUniformLocation(shader->shader.handle, "proctex_color_map");
         if (uniform_proctex_color_map != -1) {
             glUniform1i(uniform_proctex_color_map, TextureUnits::ProcTexColorMap.id);
         }
 
-        GLuint uniform_proctex_alpha_map =
+        GLint uniform_proctex_alpha_map =
             glGetUniformLocation(shader->shader.handle, "proctex_alpha_map");
         if (uniform_proctex_alpha_map != -1) {
             glUniform1i(uniform_proctex_alpha_map, TextureUnits::ProcTexAlphaMap.id);
         }
 
-        GLuint uniform_proctex_lut = glGetUniformLocation(shader->shader.handle, "proctex_lut");
+        GLint uniform_proctex_lut = glGetUniformLocation(shader->shader.handle, "proctex_lut");
         if (uniform_proctex_lut != -1) {
             glUniform1i(uniform_proctex_lut, TextureUnits::ProcTexLUT.id);
         }
 
-        GLuint uniform_proctex_diff_lut =
+        GLint uniform_proctex_diff_lut =
             glGetUniformLocation(shader->shader.handle, "proctex_diff_lut");
         if (uniform_proctex_diff_lut != -1) {
             glUniform1i(uniform_proctex_diff_lut, TextureUnits::ProcTexDiffLUT.id);

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -102,7 +102,7 @@ RasterizerOpenGL::RasterizerOpenGL() : shader_dirty(true) {
     glBufferData(GL_TEXTURE_BUFFER,
                  sizeof(GLfloat) * 2 * 256 * Pica::LightingRegs::NumLightingSampler, nullptr,
                  GL_DYNAMIC_DRAW);
-    glActiveTexture(GL_TEXTURE15);
+    glActiveTexture(TextureUnits::LightingLUT.Enum());
     glTexBuffer(GL_TEXTURE_BUFFER, GL_RG32F, lighting_lut_buffer.handle);
 
     // Setup the LUT for the fog
@@ -112,7 +112,7 @@ RasterizerOpenGL::RasterizerOpenGL() : shader_dirty(true) {
     }
     state.Apply();
 
-    glActiveTexture(GL_TEXTURE9);
+    glActiveTexture(TextureUnits::FogLUT.Enum());
     glTexImage1D(GL_TEXTURE_1D, 0, GL_R32UI, 128, 0, GL_RED_INTEGER, GL_UNSIGNED_INT, nullptr);
     glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
@@ -121,7 +121,7 @@ RasterizerOpenGL::RasterizerOpenGL() : shader_dirty(true) {
     proctex_noise_lut.Create();
     state.proctex_noise_lut.texture_1d = proctex_noise_lut.handle;
     state.Apply();
-    glActiveTexture(GL_TEXTURE10);
+    glActiveTexture(TextureUnits::ProcTexNoiseLUT.Enum());
     glTexImage1D(GL_TEXTURE_1D, 0, GL_RG32F, 128, 0, GL_RG, GL_FLOAT, nullptr);
     glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
@@ -130,7 +130,7 @@ RasterizerOpenGL::RasterizerOpenGL() : shader_dirty(true) {
     proctex_color_map.Create();
     state.proctex_color_map.texture_1d = proctex_color_map.handle;
     state.Apply();
-    glActiveTexture(GL_TEXTURE11);
+    glActiveTexture(TextureUnits::ProcTexColorMap.Enum());
     glTexImage1D(GL_TEXTURE_1D, 0, GL_RG32F, 128, 0, GL_RG, GL_FLOAT, nullptr);
     glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
@@ -139,7 +139,7 @@ RasterizerOpenGL::RasterizerOpenGL() : shader_dirty(true) {
     proctex_alpha_map.Create();
     state.proctex_alpha_map.texture_1d = proctex_alpha_map.handle;
     state.Apply();
-    glActiveTexture(GL_TEXTURE12);
+    glActiveTexture(TextureUnits::ProcTexAlphaMap.Enum());
     glTexImage1D(GL_TEXTURE_1D, 0, GL_RG32F, 128, 0, GL_RG, GL_FLOAT, nullptr);
     glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
@@ -148,7 +148,7 @@ RasterizerOpenGL::RasterizerOpenGL() : shader_dirty(true) {
     proctex_lut.Create();
     state.proctex_lut.texture_1d = proctex_lut.handle;
     state.Apply();
-    glActiveTexture(GL_TEXTURE13);
+    glActiveTexture(TextureUnits::ProcTexLUT.Enum());
     glTexImage1D(GL_TEXTURE_1D, 0, GL_RGBA32F, 256, 0, GL_RGBA, GL_FLOAT, nullptr);
     glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
@@ -157,7 +157,7 @@ RasterizerOpenGL::RasterizerOpenGL() : shader_dirty(true) {
     proctex_diff_lut.Create();
     state.proctex_diff_lut.texture_1d = proctex_diff_lut.handle;
     state.Apply();
-    glActiveTexture(GL_TEXTURE14);
+    glActiveTexture(TextureUnits::ProcTexDiffLUT.Enum());
     glTexImage1D(GL_TEXTURE_1D, 0, GL_RGBA32F, 256, 0, GL_RGBA, GL_FLOAT, nullptr);
     glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_1D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
@@ -1185,55 +1185,55 @@ void RasterizerOpenGL::SetShader() {
         // Set the texture samplers to correspond to different texture units
         GLuint uniform_tex = glGetUniformLocation(shader->shader.handle, "tex[0]");
         if (uniform_tex != -1) {
-            glUniform1i(uniform_tex, 0);
+            glUniform1i(uniform_tex, TextureUnits::PicaTexture(0).id);
         }
         uniform_tex = glGetUniformLocation(shader->shader.handle, "tex[1]");
         if (uniform_tex != -1) {
-            glUniform1i(uniform_tex, 1);
+            glUniform1i(uniform_tex, TextureUnits::PicaTexture(1).id);
         }
         uniform_tex = glGetUniformLocation(shader->shader.handle, "tex[2]");
         if (uniform_tex != -1) {
-            glUniform1i(uniform_tex, 2);
+            glUniform1i(uniform_tex, TextureUnits::PicaTexture(2).id);
         }
 
         // Set the texture samplers to correspond to different lookup table texture units
         GLuint uniform_lut = glGetUniformLocation(shader->shader.handle, "lighting_lut");
         if (uniform_lut != -1) {
-            glUniform1i(uniform_lut, 15);
+            glUniform1i(uniform_lut, TextureUnits::LightingLUT.id);
         }
 
         GLuint uniform_fog_lut = glGetUniformLocation(shader->shader.handle, "fog_lut");
         if (uniform_fog_lut != -1) {
-            glUniform1i(uniform_fog_lut, 9);
+            glUniform1i(uniform_fog_lut, TextureUnits::FogLUT.id);
         }
 
         GLuint uniform_proctex_noise_lut =
             glGetUniformLocation(shader->shader.handle, "proctex_noise_lut");
         if (uniform_proctex_noise_lut != -1) {
-            glUniform1i(uniform_proctex_noise_lut, 10);
+            glUniform1i(uniform_proctex_noise_lut, TextureUnits::ProcTexNoiseLUT.id);
         }
 
         GLuint uniform_proctex_color_map =
             glGetUniformLocation(shader->shader.handle, "proctex_color_map");
         if (uniform_proctex_color_map != -1) {
-            glUniform1i(uniform_proctex_color_map, 11);
+            glUniform1i(uniform_proctex_color_map, TextureUnits::ProcTexColorMap.id);
         }
 
         GLuint uniform_proctex_alpha_map =
             glGetUniformLocation(shader->shader.handle, "proctex_alpha_map");
         if (uniform_proctex_alpha_map != -1) {
-            glUniform1i(uniform_proctex_alpha_map, 12);
+            glUniform1i(uniform_proctex_alpha_map, TextureUnits::ProcTexAlphaMap.id);
         }
 
         GLuint uniform_proctex_lut = glGetUniformLocation(shader->shader.handle, "proctex_lut");
         if (uniform_proctex_lut != -1) {
-            glUniform1i(uniform_proctex_lut, 13);
+            glUniform1i(uniform_proctex_lut, TextureUnits::ProcTexLUT.id);
         }
 
         GLuint uniform_proctex_diff_lut =
             glGetUniformLocation(shader->shader.handle, "proctex_diff_lut");
         if (uniform_proctex_diff_lut != -1) {
-            glUniform1i(uniform_proctex_diff_lut, 14);
+            glUniform1i(uniform_proctex_diff_lut, TextureUnits::ProcTexDiffLUT.id);
         }
 
         current_shader = shader_cache.emplace(config, std::move(shader)).first->second.get();
@@ -1363,7 +1363,7 @@ void RasterizerOpenGL::SyncFogLUT() {
 
     if (new_data != fog_lut_data) {
         fog_lut_data = new_data;
-        glActiveTexture(GL_TEXTURE9);
+        glActiveTexture(TextureUnits::FogLUT.Enum());
         glTexSubImage1D(GL_TEXTURE_1D, 0, 0, 128, GL_RED_INTEGER, GL_UNSIGNED_INT,
                         fog_lut_data.data());
     }
@@ -1402,17 +1402,18 @@ static void SyncProcTexValueLUT(const std::array<Pica::State::ProcTex::ValueEntr
 }
 
 void RasterizerOpenGL::SyncProcTexNoiseLUT() {
-    SyncProcTexValueLUT(Pica::g_state.proctex.noise_table, proctex_noise_lut_data, GL_TEXTURE10);
+    SyncProcTexValueLUT(Pica::g_state.proctex.noise_table, proctex_noise_lut_data,
+                        TextureUnits::ProcTexNoiseLUT.Enum());
 }
 
 void RasterizerOpenGL::SyncProcTexColorMap() {
     SyncProcTexValueLUT(Pica::g_state.proctex.color_map_table, proctex_color_map_data,
-                        GL_TEXTURE11);
+                        TextureUnits::ProcTexColorMap.Enum());
 }
 
 void RasterizerOpenGL::SyncProcTexAlphaMap() {
     SyncProcTexValueLUT(Pica::g_state.proctex.alpha_map_table, proctex_alpha_map_data,
-                        GL_TEXTURE12);
+                        TextureUnits::ProcTexAlphaMap.Enum());
 }
 
 void RasterizerOpenGL::SyncProcTexLUT() {
@@ -1427,7 +1428,7 @@ void RasterizerOpenGL::SyncProcTexLUT() {
 
     if (new_data != proctex_lut_data) {
         proctex_lut_data = new_data;
-        glActiveTexture(GL_TEXTURE13);
+        glActiveTexture(TextureUnits::ProcTexLUT.Enum());
         glTexSubImage1D(GL_TEXTURE_1D, 0, 0, 256, GL_RGBA, GL_FLOAT, proctex_lut_data.data());
     }
 }
@@ -1444,7 +1445,7 @@ void RasterizerOpenGL::SyncProcTexDiffLUT() {
 
     if (new_data != proctex_diff_lut_data) {
         proctex_diff_lut_data = new_data;
-        glActiveTexture(GL_TEXTURE14);
+        glActiveTexture(TextureUnits::ProcTexDiffLUT.Enum());
         glTexSubImage1D(GL_TEXTURE_1D, 0, 0, 256, GL_RGBA, GL_FLOAT, proctex_diff_lut_data.data());
     }
 }

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -263,7 +263,7 @@ private:
 
     struct {
         UniformData data;
-        bool lut_dirty[6];
+        std::array<bool, Pica::LightingRegs::NumLightingSampler> lut_dirty;
         bool fog_lut_dirty;
         bool proctex_noise_lut_dirty;
         bool proctex_color_map_dirty;
@@ -279,8 +279,9 @@ private:
     OGLBuffer uniform_buffer;
     OGLFramebuffer framebuffer;
 
-    std::array<OGLTexture, 6> lighting_luts;
-    std::array<std::array<GLvec4, 256>, 6> lighting_lut_data{};
+    OGLBuffer lighting_lut_buffer;
+    OGLTexture lighting_lut;
+    std::array<std::array<GLvec2, 256>, Pica::LightingRegs::NumLightingSampler> lighting_lut_data{};
 
     OGLTexture fog_lut;
     std::array<GLuint, 128> fog_lut_data{};

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -183,7 +183,7 @@ void OpenGLState::Apply() const {
     // Textures
     for (unsigned i = 0; i < ARRAY_SIZE(texture_units); ++i) {
         if (texture_units[i].texture_2d != cur_state.texture_units[i].texture_2d) {
-            glActiveTexture(GL_TEXTURE0 + i);
+            glActiveTexture(TextureUnits::PicaTexture(i).Enum());
             glBindTexture(GL_TEXTURE_2D, texture_units[i].texture_2d);
         }
         if (texture_units[i].sampler != cur_state.texture_units[i].sampler) {
@@ -193,43 +193,43 @@ void OpenGLState::Apply() const {
 
     // Lighting LUTs
     if (lighting_lut.texture_buffer != cur_state.lighting_lut.texture_buffer) {
-        glActiveTexture(GL_TEXTURE15);
+        glActiveTexture(TextureUnits::LightingLUT.Enum());
         glBindTexture(GL_TEXTURE_BUFFER, cur_state.lighting_lut.texture_buffer);
     }
 
     // Fog LUT
     if (fog_lut.texture_1d != cur_state.fog_lut.texture_1d) {
-        glActiveTexture(GL_TEXTURE9);
+        glActiveTexture(TextureUnits::FogLUT.Enum());
         glBindTexture(GL_TEXTURE_1D, fog_lut.texture_1d);
     }
 
     // ProcTex Noise LUT
     if (proctex_noise_lut.texture_1d != cur_state.proctex_noise_lut.texture_1d) {
-        glActiveTexture(GL_TEXTURE10);
+        glActiveTexture(TextureUnits::ProcTexNoiseLUT.Enum());
         glBindTexture(GL_TEXTURE_1D, proctex_noise_lut.texture_1d);
     }
 
     // ProcTex Color Map
     if (proctex_color_map.texture_1d != cur_state.proctex_color_map.texture_1d) {
-        glActiveTexture(GL_TEXTURE11);
+        glActiveTexture(TextureUnits::ProcTexColorMap.Enum());
         glBindTexture(GL_TEXTURE_1D, proctex_color_map.texture_1d);
     }
 
     // ProcTex Alpha Map
     if (proctex_alpha_map.texture_1d != cur_state.proctex_alpha_map.texture_1d) {
-        glActiveTexture(GL_TEXTURE12);
+        glActiveTexture(TextureUnits::ProcTexAlphaMap.Enum());
         glBindTexture(GL_TEXTURE_1D, proctex_alpha_map.texture_1d);
     }
 
     // ProcTex LUT
     if (proctex_lut.texture_1d != cur_state.proctex_lut.texture_1d) {
-        glActiveTexture(GL_TEXTURE13);
+        glActiveTexture(TextureUnits::ProcTexLUT.Enum());
         glBindTexture(GL_TEXTURE_1D, proctex_lut.texture_1d);
     }
 
     // ProcTex Diff LUT
     if (proctex_diff_lut.texture_1d != cur_state.proctex_diff_lut.texture_1d) {
-        glActiveTexture(GL_TEXTURE14);
+        glActiveTexture(TextureUnits::ProcTexDiffLUT.Enum());
         glBindTexture(GL_TEXTURE_1D, proctex_diff_lut.texture_1d);
     }
 

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -52,9 +52,7 @@ OpenGLState::OpenGLState() {
         texture_unit.sampler = 0;
     }
 
-    for (auto& lut : lighting_luts) {
-        lut.texture_1d = 0;
-    }
+    lighting_lut.texture_buffer = 0;
 
     fog_lut.texture_1d = 0;
 
@@ -194,11 +192,9 @@ void OpenGLState::Apply() const {
     }
 
     // Lighting LUTs
-    for (unsigned i = 0; i < ARRAY_SIZE(lighting_luts); ++i) {
-        if (lighting_luts[i].texture_1d != cur_state.lighting_luts[i].texture_1d) {
-            glActiveTexture(GL_TEXTURE3 + i);
-            glBindTexture(GL_TEXTURE_1D, lighting_luts[i].texture_1d);
-        }
+    if (lighting_lut.texture_buffer != cur_state.lighting_lut.texture_buffer) {
+        glActiveTexture(GL_TEXTURE15);
+        glBindTexture(GL_TEXTURE_BUFFER, cur_state.lighting_lut.texture_buffer);
     }
 
     // Fog LUT

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -270,6 +270,20 @@ void OpenGLState::ResetTexture(GLuint handle) {
             unit.texture_2d = 0;
         }
     }
+    if (cur_state.lighting_lut.texture_buffer == handle)
+        cur_state.lighting_lut.texture_buffer = 0;
+    if (cur_state.fog_lut.texture_1d == handle)
+        cur_state.fog_lut.texture_1d = 0;
+    if (cur_state.proctex_noise_lut.texture_1d == handle)
+        cur_state.proctex_noise_lut.texture_1d = 0;
+    if (cur_state.proctex_color_map.texture_1d == handle)
+        cur_state.proctex_color_map.texture_1d = 0;
+    if (cur_state.proctex_alpha_map.texture_1d == handle)
+        cur_state.proctex_alpha_map.texture_1d = 0;
+    if (cur_state.proctex_lut.texture_1d == handle)
+        cur_state.proctex_lut.texture_1d = 0;
+    if (cur_state.proctex_diff_lut.texture_1d == handle)
+        cur_state.proctex_diff_lut.texture_1d = 0;
 }
 
 void OpenGLState::ResetSampler(GLuint handle) {

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -64,8 +64,8 @@ public:
     } texture_units[3];
 
     struct {
-        GLuint texture_1d; // GL_TEXTURE_BINDING_1D
-    } lighting_luts[6];
+        GLuint texture_buffer; // GL_TEXTURE_BINDING_BUFFER
+    } lighting_lut;
 
     struct {
         GLuint texture_1d; // GL_TEXTURE_BINDING_1D

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -6,6 +6,29 @@
 
 #include <glad/glad.h>
 
+namespace TextureUnits {
+
+struct TextureUnit {
+    GLint id;
+    constexpr GLenum Enum() const {
+        return static_cast<GLenum>(GL_TEXTURE0 + id);
+    }
+};
+
+constexpr TextureUnit PicaTexture(int unit) {
+    return TextureUnit{unit};
+}
+
+constexpr TextureUnit LightingLUT{3};
+constexpr TextureUnit FogLUT{4};
+constexpr TextureUnit ProcTexNoiseLUT{5};
+constexpr TextureUnit ProcTexColorMap{6};
+constexpr TextureUnit ProcTexAlphaMap{7};
+constexpr TextureUnit ProcTexLUT{8};
+constexpr TextureUnit ProcTexDiffLUT{9};
+
+} // namespace TextureUnits
+
 class OpenGLState {
 public:
     struct {


### PR DESCRIPTION
## gl_rasterizer/lighting: fix LUT interpolation

Currently on the GL renderer, we use the texture linear filter for LUT interpolation. This approach have the following problems:
 - if the delta entry the game assigns is not the difference between two entries, linear filter will produce different output from real 3DS. (less likely)
 - hard to handle sampling at the edge due to different coordinates convention between OpenGL and PICA (see #2367 and #2551). Note that the [-1.0, 1.0] sampling mode in PICA, which works in a two's complement way, is the root of most lighting issue, because GL will interpolate between LUT(-1.0) and LUT(1.0) and generate wrong result at the adge.

Solution: just do what PICA do. Both LUT value and delta are uploaded to the shader and proper interpolation is calculated there. Since the filter is not used any more, texture can be also replaced 
by cheaper mechanism. Two alternative, uniform buffer and texture buffer, are considered.

---

### texture buffer
(this was originally suggested by @degasus)
Buffer texture is still sampled as texture units, but uploaded as a buffer. Because we are going to upload delta as well, the current "packing 4 LUT into one texture" method must change. Here are some options:
 - break them into 24 textures. But this is not feasible because the total texture unit limit is only guaranteed at least 16.
 - upload them into one texture buffer. The total size off all LUT is `24*256*8 = 49152` (assuming an entry is stored as two float), while the texture buffer size limit is at least 65536, meaning that it can hold all LUT data. Partially uploading the texture buffer is much cheaper than normal texture, so this is feasible
 - keep 4 LUT in one texture and change the structure of packing. This should still work, but the number  4 looks pretty arbitrary now. IMO it reduces the code readability. Also, we are already close to the 16 textures limit (15 currently), so we should take this opportunity to reduce it.

### uniform buffer
Recall that the total size off all LUT 49152, while the size limit of a uniform buffer is 16384, so one uniform buffer can't hold it. The number limits of uniform buffer is 12, meaning using one buffer for each LUT is not possible either. So a similar "packing" is needed, which has the same readability issue as packed textures.

---

There is another different between the two alternatives: texture buffer prefers random memory access, while uniform buffer prefers coherent memory access (source [here](http://rastergrid.com/blog/2010/01/uniform-buffers-vs-texture-buffers/)). For the case of LUT, the pattern is random access, so texture buffer is better.

Considering these, I chose to use one texture buffer to store all LUT. The texture buffer is used as a `vec2[256 * 24]` array, where the two components of the vector are for entry value and delta, and all LUT are concatenated to each other.

I didn't touch proctex and fog LUT. They are already properly interpolated using delta, but still using 1D textures. To avoid making a giant PR, I decided to leave them for the next one.

---

## Additional commits

### gl_rasterizer: manage texture ids in one place
Originally proposed in proctex PR. Though I didn't use `enum`, but constants of a helper class instead. In this way, it can be easily used for both texture unit enum and uniform value.

### gl_rasterizer: fix glGetUniformLocation type 
:expressionless:

### gl_state: reset 1D textures
This fixes the log spam when switching from hw renderer to sw renderer. Originally the reset function only resets the 2D texture units, but not for 1D texture units.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2792)
<!-- Reviewable:end -->
