### PR TITLE
input_common/sdl: Silence a -Wpessimizing-move warning

### DIFF
--- a/src/input_common/sdl/sdl.cpp
+++ b/src/input_common/sdl/sdl.cpp
@@ -425,7 +425,7 @@ std::vector<std::unique_ptr<InputCommon::Polling::DevicePoller>> GetPollers(
         pollers.push_back(std::make_unique<SDLButtonPoller>());
         break;
     }
-    return std::move(pollers);
+    return pollers;
 }
 } // namespace Polling
 } // namespace SDL


### PR DESCRIPTION
Moving when returning by value can inhibit copy elision.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3263)
<!-- Reviewable:end -->
