### PR TITLE
Remove unnecessary WIN32_LEAN_AND_MEAN macro definition

### DIFF
--- a/src/common/logging/text_formatter.cpp
+++ b/src/common/logging/text_formatter.cpp
@@ -6,7 +6,6 @@
 #include <cstdio>
 
 #ifdef _WIN32
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif
 


### PR DESCRIPTION
Already defined here: https://github.com/citra-emu/citra/blob/56d718b2a1d6385c88c2044f780280a5dfbc6072/CMakeLists.txt#L83

Which generates the following warning.

```
C:\projects\citra\src\common\logging\text_formatter.cpp(9): warning C4005: 'WIN32_LEAN_AND_MEAN': macro redefinition
```

There are more on Cryptopp and Dynarmic, to a total of 9... but I think that those ones should be addressed  with an `#ifndef` on the upstream, and not silenced by adding /wd4005.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2814)
<!-- Reviewable:end -->
