### PR TITLE
citra-qt: add compatibility to the game_list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,16 @@ if(NOT EXISTS ${CMAKE_SOURCE_DIR}/.git/hooks/pre-commit)
         DESTINATION ${CMAKE_SOURCE_DIR}/.git/hooks)
 endif()
 
+configure_file(${CMAKE_SOURCE_DIR}/dist/compatibility_list/compatibility_list.qrc
+               ${CMAKE_BINARY_DIR}/dist/compatibility_list/compatibility_list.qrc
+               COPYONLY)
+
+if (NOT EXISTS ${CMAKE_BINARY_DIR}/dist/compatibility_list/compatibility_list.json)
+    message(STATUS "Downloading compatibility list for citra...")
+    file(DOWNLOAD
+        https://citra-emu.org/game/index.json
+        "${CMAKE_BINARY_DIR}/dist/compatibility_list/compatibility_list.json" SHOW_PROGRESS)
+endif()
 
 # Detect current compilation architecture and create standard definitions
 # =======================================================================

--- a/dist/compatibility_list/compatibility_list.qrc
+++ b/dist/compatibility_list/compatibility_list.qrc
@@ -1,0 +1,5 @@
+<RCC>
+  <qresource prefix="compatibility_list">
+      <file>compatibility_list.json</file>
+  </qresource>
+</RCC>

--- a/src/citra_qt/CMakeLists.txt
+++ b/src/citra_qt/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/CMakeModules)
 
@@ -75,6 +76,10 @@ set(UIS
             main.ui
             )
 
+file(GLOB COMPAT_LIST
+            ${CMAKE_BINARY_DIR}/dist/compatibility_list/compatibility_list.qrc
+            ${CMAKE_BINARY_DIR}/dist/compatibility_list/compatibility_list.json)
+
 create_directory_groups(${SRCS} ${HEADERS} ${UIS})
 
 if (Qt5_FOUND)
@@ -86,10 +91,10 @@ endif()
 if (APPLE)
     set(MACOSX_ICON "../../dist/citra.icns")
     set_source_files_properties(${MACOSX_ICON} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
-    add_executable(citra-qt MACOSX_BUNDLE ${SRCS} ${HEADERS} ${UI_HDRS} ${MACOSX_ICON})
+    add_executable(citra-qt MACOSX_BUNDLE ${SRCS} ${HEADERS} ${UI_HDRS} ${COMPAT_LIST} ${MACOSX_ICON})
     set_target_properties(citra-qt PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/Info.plist)
 else()
-    add_executable(citra-qt ${SRCS} ${HEADERS} ${UI_HDRS})
+    add_executable(citra-qt ${SRCS} ${HEADERS} ${UI_HDRS} ${COMPAT_LIST})
 endif()
 target_link_libraries(citra-qt PRIVATE audio_core common core input_common video_core)
 target_link_libraries(citra-qt PRIVATE Boost::boost glad nihstro-headers Qt5::OpenGL Qt5::Widgets)

--- a/src/citra_qt/game_list.h
+++ b/src/citra_qt/game_list.h
@@ -27,6 +27,7 @@ class GameList : public QWidget {
 public:
     enum {
         COLUMN_NAME,
+        COLUMN_COMPATIBILITY,
         COLUMN_FILE_TYPE,
         COLUMN_SIZE,
         COLUMN_COUNT, // Number of columns
@@ -66,6 +67,7 @@ public:
     void setFilterFocus();
     void setFilterVisible(bool visibility);
 
+    void LoadCompatibilityList();
     void PopulateAsync(const QString& dir_path, bool deep_scan);
 
     void SaveInterfaceLayout();
@@ -83,6 +85,7 @@ private slots:
     void onFilterCloseClicked();
 
 private:
+    QString GetReadableCompatibility(QString compat);
     void AddEntry(const QList<QStandardItem*>& entry_items);
     void ValidateEntry(const QModelIndex& item);
     void DonePopulating(QStringList watch_list);
@@ -98,4 +101,5 @@ private:
     QStandardItemModel* item_model = nullptr;
     GameListWorker* current_worker = nullptr;
     QFileSystemWatcher* watcher = nullptr;
+    std::vector<std::pair<std::string, QString>> compatibility_list;
 };

--- a/src/citra_qt/game_list_p.h
+++ b/src/citra_qt/game_list_p.h
@@ -152,8 +152,10 @@ class GameListWorker : public QObject, public QRunnable {
     Q_OBJECT
 
 public:
-    GameListWorker(QString dir_path, bool deep_scan)
-        : QObject(), QRunnable(), dir_path(dir_path), deep_scan(deep_scan) {}
+    GameListWorker(QString dir_path, bool deep_scan,
+                   std::vector<std::pair<std::string, QString>> compatibility_list)
+        : QObject(), QRunnable(), dir_path(dir_path), deep_scan(deep_scan),
+          compatibility_list(compatibility_list) {}
 
 public slots:
     /// Starts the processing of directory tree information.
@@ -179,6 +181,7 @@ private:
     QStringList watch_list;
     QString dir_path;
     bool deep_scan;
+    std::vector<std::pair<std::string, QString>> compatibility_list;
     std::atomic_bool stop_processing;
 
     void AddFstEntriesToGameList(const std::string& dir_path, unsigned int recursion = 0);

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -69,6 +69,7 @@ GMainWindow::GMainWindow() : config(new Config()), emu_thread(nullptr) {
                        .arg(Common::g_build_name, Common::g_scm_branch, Common::g_scm_desc));
     show();
 
+    game_list->LoadCompatibilityList();
     game_list->PopulateAsync(UISettings::values.gamedir, UISettings::values.gamedir_deepscan);
 
     QStringList args = QApplication::arguments();


### PR DESCRIPTION
Add the Game Compatibility information to the citra-qt game list.

The game list it's downloaded by CMake, that way each nightly version will have the latest version of it ;)

Mandatory Screenshot:
![image](https://user-images.githubusercontent.com/9112818/28227719-7fb23a02-68db-11e7-86a6-e909ec97e686.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2828)
<!-- Reviewable:end -->
