### PR TITLE
Change command header in nwm::UDS Initialize function

### DIFF
--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -975,7 +975,7 @@ void OnClientConnected(u16 network_node_id) {
 }
 
 const Interface::FunctionInfo FunctionTable[] = {
-    {0x00010442, nullptr, "Initialize (deprecated)"},
+    {0x000102C2, nullptr, "Initialize (deprecated)"},
     {0x00020000, nullptr, "Scrap"},
     {0x00030000, Shutdown, "Shutdown"},
     {0x00040402, nullptr, "CreateNetwork (deprecated)"},


### PR DESCRIPTION
**_Super Street Fighter IV: 3D Edition_** is calling the deprecated _nwm::UDS Initialize_ function with command header `0x000102C2` but in _Citra_ it uses `0x00010442` instead which causes the crash due to the game receiving garbage data.

Credits to @Subv
https://github.com/citra-emu/citra/issues/2959#issuecomment-332081439

Fixes issue #2959

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3002)
<!-- Reviewable:end -->
