### PR TITLE
Refactor touch input into a TouchDevice

### DIFF
--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -78,6 +78,8 @@ void Config::ReadValues() {
 
     Settings::values.motion_device = sdl2_config->Get(
         "Controls", "motion_device", "engine:motion_emu,update_period:100,sensitivity:0.01");
+    Settings::values.touch_device =
+        sdl2_config->Get("Controls", "touch_device", "engine:emu_window");
 
     // Core
     Settings::values.use_cpu_jit = sdl2_config->GetBoolean("Core", "use_cpu_jit", true);

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -62,6 +62,10 @@ c_stick=
 #      - "sensitivity": the coefficient converting mouse movement to tilting angle (default to 0.01)
 motion_device=
 
+# for touch input, the following devices are available:
+#  - "emu_window" (default) for emulating touch input from mouse input to the emulation window. No parameters required
+touch_device=
+
 [Core]
 # Whether to use the Just-In-Time (JIT) compiler for CPU emulation
 # 0: Interpreter (slow), 1 (default): JIT (fast)

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -61,6 +61,8 @@ void Config::ReadValues() {
         qt_config->value("motion_device", "engine:motion_emu,update_period:100,sensitivity:0.01")
             .toString()
             .toStdString();
+    Settings::values.touch_device =
+        qt_config->value("touch_device", "engine:emu_window").toString().toStdString();
 
     qt_config->endGroup();
 
@@ -209,6 +211,7 @@ void Config::SaveValues() {
                             QString::fromStdString(Settings::values.analogs[i]));
     }
     qt_config->setValue("motion_device", QString::fromStdString(Settings::values.motion_device));
+    qt_config->setValue("touch_device", QString::fromStdString(Settings::values.touch_device));
     qt_config->endGroup();
 
     qt_config->beginGroup("Core");

--- a/src/core/frontend/input.h
+++ b/src/core/frontend/input.h
@@ -126,4 +126,10 @@ using AnalogDevice = InputDevice<std::tuple<float, float>>;
  */
 using MotionDevice = InputDevice<std::tuple<Math::Vec3<float>, Math::Vec3<float>>>;
 
+/**
+ * A touch device is an input device that returns a tuple of two floats and a bool. The floats are
+ * x and y coordinates in the range 0.0 - 1.0, and the bool indicates whether it is pressed.
+ */
+using TouchDevice = InputDevice<std::tuple<float, float, bool>>;
+
 } // namespace Input

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -80,6 +80,7 @@ struct Values {
     std::array<std::string, NativeButton::NumButtons> buttons;
     std::array<std::string, NativeAnalog::NumAnalogs> analogs;
     std::string motion_device;
+    std::string touch_device;
 
     // Core
     bool use_cpu_jit;


### PR DESCRIPTION
This is a follow-up of #2497 and #2861 , and it is the last one remained to integrate into the input system.

Unlike the other inputs, touch input is highly bound to the window, so instead of decoupling it from `EmuWindow`, I let `EmuWindow` becomes the factory provider, and wrapped the plain touch state previously in `EmuWindow` into the `TouchState`, which implements the device factory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2899)
<!-- Reviewable:end -->
