### PR TITLE
Kernel/Thread: Run the main thread in the CPU specified by the process' exheader.

### DIFF
--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -497,8 +497,9 @@ void Thread::BoostPriority(u32 priority) {
 
 SharedPtr<Thread> SetupMainThread(u32 entry_point, u32 priority, SharedPtr<Process> owner_process) {
     // Initialize new "main" thread
-    auto thread_res = Thread::Create("main", entry_point, priority, 0, THREADPROCESSORID_0,
-                                     Memory::HEAP_VADDR_END, owner_process);
+    auto thread_res =
+        Thread::Create("main", entry_point, priority, 0, owner_process->ideal_processor,
+                       Memory::HEAP_VADDR_END, owner_process);
 
     SharedPtr<Thread> thread = std::move(thread_res).Unwrap();
 
@@ -571,4 +572,4 @@ const std::vector<SharedPtr<Thread>>& GetThreadList() {
     return thread_list;
 }
 
-} // namespace
+} // namespace Kernel


### PR DESCRIPTION
System services usually have Core1 in this field, but citra was running them in Core0 regardless.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3082)
<!-- Reviewable:end -->
