### PR TITLE
externals: Remove Crypto++ weak algorithm warning

### DIFF
--- a/src/core/hle/service/nwm/uds_beacon.cpp
+++ b/src/core/hle/service/nwm/uds_beacon.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#define CRYPTOPP_ENABLE_NAMESPACE_WEAK 1
+
 #include <cstring>
 #include <cryptopp/aes.h>
 #include <cryptopp/md5.h>
@@ -204,9 +206,10 @@ std::vector<u8> GeneratedEncryptedData(const NetworkInfo& network_info, const No
     }
 
     // Calculate the MD5 hash of the data in the buffer, not including the hash field.
-    std::array<u8, CryptoPP::MD5::DIGESTSIZE> hash;
-    CryptoPP::MD5().CalculateDigest(hash.data(), buffer.data() + offsetof(BeaconData, bitmask),
-                                    buffer.size() - sizeof(data.md5_hash));
+    std::array<u8, CryptoPP::Weak::MD5::DIGESTSIZE> hash;
+    CryptoPP::Weak::MD5().CalculateDigest(hash.data(),
+                                          buffer.data() + offsetof(BeaconData, bitmask),
+                                          buffer.size() - sizeof(data.md5_hash));
 
     // Copy the hash into the buffer.
     std::memcpy(buffer.data(), hash.data(), hash.size());


### PR DESCRIPTION
Eliminate the following warning shown in GNU/MinGW compiler
`#warning "You may be using a weak algorithm that has been retained for backwards compatibility. Please '#define CRYPTOPP_ENABLE_NAMESPACE_WEAK 1' before including this .h file and prepend the class name with 'Weak::' to remove this warning."`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3031)
<!-- Reviewable:end -->
