### PR TITLE
ipc_helpers: Add member functions for pushing and popping strongly typed enums

### DIFF
--- a/src/core/hle/ipc_helpers.h
+++ b/src/core/hle/ipc_helpers.h
@@ -98,6 +98,15 @@ public:
     template <typename First, typename... Other>
     void Push(const First& first_value, const Other&... other_values);
 
+    template <typename T>
+    void PushEnum(T value) {
+        static_assert(std::is_enum<T>(), "T must be an enum type within a PushEnum call.");
+        static_assert(!std::is_convertible<T, int>(),
+                      "enum type in PushEnum must be a strongly typed enum.");
+        static_assert(sizeof(value) < sizeof(u64), "64-bit enums may not be pushed.");
+        Push(static_cast<std::underlying_type_t<T>>(value));
+    }
+
     /**
      * @brief Copies the content of the given trivially copyable class to the buffer as a normal
      * param
@@ -272,6 +281,15 @@ public:
 
     template <typename First, typename... Other>
     void Pop(First& first_value, Other&... other_values);
+
+    template <typename T>
+    T PopEnum() {
+        static_assert(std::is_enum<T>(), "T must be an enum type within a PopEnum call.");
+        static_assert(!std::is_convertible<T, int>(),
+                      "enum type in PopEnum must be a strongly typed enum.");
+        static_assert(sizeof(T) < sizeof(u64), "64-bit enums cannot be popped.");
+        return static_cast<T>(Pop<std::underlying_type_t<T>>());
+    }
 
     /// Equivalent to calling `PopHandles<1>()[0]`.
     Kernel::Handle PopHandle();


### PR DESCRIPTION
Alleviates the need to static_cast to an enum type at the call sites of the Push and Pop calls.

We only allow strongly typed enums, as they have a defined type of int by default if an underlying type isn't explicitly specified, whereas with regular enums, if an underlying type isn't specified, an implementation-defined  type is used that can fit all the enumeration values. So this opts for a "do the default consistent thing" approach.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3268)
<!-- Reviewable:end -->
