### PR TITLE
vector_math: Return by const reference for const operator[]

### DIFF
--- a/src/common/vector_math.h
+++ b/src/common/vector_math.h
@@ -131,7 +131,7 @@ public:
     {
         return *((&x) + i);
     }
-    T operator[](const int i) const {
+    const T& operator[](const int i) const {
         return *((&x) + i);
     }
 
@@ -288,7 +288,7 @@ public:
     {
         return *((&x) + i);
     }
-    T operator[](const int i) const {
+    const T& operator[](const int i) const {
         return *((&x) + i);
     }
 
@@ -502,7 +502,7 @@ public:
     {
         return *((&x) + i);
     }
-    T operator[](const int i) const {
+    const T& operator[](const int i) const {
         return *((&x) + i);
     }
 


### PR DESCRIPTION
Makes behavior between both overloads consistent.

Technically, `i` can also be made `size_t` or `ptrdiff_t` (if we'd like to keep signed around), to avoid sign-extending all the time before the access, but I'd probably keep that for a second PR if doing that is desirable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3185)
<!-- Reviewable:end -->
