### PR TITLE
configure_debug: Add label warning that CPU JIT needs to be disabled …

### DIFF
--- a/src/citra_qt/configuration/configure_debug.ui
+++ b/src/citra_qt/configuration/configure_debug.ui
@@ -23,6 +23,13 @@
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_2">
         <item>
+         <widget class="QLabel">
+          <property name="text">
+           <string>The GDB Stub only works correctly when the CPU JIT is off.</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <layout class="QHBoxLayout" name="horizontalLayout_3">
           <item>
            <widget class="QCheckBox" name="toggle_gdbstub">


### PR DESCRIPTION
…for gdbstub to work

<img width="208" alt="screen shot 2017-06-28 at 08 56 44" src="https://user-images.githubusercontent.com/8682882/27626376-ca64f570-5bdf-11e7-84c5-9d4deb567f73.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2811)
<!-- Reviewable:end -->
