### PR TITLE
Removed duplicate calls of WSACleanup in soc_u.

### DIFF
--- a/src/core/hle/service/soc_u.cpp
+++ b/src/core/hle/service/soc_u.cpp
@@ -794,10 +794,6 @@ static void ShutdownSockets(Interface* self) {
     // TODO(Subv): Implement
     CleanupSockets();
 
-#ifdef _WIN32
-    WSACleanup();
-#endif
-
     u32* cmd_buffer = Kernel::GetCommandBuffer();
     cmd_buffer[1] = 0;
 }
@@ -908,9 +904,6 @@ SOC_U::SOC_U() {
 
 SOC_U::~SOC_U() {
     CleanupSockets();
-#ifdef _WIN32
-    WSACleanup();
-#endif
 }
 
 } // namespace SOC

--- a/src/core/hle/service/soc_u.cpp
+++ b/src/core/hle/service/soc_u.cpp
@@ -780,10 +780,6 @@ static void Connect(Interface* self) {
 
 static void InitializeSockets(Interface* self) {
 // TODO(Subv): Implement
-#ifdef _WIN32
-    WSADATA data;
-    WSAStartup(MAKEWORD(2, 2), &data);
-#endif
 
     u32* cmd_buffer = Kernel::GetCommandBuffer();
     cmd_buffer[0] = IPC::MakeHeader(1, 1, 0);
@@ -900,10 +896,18 @@ const Interface::FunctionInfo FunctionTable[] = {
 
 SOC_U::SOC_U() {
     Register(FunctionTable);
+
+#ifdef _WIN32
+    WSADATA data;
+    WSAStartup(MAKEWORD(2, 2), &data);
+#endif
 }
 
 SOC_U::~SOC_U() {
     CleanupSockets();
+#ifdef _WIN32
+    WSACleanup();
+#endif
 }
 
 } // namespace SOC

--- a/src/core/hle/service/soc_u.cpp
+++ b/src/core/hle/service/soc_u.cpp
@@ -779,8 +779,8 @@ static void Connect(Interface* self) {
 }
 
 static void InitializeSockets(Interface* self) {
-// TODO(Subv): Implement
-
+    // TODO(Subv): Implement
+    
     u32* cmd_buffer = Kernel::GetCommandBuffer();
     cmd_buffer[0] = IPC::MakeHeader(1, 1, 0);
     cmd_buffer[1] = RESULT_SUCCESS.raw;

--- a/src/core/hle/service/soc_u.cpp
+++ b/src/core/hle/service/soc_u.cpp
@@ -780,7 +780,7 @@ static void Connect(Interface* self) {
 
 static void InitializeSockets(Interface* self) {
     // TODO(Subv): Implement
-    
+
     u32* cmd_buffer = Kernel::GetCommandBuffer();
     cmd_buffer[0] = IPC::MakeHeader(1, 1, 0);
     cmd_buffer[1] = RESULT_SUCCESS.raw;


### PR DESCRIPTION
Soc_u is the reason for most of the WSAStartup issues. It calls WSAStartup only on SOC_U::InitializeSockets,
but calls WSACleanup every time it gets destructed in addition to SOC_U::ShutdownSockets. Thus calling WSACleanup way more often than WSAStartup and thus close it although other parts of the code still need the sockets.

With that, we should test if removing WSAStartup in web_service is possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3067)
<!-- Reviewable:end -->
