### PR TITLE
Appveyor: Use Previous version of appveyor build environment

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ cache:
   - C:\ProgramData\chocolatey\bin -> appveyor.yml
   - C:\ProgramData\chocolatey\lib -> appveyor.yml
 
-os: Visual Studio 2017
+os: Previous Visual Studio 2017
 
 environment:
   # Tell msys2 to add mingw64 to the path


### PR DESCRIPTION
This is a temporary fix for the issues caused by the most recent appveyor update (issue #3051). This will only work until the next update of appyevor, since then the current (broken) version will get the previous. So we still need to find a solution, but at least until then, we have a non broken version.

P.S. @chris062689 forced me to push this

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3063)
<!-- Reviewable:end -->
