### PR TITLE
File_Sys: Add a size dependent delay for each file read

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -57,6 +57,7 @@ add_library(core STATIC
     file_sys/disk_archive.h
     file_sys/errors.h
     file_sys/file_backend.h
+    file_sys/delay_generator.h
     file_sys/ivfc_archive.cpp
     file_sys/ivfc_archive.h
     file_sys/ncch_container.cpp

--- a/src/core/file_sys/archive_extsavedata.cpp
+++ b/src/core/file_sys/archive_extsavedata.cpp
@@ -64,8 +64,9 @@ public:
         static constexpr u64 slope(183);
         static constexpr u64 offset(524879);
         static constexpr u64 minimum(631826);
-        u64 IPCDelayNanoseconds = std::max<u64>(static_cast<u64>(length) * slope + offset, minimum);
-        return IPCDelayNanoseconds;
+        u64 ipc_delay_nanoseconds =
+            std::max<u64>(static_cast<u64>(length) * slope + offset, minimum);
+        return ipc_delay_nanoseconds;
     }
 };
 

--- a/src/core/file_sys/archive_ncch.h
+++ b/src/core/file_sys/archive_ncch.h
@@ -17,7 +17,7 @@ namespace Service {
 namespace FS {
 enum class MediaType : u32;
 }
-}
+} // namespace Service
 
 namespace FileSys {
 
@@ -51,7 +51,7 @@ protected:
 // File backend for NCCH files
 class NCCHFile : public FileBackend {
 public:
-    explicit NCCHFile(std::vector<u8> buffer);
+    explicit NCCHFile(std::vector<u8> buffer, std::unique_ptr<DelayGenerator> delay_generator_);
 
     ResultVal<size_t> Read(u64 offset, size_t length, u8* buffer) const override;
     ResultVal<size_t> Write(u64 offset, size_t length, bool flush, const u8* buffer) override;

--- a/src/core/file_sys/archive_selfncch.cpp
+++ b/src/core/file_sys/archive_selfncch.cpp
@@ -245,9 +245,8 @@ void ArchiveFactory_SelfNCCH::Register(Loader::AppLoader& app_loader) {
               program_id);
 
     if (ncch_data.find(program_id) != ncch_data.end()) {
-        LOG_WARNING(Service_FS,
-                    "Registering program %016" PRIX64
-                    " with SelfNCCH will override existing mapping",
+        LOG_WARNING(Service_FS, "Registering program %016" PRIX64
+                                " with SelfNCCH will override existing mapping",
                     program_id);
     }
 
@@ -261,9 +260,9 @@ void ArchiveFactory_SelfNCCH::Register(Loader::AppLoader& app_loader) {
     }
 
     std::shared_ptr<FileUtil::IOFile> update_romfs_file;
-    if (Loader::ResultStatus::Success == app_loader.ReadUpdateRomFS(update_romfs_file,
-                                                                    data.update_romfs_offset,
-                                                                    data.update_romfs_size)) {
+    if (Loader::ResultStatus::Success ==
+        app_loader.ReadUpdateRomFS(update_romfs_file, data.update_romfs_offset,
+                                   data.update_romfs_size)) {
 
         data.update_romfs_file = std::move(update_romfs_file);
     }

--- a/src/core/file_sys/archive_selfncch.cpp
+++ b/src/core/file_sys/archive_selfncch.cpp
@@ -56,6 +56,17 @@ public:
         return ERROR_UNSUPPORTED_OPEN_FLAGS;
     }
 
+    u64 GetReadDelayNs(size_t length) const {
+        // The delay was measured on O3DS and O2DS with
+        // https://gist.github.com/B3n30/ac40eac20603f519ff106107f4ac9182
+        // from the results the average of each length was taken.
+        static constexpr u64 slope(94);
+        static constexpr u64 offset(582778);
+        static constexpr u64 minimum(663124);
+        u64 IPCDelayNanoseconds = std::max<u64>(static_cast<u64>(length) * slope + offset, minimum);
+        return IPCDelayNanoseconds;
+    }
+
     u64 GetSize() const override {
         return data->size();
     }

--- a/src/core/file_sys/delay_generator.h
+++ b/src/core/file_sys/delay_generator.h
@@ -1,0 +1,29 @@
+// Copyright 2018 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+namespace FileSys {
+
+class DelayGenerator {
+public:
+    virtual u64 GetReadDelayNs(size_t length) = 0;
+
+    // TODO (B3N30): Add getter for all other file/directory io operations
+};
+
+class DefaultDelayGenerator : public DelayGenerator {
+public:
+    u64 GetReadDelayNs(size_t length) override {
+        // This is the delay measured for a romfs read.
+        // For now we will take that as a default
+        static constexpr u64 slope(94);
+        static constexpr u64 offset(582778);
+        static constexpr u64 minimum(663124);
+        u64 IPCDelayNanoseconds = std::max<u64>(static_cast<u64>(length) * slope + offset, minimum);
+        return IPCDelayNanoseconds;
+    }
+};
+
+} // namespace FileSys

--- a/src/core/file_sys/disk_archive.cpp
+++ b/src/core/file_sys/disk_archive.cpp
@@ -36,20 +36,6 @@ ResultVal<size_t> DiskFile::Write(const u64 offset, const size_t length, const b
     return MakeResult<size_t>(written);
 }
 
-u64 DiskFile::GetReadDelayNs(size_t length) const {
-    // TODO(B3N30): figure out the time a 3ds needs for those write
-    // for that backend.
-    // For now take the results from the romfs test.
-    // The delay was measured on O3DS and O2DS with
-    // https://gist.github.com/B3n30/ac40eac20603f519ff106107f4ac9182
-    // from the results the average of each length was taken.
-    static constexpr u64 slope(183);
-    static constexpr u64 offset(524879);
-    static constexpr u64 minimum(631826);
-    u64 IPCDelayNanoseconds = std::max<u64>(static_cast<u64>(length) * slope + offset, minimum);
-    return IPCDelayNanoseconds;
-}
-
 u64 DiskFile::GetSize() const {
     return file->GetSize();
 }

--- a/src/core/file_sys/disk_archive.cpp
+++ b/src/core/file_sys/disk_archive.cpp
@@ -36,6 +36,20 @@ ResultVal<size_t> DiskFile::Write(const u64 offset, const size_t length, const b
     return MakeResult<size_t>(written);
 }
 
+u64 DiskFile::GetReadDelayNs(size_t length) const {
+    // TODO(B3N30): figure out the time a 3ds needs for those write
+    // for that backend.
+    // For now take the results from the romfs test.
+    // The delay was measured on O3DS and O2DS with
+    // https://gist.github.com/B3n30/ac40eac20603f519ff106107f4ac9182
+    // from the results the average of each length was taken.
+    static constexpr u64 slope(183);
+    static constexpr u64 offset(524879);
+    static constexpr u64 minimum(631826);
+    u64 IPCDelayNanoseconds = std::max<u64>(static_cast<u64>(length) * slope + offset, minimum);
+    return IPCDelayNanoseconds;
+}
+
 u64 DiskFile::GetSize() const {
     return file->GetSize();
 }

--- a/src/core/file_sys/disk_archive.h
+++ b/src/core/file_sys/disk_archive.h
@@ -22,14 +22,15 @@ namespace FileSys {
 
 class DiskFile : public FileBackend {
 public:
-    DiskFile(FileUtil::IOFile&& file_, const Mode& mode_)
+    DiskFile(FileUtil::IOFile&& file_, const Mode& mode_,
+             std::unique_ptr<DelayGenerator> delay_generator_)
         : file(new FileUtil::IOFile(std::move(file_))) {
+        delay_generator = std::move(delay_generator_);
         mode.hex = mode_.hex;
     }
 
     ResultVal<size_t> Read(u64 offset, size_t length, u8* buffer) const override;
     ResultVal<size_t> Write(u64 offset, size_t length, bool flush, const u8* buffer) override;
-    u64 GetReadDelayNs(size_t length) const override;
     u64 GetSize() const override;
     bool SetSize(u64 size) const override;
     bool Close() const override;

--- a/src/core/file_sys/disk_archive.h
+++ b/src/core/file_sys/disk_archive.h
@@ -29,6 +29,7 @@ public:
 
     ResultVal<size_t> Read(u64 offset, size_t length, u8* buffer) const override;
     ResultVal<size_t> Write(u64 offset, size_t length, bool flush, const u8* buffer) override;
+    u64 GetReadDelayNs(size_t length) const override;
     u64 GetSize() const override;
     bool SetSize(u64 size) const override;
     bool Close() const override;

--- a/src/core/file_sys/file_backend.h
+++ b/src/core/file_sys/file_backend.h
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <memory>
 #include "common/common_types.h"
 #include "core/hle/result.h"
 #include "delay_generator.h"

--- a/src/core/file_sys/ivfc_archive.cpp
+++ b/src/core/file_sys/ivfc_archive.cpp
@@ -107,6 +107,17 @@ ResultVal<size_t> IVFCFile::Write(const u64 offset, const size_t length, const b
     return MakeResult<size_t>(0);
 }
 
+u64 IVFCFile::GetReadDelayNs(size_t length) const {
+    // The delay was measured on O3DS and O2DS with
+    // https://gist.github.com/B3n30/ac40eac20603f519ff106107f4ac9182
+    // from the results the average of each length was taken.
+    static constexpr u64 slope(94);
+    static constexpr u64 offset(582778);
+    static constexpr u64 minimum(663124);
+    u64 IPCDelayNanoseconds = std::max<u64>(static_cast<u64>(length) * slope + offset, minimum);
+    return IPCDelayNanoseconds;
+}
+
 u64 IVFCFile::GetSize() const {
     return data_size;
 }

--- a/src/core/file_sys/ivfc_archive.h
+++ b/src/core/file_sys/ivfc_archive.h
@@ -54,6 +54,7 @@ public:
 
     ResultVal<size_t> Read(u64 offset, size_t length, u8* buffer) const override;
     ResultVal<size_t> Write(u64 offset, size_t length, bool flush, const u8* buffer) override;
+    u64 GetReadDelayNs(size_t length) const override;
     u64 GetSize() const override;
     bool SetSize(u64 size) const override;
     bool Close() const override {

--- a/src/core/file_sys/ivfc_archive.h
+++ b/src/core/file_sys/ivfc_archive.h
@@ -19,6 +19,46 @@
 
 namespace FileSys {
 
+class IVFCDelayGenerator : public DelayGenerator {
+    u64 GetReadDelayNs(size_t length) override {
+        // This is the delay measured for a romfs read.
+        // For now we will take that as a default
+        static constexpr u64 slope(94);
+        static constexpr u64 offset(582778);
+        static constexpr u64 minimum(663124);
+        u64 IPCDelayNanoseconds = std::max<u64>(static_cast<u64>(length) * slope + offset, minimum);
+        return IPCDelayNanoseconds;
+    }
+};
+
+class RomFSDelayGenerator : public DelayGenerator {
+public:
+    u64 GetReadDelayNs(size_t length) override {
+        // The delay was measured on O3DS and O2DS with
+        // https://gist.github.com/B3n30/ac40eac20603f519ff106107f4ac9182
+        // from the results the average of each length was taken.
+        static constexpr u64 slope(94);
+        static constexpr u64 offset(582778);
+        static constexpr u64 minimum(663124);
+        u64 IPCDelayNanoseconds = std::max<u64>(static_cast<u64>(length) * slope + offset, minimum);
+        return IPCDelayNanoseconds;
+    }
+};
+
+class ExeFSDelayGenerator : public DelayGenerator {
+public:
+    u64 GetReadDelayNs(size_t length) override {
+        // The delay was measured on O3DS and O2DS with
+        // https://gist.github.com/B3n30/ac40eac20603f519ff106107f4ac9182
+        // from the results the average of each length was taken.
+        static constexpr u64 slope(94);
+        static constexpr u64 offset(582778);
+        static constexpr u64 minimum(663124);
+        u64 IPCDelayNanoseconds = std::max<u64>(static_cast<u64>(length) * slope + offset, minimum);
+        return IPCDelayNanoseconds;
+    }
+};
+
 /**
  * Helper which implements an interface to deal with IVFC images used in some archives
  * This should be subclassed by concrete archive types, which will provide the
@@ -50,11 +90,11 @@ protected:
 
 class IVFCFile : public FileBackend {
 public:
-    IVFCFile(std::shared_ptr<FileUtil::IOFile> file, u64 offset, u64 size);
+    IVFCFile(std::shared_ptr<FileUtil::IOFile> file, u64 offset, u64 size,
+             std::unique_ptr<DelayGenerator> delay_generator_);
 
     ResultVal<size_t> Read(u64 offset, size_t length, u8* buffer) const override;
     ResultVal<size_t> Write(u64 offset, size_t length, bool flush, const u8* buffer) override;
-    u64 GetReadDelayNs(size_t length) const override;
     u64 GetSize() const override;
     bool SetSize(u64 size) const override;
     bool Close() const override {

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -31,6 +31,7 @@
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/client_port.h"
 #include "core/hle/kernel/client_session.h"
+#include "core/hle/kernel/event.h"
 #include "core/hle/kernel/handle_table.h"
 #include "core/hle/kernel/server_session.h"
 #include "core/hle/result.h"
@@ -121,6 +122,13 @@ void File::Read(Kernel::HLERequestContext& ctx) {
         rb.Push<u32>(*read);
     }
     rb.PushMappedBuffer(buffer);
+
+    u64 read_timeout_ns = backend->GetReadDelayNs(length);
+    ctx.SleepClientThread(Kernel::GetCurrentThread(), "file::read", read_timeout_ns,
+                          [](Kernel::SharedPtr<Kernel::Thread> thread,
+                             Kernel::HLERequestContext& ctx, ThreadWakeupReason reason) {
+                              // Nothing to do here
+                          });
 }
 
 void File::Write(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -123,7 +123,7 @@ void File::Read(Kernel::HLERequestContext& ctx) {
     }
     rb.PushMappedBuffer(buffer);
 
-    u64 read_timeout_ns = backend->GetReadDelayNs(length);
+    std::chrono::nanoseconds read_timeout_ns{backend->GetReadDelayNs(length)};
     ctx.SleepClientThread(Kernel::GetCurrentThread(), "file::read", read_timeout_ns,
                           [](Kernel::SharedPtr<Kernel::Thread> thread,
                              Kernel::HLERequestContext& ctx, ThreadWakeupReason reason) {


### PR DESCRIPTION
File IOs on a 3DS take much longer then our currently emulated 39000 ns for each SVC call. Without the additional delay added by that PR the thread reading a file is executed much faster then it should, leading e.g. to deadlocks.

Also the emulated timing is a lot more precise with that PR. The testing homebrew https://gist.github.com/B3n30/9c08a8103880f661fd9eee284044eff4 took on a 3ds about 10 min while in citra without that PR it was finished in 30 sec (with framelimiter enabled). With that PR the timings were about the same.

The time it took for the reads were tested with that homebrew and the average for each file size was determined. The values were then extracted from that averages. For now RomFS, ExeFS, and reading savefiles were tested. For all other values for now the RomFS/ExeFS delay was assumed until they get measured to. Adding that delay instead of the 39000 ns seems to be at least a bit more precise.

For savefiles it was also tested if dublicateData and reading at exactly multiples of the block size changes the read time.

The final goal is to measure that delay for all File IOs (Read, FileCreate, FileDelete, DirCreate, DirDelete, etc... )and add it to Citra.

This PR requires #3101 to get merged first

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3440)
<!-- Reviewable:end -->
