### PR TITLE
Inih: Switch inih to It's Official Repository @ benhoyt/inih

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "inih"]
-    path = externals/inih/inih
-    url = https://github.com/svn2github/inih
 [submodule "boost"]
     path = externals/boost
     url = https://github.com/citra-emu/ext-boost.git
@@ -27,7 +24,10 @@
     url = https://github.com/fmtlib/fmt.git
 [submodule "enet"]
     path = externals/enet
-    url = https://github.com/lsalzman/enet
+    url = https://github.com/lsalzman/enet.git
 [submodule "cpr"]
     path = externals/cpr
     url = https://github.com/whoshuu/cpr.git
+[submodule "inih"]
+    path = externals/inih/inih
+    url = https://github.com/benhoyt/inih.git


### PR DESCRIPTION
## Info
This PR switches the Inih Submodule from it's mirror repository `svn2github/inih` to it's official repo at `benhoyt/inih`

## Reasoning
As explained in Info, svn2github is a Mirror Host, which was used mainly as there was no official repo for inih at the time it was originally added. However, now that there is a Official repo, svn2github would be considered unnecessary as well as inconsistent to keep around. This commit aims to make it easier to manage this submodule in the future, as well as able to fix/report issues related to inih, should any appear in the foreseeable future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3178)
<!-- Reviewable:end -->
