### PR TITLE
ir: convert to ServiceFramework

### DIFF
--- a/src/core/hle/service/ir/ir.cpp
+++ b/src/core/hle/service/ir/ir.cpp
@@ -13,7 +13,6 @@ namespace IR {
 
 void Init() {
     AddService(new IR_RST_Interface);
-    AddService(new IR_U_Interface);
     AddService(new IR_User_Interface);
 
     InitUser();
@@ -28,6 +27,10 @@ void Shutdown() {
 void ReloadInputDevices() {
     ReloadInputDevicesUser();
     ReloadInputDevicesRST();
+}
+
+void InstallInterfaces(SM::ServiceManager& service_manager) {
+    std::make_shared<IR_U>()->InstallAsService(service_manager);
 }
 
 } // namespace IR

--- a/src/core/hle/service/ir/ir.cpp
+++ b/src/core/hle/service/ir/ir.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <memory>
 #include "core/hle/service/ir/ir.h"
 #include "core/hle/service/ir/ir_rst.h"
 #include "core/hle/service/ir/ir_u.h"
@@ -11,26 +12,31 @@
 namespace Service {
 namespace IR {
 
+static std::weak_ptr<IR_RST> current_ir_rst;
+
 void Init() {
-    AddService(new IR_RST_Interface);
     AddService(new IR_User_Interface);
 
     InitUser();
-    InitRST();
 }
 
 void Shutdown() {
     ShutdownUser();
-    ShutdownRST();
 }
 
 void ReloadInputDevices() {
     ReloadInputDevicesUser();
-    ReloadInputDevicesRST();
+
+    if (auto ir_rst = current_ir_rst.lock())
+        ir_rst->ReloadInputDevices();
 }
 
 void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<IR_U>()->InstallAsService(service_manager);
+
+    auto ir_rst = std::make_shared<IR_RST>();
+    ir_rst->InstallAsService(service_manager);
+    current_ir_rst = ir_rst;
 }
 
 } // namespace IR

--- a/src/core/hle/service/ir/ir.cpp
+++ b/src/core/hle/service/ir/ir.cpp
@@ -13,19 +13,11 @@ namespace Service {
 namespace IR {
 
 static std::weak_ptr<IR_RST> current_ir_rst;
-
-void Init() {
-    AddService(new IR_User_Interface);
-
-    InitUser();
-}
-
-void Shutdown() {
-    ShutdownUser();
-}
+static std::weak_ptr<IR_USER> current_ir_user;
 
 void ReloadInputDevices() {
-    ReloadInputDevicesUser();
+    if (auto ir_user = current_ir_user.lock())
+        ir_user->ReloadInputDevices();
 
     if (auto ir_rst = current_ir_rst.lock())
         ir_rst->ReloadInputDevices();
@@ -33,6 +25,10 @@ void ReloadInputDevices() {
 
 void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<IR_U>()->InstallAsService(service_manager);
+
+    auto ir_user = std::make_shared<IR_USER>();
+    ir_user->InstallAsService(service_manager);
+    current_ir_user = ir_user;
 
     auto ir_rst = std::make_shared<IR_RST>();
     ir_rst->InstallAsService(service_manager);

--- a/src/core/hle/service/ir/ir.h
+++ b/src/core/hle/service/ir/ir.h
@@ -11,12 +11,6 @@ class ServiceManager;
 namespace Service {
 namespace IR {
 
-/// Initialize IR service
-void Init();
-
-/// Shutdown IR service
-void Shutdown();
-
 /// Reload input devices. Used when input configuration changed
 void ReloadInputDevices();
 

--- a/src/core/hle/service/ir/ir.h
+++ b/src/core/hle/service/ir/ir.h
@@ -4,10 +4,11 @@
 
 #pragma once
 
+namespace SM {
+class ServiceManager;
+}
+
 namespace Service {
-
-class Interface;
-
 namespace IR {
 
 /// Initialize IR service
@@ -18,6 +19,8 @@ void Shutdown();
 
 /// Reload input devices. Used when input configuration changed
 void ReloadInputDevices();
+
+void InstallInterfaces(SM::ServiceManager& service_manager);
 
 } // namespace IR
 } // namespace Service

--- a/src/core/hle/service/ir/ir_u.cpp
+++ b/src/core/hle/service/ir/ir_u.cpp
@@ -7,31 +7,28 @@
 namespace Service {
 namespace IR {
 
-const Interface::FunctionInfo FunctionTable[] = {
-    // clang-format off
-    {0x00010000, nullptr, "Initialize"},
-    {0x00020000, nullptr, "Shutdown"},
-    {0x00030042, nullptr, "StartSendTransfer"},
-    {0x00040000, nullptr, "WaitSendTransfer"},
-    {0x000500C2, nullptr, "StartRecvTransfer"},
-    {0x00060000, nullptr, "WaitRecvTransfer"},
-    {0x00070080, nullptr, "GetRecvTransferCount"},
-    {0x00080000, nullptr, "GetSendState"},
-    {0x00090040, nullptr, "SetBitRate"},
-    {0x000A0000, nullptr, "GetBitRate"},
-    {0x000B0040, nullptr, "SetIRLEDState"},
-    {0x000C0000, nullptr, "GetIRLEDRecvState"},
-    {0x000D0000, nullptr, "GetSendFinishedEvent"},
-    {0x000E0000, nullptr, "GetRecvFinishedEvent"},
-    {0x000F0000, nullptr, "GetTransferState"},
-    {0x00100000, nullptr, "GetErrorStatus"},
-    {0x00110040, nullptr, "SetSleepModeActive"},
-    {0x00120040, nullptr, "SetSleepModeState"},
-    // clang-format on
-};
-
-IR_U_Interface::IR_U_Interface() {
-    Register(FunctionTable);
+IR_U::IR_U() : ServiceFramework("ir:u", 1) {
+    static const FunctionInfo functions[] = {
+        {0x00010000, nullptr, "Initialize"},
+        {0x00020000, nullptr, "Shutdown"},
+        {0x00030042, nullptr, "StartSendTransfer"},
+        {0x00040000, nullptr, "WaitSendTransfer"},
+        {0x000500C2, nullptr, "StartRecvTransfer"},
+        {0x00060000, nullptr, "WaitRecvTransfer"},
+        {0x00070080, nullptr, "GetRecvTransferCount"},
+        {0x00080000, nullptr, "GetSendState"},
+        {0x00090040, nullptr, "SetBitRate"},
+        {0x000A0000, nullptr, "GetBitRate"},
+        {0x000B0040, nullptr, "SetIRLEDState"},
+        {0x000C0000, nullptr, "GetIRLEDRecvState"},
+        {0x000D0000, nullptr, "GetSendFinishedEvent"},
+        {0x000E0000, nullptr, "GetRecvFinishedEvent"},
+        {0x000F0000, nullptr, "GetTransferState"},
+        {0x00100000, nullptr, "GetErrorStatus"},
+        {0x00110040, nullptr, "SetSleepModeActive"},
+        {0x00120040, nullptr, "SetSleepModeState"},
+    };
+    RegisterHandlers(functions);
 }
 
 } // namespace IR

--- a/src/core/hle/service/ir/ir_u.h
+++ b/src/core/hle/service/ir/ir_u.h
@@ -9,13 +9,10 @@
 namespace Service {
 namespace IR {
 
-class IR_U_Interface : public Service::Interface {
+/// Interface to "ir:u" service
+class IR_U final : public ServiceFramework<IR_U> {
 public:
-    IR_U_Interface();
-
-    std::string GetPortName() const override {
-        return "ir:u";
-    }
+    IR_U();
 };
 
 } // namespace IR

--- a/src/core/hle/service/ir/ir_user.h
+++ b/src/core/hle/service/ir/ir_user.h
@@ -5,10 +5,24 @@
 #pragma once
 
 #include <functional>
+#include <memory>
+#include <vector>
 #include "core/hle/service/service.h"
+
+namespace Kernel {
+class Event;
+class SharedMemory;
+}
+
+namespace CoreTiming {
+class EventType;
+};
 
 namespace Service {
 namespace IR {
+
+class BufferManager;
+class ExtraHID;
 
 /// An interface representing a device that can communicate with 3DS via ir:USER service
 class IRDevice {
@@ -39,20 +53,126 @@ private:
     const SendFunc send_func;
 };
 
-class IR_User_Interface : public Service::Interface {
+/// Interface to "ir:USER" service
+class IR_USER final : public ServiceFramework<IR_USER> {
 public:
-    IR_User_Interface();
+    IR_USER();
+    ~IR_USER();
 
-    std::string GetPortName() const override {
-        return "ir:USER";
-    }
+    void ReloadInputDevices();
+
+private:
+    /**
+     * InitializeIrNopShared service function
+     * Initializes ir:USER service with a user provided shared memory. The shared memory is
+     * configured
+     * to shared mode (with SharedMemoryHeader at the beginning of the shared memory).
+     *  Inputs:
+     *      1 : Size of shared memory
+     *      2 : Recv buffer size
+     *      3 : Recv buffer packet count
+     *      4 : Send buffer size
+     *      5 : Send buffer packet count
+     *      6 : BaudRate (u8)
+     *      7 : 0 (Handle descriptor)
+     *      8 : Handle of shared memory
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void InitializeIrNopShared(Kernel::HLERequestContext& ctx);
+
+    /**
+     * RequireConnection service function
+     * Searches for an IR device and connects to it. After connecting to the device, applications
+     * can
+     * use SendIrNop function, ReceiveIrNop function (or read from the buffer directly) to
+     * communicate
+     * with the device.
+     *  Inputs:
+     *      1 : device ID? always 1 for circle pad pro
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void RequireConnection(Kernel::HLERequestContext& ctx);
+
+    /**
+     * GetReceiveEvent service function
+     * Gets an event that is signaled when a packet is received from the IR device.
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     *      2 : 0 (Handle descriptor)
+     *      3 : Receive event handle
+     */
+    void GetReceiveEvent(Kernel::HLERequestContext& ctx);
+
+    /**
+     * GetSendEvent service function
+     * Gets an event that is signaled when the sending of a packet is complete
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     *      2 : 0 (Handle descriptor)
+     *      3 : Send event handle
+     */
+    void GetSendEvent(Kernel::HLERequestContext& ctx);
+
+    /**
+     * Disconnect service function
+     * Disconnects from the current connected IR device.
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void Disconnect(Kernel::HLERequestContext& ctx);
+
+    /**
+     * GetConnectionStatusEvent service function
+     * Gets an event that is signaled when the connection status is changed
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     *      2 : 0 (Handle descriptor)
+     *      3 : Connection Status Event handle
+     */
+    void GetConnectionStatusEvent(Kernel::HLERequestContext& ctx);
+
+    /**
+     * FinalizeIrNop service function
+     * Finalize ir:USER service.
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void FinalizeIrNop(Kernel::HLERequestContext& ctx);
+
+    /**
+     * SendIrNop service function
+     * Sends a packet to the connected IR device
+     *  Inpus:
+     *      1 : Size of data to send
+     *      2 : 2 + (size << 14) (Static buffer descriptor)
+     *      3 : Data buffer address
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void SendIrNop(Kernel::HLERequestContext& ctx);
+
+    /**
+     * ReleaseReceivedData function
+     * Release a specified amount of packet from the receive buffer. This is called after the
+     * application reads received packet from the buffer directly, to release the buffer space for
+     * future packets.
+     *  Inpus:
+     *      1 : Number of packets to release
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void ReleaseReceivedData(Kernel::HLERequestContext& ctx);
+
+    void PutToReceive(const std::vector<u8>& payload);
+
+    Kernel::SharedPtr<Kernel::Event> conn_status_event, send_event, receive_event;
+    Kernel::SharedPtr<Kernel::SharedMemory> shared_memory;
+    IRDevice* connected_device{nullptr};
+    std::unique_ptr<BufferManager> receive_buffer;
+    std::unique_ptr<ExtraHID> extra_hid;
 };
-
-void InitUser();
-void ShutdownUser();
-
-/// Reload input devices. Used when input configuration changed
-void ReloadInputDevicesUser();
 
 } // namespace IR
 } // namespace Service

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -274,6 +274,7 @@ void Init() {
     FRD::Init();
     HID::Init();
     IR::Init();
+    IR::InstallInterfaces(*SM::g_service_manager);
     MVD::Init();
     NDM::Init();
     NEWS::Init();

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -273,7 +273,6 @@ void Init() {
     DLP::Init();
     FRD::Init();
     HID::Init();
-    IR::Init();
     IR::InstallInterfaces(*SM::g_service_manager);
     MVD::Init();
     NDM::Init();
@@ -306,7 +305,6 @@ void Shutdown() {
     NIM::Shutdown();
     NEWS::Shutdown();
     NDM::Shutdown();
-    IR::Shutdown();
     HID::Shutdown();
     FRD::Shutdown();
     DLP::Shutdown();


### PR DESCRIPTION
Besides moving around code, there are three small changes made:

 - Fixed request parser header code for `IR_RST::Shutdown`
 - `IR_USER::receive_buffer` is changed from a `boost::optional` to `std::unique_ptr`, to avoid moving around the definition of `BufferManager` because `boost::optional` doesn't support forward declaration.
 - ir.cpp keeps weak references to `IR_RST` and `IR_USER` in order to inform them about input device reloading. I need more opinion on this to see if there is a better way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3248)
<!-- Reviewable:end -->
