### PR TITLE
Produce 7zip artifacts on Travis and Appveyor

### DIFF
--- a/.travis-deps.sh
+++ b/.travis-deps.sh
@@ -36,5 +36,5 @@ if [ "$TRAVIS_OS_NAME" = "linux" -o -z "$TRAVIS_OS_NAME" ]; then
 
 elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
     brew update
-    brew install qt5 sdl2 dylibbundler
+    brew install qt5 sdl2 dylibbundler p7zip
 fi

--- a/.travis-upload.sh
+++ b/.travis-upload.sh
@@ -124,6 +124,11 @@ EOL
 
     tar $COMPRESSION_FLAGS "$ARCHIVE_NAME" "$REV_NAME"
 
+    mv "$REV_NAME" nightly
+
+    7z a "$REV_NAME.7z" nightly
+
     # move the compiled archive into the artifacts directory to be uploaded by travis releases
     mv "$ARCHIVE_NAME" artifacts/
+    mv "$REV_NAME.7z" artifacts/
 fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ addons:
       - libqt5opengl5-dev
       - xorg-dev
       - lib32stdc++6 # For CMake
+      - p7zip-full
 
 cache:
   directories:
@@ -33,7 +34,7 @@ deploy:
   api_key:
     secure: Mck15DIWaJdxDiS3aYVlM9N3G6y8VKUI1rnwII7/iolfm1s94U+tgvbheZDmT7SSbFyaGaYO/E8HrV/uZR9Vvs7ev20sHsTN1u60OTWfDIIyHs9SqjhcGbtq95m9/dMFschOYqTOR+gAs5BsxjuoeAotHdhpQEwvkO2oo5oR0zhGy45gjFnVvtcxT/IfpZBIpVgcK3aLb9zT6ekcJbSiPmEB15iLq3xXd0nFUNtEZdX3D6Veye4n5jB6n72qN8JVoKvPZAwaC2K0pZxpcGJaXDchLsw1q+4eCvdz6UJfUemeQ/uMAmjfeQ3wrzYGXe3nCM3WmX5wosCsB0mw4zYatzl3si6CZ1W+0GkV4Rwlx03dfp7v3EeFhTsXYCaXqhwuLZnWOLUik8t9vaSoFUx4nUIRwfO9kAMUJQSpLuHNO2nT01s3GxvqxzczuLQ9he5nGSi0RRodUzDwek1qUp6I4uV3gRHKz4B07YIc1i2fK88NLXjyQ0uLVZ+7Oq1+kgDp6+N7vvXXZ5qZ17tdaysSbKEE0Y8zsoXw7Rk1tPN19vrCS+TSpomNMyQyne1k+I5iZ/qkxPTLAS5qI6Utc2dL3GJdxWRAEfGNO9AIX3GV/jmmKfdcvwGsCYP8hxqs5vLYfgacw3D8NLf1941lQUwavC17jm9EV9g5G3Pn1Cp516E=
   file_glob: true
-  file: "artifacts/*.tar.*"
+  file: "artifacts/*"
   skip_cleanup: true
   on:
     repo: citra-emu/citra-nightly

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,16 +37,25 @@ after_build:
         # Where are these spaces coming from? Regardless, let's remove them
         $MSVC_BUILD_NAME = "citra-windows-msvc-$GITDATE-$GITREV.zip" -replace " ", ""
         $MSVC_BUILD_PDB = "citra-windows-msvc-$GITDATE-$GITREV-debugsymbols.zip" -replace " ", ""
+        $MSVC_SEVENZIP = "citra-windows-msvc-$GITDATE-$GITREV.7z" -replace " ", ""
         $BINTRAY_VERSION = "nightly-$GIT_LONG_HASH" -replace " ", ""
 
         # set the build names as env vars so the artifacts can upload them
         $env:MSVC_BUILD_NAME = $MSVC_BUILD_NAME
         $env:MSVC_BUILD_PDB = $MSVC_BUILD_PDB
+        $env:MSVC_SEVENZIP = $MSVC_SEVENZIP
         $env:GITREV = $GITREV
 
         7z a -tzip $MSVC_BUILD_PDB .\build\bin\release\*.pdb
         rm .\build\bin\release\*.pdb
-        7z a -tzip $MSVC_BUILD_NAME .\build\bin\release\* .\license.txt .\README.md
+
+        mkdir nightly
+        Copy-Item .\build\bin\release\* -Destination nightly -Recurse
+        Copy-Item .\license.txt -Destination nightly
+        Copy-Item .\README.md -Destination nightly
+
+        7z a -tzip $MSVC_BUILD_NAME nightly\*
+        7z a $MSVC_SEVENZIP nightly
 
 test_script:
   - cd build && ctest -VV -C Release && cd ..
@@ -58,6 +67,8 @@ artifacts:
   - path: $(MSVC_BUILD_PDB)
     name: msvcdebug
     type: zip
+  - path: $(MSVC_SEVENZIP)
+    name: msvcupdate
 
 deploy:
   provider: GitHub
@@ -68,7 +79,7 @@ deploy:
     Short Commit Hash $(GITREV)
   auth_token:
     secure: "dbpsMC/MgPKWFNJCXpQl4cR8FYhepkPLjgNp/pRMktZ8oLKTqPYErfreaIxb/4P1"
-  artifact: msvcbuild
+  artifact: msvcupdate,msvcbuild
   draft: false
   prerelease: false
   on:


### PR DESCRIPTION
This PR introduces 7zip artifacts for both the Travis and Appveyor buildbots. This is so that the Qt Installer Framework can actually grab binary files directly from Github.

Why does this make references to nightly, rather then abstract for nightly/bleeding-edge?
Few reasons - the main repository is currently designed exclusively to produce artifacts for nightly. This is something that should hopefully change in a future PR, but that also requires changes on the bleeding edge/canary side, so I will defer that.

Why are subfolders used ("nightly") inside archives?
Qt Installer Framework extracts archives into the root of the installation folder. This allows for clean seperation between nightly & canary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2849)
<!-- Reviewable:end -->
