### PR TITLE
HLE/APT: Implement GetAppletInfo for LLE applets.

### DIFF
--- a/src/core/hle/service/apt/apt.h
+++ b/src/core/hle/service/apt/apt.h
@@ -441,6 +441,17 @@ void PrepareToStartNewestHomeMenu(Service::Interface* self);
 void PreloadLibraryApplet(Service::Interface* self);
 
 /**
+ * APT::FinishPreloadingLibraryApplet service function
+ *  Inputs:
+ *      0 : Command header [0x00170040]
+ *      1 : Id of the applet
+ *  Outputs:
+ *      0 : Return header
+ *      1 : Result of function, 0 on success, otherwise error code
+ */
+void FinishPreloadingLibraryApplet(Service::Interface* self);
+
+/**
  * APT::StartLibraryApplet service function
  *  Inputs:
  *      0 : Command header [0x001E0084]

--- a/src/core/hle/service/apt/apt_s.cpp
+++ b/src/core/hle/service/apt/apt_s.cpp
@@ -31,7 +31,7 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x00140040, nullptr, "SetPreparationState"},
     {0x00150140, PrepareToStartApplication, "PrepareToStartApplication"},
     {0x00160040, PreloadLibraryApplet, "PreloadLibraryApplet"},
-    {0x00170040, nullptr, "FinishPreloadingLibraryApplet"},
+    {0x00170040, FinishPreloadingLibraryApplet, "FinishPreloadingLibraryApplet"},
     {0x00180040, PrepareToStartLibraryApplet, "PrepareToStartLibraryApplet"},
     {0x00190040, nullptr, "PrepareToStartSystemApplet"},
     {0x001A0000, PrepareToStartNewestHomeMenu, "PrepareToStartNewestHomeMenu"},

--- a/src/core/hle/service/apt/apt_u.cpp
+++ b/src/core/hle/service/apt/apt_u.cpp
@@ -31,7 +31,7 @@ const Interface::FunctionInfo FunctionTable[] = {
     {0x00140040, nullptr, "SetPreparationState"},
     {0x00150140, PrepareToStartApplication, "PrepareToStartApplication"},
     {0x00160040, PreloadLibraryApplet, "PreloadLibraryApplet"},
-    {0x00170040, nullptr, "FinishPreloadingLibraryApplet"},
+    {0x00170040, FinishPreloadingLibraryApplet, "FinishPreloadingLibraryApplet"},
     {0x00180040, PrepareToStartLibraryApplet, "PrepareToStartLibraryApplet"},
     {0x00190040, nullptr, "PrepareToStartSystemApplet"},
     {0x001A0000, nullptr, "PrepareToStartNewestHomeMenu"},


### PR DESCRIPTION
Calling this function for AppletId::Application is not yet implemented because we don't support launching applications from APT.

The HLE applet machinery is showing its age, it's getting awkward to still support it alongside LLE applets. I want to rewrite it one day to make it use an interface more similar to real applets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3265)
<!-- Reviewable:end -->
