### PR TITLE
Get rid of narrowing conversion warning (-Wnarrowing)

### DIFF
--- a/src/video_core/swrasterizer/clipper.cpp
+++ b/src/video_core/swrasterizer/clipper.cpp
@@ -20,7 +20,6 @@
 using Pica::Rasterizer::Vertex;
 
 namespace Pica {
-
 namespace Clipper {
 
 struct ClippingEdge {
@@ -192,6 +191,5 @@ void ProcessTriangle(const OutputVertex& v0, const OutputVertex& v1, const Outpu
     }
 }
 
-} // namespace
-
-} // namespace
+} // namespace Clipper
+} // namespace Pica

--- a/src/video_core/swrasterizer/clipper.h
+++ b/src/video_core/swrasterizer/clipper.h
@@ -5,7 +5,6 @@
 #pragma once
 
 namespace Pica {
-
 namespace Shader {
 struct OutputVertex;
 }
@@ -16,6 +15,5 @@ using Shader::OutputVertex;
 
 void ProcessTriangle(const OutputVertex& v0, const OutputVertex& v1, const OutputVertex& v2);
 
-} // namespace
-
-} // namespace
+} // namespace Clipper
+} // namespace Pica

--- a/src/video_core/swrasterizer/rasterizer.cpp
+++ b/src/video_core/swrasterizer/rasterizer.cpp
@@ -376,9 +376,9 @@ static void ProcessTriangleInternal(const Vertex& v0, const Vertex& v1, const Ve
 
                 if (use_border_s || use_border_t) {
                     auto border_color = texture.config.border_color;
-                    texture_color[i] = {
-                        static_cast<u8>(border_color.r), static_cast<u8>(border_color.g),
-                        static_cast<u8>(border_color.b), static_cast<u8>(border_color.a)};
+                    texture_color[i] = Math::MakeVec(border_color.r.Value(), border_color.g.Value(),
+                                                     border_color.b.Value(), border_color.a.Value())
+                                           .Cast<u8>();
                 } else {
                     // Textures are laid out from bottom to top, hence we invert the t coordinate.
                     // NOTE: This may not be the right place for the inversion.
@@ -415,12 +415,12 @@ static void ProcessTriangleInternal(const Vertex& v0, const Vertex& v1, const Ve
             // analogously.
             Math::Vec4<u8> combiner_output;
             Math::Vec4<u8> combiner_buffer = {0, 0, 0, 0};
-            Math::Vec4<u8> next_combiner_buffer = {
-                static_cast<u8>(regs.texturing.tev_combiner_buffer_color.r),
-                static_cast<u8>(regs.texturing.tev_combiner_buffer_color.g),
-                static_cast<u8>(regs.texturing.tev_combiner_buffer_color.b),
-                static_cast<u8>(regs.texturing.tev_combiner_buffer_color.a),
-            };
+            Math::Vec4<u8> next_combiner_buffer =
+                Math::MakeVec(regs.texturing.tev_combiner_buffer_color.r.Value(),
+                              regs.texturing.tev_combiner_buffer_color.g.Value(),
+                              regs.texturing.tev_combiner_buffer_color.b.Value(),
+                              regs.texturing.tev_combiner_buffer_color.a.Value())
+                    .Cast<u8>();
 
             Math::Vec4<u8> primary_fragment_color = {0, 0, 0, 0};
             Math::Vec4<u8> secondary_fragment_color = {0, 0, 0, 0};
@@ -474,9 +474,9 @@ static void ProcessTriangleInternal(const Vertex& v0, const Vertex& v1, const Ve
                         return combiner_buffer;
 
                     case Source::Constant:
-                        return {
-                            static_cast<u8>(tev_stage.const_r), static_cast<u8>(tev_stage.const_g),
-                            static_cast<u8>(tev_stage.const_b), static_cast<u8>(tev_stage.const_a)};
+                        return Math::MakeVec(tev_stage.const_r.Value(), tev_stage.const_g.Value(),
+                                             tev_stage.const_b.Value(), tev_stage.const_a.Value())
+                            .Cast<u8>();
 
                     case Source::Previous:
                         return combiner_output;
@@ -589,11 +589,10 @@ static void ProcessTriangleInternal(const Vertex& v0, const Vertex& v1, const Ve
             // store the depth etc. Using float for now until we know more
             // about Pica datatypes
             if (regs.texturing.fog_mode == TexturingRegs::FogMode::Fog) {
-                const Math::Vec3<u8> fog_color = {
-                    static_cast<u8>(regs.texturing.fog_color.r.Value()),
-                    static_cast<u8>(regs.texturing.fog_color.g.Value()),
-                    static_cast<u8>(regs.texturing.fog_color.b.Value()),
-                };
+                const Math::Vec3<u8> fog_color = Math::MakeVec(regs.texturing.fog_color.r.Value(),
+                                                               regs.texturing.fog_color.g.Value(),
+                                                               regs.texturing.fog_color.b.Value())
+                                                     .Cast<u8>();
 
                 // Get index into fog LUT
                 float fog_index;
@@ -745,12 +744,12 @@ static void ProcessTriangleInternal(const Vertex& v0, const Vertex& v1, const Ve
                                         FramebufferRegs::BlendFactor factor) -> u8 {
                     DEBUG_ASSERT(channel < 4);
 
-                    const Math::Vec4<u8> blend_const = {
-                        static_cast<u8>(output_merger.blend_const.r),
-                        static_cast<u8>(output_merger.blend_const.g),
-                        static_cast<u8>(output_merger.blend_const.b),
-                        static_cast<u8>(output_merger.blend_const.a),
-                    };
+                    const Math::Vec4<u8> blend_const =
+                        Math::MakeVec(output_merger.blend_const.r.Value(),
+                                      output_merger.blend_const.g.Value(),
+                                      output_merger.blend_const.b.Value(),
+                                      output_merger.blend_const.a.Value())
+                            .Cast<u8>();
 
                     switch (factor) {
                     case FramebufferRegs::BlendFactor::Zero:
@@ -851,5 +850,4 @@ void ProcessTriangle(const Vertex& v0, const Vertex& v1, const Vertex& v2) {
 }
 
 } // namespace Rasterizer
-
 } // namespace Pica

--- a/src/video_core/swrasterizer/rasterizer.cpp
+++ b/src/video_core/swrasterizer/rasterizer.cpp
@@ -376,8 +376,9 @@ static void ProcessTriangleInternal(const Vertex& v0, const Vertex& v1, const Ve
 
                 if (use_border_s || use_border_t) {
                     auto border_color = texture.config.border_color;
-                    texture_color[i] = {border_color.r, border_color.g, border_color.b,
-                                        border_color.a};
+                    texture_color[i] = {
+                        static_cast<u8>(border_color.r), static_cast<u8>(border_color.g),
+                        static_cast<u8>(border_color.b), static_cast<u8>(border_color.a)};
                 } else {
                     // Textures are laid out from bottom to top, hence we invert the t coordinate.
                     // NOTE: This may not be the right place for the inversion.
@@ -415,10 +416,10 @@ static void ProcessTriangleInternal(const Vertex& v0, const Vertex& v1, const Ve
             Math::Vec4<u8> combiner_output;
             Math::Vec4<u8> combiner_buffer = {0, 0, 0, 0};
             Math::Vec4<u8> next_combiner_buffer = {
-                regs.texturing.tev_combiner_buffer_color.r,
-                regs.texturing.tev_combiner_buffer_color.g,
-                regs.texturing.tev_combiner_buffer_color.b,
-                regs.texturing.tev_combiner_buffer_color.a,
+                static_cast<u8>(regs.texturing.tev_combiner_buffer_color.r),
+                static_cast<u8>(regs.texturing.tev_combiner_buffer_color.g),
+                static_cast<u8>(regs.texturing.tev_combiner_buffer_color.b),
+                static_cast<u8>(regs.texturing.tev_combiner_buffer_color.a),
             };
 
             Math::Vec4<u8> primary_fragment_color = {0, 0, 0, 0};
@@ -473,8 +474,9 @@ static void ProcessTriangleInternal(const Vertex& v0, const Vertex& v1, const Ve
                         return combiner_buffer;
 
                     case Source::Constant:
-                        return {tev_stage.const_r, tev_stage.const_g, tev_stage.const_b,
-                                tev_stage.const_a};
+                        return {
+                            static_cast<u8>(tev_stage.const_r), static_cast<u8>(tev_stage.const_g),
+                            static_cast<u8>(tev_stage.const_b), static_cast<u8>(tev_stage.const_a)};
 
                     case Source::Previous:
                         return combiner_output;

--- a/src/video_core/swrasterizer/rasterizer.h
+++ b/src/video_core/swrasterizer/rasterizer.h
@@ -7,7 +7,6 @@
 #include "video_core/shader/shader.h"
 
 namespace Pica {
-
 namespace Rasterizer {
 
 struct Vertex : Shader::OutputVertex {
@@ -44,5 +43,4 @@ struct Vertex : Shader::OutputVertex {
 void ProcessTriangle(const Vertex& v0, const Vertex& v1, const Vertex& v2);
 
 } // namespace Rasterizer
-
 } // namespace Pica

--- a/src/video_core/swrasterizer/swrasterizer.cpp
+++ b/src/video_core/swrasterizer/swrasterizer.cpp
@@ -12,4 +12,5 @@ void SWRasterizer::AddTriangle(const Pica::Shader::OutputVertex& v0,
                                const Pica::Shader::OutputVertex& v2) {
     Pica::Clipper::ProcessTriangle(v0, v1, v2);
 }
-}
+
+} // namespace VideoCore

--- a/src/video_core/swrasterizer/swrasterizer.h
+++ b/src/video_core/swrasterizer/swrasterizer.h
@@ -24,4 +24,5 @@ class SWRasterizer : public RasterizerInterface {
     void FlushRegion(PAddr addr, u32 size) override {}
     void FlushAndInvalidateRegion(PAddr addr, u32 size) override {}
 };
-}
+
+} // namespace VideoCore


### PR DESCRIPTION
I'm not sure if I am doing it correctly, hence the [RFC] tag.
I've read online and got to know that `static_cast` performs no runtime checks and I believe that is the reason all warnings got rid completely.

These are the warnings I'm trying to get rid of in GNU/MinGW compiler:
```
C:/projects/citra/src/video_core/swrasterizer/rasterizer.cpp: In function 'void Pica::Rasterizer::ProcessTriangleInternal(const Pica::Rasterizer::Vertex&, const Pica::Rasterizer::Vertex&, const Pica::Rasterizer::Vertex&, bool)':
C:/projects/citra/src/video_core/swrasterizer/rasterizer.cpp:380:55: warning: narrowing conversion of 'border_color.Pica::TexturingRegs::TextureConfig::<unnamed union>::r.BitField<0, 8, unsigned int>::operator unsigned int()' from 'unsigned int' to 'unsigned char' inside { } [-Wnarrowing]
                                         border_color.a};
                                                       ^
C:/projects/citra/src/video_core/swrasterizer/rasterizer.cpp:380:55: warning: narrowing conversion of 'border_color.Pica::TexturingRegs::TextureConfig::<unnamed union>::g.BitField<8, 8, unsigned int>::operator unsigned int()' from 'unsigned int' to 'unsigned char' inside { } [-Wnarrowing]
C:/projects/citra/src/video_core/swrasterizer/rasterizer.cpp:380:55: warning: narrowing conversion of 'border_color.Pica::TexturingRegs::TextureConfig::<unnamed union>::b.BitField<16, 8, unsigned int>::operator unsigned int()' from 'unsigned int' to 'unsigned char' inside { } [-Wnarrowing]
C:/projects/citra/src/video_core/swrasterizer/rasterizer.cpp:380:55: warning: narrowing conversion of 'border_color.Pica::TexturingRegs::TextureConfig::<unnamed union>::a.BitField<24, 8, unsigned int>::operator unsigned int()' from 'unsigned int' to 'unsigned char' inside { } [-Wnarrowing]
C:/projects/citra/src/video_core/swrasterizer/rasterizer.cpp:422:13: warning: narrowing conversion of 'regs.Pica::Regs::<anonymous>.Pica::Regs::<unnamed union>::<anonymous>.Pica::Regs::<unnamed union>::<unnamed struct>::texturing.Pica::TexturingRegs::tev_combiner_buffer_color.Pica::TexturingRegs::<unnamed union>::r.BitField<0, 8, unsigned int>::operator unsigned int()' from 'unsigned int' to 'unsigned char' inside { } [-Wnarrowing]
             };
             ^
C:/projects/citra/src/video_core/swrasterizer/rasterizer.cpp:422:13: warning: narrowing conversion of 'regs.Pica::Regs::<anonymous>.Pica::Regs::<unnamed union>::<anonymous>.Pica::Regs::<unnamed union>::<unnamed struct>::texturing.Pica::TexturingRegs::tev_combiner_buffer_color.Pica::TexturingRegs::<unnamed union>::g.BitField<8, 8, unsigned int>::operator unsigned int()' from 'unsigned int' to 'unsigned char' inside { } [-Wnarrowing]
C:/projects/citra/src/video_core/swrasterizer/rasterizer.cpp:422:13: warning: narrowing conversion of 'regs.Pica::Regs::<anonymous>.Pica::Regs::<unnamed union>::<anonymous>.Pica::Regs::<unnamed union>::<unnamed struct>::texturing.Pica::TexturingRegs::tev_combiner_buffer_color.Pica::TexturingRegs::<unnamed union>::b.BitField<16, 8, unsigned int>::operator unsigned int()' from 'unsigned int' to 'unsigned char' inside { } [-Wnarrowing]
C:/projects/citra/src/video_core/swrasterizer/rasterizer.cpp:422:13: warning: narrowing conversion of 'regs.Pica::Regs::<anonymous>.Pica::Regs::<unnamed union>::<anonymous>.Pica::Regs::<unnamed union>::<unnamed struct>::texturing.Pica::TexturingRegs::tev_combiner_buffer_color.Pica::TexturingRegs::<unnamed union>::a.BitField<24, 8, unsigned int>::operator unsigned int()' from 'unsigned int' to 'unsigned char' inside { } [-Wnarrowing]
C:/projects/citra/src/video_core/swrasterizer/rasterizer.cpp: In lambda function:
C:/projects/citra/src/video_core/swrasterizer/rasterizer.cpp:477:50: warning: narrowing conversion of 'tev_stage.Pica::TexturingRegs::TevStageConfig::<anonymous>.Pica::TexturingRegs::TevStageConfig::<unnamed union>::const_r.BitField<0, 8, unsigned int>::operator unsigned int()' from 'unsigned int' to 'unsigned char' inside { } [-Wnarrowing]
                                 tev_stage.const_a};
                                                  ^
C:/projects/citra/src/video_core/swrasterizer/rasterizer.cpp:477:50: warning: narrowing conversion of 'tev_stage.Pica::TexturingRegs::TevStageConfig::<anonymous>.Pica::TexturingRegs::TevStageConfig::<unnamed union>::const_g.BitField<8, 8, unsigned int>::operator unsigned int()' from 'unsigned int' to 'unsigned char' inside { } [-Wnarrowing]
C:/projects/citra/src/video_core/swrasterizer/rasterizer.cpp:477:50: warning: narrowing conversion of 'tev_stage.Pica::TexturingRegs::TevStageConfig::<anonymous>.Pica::TexturingRegs::TevStageConfig::<unnamed union>::const_b.BitField<16, 8, unsigned int>::operator unsigned int()' from 'unsigned int' to 'unsigned char' inside { } [-Wnarrowing]
C:/projects/citra/src/video_core/swrasterizer/rasterizer.cpp:477:50: warning: narrowing conversion of 'tev_stage.Pica::TexturingRegs::TevStageConfig::<anonymous>.Pica::TexturingRegs::TevStageConfig::<unnamed union>::const_a.BitField<24, 8, unsigned int>::operator unsigned int()' from 'unsigned int' to 'unsigned char' inside { } [-Wnarrowing]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3044)
<!-- Reviewable:end -->
