### PR TITLE
Services/AM: Add errors and adjust naming for accuracy

### DIFF
--- a/src/core/file_sys/cia_container.cpp
+++ b/src/core/file_sys/cia_container.cpp
@@ -215,7 +215,7 @@ void CIAContainer::Print() const {
     LOG_DEBUG(Service_FS, "Ticket Size:      0x%08x bytes", GetTicketSize());
     LOG_DEBUG(Service_FS, "TMD Size:         0x%08x bytes", GetTitleMetadataSize());
     LOG_DEBUG(Service_FS, "Meta Size:        0x%08x bytes", GetMetadataSize());
-    LOG_DEBUG(Service_FS, "Content Size:     0x%08x bytes\n", GetTotalContentSize());
+    LOG_DEBUG(Service_FS, "Content Size:     0x%08" PRIx64 " bytes\n", GetTotalContentSize());
 
     LOG_DEBUG(Service_FS, "Certificate Offset: 0x%08" PRIx64 " bytes", GetCertificateOffset());
     LOG_DEBUG(Service_FS, "Ticket Offset:      0x%08" PRIx64 " bytes", GetTicketOffset());

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -685,7 +685,7 @@ void GetNumContentInfos(Service::Interface* self) {
     } else {
         rb.Push<u32>(1); // Number of content infos plus one
         LOG_WARNING(Service_AM, "(STUBBED) called media_type=%u, title_id=0x%016" PRIx64,
-                    media_type, title_id);
+                    static_cast<u32>(media_type), title_id);
     }
 }
 
@@ -793,7 +793,7 @@ void BeginImportProgram(Service::Interface* self) {
         Kernel::g_handle_table.Create(std::get<Kernel::SharedPtr<Kernel::ClientSession>>(sessions))
             .Unwrap());
 
-    LOG_WARNING(Service_AM, "(STUBBED) media_type=%u", media_type);
+    LOG_WARNING(Service_AM, "(STUBBED) media_type=%u", static_cast<u32>(media_type));
 }
 
 void EndImportProgram(Service::Interface* self) {

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -701,10 +701,20 @@ void ListDataTitleTicketInfos(Service::Interface* self) {
                 ticket_count, title_id, start_index, ticket_info_out);
 }
 
-void GetNumContentInfos(Service::Interface* self) {
+void GetDLCContentInfoCount(Service::Interface* self) {
     IPC::RequestParser rp(Kernel::GetCommandBuffer(), 0x1001, 3, 0); // 0x100100C0
     auto media_type = static_cast<Service::FS::MediaType>(rp.Pop<u8>());
     u64 title_id = rp.Pop<u64>();
+
+    // Validate that only DLC TIDs are passed in
+    u32 tid_high = static_cast<u32>(title_id >> 32);
+    if (tid_high != TID_HIGH_DLC) {
+        IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
+        rb.Push(ResultCode(ErrCodes::InvalidTID, ErrorModule::AM, ErrorSummary::InvalidArgument,
+                           ErrorLevel::Usage));
+        rb.Push<u32>(0);
+        return;
+    }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
     rb.Push(RESULT_SUCCESS); // No error

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -96,7 +96,8 @@ void ScanForAllTitles();
 void GetNumPrograms(Service::Interface* self);
 
 /**
- * AM::FindContentInfos service function
+ * AM::FindDLCContentInfos service function
+ * Explicitly checks that TID high value is 0004008C or an error is returned.
  *  Inputs:
  *      1 : MediaType
  *    2-3 : u64, Title ID
@@ -106,7 +107,7 @@ void GetNumPrograms(Service::Interface* self);
  *  Outputs:
  *      1 : Result, 0 on success, otherwise error code
  */
-void FindContentInfos(Service::Interface* self);
+void FindDLCContentInfos(Service::Interface* self);
 
 /**
  * AM::ListContentInfos service function

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -22,6 +22,7 @@ namespace AM {
 namespace ErrCodes {
 enum {
     CIACurrentlyInstalling = 4,
+    InvalidTID = 31,
     EmptyCIA = 32,
     InvalidTIDInList = 60,
     InvalidCIAHeader = 104,
@@ -204,7 +205,8 @@ void GetPatchTitleInfos(Service::Interface* self);
 void ListDataTitleTicketInfos(Service::Interface* self);
 
 /**
- * AM::GetNumContentInfos service function
+ * AM::GetDLCContentInfoCount service function
+ * Explicitly checks that TID high value is 0004008C or an error is returned.
  *  Inputs:
  *      0 : Command header (0x100100C0)
  *      1 : MediaType
@@ -213,7 +215,7 @@ void ListDataTitleTicketInfos(Service::Interface* self);
  *      1 : Result, 0 on success, otherwise error code
  *      2 : Number of content infos plus one
  */
-void GetNumContentInfos(Service::Interface* self);
+void GetDLCContentInfoCount(Service::Interface* self);
 
 /**
  * AM::DeleteTicket service function

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -110,7 +110,8 @@ void GetNumPrograms(Service::Interface* self);
 void FindDLCContentInfos(Service::Interface* self);
 
 /**
- * AM::ListContentInfos service function
+ * AM::ListDLCContentInfos service function
+ * Explicitly checks that TID high value is 0004008C or an error is returned.
  *  Inputs:
  *      1 : Content count
  *      2 : MediaType
@@ -121,7 +122,7 @@ void FindDLCContentInfos(Service::Interface* self);
  *      1 : Result, 0 on success, otherwise error code
  *      2 : Number of content infos returned
  */
-void ListContentInfos(Service::Interface* self);
+void ListDLCContentInfos(Service::Interface* self);
 
 /**
  * AM::DeleteContents service function

--- a/src/core/hle/service/am/am_app.cpp
+++ b/src/core/hle/service/am/am_app.cpp
@@ -11,7 +11,7 @@ namespace AM {
 const Interface::FunctionInfo FunctionTable[] = {
     {0x100100C0, GetNumContentInfos, "GetNumContentInfos"},
     {0x10020104, FindDLCContentInfos, "FindDLCContentInfos"},
-    {0x10030142, ListContentInfos, "ListContentInfos"},
+    {0x10030142, ListDLCContentInfos, "ListDLCContentInfos"},
     {0x10040102, DeleteContents, "DeleteContents"},
     {0x10050084, GetDLCTitleInfos, "GetDLCTitleInfos"},
     {0x10060080, nullptr, "GetNumDataTitleTickets"},

--- a/src/core/hle/service/am/am_app.cpp
+++ b/src/core/hle/service/am/am_app.cpp
@@ -10,7 +10,7 @@ namespace AM {
 
 const Interface::FunctionInfo FunctionTable[] = {
     {0x100100C0, GetNumContentInfos, "GetNumContentInfos"},
-    {0x10020104, FindContentInfos, "FindContentInfos"},
+    {0x10020104, FindDLCContentInfos, "FindDLCContentInfos"},
     {0x10030142, ListContentInfos, "ListContentInfos"},
     {0x10040102, DeleteContents, "DeleteContents"},
     {0x10050084, GetDLCTitleInfos, "GetDLCTitleInfos"},

--- a/src/core/hle/service/am/am_app.cpp
+++ b/src/core/hle/service/am/am_app.cpp
@@ -9,7 +9,7 @@ namespace Service {
 namespace AM {
 
 const Interface::FunctionInfo FunctionTable[] = {
-    {0x100100C0, GetNumContentInfos, "GetNumContentInfos"},
+    {0x100100C0, GetDLCContentInfoCount, "GetDLCContentInfoCount"},
     {0x10020104, FindDLCContentInfos, "FindDLCContentInfos"},
     {0x10030142, ListDLCContentInfos, "ListDLCContentInfos"},
     {0x10040102, DeleteContents, "DeleteContents"},

--- a/src/core/hle/service/am/am_sys.cpp
+++ b/src/core/hle/service/am/am_sys.cpp
@@ -54,7 +54,7 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x002B0142, nullptr, "ListExistingContentInfosSystem"},
     {0x002C0084, nullptr, "GetProgramInfosIgnorePlatform"},
     {0x002D00C0, CheckContentRightsIgnorePlatform, "CheckContentRightsIgnorePlatform"},
-    {0x100100C0, GetNumContentInfos, "GetNumContentInfos"},
+    {0x100100C0, GetDLCContentInfoCount, "GetDLCContentInfoCount"},
     {0x10020104, FindDLCContentInfos, "FindDLCContentInfos"},
     {0x10030142, ListDLCContentInfos, "ListDLCContentInfos"},
     {0x10040102, DeleteContents, "DeleteContents"},

--- a/src/core/hle/service/am/am_sys.cpp
+++ b/src/core/hle/service/am/am_sys.cpp
@@ -56,7 +56,7 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x002D00C0, CheckContentRightsIgnorePlatform, "CheckContentRightsIgnorePlatform"},
     {0x100100C0, GetNumContentInfos, "GetNumContentInfos"},
     {0x10020104, FindDLCContentInfos, "FindDLCContentInfos"},
-    {0x10030142, ListContentInfos, "ListContentInfos"},
+    {0x10030142, ListDLCContentInfos, "ListDLCContentInfos"},
     {0x10040102, DeleteContents, "DeleteContents"},
     {0x10050084, GetDLCTitleInfos, "GetDLCTitleInfos"},
     {0x10060080, nullptr, "GetNumDataTitleTickets"},

--- a/src/core/hle/service/am/am_sys.cpp
+++ b/src/core/hle/service/am/am_sys.cpp
@@ -55,7 +55,7 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x002C0084, nullptr, "GetProgramInfosIgnorePlatform"},
     {0x002D00C0, CheckContentRightsIgnorePlatform, "CheckContentRightsIgnorePlatform"},
     {0x100100C0, GetNumContentInfos, "GetNumContentInfos"},
-    {0x10020104, FindContentInfos, "FindContentInfos"},
+    {0x10020104, FindDLCContentInfos, "FindDLCContentInfos"},
     {0x10030142, ListContentInfos, "ListContentInfos"},
     {0x10040102, DeleteContents, "DeleteContents"},
     {0x10050084, GetDLCTitleInfos, "GetDLCTitleInfos"},


### PR DESCRIPTION
This PR can be reviewed commit-by-commit.

This PR renames three functions which require DLC TIDs and adds appropriate errors for when non-DLC TIDs are passed to them. Mapped buffers are passed back as appropriate. Some previous warnings have also been fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3087)
<!-- Reviewable:end -->
