### PR TITLE
Enable data transfer over ENet

### DIFF
--- a/src/citra/CMakeLists.txt
+++ b/src/citra/CMakeLists.txt
@@ -16,7 +16,7 @@ set(HEADERS
 create_directory_groups(${SRCS} ${HEADERS})
 
 add_executable(citra ${SRCS} ${HEADERS})
-target_link_libraries(citra PRIVATE common core input_common)
+target_link_libraries(citra PRIVATE common core input_common network)
 target_link_libraries(citra PRIVATE inih glad)
 if (MSVC)
     target_link_libraries(citra PRIVATE getopt)

--- a/src/citra/emu_window/emu_window_sdl2.cpp
+++ b/src/citra/emu_window/emu_window_sdl2.cpp
@@ -16,6 +16,7 @@
 #include "core/settings.h"
 #include "input_common/keyboard.h"
 #include "input_common/main.h"
+#include "network/network.h"
 
 void EmuWindow_SDL2::OnMouseMotion(s32 x, s32 y) {
     TouchMoved((unsigned)std::max(x, 0), (unsigned)std::max(y, 0));
@@ -58,6 +59,7 @@ void EmuWindow_SDL2::OnResize() {
 
 EmuWindow_SDL2::EmuWindow_SDL2() {
     InputCommon::Init();
+    Network::Init();
 
     motion_emu = std::make_unique<Motion::MotionEmu>(*this);
 
@@ -116,6 +118,8 @@ EmuWindow_SDL2::~EmuWindow_SDL2() {
     SDL_GL_DeleteContext(gl_context);
     SDL_Quit();
     motion_emu = nullptr;
+
+    Network::Shutdown();
     InputCommon::Shutdown();
 }
 

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -1,11 +1,13 @@
 set(SRCS
             network.cpp
+            packet.cpp
             room.cpp
             room_member.cpp
             )
 
 set(HEADERS
             network.h
+            packet.h
             room.h
             room_member.h
             )

--- a/src/network/packet.cpp
+++ b/src/network/packet.cpp
@@ -1,0 +1,229 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#ifdef _WIN32
+#include <winsock2.h>
+#else
+#include <arpa/inet.h>
+#endif
+#include <cstring>
+#include <string>
+#include "network/packet.h"
+
+namespace Network {
+
+Packet::Packet() : read_pos(0), is_valid(true) {}
+
+Packet::~Packet() {}
+
+void Packet::Append(const void* in_data, std::size_t size_in_bytes) {
+    if (in_data && (size_in_bytes > 0)) {
+        std::size_t start = data.size();
+        data.resize(start + size_in_bytes);
+        std::memcpy(&data[start], in_data, size_in_bytes);
+    }
+}
+
+void Packet::Read(void* out_data, std::size_t size_in_bytes) {
+    if (out_data && CheckSize(size_in_bytes)) {
+        std::memcpy(out_data, &data[read_pos], size_in_bytes);
+        read_pos += size_in_bytes;
+    }
+}
+
+void Packet::Clear() {
+    data.clear();
+    read_pos = 0;
+    is_valid = true;
+}
+
+const void* Packet::GetData() const {
+    return !data.empty() ? &data[0] : NULL;
+}
+
+void Packet::IgnoreBytes(u32 length) {
+    read_pos += length;
+}
+
+std::size_t Packet::GetDataSize() const {
+    return data.size();
+}
+
+bool Packet::EndOfPacket() const {
+    return read_pos >= data.size();
+}
+
+Packet::operator BoolType() const {
+    return is_valid ? &Packet::CheckSize : NULL;
+}
+
+Packet& Packet::operator>>(bool& out_data) {
+    u8 value;
+    if (*this >> value) {
+        out_data = (value != 0);
+    }
+    return *this;
+}
+
+Packet& Packet::operator>>(s8& out_data) {
+    Read(&out_data, sizeof(out_data));
+    return *this;
+}
+
+Packet& Packet::operator>>(u8& out_data) {
+    Read(&out_data, sizeof(out_data));
+    return *this;
+}
+
+Packet& Packet::operator>>(s16& out_data) {
+    s16 value;
+    Read(&value, sizeof(value));
+    out_data = ntohs(value);
+    return *this;
+}
+
+Packet& Packet::operator>>(u16& out_data) {
+    u16 value;
+    Read(&value, sizeof(value));
+    out_data = ntohs(value);
+    return *this;
+}
+
+Packet& Packet::operator>>(s32& out_data) {
+    s32 value;
+    Read(&value, sizeof(value));
+    out_data = ntohl(value);
+    return *this;
+}
+
+Packet& Packet::operator>>(u32& out_data) {
+    u32 value;
+    Read(&value, sizeof(value));
+    out_data = ntohl(value);
+    return *this;
+}
+
+Packet& Packet::operator>>(float& out_data) {
+    Read(&out_data, sizeof(out_data));
+    return *this;
+}
+
+Packet& Packet::operator>>(double& out_data) {
+    Read(&out_data, sizeof(out_data));
+    return *this;
+}
+
+Packet& Packet::operator>>(char* out_data) {
+    // First extract string length
+    u32 length = 0;
+    *this >> length;
+
+    if ((length > 0) && CheckSize(length)) {
+        // Then extract characters
+        std::memcpy(out_data, &data[read_pos], length);
+        out_data[length] = '\0';
+
+        // Update reading position
+        read_pos += length;
+    }
+
+    return *this;
+}
+
+Packet& Packet::operator>>(std::string& out_data) {
+    // First extract string length
+    u32 length = 0;
+    *this >> length;
+
+    out_data.clear();
+    if ((length > 0) && CheckSize(length)) {
+        // Then extract characters
+        out_data.assign(&data[read_pos], length);
+
+        // Update reading position
+        read_pos += length;
+    }
+
+    return *this;
+}
+
+Packet& Packet::operator<<(bool in_data) {
+    *this << static_cast<u8>(in_data);
+    return *this;
+}
+
+Packet& Packet::operator<<(s8 in_data) {
+    Append(&in_data, sizeof(in_data));
+    return *this;
+}
+
+Packet& Packet::operator<<(u8 in_data) {
+    Append(&in_data, sizeof(in_data));
+    return *this;
+}
+
+Packet& Packet::operator<<(s16 in_data) {
+    s16 toWrite = htons(in_data);
+    Append(&toWrite, sizeof(toWrite));
+    return *this;
+}
+
+Packet& Packet::operator<<(u16 in_data) {
+    u16 toWrite = htons(in_data);
+    Append(&toWrite, sizeof(toWrite));
+    return *this;
+}
+
+Packet& Packet::operator<<(s32 in_data) {
+    s32 toWrite = htonl(in_data);
+    Append(&toWrite, sizeof(toWrite));
+    return *this;
+}
+
+Packet& Packet::operator<<(u32 in_data) {
+    u32 toWrite = htonl(in_data);
+    Append(&toWrite, sizeof(toWrite));
+    return *this;
+}
+
+Packet& Packet::operator<<(float in_data) {
+    Append(&in_data, sizeof(in_data));
+    return *this;
+}
+
+Packet& Packet::operator<<(double in_data) {
+    Append(&in_data, sizeof(in_data));
+    return *this;
+}
+
+Packet& Packet::operator<<(const char* in_data) {
+    // First insert string length
+    u32 length = std::strlen(in_data);
+    *this << length;
+
+    // Then insert characters
+    Append(in_data, length * sizeof(char));
+
+    return *this;
+}
+
+Packet& Packet::operator<<(const std::string& in_data) {
+    // First insert string length
+    u32 length = static_cast<u32>(in_data.size());
+    *this << length;
+
+    // Then insert characters
+    if (length > 0)
+        Append(in_data.c_str(), length * sizeof(std::string::value_type));
+
+    return *this;
+}
+
+bool Packet::CheckSize(std::size_t size) {
+    is_valid = is_valid && (read_pos + size <= data.size());
+
+    return is_valid;
+}
+
+} // namespace Network

--- a/src/network/packet.cpp
+++ b/src/network/packet.cpp
@@ -13,10 +13,6 @@
 
 namespace Network {
 
-Packet::Packet() : read_pos(0), is_valid(true) {}
-
-Packet::~Packet() {}
-
 void Packet::Append(const void* in_data, std::size_t size_in_bytes) {
     if (in_data && (size_in_bytes > 0)) {
         std::size_t start = data.size();
@@ -39,7 +35,7 @@ void Packet::Clear() {
 }
 
 const void* Packet::GetData() const {
-    return !data.empty() ? &data[0] : NULL;
+    return !data.empty() ? &data[0] : nullptr;
 }
 
 void Packet::IgnoreBytes(u32 length) {
@@ -54,8 +50,8 @@ bool Packet::EndOfPacket() const {
     return read_pos >= data.size();
 }
 
-Packet::operator BoolType() const {
-    return is_valid ? &Packet::CheckSize : NULL;
+Packet::operator bool() const {
+    return is_valid ? &Packet::CheckSize : nullptr;
 }
 
 Packet& Packet::operator>>(bool& out_data) {

--- a/src/network/packet.h
+++ b/src/network/packet.h
@@ -115,6 +115,12 @@ private:
 
 template <typename T>
 Packet& Packet::operator>>(std::vector<T>& out_data) {
+    // First extract the size
+    u32 size = 0;
+    *this >> size;
+    out_data.resize(size);
+
+    // Then extract the data
     for (std::size_t i = 0; i < out_data.size(); ++i) {
         T character = 0;
         *this >> character;
@@ -135,6 +141,10 @@ Packet& Packet::operator>>(std::array<T, S>& out_data) {
 
 template <typename T>
 Packet& Packet::operator<<(const std::vector<T>& in_data) {
+    // First insert the size
+    *this << static_cast<u32>(in_data.size());
+
+    // Then insert the data
     for (std::size_t i = 0; i < in_data.size(); ++i) {
         *this << in_data[i];
     }

--- a/src/network/packet.h
+++ b/src/network/packet.h
@@ -1,0 +1,192 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <array>
+#include <vector>
+#include "common/common_types.h"
+
+namespace Network {
+
+/// A class for serialize data for network transfer. It also handles endianess
+class Packet {
+    /// A bool-like type that cannot be converted to integer or pointer types
+    typedef bool (Packet::*BoolType)(std::size_t);
+
+public:
+    Packet();
+    ~Packet();
+
+    /**
+     * Append data to the end of the packet
+     * @param data        Pointer to the sequence of bytes to append
+     * @param size_in_bytes Number of bytes to append
+     */
+    void Append(const void* data, std::size_t size_in_bytes);
+
+    /**
+     * Reads data from the current read position of the packet
+     * @param out_data        Pointer where the data should get written to
+     * @param size_in_bytes Number of bytes to read
+     */
+    void Read(void* out_data, std::size_t size_in_bytes);
+
+    /**
+     * Clear the packet
+     * After calling Clear, the packet is empty.
+     */
+    void Clear();
+
+    /**
+     * Ignores bytes while reading
+     * @param length THe number of bytes to ignore
+     */
+    void IgnoreBytes(u32 length);
+
+    /**
+     * Get a pointer to the data contained in the packet
+     * @return Pointer to the data
+     */
+    const void* GetData() const;
+
+    /**
+     * This function returns the number of bytes pointed to by
+     * what getData returns.
+     * @return Data size, in bytes
+     */
+    std::size_t GetDataSize() const;
+
+    /**
+     * This function is useful to know if there is some data
+     * left to be read, without actually reading it.
+     * @return True if all data was read, false otherwise
+     */
+    bool EndOfPacket() const;
+    /**
+     * Test the validity of the packet, for reading
+     * This operator allows to test the packet as a boolean
+     * variable, to check if a reading operation was successful.
+     *
+     * A packet will be in an invalid state if it has no more
+     * data to read.
+     *
+     * This behaviour is the same as standard C++ streams.
+     *
+     * Usage example:
+     * @code
+     * float x;
+     * packet >> x;
+     * if (packet)
+     * {
+     *    // ok, x was extracted successfully
+     * }
+     *
+     * // -- or --
+     *
+     * float x;
+     * if (packet >> x)
+     * {
+     *    // ok, x was extracted successfully
+     * }
+     * @endcode
+     *
+     * Don't focus on the return type, it's equivalent to bool but
+     * it disallows unwanted implicit conversions to integer or
+     * pointer types.
+     *
+     * @return True if last data extraction from packet was successful
+     */
+    operator BoolType() const;
+
+    /// Overloads of operator >> to read data from the packet
+    Packet& operator>>(bool& out_data);
+    Packet& operator>>(s8& out_data);
+    Packet& operator>>(u8& out_data);
+    Packet& operator>>(s16& out_data);
+    Packet& operator>>(u16& out_data);
+    Packet& operator>>(s32& out_data);
+    Packet& operator>>(u32& out_data);
+    Packet& operator>>(float& out_data);
+    Packet& operator>>(double& out_data);
+    Packet& operator>>(char* out_data);
+    Packet& operator>>(std::string& out_data);
+    template <typename T>
+    Packet& operator>>(std::vector<T>& out_data);
+    template <typename T, std::size_t S>
+    Packet& operator>>(std::array<T, S>& out_data);
+
+    /// Overloads of operator << to write data into the packet
+    Packet& operator<<(bool in_data);
+    Packet& operator<<(s8 in_data);
+    Packet& operator<<(u8 in_data);
+    Packet& operator<<(s16 in_data);
+    Packet& operator<<(u16 in_data);
+    Packet& operator<<(s32 in_data);
+    Packet& operator<<(u32 in_data);
+    Packet& operator<<(float in_data);
+    Packet& operator<<(double in_data);
+    Packet& operator<<(const char* in_data);
+    Packet& operator<<(const std::string& in_data);
+    template <typename T>
+    Packet& operator<<(const std::vector<T>& in_data);
+    template <typename T, std::size_t S>
+    Packet& operator<<(const std::array<T, S>& data);
+
+private:
+    /// Disallow comparisons between packets
+    bool operator==(const Packet& right) const;
+    bool operator!=(const Packet& right) const;
+
+    /**
+     * Check if the packet can extract a given number of bytes
+     * This function updates accordingly the state of the packet.
+     * @param size Size to check
+     * @return True if size bytes can be read from the packet
+     */
+    bool CheckSize(std::size_t size);
+
+    // Member data
+    std::vector<char> data; ///< Data stored in the packet
+    std::size_t read_pos;   ///< Current reading position in the packet
+    bool is_valid;          ///< Reading state of the packet
+};
+
+template <typename T>
+Packet& Packet::operator>>(std::vector<T>& out_data) {
+    for (u32 i = 0; i < out_data.size(); ++i) {
+        T character = 0;
+        *this >> character;
+        out_data[i] = character;
+    }
+    return *this;
+}
+
+template <typename T, std::size_t S>
+Packet& Packet::operator>>(std::array<T, S>& out_data) {
+    for (u32 i = 0; i < out_data.size(); ++i) {
+        T character = 0;
+        *this >> character;
+        out_data[i] = character;
+    }
+    return *this;
+}
+
+template <typename T>
+Packet& Packet::operator<<(const std::vector<T>& in_data) {
+    for (u32 i = 0; i < in_data.size(); ++i) {
+        *this << in_data[i];
+    }
+    return *this;
+}
+
+template <typename T, std::size_t S>
+Packet& Packet::operator<<(const std::array<T, S>& in_data) {
+    for (u32 i = 0; i < in_data.size(); ++i) {
+        *this << in_data[i];
+    }
+    return *this;
+}
+
+} // namespace Network

--- a/src/network/packet.h
+++ b/src/network/packet.h
@@ -10,14 +10,11 @@
 
 namespace Network {
 
-/// A class for serialize data for network transfer. It also handles endianess
+/// A class that serializes data for network transfer. It also handles endianess
 class Packet {
-    /// A bool-like type that cannot be converted to integer or pointer types
-    typedef bool (Packet::*BoolType)(std::size_t);
-
 public:
-    Packet();
-    ~Packet();
+    Packet() = default;
+    ~Packet() = default;
 
     /**
      * Append data to the end of the packet
@@ -64,41 +61,8 @@ public:
      * @return True if all data was read, false otherwise
      */
     bool EndOfPacket() const;
-    /**
-     * Test the validity of the packet, for reading
-     * This operator allows to test the packet as a boolean
-     * variable, to check if a reading operation was successful.
-     *
-     * A packet will be in an invalid state if it has no more
-     * data to read.
-     *
-     * This behaviour is the same as standard C++ streams.
-     *
-     * Usage example:
-     * @code
-     * float x;
-     * packet >> x;
-     * if (packet)
-     * {
-     *    // ok, x was extracted successfully
-     * }
-     *
-     * // -- or --
-     *
-     * float x;
-     * if (packet >> x)
-     * {
-     *    // ok, x was extracted successfully
-     * }
-     * @endcode
-     *
-     * Don't focus on the return type, it's equivalent to bool but
-     * it disallows unwanted implicit conversions to integer or
-     * pointer types.
-     *
-     * @return True if last data extraction from packet was successful
-     */
-    operator BoolType() const;
+
+    explicit operator bool() const;
 
     /// Overloads of operator >> to read data from the packet
     Packet& operator>>(bool& out_data);
@@ -135,10 +99,6 @@ public:
     Packet& operator<<(const std::array<T, S>& data);
 
 private:
-    /// Disallow comparisons between packets
-    bool operator==(const Packet& right) const;
-    bool operator!=(const Packet& right) const;
-
     /**
      * Check if the packet can extract a given number of bytes
      * This function updates accordingly the state of the packet.
@@ -148,14 +108,14 @@ private:
     bool CheckSize(std::size_t size);
 
     // Member data
-    std::vector<char> data; ///< Data stored in the packet
-    std::size_t read_pos;   ///< Current reading position in the packet
-    bool is_valid;          ///< Reading state of the packet
+    std::vector<char> data;   ///< Data stored in the packet
+    std::size_t read_pos = 0; ///< Current reading position in the packet
+    bool is_valid = true;     ///< Reading state of the packet
 };
 
 template <typename T>
 Packet& Packet::operator>>(std::vector<T>& out_data) {
-    for (u32 i = 0; i < out_data.size(); ++i) {
+    for (std::size_t i = 0; i < out_data.size(); ++i) {
         T character = 0;
         *this >> character;
         out_data[i] = character;
@@ -165,7 +125,7 @@ Packet& Packet::operator>>(std::vector<T>& out_data) {
 
 template <typename T, std::size_t S>
 Packet& Packet::operator>>(std::array<T, S>& out_data) {
-    for (u32 i = 0; i < out_data.size(); ++i) {
+    for (std::size_t i = 0; i < out_data.size(); ++i) {
         T character = 0;
         *this >> character;
         out_data[i] = character;
@@ -175,7 +135,7 @@ Packet& Packet::operator>>(std::array<T, S>& out_data) {
 
 template <typename T>
 Packet& Packet::operator<<(const std::vector<T>& in_data) {
-    for (u32 i = 0; i < in_data.size(); ++i) {
+    for (std::size_t i = 0; i < in_data.size(); ++i) {
         *this << in_data[i];
     }
     return *this;
@@ -183,7 +143,7 @@ Packet& Packet::operator<<(const std::vector<T>& in_data) {
 
 template <typename T, std::size_t S>
 Packet& Packet::operator<<(const std::array<T, S>& in_data) {
-    for (u32 i = 0; i < in_data.size(); ++i) {
+    for (std::size_t i = 0; i < in_data.size(); ++i) {
         *this << in_data[i];
     }
     return *this;

--- a/src/network/room.cpp
+++ b/src/network/room.cpp
@@ -3,8 +3,11 @@
 // Refer to the license.txt file included.
 
 #include <atomic>
+#include <random>
 #include <thread>
+#include <vector>
 #include "enet/enet.h"
+#include "network/packet.h"
 #include "network/room.h"
 
 namespace Network {
@@ -14,10 +17,25 @@ static constexpr u32 MaxConcurrentConnections = 10;
 
 class Room::RoomImpl {
 public:
+    // This MAC address is used to generate a 'Nintendo' like Mac address.
+    const MacAddress NintendoOUI = {0x00, 0x1F, 0x32, 0x00, 0x00, 0x00};
+    std::mt19937 random_gen; ///< Random number generator. Used for GenerateMacAddress
+
     ENetHost* server = nullptr; ///< Network interface.
 
     std::atomic<State> state{State::Closed}; ///< Current state of the room.
     RoomInformation room_information;        ///< Information about this room.
+
+    struct Member {
+        std::string nickname;   ///< The nickname of the member.
+        std::string game_name;  ///< The current game of the member
+        MacAddress mac_address; ///< The assigned mac address of the member.
+        ENetPeer* peer;         ///< The remote peer.
+    };
+    using MemberList = std::vector<Member>;
+    MemberList members; ///< Information about the members of this room.
+
+    RoomImpl() : random_gen(std::random_device()()) {}
 
     /// Thread that receives and dispatches network packets
     std::unique_ptr<std::thread> room_thread;
@@ -25,6 +43,61 @@ public:
     /// Thread function that will receive and dispatch messages until the room is destroyed.
     void ServerLoop();
     void StartLoop();
+
+    /**
+     * Parses and answers a room join request from a client.
+     * Validates the uniqueness of the username and assigns the MAC address
+     * that the client will use for the remainder of the connection.
+     */
+    void HandleJoinRequest(const ENetEvent* event);
+
+    /**
+     * Returns whether the nickname is valid, ie. isn't already taken by someone else in the room.
+     */
+    bool IsValidNickname(const std::string& nickname) const;
+
+    /**
+     * Returns whether the MAC address is valid, ie. isn't already taken by someone else in the
+     * room.
+     */
+    bool IsValidMacAddress(const MacAddress& address) const;
+
+    /**
+     * Sends a ID_ROOM_NAME_COLLISION message telling the client that the name is invalid.
+     */
+    void SendNameCollision(ENetPeer* client);
+
+    /**
+     * Sends a ID_ROOM_MAC_COLLISION message telling the client that the MAC is invalid.
+     */
+    void SendMacCollision(ENetPeer* client);
+
+    /**
+     * Notifies the member that its connection attempt was successful,
+     * and it is now part of the room.
+     */
+    void SendJoinSuccess(ENetPeer* client, MacAddress mac_address);
+
+    /**
+     * Sends the information about the room, along with the list of members
+     * to every connected client in the room.
+     * The packet has the structure:
+     * <MessageID>ID_ROOM_INFORMATION
+     * <String> room_name
+     * <uint32_t> member_slots: The max number of clients allowed in this room
+     * <uint32_t> num_members: the number of currently joined clients
+     * This is followed by the following three values for each member:
+     * <String> nickname of that member
+     * <MacAddress> mac_address of that member
+     * <String> game_name of that member
+     */
+    void BroadcastRoomInformation();
+
+    /**
+     * Generates a free MAC address to assign to a new client.
+     * The first 3 bytes are the NintendoOUI 0x00, 0x1F, 0x32
+     */
+    MacAddress GenerateMacAddress();
 };
 
 // RoomImpl
@@ -34,7 +107,12 @@ void Room::RoomImpl::ServerLoop() {
         if (enet_host_service(server, &event, 1000) > 0) {
             switch (event.type) {
             case ENET_EVENT_TYPE_RECEIVE:
-                // TODO(B3N30): Select the type of message and handle it
+                switch (event.packet->data[0]) {
+                case IdJoinRequest:
+                    HandleJoinRequest(&event);
+                    break;
+                    // TODO(B3N30): Handle the other message types
+                }
                 enet_packet_destroy(event.packet);
                 break;
             case ENET_EVENT_TYPE_DISCONNECT:
@@ -47,6 +125,126 @@ void Room::RoomImpl::ServerLoop() {
 
 void Room::RoomImpl::StartLoop() {
     room_thread = std::make_unique<std::thread>(&Room::RoomImpl::ServerLoop, this);
+}
+
+void Room::RoomImpl::HandleJoinRequest(const ENetEvent* event) {
+    Packet packet;
+    packet.Append(event->packet->data, event->packet->dataLength);
+    packet.IgnoreBytes(sizeof(MessageID));
+    std::string nickname;
+    packet >> nickname;
+
+    MacAddress preferred_mac;
+    packet >> preferred_mac;
+
+    if (!IsValidNickname(nickname)) {
+        SendNameCollision(event->peer);
+        return;
+    }
+
+    if (preferred_mac != NoPreferredMac) {
+        // Verify if the preferred mac is available
+        if (!IsValidMacAddress(preferred_mac)) {
+            SendMacCollision(event->peer);
+            return;
+        }
+    } else {
+        // Assign a MAC address of this client automatically
+        preferred_mac = GenerateMacAddress();
+    }
+
+    // At this point the client is ready to be added to the room.
+    Member member{};
+    member.mac_address = preferred_mac;
+    member.nickname = nickname;
+    member.peer = event->peer;
+
+    members.push_back(member);
+
+    // Notify everyone that the room information has changed.
+    BroadcastRoomInformation();
+    SendJoinSuccess(event->peer, preferred_mac);
+}
+
+bool Room::RoomImpl::IsValidNickname(const std::string& nickname) const {
+    // A nickname is valid if it is not already taken by anybody else in the room.
+    // TODO(B3N30): Check for empty names, spaces, etc.
+    for (const Member& member : members) {
+        if (member.nickname == nickname) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool Room::RoomImpl::IsValidMacAddress(const MacAddress& address) const {
+    // A MAC address is valid if it is not already taken by anybody else in the room.
+    for (const Member& member : members) {
+        if (member.mac_address == address) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void Room::RoomImpl::SendNameCollision(ENetPeer* client) {
+    Packet packet;
+    packet << static_cast<MessageID>(IdNameCollision);
+
+    ENetPacket* enet_packet =
+        enet_packet_create(packet.GetData(), packet.GetDataSize(), ENET_PACKET_FLAG_RELIABLE);
+    enet_peer_send(client, 0, enet_packet);
+    enet_host_flush(server);
+}
+
+void Room::RoomImpl::SendMacCollision(ENetPeer* client) {
+    Packet packet;
+    packet << static_cast<MessageID>(IdMacCollision);
+
+    ENetPacket* enet_packet =
+        enet_packet_create(packet.GetData(), packet.GetDataSize(), ENET_PACKET_FLAG_RELIABLE);
+    enet_peer_send(client, 0, enet_packet);
+    enet_host_flush(server);
+}
+
+void Room::RoomImpl::SendJoinSuccess(ENetPeer* client, MacAddress mac_address) {
+    Packet packet;
+    packet << static_cast<MessageID>(IdJoinSuccess);
+    packet << mac_address;
+    ENetPacket* enet_packet =
+        enet_packet_create(packet.GetData(), packet.GetDataSize(), ENET_PACKET_FLAG_RELIABLE);
+    enet_peer_send(client, 0, enet_packet);
+    enet_host_flush(server);
+}
+
+void Room::RoomImpl::BroadcastRoomInformation() {
+    Packet packet;
+    packet << static_cast<MessageID>(IdRoomInformation);
+    packet << room_information.name;
+    packet << room_information.member_slots;
+
+    packet << static_cast<uint32_t>(members.size());
+    for (const auto& member : members) {
+        packet << member.nickname;
+        packet << member.mac_address;
+        packet << member.game_name;
+    }
+
+    ENetPacket* enet_packet =
+        enet_packet_create(packet.GetData(), packet.GetDataSize(), ENET_PACKET_FLAG_RELIABLE);
+    enet_host_broadcast(server, 0, enet_packet);
+    enet_host_flush(server);
+}
+
+MacAddress Room::RoomImpl::GenerateMacAddress() {
+    MacAddress result_mac = NintendoOUI;
+    std::uniform_int_distribution<> dis(0x00, 0xFF); // Random byte between 0 and 0xFF
+    do {
+        for (int i = 3; i < result_mac.size(); ++i) {
+            result_mac[i] = dis(random_gen);
+        }
+    } while (!IsValidMacAddress(result_mac));
+    return result_mac;
 }
 
 // Room

--- a/src/network/room.h
+++ b/src/network/room.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <array>
 #include <memory>
 #include <string>
 #include "common/common_types.h"
@@ -17,6 +18,11 @@ struct RoomInformation {
     std::string name; ///< Name of the server
     u32 member_slots; ///< Maximum number of members in this room
 };
+
+using MacAddress = std::array<uint8_t, 6>;
+/// A special MAC address that tells the room we're joining to assign us a MAC address
+/// automatically.
+const MacAddress NoPreferredMac = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
 // The different types of messages that can be sent. The first byte of each packet defines the type
 typedef uint8_t MessageID;

--- a/src/network/room.h
+++ b/src/network/room.h
@@ -30,8 +30,7 @@ const MacAddress NoPreferredMac = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 constexpr MacAddress BroadcastMac = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
 // The different types of messages that can be sent. The first byte of each packet defines the type
-using MessageID = u8;
-enum RoomMessageTypes {
+enum RoomMessageTypes : u8 {
     IdJoinRequest = 1,
     IdJoinSuccess,
     IdRoomInformation,

--- a/src/network/room.h
+++ b/src/network/room.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <atomic>
 #include <memory>
 #include <string>
 #include "common/common_types.h"
@@ -17,6 +16,19 @@ constexpr size_t NumChannels = 1; // Number of channels used for the connection
 struct RoomInformation {
     std::string name; ///< Name of the server
     u32 member_slots; ///< Maximum number of members in this room
+};
+
+// The different types of messages that can be sent. The first byte of each packet defines the type
+typedef uint8_t MessageID;
+enum RoomMessageTypes {
+    IdJoinRequest = 1,
+    IdJoinSuccess,
+    IdRoomInformation,
+    IdSetGameName,
+    IdWifiPacket,
+    IdChatMessage,
+    IdNameCollision,
+    IdMacCollision
 };
 
 /// This is what a server [person creating a server] would use.

--- a/src/network/room.h
+++ b/src/network/room.h
@@ -19,13 +19,16 @@ struct RoomInformation {
     u32 member_slots; ///< Maximum number of members in this room
 };
 
-using MacAddress = std::array<uint8_t, 6>;
+using MacAddress = std::array<u8, 6>;
 /// A special MAC address that tells the room we're joining to assign us a MAC address
 /// automatically.
 const MacAddress NoPreferredMac = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
+// 802.11 broadcast MAC address
+constexpr MacAddress BroadcastMac = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+
 // The different types of messages that can be sent. The first byte of each packet defines the type
-typedef uint8_t MessageID;
+using MessageID = u8;
 enum RoomMessageTypes {
     IdJoinRequest = 1,
     IdJoinSuccess,

--- a/src/network/room.h
+++ b/src/network/room.h
@@ -11,6 +11,8 @@
 
 namespace Network {
 
+constexpr u32 network_version = 1; ///< The version of this Room and RoomMember
+
 constexpr u16 DefaultRoomPort = 1234;
 constexpr size_t NumChannels = 1; // Number of channels used for the connection
 
@@ -37,7 +39,9 @@ enum RoomMessageTypes {
     IdWifiPacket,
     IdChatMessage,
     IdNameCollision,
-    IdMacCollision
+    IdMacCollision,
+    IdVersionMismatch,
+    IdCloseRoom
 };
 
 /// This is what a server [person creating a server] would use.

--- a/src/network/room_member.cpp
+++ b/src/network/room_member.cpp
@@ -127,6 +127,9 @@ void RoomMember::RoomMemberImpl::MemberLoop() {
                 case IdVersionMismatch:
                     SetState(State::WrongVersion);
                     break;
+                case IdCloseRoom:
+                    SetState(State::LostConnection);
+                    break;
                 default:
                     break;
                 }
@@ -307,7 +310,7 @@ RoomInformation RoomMember::GetRoomInformation() const {
 }
 
 void RoomMember::Join(const std::string& nick, const char* server_addr, u16 server_port,
-                      u16 client_port) {
+                      u16 client_port, const MacAddress& preferred_mac) {
     // If the member is connected, kill the connection first
     if (room_member_impl->loop_thread && room_member_impl->loop_thread->joinable()) {
         room_member_impl->SetState(State::Error);
@@ -336,7 +339,7 @@ void RoomMember::Join(const std::string& nick, const char* server_addr, u16 serv
         room_member_impl->nickname = nick;
         room_member_impl->SetState(State::Joining);
         room_member_impl->StartLoop();
-        room_member_impl->SendJoinRequest(nick);
+        room_member_impl->SendJoinRequest(nick, preferred_mac);
     } else {
         room_member_impl->SetState(State::CouldNotConnect);
     }

--- a/src/network/room_member.cpp
+++ b/src/network/room_member.cpp
@@ -7,6 +7,7 @@
 #include <thread>
 #include "common/assert.h"
 #include "enet/enet.h"
+#include "network/packet.h"
 #include "network/room_member.h"
 
 namespace Network {
@@ -18,17 +19,49 @@ public:
     ENetHost* client = nullptr; ///< ENet network interface.
     ENetPeer* server = nullptr; ///< The server peer the client is connected to
 
+    /// Information about the clients connected to the same room as us.
+    MemberList member_information;
+    /// Information about the room we're connected to.
+    RoomInformation room_information;
+
     std::atomic<State> state{State::Idle}; ///< Current state of the RoomMember.
     void SetState(const State new_state);
     bool IsConnected() const;
 
-    std::string nickname; ///< The nickname of this member.
+    std::string nickname;   ///< The nickname of this member.
+    MacAddress mac_address; ///< The mac_address of this member.
 
     std::mutex network_mutex; ///< Mutex that controls access to the `client` variable.
     /// Thread that receives and dispatches network packets
     std::unique_ptr<std::thread> receive_thread;
     void ReceiveLoop();
     void StartLoop();
+
+    /**
+     * Sends data to the room. It will be send on channel 0 with flag RELIABLE
+     * @param packet The data to send
+     */
+    void Send(Packet& packet);
+    /**
+     * Sends a request to the server, asking for permission to join a room with the specified
+     * nickname and preferred mac.
+     * @params nickname The desired nickname.
+     * @params preferred_mac The preferred MAC address to use in the room, the NoPreferredMac tells
+     * the server to assign one for us.
+     */
+    void SendJoinRequest(const std::string& nickname,
+                         const MacAddress& preferred_mac = NoPreferredMac);
+
+    /**
+     * Extracts a MAC Address from a received ENet packet.
+     * @param event The ENet event that was received.
+     */
+    void HandleJoinPacket(const ENetEvent* event);
+    /**
+     * Extracts RoomInformation and MemberInformation from a received RakNet packet.
+     * @param event The ENet event that was received.
+     */
+    void HandleRoomInformationPacket(const ENetEvent* event);
 };
 
 // RoomMemberImpl
@@ -50,6 +83,17 @@ void RoomMember::RoomMemberImpl::ReceiveLoop() {
             if (event.type == ENET_EVENT_TYPE_RECEIVE) {
                 switch (event.packet->data[0]) {
                 // TODO(B3N30): Handle the other message types
+                case IdRoomInformation:
+                    HandleRoomInformationPacket(&event);
+                    break;
+                case IdJoinSuccess:
+                    // The join request was successful, we are now in the room.
+                    // If we joined successfully, there must be at least one client in the room: us.
+                    ASSERT_MSG(member_information.size() > 0,
+                               "We have not yet received member information.");
+                    HandleJoinPacket(&event); // Get the MAC Address for the client
+                    SetState(State::Joined);
+                    break;
                 case IdNameCollision:
                     SetState(State::NameCollision);
                     enet_packet_destroy(event.packet);
@@ -77,6 +121,59 @@ void RoomMember::RoomMemberImpl::StartLoop() {
     receive_thread = std::make_unique<std::thread>(&RoomMember::RoomMemberImpl::ReceiveLoop, this);
 }
 
+void RoomMember::RoomMemberImpl::Send(Packet& packet) {
+    ENetPacket* enetPacket =
+        enet_packet_create(packet.GetData(), packet.GetDataSize(), ENET_PACKET_FLAG_RELIABLE);
+    enet_peer_send(server, 0, enetPacket);
+    enet_host_flush(client);
+}
+
+void RoomMember::RoomMemberImpl::SendJoinRequest(const std::string& nickname,
+                                                 const MacAddress& preferred_mac) {
+    Packet packet;
+    packet << static_cast<MessageID>(IdJoinRequest);
+    packet << nickname;
+    packet << preferred_mac;
+    Send(packet);
+}
+
+void RoomMember::RoomMemberImpl::HandleRoomInformationPacket(const ENetEvent* event) {
+    Packet packet;
+    packet.Append(event->packet->data, event->packet->dataLength);
+
+    // Ignore the first byte, which is the message id.
+    packet.IgnoreBytes(sizeof(MessageID));
+
+    RoomInformation info{};
+    packet >> info.name;
+    packet >> info.member_slots;
+    room_information.name = info.name;
+    room_information.member_slots = info.member_slots;
+
+    uint32_t num_members;
+    packet >> num_members;
+    member_information.resize(num_members);
+
+    for (auto& member : member_information) {
+        packet >> member.nickname;
+        packet >> member.mac_address;
+        packet >> member.game_name;
+    }
+    // TODO(B3N30): Invoke callbacks
+}
+
+void RoomMember::RoomMemberImpl::HandleJoinPacket(const ENetEvent* event) {
+    Packet packet;
+    packet.Append(event->packet->data, event->packet->dataLength);
+
+    // Ignore the first byte, which is the message id.
+    packet.IgnoreBytes(sizeof(MessageID));
+
+    // Parse the MAC Address from the BitStream
+    packet >> mac_address;
+    // TODO(B3N30): Invoke callbacks
+}
+
 // RoomMember
 RoomMember::RoomMember() : room_member_impl{std::make_unique<RoomMemberImpl>()} {
     room_member_impl->client = enet_host_create(nullptr, 1, NumChannels, 0, 0);
@@ -90,6 +187,14 @@ RoomMember::~RoomMember() {
 
 RoomMember::State RoomMember::GetState() const {
     return room_member_impl->state;
+}
+
+const RoomMember::MemberList& RoomMember::GetMemberInformation() const {
+    return room_member_impl->member_information;
+}
+
+RoomInformation RoomMember::GetRoomInformation() const {
+    return room_member_impl->room_information;
 }
 
 void RoomMember::Join(const std::string& nick, const char* server_addr, u16 server_port,
@@ -112,7 +217,7 @@ void RoomMember::Join(const std::string& nick, const char* server_addr, u16 serv
         room_member_impl->nickname = nick;
         room_member_impl->SetState(State::Joining);
         room_member_impl->StartLoop();
-        // TODO(B3N30): Send a join request with the nickname to the server
+        room_member_impl->SendJoinRequest(nick);
     } else {
         room_member_impl->SetState(State::CouldNotConnect);
     }

--- a/src/network/room_member.cpp
+++ b/src/network/room_member.cpp
@@ -2,6 +2,9 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <atomic>
+#include <mutex>
+#include <thread>
 #include "common/assert.h"
 #include "enet/enet.h"
 #include "network/room_member.h"
@@ -16,10 +19,65 @@ public:
     ENetPeer* server = nullptr; ///< The server peer the client is connected to
 
     std::atomic<State> state{State::Idle}; ///< Current state of the RoomMember.
+    void SetState(const State new_state);
+    bool IsConnected() const;
 
     std::string nickname; ///< The nickname of this member.
+
+    std::mutex network_mutex; ///< Mutex that controls access to the `client` variable.
+    /// Thread that receives and dispatches network packets
+    std::unique_ptr<std::thread> receive_thread;
+    void ReceiveLoop();
+    void StartLoop();
 };
 
+// RoomMemberImpl
+void RoomMember::RoomMemberImpl::SetState(const State new_state) {
+    state = new_state;
+    // TODO(B3N30): Invoke the callback functions
+}
+
+bool RoomMember::RoomMemberImpl::IsConnected() const {
+    return state == State::Joining || state == State::Joined;
+}
+
+void RoomMember::RoomMemberImpl::ReceiveLoop() {
+    // Receive packets while the connection is open
+    while (IsConnected()) {
+        std::lock_guard<std::mutex> lock(network_mutex);
+        ENetEvent event;
+        if (enet_host_service(client, &event, 1000) > 0) {
+            if (event.type == ENET_EVENT_TYPE_RECEIVE) {
+                switch (event.packet->data[0]) {
+                // TODO(B3N30): Handle the other message types
+                case IdNameCollision:
+                    SetState(State::NameCollision);
+                    enet_packet_destroy(event.packet);
+                    enet_peer_disconnect(server, 0);
+                    enet_peer_reset(server);
+                    return;
+                    break;
+                case IdMacCollision:
+                    SetState(State::MacCollision);
+                    enet_packet_destroy(event.packet);
+                    enet_peer_disconnect(server, 0);
+                    enet_peer_reset(server);
+                    return;
+                    break;
+                default:
+                    break;
+                }
+                enet_packet_destroy(event.packet);
+            }
+        }
+    }
+};
+
+void RoomMember::RoomMemberImpl::StartLoop() {
+    receive_thread = std::make_unique<std::thread>(&RoomMember::RoomMemberImpl::ReceiveLoop, this);
+}
+
+// RoomMember
 RoomMember::RoomMember() : room_member_impl{std::make_unique<RoomMemberImpl>()} {
     room_member_impl->client = enet_host_create(nullptr, 1, NumChannels, 0, 0);
     ASSERT_MSG(room_member_impl->client != nullptr, "Could not create client");
@@ -44,7 +102,7 @@ void RoomMember::Join(const std::string& nick, const char* server_addr, u16 serv
         enet_host_connect(room_member_impl->client, &address, NumChannels, 0);
 
     if (!room_member_impl->server) {
-        room_member_impl->state = State::Error;
+        room_member_impl->SetState(State::Error);
         return;
     }
 
@@ -52,22 +110,27 @@ void RoomMember::Join(const std::string& nick, const char* server_addr, u16 serv
     int net = enet_host_service(room_member_impl->client, &event, ConnectionTimeoutMs);
     if (net > 0 && event.type == ENET_EVENT_TYPE_CONNECT) {
         room_member_impl->nickname = nick;
-        room_member_impl->state = State::Joining;
+        room_member_impl->SetState(State::Joining);
+        room_member_impl->StartLoop();
         // TODO(B3N30): Send a join request with the nickname to the server
-        // TODO(B3N30): Start the receive thread
     } else {
-        room_member_impl->state = State::CouldNotConnect;
+        room_member_impl->SetState(State::CouldNotConnect);
     }
 }
 
 bool RoomMember::IsConnected() const {
-    return room_member_impl->state == State::Joining || room_member_impl->state == State::Joined;
+    return room_member_impl->IsConnected();
 }
 
 void RoomMember::Leave() {
-    enet_peer_disconnect(room_member_impl->server, 0);
-    room_member_impl->state = State::Idle;
-    // TODO(B3N30): Close the receive thread
+    ASSERT_MSG(room_member_impl->receive_thread != nullptr, "Must be in a room to leave it.");
+    {
+        std::lock_guard<std::mutex> lock(room_member_impl->network_mutex);
+        enet_peer_disconnect(room_member_impl->server, 0);
+        room_member_impl->SetState(State::Idle);
+    }
+    room_member_impl->receive_thread->join();
+    room_member_impl->receive_thread.reset();
     enet_peer_reset(room_member_impl->server);
 }
 

--- a/src/network/room_member.h
+++ b/src/network/room_member.h
@@ -24,6 +24,12 @@ struct WifiPacket {
     uint8_t channel;                ///< WiFi channel where this frame was transmitted.
 };
 
+/// Represents a chat message.
+struct ChatEntry {
+    std::string nickname; ///< Nickname of the client who sent this message.
+    std::string message;  ///< Body of the message.
+};
+
 /**
  * This is what a client [person joining a server] would use.
  * It also has to be used if you host a game yourself (You'd create both, a Room and a
@@ -86,6 +92,12 @@ public:
      * @param packet The WiFi packet to send.
      */
     void SendWifiPacket(const WifiPacket& packet);
+
+    /**
+     * Sends a chat message to the room.
+     * @param message The contents of the message.
+     */
+    void SendChatMessage(const std::string& message);
 
     /**
      * Leaves the current room.

--- a/src/network/room_member.h
+++ b/src/network/room_member.h
@@ -15,7 +15,7 @@ namespace Network {
 /// Information about the received WiFi packets.
 /// Acts as our own 802.11 header.
 struct WifiPacket {
-    enum class PacketType { Beacon, Data, Authentication, AssociationResponse };
+    enum class PacketType : u8 { Beacon, Data, Authentication, AssociationResponse };
     PacketType type;      ///< The type of 802.11 frame.
     std::vector<u8> data; ///< Raw 802.11 frame data, starting at the management frame header
                           /// for management frames.

--- a/src/network/room_member.h
+++ b/src/network/room_member.h
@@ -15,13 +15,13 @@ namespace Network {
 /// Information about the received WiFi packets.
 /// Acts as our own 802.11 header.
 struct WifiPacket {
-    enum class PacketType { Beacon, Data, Management };
-    PacketType type;           ///< The type of 802.11 frame, Beacon / Data.
-    std::vector<uint8_t> data; ///< Raw 802.11 frame data, starting at the management frame header
-                               /// for management frames.
+    enum class PacketType { Beacon, Data, Authentication, AssociationResponse };
+    PacketType type;      ///< The type of 802.11 frame.
+    std::vector<u8> data; ///< Raw 802.11 frame data, starting at the management frame header
+                          /// for management frames.
     MacAddress transmitter_address; ///< Mac address of the transmitter.
     MacAddress destination_address; ///< Mac address of the receiver.
-    uint8_t channel;                ///< WiFi channel where this frame was transmitted.
+    u8 channel;                     ///< WiFi channel where this frame was transmitted.
 };
 
 /// Represents a chat message.
@@ -70,6 +70,17 @@ public:
      * Returns information about the members in the room we're currently connected to.
      */
     const MemberList& GetMemberInformation() const;
+
+    /**
+     * Returns the nickname of the RoomMember.
+     */
+    const std::string& GetNickname() const;
+
+    /**
+     * Returns the MAC address of the RoomMember.
+     */
+    const MacAddress& GetMacAddress() const;
+
     /**
      * Returns information about the room we're currently connected to.
      */
@@ -98,6 +109,12 @@ public:
      * @param message The contents of the message.
      */
     void SendChatMessage(const std::string& message);
+
+    /**
+     * Sends the current game name  to the room.
+     * @param game_name The game name.
+     */
+    void SendGameName(const std::string& game_name);
 
     /**
      * Leaves the current room.

--- a/src/network/room_member.h
+++ b/src/network/room_member.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 #include "common/common_types.h"
 #include "network/room.h"
 
@@ -31,6 +32,14 @@ public:
         CouldNotConnect ///< The room is not responding to a connection attempt
     };
 
+    struct MemberInformation {
+        std::string nickname;   ///< Nickname of the member.
+        std::string game_name;  ///< Name of the game they're currently playing, or empty if they're
+                                /// not playing anything.
+        MacAddress mac_address; ///< MAC address associated with this member.
+    };
+    using MemberList = std::vector<MemberInformation>;
+
     RoomMember();
     ~RoomMember();
 
@@ -38,6 +47,15 @@ public:
      * Returns the status of our connection to the room.
      */
     State GetState() const;
+
+    /**
+     * Returns information about the members in the room we're currently connected to.
+     */
+    const MemberList& GetMemberInformation() const;
+    /**
+     * Returns information about the room we're currently connected to.
+     */
+    RoomInformation GetRoomInformation() const;
 
     /**
      * Returns whether we're connected to a server or not.

--- a/src/network/room_member.h
+++ b/src/network/room_member.h
@@ -47,6 +47,7 @@ public:
         // Reasons why connection was rejected
         NameCollision,  ///< Somebody is already using this name
         MacCollision,   ///< Somebody is already using that mac-address
+        WrongVersion,   ///< The room version is not the same as for this RoomMember
         CouldNotConnect ///< The room is not responding to a connection attempt
     };
 

--- a/src/network/room_member.h
+++ b/src/network/room_member.h
@@ -12,6 +12,18 @@
 
 namespace Network {
 
+/// Information about the received WiFi packets.
+/// Acts as our own 802.11 header.
+struct WifiPacket {
+    enum class PacketType { Beacon, Data, Management };
+    PacketType type;           ///< The type of 802.11 frame, Beacon / Data.
+    std::vector<uint8_t> data; ///< Raw 802.11 frame data, starting at the management frame header
+                               /// for management frames.
+    MacAddress transmitter_address; ///< Mac address of the transmitter.
+    MacAddress destination_address; ///< Mac address of the receiver.
+    uint8_t channel;                ///< WiFi channel where this frame was transmitted.
+};
+
 /**
  * This is what a client [person joining a server] would use.
  * It also has to be used if you host a game yourself (You'd create both, a Room and a
@@ -68,6 +80,12 @@ public:
      */
     void Join(const std::string& nickname, const char* server_addr = "127.0.0.1",
               const u16 serverPort = DefaultRoomPort, const u16 clientPort = 0);
+
+    /**
+     * Sends a WiFi packet to the room.
+     * @param packet The WiFi packet to send.
+     */
+    void SendWifiPacket(const WifiPacket& packet);
 
     /**
      * Leaves the current room.

--- a/src/network/room_member.h
+++ b/src/network/room_member.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <atomic>
 #include <memory>
 #include <string>
 #include "common/common_types.h"

--- a/src/network/room_member.h
+++ b/src/network/room_member.h
@@ -97,7 +97,8 @@ public:
      * This may fail if the username is already taken.
      */
     void Join(const std::string& nickname, const char* server_addr = "127.0.0.1",
-              const u16 serverPort = DefaultRoomPort, const u16 clientPort = 0);
+              const u16 serverPort = DefaultRoomPort, const u16 clientPort = 0,
+              const MacAddress& preferred_mac = NoPreferredMac);
 
     /**
      * Sends a WiFi packet to the room.


### PR DESCRIPTION
This PR is a continuation of #2803 

It implements:

- Sending/handling JoinRequests
- Sending/receiving WifiPackets
- Disconnect handling
- Send/receive chat messages
- Send a game title

Things still to come:

1. A way to register and invoke callbacks
2. A way to register a room to our server api
3. Make use of the network implementation inside nwm::uds
4. The UI

It's probably best to review each commit separately.

To test this PR use [https://github.com/B3n30/citra-1/tree/network_test](https://github.com/B3n30/citra-1/tree/network_test)
It's currently possible to test:
- create room
- destroy room
- join room
- leave room
- send/receive chat messages
- receive RoomInformation

What's currently missing in test:
- send/receive WifiPackets
- send game title 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2818)
<!-- Reviewable:end -->
