### PR TITLE
citra_qt: Pause emulation on CoreError

### DIFF
--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -36,6 +36,7 @@ void EmuThread::run() {
 
             Core::System::ResultStatus result = Core::System::GetInstance().RunLoop();
             if (result != Core::System::ResultStatus::Success) {
+                this->SetRunning(false);
                 emit ErrorThrown(result, Core::System::GetInstance().GetStatusDetails());
             }
 

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -918,6 +918,7 @@ void GMainWindow::UpdateStatusBar() {
 }
 
 void GMainWindow::OnCoreError(Core::System::ResultStatus result, std::string details) {
+    emu_thread->SetRunning(false);
     QMessageBox::StandardButton answer;
     QString status_message;
     const QString common_message =
@@ -974,6 +975,7 @@ void GMainWindow::OnCoreError(Core::System::ResultStatus result, std::string det
     } else {
         // Only show the message if the game is still running.
         if (emu_thread) {
+            emu_thread->SetRunning(true);            
             message_label->setText(status_message);
             message_label->setVisible(true);
         }

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -918,7 +918,6 @@ void GMainWindow::UpdateStatusBar() {
 }
 
 void GMainWindow::OnCoreError(Core::System::ResultStatus result, std::string details) {
-    emu_thread->SetRunning(false);
     QMessageBox::StandardButton answer;
     QString status_message;
     const QString common_message =

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -974,7 +974,7 @@ void GMainWindow::OnCoreError(Core::System::ResultStatus result, std::string det
     } else {
         // Only show the message if the game is still running.
         if (emu_thread) {
-            emu_thread->SetRunning(true);            
+            emu_thread->SetRunning(true);
             message_label->setText(status_message);
             message_label->setVisible(true);
         }


### PR DESCRIPTION
Just a small commit to pause the emulation thread on CoreError because some games will spam the dialog boxes when the users are missing system files or shared fonts #3331

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3333)
<!-- Reviewable:end -->
