### PR TITLE
citra_qt: Migrate to Qt 5 signal/slot connection syntax where applicable

### DIFF
--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -292,6 +292,6 @@ void GRenderWindow::showEvent(QShowEvent* event) {
     QWidget::showEvent(event);
 
     // windowHandle() is not initialized until the Window is shown, so we connect it here.
-    connect(this->windowHandle(), SIGNAL(screenChanged(QScreen*)), this,
-            SLOT(OnFramebufferSizeChanged()), Qt::UniqueConnection);
+    connect(windowHandle(), &QWindow::screenChanged, this, &GRenderWindow::OnFramebufferSizeChanged,
+            Qt::UniqueConnection);
 }

--- a/src/citra_qt/configuration/configure_audio.cpp
+++ b/src/citra_qt/configuration/configure_audio.cpp
@@ -21,8 +21,9 @@ ConfigureAudio::ConfigureAudio(QWidget* parent)
     }
 
     this->setConfiguration();
-    connect(ui->output_sink_combo_box, SIGNAL(currentIndexChanged(int)), this,
-            SLOT(updateAudioDevices(int)));
+    connect(ui->output_sink_combo_box,
+            static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+            &ConfigureAudio::updateAudioDevices);
 }
 
 ConfigureAudio::~ConfigureAudio() {}

--- a/src/citra_qt/debugger/graphics/graphics.cpp
+++ b/src/citra_qt/debugger/graphics/graphics.cpp
@@ -10,7 +10,8 @@ extern GraphicsDebugger g_debugger;
 
 GPUCommandStreamItemModel::GPUCommandStreamItemModel(QObject* parent)
     : QAbstractListModel(parent), command_count(0) {
-    connect(this, SIGNAL(GXCommandFinished(int)), this, SLOT(OnGXCommandFinishedInternal(int)));
+    connect(this, &GPUCommandStreamItemModel::GXCommandFinished, this,
+            &GPUCommandStreamItemModel::OnGXCommandFinishedInternal);
 }
 
 int GPUCommandStreamItemModel::rowCount(const QModelIndex& parent) const {

--- a/src/citra_qt/debugger/graphics/graphics_breakpoint_observer.cpp
+++ b/src/citra_qt/debugger/graphics/graphics_breakpoint_observer.cpp
@@ -10,12 +10,12 @@ BreakPointObserverDock::BreakPointObserverDock(std::shared_ptr<Pica::DebugContex
     : QDockWidget(title, parent), BreakPointObserver(debug_context) {
     qRegisterMetaType<Pica::DebugContext::Event>("Pica::DebugContext::Event");
 
-    connect(this, SIGNAL(Resumed()), this, SLOT(OnResumed()));
+    connect(this, &BreakPointObserverDock::Resumed, this, &BreakPointObserverDock::OnResumed);
 
     // NOTE: This signal is emitted from a non-GUI thread, but connect() takes
     //       care of delaying its handling to the GUI thread.
-    connect(this, SIGNAL(BreakPointHit(Pica::DebugContext::Event, void*)), this,
-            SLOT(OnBreakPointHit(Pica::DebugContext::Event, void*)), Qt::BlockingQueuedConnection);
+    connect(this, &BreakPointObserverDock::BreakPointHit, this,
+            &BreakPointObserverDock::OnBreakPointHit, Qt::BlockingQueuedConnection);
 }
 
 void BreakPointObserverDock::OnPicaBreakPointHit(Pica::DebugContext::Event event, void* data) {

--- a/src/citra_qt/debugger/graphics/graphics_breakpoints.cpp
+++ b/src/citra_qt/debugger/graphics/graphics_breakpoints.cpp
@@ -145,21 +145,25 @@ GraphicsBreakPointsWidget::GraphicsBreakPointsWidget(
 
     qRegisterMetaType<Pica::DebugContext::Event>("Pica::DebugContext::Event");
 
-    connect(breakpoint_list, SIGNAL(doubleClicked(const QModelIndex&)), this,
-            SLOT(OnItemDoubleClicked(const QModelIndex&)));
+    connect(breakpoint_list, &QTreeView::doubleClicked, this,
+            &GraphicsBreakPointsWidget::OnItemDoubleClicked);
 
-    connect(resume_button, SIGNAL(clicked()), this, SLOT(OnResumeRequested()));
+    connect(resume_button, &QPushButton::clicked, this,
+            &GraphicsBreakPointsWidget::OnResumeRequested);
 
-    connect(this, SIGNAL(BreakPointHit(Pica::DebugContext::Event, void*)), this,
-            SLOT(OnBreakPointHit(Pica::DebugContext::Event, void*)), Qt::BlockingQueuedConnection);
-    connect(this, SIGNAL(Resumed()), this, SLOT(OnResumed()));
+    connect(this, &GraphicsBreakPointsWidget::BreakPointHit, this,
+            &GraphicsBreakPointsWidget::OnBreakPointHit, Qt::BlockingQueuedConnection);
+    connect(this, &GraphicsBreakPointsWidget::Resumed, this, &GraphicsBreakPointsWidget::OnResumed);
 
-    connect(this, SIGNAL(BreakPointHit(Pica::DebugContext::Event, void*)), breakpoint_model,
-            SLOT(OnBreakPointHit(Pica::DebugContext::Event)), Qt::BlockingQueuedConnection);
-    connect(this, SIGNAL(Resumed()), breakpoint_model, SLOT(OnResumed()));
+    connect(this, &GraphicsBreakPointsWidget::BreakPointHit, breakpoint_model,
+            &BreakPointModel::OnBreakPointHit, Qt::BlockingQueuedConnection);
+    connect(this, &GraphicsBreakPointsWidget::Resumed, breakpoint_model,
+            &BreakPointModel::OnResumed);
 
-    connect(this, SIGNAL(BreakPointsChanged(const QModelIndex&, const QModelIndex&)),
-            breakpoint_model, SIGNAL(dataChanged(const QModelIndex&, const QModelIndex&)));
+    connect(this, &GraphicsBreakPointsWidget::BreakPointsChanged,
+            [this](const QModelIndex& top_left, const QModelIndex& bottom_right) {
+                breakpoint_model->dataChanged(top_left, bottom_right);
+            });
 
     QWidget* main_widget = new QWidget;
     auto main_layout = new QVBoxLayout;

--- a/src/citra_qt/debugger/graphics/graphics_cmdlists.cpp
+++ b/src/citra_qt/debugger/graphics/graphics_cmdlists.cpp
@@ -194,20 +194,19 @@ GPUCommandListWidget::GPUCommandListWidget(QWidget* parent)
     list_widget->setUniformRowHeights(true);
     list_widget->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
 
-    connect(list_widget->selectionModel(),
-            SIGNAL(currentChanged(const QModelIndex&, const QModelIndex&)), this,
-            SLOT(SetCommandInfo(const QModelIndex&)));
-    connect(list_widget, SIGNAL(doubleClicked(const QModelIndex&)), this,
-            SLOT(OnCommandDoubleClicked(const QModelIndex&)));
+    connect(list_widget->selectionModel(), &QItemSelectionModel::currentChanged, this,
+            &GPUCommandListWidget::SetCommandInfo);
+    connect(list_widget, &QTreeView::doubleClicked, this,
+            &GPUCommandListWidget::OnCommandDoubleClicked);
 
     toggle_tracing = new QPushButton(tr("Start Tracing"));
     QPushButton* copy_all = new QPushButton(tr("Copy All"));
 
-    connect(toggle_tracing, SIGNAL(clicked()), this, SLOT(OnToggleTracing()));
-    connect(this, SIGNAL(TracingFinished(const Pica::DebugUtils::PicaTrace&)), model,
-            SLOT(OnPicaTraceFinished(const Pica::DebugUtils::PicaTrace&)));
+    connect(toggle_tracing, &QPushButton::clicked, this, &GPUCommandListWidget::OnToggleTracing);
+    connect(this, &GPUCommandListWidget::TracingFinished, model,
+            &GPUCommandListModel::OnPicaTraceFinished);
 
-    connect(copy_all, SIGNAL(clicked()), this, SLOT(CopyAllToClipboard()));
+    connect(copy_all, &QPushButton::clicked, this, &GPUCommandListWidget::CopyAllToClipboard);
 
     command_info_widget = nullptr;
 

--- a/src/citra_qt/debugger/graphics/graphics_surface.cpp
+++ b/src/citra_qt/debugger/graphics/graphics_surface.cpp
@@ -118,22 +118,24 @@ GraphicsSurfaceWidget::GraphicsSurfaceWidget(std::shared_ptr<Pica::DebugContext>
     save_surface = new QPushButton(QIcon::fromTheme("document-save"), tr("Save"));
 
     // Connections
-    connect(this, SIGNAL(Update()), this, SLOT(OnUpdate()));
-    connect(surface_source_list, SIGNAL(currentIndexChanged(int)), this,
-            SLOT(OnSurfaceSourceChanged(int)));
-    connect(surface_address_control, SIGNAL(ValueChanged(qint64)), this,
-            SLOT(OnSurfaceAddressChanged(qint64)));
-    connect(surface_width_control, SIGNAL(valueChanged(int)), this,
-            SLOT(OnSurfaceWidthChanged(int)));
-    connect(surface_height_control, SIGNAL(valueChanged(int)), this,
-            SLOT(OnSurfaceHeightChanged(int)));
-    connect(surface_format_control, SIGNAL(currentIndexChanged(int)), this,
-            SLOT(OnSurfaceFormatChanged(int)));
-    connect(surface_picker_x_control, SIGNAL(valueChanged(int)), this,
-            SLOT(OnSurfacePickerXChanged(int)));
-    connect(surface_picker_y_control, SIGNAL(valueChanged(int)), this,
-            SLOT(OnSurfacePickerYChanged(int)));
-    connect(save_surface, SIGNAL(clicked()), this, SLOT(SaveSurface()));
+    connect(this, &GraphicsSurfaceWidget::Update, this, &GraphicsSurfaceWidget::OnUpdate);
+    connect(surface_source_list,
+            static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+            &GraphicsSurfaceWidget::OnSurfaceSourceChanged);
+    connect(surface_address_control, &CSpinBox::ValueChanged, this,
+            &GraphicsSurfaceWidget::OnSurfaceAddressChanged);
+    connect(surface_width_control, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+            this, &GraphicsSurfaceWidget::OnSurfaceWidthChanged);
+    connect(surface_height_control, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+            this, &GraphicsSurfaceWidget::OnSurfaceHeightChanged);
+    connect(surface_format_control,
+            static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+            &GraphicsSurfaceWidget::OnSurfaceFormatChanged);
+    connect(surface_picker_x_control, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+            this, &GraphicsSurfaceWidget::OnSurfacePickerXChanged);
+    connect(surface_picker_y_control, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+            this, &GraphicsSurfaceWidget::OnSurfacePickerYChanged);
+    connect(save_surface, &QPushButton::clicked, this, &GraphicsSurfaceWidget::SaveSurface);
 
     auto main_widget = new QWidget;
     auto main_layout = new QVBoxLayout;

--- a/src/citra_qt/debugger/graphics/graphics_tracing.cpp
+++ b/src/citra_qt/debugger/graphics/graphics_tracing.cpp
@@ -31,15 +31,15 @@ GraphicsTracingWidget::GraphicsTracingWidget(std::shared_ptr<Pica::DebugContext>
         new QPushButton(QIcon::fromTheme("document-save"), tr("Stop and Save"));
     QPushButton* abort_recording = new QPushButton(tr("Abort Recording"));
 
-    connect(this, SIGNAL(SetStartTracingButtonEnabled(bool)), start_recording,
-            SLOT(setVisible(bool)));
-    connect(this, SIGNAL(SetStopTracingButtonEnabled(bool)), stop_recording,
-            SLOT(setVisible(bool)));
-    connect(this, SIGNAL(SetAbortTracingButtonEnabled(bool)), abort_recording,
-            SLOT(setVisible(bool)));
-    connect(start_recording, SIGNAL(clicked()), this, SLOT(StartRecording()));
-    connect(stop_recording, SIGNAL(clicked()), this, SLOT(StopRecording()));
-    connect(abort_recording, SIGNAL(clicked()), this, SLOT(AbortRecording()));
+    connect(this, &GraphicsTracingWidget::SetStartTracingButtonEnabled, start_recording,
+            &QPushButton::setVisible);
+    connect(this, &GraphicsTracingWidget::SetStopTracingButtonEnabled, stop_recording,
+            &QPushButton::setVisible);
+    connect(this, &GraphicsTracingWidget::SetAbortTracingButtonEnabled, abort_recording,
+            &QPushButton::setVisible);
+    connect(start_recording, &QPushButton::clicked, this, &GraphicsTracingWidget::StartRecording);
+    connect(stop_recording, &QPushButton::clicked, this, &GraphicsTracingWidget::StopRecording);
+    connect(abort_recording, &QPushButton::clicked, this, &GraphicsTracingWidget::AbortRecording);
 
     stop_recording->setVisible(false);
     abort_recording->setVisible(false);

--- a/src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp
+++ b/src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp
@@ -393,15 +393,18 @@ GraphicsVertexShaderWidget::GraphicsVertexShaderWidget(
 
     cycle_index = new QSpinBox;
 
-    connect(dump_shader, SIGNAL(clicked()), this, SLOT(DumpShader()));
+    connect(dump_shader, &QPushButton::clicked, this, &GraphicsVertexShaderWidget::DumpShader);
 
-    connect(cycle_index, SIGNAL(valueChanged(int)), this, SLOT(OnCycleIndexChanged(int)));
+    connect(cycle_index, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this,
+            &GraphicsVertexShaderWidget::OnCycleIndexChanged);
 
     for (unsigned i = 0; i < ARRAY_SIZE(input_data); ++i) {
-        connect(input_data[i], SIGNAL(textEdited(const QString&)), input_data_mapper, SLOT(map()));
+        connect(input_data[i], &QLineEdit::textEdited, input_data_mapper,
+                static_cast<void (QSignalMapper::*)()>(&QSignalMapper::map));
         input_data_mapper->setMapping(input_data[i], i);
     }
-    connect(input_data_mapper, SIGNAL(mapped(int)), this, SLOT(OnInputAttributeChanged(int)));
+    connect(input_data_mapper, static_cast<void (QSignalMapper::*)(int)>(&QSignalMapper::mapped),
+            this, &GraphicsVertexShaderWidget::OnInputAttributeChanged);
 
     auto main_widget = new QWidget;
     auto main_layout = new QVBoxLayout;

--- a/src/citra_qt/debugger/profiler.cpp
+++ b/src/citra_qt/debugger/profiler.cpp
@@ -74,7 +74,7 @@ QAction* MicroProfileDialog::toggleViewAction() {
         toggle_view_action = new QAction(windowTitle(), this);
         toggle_view_action->setCheckable(true);
         toggle_view_action->setChecked(isVisible());
-        connect(toggle_view_action, SIGNAL(toggled(bool)), SLOT(setVisible(bool)));
+        connect(toggle_view_action, &QAction::toggled, this, &MicroProfileDialog::setVisible);
     }
 
     return toggle_view_action;
@@ -107,7 +107,8 @@ MicroProfileWidget::MicroProfileWidget(QWidget* parent) : QWidget(parent) {
     MicroProfileSetDisplayMode(1); // Timers screen
     MicroProfileInitUI();
 
-    connect(&update_timer, SIGNAL(timeout()), SLOT(update()));
+    connect(&update_timer, &QTimer::timeout, this,
+            static_cast<void (MicroProfileWidget::*)()>(&MicroProfileWidget::update));
 }
 
 void MicroProfileWidget::paintEvent(QPaintEvent* ev) {

--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -124,8 +124,7 @@ GameList::SearchField::SearchField(GameList* parent) : QWidget{parent} {
     edit_filter->setPlaceholderText(tr("Enter pattern to filter"));
     edit_filter->installEventFilter(keyReleaseEater);
     edit_filter->setClearButtonEnabled(true);
-    connect(edit_filter, SIGNAL(textChanged(const QString&)), parent,
-            SLOT(onTextChanged(const QString&)));
+    connect(edit_filter, &QLineEdit::textChanged, parent, &GameList::onTextChanged);
     label_filter_result = new QLabel;
     button_filter_close = new QToolButton(this);
     button_filter_close->setText("X");
@@ -134,7 +133,7 @@ GameList::SearchField::SearchField(GameList* parent) : QWidget{parent} {
                                        "#000000; font-weight: bold; background: #F0F0F0; }"
                                        "QToolButton:hover{ border: none; padding: 0px; color: "
                                        "#EEEEEE; font-weight: bold; background: #E81123}");
-    connect(button_filter_close, SIGNAL(clicked()), parent, SLOT(onFilterCloseClicked()));
+    connect(button_filter_close, &QToolButton::clicked, parent, &GameList::onFilterCloseClicked);
     layout_filter->setSpacing(10);
     layout_filter->addWidget(label_filter);
     layout_filter->addWidget(edit_filter);

--- a/src/citra_qt/util/spinbox.cpp
+++ b/src/citra_qt/util/spinbox.cpp
@@ -39,7 +39,7 @@ CSpinBox::CSpinBox(QWidget* parent)
     // TODO: Might be nice to not immediately call the slot.
     //       Think of an address that is being replaced by a different one, in which case a lot
     //       invalid intermediate addresses would be read from during editing.
-    connect(lineEdit(), SIGNAL(textEdited(QString)), this, SLOT(OnEditingFinished()));
+    connect(lineEdit(), &QLineEdit::textEdited, this, &CSpinBox::OnEditingFinished);
 
     UpdateText();
 }


### PR DESCRIPTION
This is more type-safe than the string-based signal/slot syntax that was being used. It also makes the connections throughout the UI code consistent.

Unfortunately, since we don't have Qt 5.7 as a requirement, we can't leverage [qOverload](https://doc.qt.io/qt-5/qtglobal.html#qOverload) to make this a little neater in terms of the `static_cast`s currently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3312)
<!-- Reviewable:end -->
