### PR TITLE
Disable unary operator- on Math::Vec2/Vec3/Vec4 for unsigned types.

### DIFF
--- a/src/common/vector_math.h
+++ b/src/common/vector_math.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include <cmath>
+#include <type_traits>
 
 namespace Math {
 
@@ -90,7 +91,8 @@ public:
         y -= other.y;
     }
 
-    Vec2<decltype(-T{})> operator-() const {
+    template <typename U = T>
+    Vec2<std::enable_if_t<std::is_signed<U>::value, U>> operator-() const {
         return MakeVec(-x, -y);
     }
     Vec2<decltype(T{} * T{})> operator*(const Vec2& other) const {
@@ -247,7 +249,8 @@ public:
         z -= other.z;
     }
 
-    Vec3<decltype(-T{})> operator-() const {
+    template <typename U = T>
+    Vec3<std::enable_if_t<std::is_signed<U>::value, U>> operator-() const {
         return MakeVec(-x, -y, -z);
     }
     Vec3<decltype(T{} * T{})> operator*(const Vec3& other) const {
@@ -462,7 +465,8 @@ public:
         w -= other.w;
     }
 
-    Vec4<decltype(-T{})> operator-() const {
+    template <typename U = T>
+    Vec4<std::enable_if_t<std::is_signed<U>::value, U>> operator-() const {
         return MakeVec(-x, -y, -z, -w);
     }
     Vec4<decltype(T{} * T{})> operator*(const Vec4& other) const {
@@ -720,4 +724,4 @@ static inline Vec4<T> MakeVec(const T& x, const Vec3<T>& yzw) {
     return MakeVec(x, yzw[0], yzw[1], yzw[2]);
 }
 
-} // namespace
+} // namespace Math

--- a/src/video_core/swrasterizer/clipper.cpp
+++ b/src/video_core/swrasterizer/clipper.cpp
@@ -98,7 +98,7 @@ void ProcessTriangle(const OutputVertex& v0, const OutputVertex& v1, const Outpu
 
     auto FlipQuaternionIfOpposite = [](auto& a, const auto& b) {
         if (Math::Dot(a, b) < float24::Zero())
-            a = -a;
+            a = a * float24::FromFloat32(-1.0f);
     };
 
     // Flip the quaternions if they are opposite to prevent interpolating them over the wrong


### PR DESCRIPTION
It is unlikely we will ever use this without first doing a Cast to a signed type.
Fixes 9 "unary minus operator applied to unsigned type, result still unsigned" warnings on MSVC2017.3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2907)
<!-- Reviewable:end -->
