### PR TITLE
citra-qt: Add customizable speed limit target

### DIFF
--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -90,8 +90,8 @@ void Config::ReadValues() {
     Settings::values.resolution_factor =
         (float)sdl2_config->GetReal("Renderer", "resolution_factor", 1.0);
     Settings::values.use_vsync = sdl2_config->GetBoolean("Renderer", "use_vsync", false);
-    Settings::values.toggle_framelimit =
-        sdl2_config->GetBoolean("Renderer", "toggle_framelimit", true);
+    Settings::values.frame_limit =
+        static_cast<u16>(sdl2_config->GetInteger("Renderer", "frame_limit", 100));
 
     Settings::values.bg_red = (float)sdl2_config->GetReal("Renderer", "bg_red", 0.0);
     Settings::values.bg_green = (float)sdl2_config->GetReal("Renderer", "bg_green", 0.0);

--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -90,6 +90,7 @@ void Config::ReadValues() {
     Settings::values.resolution_factor =
         (float)sdl2_config->GetReal("Renderer", "resolution_factor", 1.0);
     Settings::values.use_vsync = sdl2_config->GetBoolean("Renderer", "use_vsync", false);
+    Settings::values.use_frame_limit = sdl2_config->GetBoolean("Renderer", "use_frame_limit", true);
     Settings::values.frame_limit =
         static_cast<u16>(sdl2_config->GetInteger("Renderer", "frame_limit", 100));
 

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -115,9 +115,9 @@ custom_bottom_top =
 custom_bottom_right =
 custom_bottom_bottom =
 
-# Whether to toggle frame limiter on or off.
-# 0: Off, 1 (default): On
-toggle_framelimit =
+# Limits the speed of the game to run no faster than this value as a percentage of target speed
+# 0: Off, 1 - 9999: Speed limit as a percentage of target game speed. 100 (default)
+frame_limit =
 
 # Swaps the prominent screen with the other screen.
 # For example, if Single Screen is chosen, setting this to 1 will display the bottom screen instead of the top screen.

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -89,6 +89,14 @@ resolution_factor =
 # 0 (default): Off, 1: On
 use_vsync =
 
+# Turns on the frame limiter, which will limit frames output to the target game speed
+# 0: Off, 1: On (default)
+use_frame_limit =
+
+# Limits the speed of the game to run no faster than this value as a percentage of target speed
+# 1 - 9999: Speed limit as a percentage of target game speed. 100 (default)
+frame_limit =
+
 # The clear color for the renderer. What shows up on the sides of the bottom screen.
 # Must be in range of 0.0-1.0. Defaults to 1.0 for all.
 bg_red =
@@ -114,10 +122,6 @@ custom_bottom_left =
 custom_bottom_top =
 custom_bottom_right =
 custom_bottom_bottom =
-
-# Limits the speed of the game to run no faster than this value as a percentage of target speed
-# 0: Off, 1 - 9999: Speed limit as a percentage of target game speed. 100 (default)
-frame_limit =
 
 # Swaps the prominent screen with the other screen.
 # For example, if Single Screen is chosen, setting this to 1 will display the bottom screen instead of the top screen.

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -75,7 +75,7 @@ void Config::ReadValues() {
     Settings::values.use_shader_jit = qt_config->value("use_shader_jit", true).toBool();
     Settings::values.resolution_factor = qt_config->value("resolution_factor", 1.0).toFloat();
     Settings::values.use_vsync = qt_config->value("use_vsync", false).toBool();
-    Settings::values.toggle_framelimit = qt_config->value("toggle_framelimit", true).toBool();
+    Settings::values.frame_limit = qt_config->value("frame_limit", 100).toInt();
 
     Settings::values.bg_red = qt_config->value("bg_red", 0.0).toFloat();
     Settings::values.bg_green = qt_config->value("bg_green", 0.0).toFloat();
@@ -238,7 +238,7 @@ void Config::SaveValues() {
     qt_config->setValue("use_shader_jit", Settings::values.use_shader_jit);
     qt_config->setValue("resolution_factor", (double)Settings::values.resolution_factor);
     qt_config->setValue("use_vsync", Settings::values.use_vsync);
-    qt_config->setValue("toggle_framelimit", Settings::values.toggle_framelimit);
+    qt_config->setValue("frame_limit", Settings::values.frame_limit);
 
     // Cast to double because Qt's written float values are not human-readable
     qt_config->setValue("bg_red", (double)Settings::values.bg_red);

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -75,6 +75,7 @@ void Config::ReadValues() {
     Settings::values.use_shader_jit = qt_config->value("use_shader_jit", true).toBool();
     Settings::values.resolution_factor = qt_config->value("resolution_factor", 1.0).toFloat();
     Settings::values.use_vsync = qt_config->value("use_vsync", false).toBool();
+    Settings::values.use_frame_limit = qt_config->value("use_frame_limit", true).toBool();
     Settings::values.frame_limit = qt_config->value("frame_limit", 100).toInt();
 
     Settings::values.bg_red = qt_config->value("bg_red", 0.0).toFloat();
@@ -238,6 +239,7 @@ void Config::SaveValues() {
     qt_config->setValue("use_shader_jit", Settings::values.use_shader_jit);
     qt_config->setValue("resolution_factor", (double)Settings::values.resolution_factor);
     qt_config->setValue("use_vsync", Settings::values.use_vsync);
+    qt_config->setValue("use_frame_limit", Settings::values.use_frame_limit);
     qt_config->setValue("frame_limit", Settings::values.frame_limit);
 
     // Cast to double because Qt's written float values are not human-readable

--- a/src/citra_qt/configuration/configure_graphics.cpp
+++ b/src/citra_qt/configuration/configure_graphics.cpp
@@ -96,6 +96,7 @@ void ConfigureGraphics::setConfiguration() {
     ui->resolution_factor_combobox->setCurrentIndex(
         static_cast<int>(FromResolutionFactor(Settings::values.resolution_factor)));
     ui->toggle_vsync->setChecked(Settings::values.use_vsync);
+    ui->toggle_frame_limit->setChecked(Settings::values.use_frame_limit);
     ui->frame_limit->setValue(Settings::values.frame_limit);
     ui->layout_combobox->setCurrentIndex(static_cast<int>(Settings::values.layout_option));
     ui->swap_screen->setChecked(Settings::values.swap_screen);
@@ -107,6 +108,7 @@ void ConfigureGraphics::applyConfiguration() {
     Settings::values.resolution_factor =
         ToResolutionFactor(static_cast<Resolution>(ui->resolution_factor_combobox->currentIndex()));
     Settings::values.use_vsync = ui->toggle_vsync->isChecked();
+    Settings::values.use_frame_limit = ui->toggle_frame_limit->isChecked();
     Settings::values.frame_limit = ui->frame_limit->value();
     Settings::values.layout_option =
         static_cast<Settings::LayoutOption>(ui->layout_combobox->currentIndex());

--- a/src/citra_qt/configuration/configure_graphics.cpp
+++ b/src/citra_qt/configuration/configure_graphics.cpp
@@ -14,6 +14,8 @@ ConfigureGraphics::ConfigureGraphics(QWidget* parent)
     this->setConfiguration();
 
     ui->toggle_vsync->setEnabled(!Core::System::GetInstance().IsPoweredOn());
+    ui->frame_limit->setEnabled(Settings::values.use_frame_limit);
+    connect(ui->toggle_frame_limit, &QCheckBox::stateChanged, ui->frame_limit, &QSpinBox::setEnabled);
 
     ui->layoutBox->setEnabled(!Settings::values.custom_layout);
 }

--- a/src/citra_qt/configuration/configure_graphics.cpp
+++ b/src/citra_qt/configuration/configure_graphics.cpp
@@ -96,7 +96,7 @@ void ConfigureGraphics::setConfiguration() {
     ui->resolution_factor_combobox->setCurrentIndex(
         static_cast<int>(FromResolutionFactor(Settings::values.resolution_factor)));
     ui->toggle_vsync->setChecked(Settings::values.use_vsync);
-    ui->toggle_framelimit->setChecked(Settings::values.toggle_framelimit);
+    ui->frame_limit->setValue(Settings::values.frame_limit);
     ui->layout_combobox->setCurrentIndex(static_cast<int>(Settings::values.layout_option));
     ui->swap_screen->setChecked(Settings::values.swap_screen);
 }
@@ -107,7 +107,7 @@ void ConfigureGraphics::applyConfiguration() {
     Settings::values.resolution_factor =
         ToResolutionFactor(static_cast<Resolution>(ui->resolution_factor_combobox->currentIndex()));
     Settings::values.use_vsync = ui->toggle_vsync->isChecked();
-    Settings::values.toggle_framelimit = ui->toggle_framelimit->isChecked();
+    Settings::values.frame_limit = ui->frame_limit->value();
     Settings::values.layout_option =
         static_cast<Settings::LayoutOption>(ui->layout_combobox->currentIndex());
     Settings::values.swap_screen = ui->swap_screen->isChecked();

--- a/src/citra_qt/configuration/configure_graphics.ui
+++ b/src/citra_qt/configuration/configure_graphics.ui
@@ -44,81 +44,98 @@
          </widget>
         </item>
         <item>
-         <widget class="QCheckBox" name="toggle_framelimit">
-          <property name="text">
-           <string>Limit framerate</string>
-          </property>
-         </widget>
+         <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <item>
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>Limit Speed Percent</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QSpinBox" name="frame_limit">
+            <property name="suffix">
+             <string>%</string>
+            </property>
+            <property name="maximum">
+             <number>9999</number>
+            </property>
+            <property name="value">
+             <number>100</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout">
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <item>
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Internal Resolution:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="resolution_factor_combobox">
             <item>
-              <widget class="QLabel" name="label">
-                <property name="text">
-                  <string>Internal Resolution:</string>
-                </property>
-              </widget>
+             <property name="text">
+              <string>Auto (Window Size)</string>
+             </property>
             </item>
             <item>
-              <widget class="QComboBox" name="resolution_factor_combobox">
-                <item>
-                  <property name="text">
-                    <string>Auto (Window Size)</string>
-                  </property>
-                </item>
-                <item>
-                  <property name="text">
-                    <string>Native (400x240)</string>
-                  </property>
-                </item>
-                <item>
-                  <property name="text">
-                    <string>2x Native (800x480)</string>
-                  </property>
-                </item>
-                <item>
-                  <property name="text">
-                    <string>3x Native (1200x720)</string>
-                  </property>
-                </item>
-                <item>
-                  <property name="text">
-                    <string>4x Native (1600x960)</string>
-                  </property>
-                </item>
-                <item>
-                  <property name="text">
-                    <string>5x Native (2000x1200)</string>
-                  </property>
-                </item>
-                <item>
-                  <property name="text">
-                    <string>6x Native (2400x1440)</string>
-                  </property>
-                </item>
-                <item>
-                  <property name="text">
-                    <string>7x Native (2800x1680)</string>
-                  </property>
-                </item>
-                <item>
-                  <property name="text">
-                    <string>8x Native (3200x1920)</string>
-                  </property>
-                </item>
-                <item>
-                  <property name="text">
-                    <string>9x Native (3600x2160)</string>
-                  </property>
-                </item>
-                <item>
-                  <property name="text">
-                    <string>10x Native (4000x2400)</string>
-                  </property>
-                </item>
-              </widget>
+             <property name="text">
+              <string>Native (400x240)</string>
+             </property>
             </item>
-          </layout>
+            <item>
+             <property name="text">
+              <string>2x Native (800x480)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>3x Native (1200x720)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>4x Native (1600x960)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>5x Native (2000x1200)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>6x Native (2400x1440)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>7x Native (2800x1680)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>8x Native (3200x1920)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>9x Native (3600x2160)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>10x Native (4000x2400)</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+         </layout>
         </item>
        </layout>
       </widget>
@@ -202,6 +219,16 @@
    <signal>toggled(bool)</signal>
    <receiver>resolution_factor_combobox</receiver>
    <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
   </connection>
  </connections>
 </ui>

--- a/src/citra_qt/configuration/configure_graphics.ui
+++ b/src/citra_qt/configuration/configure_graphics.ui
@@ -46,7 +46,7 @@
         <item>
          <layout class="QHBoxLayout" name="horizontalLayout_2">
           <item>
-           <widget class="QLabel" name="label_2">
+           <widget class="QCheckBox" name="toggle_frame_limit">
             <property name="text">
              <string>Limit Speed Percent</string>
             </property>
@@ -56,6 +56,9 @@
            <widget class="QSpinBox" name="frame_limit">
             <property name="suffix">
              <string>%</string>
+            </property>
+            <property name="minimum">
+             <number>1</number>
             </property>
             <property name="maximum">
              <number>9999</number>

--- a/src/citra_qt/configuration/configure_graphics.ui
+++ b/src/citra_qt/configuration/configure_graphics.ui
@@ -222,16 +222,6 @@
    <signal>toggled(bool)</signal>
    <receiver>resolution_factor_combobox</receiver>
    <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
   </connection>
  </connections>
 </ui>

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -289,15 +289,20 @@ void GMainWindow::InitializeHotkeys() {
             ToggleFullscreen();
         }
     });
+    constexpr u16 SPEED_LIMIT_STEP = 5;
     connect(GetHotkey("Main Window", "Increase Speed Limit", this), &QShortcut::activated, this,
             [&] {
-                Settings::values.frame_limit += 5;
-                UpdateStatusBar();
+                if (Settings::values.frame_limit < 9999 - SPEED_LIMIT_STEP) {
+                    Settings::values.frame_limit += SPEED_LIMIT_STEP;
+                    UpdateStatusBar();
+                }
             });
     connect(GetHotkey("Main Window", "Decrease Speed Limit", this), &QShortcut::activated, this,
             [&] {
-                Settings::values.frame_limit -= 5;
-                UpdateStatusBar();
+                if (Settings::values.frame_limit > SPEED_LIMIT_STEP) {
+                    Settings::values.frame_limit -= SPEED_LIMIT_STEP;
+                    UpdateStatusBar();
+                }
             });
 }
 

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -927,9 +927,14 @@ void GMainWindow::UpdateStatusBar() {
 
     auto results = Core::System::GetInstance().GetAndResetPerfStats();
 
-    emu_speed_label->setText(tr("Speed: %1% / %2%")
-                                 .arg(results.emulation_speed * 100.0, 0, 'f', 0)
-                                 .arg(Settings::values.frame_limit));
+    if (Settings::values.use_frame_limit) {
+        emu_speed_label->setText(tr("Speed: %1% / %2%")
+                                    .arg(results.emulation_speed * 100.0, 0, 'f', 0)
+                                    .arg(Settings::values.frame_limit));
+    } else {
+        emu_speed_label->setText(tr("Speed: %1%")
+                                    .arg(results.emulation_speed * 100.0, 0, 'f', 0));
+    }
     game_fps_label->setText(tr("Game: %1 FPS").arg(results.game_fps, 0, 'f', 0));
     emu_frametime_label->setText(tr("Frame: %1 ms").arg(results.frametime * 1000.0, 0, 'f', 2));
 

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -267,6 +267,10 @@ void GMainWindow::InitializeHotkeys() {
     RegisterHotkey("Main Window", "Fullscreen", QKeySequence::FullScreen);
     RegisterHotkey("Main Window", "Exit Fullscreen", QKeySequence(Qt::Key_Escape),
                    Qt::ApplicationShortcut);
+    RegisterHotkey("Main Window", "Increase Speed Limit", QKeySequence("+"),
+                   Qt::ApplicationShortcut);
+    RegisterHotkey("Main Window", "Decrease Speed Limit", QKeySequence("-"),
+                   Qt::ApplicationShortcut);
     LoadHotkeys();
 
     connect(GetHotkey("Main Window", "Load File", this), &QShortcut::activated, this,
@@ -285,6 +289,16 @@ void GMainWindow::InitializeHotkeys() {
             ToggleFullscreen();
         }
     });
+    connect(GetHotkey("Main Window", "Increase Speed Limit", this), &QShortcut::activated, this,
+            [&] {
+                Settings::values.frame_limit += 5;
+                UpdateStatusBar();
+            });
+    connect(GetHotkey("Main Window", "Decrease Speed Limit", this), &QShortcut::activated, this,
+            [&] {
+                Settings::values.frame_limit -= 5;
+                UpdateStatusBar();
+            });
 }
 
 void GMainWindow::ShowUpdaterWidgets() {
@@ -908,7 +922,9 @@ void GMainWindow::UpdateStatusBar() {
 
     auto results = Core::System::GetInstance().GetAndResetPerfStats();
 
-    emu_speed_label->setText(tr("Speed: %1%").arg(results.emulation_speed * 100.0, 0, 'f', 0));
+    emu_speed_label->setText(tr("Speed: %1% / %2%")
+                                 .arg(results.emulation_speed * 100.0, 0, 'f', 0)
+                                 .arg(Settings::values.frame_limit));
     game_fps_label->setText(tr("Game: %1 FPS").arg(results.game_fps, 0, 'f', 0));
     emu_frametime_label->setText(tr("Frame: %1 ms").arg(results.frametime * 1000.0, 0, 'f', 2));
 

--- a/src/core/perf_stats.cpp
+++ b/src/core/perf_stats.cpp
@@ -77,22 +77,24 @@ double PerfStats::GetLastFrameTimeScale() {
 void FrameLimiter::DoFrameLimiting(u64 current_system_time_us) {
     // Max lag caused by slow frames. Can be adjusted to compensate for too many slow frames. Higher
     // values increase the time needed to recover and limit framerate again after spikes.
-    constexpr microseconds MAX_LAG_TIME_US = 25ms;
+    constexpr microseconds MAX_LAG_TIME_US = 250ms;
 
-    if (!Settings::values.toggle_framelimit) {
+    if (!Settings::values.frame_limit) {
         return;
     }
 
     auto now = Clock::now();
 
-    frame_limiting_delta_err += microseconds(current_system_time_us - previous_system_time_us);
+    double sleep_scale = (Settings::values.frame_limit / 100.0);
+    frame_limiting_delta_err += duration_cast<microseconds>(
+        std::chrono::duration<double, std::chrono::microseconds::period>(
+            (current_system_time_us - previous_system_time_us) / sleep_scale));
     frame_limiting_delta_err -= duration_cast<microseconds>(now - previous_walltime);
     frame_limiting_delta_err =
         MathUtil::Clamp(frame_limiting_delta_err, -MAX_LAG_TIME_US, MAX_LAG_TIME_US);
 
     if (frame_limiting_delta_err > microseconds::zero()) {
         std::this_thread::sleep_for(frame_limiting_delta_err);
-
         auto now_after_sleep = Clock::now();
         frame_limiting_delta_err -= duration_cast<microseconds>(now_after_sleep - now);
         now = now_after_sleep;

--- a/src/core/perf_stats.cpp
+++ b/src/core/perf_stats.cpp
@@ -75,23 +75,24 @@ double PerfStats::GetLastFrameTimeScale() {
 }
 
 void FrameLimiter::DoFrameLimiting(u64 current_system_time_us) {
-    // Max lag caused by slow frames. Can be adjusted to compensate for too many slow frames. Higher
-    // values increase the time needed to recover and limit framerate again after spikes.
-    constexpr microseconds MAX_LAG_TIME_US = 250ms;
-
-    if (!Settings::values.frame_limit) {
+    if (!Settings::values.use_frame_limit) {
         return;
     }
 
     auto now = Clock::now();
+    double sleep_scale = Settings::values.frame_limit / 100.0;
 
-    double sleep_scale = (Settings::values.frame_limit / 100.0);
+    // Max lag caused by slow frames. Shouldn't be more than the length of a frame at the current
+    // speed percent or it will clamp too much and prevent this from properly limiting to that
+    // percent. High values means it'll take longer after a slow frame to recover and start limiting
+    const microseconds max_lag_time_us = duration_cast<microseconds>(
+        std::chrono::duration<double, std::chrono::microseconds::period>(25ms / sleep_scale));
     frame_limiting_delta_err += duration_cast<microseconds>(
         std::chrono::duration<double, std::chrono::microseconds::period>(
             (current_system_time_us - previous_system_time_us) / sleep_scale));
     frame_limiting_delta_err -= duration_cast<microseconds>(now - previous_walltime);
     frame_limiting_delta_err =
-        MathUtil::Clamp(frame_limiting_delta_err, -MAX_LAG_TIME_US, MAX_LAG_TIME_US);
+        MathUtil::Clamp(frame_limiting_delta_err, -max_lag_time_us, max_lag_time_us);
 
     if (frame_limiting_delta_err > microseconds::zero()) {
         std::this_thread::sleep_for(frame_limiting_delta_err);

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -22,7 +22,6 @@ void Apply() {
 
     VideoCore::g_hw_renderer_enabled = values.use_hw_renderer;
     VideoCore::g_shader_jit_enabled = values.use_shader_jit;
-    VideoCore::g_frame_limit = values.frame_limit;
 
     if (VideoCore::g_emu_window) {
         auto layout = VideoCore::g_emu_window->GetFramebufferLayout();

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -22,7 +22,7 @@ void Apply() {
 
     VideoCore::g_hw_renderer_enabled = values.use_hw_renderer;
     VideoCore::g_shader_jit_enabled = values.use_shader_jit;
-    VideoCore::g_toggle_framelimit_enabled = values.toggle_framelimit;
+    VideoCore::g_frame_limit = values.frame_limit;
 
     if (VideoCore::g_emu_window) {
         auto layout = VideoCore::g_emu_window->GetFramebufferLayout();

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -97,6 +97,7 @@ struct Values {
     bool use_shader_jit;
     float resolution_factor;
     bool use_vsync;
+    bool use_frame_limit;
     u16 frame_limit;
 
     LayoutOption layout_option;

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -97,7 +97,7 @@ struct Values {
     bool use_shader_jit;
     float resolution_factor;
     bool use_vsync;
-    bool toggle_framelimit;
+    u16 frame_limit;
 
     LayoutOption layout_option;
     bool swap_screen;

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -159,8 +159,8 @@ TelemetrySession::TelemetrySession() {
     AddField(Telemetry::FieldType::UserConfig, "Core_UseCpuJit", Settings::values.use_cpu_jit);
     AddField(Telemetry::FieldType::UserConfig, "Renderer_ResolutionFactor",
              Settings::values.resolution_factor);
-    AddField(Telemetry::FieldType::UserConfig, "Renderer_ToggleFramelimit",
-             Settings::values.toggle_framelimit);
+    AddField(Telemetry::FieldType::UserConfig, "Renderer_FrameLimit",
+             Settings::values.frame_limit);
     AddField(Telemetry::FieldType::UserConfig, "Renderer_UseHwRenderer",
              Settings::values.use_hw_renderer);
     AddField(Telemetry::FieldType::UserConfig, "Renderer_UseShaderJit",

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -159,8 +159,7 @@ TelemetrySession::TelemetrySession() {
     AddField(Telemetry::FieldType::UserConfig, "Core_UseCpuJit", Settings::values.use_cpu_jit);
     AddField(Telemetry::FieldType::UserConfig, "Renderer_ResolutionFactor",
              Settings::values.resolution_factor);
-    AddField(Telemetry::FieldType::UserConfig, "Renderer_FrameLimit",
-             Settings::values.frame_limit);
+    AddField(Telemetry::FieldType::UserConfig, "Renderer_FrameLimit", Settings::values.frame_limit);
     AddField(Telemetry::FieldType::UserConfig, "Renderer_UseHwRenderer",
              Settings::values.use_hw_renderer);
     AddField(Telemetry::FieldType::UserConfig, "Renderer_UseShaderJit",

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -159,6 +159,8 @@ TelemetrySession::TelemetrySession() {
     AddField(Telemetry::FieldType::UserConfig, "Core_UseCpuJit", Settings::values.use_cpu_jit);
     AddField(Telemetry::FieldType::UserConfig, "Renderer_ResolutionFactor",
              Settings::values.resolution_factor);
+    AddField(Telemetry::FieldType::UserConfig, "Renderer_UseFrameLimit",
+             Settings::values.use_frame_limit);
     AddField(Telemetry::FieldType::UserConfig, "Renderer_FrameLimit", Settings::values.frame_limit);
     AddField(Telemetry::FieldType::UserConfig, "Renderer_UseHwRenderer",
              Settings::values.use_hw_renderer);

--- a/src/video_core/video_core.cpp
+++ b/src/video_core/video_core.cpp
@@ -20,7 +20,7 @@ std::unique_ptr<RendererBase> g_renderer; ///< Renderer plugin
 std::atomic<bool> g_hw_renderer_enabled;
 std::atomic<bool> g_shader_jit_enabled;
 std::atomic<bool> g_vsync_enabled;
-std::atomic<bool> g_toggle_framelimit_enabled;
+std::atomic<u16> g_frame_limit;
 
 /// Initialize the video core
 bool Init(EmuWindow* emu_window) {

--- a/src/video_core/video_core.cpp
+++ b/src/video_core/video_core.cpp
@@ -20,7 +20,6 @@ std::unique_ptr<RendererBase> g_renderer; ///< Renderer plugin
 std::atomic<bool> g_hw_renderer_enabled;
 std::atomic<bool> g_shader_jit_enabled;
 std::atomic<bool> g_vsync_enabled;
-std::atomic<u16> g_frame_limit;
 
 /// Initialize the video core
 bool Init(EmuWindow* emu_window) {
@@ -47,4 +46,4 @@ void Shutdown() {
     LOG_DEBUG(Render, "shutdown OK");
 }
 
-} // namespace
+} // namespace VideoCore

--- a/src/video_core/video_core.h
+++ b/src/video_core/video_core.h
@@ -22,7 +22,7 @@ extern EmuWindow* g_emu_window;                  ///< Emu window
 // qt ui)
 extern std::atomic<bool> g_hw_renderer_enabled;
 extern std::atomic<bool> g_shader_jit_enabled;
-extern std::atomic<bool> g_toggle_framelimit_enabled;
+extern std::atomic<u16> g_frame_limit;
 
 /// Start the video core
 void Start();

--- a/src/video_core/video_core.h
+++ b/src/video_core/video_core.h
@@ -22,7 +22,6 @@ extern EmuWindow* g_emu_window;                  ///< Emu window
 // qt ui)
 extern std::atomic<bool> g_hw_renderer_enabled;
 extern std::atomic<bool> g_shader_jit_enabled;
-extern std::atomic<u16> g_frame_limit;
 
 /// Start the video core
 void Start();
@@ -33,4 +32,4 @@ bool Init(EmuWindow* emu_window);
 /// Shutdown the video core
 void Shutdown();
 
-} // namespace
+} // namespace VideoCore


### PR DESCRIPTION
Allows the user to customize the speed limit instead of a binary off/on frame limiter. 

Things to know:
* Adjusts the max frametime lag to 250ms instead to allow lower frame limits. If the max lag is too small, the clamp will prevent limiting to smaller values. In practice: at the original 25ms value, the limiter could clamp around values of 60%, so half speed play wasn't possible. 250ms was selected as it allows clamps around 6%. This can be changed if someone thinks that limiting to such values would be pointless.
* Adds a hotkey (+ / - by default) to adjust the speed limit by +- 5%
* Status bar changed to display the limit
![Status bar changed to display the limit](https://user-images.githubusercontent.com/952515/34682780-3045e546-f45d-11e7-8f7e-7ed6d0c8aea4.png)
* Using a spinbox lets the user choose a precise limit as its adjustable by +- 1%
![Using a spinbox lets the user choose a precise limit](https://user-images.githubusercontent.com/952515/34682845-687d8874-f45d-11e7-95fa-26468b50d669.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3353)
<!-- Reviewable:end -->
