### PR TITLE
 Services/APT: Use an array to hold data about the 4 possible concurrent applet types (Application, Library, HomeMenu, System)

### DIFF
--- a/src/core/hle/service/apt/apt.h
+++ b/src/core/hle/service/apt/apt.h
@@ -72,6 +72,8 @@ enum class SignalType : u32 {
 
 /// App Id's used by APT functions
 enum class AppletId : u32 {
+    None = 0,
+    AnySystemApplet = 0x100,
     HomeMenu = 0x101,
     AlternateMenu = 0x103,
     Camera = 0x110,
@@ -83,6 +85,7 @@ enum class AppletId : u32 {
     Miiverse = 0x117,
     MiiversePost = 0x118,
     AmiiboSettings = 0x119,
+    AnySysLibraryApplet = 0x200,
     SoftwareKeyboard1 = 0x201,
     Ed1 = 0x202,
     PnoteApp = 0x204,
@@ -119,8 +122,9 @@ enum class ScreencapPostPermission : u32 {
 namespace ErrCodes {
 enum {
     ParameterPresent = 2,
+    InvalidAppletSlot = 4,
 };
-}
+} // namespace ErrCodes
 
 /// Send a parameter to the currently-running application, which will read it via ReceiveParameter
 void SendParameter(const MessageParameter& parameter);


### PR DESCRIPTION
This gives each applet type its own set of events as per the real NS module.

This depends on #2840 , reviewers should focus on the last commit only.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2843)
<!-- Reviewable:end -->
