### PR TITLE
Fix Missing libpcre2-16-0.dll from both latest Nightly and Canary builds #3036

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -122,7 +122,7 @@ after_build:
                        # QT dll dependencies
                        "libbz2-*.dll","libicudt*.dll","libicuin*.dll","libicuuc*.dll","libffi-*.dll",
                        "libfreetype-*.dll","libglib-*.dll","libgobject-*.dll","libgraphite2.dll","libiconv-*.dll",
-                       "libharfbuzz-*.dll","libintl-*.dll","libpcre-*.dll","libpcre16-*.dll","libpng16-*.dll",
+                       "libharfbuzz-*.dll","libintl-*.dll","libpcre-*.dll","libpcre16-*.dll","libpcre2-16-*.dll","libpng16-*.dll",
                        # Runtime/Other dependencies
                        "libgcc_s_seh-*.dll","libstdc++-*.dll","libwinpthread-*.dll","SDL2.dll","zlib1.dll"
           foreach ($file in $MingwDLLs) {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3037)
<!-- Reviewable:end -->
