### PR TITLE
Appveyor: on mingw set cmake version to 3.9.6

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,14 +26,15 @@ install:
   - git submodule update --init --recursive
   - ps: |
         if ($env:BUILD_TYPE -eq 'mingw') {
-          $dependencies = "mingw64/mingw-w64-x86_64-cmake",
-                          "mingw64/mingw-w64-x86_64-qt5",
+          $dependencies = "mingw64/mingw-w64-x86_64-qt5",
                           "mingw64/mingw-w64-x86_64-curl"
           # redirect err to null to prevent warnings from becoming errors
           # workaround to prevent pacman from failing due to cyclical dependencies
           C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S mingw64/mingw-w64-x86_64-freetype mingw64/mingw-w64-x86_64-fontconfig" 2> $null
           C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-SDL2-2.0.5-2-any.pkg.tar.xz" 2> $null
           C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S $dependencies" 2> $null
+          # stick to cmake 3.9.6 since on lower versions it could happen that cmake generates a Makefile that links against gcc_eh
+          C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-cmake-3.9.6-1-any.pkg.tar.xz" 2> $null
         }
 
 before_build:


### PR DESCRIPTION
This fixes #3051. The main cause is described here https://gitlab.kitware.com/cmake/cmake/issues/17436. Appveyor currently uses cmake 3.9.2 which has this issue. In 3.9.6 the issue is fixed. So we set mingw to use that version. This will also prevent future updates of cmake (which can be positive and negative). The other solution described in the link would be to insert `list(REMOVE_ITEM CMAKE_C_IMPLICIT_LINK_LIBRARIES gcc_eh)`.

Since i can't go in-game with my Windows VM I only tested that citra doesn't crash on verifying the token. Would be good to test if the other crashes are fixed, too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3141)
<!-- Reviewable:end -->
