### PR TITLE
pica: upload shared shader code & swizzle to both unit

### DIFF
--- a/src/video_core/regs_pipeline.h
+++ b/src/video_core/regs_pipeline.h
@@ -202,7 +202,14 @@ struct PipelineRegs {
     /// Number of input attributes to the vertex shader minus 1
     BitField<0, 4, u32> max_input_attrib_index;
 
-    INSERT_PADDING_WORDS(2);
+    INSERT_PADDING_WORDS(1);
+
+    // The shader unit 3, which can be used for both vertex and geometry shader, gets its
+    // configuration depending on this register. If this is not set, unit 3 will share some
+    // configuration with other units. It is known that program code and swizzle pattern uploaded
+    // via regs.vs will be also uploaded to unit 3 if this is not set. Although very likely, it is
+    // still unclear whether uniforms and other configuration can be also shared.
+    BitField<0, 1, u32> gs_unit_exclusive_configuration;
 
     enum class GPUMode : u32 {
         Drawing = 0,


### PR DESCRIPTION
One step toward GS. This is the most tricky finding about GS until now, so I want to put it here for discussion first.

I didn't hwtest the exact behaviour of the register `gs_unit_exclusive_configuration` (0x0244, `GPUREG_VSH_COM_MODE` on [3dbrew](https://www.3dbrew.org/wiki/GPU/Internal_Registers#GPUREG_VSH_COM_MODE)), but as the theory suggested

> This register sets whether to use the geometry shader configuration or reuse the vertex shader configuration for the geometry shader shading unit. 

This means everything uploaded to VS regs should also be uploaded to the special GS unit.
A real use case of this, _Professor Layton and the Miracle Mask_, is found in recent test of GS experimental implementation. A simplified PICA command list the game sends is [here](https://pastebin.com/i0cvfhPC). As can be seen, the game sends both VS & GS program & swizzle via VS regs. Only part of GS program, whose offset excesses the maximum VS program size, is sent via GS regs (which also shows that, even in shared configuration mode, GS regs can still upload code to GS unit)

However, the game doesn't set uniforms in this way, so due to lack of evidence, I leave TODOs for uniform regs. But anyway, even if they behave the same way as program & swizzle, it is much less likely that a game will use it in this way, as the uniform is hard to share the same space between VS and GS.

Questions
 - Is there anyway to easily test this? ctrulib is managing this register depending on shader type, so I can't make program in a standard way to test this.
 - Should I use the register name "vs(h)_com_mode" instead? or some other better name?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2856)
<!-- Reviewable:end -->
