### PR TITLE
SDL CIA Installation

### DIFF
--- a/src/citra/citra.cpp
+++ b/src/citra/citra.cpp
@@ -98,7 +98,8 @@ int main(int argc, char** argv) {
                 const auto cia_progress = [](size_t written, size_t total) {
                     LOG_INFO(Frontend, "%02zu%%", (written * 100 / total));
                 };
-                if (!Service::AM::InstallCIA(std::string(optarg), cia_progress))
+                if (Service::AM::InstallCIA(std::string(optarg), cia_progress) !=
+                    Service::AM::InstallStatus::Success)
                     errno = EINVAL;
                 if (errno != 0)
                     exit(1);

--- a/src/core/file_sys/title_metadata.h
+++ b/src/core/file_sys/title_metadata.h
@@ -29,7 +29,7 @@ enum TMDSignatureType : u32 {
 };
 
 enum TMDContentTypeFlag : u16 {
-    Encrypted = 1 << 1,
+    Encrypted = 1 << 0,
     Disc = 1 << 2,
     CFM = 1 << 3,
     Optional = 1 << 14,

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -37,6 +37,10 @@
 namespace Service {
 namespace AM {
 
+constexpr u16 PLATFORM_CTR = 0x0004;
+constexpr u16 CATEGORY_SYSTEM = 0x0010;
+constexpr u16 CATEGORY_DLP = 0x0001;
+constexpr u8 VARIATION_SYSTEM = 0x02;
 constexpr u32 TID_HIGH_UPDATE = 0x0004000E;
 constexpr u32 TID_HIGH_DLC = 0x0004008C;
 
@@ -262,6 +266,20 @@ private:
     std::vector<u64> content_written;
     Service::FS::MediaType media_type;
 };
+
+Service::FS::MediaType GetTitleMediaType(u64 titleId) {
+    u16 platform = static_cast<u16>(titleId >> 48);
+    u16 category = static_cast<u16>((titleId >> 32) & 0xFFFF);
+    u8 variation = static_cast<u8>(titleId & 0xFF);
+
+    if (platform != PLATFORM_CTR)
+        return Service::FS::MediaType::NAND;
+
+    if (category & CATEGORY_SYSTEM || category & CATEGORY_DLP || variation & VARIATION_SYSTEM)
+        return Service::FS::MediaType::NAND;
+
+    return Service::FS::MediaType::SDMC;
+}
 
 std::string GetTitleMetadataPath(Service::FS::MediaType media_type, u64 tid, bool update) {
     std::string content_path = GetTitlePath(media_type, tid) + "content/";

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -297,6 +297,14 @@ InstallStatus InstallCIA(const std::string& path,
         Service::AM::CIAFile installFile(
             Service::AM::GetTitleMediaType(container.GetTitleMetadata().GetTitleID()));
 
+        for (size_t i = 0; i < container.GetTitleMetadata().GetContentCount(); i++) {
+            if (container.GetTitleMetadata().GetContentTypeByIndex(i) &
+                FileSys::TMDContentTypeFlag::Encrypted) {
+                LOG_ERROR(Service_AM, "File %s is encrypted! Aborting...", path.c_str());
+                return InstallStatus::ErrorEncrypted;
+            }
+        }
+
         FileUtil::IOFile file(path, "rb");
         if (!file.IsOpen())
             return InstallStatus::ErrorFailedToOpenFile;

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -283,12 +283,13 @@ bool CIAFile::Close() const {
 
 void CIAFile::Flush() const {}
 
-bool InstallCIA(const std::string& path, std::function<ProgressCallback>&& update_callback) {
+InstallStatus InstallCIA(const std::string& path,
+                         std::function<ProgressCallback>&& update_callback) {
     LOG_INFO(Service_AM, "Installing %s...", path.c_str());
 
     if (!FileUtil::Exists(path)) {
         LOG_ERROR(Service_AM, "File %s does not exist!", path.c_str());
-        return false;
+        return InstallStatus::ErrorFileNotFound;
     }
 
     FileSys::CIAContainer container;
@@ -298,7 +299,7 @@ bool InstallCIA(const std::string& path, std::function<ProgressCallback>&& updat
 
         FileUtil::IOFile file(path, "rb");
         if (!file.IsOpen())
-            return false;
+            return InstallStatus::ErrorFailedToOpenFile;
 
         std::array<u8, 0x10000> buffer;
         size_t total_bytes_read = 0;
@@ -312,18 +313,18 @@ bool InstallCIA(const std::string& path, std::function<ProgressCallback>&& updat
             if (result.Failed()) {
                 LOG_ERROR(Service_AM, "CIA file installation aborted with error code %08x",
                           result.Code());
-                return false;
+                return InstallStatus::ErrorAborted;
             }
             total_bytes_read += bytes_read;
         }
         installFile.Close();
 
         LOG_INFO(Service_AM, "Installed %s successfully.", path.c_str());
-        return true;
+        return InstallStatus::Success;
     }
 
     LOG_ERROR(Service_AM, "CIA file %s is invalid!", path.c_str());
-    return false;
+    return InstallStatus::ErrorInvalid;
 }
 
 Service::FS::MediaType GetTitleMediaType(u64 titleId) {

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <functional>
 #include <string>
 #include "common/common_types.h"
 #include "core/file_sys/cia_container.h"
@@ -41,6 +42,9 @@ enum class CIAInstallState : u32 {
     ContentWritten,
 };
 
+// Progress callback for InstallCIA, recieves bytes written and total bytes
+using ProgressCallback = void(size_t, size_t);
+
 // A file handled returned for CIAs to be written into and subsequently installed.
 class CIAFile final : public FileSys::FileBackend {
 public:
@@ -72,6 +76,15 @@ private:
     std::vector<u64> content_written;
     Service::FS::MediaType media_type;
 };
+
+/**
+ * Installs a CIA file from a specified file path.
+ * @param path file path of the CIA file to install
+ * @param update_callback callback function called during filesystem write
+ * @returns bool whether the install was successful
+ */
+bool InstallCIA(const std::string& path,
+                std::function<ProgressCallback>&& update_callback = nullptr);
 
 /**
  * Get the mediatype for an installed title

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -6,6 +6,9 @@
 
 #include <string>
 #include "common/common_types.h"
+#include "core/file_sys/cia_container.h"
+#include "core/file_sys/file_backend.h"
+#include "core/hle/result.h"
 
 namespace Service {
 namespace FS {
@@ -36,6 +39,35 @@ enum class CIAInstallState : u32 {
     TicketLoaded,
     TMDLoaded,
     ContentWritten,
+};
+
+// A file handled returned for CIAs to be written into and subsequently installed.
+class CIAFile final : public FileSys::FileBackend {
+public:
+    explicit CIAFile(Service::FS::MediaType media_type) : media_type(media_type) {}
+
+    ResultVal<size_t> Read(u64 offset, size_t length, u8* buffer) const override;
+    ResultVal<size_t> WriteTitleMetadata(u64 offset, size_t length, const u8* buffer);
+    ResultVal<size_t> WriteContentData(u64 offset, size_t length, const u8* buffer);
+    ResultVal<size_t> Write(u64 offset, size_t length, bool flush, const u8* buffer) override;
+    u64 GetSize() const override;
+    bool SetSize(u64 size) const override;
+    bool Close() const override;
+    void Flush() const override;
+
+private:
+    // Whether it's installing an update, and what step of installation it is at
+    bool is_update = false;
+    CIAInstallState install_state = CIAInstallState::InstallStarted;
+
+    // How much has been written total, CIAContainer for the installing CIA, buffer of all data
+    // prior to content data, how much of each content index has been written, and where the CIA
+    // is being installed to
+    u64 written = 0;
+    FileSys::CIAContainer container;
+    std::vector<u8> data;
+    std::vector<u64> content_written;
+    Service::FS::MediaType media_type;
 };
 
 /**

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -42,6 +42,15 @@ enum class CIAInstallState : u32 {
     ContentWritten,
 };
 
+enum class InstallStatus : u32 {
+    Success,
+    ErrorFailedToOpenFile,
+    ErrorFileNotFound,
+    ErrorAborted,
+    ErrorInvalid,
+    ErrorEncrypted,
+};
+
 // Progress callback for InstallCIA, recieves bytes written and total bytes
 using ProgressCallback = void(size_t, size_t);
 
@@ -83,8 +92,8 @@ private:
  * @param update_callback callback function called during filesystem write
  * @returns bool whether the install was successful
  */
-bool InstallCIA(const std::string& path,
-                std::function<ProgressCallback>&& update_callback = nullptr);
+InstallStatus InstallCIA(const std::string& path,
+                         std::function<ProgressCallback>&& update_callback = nullptr);
 
 /**
  * Get the mediatype for an installed title

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -45,6 +45,9 @@ enum class CIAInstallState : u32 {
 class CIAFile final : public FileSys::FileBackend {
 public:
     explicit CIAFile(Service::FS::MediaType media_type) : media_type(media_type) {}
+    ~CIAFile() {
+        Close();
+    }
 
     ResultVal<size_t> Read(u64 offset, size_t length, u8* buffer) const override;
     ResultVal<size_t> WriteTitleMetadata(u64 offset, size_t length, const u8* buffer);

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -39,6 +39,13 @@ enum class CIAInstallState : u32 {
 };
 
 /**
+ * Get the mediatype for an installed title
+ * @param titleId the installed title ID
+ * @returns MediaType which the installed title will reside on
+ */
+Service::FS::MediaType GetTitleMediaType(u64 titleId);
+
+/**
  * Get the .tmd path for a title
  * @param media_type the media the title exists on
  * @param tid the title ID to get


### PR DESCRIPTION
This PR can be reviewed commit-by-commit.

This PR adds command-line CIA installs with the `-i` or `--install=` argument. Installation is done using the `CIAContainer` and `CIAFile` classes, `CIAContainer` to initially check if a CIA is valid, and `CIAFile` to handle the actual installation.

Example CIA installation command:
`citra -i scummvm.cia`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3113)
<!-- Reviewable:end -->
