### PR TITLE
Build: Enable SSL in mingw by linking against WinSSL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@
 cmake_minimum_required(VERSION 3.6)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/externals/cmake-modules")
+include(DownloadExternals)
 
 project(citra)
 
@@ -12,6 +13,15 @@ option(ENABLE_QT "Enable the Qt frontend" ON)
 option(CITRA_USE_BUNDLED_QT "Download bundled Qt binaries" OFF)
 
 option(ENABLE_WEB_SERVICE "Enable web services (telemetry, etc.)" ON)
+option(CITRA_USE_BUNDLED_CURL "FOR MINGW ONLY: Download curl configured against winssl instead of openssl" OFF)
+if (ENABLE_WEB_SERVICE AND CITRA_USE_BUNDLED_CURL AND WINDOWS AND MSVC)
+    message("Turning off use bundled curl as msvc can compile curl on cpr")
+    SET(CITRA_USE_BUNDLED_CURL OFF CACHE BOOL "" FORCE)
+endif()
+if (ENABLE_WEB_SERVICE AND NOT CITRA_USE_BUNDLED_CURL AND MINGW)
+    message(AUTHOR_WARNING "Turning on CITRA_USE_BUNDLED_CURL. Override it only if you know what you are doing.")
+    SET(CITRA_USE_BUNDLED_CURL ON CACHE BOOL "" FORCE)
+endif()
 
 if(NOT EXISTS ${CMAKE_SOURCE_DIR}/.git/hooks/pre-commit)
     message(STATUS "Copying pre-commit hook")
@@ -150,24 +160,6 @@ set_property(DIRECTORY APPEND PROPERTY
 
 # System imported libraries
 # ======================
-
-# This function downloads a binary library package from our external repo.
-# Params:
-#   remote_path: path to the file to download, relative to the remote repository root
-#   prefix_var: name of a variable which will be set with the path to the extracted contents
-function(download_bundled_external remote_path lib_name prefix_var)
-    set(prefix "${CMAKE_BINARY_DIR}/externals/${lib_name}")
-    if (NOT EXISTS "${prefix}")
-        message(STATUS "Downloading binaries for ${lib_name}...")
-        file(DOWNLOAD
-            https://github.com/citra-emu/ext-windows-bin/raw/master/${remote_path}${lib_name}.7z
-            "${CMAKE_BINARY_DIR}/externals/${lib_name}.7z" SHOW_PROGRESS)
-        execute_process(COMMAND ${CMAKE_COMMAND} -E tar xf "${CMAKE_BINARY_DIR}/externals/${lib_name}.7z"
-            WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/externals")
-    endif()
-    message(STATUS "Using bundled binaries at ${prefix}")
-    set(${prefix_var} "${prefix}" PARENT_SCOPE)
-endfunction()
 
 find_package(PNG QUIET)
 if (NOT PNG_FOUND)

--- a/CMakeModules/DownloadExternals.cmake
+++ b/CMakeModules/DownloadExternals.cmake
@@ -1,0 +1,18 @@
+
+# This function downloads a binary library package from our external repo.
+# Params:
+#   remote_path: path to the file to download, relative to the remote repository root
+#   prefix_var: name of a variable which will be set with the path to the extracted contents
+function(download_bundled_external remote_path lib_name prefix_var)
+set(prefix "${CMAKE_BINARY_DIR}/externals/${lib_name}")
+if (NOT EXISTS "${prefix}")
+    message(STATUS "Downloading binaries for ${lib_name}...")
+    file(DOWNLOAD
+        https://github.com/citra-emu/ext-windows-bin/raw/master/${remote_path}${lib_name}.7z
+        "${CMAKE_BINARY_DIR}/externals/${lib_name}.7z" SHOW_PROGRESS)
+    execute_process(COMMAND ${CMAKE_COMMAND} -E tar xf "${CMAKE_BINARY_DIR}/externals/${lib_name}.7z"
+        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/externals")
+endif()
+message(STATUS "Using bundled binaries at ${prefix}")
+set(${prefix_var} "${prefix}" PARENT_SCOPE)
+endfunction()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,7 +44,7 @@ before_build:
           # redirect stderr and change the exit code to prevent powershell from cancelling the build if cmake prints a warning
           cmd /C 'cmake -G "Visual Studio 15 2017 Win64" -DCITRA_USE_BUNDLED_QT=1 -DCITRA_USE_BUNDLED_SDL2=1 -DCMAKE_USE_OPENSSL=0 .. 2>&1 && exit 0'
         } else {
-          C:\msys64\usr\bin\bash.exe -lc "cmake -G 'MSYS Makefiles' -DUSE_SYSTEM_CURL=1 -DCMAKE_BUILD_TYPE=Release .. 2>&1"
+          C:\msys64\usr\bin\bash.exe -lc "cmake -G 'MSYS Makefiles' -DUSE_SYSTEM_CURL=1 -DCITRA_USE_BUNDLED_CURL=1 -DCMAKE_BUILD_TYPE=Release .. 2>&1"
         }
   - cd ..
 
@@ -112,9 +112,10 @@ after_build:
 
           # copy the compiled binaries and other release files to the release folder
           Get-ChildItem "$CMAKE_BINARY_DIR" -Recurse -Filter "citra*.exe" | Copy-Item -destination $RELEASE_DIST
+          # copy the libcurl dll
+          Get-ChildItem "$CMAKE_BINARY_DIR" -Recurse -Filter "libcurl.dll" | Copy-Item -destination $RELEASE_DIST
           Copy-Item -path "$CMAKE_SOURCE_DIR/license.txt" -destination $RELEASE_DIST
           Copy-Item -path "$CMAKE_SOURCE_DIR/README.md" -destination $RELEASE_DIST
-
           # copy all the dll dependencies to the release folder
           # hardcoded list because we don't build static and determining the list of dlls from the binary is a pain.
           $MingwDLLs = "Qt5Core.dll","Qt5Widgets.dll","Qt5Gui.dll","Qt5OpenGL.dll",
@@ -123,11 +124,7 @@ after_build:
                        "libfreetype-*.dll","libglib-*.dll","libgobject-*.dll","libgraphite2.dll","libiconv-*.dll",
                        "libharfbuzz-*.dll","libintl-*.dll","libpcre-*.dll","libpcre16-*.dll","libpng16-*.dll",
                        # Runtime/Other dependencies
-                       "libgcc_s_seh-*.dll","libstdc++-*.dll","libwinpthread-*.dll","SDL2.dll","zlib1.dll",
-                       # curl dependencies
-                       "libcurl-*.dll","libnghttp2-*.dll","libeay32.dll","libgmp-*.dll","librtmp-*.dll",
-                       "libgnutls-*.dll","libhogweed-*.dll","libnettle-*.dll","libssh2-*.dll",
-                       "ssleay32.dll","libidn-*.dll","libp11-kit-*.dll","libtasn1-*.dll","libunistring-*.dll"
+                       "libgcc_s_seh-*.dll","libstdc++-*.dll","libwinpthread-*.dll","SDL2.dll","zlib1.dll"
           foreach ($file in $MingwDLLs) {
             Copy-Item -path "C:/msys64/mingw64/bin/$file" -force -destination "$RELEASE_DIST"
           }

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -1,5 +1,8 @@
 # Definitions for all external bundled libraries
 
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/CMakeModules)
+include(DownloadExternals)
+
 # Catch
 add_library(catch-single-include INTERFACE)
 target_include_directories(catch-single-include INTERFACE catch/single_include)
@@ -54,9 +57,21 @@ add_subdirectory(enet)
 target_include_directories(enet INTERFACE ./enet/include)
 
 if (ENABLE_WEB_SERVICE)
+    # msys installed curl is configured to use openssl, but that isn't portable
+    # since it relies on having the bundled certs install in the home folder for SSL
+    # by default on mingw, download the precompiled curl thats linked against windows native ssl
+    if (MINGW AND CITRA_USE_BUNDLED_CURL)
+        download_bundled_external("curl/" "curl-7_55_1" CURL_PREFIX)
+        set(CURL_PREFIX "${CMAKE_BINARY_DIR}/externals/curl-7_55_1")
+        set(CURL_FOUND YES)
+        set(CURL_INCLUDE_DIR "${CURL_PREFIX}/include" CACHE PATH "Path to curl headers")
+        set(CURL_LIBRARY "${CURL_PREFIX}/lib/libcurldll.a" CACHE PATH "Path to curl library")
+        set(CURL_DLL_DIR "${CURL_PREFIX}/lib/" CACHE PATH "Path to curl.dll")
+        set(USE_SYSTEM_CURL ON CACHE BOOL "")
+    endif()
     # CPR
-    option(BUILD_TESTING OFF)
-    option(BUILD_CPR_TESTS OFF)
+    set(BUILD_TESTING OFF CACHE BOOL "")
+    set(BUILD_CPR_TESTS OFF CACHE BOOL "")
     add_subdirectory(cpr)
     target_include_directories(cpr INTERFACE ./cpr/include)
 


### PR DESCRIPTION
The mingw builds aren't submitting telemetry because the curl library
they are linked against is configured to use openSSL and openSSL looks
for the certificates in the users home folder. This keeps it from
contacting web services because it can't communicate over SSL.

This commit adds a download in mingw builds that will download a
precompiled curl for mingw linked against winssl and sspi.

This change is dependent on https://github.com/citra-emu/ext-windows-bin/pull/7 so **do not merge before that one** This PR won't even build properly without it. I'm submitting this PR now so we can get the ext-win-bin one merged sooner than later, so we can get this one merged as well. After that one is merged, we will need to do some more testing on different machines to verify that everything is still working in both mingw and msvc builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2922)
<!-- Reviewable:end -->
