### PR TITLE
Added string to display Compile date in the titlebar

### DIFF
--- a/src/citra/emu_window/emu_window_sdl2.cpp
+++ b/src/citra/emu_window/emu_window_sdl2.cpp
@@ -79,8 +79,8 @@ EmuWindow_SDL2::EmuWindow_SDL2() {
     SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 8);
     SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 0);
 
-    std::string window_title = Common::StringFromFormat("Citra %s| %s-%s ", Common::g_build_name,
-                                                        Common::g_scm_branch, Common::g_scm_desc);
+    std::string window_title = Common::StringFromFormat("Citra %s| %s-%s| Build date: " + "%4", Common::g_build_name,
+                                                        Common::g_scm_branch, Common::g_scm_desc, Common::g_build_date);
     render_window =
         SDL_CreateWindow(window_title.c_str(),
                          SDL_WINDOWPOS_UNDEFINED, // x position


### PR DESCRIPTION
Shows the Build date for when the Application is compiled. Pretty straight forward. 

If you don't want the text `Build date:` it can just be easily removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3394)
<!-- Reviewable:end -->
