### PR TITLE
Round primary color in swrast

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -168,6 +168,8 @@ RasterizerOpenGL::RasterizerOpenGL() : shader_dirty(true) {
     glActiveTexture(TextureUnits::ProcTexDiffLUT.Enum());
     glTexBuffer(GL_TEXTURE_BUFFER, GL_RGBA32F, proctex_diff_lut_buffer.handle);
 
+    glEnable(GL_BLEND);
+
     // Sync fixed function OpenGL state
     SyncClipEnabled();
     SyncClipCoef();

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -234,7 +234,7 @@ static void AppendSource(std::string& out, const PicaShaderConfig& config,
     using Source = TevStageConfig::Source;
     switch (source) {
     case Source::PrimaryColor:
-        out += "primary_color";
+        out += "rounded_primary_color";
         break;
     case Source::PrimaryFragmentColor:
         out += "primary_fragment_color";
@@ -1100,8 +1100,11 @@ float LookupLightingLUTSigned(int lut_index, float pos) {
     if (config.state.proctex.enable)
         AppendProcTexSampler(out, config);
 
+    // We round the interpolated primary color to the nearest 1/255th
+    // This maintains the PICA's 8 bits of precision
     out += R"(
 void main() {
+vec4 rounded_primary_color = round(primary_color * 255.0) / 255.0;
 vec4 primary_fragment_color = vec4(0.0);
 vec4 secondary_fragment_color = vec4(0.0);
 )";

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -33,7 +33,7 @@ OpenGLState::OpenGLState() {
     stencil.action_depth_pass = GL_KEEP;
     stencil.action_stencil_fail = GL_KEEP;
 
-    blend.enabled = false;
+    blend.enabled = true;
     blend.rgb_equation = GL_FUNC_ADD;
     blend.a_equation = GL_FUNC_ADD;
     blend.src_rgb_func = GL_ONE;
@@ -148,9 +148,6 @@ void OpenGLState::Apply() const {
     if (blend.enabled != cur_state.blend.enabled) {
         if (blend.enabled) {
             glEnable(GL_BLEND);
-
-            cur_state.logic_op = GL_COPY;
-            glLogicOp(cur_state.logic_op);
             glDisable(GL_COLOR_LOGIC_OP);
         } else {
             glDisable(GL_BLEND);

--- a/src/video_core/swrasterizer/rasterizer.cpp
+++ b/src/video_core/swrasterizer/rasterizer.cpp
@@ -293,18 +293,18 @@ static void ProcessTriangleInternal(const Vertex& v0, const Vertex& v1, const Ve
             };
 
             Math::Vec4<u8> primary_color{
-                (u8)(
+                static_cast<u8>(round(
                     GetInterpolatedAttribute(v0.color.r(), v1.color.r(), v2.color.r()).ToFloat32() *
-                    255),
-                (u8)(
+                    255)),
+                static_cast<u8>(round(
                     GetInterpolatedAttribute(v0.color.g(), v1.color.g(), v2.color.g()).ToFloat32() *
-                    255),
-                (u8)(
+                    255)),
+                static_cast<u8>(round(
                     GetInterpolatedAttribute(v0.color.b(), v1.color.b(), v2.color.b()).ToFloat32() *
-                    255),
-                (u8)(
+                    255)),
+                static_cast<u8>(round(
                     GetInterpolatedAttribute(v0.color.a(), v1.color.a(), v2.color.a()).ToFloat32() *
-                    255),
+                    255)),
             };
 
             Math::Vec2<float24> uv[3];


### PR DESCRIPTION
Also includes a fix for logic ops not being enabled in OpenGL (depending on circumstances).

Also ports the hack from the hardware renderer to software rasterizer where null texture addresses are ignored. (Otherwise the software rasterizer will crash doing a null deref).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3097)
<!-- Reviewable:end -->
