### PR TITLE
dyncom: Remove VFP_REG_ZERO

### DIFF
--- a/src/core/arm/skyeye_common/vfp/vfp_helper.h
+++ b/src/core/arm/skyeye_common/vfp/vfp_helper.h
@@ -301,15 +301,6 @@ struct vfp_double {
     u64 significand;
 };
 
-// VFP_REG_ZERO is a special register number for vfp_get_double
-// which returns (double)0.0.  This is useful for the compare with
-// zero instructions.
-#ifdef CONFIG_VFPv3
-#define VFP_REG_ZERO 32
-#else
-#define VFP_REG_ZERO 16
-#endif
-
 #define VFP_DOUBLE_MANTISSA_BITS (52)
 #define VFP_DOUBLE_EXPONENT_BITS (11)
 #define VFP_DOUBLE_LOW_BITS (64 - VFP_DOUBLE_MANTISSA_BITS - 2)

--- a/src/core/arm/skyeye_common/vfp/vfpdouble.cpp
+++ b/src/core/arm/skyeye_common/vfp/vfpdouble.cpp
@@ -383,12 +383,11 @@ static u32 vfp_double_fsqrt(ARMul_State* state, int dd, int unused, int dm, u32 
  * Greater than	:= C
  * Unordered	:= CV
  */
-static u32 vfp_compare(ARMul_State* state, int dd, int signal_on_qnan, int dm, u32 fpscr) {
-    s64 d, m;
+static u32 vfp_compare(ARMul_State* state, int dd, int signal_on_qnan, s64 m, u32 fpscr) {
+    s64 d;
     u32 ret = 0;
 
     LOG_TRACE(Core_ARM11, "In %s, state=0x%p, fpscr=0x%x", __FUNCTION__, state, fpscr);
-    m = vfp_get_double(state, dm);
     if (vfp_double_packed_exponent(m) == 2047 && vfp_double_packed_mantissa(m)) {
         ret |= FPSCR_CFLAG | FPSCR_VFLAG;
         if (signal_on_qnan ||
@@ -451,22 +450,22 @@ static u32 vfp_compare(ARMul_State* state, int dd, int signal_on_qnan, int dm, u
 
 static u32 vfp_double_fcmp(ARMul_State* state, int dd, int unused, int dm, u32 fpscr) {
     LOG_TRACE(Core_ARM11, "In %s", __FUNCTION__);
-    return vfp_compare(state, dd, 0, dm, fpscr);
+    return vfp_compare(state, dd, 0, vfp_get_double(state, dm), fpscr);
 }
 
 static u32 vfp_double_fcmpe(ARMul_State* state, int dd, int unused, int dm, u32 fpscr) {
     LOG_TRACE(Core_ARM11, "In %s", __FUNCTION__);
-    return vfp_compare(state, dd, 1, dm, fpscr);
+    return vfp_compare(state, dd, 1, vfp_get_double(state, dm), fpscr);
 }
 
 static u32 vfp_double_fcmpz(ARMul_State* state, int dd, int unused, int dm, u32 fpscr) {
     LOG_TRACE(Core_ARM11, "In %s", __FUNCTION__);
-    return vfp_compare(state, dd, 0, VFP_REG_ZERO, fpscr);
+    return vfp_compare(state, dd, 0, 0, fpscr);
 }
 
 static u32 vfp_double_fcmpez(ARMul_State* state, int dd, int unused, int dm, u32 fpscr) {
     LOG_TRACE(Core_ARM11, "In %s", __FUNCTION__);
-    return vfp_compare(state, dd, 1, VFP_REG_ZERO, fpscr);
+    return vfp_compare(state, dd, 1, 0, fpscr);
 }
 
 static u32 vfp_double_fcvts(ARMul_State* state, int sd, int unused, int dm, u32 fpscr) {


### PR DESCRIPTION
Fixes two issues that will never happen:

1. There are cases when VFP_REG_ZERO will be non-zero, but these will never be encoutered in well behaved guest code (i.e. writing to D16).
2. If CONFIG_VFPv3 is defined, accessing VFP_REG_ZERO would be out of bounds.

The double `vfp_compare` is now more-or-less identical to its single counterpart.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3174)
<!-- Reviewable:end -->
