### PR TITLE
Travis/AppVeyor: Deploy based upon tags

### DIFF
--- a/.travis-upload.sh
+++ b/.travis-upload.sh
@@ -1,134 +1,132 @@
-if [ "$TRAVIS_EVENT_TYPE" = "push" ]&&[ "$TRAVIS_BRANCH" = "master" ]; then
-    GITDATE="`git show -s --date=short --format='%ad' | sed 's/-//g'`"
-    GITREV="`git show -s --format='%h'`"
-    mkdir -p artifacts
+GITDATE="`git show -s --date=short --format='%ad' | sed 's/-//g'`"
+GITREV="`git show -s --format='%h'`"
+mkdir -p artifacts
 
-    if [ "$TRAVIS_OS_NAME" = "linux" -o -z "$TRAVIS_OS_NAME" ]; then
-        REV_NAME="citra-linux-${GITDATE}-${GITREV}"
-        ARCHIVE_NAME="${REV_NAME}.tar.xz"
-        COMPRESSION_FLAGS="-cJvf"
-        mkdir "$REV_NAME"
+if [ "$TRAVIS_OS_NAME" = "linux" -o -z "$TRAVIS_OS_NAME" ]; then
+    REV_NAME="citra-linux-${GITDATE}-${GITREV}"
+    ARCHIVE_NAME="${REV_NAME}.tar.xz"
+    COMPRESSION_FLAGS="-cJvf"
+    mkdir "$REV_NAME"
 
-        cp build/src/citra/citra "$REV_NAME"
-        cp build/src/citra_qt/citra-qt "$REV_NAME"
-    elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
-        REV_NAME="citra-osx-${GITDATE}-${GITREV}"
-        ARCHIVE_NAME="${REV_NAME}.tar.gz"
-        COMPRESSION_FLAGS="-czvf"
-        mkdir "$REV_NAME"
+    cp build/src/citra/citra "$REV_NAME"
+    cp build/src/citra_qt/citra-qt "$REV_NAME"
+elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
+    REV_NAME="citra-osx-${GITDATE}-${GITREV}"
+    ARCHIVE_NAME="${REV_NAME}.tar.gz"
+    COMPRESSION_FLAGS="-czvf"
+    mkdir "$REV_NAME"
 
-        cp build/src/citra/Release/citra "$REV_NAME"
-        cp -r build/src/citra_qt/Release/citra-qt.app "$REV_NAME"
+    cp build/src/citra/Release/citra "$REV_NAME"
+    cp -r build/src/citra_qt/Release/citra-qt.app "$REV_NAME"
 
-        # move qt libs into app bundle for deployment
-        $(brew --prefix)/opt/qt5/bin/macdeployqt "${REV_NAME}/citra-qt.app"
+    # move qt libs into app bundle for deployment
+    $(brew --prefix)/opt/qt5/bin/macdeployqt "${REV_NAME}/citra-qt.app"
 
-        # move SDL2 libs into folder for deployment
-        dylibbundler -b -x "${REV_NAME}/citra" -cd -d "${REV_NAME}/libs" -p "@executable_path/libs/"
+    # move SDL2 libs into folder for deployment
+    dylibbundler -b -x "${REV_NAME}/citra" -cd -d "${REV_NAME}/libs" -p "@executable_path/libs/"
 
-        # Make the changes to make the citra-qt app standalone (i.e. not dependent on the current brew installation).
-        # To do this, the absolute references to each and every QT framework must be re-written to point to the local frameworks
-        # (in the Contents/Frameworks folder).
-        # The "install_name_tool" is used to do so.
+    # Make the changes to make the citra-qt app standalone (i.e. not dependent on the current brew installation).
+    # To do this, the absolute references to each and every QT framework must be re-written to point to the local frameworks
+    # (in the Contents/Frameworks folder).
+    # The "install_name_tool" is used to do so.
 
-        # Coreutils is a hack to coerce Homebrew to point to the absolute Cellar path (symlink dereferenced). i.e:
-        # ls -l /usr/local/opt/qt5:: /usr/local/opt/qt5 -> ../Cellar/qt5/5.6.1-1
-        # grealpath ../Cellar/qt5/5.6.1-1:: /usr/local/Cellar/qt5/5.6.1-1
-        brew install coreutils
+    # Coreutils is a hack to coerce Homebrew to point to the absolute Cellar path (symlink dereferenced). i.e:
+    # ls -l /usr/local/opt/qt5:: /usr/local/opt/qt5 -> ../Cellar/qt5/5.6.1-1
+    # grealpath ../Cellar/qt5/5.6.1-1:: /usr/local/Cellar/qt5/5.6.1-1
+    brew install coreutils
 
-        REV_NAME_ALT=$REV_NAME/
-        # grealpath is located in coreutils, there is no "realpath" for OS X :(
-        QT_BREWS_PATH=$(grealpath "$(brew --prefix qt5)")
-        BREW_PATH=$(brew --prefix)
-        QT_VERSION_NUM=5
+    REV_NAME_ALT=$REV_NAME/
+    # grealpath is located in coreutils, there is no "realpath" for OS X :(
+    QT_BREWS_PATH=$(grealpath "$(brew --prefix qt5)")
+    BREW_PATH=$(brew --prefix)
+    QT_VERSION_NUM=5
 
-        $BREW_PATH/opt/qt5/bin/macdeployqt "${REV_NAME_ALT}citra-qt.app" \
-            -executable="${REV_NAME_ALT}citra-qt.app/Contents/MacOS/citra-qt"
+    $BREW_PATH/opt/qt5/bin/macdeployqt "${REV_NAME_ALT}citra-qt.app" \
+        -executable="${REV_NAME_ALT}citra-qt.app/Contents/MacOS/citra-qt"
 
-        # These are the files that macdeployqt packed into Contents/Frameworks/ - we don't want those, so we replace them.
-        declare -a macos_libs=("QtCore" "QtWidgets" "QtGui" "QtOpenGL" "QtPrintSupport")
+    # These are the files that macdeployqt packed into Contents/Frameworks/ - we don't want those, so we replace them.
+    declare -a macos_libs=("QtCore" "QtWidgets" "QtGui" "QtOpenGL" "QtPrintSupport")
 
-        for macos_lib in "${macos_libs[@]}"
+    for macos_lib in "${macos_libs[@]}"
+    do
+        SC_FRAMEWORK_PART=$macos_lib.framework/Versions/$QT_VERSION_NUM/$macos_lib
+        # Replace macdeployqt versions of the Frameworks with our own (from /usr/local/opt/qt5/lib/)
+        cp "$BREW_PATH/opt/qt5/lib/$SC_FRAMEWORK_PART" "${REV_NAME_ALT}citra-qt.app/Contents/Frameworks/$SC_FRAMEWORK_PART"
+
+        # Replace references within the embedded Framework files with "internal" versions.
+        for macos_lib2 in "${macos_libs[@]}"
         do
-            SC_FRAMEWORK_PART=$macos_lib.framework/Versions/$QT_VERSION_NUM/$macos_lib
-            # Replace macdeployqt versions of the Frameworks with our own (from /usr/local/opt/qt5/lib/)
-            cp "$BREW_PATH/opt/qt5/lib/$SC_FRAMEWORK_PART" "${REV_NAME_ALT}citra-qt.app/Contents/Frameworks/$SC_FRAMEWORK_PART"
-
-            # Replace references within the embedded Framework files with "internal" versions.
-            for macos_lib2 in "${macos_libs[@]}"
-            do
-                # Since brew references both the non-symlinked and symlink paths of QT5, it needs to be duplicated.
-                # /usr/local/Cellar/qt5/5.6.1-1/lib and /usr/local/opt/qt5/lib both resolve to the same files.
-                # So the two lines below are effectively duplicates when resolved as a path, but as strings, they aren't.
-                RM_FRAMEWORK_PART=$macos_lib2.framework/Versions/$QT_VERSION_NUM/$macos_lib2
-                install_name_tool -change \
-                    $QT_BREWS_PATH/lib/$RM_FRAMEWORK_PART \
-                    @executable_path/../Frameworks/$RM_FRAMEWORK_PART \
-                    "${REV_NAME_ALT}citra-qt.app/Contents/Frameworks/$SC_FRAMEWORK_PART"
-                install_name_tool -change \
-                    "$BREW_PATH/opt/qt5/lib/$RM_FRAMEWORK_PART" \
-                    @executable_path/../Frameworks/$RM_FRAMEWORK_PART \
-                    "${REV_NAME_ALT}citra-qt.app/Contents/Frameworks/$SC_FRAMEWORK_PART"
-            done
+            # Since brew references both the non-symlinked and symlink paths of QT5, it needs to be duplicated.
+            # /usr/local/Cellar/qt5/5.6.1-1/lib and /usr/local/opt/qt5/lib both resolve to the same files.
+            # So the two lines below are effectively duplicates when resolved as a path, but as strings, they aren't.
+            RM_FRAMEWORK_PART=$macos_lib2.framework/Versions/$QT_VERSION_NUM/$macos_lib2
+            install_name_tool -change \
+                $QT_BREWS_PATH/lib/$RM_FRAMEWORK_PART \
+                @executable_path/../Frameworks/$RM_FRAMEWORK_PART \
+                "${REV_NAME_ALT}citra-qt.app/Contents/Frameworks/$SC_FRAMEWORK_PART"
+            install_name_tool -change \
+                "$BREW_PATH/opt/qt5/lib/$RM_FRAMEWORK_PART" \
+                @executable_path/../Frameworks/$RM_FRAMEWORK_PART \
+                "${REV_NAME_ALT}citra-qt.app/Contents/Frameworks/$SC_FRAMEWORK_PART"
         done
+    done
 
-        # Handles `This application failed to start because it could not find or load the Qt platform plugin "cocoa"`
-        # Which manifests itself as:
-        # "Exception Type: EXC_CRASH (SIGABRT) | Exception Codes: 0x0000000000000000, 0x0000000000000000 | Exception Note: EXC_CORPSE_NOTIFY"
-        # There may be more dylibs needed to be fixed...
-        declare -a macos_plugins=("Plugins/platforms/libqcocoa.dylib")
+    # Handles `This application failed to start because it could not find or load the Qt platform plugin "cocoa"`
+    # Which manifests itself as:
+    # "Exception Type: EXC_CRASH (SIGABRT) | Exception Codes: 0x0000000000000000, 0x0000000000000000 | Exception Note: EXC_CORPSE_NOTIFY"
+    # There may be more dylibs needed to be fixed...
+    declare -a macos_plugins=("Plugins/platforms/libqcocoa.dylib")
 
-        for macos_lib in "${macos_plugins[@]}"
+    for macos_lib in "${macos_plugins[@]}"
+    do
+        install_name_tool -id @executable_path/../$macos_lib "${REV_NAME_ALT}citra-qt.app/Contents/$macos_lib"
+        for macos_lib2 in "${macos_libs[@]}"
         do
-            install_name_tool -id @executable_path/../$macos_lib "${REV_NAME_ALT}citra-qt.app/Contents/$macos_lib"
-            for macos_lib2 in "${macos_libs[@]}"
-            do
-                RM_FRAMEWORK_PART=$macos_lib2.framework/Versions/$QT_VERSION_NUM/$macos_lib2
-                install_name_tool -change \
-                    $QT_BREWS_PATH/lib/$RM_FRAMEWORK_PART \
-                    @executable_path/../Frameworks/$RM_FRAMEWORK_PART \
-                    "${REV_NAME_ALT}citra-qt.app/Contents/$macos_lib"
-                install_name_tool -change \
-                    "$BREW_PATH/opt/qt5/lib/$RM_FRAMEWORK_PART" \
-                    @executable_path/../Frameworks/$RM_FRAMEWORK_PART \
-                    "${REV_NAME_ALT}citra-qt.app/Contents/$macos_lib"
-            done
+            RM_FRAMEWORK_PART=$macos_lib2.framework/Versions/$QT_VERSION_NUM/$macos_lib2
+            install_name_tool -change \
+                $QT_BREWS_PATH/lib/$RM_FRAMEWORK_PART \
+                @executable_path/../Frameworks/$RM_FRAMEWORK_PART \
+                "${REV_NAME_ALT}citra-qt.app/Contents/$macos_lib"
+            install_name_tool -change \
+                "$BREW_PATH/opt/qt5/lib/$RM_FRAMEWORK_PART" \
+                @executable_path/../Frameworks/$RM_FRAMEWORK_PART \
+                "${REV_NAME_ALT}citra-qt.app/Contents/$macos_lib"
         done
+    done
 
-        for macos_lib in "${macos_libs[@]}"
-        do
-            # Debugging info for Travis-CI
-            otool -L "${REV_NAME_ALT}citra-qt.app/Contents/Frameworks/$macos_lib.framework/Versions/$QT_VERSION_NUM/$macos_lib"
-        done
+    for macos_lib in "${macos_libs[@]}"
+    do
+        # Debugging info for Travis-CI
+        otool -L "${REV_NAME_ALT}citra-qt.app/Contents/Frameworks/$macos_lib.framework/Versions/$QT_VERSION_NUM/$macos_lib"
+    done
 
-        # Make the citra-qt.app application launch a debugging terminal.
-        # Store away the actual binary
-        mv ${REV_NAME_ALT}citra-qt.app/Contents/MacOS/citra-qt ${REV_NAME_ALT}citra-qt.app/Contents/MacOS/citra-qt-bin
+    # Make the citra-qt.app application launch a debugging terminal.
+    # Store away the actual binary
+    mv ${REV_NAME_ALT}citra-qt.app/Contents/MacOS/citra-qt ${REV_NAME_ALT}citra-qt.app/Contents/MacOS/citra-qt-bin
 
-        cat > ${REV_NAME_ALT}citra-qt.app/Contents/MacOS/citra-qt <<EOL
+    cat > ${REV_NAME_ALT}citra-qt.app/Contents/MacOS/citra-qt <<EOL
 #!/usr/bin/env bash
 cd "\`dirname "\$0"\`"
 chmod +x citra-qt-bin
 open citra-qt-bin --args "\$@"
 EOL
-        # Content that will serve as the launching script for citra (within the .app folder)
+    # Content that will serve as the launching script for citra (within the .app folder)
 
-        # Make the launching script executable
-        chmod +x ${REV_NAME_ALT}citra-qt.app/Contents/MacOS/citra-qt
+    # Make the launching script executable
+    chmod +x ${REV_NAME_ALT}citra-qt.app/Contents/MacOS/citra-qt
 
-    fi
-
-    # Copy documentation
-    cp license.txt "$REV_NAME"
-    cp README.md "$REV_NAME"
-
-    tar $COMPRESSION_FLAGS "$ARCHIVE_NAME" "$REV_NAME"
-
-    mv "$REV_NAME" nightly
-
-    7z a "$REV_NAME.7z" nightly
-
-    # move the compiled archive into the artifacts directory to be uploaded by travis releases
-    mv "$ARCHIVE_NAME" artifacts/
-    mv "$REV_NAME.7z" artifacts/
 fi
+
+# Copy documentation
+cp license.txt "$REV_NAME"
+cp README.md "$REV_NAME"
+
+tar $COMPRESSION_FLAGS "$ARCHIVE_NAME" "$REV_NAME"
+
+mv "$REV_NAME" nightly
+
+7z a "$REV_NAME.7z" nightly
+
+# move the compiled archive into the artifacts directory to be uploaded by travis releases
+mv "$ARCHIVE_NAME" artifacts/
+mv "$REV_NAME.7z" artifacts/

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,4 +37,4 @@ deploy:
   file: "artifacts/*"
   skip_cleanup: true
   on:
-    repo: citra-emu/citra-nightly
+    tags: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,6 @@
 # shallow clone
 clone_depth: 10
 
-# don't build on tag
-skip_tags: true
-
 cache:
   - C:\ProgramData\chocolatey\bin -> appveyor.yml
   - C:\ProgramData\chocolatey\lib -> appveyor.yml
@@ -72,16 +69,11 @@ artifacts:
 
 deploy:
   provider: GitHub
-  release: nightly-$(appveyor_build_number)
-  description: |
-    Citra nightly releases. Please choose the correct download for your operating system from the list below.
-
-    Short Commit Hash $(GITREV)
+  release: $(appveyor_repo_tag_name)
   auth_token:
     secure: "dbpsMC/MgPKWFNJCXpQl4cR8FYhepkPLjgNp/pRMktZ8oLKTqPYErfreaIxb/4P1"
   artifact: msvcupdate,msvcbuild
   draft: false
   prerelease: false
   on:
-    branch: master
-    appveyor_repo_name: citra-emu/citra-nightly
+    appveyor_repo_tag: true


### PR DESCRIPTION
Previously, Citra would deploy when it was on `citra-emu/citra-nightly`. This hardcoded branch meant that building bleeding-edge/canary required a dedicated patchset, and that references to tags could not be used (both AppVeyor and Travis only support `branch` filtering or `tags`, not both).

This fixes this, by deploying only when a tag has been specified. This has a host of advantages:
- Nightly and canary no longer need to have their own independent build scripts.
- Tags can be created as required (which includes `citra-emu/citra` itself, if "stable" builds wanted to be created), and individual pushes won't cause the entire system to collapse.
- This fixes the race condition between Travis and AppVeyor.

This introduces a few issues:
- Webhooks need to be fixed (nightly is ready, be/canary is coming)
- Both AppVeyor and Travis build both for a commit, and for a tag. I haven't disabled this by default, as Travis/etc is also used for testing. Travis builds fine in parallel, but AppVeyor builds are now delayed by ~10 minutes, depending on if the commit builds first, or if the tag does.

This disables checking for the kind of task that we are building in the Travis upload task - this doesn't actually do any uploading for itself, and uploads are filtered by Travis itself. This doesn't really hurt normal builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2857)
<!-- Reviewable:end -->
