### PR TITLE
Kernel/Threads: Add a new thread status that will allow using a Kernel::Event to put a guest thread to sleep inside an HLE handler until said event is signaled

### DIFF
--- a/src/citra_qt/debugger/wait_tree.cpp
+++ b/src/citra_qt/debugger/wait_tree.cpp
@@ -158,6 +158,9 @@ QString WaitTreeThread::GetText() const {
     case THREADSTATUS_WAIT_SYNCH_ANY:
         status = tr("waiting for objects");
         break;
+    case THREADSTATUS_WAIT_HLE_EVENT:
+        status = tr("waiting for HLE return");
+        break;
     case THREADSTATUS_DORMANT:
         status = tr("dormant");
         break;
@@ -184,6 +187,7 @@ QColor WaitTreeThread::GetColor() const {
         return QColor(Qt::GlobalColor::darkYellow);
     case THREADSTATUS_WAIT_SYNCH_ALL:
     case THREADSTATUS_WAIT_SYNCH_ANY:
+    case THREADSTATUS_WAIT_HLE_EVENT:
         return QColor(Qt::GlobalColor::red);
     case THREADSTATUS_DORMANT:
         return QColor(Qt::GlobalColor::darkCyan);
@@ -232,7 +236,8 @@ std::vector<std::unique_ptr<WaitTreeItem>> WaitTreeThread::GetChildren() const {
         list.push_back(std::make_unique<WaitTreeMutexList>(thread.held_mutexes));
     }
     if (thread.status == THREADSTATUS_WAIT_SYNCH_ANY ||
-        thread.status == THREADSTATUS_WAIT_SYNCH_ALL) {
+        thread.status == THREADSTATUS_WAIT_SYNCH_ALL ||
+        thread.status == THREADSTATUS_WAIT_HLE_EVENT) {
         list.push_back(std::make_unique<WaitTreeObjectList>(thread.wait_objects,
                                                             thread.IsSleepingOnWaitAll()));
     }

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -276,6 +276,7 @@ void Thread::ResumeFromWait() {
     switch (status) {
     case THREADSTATUS_WAIT_SYNCH_ALL:
     case THREADSTATUS_WAIT_SYNCH_ANY:
+    case THREADSTATUS_WAIT_HLE_EVENT:
     case THREADSTATUS_WAIT_ARB:
     case THREADSTATUS_WAIT_SLEEP:
         break;

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -37,6 +37,7 @@ enum ThreadStatus {
     THREADSTATUS_WAIT_SLEEP,     ///< Waiting due to a SleepThread SVC
     THREADSTATUS_WAIT_SYNCH_ANY, ///< Waiting due to WaitSynch1 or WaitSynchN with wait_all = false
     THREADSTATUS_WAIT_SYNCH_ALL, ///< Waiting due to WaitSynchronizationN with wait_all = true
+    THREADSTATUS_WAIT_HLE_EVENT, ///< Waiting due to an HLE handler pausing the thread
     THREADSTATUS_DORMANT,        ///< Created but not yet made ready
     THREADSTATUS_DEAD            ///< Run to completion, or forcefully terminated
 };

--- a/src/core/hle/kernel/wait_object.cpp
+++ b/src/core/hle/kernel/wait_object.cpp
@@ -39,7 +39,8 @@ SharedPtr<Thread> WaitObject::GetHighestPriorityReadyThread() {
     for (const auto& thread : waiting_threads) {
         // The list of waiting threads must not contain threads that are not waiting to be awakened.
         ASSERT_MSG(thread->status == THREADSTATUS_WAIT_SYNCH_ANY ||
-                       thread->status == THREADSTATUS_WAIT_SYNCH_ALL,
+                       thread->status == THREADSTATUS_WAIT_SYNCH_ALL ||
+                       thread->status == THREADSTATUS_WAIT_HLE_EVENT,
                    "Inconsistent thread statuses in waiting_threads");
 
         if (thread->current_priority >= candidate_priority)

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -9,6 +9,7 @@
 #include "common/string_util.h"
 #include "core/hle/ipc.h"
 #include "core/hle/kernel/client_port.h"
+#include "core/hle/kernel/event.h"
 #include "core/hle/kernel/process.h"
 #include "core/hle/kernel/server_port.h"
 #include "core/hle/kernel/server_session.h"
@@ -210,6 +211,47 @@ void AddService(Interface* interface_) {
     server_port->SetHleHandler(std::shared_ptr<Interface>(interface_));
 }
 
+bool ThreadContinuationToken::IsValid() {
+    return thread != nullptr && event != nullptr;
+}
+
+ThreadContinuationToken SleepClientThread(const std::string& reason,
+                                          ThreadContinuationToken::Callback callback) {
+    auto thread = Kernel::GetCurrentThread();
+
+    ASSERT(thread->status == THREADSTATUS_RUNNING);
+
+    ThreadContinuationToken token;
+
+    token.event = Kernel::Event::Create(Kernel::ResetType::OneShot, "HLE Pause Event: " + reason);
+    token.thread = thread;
+    token.callback = std::move(callback);
+    token.pause_reason = std::move(reason);
+
+    // Make the thread wait on our newly created event, it will be signaled when
+    // ContinueClientThread is called.
+    thread->status = THREADSTATUS_WAIT_HLE_EVENT;
+    thread->wait_objects = {token.event};
+    token.event->AddWaitingThread(thread);
+
+    return token;
+}
+
+void ContinueClientThread(ThreadContinuationToken& token) {
+    ASSERT_MSG(token.IsValid(), "Invalid continuation token");
+    ASSERT(token.thread->status == THREADSTATUS_WAIT_HLE_EVENT);
+
+    // Signal the event to wake up the thread
+    token.event->Signal();
+    ASSERT(token.thread->status == THREADSTATUS_READY);
+
+    token.callback(token.thread);
+
+    token.event = nullptr;
+    token.thread = nullptr;
+    token.callback = nullptr;
+}
+
 /// Initialize ServiceManager
 void Init() {
     SM::g_service_manager = std::make_shared<SM::ServiceManager>();
@@ -280,4 +322,4 @@ void Shutdown() {
     g_kernel_named_ports.clear();
     LOG_DEBUG(Service, "shutdown OK");
 }
-}
+} // namespace Service


### PR DESCRIPTION
Some service functions should block the caller guest thread on SendSyncRequest until an async response can be calculated and returned (Most soc:U functions when dealing with blocking sockets, some UDS functions like ConnectToNetwork, most http:C functions, etc).

This change lets us put the threads to wait in the HLE handler and wake them up when the response comes back from another host thread, without having to neither spinlock (and freezing the entirety of the emulator thread) nor ignore the blocking nature of the function.

It is used like so:
```cpp
// In service function
auto future = PerformAsyncOperation();
auto token = SleepClientThread("soc::sendto", [future](SharedPtr<Thread> thread) {
    // Write response to thread's command buffer
    auto response = future.get();
});
...
// Somewhere else, when the async operation has finished
std::lock_guard<std::mutex> lock(HLE::g_hle_lock);
ContinueClientThread(token);
// Now the thread is awake and back into the scheduler queue.
```

This change, alongside #2967 will allow for much better control over the wait and wakeup behaviors of the guest threads.

# Concerns
* How should we handle the command buffer translation in HLERequestContext-based services? WriteToOutgoingCommandBuffer might be called with an incomplete response buffer.
* How should we write to the response buffer inside the callback? Tentative code:
```cpp
VAddr address = thread->GetCommandBufferAddress();
std::array<u8, IPC::COMMAND_BUFFER_LENGTH> buffer;
RequestBuilder rb(buffer.data(), params);
rb.Push(RESULT_SUCCESS);
Memory::WriteBlock(address, *thread->owner_process, buffer.data());
```
but we'd have to repeat that boilerplate in every callback.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2968)
<!-- Reviewable:end -->
