### PR TITLE
Groundwork for Screenshot functionality

### DIFF
--- a/src/citra/emu_window/emu_window_sdl2.cpp
+++ b/src/citra/emu_window/emu_window_sdl2.cpp
@@ -13,6 +13,7 @@
 #include "common/scm_rev.h"
 #include "common/string_util.h"
 #include "core/3ds.h"
+#include "core/frontend/screenshot_data.h"
 #include "core/settings.h"
 #include "input_common/keyboard.h"
 #include "input_common/main.h"
@@ -175,4 +176,20 @@ void EmuWindow_SDL2::OnMinimalClientAreaChangeRequest(
     const std::pair<unsigned, unsigned>& minimal_size) {
 
     SDL_SetWindowMinimumSize(render_window, minimal_size.first, minimal_size.second);
+}
+
+void EmuWindow_SDL2::ReceiveScreenshot(std::unique_ptr<ScreenshotData> screenshot) {
+    SDL_Surface* image = SDL_CreateRGBSurfaceFrom(
+        screenshot->screens[0].data.data(), screenshot->screens[0].width,
+        screenshot->screens[0].height, 3 * 8, screenshot->screens[0].width * 3, 0x000000FF,
+        0x0000FF00, 0x00FF0000, 0);
+    SDL_SaveBMP(image, "screenshot_0.bmp");
+    SDL_FreeSurface(image);
+
+    image = SDL_CreateRGBSurfaceFrom(screenshot->screens[1].data.data(),
+                                     screenshot->screens[1].width, screenshot->screens[1].height,
+                                     3 * 8, screenshot->screens[1].width * 3, 0x000000FF,
+                                     0x0000FF00, 0x00FF0000, 0);
+    SDL_SaveBMP(image, "screenshot_1.bmp");
+    SDL_FreeSurface(image);
 }

--- a/src/citra/emu_window/emu_window_sdl2.h
+++ b/src/citra/emu_window/emu_window_sdl2.h
@@ -30,6 +30,8 @@ public:
     /// Whether the window is still open, and a close request hasn't yet been sent
     bool IsOpen() const;
 
+    void ReceiveScreenshot(std::unique_ptr<ScreenshotData> screenshot) override;
+
 private:
     /// Called by PollEvents when a key is pressed or released.
     void OnKeyEvent(int key, u8 state);

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -1,5 +1,6 @@
 #include <QApplication>
 #include <QHBoxLayout>
+#include <QImage>
 #include <QKeyEvent>
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
@@ -14,6 +15,7 @@
 #include "common/string_util.h"
 #include "core/3ds.h"
 #include "core/core.h"
+#include "core/frontend/screenshot_data.h"
 #include "core/settings.h"
 #include "input_common/keyboard.h"
 #include "input_common/main.h"
@@ -153,6 +155,16 @@ void GRenderWindow::DoneCurrent() {
 }
 
 void GRenderWindow::PollEvents() {}
+
+void GRenderWindow::ReceiveScreenshot(std::unique_ptr<ScreenshotData> screenshot) {
+    QImage image(screenshot->screens[0].data.data(), screenshot->screens[0].width,
+                 screenshot->screens[0].height, QImage::Format::Format_RGB888);
+    image.save("screenshot_0.png");
+
+    image = QImage(screenshot->screens[1].data.data(), screenshot->screens[1].width,
+                   screenshot->screens[1].height, QImage::Format::Format_RGB888);
+    image.save("screenshot_1.png");
+}
 
 // On Qt 5.0+, this correctly gets the size of the framebuffer (pixels).
 //

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -113,6 +113,7 @@ public:
     void MakeCurrent() override;
     void DoneCurrent() override;
     void PollEvents() override;
+    void ReceiveScreenshot(std::unique_ptr<ScreenshotData> screenshot) override;
 
     void BackupGeometry();
     void RestoreGeometry();

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -225,6 +225,7 @@ set(HEADERS
             frontend/emu_window.h
             frontend/framebuffer_layout.h
             frontend/input.h
+            frontend/screenshot_data.h
             gdbstub/gdbstub.h
             hle/config_mem.h
             hle/function_wrappers.h

--- a/src/core/frontend/emu_window.h
+++ b/src/core/frontend/emu_window.h
@@ -11,6 +11,8 @@
 #include "common/math_util.h"
 #include "core/frontend/framebuffer_layout.h"
 
+class ScreenshotData;
+
 /**
  * Abstraction class used to provide an interface between emulation code and the frontend
  * (e.g. SDL, QGLWidget, GLFW, etc...).
@@ -112,6 +114,12 @@ public:
      */
     void UpdateCurrentFramebufferLayout(unsigned width, unsigned height);
 
+    bool IsScreenshotRequested() const {
+        return screenshot_requested;
+    }
+
+    virtual void ReceiveScreenshot(std::unique_ptr<ScreenshotData> screenshot) = 0;
+
 protected:
     EmuWindow() {
         // TODO: Find a better place to set this.
@@ -120,6 +128,7 @@ protected:
         touch_x = 0;
         touch_y = 0;
         touch_pressed = false;
+        screenshot_requested = false;
     }
     virtual ~EmuWindow() {}
 
@@ -181,6 +190,8 @@ private:
 
     u16 touch_x; ///< Touchpad X-position in native 3DS pixel coordinates (0-320)
     u16 touch_y; ///< Touchpad Y-position in native 3DS pixel coordinates (0-240)
+
+    bool screenshot_requested;
 
     /**
      * Clip the provided coordinates to be inside the touchscreen area.

--- a/src/core/frontend/screenshot_data.h
+++ b/src/core/frontend/screenshot_data.h
@@ -1,0 +1,36 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <array>
+#include <vector>
+#include "common/common_types.h"
+
+/**
+ * Screenshot data for a screen.
+ * data is in RGB888 format, left to right then top to bottom
+ */
+class ScreenshotScreen {
+public:
+    size_t width;
+    size_t height;
+
+    std::vector<u8> data;
+};
+class ScreenshotData {
+public:
+    ScreenshotData(const size_t& top_width, const size_t& top_height, const size_t& bottom_width,
+                   const size_t& bottom_height) {
+        screens[0].width = top_width;
+        screens[0].height = top_height;
+        screens[0].data.resize(top_width * top_height * 3);
+
+        screens[1].width = bottom_width;
+        screens[1].height = bottom_height;
+        screens[1].data.resize(bottom_width * bottom_height * 3);
+    }
+
+    std::array<ScreenshotScreen, 2> screens;
+};

--- a/src/video_core/renderer_base.cpp
+++ b/src/video_core/renderer_base.cpp
@@ -4,6 +4,9 @@
 
 #include <atomic>
 #include <memory>
+#include "common/color.h"
+#include "core/frontend/emu_window.h"
+#include "core/frontend/screenshot_data.h"
 #include "core/hw/hw.h"
 #include "core/hw/lcd.h"
 #include "video_core/renderer_base.h"
@@ -32,4 +35,71 @@ u32 RendererBase::GetColorFillForFramebuffer(int framebuffer_index) {
     LCD::Regs::ColorFill color_fill = {0};
     LCD::Read(color_fill.raw, lcd_color_addr);
     return color_fill.raw;
+}
+
+void RendererBase::SaveScreenshot() {
+    // We swap width and height here as we are going to rotate the image as we copy it
+    // 3ds framebuffers are stored rotate 90 degrees
+    std::unique_ptr<ScreenshotData> screenshot = std::make_unique<ScreenshotData>(
+        GPU::g_regs.framebuffer_config[0].height, GPU::g_regs.framebuffer_config[0].width,
+        GPU::g_regs.framebuffer_config[1].height, GPU::g_regs.framebuffer_config[1].width);
+
+    for (int i : {0, 1}) {
+        const auto& framebuffer = GPU::g_regs.framebuffer_config[i];
+        LCD::Regs::ColorFill color_fill{GetColorFillForFramebuffer(i)};
+
+        u8* dest_buffer = screenshot->screens[i].data.data();
+
+        if (color_fill.is_enabled) {
+            std::array<u8, 3> source;
+            source[0] = color_fill.color_b;
+            source[1] = color_fill.color_g;
+            source[2] = color_fill.color_r;
+
+            for (u32 y = 0; y < framebuffer.width; y++) {
+                for (u32 x = 0; x < framebuffer.height; x++) {
+                    u8* px_dest = dest_buffer + 3 * (x + framebuffer.height * y);
+                    std::memcpy(px_dest, source.data(), 3);
+                }
+            }
+        } else {
+            const PAddr framebuffer_addr =
+                framebuffer.active_fb == 0 ? framebuffer.address_left1 : framebuffer.address_left2;
+            Memory::RasterizerFlushRegion(framebuffer_addr,
+                                          framebuffer.stride * framebuffer.height);
+            const u8* framebuffer_data = Memory::GetPhysicalPointer(framebuffer_addr);
+
+            int bpp = GPU::Regs::BytesPerPixel(framebuffer.color_format);
+
+            // x,y here are in destination pixels
+            for (u32 y = 0; y < framebuffer.width; y++) {
+                for (u32 x = 0; x < framebuffer.height; x++) {
+                    u8* px_dest =
+                        dest_buffer + 3 * (x + framebuffer.height * (framebuffer.width - y - 1));
+                    const u8* px_source = framebuffer_data + bpp * (y + framebuffer.width * x);
+                    Math::Vec4<u8> source;
+                    switch (framebuffer.color_format) {
+                    case GPU::Regs::PixelFormat::RGB8:
+                        source = Color::DecodeRGB8(px_source);
+                        break;
+                    case GPU::Regs::PixelFormat::RGBA8:
+                        source = Color::DecodeRGBA8(px_source);
+                        break;
+                    case GPU::Regs::PixelFormat::RGBA4:
+                        source = Color::DecodeRGBA4(px_source);
+                        break;
+                    case GPU::Regs::PixelFormat::RGB5A1:
+                        source = Color::DecodeRGB5A1(px_source);
+                        break;
+                    case GPU::Regs::PixelFormat::RGB565:
+                        source = Color::DecodeRGB565(px_source);
+                        break;
+                    }
+                    std::memcpy(px_dest, &source, 3);
+                }
+            }
+        }
+    }
+
+    render_window->ReceiveScreenshot(std::move(screenshot));
 }

--- a/src/video_core/renderer_base.cpp
+++ b/src/video_core/renderer_base.cpp
@@ -4,6 +4,8 @@
 
 #include <atomic>
 #include <memory>
+#include "core/hw/hw.h"
+#include "core/hw/lcd.h"
 #include "video_core/renderer_base.h"
 #include "video_core/renderer_opengl/gl_rasterizer.h"
 #include "video_core/swrasterizer/swrasterizer.h"
@@ -20,4 +22,14 @@ void RendererBase::RefreshRasterizerSetting() {
             rasterizer = std::make_unique<VideoCore::SWRasterizer>();
         }
     }
+}
+
+u32 RendererBase::GetColorFillForFramebuffer(int framebuffer_index) {
+    // Main LCD (0): 0x1ED02204, Sub LCD (1): 0x1ED02A04
+    u32 lcd_color_addr =
+        (framebuffer_index == 0) ? LCD_REG_INDEX(color_fill_top) : LCD_REG_INDEX(color_fill_bottom);
+    lcd_color_addr = HW::VADDR_LCD + 4 * lcd_color_addr;
+    LCD::Regs::ColorFill color_fill = {0};
+    LCD::Read(color_fill.raw, lcd_color_addr);
+    return color_fill.raw;
 }

--- a/src/video_core/renderer_base.h
+++ b/src/video_core/renderer_base.h
@@ -59,6 +59,8 @@ protected:
 
     u32 GetColorFillForFramebuffer(int framebuffer_index);
 
+    void SaveScreenshot();
+
 private:
     bool opengl_rasterizer_active = false;
 };

--- a/src/video_core/renderer_base.h
+++ b/src/video_core/renderer_base.h
@@ -24,7 +24,9 @@ public:
      * Set the emulator window to use for renderer
      * @param window EmuWindow handle to emulator window to use for rendering
      */
-    virtual void SetWindow(EmuWindow* window) = 0;
+    void SetWindow(EmuWindow* window) {
+        render_window = window;
+    }
 
     /// Initialize the renderer
     virtual bool Init() = 0;
@@ -53,6 +55,9 @@ protected:
     std::unique_ptr<VideoCore::RasterizerInterface> rasterizer;
     f32 m_current_fps = 0.0f; ///< Current framerate, should be set by the renderer
     int m_current_frame = 0;  ///< Current frame, should be set by the renderer
+    EmuWindow* render_window; ///< Handle to render window
+
+    u32 GetColorFillForFramebuffer(int framebuffer_index);
 
 private:
     bool opengl_rasterizer_active = false;

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -13,6 +13,7 @@
 #include "core/core.h"
 #include "core/core_timing.h"
 #include "core/frontend/emu_window.h"
+#include "core/frontend/screenshot_data.h"
 #include "core/hw/gpu.h"
 #include "core/hw/lcd.h"
 #include "core/memory.h"
@@ -134,6 +135,9 @@ void RendererOpenGL::SwapBuffers() {
     DrawScreens();
 
     Core::System::GetInstance().perf_stats.EndSystemFrame();
+
+    if (render_window->IsScreenshotRequested())
+        SaveScreenshot();
 
     // Swap buffers
     render_window->PollEvents();

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -14,7 +14,6 @@
 #include "core/core_timing.h"
 #include "core/frontend/emu_window.h"
 #include "core/hw/gpu.h"
-#include "core/hw/hw.h"
 #include "core/hw/lcd.h"
 #include "core/memory.h"
 #include "core/settings.h"
@@ -106,12 +105,7 @@ void RendererOpenGL::SwapBuffers() {
     for (int i : {0, 1}) {
         const auto& framebuffer = GPU::g_regs.framebuffer_config[i];
 
-        // Main LCD (0): 0x1ED02204, Sub LCD (1): 0x1ED02A04
-        u32 lcd_color_addr =
-            (i == 0) ? LCD_REG_INDEX(color_fill_top) : LCD_REG_INDEX(color_fill_bottom);
-        lcd_color_addr = HW::VADDR_LCD + 4 * lcd_color_addr;
-        LCD::Regs::ColorFill color_fill = {0};
-        LCD::Read(color_fill.raw, lcd_color_addr);
+        LCD::Regs::ColorFill color_fill{GetColorFillForFramebuffer(i)};
 
         if (color_fill.is_enabled) {
             LoadColorToActiveGLTexture(color_fill.color_r, color_fill.color_g, color_fill.color_b,
@@ -409,14 +403,6 @@ void RendererOpenGL::DrawScreens() {
 
 /// Updates the framerate
 void RendererOpenGL::UpdateFramerate() {}
-
-/**
- * Set the emulator window to use for renderer
- * @param window EmuWindow handle to emulator window to use for rendering
- */
-void RendererOpenGL::SetWindow(EmuWindow* window) {
-    render_window = window;
-}
 
 static const char* GetSource(GLenum source) {
 #define RET(s)                                                                                     \

--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -40,12 +40,6 @@ public:
     /// Swap buffers (render frame)
     void SwapBuffers() override;
 
-    /**
-     * Set the emulator window to use for renderer
-     * @param window EmuWindow handle to emulator window to use for rendering
-     */
-    void SetWindow(EmuWindow* window) override;
-
     /// Initialize the renderer
     bool Init() override;
 
@@ -65,8 +59,6 @@ private:
                             ScreenInfo& screen_info);
     // Fills active OpenGL texture with the given RGB color.
     void LoadColorToActiveGLTexture(u8 color_r, u8 color_g, u8 color_b, const TextureInfo& texture);
-
-    EmuWindow* render_window; ///< Handle to render window
 
     OpenGLState state;
 


### PR DESCRIPTION
Adds functionality to take a screenshot from the framebuffer memory.
The EmuWindow requests a screenshot by returning true from `IsScreenshotRequested`, which `RendererOpenGL` checks once per frame.
When set, the renderer copies the framebuffer in to a `ScreenshotData` object and passes it through to `emu_window->ReceiveScreenshot`.

Currently the frontends just contain sample implementations of saving an image. QT will need some UI for it, but SDL can probably stay as it is (or get a keyboard shortcut?).

When using increased Internal Resolution rendering we still produce screenshots in normal 3ds resolution.
I think we could read back the rasterizer framebuffer textures instead if capturing this is desirable.

TBH I'm not sure if any of this is done the right way, so feedback is desired :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2895)
<!-- Reviewable:end -->
