### PR TITLE
arm_dynarmic: ClearInstructionCache should clear all instruction caches

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -168,7 +168,9 @@ void ARM_Dynarmic::PrepareReschedule() {
 }
 
 void ARM_Dynarmic::ClearInstructionCache() {
-    jit->ClearCache();
+    for (const auto& j : jits) {
+        j.second->ClearCache();
+    }
 }
 
 void ARM_Dynarmic::PageTableChanged() {


### PR DESCRIPTION
Bugfix of 67a70bd.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3135)
<!-- Reviewable:end -->
