### PR TITLE
Optimize AttributeBuffer to OutputVertex conversion

### DIFF
--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -289,6 +289,7 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
         // Later, these can be compiled and cached.
         const u32 base_address = regs.pipeline.vertex_attributes.GetPhysicalBaseAddress();
         VertexLoader loader(regs.pipeline);
+        Pica::Shader::OutputVertex::ValidateSemantics(regs.rasterizer);
 
         // Load vertices
         bool is_indexed = (id == PICA_REG_INDEX(pipeline.trigger_draw_indexed));

--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -221,6 +221,8 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
                     MICROPROFILE_SCOPE(GPU_Drawing);
                     immediate_attribute_id = 0;
 
+                    Shader::OutputVertex::ValidateSemantics(regs.rasterizer);
+
                     auto* shader_engine = Shader::GetEngine();
                     shader_engine->SetupBatch(g_state.vs, regs.vs.main_offset);
 
@@ -289,7 +291,7 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
         // Later, these can be compiled and cached.
         const u32 base_address = regs.pipeline.vertex_attributes.GetPhysicalBaseAddress();
         VertexLoader loader(regs.pipeline);
-        Pica::Shader::OutputVertex::ValidateSemantics(regs.rasterizer);
+        Shader::OutputVertex::ValidateSemantics(regs.rasterizer);
 
         // Load vertices
         bool is_indexed = (id == PICA_REG_INDEX(pipeline.trigger_draw_indexed));

--- a/src/video_core/regs_rasterizer.h
+++ b/src/video_core/regs_rasterizer.h
@@ -87,6 +87,8 @@ struct RasterizerRegs {
         BitField<8, 5, Semantic> map_y;
         BitField<16, 5, Semantic> map_z;
         BitField<24, 5, Semantic> map_w;
+
+        u32 raw;
     } vs_output_attributes[7];
 
     INSERT_PADDING_WORDS(0xe);

--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -24,9 +24,9 @@ namespace Shader {
 void OutputVertex::ValidateSemantics(const RasterizerRegs& regs) {
     unsigned int num_attributes = regs.vs_output_total;
     ASSERT(num_attributes <= 7);
-    for (size_t i = 0; i < num_attributes; ++i) {
-        u32 output_register_map = regs.vs_output_attributes[i].raw;
-        for (size_t j = 0; j < 4; j++) {
+    for (size_t attrib = 0; attrib < num_attributes; attrib++) {
+        u32 output_register_map = regs.vs_output_attributes[attrib].raw;
+        for (size_t comp = 0; comp < 4; comp++) {
             u32 semantic = output_register_map & 0x1F;
             ASSERT_MSG(semantic < 24 || semantic == RasterizerRegs::VSOutputAttributes::INVALID,
                        "Invalid/unknown semantic id: %u", semantic);
@@ -41,18 +41,20 @@ OutputVertex OutputVertex::FromAttributeBuffer(const RasterizerRegs& regs,
     union {
         OutputVertex ret{};
         std::array<float24, 24> vertex_slots;
-        // Allow us to overflow vertex_slots to avoid branches
+        // Allow us to overflow vertex_slots to avoid branches, since
+        // RasterizerRegs::VSOutputAttributes::INVALID would write to slot 31, which
+        // would be out of bounds otherwise.
         std::array<float24, 32> vertex_slots_overflow;
     };
     static_assert(sizeof(vertex_slots) == sizeof(ret), "Struct and array have different sizes.");
 
     unsigned int num_attributes = regs.vs_output_total & 7;
-    for (size_t i = 0; i < num_attributes; ++i) {
-        u32 output_register_map = regs.vs_output_attributes[i].raw;
-        vertex_slots_overflow[output_register_map & 0x1F] = input.attr[i][0];
-        vertex_slots_overflow[(output_register_map >> 8) & 0x1F] = input.attr[i][1];
-        vertex_slots_overflow[(output_register_map >> 16) & 0x1F] = input.attr[i][2];
-        vertex_slots_overflow[(output_register_map >> 24) & 0x1F] = input.attr[i][3];
+    for (size_t attrib = 0; attrib < num_attributes; attrib++) {
+        u32 output_register_map = regs.vs_output_attributes[attrib].raw;
+        vertex_slots_overflow[output_register_map & 0x1F] = input.attr[attrib][0];
+        vertex_slots_overflow[(output_register_map >> 8) & 0x1F] = input.attr[attrib][1];
+        vertex_slots_overflow[(output_register_map >> 16) & 0x1F] = input.attr[attrib][2];
+        vertex_slots_overflow[(output_register_map >> 24) & 0x1F] = input.attr[attrib][3];
     }
 
     // The hardware takes the absolute and saturates vertex colors like this, *before* doing

--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -28,10 +28,9 @@ void OutputVertex::ValidateSemantics(const RasterizerRegs& regs) {
     for (size_t attrib = 0; attrib < num_attributes; ++attrib) {
         u32 output_register_map = regs.vs_output_attributes[attrib].raw;
         for (size_t comp = 0; comp < 4; ++comp) {
-            u32 semantic = output_register_map & 0x1F;
+            u32 semantic = (output_register_map >> 8 * comp) & 0x1F;
             ASSERT_MSG(semantic < 24 || semantic == RasterizerRegs::VSOutputAttributes::INVALID,
                        "Invalid/unknown semantic id: %" PRIu32, semantic);
-            output_register_map >>= 8;
         }
     }
 }
@@ -48,15 +47,16 @@ OutputVertex OutputVertex::FromAttributeBuffer(const RasterizerRegs& regs,
     };
 
     // Assert that OutputVertex has enough space for 24 semantic registers
-    static_assert(sizeof(std::array<float24, 24>) == sizeof(ret), "Struct and array have different sizes.");
+    static_assert(sizeof(std::array<float24, 24>) == sizeof(ret),
+                  "Struct and array have different sizes.");
 
     unsigned int num_attributes = regs.vs_output_total & 7;
     for (size_t attrib = 0; attrib < num_attributes; ++attrib) {
-        u32 output_register_map = regs.vs_output_attributes[attrib].raw;
-        vertex_slots_overflow[output_register_map & 0x1F] = input.attr[attrib][0];
-        vertex_slots_overflow[(output_register_map >> 8) & 0x1F] = input.attr[attrib][1];
-        vertex_slots_overflow[(output_register_map >> 16) & 0x1F] = input.attr[attrib][2];
-        vertex_slots_overflow[(output_register_map >> 24) & 0x1F] = input.attr[attrib][3];
+        const auto &output_register_map = regs.vs_output_attributes[attrib];
+        vertex_slots_overflow[output_register_map.map_x] = input.attr[attrib][0];
+        vertex_slots_overflow[output_register_map.map_y] = input.attr[attrib][1];
+        vertex_slots_overflow[output_register_map.map_z] = input.attr[attrib][2];
+        vertex_slots_overflow[output_register_map.map_w] = input.attr[attrib][3];
     }
 
     // The hardware takes the absolute and saturates vertex colors like this, *before* doing

--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <cinttypes>
 #include <cmath>
 #include <cstring>
 #include "common/bit_set.h"
@@ -24,12 +25,12 @@ namespace Shader {
 void OutputVertex::ValidateSemantics(const RasterizerRegs& regs) {
     unsigned int num_attributes = regs.vs_output_total;
     ASSERT(num_attributes <= 7);
-    for (size_t attrib = 0; attrib < num_attributes; attrib++) {
+    for (size_t attrib = 0; attrib < num_attributes; ++attrib) {
         u32 output_register_map = regs.vs_output_attributes[attrib].raw;
-        for (size_t comp = 0; comp < 4; comp++) {
+        for (size_t comp = 0; comp < 4; ++comp) {
             u32 semantic = output_register_map & 0x1F;
             ASSERT_MSG(semantic < 24 || semantic == RasterizerRegs::VSOutputAttributes::INVALID,
-                       "Invalid/unknown semantic id: %u", semantic);
+                       "Invalid/unknown semantic id: %" PRIu32, semantic);
             output_register_map >>= 8;
         }
     }
@@ -40,16 +41,17 @@ OutputVertex OutputVertex::FromAttributeBuffer(const RasterizerRegs& regs,
     // Setup output data
     union {
         OutputVertex ret{};
-        std::array<float24, 24> vertex_slots;
-        // Allow us to overflow vertex_slots to avoid branches, since
+        // Allow us to overflow OutputVertex to avoid branches, since
         // RasterizerRegs::VSOutputAttributes::INVALID would write to slot 31, which
         // would be out of bounds otherwise.
         std::array<float24, 32> vertex_slots_overflow;
     };
-    static_assert(sizeof(vertex_slots) == sizeof(ret), "Struct and array have different sizes.");
+
+    // Assert that OutputVertex has enough space for 24 semantic registers
+    static_assert(sizeof(std::array<float24, 24>) == sizeof(ret), "Struct and array have different sizes.");
 
     unsigned int num_attributes = regs.vs_output_total & 7;
-    for (size_t attrib = 0; attrib < num_attributes; attrib++) {
+    for (size_t attrib = 0; attrib < num_attributes; ++attrib) {
         u32 output_register_map = regs.vs_output_attributes[attrib].raw;
         vertex_slots_overflow[output_register_map & 0x1F] = input.attr[attrib][0];
         vertex_slots_overflow[(output_register_map >> 8) & 0x1F] = input.attr[attrib][1];

--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -28,7 +28,7 @@ void OutputVertex::ValidateSemantics(const RasterizerRegs& regs) {
     for (size_t attrib = 0; attrib < num_attributes; ++attrib) {
         u32 output_register_map = regs.vs_output_attributes[attrib].raw;
         for (size_t comp = 0; comp < 4; ++comp) {
-            u32 semantic = (output_register_map >> 8 * comp) & 0x1F;
+            u32 semantic = (output_register_map >> (8 * comp)) & 0x1F;
             ASSERT_MSG(semantic < 24 || semantic == RasterizerRegs::VSOutputAttributes::INVALID,
                        "Invalid/unknown semantic id: %" PRIu32, semantic);
         }
@@ -52,7 +52,7 @@ OutputVertex OutputVertex::FromAttributeBuffer(const RasterizerRegs& regs,
 
     unsigned int num_attributes = regs.vs_output_total & 7;
     for (size_t attrib = 0; attrib < num_attributes; ++attrib) {
-        const auto &output_register_map = regs.vs_output_attributes[attrib];
+        const auto output_register_map = regs.vs_output_attributes[attrib];
         vertex_slots_overflow[output_register_map.map_x] = input.attr[attrib][0];
         vertex_slots_overflow[output_register_map.map_y] = input.attr[attrib][1];
         vertex_slots_overflow[output_register_map.map_z] = input.attr[attrib][2];

--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -24,13 +24,12 @@ namespace Shader {
 void OutputVertex::ValidateSemantics(const RasterizerRegs& regs) {
     unsigned int num_attributes = regs.vs_output_total;
     ASSERT(num_attributes <= 7);
-    for (unsigned int i = 0; i < num_attributes; ++i) {
+    for (size_t i = 0; i < num_attributes; ++i) {
         u32 output_register_map = regs.vs_output_attributes[i].raw;
-        for (unsigned int j = 0; j < 4; j++) {
-            auto semantic = output_register_map & 0x1F;
-            ASSERT_MSG(semantic < 24 ||
-                semantic == RasterizerRegs::VSOutputAttributes::INVALID,
-                "Invalid/unknown semantic id: %u", (unsigned int)semantic);
+        for (size_t j = 0; j < 4; j++) {
+            u32 semantic = output_register_map & 0x1F;
+            ASSERT_MSG(semantic < 24 || semantic == RasterizerRegs::VSOutputAttributes::INVALID,
+                       "Invalid/unknown semantic id: %u", semantic);
             output_register_map >>= 8;
         }
     }
@@ -40,7 +39,7 @@ OutputVertex OutputVertex::FromAttributeBuffer(const RasterizerRegs& regs,
                                                const AttributeBuffer& input) {
     // Setup output data
     union {
-        OutputVertex ret {};
+        OutputVertex ret{};
         std::array<float24, 24> vertex_slots;
         // Allow us to overflow vertex_slots to avoid branches
         std::array<float24, 32> vertex_slots_overflow;
@@ -48,7 +47,7 @@ OutputVertex OutputVertex::FromAttributeBuffer(const RasterizerRegs& regs,
     static_assert(sizeof(vertex_slots) == sizeof(ret), "Struct and array have different sizes.");
 
     unsigned int num_attributes = regs.vs_output_total & 7;
-    for (unsigned int i = 0; i < num_attributes; ++i) {
+    for (size_t i = 0; i < num_attributes; ++i) {
         u32 output_register_map = regs.vs_output_attributes[i].raw;
         vertex_slots_overflow[output_register_map & 0x1F] = input.attr[i][0];
         vertex_slots_overflow[(output_register_map >> 8) & 0x1F] = input.attr[i][1];

--- a/src/video_core/shader/shader.h
+++ b/src/video_core/shader/shader.h
@@ -50,6 +50,7 @@ struct OutputVertex {
     INSERT_PADDING_WORDS(1);
     Math::Vec2<float24> tc2;
 
+    static void ValidateSemantics(const RasterizerRegs& regs);
     static OutputVertex FromAttributeBuffer(const RasterizerRegs& regs,
                                             const AttributeBuffer& output);
 };


### PR DESCRIPTION
First I unrolled the inner loop, then I pushed semantics validation
outside of the hotloop.

I also added overflow slots to avoid conditional branches.

Super Mario 3D Land's intro runs at almost full speed when compiled with
Clang, and theres a noticible speed increase in MSVC. GCC hasn't been
tested but I'm confident in its ability to optimize this code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3283)
<!-- Reviewable:end -->
