### PR TITLE
file_sys: std::move data argumnets in the constructor where applicable

### DIFF
--- a/src/core/file_sys/archive_ncch.cpp
+++ b/src/core/file_sys/archive_ncch.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cinttypes>
 #include <memory>
+#include <utility>
 #include <vector>
 #include "common/common_types.h"
 #include "common/file_util.h"
@@ -83,7 +84,7 @@ ResultVal<std::unique_ptr<FileBackend>> NCCHArchive::OpenFile(const Path& path,
 
         // Load NCCH .code or icon/banner/logo
         result = ncch_container.LoadSectionExeFS(openfile_path.exefs_filepath.data(), buffer);
-        file = std::make_unique<NCCHFile>(buffer);
+        file = std::make_unique<NCCHFile>(std::move(buffer));
     } else {
         LOG_ERROR(Service_FS, "Unknown NCCH archive type %u!", openfile_path.filepath_type);
         result = Loader::ResultStatus::Error;
@@ -192,6 +193,8 @@ u64 NCCHArchive::GetFreeBytes() const {
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
+
+NCCHFile::NCCHFile(std::vector<u8> buffer) : file_buffer(std::move(buffer)) {}
 
 ResultVal<size_t> NCCHFile::Read(const u64 offset, const size_t length, u8* buffer) const {
     LOG_TRACE(Service_FS, "called offset=%" PRIu64 ", length=%zu", offset, length);

--- a/src/core/file_sys/archive_ncch.cpp
+++ b/src/core/file_sys/archive_ncch.cpp
@@ -76,7 +76,7 @@ ResultVal<std::unique_ptr<FileBackend>> NCCHArchive::OpenFile(const Path& path,
         u64 romfs_size = 0;
 
         result = ncch_container.ReadRomFS(romfs_file, romfs_offset, romfs_size);
-        file = std::make_unique<IVFCFile>(romfs_file, romfs_offset, romfs_size);
+        file = std::make_unique<IVFCFile>(std::move(romfs_file), romfs_offset, romfs_size);
     } else if (filepath_type == NCCHFilePathType::Code ||
                filepath_type == NCCHFilePathType::ExeFS) {
         std::vector<u8> buffer;

--- a/src/core/file_sys/archive_ncch.h
+++ b/src/core/file_sys/archive_ncch.h
@@ -51,7 +51,7 @@ protected:
 // File backend for NCCH files
 class NCCHFile : public FileBackend {
 public:
-    NCCHFile(std::vector<u8> buffer) : file_buffer(buffer) {}
+    explicit NCCHFile(std::vector<u8> buffer);
 
     ResultVal<size_t> Read(u64 offset, size_t length, u8* buffer) const override;
     ResultVal<size_t> Write(u64 offset, size_t length, bool flush, const u8* buffer) override;

--- a/src/core/file_sys/archive_other_savedata.cpp
+++ b/src/core/file_sys/archive_other_savedata.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <tuple>
+#include <utility>
 #include "core/file_sys/archive_other_savedata.h"
 #include "core/file_sys/errors.h"
 #include "core/hle/kernel/process.h"
@@ -60,7 +61,7 @@ ResultVal<std::tuple<MediaType, u64>> ParsePathGeneral(const Path& path) {
 
 ArchiveFactory_OtherSaveDataPermitted::ArchiveFactory_OtherSaveDataPermitted(
     std::shared_ptr<ArchiveSource_SDSaveData> sd_savedata)
-    : sd_savedata_source(sd_savedata) {}
+    : sd_savedata_source(std::move(sd_savedata)) {}
 
 ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_OtherSaveDataPermitted::Open(
     const Path& path) {
@@ -98,7 +99,7 @@ ResultVal<ArchiveFormatInfo> ArchiveFactory_OtherSaveDataPermitted::GetFormatInf
 
 ArchiveFactory_OtherSaveDataGeneral::ArchiveFactory_OtherSaveDataGeneral(
     std::shared_ptr<ArchiveSource_SDSaveData> sd_savedata)
-    : sd_savedata_source(sd_savedata) {}
+    : sd_savedata_source(std::move(sd_savedata)) {}
 
 ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_OtherSaveDataGeneral::Open(
     const Path& path) {

--- a/src/core/file_sys/archive_savedata.cpp
+++ b/src/core/file_sys/archive_savedata.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <utility>
 #include "core/file_sys/archive_savedata.h"
 #include "core/hle/kernel/process.h"
 
@@ -12,7 +13,7 @@ namespace FileSys {
 
 ArchiveFactory_SaveData::ArchiveFactory_SaveData(
     std::shared_ptr<ArchiveSource_SDSaveData> sd_savedata)
-    : sd_savedata_source(sd_savedata) {}
+    : sd_savedata_source(std::move(sd_savedata)) {}
 
 ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_SaveData::Open(const Path& path) {
     return sd_savedata_source->Open(Kernel::g_current_process->codeset->program_id);

--- a/src/core/file_sys/ivfc_archive.cpp
+++ b/src/core/file_sys/ivfc_archive.cpp
@@ -4,6 +4,7 @@
 
 #include <cstring>
 #include <memory>
+#include <utility>
 #include "common/common_types.h"
 #include "common/logging/log.h"
 #include "core/file_sys/ivfc_archive.h"
@@ -12,6 +13,9 @@
 // FileSys namespace
 
 namespace FileSys {
+
+IVFCArchive::IVFCArchive(std::shared_ptr<FileUtil::IOFile> file, u64 offset, u64 size)
+    : romfs_file(std::move(file)), data_offset(offset), data_size(size) {}
 
 std::string IVFCArchive::GetName() const {
     return "IVFC";
@@ -84,6 +88,9 @@ u64 IVFCArchive::GetFreeBytes() const {
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
+
+IVFCFile::IVFCFile(std::shared_ptr<FileUtil::IOFile> file, u64 offset, u64 size)
+    : romfs_file(std::move(file)), data_offset(offset), data_size(size) {}
 
 ResultVal<size_t> IVFCFile::Read(const u64 offset, const size_t length, u8* buffer) const {
     LOG_TRACE(Service_FS, "called offset=%llu, length=%zu", offset, length);

--- a/src/core/file_sys/ivfc_archive.h
+++ b/src/core/file_sys/ivfc_archive.h
@@ -7,7 +7,6 @@
 #include <cstddef>
 #include <memory>
 #include <string>
-#include <vector>
 #include "common/common_types.h"
 #include "common/file_util.h"
 #include "core/file_sys/archive_backend.h"
@@ -27,8 +26,7 @@ namespace FileSys {
  */
 class IVFCArchive : public ArchiveBackend {
 public:
-    IVFCArchive(std::shared_ptr<FileUtil::IOFile> file, u64 offset, u64 size)
-        : romfs_file(file), data_offset(offset), data_size(size) {}
+    IVFCArchive(std::shared_ptr<FileUtil::IOFile> file, u64 offset, u64 size);
 
     std::string GetName() const override;
 
@@ -52,8 +50,7 @@ protected:
 
 class IVFCFile : public FileBackend {
 public:
-    IVFCFile(std::shared_ptr<FileUtil::IOFile> file, u64 offset, u64 size)
-        : romfs_file(file), data_offset(offset), data_size(size) {}
+    IVFCFile(std::shared_ptr<FileUtil::IOFile> file, u64 offset, u64 size);
 
     ResultVal<size_t> Read(u64 offset, size_t length, u8* buffer) const override;
     ResultVal<size_t> Write(u64 offset, size_t length, bool flush, const u8* buffer) override;


### PR DESCRIPTION
Just avoids some unnecessary atomic inc/dec and copies. A fairly trivial change

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3254)
<!-- Reviewable:end -->
