### PR TITLE
Telemetry UI and final touches

### DIFF
--- a/src/citra/citra.cpp
+++ b/src/citra/citra.cpp
@@ -165,6 +165,8 @@ int main(int argc, char** argv) {
         break; // Expected case
     }
 
+    Core::Telemetry().AddField(Telemetry::FieldType::App, "Frontend", "SDL");
+
     while (emu_window->IsOpen()) {
         system.RunLoop();
     }

--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -156,8 +156,12 @@ void Config::ReadValues() {
         static_cast<u16>(sdl2_config->GetInteger("Debugging", "gdbstub_port", 24689));
 
     // Web Service
+    Settings::values.enable_telemetry =
+        sdl2_config->GetBoolean("WebService", "enable_telemetry", true);
     Settings::values.telemetry_endpoint_url = sdl2_config->Get(
         "WebService", "telemetry_endpoint_url", "https://services.citra-emu.org/api/telemetry");
+    Settings::values.citra_username = sdl2_config->Get("WebService", "citra_username", "");
+    Settings::values.citra_token = sdl2_config->Get("WebService", "citra_token", "");
 }
 
 void Config::Reload() {

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -180,7 +180,7 @@ gdbstub_port=24689
 # 0: No, 1 (default): Yes
 enable_telemetry =
 # Endpoint URL for submitting telemetry data
-telemetry_endpoint_url =
+telemetry_endpoint_url = https://services.citra-emu.org/api/telemetry
 # Username and token for Citra Web Service
 # See https://services.citra-emu.org/ for more info
 citra_username =

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -176,7 +176,14 @@ use_gdbstub=false
 gdbstub_port=24689
 
 [WebService]
+# Whether or not to enable telemetry
+# 0: No, 1 (default): Yes
+enable_telemetry =
 # Endpoint URL for submitting telemetry data
 telemetry_endpoint_url =
+# Username and token for Citra Web Service
+# See https://services.citra-emu.org/ for more info
+citra_username =
+citra_token =
 )";
 }

--- a/src/citra_qt/CMakeLists.txt
+++ b/src/citra_qt/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SRCS
             configuration/configure_graphics.cpp
             configuration/configure_input.cpp
             configuration/configure_system.cpp
+            configuration/configure_web.cpp
             debugger/graphics/graphics.cpp
             debugger/graphics/graphics_breakpoint_observer.cpp
             debugger/graphics/graphics_breakpoints.cpp
@@ -42,6 +43,7 @@ set(HEADERS
             configuration/configure_graphics.h
             configuration/configure_input.h
             configuration/configure_system.h
+            configuration/configure_web.h
             debugger/graphics/graphics.h
             debugger/graphics/graphics_breakpoint_observer.h
             debugger/graphics/graphics_breakpoints.h
@@ -71,6 +73,7 @@ set(UIS
             configuration/configure_graphics.ui
             configuration/configure_input.ui
             configuration/configure_system.ui
+            configuration/configure_web.ui
             debugger/registers.ui
             hotkeys.ui
             main.ui

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -139,10 +139,13 @@ void Config::ReadValues() {
     qt_config->endGroup();
 
     qt_config->beginGroup("WebService");
+    Settings::values.enable_telemetry = qt_config->value("enable_telemetry", true).toBool();
     Settings::values.telemetry_endpoint_url =
         qt_config->value("telemetry_endpoint_url", "https://services.citra-emu.org/api/telemetry")
             .toString()
             .toStdString();
+    Settings::values.citra_username = qt_config->value("citra_username").toString().toStdString();
+    Settings::values.citra_token = qt_config->value("citra_token").toString().toStdString();
     qt_config->endGroup();
 
     qt_config->beginGroup("UI");
@@ -284,8 +287,11 @@ void Config::SaveValues() {
     qt_config->endGroup();
 
     qt_config->beginGroup("WebService");
+    qt_config->setValue("enable_telemetry", Settings::values.enable_telemetry);
     qt_config->setValue("telemetry_endpoint_url",
                         QString::fromStdString(Settings::values.telemetry_endpoint_url));
+    qt_config->setValue("citra_username", QString::fromStdString(Settings::values.citra_username));
+    qt_config->setValue("citra_token", QString::fromStdString(Settings::values.citra_token));
     qt_config->endGroup();
 
     qt_config->beginGroup("UI");

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -194,6 +194,7 @@ void Config::ReadValues() {
     UISettings::values.show_status_bar = qt_config->value("showStatusBar", true).toBool();
     UISettings::values.confirm_before_closing = qt_config->value("confirmClose", true).toBool();
     UISettings::values.first_start = qt_config->value("firstStart", true).toBool();
+    UISettings::values.callout_flags = qt_config->value("calloutFlags", 0).toUInt();
 
     qt_config->endGroup();
 }
@@ -320,6 +321,7 @@ void Config::SaveValues() {
     qt_config->setValue("showStatusBar", UISettings::values.show_status_bar);
     qt_config->setValue("confirmClose", UISettings::values.confirm_before_closing);
     qt_config->setValue("firstStart", UISettings::values.first_start);
+    qt_config->setValue("calloutFlags", UISettings::values.callout_flags);
 
     qt_config->endGroup();
 }

--- a/src/citra_qt/configuration/configure.ui
+++ b/src/citra_qt/configuration/configure.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>441</width>
-    <height>501</height>
+    <width>740</width>
+    <height>500</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -47,6 +47,11 @@
      <widget class="ConfigureDebug" name="debugTab">
       <attribute name="title">
        <string>Debug</string>
+      </attribute>
+     </widget>
+     <widget class="ConfigureWeb" name="webTab">
+      <attribute name="title">
+       <string>Web</string>
       </attribute>
      </widget>
     </widget>
@@ -95,6 +100,12 @@
    <class>ConfigureGraphics</class>
    <extends>QWidget</extends>
    <header>configuration/configure_graphics.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ConfigureWeb</class>
+   <extends>QWidget</extends>
+   <header>configuration/configure_web.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/citra_qt/configuration/configure_dialog.cpp
+++ b/src/citra_qt/configuration/configure_dialog.cpp
@@ -23,5 +23,6 @@ void ConfigureDialog::applyConfiguration() {
     ui->graphicsTab->applyConfiguration();
     ui->audioTab->applyConfiguration();
     ui->debugTab->applyConfiguration();
+    ui->webTab->applyConfiguration();
     Settings::Apply();
 }

--- a/src/citra_qt/configuration/configure_web.cpp
+++ b/src/citra_qt/configuration/configure_web.cpp
@@ -1,0 +1,44 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "citra_qt/configuration/configure_web.h"
+#include "core/settings.h"
+#include "ui_configure_web.h"
+
+ConfigureWeb::ConfigureWeb(QWidget* parent)
+    : QWidget(parent), ui(std::make_unique<Ui::ConfigureWeb>()) {
+    ui->setupUi(this);
+    this->setConfiguration();
+}
+
+ConfigureWeb::~ConfigureWeb() {}
+
+void ConfigureWeb::setConfiguration() {
+    ui->web_credentials_disclaimer->setWordWrap(true);
+    ui->telemetry_learn_more->setOpenExternalLinks(true);
+    ui->telemetry_learn_more->setText("<a "
+                                      "href='https://citra-emu.org/entry/"
+                                      "telemetry-and-why-thats-a-good-thing/'>Learn more</a>");
+
+    ui->web_signup_link->setOpenExternalLinks(true);
+    ui->web_signup_link->setText("<a href='https://services.citra-emu.org/'>Sign up</a>");
+    ui->web_token_info_link->setOpenExternalLinks(true);
+    ui->web_token_info_link->setText(
+        "<a href='https://citra-emu.org/wiki/citra-web-service/'>What is my token?</a>");
+
+    ui->toggle_telemetry->setChecked(Settings::values.enable_telemetry);
+    ui->edit_username->setText(QString::fromStdString(Settings::values.citra_username));
+    ui->edit_token->setText(QString::fromStdString(Settings::values.citra_token));
+
+    updateWeb();
+}
+
+void ConfigureWeb::applyConfiguration() {
+    Settings::values.enable_telemetry = ui->toggle_telemetry->isChecked();
+    Settings::values.citra_username = ui->edit_username->text().toStdString();
+    Settings::values.citra_token = ui->edit_token->text().toStdString();
+    Settings::Apply();
+}
+
+void ConfigureWeb::updateWeb() {}

--- a/src/citra_qt/configuration/configure_web.cpp
+++ b/src/citra_qt/configuration/configure_web.cpp
@@ -4,11 +4,15 @@
 
 #include "citra_qt/configuration/configure_web.h"
 #include "core/settings.h"
+#include "core/telemetry_session.h"
 #include "ui_configure_web.h"
 
 ConfigureWeb::ConfigureWeb(QWidget* parent)
     : QWidget(parent), ui(std::make_unique<Ui::ConfigureWeb>()) {
     ui->setupUi(this);
+    connect(ui->button_regenerate_telemetry_id, &QPushButton::clicked, this,
+            &ConfigureWeb::refreshTelemetryID);
+
     this->setConfiguration();
 }
 
@@ -30,8 +34,8 @@ void ConfigureWeb::setConfiguration() {
     ui->toggle_telemetry->setChecked(Settings::values.enable_telemetry);
     ui->edit_username->setText(QString::fromStdString(Settings::values.citra_username));
     ui->edit_token->setText(QString::fromStdString(Settings::values.citra_token));
-
-    updateWeb();
+    ui->label_telemetry_id->setText("Telemetry ID: 0x" +
+                                    QString::number(Core::GetTelemetryId(), 16).toUpper());
 }
 
 void ConfigureWeb::applyConfiguration() {
@@ -41,4 +45,8 @@ void ConfigureWeb::applyConfiguration() {
     Settings::Apply();
 }
 
-void ConfigureWeb::updateWeb() {}
+void ConfigureWeb::refreshTelemetryID() {
+    const u64 new_telemetry_id{Core::RegenerateTelemetryId()};
+    ui->label_telemetry_id->setText("Telemetry ID: 0x" +
+                                    QString::number(new_telemetry_id, 16).toUpper());
+}

--- a/src/citra_qt/configuration/configure_web.h
+++ b/src/citra_qt/configuration/configure_web.h
@@ -21,7 +21,7 @@ public:
     void applyConfiguration();
 
 public slots:
-    void updateWeb();
+    void refreshTelemetryID();
 
 private:
     void setConfiguration();

--- a/src/citra_qt/configuration/configure_web.h
+++ b/src/citra_qt/configuration/configure_web.h
@@ -1,0 +1,30 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include <QWidget>
+
+namespace Ui {
+class ConfigureWeb;
+}
+
+class ConfigureWeb : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ConfigureWeb(QWidget* parent = nullptr);
+    ~ConfigureWeb();
+
+    void applyConfiguration();
+
+public slots:
+    void updateWeb();
+
+private:
+    void setConfiguration();
+
+    std::unique_ptr<Ui::ConfigureWeb> ui;
+};

--- a/src/citra_qt/configuration/configure_web.ui
+++ b/src/citra_qt/configuration/configure_web.ui
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConfigureWeb</class>
+ <widget class="QWidget" name="ConfigureWeb">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout_3">
+     <item>
+      <widget class="QGroupBox" name="groupBox">
+       <property name="title">
+        <string>Citra Web Service</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <widget class="QLabel" name="web_credentials_disclaimer">
+          <property name="text">
+           <string>By providing your username and token, you agree to allow Citra to collect additional usage data, which may include user identifying information.</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QGridLayout" name="gridLayout">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_username">
+            <property name="text">
+             <string>Username: </string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="edit_username">
+            <property name="maxLength">
+             <number>36</number>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_token">
+            <property name="text">
+             <string>Token: </string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="edit_token">
+            <property name="maxLength">
+             <number>36</number>
+            </property>
+            <property name="echoMode">
+             <enum>QLineEdit::Password</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="web_signup_link">
+            <property name="text">
+             <string>Sign up</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLabel" name="web_token_info_link">
+            <property name="text">
+             <string>What is my token?</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="groupBox">
+       <property name="title">
+        <string>Telemetry</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <widget class="QCheckBox" name="toggle_telemetry">
+          <property name="text">
+           <string>Share anonymous usage data with the Citra team</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="telemetry_learn_more">
+          <property name="text">
+           <string>Learn more</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/citra_qt/configuration/configure_web.ui
+++ b/src/citra_qt/configuration/configure_web.ui
@@ -17,11 +17,11 @@
    <item>
     <layout class="QVBoxLayout" name="verticalLayout_3">
      <item>
-      <widget class="QGroupBox" name="groupBox">
+      <widget class="QGroupBox" name="groupBoxWebConfig">
        <property name="title">
         <string>Citra Web Service</string>
        </property>
-       <layout class="QVBoxLayout" name="verticalLayout_2">
+       <layout class="QVBoxLayout" name="verticalLayoutCitraWebService">
         <item>
          <widget class="QLabel" name="web_credentials_disclaimer">
           <property name="text">
@@ -30,7 +30,7 @@
          </widget>
         </item>
         <item>
-         <layout class="QGridLayout" name="gridLayout">
+         <layout class="QGridLayout" name="gridLayoutCitraUsername">
           <item row="0" column="0">
            <widget class="QLabel" name="label_username">
             <property name="text">
@@ -100,6 +100,33 @@
            <string>Learn more</string>
           </property>
          </widget>
+        </item>
+        <item>
+         <layout class="QGridLayout" name="gridLayoutTelemetryId">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_telemetry_id">
+             <property name="text">
+              <string>Telemetry ID:</string>
+             </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QPushButton" name="button_regenerate_telemetry_id">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="layoutDirection">
+             <enum>Qt::RightToLeft</enum>
+            </property>
+            <property name="text">
+             <string>Regenerate</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
        </layout>
       </widget>

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -364,6 +364,8 @@ bool GMainWindow::LoadROM(const QString& filename) {
 
     const Core::System::ResultStatus result{system.Load(render_window, filename.toStdString())};
 
+    Core::Telemetry().AddField(Telemetry::FieldType::App, "Frontend", "Qt");
+
     if (result != Core::System::ResultStatus::Success) {
         switch (result) {
         case Core::System::ResultStatus::ErrorGetLoader:

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -80,6 +80,8 @@ private:
     void BootGame(const QString& filename);
     void ShutdownGame();
 
+    void ShowCallouts();
+
     /**
      * Stores the filename in the recently loaded files list.
      * The new filename is stored at the beginning of the recently loaded files list.

--- a/src/citra_qt/ui_settings.h
+++ b/src/citra_qt/ui_settings.h
@@ -48,6 +48,8 @@ struct Values {
 
     // Shortcut name <Shortcut, context>
     std::vector<Shortcut> shortcuts;
+
+    uint32_t callout_flags;
 };
 
 extern Values values;

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -130,7 +130,10 @@ struct Values {
     u16 gdbstub_port;
 
     // WebService
+    bool enable_telemetry;
     std::string telemetry_endpoint_url;
+    std::string citra_username;
+    std::string citra_token;
 } extern values;
 
 // a special value for Values::region_value indicating that citra will automatically select a region

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -77,7 +77,13 @@ u64 RegenerateTelemetryId() {
 
 TelemetrySession::TelemetrySession() {
 #ifdef ENABLE_WEB_SERVICE
-    backend = std::make_unique<WebService::TelemetryJson>();
+    if (Settings::values.enable_telemetry) {
+        backend = std::make_unique<WebService::TelemetryJson>(
+            Settings::values.telemetry_endpoint_url, Settings::values.citra_username,
+            Settings::values.citra_token);
+    } else {
+        backend = std::make_unique<Telemetry::NullVisitor>();
+    }
 #else
     backend = std::make_unique<Telemetry::NullVisitor>();
 #endif

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -38,21 +38,21 @@ static u64 GenerateTelemetryId() {
     return telemetry_id;
 }
 
-static u64 GetTelemetryId() {
+u64 GetTelemetryId() {
     u64 telemetry_id{};
     static const std::string& filename{FileUtil::GetUserPath(D_CONFIG_IDX) + "telemetry_id"};
 
     if (FileUtil::Exists(filename)) {
         FileUtil::IOFile file(filename, "rb");
         if (!file.IsOpen()) {
-            LOG_ERROR(WebService, "failed to open telemetry_id: %s", filename.c_str());
+            LOG_ERROR(Core, "failed to open telemetry_id: %s", filename.c_str());
             return {};
         }
         file.ReadBytes(&telemetry_id, sizeof(u64));
     } else {
         FileUtil::IOFile file(filename, "wb");
         if (!file.IsOpen()) {
-            LOG_ERROR(WebService, "failed to open telemetry_id: %s", filename.c_str());
+            LOG_ERROR(Core, "failed to open telemetry_id: %s", filename.c_str());
             return {};
         }
         telemetry_id = GenerateTelemetryId();
@@ -60,6 +60,19 @@ static u64 GetTelemetryId() {
     }
 
     return telemetry_id;
+}
+
+u64 RegenerateTelemetryId() {
+    const u64 new_telemetry_id{GenerateTelemetryId()};
+    static const std::string& filename{FileUtil::GetUserPath(D_CONFIG_IDX) + "telemetry_id"};
+
+    FileUtil::IOFile file(filename, "wb");
+    if (!file.IsOpen()) {
+        LOG_ERROR(Core, "failed to open telemetry_id: %s", filename.c_str());
+        return {};
+    }
+    file.WriteBytes(&new_telemetry_id, sizeof(u64));
+    return new_telemetry_id;
 }
 
 TelemetrySession::TelemetrySession() {

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -3,8 +3,10 @@
 // Refer to the license.txt file included.
 
 #include <cstring>
+#include <cryptopp/osrng.h>
 
 #include "common/assert.h"
+#include "common/file_util.h"
 #include "common/scm_rev.h"
 #include "common/x64/cpu_detect.h"
 #include "core/core.h"
@@ -29,12 +31,46 @@ static const char* CpuVendorToStr(Common::CPUVendor vendor) {
     UNREACHABLE();
 }
 
+static u64 GenerateTelemetryId() {
+    u64 telemetry_id{};
+    CryptoPP::AutoSeededRandomPool rng;
+    rng.GenerateBlock(reinterpret_cast<CryptoPP::byte*>(&telemetry_id), sizeof(u64));
+    return telemetry_id;
+}
+
+static u64 GetTelemetryId() {
+    u64 telemetry_id{};
+    static const std::string& filename{FileUtil::GetUserPath(D_CONFIG_IDX) + "telemetry_id"};
+
+    if (FileUtil::Exists(filename)) {
+        FileUtil::IOFile file(filename, "rb");
+        if (!file.IsOpen()) {
+            LOG_ERROR(WebService, "failed to open telemetry_id: %s", filename.c_str());
+            return {};
+        }
+        file.ReadBytes(&telemetry_id, sizeof(u64));
+    } else {
+        FileUtil::IOFile file(filename, "wb");
+        if (!file.IsOpen()) {
+            LOG_ERROR(WebService, "failed to open telemetry_id: %s", filename.c_str());
+            return {};
+        }
+        telemetry_id = GenerateTelemetryId();
+        file.WriteBytes(&telemetry_id, sizeof(u64));
+    }
+
+    return telemetry_id;
+}
+
 TelemetrySession::TelemetrySession() {
 #ifdef ENABLE_WEB_SERVICE
     backend = std::make_unique<WebService::TelemetryJson>();
 #else
     backend = std::make_unique<Telemetry::NullVisitor>();
 #endif
+    // Log one-time top-level information
+    AddField(Telemetry::FieldType::None, "TelemetryId", GetTelemetryId());
+
     // Log one-time session start information
     const s64 init_time{std::chrono::duration_cast<std::chrono::milliseconds>(
                             std::chrono::system_clock::now().time_since_epoch())

--- a/src/core/telemetry_session.h
+++ b/src/core/telemetry_session.h
@@ -35,4 +35,16 @@ private:
     std::unique_ptr<Telemetry::VisitorInterface> backend; ///< Backend interface that logs fields
 };
 
+/**
+ * Gets TelemetryId, a unique identifier used for the user's telemetry sessions.
+ * @returns The current TelemetryId for the session.
+ */
+u64 GetTelemetryId();
+
+/**
+ * Regenerates TelemetryId, a unique identifier used for the user's telemetry sessions.
+ * @returns The new TelemetryId that was generated.
+ */
+u64 RegenerateTelemetryId();
+
 } // namespace Core

--- a/src/web_service/telemetry_json.cpp
+++ b/src/web_service/telemetry_json.cpp
@@ -3,7 +3,6 @@
 // Refer to the license.txt file included.
 
 #include "common/assert.h"
-#include "core/settings.h"
 #include "web_service/telemetry_json.h"
 #include "web_service/web_backend.h"
 
@@ -81,7 +80,7 @@ void TelemetryJson::Complete() {
     SerializeSection(Telemetry::FieldType::UserFeedback, "UserFeedback");
     SerializeSection(Telemetry::FieldType::UserConfig, "UserConfig");
     SerializeSection(Telemetry::FieldType::UserSystem, "UserSystem");
-    PostJson(Settings::values.telemetry_endpoint_url, TopSection().dump());
+    PostJson(endpoint_url, TopSection().dump(), true, username, token);
 }
 
 } // namespace WebService

--- a/src/web_service/telemetry_json.h
+++ b/src/web_service/telemetry_json.h
@@ -17,7 +17,9 @@ namespace WebService {
  */
 class TelemetryJson : public Telemetry::VisitorInterface {
 public:
-    TelemetryJson() = default;
+    TelemetryJson(const std::string& endpoint_url, const std::string& username,
+                  const std::string& token)
+        : endpoint_url(endpoint_url), username(username), token(token) {}
     ~TelemetryJson() = default;
 
     void Visit(const Telemetry::Field<bool>& field) override;
@@ -49,6 +51,9 @@ private:
 
     nlohmann::json output;
     std::array<nlohmann::json, 7> sections;
+    std::string endpoint_url;
+    std::string username;
+    std::string token;
 };
 
 } // namespace WebService

--- a/src/web_service/web_backend.cpp
+++ b/src/web_service/web_backend.cpp
@@ -2,14 +2,28 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <cstdlib>
+#include <thread>
 #include <cpr/cpr.h>
-#include <stdlib.h>
 #include "common/logging/log.h"
 #include "web_service/web_backend.h"
 
 namespace WebService {
 
 static constexpr char API_VERSION[]{"1"};
+
+static void PostJsonAuthenticated(const std::string& url, const std::string& data,
+                                  const std::string& username, const std::string& token) {
+    cpr::Post(cpr::Url{url}, cpr::Body{data}, cpr::Header{{"Content-Type", "application/json"},
+                                                          {"x-username", username},
+                                                          {"x-token", token},
+                                                          {"api-version", API_VERSION}});
+}
+
+static void PostJsonAnonymous(const std::string& url, const std::string& data) {
+    cpr::Post(cpr::Url{url}, cpr::Body{data},
+              cpr::Header{{"Content-Type", "application/json"}, {"api-version", API_VERSION}});
+}
 
 void PostJson(const std::string& url, const std::string& data, bool allow_anonymous,
               const std::string& username, const std::string& token) {
@@ -24,18 +38,13 @@ void PostJson(const std::string& url, const std::string& data, bool allow_anonym
         return;
     }
 
+    // Post JSON asynchronously by spawning a new thread
     if (are_credentials_provided) {
         // Authenticated request if credentials are provided
-        cpr::PostAsync(cpr::Url{url}, cpr::Body{data},
-                       cpr::Header{{"Content-Type", "application/json"},
-                                   {"x-username", username},
-                                   {"x-token", token},
-                                   {"api-version", API_VERSION}});
+        std::thread{PostJsonAuthenticated, url, data, username, token}.detach();
     } else {
         // Otherwise, anonymous request
-        cpr::PostAsync(
-            cpr::Url{url}, cpr::Body{data},
-            cpr::Header{{"Content-Type", "application/json"}, {"api-version", API_VERSION}});
+        std::thread{PostJsonAnonymous, url, data}.detach();
     }
 }
 

--- a/src/web_service/web_backend.cpp
+++ b/src/web_service/web_backend.cpp
@@ -5,36 +5,37 @@
 #include <cpr/cpr.h>
 #include <stdlib.h>
 #include "common/logging/log.h"
-#include "core/settings.h"
 #include "web_service/web_backend.h"
 
 namespace WebService {
 
 static constexpr char API_VERSION[]{"1"};
 
-void PostJson(const std::string& url, const std::string& data) {
-    if (!Settings::values.enable_telemetry) {
-        // Telemetry disabled by user configuration
-        return;
-    }
-
+void PostJson(const std::string& url, const std::string& data, bool allow_anonymous,
+              const std::string& username, const std::string& token) {
     if (url.empty()) {
         LOG_ERROR(WebService, "URL is invalid");
         return;
     }
 
-    if (Settings::values.citra_token.empty() || Settings::values.citra_username.empty()) {
-        // Anonymous request if citra token or username are empty
+    const bool are_credentials_provided{!token.empty() && !username.empty()};
+    if (!allow_anonymous && !are_credentials_provided) {
+        LOG_ERROR(WebService, "Credentials must be provided for authenticated requests");
+        return;
+    }
+
+    if (are_credentials_provided) {
+        // Authenticated request if credentials are provided
+        cpr::PostAsync(cpr::Url{url}, cpr::Body{data},
+                       cpr::Header{{"Content-Type", "application/json"},
+                                   {"x-username", username},
+                                   {"x-token", token},
+                                   {"api-version", API_VERSION}});
+    } else {
+        // Otherwise, anonymous request
         cpr::PostAsync(
             cpr::Url{url}, cpr::Body{data},
             cpr::Header{{"Content-Type", "application/json"}, {"api-version", API_VERSION}});
-    } else {
-        // We have both, do an authenticated request
-        cpr::PostAsync(cpr::Url{url}, cpr::Body{data},
-                       cpr::Header{{"Content-Type", "application/json"},
-                                   {"x-username", Settings::values.citra_username},
-                                   {"x-token", Settings::values.citra_token},
-                                   {"api-version", API_VERSION}});
     }
 }
 

--- a/src/web_service/web_backend.h
+++ b/src/web_service/web_backend.h
@@ -13,7 +13,11 @@ namespace WebService {
  * Posts JSON to services.citra-emu.org.
  * @param url URL of the services.citra-emu.org endpoint to post data to.
  * @param data String of JSON data to use for the body of the POST request.
+ * @param allow_anonymous If true, allow anonymous unauthenticated requests.
+ * @param username Citra username to use for authentication.
+ * @param token Citra token to use for authentication.
  */
-void PostJson(const std::string& url, const std::string& data);
+void PostJson(const std::string& url, const std::string& data, bool allow_anonymous,
+              const std::string& username = {}, const std::string& token = {});
 
 } // namespace WebService

--- a/src/web_service/web_backend.h
+++ b/src/web_service/web_backend.h
@@ -10,18 +10,6 @@
 namespace WebService {
 
 /**
- * Gets the current username for accessing services.citra-emu.org.
- * @returns Username as a string, empty if not set.
- */
-const std::string& GetUsername();
-
-/**
- * Gets the current token for accessing services.citra-emu.org.
- * @returns Token as a string, empty if not set.
- */
-const std::string& GetToken();
-
-/**
  * Posts JSON to services.citra-emu.org.
  * @param url URL of the services.citra-emu.org endpoint to post data to.
  * @param data String of JSON data to use for the body of the POST request.


### PR DESCRIPTION
This is the fourth part of a set of changes to add a telemetry framework to Citra. In the near term, this will be used for user-submitted compatibility data to our own custom service endpoint (services.citra-emu.org). My goal, however, is to make this very generic, and allow us to easily log useful/interesting data fields throughout the emulator, and then upload them to our service at a later time. In the long term, we may use this for anonymous telemetry, critical errors and crash reports, measuring how often features are used, etc.

With this change, I've added the following:
* Settings UI for configuring telemetry related fields
* "Callouts", one-time important messages to the user, which is currently used to indicate the addition of telemetry
* TelemetryId, a user-unique random number used for grouping telemetry data by user
* Support for unauthenticated/anonymous telemetry
* Logging of the emulation frontend type (Qt or SDL)

As I mentioned above, this is a multi-part submission. Here is what has been completed thus far, as well as what is to come next:

- [x] [#2683] Common interface for submitting data fields to the telemetry log
- [x] [#2683] Dummy backend that does nothing with the telemetry log
- [x] [#2683] Core instantiation of the telemetry interface with a single global log used for game compatibility
- [x] [#2683] A few example fields are logged in core
- [x] [#2819] Implement a backend that does an authenticated log submission to our service
- [x] [#2823] Implement remaining fields for game compatibility submission
- [x] Implement Qt UI for authenticating users and user-submitted data
- [ ] Support multiple logs for different purposes

Obligatory UI screenshots:
![](http://i.imgur.com/f6zofZT.png)
![](http://i.imgur.com/N42oDOK.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2897)
<!-- Reviewable:end -->
