### PR TITLE
Services/NFC: Stub StartTagScanning as it should be for o3DS

### DIFF
--- a/src/core/hle/service/nfc/nfc.cpp
+++ b/src/core/hle/service/nfc/nfc.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "core/hle/ipc.h"
+#include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/event.h"
 #include "core/hle/kernel/handle_table.h"
 #include "core/hle/service/nfc/nfc.h"
@@ -53,13 +54,23 @@ void StopCommunication(Interface* self) {
 }
 
 void StartTagScanning(Interface* self) {
-    u32* cmd_buff = Kernel::GetCommandBuffer();
+    IPC::RequestParser rp(Kernel::GetCommandBuffer(), 5, 1, 0); // 0x00050040
+    u16 in_val = rp.Pop<u16>();
 
-    nfc_tag_state = TagState::TagInRange;
-    tag_in_range_event->Signal();
+    ResultCode result = RESULT_SUCCESS;
 
-    cmd_buff[1] = RESULT_SUCCESS.raw; // No error
-    LOG_WARNING(Service_NFC, "(STUBBED) called");
+    // TODO(shinyquagsire23): Implement NFC tag detection, for now stub result
+    result = ResultCode(ErrCodes::CommandInvalidForState, ErrorModule::NFC,
+                        ErrorSummary::InvalidState, ErrorLevel::Status);
+
+    if (result == RESULT_SUCCESS) {
+        nfc_tag_state = TagState::TagInRange;
+        tag_in_range_event->Signal();
+    }
+
+    IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
+    rb.Push(result);
+    LOG_WARNING(Service_NFC, "(STUBBED) called, in_val=%04x", in_val);
 }
 
 void StopTagScanning(Interface* self) {

--- a/src/core/hle/service/nfc/nfc.h
+++ b/src/core/hle/service/nfc/nfc.h
@@ -12,6 +12,12 @@ class Interface;
 
 namespace NFC {
 
+namespace ErrCodes {
+enum {
+    CommandInvalidForState = 512,
+};
+} // namespace ErrCodes
+
 enum class TagState : u8 {
     NotInitialized = 0,
     NotScanning = 1,


### PR DESCRIPTION
Fixes an issue in Smash 4's version 1.1.7 where a Kirby amiibo (or an invalid Amiibo) would constantly be scanned in.

Before:
![Smash 4 Kirby Amiibo](https://pbs.twimg.com/media/DJ0HInlVAAAEvkT.jpg)

After:
![Smash 4 Fixed Kirby Amiibo](https://i.imgur.com/oVvc6II.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3173)
<!-- Reviewable:end -->
