### PR TITLE
HID: zero unused PadState bits

### DIFF
--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -24,7 +24,7 @@ namespace HID {
  */
 struct PadState {
     union {
-        u32 hex;
+        u32 hex{};
 
         BitField<0, 1, u32> a;
         BitField<1, 1, u32> b;

--- a/src/core/hle/service/ir/ir_rst.cpp
+++ b/src/core/hle/service/ir/ir_rst.cpp
@@ -18,7 +18,7 @@ namespace Service {
 namespace IR {
 
 union PadState {
-    u32_le hex;
+    u32_le hex{};
 
     BitField<14, 1, u32_le> zl;
     BitField<15, 1, u32_le> zr;


### PR DESCRIPTION
Unused PadState bits usually means nothing to commercial games, but some homebrew programs (such as devkitPro-3ds-examples/input/read-controls) assume they are all zero.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2863)
<!-- Reviewable:end -->
