### PR TITLE
[RFC] Assert: Don't crash citra completely on assert, but stop the emu_thread

### DIFF
--- a/src/common/assert.h
+++ b/src/common/assert.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstdlib>
+#include <exception>
 #include "common/common_funcs.h"
 #include "common/logging/log.h"
 
@@ -15,6 +16,9 @@
 // template that calls the lambda. This seems to generate an extra instruction at the call-site
 // compared to the ideal implementation (which wouldn't support ASSERT_MSG parameters), but is good
 // enough for our purposes.
+
+class AssertException : std::exception {};
+
 template <typename Fn>
 #if defined(_MSC_VER)
 __declspec(noinline, noreturn)
@@ -23,8 +27,7 @@ __declspec(noinline, noreturn)
 #endif
     static void assert_noinline_call(const Fn& fn) {
     fn();
-    Crash();
-    exit(1); // Keeps GCC's mouth shut about this actually returning
+    throw AssertException();
 }
 
 #define ASSERT(_a_)                                                                                \

--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <csetjmp>
 #include <cstring>
 #include <dynarmic/dynarmic.h>
 #include "common/assert.h"
@@ -13,6 +14,27 @@
 #include "core/core_timing.h"
 #include "core/hle/kernel/svc.h"
 #include "core/memory.h"
+
+jmp_buf jit_exit_point;
+AssertException assert_exception;
+
+template < class T, T >
+struct ExceptionCatchJmpWrapper;
+
+template < class R, typename... Args, R Func(Args...) >
+struct ExceptionCatchJmpWrapper<R (*)(Args...), Func > {
+    static R call(Args... args) {
+        try {
+            return Func(args...);
+        } catch (const AssertException& e) {
+            assert_exception = e;
+            longjmp(jit_exit_point, 1);
+        }
+    }
+};
+
+#define WRAP_EXCEPTION_HANDLER(x) ExceptionCatchJmpWrapper< decltype(x), (x) >::call
+
 
 static void InterpreterFallback(u32 pc, Dynarmic::Jit* jit, void* user_arg) {
     ARMul_State* state = static_cast<ARMul_State*>(user_arg);
@@ -52,21 +74,21 @@ static u64 GetTicksRemaining() {
 static Dynarmic::UserCallbacks GetUserCallbacks(
     const std::shared_ptr<ARMul_State>& interpreter_state, Memory::PageTable* current_page_table) {
     Dynarmic::UserCallbacks user_callbacks{};
-    user_callbacks.InterpreterFallback = &InterpreterFallback;
+    user_callbacks.InterpreterFallback = WRAP_EXCEPTION_HANDLER(&InterpreterFallback);
     user_callbacks.user_arg = static_cast<void*>(interpreter_state.get());
-    user_callbacks.CallSVC = &Kernel::CallSVC;
-    user_callbacks.memory.IsReadOnlyMemory = &IsReadOnlyMemory;
-    user_callbacks.memory.ReadCode = &Memory::Read32;
-    user_callbacks.memory.Read8 = &Memory::Read8;
-    user_callbacks.memory.Read16 = &Memory::Read16;
-    user_callbacks.memory.Read32 = &Memory::Read32;
-    user_callbacks.memory.Read64 = &Memory::Read64;
-    user_callbacks.memory.Write8 = &Memory::Write8;
-    user_callbacks.memory.Write16 = &Memory::Write16;
-    user_callbacks.memory.Write32 = &Memory::Write32;
-    user_callbacks.memory.Write64 = &Memory::Write64;
-    user_callbacks.AddTicks = &AddTicks;
-    user_callbacks.GetTicksRemaining = &GetTicksRemaining;
+    user_callbacks.CallSVC = WRAP_EXCEPTION_HANDLER(&Kernel::CallSVC);
+    user_callbacks.memory.IsReadOnlyMemory = WRAP_EXCEPTION_HANDLER(&IsReadOnlyMemory);
+    user_callbacks.memory.ReadCode = WRAP_EXCEPTION_HANDLER(&Memory::Read32);
+    user_callbacks.memory.Read8 = WRAP_EXCEPTION_HANDLER(&Memory::Read8);
+    user_callbacks.memory.Read16 = WRAP_EXCEPTION_HANDLER(&Memory::Read16);
+    user_callbacks.memory.Read32 = WRAP_EXCEPTION_HANDLER(&Memory::Read32);
+    user_callbacks.memory.Read64 = WRAP_EXCEPTION_HANDLER(&Memory::Read64);
+    user_callbacks.memory.Write8 = WRAP_EXCEPTION_HANDLER(&Memory::Write8);
+    user_callbacks.memory.Write16 = WRAP_EXCEPTION_HANDLER(&Memory::Write16);
+    user_callbacks.memory.Write32 = WRAP_EXCEPTION_HANDLER(&Memory::Write32);
+    user_callbacks.memory.Write64 = WRAP_EXCEPTION_HANDLER(&Memory::Write64);
+    user_callbacks.AddTicks = WRAP_EXCEPTION_HANDLER(&AddTicks);
+    user_callbacks.GetTicksRemaining = WRAP_EXCEPTION_HANDLER(&GetTicksRemaining);
     user_callbacks.page_table = &current_page_table->pointers;
     user_callbacks.coprocessors[15] = std::make_shared<DynarmicCP15>(interpreter_state);
     return user_callbacks;
@@ -82,8 +104,12 @@ MICROPROFILE_DEFINE(ARM_Jit, "ARM JIT", "ARM JIT", MP_RGB(255, 64, 64));
 void ARM_Dynarmic::Run() {
     ASSERT(Memory::GetCurrentPageTable() == current_page_table);
     MICROPROFILE_SCOPE(ARM_Jit);
-
-    jit->Run(GetTicksRemaining());
+    int asserted = setjmp(jit_exit_point);
+    if (!asserted) {
+        jit->Run(GetTicksRemaining());
+    } else {
+        throw assert_exception;
+    }
 }
 
 void ARM_Dynarmic::Step() {


### PR DESCRIPTION
This will allow to do things like log storing from within the ui when citra crashes.
The exception should only be thrown from within emu_thread.
Since the exception isn't handled in JIT we have to circumvent it.
Future work will include:

- [ ] Add separate macros for this type of assert (Something like EMU_ASSERT)
- [ ] Close the renderer window
- [ ] Show an error dialog on that error 
- [ ] Add the stack trace to the log

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3280)
<!-- Reviewable:end -->
