### PR TITLE
telemetry: Log performance, configuration, and system data.

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -168,6 +168,16 @@ System::ResultStatus System::Init(EmuWindow* emu_window, u32 system_mode) {
 }
 
 void System::Shutdown() {
+    // Log last frame performance stats
+    auto perf_results = GetAndResetPerfStats();
+    Telemetry().AddField(Telemetry::FieldType::Performance, "Shutdown_EmulationSpeed",
+                         perf_results.emulation_speed * 100.0);
+    Telemetry().AddField(Telemetry::FieldType::Performance, "Shutdown_Framerate",
+                         perf_results.game_fps);
+    Telemetry().AddField(Telemetry::FieldType::Performance, "Shutdown_Frametime",
+                         perf_results.frametime * 1000.0);
+
+    // Shutdown emulation session
     GDBStub::Shutdown();
     AudioCore::Shutdown();
     VideoCore::Shutdown();

--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -342,9 +342,11 @@ ResultStatus AppLoader_NCCH::Load() {
     if (result != ResultStatus::Success)
         return result;
 
-    LOG_INFO(Loader, "Program ID: %016" PRIX64, ncch_header.program_id);
+    std::string program_id{Common::StringFromFormat("%016" PRIX64, ncch_header.program_id)};
 
-    Core::Telemetry().AddField(Telemetry::FieldType::Session, "ProgramId", ncch_header.program_id);
+    LOG_INFO(Loader, "Program ID: %s", program_id.c_str());
+
+    Core::Telemetry().AddField(Telemetry::FieldType::Session, "ProgramId", program_id);
 
     is_loaded = true; // Set state to loaded
 

--- a/src/video_core/renderer_opengl/pica_to_gl.h
+++ b/src/video_core/renderer_opengl/pica_to_gl.h
@@ -12,6 +12,7 @@
 #include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "common/logging/log.h"
+#include "core/core.h"
 #include "video_core/regs_framebuffer.h"
 #include "video_core/regs_lighting.h"
 #include "video_core/regs_texturing.h"
@@ -72,9 +73,9 @@ inline GLenum WrapMode(Pica::TexturingRegs::TextureConfig::WrapMode mode) {
     }
 
     if (static_cast<u32>(mode) > 3) {
-        // It is still unclear whether mode 4-7 are valid, so log it if a game uses them.
-        // TODO(wwylele): telemetry should be added here so we can collect more info about which
-        // game uses this.
+        Core::Telemetry().AddField(Telemetry::FieldType::Session,
+                                   "VideoCore_Pica_UnsupportedTextureWrapMode",
+                                   static_cast<u32>(mode));
         LOG_WARNING(Render_OpenGL, "Using texture wrap mode %u", static_cast<u32>(mode));
     }
 

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -481,9 +481,18 @@ bool RendererOpenGL::Init() {
         glDebugMessageCallback(DebugHandler, nullptr);
     }
 
-    LOG_INFO(Render_OpenGL, "GL_VERSION: %s", glGetString(GL_VERSION));
-    LOG_INFO(Render_OpenGL, "GL_VENDOR: %s", glGetString(GL_VENDOR));
-    LOG_INFO(Render_OpenGL, "GL_RENDERER: %s", glGetString(GL_RENDERER));
+    const char* gl_version{reinterpret_cast<char const*>(glGetString(GL_VERSION))};
+    const char* gpu_vendor{reinterpret_cast<char const*>(glGetString(GL_VENDOR))};
+    const char* gpu_model{reinterpret_cast<char const*>(glGetString(GL_RENDERER))};
+
+    LOG_INFO(Render_OpenGL, "GL_VERSION: %s", gl_version);
+    LOG_INFO(Render_OpenGL, "GL_VENDOR: %s", gpu_vendor);
+    LOG_INFO(Render_OpenGL, "GL_RENDERER: %s", gpu_model);
+
+    Core::Telemetry().AddField(Telemetry::FieldType::UserSystem, "GPU_Vendor", gpu_vendor);
+    Core::Telemetry().AddField(Telemetry::FieldType::UserSystem, "GPU_Model", gpu_model);
+    Core::Telemetry().AddField(Telemetry::FieldType::UserSystem, "GPU_OpenGL_Version", gl_version);
+
     if (!GLAD_GL_VERSION_3_3) {
         return false;
     }


### PR DESCRIPTION
This is the third part of a set of changes to add a telemetry framework to Citra. In the near term, this will be used for user-submitted compatibility data to our own custom service endpoint (services.citra-emu.org). My goal, however, is to make this very generic, and allow us to easily log useful/interesting data fields throughout the emulator, and then upload them to our service at a later time. In the long term, we may use this for anonymous telemetry, critical errors and crash reports, measuring how often features are used, etc.

The general design right now is to have essentially a "metadata log", which is just a list of logged data fields. A data field considers of:
* **Name** - String used as a key to access the field, must be unique to a given log (otherwise overwrite previous value).
* **Type** - Predefined enum of field types (e.g. Performance, UserFeedback, etc.). This is just used to group fields together, and is optional.
* **Value** - Value to log for the field

For now, we have just a single global metadata log (used for the emulation session compatibility log), but I envision that we might want to eventually have multiple different logs for different purposes (e.g. anonymous telemetry vs. authenticated user compatibility submission).

With this change, I've added additional telemetry logging throughout the emulator. These include:
* User configuration settings of interest (just things that affect how games run / performance, if I'm missing anything of interest - feel free to let me know)
* User system information (just CPU and GPU for now)
* Simple performance metrics (just emulation speed and frame rate when shutdown is initiated)

As I mentioned above, this is a multi-part submission. Here is what has been completed thus far, as well as what is to come next:

- [x] [#2683] Common interface for submitting data fields to the telemetry log
- [x] [#2683] Dummy backend that does nothing with the telemetry log
- [x] [#2683] Core instantiation of the telemetry interface with a single global log used for game compatibility
- [x] [#2683] A few example fields are logged in core
- [x] [#2819] Implement a backend that does an authenticated log submission to our service
- [x] Implement remaining fields for game compatibility submission
- [ ] Implement Qt UI for authenticating users and user-submitted data
- [ ] Support multiple logs for different purposes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2823)
<!-- Reviewable:end -->
