### PR TITLE
macOS: Build x86_64h slice

### DIFF
--- a/.travis-build.sh
+++ b/.travis-build.sh
@@ -52,8 +52,8 @@ elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
     export Qt5_DIR=$(brew --prefix)/opt/qt5
 
     mkdir build && cd build
-    cmake .. -DUSE_SYSTEM_CURL=ON -GXcode
-    xcodebuild -configuration Release
+    cmake .. -DUSE_SYSTEM_CURL=ON -DCMAKE_OSX_ARCHITECTURES="x86_64;x86_64h" -DCMAKE_BUILD_TYPE=Release
+    make -j4
 
     ctest -VV -C Release
 fi

--- a/.travis-upload.sh
+++ b/.travis-upload.sh
@@ -16,8 +16,8 @@ elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
     COMPRESSION_FLAGS="-czvf"
     mkdir "$REV_NAME"
 
-    cp build/src/citra/Release/citra "$REV_NAME"
-    cp -r build/src/citra_qt/Release/citra-qt.app "$REV_NAME"
+    cp build/src/citra/citra "$REV_NAME"
+    cp -r build/src/citra_qt/citra-qt.app "$REV_NAME"
 
     # move qt libs into app bundle for deployment
     $(brew --prefix)/opt/qt5/bin/macdeployqt "${REV_NAME}/citra-qt.app"


### PR DESCRIPTION
This commit produces a fat-binary with two slices. The x86_64 slice
is for all x64 systems, and the x86_64h slice targets x64 systems
starting with Haswell. The latter allows the compiler to use newer
instructions that are not available on older microarchitectures.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2982)
<!-- Reviewable:end -->
