### PR TITLE
shader_jit_x64_compiler: Remove ABI overhead of LG2 and EX2

### DIFF
--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -13,11 +13,17 @@ set(HEADERS
             core/arm/arm_test_common.h
             )
 
+if (ARCHITECTURE_x86_64)
+    set(SRCS ${SRCS}
+            video_core/shader/shader_jit_x64_compiler.cpp
+            )
+endif()
+
 create_directory_groups(${SRCS} ${HEADERS})
 
 add_executable(tests ${SRCS} ${HEADERS})
-target_link_libraries(tests PRIVATE common core)
+target_link_libraries(tests PRIVATE common core video_core)
 target_link_libraries(tests PRIVATE glad) # To support linker work-around
-target_link_libraries(tests PRIVATE ${PLATFORM_LIBRARIES} catch-single-include Threads::Threads)
+target_link_libraries(tests PRIVATE ${PLATFORM_LIBRARIES} catch-single-include nihstro-headers Threads::Threads)
 
 add_test(NAME tests COMMAND tests)

--- a/src/tests/video_core/shader/shader_jit_x64_compiler.cpp
+++ b/src/tests/video_core/shader/shader_jit_x64_compiler.cpp
@@ -1,0 +1,91 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <catch.hpp>
+#include <nihstro/inline_assembly.h>
+#include "video_core/shader/shader_jit_x64_compiler.h"
+
+using float24 = Pica::float24;
+using JitShader = Pica::Shader::JitShader;
+
+using DestRegister = nihstro::DestRegister;
+using OpCode = nihstro::OpCode;
+using SourceRegister = nihstro::SourceRegister;
+
+static std::unique_ptr<JitShader> CompileShader(std::initializer_list<nihstro::InlineAsm> code) {
+    const auto shbin = nihstro::InlineAsm::CompileToRawBinary(code);
+
+    std::array<u32, Pica::Shader::MAX_PROGRAM_CODE_LENGTH> program_code{};
+    std::array<u32, Pica::Shader::MAX_SWIZZLE_DATA_LENGTH> swizzle_data{};
+
+    std::transform(shbin.program.begin(), shbin.program.end(), program_code.begin(),
+                   [](const auto& x) { return x.hex; });
+    std::transform(shbin.swizzle_table.begin(), shbin.swizzle_table.end(), swizzle_data.begin(),
+                   [](const auto& x) { return x.hex; });
+
+    auto shader = std::make_unique<JitShader>();
+    shader->Compile(&program_code, &swizzle_data);
+
+    return shader;
+}
+
+class ShaderTest {
+public:
+    explicit ShaderTest(std::initializer_list<nihstro::InlineAsm> code)
+        : shader(CompileShader(code)) {}
+
+    float Run(float input) {
+        Pica::Shader::ShaderSetup shader_setup;
+        Pica::Shader::UnitState shader_unit;
+
+        shader_unit.registers.input[0].x = float24::FromFloat32(input);
+        shader->Run(shader_setup, shader_unit, 0);
+        return shader_unit.registers.output[0].x.ToFloat32();
+    }
+
+public:
+    std::unique_ptr<JitShader> shader;
+};
+
+TEST_CASE("LG2", "[video_core][shader][shader_jit]") {
+    const auto sh_input = SourceRegister::MakeInput(0);
+    const auto sh_output = DestRegister::MakeOutput(0);
+
+    auto shader = ShaderTest({
+        // clang-format off
+        {OpCode::Id::LG2, sh_output, sh_input},
+        {OpCode::Id::END},
+        // clang-format on
+    });
+
+    REQUIRE(std::isnan(shader.Run(NAN)));
+    REQUIRE(std::isnan(shader.Run(-1.f)));
+    REQUIRE(std::isinf(shader.Run(0.f)));
+    REQUIRE(shader.Run(4.f) == Approx(2.f));
+    REQUIRE(shader.Run(64.f) == Approx(6.f));
+    REQUIRE(shader.Run(1.e24f) == Approx(79.7262742773f));
+}
+
+TEST_CASE("EX2", "[video_core][shader][shader_jit]") {
+    const auto sh_input = SourceRegister::MakeInput(0);
+    const auto sh_output = DestRegister::MakeOutput(0);
+
+    auto shader = ShaderTest({
+        // clang-format off
+        {OpCode::Id::EX2, sh_output, sh_input},
+        {OpCode::Id::END},
+        // clang-format on
+    });
+
+    REQUIRE(std::isnan(shader.Run(NAN)));
+    REQUIRE(shader.Run(-800.f) == Approx(0.f));
+    REQUIRE(shader.Run(0.f) == Approx(1.f));
+    REQUIRE(shader.Run(2.f) == Approx(4.f));
+    REQUIRE(shader.Run(6.f) == Approx(64.f));
+    REQUIRE(shader.Run(79.7262742773f) == Approx(1.e24f));
+    REQUIRE(std::isinf(shader.Run(800.f)));
+}

--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -87,7 +87,7 @@ target_link_libraries(video_core PUBLIC common core)
 target_link_libraries(video_core PRIVATE glad nihstro-headers)
 
 if (ARCHITECTURE_x86_64)
-    target_link_libraries(video_core PRIVATE xbyak)
+    target_link_libraries(video_core PUBLIC xbyak)
 endif()
 
 if (PNG_FOUND)

--- a/src/video_core/shader/shader_jit_x64_compiler.h
+++ b/src/video_core/shader/shader_jit_x64_compiler.h
@@ -106,6 +106,13 @@ private:
      */
     void FindReturnOffsets();
 
+    /**
+     * Emits data and code for utility functions.
+     */
+    void CompilePrelude();
+    Xbyak::Label CompilePrelude_Log2();
+    Xbyak::Label CompilePrelude_Exp2();
+
     const std::array<u32, MAX_PROGRAM_CODE_LENGTH>* program_code = nullptr;
     const std::array<u32, MAX_SWIZZLE_DATA_LENGTH>* swizzle_data = nullptr;
 
@@ -120,6 +127,9 @@ private:
 
     using CompiledShader = void(const void* setup, void* state, const u8* start_addr);
     CompiledShader* program = nullptr;
+
+    Xbyak::Label log2_subroutine;
+    Xbyak::Label exp2_subroutine;
 };
 
 } // Shader


### PR DESCRIPTION
We reimplement log2f and exp2f in assembly.

Algorithms were inspired by those found in Mesa I've used a higher order approximation for exp2 than they did for more accuracy.

Performance numbers (for 1.2 billion sequential calls of the same instruction on my machine):

| Instruction | Old time | New time |
| ------------- | ------------- |  ------------- |
| `ex2` | 21.5s | 8.8s |
| `lg2` | 13.3s | 7.3s |

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3145)
<!-- Reviewable:end -->
