### PR TITLE
motion_emu: fix initialization order

### DIFF
--- a/src/input_common/motion_emu.cpp
+++ b/src/input_common/motion_emu.cpp
@@ -74,10 +74,13 @@ private:
     bool is_tilting = false;
 
     Common::Event shutdown_event;
-    std::thread motion_emu_thread;
 
     std::tuple<Math::Vec3<float>, Math::Vec3<float>> status;
     std::mutex status_mutex;
+
+    // Note: always keep the thread declaration at the end so that other objects are initialized
+    // before this!
+    std::thread motion_emu_thread;
 
     void MotionEmuThread() {
         auto update_time = std::chrono::steady_clock::now();


### PR DESCRIPTION
Sorry, this is a flaw from #2861 . The thread is initialized before `status_mutex` and can run fast enough to access the uninitialized mutex.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2894)
<!-- Reviewable:end -->
