### PR TITLE
Kernel/SVC: Don't let svcReleaseMutex release a mutex owned by another thread

### DIFF
--- a/src/core/hle/kernel/errors.h
+++ b/src/core/hle/kernel/errors.h
@@ -13,6 +13,7 @@ enum {
     OutOfHandles = 19,
     SessionClosedByRemote = 26,
     PortNameTooLong = 30,
+    WrongLockingThread = 31,
     NoPendingSessions = 35,
     WrongPermission = 46,
     InvalidBufferDescriptor = 48,

--- a/src/core/hle/kernel/mutex.h
+++ b/src/core/hle/kernel/mutex.h
@@ -8,6 +8,7 @@
 #include "common/common_types.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/wait_object.h"
+#include "core/hle/result.h"
 
 namespace Kernel {
 
@@ -52,7 +53,12 @@ public:
     void AddWaitingThread(SharedPtr<Thread> thread) override;
     void RemoveWaitingThread(Thread* thread) override;
 
-    void Release();
+    /**
+     * Attempts to release the mutex from the specified thread.
+     * @param thread Thread that wants to release the mutex.
+     * @returns The result code of the operation.
+     */
+    ResultCode Release(Thread* thread);
 
 private:
     Mutex();
@@ -65,4 +71,4 @@ private:
  */
 void ReleaseThreadMutexes(Thread* thread);
 
-} // namespace
+} // namespace Kernel

--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -818,9 +818,7 @@ static ResultCode ReleaseMutex(Kernel::Handle handle) {
     if (mutex == nullptr)
         return ERR_INVALID_HANDLE;
 
-    mutex->Release();
-
-    return RESULT_SUCCESS;
+    return mutex->Release(Kernel::GetCurrentThread());
 }
 
 /// Get the ID of the specified process


### PR DESCRIPTION
This behavior was reverse engineered from the 3DS kernel.

It is unknown if this affects any games.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3042)
<!-- Reviewable:end -->
