### PR TITLE
citra_qt: Remove use of QKeySequence::Cancel

### DIFF
--- a/.travis/linux/build.sh
+++ b/.travis/linux/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -ex
 
-docker run -v $(pwd):/citra ubuntu:16.04 /bin/bash /citra/.travis/linux/docker.sh
+docker run -v $(pwd):/citra ubuntu:16.04 /bin/bash -ex /citra/.travis/linux/docker.sh

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -245,7 +245,8 @@ void GMainWindow::InitializeHotkeys() {
     RegisterHotkey("Main Window", "Swap Screens", QKeySequence::NextChild);
     RegisterHotkey("Main Window", "Start Emulation");
     RegisterHotkey("Main Window", "Fullscreen", QKeySequence::FullScreen);
-    RegisterHotkey("Main Window", "Exit Fullscreen", QKeySequence::Cancel, Qt::ApplicationShortcut);
+    RegisterHotkey("Main Window", "Exit Fullscreen", QKeySequence(Qt::Key_Escape),
+                   Qt::ApplicationShortcut);
     LoadHotkeys();
 
     connect(GetHotkey("Main Window", "Load File", this), SIGNAL(activated()), this,


### PR DESCRIPTION
QKeySequence::Cancel requires Qt 5.6, which our buildbots do not support.

Also ensure that an error in the Linux build-script propagates upwards.

Closes #3022 and #3023.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3028)
<!-- Reviewable:end -->
