### PR TITLE
Travis: Use Docker to build for Linux

### DIFF
--- a/.travis-build-docker.sh
+++ b/.travis-build-docker.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -e
+set -x
+
+cd /citra
+
+apt-get update
+apt-get install -y build-essential libsdl2-dev qtbase5-dev libqt5opengl5-dev libcurl4-openssl-dev libssl-dev wget git
+
+# Get a recent version of CMake
+wget https://cmake.org/files/v3.9/cmake-3.9.0-Linux-x86_64.sh
+echo y | sh cmake-3.9.0-Linux-x86_64.sh --prefix=cmake
+export PATH=/citra/cmake/cmake-3.9.0-Linux-x86_64/bin:$PATH
+
+mkdir build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release
+make -j4
+
+ctest -VV -C Release

--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -44,15 +44,7 @@ fi
 
 #if OS is linux or is not set
 if [ "$TRAVIS_OS_NAME" = "linux" -o -z "$TRAVIS_OS_NAME" ]; then
-    export CC=gcc-6
-    export CXX=g++-6
-    export PKG_CONFIG_PATH=$HOME/.local/lib/pkgconfig:$PKG_CONFIG_PATH
-
-    mkdir build && cd build
-    cmake ..
-    make -j4
-
-    ctest -VV -C Release
+    docker run -v $(pwd):/citra ubuntu:16.04 /bin/bash /citra/.travis-build-docker.sh
 elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
     set -o pipefail
 

--- a/.travis-deps.sh
+++ b/.travis-deps.sh
@@ -5,35 +5,7 @@ set -x
 
 #if OS is linux or is not set
 if [ "$TRAVIS_OS_NAME" = "linux" -o -z "$TRAVIS_OS_NAME" ]; then
-    export CC=gcc-6
-    export CXX=g++-6
-    mkdir -p $HOME/.local
-
-    if [ ! -e $HOME/.local/bin/cmake ]; then
-        echo "CMake not found in the cache, get and extract it..."
-        curl -L http://www.cmake.org/files/v3.6/cmake-3.6.3-Linux-x86_64.tar.gz \
-            | tar -xz -C $HOME/.local --strip-components=1
-    else
-        echo "Using cached CMake"
-    fi
-
-    if [ ! -e $HOME/.local/lib/libSDL2.la ]; then
-        echo "SDL2 not found in cache, get and build it..."
-        wget http://libsdl.org/release/SDL2-2.0.5.tar.gz -O - | tar xz
-        cd SDL2-2.0.5
-        ./configure --prefix=$HOME/.local
-        make -j4 && make install
-    else
-        echo "Using cached SDL2"
-    fi
-
-    export DEBIAN_FRONTEND=noninteractive
-    # Amazing placebo security
-    curl http://apt.llvm.org/llvm-snapshot.gpg.key | sudo -E apt-key add -
-    sudo -E add-apt-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main"
-    sudo -E apt-get -yq update
-    sudo -E apt-get -yq install clang-format-3.9
-
+    docker pull ubuntu:16.04
 elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
     brew update
     brew install qt5 sdl2 dylibbundler p7zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,22 +8,14 @@ matrix:
       sudo: false
       osx_image: xcode7.3
 
+services:
+  - docker
+
 addons:
   apt:
-    sources:
-      - ubuntu-toolchain-r-test
     packages:
-      - gcc-6
-      - g++-6
-      - qt5-default
-      - libqt5opengl5-dev
-      - xorg-dev
-      - lib32stdc++6 # For CMake
+      - clang-format-3.9
       - p7zip-full
-
-cache:
-  directories:
-    - "$HOME/.local"
 
 install: "./.travis-deps.sh"
 script: "./.travis-build.sh"


### PR DESCRIPTION
Travis seems to be sticking to Ubuntu 14.04 for the next century, so this PR implements Docker as a means to get around that. A standard Ubuntu 16.04 image from the Docker repository is used, and there is no need for hacked up PPAs/etc. This adds a minute or two of additional build time.

This fixes Linux builds not finding the correct versions of linked libraries, and ensures that we are using `libpng16` as well. This has been tested on Arch (02/08/17) and Ubuntu 16.04.

This also has the additional benefit of allowing Docker images of different distributions to be used, if that was a requirement (Debian, Ubuntu 17.04, etc).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2869)
<!-- Reviewable:end -->
