### PR TITLE
Implement correct folder structure for CI builds

### DIFF
--- a/.travis-upload.sh
+++ b/.travis-upload.sh
@@ -123,9 +123,16 @@ cp README.md "$REV_NAME"
 
 tar $COMPRESSION_FLAGS "$ARCHIVE_NAME" "$REV_NAME"
 
-mv "$REV_NAME" nightly
+# Find out what release we are building
+if [ -z $TRAVIS_TAG ]; then
+    RELEASE_NAME=head
+else
+    RELEASE_NAME=$(echo $TRAVIS_TAG | cut -d- -f1)
+fi
 
-7z a "$REV_NAME.7z" nightly
+mv "$REV_NAME" $RELEASE_NAME
+
+7z a "$REV_NAME.7z" $RELEASE_NAME
 
 # move the compiled archive into the artifacts directory to be uploaded by travis releases
 mv "$ARCHIVE_NAME" artifacts/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,13 +46,21 @@ after_build:
         7z a -tzip $MSVC_BUILD_PDB .\build\bin\release\*.pdb
         rm .\build\bin\release\*.pdb
 
-        mkdir nightly
-        Copy-Item .\build\bin\release\* -Destination nightly -Recurse
-        Copy-Item .\license.txt -Destination nightly
-        Copy-Item .\README.md -Destination nightly
+        # Find out which kind of release we are producing by tag name
+        if ($env:APPVEYOR_REPO_TAG_NAME) {
+            $RELEASE_DIST, $RELEASE_VERSION = $env:APPVEYOR_REPO_TAG_NAME.split('-')
+        } else {
+            # There is no repo tag - make assumptions
+            $RELEASE_DIST = "head"
+        }
 
-        7z a -tzip $MSVC_BUILD_NAME nightly\*
-        7z a $MSVC_SEVENZIP nightly
+        mkdir $RELEASE_DIST
+        Copy-Item .\build\bin\release\* -Destination $RELEASE_DIST -Recurse
+        Copy-Item .\license.txt -Destination $RELEASE_DIST
+        Copy-Item .\README.md -Destination $RELEASE_DIST
+
+        7z a -tzip $MSVC_BUILD_NAME $RELEASE_DIST\*
+        7z a $MSVC_SEVENZIP $RELEASE_DIST
 
 test_script:
   - cd build && ctest -VV -C Release && cd ..


### PR DESCRIPTION
This generates the correct folder structure for QtIFW builds from the tag name.

Tag -> folder conversion:

Tag name    |  Folder name
------------- | --------------
canary-212  |   canary
nightly-999 |  nightly
nightly        |  nightly
\<undef\>     |  head

Overall directory structure:
```
C:\Program Files\Citra: (or Linux/Mac equiv.)
    nightly:
        citra[.exe]
        citra-qt[.exe]
        ...
    canary:
        citra[.exe]
        citra-qt[.exe]
        ...
    <folder name>:
        citra[.exe]
        citra-qt[.exe]
        ...
    maintenancetool[.exe]
    ...
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2867)
<!-- Reviewable:end -->
