### PR TITLE
Disable telemetry by default in SDL frontend

### DIFF
--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -159,7 +159,7 @@ void Config::ReadValues() {
 
     // Web Service
     Settings::values.enable_telemetry =
-        sdl2_config->GetBoolean("WebService", "enable_telemetry", true);
+        sdl2_config->GetBoolean("WebService", "enable_telemetry", false);
     Settings::values.telemetry_endpoint_url = sdl2_config->Get(
         "WebService", "telemetry_endpoint_url", "https://services.citra-emu.org/api/telemetry");
     Settings::values.verify_endpoint_url = sdl2_config->Get(


### PR DESCRIPTION
As noted in issue #3289, SDL frontend users are never notified about telemetry at startup. This should not be enabled without explicit permission from the user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3290)
<!-- Reviewable:end -->
