### PR TITLE
PICA: implement custom clip plane

### DIFF
--- a/src/video_core/regs_rasterizer.h
+++ b/src/video_core/regs_rasterizer.h
@@ -5,10 +5,10 @@
 #pragma once
 
 #include <array>
-
 #include "common/bit_field.h"
 #include "common/common_funcs.h"
 #include "common/common_types.h"
+#include "video_core/pica_types.h"
 
 namespace Pica {
 
@@ -31,7 +31,17 @@ struct RasterizerRegs {
 
     BitField<0, 24, u32> viewport_size_y;
 
-    INSERT_PADDING_WORDS(0x9);
+    INSERT_PADDING_WORDS(0x3);
+
+    BitField<0, 1, u32> clip_enable;
+    BitField<0, 24, u32> clip_coef[4]; // float24
+
+    Math::Vec4<float24> GetClipCoef() const {
+        return {float24::FromRaw(clip_coef[0]), float24::FromRaw(clip_coef[1]),
+                float24::FromRaw(clip_coef[2]), float24::FromRaw(clip_coef[3])};
+    }
+
+    INSERT_PADDING_WORDS(0x1);
 
     BitField<0, 24, u32> viewport_depth_range;      // float24
     BitField<0, 24, u32> viewport_depth_near_plane; // float24

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -151,13 +151,20 @@ private:
         LightSrc light_src[8];
         alignas(16) GLvec4 const_color[6]; // A vec4 color for each of the six tev stages
         alignas(16) GLvec4 tev_combiner_buffer_color;
+        alignas(16) GLvec4 clip_coef;
     };
 
     static_assert(
-        sizeof(UniformData) == 0x460,
+        sizeof(UniformData) == 0x470,
         "The size of the UniformData structure has changed, update the structure in the shader");
     static_assert(sizeof(UniformData) < 16384,
                   "UniformData structure must be less than 16kb as per the OpenGL spec");
+
+    /// Syncs the clip enabled status to match the PICA register
+    void SyncClipEnabled();
+
+    /// Syncs the clip coefficients to match the PICA register
+    void SyncClipCoef();
 
     /// Sets the OpenGL shader in accordance with the current PICA register state
     void SetShader();

--- a/src/video_core/swrasterizer/clipper.cpp
+++ b/src/video_core/swrasterizer/clipper.cpp
@@ -31,7 +31,7 @@ public:
         : coeffs(coeffs), bias(bias) {}
 
     bool IsInside(const Vertex& vertex) const {
-        return Math::Dot(vertex.pos + bias, coeffs) <= float24::FromFloat32(0);
+        return Math::Dot(vertex.pos + bias, coeffs) >= float24::FromFloat32(0);
     }
 
     bool IsOutSide(const Vertex& vertex) const {
@@ -116,13 +116,13 @@ void ProcessTriangle(const OutputVertex& v0, const OutputVertex& v1, const Outpu
     static const float24 f0 = float24::FromFloat32(0.0);
     static const float24 f1 = float24::FromFloat32(1.0);
     static const std::array<ClippingEdge, 7> clipping_edges = {{
-        {Math::MakeVec(f1, f0, f0, -f1)},                                           // x = +w
-        {Math::MakeVec(-f1, f0, f0, -f1)},                                          // x = -w
-        {Math::MakeVec(f0, f1, f0, -f1)},                                           // y = +w
-        {Math::MakeVec(f0, -f1, f0, -f1)},                                          // y = -w
-        {Math::MakeVec(f0, f0, f1, f0)},                                            // z =  0
-        {Math::MakeVec(f0, f0, -f1, -f1)},                                          // z = -w
-        {Math::MakeVec(f0, f0, f0, -f1), Math::Vec4<float24>(f0, f0, f0, EPSILON)}, // w = EPSILON
+        {Math::MakeVec(-f1, f0, f0, f1)},                                          // x = +w
+        {Math::MakeVec(f1, f0, f0, f1)},                                           // x = -w
+        {Math::MakeVec(f0, -f1, f0, f1)},                                          // y = +w
+        {Math::MakeVec(f0, f1, f0, f1)},                                           // y = -w
+        {Math::MakeVec(f0, f0, -f1, f0)},                                          // z =  0
+        {Math::MakeVec(f0, f0, f1, f1)},                                           // z = -w
+        {Math::MakeVec(f0, f0, f0, f1), Math::Vec4<float24>(f0, f0, f0, EPSILON)}, // w = EPSILON
     }};
 
     // Simple implementation of the Sutherland-Hodgman clipping algorithm.
@@ -157,7 +157,7 @@ void ProcessTriangle(const OutputVertex& v0, const OutputVertex& v1, const Outpu
     }
 
     if (g_state.regs.rasterizer.clip_enable) {
-        ClippingEdge custom_edge{-g_state.regs.rasterizer.GetClipCoef()};
+        ClippingEdge custom_edge{g_state.regs.rasterizer.GetClipCoef()};
         Clip(custom_edge);
 
         if (output_list->size() < 3)

--- a/src/video_core/swrasterizer/clipper.cpp
+++ b/src/video_core/swrasterizer/clipper.cpp
@@ -127,8 +127,7 @@ void ProcessTriangle(const OutputVertex& v0, const OutputVertex& v1, const Outpu
 
     // Simple implementation of the Sutherland-Hodgman clipping algorithm.
     // TODO: Make this less inefficient (currently lots of useless buffering overhead happens here)
-    for (auto edge : clipping_edges) {
-
+    auto Clip = [&](const ClippingEdge& edge) {
         std::swap(input_list, output_list);
         output_list->clear();
 
@@ -147,8 +146,20 @@ void ProcessTriangle(const OutputVertex& v0, const OutputVertex& v1, const Outpu
             }
             reference_vertex = &vertex;
         }
+    };
+
+    for (auto edge : clipping_edges) {
+        Clip(edge);
 
         // Need to have at least a full triangle to continue...
+        if (output_list->size() < 3)
+            return;
+    }
+
+    if (g_state.regs.rasterizer.clip_enable) {
+        ClippingEdge custom_edge{-g_state.regs.rasterizer.GetClipCoef()};
+        Clip(custom_edge);
+
         if (output_list->size() < 3)
             return;
     }


### PR DESCRIPTION
Not sure if this is used by any games, but since it was also tested in my previous PR, it can be just implemented now so that we won't forget it later.

[Here is a test program](https://github.com/wwylele/ctrhwtest/tree/master/clip-plane)

In GL implementation, the clipping calculation is in the vertex shader, which now needs uniform input. So I let vertex shader and fragment shader share the same uniform block and put the clip coefficient there.

I also flipped the sign convention of the sw clipper to use the same rule that GL and PICA use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2900)
<!-- Reviewable:end -->
