### PR TITLE
ipc_helper: split PushMoveObjects and PushCopyObjects

### DIFF
--- a/src/core/hle/ipc_helpers.h
+++ b/src/core/hle/ipc_helpers.h
@@ -114,7 +114,10 @@ public:
     void PushMoveHandles(H... handles);
 
     template <typename... O>
-    void PushObjects(Kernel::SharedPtr<O>... pointers);
+    void PushCopyObjects(Kernel::SharedPtr<O>... pointers);
+
+    template <typename... O>
+    void PushMoveObjects(Kernel::SharedPtr<O>... pointers);
 
     void PushCurrentPIDHandle();
 
@@ -187,7 +190,12 @@ inline void RequestBuilder::PushMoveHandles(H... handles) {
 }
 
 template <typename... O>
-inline void RequestBuilder::PushObjects(Kernel::SharedPtr<O>... pointers) {
+inline void RequestBuilder::PushCopyObjects(Kernel::SharedPtr<O>... pointers) {
+    PushCopyHandles(context->AddOutgoingHandle(std::move(pointers))...);
+}
+
+template <typename... O>
+inline void RequestBuilder::PushMoveObjects(Kernel::SharedPtr<O>... pointers) {
     PushMoveHandles(context->AddOutgoingHandle(std::move(pointers))...);
 }
 

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -206,7 +206,7 @@ void File::OpenLinkFile(Kernel::HLERequestContext& ctx) {
     ClientConnected(std::get<SharedPtr<ServerSession>>(sessions));
 
     rb.Push(RESULT_SUCCESS);
-    rb.PushObjects(std::get<SharedPtr<ClientSession>>(sessions));
+    rb.PushMoveObjects(std::get<SharedPtr<ClientSession>>(sessions));
 }
 
 File::~File() {}

--- a/src/core/hle/service/sm/srv.cpp
+++ b/src/core/hle/service/sm/srv.cpp
@@ -66,7 +66,7 @@ void SRV::EnableNotification(Kernel::HLERequestContext& ctx) {
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
     rb.Push(RESULT_SUCCESS);
-    rb.PushObjects(notification_semaphore);
+    rb.PushCopyObjects(notification_semaphore);
     LOG_WARNING(Service_SRV, "(STUBBED) called");
 }
 
@@ -114,7 +114,7 @@ void SRV::GetServiceHandle(Kernel::HLERequestContext& ctx) {
                   (*session)->GetObjectId());
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
         rb.Push(session.Code());
-        rb.PushObjects(std::move(session).Unwrap());
+        rb.PushMoveObjects(std::move(session).Unwrap());
     } else if (session.Code() == Kernel::ERR_MAX_CONNECTIONS_REACHED && wait_until_available) {
         LOG_WARNING(Service_SRV, "called service=%s -> ERR_MAX_CONNECTIONS_REACHED", name.c_str());
         // TODO(Subv): Put the caller guest thread to sleep until this port becomes available again.
@@ -204,7 +204,7 @@ void SRV::RegisterService(Kernel::HLERequestContext& ctx) {
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
     rb.Push(RESULT_SUCCESS);
-    rb.PushObjects(port.Unwrap());
+    rb.PushMoveObjects(port.Unwrap());
 }
 
 SRV::SRV(std::shared_ptr<ServiceManager> service_manager)


### PR DESCRIPTION
Although the move/copy bit in the handle descriptor doesn't mean anything to HLE service, it does make a different from client's point of view. A game can specifically check this bit if it matches expected result. IIRC I observed a similar checking code in service, which can be reused by games. So we should allow HLE service be able to specify this move/copy bit.

Among the four current user of `PushObjects`, `SRV::EnableNotification` was specifically marked as copying handles before `HLERequestContext` implemented, so this behaviour is restored here. ~~The other three don't have clear documentation anywhere whether they were move or copy, so I left them as-is.~~ According to Subv, they are indeed all `Move`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3181)
<!-- Reviewable:end -->
