### PR TITLE
core: Don't Shutdown before we've even Init-ed

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -87,7 +87,6 @@ System::ResultStatus System::Load(EmuWindow* emu_window, const std::string& file
     if (system_mode.second != Loader::ResultStatus::Success) {
         LOG_CRITICAL(Core, "Failed to determine system mode (Error %i)!",
                      static_cast<int>(system_mode.second));
-        System::Shutdown();
 
         switch (system_mode.second) {
         case Loader::ResultStatus::ErrorEncrypted:


### PR DESCRIPTION
This causes crashes such as [this one](https://www.reddit.com/r/Citra/comments/7j3sbn/automatic_crash/).

Init is called [a few lines down](https://github.com/citra-emu/citra/pull/3275/files#diff-5db0ca19c12b31af1e97555eeadc9eeaR101).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3275)
<!-- Reviewable:end -->
