### PR TITLE
travis: Add build with frozen versions for dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,12 @@ matrix:
       install: "./.travis/macos/deps.sh"
       script: "./.travis/macos/build.sh"
       after_success: "./.travis/macos/upload.sh"
+    - os: linux
+      env: NAME="linux build (frozen versions of dependencies)"
+      sudo: required
+      dist: trusty
+      services: docker
+      script: "./.travis/linux-frozen/build.sh"
 
 deploy:
   provider: releases

--- a/.travis/linux-frozen/build.sh
+++ b/.travis/linux-frozen/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -ex
+
+docker pull ubuntu:16.04
+docker run -v $(pwd):/citra ubuntu:16.04 /bin/bash -ex /citra/.travis/linux-frozen/docker.sh

--- a/.travis/linux-frozen/docker.sh
+++ b/.travis/linux-frozen/docker.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -ex
+
+cd /citra
+
+apt-get update
+apt-get install -y build-essential wget git python-launchpadlib libssl-dev
+
+# Install specific versions of packages with their dependencies
+# The apt repositories remove older versions regularly, so we can't use
+# apt-get and have to pull the packages directly from the archives.
+/citra/.travis/linux-frozen/install_package.py       \
+    libsdl2-dev 2.0.4+dfsg1-2ubuntu2 xenial          \
+    qtbase5-dev 5.2.1+dfsg-1ubuntu14.3 trusty        \
+    libqt5opengl5-dev 5.2.1+dfsg-1ubuntu14.3 trusty  \
+    libcurl4-openssl-dev 7.47.0-1ubuntu2.3 xenial    \
+    libicu52 52.1-3ubuntu0.6 trusty
+
+# Get a recent version of CMake
+wget https://cmake.org/files/v3.9/cmake-3.9.0-Linux-x86_64.sh
+echo y | sh cmake-3.9.0-Linux-x86_64.sh --prefix=cmake
+export PATH=/citra/cmake/cmake-3.9.0-Linux-x86_64/bin:$PATH
+
+mkdir build && cd build
+cmake .. -DUSE_SYSTEM_CURL=ON -DCMAKE_BUILD_TYPE=Release
+make -j4
+
+ctest -VV -C Release

--- a/.travis/linux-frozen/install_package.py
+++ b/.travis/linux-frozen/install_package.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python
+
+import sys, re, subprocess
+from launchpadlib.launchpad import Launchpad
+
+cachedir = '/.launchpadlib/cache/'
+launchpad = Launchpad.login_anonymously('grab build info', 'production', cachedir, version='devel')
+
+processed_packages = []
+deb_file_list = []
+
+def get_url(pkg, distro):
+    build_link = launchpad.archives.getByReference(reference='ubuntu').getPublishedBinaries(binary_name=pkg[0], distro_arch_series='https://api.launchpad.net/devel/ubuntu/'+distro+'/amd64', version=pkg[1], exact_match=True, order_by_date=True).entries[0]['build_link']
+    deb_name = pkg[0] + '_' + pkg[1] + '_amd64.deb'
+    deb_link = build_link + '/+files/' + deb_name
+    return [deb_link, deb_name]
+
+def list_dependencies(deb_file):
+    t=subprocess.check_output(['bash', '-c', 'dpkg -I ' + deb_file + ' | grep -oP "^ Depends\: \K.*$"'])
+    deps=[i.strip() for i in t.split(',')]
+    equals_re = re.compile(r'^(.*) \(= (.*)\)$')
+    return [equals_re.sub(r'\1=\2', i).split('=') for i in filter(equals_re.match, deps)]
+
+def get_package(pkg, distro):
+    if pkg in processed_packages:
+        return
+    print 'Getting ' + pkg[0] + '...'
+    url = get_url(pkg, distro)
+    subprocess.check_call(['wget', '--quiet', url[0], '-O', url[1]])
+    for dep in list_dependencies(url[1]):
+        get_package(dep, distro)
+    processed_packages.append(pkg)
+    deb_file_list.append('./' + url[1])
+
+for i in xrange(1, len(sys.argv), 3):
+    get_package([sys.argv[i], sys.argv[i + 1]], sys.argv[i + 2])
+
+subprocess.check_call(['apt-get', 'install', '-y'] + deb_file_list)


### PR DESCRIPTION
Related to #3023.

Adds a build which pulls specific versions of packages so we can ensure new code is compatible with those specific library versions. Unfortunately Ubuntu's apt repositories remove older versions regularly, so we can't use apt-get's built-in version specifiers and have to pull the packages directly from Ubuntu's archives.

Justification for each version:

* Qt 5.2: 5.2 is the newest version available in repositories of some Linux distributions
* SDL 2.0.4: No particular reason
* libicu52: Required for pulling Qt 5.2 because the Xenial repositories no longer have this package

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3027)
<!-- Reviewable:end -->
