### PR TITLE
Change build order to check clang-format first

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,14 @@ language: cpp
 matrix:
   include:
     - os: linux
+      env: NAME="clang-format"
+      dist: trusty
+      addons:
+        apt:
+          packages:
+            - clang-format-3.9
+      script: "./.travis/clang-format/script.sh"
+    - os: linux
       env: NAME="linux build"
       sudo: required
       dist: trusty
@@ -20,14 +28,6 @@ matrix:
       install: "./.travis/macos/deps.sh"
       script: "./.travis/macos/build.sh"
       after_success: "./.travis/macos/upload.sh"
-    - os: linux
-      env: NAME="clang-format"
-      dist: trusty
-      addons:
-        apt:
-          packages:
-            - clang-format-3.9
-      script: "./.travis/clang-format/script.sh"
 
 deploy:
   provider: releases


### PR DESCRIPTION
It's annoying to wait for travis-ci to build for linux and osx, to then see that clang-format is wrong. This changes the build order to first check for clang-format, then build linux and then osx

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3034)
<!-- Reviewable:end -->
