### PR TITLE
Fix typo for -Wunused-local-typedefs

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -10,7 +10,7 @@
 #include <tuple>
 #ifdef __GNUC__
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-local-typedef"
+#pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif
 #include <boost/icl/interval_map.hpp>
 #ifdef __GNUC__


### PR DESCRIPTION
Eliminate the following warning in MinGW:
```
warning: unknown option after '#pragma GCC diagnostic' kind [-Wpragmas]
 #pragma GCC diagnostic ignored "-Wunused-local-typedef"
                                ^~~~~~~~~~~~~~~~~~~~~~~~
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3033)
<!-- Reviewable:end -->
