### PR TITLE
file_sys: Add missing header for PRIU64

### DIFF
--- a/src/core/file_sys/archive_ncch.cpp
+++ b/src/core/file_sys/archive_ncch.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
+#include <cinttypes>
 #include <memory>
 #include <vector>
 #include "common/common_types.h"


### PR DESCRIPTION
https://github.com/citra-emu/citra/blob/f75dd34747f35cda5ae8ca2c74439034aa0f5b1f/src/core/file_sys/archive_ncch.cpp#L196

This is hidden behind `LOG_TRACE` so it only breaks debug build. So again, please consider adding debug build to CI

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3053)
<!-- Reviewable:end -->
