### PR TITLE
Memory: Add overloads for ReadBlock and WriteBlock that operate on a specific process.

### DIFF
--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -534,6 +534,12 @@ s32 Thread::GetWaitObjectIndex(WaitObject* object) const {
     return static_cast<s32>(std::distance(match, wait_objects.rend()) - 1);
 }
 
+VAddr Thread::GetCommandBufferAddress() const {
+    // Offset from the start of TLS at which the IPC command buffer begins.
+    static constexpr int CommandHeaderOffset = 0x80;
+    return GetTLSAddress() + CommandHeaderOffset;
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void ThreadingInit() {

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -159,6 +159,12 @@ public:
         return tls_address;
     }
 
+    /*
+     * Returns the address of the current thread's command buffer, located in the TLS.
+     * @returns VAddr of the thread's command buffer.
+     */
+    VAddr GetCommandBufferAddress() const;
+
     /**
      * Returns whether this thread is waiting for all the objects in
      * its wait list to become ready, as a result of a WaitSynchronizationN call

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -555,7 +555,9 @@ void Write64(const VAddr addr, const u64 data) {
     Write<u64_le>(addr, data);
 }
 
-void WriteBlock(const VAddr dest_addr, const void* src_buffer, const size_t size) {
+void WriteBlock(const Kernel::Process& process, const VAddr dest_addr, const void* src_buffer,
+                const size_t size) {
+    auto& page_table = process.vm_manager.page_table;
     size_t remaining_size = size;
     size_t page_index = dest_addr >> PAGE_BITS;
     size_t page_offset = dest_addr & PAGE_MASK;
@@ -564,7 +566,7 @@ void WriteBlock(const VAddr dest_addr, const void* src_buffer, const size_t size
         const size_t copy_amount = std::min(PAGE_SIZE - page_offset, remaining_size);
         const VAddr current_vaddr = static_cast<VAddr>((page_index << PAGE_BITS) + page_offset);
 
-        switch (current_page_table->attributes[page_index]) {
+        switch (page_table.attributes[page_index]) {
         case PageType::Unmapped: {
             LOG_ERROR(HW_Memory,
                       "unmapped WriteBlock @ 0x%08X (start address = 0x%08X, size = %zu)",
@@ -572,29 +574,30 @@ void WriteBlock(const VAddr dest_addr, const void* src_buffer, const size_t size
             break;
         }
         case PageType::Memory: {
-            DEBUG_ASSERT(current_page_table->pointers[page_index]);
+            DEBUG_ASSERT(page_table.pointers[page_index]);
 
-            u8* dest_ptr = current_page_table->pointers[page_index] + page_offset;
+            u8* dest_ptr = page_table.pointers[page_index] + page_offset;
             std::memcpy(dest_ptr, src_buffer, copy_amount);
             break;
         }
         case PageType::Special: {
-            DEBUG_ASSERT(GetMMIOHandler(current_vaddr));
-
-            GetMMIOHandler(current_vaddr)->WriteBlock(current_vaddr, src_buffer, copy_amount);
+            MMIORegionPointer handler = GetMMIOHandler(page_table, current_vaddr);
+            DEBUG_ASSERT(handler);
+            handler->WriteBlock(current_vaddr, src_buffer, copy_amount);
             break;
         }
         case PageType::RasterizerCachedMemory: {
             RasterizerFlushVirtualRegion(current_vaddr, static_cast<u32>(copy_amount),
                                          FlushMode::FlushAndInvalidate);
-            std::memcpy(GetPointerFromVMA(current_vaddr), src_buffer, copy_amount);
+            std::memcpy(GetPointerFromVMA(process, current_vaddr), src_buffer, copy_amount);
             break;
         }
         case PageType::RasterizerCachedSpecial: {
-            DEBUG_ASSERT(GetMMIOHandler(current_vaddr));
+            MMIORegionPointer handler = GetMMIOHandler(page_table, current_vaddr);
+            DEBUG_ASSERT(handler);
             RasterizerFlushVirtualRegion(current_vaddr, static_cast<u32>(copy_amount),
                                          FlushMode::FlushAndInvalidate);
-            GetMMIOHandler(current_vaddr)->WriteBlock(current_vaddr, src_buffer, copy_amount);
+            handler->WriteBlock(current_vaddr, src_buffer, copy_amount);
             break;
         }
         default:
@@ -606,6 +609,10 @@ void WriteBlock(const VAddr dest_addr, const void* src_buffer, const size_t size
         src_buffer = static_cast<const u8*>(src_buffer) + copy_amount;
         remaining_size -= copy_amount;
     }
+}
+
+void WriteBlock(const VAddr dest_addr, const void* src_buffer, const size_t size) {
+    WriteBlock(*Kernel::g_current_process, dest_addr, src_buffer, size);
 }
 
 void ZeroBlock(const VAddr dest_addr, const size_t size) {

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -208,6 +208,8 @@ void Write64(VAddr addr, u64 data);
 void ReadBlock(const Kernel::Process& process, const VAddr src_addr, void* dest_buffer,
                size_t size);
 void ReadBlock(const VAddr src_addr, void* dest_buffer, size_t size);
+void WriteBlock(const Kernel::Process& process, const VAddr dest_addr, const void* src_buffer,
+                size_t size);
 void WriteBlock(const VAddr dest_addr, const void* src_buffer, size_t size);
 void ZeroBlock(const VAddr dest_addr, const size_t size);
 void CopyBlock(VAddr dest_addr, VAddr src_addr, size_t size);

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -205,6 +205,8 @@ void Write16(VAddr addr, u16 data);
 void Write32(VAddr addr, u32 data);
 void Write64(VAddr addr, u64 data);
 
+void ReadBlock(const Kernel::Process& process, const VAddr src_addr, void* dest_buffer,
+               size_t size);
 void ReadBlock(const VAddr src_addr, void* dest_buffer, size_t size);
 void WriteBlock(const VAddr dest_addr, const void* src_buffer, size_t size);
 void ZeroBlock(const VAddr dest_addr, const size_t size);


### PR DESCRIPTION
We can use these for accessing the memory of a different process using virtual addresses.

I plan on using these overloads when implementing command buffer translation for svcReplyAndReceive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2971)
<!-- Reviewable:end -->
