### PR TITLE
Kernel/IPC: Implement StaticBuffer translation for HLE services that use the HLERequestContext architecture.

### DIFF
--- a/src/core/hle/ipc.h
+++ b/src/core/hle/ipc.h
@@ -40,12 +40,15 @@ static const int kStaticBuffersOffset = 0x100;
 inline u32* GetStaticBuffers(const int offset = 0) {
     return GetCommandBuffer(kStaticBuffersOffset + offset);
 }
-}
+} // namespace Kernel
 
 namespace IPC {
 
 /// Size of the command buffer area, in 32-bit words.
 constexpr size_t COMMAND_BUFFER_LENGTH = 0x100 / sizeof(u32);
+
+// Maximum number of static buffers per thread.
+constexpr size_t MAX_STATIC_BUFFERS = 16;
 
 // These errors are commonly returned by invalid IPC translations, so alias them here for
 // convenience.

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -119,6 +119,18 @@ public:
      */
     void ClearIncomingObjects();
 
+    /**
+     * Retrieves the static buffer identified by the input buffer_id. The static buffer *must* have
+     * been created in PopulateFromIncomingCommandBuffer by way of an input StaticBuffer descriptor.
+     */
+    const std::vector<u8>& GetStaticBuffer(u8 buffer_id) const;
+
+    /**
+     * Sets up a static buffer that will be copied to the target process when the request is
+     * translated.
+     */
+    void AddStaticBuffer(u8 buffer_id, std::vector<u8> data);
+
     /// Populates this context with data from the requesting process/thread.
     ResultCode PopulateFromIncomingCommandBuffer(const u32_le* src_cmdbuf, Process& src_process,
                                                  HandleTable& src_table);
@@ -131,6 +143,8 @@ private:
     SharedPtr<ServerSession> session;
     // TODO(yuriks): Check common usage of this and optimize size accordingly
     boost::container::small_vector<SharedPtr<Object>, 8> request_handles;
+    // The static buffers will be created when the IPC request is translated.
+    std::array<std::vector<u8>, IPC::MAX_STATIC_BUFFERS> static_buffers;
 };
 
 } // namespace Kernel

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -720,7 +720,7 @@ void AppletUtility(Service::Interface* self) {
     u32 utility_command = rp.Pop<u32>();
     u32 input_size = rp.Pop<u32>();
     u32 output_size = rp.Pop<u32>();
-    VAddr input_addr = rp.PopStaticBuffer();
+    VAddr input_addr = rp.PopStaticBuffer(nullptr);
 
     VAddr output_addr = rp.PeekStaticBuffer(0);
 
@@ -823,7 +823,7 @@ void StartLibraryApplet(Service::Interface* self) {
 
     size_t buffer_size = rp.Pop<u32>();
     Kernel::Handle handle = rp.PopHandle();
-    VAddr buffer_addr = rp.PopStaticBuffer();
+    VAddr buffer_addr = rp.PopStaticBuffer(nullptr);
 
     LOG_DEBUG(Service_APT, "called applet_id=%08X", static_cast<u32>(applet_id));
 

--- a/src/core/hle/service/frd/frd.cpp
+++ b/src/core/hle/service/frd/frd.cpp
@@ -113,7 +113,7 @@ void UnscrambleLocalFriendCode(Service::Interface* self) {
     IPC::RequestParser rp(Kernel::GetCommandBuffer(), 0x1C, 1, 2);
     const u32 friend_code_count = rp.Pop<u32>();
     size_t in_buffer_size;
-    const VAddr scrambled_friend_codes = rp.PopStaticBuffer(&in_buffer_size, false);
+    const VAddr scrambled_friend_codes = rp.PopStaticBuffer(&in_buffer_size);
     ASSERT_MSG(in_buffer_size == (friend_code_count * scrambled_friend_code_size),
                "Wrong input buffer size");
 

--- a/src/core/hle/service/fs/fs_user.cpp
+++ b/src/core/hle/service/fs/fs_user.cpp
@@ -72,7 +72,7 @@ static void OpenFile(Service::Interface* self) {
     FileSys::Mode mode;
     mode.hex = rp.Pop<u32>();
     u32 attributes = rp.Pop<u32>(); // TODO(Link Mauve): do something with those attributes.
-    VAddr filename_ptr = rp.PopStaticBuffer();
+    VAddr filename_ptr = rp.PopStaticBuffer(nullptr);
     FileSys::Path file_path(filename_type, filename_size, filename_ptr);
 
     LOG_DEBUG(Service_FS, "path=%s, mode=%u attrs=%u", file_path.DebugStr().c_str(), mode.hex,

--- a/src/core/hle/service/ir/ir_user.cpp
+++ b/src/core/hle/service/ir/ir_user.cpp
@@ -433,7 +433,7 @@ static void FinalizeIrNop(Interface* self) {
 static void SendIrNop(Interface* self) {
     IPC::RequestParser rp(Kernel::GetCommandBuffer(), 0x0D, 1, 2);
     const u32 size = rp.Pop<u32>();
-    const VAddr address = rp.PopStaticBuffer();
+    const VAddr address = rp.PopStaticBuffer(nullptr);
 
     std::vector<u8> buffer(size);
     Memory::ReadBlock(address, buffer.data(), size);

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -771,9 +771,9 @@ static void BeginHostingNetwork(Interface* self) {
     const u32 passphrase_size = rp.Pop<u32>();
 
     size_t desc_size;
-    const VAddr network_info_address = rp.PopStaticBuffer(&desc_size, false);
+    const VAddr network_info_address = rp.PopStaticBuffer(&desc_size);
     ASSERT(desc_size == sizeof(NetworkInfo));
-    const VAddr passphrase_address = rp.PopStaticBuffer(&desc_size, false);
+    const VAddr passphrase_address = rp.PopStaticBuffer(&desc_size);
     ASSERT(desc_size == passphrase_size);
 
     // TODO(Subv): Store the passphrase and verify it when attempting a connection.
@@ -907,7 +907,7 @@ static void SendTo(Interface* self) {
     u32 flags = rp.Pop<u32>();
 
     size_t desc_size;
-    const VAddr input_address = rp.PopStaticBuffer(&desc_size, false);
+    const VAddr input_address = rp.PopStaticBuffer(&desc_size);
     ASSERT(desc_size >= data_size);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
@@ -1093,7 +1093,7 @@ static void SetApplicationData(Interface* self) {
     u32 size = rp.Pop<u32>();
 
     size_t desc_size;
-    const VAddr address = rp.PopStaticBuffer(&desc_size, false);
+    const VAddr address = rp.PopStaticBuffer(&desc_size);
     ASSERT(desc_size == size);
 
     LOG_DEBUG(Service_NWM, "called");


### PR DESCRIPTION
The real kernel requires services to set up their static buffer targets ahead of time. This implementation does not require that and will simply create the storage for the buffers as they are processed in the incoming IPC request.

Static buffers are kept in an unordered_map keyed by their buffer id, and are written into the already-setup area of the request thread when responding an IPC request.

This fixes a regression (crash) introduced in #2992.

This PR introduces more warnings due to the [[deprecated]] attribute being added to void PushStaticBuffer(VAddr buffer_vaddr, size_t size, u8 buffer_id); and VAddr PopStaticBuffer(size_t* data_size);

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3077)
<!-- Reviewable:end -->
