### PR TITLE
Remove more usages of GetPointer.

### DIFF
--- a/src/core/hle/function_wrappers.h
+++ b/src/core/hle/function_wrappers.h
@@ -69,11 +69,10 @@ void Wrap() {
     FuncReturn(retval);
 }
 
-template <ResultCode func(s32*, u32*, s32, u32)>
+template <ResultCode func(s32*, VAddr, s32, u32)>
 void Wrap() {
     s32 param_1 = 0;
-    u32 retval =
-        func(&param_1, (Kernel::Handle*)Memory::GetPointer(PARAM(1)), (s32)PARAM(2), PARAM(3)).raw;
+    u32 retval = func(&param_1, PARAM(1), (s32)PARAM(2), PARAM(3)).raw;
 
     Core::CPU().SetReg(1, (u32)param_1);
     FuncReturn(retval);

--- a/src/core/hle/function_wrappers.h
+++ b/src/core/hle/function_wrappers.h
@@ -267,9 +267,9 @@ void Wrap() {
     func(((s64)PARAM(1) << 32) | PARAM(0));
 }
 
-template <void func(const char*, int len)>
+template <void func(VAddr, int len)>
 void Wrap() {
-    func((char*)Memory::GetPointer(PARAM(0)), PARAM(1));
+    func(PARAM(0), PARAM(1));
 }
 
 template <void func(u8)>

--- a/src/core/hle/function_wrappers.h
+++ b/src/core/hle/function_wrappers.h
@@ -206,13 +206,11 @@ void Wrap() {
     FuncReturn(func(PARAM(0), PARAM(1)).raw);
 }
 
-template <ResultCode func(Kernel::Handle*, Kernel::Handle*, const char*, u32)>
+template <ResultCode func(Kernel::Handle*, Kernel::Handle*, VAddr, u32)>
 void Wrap() {
     Kernel::Handle param_1 = 0;
     Kernel::Handle param_2 = 0;
-    u32 retval = func(&param_1, &param_2,
-                      reinterpret_cast<const char*>(Memory::GetPointer(PARAM(2))), PARAM(3))
-                     .raw;
+    u32 retval = func(&param_1, &param_2, PARAM(2), PARAM(3)).raw;
     Core::CPU().SetReg(1, param_1);
     Core::CPU().SetReg(2, param_2);
     FuncReturn(retval);

--- a/src/core/hle/function_wrappers.h
+++ b/src/core/hle/function_wrappers.h
@@ -58,12 +58,12 @@ void Wrap() {
     FuncReturn(retval);
 }
 
-template <ResultCode func(s32*, u32*, s32, bool, s64)>
+template <ResultCode func(s32*, VAddr, s32, bool, s64)>
 void Wrap() {
     s32 param_1 = 0;
-    s32 retval = func(&param_1, (Kernel::Handle*)Memory::GetPointer(PARAM(1)), (s32)PARAM(2),
-                      (PARAM(3) != 0), (((s64)PARAM(4) << 32) | PARAM(0)))
-                     .raw;
+    s32 retval =
+        func(&param_1, PARAM(1), (s32)PARAM(2), (PARAM(3) != 0), (((s64)PARAM(4) << 32) | PARAM(0)))
+            .raw;
 
     Core::CPU().SetReg(1, (u32)param_1);
     FuncReturn(retval);

--- a/src/core/hle/function_wrappers.h
+++ b/src/core/hle/function_wrappers.h
@@ -151,21 +151,6 @@ void Wrap() {
     FuncReturn(func(PARAM(0)).raw);
 }
 
-template <ResultCode func(s64*, u32, u32*, u32)>
-void Wrap() {
-    FuncReturn(func((s64*)Memory::GetPointer(PARAM(0)), PARAM(1),
-                    (u32*)Memory::GetPointer(PARAM(2)), (s32)PARAM(3))
-                   .raw);
-}
-
-template <ResultCode func(u32*, const char*)>
-void Wrap() {
-    u32 param_1 = 0;
-    u32 retval = func(&param_1, (char*)Memory::GetPointer(PARAM(1))).raw;
-    Core::CPU().SetReg(1, param_1);
-    FuncReturn(retval);
-}
-
 template <ResultCode func(u32*, s32, s32)>
 void Wrap() {
     u32 param_1 = 0;

--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -619,8 +619,10 @@ static void Break(u8 break_reason) {
 }
 
 /// Used to output a message on a debug hardware unit - does nothing on a retail unit
-static void OutputDebugString(const char* string, int len) {
-    LOG_DEBUG(Debug_Emulated, "%.*s", len, string);
+static void OutputDebugString(VAddr address, int len) {
+    std::vector<char> string(len);
+    Memory::ReadBlock(address, string.data(), len);
+    LOG_DEBUG(Debug_Emulated, "%.*s", len, string.data());
 }
 
 /// Get resource limit

--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -452,10 +452,9 @@ static ResultCode WaitSynchronizationN(s32* out, VAddr handles_address, s32 hand
 }
 
 /// In a single operation, sends a IPC reply and waits for a new request.
-static ResultCode ReplyAndReceive(s32* index, Kernel::Handle* handles, s32 handle_count,
+static ResultCode ReplyAndReceive(s32* index, VAddr handles_address, s32 handle_count,
                                   Kernel::Handle reply_target) {
-    // 'handles' has to be a valid pointer even if 'handle_count' is 0.
-    if (handles == nullptr)
+    if (!Memory::IsValidVirtualAddress(handles_address))
         return Kernel::ERR_INVALID_POINTER;
 
     // Check if 'handle_count' is invalid
@@ -466,7 +465,8 @@ static ResultCode ReplyAndReceive(s32* index, Kernel::Handle* handles, s32 handl
     std::vector<ObjectPtr> objects(handle_count);
 
     for (int i = 0; i < handle_count; ++i) {
-        auto object = Kernel::g_handle_table.Get<Kernel::WaitObject>(handles[i]);
+        Kernel::Handle handle = Memory::Read32(handles_address + i * sizeof(Kernel::Handle));
+        auto object = Kernel::g_handle_table.Get<Kernel::WaitObject>(handle);
         if (object == nullptr)
             return ERR_INVALID_HANDLE;
         objects[i] = object;

--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -644,9 +644,9 @@ static ResultCode GetResourceLimit(Kernel::Handle* resource_limit, Kernel::Handl
 }
 
 /// Get resource limit current values
-static ResultCode GetResourceLimitCurrentValues(s64* values, Kernel::Handle resource_limit_handle,
-                                                u32* names, u32 name_count) {
-    LOG_TRACE(Kernel_SVC, "called resource_limit=%08X, names=%p, name_count=%d",
+static ResultCode GetResourceLimitCurrentValues(VAddr values, Kernel::Handle resource_limit_handle,
+                                                VAddr names, u32 name_count) {
+    LOG_TRACE(Kernel_SVC, "called resource_limit=%08X, names=%08X, name_count=%d",
               resource_limit_handle, names, name_count);
 
     SharedPtr<Kernel::ResourceLimit> resource_limit =
@@ -654,16 +654,19 @@ static ResultCode GetResourceLimitCurrentValues(s64* values, Kernel::Handle reso
     if (resource_limit == nullptr)
         return ERR_INVALID_HANDLE;
 
-    for (unsigned int i = 0; i < name_count; ++i)
-        values[i] = resource_limit->GetCurrentResourceValue(names[i]);
+    for (unsigned int i = 0; i < name_count; ++i) {
+        u32 name = Memory::Read32(names + i * sizeof(u32));
+        s64 value = resource_limit->GetCurrentResourceValue(name);
+        Memory::Write64(values + i * sizeof(u64), value);
+    }
 
     return RESULT_SUCCESS;
 }
 
 /// Get resource limit max values
-static ResultCode GetResourceLimitLimitValues(s64* values, Kernel::Handle resource_limit_handle,
-                                              u32* names, u32 name_count) {
-    LOG_TRACE(Kernel_SVC, "called resource_limit=%08X, names=%p, name_count=%d",
+static ResultCode GetResourceLimitLimitValues(VAddr values, Kernel::Handle resource_limit_handle,
+                                              VAddr names, u32 name_count) {
+    LOG_TRACE(Kernel_SVC, "called resource_limit=%08X, names=%08X, name_count=%d",
               resource_limit_handle, names, name_count);
 
     SharedPtr<Kernel::ResourceLimit> resource_limit =
@@ -671,8 +674,11 @@ static ResultCode GetResourceLimitLimitValues(s64* values, Kernel::Handle resour
     if (resource_limit == nullptr)
         return ERR_INVALID_HANDLE;
 
-    for (unsigned int i = 0; i < name_count; ++i)
-        values[i] = resource_limit->GetMaxResourceValue(names[i]);
+    for (unsigned int i = 0; i < name_count; ++i) {
+        u32 name = Memory::Read32(names + i * sizeof(u32));
+        s64 value = resource_limit->GetMaxResourceValue(names);
+        Memory::Write64(values + i * sizeof(u64), value);
+    }
 
     return RESULT_SUCCESS;
 }

--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -1104,9 +1104,9 @@ static ResultCode CreateMemoryBlock(Kernel::Handle* out_handle, u32 addr, u32 si
 }
 
 static ResultCode CreatePort(Kernel::Handle* server_port, Kernel::Handle* client_port,
-                             const char* name, u32 max_sessions) {
+                             VAddr name_address, u32 max_sessions) {
     // TODO(Subv): Implement named ports.
-    ASSERT_MSG(name == nullptr, "Named ports are currently unimplemented");
+    ASSERT_MSG(name_address == 0, "Named ports are currently unimplemented");
 
     using Kernel::ServerPort;
     using Kernel::ClientPort;


### PR DESCRIPTION
Memory::GetPointer is an unsafe function that will only bring us potential out-of-bounds access and buffer overruns if the emulated address space stops being always contiguous for whatever reason.

After this PR there are only 7 remaining references to GetPointer, 2 of which are the declaration and definition.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2991)
<!-- Reviewable:end -->
