### PR TITLE
arm_dyncom_dec: Hide the decoding table from external view

### DIFF
--- a/src/core/arm/dyncom/arm_dyncom_dec.cpp
+++ b/src/core/arm/dyncom/arm_dyncom_dec.cpp
@@ -5,6 +5,31 @@
 #include "core/arm/dyncom/arm_dyncom_dec.h"
 #include "core/arm/skyeye_common/armsupp.h"
 
+namespace {
+struct InstructionSetEncodingItem {
+    const char* name;
+    int attribute_value;
+    int version;
+    u32 content[21];
+};
+
+// ARM versions
+enum {
+    INVALID = 0,
+    ARMALL,
+    ARMV4,
+    ARMV4T,
+    ARMV5T,
+    ARMV5TE,
+    ARMV5TEJ,
+    ARMV6,
+    ARM1176JZF_S,
+    ARMVFP2,
+    ARMVFP3,
+    ARMV6K,
+};
+}
+
 // clang-format off
 const InstructionSetEncodingItem arm_instruction[] = {
     { "vmla", 5, ARMVFP2,      { 23, 27, 0x1C, 20, 21, 0x0, 9, 11, 0x5, 6, 6, 0, 4, 4, 0 }},

--- a/src/core/arm/dyncom/arm_dyncom_dec.h
+++ b/src/core/arm/dyncom/arm_dyncom_dec.h
@@ -9,28 +9,3 @@
 enum class ARMDecodeStatus { SUCCESS, FAILURE };
 
 ARMDecodeStatus DecodeARMInstruction(u32 instr, int* idx);
-
-struct InstructionSetEncodingItem {
-    const char* name;
-    int attribute_value;
-    int version;
-    u32 content[21];
-};
-
-// ARM versions
-enum {
-    INVALID = 0,
-    ARMALL,
-    ARMV4,
-    ARMV4T,
-    ARMV5T,
-    ARMV5TE,
-    ARMV5TEJ,
-    ARMV6,
-    ARM1176JZF_S,
-    ARMVFP2,
-    ARMVFP3,
-    ARMV6K,
-};
-
-extern const InstructionSetEncodingItem arm_instruction[];


### PR DESCRIPTION
This isn't used externally anywhere (and really shouldn't be, because it would mean decoding logic is being duplicated elsewhere in some form, or that assumptions are being hardcoded about the table layout).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3229)
<!-- Reviewable:end -->
