### PR TITLE
[Qt] Add an animation for the menubar

### DIFF
--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -8,6 +8,8 @@
 #include <memory>
 #include <QMainWindow>
 #include <QTimer>
+#include <QPropertyAnimation>
+#include <QGraphicsOpacityEffect>
 #include "core/core.h"
 #include "ui_main.h"
 
@@ -69,6 +71,7 @@ private:
     void InitializeDebugWidgets();
     void InitializeRecentFileMenuActions();
     void InitializeHotkeys();
+    void InitializeAnimations();
 
     void SetDefaultUIGeometry();
     void RestoreUIState();
@@ -133,6 +136,7 @@ private slots:
 
 private:
     void UpdateStatusBar();
+    void AnimateMenubar(bool show);
 
     Ui::MainWindow ui;
 
@@ -165,10 +169,16 @@ private:
 
     QAction* actions_recent_files[max_recent_files_item];
 
+    // Animations
+    QTimer menubar_timer;
+    QPropertyAnimation* menubar_animation;
+    QGraphicsOpacityEffect* menubar_effect;
+
 protected:
     void dropEvent(QDropEvent* event) override;
     void dragEnterEvent(QDragEnterEvent* event) override;
     void dragMoveEvent(QDragMoveEvent* event) override;
+    bool eventFilter(QObject* obj, QEvent* ev) override;
 };
 
 #endif // _CITRA_QT_MAIN_HXX_


### PR DESCRIPTION
Hello, I added an opacity animation feature in the menu bar.  When the menu bar is active and the cursor isn't at the top (but in the application), a timer will be triggered after 3 secsto hide the menu. If the cursor is at the top, the menu bar will be displayed.
For display in :
Windows :  the cursor will be at top of centralWidget or in title bar
Mac OS :  the cursor will be at top of centralWidget or ?
Linux :  the cursor will be at top of centralWidget. 

I can use mouseMoveEvent but the tracking will be activated only in the centralWidget.

[Animation menubar.zip](https://github.com/citra-emu/citra/files/1403416/Animation.menubar.zip)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3020)
<!-- Reviewable:end -->
