### PR TITLE
Quickfix typo in OpenGL 3.3 error message

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -311,7 +311,7 @@ bool GMainWindow::LoadROM(const QString& filename) {
 
     if (!gladLoadGL()) {
         QMessageBox::critical(this, tr("Error while initializing OpenGL 3.3 Core!"),
-                              tr("Your GPU may not support OpenGL 3.3, or you do not"
+                              tr("Your GPU may not support OpenGL 3.3, or you do not "
                                  "have the latest graphics driver."));
         return false;
     }


### PR DESCRIPTION
User pointed out on the Discord server that "nothave" is erroneously concatenated. Added a space to prevent it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2860)
<!-- Reviewable:end -->
