### PR TITLE
Applet: Print unknown AppletId on ASSERT

### DIFF
--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -114,7 +114,7 @@ static u64 GetTitleIdForApplet(AppletId id) {
                                 return data.applet_ids[0] == id || data.applet_ids[1] == id;
                             });
 
-    ASSERT_MSG(itr != applet_titleids.end(), "Unknown applet id %u", id);
+    ASSERT_MSG(itr != applet_titleids.end(), "Unknown applet id 0x%03X", static_cast<u32>(id));
 
     return itr->title_ids[CFG::GetRegionValue()];
 }

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -114,7 +114,7 @@ static u64 GetTitleIdForApplet(AppletId id) {
                                 return data.applet_ids[0] == id || data.applet_ids[1] == id;
                             });
 
-    ASSERT_MSG(itr != applet_titleids.end(), "Unknown applet id");
+    ASSERT_MSG(itr != applet_titleids.end(), "Unknown applet id %u", id);
 
     return itr->title_ids[CFG::GetRegionValue()];
 }


### PR DESCRIPTION
This adds the Applet ID to the message on Assert when a unknown id is encountered.

We recently get some messages that games crash on that point. The games usually crash later when citra tries to emulate the applet.

This will help to identify which applets are missing. Dumping that applet and adding the id to the list of applets could fix those games.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3225)
<!-- Reviewable:end -->
