### PR TITLE
dsp_dsp: Remove size assertion in LoadComponent

### DIFF
--- a/src/core/hle/service/dsp_dsp.cpp
+++ b/src/core/hle/service/dsp_dsp.cpp
@@ -147,9 +147,10 @@ static void LoadComponent(Service::Interface* self) {
     LOG_INFO(Service_DSP, "Firmware hash: %#" PRIx64,
              Common::ComputeHash64(component_data.data(), component_data.size()));
     // Some versions of the firmware have the location of DSP structures listed here.
-    ASSERT(size > 0x37C);
-    LOG_INFO(Service_DSP, "Structures hash: %#" PRIx64,
-             Common::ComputeHash64(component_data.data() + 0x340, 60));
+    if (size > 0x37C) {
+        LOG_INFO(Service_DSP, "Structures hash: %#" PRIx64,
+                 Common::ComputeHash64(component_data.data() + 0x340, 60));
+    }
 
     LOG_WARNING(Service_DSP,
                 "(STUBBED) called size=0x%X, prog_mask=0x%08X, data_mask=0x%08X, buffer=0x%08X",


### PR DESCRIPTION
It is possible to write DSP firmware that's smaller than 0x37C bytes in size.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2881)
<!-- Reviewable:end -->
