### PR TITLE
Workaround for SDL2 2.0.6 audio issues

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,11 +28,11 @@ install:
         if ($env:BUILD_TYPE -eq 'mingw') {
           $dependencies = "mingw64/mingw-w64-x86_64-cmake",
                           "mingw64/mingw-w64-x86_64-qt5",
-                          "mingw64/mingw-w64-x86_64-curl",
-                          "mingw64/mingw-w64-x86_64-SDL2"
+                          "mingw64/mingw-w64-x86_64-curl"
           # redirect err to null to prevent warnings from becoming errors
           # workaround to prevent pacman from failing due to cyclical dependencies
           C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S mingw64/mingw-w64-x86_64-freetype mingw64/mingw-w64-x86_64-fontconfig" 2> $null
+          C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-SDL2-2.0.5-2-any.pkg.tar.xz" 2> $null
           C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S $dependencies" 2> $null
         }
 


### PR DESCRIPTION
This PR is a workaround for SDL2 2.0.6 having a bug with audio output, the bug report is right here: https://bugzilla.libsdl.org/show_bug.cgi?id=3858 - Thanks @MerryMage !
This PR also downgrades the SDL2 version to 2.0.5.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3047)
<!-- Reviewable:end -->
