### PR TITLE
Service/PTM: convert to ServiceFramework

### DIFF
--- a/src/core/hle/service/ptm/ptm.h
+++ b/src/core/hle/service/ptm/ptm.h
@@ -4,13 +4,12 @@
 
 #pragma once
 
+#include <memory>
 #include "common/common_types.h"
 #include "core/hle/ipc_helpers.h"
+#include "core/hle/service/service.h"
 
 namespace Service {
-
-class Interface;
-
 namespace PTM {
 
 /// Charge levels used by PTM functions
@@ -38,93 +37,109 @@ struct GameCoin {
     u8 day;
 };
 
-/**
- * It is unknown if GetAdapterState is the same as GetBatteryChargeState,
- * it is likely to just be a duplicate function of GetBatteryChargeState
- * that controls another part of the HW.
- * PTM::GetAdapterState service function
- *  Outputs:
- *      1 : Result of function, 0 on success, otherwise error code
- *      2 : Output of function, 0 = not charging, 1 = charging.
- */
-void GetAdapterState(Interface* self);
-
-/**
- * PTM::GetShellState service function.
- *  Outputs:
- *      1 : Result of function, 0 on success, otherwise error code
- *      2 : Whether the 3DS's physical shell casing is open (1) or closed (0)
- */
-void GetShellState(Interface* self);
-
-/**
- * PTM::GetBatteryLevel service function
- *  Outputs:
- *      1 : Result of function, 0 on success, otherwise error code
- *      2 : Battery level, 5 = completely full battery, 4 = mostly full battery,
- *          3 = half full battery, 2 =  low battery, 1 = critical battery.
- */
-void GetBatteryLevel(Interface* self);
-
-/**
- * PTM::GetBatteryChargeState service function
- *  Outputs:
- *      1 : Result of function, 0 on success, otherwise error code
- *      2 : Output of function, 0 = not charging, 1 = charging.
- */
-void GetBatteryChargeState(Interface* self);
-
-/**
- * PTM::GetPedometerState service function
- *  Outputs:
- *      1 : Result of function, 0 on success, otherwise error code
- *      2 : Output of function, 0 = not counting steps, 1 = counting steps.
- */
-void GetPedometerState(Interface* self);
-
-/**
- * PTM::GetStepHistory service function
- *  Inputs:
- *      1 : Number of hours
- *    2-3 : Start time
- *      4 : Buffer mapping descriptor
- *      5 : (short*) Buffer for step counts
- *  Outputs:
- *      1 : Result of function, 0 on success, otherwise error code
- */
-void GetStepHistory(Interface* self);
-
-/**
- * PTM::GetTotalStepCount service function
- *  Outputs:
- *      1 : Result of function, 0 on success, otherwise error code
- *      2 : Output of function, * = total step count
- */
-void GetTotalStepCount(Interface* self);
-
-/**
- * PTM::GetSoftwareClosedFlag service function
- *  Outputs:
- *      1: Result code, 0 on success, otherwise error code
- *      2: Whether or not the "software closed" dialog was requested by the last FIRM
- *         and should be displayed.
- */
-void GetSoftwareClosedFlag(Interface* self);
-
-/**
- * PTM::CheckNew3DS service function
- *  Outputs:
- *      1: Result code, 0 on success, otherwise error code
- *      2: u8 output: 0 = Old3DS, 1 = New3DS.
- */
-void CheckNew3DS(Interface* self);
 void CheckNew3DS(IPC::RequestBuilder& rb);
 
-/// Initialize the PTM service
-void Init();
+class Module final {
+public:
+    Module();
 
-/// Shutdown the PTM service
-void Shutdown();
+    class Interface : public ServiceFramework<Interface> {
+    public:
+        Interface(std::shared_ptr<Module> ptm, const char* name, u32 max_session);
+
+    protected:
+        /**
+         * It is unknown if GetAdapterState is the same as GetBatteryChargeState,
+         * it is likely to just be a duplicate function of GetBatteryChargeState
+         * that controls another part of the HW.
+         * PTM::GetAdapterState service function
+         *  Outputs:
+         *      1 : Result of function, 0 on success, otherwise error code
+         *      2 : Output of function, 0 = not charging, 1 = charging.
+         */
+        void GetAdapterState(Kernel::HLERequestContext& ctx);
+
+        /**
+         * PTM::GetShellState service function.
+         *  Outputs:
+         *      1 : Result of function, 0 on success, otherwise error code
+         *      2 : Whether the 3DS's physical shell casing is open (1) or closed (0)
+         */
+        void GetShellState(Kernel::HLERequestContext& ctx);
+
+        /**
+         * PTM::GetBatteryLevel service function
+         *  Outputs:
+         *      1 : Result of function, 0 on success, otherwise error code
+         *      2 : Battery level, 5 = completely full battery, 4 = mostly full battery,
+         *          3 = half full battery, 2 =  low battery, 1 = critical battery.
+         */
+        void GetBatteryLevel(Kernel::HLERequestContext& ctx);
+
+        /**
+         * PTM::GetBatteryChargeState service function
+         *  Outputs:
+         *      1 : Result of function, 0 on success, otherwise error code
+         *      2 : Output of function, 0 = not charging, 1 = charging.
+         */
+        void GetBatteryChargeState(Kernel::HLERequestContext& ctx);
+
+        /**
+         * PTM::GetPedometerState service function
+         *  Outputs:
+         *      1 : Result of function, 0 on success, otherwise error code
+         *      2 : Output of function, 0 = not counting steps, 1 = counting steps.
+         */
+        void GetPedometerState(Kernel::HLERequestContext& ctx);
+
+        /**
+         * PTM::GetStepHistory service function
+         *  Inputs:
+         *      1 : Number of hours
+         *    2-3 : Start time
+         *      4 : Buffer mapping descriptor
+         *      5 : (short*) Buffer for step counts
+         *  Outputs:
+         *      1 : Result of function, 0 on success, otherwise error code
+         */
+        void GetStepHistory(Kernel::HLERequestContext& ctx);
+
+        /**
+         * PTM::GetTotalStepCount service function
+         *  Outputs:
+         *      1 : Result of function, 0 on success, otherwise error code
+         *      2 : Output of function, * = total step count
+         */
+        void GetTotalStepCount(Kernel::HLERequestContext& ctx);
+
+        /**
+         * PTM::GetSoftwareClosedFlag service function
+         *  Outputs:
+         *      1: Result code, 0 on success, otherwise error code
+         *      2: Whether or not the "software closed" dialog was requested by the last FIRM
+         *         and should be displayed.
+         */
+        void GetSoftwareClosedFlag(Kernel::HLERequestContext& ctx);
+
+        /**
+         * PTM::CheckNew3DS service function
+         *  Outputs:
+         *      1: Result code, 0 on success, otherwise error code
+         *      2: u8 output: 0 = Old3DS, 1 = New3DS.
+         */
+        void CheckNew3DS(Kernel::HLERequestContext& ctx);
+
+    private:
+        std::shared_ptr<Module> ptm;
+    };
+
+private:
+    bool shell_open = true;
+    bool battery_is_charging = true;
+    bool pedometer_is_counting = false;
+};
+
+void InstallInterfaces(SM::ServiceManager& service_manager);
 
 } // namespace PTM
 } // namespace Service

--- a/src/core/hle/service/ptm/ptm_gets.cpp
+++ b/src/core/hle/service/ptm/ptm_gets.cpp
@@ -2,35 +2,34 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include "core/hle/service/ptm/ptm.h"
 #include "core/hle/service/ptm/ptm_gets.h"
 
 namespace Service {
 namespace PTM {
 
-const Interface::FunctionInfo FunctionTable[] = {
-    // ptm:u common commands
-    {0x00010002, nullptr, "RegisterAlarmClient"},
-    {0x00020080, nullptr, "SetRtcAlarm"},
-    {0x00030000, nullptr, "GetRtcAlarm"},
-    {0x00040000, nullptr, "CancelRtcAlarm"},
-    {0x00050000, GetAdapterState, "GetAdapterState"},
-    {0x00060000, GetShellState, "GetShellState"},
-    {0x00070000, GetBatteryLevel, "GetBatteryLevel"},
-    {0x00080000, GetBatteryChargeState, "GetBatteryChargeState"},
-    {0x00090000, nullptr, "GetPedometerState"},
-    {0x000A0042, nullptr, "GetStepHistoryEntry"},
-    {0x000B00C2, GetStepHistory, "GetStepHistory"},
-    {0x000C0000, GetTotalStepCount, "GetTotalStepCount"},
-    {0x000D0040, nullptr, "SetPedometerRecordingMode"},
-    {0x000E0000, nullptr, "GetPedometerRecordingMode"},
-    {0x000F0084, nullptr, "GetStepHistoryAll"},
-    // ptm:gets
-    {0x04010000, nullptr, "GetSystemTime"},
-};
-
-PTM_Gets::PTM_Gets() {
-    Register(FunctionTable);
+PTM_Gets::PTM_Gets(std::shared_ptr<Module> ptm)
+    : Module::Interface(std::move(ptm), "ptm:gets", 26) {
+    static const FunctionInfo functions[] = {
+        // ptm:u common commands
+        {0x00010002, nullptr, "RegisterAlarmClient"},
+        {0x00020080, nullptr, "SetRtcAlarm"},
+        {0x00030000, nullptr, "GetRtcAlarm"},
+        {0x00040000, nullptr, "CancelRtcAlarm"},
+        {0x00050000, &PTM_Gets::GetAdapterState, "GetAdapterState"},
+        {0x00060000, &PTM_Gets::GetShellState, "GetShellState"},
+        {0x00070000, &PTM_Gets::GetBatteryLevel, "GetBatteryLevel"},
+        {0x00080000, &PTM_Gets::GetBatteryChargeState, "GetBatteryChargeState"},
+        {0x00090000, nullptr, "GetPedometerState"},
+        {0x000A0042, nullptr, "GetStepHistoryEntry"},
+        {0x000B00C2, &PTM_Gets::GetStepHistory, "GetStepHistory"},
+        {0x000C0000, &PTM_Gets::GetTotalStepCount, "GetTotalStepCount"},
+        {0x000D0040, nullptr, "SetPedometerRecordingMode"},
+        {0x000E0000, nullptr, "GetPedometerRecordingMode"},
+        {0x000F0084, nullptr, "GetStepHistoryAll"},
+        // ptm:gets
+        {0x04010000, nullptr, "GetSystemTime"},
+    };
+    RegisterHandlers(functions);
 }
 
 } // namespace PTM

--- a/src/core/hle/service/ptm/ptm_gets.h
+++ b/src/core/hle/service/ptm/ptm_gets.h
@@ -4,18 +4,15 @@
 
 #pragma once
 
-#include "core/hle/service/service.h"
+#include <memory>
+#include "core/hle/service/ptm/ptm.h"
 
 namespace Service {
 namespace PTM {
 
-class PTM_Gets final : public Interface {
+class PTM_Gets final : public Module::Interface {
 public:
-    PTM_Gets();
-
-    std::string GetPortName() const override {
-        return "ptm:gets";
-    }
+    explicit PTM_Gets(std::shared_ptr<Module> ptm);
 };
 
 } // namespace PTM

--- a/src/core/hle/service/ptm/ptm_play.cpp
+++ b/src/core/hle/service/ptm/ptm_play.cpp
@@ -2,38 +2,37 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include "core/hle/service/ptm/ptm.h"
 #include "core/hle/service/ptm/ptm_play.h"
 
 namespace Service {
 namespace PTM {
 
-const Interface::FunctionInfo FunctionTable[] = {
-    // ptm:u common commands
-    {0x00010002, nullptr, "RegisterAlarmClient"},
-    {0x00020080, nullptr, "SetRtcAlarm"},
-    {0x00030000, nullptr, "GetRtcAlarm"},
-    {0x00040000, nullptr, "CancelRtcAlarm"},
-    {0x00050000, GetAdapterState, "GetAdapterState"},
-    {0x00060000, GetShellState, "GetShellState"},
-    {0x00070000, GetBatteryLevel, "GetBatteryLevel"},
-    {0x00080000, GetBatteryChargeState, "GetBatteryChargeState"},
-    {0x00090000, nullptr, "GetPedometerState"},
-    {0x000A0042, nullptr, "GetStepHistoryEntry"},
-    {0x000B00C2, GetStepHistory, "GetStepHistory"},
-    {0x000C0000, GetTotalStepCount, "GetTotalStepCount"},
-    {0x000D0040, nullptr, "SetPedometerRecordingMode"},
-    {0x000E0000, nullptr, "GetPedometerRecordingMode"},
-    {0x000F0084, nullptr, "GetStepHistoryAll"},
-    // ptm:play
-    {0x08070082, nullptr, "GetPlayHistory"},
-    {0x08080000, nullptr, "GetPlayHistoryStart"},
-    {0x08090000, nullptr, "GetPlayHistoryLength"},
-    {0x080B0080, nullptr, "CalcPlayHistoryStart"},
-};
-
-PTM_Play::PTM_Play() {
-    Register(FunctionTable);
+PTM_Play::PTM_Play(std::shared_ptr<Module> ptm)
+    : Module::Interface(std::move(ptm), "ptm:play", 26) {
+    static const FunctionInfo functions[] = {
+        // ptm:u common commands
+        {0x00010002, nullptr, "RegisterAlarmClient"},
+        {0x00020080, nullptr, "SetRtcAlarm"},
+        {0x00030000, nullptr, "GetRtcAlarm"},
+        {0x00040000, nullptr, "CancelRtcAlarm"},
+        {0x00050000, &PTM_Play::GetAdapterState, "GetAdapterState"},
+        {0x00060000, &PTM_Play::GetShellState, "GetShellState"},
+        {0x00070000, &PTM_Play::GetBatteryLevel, "GetBatteryLevel"},
+        {0x00080000, &PTM_Play::GetBatteryChargeState, "GetBatteryChargeState"},
+        {0x00090000, nullptr, "GetPedometerState"},
+        {0x000A0042, nullptr, "GetStepHistoryEntry"},
+        {0x000B00C2, &PTM_Play::GetStepHistory, "GetStepHistory"},
+        {0x000C0000, &PTM_Play::GetTotalStepCount, "GetTotalStepCount"},
+        {0x000D0040, nullptr, "SetPedometerRecordingMode"},
+        {0x000E0000, nullptr, "GetPedometerRecordingMode"},
+        {0x000F0084, nullptr, "GetStepHistoryAll"},
+        // ptm:play
+        {0x08070082, nullptr, "GetPlayHistory"},
+        {0x08080000, nullptr, "GetPlayHistoryStart"},
+        {0x08090000, nullptr, "GetPlayHistoryLength"},
+        {0x080B0080, nullptr, "CalcPlayHistoryStart"},
+    };
+    RegisterHandlers(functions);
 }
 
 } // namespace PTM

--- a/src/core/hle/service/ptm/ptm_play.h
+++ b/src/core/hle/service/ptm/ptm_play.h
@@ -4,18 +4,15 @@
 
 #pragma once
 
-#include "core/hle/service/service.h"
+#include <memory>
+#include "core/hle/service/ptm/ptm.h"
 
 namespace Service {
 namespace PTM {
 
-class PTM_Play final : public Interface {
+class PTM_Play final : public Module::Interface {
 public:
-    PTM_Play();
-
-    std::string GetPortName() const override {
-        return "ptm:play";
-    }
+    explicit PTM_Play(std::shared_ptr<Module> ptm);
 };
 
 } // namespace PTM

--- a/src/core/hle/service/ptm/ptm_sets.cpp
+++ b/src/core/hle/service/ptm/ptm_sets.cpp
@@ -7,13 +7,12 @@
 namespace Service {
 namespace PTM {
 
-const Interface::FunctionInfo FunctionTable[] = {
-    // Note that this service does not have access to ptm:u's common commands
-    {0x00010080, nullptr, "SetSystemTime"},
-};
-
-PTM_Sets::PTM_Sets() {
-    Register(FunctionTable);
+PTM_Sets::PTM_Sets(std::shared_ptr<Module> ptm) : Module::Interface(std::move(ptm), "ptm:sets", 1) {
+    static const FunctionInfo functions[] = {
+        // Note that this service does not have access to ptm:u's common commands
+        {0x00010080, nullptr, "SetSystemTime"},
+    };
+    RegisterHandlers(functions);
 }
 
 } // namespace PTM

--- a/src/core/hle/service/ptm/ptm_sets.h
+++ b/src/core/hle/service/ptm/ptm_sets.h
@@ -4,18 +4,15 @@
 
 #pragma once
 
-#include "core/hle/service/service.h"
+#include <memory>
+#include "core/hle/service/ptm/ptm.h"
 
 namespace Service {
 namespace PTM {
 
-class PTM_Sets final : public Interface {
+class PTM_Sets final : public Module::Interface {
 public:
-    PTM_Sets();
-
-    std::string GetPortName() const override {
-        return "ptm:sets";
-    }
+    explicit PTM_Sets(std::shared_ptr<Module> ptm);
 };
 
 } // namespace PTM

--- a/src/core/hle/service/ptm/ptm_sysm.cpp
+++ b/src/core/hle/service/ptm/ptm_sysm.cpp
@@ -2,70 +2,69 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include "core/hle/service/ptm/ptm.h"
 #include "core/hle/service/ptm/ptm_sysm.h"
 
 namespace Service {
 namespace PTM {
 
-const Interface::FunctionInfo FunctionTable[] = {
-    // ptm:u common commands
-    {0x00010002, nullptr, "RegisterAlarmClient"},
-    {0x00020080, nullptr, "SetRtcAlarm"},
-    {0x00030000, nullptr, "GetRtcAlarm"},
-    {0x00040000, nullptr, "CancelRtcAlarm"},
-    {0x00050000, GetAdapterState, "GetAdapterState"},
-    {0x00060000, GetShellState, "GetShellState"},
-    {0x00070000, GetBatteryLevel, "GetBatteryLevel"},
-    {0x00080000, GetBatteryChargeState, "GetBatteryChargeState"},
-    {0x00090000, nullptr, "GetPedometerState"},
-    {0x000A0042, nullptr, "GetStepHistoryEntry"},
-    {0x000B00C2, GetStepHistory, "GetStepHistory"},
-    {0x000C0000, GetTotalStepCount, "GetTotalStepCount"},
-    {0x000D0040, nullptr, "SetPedometerRecordingMode"},
-    {0x000E0000, nullptr, "GetPedometerRecordingMode"},
-    {0x000F0084, nullptr, "GetStepHistoryAll"},
-    // ptm:sysm
-    {0x040100C0, nullptr, "SetRtcAlarmEx"},
-    {0x04020042, nullptr, "ReplySleepQuery"},
-    {0x04030042, nullptr, "NotifySleepPreparationComplete"},
-    {0x04040102, nullptr, "SetWakeupTrigger"},
-    {0x04050000, nullptr, "GetAwakeReason"},
-    {0x04060000, nullptr, "RequestSleep"},
-    {0x040700C0, nullptr, "ShutdownAsync"},
-    {0x04080000, nullptr, "Awake"},
-    {0x04090080, nullptr, "RebootAsync"},
-    {0x040A0000, CheckNew3DS, "CheckNew3DS"},
-    {0x08010640, nullptr, "SetInfoLEDPattern"},
-    {0x08020040, nullptr, "SetInfoLEDPatternHeader"},
-    {0x08030000, nullptr, "GetInfoLEDStatus"},
-    {0x08040040, nullptr, "SetBatteryEmptyLEDPattern"},
-    {0x08050000, nullptr, "ClearStepHistory"},
-    {0x080600C2, nullptr, "SetStepHistory"},
-    {0x08070082, nullptr, "GetPlayHistory"},
-    {0x08080000, nullptr, "GetPlayHistoryStart"},
-    {0x08090000, nullptr, "GetPlayHistoryLength"},
-    {0x080A0000, nullptr, "ClearPlayHistory"},
-    {0x080B0080, nullptr, "CalcPlayHistoryStart"},
-    {0x080C0080, nullptr, "SetUserTime"},
-    {0x080D0000, nullptr, "InvalidateSystemTime"},
-    {0x080E0140, nullptr, "NotifyPlayEvent"},
-    {0x080F0000, GetSoftwareClosedFlag, "GetSoftwareClosedFlag"},
-    {0x08100000, nullptr, "ClearSoftwareClosedFlag"},
-    {0x08110000, GetShellState, "GetShellState"},
-    {0x08120000, nullptr, "IsShutdownByBatteryEmpty"},
-    {0x08130000, nullptr, "FormatSavedata"},
-    {0x08140000, nullptr, "GetLegacyJumpProhibitedFlag"},
-    {0x08180040, nullptr, "ConfigureNew3DSCPU"},
-};
-
-PTM_S::PTM_S() {
-    Register(FunctionTable);
+PTM_S_Common::PTM_S_Common(std::shared_ptr<Module> ptm, const char* name)
+    : Module::Interface(std::move(ptm), name, 26) {
+    static const FunctionInfo functions[] = {
+        // ptm:u common commands
+        {0x00010002, nullptr, "RegisterAlarmClient"},
+        {0x00020080, nullptr, "SetRtcAlarm"},
+        {0x00030000, nullptr, "GetRtcAlarm"},
+        {0x00040000, nullptr, "CancelRtcAlarm"},
+        {0x00050000, &PTM_S_Common::GetAdapterState, "GetAdapterState"},
+        {0x00060000, &PTM_S_Common::GetShellState, "GetShellState"},
+        {0x00070000, &PTM_S_Common::GetBatteryLevel, "GetBatteryLevel"},
+        {0x00080000, &PTM_S_Common::GetBatteryChargeState, "GetBatteryChargeState"},
+        {0x00090000, nullptr, "GetPedometerState"},
+        {0x000A0042, nullptr, "GetStepHistoryEntry"},
+        {0x000B00C2, &PTM_S_Common::GetStepHistory, "GetStepHistory"},
+        {0x000C0000, &PTM_S_Common::GetTotalStepCount, "GetTotalStepCount"},
+        {0x000D0040, nullptr, "SetPedometerRecordingMode"},
+        {0x000E0000, nullptr, "GetPedometerRecordingMode"},
+        {0x000F0084, nullptr, "GetStepHistoryAll"},
+        // ptm:sysm & ptm:s
+        {0x040100C0, nullptr, "SetRtcAlarmEx"},
+        {0x04020042, nullptr, "ReplySleepQuery"},
+        {0x04030042, nullptr, "NotifySleepPreparationComplete"},
+        {0x04040102, nullptr, "SetWakeupTrigger"},
+        {0x04050000, nullptr, "GetAwakeReason"},
+        {0x04060000, nullptr, "RequestSleep"},
+        {0x040700C0, nullptr, "ShutdownAsync"},
+        {0x04080000, nullptr, "Awake"},
+        {0x04090080, nullptr, "RebootAsync"},
+        {0x040A0000, &PTM_S_Common::CheckNew3DS, "CheckNew3DS"},
+        {0x08010640, nullptr, "SetInfoLEDPattern"},
+        {0x08020040, nullptr, "SetInfoLEDPatternHeader"},
+        {0x08030000, nullptr, "GetInfoLEDStatus"},
+        {0x08040040, nullptr, "SetBatteryEmptyLEDPattern"},
+        {0x08050000, nullptr, "ClearStepHistory"},
+        {0x080600C2, nullptr, "SetStepHistory"},
+        {0x08070082, nullptr, "GetPlayHistory"},
+        {0x08080000, nullptr, "GetPlayHistoryStart"},
+        {0x08090000, nullptr, "GetPlayHistoryLength"},
+        {0x080A0000, nullptr, "ClearPlayHistory"},
+        {0x080B0080, nullptr, "CalcPlayHistoryStart"},
+        {0x080C0080, nullptr, "SetUserTime"},
+        {0x080D0000, nullptr, "InvalidateSystemTime"},
+        {0x080E0140, nullptr, "NotifyPlayEvent"},
+        {0x080F0000, &PTM_S_Common::GetSoftwareClosedFlag, "GetSoftwareClosedFlag"},
+        {0x08100000, nullptr, "ClearSoftwareClosedFlag"},
+        {0x08110000, &PTM_S_Common::GetShellState, "GetShellState"},
+        {0x08120000, nullptr, "IsShutdownByBatteryEmpty"},
+        {0x08130000, nullptr, "FormatSavedata"},
+        {0x08140000, nullptr, "GetLegacyJumpProhibitedFlag"},
+        {0x08180040, nullptr, "ConfigureNew3DSCPU"},
+    };
+    RegisterHandlers(functions);
 }
 
-PTM_Sysm::PTM_Sysm() {
-    Register(FunctionTable);
-}
+PTM_S::PTM_S(std::shared_ptr<Module> ptm) : PTM_S_Common(std::move(ptm), "ptm:s") {}
+
+PTM_Sysm::PTM_Sysm(std::shared_ptr<Module> ptm) : PTM_S_Common(std::move(ptm), "ptm:sysm") {}
 
 } // namespace PTM
 } // namespace Service

--- a/src/core/hle/service/ptm/ptm_sysm.h
+++ b/src/core/hle/service/ptm/ptm_sysm.h
@@ -4,27 +4,25 @@
 
 #pragma once
 
-#include "core/hle/service/service.h"
+#include <memory>
+#include "core/hle/service/ptm/ptm.h"
 
 namespace Service {
 namespace PTM {
 
-class PTM_S final : public Interface {
+class PTM_S_Common : public Module::Interface {
 public:
-    PTM_S();
-
-    std::string GetPortName() const override {
-        return "ptm:s";
-    }
+    explicit PTM_S_Common(std::shared_ptr<Module> ptm, const char* name);
 };
 
-class PTM_Sysm final : public Interface {
+class PTM_S final : public PTM_S_Common {
 public:
-    PTM_Sysm();
+    explicit PTM_S(std::shared_ptr<Module> ptm);
+};
 
-    std::string GetPortName() const override {
-        return "ptm:sysm";
-    }
+class PTM_Sysm final : public PTM_S_Common {
+public:
+    explicit PTM_Sysm(std::shared_ptr<Module> ptm);
 };
 
 } // namespace PTM

--- a/src/core/hle/service/ptm/ptm_u.cpp
+++ b/src/core/hle/service/ptm/ptm_u.cpp
@@ -2,32 +2,30 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include "core/hle/service/ptm/ptm.h"
 #include "core/hle/service/ptm/ptm_u.h"
 
 namespace Service {
 namespace PTM {
 
-const Interface::FunctionInfo FunctionTable[] = {
-    {0x00010002, nullptr, "RegisterAlarmClient"},
-    {0x00020080, nullptr, "SetRtcAlarm"},
-    {0x00030000, nullptr, "GetRtcAlarm"},
-    {0x00040000, nullptr, "CancelRtcAlarm"},
-    {0x00050000, GetAdapterState, "GetAdapterState"},
-    {0x00060000, GetShellState, "GetShellState"},
-    {0x00070000, GetBatteryLevel, "GetBatteryLevel"},
-    {0x00080000, GetBatteryChargeState, "GetBatteryChargeState"},
-    {0x00090000, GetPedometerState, "GetPedometerState"},
-    {0x000A0042, nullptr, "GetStepHistoryEntry"},
-    {0x000B00C2, GetStepHistory, "GetStepHistory"},
-    {0x000C0000, GetTotalStepCount, "GetTotalStepCount"},
-    {0x000D0040, nullptr, "SetPedometerRecordingMode"},
-    {0x000E0000, nullptr, "GetPedometerRecordingMode"},
-    {0x000F0084, nullptr, "GetStepHistoryAll"},
-};
-
-PTM_U::PTM_U() {
-    Register(FunctionTable);
+PTM_U::PTM_U(std::shared_ptr<Module> ptm) : Module::Interface(std::move(ptm), "ptm:u", 26) {
+    static const FunctionInfo functions[] = {
+        {0x00010002, nullptr, "RegisterAlarmClient"},
+        {0x00020080, nullptr, "SetRtcAlarm"},
+        {0x00030000, nullptr, "GetRtcAlarm"},
+        {0x00040000, nullptr, "CancelRtcAlarm"},
+        {0x00050000, &PTM_U::GetAdapterState, "GetAdapterState"},
+        {0x00060000, &PTM_U::GetShellState, "GetShellState"},
+        {0x00070000, &PTM_U::GetBatteryLevel, "GetBatteryLevel"},
+        {0x00080000, &PTM_U::GetBatteryChargeState, "GetBatteryChargeState"},
+        {0x00090000, &PTM_U::GetPedometerState, "GetPedometerState"},
+        {0x000A0042, nullptr, "GetStepHistoryEntry"},
+        {0x000B00C2, &PTM_U::GetStepHistory, "GetStepHistory"},
+        {0x000C0000, &PTM_U::GetTotalStepCount, "GetTotalStepCount"},
+        {0x000D0040, nullptr, "SetPedometerRecordingMode"},
+        {0x000E0000, nullptr, "GetPedometerRecordingMode"},
+        {0x000F0084, nullptr, "GetStepHistoryAll"},
+    };
+    RegisterHandlers(functions);
 }
 
 } // namespace PTM

--- a/src/core/hle/service/ptm/ptm_u.h
+++ b/src/core/hle/service/ptm/ptm_u.h
@@ -4,18 +4,15 @@
 
 #pragma once
 
-#include "core/hle/service/service.h"
+#include <memory>
+#include "core/hle/service/ptm/ptm.h"
 
 namespace Service {
 namespace PTM {
 
-class PTM_U final : public Interface {
+class PTM_U final : public Module::Interface {
 public:
-    PTM_U();
-
-    std::string GetPortName() const override {
-        return "ptm:u";
-    }
+    explicit PTM_U(std::shared_ptr<Module> ptm);
 };
 
 } // namespace PTM

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -285,7 +285,7 @@ void Init() {
     NFC::Init();
     NIM::Init();
     NWM::Init();
-    PTM::Init();
+    PTM::InstallInterfaces(*SM::g_service_manager);
     QTM::Init();
 
     AddService(new CSND::CSND_SND);
@@ -302,7 +302,6 @@ void Init() {
 
 /// Shutdown ServiceManager
 void Shutdown() {
-    PTM::Shutdown();
     NFC::Shutdown();
     NIM::Shutdown();
     NEWS::Shutdown();


### PR DESCRIPTION
Functional change:
 - the maximum session for each port is RE-ed from PTM code. All are 26, except for the one for `ptm:sets`, which is 1.
 - Push mapped buffer in response in `GetStepHistory`.
 - Fixed response header in `CheckNew3DS`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3361)
<!-- Reviewable:end -->
