### PR TITLE
Kernel/IPC: Implement MappedBuffer translation for HLE services that use the HLERequestContext architecture.

### DIFF
--- a/src/core/hle/ipc_helpers.h
+++ b/src/core/hle/ipc_helpers.h
@@ -121,7 +121,11 @@ public:
     [[deprecated]] void PushStaticBuffer(VAddr buffer_vaddr, size_t size, u8 buffer_id);
     void PushStaticBuffer(const std::vector<u8>& buffer, u8 buffer_id);
 
-    void PushMappedBuffer(VAddr buffer_vaddr, size_t size, MappedBufferPermissions perms);
+    [[deprecated]] void PushMappedBuffer(VAddr buffer_vaddr, size_t size,
+                                         MappedBufferPermissions perms);
+
+    /// Pushes an HLE MappedBuffer interface back to unmapped the buffer.
+    void PushMappedBuffer(const Kernel::MappedBuffer& mapped_buffer);
 };
 
 /// Push ///
@@ -211,6 +215,11 @@ inline void RequestBuilder::PushMappedBuffer(VAddr buffer_vaddr, size_t size,
                                              MappedBufferPermissions perms) {
     Push(MappedBufferDesc(size, perms));
     Push(buffer_vaddr);
+}
+
+inline void RequestBuilder::PushMappedBuffer(const Kernel::MappedBuffer& mapped_buffer) {
+    Push(mapped_buffer.GenerateDescriptor());
+    Push(mapped_buffer.GetId());
 }
 
 class RequestParser : public RequestHelperBase {
@@ -333,8 +342,11 @@ public:
      * @param[out] buffer_perms If non-null, the pointed value will be set to the permissions of the
      * buffer
      */
-    VAddr PopMappedBuffer(size_t* data_size = nullptr,
-                          MappedBufferPermissions* buffer_perms = nullptr);
+    [[deprecated]] VAddr PopMappedBuffer(size_t* data_size,
+                                         MappedBufferPermissions* buffer_perms = nullptr);
+
+    /// Pops a mapped buffer descriptor with its vaddr and resolves it to an HLE interface
+    Kernel::MappedBuffer& PopMappedBuffer();
 
     /**
      * @brief Reads the next normal parameters as a struct, by copying it
@@ -495,6 +507,13 @@ inline VAddr RequestParser::PopMappedBuffer(size_t* data_size,
     if (buffer_perms != nullptr)
         *buffer_perms = bufferInfo.perms;
     return Pop<VAddr>();
+}
+
+inline Kernel::MappedBuffer& RequestParser::PopMappedBuffer() {
+    u32 mapped_buffer_descriptor = Pop<u32>();
+    ASSERT_MSG(GetDescriptorType(mapped_buffer_descriptor) == MappedBuffer,
+               "Tried to pop mapped buffer but the descriptor is not a mapped buffer descriptor");
+    return context->GetMappedBuffer(Pop<u32>());
 }
 
 } // namespace IPC

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -107,6 +107,12 @@ ResultCode HLERequestContext::PopulateFromIncomingCommandBuffer(const u32_le* sr
             cmd_buf[i++] = source_address;
             break;
         }
+        case IPC::DescriptorType::MappedBuffer: {
+            u32 next_id = static_cast<u32>(request_mapped_buffers.size());
+            request_mapped_buffers.emplace_back(src_process, descriptor, src_cmdbuf[i], next_id);
+            cmd_buf[i++] = next_id;
+            break;
+        }
         default:
             UNIMPLEMENTED_MSG("Unsupported handle translation: 0x%08X", descriptor);
         }
@@ -166,12 +172,41 @@ ResultCode HLERequestContext::WriteToOutgoingCommandBuffer(u32_le* dst_cmdbuf, P
             dst_cmdbuf[i++] = target_address;
             break;
         }
+        case IPC::DescriptorType::MappedBuffer: {
+            VAddr addr = request_mapped_buffers[cmd_buf[i]].address;
+            dst_cmdbuf[i++] = addr;
+            break;
+        }
         default:
             UNIMPLEMENTED_MSG("Unsupported handle translation: 0x%08X", descriptor);
         }
     }
 
     return RESULT_SUCCESS;
+}
+
+MappedBuffer& HLERequestContext::GetMappedBuffer(u32 id_from_cmdbuf) {
+    ASSERT_MSG(id_from_cmdbuf < request_mapped_buffers.size(), "Mapped Buffer ID out of range!");
+    return request_mapped_buffers[id_from_cmdbuf];
+}
+
+MappedBuffer::MappedBuffer(const Process& process, u32 descriptor, VAddr address, u32 id)
+    : process(&process), address(address), id(id) {
+    IPC::MappedBufferDescInfo desc{descriptor};
+    size = desc.size;
+    perms = desc.perms;
+}
+
+void MappedBuffer::Read(void* dest_buffer, size_t offset, size_t size) {
+    ASSERT(perms & IPC::R);
+    ASSERT(offset + size <= this->size);
+    Memory::ReadBlock(*process, address + offset, dest_buffer, size);
+}
+
+void MappedBuffer::Write(const void* src_buffer, size_t offset, size_t size) {
+    ASSERT(perms & IPC::W);
+    ASSERT(offset + size <= this->size);
+    Memory::WriteBlock(*process, address + offset, src_buffer, size);
 }
 
 } // namespace Kernel

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -63,6 +63,35 @@ protected:
     std::vector<SharedPtr<ServerSession>> connected_sessions;
 };
 
+class MappedBuffer {
+public:
+    MappedBuffer(const Process& process, u32 descriptor, VAddr address, u32 id);
+
+    // interface for service
+    void Read(void* dest_buffer, size_t offset, size_t size);
+    void Write(const void* src_buffer, size_t offset, size_t size);
+    size_t GetSize() const {
+        return size;
+    }
+
+    // interface for ipc helper
+    u32 GenerateDescriptor() const {
+        return IPC::MappedBufferDesc(size, perms);
+    }
+
+    u32 GetId() const {
+        return id;
+    }
+
+private:
+    friend class HLERequestContext;
+    u32 id;
+    VAddr address;
+    const Process* process;
+    size_t size;
+    IPC::MappedBufferPermissions perms;
+};
+
 /**
  * Class containing information about an in-flight IPC request being handled by an HLE service
  * implementation. Services should avoid using old global APIs (e.g. Kernel::GetCommandBuffer()) and
@@ -81,6 +110,17 @@ protected:
  * The end result is similar to just giving services their own real handle tables, but since these
  * ids are local to a specific context, it avoids requiring services to manage handles for objects
  * across multiple calls and ensuring that unneeded handles are cleaned up.
+ *
+ * HLE mapped buffer protocol
+ * ==========================
+ *
+ * HLE services don't have their own virtual memory space, a tweaked protocol is used to simulate
+ * memory mapping. The kernel will wrap the incoming buffers into a memory interface on which HLE
+ * services can operate, and insert a id in the buffer where the vaddr would normally be. The
+ * service then calls GetMappedBuffer with that id to get the memory interface. On response, like
+ * real services pushing back the mapped buffer address to unmap it, HLE services push back the
+ * id of the memory interface and let kernel convert it back to client vaddr. No real unmapping is
+ * needed in this case, though.
  */
 class HLERequestContext {
 public:
@@ -131,6 +171,12 @@ public:
      */
     void AddStaticBuffer(u8 buffer_id, std::vector<u8> data);
 
+    /**
+     * Gets a memory interface by the id from the request command buffer. See the "HLE mapped buffer
+     * protocol" section in the class documentation for more details.
+     */
+    MappedBuffer& GetMappedBuffer(u32 id_from_cmdbuf);
+
     /// Populates this context with data from the requesting process/thread.
     ResultCode PopulateFromIncomingCommandBuffer(const u32_le* src_cmdbuf, Process& src_process,
                                                  HandleTable& src_table);
@@ -145,6 +191,8 @@ private:
     boost::container::small_vector<SharedPtr<Object>, 8> request_handles;
     // The static buffers will be created when the IPC request is translated.
     std::array<std::vector<u8>, IPC::MAX_STATIC_BUFFERS> static_buffers;
+    // The mapped buffers will be created when the IPC request is translated
+    boost::container::small_vector<MappedBuffer, 8> request_mapped_buffers;
 };
 
 } // namespace Kernel

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -520,7 +520,7 @@ void DeleteContents(Service::Interface* self) {
     u8 media_type = rp.Pop<u8>();
     u64 title_id = rp.Pop<u64>();
     u32 content_count = rp.Pop<u32>();
-    VAddr content_ids_in = rp.PopMappedBuffer();
+    VAddr content_ids_in = rp.PopMappedBuffer(nullptr);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     rb.Push(RESULT_SUCCESS);
@@ -534,7 +534,7 @@ void GetProgramList(Service::Interface* self) {
 
     u32 count = rp.Pop<u32>();
     u8 media_type = rp.Pop<u8>();
-    VAddr title_ids_output_pointer = rp.PopMappedBuffer();
+    VAddr title_ids_output_pointer = rp.PopMappedBuffer(nullptr);
 
     if (!Memory::IsValidVirtualAddress(title_ids_output_pointer) || media_type > 2) {
         IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
@@ -679,7 +679,7 @@ void ListDataTitleTicketInfos(Service::Interface* self) {
     u32 ticket_count = rp.Pop<u32>();
     u64 title_id = rp.Pop<u64>();
     u32 start_index = rp.Pop<u32>();
-    VAddr ticket_info_out = rp.PopMappedBuffer();
+    VAddr ticket_info_out = rp.PopMappedBuffer(nullptr);
     VAddr ticket_info_write = ticket_info_out;
 
     for (u32 i = 0; i < ticket_count; i++) {
@@ -754,7 +754,7 @@ void GetTicketList(Service::Interface* self) {
     IPC::RequestParser rp(Kernel::GetCommandBuffer(), 9, 2, 2); // 0x00090082
     u32 ticket_list_count = rp.Pop<u32>();
     u32 ticket_index = rp.Pop<u32>();
-    VAddr ticket_tids_out = rp.PopMappedBuffer();
+    VAddr ticket_tids_out = rp.PopMappedBuffer(nullptr);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
     rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/fs/archive.h
+++ b/src/core/hle/service/fs/archive.h
@@ -10,6 +10,7 @@
 #include "core/file_sys/archive_backend.h"
 #include "core/hle/kernel/hle_ipc.h"
 #include "core/hle/result.h"
+#include "core/hle/service/service.h"
 
 namespace FileSys {
 class DirectoryBackend;
@@ -47,7 +48,9 @@ enum class MediaType : u32 { NAND = 0, SDMC = 1, GameCard = 2 };
 
 typedef u64 ArchiveHandle;
 
-class File final : public Kernel::SessionRequestHandler {
+// TODO: File is not a real service, but it can still utilize ServiceFramework::RegisterHandlers.
+// Consider splitting ServiceFramework interface.
+class File final : public ServiceFramework<File> {
 public:
     File(std::unique_ptr<FileSys::FileBackend>&& backend, const FileSys::Path& path);
     ~File();
@@ -60,8 +63,16 @@ public:
     u32 priority;       ///< Priority of the file. TODO(Subv): Find out what this means
     std::unique_ptr<FileSys::FileBackend> backend; ///< File backend interface
 
-protected:
-    void HandleSyncRequest(Kernel::SharedPtr<Kernel::ServerSession> server_session) override;
+private:
+    void Read(Kernel::HLERequestContext& ctx);
+    void Write(Kernel::HLERequestContext& ctx);
+    void GetSize(Kernel::HLERequestContext& ctx);
+    void SetSize(Kernel::HLERequestContext& ctx);
+    void Close(Kernel::HLERequestContext& ctx);
+    void Flush(Kernel::HLERequestContext& ctx);
+    void SetPriority(Kernel::HLERequestContext& ctx);
+    void GetPriority(Kernel::HLERequestContext& ctx);
+    void OpenLinkFile(Kernel::HLERequestContext& ctx);
 };
 
 class Directory final : public Kernel::SessionRequestHandler {


### PR DESCRIPTION
The last missing block of `HLERequestContext`. A `MappedBuffer` object is used to represent the memory block the kernel sets up for the service.

Note that this kind of translation is asymmetrical: for client->service request, the kernel sets up the mapped buffer; for service->client response, the kernel unmaps the buffer instead. Because `MappedBuffer`'s lifetime is managed by the context, we don't need to do anything in the response other than modifying the command buffer.

In the test, the reading buffer (with permission R) is tested in command buffer request, while writing buffer (with permission W) is tested after command buffer response. This is because the real kernel can copy the buffer data only after unmapping when handling response, and the HLE implementation can be in the same way (although it is not in this code).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3138)
<!-- Reviewable:end -->
