### PR TITLE
Service/UDS: Implement Bind, Unbind, SendTo, PullPacket, and GetNodeInformation

### DIFF
--- a/src/core/hle/service/nwm/nwm_uds.h
+++ b/src/core/hle/service/nwm/nwm_uds.h
@@ -32,7 +32,7 @@ struct NodeInfo {
     std::array<u16_le, 10> username;
     INSERT_PADDING_BYTES(4);
     u16_le network_node_id;
-    std::array<u8, 6> address;
+    INSERT_PADDING_BYTES(6);
 };
 
 static_assert(sizeof(NodeInfo) == 40, "NodeInfo has incorrect size.");
@@ -42,6 +42,7 @@ using NodeList = std::vector<NodeInfo>;
 enum class NetworkStatus {
     NotConnected = 3,
     ConnectedAsHost = 6,
+    Connecting = 7,
     ConnectedAsClient = 9,
     ConnectedAsSpectator = 10,
 };

--- a/src/core/hle/service/nwm/nwm_uds.h
+++ b/src/core/hle/service/nwm/nwm_uds.h
@@ -42,7 +42,6 @@ using NodeList = std::vector<NodeInfo>;
 enum class NetworkStatus {
     NotConnected = 3,
     ConnectedAsHost = 6,
-    Connecting = 7,
     ConnectedAsClient = 9,
     ConnectedAsSpectator = 10,
 };

--- a/src/core/hle/service/nwm/nwm_uds.h
+++ b/src/core/hle/service/nwm/nwm_uds.h
@@ -32,7 +32,7 @@ struct NodeInfo {
     std::array<u16_le, 10> username;
     INSERT_PADDING_BYTES(4);
     u16_le network_node_id;
-    INSERT_PADDING_BYTES(6);
+    std::array<u8, 6> address;
 };
 
 static_assert(sizeof(NodeInfo) == 40, "NodeInfo has incorrect size.");

--- a/src/core/hle/service/nwm/uds_data.cpp
+++ b/src/core/hle/service/nwm/uds_data.cpp
@@ -275,6 +275,15 @@ std::vector<u8> GenerateDataPayload(const std::vector<u8>& data, u8 channel, u16
     return buffer;
 }
 
+SecureDataHeader ParseSecureDataHeader(const std::vector<u8>& data) {
+    SecureDataHeader header;
+
+    // Skip the LLC header
+    std::memcpy(&header, data.data() + sizeof(LLCHeader), sizeof(header));
+
+    return header;
+}
+
 std::vector<u8> GenerateEAPoLStartFrame(u16 association_id, const NodeInfo& node_info) {
     EAPoLStartPacket eapol_start{};
     eapol_start.association_id = association_id;

--- a/src/core/hle/service/nwm/uds_data.h
+++ b/src/core/hle/service/nwm/uds_data.h
@@ -52,7 +52,7 @@ struct SecureDataHeader {
     u16_be dest_node_id;
     u16_be src_node_id;
 
-    u32 GetActualDataSize() {
+    u32 GetActualDataSize() const {
         return protocol_size - sizeof(SecureDataHeader);
     }
 };

--- a/src/core/hle/service/nwm/uds_data.h
+++ b/src/core/hle/service/nwm/uds_data.h
@@ -51,6 +51,10 @@ struct SecureDataHeader {
     u16_be sequence_number;
     u16_be dest_node_id;
     u16_be src_node_id;
+
+    u32 GetActualDataSize() {
+        return protocol_size - sizeof(SecureDataHeader);
+    }
 };
 
 static_assert(sizeof(SecureDataHeader) == 14, "SecureDataHeader has the wrong size");
@@ -117,6 +121,11 @@ static_assert(sizeof(EAPoLLogoffPacket) == 0x298, "EAPoLLogoffPacket has the wro
  */
 std::vector<u8> GenerateDataPayload(const std::vector<u8>& data, u8 channel, u16 dest_node,
                                     u16 src_node, u16 sequence_number);
+
+/*
+ * Returns the SecureDataHeader stored in an 802.11 data frame.
+ */
+SecureDataHeader ParseSecureDataHeader(const std::vector<u8>& data);
 
 /*
  * Generates an unencrypted 802.11 data frame body with the EAPoL-Start format for UDS


### PR DESCRIPTION
This implements some missing/unimplemented functions in the NWM::UDS-Service:
- SendTo
- PullPacket
- Bind
- Unbind
- GetNodeInformation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2989)
<!-- Reviewable:end -->
