### PR TITLE
HLE: Add pxi:dev stub.

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -159,6 +159,8 @@ set(SRCS
             hle/service/ptm/ptm_sets.cpp
             hle/service/ptm/ptm_sysm.cpp
             hle/service/ptm/ptm_u.cpp
+            hle/service/pxi/dev.cpp
+            hle/service/pxi/pxi.cpp
             hle/service/qtm/qtm.cpp
             hle/service/qtm/qtm_s.cpp
             hle/service/qtm/qtm_sp.cpp
@@ -364,6 +366,8 @@ set(HEADERS
             hle/service/ptm/ptm_sets.h
             hle/service/ptm/ptm_sysm.h
             hle/service/ptm/ptm_u.h
+            hle/service/pxi/dev.h
+            hle/service/pxi/pxi.h
             hle/service/qtm/qtm.h
             hle/service/qtm/qtm_s.h
             hle/service/qtm/qtm_sp.h

--- a/src/core/hle/service/pxi/dev.cpp
+++ b/src/core/hle/service/pxi/dev.cpp
@@ -1,0 +1,36 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/service/pxi/dev.h"
+
+namespace Service {
+namespace PXI {
+
+DEV::DEV() : ServiceFramework("pxi:dev", 1) {
+    // clang-format off
+    static const FunctionInfo functions[] = {
+        {0x000101C2, nullptr, "ReadHostIO"},
+        {0x000201C2, nullptr, "WriteHostIO"},
+        {0x00030102, nullptr, "ReadHostEx"},
+        {0x00040102, nullptr, "WriteHostEx"},
+        {0x00050102, nullptr, "WriteHostExStart"},
+        {0x00060102, nullptr, "WriteHostExChunk"},
+        {0x00070000, nullptr, "WriteHostExEnd"},
+        {0x00080000, nullptr, "InitializeMIDI"},
+        {0x00090000, nullptr, "FinalizeMIDI"},
+        {0x000A0000, nullptr, "GetMIDIInfo"},
+        {0x000B0000, nullptr, "GetMIDIBufferSize"},
+        {0x000C0042, nullptr, "ReadMIDI"},
+        {0x000D0688, nullptr, "SPIMultiWriteRead"},
+        {0x000E0284, nullptr, "SPIWriteRead"},
+        {0x000F0000, nullptr, "GetCardDevice"},
+    };
+    // clang-format on
+    RegisterHandlers(functions);
+}
+
+DEV::~DEV() = default;
+
+} // namespace PXI
+} // namespace Service

--- a/src/core/hle/service/pxi/dev.h
+++ b/src/core/hle/service/pxi/dev.h
@@ -1,0 +1,21 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/kernel/kernel.h"
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace PXI {
+
+/// Interface to "pxi:dev" service
+class DEV final : public ServiceFramework<DEV> {
+public:
+    DEV();
+    ~DEV();
+};
+
+} // namespace PXI
+} // namespace Service

--- a/src/core/hle/service/pxi/pxi.cpp
+++ b/src/core/hle/service/pxi/pxi.cpp
@@ -1,0 +1,16 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/service/pxi/dev.h"
+#include "core/hle/service/pxi/pxi.h"
+
+namespace Service {
+namespace PXI {
+
+void InstallInterfaces(SM::ServiceManager& service_manager) {
+    std::make_shared<DEV>()->InstallAsService(service_manager);
+}
+
+} // namespace PXI
+} // namespace Service

--- a/src/core/hle/service/pxi/pxi.h
+++ b/src/core/hle/service/pxi/pxi.h
@@ -1,0 +1,16 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace PXI {
+
+/// Registers all PXI services with the specified service manager.
+void InstallInterfaces(SM::ServiceManager& service_manager);
+
+} // namespace PXI
+} // namespace Service

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -43,6 +43,7 @@
 #include "core/hle/service/nwm/nwm.h"
 #include "core/hle/service/pm_app.h"
 #include "core/hle/service/ptm/ptm.h"
+#include "core/hle/service/pxi/pxi.h"
 #include "core/hle/service/qtm/qtm.h"
 #include "core/hle/service/service.h"
 #include "core/hle/service/sm/sm.h"
@@ -259,6 +260,7 @@ void Init() {
 
     ERR::InstallInterfaces();
 
+    PXI::InstallInterfaces(*SM::g_service_manager);
     NS::InstallInterfaces(*SM::g_service_manager);
     AC::InstallInterfaces(*SM::g_service_manager);
 


### PR DESCRIPTION
Adds a simple pxi:dev stub so that apps that use it (e.g. FBI) won't error when trying to retrieve a handle.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3246)
<!-- Reviewable:end -->
