### PR TITLE
file_sys/ncch_container: Expose ncch_offset during instantiation and in OpenFile

### DIFF
--- a/src/core/file_sys/ncch_container.h
+++ b/src/core/file_sys/ncch_container.h
@@ -168,10 +168,10 @@ namespace FileSys {
  */
 class NCCHContainer {
 public:
-    NCCHContainer(const std::string& filepath);
+    NCCHContainer(const std::string& filepath, u32 ncch_offset = 0);
     NCCHContainer() {}
 
-    Loader::ResultStatus OpenFile(const std::string& filepath);
+    Loader::ResultStatus OpenFile(const std::string& filepath, u32 ncch_offset = 0);
 
     /**
      * Ensure ExeFS and exheader is loaded and ready for reading sections
@@ -263,7 +263,7 @@ private:
     bool is_loaded = false;
     bool is_compressed = false;
 
-    u32 ncch_offset = 0; // Offset to NCCH header, can be 0 or after NCSD header
+    u32 ncch_offset = 0; // Offset to NCCH header, can be 0 for NCCHs or non-zero for CIAs/NCSDs
     u32 exefs_offset = 0;
 
     std::string filepath;


### PR DESCRIPTION
Paves the way for proper NCSD loading, NCSD partition parsing in NCCH archives (for the manual applet, DLP, maybe update partitions), parsing of NCCHs held within CIAs (for frontend parsing, possible loaders). Pretty much anything with an NCCH (or several) not at 0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3120)
<!-- Reviewable:end -->
