### PR TITLE
HLE/IPC: Don't assert in HLERequestContext::AddStaticBuffer when there's already a static buffer with the desired id

### DIFF
--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -51,7 +51,6 @@ const std::vector<u8>& HLERequestContext::GetStaticBuffer(u8 buffer_id) const {
 }
 
 void HLERequestContext::AddStaticBuffer(u8 buffer_id, std::vector<u8> data) {
-    ASSERT(static_buffers[buffer_id].empty() && !data.empty());
     static_buffers[buffer_id] = std::move(data);
 }
 


### PR DESCRIPTION
This could happen if the guest application performs a request with static buffer id X, and the service module responds with another static buffer with the same id X.

Closes #3158 #3152

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3160)
<!-- Reviewable:end -->
