### PR TITLE
Added missing parts in libnetwork

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -388,7 +388,7 @@ set(HEADERS
 
 create_directory_groups(${SRCS} ${HEADERS})
 add_library(core STATIC ${SRCS} ${HEADERS})
-target_link_libraries(core PUBLIC common PRIVATE audio_core video_core)
+target_link_libraries(core PUBLIC common PRIVATE audio_core network video_core)
 target_link_libraries(core PUBLIC Boost::boost PRIVATE cryptopp dynarmic fmt)
 if (ENABLE_WEB_SERVICE)
     target_link_libraries(core PUBLIC json-headers web_service)

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -19,6 +19,7 @@
 #include "core/loader/loader.h"
 #include "core/memory_setup.h"
 #include "core/settings.h"
+#include "network/network.h"
 #include "video_core/video_core.h"
 
 namespace Core {
@@ -188,6 +189,10 @@ void System::Shutdown() {
     cpu_core = nullptr;
     app_loader = nullptr;
     telemetry_session = nullptr;
+    if (auto room_member = Network::GetRoomMember().lock()) {
+        Network::GameInfo game_info{};
+        room_member->SendGameInfo(game_info);
+    }
 
     LOG_DEBUG(Core, "Shutdown OK");
 }

--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -358,9 +358,10 @@ ResultStatus AppLoader_NCCH::Load() {
         SMDH smdh;
         std::memcpy(&smdh, smdh_data.data(), sizeof(SMDH));
         auto title = smdh.GetShortTitle(SMDH::TitleLanguage::English);
-        game_info.name.assign(Common::UTF16ToUTF8(std::u16string{title.begin(), title.end()}));
+        auto result = std::find_if(title.begin(), title.end(),
+                                   [](const auto& text) -> bool { return text == '\u0000'; });
+        game_info.name = Common::UTF16ToUTF8(std::u16string{title.begin(), result});
         game_info.id = ncch_header.program_id;
-        game_info.version = ncch_header.version;
         room_member->SendGameInfo(game_info);
     }
 

--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -358,9 +358,8 @@ ResultStatus AppLoader_NCCH::Load() {
         SMDH smdh;
         std::memcpy(&smdh, smdh_data.data(), sizeof(SMDH));
         auto title = smdh.GetShortTitle(SMDH::TitleLanguage::English);
-        auto result = std::find_if(title.begin(), title.end(),
-                                   [](const auto& text) -> bool { return text == '\u0000'; });
-        game_info.name = Common::UTF16ToUTF8(std::u16string{title.begin(), result});
+        auto title_end = std::find(title.begin(), title.end(), u'\0');
+        game_info.name = Common::UTF16ToUTF8(std::u16string{title.begin(), title_end});
         game_info.id = ncch_header.program_id;
         room_member->SendGameInfo(game_info);
     }

--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -353,13 +353,7 @@ ResultStatus AppLoader_NCCH::Load() {
 
     if (auto room_member = Network::GetRoomMember().lock()) {
         Network::GameInfo game_info;
-        std::vector<u8> smdh_data;
-        ReadIcon(smdh_data);
-        SMDH smdh;
-        std::memcpy(&smdh, smdh_data.data(), sizeof(SMDH));
-        auto title = smdh.GetShortTitle(SMDH::TitleLanguage::English);
-        auto title_end = std::find(title.begin(), title.end(), u'\0');
-        game_info.name = Common::UTF16ToUTF8(std::u16string{title.begin(), title_end});
+        ReadTitle(game_info.name);
         game_info.id = ncch_header.program_id;
         room_member->SendGameInfo(game_info);
     }

--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -20,6 +20,7 @@
 #include "core/loader/ncch.h"
 #include "core/loader/smdh.h"
 #include "core/memory.h"
+#include "network/network.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Loader namespace
@@ -349,6 +350,19 @@ ResultStatus AppLoader_NCCH::Load() {
     LOG_INFO(Loader, "Program ID: %s", program_id.c_str());
 
     Core::Telemetry().AddField(Telemetry::FieldType::Session, "ProgramId", program_id);
+
+    if (auto room_member = Network::GetRoomMember().lock()) {
+        Network::GameInfo game_info;
+        std::vector<u8> smdh_data;
+        ReadIcon(smdh_data);
+        SMDH smdh;
+        std::memcpy(&smdh, smdh_data.data(), sizeof(SMDH));
+        auto title = smdh.GetShortTitle(SMDH::TitleLanguage::English);
+        game_info.name.assign(Common::UTF16ToUTF8(std::u16string{title.begin(), title.end()}));
+        game_info.id = ncch_header.program_id;
+        game_info.version = ncch_header.version;
+        room_member->SendGameInfo(game_info);
+    }
 
     is_loaded = true; // Set state to loaded
 

--- a/src/network/packet.cpp
+++ b/src/network/packet.cpp
@@ -13,6 +13,18 @@
 
 namespace Network {
 
+#ifndef htonll
+u64 htonll(u64 x) {
+    return ((1 == htonl(1)) ? (x) : ((uint64_t)htonl((x)&0xFFFFFFFF) << 32) | htonl((x) >> 32));
+}
+#endif
+
+#ifndef ntohll
+u64 ntohll(u64 x) {
+    return ((1 == ntohl(1)) ? (x) : ((uint64_t)ntohl((x)&0xFFFFFFFF) << 32) | ntohl((x) >> 32));
+}
+#endif
+
 void Packet::Append(const void* in_data, std::size_t size_in_bytes) {
     if (in_data && (size_in_bytes > 0)) {
         std::size_t start = data.size();
@@ -100,6 +112,20 @@ Packet& Packet::operator>>(u32& out_data) {
     return *this;
 }
 
+Packet& Packet::operator>>(s64& out_data) {
+    s64 value;
+    Read(&value, sizeof(value));
+    out_data = ntohll(value);
+    return *this;
+}
+
+Packet& Packet::operator>>(u64& out_data) {
+    u64 value;
+    Read(&value, sizeof(value));
+    out_data = ntohll(value);
+    return *this;
+}
+
 Packet& Packet::operator>>(float& out_data) {
     Read(&out_data, sizeof(out_data));
     return *this;
@@ -179,6 +205,18 @@ Packet& Packet::operator<<(s32 in_data) {
 
 Packet& Packet::operator<<(u32 in_data) {
     u32 toWrite = htonl(in_data);
+    Append(&toWrite, sizeof(toWrite));
+    return *this;
+}
+
+Packet& Packet::operator<<(s64 in_data) {
+    s64 toWrite = htonll(in_data);
+    Append(&toWrite, sizeof(toWrite));
+    return *this;
+}
+
+Packet& Packet::operator<<(u64 in_data) {
+    u64 toWrite = htonll(in_data);
     Append(&toWrite, sizeof(toWrite));
     return *this;
 }

--- a/src/network/packet.h
+++ b/src/network/packet.h
@@ -72,6 +72,8 @@ public:
     Packet& operator>>(u16& out_data);
     Packet& operator>>(s32& out_data);
     Packet& operator>>(u32& out_data);
+    Packet& operator>>(s64& out_data);
+    Packet& operator>>(u64& out_data);
     Packet& operator>>(float& out_data);
     Packet& operator>>(double& out_data);
     Packet& operator>>(char* out_data);
@@ -89,6 +91,8 @@ public:
     Packet& operator<<(u16 in_data);
     Packet& operator<<(s32 in_data);
     Packet& operator<<(u32 in_data);
+    Packet& operator<<(s64 in_data);
+    Packet& operator<<(u64 in_data);
     Packet& operator<<(float in_data);
     Packet& operator<<(double in_data);
     Packet& operator<<(const char* in_data);

--- a/src/network/room.cpp
+++ b/src/network/room.cpp
@@ -310,7 +310,6 @@ void Room::RoomImpl::BroadcastRoomInformation() {
             packet << member.mac_address;
             packet << member.game_info.name;
             packet << member.game_info.id;
-            packet << member.game_info.version;
         }
     }
 
@@ -405,7 +404,6 @@ void Room::RoomImpl::HandleGameNamePacket(const ENetEvent* event) {
     GameInfo game_info;
     in_packet >> game_info.name;
     in_packet >> game_info.id;
-    in_packet >> game_info.version;
 
     {
         std::lock_guard<std::mutex> lock(member_mutex);
@@ -465,7 +463,7 @@ const RoomInformation& Room::GetRoomInformation() const {
     return room_impl->room_information;
 }
 
-const std::vector<Room::Member>&& Room::GetRoomMemberList() const {
+const std::vector<Room::Member> Room::GetRoomMemberList() const {
     std::vector<Room::Member> member_list;
     std::lock_guard<std::mutex> lock(room_impl->member_mutex);
     for (const auto& member_impl : room_impl->members) {
@@ -475,7 +473,7 @@ const std::vector<Room::Member>&& Room::GetRoomMemberList() const {
         member.game_info = member_impl.game_info;
         member_list.push_back(member);
     }
-    return std::move(member_list);
+    return member_list;
 };
 
 void Room::Destroy() {

--- a/src/network/room.cpp
+++ b/src/network/room.cpp
@@ -463,7 +463,7 @@ const RoomInformation& Room::GetRoomInformation() const {
     return room_impl->room_information;
 }
 
-const std::vector<Room::Member> Room::GetRoomMemberList() const {
+std::vector<Room::Member> Room::GetRoomMemberList() const {
     std::vector<Room::Member> member_list;
     std::lock_guard<std::mutex> lock(room_impl->member_mutex);
     for (const auto& member_impl : room_impl->members) {

--- a/src/network/room.h
+++ b/src/network/room.h
@@ -25,7 +25,6 @@ struct RoomInformation {
 struct GameInfo {
     std::string name{""};
     u64 id{0};
-    u16 version{0};
 };
 
 using MacAddress = std::array<u8, 6>;
@@ -80,7 +79,7 @@ public:
     /**
      * Gets a list of the mbmers connected to the room.
      */
-    const std::vector<Member>&& GetRoomMemberList() const;
+    const std::vector<Member> GetRoomMemberList() const;
 
     /**
      * Creates the socket for this room. Will bind to default address if

--- a/src/network/room.h
+++ b/src/network/room.h
@@ -79,7 +79,7 @@ public:
     /**
      * Gets a list of the mbmers connected to the room.
      */
-    const std::vector<Member> GetRoomMemberList() const;
+    std::vector<Member> GetRoomMemberList() const;
 
     /**
      * Creates the socket for this room. Will bind to default address if

--- a/src/network/room.h
+++ b/src/network/room.h
@@ -21,6 +21,12 @@ struct RoomInformation {
     u32 member_slots; ///< Maximum number of members in this room
 };
 
+struct GameInfo {
+    std::string name{""};
+    u64 id{0};
+    u16 version{0};
+};
+
 using MacAddress = std::array<u8, 6>;
 /// A special MAC address that tells the room we're joining to assign us a MAC address
 /// automatically.
@@ -34,7 +40,7 @@ enum RoomMessageTypes : u8 {
     IdJoinRequest = 1,
     IdJoinSuccess,
     IdRoomInformation,
-    IdSetGameName,
+    IdSetGameInfo,
     IdWifiPacket,
     IdChatMessage,
     IdNameCollision,

--- a/src/network/room.h
+++ b/src/network/room.h
@@ -7,6 +7,7 @@
 #include <array>
 #include <memory>
 #include <string>
+#include <vector>
 #include "common/common_types.h"
 
 namespace Network {
@@ -57,6 +58,12 @@ public:
         Closed, ///< The room is not opened and can not accept connections.
     };
 
+    struct Member {
+        std::string nickname;   ///< The nickname of the member.
+        GameInfo game_info;     ///< The current game of the member
+        MacAddress mac_address; ///< The assigned mac address of the member.
+    };
+
     Room();
     ~Room();
 
@@ -69,6 +76,11 @@ public:
      * Gets the room information of the room.
      */
     const RoomInformation& GetRoomInformation() const;
+
+    /**
+     * Gets a list of the mbmers connected to the room.
+     */
+    const std::vector<Member>&& GetRoomMemberList() const;
 
     /**
      * Creates the socket for this room. Will bind to default address if

--- a/src/network/room_member.h
+++ b/src/network/room_member.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -58,6 +59,17 @@ public:
         MacAddress mac_address; ///< MAC address associated with this member.
     };
     using MemberList = std::vector<MemberInformation>;
+
+    // The handle for the callback functions
+    template <typename T>
+    using Connection = std::shared_ptr<std::function<void(const T&)>>;
+
+    /**
+     * Disconnect a callback function from the events.
+     * @param connection The connection handle to disconnect
+     */
+    template <typename T>
+    void Disconnect(Connection<T> connection);
 
     RoomMember();
     ~RoomMember();
@@ -117,6 +129,24 @@ public:
      * @param game_info The game information.
      */
     void SendGameInfo(const GameInfo& game_info);
+
+    /**
+     * Register a function to an event. The function wil be called everytime the event occurs.
+     * Depending on the type of the parameter the function is only called for the coresponding
+     * event.
+     * The events could be:
+     * - Change of the room member state
+     * -
+     * @param callback The function to call
+     * @return A Connection used for removing the function from the registered list
+     */
+    Connection<State> ConnectOnStateChanged(std::function<void(const State&)> callback);
+    Connection<WifiPacket> ConnectOnWifiPacketReceived(
+        std::function<void(const WifiPacket&)> callback);
+    Connection<RoomInformation> ConnectOnRoomInformationChanged(
+        std::function<void(const RoomInformation&)> callback);
+    Connection<ChatEntry> ConnectOnChatMessageRecieved(
+        std::function<void(const ChatEntry&)> callback);
 
     /**
      * Leaves the current room.

--- a/src/network/room_member.h
+++ b/src/network/room_member.h
@@ -53,7 +53,7 @@ public:
 
     struct MemberInformation {
         std::string nickname;   ///< Nickname of the member.
-        std::string game_name;  ///< Name of the game they're currently playing, or empty if they're
+        GameInfo game_info;     ///< Name of the game they're currently playing, or empty if they're
                                 /// not playing anything.
         MacAddress mac_address; ///< MAC address associated with this member.
     };
@@ -113,10 +113,10 @@ public:
     void SendChatMessage(const std::string& message);
 
     /**
-     * Sends the current game name  to the room.
-     * @param game_name The game name.
+     * Sends the current game info to the room.
+     * @param game_info The game information.
      */
-    void SendGameName(const std::string& game_name);
+    void SendGameInfo(const GameInfo& game_info);
 
     /**
      * Leaves the current room.

--- a/src/network/room_member.h
+++ b/src/network/room_member.h
@@ -131,23 +131,41 @@ public:
     void SendGameInfo(const GameInfo& game_info);
 
     /**
-     * Binds a function to an event. The function wil be called everytime the event occurs.
-     * Depending on the type of the parameter the function is only called for the coresponding
-     * event.
-     * The callback function must not bind or unbind a function. Doing so will cause a deadlock
-     * The events could be:
-     * - Change of the room member state
-     * - A WifiPacket was received
-     * - The room information was changed
-     * - A chat message was received
+     * Binds a function to an event that will be triggered every time the State of the member
+     * changed. The function wil be called every time the event is triggered. The callback function
+     * must not bind or unbind a function. Doing so will cause a deadlock
      * @param callback The function to call
      * @return A handle used for removing the function from the registered list
      */
     CallbackHandle<State> BindOnStateChanged(std::function<void(const State&)> callback);
+
+    /**
+     * Binds a function to an event that will be triggered every time a WifiPacket is received.
+     * The function wil be called everytime the event is triggered.
+     * The callback function must not bind or unbind a function. Doing so will cause a deadlock
+     * @param callback The function to call
+     * @return A handle used for removing the function from the registered list
+     */
     CallbackHandle<WifiPacket> BindOnWifiPacketReceived(
         std::function<void(const WifiPacket&)> callback);
+
+    /**
+     * Binds a function to an event that will be triggered every time the RoomInformation changes.
+     * The function wil be called every time the event is triggered.
+     * The callback function must not bind or unbind a function. Doing so will cause a deadlock
+     * @param callback The function to call
+     * @return A handle used for removing the function from the registered list
+     */
     CallbackHandle<RoomInformation> BindOnRoomInformationChanged(
         std::function<void(const RoomInformation&)> callback);
+
+    /**
+     * Binds a function to an event that will be triggered every time a ChatMessage is received.
+     * The function wil be called every time the event is triggered.
+     * The callback function must not bind or unbind a function. Doing so will cause a deadlock
+     * @param callback The function to call
+     * @return A handle used for removing the function from the registered list
+     */
     CallbackHandle<ChatEntry> BindOnChatMessageRecieved(
         std::function<void(const ChatEntry&)> callback);
 

--- a/src/network/room_member.h
+++ b/src/network/room_member.h
@@ -62,14 +62,14 @@ public:
 
     // The handle for the callback functions
     template <typename T>
-    using Connection = std::shared_ptr<std::function<void(const T&)>>;
+    using CallbackHandle = std::shared_ptr<std::function<void(const T&)>>;
 
     /**
-     * Disconnect a callback function from the events.
-     * @param connection The connection handle to disconnect
+     * Unbinds a callback function from the events.
+     * @param handle The connection handle to disconnect
      */
     template <typename T>
-    void Disconnect(Connection<T> connection);
+    void Unbind(CallbackHandle<T> handle);
 
     RoomMember();
     ~RoomMember();
@@ -131,21 +131,24 @@ public:
     void SendGameInfo(const GameInfo& game_info);
 
     /**
-     * Register a function to an event. The function wil be called everytime the event occurs.
+     * Binds a function to an event. The function wil be called everytime the event occurs.
      * Depending on the type of the parameter the function is only called for the coresponding
      * event.
+     * The callback function must not bind or unbind a function. Doing so will cause a deadlock
      * The events could be:
      * - Change of the room member state
-     * -
+     * - A WifiPacket was received
+     * - The room information was changed
+     * - A chat message was received
      * @param callback The function to call
-     * @return A Connection used for removing the function from the registered list
+     * @return A handle used for removing the function from the registered list
      */
-    Connection<State> ConnectOnStateChanged(std::function<void(const State&)> callback);
-    Connection<WifiPacket> ConnectOnWifiPacketReceived(
+    CallbackHandle<State> BindOnStateChanged(std::function<void(const State&)> callback);
+    CallbackHandle<WifiPacket> BindOnWifiPacketReceived(
         std::function<void(const WifiPacket&)> callback);
-    Connection<RoomInformation> ConnectOnRoomInformationChanged(
+    CallbackHandle<RoomInformation> BindOnRoomInformationChanged(
         std::function<void(const RoomInformation&)> callback);
-    Connection<ChatEntry> ConnectOnChatMessageRecieved(
+    CallbackHandle<ChatEntry> BindOnChatMessageRecieved(
         std::function<void(const ChatEntry&)> callback);
 
     /**


### PR DESCRIPTION
This PR is the third regarding the ENet inclusion.
With this PR the libnetwork is fully functional. There might still be some features that could be added, though.

The features added in this PR:
- Set the GameInformation of the RoomMember the moment they change
- The callback interface for RoomMember
here's an example of how to hook a function to one of the events:
``` // Callback identifier for the OnStateChanged event.
static Network::RoomMember::Connection<Network::RoomMember::State> state_changed;

void OnStateChanged(const Network::RoomMember::State) {
 ...
}

if (auto room_member = Network::GetRoomMember().lock())
        wifi_packet_received = room_member->ConnectOnWifiPacketReceived(OnWifiPacketReceived);

...
//Every connected function must be disconnected
if (auto room_member = Network::GetRoomMember().lock())
        room_member->Disconnect(state_changed);
```
To use this with class members:
``` 
room_member->ConnectOnStateChanged(std::bind(&SomeClass::OnStateChanged, 
                                             this, std::placeholders::_1));
```

- The GetMemberList function for Room, which is needed for the announce web_service

Things to come, regarding this topic:

- [ ] UI
- [ ] Announce web_service
- [ ] Integrating libnetwork into uds

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2838)
<!-- Reviewable:end -->
