### PR TITLE
Cached sequential access of GetPhysicalPointer

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -24,6 +24,39 @@ namespace Memory {
 static std::array<u8, Memory::VRAM_SIZE> vram;
 static std::array<u8, Memory::N3DS_EXTRA_RAM_SIZE> n3ds_extra_ram;
 
+class AreaCache {
+public:
+    void CacheNewArea(u8* p_ptr, u32 base, u32 start, u32 size) {
+        physical_base = p_ptr;
+        address_base = base;
+        region_start = start;
+        region_end = start + size;
+    }
+
+    void CacheNewArea(u8* p_ptr, u32 base, u32 size) {
+        CacheNewArea(p_ptr, base, base, size);
+    }
+
+    u8* GetCachedAreaPointer(PAddr address) {
+        if (address < region_end && address >= region_start) {
+            return physical_base + (address - address_base);
+        }
+        Invalidate();
+        return nullptr;
+    }
+
+    void Invalidate() {
+        region_start = region_end = 0;
+    }
+
+private:
+    u8* physical_base;
+    PAddr address_base = 0;
+    PAddr region_start = 0;
+    PAddr region_end = 0;
+};
+
+static AreaCache area_cache;
 static PageTable* current_page_table = nullptr;
 
 void SetCurrentPageTable(PageTable* page_table) {
@@ -40,6 +73,8 @@ PageTable* GetCurrentPageTable() {
 static void MapPages(PageTable& page_table, u32 base, u32 size, u8* memory, PageType type) {
     LOG_DEBUG(HW_Memory, "Mapping %p onto %08X-%08X", memory, base * PAGE_SIZE,
               (base + size) * PAGE_SIZE);
+
+    area_cache.Invalidate();
 
     RasterizerFlushVirtualRegion(base << PAGE_BITS, size * PAGE_SIZE,
                                  FlushMode::FlushAndInvalidate);
@@ -275,6 +310,9 @@ std::string ReadCString(VAddr vaddr, std::size_t max_length) {
 }
 
 u8* GetPhysicalPointer(PAddr address) {
+    if (u8* cached_ptr = area_cache.GetCachedAreaPointer(address))
+        return cached_ptr;
+
     struct MemoryArea {
         PAddr paddr_base;
         u32 size;
@@ -305,27 +343,36 @@ u8* GetPhysicalPointer(PAddr address) {
 
     u32 offset_into_region = address - area->paddr_base;
 
+    u8* target_base;
     u8* target_pointer = nullptr;
     switch (area->paddr_base) {
     case VRAM_PADDR:
-        target_pointer = vram.data() + offset_into_region;
+        target_base = vram.data();
+        target_pointer = target_base + offset_into_region;
+        area_cache.CacheNewArea(target_base, area->paddr_base, area->size);
         break;
     case DSP_RAM_PADDR:
-        target_pointer = AudioCore::GetDspMemory().data() + offset_into_region;
+        target_base = AudioCore::GetDspMemory().data();
+        target_pointer = target_base + offset_into_region;
+        area_cache.CacheNewArea(target_base, area->paddr_base, area->size);
         break;
     case FCRAM_PADDR:
         for (const auto& region : Kernel::memory_regions) {
             if (offset_into_region >= region.base &&
                 offset_into_region < region.base + region.size) {
-                target_pointer =
-                    region.linear_heap_memory->data() + offset_into_region - region.base;
+                target_base = region.linear_heap_memory->data();
+                target_pointer = target_base + offset_into_region - region.base;
+                area_cache.CacheNewArea(target_base - region.base, area->paddr_base,
+                                        area->paddr_base + region.base, region.size);
                 break;
             }
         }
         ASSERT_MSG(target_pointer != nullptr, "Invalid FCRAM address");
         break;
     case N3DS_EXTRA_RAM_PADDR:
-        target_pointer = n3ds_extra_ram.data() + offset_into_region;
+        target_base = n3ds_extra_ram.data();
+        target_pointer = target_base + offset_into_region;
+        area_cache.CacheNewArea(target_base, area->paddr_base, area->size);
         break;
     default:
         UNREACHABLE();


### PR DESCRIPTION
Often memory is accessed in sequence, checking the
previous area before searching other areas reduces
the cost of lookup.

Tested running Pokemon Moon with
Visual Studio 2017 Profiler (100,000~ samples):

BaseLine:
Memory::GetPhysicalPointer    1.8% CPU samples (exclusive)
SVC::CallSVC                  56.71% CPU samples (inclusive)

With AreaCache:
Memory::GetPhysicalPointer    0.4% CPU samples (exclusive)
SVC::CallSVC                  55.01% CPU samples (inclusive)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3026)
<!-- Reviewable:end -->
