### PR TITLE
HLE/FS: Implemented FSFile::OpenSubFile.

### DIFF
--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -54,7 +54,7 @@ public:
      * associated ServerSession.
      * @param server_session ServerSession associated with the connection.
      */
-    void ClientDisconnected(SharedPtr<ServerSession> server_session);
+    virtual void ClientDisconnected(SharedPtr<ServerSession> server_session);
 
 protected:
     /// List of sessions that are connected to this handler.

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -909,16 +909,12 @@ void BeginImportProgram(Service::Interface* self) {
     const FileSys::Path cia_path = {};
     auto file =
         std::make_shared<Service::FS::File>(std::make_unique<CIAFile>(media_type), cia_path);
-    auto sessions = Kernel::ServerSession::CreateSessionPair(file->GetName());
-    file->ClientConnected(std::get<Kernel::SharedPtr<Kernel::ServerSession>>(sessions));
 
     cia_installing = true;
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
     rb.Push(RESULT_SUCCESS); // No error
-    rb.PushCopyHandles(
-        Kernel::g_handle_table.Create(std::get<Kernel::SharedPtr<Kernel::ClientSession>>(sessions))
-            .Unwrap());
+    rb.PushCopyHandles(Kernel::g_handle_table.Create(file->Connect()).Unwrap());
 
     LOG_WARNING(Service_AM, "(STUBBED) media_type=%u", static_cast<u32>(media_type));
 }

--- a/src/core/hle/service/fs/fs_user.cpp
+++ b/src/core/hle/service/fs/fs_user.cpp
@@ -86,11 +86,7 @@ static void OpenFile(Service::Interface* self) {
     rb.Push(file_res.Code());
     if (file_res.Succeeded()) {
         std::shared_ptr<File> file = *file_res;
-        auto sessions = ServerSession::CreateSessionPair(file->GetName());
-        file->ClientConnected(std::get<SharedPtr<ServerSession>>(sessions));
-
-        rb.PushMoveHandles(
-            Kernel::g_handle_table.Create(std::get<SharedPtr<ClientSession>>(sessions)).Unwrap());
+        rb.PushMoveHandles(Kernel::g_handle_table.Create(file->Connect()).Unwrap());
     } else {
         rb.PushMoveHandles(0);
         LOG_ERROR(Service_FS, "failed to get a handle for file %s", file_path.DebugStr().c_str());
@@ -152,11 +148,7 @@ static void OpenFileDirectly(Service::Interface* self) {
     cmd_buff[1] = file_res.Code().raw;
     if (file_res.Succeeded()) {
         std::shared_ptr<File> file = *file_res;
-        auto sessions = ServerSession::CreateSessionPair(file->GetName());
-        file->ClientConnected(std::get<SharedPtr<ServerSession>>(sessions));
-
-        cmd_buff[3] =
-            Kernel::g_handle_table.Create(std::get<SharedPtr<ClientSession>>(sessions)).Unwrap();
+        cmd_buff[3] = Kernel::g_handle_table.Create(file->Connect()).Unwrap();
     } else {
         cmd_buff[3] = 0;
         LOG_ERROR(Service_FS, "failed to get a handle for file %s mode=%u attributes=%u",


### PR DESCRIPTION
The File class now holds a list of connected sessions along with data unique to each session.

A subfile is a window into an existing file. They have a few limitations compared to normal files:

* They can't be written to.
* They can't be flushed.
* Their size can not be changed.
* New subfiles can't be created from another subfile.

This function is used by the DLP module to open the DLPChild CIA from the game's RomFS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3235)
<!-- Reviewable:end -->
