### PR TITLE
core/arm: Backend-specific context implementations

### DIFF
--- a/src/citra_qt/debugger/wait_tree.cpp
+++ b/src/citra_qt/debugger/wait_tree.cpp
@@ -172,8 +172,8 @@ QString WaitTreeThread::GetText() const {
         break;
     }
     QString pc_info = tr(" PC = 0x%1 LR = 0x%2")
-                          .arg(thread.context.pc, 8, 16, QLatin1Char('0'))
-                          .arg(thread.context.lr, 8, 16, QLatin1Char('0'));
+                          .arg(thread.context->GetProgramCounter(), 8, 16, QLatin1Char('0'))
+                          .arg(thread.context->GetLinkRegister(), 8, 16, QLatin1Char('0'));
     return WaitTreeWaitObject::GetText() + pc_info + " (" + status + ") ";
 }
 

--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <cstring>
+#include <dynarmic/context.h>
 #include <dynarmic/dynarmic.h>
 #include "common/assert.h"
 #include "common/microprofile.h"
@@ -13,6 +14,59 @@
 #include "core/core_timing.h"
 #include "core/hle/kernel/svc.h"
 #include "core/memory.h"
+
+class DynarmicThreadContext final : public ARM_Interface::ThreadContext {
+public:
+    DynarmicThreadContext() {
+        Reset();
+    }
+    ~DynarmicThreadContext() override = default;
+
+    void Reset() override {
+        ctx.Regs() = {};
+        ctx.SetCpsr(0);
+        ctx.ExtRegs() = {};
+        ctx.SetFpscr(0);
+        fpexc = 0;
+    }
+
+    u32 GetCpuRegister(size_t index) const override {
+        return ctx.Regs()[index];
+    }
+    void SetCpuRegister(size_t index, u32 value) override {
+        ctx.Regs()[index] = value;
+    }
+    u32 GetCpsr() const override {
+        return ctx.Cpsr();
+    }
+    void SetCpsr(u32 value) override {
+        ctx.SetCpsr(value);
+    }
+    u32 GetFpuRegister(size_t index) const override {
+        return ctx.ExtRegs()[index];
+    }
+    void SetFpuRegister(size_t index, u32 value) override {
+        ctx.ExtRegs()[index] = value;
+    }
+    u32 GetFpscr() const override {
+        return ctx.Fpscr();
+    }
+    void SetFpscr(u32 value) override {
+        ctx.SetFpscr(value);
+    }
+    u32 GetFpexc() const override {
+        return fpexc;
+    }
+    void SetFpexc(u32 value) override {
+        fpexc = value;
+    }
+
+private:
+    friend class ARM_Dynarmic;
+
+    Dynarmic::Context ctx;
+    u32 fpexc;
+};
 
 static void InterpreterFallback(u32 pc, Dynarmic::Jit* jit, void* user_arg) {
     ARMul_State* state = static_cast<ARMul_State*>(user_arg);
@@ -148,30 +202,24 @@ void ARM_Dynarmic::SetCP15Register(CP15Register reg, u32 value) {
     interpreter_state->CP15[reg] = value;
 }
 
-void ARM_Dynarmic::SaveContext(ARM_Interface::ThreadContext& ctx) {
-    memcpy(ctx.cpu_registers, jit->Regs().data(), sizeof(ctx.cpu_registers));
-    memcpy(ctx.fpu_registers, jit->ExtRegs().data(), sizeof(ctx.fpu_registers));
-
-    ctx.sp = jit->Regs()[13];
-    ctx.lr = jit->Regs()[14];
-    ctx.pc = jit->Regs()[15];
-    ctx.cpsr = jit->Cpsr();
-
-    ctx.fpscr = jit->Fpscr();
-    ctx.fpexc = interpreter_state->VFP[VFP_FPEXC];
+std::unique_ptr<ARM_Interface::ThreadContext> ARM_Dynarmic::NewContext() const {
+    return std::make_unique<DynarmicThreadContext>();
 }
 
-void ARM_Dynarmic::LoadContext(const ARM_Interface::ThreadContext& ctx) {
-    memcpy(jit->Regs().data(), ctx.cpu_registers, sizeof(ctx.cpu_registers));
-    memcpy(jit->ExtRegs().data(), ctx.fpu_registers, sizeof(ctx.fpu_registers));
+void ARM_Dynarmic::SaveContext(const std::unique_ptr<ThreadContext>& arg) {
+    DynarmicThreadContext* ctx = dynamic_cast<DynarmicThreadContext*>(arg.get());
+    ASSERT(ctx);
 
-    jit->Regs()[13] = ctx.sp;
-    jit->Regs()[14] = ctx.lr;
-    jit->Regs()[15] = ctx.pc;
-    jit->SetCpsr(ctx.cpsr);
+    jit->SaveContext(ctx->ctx);
+    ctx->fpexc = interpreter_state->VFP[VFP_FPEXC];
+}
 
-    jit->SetFpscr(ctx.fpscr);
-    interpreter_state->VFP[VFP_FPEXC] = ctx.fpexc;
+void ARM_Dynarmic::LoadContext(const std::unique_ptr<ThreadContext>& arg) {
+    const DynarmicThreadContext* ctx = dynamic_cast<DynarmicThreadContext*>(arg.get());
+    ASSERT(ctx);
+
+    jit->LoadContext(ctx->ctx);
+    interpreter_state->VFP[VFP_FPEXC] = ctx->fpexc;
 }
 
 void ARM_Dynarmic::PrepareReschedule() {

--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -30,7 +30,7 @@ static void InterpreterFallback(u32 pc, Dynarmic::Jit* jit, void* user_arg) {
     state->Reg[15] &= (is_thumb ? 0xFFFFFFFE : 0xFFFFFFFC);
 
     jit->Regs() = state->Reg;
-    jit->Cpsr() = state->Cpsr;
+    jit->SetCpsr(state->Cpsr);
     jit->ExtRegs() = state->ExtReg;
     jit->SetFpscr(state->VFP[VFP_FPSCR]);
 }
@@ -137,7 +137,7 @@ u32 ARM_Dynarmic::GetCPSR() const {
 }
 
 void ARM_Dynarmic::SetCPSR(u32 cpsr) {
-    jit->Cpsr() = cpsr;
+    jit->SetCpsr(cpsr);
 }
 
 u32 ARM_Dynarmic::GetCP15Register(CP15Register reg) {
@@ -168,7 +168,7 @@ void ARM_Dynarmic::LoadContext(const ARM_Interface::ThreadContext& ctx) {
     jit->Regs()[13] = ctx.sp;
     jit->Regs()[14] = ctx.lr;
     jit->Regs()[15] = ctx.pc;
-    jit->Cpsr() = ctx.cpsr;
+    jit->SetCpsr(ctx.cpsr);
 
     jit->SetFpscr(ctx.fpscr);
     interpreter_state->VFP[VFP_FPEXC] = ctx.fpexc;

--- a/src/core/arm/dynarmic/arm_dynarmic.h
+++ b/src/core/arm/dynarmic/arm_dynarmic.h
@@ -35,8 +35,9 @@ public:
     u32 GetCP15Register(CP15Register reg) override;
     void SetCP15Register(CP15Register reg, u32 value) override;
 
-    void SaveContext(ThreadContext& ctx) override;
-    void LoadContext(const ThreadContext& ctx) override;
+    std::unique_ptr<ThreadContext> NewContext() const override;
+    void SaveContext(const std::unique_ptr<ThreadContext>& arg) override;
+    void LoadContext(const std::unique_ptr<ThreadContext>& arg) override;
 
     void PrepareReschedule() override;
 

--- a/src/core/arm/dyncom/arm_dyncom.h
+++ b/src/core/arm/dyncom/arm_dyncom.h
@@ -35,8 +35,9 @@ public:
     u32 GetCP15Register(CP15Register reg) override;
     void SetCP15Register(CP15Register reg, u32 value) override;
 
-    void SaveContext(ThreadContext& ctx) override;
-    void LoadContext(const ThreadContext& ctx) override;
+    std::unique_ptr<ThreadContext> NewContext() const override;
+    void SaveContext(const std::unique_ptr<ThreadContext>& arg) override;
+    void LoadContext(const std::unique_ptr<ThreadContext>& arg) override;
 
     void PrepareReschedule() override;
 

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -733,8 +733,8 @@ static ResultCode CreateThread(Handle* out_handle, u32 priority, u32 entry_point
                    Thread::Create(name, entry_point, priority, arg, processor_id, stack_top,
                                   g_current_process));
 
-    thread->context.fpscr =
-        FPSCR_DEFAULT_NAN | FPSCR_FLUSH_TO_ZERO | FPSCR_ROUND_TOZERO; // 0x03C00000
+    thread->context->SetFpscr(FPSCR_DEFAULT_NAN | FPSCR_FLUSH_TO_ZERO |
+                              FPSCR_ROUND_TOZERO); // 0x03C00000
 
     CASCADE_RESULT(*out_handle, g_handle_table.Create(std::move(thread)));
 

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -181,7 +181,7 @@ public:
         return status == THREADSTATUS_WAIT_SYNCH_ALL;
     }
 
-    ARM_Interface::ThreadContext context;
+    std::unique_ptr<ARM_Interface::ThreadContext> context;
 
     u32 thread_id;
 


### PR DESCRIPTION
~~WIP as dynarmic side changes are in flux.~~

Advantage is this avoids needing to invalidate cache-like structures on the CPU emulator like the Return Stack Buffer when doing a context-switch. This also avoids the cost of seralizing and deseralizing the CPSR and FPSCR when the CPU backend has a non-canonical representation of these things.

On dynarmic's side we also have the following changes for speed:

* Split CPSR for slightly faster GE flags access and slightly faster runtime location-hash calculation.
* Added prediction for where the next basic block would be when exiting due to exhaustion of time slice to avoid an expensive std::unordered_map lookup on re-entry.
* Turn RSB back into a stack since it offers better predictions with the context changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3272)
<!-- Reviewable:end -->
