### PR TITLE
Added batch fix in command_processor; Make it optional (opt-out)

### DIFF
--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -87,6 +87,7 @@ void Config::ReadValues() {
     Settings::values.use_vsync = sdl2_config->GetBoolean("Renderer", "use_vsync", false);
     Settings::values.toggle_framelimit =
         sdl2_config->GetBoolean("Renderer", "toggle_framelimit", true);
+    Settings::values.use_batch_fix = sdl2_config->GetBoolean("Renderer", "use_batch_fix", true);
 
     Settings::values.bg_red = (float)sdl2_config->GetReal("Renderer", "bg_red", 0.0);
     Settings::values.bg_green = (float)sdl2_config->GetReal("Renderer", "bg_green", 0.0);

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -109,6 +109,10 @@ custom_bottom_bottom =
 # 0: Off , 1  (default): On
 toggle_framelimit =
 
+#Enable batch fix.
+# 0: Off , 1  (default): On
+use_batch_fix =
+
 # Swaps the prominent screen with the other screen.
 # For example, if Single Screen is chosen, setting this to 1 will display the bottom screen instead of the top screen.
 # 0 (default): Top Screen is prominent, 1: Bottom Screen is prominent

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -69,6 +69,7 @@ void Config::ReadValues() {
     Settings::values.resolution_factor = qt_config->value("resolution_factor", 1.0).toFloat();
     Settings::values.use_vsync = qt_config->value("use_vsync", false).toBool();
     Settings::values.toggle_framelimit = qt_config->value("toggle_framelimit", true).toBool();
+    Settings::values.use_batch_fix = qt_config->value("use_batch_fix", true).toBool();
 
     Settings::values.bg_red = qt_config->value("bg_red", 0.0).toFloat();
     Settings::values.bg_green = qt_config->value("bg_green", 0.0).toFloat();
@@ -215,6 +216,7 @@ void Config::SaveValues() {
     qt_config->setValue("resolution_factor", (double)Settings::values.resolution_factor);
     qt_config->setValue("use_vsync", Settings::values.use_vsync);
     qt_config->setValue("toggle_framelimit", Settings::values.toggle_framelimit);
+    qt_config->setValue("use_batch_fix", Settings::values.use_batch_fix);
 
     // Cast to double because Qt's written float values are not human-readable
     qt_config->setValue("bg_red", (double)Settings::values.bg_red);

--- a/src/citra_qt/configuration/configure_graphics.cpp
+++ b/src/citra_qt/configuration/configure_graphics.cpp
@@ -97,6 +97,7 @@ void ConfigureGraphics::setConfiguration() {
         static_cast<int>(FromResolutionFactor(Settings::values.resolution_factor)));
     ui->toggle_vsync->setChecked(Settings::values.use_vsync);
     ui->toggle_framelimit->setChecked(Settings::values.toggle_framelimit);
+    ui->use_batch_fix->setChecked(Settings::values.use_batch_fix);
     ui->layout_combobox->setCurrentIndex(static_cast<int>(Settings::values.layout_option));
     ui->swap_screen->setChecked(Settings::values.swap_screen);
 }
@@ -108,6 +109,7 @@ void ConfigureGraphics::applyConfiguration() {
         ToResolutionFactor(static_cast<Resolution>(ui->resolution_factor_combobox->currentIndex()));
     Settings::values.use_vsync = ui->toggle_vsync->isChecked();
     Settings::values.toggle_framelimit = ui->toggle_framelimit->isChecked();
+    Settings::values.use_batch_fix = ui->use_batch_fix->isChecked();
     Settings::values.layout_option =
         static_cast<Settings::LayoutOption>(ui->layout_combobox->currentIndex());
     Settings::values.swap_screen = ui->swap_screen->isChecked();

--- a/src/citra_qt/configuration/configure_graphics.ui
+++ b/src/citra_qt/configuration/configure_graphics.ui
@@ -51,6 +51,13 @@
          </widget>
         </item>
         <item>
+         <widget class="QCheckBox" name="use_batch_fix">
+          <property name="text">
+           <string>Batch Fix</string>
+          </property>
+         </widget>
+        </item>
+        <item>
           <layout class="QHBoxLayout" name="horizontalLayout">
             <item>
               <widget class="QLabel" name="label">

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -23,6 +23,7 @@ void Apply() {
     VideoCore::g_hw_renderer_enabled = values.use_hw_renderer;
     VideoCore::g_shader_jit_enabled = values.use_shader_jit;
     VideoCore::g_toggle_framelimit_enabled = values.toggle_framelimit;
+    VideoCore::g_batch_fix_enabled = values.use_batch_fix;
 
     if (VideoCore::g_emu_window) {
         auto layout = VideoCore::g_emu_window->GetFramebufferLayout();

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -95,6 +95,7 @@ struct Values {
     float resolution_factor;
     bool use_vsync;
     bool toggle_framelimit;
+    bool use_batch_fix;
 
     LayoutOption layout_option;
     bool swap_screen;

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -94,6 +94,8 @@ TelemetrySession::TelemetrySession() {
              Settings::values.resolution_factor);
     AddField(Telemetry::FieldType::UserConfig, "Renderer_ToggleFramelimit",
              Settings::values.toggle_framelimit);
+    AddField(Telemetry::FieldType::UserConfig, "Renderer_UseBatchFix",
+             Settings::values.use_batch_fix);
     AddField(Telemetry::FieldType::UserConfig, "Renderer_UseHwRenderer",
              Settings::values.use_hw_renderer);
     AddField(Telemetry::FieldType::UserConfig, "Renderer_UseShaderJit",

--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -398,6 +398,13 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
                                                       range.second, range.first);
         }
 
+        if (VideoCore::g_batch_fix_enabled) {
+            VideoCore::g_renderer->Rasterizer()->DrawTriangles();
+            if (g_debug_context) {
+                g_debug_context->OnEvent(DebugContext::Event::FinishedPrimitiveBatch, nullptr);
+            }
+        }
+
         break;
     }
 

--- a/src/video_core/video_core.cpp
+++ b/src/video_core/video_core.cpp
@@ -21,6 +21,7 @@ std::atomic<bool> g_hw_renderer_enabled;
 std::atomic<bool> g_shader_jit_enabled;
 std::atomic<bool> g_vsync_enabled;
 std::atomic<bool> g_toggle_framelimit_enabled;
+std::atomic<bool> g_batch_fix_enabled;
 
 /// Initialize the video core
 bool Init(EmuWindow* emu_window) {

--- a/src/video_core/video_core.h
+++ b/src/video_core/video_core.h
@@ -23,6 +23,7 @@ extern EmuWindow* g_emu_window;                  ///< Emu window
 extern std::atomic<bool> g_hw_renderer_enabled;
 extern std::atomic<bool> g_shader_jit_enabled;
 extern std::atomic<bool> g_toggle_framelimit_enabled;
+extern std::atomic<bool> g_batch_fix_enabled;
 
 /// Start the video core
 void Start();


### PR DESCRIPTION
This fix resides inside BE since Oct. 2016 (credit to @JayFoxRox ). It fixes some graphical glitches (e.g. #2791, #1681)
This fix should also be in nightly and canary.

Since for most games it adds unnecessary draws, I added an option in the settings to disable the fix. By default batch_fix is enabled, thus BE users won't even recognize the change. 
I tested it with some games and couldn't see any slowdowns (maybe 1 fps). 

With batch_fix:
<img width="391" alt="bildschirmfoto 2017-08-10 um 08 15 40" src="https://user-images.githubusercontent.com/26032316/29157166-eede716e-7da5-11e7-90f2-626642f08d21.png">

Without batch_fix:
<img width="397" alt="bildschirmfoto 2017-08-10 um 08 17 01" src="https://user-images.githubusercontent.com/26032316/29157167-f255475a-7da5-11e7-95ef-089ee302cff8.png">

The option for enable/disable the batch fix in qt is located together with the other video settings:
<img width="568" alt="bildschirmfoto 2017-08-10 um 08 17 24" src="https://user-images.githubusercontent.com/26032316/29157223-2a1a49a6-7da6-11e7-8173-02a264f62e8a.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2866)
<!-- Reviewable:end -->
