### PR TITLE
citra_qt: Drop Qt 5 version checks in code

### DIFF
--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -1,12 +1,8 @@
 #include <QApplication>
 #include <QHBoxLayout>
 #include <QKeyEvent>
-
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-// Required for screen DPI information
 #include <QScreen>
 #include <QWindow>
-#endif
 
 #include "citra_qt/bootmanager.h"
 #include "common/microprofile.h"
@@ -121,15 +117,13 @@ GRenderWindow::~GRenderWindow() {
 
 void GRenderWindow::moveContext() {
     DoneCurrent();
-// We need to move GL context to the swapping thread in Qt5
-#if QT_VERSION > QT_VERSION_CHECK(5, 0, 0)
+
     // If the thread started running, move the GL Context to the new thread. Otherwise, move it
     // back.
     auto thread = (QThread::currentThread() == qApp->thread() && emu_thread != nullptr)
                       ? emu_thread
                       : qApp->thread();
     child->context()->moveToThread(thread);
-#endif
 }
 
 void GRenderWindow::SwapBuffers() {
@@ -192,12 +186,8 @@ QByteArray GRenderWindow::saveGeometry() {
 }
 
 qreal GRenderWindow::windowPixelRatio() {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
     // windowHandle() might not be accessible until the window is displayed to screen.
     return windowHandle() ? windowHandle()->screen()->devicePixelRatio() : 1.0f;
-#else
-    return 1.0f;
-#endif
 }
 
 void GRenderWindow::closeEvent(QCloseEvent* event) {
@@ -301,9 +291,7 @@ void GRenderWindow::OnEmulationStopping() {
 void GRenderWindow::showEvent(QShowEvent* event) {
     QWidget::showEvent(event);
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
     // windowHandle() is not initialized until the Window is shown, so we connect it here.
     connect(this->windowHandle(), SIGNAL(screenChanged(QScreen*)), this,
             SLOT(OnFramebufferSizeChanged()), Qt::UniqueConnection);
-#endif
 }

--- a/src/citra_qt/debugger/graphics/graphics_cmdlists.cpp
+++ b/src/citra_qt/debugger/graphics/graphics_cmdlists.cpp
@@ -192,12 +192,7 @@ GPUCommandListWidget::GPUCommandListWidget(QWidget* parent)
     list_widget->setFont(GetMonospaceFont());
     list_widget->setRootIsDecorated(false);
     list_widget->setUniformRowHeights(true);
-
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
     list_widget->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
-#else
-    list_widget->header()->setResizeMode(QHeaderView::ResizeToContents);
-#endif
 
     connect(list_widget->selectionModel(),
             SIGNAL(currentChanged(const QModelIndex&, const QModelIndex&)), this,


### PR DESCRIPTION
We don't support Qt 4.x anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3306)
<!-- Reviewable:end -->
