### PR TITLE
input_common: Remove redundant target_sources in CMakeLists

### DIFF
--- a/src/input_common/CMakeLists.txt
+++ b/src/input_common/CMakeLists.txt
@@ -11,14 +11,6 @@ add_library(input_common STATIC
     $<$<BOOL:SDL2_FOUND>:sdl/sdl.cpp sdl/sdl.h>
 )
 
-if(SDL2_FOUND)
-    target_sources(input_common
-        PRIVATE
-            sdl/sdl.cpp
-            sdl/sdl.h
-    )
-endif()
-
 create_target_directory_groups(input_common)
 
 target_link_libraries(input_common PUBLIC core PRIVATE common)


### PR DESCRIPTION
This is a leftover that I stupidly left in. The generator expression above it already conditionally adds it

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3294)
<!-- Reviewable:end -->
