### PR TITLE
Make enet use the same convention as other submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,7 +25,7 @@
 [submodule "fmt"]
     path = externals/fmt
     url = https://github.com/fmtlib/fmt.git
-[submodule "externals/enet"]
+[submodule "enet"]
     path = externals/enet
     url = https://github.com/lsalzman/enet
 [submodule "cpr"]


### PR DESCRIPTION
This makes it easier for packagers to preload all submodules.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2830)
<!-- Reviewable:end -->
