### PR TITLE
Remove excess debug dlls for mingw build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -131,6 +131,12 @@ after_build:
           foreach ($file in $MingwDLLs) {
             Copy-Item -path "C:/msys64/mingw64/bin/$file" -force -destination "$RELEASE_DIST"
           }
+          # the above list copies a few extra debug dlls that aren't needed (thanks globbing patterns!)
+          # so we can remove them by hardcoding another list of extra dlls to remove
+          $DebugDLLs = "libicudtd*.dll","libicuind*.dll","libicuucd*.dll"
+          foreach ($file in $DebugDLLs) {
+            Remove-Item -path "$RELEASE_DIST/$file"
+          }
 
           # copy the qt windows plugin dll to platforms
           Copy-Item -path "C:/msys64/mingw64/share/qt5/plugins/platforms/qwindows.dll" -force -destination "$RELEASE_DIST/platforms"


### PR DESCRIPTION
`libicu` needs to be included for mingw, but the current globbing pattern used to copy the dlls to the build directory also grabs the dlls for debug. The purpose of using file globbing was to avoid hard coding versions for the dlls, in order to make sure that future updates to appveyor's version of mingw won't break the build. This change just removes any of the debug dlls for `icu` which shaves off over 10MB from the mingw download

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2918)
<!-- Reviewable:end -->
