### PR TITLE
Change default UI background from white to black.

### DIFF
--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -88,9 +88,9 @@ void Config::ReadValues() {
     Settings::values.toggle_framelimit =
         sdl2_config->GetBoolean("Renderer", "toggle_framelimit", true);
 
-    Settings::values.bg_red = (float)sdl2_config->GetReal("Renderer", "bg_red", 1.0);
-    Settings::values.bg_green = (float)sdl2_config->GetReal("Renderer", "bg_green", 1.0);
-    Settings::values.bg_blue = (float)sdl2_config->GetReal("Renderer", "bg_blue", 1.0);
+    Settings::values.bg_red = (float)sdl2_config->GetReal("Renderer", "bg_red", 0.0);
+    Settings::values.bg_green = (float)sdl2_config->GetReal("Renderer", "bg_green", 0.0);
+    Settings::values.bg_blue = (float)sdl2_config->GetReal("Renderer", "bg_blue", 0.0);
 
     // Layout
     Settings::values.layout_option =

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -70,9 +70,9 @@ void Config::ReadValues() {
     Settings::values.use_vsync = qt_config->value("use_vsync", false).toBool();
     Settings::values.toggle_framelimit = qt_config->value("toggle_framelimit", true).toBool();
 
-    Settings::values.bg_red = qt_config->value("bg_red", 1.0).toFloat();
-    Settings::values.bg_green = qt_config->value("bg_green", 1.0).toFloat();
-    Settings::values.bg_blue = qt_config->value("bg_blue", 1.0).toFloat();
+    Settings::values.bg_red = qt_config->value("bg_red", 0.0).toFloat();
+    Settings::values.bg_green = qt_config->value("bg_green", 0.0).toFloat();
+    Settings::values.bg_blue = qt_config->value("bg_blue", 0.0).toFloat();
     qt_config->endGroup();
 
     qt_config->beginGroup("Layout");


### PR DESCRIPTION
Changing the default game UI screen from white (1.0) to black (0.0) allows for easier viewing of the game window.

When taking screenshots for the compatibility database, we agreed on a black background would be easier. 

Making this the default background color.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2795)
<!-- Reviewable:end -->
