### PR TITLE
citra-qt: fix some untranslated strings

### DIFF
--- a/src/citra_qt/configuration/configure_graphics.ui
+++ b/src/citra_qt/configuration/configure_graphics.ui
@@ -63,57 +63,57 @@
               <widget class="QComboBox" name="resolution_factor_combobox">
                 <item>
                   <property name="text">
-                    <string notr="true">Auto (Window Size)</string>
+                    <string>Auto (Window Size)</string>
                   </property>
                 </item>
                 <item>
                   <property name="text">
-                    <string notr="true">Native (400x240)</string>
+                    <string>Native (400x240)</string>
                   </property>
                 </item>
                 <item>
                   <property name="text">
-                    <string notr="true">2x Native (800x480)</string>
+                    <string>2x Native (800x480)</string>
                   </property>
                 </item>
                 <item>
                   <property name="text">
-                    <string notr="true">3x Native (1200x720)</string>
+                    <string>3x Native (1200x720)</string>
                   </property>
                 </item>
                 <item>
                   <property name="text">
-                    <string notr="true">4x Native (1600x960)</string>
+                    <string>4x Native (1600x960)</string>
                   </property>
                 </item>
                 <item>
                   <property name="text">
-                    <string notr="true">5x Native (2000x1200)</string>
+                    <string>5x Native (2000x1200)</string>
                   </property>
                 </item>
                 <item>
                   <property name="text">
-                    <string notr="true">6x Native (2400x1440)</string>
+                    <string>6x Native (2400x1440)</string>
                   </property>
                 </item>
                 <item>
                   <property name="text">
-                    <string notr="true">7x Native (2800x1680)</string>
+                    <string>7x Native (2800x1680)</string>
                   </property>
                 </item>
                 <item>
                   <property name="text">
-                    <string notr="true">8x Native (3200x1920)</string>
+                    <string>8x Native (3200x1920)</string>
                   </property>
                 </item>
                 <item>
                   <property name="text">
-                    <string notr="true">9x Native (3600x2160)</string>
+                    <string>9x Native (3600x2160)</string>
                   </property>
                 </item>
                 <item>
                   <property name="text">
-                    <string notr="true">10x Native (4000x2400)</string>
+                    <string>10x Native (4000x2400)</string>
                   </property>
                 </item>
               </widget>

--- a/src/citra_qt/configuration/configure_system.cpp
+++ b/src/citra_qt/configuration/configure_system.cpp
@@ -78,7 +78,8 @@ void ConfigureSystem::ReadSystemSettings() {
 
     // set the console id
     u64 console_id = Service::CFG::GetConsoleUniqueId();
-    ui->label_console_id->setText("Console ID: 0x" + QString::number(console_id, 16).toUpper());
+    ui->label_console_id->setText(
+        tr("Console ID: 0x%1").arg(QString::number(console_id, 16).toUpper()));
 }
 
 void ConfigureSystem::applyConfiguration() {

--- a/src/citra_qt/configuration/configure_web.cpp
+++ b/src/citra_qt/configuration/configure_web.cpp
@@ -24,15 +24,15 @@ ConfigureWeb::~ConfigureWeb() {}
 void ConfigureWeb::setConfiguration() {
     ui->web_credentials_disclaimer->setWordWrap(true);
     ui->telemetry_learn_more->setOpenExternalLinks(true);
-    ui->telemetry_learn_more->setText("<a "
-                                      "href='https://citra-emu.org/entry/"
-                                      "telemetry-and-why-thats-a-good-thing/'>Learn more</a>");
+    ui->telemetry_learn_more->setText(tr("<a "
+                                         "href='https://citra-emu.org/entry/"
+                                         "telemetry-and-why-thats-a-good-thing/'>Learn more</a>"));
 
     ui->web_signup_link->setOpenExternalLinks(true);
-    ui->web_signup_link->setText("<a href='https://services.citra-emu.org/'>Sign up</a>");
+    ui->web_signup_link->setText(tr("<a href='https://services.citra-emu.org/'>Sign up</a>"));
     ui->web_token_info_link->setOpenExternalLinks(true);
     ui->web_token_info_link->setText(
-        "<a href='https://citra-emu.org/wiki/citra-web-service/'>What is my token?</a>");
+        tr("<a href='https://citra-emu.org/wiki/citra-web-service/'>What is my token?</a>"));
 
     ui->toggle_telemetry->setChecked(Settings::values.enable_telemetry);
     ui->edit_username->setText(QString::fromStdString(Settings::values.citra_username));
@@ -40,8 +40,8 @@ void ConfigureWeb::setConfiguration() {
     // Connect after setting the values, to avoid calling OnLoginChanged now
     connect(ui->edit_token, &QLineEdit::textChanged, this, &ConfigureWeb::OnLoginChanged);
     connect(ui->edit_username, &QLineEdit::textChanged, this, &ConfigureWeb::OnLoginChanged);
-    ui->label_telemetry_id->setText("Telemetry ID: 0x" +
-                                    QString::number(Core::GetTelemetryId(), 16).toUpper());
+    ui->label_telemetry_id->setText(
+        tr("Telemetry ID: 0x%1").arg(QString::number(Core::GetTelemetryId(), 16).toUpper()));
     user_verified = true;
 }
 
@@ -60,8 +60,8 @@ void ConfigureWeb::applyConfiguration() {
 
 void ConfigureWeb::RefreshTelemetryID() {
     const u64 new_telemetry_id{Core::RegenerateTelemetryId()};
-    ui->label_telemetry_id->setText("Telemetry ID: 0x" +
-                                    QString::number(new_telemetry_id, 16).toUpper());
+    ui->label_telemetry_id->setText(
+        tr("Telemetry ID: 0x%1").arg(QString::number(new_telemetry_id, 16).toUpper()));
 }
 
 void ConfigureWeb::OnLoginChanged() {


### PR DESCRIPTION
This doesn't fix all untranslated strings, though. There are some strange problem with game_list.cpp where adding missing tr() generates `tr cannot be called without context` warnings. Qt might gets confused with multiple/nested class there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2949)
<!-- Reviewable:end -->
