### PR TITLE
gdbstub: Correct typo

### DIFF
--- a/src/core/gdbstub/gdbstub.cpp
+++ b/src/core/gdbstub/gdbstub.cpp
@@ -908,7 +908,7 @@ void ToggleServer(bool status) {
         server_enabled = status;
 
         // Start server
-        if (!IsConnected() && Core::System().GetInstance().IsPoweredOn()) {
+        if (!IsConnected() && Core::System::GetInstance().IsPoweredOn()) {
             Init();
         }
     } else {


### PR DESCRIPTION
Constructing and destructing a Core::System instance for the GetInstance() call isn't the smartest thing to do.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3318)
<!-- Reviewable:end -->
