### PR TITLE
citra-qt : Adding fullscreen mode

### DIFF
--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -198,6 +198,7 @@ void Config::ReadValues() {
     qt_config->endGroup();
 
     UISettings::values.single_window_mode = qt_config->value("singleWindowMode", true).toBool();
+    UISettings::values.fullscreen = qt_config->value("fullscreen", false).toBool();
     UISettings::values.display_titlebar = qt_config->value("displayTitleBars", true).toBool();
     UISettings::values.show_filter_bar = qt_config->value("showFilterBar", true).toBool();
     UISettings::values.show_status_bar = qt_config->value("showStatusBar", true).toBool();
@@ -331,6 +332,7 @@ void Config::SaveValues() {
     qt_config->endGroup();
 
     qt_config->setValue("singleWindowMode", UISettings::values.single_window_mode);
+    qt_config->setValue("fullscreen", UISettings::values.fullscreen);
     qt_config->setValue("displayTitleBars", UISettings::values.display_titlebar);
     qt_config->setValue("showFilterBar", UISettings::values.show_filter_bar);
     qt_config->setValue("showStatusBar", UISettings::values.show_status_bar);

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -244,6 +244,8 @@ void GMainWindow::InitializeHotkeys() {
     RegisterHotkey("Main Window", "Load File", QKeySequence::Open);
     RegisterHotkey("Main Window", "Swap Screens", QKeySequence::NextChild);
     RegisterHotkey("Main Window", "Start Emulation");
+    RegisterHotkey("Main Window", "Fullscreen", QKeySequence::FullScreen);
+    RegisterHotkey("Main Window", "Exit Fullscreen", QKeySequence::Cancel, Qt::ApplicationShortcut);
     LoadHotkeys();
 
     connect(GetHotkey("Main Window", "Load File", this), SIGNAL(activated()), this,
@@ -252,6 +254,16 @@ void GMainWindow::InitializeHotkeys() {
             SLOT(OnStartGame()));
     connect(GetHotkey("Main Window", "Swap Screens", render_window), SIGNAL(activated()), this,
             SLOT(OnSwapScreens()));
+    connect(GetHotkey("Main Window", "Fullscreen", render_window), &QShortcut::activated,
+            ui.action_Fullscreen, &QAction::trigger);
+    connect(GetHotkey("Main Window", "Fullscreen", render_window), &QShortcut::activatedAmbiguously,
+            ui.action_Fullscreen, &QAction::trigger);
+    connect(GetHotkey("Main Window", "Exit Fullscreen", this), &QShortcut::activated, this, [&] {
+        if (emulation_running) {
+            ui.action_Fullscreen->setChecked(false);
+            ToggleFullscreen();
+        }
+    });
 }
 
 void GMainWindow::SetDefaultUIGeometry() {
@@ -279,6 +291,8 @@ void GMainWindow::RestoreUIState() {
 
     ui.action_Single_Window_Mode->setChecked(UISettings::values.single_window_mode);
     ToggleWindowMode();
+
+    ui.action_Fullscreen->setChecked(UISettings::values.fullscreen);
 
     ui.action_Display_Dock_Widget_Headers->setChecked(UISettings::values.display_titlebar);
     OnDisplayTitleBars(ui.action_Display_Dock_Widget_Headers->isChecked());
@@ -323,6 +337,8 @@ void GMainWindow::ConnectMenuEvents() {
     ui.action_Show_Filter_Bar->setShortcut(tr("CTRL+F"));
     connect(ui.action_Show_Filter_Bar, &QAction::triggered, this, &GMainWindow::OnToggleFilterBar);
     connect(ui.action_Show_Status_Bar, &QAction::triggered, statusBar(), &QStatusBar::setVisible);
+    ui.action_Fullscreen->setShortcut(GetHotkey("Main Window", "Fullscreen", this)->key());
+    connect(ui.action_Fullscreen, &QAction::triggered, this, &GMainWindow::ToggleFullscreen);
 }
 
 void GMainWindow::OnDisplayTitleBars(bool show) {
@@ -460,6 +476,7 @@ void GMainWindow::BootGame(const QString& filename) {
     render_window->setFocus();
 
     emulation_running = true;
+    ToggleFullscreen();
     OnStartGame();
 }
 
@@ -624,6 +641,29 @@ void GMainWindow::OnStopGame() {
     ShutdownGame();
 }
 
+void GMainWindow::ToggleFullscreen() {
+    if (!emulation_running) {
+        return;
+    }
+    if (ui.action_Fullscreen->isChecked()) {
+        if (ui.action_Single_Window_Mode->isChecked()) {
+            ui.menubar->hide();
+            statusBar()->hide();
+            showFullScreen();
+        } else {
+            render_window->showFullScreen();
+        }
+    } else {
+        if (ui.action_Single_Window_Mode->isChecked()) {
+            statusBar()->setVisible(ui.action_Show_Status_Bar->isChecked());
+            ui.menubar->show();
+            showNormal();
+        } else {
+            render_window->showNormal();
+        }
+    }
+}
+
 void GMainWindow::ToggleWindowMode() {
     if (ui.action_Single_Window_Mode->isChecked()) {
         // Render in the main window...
@@ -784,6 +824,7 @@ void GMainWindow::closeEvent(QCloseEvent* event) {
     UISettings::values.microprofile_visible = microProfileDialog->isVisible();
 #endif
     UISettings::values.single_window_mode = ui.action_Single_Window_Mode->isChecked();
+    UISettings::values.fullscreen = ui.action_Fullscreen->isChecked();
     UISettings::values.display_titlebar = ui.action_Display_Dock_Widget_Headers->isChecked();
     UISettings::values.show_filter_bar = ui.action_Show_Filter_Bar->isChecked();
     UISettings::values.show_status_bar = ui.action_Show_Status_Bar->isChecked();

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -127,6 +127,7 @@ private slots:
     void OnConfigure();
     void OnToggleFilterBar();
     void OnDisplayTitleBars(bool);
+    void ToggleFullscreen();
     void ToggleWindowMode();
     void OnCreateGraphicsSurfaceViewer();
     void OnCoreError(Core::System::ResultStatus, std::string);

--- a/src/citra_qt/main.ui
+++ b/src/citra_qt/main.ui
@@ -45,7 +45,7 @@
      <x>0</x>
      <y>0</y>
      <width>1081</width>
-     <height>19</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">
@@ -85,6 +85,7 @@
      <addaction name="action_Create_Pica_Surface_Viewer"/>
      <addaction name="separator"/>
     </widget>
+    <addaction name="action_Fullscreen"/>
     <addaction name="action_Single_Window_Mode"/>
     <addaction name="action_Display_Dock_Widget_Headers"/>
     <addaction name="action_Show_Filter_Bar"/>
@@ -194,6 +195,14 @@
   <action name="action_Create_Pica_Surface_Viewer">
    <property name="text">
     <string>Create Pica Surface Viewer</string>
+   </property>
+  </action>
+  <action name="action_Fullscreen">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Fullscreen</string>
    </property>
   </action>
  </widget>

--- a/src/citra_qt/ui_settings.h
+++ b/src/citra_qt/ui_settings.h
@@ -31,6 +31,7 @@ struct Values {
     bool microprofile_visible;
 
     bool single_window_mode;
+    bool fullscreen;
     bool display_titlebar;
     bool show_filter_bar;
     bool show_status_bar;
@@ -53,4 +54,5 @@ struct Values {
 };
 
 extern Values values;
-}
+
+} // namespace UISettings


### PR DESCRIPTION
I  added mode fullscreen for play with more comfort.
For display fullscreen,  just click on action bar or the shortcut : alt+return

![1](https://user-images.githubusercontent.com/18513759/31321935-d7ad747e-ac8d-11e7-9458-26ca0c1ce831.png)

![6](https://user-images.githubusercontent.com/18513759/31321911-96f6c2be-ac8d-11e7-8434-a8cca2b71740.png)

![2](https://user-images.githubusercontent.com/18513759/31321855-c24121d6-ac8c-11e7-9022-01f965125977.png)

For exit fullscreen just click in alt+return or escape

![3](https://user-images.githubusercontent.com/18513759/31321858-c9896b74-ac8c-11e7-8edb-361b1d9db067.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3001)
<!-- Reviewable:end -->
