### PR TITLE
gl_rasterizer: use texture buffer for proctex LUT

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -287,18 +287,23 @@ private:
     OGLTexture fog_lut;
     std::array<GLvec2, 128> fog_lut_data{};
 
+    OGLBuffer proctex_noise_lut_buffer;
     OGLTexture proctex_noise_lut;
     std::array<GLvec2, 128> proctex_noise_lut_data{};
 
+    OGLBuffer proctex_color_map_buffer;
     OGLTexture proctex_color_map;
     std::array<GLvec2, 128> proctex_color_map_data{};
 
+    OGLBuffer proctex_alpha_map_buffer;
     OGLTexture proctex_alpha_map;
     std::array<GLvec2, 128> proctex_alpha_map_data{};
 
+    OGLBuffer proctex_lut_buffer;
     OGLTexture proctex_lut;
     std::array<GLvec4, 256> proctex_lut_data{};
 
+    OGLBuffer proctex_diff_lut_buffer;
     OGLTexture proctex_diff_lut;
     std::array<GLvec4, 256> proctex_diff_lut_data{};
 };

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -886,12 +886,12 @@ void AppendProcTexSampler(std::string& out, const PicaShaderConfig& config) {
     // coord=1.0 is lut[127]+lut_diff[127]. For other indices, the result is interpolated using
     // value entries and difference entries.
     out += R"(
-float ProcTexLookupLUT(sampler1D lut, float coord) {
+float ProcTexLookupLUT(samplerBuffer lut, float coord) {
     coord *= 128;
     float index_i = clamp(floor(coord), 0.0, 127.0);
     float index_f = coord - index_i; // fract() cannot be used here because 128.0 needs to be
                                      // extracted as index_i = 127.0 and index_f = 1.0
-    vec2 entry = texelFetch(lut, int(index_i), 0).rg;
+    vec2 entry = texelFetch(lut, int(index_i)).rg;
     return clamp(entry.r + entry.g * index_f, 0.0, 1.0);
 }
     )";
@@ -979,14 +979,14 @@ float ProcTexNoiseCoef(vec2 x) {
         out += "int lut_index_i = int(lut_coord) + " +
                std::to_string(config.state.proctex.lut_offset) + ";\n";
         out += "float lut_index_f = fract(lut_coord);\n";
-        out += "vec4 final_color = texelFetch(proctex_lut, lut_index_i, 0) + lut_index_f * "
-               "texelFetch(proctex_diff_lut, lut_index_i, 0);\n";
+        out += "vec4 final_color = texelFetch(proctex_lut, lut_index_i) + lut_index_f * "
+               "texelFetch(proctex_diff_lut, lut_index_i);\n";
         break;
     case ProcTexFilter::Nearest:
     case ProcTexFilter::NearestMipmapLinear:
     case ProcTexFilter::NearestMipmapNearest:
         out += "lut_coord += " + std::to_string(config.state.proctex.lut_offset) + ";\n";
-        out += "vec4 final_color = texelFetch(proctex_lut, int(round(lut_coord)), 0);\n";
+        out += "vec4 final_color = texelFetch(proctex_lut, int(round(lut_coord)));\n";
         break;
     }
 
@@ -1053,11 +1053,11 @@ layout (std140) uniform shader_data {
 uniform sampler2D tex[3];
 uniform samplerBuffer lighting_lut;
 uniform samplerBuffer fog_lut;
-uniform sampler1D proctex_noise_lut;
-uniform sampler1D proctex_color_map;
-uniform sampler1D proctex_alpha_map;
-uniform sampler1D proctex_lut;
-uniform sampler1D proctex_diff_lut;
+uniform samplerBuffer proctex_noise_lut;
+uniform samplerBuffer proctex_color_map;
+uniform samplerBuffer proctex_alpha_map;
+uniform samplerBuffer proctex_lut;
+uniform samplerBuffer proctex_diff_lut;
 
 // Rotate the vector v by the quaternion q
 vec3 quaternion_rotate(vec4 q, vec3 v) {

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -56,11 +56,11 @@ OpenGLState::OpenGLState() {
 
     fog_lut.texture_buffer = 0;
 
-    proctex_lut.texture_1d = 0;
-    proctex_diff_lut.texture_1d = 0;
-    proctex_color_map.texture_1d = 0;
-    proctex_alpha_map.texture_1d = 0;
-    proctex_noise_lut.texture_1d = 0;
+    proctex_lut.texture_buffer = 0;
+    proctex_diff_lut.texture_buffer = 0;
+    proctex_color_map.texture_buffer = 0;
+    proctex_alpha_map.texture_buffer = 0;
+    proctex_noise_lut.texture_buffer = 0;
 
     draw.read_framebuffer = 0;
     draw.draw_framebuffer = 0;
@@ -204,33 +204,33 @@ void OpenGLState::Apply() const {
     }
 
     // ProcTex Noise LUT
-    if (proctex_noise_lut.texture_1d != cur_state.proctex_noise_lut.texture_1d) {
+    if (proctex_noise_lut.texture_buffer != cur_state.proctex_noise_lut.texture_buffer) {
         glActiveTexture(TextureUnits::ProcTexNoiseLUT.Enum());
-        glBindTexture(GL_TEXTURE_1D, proctex_noise_lut.texture_1d);
+        glBindTexture(GL_TEXTURE_BUFFER, proctex_noise_lut.texture_buffer);
     }
 
     // ProcTex Color Map
-    if (proctex_color_map.texture_1d != cur_state.proctex_color_map.texture_1d) {
+    if (proctex_color_map.texture_buffer != cur_state.proctex_color_map.texture_buffer) {
         glActiveTexture(TextureUnits::ProcTexColorMap.Enum());
-        glBindTexture(GL_TEXTURE_1D, proctex_color_map.texture_1d);
+        glBindTexture(GL_TEXTURE_BUFFER, proctex_color_map.texture_buffer);
     }
 
     // ProcTex Alpha Map
-    if (proctex_alpha_map.texture_1d != cur_state.proctex_alpha_map.texture_1d) {
+    if (proctex_alpha_map.texture_buffer != cur_state.proctex_alpha_map.texture_buffer) {
         glActiveTexture(TextureUnits::ProcTexAlphaMap.Enum());
-        glBindTexture(GL_TEXTURE_1D, proctex_alpha_map.texture_1d);
+        glBindTexture(GL_TEXTURE_BUFFER, proctex_alpha_map.texture_buffer);
     }
 
     // ProcTex LUT
-    if (proctex_lut.texture_1d != cur_state.proctex_lut.texture_1d) {
+    if (proctex_lut.texture_buffer != cur_state.proctex_lut.texture_buffer) {
         glActiveTexture(TextureUnits::ProcTexLUT.Enum());
-        glBindTexture(GL_TEXTURE_1D, proctex_lut.texture_1d);
+        glBindTexture(GL_TEXTURE_BUFFER, proctex_lut.texture_buffer);
     }
 
     // ProcTex Diff LUT
-    if (proctex_diff_lut.texture_1d != cur_state.proctex_diff_lut.texture_1d) {
+    if (proctex_diff_lut.texture_buffer != cur_state.proctex_diff_lut.texture_buffer) {
         glActiveTexture(TextureUnits::ProcTexDiffLUT.Enum());
-        glBindTexture(GL_TEXTURE_1D, proctex_diff_lut.texture_1d);
+        glBindTexture(GL_TEXTURE_BUFFER, proctex_diff_lut.texture_buffer);
     }
 
     // Framebuffer
@@ -274,16 +274,16 @@ void OpenGLState::ResetTexture(GLuint handle) {
         cur_state.lighting_lut.texture_buffer = 0;
     if (cur_state.fog_lut.texture_buffer == handle)
         cur_state.fog_lut.texture_buffer = 0;
-    if (cur_state.proctex_noise_lut.texture_1d == handle)
-        cur_state.proctex_noise_lut.texture_1d = 0;
-    if (cur_state.proctex_color_map.texture_1d == handle)
-        cur_state.proctex_color_map.texture_1d = 0;
-    if (cur_state.proctex_alpha_map.texture_1d == handle)
-        cur_state.proctex_alpha_map.texture_1d = 0;
-    if (cur_state.proctex_lut.texture_1d == handle)
-        cur_state.proctex_lut.texture_1d = 0;
-    if (cur_state.proctex_diff_lut.texture_1d == handle)
-        cur_state.proctex_diff_lut.texture_1d = 0;
+    if (cur_state.proctex_noise_lut.texture_buffer == handle)
+        cur_state.proctex_noise_lut.texture_buffer = 0;
+    if (cur_state.proctex_color_map.texture_buffer == handle)
+        cur_state.proctex_color_map.texture_buffer = 0;
+    if (cur_state.proctex_alpha_map.texture_buffer == handle)
+        cur_state.proctex_alpha_map.texture_buffer = 0;
+    if (cur_state.proctex_lut.texture_buffer == handle)
+        cur_state.proctex_lut.texture_buffer = 0;
+    if (cur_state.proctex_diff_lut.texture_buffer == handle)
+        cur_state.proctex_diff_lut.texture_buffer = 0;
 }
 
 void OpenGLState::ResetSampler(GLuint handle) {

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -95,23 +95,23 @@ public:
     } fog_lut;
 
     struct {
-        GLuint texture_1d; // GL_TEXTURE_BINDING_1D
+        GLuint texture_buffer; // GL_TEXTURE_BINDING_BUFFER
     } proctex_noise_lut;
 
     struct {
-        GLuint texture_1d; // GL_TEXTURE_BINDING_1D
+        GLuint texture_buffer; // GL_TEXTURE_BINDING_BUFFER
     } proctex_color_map;
 
     struct {
-        GLuint texture_1d; // GL_TEXTURE_BINDING_1D
+        GLuint texture_buffer; // GL_TEXTURE_BINDING_BUFFER
     } proctex_alpha_map;
 
     struct {
-        GLuint texture_1d; // GL_TEXTURE_BINDING_1D
+        GLuint texture_buffer; // GL_TEXTURE_BINDING_BUFFER
     } proctex_lut;
 
     struct {
-        GLuint texture_1d; // GL_TEXTURE_BINDING_1D
+        GLuint texture_buffer; // GL_TEXTURE_BINDING_BUFFER
     } proctex_diff_lut;
 
     struct {


### PR DESCRIPTION
Follow up of #2800 . I still kept these textures in separate unites because they don't have good numerical relationship to pack them into one texture like the lighting LUT one. We can pack them whenever it is more unit space is needed, anyway

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2816)
<!-- Reviewable:end -->
