### PR TITLE
Services/AM: Fix content writing on Windows

### DIFF
--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -149,7 +149,7 @@ public:
                 FileSys::TitleMetadata tmd = container.GetTitleMetadata();
                 FileUtil::IOFile file(
                     GetTitleContentPath(media_type, tmd.GetTitleID(), i, is_update),
-                    content_written[i] ? "a" : "w");
+                    content_written[i] ? "ab" : "wb");
 
                 if (!file.IsOpen())
                     return FileSys::ERROR_INSUFFICIENT_SPACE;


### PR DESCRIPTION
"a" and "w" screws with 0xA (\n) bytes on Windows machines.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3114)
<!-- Reviewable:end -->
