### PR TITLE
citra_qt: Resized main config window

### DIFF
--- a/src/citra_qt/configuration/configure.ui
+++ b/src/citra_qt/configuration/configure.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>740</width>
+    <width>461</width>
     <height>500</height>
    </rect>
   </property>
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>4</number>
      </property>
      <widget class="ConfigureGeneral" name="generalTab">
       <attribute name="title">
@@ -34,15 +34,15 @@
        <string>Input</string>
       </attribute>
      </widget>
-      <widget class="ConfigureGraphics" name="graphicsTab">
-        <attribute name="title">
-          <string>Graphics</string>
-        </attribute>
-      </widget>
+     <widget class="ConfigureGraphics" name="graphicsTab">
+      <attribute name="title">
+       <string>Graphics</string>
+      </attribute>
+     </widget>
      <widget class="ConfigureAudio" name="audioTab">
-       <attribute name="title">
-         <string>Audio</string>
-       </attribute>
+      <attribute name="title">
+       <string>Audio</string>
+      </attribute>
      </widget>
      <widget class="ConfigureDebug" name="debugTab">
       <attribute name="title">

--- a/src/citra_qt/configuration/configure.ui
+++ b/src/citra_qt/configuration/configure.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>4</number>
+      <number>0</number>
      </property>
      <widget class="ConfigureGeneral" name="generalTab">
       <attribute name="title">


### PR DESCRIPTION
Hello there! This is my first pull request. I thought I could do some work on the front-end so I decided to resize the default configuration layout width. It looks too wide and It looks much nicer when it's not so stretched out. Let me know if this is all good. :)

Original
![original](https://user-images.githubusercontent.com/22819862/34451110-f2ee5e6e-ed6b-11e7-9263-8a22f3f846e0.png)

Fixed
![fixed](https://user-images.githubusercontent.com/22819862/34451104-a867ae54-ed6b-11e7-84fd-783fc666995b.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3336)
<!-- Reviewable:end -->
