### PR TITLE
 HLE/Services: Allow specifying a SessionData template parameter to ServiceFramework.

### DIFF
--- a/src/core/hle/service/fs/archive.h
+++ b/src/core/hle/service/fs/archive.h
@@ -108,6 +108,10 @@ public:
 
 protected:
     void HandleSyncRequest(Kernel::SharedPtr<Kernel::ServerSession> server_session) override;
+
+    std::unique_ptr<SessionDataBase> MakeSessionData() const override {
+        return nullptr;
+    }
 };
 
 /**

--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -87,6 +87,10 @@ public:
 protected:
     void HandleSyncRequest(Kernel::SharedPtr<Kernel::ServerSession> server_session) override;
 
+    std::unique_ptr<SessionDataBase> MakeSessionData() const override {
+        return nullptr;
+    }
+
     /**
      * Registers the functions in the service
      */
@@ -144,7 +148,7 @@ protected:
     using HandlerFnP = void (Self::*)(Kernel::HLERequestContext&);
 
 private:
-    template <typename T>
+    template <typename T, typename SessionData>
     friend class ServiceFramework;
 
     struct FunctionInfoBase {
@@ -190,7 +194,7 @@ private:
  * of the passed in function pointers and then delegate the actual work to the implementation in the
  * base class.
  */
-template <typename Self>
+template <typename Self, typename SessionData = Kernel::SessionRequestHandler::SessionDataBase>
 class ServiceFramework : public ServiceFrameworkBase {
 protected:
     /// Contains information about a request type which is handled by the service.
@@ -234,6 +238,14 @@ protected:
      */
     void RegisterHandlers(const FunctionInfo* functions, size_t n) {
         RegisterHandlersBase(functions, n);
+    }
+
+    std::unique_ptr<SessionDataBase> MakeSessionData() const override {
+        return std::make_unique<SessionData>();
+    }
+
+    SessionData* GetSessionData(Kernel::SharedPtr<Kernel::ServerSession> server_session) {
+        return ServiceFrameworkBase::GetSessionData<SessionData>(server_session);
     }
 
 private:


### PR DESCRIPTION
Some services can have multiple clients at the same time, and they identify the different clients using the server session as a key.
This parameter (if present) should be a structure that contains the per-session data for each service.
The data can be retrieved using ServiceFramework::GetSessionData(session)

cc @wwylele

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3284)
<!-- Reviewable:end -->
