### PR TITLE
[WIP] Allow user-configurable analog input deadzones

### DIFF
--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -65,7 +65,7 @@ DirectionState GetStickDirectionState(s16 circle_pad_x, s16 circle_pad_y) {
     constexpr float TAN30 = 0.577350269f;
     constexpr float TAN60 = 1 / TAN30;
     // a circle pad radius greater than 40 will trigger circle pad direction
-    constexpr int CIRCLE_PAD_THRESHOLD_SQUARE = 40 * 40;
+    int CIRCLE_PAD_THRESHOLD_SQUARE = Settings::Values::input_threshold * 0x9c;
     DirectionState state{false, false, false, false};
 
     if (circle_pad_x * circle_pad_x + circle_pad_y * circle_pad_y > CIRCLE_PAD_THRESHOLD_SQUARE) {

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -82,6 +82,7 @@ struct Values {
     std::array<std::string, NativeAnalog::NumAnalogs> analogs;
     std::string motion_device;
     std::string touch_device;
+    float input_threshold;
 
     // Core
     bool use_cpu_jit;


### PR DESCRIPTION
Still working on the solution for this, but I think a good approach to fix the problem with strange dead zones for analog inputs is to allow users to configure the dead zones in the application. Currently, a hard coded threshold value of 40 is used in the HID analog input handler. This could be exposed to the user through the application settings and allow them to find a dead zone value that works for their hard ware.

There's also a possible integer overflow error in `src/core/hle/hid/hid.cpp l:71`, so perhaps addressing that will also fix the problems outlined in the linked issue.

I'm still setting up my development environment for debugging, so I've only arrived at these conclusions from speculation from looking at the code.

Fixes #3291

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3293)
<!-- Reviewable:end -->
