### PR TITLE
SwRasterizer/Lighting: use make_tuple instead of constructor

### DIFF
--- a/src/video_core/swrasterizer/lighting.cpp
+++ b/src/video_core/swrasterizer/lighting.cpp
@@ -244,7 +244,7 @@ std::tuple<Math::Vec4<u8>, Math::Vec4<u8>> ComputeFragmentsColors(
                                          MathUtil::Clamp(specular_sum.z, 0.0f, 1.0f) * 255,
                                          MathUtil::Clamp(specular_sum.w, 0.0f, 1.0f) * 255)
                         .Cast<u8>();
-    return {diffuse, specular};
+    return std::make_tuple(diffuse, specular);
 }
 
 } // namespace Pica


### PR DESCRIPTION
implicit tuple constructor is c++17 thing, which is not supported by some not-so-old libraries (for example, the one with gcc5). Play safe for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2868)
<!-- Reviewable:end -->
