### PR TITLE
Fixed build error "too many initializers for ‘const MacAddress"

### DIFF
--- a/src/network/room.cpp
+++ b/src/network/room.cpp
@@ -19,7 +19,7 @@ static constexpr u32 MaxConcurrentConnections = 10;
 class Room::RoomImpl {
 public:
     // This MAC address is used to generate a 'Nintendo' like Mac address.
-    const MacAddress NintendoOUI = {0x00, 0x1F, 0x32, 0x00, 0x00, 0x00};
+    const MacAddress NintendoOUI;
     std::mt19937 random_gen; ///< Random number generator. Used for GenerateMacAddress
 
     ENetHost* server = nullptr; ///< Network interface.
@@ -36,7 +36,8 @@ public:
     using MemberList = std::vector<Member>;
     MemberList members; ///< Information about the members of this room.
 
-    RoomImpl() : random_gen(std::random_device()()) {}
+    RoomImpl()
+        : random_gen(std::random_device()()), NintendoOUI{0x00, 0x1F, 0x32, 0x00, 0x00, 0x00} {}
 
     /// Thread that receives and dispatches network packets
     std::unique_ptr<std::thread> room_thread;

--- a/src/network/room.h
+++ b/src/network/room.h
@@ -24,7 +24,7 @@ struct RoomInformation {
 using MacAddress = std::array<u8, 6>;
 /// A special MAC address that tells the room we're joining to assign us a MAC address
 /// automatically.
-const MacAddress NoPreferredMac = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+constexpr MacAddress NoPreferredMac = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
 // 802.11 broadcast MAC address
 constexpr MacAddress BroadcastMac = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};


### PR DESCRIPTION
This fixes issue https://community.citra-emu.org/t/latest-nightly-fails-to-make-in-linux/2628.
The main issue is that there is a bug in gcc < 6.0 leading to this error message although the code is by C++11 definition totally legit.
But since a lot of distributions/packages ship as their default gcc version 5.4, this issue should be addressed.

This PR also fixes a const definition the should be a constexpr

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2847)
<!-- Reviewable:end -->
