### PR TITLE
externals: Update catch to v2.0.1

### DIFF
--- a/src/tests/common/param_package.cpp
+++ b/src/tests/common/param_package.cpp
@@ -2,8 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <cmath>
 #include <catch.hpp>
-#include <math.h>
 #include "common/param_package.h"
 
 namespace Common {


### PR DESCRIPTION
Keeps our unit-testing library up to date. Since it's a major version update, quite a bit of legacy stuff was removed from the library, along with several improvements, which can be found in the changelog [here](https://github.com/catchorg/Catch2/releases)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3161)
<!-- Reviewable:end -->
