### PR TITLE
packet: Simplify operator bool overload

### DIFF
--- a/src/network/packet.cpp
+++ b/src/network/packet.cpp
@@ -63,7 +63,7 @@ bool Packet::EndOfPacket() const {
 }
 
 Packet::operator bool() const {
-    return is_valid ? &Packet::CheckSize : nullptr;
+    return is_valid;
 }
 
 Packet& Packet::operator>>(bool& out_data) {


### PR DESCRIPTION
Previously this would cause a -Wnull-conversion warning

This is a remnant of the safe-bool idiom that was made obsolete with C++11 and greater via explicit conversion operators.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3162)
<!-- Reviewable:end -->
