### PR TITLE
Kernel/Threads: Add a new thread status that will allow using a Kernel::Event to put a guest thread to sleep inside an HLE handler until said event is signaled

### DIFF
--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -39,7 +39,7 @@ SharedPtr<Event> HLERequestContext::SleepClientThread(SharedPtr<Thread> thread,
         // We must copy the entire command buffer *plus* the entire static buffers area, since
         // the translation might need to read from it in order to retrieve the StaticBuffer
         // target addresses.
-        std::array<u32, IPC::COMMAND_BUFFER_LENGTH + 2 * IPC::MAX_STATIC_BUFFERS> cmd_buff;
+        std::array<u32_le, IPC::COMMAND_BUFFER_LENGTH + 2 * IPC::MAX_STATIC_BUFFERS> cmd_buff;
         Memory::ReadBlock(*process, thread->GetCommandBufferAddress(), cmd_buff.data(),
                           cmd_buff.size() * sizeof(u32));
         context.WriteToOutgoingCommandBuffer(cmd_buff.data(), *process, Kernel::g_handle_table);

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -29,9 +29,8 @@ SharedPtr<Event> HLERequestContext::SleepClientThread(SharedPtr<Thread> thread,
                                                       const std::string& reason, u64 timeout,
                                                       WakeupCallback&& callback) {
     // Put the client thread to sleep until the wait event is signaled or the timeout expires.
-    thread->wakeup_callback = [context = *this, callback](ThreadWakeupReason reason,
-                                                          SharedPtr<Thread> thread,
-                                                          SharedPtr<WaitObject> object) mutable {
+    thread->wakeup_callback = [ context = *this, callback ](
+        ThreadWakeupReason reason, SharedPtr<Thread> thread, SharedPtr<WaitObject> object) mutable {
         ASSERT(thread->status == THREADSTATUS_WAIT_HLE_EVENT);
         callback(thread, context, reason);
 

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -26,7 +26,8 @@ void SessionRequestHandler::ClientDisconnected(SharedPtr<ServerSession> server_s
 }
 
 SharedPtr<Event> HLERequestContext::SleepClientThread(SharedPtr<Thread> thread,
-                                                      const std::string& reason, u64 timeout,
+                                                      const std::string& reason,
+                                                      std::chrono::nanoseconds timeout,
                                                       WakeupCallback&& callback) {
     // Put the client thread to sleep until the wait event is signaled or the timeout expires.
     thread->wakeup_callback = [ context = *this, callback ](
@@ -52,8 +53,8 @@ SharedPtr<Event> HLERequestContext::SleepClientThread(SharedPtr<Thread> thread,
     thread->wait_objects = {event};
     event->AddWaitingThread(thread);
 
-    if (timeout > 0)
-        thread->WakeAfterDelay(timeout);
+    if (timeout.count() > 0)
+        thread->WakeAfterDelay(timeout.count());
 
     return event;
 }

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -6,6 +6,7 @@
 #include <boost/range/algorithm_ext/erase.hpp>
 #include "common/assert.h"
 #include "common/common_types.h"
+#include "core/hle/kernel/event.h"
 #include "core/hle/kernel/handle_table.h"
 #include "core/hle/kernel/hle_ipc.h"
 #include "core/hle/kernel/kernel.h"
@@ -22,6 +23,40 @@ void SessionRequestHandler::ClientConnected(SharedPtr<ServerSession> server_sess
 void SessionRequestHandler::ClientDisconnected(SharedPtr<ServerSession> server_session) {
     server_session->SetHleHandler(nullptr);
     boost::range::remove_erase(connected_sessions, server_session);
+}
+
+SharedPtr<Event> HLERequestContext::SleepClientThread(SharedPtr<Thread> thread,
+                                                      const std::string& reason, u64 timeout,
+                                                      WakeupCallback&& callback) {
+    // Put the client thread to sleep until the wait event is signaled or the timeout expires.
+    thread->wakeup_callback = [context = *this, callback](ThreadWakeupReason reason,
+                                                          SharedPtr<Thread> thread,
+                                                          SharedPtr<WaitObject> object) mutable {
+        ASSERT(thread->status == THREADSTATUS_WAIT_HLE_EVENT);
+        callback(thread, context, reason);
+
+        auto& process = thread->owner_process;
+        // We must copy the entire command buffer *plus* the entire static buffers area, since
+        // the translation might need to read from it in order to retrieve the StaticBuffer
+        // target addresses.
+        std::array<u32, IPC::COMMAND_BUFFER_LENGTH + 2 * IPC::MAX_STATIC_BUFFERS> cmd_buff;
+        Memory::ReadBlock(*process, thread->GetCommandBufferAddress(), cmd_buff.data(),
+                          cmd_buff.size() * sizeof(u32));
+        context.WriteToOutgoingCommandBuffer(cmd_buff.data(), *process, Kernel::g_handle_table);
+        // Copy the translated command buffer back into the thread's command buffer area.
+        Memory::WriteBlock(*process, thread->GetCommandBufferAddress(), cmd_buff.data(),
+                           cmd_buff.size() * sizeof(u32));
+    };
+
+    auto event = Kernel::Event::Create(Kernel::ResetType::OneShot, "HLE Pause Event: " + reason);
+    thread->status = THREADSTATUS_WAIT_HLE_EVENT;
+    thread->wait_objects = {event};
+    event->AddWaitingThread(thread);
+
+    if (timeout > 0)
+        thread->WakeAfterDelay(timeout);
+
+    return event;
 }
 
 HLERequestContext::HLERequestContext(SharedPtr<ServerSession> session)

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include <chrono>
 #include <memory>
 #include <string>
 #include <vector>
@@ -146,7 +147,7 @@ public:
     using WakeupCallback = std::function<void(SharedPtr<Thread> thread, HLERequestContext& context,
                                               ThreadWakeupReason reason)>;
 
-    /*
+    /**
      * Puts the specified guest thread to sleep until the returned event is signaled or until the
      * specified timeout expires.
      * @param thread Thread to be put to sleep.
@@ -159,7 +160,7 @@ public:
      * @returns Event that when signaled will resume the thread and call the callback function.
      */
     SharedPtr<Event> SleepClientThread(SharedPtr<Thread> thread, const std::string& reason,
-                                       u64 timeout, WakeupCallback&& callback);
+                                       std::chrono::nanoseconds timeout, WakeupCallback&& callback);
 
     /**
      * Resolves a object id from the request command buffer into a pointer to an object. See the

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -196,7 +196,8 @@ static void ThreadWakeupCallback(u64 thread_handle, int cycles_late) {
     }
 
     if (thread->status == THREADSTATUS_WAIT_SYNCH_ANY ||
-        thread->status == THREADSTATUS_WAIT_SYNCH_ALL || thread->status == THREADSTATUS_WAIT_ARB) {
+        thread->status == THREADSTATUS_WAIT_SYNCH_ALL || thread->status == THREADSTATUS_WAIT_ARB ||
+        thread->status == THREADSTATUS_WAIT_HLE_EVENT) {
 
         // Invoke the wakeup callback before clearing the wait objects
         if (thread->wakeup_callback)

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -181,8 +181,16 @@ void ServiceFrameworkBase::HandleSyncRequest(SharedPtr<ServerSession> server_ses
     LOG_TRACE(Service, "%s",
               MakeFunctionString(info->name, GetServiceName().c_str(), cmd_buf).c_str());
     handler_invoker(this, info->handler_callback, context);
-    context.WriteToOutgoingCommandBuffer(cmd_buf, *Kernel::g_current_process,
-                                         Kernel::g_handle_table);
+
+    auto thread = Kernel::GetCurrentThread();
+    ASSERT(thread->status == THREADSTATUS_RUNNING || thread->status == THREADSTATUS_WAIT_HLE_EVENT);
+    // Only write the response immediately if the thread is still running. If the HLE handler put
+    // the thread to sleep then the writing of the command buffer will be deferred to the wakeup
+    // callback.
+    if (thread->status == THREADSTATUS_RUNNING) {
+        context.WriteToOutgoingCommandBuffer(cmd_buf, *Kernel::g_current_process,
+                                             Kernel::g_handle_table);
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This is an improved take on #2968

Some service functions should block the caller guest thread on SendSyncRequest until an async response can be calculated and returned (Most soc:U functions when dealing with blocking sockets, some UDS functions like ConnectToNetwork, most http:C functions, etc).

This change lets us put the threads to wait in the HLE handler and wake them up when the response comes back from another host thread, without having to neither spinlock (and freezing the entirety of the emulator thread) nor ignore the blocking nature of the function.

It is used like so:
```cpp
// In service function
auto promise = PerformAsyncOperation();
auto event = ctx.SleepClientThread(
        Kernel::GetCurrentThread(), "soc::sendto", SOCSendToTimeout,
        [&promise](Kernel::SharedPtr<Kernel::Thread> thread, Kernel::HLERequestContext& ctx,
           ThreadWakeupReason reason) {
        if (reason == ThreadWakeupReason::Timeout) {
            // Construct RequestBuilder and write Timeout response.
        } else {
            // Construct RequestBuilder and write Success response.
        }
    });
...
// Somewhere else, when the async operation has finished
promise.set_value(ResultOfOperation);
std::lock_guard<std::mutex> lock(HLE::g_hle_lock);
event->Signal();
// Now the thread is awake and back into the scheduler queue.
```

# Concerns
The timeout value is specified in nanoseconds elapsed in the guest CPU, but if no threads are eligible to run then CoreTiming might decide to advance the time to the next queued event. This means we have to carefully choose the timeout values when implementing such logic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3101)
<!-- Reviewable:end -->
