### PR TITLE
travis_OSX: build with system curl

### DIFF
--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -52,7 +52,7 @@ elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
     export Qt5_DIR=$(brew --prefix)/opt/qt5
 
     mkdir build && cd build
-    cmake .. -GXcode
+    cmake .. -DUSE_SYSTEM_CURL=ON -GXcode
     xcodebuild -configuration Release
 
     ctest -VV -C Release


### PR DESCRIPTION
This fixes that osx builds won't send any telemetry

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2923)
<!-- Reviewable:end -->
