### PR TITLE
Fix minor spelling error in CMakeLists 

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -17,7 +17,7 @@ if ($ENV{CI})
       string(SUBSTRING ${WORD} 1 -1 REMAINDER)
       string(TOUPPER ${FIRST_LETTER} FIRST_LETTER)
       # this leaves a trailing space on the last word, but we actually want that
-      # because of how its styled in the title bar.
+      # because of how it's styled in the title bar.
       set(REPO_NAME "${REPO_NAME}${FIRST_LETTER}${REMAINDER} ")
     endforeach()
   endif()


### PR DESCRIPTION
**its -> it's**
 (This is a straight port of https://github.com/yuzu-emu/yuzu/pull/124)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3404)
<!-- Reviewable:end -->
