### PR TITLE
Loader/NCCH: Add support for loading application updates

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SRCS
             file_sys/archive_systemsavedata.cpp
             file_sys/disk_archive.cpp
             file_sys/ivfc_archive.cpp
+            file_sys/ncch_container.cpp
             file_sys/path_parser.cpp
             file_sys/savedata_archive.cpp
             frontend/camera/blank_camera.cpp

--- a/src/core/file_sys/archive_selfncch.cpp
+++ b/src/core/file_sys/archive_selfncch.cpp
@@ -102,8 +102,7 @@ public:
 
         switch (static_cast<SelfNCCHFilePathType>(file_path.type)) {
         case SelfNCCHFilePathType::UpdateRomFS:
-            LOG_WARNING(Service_FS, "(STUBBED) open update RomFS");
-            return OpenRomFS();
+            return OpenUpdateRomFS();
 
         case SelfNCCHFilePathType::RomFS:
             return OpenRomFS();
@@ -179,6 +178,16 @@ private:
         }
     }
 
+    ResultVal<std::unique_ptr<FileBackend>> OpenUpdateRomFS() const {
+        if (ncch_data.update_romfs_file) {
+            return MakeResult<std::unique_ptr<FileBackend>>(std::make_unique<IVFCFile>(
+                ncch_data.update_romfs_file, ncch_data.update_romfs_offset, ncch_data.update_romfs_size));
+        } else {
+            LOG_INFO(Service_FS, "Unable to read update RomFS");
+            return ERROR_ROMFS_NOT_FOUND;
+        }
+    }
+
     ResultVal<std::unique_ptr<FileBackend>> OpenExeFS(const std::string& filename) const {
         if (filename == "icon") {
             if (ncch_data.icon) {
@@ -223,6 +232,13 @@ ArchiveFactory_SelfNCCH::ArchiveFactory_SelfNCCH(Loader::AppLoader& app_loader) 
         app_loader.ReadRomFS(romfs_file_, ncch_data.romfs_offset, ncch_data.romfs_size)) {
 
         ncch_data.romfs_file = std::move(romfs_file_);
+    }
+
+    std::shared_ptr<FileUtil::IOFile> update_romfs_file_;
+    if (Loader::ResultStatus::Success ==
+        app_loader.ReadUpdateRomFS(update_romfs_file_, ncch_data.update_romfs_offset, ncch_data.update_romfs_size)) {
+
+        ncch_data.update_romfs_file = std::move(update_romfs_file_);
     }
 
     std::vector<u8> buffer;

--- a/src/core/file_sys/archive_selfncch.cpp
+++ b/src/core/file_sys/archive_selfncch.cpp
@@ -228,19 +228,19 @@ private:
 };
 
 ArchiveFactory_SelfNCCH::ArchiveFactory_SelfNCCH(Loader::AppLoader& app_loader) {
-    std::shared_ptr<FileUtil::IOFile> romfs_file_;
+    std::shared_ptr<FileUtil::IOFile> romfs_file;
     if (Loader::ResultStatus::Success ==
-        app_loader.ReadRomFS(romfs_file_, ncch_data.romfs_offset, ncch_data.romfs_size)) {
+        app_loader.ReadRomFS(romfs_file, ncch_data.romfs_offset, ncch_data.romfs_size)) {
 
-        ncch_data.romfs_file = std::move(romfs_file_);
+        ncch_data.romfs_file = std::move(romfs_file);
     }
 
-    std::shared_ptr<FileUtil::IOFile> update_romfs_file_;
+    std::shared_ptr<FileUtil::IOFile> update_romfs_file;
     if (Loader::ResultStatus::Success ==
-        app_loader.ReadUpdateRomFS(update_romfs_file_, ncch_data.update_romfs_offset,
+        app_loader.ReadUpdateRomFS(update_romfs_file, ncch_data.update_romfs_offset,
                                    ncch_data.update_romfs_size)) {
 
-        ncch_data.update_romfs_file = std::move(update_romfs_file_);
+        ncch_data.update_romfs_file = std::move(update_romfs_file);
     }
 
     std::vector<u8> buffer;

--- a/src/core/file_sys/archive_selfncch.cpp
+++ b/src/core/file_sys/archive_selfncch.cpp
@@ -181,7 +181,8 @@ private:
     ResultVal<std::unique_ptr<FileBackend>> OpenUpdateRomFS() const {
         if (ncch_data.update_romfs_file) {
             return MakeResult<std::unique_ptr<FileBackend>>(std::make_unique<IVFCFile>(
-                ncch_data.update_romfs_file, ncch_data.update_romfs_offset, ncch_data.update_romfs_size));
+                ncch_data.update_romfs_file, ncch_data.update_romfs_offset,
+                ncch_data.update_romfs_size));
         } else {
             LOG_INFO(Service_FS, "Unable to read update RomFS");
             return ERROR_ROMFS_NOT_FOUND;
@@ -236,7 +237,8 @@ ArchiveFactory_SelfNCCH::ArchiveFactory_SelfNCCH(Loader::AppLoader& app_loader) 
 
     std::shared_ptr<FileUtil::IOFile> update_romfs_file_;
     if (Loader::ResultStatus::Success ==
-        app_loader.ReadUpdateRomFS(update_romfs_file_, ncch_data.update_romfs_offset, ncch_data.update_romfs_size)) {
+        app_loader.ReadUpdateRomFS(update_romfs_file_, ncch_data.update_romfs_offset,
+                                   ncch_data.update_romfs_size)) {
 
         ncch_data.update_romfs_file = std::move(update_romfs_file_);
     }

--- a/src/core/file_sys/archive_selfncch.h
+++ b/src/core/file_sys/archive_selfncch.h
@@ -24,6 +24,10 @@ struct NCCHData {
     std::shared_ptr<FileUtil::IOFile> romfs_file;
     u64 romfs_offset = 0;
     u64 romfs_size = 0;
+
+    std::shared_ptr<FileUtil::IOFile> update_romfs_file;
+    u64 update_romfs_offset = 0;
+    u64 update_romfs_size = 0;
 };
 
 /// File system interface to the SelfNCCH archive

--- a/src/core/file_sys/ncch_container.cpp
+++ b/src/core/file_sys/ncch_container.cpp
@@ -18,7 +18,7 @@ namespace FileSys {
 
 static const int kMaxSections = 8;   ///< Maximum number of sections (files) in an ExeFs
 static const int kBlockSize = 0x200; ///< Size of ExeFS blocks (in bytes)
-static const u64_le updateMask = 0x0000000e00000000;
+static const u64 UPDATE_MASK = 0x0000000e00000000;
 
 /**
  * Get the decompressed size of an LZSS compressed ExeFS file
@@ -163,7 +163,7 @@ Loader::ResultStatus NCCHContainer::Load() {
               static_cast<int>(exheader_header.arm11_system_local_caps.system_mode));
 
     if (exheader_header.arm11_system_local_caps.program_id &
-        ~updateMask != ncch_header.program_id) {
+        ~UPDATE_MASK != ncch_header.program_id) {
         LOG_ERROR(Service_FS, "ExHeader Program ID mismatch: the ROM is probably encrypted.");
         return Loader::ResultStatus::ErrorEncrypted;
     }

--- a/src/core/file_sys/ncch_container.cpp
+++ b/src/core/file_sys/ncch_container.cpp
@@ -104,7 +104,13 @@ Loader::ResultStatus NCCHContainer::OpenFile(std::string filepath) {
     this->filepath = filepath;
     file = FileUtil::IOFile(filepath, "rb");
 
-    LOG_DEBUG(Service_FS, "Opening %s", filepath.c_str());
+    if (!file.IsOpen()) {
+        LOG_WARNING(Service_FS, "Failed to open %s", filepath.c_str());
+        return Loader::ResultStatus::Error;
+    }
+
+    LOG_DEBUG(Service_FS, "Opened %s", filepath.c_str());
+    return Loader::ResultStatus::Success;
 }
 
 Loader::ResultStatus NCCHContainer::Load() {

--- a/src/core/file_sys/ncch_container.cpp
+++ b/src/core/file_sys/ncch_container.cpp
@@ -16,259 +16,256 @@
 
 namespace FileSys {
 
-    static const int kMaxSections = 8;   ///< Maximum number of sections (files) in an ExeFs
-    static const int kBlockSize = 0x200; ///< Size of ExeFS blocks (in bytes)
-    static const u64_le updateMask = 0x0000000e00000000;
+static const int kMaxSections = 8;   ///< Maximum number of sections (files) in an ExeFs
+static const int kBlockSize = 0x200; ///< Size of ExeFS blocks (in bytes)
+static const u64_le updateMask = 0x0000000e00000000;
 
-    /**
-     * Get the decompressed size of an LZSS compressed ExeFS file
-     * @param buffer Buffer of compressed file
-     * @param size Size of compressed buffer
-     * @return Size of decompressed buffer
-     */
-    static u32 LZSS_GetDecompressedSize(const u8* buffer, u32 size) {
-        u32 offset_size = *(u32*)(buffer + size - 4);
-        return offset_size + size;
-    }
+/**
+ * Get the decompressed size of an LZSS compressed ExeFS file
+ * @param buffer Buffer of compressed file
+ * @param size Size of compressed buffer
+ * @return Size of decompressed buffer
+ */
+static u32 LZSS_GetDecompressedSize(const u8* buffer, u32 size) {
+    u32 offset_size = *(u32*)(buffer + size - 4);
+    return offset_size + size;
+}
 
-    /**
-     * Decompress ExeFS file (compressed with LZSS)
-     * @param compressed Compressed buffer
-     * @param compressed_size Size of compressed buffer
-     * @param decompressed Decompressed buffer
-     * @param decompressed_size Size of decompressed buffer
-     * @return True on success, otherwise false
-     */
-    static bool LZSS_Decompress(const u8* compressed, u32 compressed_size, u8* decompressed,
-                                u32 decompressed_size) {
-        const u8* footer = compressed + compressed_size - 8;
-        u32 buffer_top_and_bottom = *reinterpret_cast<const u32*>(footer);
-        u32 out = decompressed_size;
-        u32 index = compressed_size - ((buffer_top_and_bottom >> 24) & 0xFF);
-        u32 stop_index = compressed_size - (buffer_top_and_bottom & 0xFFFFFF);
+/**
+ * Decompress ExeFS file (compressed with LZSS)
+ * @param compressed Compressed buffer
+ * @param compressed_size Size of compressed buffer
+ * @param decompressed Decompressed buffer
+ * @param decompressed_size Size of decompressed buffer
+ * @return True on success, otherwise false
+ */
+static bool LZSS_Decompress(const u8* compressed, u32 compressed_size, u8* decompressed,
+                            u32 decompressed_size) {
+    const u8* footer = compressed + compressed_size - 8;
+    u32 buffer_top_and_bottom = *reinterpret_cast<const u32*>(footer);
+    u32 out = decompressed_size;
+    u32 index = compressed_size - ((buffer_top_and_bottom >> 24) & 0xFF);
+    u32 stop_index = compressed_size - (buffer_top_and_bottom & 0xFFFFFF);
 
-        memset(decompressed, 0, decompressed_size);
-        memcpy(decompressed, compressed, compressed_size);
+    memset(decompressed, 0, decompressed_size);
+    memcpy(decompressed, compressed, compressed_size);
 
-        while (index > stop_index) {
-            u8 control = compressed[--index];
+    while (index > stop_index) {
+        u8 control = compressed[--index];
 
-            for (unsigned i = 0; i < 8; i++) {
-                if (index <= stop_index)
-                    break;
-                if (index <= 0)
-                    break;
-                if (out <= 0)
-                    break;
+        for (unsigned i = 0; i < 8; i++) {
+            if (index <= stop_index)
+                break;
+            if (index <= 0)
+                break;
+            if (out <= 0)
+                break;
 
-                if (control & 0x80) {
+            if (control & 0x80) {
+                // Check if compression is out of bounds
+                if (index < 2)
+                    return false;
+                index -= 2;
+
+                u32 segment_offset = compressed[index] | (compressed[index + 1] << 8);
+                u32 segment_size = ((segment_offset >> 12) & 15) + 3;
+                segment_offset &= 0x0FFF;
+                segment_offset += 2;
+
+                // Check if compression is out of bounds
+                if (out < segment_size)
+                    return false;
+
+                for (unsigned j = 0; j < segment_size; j++) {
                     // Check if compression is out of bounds
-                    if (index < 2)
-                        return false;
-                    index -= 2;
-
-                    u32 segment_offset = compressed[index] | (compressed[index + 1] << 8);
-                    u32 segment_size = ((segment_offset >> 12) & 15) + 3;
-                    segment_offset &= 0x0FFF;
-                    segment_offset += 2;
-
-                    // Check if compression is out of bounds
-                    if (out < segment_size)
+                    if (out + segment_offset >= decompressed_size)
                         return false;
 
-                    for (unsigned j = 0; j < segment_size; j++) {
-                        // Check if compression is out of bounds
-                        if (out + segment_offset >= decompressed_size)
-                            return false;
-
-                        u8 data = decompressed[out + segment_offset];
-                        decompressed[--out] = data;
-                    }
-                } else {
-                    // Check if compression is out of bounds
-                    if (out < 1)
-                        return false;
-                    decompressed[--out] = compressed[--index];
+                    u8 data = decompressed[out + segment_offset];
+                    decompressed[--out] = data;
                 }
-                control <<= 1;
+            } else {
+                // Check if compression is out of bounds
+                if (out < 1)
+                    return false;
+                decompressed[--out] = compressed[--index];
             }
+            control <<= 1;
         }
-        return true;
     }
+    return true;
+}
 
-    NCCHContainer::NCCHContainer(std::string filepath)
-        : filepath(filepath)
-    {
-        file = FileUtil::IOFile(filepath, "rb");
-    }
+NCCHContainer::NCCHContainer(std::string filepath) : filepath(filepath) {
+    file = FileUtil::IOFile(filepath, "rb");
+}
 
-    Loader::ResultStatus NCCHContainer::OpenFile(std::string filepath)
-    {
-        this->filepath = filepath;
-        file = FileUtil::IOFile(filepath, "rb");
+Loader::ResultStatus NCCHContainer::OpenFile(std::string filepath) {
+    this->filepath = filepath;
+    file = FileUtil::IOFile(filepath, "rb");
 
-        LOG_DEBUG(Loader, "Opening %s", filepath.c_str());
-    }
+    LOG_DEBUG(Service_FS, "Opening %s", filepath.c_str());
+}
 
-    Loader::ResultStatus NCCHContainer::Load() {
-        if (is_loaded)
-            return Loader::ResultStatus::Success;
-
-        // Reset read pointer in case this file has been read before.
-        file.Seek(0, SEEK_SET);
-
-        if (file.ReadBytes(&ncch_header, sizeof(NCCH_Header)) != sizeof(NCCH_Header))
-            return Loader::ResultStatus::Error;
-
-        // Skip NCSD header and load first NCCH (NCSD is just a container of NCCH files)...
-        if (Loader::MakeMagic('N', 'C', 'S', 'D') == ncch_header.magic) {
-            LOG_DEBUG(Loader, "Only loading the first (bootable) NCCH within the NCSD file!");
-            ncch_offset = 0x4000;
-            file.Seek(ncch_offset, SEEK_SET);
-            file.ReadBytes(&ncch_header, sizeof(NCCH_Header));
-        }
-
-        // Verify we are loading the correct file type...
-        if (Loader::MakeMagic('N', 'C', 'C', 'H') != ncch_header.magic)
-            return Loader::ResultStatus::ErrorInvalidFormat;
-
-        // Read ExHeader...
-
-        if (file.ReadBytes(&exheader_header, sizeof(ExHeader_Header)) != sizeof(ExHeader_Header))
-            return Loader::ResultStatus::Error;
-
-        is_compressed = (exheader_header.codeset_info.flags.flag & 1) == 1;
-        u32 entry_point = exheader_header.codeset_info.text.address;
-        u32 code_size = exheader_header.codeset_info.text.code_size;
-        u32 stack_size = exheader_header.codeset_info.stack_size;
-        u32 bss_size = exheader_header.codeset_info.bss_size;
-        u32 core_version = exheader_header.arm11_system_local_caps.core_version;
-        u8 priority = exheader_header.arm11_system_local_caps.priority;
-        u8 resource_limit_category = exheader_header.arm11_system_local_caps.resource_limit_category;
-
-        LOG_DEBUG(Loader, "Name:                        %s", exheader_header.codeset_info.name);
-        LOG_DEBUG(Loader, "Program ID:                  %016" PRIX64, ncch_header.program_id);
-        LOG_DEBUG(Loader, "Code compressed:             %s", is_compressed ? "yes" : "no");
-        LOG_DEBUG(Loader, "Entry point:                 0x%08X", entry_point);
-        LOG_DEBUG(Loader, "Code size:                   0x%08X", code_size);
-        LOG_DEBUG(Loader, "Stack size:                  0x%08X", stack_size);
-        LOG_DEBUG(Loader, "Bss size:                    0x%08X", bss_size);
-        LOG_DEBUG(Loader, "Core version:                %d", core_version);
-        LOG_DEBUG(Loader, "Thread priority:             0x%X", priority);
-        LOG_DEBUG(Loader, "Resource limit category:     %d", resource_limit_category);
-        LOG_DEBUG(Loader, "System Mode:                 %d",
-                  static_cast<int>(exheader_header.arm11_system_local_caps.system_mode));
-
-        if (exheader_header.arm11_system_local_caps.program_id & ~updateMask != ncch_header.program_id) {
-            LOG_ERROR(Loader, "ExHeader Program ID mismatch: the ROM is probably encrypted.");
-            return Loader::ResultStatus::ErrorEncrypted;
-        }
-
-        // Read ExeFS...
-
-        exefs_offset = ncch_header.exefs_offset * kBlockSize;
-        u32 exefs_size = ncch_header.exefs_size * kBlockSize;
-
-        LOG_DEBUG(Loader, "ExeFS offset:                0x%08X", exefs_offset);
-        LOG_DEBUG(Loader, "ExeFS size:                  0x%08X", exefs_size);
-
-        file.Seek(exefs_offset + ncch_offset, SEEK_SET);
-        if (file.ReadBytes(&exefs_header, sizeof(ExeFs_Header)) != sizeof(ExeFs_Header))
-            return Loader::ResultStatus::Error;
-
-        is_loaded = true;
+Loader::ResultStatus NCCHContainer::Load() {
+    if (is_loaded)
         return Loader::ResultStatus::Success;
+
+    // Reset read pointer in case this file has been read before.
+    file.Seek(0, SEEK_SET);
+
+    if (file.ReadBytes(&ncch_header, sizeof(NCCH_Header)) != sizeof(NCCH_Header))
+        return Loader::ResultStatus::Error;
+
+    // Skip NCSD header and load first NCCH (NCSD is just a container of NCCH files)...
+    if (Loader::MakeMagic('N', 'C', 'S', 'D') == ncch_header.magic) {
+        LOG_DEBUG(Service_FS, "Only loading the first (bootable) NCCH within the NCSD file!");
+        ncch_offset = 0x4000;
+        file.Seek(ncch_offset, SEEK_SET);
+        file.ReadBytes(&ncch_header, sizeof(NCCH_Header));
     }
 
-    Loader::ResultStatus NCCHContainer::LoadSectionExeFS(const char* name, std::vector<u8>& buffer) {
-        if (!file.IsOpen())
-            return Loader::ResultStatus::Error;
+    // Verify we are loading the correct file type...
+    if (Loader::MakeMagic('N', 'C', 'C', 'H') != ncch_header.magic)
+        return Loader::ResultStatus::ErrorInvalidFormat;
 
-        Loader::ResultStatus result = Load();
-        if (result != Loader::ResultStatus::Success)
-            return result;
+    // Read ExHeader...
 
-        LOG_DEBUG(Loader, "%d sections:", kMaxSections);
-        // Iterate through the ExeFs archive until we find a section with the specified name...
-        for (unsigned section_number = 0; section_number < kMaxSections; section_number++) {
-            const auto& section = exefs_header.section[section_number];
+    if (file.ReadBytes(&exheader_header, sizeof(ExHeader_Header)) != sizeof(ExHeader_Header))
+        return Loader::ResultStatus::Error;
 
-            // Load the specified section...
-            if (strcmp(section.name, name) == 0) {
-                LOG_DEBUG(Loader, "%d - offset: 0x%08X, size: 0x%08X, name: %s", section_number,
-                          section.offset, section.size, section.name);
+    is_compressed = (exheader_header.codeset_info.flags.flag & 1) == 1;
+    u32 entry_point = exheader_header.codeset_info.text.address;
+    u32 code_size = exheader_header.codeset_info.text.code_size;
+    u32 stack_size = exheader_header.codeset_info.stack_size;
+    u32 bss_size = exheader_header.codeset_info.bss_size;
+    u32 core_version = exheader_header.arm11_system_local_caps.core_version;
+    u8 priority = exheader_header.arm11_system_local_caps.priority;
+    u8 resource_limit_category = exheader_header.arm11_system_local_caps.resource_limit_category;
 
-                s64 section_offset =
-                    (section.offset + exefs_offset + sizeof(ExeFs_Header) + ncch_offset);
-                file.Seek(section_offset, SEEK_SET);
+    LOG_DEBUG(Service_FS, "Name:                        %s", exheader_header.codeset_info.name);
+    LOG_DEBUG(Service_FS, "Program ID:                  %016" PRIX64, ncch_header.program_id);
+    LOG_DEBUG(Service_FS, "Code compressed:             %s", is_compressed ? "yes" : "no");
+    LOG_DEBUG(Service_FS, "Entry point:                 0x%08X", entry_point);
+    LOG_DEBUG(Service_FS, "Code size:                   0x%08X", code_size);
+    LOG_DEBUG(Service_FS, "Stack size:                  0x%08X", stack_size);
+    LOG_DEBUG(Service_FS, "Bss size:                    0x%08X", bss_size);
+    LOG_DEBUG(Service_FS, "Core version:                %d", core_version);
+    LOG_DEBUG(Service_FS, "Thread priority:             0x%X", priority);
+    LOG_DEBUG(Service_FS, "Resource limit category:     %d", resource_limit_category);
+    LOG_DEBUG(Service_FS, "System Mode:                 %d",
+              static_cast<int>(exheader_header.arm11_system_local_caps.system_mode));
 
-                if (strcmp(section.name, ".code") == 0 && is_compressed) {
-                    // Section is compressed, read compressed .code section...
-                    std::unique_ptr<u8[]> temp_buffer;
-                    try {
-                        temp_buffer.reset(new u8[section.size]);
-                    } catch (std::bad_alloc&) {
-                        return Loader::ResultStatus::ErrorMemoryAllocationFailed;
-                    }
+    if (exheader_header.arm11_system_local_caps.program_id &
+        ~updateMask != ncch_header.program_id) {
+        LOG_ERROR(Service_FS, "ExHeader Program ID mismatch: the ROM is probably encrypted.");
+        return Loader::ResultStatus::ErrorEncrypted;
+    }
 
-                    if (file.ReadBytes(&temp_buffer[0], section.size) != section.size)
-                        return Loader::ResultStatus::Error;
+    // Read ExeFS...
 
-                    // Decompress .code section...
-                    u32 decompressed_size = LZSS_GetDecompressedSize(&temp_buffer[0], section.size);
-                    buffer.resize(decompressed_size);
-                    if (!LZSS_Decompress(&temp_buffer[0], section.size, &buffer[0], decompressed_size))
-                        return Loader::ResultStatus::ErrorInvalidFormat;
-                } else {
-                    // Section is uncompressed...
-                    buffer.resize(section.size);
-                    if (file.ReadBytes(&buffer[0], section.size) != section.size)
-                        return Loader::ResultStatus::Error;
+    exefs_offset = ncch_header.exefs_offset * kBlockSize;
+    u32 exefs_size = ncch_header.exefs_size * kBlockSize;
+
+    LOG_DEBUG(Service_FS, "ExeFS offset:                0x%08X", exefs_offset);
+    LOG_DEBUG(Service_FS, "ExeFS size:                  0x%08X", exefs_size);
+
+    file.Seek(exefs_offset + ncch_offset, SEEK_SET);
+    if (file.ReadBytes(&exefs_header, sizeof(ExeFs_Header)) != sizeof(ExeFs_Header))
+        return Loader::ResultStatus::Error;
+
+    is_loaded = true;
+    return Loader::ResultStatus::Success;
+}
+
+Loader::ResultStatus NCCHContainer::LoadSectionExeFS(const char* name, std::vector<u8>& buffer) {
+    if (!file.IsOpen())
+        return Loader::ResultStatus::Error;
+
+    Loader::ResultStatus result = Load();
+    if (result != Loader::ResultStatus::Success)
+        return result;
+
+    LOG_DEBUG(Service_FS, "%d sections:", kMaxSections);
+    // Iterate through the ExeFs archive until we find a section with the specified name...
+    for (unsigned section_number = 0; section_number < kMaxSections; section_number++) {
+        const auto& section = exefs_header.section[section_number];
+
+        // Load the specified section...
+        if (strcmp(section.name, name) == 0) {
+            LOG_DEBUG(Service_FS, "%d - offset: 0x%08X, size: 0x%08X, name: %s", section_number,
+                      section.offset, section.size, section.name);
+
+            s64 section_offset =
+                (section.offset + exefs_offset + sizeof(ExeFs_Header) + ncch_offset);
+            file.Seek(section_offset, SEEK_SET);
+
+            if (strcmp(section.name, ".code") == 0 && is_compressed) {
+                // Section is compressed, read compressed .code section...
+                std::unique_ptr<u8[]> temp_buffer;
+                try {
+                    temp_buffer.reset(new u8[section.size]);
+                } catch (std::bad_alloc&) {
+                    return Loader::ResultStatus::ErrorMemoryAllocationFailed;
                 }
-                return Loader::ResultStatus::Success;
+
+                if (file.ReadBytes(&temp_buffer[0], section.size) != section.size)
+                    return Loader::ResultStatus::Error;
+
+                // Decompress .code section...
+                u32 decompressed_size = LZSS_GetDecompressedSize(&temp_buffer[0], section.size);
+                buffer.resize(decompressed_size);
+                if (!LZSS_Decompress(&temp_buffer[0], section.size, &buffer[0], decompressed_size))
+                    return Loader::ResultStatus::ErrorInvalidFormat;
+            } else {
+                // Section is uncompressed...
+                buffer.resize(section.size);
+                if (file.ReadBytes(&buffer[0], section.size) != section.size)
+                    return Loader::ResultStatus::Error;
             }
-        }
-        return Loader::ResultStatus::ErrorNotUsed;
-    }
-
-    Loader::ResultStatus NCCHContainer::ReadRomFS(std::shared_ptr<FileUtil::IOFile>& romfs_file, u64& offset,
-                                           u64& size) {
-        if (!file.IsOpen())
-            return Loader::ResultStatus::Error;
-
-        // Check if the NCCH has a RomFS...
-        if (ncch_header.romfs_offset != 0 && ncch_header.romfs_size != 0) {
-            u32 romfs_offset = ncch_offset + (ncch_header.romfs_offset * kBlockSize) + 0x1000;
-            u32 romfs_size = (ncch_header.romfs_size * kBlockSize) - 0x1000;
-
-            LOG_DEBUG(Loader, "RomFS offset:           0x%08X", romfs_offset);
-            LOG_DEBUG(Loader, "RomFS size:             0x%08X", romfs_size);
-
-            if (file.GetSize() < romfs_offset + romfs_size)
-                return Loader::ResultStatus::Error;
-
-            // We reopen the file, to allow its position to be independent from file's
-            romfs_file = std::make_shared<FileUtil::IOFile>(filepath, "rb");
-            if (!romfs_file->IsOpen())
-                return Loader::ResultStatus::Error;
-
-            offset = romfs_offset;
-            size = romfs_size;
-
             return Loader::ResultStatus::Success;
         }
-        LOG_DEBUG(Loader, "NCCH has no RomFS");
-        return Loader::ResultStatus::ErrorNotUsed;
     }
+    return Loader::ResultStatus::ErrorNotUsed;
+}
 
-    Loader::ResultStatus NCCHContainer::ReadProgramId(u64_le& program_id)
-    {
-        Loader::ResultStatus result = Load();
-        if (result != Loader::ResultStatus::Success)
-            return result;
+Loader::ResultStatus NCCHContainer::ReadRomFS(std::shared_ptr<FileUtil::IOFile>& romfs_file,
+                                              u64& offset, u64& size) {
+    if (!file.IsOpen())
+        return Loader::ResultStatus::Error;
 
-        program_id = ncch_header.program_id;
+    // Check if the NCCH has a RomFS...
+    if (ncch_header.romfs_offset != 0 && ncch_header.romfs_size != 0) {
+        u32 romfs_offset = ncch_offset + (ncch_header.romfs_offset * kBlockSize) + 0x1000;
+        u32 romfs_size = (ncch_header.romfs_size * kBlockSize) - 0x1000;
+
+        LOG_DEBUG(Service_FS, "RomFS offset:           0x%08X", romfs_offset);
+        LOG_DEBUG(Service_FS, "RomFS size:             0x%08X", romfs_size);
+
+        if (file.GetSize() < romfs_offset + romfs_size)
+            return Loader::ResultStatus::Error;
+
+        // We reopen the file, to allow its position to be independent from file's
+        romfs_file = std::make_shared<FileUtil::IOFile>(filepath, "rb");
+        if (!romfs_file->IsOpen())
+            return Loader::ResultStatus::Error;
+
+        offset = romfs_offset;
+        size = romfs_size;
+
         return Loader::ResultStatus::Success;
     }
+    LOG_DEBUG(Service_FS, "NCCH has no RomFS");
+    return Loader::ResultStatus::ErrorNotUsed;
+}
+
+Loader::ResultStatus NCCHContainer::ReadProgramId(u64_le& program_id) {
+    Loader::ResultStatus result = Load();
+    if (result != Loader::ResultStatus::Success)
+        return result;
+
+    program_id = ncch_header.program_id;
+    return Loader::ResultStatus::Success;
+}
 
 } // namespace FileSys

--- a/src/core/file_sys/ncch_container.cpp
+++ b/src/core/file_sys/ncch_container.cpp
@@ -1,0 +1,265 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <cinttypes>
+#include <cstring>
+#include <memory>
+#include "common/common_types.h"
+#include "common/logging/log.h"
+#include "core/core.h"
+#include "core/file_sys/ncch_container.h"
+#include "core/loader/loader.h"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// FileSys namespace
+
+namespace FileSys {
+
+    static const int kMaxSections = 8;   ///< Maximum number of sections (files) in an ExeFs
+    static const int kBlockSize = 0x200; ///< Size of ExeFS blocks (in bytes)
+
+    /**
+     * Get the decompressed size of an LZSS compressed ExeFS file
+     * @param buffer Buffer of compressed file
+     * @param size Size of compressed buffer
+     * @return Size of decompressed buffer
+     */
+    static u32 LZSS_GetDecompressedSize(const u8* buffer, u32 size) {
+        u32 offset_size = *(u32*)(buffer + size - 4);
+        return offset_size + size;
+    }
+
+    /**
+     * Decompress ExeFS file (compressed with LZSS)
+     * @param compressed Compressed buffer
+     * @param compressed_size Size of compressed buffer
+     * @param decompressed Decompressed buffer
+     * @param decompressed_size Size of decompressed buffer
+     * @return True on success, otherwise false
+     */
+    static bool LZSS_Decompress(const u8* compressed, u32 compressed_size, u8* decompressed,
+                                u32 decompressed_size) {
+        const u8* footer = compressed + compressed_size - 8;
+        u32 buffer_top_and_bottom = *reinterpret_cast<const u32*>(footer);
+        u32 out = decompressed_size;
+        u32 index = compressed_size - ((buffer_top_and_bottom >> 24) & 0xFF);
+        u32 stop_index = compressed_size - (buffer_top_and_bottom & 0xFFFFFF);
+
+        memset(decompressed, 0, decompressed_size);
+        memcpy(decompressed, compressed, compressed_size);
+
+        while (index > stop_index) {
+            u8 control = compressed[--index];
+
+            for (unsigned i = 0; i < 8; i++) {
+                if (index <= stop_index)
+                    break;
+                if (index <= 0)
+                    break;
+                if (out <= 0)
+                    break;
+
+                if (control & 0x80) {
+                    // Check if compression is out of bounds
+                    if (index < 2)
+                        return false;
+                    index -= 2;
+
+                    u32 segment_offset = compressed[index] | (compressed[index + 1] << 8);
+                    u32 segment_size = ((segment_offset >> 12) & 15) + 3;
+                    segment_offset &= 0x0FFF;
+                    segment_offset += 2;
+
+                    // Check if compression is out of bounds
+                    if (out < segment_size)
+                        return false;
+
+                    for (unsigned j = 0; j < segment_size; j++) {
+                        // Check if compression is out of bounds
+                        if (out + segment_offset >= decompressed_size)
+                            return false;
+
+                        u8 data = decompressed[out + segment_offset];
+                        decompressed[--out] = data;
+                    }
+                } else {
+                    // Check if compression is out of bounds
+                    if (out < 1)
+                        return false;
+                    decompressed[--out] = compressed[--index];
+                }
+                control <<= 1;
+            }
+        }
+        return true;
+    }
+
+    NCCHContainer::NCCHContainer(std::string filepath)
+        : filepath(filepath)
+    {
+        file = FileUtil::IOFile(filepath, "rb");
+    }
+
+    Loader::ResultStatus NCCHContainer::Load() {
+        if (is_loaded)
+            return Loader::ResultStatus::Success;
+
+        // Reset read pointer in case this file has been read before.
+        file.Seek(0, SEEK_SET);
+
+        if (file.ReadBytes(&ncch_header, sizeof(NCCH_Header)) != sizeof(NCCH_Header))
+            return Loader::ResultStatus::Error;
+
+        // Skip NCSD header and load first NCCH (NCSD is just a container of NCCH files)...
+        if (Loader::MakeMagic('N', 'C', 'S', 'D') == ncch_header.magic) {
+            LOG_DEBUG(Loader, "Only loading the first (bootable) NCCH within the NCSD file!");
+            ncch_offset = 0x4000;
+            file.Seek(ncch_offset, SEEK_SET);
+            file.ReadBytes(&ncch_header, sizeof(NCCH_Header));
+        }
+
+        // Verify we are loading the correct file type...
+        if (Loader::MakeMagic('N', 'C', 'C', 'H') != ncch_header.magic)
+            return Loader::ResultStatus::ErrorInvalidFormat;
+
+        // Read ExHeader...
+
+        if (file.ReadBytes(&exheader_header, sizeof(ExHeader_Header)) != sizeof(ExHeader_Header))
+            return Loader::ResultStatus::Error;
+
+        is_compressed = (exheader_header.codeset_info.flags.flag & 1) == 1;
+        u32 entry_point = exheader_header.codeset_info.text.address;
+        u32 code_size = exheader_header.codeset_info.text.code_size;
+        u32 stack_size = exheader_header.codeset_info.stack_size;
+        u32 bss_size = exheader_header.codeset_info.bss_size;
+        u32 core_version = exheader_header.arm11_system_local_caps.core_version;
+        u8 priority = exheader_header.arm11_system_local_caps.priority;
+        u8 resource_limit_category = exheader_header.arm11_system_local_caps.resource_limit_category;
+
+        LOG_DEBUG(Loader, "Name:                        %s", exheader_header.codeset_info.name);
+        LOG_DEBUG(Loader, "Program ID:                  %016" PRIX64, ncch_header.program_id);
+        LOG_DEBUG(Loader, "Code compressed:             %s", is_compressed ? "yes" : "no");
+        LOG_DEBUG(Loader, "Entry point:                 0x%08X", entry_point);
+        LOG_DEBUG(Loader, "Code size:                   0x%08X", code_size);
+        LOG_DEBUG(Loader, "Stack size:                  0x%08X", stack_size);
+        LOG_DEBUG(Loader, "Bss size:                    0x%08X", bss_size);
+        LOG_DEBUG(Loader, "Core version:                %d", core_version);
+        LOG_DEBUG(Loader, "Thread priority:             0x%X", priority);
+        LOG_DEBUG(Loader, "Resource limit category:     %d", resource_limit_category);
+        LOG_DEBUG(Loader, "System Mode:                 %d",
+                  static_cast<int>(exheader_header.arm11_system_local_caps.system_mode));
+
+        if (exheader_header.arm11_system_local_caps.program_id != ncch_header.program_id) {
+            LOG_ERROR(Loader, "ExHeader Program ID mismatch: the ROM is probably encrypted.");
+            return Loader::ResultStatus::ErrorEncrypted;
+        }
+
+        // Read ExeFS...
+
+        exefs_offset = ncch_header.exefs_offset * kBlockSize;
+        u32 exefs_size = ncch_header.exefs_size * kBlockSize;
+
+        LOG_DEBUG(Loader, "ExeFS offset:                0x%08X", exefs_offset);
+        LOG_DEBUG(Loader, "ExeFS size:                  0x%08X", exefs_size);
+
+        file.Seek(exefs_offset + ncch_offset, SEEK_SET);
+        if (file.ReadBytes(&exefs_header, sizeof(ExeFs_Header)) != sizeof(ExeFs_Header))
+            return Loader::ResultStatus::Error;
+
+        is_loaded = true;
+        return Loader::ResultStatus::Success;
+    }
+
+    Loader::ResultStatus NCCHContainer::LoadSectionExeFS(const char* name, std::vector<u8>& buffer) {
+        if (!file.IsOpen())
+            return Loader::ResultStatus::Error;
+
+        Loader::ResultStatus result = Load();
+        if (result != Loader::ResultStatus::Success)
+            return result;
+
+        LOG_DEBUG(Loader, "%d sections:", kMaxSections);
+        // Iterate through the ExeFs archive until we find a section with the specified name...
+        for (unsigned section_number = 0; section_number < kMaxSections; section_number++) {
+            const auto& section = exefs_header.section[section_number];
+
+            // Load the specified section...
+            if (strcmp(section.name, name) == 0) {
+                LOG_DEBUG(Loader, "%d - offset: 0x%08X, size: 0x%08X, name: %s", section_number,
+                          section.offset, section.size, section.name);
+
+                s64 section_offset =
+                    (section.offset + exefs_offset + sizeof(ExeFs_Header) + ncch_offset);
+                file.Seek(section_offset, SEEK_SET);
+
+                if (strcmp(section.name, ".code") == 0 && is_compressed) {
+                    // Section is compressed, read compressed .code section...
+                    std::unique_ptr<u8[]> temp_buffer;
+                    try {
+                        temp_buffer.reset(new u8[section.size]);
+                    } catch (std::bad_alloc&) {
+                        return Loader::ResultStatus::ErrorMemoryAllocationFailed;
+                    }
+
+                    if (file.ReadBytes(&temp_buffer[0], section.size) != section.size)
+                        return Loader::ResultStatus::Error;
+
+                    // Decompress .code section...
+                    u32 decompressed_size = LZSS_GetDecompressedSize(&temp_buffer[0], section.size);
+                    buffer.resize(decompressed_size);
+                    if (!LZSS_Decompress(&temp_buffer[0], section.size, &buffer[0], decompressed_size))
+                        return Loader::ResultStatus::ErrorInvalidFormat;
+                } else {
+                    // Section is uncompressed...
+                    buffer.resize(section.size);
+                    if (file.ReadBytes(&buffer[0], section.size) != section.size)
+                        return Loader::ResultStatus::Error;
+                }
+                return Loader::ResultStatus::Success;
+            }
+        }
+        return Loader::ResultStatus::ErrorNotUsed;
+    }
+
+    Loader::ResultStatus NCCHContainer::ReadRomFS(std::shared_ptr<FileUtil::IOFile>& romfs_file, u64& offset,
+                                           u64& size) {
+        if (!file.IsOpen())
+            return Loader::ResultStatus::Error;
+
+        // Check if the NCCH has a RomFS...
+        if (ncch_header.romfs_offset != 0 && ncch_header.romfs_size != 0) {
+            u32 romfs_offset = ncch_offset + (ncch_header.romfs_offset * kBlockSize) + 0x1000;
+            u32 romfs_size = (ncch_header.romfs_size * kBlockSize) - 0x1000;
+
+            LOG_DEBUG(Loader, "RomFS offset:           0x%08X", romfs_offset);
+            LOG_DEBUG(Loader, "RomFS size:             0x%08X", romfs_size);
+
+            if (file.GetSize() < romfs_offset + romfs_size)
+                return Loader::ResultStatus::Error;
+
+            // We reopen the file, to allow its position to be independent from file's
+            romfs_file = std::make_shared<FileUtil::IOFile>(filepath, "rb");
+            if (!romfs_file->IsOpen())
+                return Loader::ResultStatus::Error;
+
+            offset = romfs_offset;
+            size = romfs_size;
+
+            return Loader::ResultStatus::Success;
+        }
+        LOG_DEBUG(Loader, "NCCH has no RomFS");
+        return Loader::ResultStatus::ErrorNotUsed;
+    }
+
+    Loader::ResultStatus NCCHContainer::GetProgramID(u64_le& program_id)
+    {
+        Loader::ResultStatus result = Load();
+        if (result != Loader::ResultStatus::Success)
+            return result;
+
+        program_id = ncch_header.program_id;
+        return Loader::ResultStatus::Success;
+    }
+
+} // namespace FileSys

--- a/src/core/file_sys/ncch_container.cpp
+++ b/src/core/file_sys/ncch_container.cpp
@@ -95,11 +95,11 @@ static bool LZSS_Decompress(const u8* compressed, u32 compressed_size, u8* decom
     return true;
 }
 
-NCCHContainer::NCCHContainer(std::string filepath) : filepath(filepath) {
+NCCHContainer::NCCHContainer(const std::string& filepath) : filepath(filepath) {
     file = FileUtil::IOFile(filepath, "rb");
 }
 
-Loader::ResultStatus NCCHContainer::OpenFile(std::string filepath) {
+Loader::ResultStatus NCCHContainer::OpenFile(const std::string& filepath) {
     this->filepath = filepath;
     file = FileUtil::IOFile(filepath, "rb");
 

--- a/src/core/file_sys/ncch_container.h
+++ b/src/core/file_sys/ncch_container.h
@@ -1,0 +1,207 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
+#include "common/bit_field.h"
+#include "common/common_types.h"
+#include "common/swap.h"
+#include "common/file_util.h"
+#include "core/core.h"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+/// NCCH header (Note: "NCCH" appears to be a publicly unknown acronym)
+
+struct NCCH_Header {
+    u8 signature[0x100];
+    u32_le magic;
+    u32_le content_size;
+    u8 partition_id[8];
+    u16_le maker_code;
+    u16_le version;
+    u8 reserved_0[4];
+    u64_le program_id;
+    u8 reserved_1[0x10];
+    u8 logo_region_hash[0x20];
+    u8 product_code[0x10];
+    u8 extended_header_hash[0x20];
+    u32_le extended_header_size;
+    u8 reserved_2[4];
+    u8 flags[8];
+    u32_le plain_region_offset;
+    u32_le plain_region_size;
+    u32_le logo_region_offset;
+    u32_le logo_region_size;
+    u32_le exefs_offset;
+    u32_le exefs_size;
+    u32_le exefs_hash_region_size;
+    u8 reserved_3[4];
+    u32_le romfs_offset;
+    u32_le romfs_size;
+    u32_le romfs_hash_region_size;
+    u8 reserved_4[4];
+    u8 exefs_super_block_hash[0x20];
+    u8 romfs_super_block_hash[0x20];
+};
+
+static_assert(sizeof(NCCH_Header) == 0x200, "NCCH header structure size is wrong");
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// ExeFS (executable file system) headers
+
+struct ExeFs_SectionHeader {
+    char name[8];
+    u32 offset;
+    u32 size;
+};
+
+struct ExeFs_Header {
+    ExeFs_SectionHeader section[8];
+    u8 reserved[0x80];
+    u8 hashes[8][0x20];
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// ExHeader (executable file system header) headers
+
+struct ExHeader_SystemInfoFlags {
+    u8 reserved[5];
+    u8 flag;
+    u8 remaster_version[2];
+};
+
+struct ExHeader_CodeSegmentInfo {
+    u32 address;
+    u32 num_max_pages;
+    u32 code_size;
+};
+
+struct ExHeader_CodeSetInfo {
+    u8 name[8];
+    ExHeader_SystemInfoFlags flags;
+    ExHeader_CodeSegmentInfo text;
+    u32 stack_size;
+    ExHeader_CodeSegmentInfo ro;
+    u8 reserved[4];
+    ExHeader_CodeSegmentInfo data;
+    u32 bss_size;
+};
+
+struct ExHeader_DependencyList {
+    u8 program_id[0x30][8];
+};
+
+struct ExHeader_SystemInfo {
+    u64 save_data_size;
+    u8 jump_id[8];
+    u8 reserved_2[0x30];
+};
+
+struct ExHeader_StorageInfo {
+    u8 ext_save_data_id[8];
+    u8 system_save_data_id[8];
+    u8 reserved[8];
+    u8 access_info[7];
+    u8 other_attributes;
+};
+
+struct ExHeader_ARM11_SystemLocalCaps {
+    u64_le program_id;
+    u32_le core_version;
+    u8 reserved_flags[2];
+    union {
+        u8 flags0;
+        BitField<0, 2, u8> ideal_processor;
+        BitField<2, 2, u8> affinity_mask;
+        BitField<4, 4, u8> system_mode;
+    };
+    u8 priority;
+    u8 resource_limit_descriptor[0x10][2];
+    ExHeader_StorageInfo storage_info;
+    u8 service_access_control[0x20][8];
+    u8 ex_service_access_control[0x2][8];
+    u8 reserved[0xf];
+    u8 resource_limit_category;
+};
+
+struct ExHeader_ARM11_KernelCaps {
+    u32_le descriptors[28];
+    u8 reserved[0x10];
+};
+
+struct ExHeader_ARM9_AccessControl {
+    u8 descriptors[15];
+    u8 descversion;
+};
+
+struct ExHeader_Header {
+    ExHeader_CodeSetInfo codeset_info;
+    ExHeader_DependencyList dependency_list;
+    ExHeader_SystemInfo system_info;
+    ExHeader_ARM11_SystemLocalCaps arm11_system_local_caps;
+    ExHeader_ARM11_KernelCaps arm11_kernel_caps;
+    ExHeader_ARM9_AccessControl arm9_access_control;
+    struct {
+        u8 signature[0x100];
+        u8 ncch_public_key_modulus[0x100];
+        ExHeader_ARM11_SystemLocalCaps arm11_system_local_caps;
+        ExHeader_ARM11_KernelCaps arm11_kernel_caps;
+        ExHeader_ARM9_AccessControl arm9_access_control;
+    } access_desc;
+};
+
+static_assert(sizeof(ExHeader_Header) == 0x800, "ExHeader structure size is wrong");
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// FileSys namespace
+
+namespace FileSys {
+
+/**
+ * Helper which implements an interface to deal with NCCH containers which can
+ * contain ExeFS archives or RomFS archives for games or other applications.
+ */
+class NCCHContainer {
+public:
+    NCCHContainer(std::string filepath);
+
+    /**
+     * Ensure ExeFS is loaded and ready for reading sections
+     * @return ResultStatus result of function
+     */
+    Loader::ResultStatus Load();
+
+    /**
+     * Reads an application ExeFS section of an NCCH file (e.g. .code, .logo, etc.)
+     * @param name Name of section to read out of NCCH file
+     * @param buffer Vector to read data into
+     * @return ResultStatus result of function
+     */
+    Loader::ResultStatus LoadSectionExeFS(const char* name, std::vector<u8>& buffer);
+
+    Loader::ResultStatus ReadRomFS(std::shared_ptr<FileUtil::IOFile>& romfs_file, u64& offset,
+                           u64& size);
+
+    Loader::ResultStatus GetProgramID(u64_le& program_id);
+
+    NCCH_Header ncch_header;
+    ExeFs_Header exefs_header;
+    ExHeader_Header exheader_header;
+
+private:
+    bool is_loaded = false;
+    bool is_compressed = false;
+
+    u32 ncch_offset = 0; // Offset to NCCH header, can be 0 or after NCSD header
+    u32 exefs_offset = 0;
+
+    std::string filepath;
+    FileUtil::IOFile file;
+};
+
+} // namespace FileSys

--- a/src/core/file_sys/ncch_container.h
+++ b/src/core/file_sys/ncch_container.h
@@ -168,10 +168,10 @@ namespace FileSys {
  */
 class NCCHContainer {
 public:
-    NCCHContainer(std::string filepath);
+    NCCHContainer(const std::string& filepath);
     NCCHContainer() {}
 
-    Loader::ResultStatus OpenFile(std::string filepath);
+    Loader::ResultStatus OpenFile(const std::string& filepath);
 
     /**
      * Ensure ExeFS and exheader is loaded and ready for reading sections

--- a/src/core/file_sys/ncch_container.h
+++ b/src/core/file_sys/ncch_container.h
@@ -98,7 +98,7 @@ struct ExHeader_DependencyList {
 
 struct ExHeader_SystemInfo {
     u64 save_data_size;
-    u8 jump_id[8];
+    u64_le jump_id;
     u8 reserved_2[0x30];
 };
 
@@ -204,11 +204,33 @@ public:
      */
     Loader::ResultStatus ReadProgramId(u64_le& program_id);
 
+    /**
+     * Checks whether the NCCH container contains an ExeFS
+     * @return bool check result
+     */
+    bool HasExeFS();
+
+    /**
+     * Checks whether the NCCH container contains a RomFS
+     * @return bool check result
+     */
+    bool HasRomFS();
+
+    /**
+     * Checks whether the NCCH container contains an ExHeader
+     * @return bool check result
+     */
+    bool HasExHeader();
+
     NCCH_Header ncch_header;
     ExeFs_Header exefs_header;
     ExHeader_Header exheader_header;
 
 private:
+    bool has_exheader = false;
+    bool has_exefs = false;
+    bool has_romfs = false;
+
     bool is_loaded = false;
     bool is_compressed = false;
 

--- a/src/core/file_sys/ncch_container.h
+++ b/src/core/file_sys/ncch_container.h
@@ -169,9 +169,12 @@ namespace FileSys {
 class NCCHContainer {
 public:
     NCCHContainer(std::string filepath);
+    NCCHContainer() {}
+
+    Loader::ResultStatus OpenFile(std::string filepath);
 
     /**
-     * Ensure ExeFS is loaded and ready for reading sections
+     * Ensure ExeFS and exheader is loaded and ready for reading sections
      * @return ResultStatus result of function
      */
     Loader::ResultStatus Load();
@@ -184,10 +187,22 @@ public:
      */
     Loader::ResultStatus LoadSectionExeFS(const char* name, std::vector<u8>& buffer);
 
+    /**
+     * Get the RomFS of the NCCH container
+     * Since the RomFS can be huge, we return a file reference instead of copying to a buffer
+     * @param romfs_file The file containing the RomFS
+     * @param offset The offset the romfs begins on
+     * @param size The size of the romfs
+     * @return ResultStatus result of function
+     */
     Loader::ResultStatus ReadRomFS(std::shared_ptr<FileUtil::IOFile>& romfs_file, u64& offset,
                            u64& size);
 
-    Loader::ResultStatus GetProgramID(u64_le& program_id);
+    /**
+     * Get the Program ID of the NCCH container
+     * @return ResultStatus result of function
+     */
+    Loader::ResultStatus ReadProgramId(u64_le& program_id);
 
     NCCH_Header ncch_header;
     ExeFs_Header exefs_header;

--- a/src/core/file_sys/ncch_container.h
+++ b/src/core/file_sys/ncch_container.h
@@ -10,8 +10,8 @@
 #include <vector>
 #include "common/bit_field.h"
 #include "common/common_types.h"
-#include "common/swap.h"
 #include "common/file_util.h"
+#include "common/swap.h"
 #include "core/core.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -196,7 +196,7 @@ public:
      * @return ResultStatus result of function
      */
     Loader::ResultStatus ReadRomFS(std::shared_ptr<FileUtil::IOFile>& romfs_file, u64& offset,
-                           u64& size);
+                                   u64& size);
 
     /**
      * Get the Program ID of the NCCH container

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -175,7 +175,7 @@ public:
      * @return ResultStatus result of function
      */
     virtual ResultStatus ReadUpdateRomFS(std::shared_ptr<FileUtil::IOFile>& romfs_file, u64& offset,
-                                   u64& size) {
+                                         u64& size) {
         return ResultStatus::ErrorNotImplemented;
     }
 

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -167,6 +167,19 @@ public:
     }
 
     /**
+     * Get the update RomFS of the application
+     * Since the RomFS can be huge, we return a file reference instead of copying to a buffer
+     * @param romfs_file The file containing the RomFS
+     * @param offset The offset the romfs begins on
+     * @param size The size of the romfs
+     * @return ResultStatus result of function
+     */
+    virtual ResultStatus ReadUpdateRomFS(std::shared_ptr<FileUtil::IOFile>& romfs_file, u64& offset,
+                                   u64& size) {
+        return ResultStatus::ErrorNotImplemented;
+    }
+
+    /**
      * Get the title of the application
      * @param title Reference to store the application title into
      * @return ResultStatus result of function

--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -13,6 +13,7 @@
 #include "common/swap.h"
 #include "core/core.h"
 #include "core/file_sys/archive_selfncch.h"
+#include "core/file_sys/ncch_container.h"
 #include "core/hle/kernel/process.h"
 #include "core/hle/kernel/resource_limit.h"
 #include "core/hle/service/cfg/cfg.h"
@@ -26,88 +27,6 @@
 // Loader namespace
 
 namespace Loader {
-
-static const int kMaxSections = 8;   ///< Maximum number of sections (files) in an ExeFs
-static const int kBlockSize = 0x200; ///< Size of ExeFS blocks (in bytes)
-
-/**
- * Get the decompressed size of an LZSS compressed ExeFS file
- * @param buffer Buffer of compressed file
- * @param size Size of compressed buffer
- * @return Size of decompressed buffer
- */
-static u32 LZSS_GetDecompressedSize(const u8* buffer, u32 size) {
-    u32 offset_size = *(u32*)(buffer + size - 4);
-    return offset_size + size;
-}
-
-/**
- * Decompress ExeFS file (compressed with LZSS)
- * @param compressed Compressed buffer
- * @param compressed_size Size of compressed buffer
- * @param decompressed Decompressed buffer
- * @param decompressed_size Size of decompressed buffer
- * @return True on success, otherwise false
- */
-static bool LZSS_Decompress(const u8* compressed, u32 compressed_size, u8* decompressed,
-                            u32 decompressed_size) {
-    const u8* footer = compressed + compressed_size - 8;
-    u32 buffer_top_and_bottom = *reinterpret_cast<const u32*>(footer);
-    u32 out = decompressed_size;
-    u32 index = compressed_size - ((buffer_top_and_bottom >> 24) & 0xFF);
-    u32 stop_index = compressed_size - (buffer_top_and_bottom & 0xFFFFFF);
-
-    memset(decompressed, 0, decompressed_size);
-    memcpy(decompressed, compressed, compressed_size);
-
-    while (index > stop_index) {
-        u8 control = compressed[--index];
-
-        for (unsigned i = 0; i < 8; i++) {
-            if (index <= stop_index)
-                break;
-            if (index <= 0)
-                break;
-            if (out <= 0)
-                break;
-
-            if (control & 0x80) {
-                // Check if compression is out of bounds
-                if (index < 2)
-                    return false;
-                index -= 2;
-
-                u32 segment_offset = compressed[index] | (compressed[index + 1] << 8);
-                u32 segment_size = ((segment_offset >> 12) & 15) + 3;
-                segment_offset &= 0x0FFF;
-                segment_offset += 2;
-
-                // Check if compression is out of bounds
-                if (out < segment_size)
-                    return false;
-
-                for (unsigned j = 0; j < segment_size; j++) {
-                    // Check if compression is out of bounds
-                    if (out + segment_offset >= decompressed_size)
-                        return false;
-
-                    u8 data = decompressed[out + segment_offset];
-                    decompressed[--out] = data;
-                }
-            } else {
-                // Check if compression is out of bounds
-                if (out < 1)
-                    return false;
-                decompressed[--out] = compressed[--index];
-            }
-            control <<= 1;
-        }
-    }
-    return true;
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// AppLoader_NCCH class
 
 FileType AppLoader_NCCH::IdentifyType(FileUtil::IOFile& file) {
     u32 magic;
@@ -126,13 +45,17 @@ FileType AppLoader_NCCH::IdentifyType(FileUtil::IOFile& file) {
 
 std::pair<boost::optional<u32>, ResultStatus> AppLoader_NCCH::LoadKernelSystemMode() {
     if (!is_loaded) {
-        ResultStatus res = LoadExeFS();
+        ResultStatus res = ncch_container.Load();
         if (res != ResultStatus::Success) {
             return std::make_pair(boost::none, res);
         }
+
+        //TODO(shinyquagsire23): swapping between NCCH containers for update overlay
+        overlay_ncch = &ncch_container;
     }
+
     // Set the system mode as the one from the exheader.
-    return std::make_pair(exheader_header.arm11_system_local_caps.system_mode.Value(),
+    return std::make_pair(overlay_ncch->exheader_header.arm11_system_local_caps.system_mode.Value(),
                           ResultStatus::Success);
 }
 
@@ -144,29 +67,31 @@ ResultStatus AppLoader_NCCH::LoadExec() {
         return ResultStatus::ErrorNotLoaded;
 
     std::vector<u8> code;
-    if (ResultStatus::Success == ReadCode(code)) {
+    u64_le program_id;
+    if (ResultStatus::Success == ReadCode(code)
+        && ResultStatus::Success == ReadProgramId(program_id)) {
         std::string process_name = Common::StringFromFixedZeroTerminatedBuffer(
-            (const char*)exheader_header.codeset_info.name, 8);
+            (const char*)overlay_ncch->exheader_header.codeset_info.name, 8);
 
-        SharedPtr<CodeSet> codeset = CodeSet::Create(process_name, ncch_header.program_id);
+        SharedPtr<CodeSet> codeset = CodeSet::Create(process_name, program_id);
 
         codeset->code.offset = 0;
-        codeset->code.addr = exheader_header.codeset_info.text.address;
-        codeset->code.size = exheader_header.codeset_info.text.num_max_pages * Memory::PAGE_SIZE;
+        codeset->code.addr = overlay_ncch->exheader_header.codeset_info.text.address;
+        codeset->code.size = overlay_ncch->exheader_header.codeset_info.text.num_max_pages * Memory::PAGE_SIZE;
 
         codeset->rodata.offset = codeset->code.offset + codeset->code.size;
-        codeset->rodata.addr = exheader_header.codeset_info.ro.address;
-        codeset->rodata.size = exheader_header.codeset_info.ro.num_max_pages * Memory::PAGE_SIZE;
+        codeset->rodata.addr = overlay_ncch->exheader_header.codeset_info.ro.address;
+        codeset->rodata.size = overlay_ncch->exheader_header.codeset_info.ro.num_max_pages * Memory::PAGE_SIZE;
 
         // TODO(yuriks): Not sure if the bss size is added to the page-aligned .data size or just
         //               to the regular size. Playing it safe for now.
-        u32 bss_page_size = (exheader_header.codeset_info.bss_size + 0xFFF) & ~0xFFF;
+        u32 bss_page_size = (overlay_ncch->exheader_header.codeset_info.bss_size + 0xFFF) & ~0xFFF;
         code.resize(code.size() + bss_page_size, 0);
 
         codeset->data.offset = codeset->rodata.offset + codeset->rodata.size;
-        codeset->data.addr = exheader_header.codeset_info.data.address;
+        codeset->data.addr = overlay_ncch->exheader_header.codeset_info.data.address;
         codeset->data.size =
-            exheader_header.codeset_info.data.num_max_pages * Memory::PAGE_SIZE + bss_page_size;
+            overlay_ncch->exheader_header.codeset_info.data.num_max_pages * Memory::PAGE_SIZE + bss_page_size;
 
         codeset->entrypoint = codeset->code.addr;
         codeset->memory = std::make_shared<std::vector<u8>>(std::move(code));
@@ -176,148 +101,24 @@ ResultStatus AppLoader_NCCH::LoadExec() {
         // Attach a resource limit to the process based on the resource limit category
         Kernel::g_current_process->resource_limit =
             Kernel::ResourceLimit::GetForCategory(static_cast<Kernel::ResourceLimitCategory>(
-                exheader_header.arm11_system_local_caps.resource_limit_category));
+                overlay_ncch->exheader_header.arm11_system_local_caps.resource_limit_category));
 
         // Set the default CPU core for this process
         Kernel::g_current_process->ideal_processor =
-            exheader_header.arm11_system_local_caps.ideal_processor;
+            overlay_ncch->exheader_header.arm11_system_local_caps.ideal_processor;
 
         // Copy data while converting endianness
-        std::array<u32, ARRAY_SIZE(exheader_header.arm11_kernel_caps.descriptors)> kernel_caps;
-        std::copy_n(exheader_header.arm11_kernel_caps.descriptors, kernel_caps.size(),
+        std::array<u32, ARRAY_SIZE(overlay_ncch->exheader_header.arm11_kernel_caps.descriptors)> kernel_caps;
+        std::copy_n(overlay_ncch->exheader_header.arm11_kernel_caps.descriptors, kernel_caps.size(),
                     begin(kernel_caps));
         Kernel::g_current_process->ParseKernelCaps(kernel_caps.data(), kernel_caps.size());
 
-        s32 priority = exheader_header.arm11_system_local_caps.priority;
-        u32 stack_size = exheader_header.codeset_info.stack_size;
+        s32 priority = overlay_ncch->exheader_header.arm11_system_local_caps.priority;
+        u32 stack_size = overlay_ncch->exheader_header.codeset_info.stack_size;
         Kernel::g_current_process->Run(priority, stack_size);
         return ResultStatus::Success;
     }
     return ResultStatus::Error;
-}
-
-ResultStatus AppLoader_NCCH::LoadSectionExeFS(const char* name, std::vector<u8>& buffer) {
-    if (!file.IsOpen())
-        return ResultStatus::Error;
-
-    ResultStatus result = LoadExeFS();
-    if (result != ResultStatus::Success)
-        return result;
-
-    LOG_DEBUG(Loader, "%d sections:", kMaxSections);
-    // Iterate through the ExeFs archive until we find a section with the specified name...
-    for (unsigned section_number = 0; section_number < kMaxSections; section_number++) {
-        const auto& section = exefs_header.section[section_number];
-
-        // Load the specified section...
-        if (strcmp(section.name, name) == 0) {
-            LOG_DEBUG(Loader, "%d - offset: 0x%08X, size: 0x%08X, name: %s", section_number,
-                      section.offset, section.size, section.name);
-
-            s64 section_offset =
-                (section.offset + exefs_offset + sizeof(ExeFs_Header) + ncch_offset);
-            file.Seek(section_offset, SEEK_SET);
-
-            if (strcmp(section.name, ".code") == 0 && is_compressed) {
-                // Section is compressed, read compressed .code section...
-                std::unique_ptr<u8[]> temp_buffer;
-                try {
-                    temp_buffer.reset(new u8[section.size]);
-                } catch (std::bad_alloc&) {
-                    return ResultStatus::ErrorMemoryAllocationFailed;
-                }
-
-                if (file.ReadBytes(&temp_buffer[0], section.size) != section.size)
-                    return ResultStatus::Error;
-
-                // Decompress .code section...
-                u32 decompressed_size = LZSS_GetDecompressedSize(&temp_buffer[0], section.size);
-                buffer.resize(decompressed_size);
-                if (!LZSS_Decompress(&temp_buffer[0], section.size, &buffer[0], decompressed_size))
-                    return ResultStatus::ErrorInvalidFormat;
-            } else {
-                // Section is uncompressed...
-                buffer.resize(section.size);
-                if (file.ReadBytes(&buffer[0], section.size) != section.size)
-                    return ResultStatus::Error;
-            }
-            return ResultStatus::Success;
-        }
-    }
-    return ResultStatus::ErrorNotUsed;
-}
-
-ResultStatus AppLoader_NCCH::LoadExeFS() {
-    if (is_exefs_loaded)
-        return ResultStatus::Success;
-
-    if (!file.IsOpen())
-        return ResultStatus::Error;
-
-    // Reset read pointer in case this file has been read before.
-    file.Seek(0, SEEK_SET);
-
-    if (file.ReadBytes(&ncch_header, sizeof(NCCH_Header)) != sizeof(NCCH_Header))
-        return ResultStatus::Error;
-
-    // Skip NCSD header and load first NCCH (NCSD is just a container of NCCH files)...
-    if (MakeMagic('N', 'C', 'S', 'D') == ncch_header.magic) {
-        LOG_DEBUG(Loader, "Only loading the first (bootable) NCCH within the NCSD file!");
-        ncch_offset = 0x4000;
-        file.Seek(ncch_offset, SEEK_SET);
-        file.ReadBytes(&ncch_header, sizeof(NCCH_Header));
-    }
-
-    // Verify we are loading the correct file type...
-    if (MakeMagic('N', 'C', 'C', 'H') != ncch_header.magic)
-        return ResultStatus::ErrorInvalidFormat;
-
-    // Read ExHeader...
-
-    if (file.ReadBytes(&exheader_header, sizeof(ExHeader_Header)) != sizeof(ExHeader_Header))
-        return ResultStatus::Error;
-
-    is_compressed = (exheader_header.codeset_info.flags.flag & 1) == 1;
-    entry_point = exheader_header.codeset_info.text.address;
-    code_size = exheader_header.codeset_info.text.code_size;
-    stack_size = exheader_header.codeset_info.stack_size;
-    bss_size = exheader_header.codeset_info.bss_size;
-    core_version = exheader_header.arm11_system_local_caps.core_version;
-    priority = exheader_header.arm11_system_local_caps.priority;
-    resource_limit_category = exheader_header.arm11_system_local_caps.resource_limit_category;
-
-    LOG_DEBUG(Loader, "Name:                        %s", exheader_header.codeset_info.name);
-    LOG_DEBUG(Loader, "Program ID:                  %016" PRIX64, ncch_header.program_id);
-    LOG_DEBUG(Loader, "Code compressed:             %s", is_compressed ? "yes" : "no");
-    LOG_DEBUG(Loader, "Entry point:                 0x%08X", entry_point);
-    LOG_DEBUG(Loader, "Code size:                   0x%08X", code_size);
-    LOG_DEBUG(Loader, "Stack size:                  0x%08X", stack_size);
-    LOG_DEBUG(Loader, "Bss size:                    0x%08X", bss_size);
-    LOG_DEBUG(Loader, "Core version:                %d", core_version);
-    LOG_DEBUG(Loader, "Thread priority:             0x%X", priority);
-    LOG_DEBUG(Loader, "Resource limit category:     %d", resource_limit_category);
-    LOG_DEBUG(Loader, "System Mode:                 %d",
-              static_cast<int>(exheader_header.arm11_system_local_caps.system_mode));
-
-    if (exheader_header.arm11_system_local_caps.program_id != ncch_header.program_id) {
-        LOG_ERROR(Loader, "ExHeader Program ID mismatch: the ROM is probably encrypted.");
-        return ResultStatus::ErrorEncrypted;
-    }
-
-    // Read ExeFS...
-
-    exefs_offset = ncch_header.exefs_offset * kBlockSize;
-    u32 exefs_size = ncch_header.exefs_size * kBlockSize;
-
-    LOG_DEBUG(Loader, "ExeFS offset:                0x%08X", exefs_offset);
-    LOG_DEBUG(Loader, "ExeFS size:                  0x%08X", exefs_size);
-
-    file.Seek(exefs_offset + ncch_offset, SEEK_SET);
-    if (file.ReadBytes(&exefs_header, sizeof(ExeFs_Header)) != sizeof(ExeFs_Header))
-        return ResultStatus::Error;
-
-    is_exefs_loaded = true;
-    return ResultStatus::Success;
 }
 
 void AppLoader_NCCH::ParseRegionLockoutInfo() {
@@ -338,14 +139,20 @@ void AppLoader_NCCH::ParseRegionLockoutInfo() {
 }
 
 ResultStatus AppLoader_NCCH::Load() {
+    u64_le ncch_program_id;
+
     if (is_loaded)
         return ResultStatus::ErrorAlreadyLoaded;
 
-    ResultStatus result = LoadExeFS();
+    ResultStatus result = ncch_container.Load();
     if (result != ResultStatus::Success)
         return result;
 
-    std::string program_id{Common::StringFromFormat("%016" PRIX64, ncch_header.program_id)};
+    //TODO(shinyquagsire23): swapping between NCCH containers for update overlay
+    overlay_ncch = &ncch_container;
+
+    ReadProgramId(ncch_program_id);
+    std::string program_id{Common::StringFromFormat("%016" PRIX64, ncch_program_id)};
 
     LOG_INFO(Loader, "Program ID: %s", program_id.c_str());
 
@@ -354,7 +161,7 @@ ResultStatus AppLoader_NCCH::Load() {
     if (auto room_member = Network::GetRoomMember().lock()) {
         Network::GameInfo game_info;
         ReadTitle(game_info.name);
-        game_info.id = ncch_header.program_id;
+        game_info.id = ncch_program_id;
         room_member->SendGameInfo(game_info);
     }
 
@@ -373,61 +180,32 @@ ResultStatus AppLoader_NCCH::Load() {
 }
 
 ResultStatus AppLoader_NCCH::ReadCode(std::vector<u8>& buffer) {
-    return LoadSectionExeFS(".code", buffer);
+    return overlay_ncch->LoadSectionExeFS(".code", buffer);
 }
 
 ResultStatus AppLoader_NCCH::ReadIcon(std::vector<u8>& buffer) {
-    return LoadSectionExeFS("icon", buffer);
+    return overlay_ncch->LoadSectionExeFS("icon", buffer);
 }
 
 ResultStatus AppLoader_NCCH::ReadBanner(std::vector<u8>& buffer) {
-    return LoadSectionExeFS("banner", buffer);
+    return overlay_ncch->LoadSectionExeFS("banner", buffer);
 }
 
 ResultStatus AppLoader_NCCH::ReadLogo(std::vector<u8>& buffer) {
-    return LoadSectionExeFS("logo", buffer);
+    return overlay_ncch->LoadSectionExeFS("logo", buffer);
 }
 
 ResultStatus AppLoader_NCCH::ReadProgramId(u64& out_program_id) {
-    if (!file.IsOpen())
-        return ResultStatus::Error;
-
-    ResultStatus result = LoadExeFS();
+    ResultStatus result = ncch_container.GetProgramID(out_program_id);
     if (result != ResultStatus::Success)
         return result;
 
-    out_program_id = ncch_header.program_id;
     return ResultStatus::Success;
 }
 
 ResultStatus AppLoader_NCCH::ReadRomFS(std::shared_ptr<FileUtil::IOFile>& romfs_file, u64& offset,
                                        u64& size) {
-    if (!file.IsOpen())
-        return ResultStatus::Error;
-
-    // Check if the NCCH has a RomFS...
-    if (ncch_header.romfs_offset != 0 && ncch_header.romfs_size != 0) {
-        u32 romfs_offset = ncch_offset + (ncch_header.romfs_offset * kBlockSize) + 0x1000;
-        u32 romfs_size = (ncch_header.romfs_size * kBlockSize) - 0x1000;
-
-        LOG_DEBUG(Loader, "RomFS offset:           0x%08X", romfs_offset);
-        LOG_DEBUG(Loader, "RomFS size:             0x%08X", romfs_size);
-
-        if (file.GetSize() < romfs_offset + romfs_size)
-            return ResultStatus::Error;
-
-        // We reopen the file, to allow its position to be independent from file's
-        romfs_file = std::make_shared<FileUtil::IOFile>(filepath, "rb");
-        if (!romfs_file->IsOpen())
-            return ResultStatus::Error;
-
-        offset = romfs_offset;
-        size = romfs_size;
-
-        return ResultStatus::Success;
-    }
-    LOG_DEBUG(Loader, "NCCH has no RomFS");
-    return ResultStatus::ErrorNotUsed;
+    return ncch_container.ReadRomFS(romfs_file, offset, size);
 }
 
 ResultStatus AppLoader_NCCH::ReadTitle(std::string& title) {

--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -78,8 +78,8 @@ ResultStatus AppLoader_NCCH::LoadExec() {
 
     std::vector<u8> code;
     u64_le program_id;
-    if (ResultStatus::Success == ReadCode(code)
-        && ResultStatus::Success == ReadProgramId(program_id)) {
+    if (ResultStatus::Success == ReadCode(code) &&
+        ResultStatus::Success == ReadProgramId(program_id)) {
         std::string process_name = Common::StringFromFixedZeroTerminatedBuffer(
             (const char*)overlay_ncch->exheader_header.codeset_info.name, 8);
 
@@ -87,11 +87,13 @@ ResultStatus AppLoader_NCCH::LoadExec() {
 
         codeset->code.offset = 0;
         codeset->code.addr = overlay_ncch->exheader_header.codeset_info.text.address;
-        codeset->code.size = overlay_ncch->exheader_header.codeset_info.text.num_max_pages * Memory::PAGE_SIZE;
+        codeset->code.size =
+            overlay_ncch->exheader_header.codeset_info.text.num_max_pages * Memory::PAGE_SIZE;
 
         codeset->rodata.offset = codeset->code.offset + codeset->code.size;
         codeset->rodata.addr = overlay_ncch->exheader_header.codeset_info.ro.address;
-        codeset->rodata.size = overlay_ncch->exheader_header.codeset_info.ro.num_max_pages * Memory::PAGE_SIZE;
+        codeset->rodata.size =
+            overlay_ncch->exheader_header.codeset_info.ro.num_max_pages * Memory::PAGE_SIZE;
 
         // TODO(yuriks): Not sure if the bss size is added to the page-aligned .data size or just
         //               to the regular size. Playing it safe for now.
@@ -101,7 +103,8 @@ ResultStatus AppLoader_NCCH::LoadExec() {
         codeset->data.offset = codeset->rodata.offset + codeset->rodata.size;
         codeset->data.addr = overlay_ncch->exheader_header.codeset_info.data.address;
         codeset->data.size =
-            overlay_ncch->exheader_header.codeset_info.data.num_max_pages * Memory::PAGE_SIZE + bss_page_size;
+            overlay_ncch->exheader_header.codeset_info.data.num_max_pages * Memory::PAGE_SIZE +
+            bss_page_size;
 
         codeset->entrypoint = codeset->code.addr;
         codeset->memory = std::make_shared<std::vector<u8>>(std::move(code));
@@ -118,7 +121,8 @@ ResultStatus AppLoader_NCCH::LoadExec() {
             overlay_ncch->exheader_header.arm11_system_local_caps.ideal_processor;
 
         // Copy data while converting endianness
-        std::array<u32, ARRAY_SIZE(overlay_ncch->exheader_header.arm11_kernel_caps.descriptors)> kernel_caps;
+        std::array<u32, ARRAY_SIZE(overlay_ncch->exheader_header.arm11_kernel_caps.descriptors)>
+            kernel_caps;
         std::copy_n(overlay_ncch->exheader_header.arm11_kernel_caps.descriptors, kernel_caps.size(),
                     begin(kernel_caps));
         Kernel::g_current_process->ParseKernelCaps(kernel_caps.data(), kernel_caps.size());
@@ -158,7 +162,7 @@ ResultStatus AppLoader_NCCH::Load() {
     if (result != ResultStatus::Success)
         return result;
 
-    //TODO(shinyquagsire23): swapping between NCCH containers for update overlay
+    // TODO(shinyquagsire23): swapping between NCCH containers for update overlay
     overlay_ncch = &base_ncch;
 
     ReadProgramId(ncch_program_id);
@@ -224,11 +228,11 @@ ResultStatus AppLoader_NCCH::ReadRomFS(std::shared_ptr<FileUtil::IOFile>& romfs_
     return base_ncch.ReadRomFS(romfs_file, offset, size);
 }
 
-ResultStatus AppLoader_NCCH::ReadUpdateRomFS(std::shared_ptr<FileUtil::IOFile>& romfs_file, u64& offset,
-                                       u64& size) {
+ResultStatus AppLoader_NCCH::ReadUpdateRomFS(std::shared_ptr<FileUtil::IOFile>& romfs_file,
+                                             u64& offset, u64& size) {
     ResultStatus result = update_ncch.ReadRomFS(romfs_file, offset, size);
 
-    //TODO(shinyquagsire23): Validate that this is the default behavior on hardware
+    // TODO(shinyquagsire23): Validate that this is the default behavior on hardware
     if (result != ResultStatus::Success)
         return base_ncch.ReadRomFS(romfs_file, offset, size);
 }

--- a/src/core/loader/ncch.h
+++ b/src/core/loader/ncch.h
@@ -19,7 +19,8 @@ namespace Loader {
 class AppLoader_NCCH final : public AppLoader {
 public:
     AppLoader_NCCH(FileUtil::IOFile&& file, const std::string& filepath)
-        : AppLoader(std::move(file)), filepath(filepath), base_ncch(filepath) {}
+        : AppLoader(std::move(file)), filepath(filepath), base_ncch(filepath),
+          overlay_ncch(&base_ncch) {}
 
     /**
      * Returns the type of the file

--- a/src/core/loader/ncch.h
+++ b/src/core/loader/ncch.h
@@ -19,7 +19,7 @@ namespace Loader {
 class AppLoader_NCCH final : public AppLoader {
 public:
     AppLoader_NCCH(FileUtil::IOFile&& file, const std::string& filepath)
-        : AppLoader(std::move(file)), filepath(filepath), ncch_container(filepath) {}
+        : AppLoader(std::move(file)), filepath(filepath), base_ncch(filepath) {}
 
     /**
      * Returns the type of the file
@@ -53,6 +53,9 @@ public:
     ResultStatus ReadRomFS(std::shared_ptr<FileUtil::IOFile>& romfs_file, u64& offset,
                            u64& size) override;
 
+    ResultStatus ReadUpdateRomFS(std::shared_ptr<FileUtil::IOFile>& romfs_file, u64& offset,
+                           u64& size) override;
+
     ResultStatus ReadTitle(std::string& title) override;
 
 private:
@@ -66,10 +69,8 @@ private:
     /// Reads the region lockout info in the SMDH and send it to CFG service
     void ParseRegionLockoutInfo();
 
-    bool is_exefs_loaded = false;
-    bool is_compressed = false;
-
-    FileSys::NCCHContainer ncch_container;
+    FileSys::NCCHContainer base_ncch;
+    FileSys::NCCHContainer update_ncch;
     FileSys::NCCHContainer *overlay_ncch;
 
     std::string filepath;

--- a/src/core/loader/ncch.h
+++ b/src/core/loader/ncch.h
@@ -5,153 +5,10 @@
 #pragma once
 
 #include <memory>
-#include "common/bit_field.h"
 #include "common/common_types.h"
 #include "common/swap.h"
+#include "core/file_sys/ncch_container.h"
 #include "core/loader/loader.h"
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-/// NCCH header (Note: "NCCH" appears to be a publicly unknown acronym)
-
-struct NCCH_Header {
-    u8 signature[0x100];
-    u32_le magic;
-    u32_le content_size;
-    u8 partition_id[8];
-    u16_le maker_code;
-    u16_le version;
-    u8 reserved_0[4];
-    u64_le program_id;
-    u8 reserved_1[0x10];
-    u8 logo_region_hash[0x20];
-    u8 product_code[0x10];
-    u8 extended_header_hash[0x20];
-    u32_le extended_header_size;
-    u8 reserved_2[4];
-    u8 flags[8];
-    u32_le plain_region_offset;
-    u32_le plain_region_size;
-    u32_le logo_region_offset;
-    u32_le logo_region_size;
-    u32_le exefs_offset;
-    u32_le exefs_size;
-    u32_le exefs_hash_region_size;
-    u8 reserved_3[4];
-    u32_le romfs_offset;
-    u32_le romfs_size;
-    u32_le romfs_hash_region_size;
-    u8 reserved_4[4];
-    u8 exefs_super_block_hash[0x20];
-    u8 romfs_super_block_hash[0x20];
-};
-
-static_assert(sizeof(NCCH_Header) == 0x200, "NCCH header structure size is wrong");
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// ExeFS (executable file system) headers
-
-struct ExeFs_SectionHeader {
-    char name[8];
-    u32 offset;
-    u32 size;
-};
-
-struct ExeFs_Header {
-    ExeFs_SectionHeader section[8];
-    u8 reserved[0x80];
-    u8 hashes[8][0x20];
-};
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// ExHeader (executable file system header) headers
-
-struct ExHeader_SystemInfoFlags {
-    u8 reserved[5];
-    u8 flag;
-    u8 remaster_version[2];
-};
-
-struct ExHeader_CodeSegmentInfo {
-    u32 address;
-    u32 num_max_pages;
-    u32 code_size;
-};
-
-struct ExHeader_CodeSetInfo {
-    u8 name[8];
-    ExHeader_SystemInfoFlags flags;
-    ExHeader_CodeSegmentInfo text;
-    u32 stack_size;
-    ExHeader_CodeSegmentInfo ro;
-    u8 reserved[4];
-    ExHeader_CodeSegmentInfo data;
-    u32 bss_size;
-};
-
-struct ExHeader_DependencyList {
-    u8 program_id[0x30][8];
-};
-
-struct ExHeader_SystemInfo {
-    u64 save_data_size;
-    u8 jump_id[8];
-    u8 reserved_2[0x30];
-};
-
-struct ExHeader_StorageInfo {
-    u8 ext_save_data_id[8];
-    u8 system_save_data_id[8];
-    u8 reserved[8];
-    u8 access_info[7];
-    u8 other_attributes;
-};
-
-struct ExHeader_ARM11_SystemLocalCaps {
-    u64_le program_id;
-    u32_le core_version;
-    u8 reserved_flags[2];
-    union {
-        u8 flags0;
-        BitField<0, 2, u8> ideal_processor;
-        BitField<2, 2, u8> affinity_mask;
-        BitField<4, 4, u8> system_mode;
-    };
-    u8 priority;
-    u8 resource_limit_descriptor[0x10][2];
-    ExHeader_StorageInfo storage_info;
-    u8 service_access_control[0x20][8];
-    u8 ex_service_access_control[0x2][8];
-    u8 reserved[0xf];
-    u8 resource_limit_category;
-};
-
-struct ExHeader_ARM11_KernelCaps {
-    u32_le descriptors[28];
-    u8 reserved[0x10];
-};
-
-struct ExHeader_ARM9_AccessControl {
-    u8 descriptors[15];
-    u8 descversion;
-};
-
-struct ExHeader_Header {
-    ExHeader_CodeSetInfo codeset_info;
-    ExHeader_DependencyList dependency_list;
-    ExHeader_SystemInfo system_info;
-    ExHeader_ARM11_SystemLocalCaps arm11_system_local_caps;
-    ExHeader_ARM11_KernelCaps arm11_kernel_caps;
-    ExHeader_ARM9_AccessControl arm9_access_control;
-    struct {
-        u8 signature[0x100];
-        u8 ncch_public_key_modulus[0x100];
-        ExHeader_ARM11_SystemLocalCaps arm11_system_local_caps;
-        ExHeader_ARM11_KernelCaps arm11_kernel_caps;
-        ExHeader_ARM9_AccessControl arm9_access_control;
-    } access_desc;
-};
-
-static_assert(sizeof(ExHeader_Header) == 0x800, "ExHeader structure size is wrong");
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Loader namespace
@@ -162,7 +19,7 @@ namespace Loader {
 class AppLoader_NCCH final : public AppLoader {
 public:
     AppLoader_NCCH(FileUtil::IOFile&& file, const std::string& filepath)
-        : AppLoader(std::move(file)), filepath(filepath) {}
+        : AppLoader(std::move(file)), filepath(filepath), ncch_container(filepath) {}
 
     /**
      * Returns the type of the file
@@ -199,13 +56,6 @@ public:
     ResultStatus ReadTitle(std::string& title) override;
 
 private:
-    /**
-     * Reads an application ExeFS section of an NCCH file into AppLoader (e.g. .code, .logo, etc.)
-     * @param name Name of section to read out of NCCH file
-     * @param buffer Vector to read data into
-     * @return ResultStatus result of function
-     */
-    ResultStatus LoadSectionExeFS(const char* name, std::vector<u8>& buffer);
 
     /**
      * Loads .code section into memory for booting
@@ -213,31 +63,14 @@ private:
      */
     ResultStatus LoadExec();
 
-    /**
-     * Ensure ExeFS is loaded and ready for reading sections
-     * @return ResultStatus result of function
-     */
-    ResultStatus LoadExeFS();
-
     /// Reads the region lockout info in the SMDH and send it to CFG service
     void ParseRegionLockoutInfo();
 
     bool is_exefs_loaded = false;
     bool is_compressed = false;
 
-    u32 entry_point = 0;
-    u32 code_size = 0;
-    u32 stack_size = 0;
-    u32 bss_size = 0;
-    u32 core_version = 0;
-    u8 priority = 0;
-    u8 resource_limit_category = 0;
-    u32 ncch_offset = 0; // Offset to NCCH header, can be 0 or after NCSD header
-    u32 exefs_offset = 0;
-
-    NCCH_Header ncch_header;
-    ExeFs_Header exefs_header;
-    ExHeader_Header exheader_header;
+    FileSys::NCCHContainer ncch_container;
+    FileSys::NCCHContainer *overlay_ncch;
 
     std::string filepath;
 };

--- a/src/core/loader/ncch.h
+++ b/src/core/loader/ncch.h
@@ -54,12 +54,11 @@ public:
                            u64& size) override;
 
     ResultStatus ReadUpdateRomFS(std::shared_ptr<FileUtil::IOFile>& romfs_file, u64& offset,
-                           u64& size) override;
+                                 u64& size) override;
 
     ResultStatus ReadTitle(std::string& title) override;
 
 private:
-
     /**
      * Loads .code section into memory for booting
      * @return ResultStatus result of function
@@ -71,7 +70,7 @@ private:
 
     FileSys::NCCHContainer base_ncch;
     FileSys::NCCHContainer update_ncch;
-    FileSys::NCCHContainer *overlay_ncch;
+    FileSys::NCCHContainer* overlay_ncch;
 
     std::string filepath;
 };


### PR DESCRIPTION
NCCH parsing was split off into `FileSys::NCCHContainer` to allow for multiple NCCHs to be loaded in the NCCH loader. If an update NCCH is found in `sdmc:/Nintendo 3DS/.../title/<TID High>/<TID Low>/content/00000000.app` its ExeFS and ExHeader will override the base game's ExeFS and ExHeader, and the UpdateRomFS in SelfNCCH will load from the update NCCH instead of the base game NCCH.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2927)
<!-- Reviewable:end -->
