### PR TITLE
Services/AC: Converted the ac:i and ac:u services to the new service framework.

### DIFF
--- a/src/core/hle/service/ac/ac.h
+++ b/src/core/hle/service/ac/ac.h
@@ -4,131 +4,156 @@
 
 #pragma once
 
+#include <array>
+#include <memory>
+#include "core/hle/kernel/kernel.h"
+#include "core/hle/service/service.h"
+
+namespace Kernel {
+class Event;
+}
+
 namespace Service {
-
-class Interface;
-
 namespace AC {
+class Module final {
+public:
+    class Interface : public ServiceFramework<Interface> {
+    public:
+        Interface(std::shared_ptr<Module> ac, const char* name, u32 max_session);
 
-/**
- * AC::CreateDefaultConfig service function
- *  Inputs:
- *      64 : ACConfig size << 14 | 2
- *      65 : pointer to ACConfig struct
- *  Outputs:
- *      1 : Result of function, 0 on success, otherwise error code
- */
-void CreateDefaultConfig(Interface* self);
+        /**
+         * AC::CreateDefaultConfig service function
+         *  Inputs:
+         *      64 : ACConfig size << 14 | 2
+         *      65 : pointer to ACConfig struct
+         *  Outputs:
+         *      1 : Result of function, 0 on success, otherwise error code
+         */
+        void CreateDefaultConfig(Kernel::HLERequestContext& ctx);
 
-/**
- * AC::ConnectAsync service function
- *  Inputs:
- *      1 : ProcessId Header
- *      3 : Copy Handle Header
- *      4 : Connection Event handle
- *      5 : ACConfig size << 14 | 2
- *      6 : pointer to ACConfig struct
- *  Outputs:
- *      1 : Result of function, 0 on success, otherwise error code
- */
-void ConnectAsync(Interface* self);
+        /**
+         * AC::ConnectAsync service function
+         *  Inputs:
+         *      1 : ProcessId Header
+         *      3 : Copy Handle Header
+         *      4 : Connection Event handle
+         *      5 : ACConfig size << 14 | 2
+         *      6 : pointer to ACConfig struct
+         *  Outputs:
+         *      1 : Result of function, 0 on success, otherwise error code
+         */
+        void ConnectAsync(Kernel::HLERequestContext& ctx);
 
-/**
- * AC::GetConnectResult service function
- *  Inputs:
- *      1 : ProcessId Header
- *  Outputs:
- *      1 : Result of function, 0 on success, otherwise error code
- */
-void GetConnectResult(Interface* self);
+        /**
+         * AC::GetConnectResult service function
+         *  Inputs:
+         *      1 : ProcessId Header
+         *  Outputs:
+         *      1 : Result of function, 0 on success, otherwise error code
+         */
+        void GetConnectResult(Kernel::HLERequestContext& ctx);
 
-/**
- * AC::CloseAsync service function
- *  Inputs:
- *      1 : ProcessId Header
- *      3 : Copy Handle Header
- *      4 : Event handle, should be signaled when AC connection is closed
- *  Outputs:
- *      1 : Result of function, 0 on success, otherwise error code
- */
-void CloseAsync(Interface* self);
+        /**
+         * AC::CloseAsync service function
+         *  Inputs:
+         *      1 : ProcessId Header
+         *      3 : Copy Handle Header
+         *      4 : Event handle, should be signaled when AC connection is closed
+         *  Outputs:
+         *      1 : Result of function, 0 on success, otherwise error code
+         */
+        void CloseAsync(Kernel::HLERequestContext& ctx);
 
-/**
- * AC::GetCloseResult service function
- *  Inputs:
- *      1 : ProcessId Header
- *  Outputs:
- *      1 : Result of function, 0 on success, otherwise error code
- */
-void GetCloseResult(Interface* self);
+        /**
+         * AC::GetCloseResult service function
+         *  Inputs:
+         *      1 : ProcessId Header
+         *  Outputs:
+         *      1 : Result of function, 0 on success, otherwise error code
+         */
+        void GetCloseResult(Kernel::HLERequestContext& ctx);
 
-/**
- * AC::GetWifiStatus service function
- *  Outputs:
- *      1 : Result of function, 0 on success, otherwise error code
- *      2 : Output connection type, 0 = none, 1 = Old3DS Internet, 2 = New3DS Internet.
- */
-void GetWifiStatus(Interface* self);
+        /**
+         * AC::GetWifiStatus service function
+         *  Outputs:
+         *      1 : Result of function, 0 on success, otherwise error code
+         *      2 : Output connection type, 0 = none, 1 = Old3DS Internet, 2 = New3DS Internet.
+         */
+        void GetWifiStatus(Kernel::HLERequestContext& ctx);
 
-/**
- * AC::GetInfraPriority service function
- *  Inputs:
- *      1 : ACConfig size << 14 | 2
- *      2 : pointer to ACConfig struct
- *  Outputs:
- *      1 : Result of function, 0 on success, otherwise error code
- *      2 : Infra Priority
- */
-void GetInfraPriority(Interface* self);
+        /**
+         * AC::GetInfraPriority service function
+         *  Inputs:
+         *      1 : ACConfig size << 14 | 2
+         *      2 : pointer to ACConfig struct
+         *  Outputs:
+         *      1 : Result of function, 0 on success, otherwise error code
+         *      2 : Infra Priority
+         */
+        void GetInfraPriority(Kernel::HLERequestContext& ctx);
 
-/**
- * AC::SetRequestEulaVersion service function
- *  Inputs:
- *      1 : Eula Version major
- *      2 : Eula Version minor
- *      3 : ACConfig size << 14 | 2
- *      4 : Input pointer to ACConfig struct
- *      64 : ACConfig size << 14 | 2
- *      65 : Output pointer to ACConfig struct
- *  Outputs:
- *      1 : Result of function, 0 on success, otherwise error code
- *      2 : Infra Priority
- */
-void SetRequestEulaVersion(Interface* self);
+        /**
+         * AC::SetRequestEulaVersion service function
+         *  Inputs:
+         *      1 : Eula Version major
+         *      2 : Eula Version minor
+         *      3 : ACConfig size << 14 | 2
+         *      4 : Input pointer to ACConfig struct
+         *      64 : ACConfig size << 14 | 2
+         *      65 : Output pointer to ACConfig struct
+         *  Outputs:
+         *      1 : Result of function, 0 on success, otherwise error code
+         *      2 : Infra Priority
+         */
+        void SetRequestEulaVersion(Kernel::HLERequestContext& ctx);
 
-/**
- * AC::RegisterDisconnectEvent service function
- *  Inputs:
- *      1 : ProcessId Header
- *      3 : Copy Handle Header
- *      4 : Event handle, should be signaled when AC connection is closed
- *  Outputs:
- *      1 : Result of function, 0 on success, otherwise error code
- */
-void RegisterDisconnectEvent(Interface* self);
+        /**
+         * AC::RegisterDisconnectEvent service function
+         *  Inputs:
+         *      1 : ProcessId Header
+         *      3 : Copy Handle Header
+         *      4 : Event handle, should be signaled when AC connection is closed
+         *  Outputs:
+         *      1 : Result of function, 0 on success, otherwise error code
+         */
+        void RegisterDisconnectEvent(Kernel::HLERequestContext& ctx);
 
-/**
- * AC::IsConnected service function
- *  Outputs:
- *      1 : Result of function, 0 on success, otherwise error code
- *      2 : bool, is connected
- */
-void IsConnected(Interface* self);
+        /**
+         * AC::IsConnected service function
+         *  Outputs:
+         *      1 : Result of function, 0 on success, otherwise error code
+         *      2 : bool, is connected
+         */
+        void IsConnected(Kernel::HLERequestContext& ctx);
 
-/**
- * AC::SetClientVersion service function
- *  Inputs:
- *      1 : Used SDK Version
- *  Outputs:
- *      1 : Result of function, 0 on success, otherwise error code
- */
-void SetClientVersion(Interface* self);
+        /**
+         * AC::SetClientVersion service function
+         *  Inputs:
+         *      1 : Used SDK Version
+         *  Outputs:
+         *      1 : Result of function, 0 on success, otherwise error code
+         */
+        void SetClientVersion(Kernel::HLERequestContext& ctx);
 
-/// Initialize AC service
-void Init();
+    protected:
+        std::shared_ptr<Module> ac;
+    };
 
-/// Shutdown AC service
-void Shutdown();
+protected:
+    struct ACConfig {
+        std::array<u8, 0x200> data;
+    };
+
+    ACConfig default_config{};
+
+    bool ac_connected = false;
+
+    Kernel::SharedPtr<Kernel::Event> close_event;
+    Kernel::SharedPtr<Kernel::Event> connect_event;
+    Kernel::SharedPtr<Kernel::Event> disconnect_event;
+};
+
+void InstallInterfaces(SM::ServiceManager& service_manager);
 
 } // namespace AC
 } // namespace Service

--- a/src/core/hle/service/ac/ac_i.cpp
+++ b/src/core/hle/service/ac/ac_i.cpp
@@ -2,37 +2,36 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include "core/hle/service/ac/ac.h"
 #include "core/hle/service/ac/ac_i.h"
 
 namespace Service {
 namespace AC {
 
-const Interface::FunctionInfo FunctionTable[] = {
-    {0x00010000, CreateDefaultConfig, "CreateDefaultConfig"},
-    {0x00040006, ConnectAsync, "ConnectAsync"},
-    {0x00050002, GetConnectResult, "GetConnectResult"},
-    {0x00070002, nullptr, "CancelConnectAsync"},
-    {0x00080004, CloseAsync, "CloseAsync"},
-    {0x00090002, GetCloseResult, "GetCloseResult"},
-    {0x000A0000, nullptr, "GetLastErrorCode"},
-    {0x000C0000, nullptr, "GetStatus"},
-    {0x000D0000, GetWifiStatus, "GetWifiStatus"},
-    {0x000E0042, nullptr, "GetCurrentAPInfo"},
-    {0x00100042, nullptr, "GetCurrentNZoneInfo"},
-    {0x00110042, nullptr, "GetNZoneApNumService"},
-    {0x001D0042, nullptr, "ScanAPs"},
-    {0x00240042, nullptr, "AddDenyApType"},
-    {0x00270002, GetInfraPriority, "GetInfraPriority"},
-    {0x002D0082, SetRequestEulaVersion, "SetRequestEulaVersion"},
-    {0x00300004, RegisterDisconnectEvent, "RegisterDisconnectEvent"},
-    {0x003C0042, nullptr, "GetAPSSIDList"},
-    {0x003E0042, IsConnected, "IsConnected"},
-    {0x00400042, SetClientVersion, "SetClientVersion"},
-};
-
-AC_I::AC_I() {
-    Register(FunctionTable);
+// TODO(Subv): Find out the correct number of concurrent sessions allowed
+AC_I::AC_I(std::shared_ptr<Module> ac) : Module::Interface(std::move(ac), "ac:i", 1) {
+    static const FunctionInfo functions[] = {
+        {0x00010000, &AC_I::CreateDefaultConfig, "CreateDefaultConfig"},
+        {0x00040006, &AC_I::ConnectAsync, "ConnectAsync"},
+        {0x00050002, &AC_I::GetConnectResult, "GetConnectResult"},
+        {0x00070002, nullptr, "CancelConnectAsync"},
+        {0x00080004, &AC_I::CloseAsync, "CloseAsync"},
+        {0x00090002, &AC_I::GetCloseResult, "GetCloseResult"},
+        {0x000A0000, nullptr, "GetLastErrorCode"},
+        {0x000C0000, nullptr, "GetStatus"},
+        {0x000D0000, &AC_I::GetWifiStatus, "GetWifiStatus"},
+        {0x000E0042, nullptr, "GetCurrentAPInfo"},
+        {0x00100042, nullptr, "GetCurrentNZoneInfo"},
+        {0x00110042, nullptr, "GetNZoneApNumService"},
+        {0x001D0042, nullptr, "ScanAPs"},
+        {0x00240042, nullptr, "AddDenyApType"},
+        {0x00270002, &AC_I::GetInfraPriority, "GetInfraPriority"},
+        {0x002D0082, &AC_I::SetRequestEulaVersion, "SetRequestEulaVersion"},
+        {0x00300004, &AC_I::RegisterDisconnectEvent, "RegisterDisconnectEvent"},
+        {0x003C0042, nullptr, "GetAPSSIDList"},
+        {0x003E0042, &AC_I::IsConnected, "IsConnected"},
+        {0x00400042, &AC_I::SetClientVersion, "SetClientVersion"},
+    };
+    RegisterHandlers(functions);
 }
 
 } // namespace AC

--- a/src/core/hle/service/ac/ac_i.h
+++ b/src/core/hle/service/ac/ac_i.h
@@ -4,18 +4,15 @@
 
 #pragma once
 
-#include "core/hle/service/service.h"
+#include <memory>
+#include "core/hle/service/ac/ac.h"
 
 namespace Service {
 namespace AC {
 
-class AC_I final : public Interface {
+class AC_I final : public Module::Interface {
 public:
-    AC_I();
-
-    std::string GetPortName() const override {
-        return "ac:i";
-    }
+    explicit AC_I(std::shared_ptr<Module> ac);
 };
 
 } // namespace AC

--- a/src/core/hle/service/ac/ac_u.cpp
+++ b/src/core/hle/service/ac/ac_u.cpp
@@ -2,37 +2,36 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include "core/hle/service/ac/ac.h"
 #include "core/hle/service/ac/ac_u.h"
 
 namespace Service {
 namespace AC {
 
-const Interface::FunctionInfo FunctionTable[] = {
-    {0x00010000, CreateDefaultConfig, "CreateDefaultConfig"},
-    {0x00040006, ConnectAsync, "ConnectAsync"},
-    {0x00050002, GetConnectResult, "GetConnectResult"},
-    {0x00070002, nullptr, "CancelConnectAsync"},
-    {0x00080004, CloseAsync, "CloseAsync"},
-    {0x00090002, GetCloseResult, "GetCloseResult"},
-    {0x000A0000, nullptr, "GetLastErrorCode"},
-    {0x000C0000, nullptr, "GetStatus"},
-    {0x000D0000, GetWifiStatus, "GetWifiStatus"},
-    {0x000E0042, nullptr, "GetCurrentAPInfo"},
-    {0x00100042, nullptr, "GetCurrentNZoneInfo"},
-    {0x00110042, nullptr, "GetNZoneApNumService"},
-    {0x001D0042, nullptr, "ScanAPs"},
-    {0x00240042, nullptr, "AddDenyApType"},
-    {0x00270002, GetInfraPriority, "GetInfraPriority"},
-    {0x002D0082, SetRequestEulaVersion, "SetRequestEulaVersion"},
-    {0x00300004, RegisterDisconnectEvent, "RegisterDisconnectEvent"},
-    {0x003C0042, nullptr, "GetAPSSIDList"},
-    {0x003E0042, IsConnected, "IsConnected"},
-    {0x00400042, SetClientVersion, "SetClientVersion"},
-};
-
-AC_U::AC_U() {
-    Register(FunctionTable);
+// TODO(Subv): Find out the correct number of concurrent sessions allowed
+AC_U::AC_U(std::shared_ptr<Module> ac) : Module::Interface(std::move(ac), "ac:u", 1) {
+    static const FunctionInfo functions[] = {
+        {0x00010000, &AC_U::CreateDefaultConfig, "CreateDefaultConfig"},
+        {0x00040006, &AC_U::ConnectAsync, "ConnectAsync"},
+        {0x00050002, &AC_U::GetConnectResult, "GetConnectResult"},
+        {0x00070002, nullptr, "CancelConnectAsync"},
+        {0x00080004, &AC_U::CloseAsync, "CloseAsync"},
+        {0x00090002, &AC_U::GetCloseResult, "GetCloseResult"},
+        {0x000A0000, nullptr, "GetLastErrorCode"},
+        {0x000C0000, nullptr, "GetStatus"},
+        {0x000D0000, &AC_U::GetWifiStatus, "GetWifiStatus"},
+        {0x000E0042, nullptr, "GetCurrentAPInfo"},
+        {0x00100042, nullptr, "GetCurrentNZoneInfo"},
+        {0x00110042, nullptr, "GetNZoneApNumService"},
+        {0x001D0042, nullptr, "ScanAPs"},
+        {0x00240042, nullptr, "AddDenyApType"},
+        {0x00270002, &AC_U::GetInfraPriority, "GetInfraPriority"},
+        {0x002D0082, &AC_U::SetRequestEulaVersion, "SetRequestEulaVersion"},
+        {0x00300004, &AC_U::RegisterDisconnectEvent, "RegisterDisconnectEvent"},
+        {0x003C0042, nullptr, "GetAPSSIDList"},
+        {0x003E0042, &AC_U::IsConnected, "IsConnected"},
+        {0x00400042, &AC_U::SetClientVersion, "SetClientVersion"},
+    };
+    RegisterHandlers(functions);
 }
 
 } // namespace AC

--- a/src/core/hle/service/ac/ac_u.h
+++ b/src/core/hle/service/ac/ac_u.h
@@ -4,18 +4,15 @@
 
 #pragma once
 
-#include "core/hle/service/service.h"
+#include <memory>
+#include "core/hle/service/ac/ac.h"
 
 namespace Service {
 namespace AC {
 
-class AC_U final : public Interface {
+class AC_U final : public Module::Interface {
 public:
-    AC_U();
-
-    std::string GetPortName() const override {
-        return "ac:u";
-    }
+    explicit AC_U(std::shared_ptr<Module> ac);
 };
 
 } // namespace AC

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -216,11 +216,11 @@ void Init() {
     SM::ServiceManager::InstallInterfaces(SM::g_service_manager);
 
     NS::InstallInterfaces(*SM::g_service_manager);
+    AC::InstallInterfaces(*SM::g_service_manager);
 
     AddNamedPort(new ERR::ERR_F);
 
     FS::ArchiveInit();
-    AC::Init();
     ACT::Init();
     AM::Init();
     APT::Init();
@@ -273,7 +273,6 @@ void Shutdown() {
     BOSS::Shutdown();
     APT::Shutdown();
     AM::Shutdown();
-    AC::Shutdown();
     FS::ArchiveShutdown();
 
     SM::g_service_manager = nullptr;


### PR DESCRIPTION
# ~Concerns~

~There are a few service functions whose command header doesn't seem to match their parameters, why does `CreateDefaultConfig`, with a command header of `0x00010000`, work on a static buffer?~

~3dbrew has no information on that function~

I've reverse engineered a bit of the AC module and fixed some missing/wrong parameters in the response command buffers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/2992)
<!-- Reviewable:end -->
