### PR TITLE
Loaders: Don't automatically set the current process every time we load an application.

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -13,6 +13,7 @@
 #include "core/core_timing.h"
 #include "core/gdbstub/gdbstub.h"
 #include "core/hle/kernel/kernel.h"
+#include "core/hle/kernel/process.h"
 #include "core/hle/kernel/thread.h"
 #include "core/hle/service/service.h"
 #include "core/hw/hw.h"
@@ -100,7 +101,7 @@ System::ResultStatus System::Load(EmuWindow* emu_window, const std::string& file
         return init_result;
     }
 
-    const Loader::ResultStatus load_result{app_loader->Load()};
+    const Loader::ResultStatus load_result{app_loader->Load(Kernel::g_current_process)};
     if (Loader::ResultStatus::Success != load_result) {
         LOG_CRITICAL(Core, "Failed to load ROM (Error %i)!", load_result);
         System::Shutdown();
@@ -114,6 +115,7 @@ System::ResultStatus System::Load(EmuWindow* emu_window, const std::string& file
             return ResultStatus::ErrorLoader;
         }
     }
+    Memory::SetCurrentPageTable(&Kernel::g_current_process->vm_manager.page_table);
     status = ResultStatus::Success;
     return status;
 }
@@ -196,4 +198,4 @@ void System::Shutdown() {
     LOG_DEBUG(Core, "Shutdown OK");
 }
 
-} // namespace
+} // namespace Core

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -147,7 +147,7 @@ void Process::Run(s32 main_thread_priority, u32 stack_size) {
     }
 
     vm_manager.LogLayout(Log::Level::Debug);
-    Kernel::SetupMainThread(codeset->entrypoint, main_thread_priority);
+    Kernel::SetupMainThread(codeset->entrypoint, main_thread_priority, this);
 }
 
 VAddr Process::GetLinearHeapAreaAddress() const {

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -56,10 +56,12 @@ public:
      * @param arg User data to pass to the thread
      * @param processor_id The ID(s) of the processors on which the thread is desired to be run
      * @param stack_top The address of the thread's stack top
+     * @param owner_process The parent process for the thread
      * @return A shared pointer to the newly created thread
      */
     static ResultVal<SharedPtr<Thread>> Create(std::string name, VAddr entry_point, u32 priority,
-                                               u32 arg, s32 processor_id, VAddr stack_top);
+                                               u32 arg, s32 processor_id, VAddr stack_top,
+                                               SharedPtr<Process> owner_process);
 
     std::string GetName() const override {
         return name;
@@ -116,9 +118,9 @@ public:
     void ResumeFromWait();
 
     /**
-    * Schedules an event to wake up the specified thread after the specified delay
-    * @param nanoseconds The time this thread will be allowed to sleep for
-    */
+     * Schedules an event to wake up the specified thread after the specified delay
+     * @param nanoseconds The time this thread will be allowed to sleep for
+     */
     void WakeAfterDelay(s64 nanoseconds);
 
     /**
@@ -214,9 +216,10 @@ private:
  * Sets up the primary application thread
  * @param entry_point The address at which the thread should start execution
  * @param priority The priority to give the main thread
+ * @param owner_process The parent process for the main thread
  * @return A shared pointer to the main thread
  */
-SharedPtr<Thread> SetupMainThread(u32 entry_point, s32 priority);
+SharedPtr<Thread> SetupMainThread(u32 entry_point, s32 priority, SharedPtr<Process> owner_process);
 
 /**
  * Returns whether there are any threads that are ready to run.
@@ -276,4 +279,4 @@ void ThreadingShutdown();
  */
 const std::vector<SharedPtr<Thread>>& GetThreadList();
 
-} // namespace
+} // namespace Kernel

--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -656,8 +656,9 @@ static ResultCode CreateThread(Kernel::Handle* out_handle, u32 priority, u32 ent
                   "Newly created thread must run in the SysCore (Core1), unimplemented.");
     }
 
-    CASCADE_RESULT(SharedPtr<Thread> thread, Kernel::Thread::Create(name, entry_point, priority,
-                                                                    arg, processor_id, stack_top));
+    CASCADE_RESULT(SharedPtr<Thread> thread,
+                   Kernel::Thread::Create(name, entry_point, priority, arg, processor_id, stack_top,
+                                          Kernel::g_current_process));
 
     thread->context.fpscr =
         FPSCR_DEFAULT_NAN | FPSCR_FLUSH_TO_ZERO | FPSCR_ROUND_TOZERO; // 0x03C00000

--- a/src/core/loader/3dsx.h
+++ b/src/core/loader/3dsx.h
@@ -31,7 +31,7 @@ public:
         return IdentifyType(file);
     }
 
-    ResultStatus Load() override;
+    ResultStatus Load(Kernel::SharedPtr<Kernel::Process>& process) override;
 
     ResultStatus ReadIcon(std::vector<u8>& buffer) override;
 

--- a/src/core/loader/elf.h
+++ b/src/core/loader/elf.h
@@ -30,7 +30,7 @@ public:
         return IdentifyType(file);
     }
 
-    ResultStatus Load() override;
+    ResultStatus Load(Kernel::SharedPtr<Kernel::Process>& process) override;
 
 private:
     std::string filename;

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -13,10 +13,12 @@
 #include <boost/optional.hpp>
 #include "common/common_types.h"
 #include "common/file_util.h"
+#include "core/hle/kernel/kernel.h"
 
 namespace Kernel {
 struct AddressMapping;
-}
+class Process;
+} // namespace Kernel
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Loader namespace
@@ -92,10 +94,11 @@ public:
     virtual FileType GetFileType() = 0;
 
     /**
-     * Load the application
-     * @return ResultStatus result of function
+     * Load the application and return the created Process instance
+     * @param process The newly created process.
+     * @return The status result of the operation.
      */
-    virtual ResultStatus Load() = 0;
+    virtual ResultStatus Load(Kernel::SharedPtr<Kernel::Process>& process) = 0;
 
     /**
      * Loads the system mode that this application needs.
@@ -206,4 +209,4 @@ extern const std::initializer_list<Kernel::AddressMapping> default_address_mappi
  */
 std::unique_ptr<AppLoader> GetLoader(const std::string& filename);
 
-} // namespace
+} // namespace Loader

--- a/src/core/loader/ncch.h
+++ b/src/core/loader/ncch.h
@@ -33,7 +33,7 @@ public:
         return IdentifyType(file);
     }
 
-    ResultStatus Load() override;
+    ResultStatus Load(Kernel::SharedPtr<Kernel::Process>& process) override;
 
     /**
      * Loads the Exheader and returns the system mode for this application.
@@ -62,9 +62,10 @@ public:
 private:
     /**
      * Loads .code section into memory for booting
+     * @param process The newly created process
      * @return ResultStatus result of function
      */
-    ResultStatus LoadExec();
+    ResultStatus LoadExec(Kernel::SharedPtr<Kernel::Process>& process);
 
     /// Reads the region lockout info in the SMDH and send it to CFG service
     void ParseRegionLockoutInfo();

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -12,6 +12,10 @@
 #include "common/common_types.h"
 #include "core/mmio.h"
 
+namespace Kernel {
+class Process;
+}
+
 namespace Memory {
 
 /**
@@ -185,7 +189,10 @@ enum : VAddr {
 void SetCurrentPageTable(PageTable* page_table);
 PageTable* GetCurrentPageTable();
 
+/// Determines if the given VAddr is valid for the specified process.
+bool IsValidVirtualAddress(const Kernel::Process& process, const VAddr vaddr);
 bool IsValidVirtualAddress(const VAddr addr);
+
 bool IsValidPhysicalAddress(const PAddr addr);
 
 u8 Read8(VAddr addr);

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SRCS
             core/arm/dyncom/arm_dyncom_vfp_tests.cpp
             core/file_sys/path_parser.cpp
             core/hle/kernel/hle_ipc.cpp
+            core/memory/memory.cpp
             glad.cpp
             tests.cpp
             )

--- a/src/tests/core/memory/memory.cpp
+++ b/src/tests/core/memory/memory.cpp
@@ -1,0 +1,56 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <catch.hpp>
+#include "core/hle/kernel/memory.h"
+#include "core/hle/kernel/process.h"
+#include "core/memory.h"
+
+TEST_CASE("Memory::IsValidVirtualAddress", "[core][memory]") {
+    SECTION("these regions should not be mapped on an empty process") {
+        auto process = Kernel::Process::Create(Kernel::CodeSet::Create("", 0));
+        CHECK(Memory::IsValidVirtualAddress(*process, Memory::PROCESS_IMAGE_VADDR) == false);
+        CHECK(Memory::IsValidVirtualAddress(*process, Memory::HEAP_VADDR) == false);
+        CHECK(Memory::IsValidVirtualAddress(*process, Memory::LINEAR_HEAP_VADDR) == false);
+        CHECK(Memory::IsValidVirtualAddress(*process, Memory::VRAM_VADDR) == false);
+        CHECK(Memory::IsValidVirtualAddress(*process, Memory::CONFIG_MEMORY_VADDR) == false);
+        CHECK(Memory::IsValidVirtualAddress(*process, Memory::SHARED_PAGE_VADDR) == false);
+        CHECK(Memory::IsValidVirtualAddress(*process, Memory::TLS_AREA_VADDR) == false);
+    }
+
+    SECTION("CONFIG_MEMORY_VADDR and SHARED_PAGE_VADDR should be valid after mapping them") {
+        auto process = Kernel::Process::Create(Kernel::CodeSet::Create("", 0));
+        Kernel::MapSharedPages(process->vm_manager);
+        CHECK(Memory::IsValidVirtualAddress(*process, Memory::CONFIG_MEMORY_VADDR) == true);
+        CHECK(Memory::IsValidVirtualAddress(*process, Memory::SHARED_PAGE_VADDR) == true);
+    }
+
+    SECTION("special regions should be valid after mapping them") {
+        auto process = Kernel::Process::Create(Kernel::CodeSet::Create("", 0));
+        SECTION("VRAM") {
+            Kernel::HandleSpecialMapping(process->vm_manager,
+                                         {Memory::VRAM_VADDR, Memory::VRAM_SIZE, false, false});
+            CHECK(Memory::IsValidVirtualAddress(*process, Memory::VRAM_VADDR) == true);
+        }
+
+        SECTION("IO (Not yet implemented)") {
+            Kernel::HandleSpecialMapping(
+                process->vm_manager, {Memory::IO_AREA_VADDR, Memory::IO_AREA_SIZE, false, false});
+            CHECK_FALSE(Memory::IsValidVirtualAddress(*process, Memory::IO_AREA_VADDR) == true);
+        }
+
+        SECTION("DSP") {
+            Kernel::HandleSpecialMapping(
+                process->vm_manager, {Memory::DSP_RAM_VADDR, Memory::DSP_RAM_SIZE, false, false});
+            CHECK(Memory::IsValidVirtualAddress(*process, Memory::DSP_RAM_VADDR) == true);
+        }
+    }
+
+    SECTION("Unmapping a VAddr should make it invalid") {
+        auto process = Kernel::Process::Create(Kernel::CodeSet::Create("", 0));
+        Kernel::MapSharedPages(process->vm_manager);
+        process->vm_manager.UnmapRange(Memory::CONFIG_MEMORY_VADDR, Memory::CONFIG_MEMORY_SIZE);
+        CHECK(Memory::IsValidVirtualAddress(*process, Memory::CONFIG_MEMORY_VADDR) == false);
+    }
+}


### PR DESCRIPTION
The loaders will now just create a Kernel::Process, construct it and return it to the caller, which is responsible for setting it as the current process and configuring the global page table.

This behavior is needed for loading extra NCCHs while a game is already running (applets, system modules, etc).

This PR can be reviewed commit by commit.

Ultimately I want to make it so `current_page_table` is no longer needed, and all operations happen on the currently scheduled process by default, with overloads to operate on any arbitrary process:

```cpp
IsValidVirtualAddress(VAddr) = IsValidVirtualAddress(g_current_process, VAddr);
GetPointer(VAddr) = GetPointer(g_current_process, VAddr);
...
```
and so on

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2961)
<!-- Reviewable:end -->
