### PR TITLE
HLE/News: Stubbed GetTotalNotifications to always return 0 notifications.

### DIFF
--- a/src/core/hle/service/news/news_s.cpp
+++ b/src/core/hle/service/news/news_s.cpp
@@ -2,15 +2,36 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "core/hle/ipc_helpers.h"
 #include "core/hle/service/news/news.h"
 #include "core/hle/service/news/news_s.h"
 
 namespace Service {
 namespace NEWS {
 
+/**
+ * GetTotalNotifications service function.
+ *  Inputs:
+ *      0 : 0x00050000
+ *  Outputs:
+ *      0 : 0x00050080
+ *      1 : Result of function, 0 on success, otherwise error code
+ *      2 : Number of notifications
+ */
+static void GetTotalNotifications(Service::Interface* self) {
+    IPC::RequestParser rp(Kernel::GetCommandBuffer(), 0x5, 0, 0);
+
+    LOG_WARNING(Service, "(STUBBED) called");
+
+    IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
+
+    rb.Push(RESULT_SUCCESS);
+    rb.Push<u32>(0);
+}
+
 const Interface::FunctionInfo FunctionTable[] = {
     {0x000100C6, nullptr, "AddNotification"},
-    {0x00050000, nullptr, "GetTotalNotifications"},
+    {0x00050000, GetTotalNotifications, "GetTotalNotifications"},
     {0x00060042, nullptr, "SetNewsDBHeader"},
     {0x00070082, nullptr, "SetNotificationHeader"},
     {0x00080082, nullptr, "SetNotificationMessage"},


### PR DESCRIPTION
This prevents an invalid read loop on games that call it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3250)
<!-- Reviewable:end -->
