### PR TITLE
HLE/FS: Always use 0x48000 as the high dword when opening the SharedExtData archive

### DIFF
--- a/src/core/file_sys/archive_extsavedata.h
+++ b/src/core/file_sys/archive_extsavedata.h
@@ -56,6 +56,9 @@ private:
      * See GetExtSaveDataPath for the code that extracts this data from an archive path.
      */
     std::string mount_point;
+
+    /// Returns a path with the correct SaveIdHigh value for Shared extdata paths.
+    Path GetCorrectedPath(const Path& path);
 };
 
 /**


### PR DESCRIPTION
The FS module overrides whatever value was in the saveid high dword with 0x48000 when trying to open the archive.

This fixes the problem where the Home Menu would create a few SharedExtData archives with 0x48000 as the saveid high, but then try to open them with 0 as the high value and fail.

Cue '*how did anything even work at all?*' moment

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3242)
<!-- Reviewable:end -->
