### PR TITLE
Kernel/Memory: Give each process its own page table and allow switching the current page table upon reschedule

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -56,7 +56,9 @@ static Dynarmic::UserCallbacks GetUserCallbacks(
     user_callbacks.memory.Write16 = &Memory::Write16;
     user_callbacks.memory.Write32 = &Memory::Write32;
     user_callbacks.memory.Write64 = &Memory::Write64;
-    user_callbacks.page_table = Memory::GetCurrentPageTablePointers();
+    // TODO(Subv): Re-add the page table pointers once dynarmic supports switching page tables at
+    // runtime.
+    user_callbacks.page_table = nullptr;
     user_callbacks.coprocessors[15] = std::make_shared<DynarmicCP15>(interpeter_state);
     return user_callbacks;
 }

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -137,7 +137,6 @@ void System::Reschedule() {
 }
 
 System::ResultStatus System::Init(EmuWindow* emu_window, u32 system_mode) {
-    Memory::InitMemoryMap();
     LOG_DEBUG(HW_Memory, "initialized OK");
 
     if (Settings::values.use_cpu_jit) {

--- a/src/core/hle/kernel/memory.h
+++ b/src/core/hle/kernel/memory.h
@@ -26,4 +26,6 @@ MemoryRegionInfo* GetMemoryRegion(MemoryRegion region);
 
 void HandleSpecialMapping(VMManager& address_space, const AddressMapping& mapping);
 void MapSharedPages(VMManager& address_space);
+
+extern MemoryRegionInfo memory_regions[3];
 } // namespace Kernel

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -178,8 +178,18 @@ static void SwitchContext(Thread* new_thread) {
 
         Core::CPU().LoadContext(new_thread->context);
         Core::CPU().SetCP15Register(CP15_THREAD_URO, new_thread->GetTLSAddress());
+
+        if (!previous_thread || previous_thread->owner_process != current_thread->owner_process) {
+            Kernel::g_current_process = current_thread->owner_process;
+            Memory::current_page_table = &Kernel::g_current_process->vm_manager.page_table;
+            // We have switched processes and thus, page tables, clear the instruction cache so we
+            // don't keep stale data from the previous process.
+            Core::CPU().ClearInstructionCache();
+        }
     } else {
         current_thread = nullptr;
+        // Note: We do not reset the current process and current page table when idling because
+        // technically we haven't changed processes, our threads are just paused.
     }
 }
 

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -171,6 +171,8 @@ static void SwitchContext(Thread* new_thread) {
         // Cancel any outstanding wakeup events for this thread
         CoreTiming::UnscheduleEvent(ThreadWakeupEventType, new_thread->callback_handle);
 
+        auto previous_process = Kernel::g_current_process;
+
         current_thread = new_thread;
 
         ready_queue.remove(new_thread->current_priority, new_thread);
@@ -179,7 +181,7 @@ static void SwitchContext(Thread* new_thread) {
         Core::CPU().LoadContext(new_thread->context);
         Core::CPU().SetCP15Register(CP15_THREAD_URO, new_thread->GetTLSAddress());
 
-        if (!previous_thread || previous_thread->owner_process != current_thread->owner_process) {
+        if (previous_process != current_thread->owner_process) {
             Kernel::g_current_process = current_thread->owner_process;
             Memory::current_page_table = &Kernel::g_current_process->vm_manager.page_table;
             // We have switched processes and thus, page tables, clear the instruction cache so we

--- a/src/core/hle/kernel/vm_manager.h
+++ b/src/core/hle/kernel/vm_manager.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include "common/common_types.h"
 #include "core/hle/result.h"
+#include "core/memory.h"
 #include "core/mmio.h"
 
 namespace Kernel {
@@ -102,7 +103,6 @@ struct VirtualMemoryArea {
  *  - http://duartes.org/gustavo/blog/post/page-cache-the-affair-between-memory-and-files/
  */
 class VMManager final {
-    // TODO(yuriks): Make page tables switchable to support multiple VMManagers
 public:
     /**
      * The maximum amount of address space managed by the kernel. Addresses above this are never
@@ -183,6 +183,10 @@ public:
 
     /// Dumps the address space layout to the log, for debugging
     void LogLayout(Log::Level log_level) const;
+
+    /// Each VMManager has its own page table, which is set as the main one when the owning process
+    /// is scheduled.
+    Memory::PageTable page_table;
 
 private:
     using VMAIter = decltype(vma_map)::iterator;

--- a/src/core/loader/3dsx.cpp
+++ b/src/core/loader/3dsx.cpp
@@ -270,6 +270,7 @@ ResultStatus AppLoader_THREEDSX::Load() {
     Kernel::g_current_process = Kernel::Process::Create(std::move(codeset));
     Kernel::g_current_process->svc_access_mask.set();
     Kernel::g_current_process->address_mappings = default_address_mappings;
+    Memory::current_page_table = &Kernel::g_current_process->vm_manager.page_table;
 
     // Attach the default resource limit (APPLICATION) to the process
     Kernel::g_current_process->resource_limit =

--- a/src/core/loader/elf.cpp
+++ b/src/core/loader/elf.cpp
@@ -397,6 +397,7 @@ ResultStatus AppLoader_ELF::Load() {
     Kernel::g_current_process = Kernel::Process::Create(std::move(codeset));
     Kernel::g_current_process->svc_access_mask.set();
     Kernel::g_current_process->address_mappings = default_address_mappings;
+    Memory::current_page_table = &Kernel::g_current_process->vm_manager.page_table;
 
     // Attach the default resource limit (APPLICATION) to the process
     Kernel::g_current_process->resource_limit =

--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -172,6 +172,7 @@ ResultStatus AppLoader_NCCH::LoadExec() {
         codeset->memory = std::make_shared<std::vector<u8>>(std::move(code));
 
         Kernel::g_current_process = Kernel::Process::Create(std::move(codeset));
+        Memory::current_page_table = &Kernel::g_current_process->vm_manager.page_table;
 
         // Attach a resource limit to the process based on the resource limit category
         Kernel::g_current_process->resource_limit =

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -208,8 +208,7 @@ bool IsValidVirtualAddress(const VAddr vaddr) {
 }
 
 bool IsValidPhysicalAddress(const PAddr paddr) {
-    boost::optional<VAddr> vaddr = PhysicalToVirtualAddress(paddr);
-    return vaddr && IsValidVirtualAddress(*vaddr);
+    return GetPhysicalPointer(paddr) != nullptr;
 }
 
 u8* GetPointer(const VAddr vaddr) {

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -227,8 +227,6 @@ boost::optional<VAddr> PhysicalToVirtualAddress(PAddr addr);
 
 /**
  * Gets a pointer to the memory region beginning at the specified physical address.
- *
- * @note This is currently implemented using PhysicalToVirtualAddress().
  */
 u8* GetPhysicalPointer(PAddr address);
 

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -7,8 +7,10 @@
 #include <array>
 #include <cstddef>
 #include <string>
+#include <vector>
 #include <boost/optional.hpp>
 #include "common/common_types.h"
+#include "core/mmio.h"
 
 namespace Memory {
 
@@ -20,6 +22,59 @@ const u32 PAGE_SIZE = 0x1000;
 const u32 PAGE_MASK = PAGE_SIZE - 1;
 const int PAGE_BITS = 12;
 const size_t PAGE_TABLE_NUM_ENTRIES = 1 << (32 - PAGE_BITS);
+
+enum class PageType {
+    /// Page is unmapped and should cause an access error.
+    Unmapped,
+    /// Page is mapped to regular memory. This is the only type you can get pointers to.
+    Memory,
+    /// Page is mapped to regular memory, but also needs to check for rasterizer cache flushing and
+    /// invalidation
+    RasterizerCachedMemory,
+    /// Page is mapped to a I/O region. Writing and reading to this page is handled by functions.
+    Special,
+    /// Page is mapped to a I/O region, but also needs to check for rasterizer cache flushing and
+    /// invalidation
+    RasterizerCachedSpecial,
+};
+
+struct SpecialRegion {
+    VAddr base;
+    u32 size;
+    MMIORegionPointer handler;
+};
+
+/**
+ * A (reasonably) fast way of allowing switchable and remappable process address spaces. It loosely
+ * mimics the way a real CPU page table works, but instead is optimized for minimal decoding and
+ * fetching requirements when accessing. In the usual case of an access to regular memory, it only
+ * requires an indexed fetch and a check for NULL.
+ */
+struct PageTable {
+    /**
+     * Array of memory pointers backing each page. An entry can only be non-null if the
+     * corresponding entry in the `attributes` array is of type `Memory`.
+     */
+    std::array<u8*, PAGE_TABLE_NUM_ENTRIES> pointers;
+
+    /**
+     * Contains MMIO handlers that back memory regions whose entries in the `attribute` array is of
+     * type `Special`.
+     */
+    std::vector<SpecialRegion> special_regions;
+
+    /**
+     * Array of fine grained page attributes. If it is set to any value other than `Memory`, then
+     * the corresponding entry in `pointers` MUST be set to null.
+     */
+    std::array<PageType, PAGE_TABLE_NUM_ENTRIES> attributes;
+
+    /**
+     * Indicates the number of externally cached resources touching a page that should be
+     * flushed before the memory is accessed
+     */
+    std::array<u8, PAGE_TABLE_NUM_ENTRIES> cached_res_count;
+};
 
 /// Physical memory regions as seen from the ARM11
 enum : PAddr {
@@ -126,6 +181,9 @@ enum : VAddr {
     NEW_LINEAR_HEAP_VADDR_END = NEW_LINEAR_HEAP_VADDR + NEW_LINEAR_HEAP_SIZE,
 };
 
+/// Currently active page table
+extern PageTable* current_page_table;
+
 bool IsValidVirtualAddress(const VAddr addr);
 bool IsValidPhysicalAddress(const PAddr addr);
 
@@ -209,4 +267,4 @@ void RasterizerFlushVirtualRegion(VAddr start, u32 size, FlushMode mode);
  * retrieve the current page table for that purpose.
  */
 std::array<u8*, PAGE_TABLE_NUM_ENTRIES>* GetCurrentPageTablePointers();
-}
+} // namespace Memory

--- a/src/core/memory_setup.h
+++ b/src/core/memory_setup.h
@@ -9,24 +9,24 @@
 
 namespace Memory {
 
-void InitMemoryMap();
-
 /**
  * Maps an allocated buffer onto a region of the emulated process address space.
  *
+ * @param page_table The page table of the emulated process.
  * @param base The address to start mapping at. Must be page-aligned.
  * @param size The amount of bytes to map. Must be page-aligned.
  * @param target Buffer with the memory backing the mapping. Must be of length at least `size`.
  */
-void MapMemoryRegion(VAddr base, u32 size, u8* target);
+void MapMemoryRegion(PageTable& page_table, VAddr base, u32 size, u8* target);
 
 /**
  * Maps a region of the emulated process address space as a IO region.
+ * @param page_table The page table of the emulated process.
  * @param base The address to start mapping at. Must be page-aligned.
  * @param size The amount of bytes to map. Must be page-aligned.
  * @param mmio_handler The handler that backs the mapping.
  */
-void MapIoRegion(VAddr base, u32 size, MMIORegionPointer mmio_handler);
+void MapIoRegion(PageTable& page_table, VAddr base, u32 size, MMIORegionPointer mmio_handler);
 
-void UnmapRegion(VAddr base, u32 size);
+void UnmapRegion(PageTable& page_table, VAddr base, u32 size);
 }

--- a/src/tests/core/arm/arm_test_common.cpp
+++ b/src/tests/core/arm/arm_test_common.cpp
@@ -3,20 +3,30 @@
 // Refer to the license.txt file included.
 
 #include "core/core.h"
+#include "core/memory.h"
 #include "core/memory_setup.h"
 #include "tests/core/arm/arm_test_common.h"
 
 namespace ArmTests {
 
+static Memory::PageTable page_table;
+
 TestEnvironment::TestEnvironment(bool mutable_memory_)
     : mutable_memory(mutable_memory_), test_memory(std::make_shared<TestMemory>(this)) {
-    Memory::MapIoRegion(0x00000000, 0x80000000, test_memory);
-    Memory::MapIoRegion(0x80000000, 0x80000000, test_memory);
+
+    page_table.pointers.fill(nullptr);
+    page_table.attributes.fill(Memory::PageType::Unmapped);
+    page_table.cached_res_count.fill(0);
+
+    Memory::MapIoRegion(page_table, 0x00000000, 0x80000000, test_memory);
+    Memory::MapIoRegion(page_table, 0x80000000, 0x80000000, test_memory);
+
+    Memory::current_page_table = &page_table;
 }
 
 TestEnvironment::~TestEnvironment() {
-    Memory::UnmapRegion(0x80000000, 0x80000000);
-    Memory::UnmapRegion(0x00000000, 0x80000000);
+    Memory::UnmapRegion(page_table, 0x80000000, 0x80000000);
+    Memory::UnmapRegion(page_table, 0x00000000, 0x80000000);
 }
 
 void TestEnvironment::SetMemory64(VAddr vaddr, u64 value) {


### PR DESCRIPTION
This PR also implements a proper Memory::GetPhysicalPointer that doesn't depend on the current process' memory map.

This is just one step towards the ultimate goal of being able to load multiple processes simultaneously in citra.

This PR has a performance regression regarding dynarmic and fast page-table access. It should be reimplemented once dynarmic supports runtime pagetable switches.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2842)
<!-- Reviewable:end -->
