### PR TITLE
Remove some errno constants as it was already defined

### DIFF
--- a/src/core/hle/service/soc_u.cpp
+++ b/src/core/hle/service/soc_u.cpp
@@ -29,8 +29,6 @@
 #define ENOSR 124
 #define ENOSTR 125
 #define ETIME 137
-#define EIDRM 2001
-#define ENOLINK 2002
 #endif // _MSC_VER
 #else
 #include <cerrno>


### PR DESCRIPTION
Eliminate the following warning in MinGW compiler:
```
C:/projects/citra/src/core/hle/service/soc_u.cpp:32:0: warning: "EIDRM" redefined
 #define EIDRM 2001
 
In file included from C:/msys64/mingw64/x86_64-w64-mingw32/include/pthread.h:63:0,
                 from C:/msys64/mingw64/include/c++/6.3.0/x86_64-w64-mingw32/bits/gthr-default.h:35,
                 from C:/msys64/mingw64/include/c++/6.3.0/x86_64-w64-mingw32/bits/gthr.h:148,
                 from C:/msys64/mingw64/include/c++/6.3.0/ext/atomicity.h:35,
                 from C:/msys64/mingw64/include/c++/6.3.0/bits/basic_string.h:39,
                 from C:/msys64/mingw64/include/c++/6.3.0/string:52,
                 from C:/msys64/mingw64/include/c++/6.3.0/stdexcept:39,
                 from C:/msys64/mingw64/include/c++/6.3.0/array:39,
                 from C:/msys64/mingw64/include/c++/6.3.0/tuple:39,
                 from C:/msys64/mingw64/include/c++/6.3.0/unordered_map:41,
                 from C:/projects/citra/src/core/hle/service/soc_u.cpp:7:
C:/msys64/mingw64/x86_64-w64-mingw32/include/errno.h:186:0: note: this is the location of the previous definition
 #define EIDRM 111
 
C:/projects/citra/src/core/hle/service/soc_u.cpp:33:0: warning: "ENOLINK" redefined
 #define ENOLINK 2002
 
In file included from C:/msys64/mingw64/x86_64-w64-mingw32/include/pthread.h:63:0,
                 from C:/msys64/mingw64/include/c++/6.3.0/x86_64-w64-mingw32/bits/gthr-default.h:35,
                 from C:/msys64/mingw64/include/c++/6.3.0/x86_64-w64-mingw32/bits/gthr.h:148,
                 from C:/msys64/mingw64/include/c++/6.3.0/ext/atomicity.h:35,
                 from C:/msys64/mingw64/include/c++/6.3.0/bits/basic_string.h:39,
                 from C:/msys64/mingw64/include/c++/6.3.0/string:52,
                 from C:/msys64/mingw64/include/c++/6.3.0/stdexcept:39,
                 from C:/msys64/mingw64/include/c++/6.3.0/array:39,
                 from C:/msys64/mingw64/include/c++/6.3.0/tuple:39,
                 from C:/msys64/mingw64/include/c++/6.3.0/unordered_map:41,
                 from C:/projects/citra/src/core/hle/service/soc_u.cpp:7:
C:/msys64/mingw64/x86_64-w64-mingw32/include/errno.h:194:0: note: this is the location of the previous definition
 #define ENOLINK 121
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3032)
<!-- Reviewable:end -->
