### PR TITLE
Services: Keep track of per-session data in GSPGPU

### DIFF
--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -59,7 +59,9 @@ public:
 
     /// Empty placeholder structure for services with no per-session data. The session data classes
     /// in each service must inherit from this.
-    struct SessionDataBase {};
+    struct SessionDataBase {
+        virtual ~SessionDataBase() = default;
+    };
 
 protected:
     /// Creates the storage for the session data of the service.

--- a/src/core/hle/service/gsp/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp/gsp_gpu.cpp
@@ -9,7 +9,6 @@
 #include "core/core.h"
 #include "core/hle/ipc.h"
 #include "core/hle/ipc_helpers.h"
-#include "core/hle/kernel/event.h"
 #include "core/hle/kernel/handle_table.h"
 #include "core/hle/kernel/shared_memory.h"
 #include "core/hle/result.h"
@@ -319,11 +318,18 @@ void GSP_GPU::RegisterInterruptRelayQueue(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x13, 1, 2);
     u32 flags = rp.Pop<u32>();
 
-    interrupt_event = rp.PopObject<Kernel::Event>();
+    auto interrupt_event = rp.PopObject<Kernel::Event>();
     // TODO(mailwl): return right error code instead assert
     ASSERT_MSG((interrupt_event != nullptr), "handle is not valid!");
 
     interrupt_event->name = "GSP_GSP_GPU::interrupt_event";
+
+    u32 thread_id = next_thread_id++;
+
+    SessionData* session_data = GetSessionData(ctx.Session());
+    session_data->thread_id = thread_id;
+    session_data->interrupt_event = std::move(interrupt_event);
+    session_data->registered = true;
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
 
@@ -338,22 +344,23 @@ void GSP_GPU::RegisterInterruptRelayQueue(Kernel::HLERequestContext& ctx) {
     rb.Push(thread_id);
     rb.PushCopyObjects(shared_memory);
 
-    thread_id++;
-    interrupt_event->Signal(); // TODO(bunnei): Is this correct?
-
-    LOG_WARNING(Service_GSP, "called, flags=0x%08X", flags);
+    LOG_DEBUG(Service_GSP, "called, flags=0x%08X", flags);
 }
 
 void GSP_GPU::UnregisterInterruptRelayQueue(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x14, 0, 0);
 
-    thread_id = 0;
-    interrupt_event = nullptr;
+    SessionData* session_data = GetSessionData(ctx.Session());
+    session_data->thread_id = 0;
+    session_data->interrupt_event = nullptr;
+    session_data->registered = false;
+
+    // TODO(Subv): Reset next_thread_id so that it doesn't go past the maximum of 4.
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     rb.Push(RESULT_SUCCESS);
 
-    LOG_WARNING(Service_GSP, "(STUBBED) called");
+    LOG_DEBUG(Service_GSP, "called");
 }
 
 /**
@@ -366,15 +373,20 @@ void GSP_GPU::SignalInterrupt(InterruptId interrupt_id) {
     if (!gpu_right_acquired) {
         return;
     }
-    if (nullptr == interrupt_event) {
-        LOG_WARNING(Service_GSP, "cannot synchronize until GSP event has been created!");
-        return;
-    }
     if (nullptr == shared_memory) {
         LOG_WARNING(Service_GSP, "cannot synchronize until GSP shared memory has been created!");
         return;
     }
     for (int thread_id = 0; thread_id < 0x4; ++thread_id) {
+        SessionData* session_data = FindRegisteredThreadData(thread_id);
+        if (session_data == nullptr)
+            continue;
+
+        auto interrupt_event = session_data->interrupt_event;
+        if (interrupt_event == nullptr) {
+            LOG_WARNING(Service_GSP, "cannot synchronize until GSP event has been created!");
+            continue;
+        }
         InterruptRelayQueue* interrupt_relay_queue =
             GetInterruptRelayQueue(shared_memory, thread_id);
         u8 next = interrupt_relay_queue->index;
@@ -398,8 +410,8 @@ void GSP_GPU::SignalInterrupt(InterruptId interrupt_id) {
                 info->is_dirty.Assign(false);
             }
         }
+        interrupt_event->Signal();
     }
-    interrupt_event->Signal();
 }
 
 MICROPROFILE_DEFINE(GPU_GSP_DMA, "GPU", "GSP DMA", MP_RGB(100, 0, 255));
@@ -655,6 +667,17 @@ void GSP_GPU::StoreDataCache(Kernel::HLERequestContext& ctx) {
               size, process->process_id);
 }
 
+SessionData* GSP_GPU::FindRegisteredThreadData(u32 thread_id) {
+    for (auto& session_info : connected_sessions) {
+        SessionData* data = static_cast<SessionData*>(session_info.data.get())
+        if (!data->registered)
+            continue;
+        if (data->thread_id == thread_id)
+            return data;
+    }
+    return nullptr;
+}
+
 GSP_GPU::GSP_GPU() : ServiceFramework("gsp::Gpu", 2) {
     static const FunctionInfo functions[] = {
         {0x00010082, &GSP_GPU::WriteHWRegs, "WriteHWRegs"},
@@ -691,17 +714,13 @@ GSP_GPU::GSP_GPU() : ServiceFramework("gsp::Gpu", 2) {
     };
     RegisterHandlers(functions);
 
-    interrupt_event = nullptr;
-
     using Kernel::MemoryPermission;
     shared_memory = Kernel::SharedMemory::Create(nullptr, 0x1000, MemoryPermission::ReadWrite,
                                                  MemoryPermission::ReadWrite, 0,
                                                  Kernel::MemoryRegion::BASE, "GSP:SharedMemory");
 
-    thread_id = 0;
     gpu_right_acquired = false;
     first_initialization = true;
 };
-
 } // namespace GSP
 } // namespace Service

--- a/src/core/hle/service/gsp/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp/gsp_gpu.cpp
@@ -362,11 +362,8 @@ void GSP_GPU::UnregisterInterruptRelayQueue(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x14, 0, 0);
 
     SessionData* session_data = GetSessionData(ctx.Session());
-    session_data->thread_id = 0;
     session_data->interrupt_event = nullptr;
     session_data->registered = false;
-
-    // TODO(Subv): Reset next_thread_id so that it doesn't go past the maximum of 4.
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     rb.Push(RESULT_SUCCESS);
@@ -766,6 +763,11 @@ SessionData::SessionData() {
     // services don't have threads.
     thread_id = GetUnusedThreadId();
     used_thread_ids[thread_id] = true;
+}
+
+SessionData::~SessionData() {
+    // Free the thread id slot so that other sessions can use it.
+    used_thread_ids[thread_id] = false;
 }
 
 } // namespace GSP

--- a/src/core/hle/service/gsp/gsp_gpu.h
+++ b/src/core/hle/service/gsp/gsp_gpu.h
@@ -369,7 +369,9 @@ private:
     /// GSP shared memory
     Kernel::SharedPtr<Kernel::SharedMemory> shared_memory;
 
-    bool gpu_right_acquired = false;
+    /// Thread id that currently has GPU rights or -1 if none.
+    int active_thread_id = -1;
+
     bool first_initialization = true;
 };
 

--- a/src/core/hle/service/gsp/gsp_gpu.h
+++ b/src/core/hle/service/gsp/gsp_gpu.h
@@ -181,6 +181,7 @@ static_assert(sizeof(CommandBuffer) == 0x200, "CommandBuffer struct has incorrec
 
 struct SessionData : public Kernel::SessionRequestHandler::SessionDataBase {
     SessionData();
+    ~SessionData();
 
     /// Event triggered when GSP interrupt has been signalled
     Kernel::SharedPtr<Kernel::Event> interrupt_event;

--- a/src/core/hle/service/gsp/gsp_gpu.h
+++ b/src/core/hle/service/gsp/gsp_gpu.h
@@ -180,10 +180,12 @@ struct CommandBuffer {
 static_assert(sizeof(CommandBuffer) == 0x200, "CommandBuffer struct has incorrect size");
 
 struct SessionData : public Kernel::SessionRequestHandler::SessionDataBase {
+    SessionData();
+
     /// Event triggered when GSP interrupt has been signalled
     Kernel::SharedPtr<Kernel::Event> interrupt_event;
     /// Thread index into interrupt relay queue
-    u32 thread_id = 0;
+    u32 thread_id;
     /// Whether RegisterInterruptRelayQueue was called for this session
     bool registered = false;
 };
@@ -362,9 +364,6 @@ private:
 
     /// Returns the session data for the specified registered thread id, or nullptr if not found.
     SessionData* FindRegisteredThreadData(u32 thread_id);
-
-    /// Next threadid value to use when RegisterInterruptRelayQueue is called.
-    u32 next_thread_id = 0;
 
     /// GSP shared memory
     Kernel::SharedPtr<Kernel::SharedMemory> shared_memory;

--- a/src/core/hle/service/gsp/gsp_gpu.h
+++ b/src/core/hle/service/gsp/gsp_gpu.h
@@ -214,6 +214,14 @@ public:
 
 private:
     /**
+     * Signals that the specified interrupt type has occurred to userland code for the specified GSP
+     * thread id.
+     * @param interrupt_id ID of interrupt that is being signalled.
+     * @param thread_id GSP thread that will receive the interrupt.
+     */
+    void SignalInterruptForThread(InterruptId interrupt_id, u32 thread_id);
+
+    /**
      * GSP_GPU::WriteHWRegs service function
      *
      * Writes sequential GSP GPU hardware registers


### PR DESCRIPTION
Only signal the GSP interrupts for the currently active thread (set by GSP_GPU::AcquireRight).

This PR makes it so that applets won't mess up the GSP state for the running application via UnregisterInterruptRelayQueue after they're closed.

Full disclosure: I don't know if this will break any games that use the GSP in funny ways (acquiring the gsp right multiple times without releasing it, other weird but probably valid behaviors). I don't have a way to verify this since my IDB for the GSP module was recently corrupted resulting in a total data loss.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3324)
<!-- Reviewable:end -->
