### PR TITLE
Allow Installed Apps to Display in the Game List

### DIFF
--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -403,11 +403,11 @@ void GameListWorker::AddFstEntriesToGameList(const std::string& dir_path, unsign
                 std::vector<u8> original_smdh;
                 loader->ReadIcon(original_smdh);
 
-                if (program_id >= 0x4000000000000 && program_id <= 0x40000FFFFFFFF)
+                if (program_id < 0x00040000'00000000 || program_id > 0x00040000'FFFFFFFF)
                     return original_smdh;
 
                 std::string update_path = Service::AM::GetTitleContentPath(
-                    Service::FS::MediaType::SDMC, program_id + 0xe00000000);
+                    Service::FS::MediaType::SDMC, program_id + 0x0000000E'00000000);
 
                 if (!FileUtil::Exists(update_path))
                     return original_smdh;

--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -449,6 +449,10 @@ void GameListWorker::run() {
         std::string(FileUtil::GetUserPath(D_SDMC_IDX).c_str()) +
         "Nintendo "
         "3DS/00000000000000000000000000000000/00000000000000000000000000000000/title/00040000"));
+    watch_list.append(QString::fromStdString(
+        std::string(FileUtil::GetUserPath(D_SDMC_IDX).c_str()) +
+        "Nintendo "
+        "3DS/00000000000000000000000000000000/00000000000000000000000000000000/title/0004000e"));
     watch_list.append(
         QString::fromStdString(std::string(FileUtil::GetUserPath(D_NAND_IDX).c_str()) +
                                "00000000000000000000000000000000/title/00040010"));
@@ -457,10 +461,10 @@ void GameListWorker::run() {
         std::string(FileUtil::GetUserPath(D_SDMC_IDX).c_str()) +
             "Nintendo "
             "3DS/00000000000000000000000000000000/00000000000000000000000000000000/title/00040000",
-        true ? 256 : 0);
+        2);
     AddFstEntriesToGameList(std::string(FileUtil::GetUserPath(D_NAND_IDX).c_str()) +
                                 "00000000000000000000000000000000/title/00040010",
-                            true ? 256 : 0);
+                            2);
     emit Finished(watch_list);
 }
 

--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -403,7 +403,7 @@ void GameListWorker::AddFstEntriesToGameList(const std::string& dir_path, unsign
                 std::vector<u8> original_smdh;
                 loader->ReadIcon(original_smdh);
 
-                if (0x4000000000000 > program_id && program_id > 0x40000FFFFFFFF)
+                if (program_id >= 0x4000000000000 && program_id <= 0x40000FFFFFFFF)
                     return original_smdh;
 
                 std::string update_path = Service::AM::GetTitleContentPath(

--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -24,6 +24,7 @@
 #include "common/common_paths.h"
 #include "common/logging/log.h"
 #include "common/string_util.h"
+#include "core/hle/service/fs/archive.h"
 #include "core/loader/loader.h"
 
 GameList::SearchField::KeyReleaseEater::KeyReleaseEater(GameList* gamelist) {
@@ -401,8 +402,27 @@ void GameListWorker::AddFstEntriesToGameList(const std::string& dir_path, unsign
             u64 program_id = 0;
             loader->ReadProgramId(program_id);
 
+            std::vector<u8> update_smdh;
+            std::string update_path;
+            u64 update_id = 0;
+            std::unique_ptr<Loader::AppLoader> update_loader = nullptr;
+
+            if (0x4000000000000 <= program_id && program_id <= 0x40000FFFFFFFF) {
+                update_id = program_id + 0xe00000000;
+                update_path =
+                    Service::AM::GetTitleContentPath(Service::FS::MediaType::SDMC, update_id);
+                if (FileUtil::Exists(update_path)) {
+                    update_loader = Loader::GetLoader(update_path);
+                    if (update_loader) {
+                        update_loader->ReadIcon(update_smdh);
+                        update_loader->ReadProgramId(update_id);
+                    }
+                }
+            }
+
             emit EntryReady({
-                new GameListItemPath(QString::fromStdString(physical_name), smdh, program_id),
+                new GameListItemPath(QString::fromStdString(physical_name), smdh, program_id,
+                                     update_smdh),
                 new GameListItem(
                     QString::fromStdString(Loader::GetFileTypeString(loader->GetFileType()))),
                 new GameListItemSize(FileUtil::GetSize(physical_name)),
@@ -421,7 +441,22 @@ void GameListWorker::AddFstEntriesToGameList(const std::string& dir_path, unsign
 void GameListWorker::run() {
     stop_processing = false;
     watch_list.append(dir_path);
+    watch_list.append(QString::fromStdString(
+        std::string(FileUtil::GetUserPath(D_SDMC_IDX).c_str()) +
+        "Nintendo "
+        "3DS/00000000000000000000000000000000/00000000000000000000000000000000/title/00040000"));
+    watch_list.append(
+        QString::fromStdString(std::string(FileUtil::GetUserPath(D_NAND_IDX).c_str()) +
+                               "00000000000000000000000000000000/title/00040010"));
     AddFstEntriesToGameList(dir_path.toStdString(), deep_scan ? 256 : 0);
+    AddFstEntriesToGameList(
+        std::string(FileUtil::GetUserPath(D_SDMC_IDX).c_str()) +
+            "Nintendo "
+            "3DS/00000000000000000000000000000000/00000000000000000000000000000000/title/00040000",
+        true ? 256 : 0);
+    AddFstEntriesToGameList(std::string(FileUtil::GetUserPath(D_NAND_IDX).c_str()) +
+                                "00000000000000000000000000000000/title/00040010",
+                            true ? 256 : 0);
     emit Finished(watch_list);
 }
 

--- a/src/citra_qt/game_list_p.h
+++ b/src/citra_qt/game_list_p.h
@@ -72,22 +72,20 @@ public:
     static const int ProgramIdRole = Qt::UserRole + 3;
 
     GameListItemPath() : GameListItem() {}
-    GameListItemPath(const QString& game_path, const std::vector<u8>& smdh_data, u64 program_id,
-                     const std::vector<u8>& update_smdh)
+    GameListItemPath(const QString& game_path, const std::vector<u8>& smdh_data, u64 program_id)
         : GameListItem() {
         setData(game_path, FullPathRole);
         setData(qulonglong(program_id), ProgramIdRole);
 
         Loader::SMDH smdh;
-        if (Loader::IsValidSMDH(update_smdh)) {
-            memcpy(&smdh, update_smdh.data(), sizeof(Loader::SMDH));
-        } else if (Loader::IsValidSMDH(smdh_data)) {
-            memcpy(&smdh, smdh_data.data(), sizeof(Loader::SMDH));
-        } else {
+        if (!Loader::IsValidSMDH(smdh_data)) {
             // SMDH is not valid, set a default icon
             setData(GetDefaultIcon(true), Qt::DecorationRole);
             return;
         }
+
+        memcpy(&smdh, smdh_data.data(), sizeof(Loader::SMDH));
+
         // Get icon from SMDH
         setData(GetQPixmapFromSMDH(smdh, true), Qt::DecorationRole);
 

--- a/src/citra_qt/game_list_p.h
+++ b/src/citra_qt/game_list_p.h
@@ -82,7 +82,7 @@ public:
             setData(GetDefaultIcon(true), Qt::DecorationRole);
             return;
         }
-            
+
         Loader::SMDH smdh;
         memcpy(&smdh, smdh_data.data(), sizeof(Loader::SMDH));
 

--- a/src/citra_qt/game_list_p.h
+++ b/src/citra_qt/game_list_p.h
@@ -77,13 +77,13 @@ public:
         setData(game_path, FullPathRole);
         setData(qulonglong(program_id), ProgramIdRole);
 
-        Loader::SMDH smdh;
         if (!Loader::IsValidSMDH(smdh_data)) {
             // SMDH is not valid, set a default icon
             setData(GetDefaultIcon(true), Qt::DecorationRole);
             return;
         }
-
+            
+        Loader::SMDH smdh;
         memcpy(&smdh, smdh_data.data(), sizeof(Loader::SMDH));
 
         // Get icon from SMDH

--- a/src/citra_qt/game_list_p.h
+++ b/src/citra_qt/game_list_p.h
@@ -72,24 +72,26 @@ public:
     static const int ProgramIdRole = Qt::UserRole + 3;
 
     GameListItemPath() : GameListItem() {}
-    GameListItemPath(const QString& game_path, const std::vector<u8>& smdh_data, u64 program_id)
+    GameListItemPath(const QString& game_path, const std::vector<u8>& smdh_data, u64 program_id,
+                     const std::vector<u8>& update_smdh)
         : GameListItem() {
         setData(game_path, FullPathRole);
         setData(qulonglong(program_id), ProgramIdRole);
 
-        if (!Loader::IsValidSMDH(smdh_data)) {
+        Loader::SMDH smdh;
+        if (Loader::IsValidSMDH(update_smdh)) {
+            memcpy(&smdh, update_smdh.data(), sizeof(Loader::SMDH));
+        } else if (Loader::IsValidSMDH(smdh_data)) {
+            memcpy(&smdh, smdh_data.data(), sizeof(Loader::SMDH));
+        } else {
             // SMDH is not valid, set a default icon
             setData(GetDefaultIcon(true), Qt::DecorationRole);
             return;
         }
-
-        Loader::SMDH smdh;
-        memcpy(&smdh, smdh_data.data(), sizeof(Loader::SMDH));
-
         // Get icon from SMDH
         setData(GetQPixmapFromSMDH(smdh, true), Qt::DecorationRole);
 
-        // Get title form SMDH
+        // Get title from SMDH
         setData(GetQStringShortTitleFromSMDH(smdh, Loader::SMDH::TitleLanguage::English),
                 TitleRole);
     }


### PR DESCRIPTION
- Allows installed games to display in the game list
- Allows installed (executable) system applications to display in the game list
- Replaces the game icon with the icon from an installed update if available
![image](https://user-images.githubusercontent.com/28246325/35186408-532caf60-fdd9-11e7-9546-46156e647346.png)



<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3402)
<!-- Reviewable:end -->
