### PR TITLE
WebService: Set USE_SYSTEM_CURL for travis linux builds

### DIFF
--- a/.travis-build-docker.sh
+++ b/.travis-build-docker.sh
@@ -14,7 +14,7 @@ echo y | sh cmake-3.9.0-Linux-x86_64.sh --prefix=cmake
 export PATH=/citra/cmake/cmake-3.9.0-Linux-x86_64/bin:$PATH
 
 mkdir build && cd build
-cmake .. -DCMAKE_BUILD_TYPE=Release
+cmake .. -DUSE_SYSTEM_CURL=ON -DCMAKE_BUILD_TYPE=Release
 make -j4
 
 ctest -VV -C Release


### PR DESCRIPTION
Fixes issue that linux builds can't send telemetry.

It could be necessary that users have to install libcurl on their system for citra to work:
`apt-get install libcurl4-openssl-dev`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2936)
<!-- Reviewable:end -->
