### PR TITLE
Correcting word order of a comment in memory.cpp

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -393,7 +393,7 @@ void RasterizerMarkRegionCached(PAddr start, u32 size, int count_delta) {
             case PageType::RasterizerCachedMemory: {
                 u8* pointer = GetPointerFromVMA(vaddr & ~PAGE_MASK);
                 if (pointer == nullptr) {
-                    // It's possible that this function has called been while updating the pagetable
+                    // It's possible that this function has been called while updating the pagetable
                     // after unmapping a VMA. In that case the underlying VMA will no longer exist,
                     // and we should just leave the pagetable entry blank.
                     page_type = PageType::Unmapped;


### PR DESCRIPTION
Making a comment easier to read by changing the order of the verb to make a correct sentence.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3060)
<!-- Reviewable:end -->
