### PR TITLE
gpu: fix edge cases for TextureCopy

### DIFF
--- a/src/core/hw/gpu.cpp
+++ b/src/core/hw/gpu.cpp
@@ -334,25 +334,25 @@ static void TextureCopy(const Regs::DisplayTransferConfig& config) {
     u32 remaining_size = Common::AlignDown(config.texture_copy.size, 16);
 
     if (remaining_size == 0) {
-        // Real hardware freeze on this
-        LOG_CRITICAL(HW_GPU, "zero size");
+        LOG_CRITICAL(HW_GPU, "zero size. Real hardware freezes on this.");
         return;
     }
 
     u32 input_gap = config.texture_copy.input_gap * 16;
-    u32 input_width = input_gap == 0 ? remaining_size : config.texture_copy.input_width * 16;
     u32 output_gap = config.texture_copy.output_gap * 16;
+
+    // Zero gap means contiguous input/output even if width = 0. To avoid infinite loop below, width
+    // is assigned with the total size if gap = 0.
+    u32 input_width = input_gap == 0 ? remaining_size : config.texture_copy.input_width * 16;
     u32 output_width = output_gap == 0 ? remaining_size : config.texture_copy.output_width * 16;
 
     if (input_width == 0) {
-        // Real hardware freeze on this
-        LOG_CRITICAL(HW_GPU, "zero input width");
+        LOG_CRITICAL(HW_GPU, "zero input width. Real hardware freezes on this.");
         return;
     }
 
     if (output_width == 0) {
-        // Real hardware freeze on this
-        LOG_CRITICAL(HW_GPU, "zero output width");
+        LOG_CRITICAL(HW_GPU, "zero output width. Real hardware freezes on this.");
         return;
     }
 

--- a/src/core/hw/gpu.h
+++ b/src/core/hw/gpu.h
@@ -225,7 +225,7 @@ struct Regs {
         INSERT_PADDING_WORDS(0x1);
 
         struct {
-            u32 size;
+            u32 size; // The lower 4 bits are ignored
 
             union {
                 u32 input_size;


### PR DESCRIPTION
The following behaviours are confirmed on hardware and fixed in citra accordingly:
 - The total size is always aligned down to 16 bytes (i.e. the same unit of width/gap)
 - If the total size (aligned) is zero, 3DS freezes.
 - If both `input_width` and `input_gap` are zero, then the input is treated as contiguous data with length `size` (i.e. behaves the same as `input_gap == 0` and `input_width != 0`)
 - If `input_width == 0` and `input_gap != 0`, 3DS freezes
 - The two points above also apply to the output.
 - There are some other cases can cause 3DS freeze, but I didn't test it very much. Probably not worth to emulate them now.

The test program is here: https://github.com/wwylele/ctrhwtest/tree/master/texture-copy-test
(Note: if you want to run this test in citra, please merge [this](https://github.com/wwylele/citra/commits/swkbd-to-stdin) for swkbd input

Potentially fixes some `zero input width` error. I will get some test result later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2809)
<!-- Reviewable:end -->
