### PR TITLE
Service/Y2R: convert to ServiceFramework

### DIFF
--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -295,7 +295,7 @@ void Init() {
     AddService(new PM::PM_APP);
     AddService(new SOC::SOC_U);
     AddService(new SSL::SSL_C);
-    AddService(new Y2R::Y2R_U);
+    Y2R::InstallInterfaces(*SM::g_service_manager);
 
     LOG_DEBUG(Service, "initialized OK");
 }

--- a/src/core/hle/service/y2r_u.h
+++ b/src/core/hle/service/y2r_u.h
@@ -5,10 +5,16 @@
 #pragma once
 
 #include <array>
+#include <memory>
 #include <string>
 #include "common/common_types.h"
+#include "core/hle/kernel/kernel.h"
 #include "core/hle/result.h"
 #include "core/hle/service/service.h"
+
+namespace Kernel {
+class Event;
+}
 
 namespace Service {
 namespace Y2R {
@@ -125,15 +131,175 @@ struct DitheringWeightParams {
     u16 w3_xOdd_yOdd;
 };
 
-class Y2R_U final : public Interface {
+struct ConversionParameters {
+    InputFormat input_format;
+    OutputFormat output_format;
+    Rotation rotation;
+    BlockAlignment block_alignment;
+    u16 input_line_width;
+    u16 input_lines;
+    StandardCoefficient standard_coefficient;
+    u8 padding;
+    u16 alpha;
+};
+static_assert(sizeof(ConversionParameters) == 12, "ConversionParameters struct has incorrect size");
+
+class Y2R_U final : public ServiceFramework<Y2R_U> {
 public:
     Y2R_U();
     ~Y2R_U() override;
 
-    std::string GetPortName() const override {
-        return "y2r:u";
-    }
+private:
+    void SetInputFormat(Kernel::HLERequestContext& ctx);
+    void GetInputFormat(Kernel::HLERequestContext& ctx);
+    void SetOutputFormat(Kernel::HLERequestContext& ctx);
+    void GetOutputFormat(Kernel::HLERequestContext& ctx);
+    void SetRotation(Kernel::HLERequestContext& ctx);
+    void GetRotation(Kernel::HLERequestContext& ctx);
+    void SetBlockAlignment(Kernel::HLERequestContext& ctx);
+    void GetBlockAlignment(Kernel::HLERequestContext& ctx);
+
+    /**
+     * Y2R_U::SetSpacialDithering service function
+     *  Inputs:
+     *      1 : u8, 0 = Disabled, 1 = Enabled
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void SetSpacialDithering(Kernel::HLERequestContext& ctx);
+
+    /**
+     * Y2R_U::GetSpacialDithering service function
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     *      2 : u8, 0 = Disabled, 1 = Enabled
+     */
+    void GetSpacialDithering(Kernel::HLERequestContext& ctx);
+
+    /**
+     * Y2R_U::SetTemporalDithering service function
+     *  Inputs:
+     *      1 : u8, 0 = Disabled, 1 = Enabled
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void SetTemporalDithering(Kernel::HLERequestContext& ctx);
+
+    /**
+     * Y2R_U::GetTemporalDithering service function
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     *      2 : u8, 0 = Disabled, 1 = Enabled
+     */
+    void GetTemporalDithering(Kernel::HLERequestContext& ctx);
+
+    /**
+     * Y2R_U::SetTransferEndInterrupt service function
+     *  Inputs:
+     *      1 : u8, 0 = Disabled, 1 = Enabled
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void SetTransferEndInterrupt(Kernel::HLERequestContext& ctx);
+
+    /**
+     * Y2R_U::GetTransferEndInterrupt service function
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     *      2 : u8, 0 = Disabled, 1 = Enabled
+     */
+    void GetTransferEndInterrupt(Kernel::HLERequestContext& ctx);
+
+    /**
+     * Y2R_U::GetTransferEndEvent service function
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     *      3 : The handle of the completion event
+     */
+    void GetTransferEndEvent(Kernel::HLERequestContext& ctx);
+
+    void SetSendingY(Kernel::HLERequestContext& ctx);
+    void SetSendingU(Kernel::HLERequestContext& ctx);
+    void SetSendingV(Kernel::HLERequestContext& ctx);
+    void SetSendingYUYV(Kernel::HLERequestContext& ctx);
+
+    /**
+     * Y2R::IsFinishedSendingYuv service function
+     * Output:
+     *       1 : Result of the function, 0 on success, otherwise error code
+     *       2 : u8, 0 = Not Finished, 1 = Finished
+     */
+    void IsFinishedSendingYuv(Kernel::HLERequestContext& ctx);
+
+    /**
+     * Y2R::IsFinishedSendingY service function
+     * Output:
+     *       1 : Result of the function, 0 on success, otherwise error code
+     *       2 : u8, 0 = Not Finished, 1 = Finished
+     */
+    void IsFinishedSendingY(Kernel::HLERequestContext& ctx);
+
+    /**
+     * Y2R::IsFinishedSendingU service function
+     * Output:
+     *       1 : Result of the function, 0 on success, otherwise error code
+     *       2 : u8, 0 = Not Finished, 1 = Finished
+     */
+    void IsFinishedSendingU(Kernel::HLERequestContext& ctx);
+
+    /**
+     * Y2R::IsFinishedSendingV service function
+     * Output:
+     *       1 : Result of the function, 0 on success, otherwise error code
+     *       2 : u8, 0 = Not Finished, 1 = Finished
+     */
+    void IsFinishedSendingV(Kernel::HLERequestContext& ctx);
+
+    void SetReceiving(Kernel::HLERequestContext& ctx);
+
+    /**
+     * Y2R::IsFinishedReceiving service function
+     * Output:
+     *       1 : Result of the function, 0 on success, otherwise error code
+     *       2 : u8, 0 = Not Finished, 1 = Finished
+     */
+    void IsFinishedReceiving(Kernel::HLERequestContext& ctx);
+
+    void SetInputLineWidth(Kernel::HLERequestContext& ctx);
+    void GetInputLineWidth(Kernel::HLERequestContext& ctx);
+    void SetInputLines(Kernel::HLERequestContext& ctx);
+    void GetInputLines(Kernel::HLERequestContext& ctx);
+    void SetCoefficient(Kernel::HLERequestContext& ctx);
+    void GetCoefficient(Kernel::HLERequestContext& ctx);
+    void SetStandardCoefficient(Kernel::HLERequestContext& ctx);
+    void GetStandardCoefficient(Kernel::HLERequestContext& ctx);
+    void SetAlpha(Kernel::HLERequestContext& ctx);
+    void GetAlpha(Kernel::HLERequestContext& ctx);
+    void SetDitheringWeightParams(Kernel::HLERequestContext& ctx);
+    void GetDitheringWeightParams(Kernel::HLERequestContext& ctx);
+    void StartConversion(Kernel::HLERequestContext& ctx);
+    void StopConversion(Kernel::HLERequestContext& ctx);
+    void IsBusyConversion(Kernel::HLERequestContext& ctx);
+
+    /**
+     * Y2R_U::SetPackageParameter service function
+     */
+    void SetPackageParameter(Kernel::HLERequestContext& ctx);
+
+    void PingProcess(Kernel::HLERequestContext& ctx);
+    void DriverInitialize(Kernel::HLERequestContext& ctx);
+    void DriverFinalize(Kernel::HLERequestContext& ctx);
+    void GetPackageParameter(Kernel::HLERequestContext& ctx);
+
+    Kernel::SharedPtr<Kernel::Event> completion_event;
+    ConversionConfiguration conversion{};
+    DitheringWeightParams dithering_weight_params{};
+    bool temporal_dithering_enabled = false;
+    bool transfer_end_interrupt_enabled = false;
+    bool spacial_dithering_enabled = false;
 };
+
+void InstallInterfaces(SM::ServiceManager& service_manager);
 
 } // namespace Y2R
 } // namespace Service


### PR DESCRIPTION
Functional changes:
Type of `temporal_dithering_enabled`, `transfer_end_interrupt_enabled` and `spacial_dithering_enabled` is changed from `u32` to `bool`, and their corresponding functions use standard `Push/Pop<bool>`. It is confirmed from the y2r code that they follows the standard ARM ABI and IPC convention where `bool` type stores as one byte.

I only moved existing function documentation from the cpp to the header file. Should I complete the documentation for those that don't have yet?

----

Also about whether to use pImpl here (this talk derives from [here](https://github.com/citra-emu/citra/pull/3253#discussion_r155930667) in mic_u migration):
 I personally don't like it for the following reasons:
 - the header only has two file depending on it: y2r_u.cpp and service.cpp. Only two files need to recompile when the header is changed, and it is not likely we will add a third one.
 - it introduces forwarding functions for each single service functions, which have the same parameter type, meaning that they are not protected by the type system from copy-pasting typo. This can easily hide bugs.
 - the true "pImpl" analog is to put the entire `Y2R_U` class definition in the cpp file, because it is not used anywhere else. We put it in header file because it has special documentation purpose for 3DS services, which is not a feature regular c++ code has. Given that we already gave up hiding implementation details at this point, it is pointless to use pImpl to hide anything.

That being said, I won't be against others using pImpl in `ServiceFramework`, but I won't use it in my code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3367)
<!-- Reviewable:end -->
