### PR TITLE
appveyor: Determine dlls to include in package programmatically

### DIFF
--- a/.appveyor/UtilityFunctions.ps1
+++ b/.appveyor/UtilityFunctions.ps1
@@ -1,0 +1,39 @@
+# Set-up Visual Studio Command Prompt environment for PowerShell
+pushd "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\"
+cmd /c "VsDevCmd.bat -arch=x64 & set" | foreach {
+    if ($_ -match "=") {
+        $v = $_.split("="); Set-Item -Force -Path "ENV:\$($v[0])" -Value "$($v[1])"
+    }
+}
+popd
+
+function Which ($search_path, $name) {
+    ($search_path).Split(";") | Get-ChildItem -Filter $name | Select -First 1 -Exp FullName
+}
+
+function GetDeps ($search_path, $binary) {
+    ((dumpbin /dependents $binary).Where({ $_ -match "dependencies:"}, "SkipUntil") | Select-String "[^ ]*\.dll").Matches | foreach {
+        Which $search_path $_.Value
+    }
+}
+
+function RecursivelyGetDeps ($search_path, $binary) {
+    $final_deps = @()
+    $deps_to_process = GetDeps $search_path $binary
+    while ($deps_to_process.Count -gt 0) {
+        $current, $deps_to_process = $deps_to_process
+        if ($final_deps -contains $current) { continue }
+
+        # Is this a system dll file?
+        # We use the same algorithm that cmake uses to determine this.
+        if ($current -match "$([regex]::Escape($env:SystemRoot))\\sys") { continue }
+        if ($current -match "$([regex]::Escape($env:WinDir))\\sys") { continue }
+        if ($current -match "\\msvc[^\\]+dll") { continue }
+        if ($current -match "\\api-ms-win-[^\\]+dll") { continue }
+
+        $final_deps += $current
+        $new_deps = GetDeps $search_path $current
+        $deps_to_process += ($new_deps | ?{-not ($final_deps -contains $_)})
+    }
+    return $final_deps
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -116,23 +116,16 @@ after_build:
           Get-ChildItem "$CMAKE_BINARY_DIR" -Recurse -Filter "libcurl.dll" | Copy-Item -destination $RELEASE_DIST
           Copy-Item -path "$CMAKE_SOURCE_DIR/license.txt" -destination $RELEASE_DIST
           Copy-Item -path "$CMAKE_SOURCE_DIR/README.md" -destination $RELEASE_DIST
+
           # copy all the dll dependencies to the release folder
-          # hardcoded list because we don't build static and determining the list of dlls from the binary is a pain.
-          $MingwDLLs = "Qt5Core.dll","Qt5Widgets.dll","Qt5Gui.dll","Qt5OpenGL.dll",
-                       # QT dll dependencies
-                       "libbz2-*.dll","libicudt*.dll","libicuin*.dll","libicuuc*.dll","libffi-*.dll",
-                       "libfreetype-*.dll","libglib-*.dll","libgobject-*.dll","libgraphite2.dll","libiconv-*.dll",
-                       "libharfbuzz-*.dll","libintl-*.dll","libpcre-*.dll","libpcre16-*.dll","libpcre2-16-*.dll","libpng16-*.dll",
-                       # Runtime/Other dependencies
-                       "libgcc_s_seh-*.dll","libstdc++-*.dll","libwinpthread-*.dll","SDL2.dll","zlib1.dll"
+          . "./.appveyor/UtilityFunctions.ps1"
+          $DLLSearchPath = "$CMAKE_BINARY_DIR\externals\curl-7_55_1\lib;C:\msys64\mingw64\bin;$env:PATH"
+          $MingwDLLs = RecursivelyGetDeps $DLLSearchPath "$RELEASE_DIST\citra.exe"
+          $MingwDLLs += RecursivelyGetDeps $DLLSearchPath  "$RELEASE_DIST\citra-qt.exe"
+          Write-Host "Detected the following dependencies:"
+          Write-Host $MingwDLLs
           foreach ($file in $MingwDLLs) {
-            Copy-Item -path "C:/msys64/mingw64/bin/$file" -force -destination "$RELEASE_DIST"
-          }
-          # the above list copies a few extra debug dlls that aren't needed (thanks globbing patterns!)
-          # so we can remove them by hardcoding another list of extra dlls to remove
-          $DebugDLLs = "libicudtd*.dll","libicuind*.dll","libicuucd*.dll"
-          foreach ($file in $DebugDLLs) {
-            Remove-Item -path "$RELEASE_DIST/$file"
+            Copy-Item -path "$file" -force -destination "$RELEASE_DIST"
           }
 
           # copy the qt windows plugin dll to platforms


### PR DESCRIPTION
This is done by recursively calling bindump to determine the dependencies
of each binary that is required from each of the executables. Doing this
allows us to avoid hard-coding a list of required DLL files to copy into
the release archives.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3043)
<!-- Reviewable:end -->
