### PR TITLE
[RFC] Add framework for save states

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "inih"]
     path = externals/inih/inih
     url = https://github.com/benhoyt/inih.git
+[submodule "externals/cereal"]
+    path = externals/cereal
+    url = https://github.com/USCiLab/cereal

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -7,6 +7,10 @@ include(DownloadExternals)
 add_library(catch-single-include INTERFACE)
 target_include_directories(catch-single-include INTERFACE catch/single_include)
 
+# cereal
+add_library(cereal INTERFACE)
+target_include_directories(cereal INTERFACE cereal/include)
+
 # Crypto++
 add_subdirectory(cryptopp)
 

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -60,6 +60,7 @@ add_library(common STATIC
     param_package.h
     platform.h
     quaternion.h
+    save_state_helper.h
     scm_rev.cpp
     scm_rev.h
     scope_exit.h
@@ -91,7 +92,7 @@ endif()
 
 create_target_directory_groups(common)
 
-target_link_libraries(common PUBLIC Boost::boost microprofile)
+target_link_libraries(common PUBLIC Boost::boost cereal microprofile)
 if (ARCHITECTURE_x86_64)
     target_link_libraries(common PRIVATE xbyak)
 endif()

--- a/src/common/save_state_helper.h
+++ b/src/common/save_state_helper.h
@@ -1,0 +1,23 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+// The purpose of this header is to provide
+// a single place to change should any change
+// in seralization backend be made.
+//
+// Ideally there shouldn't be any reference
+// to the cereal seralization library outside
+// of this file.
+
+#include <cereal/archives/portable_binary.hpp>
+#include <cereal/types/string.hpp>
+#include <cereal/types/vector.hpp>
+
+#define INSTANTIATE_SERALIZATION_FUNCTION(FN_NAME)                                                 \
+    template void FN_NAME<cereal::PortableBinaryInputArchive>(cereal::PortableBinaryInputArchive & \
+                                                              archive);                            \
+    template void FN_NAME<cereal::PortableBinaryOutputArchive>(                                    \
+        cereal::PortableBinaryOutputArchive & archive);

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -390,6 +390,8 @@ add_library(core STATIC
     mmio.h
     perf_stats.cpp
     perf_stats.h
+    save_state.cpp
+    save_state.h
     settings.cpp
     settings.h
     telemetry_session.cpp

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -6,6 +6,7 @@
 #include <utility>
 #include "audio_core/audio_core.h"
 #include "common/logging/log.h"
+#include "common/save_state_helper.h"
 #include "core/arm/arm_interface.h"
 #include "core/arm/dynarmic/arm_dynarmic.h"
 #include "core/arm/dyncom/arm_dyncom.h"
@@ -202,5 +203,10 @@ void System::Shutdown() {
 
     LOG_DEBUG(Core, "Shutdown OK");
 }
+
+template <typename Archive>
+void System::SerializeState(Archive& ar) {
+}
+INSTANTIATE_SERALIZATION_FUNCTION(System::SerializeState)
 
 } // namespace Core

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -206,6 +206,7 @@ void System::Shutdown() {
 
 template <typename Archive>
 void System::SerializeState(Archive& ar) {
+    CoreTiming::SerializeState(ar);
 }
 INSTANTIATE_SERALIZATION_FUNCTION(System::SerializeState)
 

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -120,6 +120,9 @@ public:
         return *app_loader;
     }
 
+    template <typename Archive>
+    void SerializeState(Archive& ar);
+
 private:
     /**
      * Initialize the emulated system.

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -188,4 +188,7 @@ u64 GetGlobalTimeUs();
 
 int GetDowncount();
 
+template <class Archive>
+void SerializeState(Archive& archive);
+
 } // namespace CoreTiming

--- a/src/core/save_state.cpp
+++ b/src/core/save_state.cpp
@@ -1,0 +1,41 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <fstream>
+#include <cereal/archives/portable_binary.hpp>
+#include "common/logging/log.h"
+#include "core/core.h"
+#include "core/save_state.h"
+
+namespace State {
+
+static void WriteHeader(std::ofstream& os, StateHeader header) {
+    os << header.version;
+}
+
+static StateHeader ReadHeader(std::ifstream& is) {
+    StateHeader header;
+    is >> header.version;
+    return header;
+}
+
+void SaveState(std::ofstream os) {
+    WriteHeader(os, {SAVE_STATE_VERSION});
+    cereal::PortableBinaryOutputArchive archive(os);
+    Core::System::GetInstance().SerializeState(archive);
+}
+
+LoadStateError LoadState(std::ifstream is) {
+    StateHeader header = ReadHeader(is);
+    if (header.version != SAVE_STATE_VERSION) {
+        LOG_ERROR(Core, "Wrong version of save state: version=%d", header.version);
+        return LoadStateError::IncorrectVersion;
+    }
+
+    cereal::PortableBinaryInputArchive archive(is);
+    Core::System::GetInstance().SerializeState(archive);
+    return LoadStateError::None;
+}
+
+} // namespace State

--- a/src/core/save_state.h
+++ b/src/core/save_state.h
@@ -1,0 +1,27 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <fstream>
+#include "common/common_types.h"
+
+namespace State {
+
+constexpr u32 SAVE_STATE_VERSION = 1;
+
+struct StateHeader {
+    u32 version;
+};
+
+void SaveState(std::ofstream);
+
+enum class LoadStateError {
+    None,
+    IncorrectVersion,
+};
+
+LoadStateError LoadState(std::ifstream);
+
+} // namespace State


### PR DESCRIPTION
This adds a basic framework for saving and loading save states.
It adds an additional dependency to serialize the data: https://uscilab.github.io/cereal/index.html
cereal supports almost all types available in c++14 and c++17 types are currently under development.
The only thing cereal doesn't support are raw pointers.

The first commit is the framework, the second commit is just an example on how to save one part of citra. In this case I choose CoreTiming. If this is going to get merged I'll split it into two PRs.

The main goal is tho have the framework and then adding the serialization of different parts in small PRs. AS soon as every part is serialized we can add the UI part to actually use this feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3315)
<!-- Reviewable:end -->
