### PR TITLE
citra-qt: Print stack trace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,7 +253,7 @@ IF (APPLE)
 ELSEIF (WIN32)
     # WSAPoll and SHGetKnownFolderPath (AppData/Roaming) didn't exist before WinNT 6.x (Vista)
     add_definitions(-D_WIN32_WINNT=0x0600 -DWINVER=0x0600)
-    set(PLATFORM_LIBRARIES dbghelp winmm ws2_32)
+    set(PLATFORM_LIBRARIES dbghelp ole32 shell32 winmm ws2_32)
     IF (MINGW)
         # PSAPI is the Process Status API
         set(PLATFORM_LIBRARIES ${PLATFORM_LIBRARIES} psapi imm32 version)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,7 +253,7 @@ IF (APPLE)
 ELSEIF (WIN32)
     # WSAPoll and SHGetKnownFolderPath (AppData/Roaming) didn't exist before WinNT 6.x (Vista)
     add_definitions(-D_WIN32_WINNT=0x0600 -DWINVER=0x0600)
-    set(PLATFORM_LIBRARIES winmm ws2_32)
+    set(PLATFORM_LIBRARIES dbghelp winmm ws2_32)
     IF (MINGW)
         # PSAPI is the Process Status API
         set(PLATFORM_LIBRARIES ${PLATFORM_LIBRARIES} psapi imm32 version)

--- a/src/citra_qt/CMakeLists.txt
+++ b/src/citra_qt/CMakeLists.txt
@@ -146,7 +146,7 @@ endif()
 create_target_directory_groups(citra-qt)
 
 target_link_libraries(citra-qt PRIVATE audio_core common core input_common network video_core)
-target_link_libraries(citra-qt PRIVATE Boost::boost glad nihstro-headers Qt5::OpenGL Qt5::Widgets)
+target_link_libraries(citra-qt PRIVATE Boost::boost fmt glad nihstro-headers Qt5::OpenGL Qt5::Widgets)
 target_link_libraries(citra-qt PRIVATE ${PLATFORM_LIBRARIES} Threads::Threads)
 
 if(UNIX AND NOT APPLE)

--- a/src/citra_qt/CMakeLists.txt
+++ b/src/citra_qt/CMakeLists.txt
@@ -28,6 +28,8 @@ add_executable(citra-qt
     configuration/configure_system.h
     configuration/configure_web.cpp
     configuration/configure_web.h
+    crash_dialog/crash_dialog.cpp
+    crash_dialog/crash_dialog.h
     debugger/graphics/graphics.cpp
     debugger/graphics/graphics.h
     debugger/graphics/graphics_breakpoint_observer.cpp
@@ -78,6 +80,7 @@ set(UIS
     configuration/configure_input.ui
     configuration/configure_system.ui
     configuration/configure_web.ui
+    crash_dialog/crash_dialog.ui
     debugger/registers.ui
     aboutdialog.ui
     hotkeys.ui

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -1,6 +1,9 @@
 #include <QApplication>
+#include <QDateTime>
+#include <QDir>
 #include <QHBoxLayout>
 #include <QKeyEvent>
+#include <QStandardPaths>
 #include <QScreen>
 #include <QWindow>
 
@@ -17,7 +20,14 @@
 #include "input_common/motion_emu.h"
 #include "network/network.h"
 
+static std::string GenerateMinidumpFilename() {
+    QString dir = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
+    QString file = QDateTime::currentDateTime().toString("'minidump-citra-'yyyyMMdd-HHmmss'.dmp'");
+    return QDir::toNativeSeparators(dir + "/" + file).toStdString();
+}
+
 EmuThread::EmuThread(GRenderWindow* render_window) : render_window(render_window) {
+    // Custom types must be registered to be used with Qt signals/slots.
     qRegisterMetaType<Common::CrashInformation>("Common::CrashInformation");
 }
 
@@ -64,7 +74,8 @@ void EmuThread::run() {
                 }
             }
         },
-        [&](const Common::CrashInformation& crash_info) { emit Crashed(crash_info); });
+        [&](const Common::CrashInformation& crash_info) { emit Crashed(crash_info); },
+        GenerateMinidumpFilename());
 
     // Shutdown the core emulation
     Core::System::GetInstance().Shutdown();

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -3,12 +3,12 @@
 #include <QDir>
 #include <QHBoxLayout>
 #include <QKeyEvent>
-#include <QStandardPaths>
 #include <QScreen>
 #include <QWindow>
 
 #include "citra_qt/bootmanager.h"
 #include "common/crash_handler.h"
+#include "common/file_util.h"
 #include "common/microprofile.h"
 #include "common/scm_rev.h"
 #include "common/string_util.h"
@@ -21,7 +21,7 @@
 #include "network/network.h"
 
 static std::string GenerateMinidumpFilename() {
-    QString dir = QStandardPaths::writableLocation(QStandardPaths::DesktopLocation);
+    QString dir = QString::fromStdString(FileUtil::GetUserPath(D_LOGS_IDX));
     QString file = QDateTime::currentDateTime().toString("'minidump-citra-'yyyyMMdd-HHmmss'.dmp'");
     return QDir::toNativeSeparators(dir + "/" + file).toStdString();
 }

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -5,6 +5,7 @@
 #include <QWindow>
 
 #include "citra_qt/bootmanager.h"
+#include "common/crash_handler.h"
 #include "common/microprofile.h"
 #include "common/scm_rev.h"
 #include "common/string_util.h"
@@ -16,7 +17,9 @@
 #include "input_common/motion_emu.h"
 #include "network/network.h"
 
-EmuThread::EmuThread(GRenderWindow* render_window) : render_window(render_window) {}
+EmuThread::EmuThread(GRenderWindow* render_window) : render_window(render_window) {
+    qRegisterMetaType<Common::CrashInformation>("Common::CrashInformation");
+}
 
 void EmuThread::run() {
     render_window->MakeCurrent();
@@ -25,39 +28,43 @@ void EmuThread::run() {
 
     stop_run = false;
 
-    // Holds whether the cpu was running during the last iteration,
-    // so that the DebugModeLeft signal can be emitted before the
-    // next execution step.
-    bool was_active = false;
-    while (!stop_run) {
-        if (running) {
-            if (!was_active)
-                emit DebugModeLeft();
+    Common::CrashHandler(
+        [&]() {
+            // Holds whether the cpu was running during the last iteration,
+            // so that the DebugModeLeft signal can be emitted before the
+            // next execution step.
+            bool was_active = false;
+            while (!stop_run) {
+                if (running) {
+                    if (!was_active)
+                        emit DebugModeLeft();
 
-            Core::System::ResultStatus result = Core::System::GetInstance().RunLoop();
-            if (result != Core::System::ResultStatus::Success) {
-                this->SetRunning(false);
-                emit ErrorThrown(result, Core::System::GetInstance().GetStatusDetails());
+                    Core::System::ResultStatus result = Core::System::GetInstance().RunLoop();
+                    if (result != Core::System::ResultStatus::Success) {
+                        this->SetRunning(false);
+                        emit ErrorThrown(result, Core::System::GetInstance().GetStatusDetails());
+                    }
+
+                    was_active = running || exec_step;
+                    if (!was_active && !stop_run)
+                        emit DebugModeEntered();
+                } else if (exec_step) {
+                    if (!was_active)
+                        emit DebugModeLeft();
+
+                    exec_step = false;
+                    Core::System::GetInstance().SingleStep();
+                    emit DebugModeEntered();
+                    yieldCurrentThread();
+
+                    was_active = false;
+                } else {
+                    std::unique_lock<std::mutex> lock(running_mutex);
+                    running_cv.wait(lock, [this] { return IsRunning() || exec_step || stop_run; });
+                }
             }
-
-            was_active = running || exec_step;
-            if (!was_active && !stop_run)
-                emit DebugModeEntered();
-        } else if (exec_step) {
-            if (!was_active)
-                emit DebugModeLeft();
-
-            exec_step = false;
-            Core::System::GetInstance().SingleStep();
-            emit DebugModeEntered();
-            yieldCurrentThread();
-
-            was_active = false;
-        } else {
-            std::unique_lock<std::mutex> lock(running_mutex);
-            running_cv.wait(lock, [this] { return IsRunning() || exec_step || stop_run; });
-        }
-    }
+        },
+        [&](const Common::CrashInformation& crash_info) { emit Crashed(crash_info); });
 
     // Shutdown the core emulation
     Core::System::GetInstance().Shutdown();

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -20,6 +20,10 @@ class GGLWidgetInternal;
 class GMainWindow;
 class GRenderWindow;
 
+namespace Common {
+struct CrashInformation;
+}
+
 class EmuThread : public QThread {
     Q_OBJECT
 
@@ -97,6 +101,14 @@ signals:
      * Qt::BlockingQueuedConnection (additionally block source thread until slot returns)
      */
     void DebugModeLeft();
+
+    /**
+     * Emitted when the emulation thread crashes
+     *
+     * @warning Terminate the application soon after this signal is emitted. The program may
+     * not be in a well-defined state.
+     */
+    void Crashed(const Common::CrashInformation&);
 
     void ErrorThrown(Core::System::ResultStatus, std::string);
 };

--- a/src/citra_qt/crash_dialog/crash_dialog.cpp
+++ b/src/citra_qt/crash_dialog/crash_dialog.cpp
@@ -1,0 +1,39 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <memory>
+#include "common/crash_handler.h"
+#include "common/scm_rev.h"
+#include "crash_dialog.h"
+#include "ui_crash_dialog.h"
+
+CrashDialog::CrashDialog(QWidget* parent, const Common::CrashInformation& crash_info)
+    : QDialog(parent), ui(std::make_unique<Ui::CrashDialog>()) {
+    ui->setupUi(this);
+
+    ui->informational_box->clear();
+    ui->informational_box->appendPlainText("Citra Crash Information");
+    ui->informational_box->appendPlainText("===========================");
+    ui->informational_box->appendPlainText("Build information:");
+    ui->informational_box->appendPlainText(Common::g_build_date);
+    ui->informational_box->appendPlainText(Common::g_build_name);
+    ui->informational_box->appendPlainText("Revision:");
+    ui->informational_box->appendPlainText(Common::g_scm_rev);
+    ui->informational_box->appendPlainText("Branch:");
+    ui->informational_box->appendPlainText(Common::g_scm_branch);
+    ui->informational_box->appendPlainText(Common::g_scm_desc);
+    ui->informational_box->appendPlainText("Stack trace:");
+    for (const auto& line : crash_info.stack_trace) {
+        ui->informational_box->appendPlainText(QString::fromStdString(line));
+    }
+
+    ui->informational_box->moveCursor(QTextCursor::Start);
+    ui->informational_box->ensureCursorVisible();
+}
+
+CrashDialog::~CrashDialog() = default;
+
+void CrashDialog::on_view_minidump_button_released() {
+    // QMessageBox::critical(0, "Citra", "Unimplemented", QMessageBox::Ok);
+}

--- a/src/citra_qt/crash_dialog/crash_dialog.h
+++ b/src/citra_qt/crash_dialog/crash_dialog.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 #include <QDialog>
 
 namespace Ui {
@@ -26,5 +27,8 @@ private slots:
     void on_view_minidump_button_released();
 
 private:
+    void AddLine(const std::string& str);
+
     std::unique_ptr<Ui::CrashDialog> ui;
+    QString minidump_filename;
 };

--- a/src/citra_qt/crash_dialog/crash_dialog.h
+++ b/src/citra_qt/crash_dialog/crash_dialog.h
@@ -1,0 +1,30 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include <QDialog>
+
+namespace Ui {
+class CrashDialog;
+}
+
+namespace Common {
+struct CrashInformation;
+}
+
+class CrashDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    CrashDialog(QWidget* parent, const Common::CrashInformation& crash_info);
+    ~CrashDialog();
+
+private slots:
+    void on_view_minidump_button_released();
+
+private:
+    std::unique_ptr<Ui::CrashDialog> ui;
+};

--- a/src/citra_qt/crash_dialog/crash_dialog.ui
+++ b/src/citra_qt/crash_dialog/crash_dialog.ui
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>CrashDialog</class>
+ <widget class="QDialog" name="CrashDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>398</width>
+    <height>320</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Citra has crashed</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>&lt;p&gt;Citra has crashed.&lt;/p&gt;&lt;p&gt;You may report this on &lt;a href=&quot;https://community.citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;our forums&lt;/span&gt;&lt;/a&gt;. Please copy-and-paste the below into your report.&lt;/p&gt;</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPlainTextEdit" name="informational_box">
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="view_minidump_button">
+       <property name="text">
+        <string>View Minidump</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <layoutdefault spacing="6" margin="11"/>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/citra_qt/crash_dialog/crash_dialog.ui
+++ b/src/citra_qt/crash_dialog/crash_dialog.ui
@@ -51,6 +51,9 @@
        <property name="text">
         <string>View Minidump</string>
        </property>
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
       </widget>
      </item>
     </layout>

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -12,6 +12,10 @@
 #include "core/hle/service/am/am.h"
 #include "ui_main.h"
 
+namespace Common {
+struct CrashInformation;
+}
+
 class AboutDialog;
 class Config;
 class EmuThread;
@@ -157,6 +161,7 @@ private slots:
     void HideFullscreen();
     void ToggleWindowMode();
     void OnCreateGraphicsSurfaceViewer();
+    void OnCrashed(const Common::CrashInformation&);
     void OnCoreError(Core::System::ResultStatus, std::string);
     /// Called whenever a user selects Help->About Citra
     void OnMenuAboutCitra();

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -40,6 +40,8 @@ add_library(common STATIC
     common_funcs.h
     common_paths.h
     common_types.h
+    crash_handler.cpp
+    crash_handler.h
     file_util.cpp
     file_util.h
     hash.h

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -78,6 +78,7 @@ add_library(common STATIC
     threadsafe_queue.h
     timer.cpp
     timer.h
+    ui_util.h
     vector_math.h
 )
 
@@ -89,6 +90,23 @@ if(ARCHITECTURE_x86_64)
             x64/cpu_detect.h
             x64/xbyak_abi.h
             x64/xbyak_util.h
+    )
+endif()
+
+if (WIN32)
+    target_sources(common
+        PRIVATE
+            ui_util_windows.cpp
+    )
+elseif (APPLE)
+    target_sources(common
+        PRIVATE
+            ui_util_macos.mm
+    )
+else()
+    target_sources(common
+        PRIVATE
+            ui_util_linux.cpp
     )
 endif()
 

--- a/src/common/crash_handler.cpp
+++ b/src/common/crash_handler.cpp
@@ -1,0 +1,191 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "common/crash_handler.h"
+
+#ifdef _WIN32
+
+#include <windows.h>
+// windows.h must be included first.
+#include <dbghelp.h>
+
+#include <csetjmp>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include "common/scope_exit.h"
+#include "common/string_util.h"
+
+namespace Common {
+
+static bool unhandled_exception_called;
+static std::jmp_buf unhandled_exception_jmp_buf;
+static std::vector<std::string> unhandled_exception_stack_trace;
+
+static void Initialize();
+static LONG WINAPI UnhandledExceptionFilter(_EXCEPTION_POINTERS*);
+static void GetStackTrace(CONTEXT& c);
+
+void CrashHandler(std::function<void()> try_,
+                  std::function<void(const Common::CrashInformation&)> catch_) {
+    unhandled_exception_called = false;
+
+    if (!ctx) {
+        Initialize();
+    }
+
+    // Accessing non-volatile local variables in setjmp's scope is indeterminate.
+    volatile LPTOP_LEVEL_EXCEPTION_FILTER previous_filter;
+    previous_filter = SetUnhandledExceptionFilter(UnhandledExceptionFilter);
+
+    if (setjmp(unhandled_exception_jmp_buf) == 0) {
+        try_();
+    } else {
+        catch_({unhandled_exception_stack_trace});
+    }
+
+    SetUnhandledExceptionFilter(previous_filter);
+}
+
+static void Initialize() {
+    DWORD ctx_size = 0;
+    InitializeContext(nullptr, CONTEXT_ALL, nullptr, &ctx_size);
+    ctx_buffer = std::malloc(ctx_size);
+    InitializeContext(ctx_buffer, CONTEXT_ALL, &ctx, &ctx_size);
+}
+
+/**
+ * This function is called by the operating system when an unhandled exception occurs.
+ * This includes things like debug breakpoints when not connected to a debugger.
+ * @param ep The exception pointer containing exception information.
+ * @return See Microsoft's documentation on SetUnhandledExceptionFilter for possible return values.
+ */
+static LONG WINAPI UnhandledExceptionFilter(_EXCEPTION_POINTERS* ep) {
+    // Prevent re-entry.
+    if (unhandled_exception_called)
+        return EXCEPTION_CONTINUE_SEARCH;
+    unhandled_exception_called = true;
+
+    if (ctx) {
+        // A copy is required as getting the stack trace modifies the context.
+        CopyContext(ctx, CONTEXT_ALL, ep->ContextRecord);
+        GetStackTrace(*ctx);
+
+        // Ensure we have a log of everything in the console.
+        std::fprintf(stderr, "Unhandled Exception:\n");
+        for (const auto& line : unhandled_exception_stack_trace) {
+            std::fprintf(stderr, "%s\n", line.c_str());
+        }
+        std::fflush(stderr);
+    } else {
+        unhandled_exception_stack_trace = {"Unable to get stack trace"};
+    }
+
+    std::longjmp(unhandled_exception_jmp_buf, 1);
+
+    return EXCEPTION_CONTINUE_SEARCH;
+}
+
+/**
+ * This function walks the stack of the current thread using StackWalk64.
+ * @param ctx The context record that contains the information on the stack of interest.
+ * @return A string containing a human-readable stack trace.
+ */
+static void GetStackTrace(CONTEXT& ctx) {
+    HANDLE process = GetCurrentProcess();
+    HANDLE thread = GetCurrentThread();
+
+    // This function generates a single line of the stack trace.
+    // `return_address` is a return address found on the stack.
+    auto get_symbol_info = [&process](DWORD64 return_address) -> std::string {
+        constexpr size_t SYMBOL_NAME_SIZE = 512; // arbitrary value
+
+        // Allocate space for symbol info.
+        IMAGEHLP_SYMBOL64* symbol = static_cast<IMAGEHLP_SYMBOL64*>(
+            std::calloc(sizeof(IMAGEHLP_SYMBOL64) + SYMBOL_NAME_SIZE * sizeof(char), 1));
+        symbol->MaxNameLength = SYMBOL_NAME_SIZE;
+        symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
+        SCOPE_EXIT({ std::free(symbol); });
+
+        // Actually get symbol info.
+        DWORD64 symbol_displacement; // Offset of return_address from function entry point.
+        SymGetSymFromAddr64(process, return_address, &symbol_displacement, symbol);
+
+        // Get undecorated name.
+        char undecorated_name[SYMBOL_NAME_SIZE + 1];
+        UnDecorateSymbolName(symbol->Name, &undecorated_name[0], SYMBOL_NAME_SIZE,
+                             UNDNAME_COMPLETE);
+
+        // Get source code line information.
+        DWORD line_displacement = 0; // Offset of return_address from first instruction of line.
+        IMAGEHLP_LINE64 line = {};
+        line.SizeOfStruct = sizeof(IMAGEHLP_LINE64);
+        SymGetLineFromAddr64(process, return_address, &line_displacement, &line);
+
+        // Remove unnecessary path information before the "\\src\\" directory.
+        std::string file_name = "(null)";
+        if (line.FileName) {
+            file_name = line.FileName;
+            size_t found = file_name.find("\\src\\");
+            if (found != std::string::npos)
+                file_name = file_name.substr(found + 1);
+        }
+
+        // Format string
+        return Common::StringFromFormat("[%llx] %s+0x%llx (%s:%i)", return_address,
+                                        undecorated_name, symbol_displacement, file_name.c_str(),
+                                        line.LineNumber);
+    };
+
+    // NOTE: SymFunctionTableAccess64 doesn't work with the non-standard stack frames our JIT
+    // produces. Thus we elect to not use StackWalk64, but instead manually use the Rtl* functions.
+
+    // Initialise symbols
+    if (SymInitialize(process, nullptr, TRUE) == FALSE) {
+        std::fprintf(stderr, "Failed to get symbols. Continuing anyway...\n");
+    }
+    SymSetOptions(SymGetOptions() | SYMOPT_LOAD_LINES | SYMOPT_UNDNAME);
+    SCOPE_EXIT({ SymCleanup(process); });
+
+    // Walk the stack
+    unhandled_exception_stack_trace = {};
+    while (ctx.Rip != 0) {
+        unhandled_exception_stack_trace.emplace_back(get_symbol_info(ctx.Rip));
+
+        DWORD64 image_base;
+        PRUNTIME_FUNCTION runtime_function = RtlLookupFunctionEntry(ctx.Rip, &image_base, nullptr);
+
+        if (!runtime_function) {
+            // This is likely a leaf function. Adjust the stack appropriately.
+            if (!ctx.Rsp) {
+                unhandled_exception_stack_trace.emplace_back("Invalid rsp");
+                return;
+            }
+            ctx.Rip = *(reinterpret_cast<u64*>(ctx.Rsp));
+            ctx.Rsp += 8;
+            continue;
+        }
+
+        PVOID handler_data;
+        ULONG64 establisher_frame;
+        RtlVirtualUnwind(UNW_FLAG_NHANDLER, image_base, ctx.Rip, runtime_function, &ctx,
+                         &handler_data, &establisher_frame, nullptr);
+    }
+}
+
+} // namespace Common
+
+#else
+
+namespace Common {
+
+void CrashHandler(std::function<void()> try_,
+                  std::function<void(const Common::CrashInformation&)> catch_) {
+    // Crash handler unimplemented for this platform
+    try_();
+}
+
+} // namespace Common
+
+#endif

--- a/src/common/crash_handler.h
+++ b/src/common/crash_handler.h
@@ -5,13 +5,16 @@
 #include <functional>
 #include <string>
 #include <vector>
+#include <boost/optional.hpp>
 
 namespace Common {
 
 struct CrashInformation {
     std::vector<std::string> stack_trace;
+    boost::optional<std::string> minidump_filename;
 };
 
-void CrashHandler(std::function<void()> try_, std::function<void(const CrashInformation&)> catch_);
+void CrashHandler(std::function<void()> try_, std::function<void(const CrashInformation&)> catch_,
+                  boost::optional<std::string> minidump_filename = {});
 
 } // namespace Common

--- a/src/common/crash_handler.h
+++ b/src/common/crash_handler.h
@@ -1,0 +1,17 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace Common {
+
+struct CrashInformation {
+    std::vector<std::string> stack_trace;
+};
+
+void CrashHandler(std::function<void()> try_, std::function<void(const CrashInformation&)> catch_);
+
+} // namespace Common

--- a/src/common/ui_util.h
+++ b/src/common/ui_util.h
@@ -1,0 +1,18 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <string>
+
+namespace Common {
+
+/**
+ * Opens the system file browser with the file selected.
+ * Equivalent to "View in Explorer" on Windows or "Show in Finder" on macOS.
+ * @param filename The file to select
+ */
+void ShowInFileBrowser(const std::string& filename);
+
+} // namespace Common

--- a/src/common/ui_util_linux.cpp
+++ b/src/common/ui_util_linux.cpp
@@ -1,0 +1,20 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <string>
+#include "common/string_util.h"
+#include "common/ui_util.h"
+
+namespace Common {
+
+void ShowInFileBrowser(const std::string& filename) {
+    std::string path;
+    if (!Common::SplitPath(filename, &path, nullptr, nullptr))
+        return;
+    path = Common::ReplaceAll(path, "\\", "\\\\");
+    path = Common::ReplaceAll(path, "\"", "\\\"");
+    system(("xdg-open \"" + path + '"').c_str());
+}
+
+} // namespace Common

--- a/src/common/ui_util_macos.mm
+++ b/src/common/ui_util_macos.mm
@@ -1,0 +1,18 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#import <Cocoa/Cocoa.h>
+
+#include <string>
+#include "common/ui_util.h"
+
+namespace Common {
+
+void ShowInFileBrowser(const std::string& filename) {
+    if (NSString* ns_filename = @(filename.c_str())) {
+        [[NSWorkspace sharedWorkspace] selectFile:ns_filename inFileViewerRootedAtPath:@""];
+    }
+}
+
+} // namespace Common

--- a/src/common/ui_util_windows.cpp
+++ b/src/common/ui_util_windows.cpp
@@ -1,0 +1,24 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <windows.h>
+// windows.h must come first
+#include <objbase.h>
+#include <shlobj.h>
+
+#include <string>
+#include "common/ui_util.h"
+
+namespace Common {
+
+void ShowInFileBrowser(const std::string& filename) {
+    CoInitialize(nullptr);
+    if (ITEMIDLIST* pidl = ILCreateFromPath(filename.c_str())) {
+        SHOpenFolderAndSelectItems(pidl, 0, nullptr, 0);
+        ILFree(pidl);
+    }
+    CoUninitialize();
+}
+
+} // namespace Common


### PR DESCRIPTION
Third iteration of this concept.

* Windows-only for now
* Requires a pdb file to be present for symbols to work.
* ~~**TODO:** Actually dump minidumps, which users can then upload.~~
* **TODO:** Generate pdbs for mingw using cv2pdb or similar

<img width="402" alt="screen shot 2017-11-26 at 18 42 10" src="https://user-images.githubusercontent.com/8682882/33243261-84ba9f6c-d2da-11e7-87e6-cbd9b883810c.png">

Original PRs: #1874, #2355

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3157)
<!-- Reviewable:end -->
