### PR TITLE
CMakeLists: Check that all submodules are present

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,21 @@ if(NOT EXISTS ${CMAKE_SOURCE_DIR}/.git/hooks/pre-commit)
         DESTINATION ${CMAKE_SOURCE_DIR}/.git/hooks)
 endif()
 
+# Sanity check : Check that all submodules are present
+# =======================================================================
+
+function(check_submodules_present)
+    file(READ "${CMAKE_SOURCE_DIR}/.gitmodules" gitmodules)
+    string(REGEX MATCHALL "path *= *[^ \t\r\n]*" gitmodules ${gitmodules})
+    foreach(module ${gitmodules})
+        string(REGEX REPLACE "path *= *" "" module ${module})
+        if (NOT EXISTS "${CMAKE_SOURCE_DIR}/${module}/.git")
+            message(SEND_ERROR "Git submodule ${module} not found."
+                    "Please run: git submodule update --init --recursive")
+        endif()
+    endforeach()
+endfunction()
+check_submodules_present()
 
 # Detect current compilation architecture and create standard definitions
 # =======================================================================


### PR DESCRIPTION
Does this by looking in `.gitmodules` and grepping the paths to all the submodules out of it, and checking for the presence of the `.git` folder in each of those paths.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2829)
<!-- Reviewable:end -->
