### PR TITLE
svc: correct GetProcessInfo(20)

### DIFF
--- a/src/core/hle/svc.cpp
+++ b/src/core/hle/svc.cpp
@@ -1268,7 +1268,7 @@ static ResultCode GetProcessInfo(s64* out, Kernel::Handle process_handle, u32 ty
         LOG_ERROR(Kernel_SVC, "unimplemented GetProcessInfo type=%u", type);
         break;
     case 20:
-        *out = Memory::FCRAM_PADDR - process->GetLinearHeapBase();
+        *out = Memory::FCRAM_PADDR - process->GetLinearHeapAreaAddress();
         break;
     case 21:
     case 22:


### PR DESCRIPTION
This return value is meant to be used as a simple conversion between linear heap PAddr<->VAddr, thus it only very depends on where the entire FCRAM is mapped in VAddr (can be only 0x30000000 / 0x14000000). It shouldn't use `GetLinearHeapBase` which is for the APPLICATION/SYSTEM/BASE region base address.

Fixes new version swkbd not rendering issue

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3241)
<!-- Reviewable:end -->
