### PR TITLE
Kernel/Mutex: Add a missing return in Mutex::Release

### DIFF
--- a/src/core/hle/kernel/mutex.cpp
+++ b/src/core/hle/kernel/mutex.cpp
@@ -88,7 +88,7 @@ ResultCode Mutex::Release(Thread* thread) {
         WakeupAllWaitingThreads();
         Core::System::GetInstance().PrepareReschedule();
     }
-    
+
     return RESULT_SUCCESS;
 }
 

--- a/src/core/hle/kernel/mutex.cpp
+++ b/src/core/hle/kernel/mutex.cpp
@@ -88,6 +88,8 @@ ResultCode Mutex::Release(Thread* thread) {
         WakeupAllWaitingThreads();
         Core::System::GetInstance().PrepareReschedule();
     }
+    
+    return RESULT_SUCCESS;
 }
 
 void Mutex::AddWaitingThread(SharedPtr<Thread> thread) {


### PR DESCRIPTION
Fixes a regression in #3042.
Closes #3079

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3080)
<!-- Reviewable:end -->
