### PR TITLE
Kernel/SVC: fix typo in GetResourceLimitLimitValues

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -715,7 +715,7 @@ static ResultCode GetResourceLimitLimitValues(VAddr values, Handle resource_limi
 
     for (unsigned int i = 0; i < name_count; ++i) {
         u32 name = Memory::Read32(names + i * sizeof(u32));
-        s64 value = resource_limit->GetMaxResourceValue(names);
+        s64 value = resource_limit->GetMaxResourceValue(name);
         Memory::Write64(values + i * sizeof(u64), value);
     }
 


### PR DESCRIPTION
The one in `GetResourceLimitCurrentValues` is correct.

Are we going to make `VAddr` a strong type?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3338)
<!-- Reviewable:end -->
