### PR TITLE
Kernel/IPC: Partially implement  LLE MappedBuffer translation.

### DIFF
--- a/src/core/hle/kernel/ipc.h
+++ b/src/core/hle/kernel/ipc.h
@@ -10,5 +10,5 @@
 namespace Kernel {
 /// Performs IPC command buffer translation from one process to another.
 ResultCode TranslateCommandBuffer(SharedPtr<Thread> src_thread, SharedPtr<Thread> dst_thread,
-                                  VAddr src_address, VAddr dst_address);
+                                  VAddr src_address, VAddr dst_address, bool reply);
 } // namespace Kernel

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -472,8 +472,8 @@ static ResultCode ReceiveIPCRequest(SharedPtr<ServerSession> server_session,
     VAddr target_address = thread->GetCommandBufferAddress();
     VAddr source_address = server_session->currently_handling->GetCommandBufferAddress();
 
-    ResultCode translation_result = TranslateCommandBuffer(server_session->currently_handling,
-                                                           thread, source_address, target_address);
+    ResultCode translation_result = TranslateCommandBuffer(
+        server_session->currently_handling, thread, source_address, target_address, false);
 
     // If a translation error occurred, immediately resume the client thread.
     if (translation_result.IsError()) {
@@ -535,8 +535,8 @@ static ResultCode ReplyAndReceive(s32* index, VAddr handles_address, s32 handle_
         VAddr source_address = GetCurrentThread()->GetCommandBufferAddress();
         VAddr target_address = request_thread->GetCommandBufferAddress();
 
-        ResultCode translation_result = TranslateCommandBuffer(GetCurrentThread(), request_thread,
-                                                               source_address, target_address);
+        ResultCode translation_result = TranslateCommandBuffer(
+            Kernel::GetCurrentThread(), request_thread, source_address, target_address, true);
 
         // Note: The real kernel seems to always panic if the Server->Client buffer translation
         // fails for whatever reason.

--- a/src/core/hle/kernel/vm_manager.h
+++ b/src/core/hle/kernel/vm_manager.h
@@ -145,6 +145,18 @@ public:
                                         size_t offset, u32 size, MemoryState state);
 
     /**
+     * Maps part of a ref-counted block of memory at the first free address after the given base.
+     *
+     * @param base The base address to start the mapping at.
+     * @param block The block to be mapped.
+     * @param offset Offset into `block` to map from.
+     * @param size Size of the mapping.
+     * @param state MemoryState tag to attach to the VMA.
+     * @returns The address at which the memory was mapped.
+     */
+    ResultVal<VAddr> MapMemoryBlockToBase(VAddr base, std::shared_ptr<std::vector<u8>> block,
+                                          size_t offset, u32 size, MemoryState state);
+    /**
      * Maps an unmanaged host memory pointer at a given address.
      *
      * @param target The guest address to start the mapping at.

--- a/src/core/hle/kernel/vm_manager.h
+++ b/src/core/hle/kernel/vm_manager.h
@@ -148,14 +148,16 @@ public:
      * Maps part of a ref-counted block of memory at the first free address after the given base.
      *
      * @param base The base address to start the mapping at.
+     * @param region_size The max size of the region from where we'll try to find an address.
      * @param block The block to be mapped.
      * @param offset Offset into `block` to map from.
      * @param size Size of the mapping.
      * @param state MemoryState tag to attach to the VMA.
      * @returns The address at which the memory was mapped.
      */
-    ResultVal<VAddr> MapMemoryBlockToBase(VAddr base, std::shared_ptr<std::vector<u8>> block,
-                                          size_t offset, u32 size, MemoryState state);
+    ResultVal<VAddr> MapMemoryBlockToBase(VAddr base, u32 region_size,
+                                          std::shared_ptr<std::vector<u8>> block, size_t offset,
+                                          u32 size, MemoryState state);
     /**
      * Maps an unmanaged host memory pointer at a given address.
      *
@@ -236,4 +238,4 @@ private:
     /// Updates the pages corresponding to this VMA so they match the VMA's attributes.
     void UpdatePageTableForVMA(const VirtualMemoryArea& vma);
 };
-}
+} // namespace Kernel


### PR DESCRIPTION
Right now only MappedBuffers that only span a single page and are not aligned are implemented.

MappedBuffers are unmapped during the reply part of ReplyAndReceive. Only unmapping of ReadOnly buffers is currently implemented.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3090)
<!-- Reviewable:end -->
