### PR TITLE
shader_jit_x64_compiler: Use haddps for horizontal summation

### DIFF
--- a/src/video_core/shader/shader_jit_x64_compiler.cpp
+++ b/src/video_core/shader/shader_jit_x64_compiler.cpp
@@ -387,18 +387,8 @@ void JitShader::Compile_DP4(Instruction instr) {
 
     Compile_SanitizedMul(SRC1, SRC2, SCRATCH);
 
-    if (Common::GetCPUCaps().sse3) {
-        haddps(SRC1, SRC1);
-        haddps(SRC1, SRC1);
-    } else {
-        movaps(SRC2, SRC1);
-        shufps(SRC1, SRC1, _MM_SHUFFLE(2, 3, 0, 1)); // XYZW -> ZWXY
-        addps(SRC1, SRC2);
-
-        movaps(SRC2, SRC1);
-        shufps(SRC1, SRC1, _MM_SHUFFLE(0, 1, 2, 3)); // XYZW -> WZYX
-        addps(SRC1, SRC2);
-    }
+    haddps(SRC1, SRC1);
+    haddps(SRC1, SRC1);
 
     Compile_DestEnable(instr, SRC1);
 }
@@ -424,18 +414,8 @@ void JitShader::Compile_DPH(Instruction instr) {
 
     Compile_SanitizedMul(SRC1, SRC2, SCRATCH);
 
-    if (Common::GetCPUCaps().sse3) {
-        haddps(SRC1, SRC1);
-        haddps(SRC1, SRC1);
-    } else {
-        movaps(SRC2, SRC1);
-        shufps(SRC1, SRC1, _MM_SHUFFLE(2, 3, 0, 1)); // XYZW -> ZWXY
-        addps(SRC1, SRC2);
-
-        movaps(SRC2, SRC1);
-        shufps(SRC1, SRC1, _MM_SHUFFLE(0, 1, 2, 3)); // XYZW -> WZYX
-        addps(SRC1, SRC2);
-    }
+    haddps(SRC1, SRC1);
+    haddps(SRC1, SRC1);
 
     Compile_DestEnable(instr, SRC1);
 }

--- a/src/video_core/shader/shader_jit_x64_compiler.cpp
+++ b/src/video_core/shader/shader_jit_x64_compiler.cpp
@@ -387,13 +387,18 @@ void JitShader::Compile_DP4(Instruction instr) {
 
     Compile_SanitizedMul(SRC1, SRC2, SCRATCH);
 
-    movaps(SRC2, SRC1);
-    shufps(SRC1, SRC1, _MM_SHUFFLE(2, 3, 0, 1)); // XYZW -> ZWXY
-    addps(SRC1, SRC2);
+    if (Common::GetCPUCaps().sse3) {
+        haddps(SRC1, SRC1);
+        haddps(SRC1, SRC1);
+    } else {
+        movaps(SRC2, SRC1);
+        shufps(SRC1, SRC1, _MM_SHUFFLE(2, 3, 0, 1)); // XYZW -> ZWXY
+        addps(SRC1, SRC2);
 
-    movaps(SRC2, SRC1);
-    shufps(SRC1, SRC1, _MM_SHUFFLE(0, 1, 2, 3)); // XYZW -> WZYX
-    addps(SRC1, SRC2);
+        movaps(SRC2, SRC1);
+        shufps(SRC1, SRC1, _MM_SHUFFLE(0, 1, 2, 3)); // XYZW -> WZYX
+        addps(SRC1, SRC2);
+    }
 
     Compile_DestEnable(instr, SRC1);
 }
@@ -419,13 +424,18 @@ void JitShader::Compile_DPH(Instruction instr) {
 
     Compile_SanitizedMul(SRC1, SRC2, SCRATCH);
 
-    movaps(SRC2, SRC1);
-    shufps(SRC1, SRC1, _MM_SHUFFLE(2, 3, 0, 1)); // XYZW -> ZWXY
-    addps(SRC1, SRC2);
+    if (Common::GetCPUCaps().sse3) {
+        haddps(SRC1, SRC1);
+        haddps(SRC1, SRC1);
+    } else {
+        movaps(SRC2, SRC1);
+        shufps(SRC1, SRC1, _MM_SHUFFLE(2, 3, 0, 1)); // XYZW -> ZWXY
+        addps(SRC1, SRC2);
 
-    movaps(SRC2, SRC1);
-    shufps(SRC1, SRC1, _MM_SHUFFLE(0, 1, 2, 3)); // XYZW -> WZYX
-    addps(SRC1, SRC2);
+        movaps(SRC2, SRC1);
+        shufps(SRC1, SRC1, _MM_SHUFFLE(0, 1, 2, 3)); // XYZW -> WZYX
+        addps(SRC1, SRC2);
+    }
 
     Compile_DestEnable(instr, SRC1);
 }


### PR DESCRIPTION
ICC emits this instead for its __sec_reduce_add intrinsic when supported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3261)
<!-- Reviewable:end -->
