### PR TITLE
Kernel/Memory: Added a function to change the memory state of an address range

### DIFF
--- a/src/core/hle/kernel/vm_manager.h
+++ b/src/core/hle/kernel/vm_manager.h
@@ -166,6 +166,21 @@ public:
     ResultVal<VMAHandle> MapMMIO(VAddr target, PAddr paddr, u32 size, MemoryState state,
                                  Memory::MMIORegionPointer mmio_handler);
 
+    /**
+     * Updates the memory state and permissions of the specified range. The range's original memory
+     * state and permissions must match the `expected` parameters.
+     *
+     * @param target The guest address of the beginning of the range.
+     * @param size The size of the range
+     * @param expected_state Expected MemoryState of the range.
+     * @param expected_perms Expected VMAPermission of the range.
+     * @param new_state New MemoryState for the range.
+     * @param new_perms New VMAPermission for the range.
+     */
+    ResultCode ChangeMemoryState(VAddr target, u32 size, MemoryState expected_state,
+                                 VMAPermission expected_perms, MemoryState new_state,
+                                 VMAPermission new_perms);
+
     /// Unmaps a range of addresses, splitting VMAs as necessary.
     ResultCode UnmapRange(VAddr target, u32 size);
 
@@ -224,4 +239,4 @@ private:
     /// Updates the pages corresponding to this VMA so they match the VMA's attributes.
     void UpdatePageTableForVMA(const VirtualMemoryArea& vma);
 };
-}
+} // namespace Kernel

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(tests
     core/file_sys/path_parser.cpp
     core/hle/kernel/hle_ipc.cpp
     core/memory/memory.cpp
+    core/memory/vm_manager.cpp
     glad.cpp
     tests.cpp
 )

--- a/src/tests/core/memory/vm_manager.cpp
+++ b/src/tests/core/memory/vm_manager.cpp
@@ -1,0 +1,138 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <vector>
+#include <catch.hpp>
+#include "core/hle/kernel/errors.h"
+#include "core/hle/kernel/memory.h"
+#include "core/hle/kernel/vm_manager.h"
+#include "core/memory.h"
+
+TEST_CASE("Memory Basics", "[kernel][memory]") {
+    auto block = std::make_shared<std::vector<u8>>(Memory::PAGE_SIZE);
+    SECTION("mapping memory") {
+        // Because of the PageTable, Kernel::VMManager is too big to be created on the stack.
+        auto manager = std::make_unique<Kernel::VMManager>();
+        auto result = manager->MapMemoryBlock(Memory::HEAP_VADDR, block, 0, block->size(),
+                                              Kernel::MemoryState::Private);
+        REQUIRE(result.Code() == RESULT_SUCCESS);
+
+        auto vma = manager->FindVMA(Memory::HEAP_VADDR);
+        CHECK(vma != manager->vma_map.end());
+        CHECK(vma->second.size == block->size());
+        CHECK(vma->second.type == Kernel::VMAType::AllocatedMemoryBlock);
+        CHECK(vma->second.backing_block == block);
+        CHECK(vma->second.meminfo_state == Kernel::MemoryState::Private);
+    }
+
+    SECTION("unmapping memory") {
+        // Because of the PageTable, Kernel::VMManager is too big to be created on the stack.
+        auto manager = std::make_unique<Kernel::VMManager>();
+        auto result = manager->MapMemoryBlock(Memory::HEAP_VADDR, block, 0, block->size(),
+                                              Kernel::MemoryState::Private);
+        REQUIRE(result.Code() == RESULT_SUCCESS);
+
+        ResultCode code = manager->UnmapRange(Memory::HEAP_VADDR, block->size());
+        REQUIRE(code == RESULT_SUCCESS);
+
+        auto vma = manager->FindVMA(Memory::HEAP_VADDR);
+        CHECK(vma != manager->vma_map.end());
+        CHECK(vma->second.type == Kernel::VMAType::Free);
+        CHECK(vma->second.backing_block == nullptr);
+    }
+
+    SECTION("changing memory permissions") {
+        // Because of the PageTable, Kernel::VMManager is too big to be created on the stack.
+        auto manager = std::make_unique<Kernel::VMManager>();
+        auto result = manager->MapMemoryBlock(Memory::HEAP_VADDR, block, 0, block->size(),
+                                              Kernel::MemoryState::Private);
+        REQUIRE(result.Code() == RESULT_SUCCESS);
+
+        ResultCode code = manager->ReprotectRange(Memory::HEAP_VADDR, block->size(),
+                                                  Kernel::VMAPermission::Execute);
+        CHECK(code == RESULT_SUCCESS);
+
+        auto vma = manager->FindVMA(Memory::HEAP_VADDR);
+        CHECK(vma != manager->vma_map.end());
+        CHECK(vma->second.permissions == Kernel::VMAPermission::Execute);
+
+        code = manager->UnmapRange(Memory::HEAP_VADDR, block->size());
+        REQUIRE(code == RESULT_SUCCESS);
+    }
+
+    SECTION("changing memory state") {
+        // Because of the PageTable, Kernel::VMManager is too big to be created on the stack.
+        auto manager = std::make_unique<Kernel::VMManager>();
+        auto result = manager->MapMemoryBlock(Memory::HEAP_VADDR, block, 0, block->size(),
+                                              Kernel::MemoryState::Private);
+        REQUIRE(result.Code() == RESULT_SUCCESS);
+
+        ResultCode code = manager->ReprotectRange(Memory::HEAP_VADDR, block->size(),
+                                                  Kernel::VMAPermission::ReadWrite);
+        REQUIRE(code == RESULT_SUCCESS);
+
+        SECTION("with invalid address") {
+            ResultCode code = manager->ChangeMemoryState(
+                0xFFFFFFFF, block->size(), Kernel::MemoryState::Locked,
+                Kernel::VMAPermission::ReadWrite, Kernel::MemoryState::Aliased,
+                Kernel::VMAPermission::Execute);
+            CHECK(code == Kernel::ERR_INVALID_ADDRESS);
+        }
+
+        SECTION("ignoring the original permissions") {
+            ResultCode code = manager->ChangeMemoryState(
+                Memory::HEAP_VADDR, block->size(), Kernel::MemoryState::Private,
+                Kernel::VMAPermission::None, Kernel::MemoryState::Locked,
+                Kernel::VMAPermission::Write);
+            CHECK(code == RESULT_SUCCESS);
+
+            auto vma = manager->FindVMA(Memory::HEAP_VADDR);
+            CHECK(vma != manager->vma_map.end());
+            CHECK(vma->second.permissions == Kernel::VMAPermission::Write);
+            CHECK(vma->second.meminfo_state == Kernel::MemoryState::Locked);
+        }
+
+        SECTION("enforcing the original permissions with correct expectations") {
+            ResultCode code = manager->ChangeMemoryState(
+                Memory::HEAP_VADDR, block->size(), Kernel::MemoryState::Private,
+                Kernel::VMAPermission::ReadWrite, Kernel::MemoryState::Aliased,
+                Kernel::VMAPermission::Execute);
+            CHECK(code == RESULT_SUCCESS);
+
+            auto vma = manager->FindVMA(Memory::HEAP_VADDR);
+            CHECK(vma != manager->vma_map.end());
+            CHECK(vma->second.permissions == Kernel::VMAPermission::Execute);
+            CHECK(vma->second.meminfo_state == Kernel::MemoryState::Aliased);
+        }
+
+        SECTION("with incorrect permission expectations") {
+            ResultCode code = manager->ChangeMemoryState(
+                Memory::HEAP_VADDR, block->size(), Kernel::MemoryState::Private,
+                Kernel::VMAPermission::Execute, Kernel::MemoryState::Aliased,
+                Kernel::VMAPermission::Execute);
+            CHECK(code == Kernel::ERR_INVALID_ADDRESS_STATE);
+
+            auto vma = manager->FindVMA(Memory::HEAP_VADDR);
+            CHECK(vma != manager->vma_map.end());
+            CHECK(vma->second.permissions == Kernel::VMAPermission::ReadWrite);
+            CHECK(vma->second.meminfo_state == Kernel::MemoryState::Private);
+        }
+
+        SECTION("with incorrect state expectations") {
+            ResultCode code = manager->ChangeMemoryState(
+                Memory::HEAP_VADDR, block->size(), Kernel::MemoryState::Locked,
+                Kernel::VMAPermission::ReadWrite, Kernel::MemoryState::Aliased,
+                Kernel::VMAPermission::Execute);
+            CHECK(code == Kernel::ERR_INVALID_ADDRESS_STATE);
+
+            auto vma = manager->FindVMA(Memory::HEAP_VADDR);
+            CHECK(vma != manager->vma_map.end());
+            CHECK(vma->second.permissions == Kernel::VMAPermission::ReadWrite);
+            CHECK(vma->second.meminfo_state == Kernel::MemoryState::Private);
+        }
+
+        code = manager->UnmapRange(Memory::HEAP_VADDR, block->size());
+        REQUIRE(code == RESULT_SUCCESS);
+    }
+}


### PR DESCRIPTION
This function will be useful when implementing memory aliasing operations, see https://github.com/citra-emu/citra/commit/e55583d4f9f89b2e60da5fdda710e447ab7dabe9 for a draft of what's to come.

The function will enforce that the permissions and memory state of each block in the range match the input parameters before carving and updating the VMA.

Also added some VMManager tests, more to come.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3136)
<!-- Reviewable:end -->
