### PR TITLE
[RFC] VFS Interfaces and utility functions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,13 +1,15 @@
 # Enable modules to include each other's files
 include_directories(.)
 
+add_subdirectory(audio_core)
 add_subdirectory(common)
 add_subdirectory(core)
-add_subdirectory(video_core)
-add_subdirectory(audio_core)
-add_subdirectory(network)
 add_subdirectory(input_common)
+add_subdirectory(network)
 add_subdirectory(tests)
+add_subdirectory(vfs)
+add_subdirectory(video_core)
+
 if (ENABLE_SDL2)
     add_subdirectory(citra)
 endif()

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -62,6 +62,7 @@ add_library(common STATIC
     platform.h
     printable.h
     quaternion.h
+    result.h
     scm_rev.cpp
     scm_rev.h
     scope_exit.h

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -60,6 +60,7 @@ add_library(common STATIC
     param_package.cpp
     param_package.h
     platform.h
+    printable.h
     quaternion.h
     scm_rev.cpp
     scm_rev.h
@@ -92,7 +93,7 @@ endif()
 
 create_target_directory_groups(common)
 
-target_link_libraries(common PUBLIC Boost::boost microprofile)
+target_link_libraries(common PUBLIC Boost::boost fmt microprofile)
 if (ARCHITECTURE_x86_64)
     target_link_libraries(common PRIVATE xbyak)
 endif()

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -228,6 +228,10 @@ public:
         return nullptr != m_file;
     }
 
+    bool IsEof() const {
+        return std::feof(m_file);
+    }
+
     // m_good is set to false when a read, write or other function fails
     bool IsGood() const {
         return m_good;

--- a/src/common/printable.h
+++ b/src/common/printable.h
@@ -1,0 +1,68 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <iosfwd>
+#include <string>
+#include <type_traits>
+#include <fmt/format.h>
+
+namespace Common {
+
+/**
+ * Tag indicating that an object can create a debugging string representing itself. Type must
+ * publicly inherit from this tag and then implement a method with this signature:
+ *
+ *     void DebugFmt(fmt::Writer& w) const;
+ *
+ * If the class is already already polymorphic (has virtual functions), then prefer using
+ * VirtualPrintable instead.
+ */
+class Printable {};
+
+/**
+ * Extension of Printable for classes using virtual dispatch. This is compatible with Printable, but
+ * makes DebugFmt() a virtual function, allowing dynamically printing sub-types from a base pointer.
+ * If the class uses no virtuals then prefer plain Printable instead.
+ */
+class VirtualPrintable : public Printable {
+public:
+    /**
+     * Formats a string describing the object, for debugging purposes.
+     *
+     * @note To output a std::string, simply pipe it into the writer using `<<` (ex.: `w <<
+     * my_string;`). To write a fmt format string, use the `format(...)` method (ex.:
+     * `w.format("[Foo: {}]", my_num);`).
+     */
+    virtual void DebugFmt(fmt::Writer& w) const = 0;
+};
+
+/// Blanket implementation of formatting, which uses DebugFmt() on any type tagged with Printable.
+template <typename T, typename = std::enable_if_t<std::is_base_of_v<Printable, T>>>
+void format_arg(fmt::BasicFormatter<char>& f, const char*&, const T& object) {
+    // Enforce correct usage of the tag types.
+    static_assert(std::is_base_of_v<VirtualPrintable, T> || !std::is_polymorphic_v<T>,
+                  "Use VirtualPrintable for polymorphic types instead of Printable.");
+    static_assert(!std::is_base_of_v<VirtualPrintable, T> || std::has_virtual_destructor_v<T>,
+                  "Use Printable for non-polymorphic types instead of VirtualPrintable.");
+
+    object.DebugFmt(f.writer());
+}
+
+/// Blanket implementation of operator<<, which uses DebugFmt() on any type tagged with Printable.
+template <typename T, typename = std::enable_if_t<std::is_base_of_v<Printable, T>>>
+std::ostream& operator<<(std::ostream& s, const T& object) {
+    // Enforce correct usage of the tag types.
+    static_assert(std::is_base_of_v<VirtualPrintable, T> || !std::is_polymorphic_v<T>,
+                  "Use VirtualPrintable for polymorphic types instead of Printable.");
+    static_assert(!std::is_base_of_v<VirtualPrintable, T> || std::has_virtual_destructor_v<T>,
+                  "Use Printable for non-polymorphic types instead of VirtualPrintable.");
+
+    fmt::MemoryWriter w;
+    object.DebugFmt(w);
+    return w.str();
+}
+
+} // namespace Common

--- a/src/common/result.h
+++ b/src/common/result.h
@@ -1,0 +1,75 @@
+// Copyright 2018 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <boost/variant.hpp>
+#include "common/common_funcs.h"
+
+namespace Common {
+
+struct OkType {};
+
+template <typename T = OkType, typename E = boost::blank>
+class Result : public boost::variant<T, E> {
+public:
+    // boost::variant guarantees that if any type has a nothrow constructor, then assignments will
+    // never heap allocate and instead the variant will be set to that type. We want to enforce
+    // this, so assert that the Error type fits that criteria.
+    static_assert(boost::has_nothrow_constructor<E>::value, "Error type in Result must have "
+                                                            "nothrow default constructor in order "
+                                                            "to avoid heap allocations");
+
+    using boost::variant<T, E>::variant;
+
+    bool Succeeded() const {
+        return this->which() == 0;
+    }
+
+    bool Failed() const {
+        return this->which() == 1;
+    }
+
+    /// Asserts that the result succeeded and returns a reference to it.
+    T& Unwrap() & {
+        // TODO(yuriks): Try to format the E type here if possible
+        ASSERT_MSG(Succeeded(), "Tried to Unwrap failed ResultVal");
+        return boost::get<T>(*this);
+    }
+
+    const T& Unwrap() const& {
+        ASSERT_MSG(Succeeded(), "Tried to Unwrap failed ResultVal");
+        return boost::get<T>(*this);
+    }
+
+    T&& Unwrap() && {
+        ASSERT_MSG(Succeeded(), "Tried to Unwrap failed ResultVal");
+        return std::move(boost::get<T>(*this));
+    }
+
+    /// Asserts that the result failed and returns a reference to the error
+    E& UnwrapErr() & {
+        // TODO(yuriks): Try to format the T type here if possible
+        ASSERT_MSG(Failed(), "Tried to UnwrapErr successful ResultVal");
+        return boost::get<E>(*this);
+    }
+
+    E& UnwrapErr() const& {
+        ASSERT_MSG(Failed(), "Tried to UnwrapErr successful ResultVal");
+        return boost::get<E>(*this);
+    }
+
+    E&& UnwrapErr() && {
+        ASSERT_MSG(Failed(), "Tried to Unwrap successful ResultVal");
+        return boost::get<E>(std::move(*this));
+    }
+};
+
+#define CASCADE_COMMON_RESULT(target, source)                                                      \
+    auto CONCAT2(check_result_L, __LINE__) = source;                                               \
+    if (!CONCAT2(check_result_L, __LINE__).Succeeded())                                            \
+        return CONCAT2(check_result_L, __LINE__).UnwrapErr();                                      \
+    target = std::move(CONCAT2(check_result_L, __LINE__).Unwrap())
+
+} // namespace Common

--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -152,6 +152,7 @@ enum class ErrorModule : u32 {
     QTM = 96,
     NFP = 97,
 
+    Citra = 253,
     Application = 254,
     InvalidResult = 255
 };

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(tests
     glad.cpp
     tests.cpp
     vfs/memory_file.cpp
+    vfs/subrange_file.cpp
 )
 
 if (ARCHITECTURE_x86_64)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(tests
     core/memory/vm_manager.cpp
     glad.cpp
     tests.cpp
+    vfs/memory_file.cpp
 )
 
 if (ARCHITECTURE_x86_64)
@@ -21,7 +22,7 @@ endif()
 
 create_target_directory_groups(tests)
 
-target_link_libraries(tests PRIVATE common core video_core)
+target_link_libraries(tests PRIVATE common core vfs video_core)
 target_link_libraries(tests PRIVATE glad) # To support linker work-around
 target_link_libraries(tests PRIVATE ${PLATFORM_LIBRARIES} catch-single-include nihstro-headers Threads::Threads)
 

--- a/src/tests/vfs/memory_file.cpp
+++ b/src/tests/vfs/memory_file.cpp
@@ -1,0 +1,77 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <array>
+#include <initializer_list>
+#include <catch.hpp>
+#include "common/file_util.h"
+#include "vfs/memory_file.h"
+
+namespace Vfs {
+
+TEST_CASE("MemoryFile", "[vfs]") {
+    MemoryFile file({0, 1, 2, 3, 4});
+
+    SECTION("Read past EOF reads nothing") {
+        std::array<u8, 2> buffer{9, 9};
+
+        auto result = file.Read(6, 2, buffer.data());
+        REQUIRE(result.Unwrap() == 0);
+    }
+    SECTION("Read with smaller buffer does not overflow") {
+        std::array<u8, 5> buffer;
+        buffer.fill(9);
+
+        auto result = file.Read(1, 3, buffer.data());
+        REQUIRE(result.Unwrap() == 3);
+        REQUIRE(buffer == (std::array<u8, 5>{1, 2, 3, 9, 9}));
+    }
+    SECTION("Read with larger buffer does not overread") {
+        std::array<u8, 7> buffer;
+        buffer.fill(9);
+
+        auto result = file.Read(1, 7, buffer.data());
+        REQUIRE(result.Unwrap() == 4);
+        REQUIRE(buffer == (std::array<u8, 7>{1, 2, 3, 4, 9, 9, 9}));
+    }
+    SECTION("Write past EOF reads nothing") {
+        std::array<u8, 2> buffer{9, 9};
+
+        auto result = file.Write(6, 2, buffer.data());
+        REQUIRE(result.Unwrap() == 0);
+        REQUIRE(file.GetData() == (std::vector<u8>{0, 1, 2, 3, 4}));
+    }
+    SECTION("Write with larger buffer does not overflow") {
+        const std::array<u8, 7> buffer{10, 11, 12, 13, 14, 15, 16};
+        auto result = file.Write(1, 7, buffer.data());
+        REQUIRE(result.Unwrap() == 4);
+        REQUIRE(file.GetData() == (std::vector<u8>{0, 10, 11, 12, 13}));
+    }
+    SECTION("Write with smaller buffer does not overread") {
+        const std::array<u8, 3> buffer{10, 11, 12};
+        auto result = file.Write(1, 3, buffer.data());
+        REQUIRE(result.Unwrap() == 3);
+        REQUIRE(file.GetData() == (std::vector<u8>{0, 10, 11, 12, 4}));
+    }
+    SECTION("GetSize works") {
+        auto result = file.GetSize();
+        REQUIRE(result.Unwrap() == 5);
+    }
+    SECTION("Resize to smaller truncates") {
+        auto result = file.SetSize(3);
+        REQUIRE(result.IsSuccess());
+        REQUIRE(file.GetSize().Unwrap() == 3);
+    }
+    SECTION("Resize to larger fills with zeros") {
+        auto result = file.SetSize(7);
+        REQUIRE(result.IsSuccess());
+        REQUIRE(file.GetData() == (std::vector<u8>{0, 1, 2, 3, 4, 0, 0}));
+    }
+    SECTION("Flush succeeds") {
+        auto result = file.Flush();
+        REQUIRE(result.IsSuccess());
+    }
+}
+
+} // namespace Vfs

--- a/src/tests/vfs/memory_file.cpp
+++ b/src/tests/vfs/memory_file.cpp
@@ -60,17 +60,17 @@ TEST_CASE("MemoryFile", "[vfs]") {
     }
     SECTION("Resize to smaller truncates") {
         auto result = file.SetSize(3);
-        REQUIRE(result.IsSuccess());
+        REQUIRE(result.Succeeded());
         REQUIRE(file.GetSize().Unwrap() == 3);
     }
     SECTION("Resize to larger fills with zeros") {
         auto result = file.SetSize(7);
-        REQUIRE(result.IsSuccess());
+        REQUIRE(result.Succeeded());
         REQUIRE(file.GetData() == (std::vector<u8>{0, 1, 2, 3, 4, 0, 0}));
     }
     SECTION("Flush succeeds") {
         auto result = file.Flush();
-        REQUIRE(result.IsSuccess());
+        REQUIRE(result.Succeeded());
     }
 }
 

--- a/src/tests/vfs/subrange_file.cpp
+++ b/src/tests/vfs/subrange_file.cpp
@@ -95,7 +95,7 @@ TEST_CASE("SubrangeFile", "[vfs]") {
     SECTION("Flush succeeds") {
         SubrangeFile file(mem_file, 0, 5);
         auto result = file.Flush();
-        REQUIRE(result.IsSuccess());
+        REQUIRE(result.Succeeded());
     }
 }
 

--- a/src/tests/vfs/subrange_file.cpp
+++ b/src/tests/vfs/subrange_file.cpp
@@ -1,0 +1,102 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <array>
+#include <initializer_list>
+#include <memory>
+#include <catch.hpp>
+#include "common/file_util.h"
+#include "vfs/memory_file.h"
+#include "vfs/subrange_file.h"
+
+namespace Vfs {
+
+TEST_CASE("SubrangeFile", "[vfs]") {
+    auto mem_file = std::make_shared<MemoryFile>(std::vector<u8>{0, 1, 2, 3, 4, 5, 6});
+
+    SECTION("Read with smaller buffer does not overflow") {
+        SubrangeFile file(mem_file, 1, 5);
+
+        std::vector<u8> buffer{9, 9, 9, 9, 9};
+        auto result = file.Read(1, 3, buffer.data());
+
+        REQUIRE(result.Unwrap() == 3);
+        REQUIRE(buffer == (std::vector<u8>{2, 3, 4, 9, 9}));
+    }
+    SECTION("Read past window is clamped") {
+        SubrangeFile file(mem_file, 1, 5);
+
+        std::vector<u8> buffer{9, 9, 9, 9, 9};
+        auto result = file.Read(4, 3, buffer.data());
+
+        REQUIRE(result.Unwrap() == 1);
+        REQUIRE(buffer == (std::vector<u8>{5, 9, 9, 9, 9}));
+    }
+    SECTION("Read outside window reads nothing") {
+        SubrangeFile file(mem_file, 1, 5);
+
+        std::vector<u8> buffer{9, 9, 9, 9, 9};
+        auto result = file.Read(6, 3, buffer.data());
+
+        REQUIRE(result.Unwrap() == 0);
+        REQUIRE(buffer == (std::vector<u8>{9, 9, 9, 9, 9}));
+    }
+    SECTION("Read past underlying file is truncated by it") {
+        SubrangeFile file(mem_file, 5, 5);
+
+        std::vector<u8> buffer{9, 9, 9, 9, 9};
+        auto result = file.Read(0, 5, buffer.data());
+
+        REQUIRE(result.Unwrap() == 2);
+        REQUIRE(buffer == (std::vector<u8>{5, 6, 9, 9, 9}));
+    }
+    SECTION("Write with smaller buffer does not overread") {
+        SubrangeFile file(mem_file, 1, 5);
+
+        std::vector<u8> buffer{10, 11, 12, 13, 14};
+        auto result = file.Write(1, 3, buffer.data());
+
+        REQUIRE(result.Unwrap() == 3);
+        REQUIRE(mem_file->GetData() == (std::vector<u8>{0, 1, 10, 11, 12, 5, 6}));
+    }
+    SECTION("Write past window is clamped") {
+        SubrangeFile file(mem_file, 1, 5);
+
+        std::vector<u8> buffer{10, 11};
+        auto result = file.Write(4, 2, buffer.data());
+
+        REQUIRE(result.Unwrap() == 1);
+        REQUIRE(mem_file->GetData() == (std::vector<u8>{0, 1, 2, 3, 4, 10, 6}));
+    }
+    SECTION("Write outside window writes nothing") {
+        SubrangeFile file(mem_file, 1, 5);
+
+        std::vector<u8> buffer{10, 11, 12, 13, 14};
+        auto result = file.Write(6, 3, buffer.data());
+
+        REQUIRE(result.Unwrap() == 0);
+        REQUIRE(mem_file->GetData() == (std::vector<u8>{0, 1, 2, 3, 4, 5, 6}));
+    }
+    SECTION("Write past underlying file is truncated by it") {
+        SubrangeFile file(mem_file, 5, 5);
+
+        std::vector<u8> buffer{10, 11, 12, 13, 14};
+        auto result = file.Write(0, 5, buffer.data());
+
+        REQUIRE(result.Unwrap() == 2);
+        REQUIRE(mem_file->GetData() == (std::vector<u8>{0, 1, 2, 3, 4, 10, 11}));
+    }
+    SECTION("GetSize clamps size to window if larger") {
+        SubrangeFile file(mem_file, 1, 5);
+        auto result = file.GetSize();
+        REQUIRE(result.Unwrap() == 5);
+    }
+    SECTION("Flush succeeds") {
+        SubrangeFile file(mem_file, 0, 5);
+        auto result = file.Flush();
+        REQUIRE(result.IsSuccess());
+    }
+}
+
+} // namespace Vfs

--- a/src/vfs/CMakeLists.txt
+++ b/src/vfs/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_library(vfs STATIC
     file.h
+    memory_file.cpp
+    memory_file.h
     vfs.h
 )
 

--- a/src/vfs/CMakeLists.txt
+++ b/src/vfs/CMakeLists.txt
@@ -2,6 +2,8 @@ add_library(vfs STATIC
     file.h
     memory_file.cpp
     memory_file.h
+    random_access_adapter.cpp
+    random_access_adapter.h
     subrange_file.cpp
     subrange_file.h
     vfs.h

--- a/src/vfs/CMakeLists.txt
+++ b/src/vfs/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(vfs STATIC
+    file.h
+    vfs.h
+)
+
+create_target_directory_groups(vfs)
+
+target_link_libraries(vfs PUBLIC common core)

--- a/src/vfs/CMakeLists.txt
+++ b/src/vfs/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_library(vfs STATIC
     file.h
+    host_file.cpp
+    host_file.h
     memory_file.cpp
     memory_file.h
     random_access_adapter.cpp

--- a/src/vfs/CMakeLists.txt
+++ b/src/vfs/CMakeLists.txt
@@ -2,6 +2,8 @@ add_library(vfs STATIC
     file.h
     memory_file.cpp
     memory_file.h
+    subrange_file.cpp
+    subrange_file.h
     vfs.h
 )
 

--- a/src/vfs/CMakeLists.txt
+++ b/src/vfs/CMakeLists.txt
@@ -13,4 +13,4 @@ add_library(vfs STATIC
 
 create_target_directory_groups(vfs)
 
-target_link_libraries(vfs PUBLIC common core)
+target_link_libraries(vfs PUBLIC common)

--- a/src/vfs/file.h
+++ b/src/vfs/file.h
@@ -17,9 +17,6 @@ class File : public Common::VirtualPrintable {
 public:
     virtual ~File() = default;
 
-    /// Returns a descriptive string for the filesystem, for debugging purposes.
-    virtual std::string DebugStr() const = 0;
-
     /**
      * Reads data from the file.
      *

--- a/src/vfs/file.h
+++ b/src/vfs/file.h
@@ -1,0 +1,77 @@
+// Copyright 2014 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include "common/common_types.h"
+#include "common/printable.h"
+#include "core/hle/result.h"
+#include "vfs/vfs.h"
+
+namespace Vfs {
+
+class File : public Common::VirtualPrintable {
+public:
+    virtual ~File() = default;
+
+    /// Returns a descriptive string for the filesystem, for debugging purposes.
+    virtual std::string DebugStr() const = 0;
+
+    /**
+     * Reads data from the file.
+     *
+     * @param offset position (in bytes) to read data from
+     * @param length number of bytes to read
+     * @param buffer buffer to receive the read data
+     * @return number of bytes actually read
+     */
+    virtual ResultVal<size_t> Read(u64 offset, size_t length, u8* buffer) = 0;
+
+    /**
+     * Writes data to the file.
+     *
+     * @param offset position (in bytes) to write data to
+     * @param length number of bytes to write
+     * @param buffer buffer to write data from
+     * @return number of bytes actually written
+     */
+    virtual ResultVal<size_t> Write(u64 offset, size_t length, const u8* buffer) = 0;
+
+    /** Returns the size of the file in bytes. */
+    virtual ResultVal<u64> GetSize() = 0;
+
+    /**
+     * Changes the size of the file. If smaller than the current size, the file will be truncated.
+     * If larger, the new space will be filled with zeros.
+     *
+     * @param size new size of the file, in bytes
+     */
+    virtual ResultCode SetSize(u64 size) = 0;
+
+    /** Closes the file. */
+    virtual ResultCode Close() = 0;
+
+    /** Flushes any pending writes. */
+    virtual ResultCode Flush() = 0;
+};
+
+/// Abstract implementation of File, which stubs out functions unsupported for read-only files.
+class ReadOnlyFile : public File {
+public:
+    ResultVal<size_t> Write(u64 offset, size_t length, const u8* buffer) override {
+        return ERR_UNSUPPORTED_OPERATION;
+    }
+
+    ResultCode SetSize(u64 size) override {
+        return ERR_UNSUPPORTED_OPERATION;
+    }
+
+    ResultCode Flush() override {
+        return RESULT_SUCCESS;
+    }
+};
+
+} // namespace Vfs

--- a/src/vfs/file.h
+++ b/src/vfs/file.h
@@ -25,7 +25,7 @@ public:
      * @param buffer buffer to receive the read data
      * @return number of bytes actually read
      */
-    virtual ResultVal<size_t> Read(u64 offset, size_t length, u8* buffer) = 0;
+    virtual Result<size_t> Read(u64 offset, size_t length, u8* buffer) = 0;
 
     /**
      * Writes data to the file.
@@ -35,10 +35,10 @@ public:
      * @param buffer buffer to write data from
      * @return number of bytes actually written
      */
-    virtual ResultVal<size_t> Write(u64 offset, size_t length, const u8* buffer) = 0;
+    virtual Result<size_t> Write(u64 offset, size_t length, const u8* buffer) = 0;
 
     /** Returns the size of the file in bytes. */
-    virtual ResultVal<u64> GetSize() = 0;
+    virtual Result<u64> GetSize() = 0;
 
     /**
      * Changes the size of the file. If smaller than the current size, the file will be truncated.
@@ -46,28 +46,28 @@ public:
      *
      * @param size new size of the file, in bytes
      */
-    virtual ResultCode SetSize(u64 size) = 0;
+    virtual Result<> SetSize(u64 size) = 0;
 
     /** Closes the file. */
-    virtual ResultCode Close() = 0;
+    virtual Result<> Close() = 0;
 
     /** Flushes any pending writes. */
-    virtual ResultCode Flush() = 0;
+    virtual Result<> Flush() = 0;
 };
 
 /// Abstract implementation of File, which stubs out functions unsupported for read-only files.
 class ReadOnlyFile : public File {
 public:
-    ResultVal<size_t> Write(u64 offset, size_t length, const u8* buffer) override {
-        return ERR_UNSUPPORTED_OPERATION;
+    Result<size_t> Write(u64 offset, size_t length, const u8* buffer) override {
+        return Error::UnsupportedOperation;
     }
 
-    ResultCode SetSize(u64 size) override {
-        return ERR_UNSUPPORTED_OPERATION;
+    Result<> SetSize(u64 size) override {
+        return Error::UnsupportedOperation;
     }
 
-    ResultCode Flush() override {
-        return RESULT_SUCCESS;
+    Result<> Flush() override {
+        return Ok;
     }
 };
 
@@ -82,7 +82,7 @@ public:
      * @param buffer buffer to receive the read data
      * @return number of bytes actually read, or ERR_END_OF_FILE if at EOF
      */
-    virtual ResultVal<size_t> Read(size_t length, u8* buffer) = 0;
+    virtual Result<size_t> Read(size_t length, u8* buffer) = 0;
 
     /**
      * Writes data to the file and advances the cursor by the amount written.
@@ -91,7 +91,7 @@ public:
      * @param buffer buffer to write data from
      * @return number of bytes actually written
      */
-    virtual ResultVal<size_t> Write(size_t length, const u8* buffer) = 0;
+    virtual Result<size_t> Write(size_t length, const u8* buffer) = 0;
 
     /**
      * Moves the read/write cursor to a different position in the file.
@@ -99,13 +99,13 @@ public:
      * @param offset_from_beginning offset inside the file to move the cursor to
      * @return ERR_END_OF_FILE if position is outside current file bounds
      */
-    virtual ResultCode Seek(u64 offset_from_beginning) = 0;
+    virtual Result<> Seek(u64 offset_from_beginning) = 0;
 
     /** Returns the position of the read/write cursor in bytes from the beginning of the file. */
-    virtual ResultVal<u64> Tell() = 0;
+    virtual Result<u64> Tell() = 0;
 
     /** Returns the size of the file in bytes. */
-    virtual ResultVal<u64> GetSize() const = 0;
+    virtual Result<u64> GetSize() const = 0;
 
     /**
      * Changes the size of the file. If smaller than the current size, the file will be truncated.
@@ -113,13 +113,13 @@ public:
      *
      * @param size new size of the file, in bytes
      */
-    virtual ResultCode SetSize(u64 size) = 0;
+    virtual Result<> SetSize(u64 size) = 0;
 
     /** Closes the file. */
-    virtual ResultCode Close() = 0;
+    virtual Result<> Close() = 0;
 
     /** Flushes any pending writes. */
-    virtual ResultCode Flush() = 0;
+    virtual Result<> Flush() = 0;
 };
 
 } // namespace Vfs

--- a/src/vfs/file.h
+++ b/src/vfs/file.h
@@ -71,4 +71,55 @@ public:
     }
 };
 
+class StreamFile : public Common::VirtualPrintable {
+public:
+    virtual ~StreamFile() = default;
+
+    /**
+     * Reads data from the file and advances the cursor by the amount read.
+     *
+     * @param length number of bytes to read
+     * @param buffer buffer to receive the read data
+     * @return number of bytes actually read, or ERR_END_OF_FILE if at EOF
+     */
+    virtual ResultVal<size_t> Read(size_t length, u8* buffer) = 0;
+
+    /**
+     * Writes data to the file and advances the cursor by the amount written.
+     *
+     * @param length number of bytes to write
+     * @param buffer buffer to write data from
+     * @return number of bytes actually written
+     */
+    virtual ResultVal<size_t> Write(size_t length, const u8* buffer) = 0;
+
+    /**
+     * Moves the read/write cursor to a different position in the file.
+     *
+     * @param offset_from_beginning offset inside the file to move the cursor to
+     * @return ERR_END_OF_FILE if position is outside current file bounds
+     */
+    virtual ResultCode Seek(u64 offset_from_beginning) = 0;
+
+    /** Returns the position of the read/write cursor in bytes from the beginning of the file. */
+    virtual ResultVal<u64> Tell() = 0;
+
+    /** Returns the size of the file in bytes. */
+    virtual ResultVal<u64> GetSize() const = 0;
+
+    /**
+     * Changes the size of the file. If smaller than the current size, the file will be truncated.
+     * If larger, the new space will be filled with zeros.
+     *
+     * @param size new size of the file, in bytes
+     */
+    virtual ResultCode SetSize(u64 size) = 0;
+
+    /** Closes the file. */
+    virtual ResultCode Close() = 0;
+
+    /** Flushes any pending writes. */
+    virtual ResultCode Flush() = 0;
+};
+
 } // namespace Vfs

--- a/src/vfs/host_file.cpp
+++ b/src/vfs/host_file.cpp
@@ -6,12 +6,12 @@
 
 namespace Vfs {
 
-ResultVal<HostFile> HostFile::Open(std::string path) {
+Result<HostFile> HostFile::Open(std::string path) {
     FileUtil::IOFile file;
     if (!file.Open(path, "rb")) {
-        return ERR_UNKNOWN_ERROR;
+        return Error::UnknownError;
     }
-    return MakeResult<HostFile>(std::move(file), std::move(path));
+    return HostFile(std::move(file), std::move(path));
 }
 
 HostFile::HostFile(FileUtil::IOFile&& file, std::string debug_path)
@@ -25,47 +25,47 @@ void HostFile::DebugFmt(fmt::Writer& w) const {
     w.write("HostFile{{path={}}}", debug_path);
 }
 
-ResultVal<size_t> HostFile::Read(size_t length, u8* buffer) {
+Result<size_t> HostFile::Read(size_t length, u8* buffer) {
     size_t read = file.ReadBytes(buffer, length);
 
     if (read == 0 && file.IsEof()) {
-        return ERR_END_OF_FILE;
+        return Error::EndOfFile;
     } else if (read == -1) {
-        return ERR_UNKNOWN_ERROR;
+        return Error::UnknownError;
     } else {
-        return MakeResult<size_t>(read);
+        return read;
     }
 }
 
-ResultVal<size_t> HostFile::Write(size_t length, const u8* buffer) {
-    return ERR_UNSUPPORTED_OPERATION;
+Result<size_t> HostFile::Write(size_t length, const u8* buffer) {
+    return Error::UnsupportedOperation;
 }
 
-ResultCode HostFile::Seek(u64 offset_from_beginning) {
+Result<> HostFile::Seek(u64 offset_from_beginning) {
     file.Clear();
-    return file.Seek(offset_from_beginning, SEEK_SET) ? RESULT_SUCCESS : ERR_UNKNOWN_ERROR;
+    return file.Seek(offset_from_beginning, SEEK_SET) ? Ok : Error::UnknownError;
 }
 
-ResultVal<u64> HostFile::Tell() {
+Result<u64> HostFile::Tell() {
     u64 offset = file.Tell();
-    return offset != -1 ? MakeResult<u64>(offset) : ERR_UNKNOWN_ERROR;
+    return offset != -1 ? Result<u64>(offset) : Error::UnknownError;
 }
 
-ResultVal<u64> HostFile::GetSize() const {
-    return MakeResult<u64>(file.GetSize());
+Result<u64> HostFile::GetSize() const {
+    return file.GetSize();
 }
 
-ResultCode HostFile::SetSize(u64 size) {
-    return ERR_UNSUPPORTED_OPERATION;
+Result<> HostFile::SetSize(u64 size) {
+    return Error::UnsupportedOperation;
 }
 
-ResultCode HostFile::Close() {
+Result<> HostFile::Close() {
     file.Clear();
-    return file.Close() ? RESULT_SUCCESS : ERR_UNKNOWN_ERROR;
+    return file.Close() ? Ok : Error::UnknownError;
 }
 
-ResultCode HostFile::Flush() {
-    return RESULT_SUCCESS;
+Result<> HostFile::Flush() {
+    return Ok;
 }
 
 } // namespace Vfs

--- a/src/vfs/host_file.cpp
+++ b/src/vfs/host_file.cpp
@@ -1,0 +1,71 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "vfs/host_file.h"
+
+namespace Vfs {
+
+ResultVal<HostFile> HostFile::Open(std::string path) {
+    FileUtil::IOFile file;
+    if (!file.Open(path, "rb")) {
+        return ERR_UNKNOWN_ERROR;
+    }
+    return MakeResult<HostFile>(std::move(file), std::move(path));
+}
+
+HostFile::HostFile(FileUtil::IOFile&& file, std::string debug_path)
+    : debug_path(std::move(debug_path)), file(std::move(file)) {}
+
+HostFile::HostFile(FileUtil::IOFile&& file) : HostFile(std::move(file), "") {}
+
+HostFile::~HostFile() = default;
+
+void HostFile::DebugFmt(fmt::Writer& w) const {
+    w.write("HostFile{{path={}}}", debug_path);
+}
+
+ResultVal<size_t> HostFile::Read(size_t length, u8* buffer) {
+    size_t read = file.ReadBytes(buffer, length);
+
+    if (read == 0 && file.IsEof()) {
+        return ERR_END_OF_FILE;
+    } else if (read == -1) {
+        return ERR_UNKNOWN_ERROR;
+    } else {
+        return MakeResult<size_t>(read);
+    }
+}
+
+ResultVal<size_t> HostFile::Write(size_t length, const u8* buffer) {
+    return ERR_UNSUPPORTED_OPERATION;
+}
+
+ResultCode HostFile::Seek(u64 offset_from_beginning) {
+    file.Clear();
+    return file.Seek(offset_from_beginning, SEEK_SET) ? RESULT_SUCCESS : ERR_UNKNOWN_ERROR;
+}
+
+ResultVal<u64> HostFile::Tell() {
+    u64 offset = file.Tell();
+    return offset != -1 ? MakeResult<u64>(offset) : ERR_UNKNOWN_ERROR;
+}
+
+ResultVal<u64> HostFile::GetSize() const {
+    return MakeResult<u64>(file.GetSize());
+}
+
+ResultCode HostFile::SetSize(u64 size) {
+    return ERR_UNSUPPORTED_OPERATION;
+}
+
+ResultCode HostFile::Close() {
+    file.Clear();
+    return file.Close() ? RESULT_SUCCESS : ERR_UNKNOWN_ERROR;
+}
+
+ResultCode HostFile::Flush() {
+    return RESULT_SUCCESS;
+}
+
+} // namespace Vfs

--- a/src/vfs/host_file.h
+++ b/src/vfs/host_file.h
@@ -15,7 +15,7 @@ namespace Vfs {
 
 class HostFile : public StreamFile {
 public:
-    static ResultVal<HostFile> Open(std::string path);
+    static Result<HostFile> Open(std::string path);
     HostFile(FileUtil::IOFile&& file, std::string debug_path);
     HostFile(FileUtil::IOFile&& file);
     ~HostFile();
@@ -25,14 +25,14 @@ public:
 
     void DebugFmt(fmt::Writer& w) const override;
 
-    ResultVal<size_t> Read(size_t length, u8* buffer) override;
-    ResultVal<size_t> Write(size_t length, const u8* buffer) override;
-    ResultCode Seek(u64 offset_from_beginning) override;
-    ResultVal<u64> Tell() override;
-    ResultVal<u64> GetSize() const override;
-    ResultCode SetSize(u64 size) override;
-    ResultCode Close() override;
-    ResultCode Flush() override;
+    Result<size_t> Read(size_t length, u8* buffer) override;
+    Result<size_t> Write(size_t length, const u8* buffer) override;
+    Result<> Seek(u64 offset_from_beginning) override;
+    Result<u64> Tell() override;
+    Result<u64> GetSize() const override;
+    Result<> SetSize(u64 size) override;
+    Result<> Close() override;
+    Result<> Flush() override;
 
     const FileUtil::IOFile& GetHostFile() const {
         return file;

--- a/src/vfs/host_file.h
+++ b/src/vfs/host_file.h
@@ -1,0 +1,46 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include "common/common_types.h"
+#include "common/file_util.h"
+#include "vfs/file.h"
+
+namespace Vfs {
+
+class HostFile : public StreamFile {
+public:
+    static ResultVal<HostFile> Open(std::string path);
+    HostFile(FileUtil::IOFile&& file, std::string debug_path);
+    HostFile(FileUtil::IOFile&& file);
+    ~HostFile();
+
+    HostFile(HostFile&&) = default;
+    HostFile& operator=(HostFile&&) = default;
+
+    void DebugFmt(fmt::Writer& w) const override;
+
+    ResultVal<size_t> Read(size_t length, u8* buffer) override;
+    ResultVal<size_t> Write(size_t length, const u8* buffer) override;
+    ResultCode Seek(u64 offset_from_beginning) override;
+    ResultVal<u64> Tell() override;
+    ResultVal<u64> GetSize() const override;
+    ResultCode SetSize(u64 size) override;
+    ResultCode Close() override;
+    ResultCode Flush() override;
+
+    const FileUtil::IOFile& GetHostFile() const {
+        return file;
+    }
+
+private:
+    std::string debug_path;
+    FileUtil::IOFile file;
+};
+
+} // namespace Vfs

--- a/src/vfs/memory_file.cpp
+++ b/src/vfs/memory_file.cpp
@@ -15,41 +15,41 @@ void MemoryFile::DebugFmt(fmt::Writer& w) const {
     w.write("MemoryFile{{size={}}}", data.size());
 }
 
-ResultVal<size_t> MemoryFile::Read(u64 offset, size_t length, u8* buffer) {
+Result<size_t> MemoryFile::Read(u64 offset, size_t length, u8* buffer) {
     if (offset >= data.size()) {
         // Attempt to read past EOF
-        return MakeResult<size_t>(0);
+        return 0;
     }
     size_t read_size = std::min(length, data.size() - offset);
     std::copy_n(data.begin() + offset, read_size, buffer);
-    return MakeResult<size_t>(read_size);
+    return read_size;
 }
 
-ResultVal<size_t> MemoryFile::Write(u64 offset, size_t length, const u8* buffer) {
+Result<size_t> MemoryFile::Write(u64 offset, size_t length, const u8* buffer) {
     if (offset >= data.size()) {
         // Attempt to write past EOF
-        return MakeResult<size_t>(0);
+        return 0;
     }
     size_t write_size = std::min(length, data.size() - offset);
     std::copy_n(buffer, write_size, data.begin() + offset);
-    return MakeResult<size_t>(write_size);
+    return write_size;
 }
 
-ResultVal<u64> MemoryFile::GetSize() {
-    return MakeResult<u64>(data.size());
+Result<u64> MemoryFile::GetSize() {
+    return data.size();
 }
 
-ResultCode MemoryFile::SetSize(u64 size) {
+Result<> MemoryFile::SetSize(u64 size) {
     data.resize(size);
-    return RESULT_SUCCESS;
+    return Ok;
 }
 
-ResultCode MemoryFile::Close() {
-    return RESULT_SUCCESS;
+Result<> MemoryFile::Close() {
+    return Ok;
 }
 
-ResultCode MemoryFile::Flush() {
-    return RESULT_SUCCESS;
+Result<> MemoryFile::Flush() {
+    return Ok;
 }
 
 } // namespace Vfs

--- a/src/vfs/memory_file.cpp
+++ b/src/vfs/memory_file.cpp
@@ -1,0 +1,55 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <algorithm>
+#include <fmt/format.h>
+#include "vfs/memory_file.h"
+#include "vfs/vfs.h"
+
+namespace Vfs {
+
+MemoryFile::MemoryFile(std::vector<u8> data) : data(std::move(data)) {}
+
+void MemoryFile::DebugFmt(fmt::Writer& w) const {
+    w.write("MemoryFile{{size={}}}", data.size());
+}
+
+ResultVal<size_t> MemoryFile::Read(u64 offset, size_t length, u8* buffer) {
+    if (offset >= data.size()) {
+        // Attempt to read past EOF
+        return MakeResult<size_t>(0);
+    }
+    size_t read_size = std::min(length, data.size() - offset);
+    std::copy_n(data.begin() + offset, read_size, buffer);
+    return MakeResult<size_t>(read_size);
+}
+
+ResultVal<size_t> MemoryFile::Write(u64 offset, size_t length, const u8* buffer) {
+    if (offset >= data.size()) {
+        // Attempt to write past EOF
+        return MakeResult<size_t>(0);
+    }
+    size_t write_size = std::min(length, data.size() - offset);
+    std::copy_n(buffer, write_size, data.begin() + offset);
+    return MakeResult<size_t>(write_size);
+}
+
+ResultVal<u64> MemoryFile::GetSize() {
+    return MakeResult<u64>(data.size());
+}
+
+ResultCode MemoryFile::SetSize(u64 size) {
+    data.resize(size);
+    return RESULT_SUCCESS;
+}
+
+ResultCode MemoryFile::Close() {
+    return RESULT_SUCCESS;
+}
+
+ResultCode MemoryFile::Flush() {
+    return RESULT_SUCCESS;
+}
+
+} // namespace Vfs

--- a/src/vfs/memory_file.h
+++ b/src/vfs/memory_file.h
@@ -15,12 +15,12 @@ public:
 
     void DebugFmt(fmt::Writer& w) const override;
 
-    ResultVal<size_t> Read(u64 offset, size_t length, u8* buffer) override;
-    ResultVal<size_t> Write(u64 offset, size_t length, const u8* buffer) override;
-    ResultVal<u64> GetSize() override;
-    ResultCode SetSize(u64 size) override;
-    ResultCode Close() override;
-    ResultCode Flush() override;
+    Result<size_t> Read(u64 offset, size_t length, u8* buffer) override;
+    Result<size_t> Write(u64 offset, size_t length, const u8* buffer) override;
+    Result<u64> GetSize() override;
+    Result<> SetSize(u64 size) override;
+    Result<> Close() override;
+    Result<> Flush() override;
 
     const std::vector<u8>& GetData() const {
         return data;

--- a/src/vfs/memory_file.h
+++ b/src/vfs/memory_file.h
@@ -1,0 +1,37 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <limits>
+#include "vfs/file.h"
+
+namespace Vfs {
+
+class MemoryFile : public File {
+public:
+    explicit MemoryFile(std::vector<u8> data);
+
+    void DebugFmt(fmt::Writer& w) const override;
+
+    ResultVal<size_t> Read(u64 offset, size_t length, u8* buffer) override;
+    ResultVal<size_t> Write(u64 offset, size_t length, const u8* buffer) override;
+    ResultVal<u64> GetSize() override;
+    ResultCode SetSize(u64 size) override;
+    ResultCode Close() override;
+    ResultCode Flush() override;
+
+    const std::vector<u8>& GetData() const {
+        return data;
+    }
+
+    std::vector<u8>& GetData() {
+        return data;
+    }
+
+private:
+    std::vector<u8> data;
+};
+
+} // namespace Vfs

--- a/src/vfs/random_access_adapter.cpp
+++ b/src/vfs/random_access_adapter.cpp
@@ -1,0 +1,45 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "vfs/random_access_adapter.h"
+
+namespace Vfs {
+
+void RandomAccessAdapter::DebugFmt(fmt::Writer& w) const {
+    w.write("RandomAccessAdapter{{{}}}", *base_file);
+}
+
+ResultVal<size_t> RandomAccessAdapter::Read(u64 offset, size_t length, u8* buffer) {
+    auto result = base_file->Seek(offset);
+    if (result.IsError())
+        return result;
+
+    return base_file->Read(length, buffer);
+}
+
+ResultVal<size_t> RandomAccessAdapter::Write(u64 offset, size_t length, const u8* buffer) {
+    auto result = base_file->Seek(offset);
+    if (result.IsError())
+        return result;
+
+    return base_file->Write(length, buffer);
+}
+
+ResultVal<u64> RandomAccessAdapter::GetSize() {
+    return base_file->GetSize();
+}
+
+ResultCode RandomAccessAdapter::SetSize(u64 size) {
+    return base_file->SetSize(size);
+}
+
+ResultCode RandomAccessAdapter::Close() {
+    return base_file->Close();
+}
+
+ResultCode RandomAccessAdapter::Flush() {
+    return base_file->Flush();
+}
+
+} // namespace Vfs

--- a/src/vfs/random_access_adapter.cpp
+++ b/src/vfs/random_access_adapter.cpp
@@ -10,35 +10,29 @@ void RandomAccessAdapter::DebugFmt(fmt::Writer& w) const {
     w.write("RandomAccessAdapter{{{}}}", *base_file);
 }
 
-ResultVal<size_t> RandomAccessAdapter::Read(u64 offset, size_t length, u8* buffer) {
-    auto result = base_file->Seek(offset);
-    if (result.IsError())
-        return result;
-
+Result<size_t> RandomAccessAdapter::Read(u64 offset, size_t length, u8* buffer) {
+    CASCADE_COMMON_RESULT(auto result, base_file->Seek(offset));
     return base_file->Read(length, buffer);
 }
 
-ResultVal<size_t> RandomAccessAdapter::Write(u64 offset, size_t length, const u8* buffer) {
-    auto result = base_file->Seek(offset);
-    if (result.IsError())
-        return result;
-
+Result<size_t> RandomAccessAdapter::Write(u64 offset, size_t length, const u8* buffer) {
+    CASCADE_COMMON_RESULT(auto result, base_file->Seek(offset));
     return base_file->Write(length, buffer);
 }
 
-ResultVal<u64> RandomAccessAdapter::GetSize() {
+Result<u64> RandomAccessAdapter::GetSize() {
     return base_file->GetSize();
 }
 
-ResultCode RandomAccessAdapter::SetSize(u64 size) {
+Result<> RandomAccessAdapter::SetSize(u64 size) {
     return base_file->SetSize(size);
 }
 
-ResultCode RandomAccessAdapter::Close() {
+Result<> RandomAccessAdapter::Close() {
     return base_file->Close();
 }
 
-ResultCode RandomAccessAdapter::Flush() {
+Result<> RandomAccessAdapter::Flush() {
     return base_file->Flush();
 }
 

--- a/src/vfs/random_access_adapter.h
+++ b/src/vfs/random_access_adapter.h
@@ -18,12 +18,12 @@ public:
 
     void DebugFmt(fmt::Writer& w) const override;
 
-    ResultVal<size_t> Read(u64 offset, size_t length, u8* buffer) override;
-    ResultVal<size_t> Write(u64 offset, size_t length, const u8* buffer) override;
-    ResultVal<u64> GetSize() override;
-    ResultCode SetSize(u64 size) override;
-    ResultCode Close() override;
-    ResultCode Flush() override;
+    Result<size_t> Read(u64 offset, size_t length, u8* buffer) override;
+    Result<size_t> Write(u64 offset, size_t length, const u8* buffer) override;
+    Result<u64> GetSize() override;
+    Result<> SetSize(u64 size) override;
+    Result<> Close() override;
+    Result<> Flush() override;
 
     const StreamFile& GetBaseFile() const {
         return *base_file;

--- a/src/vfs/random_access_adapter.h
+++ b/src/vfs/random_access_adapter.h
@@ -1,0 +1,36 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include "common/common_types.h"
+#include "common/file_util.h"
+#include "vfs/file.h"
+
+namespace Vfs {
+
+class RandomAccessAdapter : public File {
+public:
+    RandomAccessAdapter(std::unique_ptr<StreamFile> base_file) : base_file(std::move(base_file)) {}
+
+    void DebugFmt(fmt::Writer& w) const override;
+
+    ResultVal<size_t> Read(u64 offset, size_t length, u8* buffer) override;
+    ResultVal<size_t> Write(u64 offset, size_t length, const u8* buffer) override;
+    ResultVal<u64> GetSize() override;
+    ResultCode SetSize(u64 size) override;
+    ResultCode Close() override;
+    ResultCode Flush() override;
+
+    const StreamFile& GetBaseFile() const {
+        return *base_file;
+    }
+
+private:
+    std::unique_ptr<StreamFile> base_file;
+};
+
+} // namespace Vfs

--- a/src/vfs/subrange_file.cpp
+++ b/src/vfs/subrange_file.cpp
@@ -15,40 +15,40 @@ void SubrangeFile::DebugFmt(fmt::Writer& w) const {
     w.write("SubrangeFile{{offset={}, size={}, base_file={}}}", file_offset, file_size, *base_file);
 }
 
-ResultVal<size_t> SubrangeFile::Read(u64 offset, size_t length, u8* buffer) {
+Result<size_t> SubrangeFile::Read(u64 offset, size_t length, u8* buffer) {
     if (offset >= file_size) {
         // Attempt to read past EOF
-        return MakeResult<size_t>(0);
+        return 0;
     }
     return base_file->Read(offset + file_offset, std::min(length, file_size - offset), buffer);
 }
 
-ResultVal<size_t> SubrangeFile::Write(u64 offset, size_t length, const u8* buffer) {
+Result<size_t> SubrangeFile::Write(u64 offset, size_t length, const u8* buffer) {
     if (offset >= file_size) {
         // Attempt to write past EOF
-        return MakeResult<size_t>(0);
+        return 0;
     }
     return base_file->Write(offset + file_offset, std::min(length, file_size - offset), buffer);
 }
 
-ResultVal<u64> SubrangeFile::GetSize() {
-    CASCADE_RESULT(u64 base_size, base_file->GetSize());
+Result<u64> SubrangeFile::GetSize() {
+    CASCADE_COMMON_RESULT(u64 base_size, base_file->GetSize());
     if (file_offset >= base_size) {
-        return MakeResult<u64>(0);
+        return 0;
     } else {
-        return MakeResult<u64>(std::min(file_size, base_size - file_offset));
+        return std::min(file_size, base_size - file_offset);
     }
 }
 
-ResultCode SubrangeFile::SetSize(u64 size) {
-    return ERR_UNSUPPORTED_OPERATION;
+Result<> SubrangeFile::SetSize(u64 size) {
+    return Error::UnsupportedOperation;
 }
 
-ResultCode SubrangeFile::Close() {
+Result<> SubrangeFile::Close() {
     return base_file->Close();
 }
 
-ResultCode SubrangeFile::Flush() {
+Result<> SubrangeFile::Flush() {
     return base_file->Flush();
 }
 

--- a/src/vfs/subrange_file.cpp
+++ b/src/vfs/subrange_file.cpp
@@ -1,0 +1,55 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <algorithm>
+#include "vfs/subrange_file.h"
+#include "vfs/vfs.h"
+
+namespace Vfs {
+
+SubrangeFile::SubrangeFile(std::shared_ptr<File> base_file, u64 offset, u64 size)
+    : base_file(base_file), file_offset(offset), file_size(size) {}
+
+void SubrangeFile::DebugFmt(fmt::Writer& w) const {
+    w.write("SubrangeFile{{offset={}, size={}, base_file={}}}", file_offset, file_size, *base_file);
+}
+
+ResultVal<size_t> SubrangeFile::Read(u64 offset, size_t length, u8* buffer) {
+    if (offset >= file_size) {
+        // Attempt to read past EOF
+        return MakeResult<size_t>(0);
+    }
+    return base_file->Read(offset + file_offset, std::min(length, file_size - offset), buffer);
+}
+
+ResultVal<size_t> SubrangeFile::Write(u64 offset, size_t length, const u8* buffer) {
+    if (offset >= file_size) {
+        // Attempt to write past EOF
+        return MakeResult<size_t>(0);
+    }
+    return base_file->Write(offset + file_offset, std::min(length, file_size - offset), buffer);
+}
+
+ResultVal<u64> SubrangeFile::GetSize() {
+    CASCADE_RESULT(u64 base_size, base_file->GetSize());
+    if (file_offset >= base_size) {
+        return MakeResult<u64>(0);
+    } else {
+        return MakeResult<u64>(std::min(file_size, base_size - file_offset));
+    }
+}
+
+ResultCode SubrangeFile::SetSize(u64 size) {
+    return ERR_UNSUPPORTED_OPERATION;
+}
+
+ResultCode SubrangeFile::Close() {
+    return base_file->Close();
+}
+
+ResultCode SubrangeFile::Flush() {
+    return base_file->Flush();
+}
+
+} // namespace Vfs

--- a/src/vfs/subrange_file.h
+++ b/src/vfs/subrange_file.h
@@ -1,0 +1,37 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <limits>
+#include "vfs/file.h"
+
+namespace Vfs {
+
+class SubrangeFile : public File {
+public:
+    static constexpr u64 UNBOUNDED_SIZE = std::numeric_limits<u64>::max();
+
+    SubrangeFile(std::shared_ptr<File> base_file, u64 offset, u64 size);
+
+    void DebugFmt(fmt::Writer& writer) const override;
+
+    ResultVal<size_t> Read(u64 offset, size_t length, u8* buffer) override;
+    ResultVal<size_t> Write(u64 offset, size_t length, const u8* buffer) override;
+    ResultVal<u64> GetSize() override;
+    ResultCode SetSize(u64 size) override;
+    ResultCode Close() override;
+    ResultCode Flush() override;
+
+    std::shared_ptr<File> GetBaseFile() const {
+        return base_file;
+    }
+
+private:
+    std::shared_ptr<File> base_file;
+    u64 file_offset;
+    u64 file_size;
+};
+
+} // namespace Vfs

--- a/src/vfs/subrange_file.h
+++ b/src/vfs/subrange_file.h
@@ -17,12 +17,12 @@ public:
 
     void DebugFmt(fmt::Writer& writer) const override;
 
-    ResultVal<size_t> Read(u64 offset, size_t length, u8* buffer) override;
-    ResultVal<size_t> Write(u64 offset, size_t length, const u8* buffer) override;
-    ResultVal<u64> GetSize() override;
-    ResultCode SetSize(u64 size) override;
-    ResultCode Close() override;
-    ResultCode Flush() override;
+    Result<size_t> Read(u64 offset, size_t length, u8* buffer) override;
+    Result<size_t> Write(u64 offset, size_t length, const u8* buffer) override;
+    Result<u64> GetSize() override;
+    Result<> SetSize(u64 size) override;
+    Result<> Close() override;
+    Result<> Flush() override;
 
     std::shared_ptr<File> GetBaseFile() const {
         return base_file;

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -4,14 +4,19 @@
 
 #pragma once
 
-#include "core/hle/result.h"
+#include "common/result.h"
 
 namespace Vfs {
 
-constexpr ResultCode ERR_UNSUPPORTED_OPERATION = UnimplementedFunction(ErrorModule::Citra);
-constexpr ResultCode ERR_UNKNOWN_ERROR(1, ErrorModule::Citra, ErrorSummary::InvalidState,
-                                       ErrorLevel::Permanent);
-constexpr ResultCode ERR_END_OF_FILE(2, ErrorModule::Citra, ErrorSummary::WouldBlock,
-                                     ErrorLevel::Status);
+enum class Error {
+    UnknownError = 0,
+    UnsupportedOperation,
+    EndOfFile,
+};
+
+template <typename T = Common::OkType>
+using Result = Common::Result<T, Error>;
+
+static const Result<> Ok = Common::OkType{};
 
 } // namespace Vfs

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -9,5 +9,9 @@
 namespace Vfs {
 
 constexpr ResultCode ERR_UNSUPPORTED_OPERATION = UnimplementedFunction(ErrorModule::Citra);
+constexpr ResultCode ERR_UNKNOWN_ERROR(1, ErrorModule::Citra, ErrorSummary::InvalidState,
+                                       ErrorLevel::Permanent);
+constexpr ResultCode ERR_END_OF_FILE(2, ErrorModule::Citra, ErrorSummary::WouldBlock,
+                                     ErrorLevel::Status);
 
 } // namespace Vfs

--- a/src/vfs/vfs.h
+++ b/src/vfs/vfs.h
@@ -1,0 +1,13 @@
+// Copyright 2017 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/result.h"
+
+namespace Vfs {
+
+constexpr ResultCode ERR_UNSUPPORTED_OPERATION = UnimplementedFunction(ErrorModule::Citra);
+
+} // namespace Vfs


### PR DESCRIPTION
The intent of this is to introduce a layerable file abstraction. This can then be used to implement file formats in a way that's transparent to whatever's using the file, e.g. HostFile -> NCSD container -> NCCH container -> decryption layer -> RomFS.

It's an explicit non-goal for this to handle any emulation behavior from the 3DS' FS module, so archives and stuff will still be their own thing, that can use these libraries to implement whatever they need if necessary.

I'm marking this as RFC because I don't actually have anything that uses this yet. I'll probably work on porting the loaders to it to start with.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3403)
<!-- Reviewable:end -->
