### PR TITLE
Kernel/SVC: Partially implemented svcExitProcess.

### DIFF
--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -40,6 +40,7 @@ SharedPtr<Process> Process::Create(SharedPtr<CodeSet> code_set) {
     process->codeset = std::move(code_set);
     process->flags.raw = 0;
     process->flags.memory_region.Assign(MemoryRegion::APPLICATION);
+    process->status = ProcessStatus::Created;
 
     process_list.push_back(process);
     return process;
@@ -150,6 +151,8 @@ void Process::Run(s32 main_thread_priority, u32 stack_size) {
     for (const auto& mapping : address_mappings) {
         HandleSpecialMapping(vm_manager, mapping);
     }
+
+    status = ProcessStatus::Running;
 
     vm_manager.LogLayout(Log::Level::Debug);
     Kernel::SetupMainThread(codeset->entrypoint, main_thread_priority, this);

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -49,6 +49,8 @@ union ProcessFlags {
     BitField<12, 1, u16> loaded_high; ///< Application loaded high (not at 0x00100000).
 };
 
+enum class ProcessStatus { Created, Running, Exited };
+
 class ResourceLimit;
 struct MemoryRegionInfo;
 
@@ -122,6 +124,8 @@ public:
     u16 kernel_version = 0;
     /// The default CPU for this process, threads are scheduled on this cpu by default.
     u8 ideal_processor = 0;
+    /// Current status of the process
+    ProcessStatus status;
 
     /// The id of this process
     u32 process_id = next_process_id++;


### PR DESCRIPTION
Terminating processes with ready threads is not currently implemented and will assert. It is currently unknown how the 3DS kernel stops ready threads or threads running in another core.

Please note that this is still not enough to allow applets to exit. Some APT functions still need to be implemented, and the GSP module needs to be changed to account for multiple clients.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3301)
<!-- Reviewable:end -->
