### PR TITLE
Service/FS: convert to ServiceFramework

### DIFF
--- a/src/core/file_sys/archive_backend.cpp
+++ b/src/core/file_sys/archive_backend.cpp
@@ -12,23 +12,22 @@
 
 namespace FileSys {
 
-Path::Path(LowPathType type, u32 size, u32 pointer) : type(type) {
+Path::Path(LowPathType type, const std::vector<u8>& data) : type(type) {
     switch (type) {
     case LowPathType::Binary: {
-        binary.resize(size);
-        Memory::ReadBlock(pointer, binary.data(), binary.size());
+        binary = data;
         break;
     }
 
     case LowPathType::Char: {
-        string.resize(size - 1); // Data is always null-terminated.
-        Memory::ReadBlock(pointer, &string[0], string.size());
+        string.resize(data.size() - 1); // Data is always null-terminated.
+        std::memcpy(string.data(), data.data(), string.size());
         break;
     }
 
     case LowPathType::Wchar: {
-        u16str.resize(size / 2 - 1); // Data is always null-terminated.
-        Memory::ReadBlock(pointer, &u16str[0], u16str.size() * sizeof(char16_t));
+        u16str.resize(data.size() / 2 - 1); // Data is always null-terminated.
+        std::memcpy(u16str.data(), data.data(), u16str.size() * sizeof(char16_t));
         break;
     }
 

--- a/src/core/file_sys/archive_backend.h
+++ b/src/core/file_sys/archive_backend.h
@@ -39,7 +39,7 @@ public:
     Path() : type(LowPathType::Invalid) {}
     Path(const char* path) : type(LowPathType::Char), string(path) {}
     Path(std::vector<u8> binary_data) : type(LowPathType::Binary), binary(std::move(binary_data)) {}
-    Path(LowPathType type, u32 size, u32 pointer);
+    Path(LowPathType type, const std::vector<u8>& data);
 
     LowPathType GetType() const {
         return type;

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -534,8 +534,9 @@ ResultVal<FileSys::ArchiveFormatInfo> GetArchiveFormatInfo(ArchiveIdCode id_code
     return archive->second->GetFormatInfo(archive_path);
 }
 
-ResultCode CreateExtSaveData(MediaType media_type, u32 high, u32 low, VAddr icon_buffer,
-                             u32 icon_size, const FileSys::ArchiveFormatInfo& format_info) {
+ResultCode CreateExtSaveData(MediaType media_type, u32 high, u32 low,
+                             const std::vector<u8>& smdh_icon,
+                             const FileSys::ArchiveFormatInfo& format_info) {
     // Construct the binary path to the archive first
     FileSys::Path path =
         FileSys::ConstructExtDataBinaryPath(static_cast<u32>(media_type), high, low);
@@ -553,11 +554,6 @@ ResultCode CreateExtSaveData(MediaType media_type, u32 high, u32 low, VAddr icon
     if (result.IsError())
         return result;
 
-    if (!Memory::IsValidVirtualAddress(icon_buffer))
-        return ResultCode(-1); // TODO(Subv): Find the right error code
-
-    std::vector<u8> smdh_icon(icon_size);
-    Memory::ReadBlock(icon_buffer, smdh_icon.data(), smdh_icon.size());
     ext_savedata->WriteIcon(path, smdh_icon.data(), smdh_icon.size());
     return RESULT_SUCCESS;
 }
@@ -690,9 +686,6 @@ void UnregisterArchiveTypes() {
 /// Initialize archives
 void ArchiveInit() {
     next_handle = 1;
-
-    AddService(new FS::Interface);
-
     RegisterArchiveTypes();
 }
 

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -39,23 +39,6 @@
 #include "core/hle/service/service.h"
 #include "core/memory.h"
 
-// Specializes std::hash for ArchiveIdCode, so that we can use it in std::unordered_map.
-// Workaroung for libstdc++ bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=60970
-namespace std {
-template <>
-struct hash<Service::FS::ArchiveIdCode> {
-    typedef Service::FS::ArchiveIdCode argument_type;
-    typedef std::size_t result_type;
-
-    result_type operator()(const argument_type& id_code) const {
-        typedef std::underlying_type<argument_type>::type Type;
-        return std::hash<Type>()(static_cast<Type>(id_code));
-    }
-};
-} // namespace std
-
-static constexpr Kernel::Handle INVALID_HANDLE{};
-
 namespace Service {
 namespace FS {
 

--- a/src/core/hle/service/fs/archive.h
+++ b/src/core/hle/service/fs/archive.h
@@ -248,13 +248,13 @@ ResultVal<FileSys::ArchiveFormatInfo> GetArchiveFormatInfo(ArchiveIdCode id_code
  * @param media_type The media type of the archive to create (NAND / SDMC)
  * @param high The high word of the extdata id to create
  * @param low The low word of the extdata id to create
- * @param icon_buffer VAddr of the SMDH icon for this ExtSaveData
- * @param icon_size Size of the SMDH icon
+ * @param smdh_icon the SMDH icon for this ExtSaveData
  * @param format_info Format information about the new archive
  * @return ResultCode 0 on success or the corresponding code on error
  */
-ResultCode CreateExtSaveData(MediaType media_type, u32 high, u32 low, VAddr icon_buffer,
-                             u32 icon_size, const FileSys::ArchiveFormatInfo& format_info);
+ResultCode CreateExtSaveData(MediaType media_type, u32 high, u32 low,
+                             const std::vector<u8>& smdh_icon,
+                             const FileSys::ArchiveFormatInfo& format_info);
 
 /**
  * Deletes the SharedExtSaveData archive for the specified extdata ID

--- a/src/core/hle/service/fs/archive.h
+++ b/src/core/hle/service/fs/archive.h
@@ -87,7 +87,7 @@ private:
     void OpenSubFile(Kernel::HLERequestContext& ctx);
 };
 
-class Directory final : public Kernel::SessionRequestHandler {
+class Directory final : public ServiceFramework<Directory> {
 public:
     Directory(std::unique_ptr<FileSys::DirectoryBackend>&& backend, const FileSys::Path& path);
     ~Directory();
@@ -100,11 +100,8 @@ public:
     std::unique_ptr<FileSys::DirectoryBackend> backend; ///< File backend interface
 
 protected:
-    void HandleSyncRequest(Kernel::SharedPtr<Kernel::ServerSession> server_session) override;
-
-    std::unique_ptr<SessionDataBase> MakeSessionData() const override {
-        return nullptr;
-    }
+    void Read(Kernel::HLERequestContext& ctx);
+    void Close(Kernel::HLERequestContext& ctx);
 };
 
 /**

--- a/src/core/hle/service/fs/fs_user.cpp
+++ b/src/core/hle/service/fs/fs_user.cpp
@@ -37,7 +37,7 @@ void FS_USER::Initialize(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x0801, 0, 2);
     rp.PopPID();
 
-    IPC::RequestBuilder rb = rp.MakeBuilder(0, 1);
+    IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     rb.Push(RESULT_SUCCESS);
 }
 

--- a/src/core/hle/service/fs/fs_user.cpp
+++ b/src/core/hle/service/fs/fs_user.cpp
@@ -693,7 +693,7 @@ void FS_USER::GetSaveDataSecureValue(Kernel::HLERequestContext& ctx) {
     rb.Push<u64>(0);      // the secure value
 }
 
-FS_USER::FS_USER() : ServiceFramework("fs:USER", 10 /*?*/) {
+FS_USER::FS_USER() : ServiceFramework("fs:USER", 30) {
     static const FunctionInfo functions[] = {
         {0x000100C6, nullptr, "Dummy1"},
         {0x040100C4, nullptr, "Control"},

--- a/src/core/hle/service/fs/fs_user.h
+++ b/src/core/hle/service/fs/fs_user.h
@@ -13,6 +13,7 @@ namespace FS {
 class FS_USER final : public ServiceFramework<FS_USER> {
 public:
     FS_USER();
+
 private:
     void Initialize(Kernel::HLERequestContext& ctx);
 
@@ -58,6 +59,7 @@ private:
     /*
      * FS_User::DeleteFile service function
      *  Inputs:
+     *      1 : Transaction
      *      2 : Archive handle lower word
      *      3 : Archive handle upper word
      *      4 : File path string type
@@ -71,6 +73,7 @@ private:
     /*
      * FS_User::RenameFile service function
      *  Inputs:
+     *      1 : Transaction
      *      2 : Source archive handle lower word
      *      3 : Source archive handle upper word
      *      4 : Source file path type
@@ -89,6 +92,7 @@ private:
     /*
      * FS_User::DeleteDirectory service function
      *  Inputs:
+     *      1 : Transaction
      *      2 : Archive handle lower word
      *      3 : Archive handle upper word
      *      4 : Directory path string type
@@ -118,6 +122,7 @@ private:
      * FS_User::CreateFile service function
      *  Inputs:
      *      0 : Command header 0x08080202
+     *      1 : Transaction
      *      2 : Archive handle lower word
      *      3 : Archive handle upper word
      *      4 : File path string type
@@ -133,10 +138,12 @@ private:
     /*
      * FS_User::CreateDirectory service function
      *  Inputs:
+     *      1 : Transaction
      *      2 : Archive handle lower word
      *      3 : Archive handle upper word
      *      4 : Directory path string type
      *      5 : Directory path string size
+     *      6 : Directory attributes
      *      8 : Directory path string data
      *  Outputs:
      *      1 : Result of function, 0 on success, otherwise error code
@@ -146,6 +153,7 @@ private:
     /*
      * FS_User::RenameDirectory service function
      *  Inputs:
+     *      1 : Transaction
      *      2 : Source archive handle lower word
      *      3 : Source archive handle upper word
      *      4 : Source dir path type
@@ -198,7 +206,7 @@ private:
      *      1 : Archive handle low word
      *      2 : Archive handle high word
      *  Outputs:
-     *      0 : ??? TODO(yuriks): Verify return header
+     *      0 : 0x080E0040
      *      1 : Result of function, 0 on success, otherwise error code
      */
     void CloseArchive(Kernel::HLERequestContext& ctx);
@@ -214,7 +222,7 @@ private:
     /**
      * FS_User::IsSdmcWriteable service function
      *  Outputs:
-     *      0 : Command header 0x08180000
+     *      0 : Command header 0x08180080
      *      1 : Result of function, 0 on success, otherwise error code
      *      2 : Whether the Sdmc is currently writeable
      */
@@ -244,7 +252,7 @@ private:
     /**
      * FS_User::FormatThisUserSaveData service function
      *  Inputs:
-     *      0: 0x080F0180
+     *      0  : 0x080F0180
      *      1  : Size in Blocks (1 block = 512 bytes)
      *      2  : Number of directories
      *      3  : Number of files

--- a/src/core/hle/service/fs/fs_user.h
+++ b/src/core/hle/service/fs/fs_user.h
@@ -4,20 +4,485 @@
 
 #pragma once
 
+#include "common/common_types.h"
 #include "core/hle/service/service.h"
 
 namespace Service {
 namespace FS {
 
-/// Interface to "fs:USER" service
-class Interface : public Service::Interface {
+class FS_USER final : public ServiceFramework<FS_USER> {
 public:
-    Interface();
+    FS_USER();
+private:
+    void Initialize(Kernel::HLERequestContext& ctx);
 
-    std::string GetPortName() const override {
-        return "fs:USER";
-    }
+    /**
+     * FS_User::OpenFile service function
+     *  Inputs:
+     *      1 : Transaction
+     *      2 : Archive handle lower word
+     *      3 : Archive handle upper word
+     *      4 : Low path type
+     *      5 : Low path size
+     *      6 : Open flags
+     *      7 : Attributes
+     *      8 : (LowPathSize << 14) | 2
+     *      9 : Low path data pointer
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     *      3 : File handle
+     */
+    void OpenFile(Kernel::HLERequestContext& ctx);
+
+    /**
+     * FS_User::OpenFileDirectly service function
+     *  Inputs:
+     *      1 : Transaction
+     *      2 : Archive ID
+     *      3 : Archive low path type
+     *      4 : Archive low path size
+     *      5 : File low path type
+     *      6 : File low path size
+     *      7 : Flags
+     *      8 : Attributes
+     *      9 : (ArchiveLowPathSize << 14) | 0x802
+     *      10 : Archive low path
+     *      11 : (FileLowPathSize << 14) | 2
+     *      12 : File low path
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     *      3 : File handle
+     */
+    void OpenFileDirectly(Kernel::HLERequestContext& ctx);
+
+    /*
+     * FS_User::DeleteFile service function
+     *  Inputs:
+     *      2 : Archive handle lower word
+     *      3 : Archive handle upper word
+     *      4 : File path string type
+     *      5 : File path string size
+     *      7 : File path string data
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void DeleteFile(Kernel::HLERequestContext& ctx);
+
+    /*
+     * FS_User::RenameFile service function
+     *  Inputs:
+     *      2 : Source archive handle lower word
+     *      3 : Source archive handle upper word
+     *      4 : Source file path type
+     *      5 : Source file path size
+     *      6 : Dest archive handle lower word
+     *      7 : Dest archive handle upper word
+     *      8 : Dest file path type
+     *      9 : Dest file path size
+     *      11: Source file path string data
+     *      13: Dest file path string
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void RenameFile(Kernel::HLERequestContext& ctx);
+
+    /*
+     * FS_User::DeleteDirectory service function
+     *  Inputs:
+     *      2 : Archive handle lower word
+     *      3 : Archive handle upper word
+     *      4 : Directory path string type
+     *      5 : Directory path string size
+     *      7 : Directory path string data
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void DeleteDirectory(Kernel::HLERequestContext& ctx);
+
+    /*
+     * FS_User::DeleteDirectoryRecursively service function
+     *  Inputs:
+     *      0 : Command header 0x08070142
+     *      1 : Transaction
+     *      2 : Archive handle lower word
+     *      3 : Archive handle upper word
+     *      4 : Directory path string type
+     *      5 : Directory path string size
+     *      7 : Directory path string data
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void DeleteDirectoryRecursively(Kernel::HLERequestContext& ctx);
+
+    /*
+     * FS_User::CreateFile service function
+     *  Inputs:
+     *      0 : Command header 0x08080202
+     *      2 : Archive handle lower word
+     *      3 : Archive handle upper word
+     *      4 : File path string type
+     *      5 : File path string size
+     *      6 : File attributes
+     *      7-8 : File size
+     *      10: File path string data
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void CreateFile(Kernel::HLERequestContext& ctx);
+
+    /*
+     * FS_User::CreateDirectory service function
+     *  Inputs:
+     *      2 : Archive handle lower word
+     *      3 : Archive handle upper word
+     *      4 : Directory path string type
+     *      5 : Directory path string size
+     *      8 : Directory path string data
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void CreateDirectory(Kernel::HLERequestContext& ctx);
+
+    /*
+     * FS_User::RenameDirectory service function
+     *  Inputs:
+     *      2 : Source archive handle lower word
+     *      3 : Source archive handle upper word
+     *      4 : Source dir path type
+     *      5 : Source dir path size
+     *      6 : Dest archive handle lower word
+     *      7 : Dest archive handle upper word
+     *      8 : Dest dir path type
+     *      9 : Dest dir path size
+     *      11: Source dir path string data
+     *      13: Dest dir path string
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void RenameDirectory(Kernel::HLERequestContext& ctx);
+
+    /**
+     * FS_User::OpenDirectory service function
+     *  Inputs:
+     *      1 : Archive handle low word
+     *      2 : Archive handle high word
+     *      3 : Low path type
+     *      4 : Low path size
+     *      7 : (LowPathSize << 14) | 2
+     *      8 : Low path data pointer
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     *      3 : Directory handle
+     */
+    void OpenDirectory(Kernel::HLERequestContext& ctx);
+
+    /**
+     * FS_User::OpenArchive service function
+     *  Inputs:
+     *      1 : Archive ID
+     *      2 : Archive low path type
+     *      3 : Archive low path size
+     *      4 : (LowPathSize << 14) | 2
+     *      5 : Archive low path
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     *      2 : Archive handle lower word (unused)
+     *      3 : Archive handle upper word (same as file handle)
+     */
+    void OpenArchive(Kernel::HLERequestContext& ctx);
+
+    /**
+     * FS_User::CloseArchive service function
+     *  Inputs:
+     *      0 : 0x080E0080
+     *      1 : Archive handle low word
+     *      2 : Archive handle high word
+     *  Outputs:
+     *      0 : ??? TODO(yuriks): Verify return header
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void CloseArchive(Kernel::HLERequestContext& ctx);
+
+    /*
+     * FS_User::IsSdmcDetected service function
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     *      2 : Whether the Sdmc could be detected
+     */
+    void IsSdmcDetected(Kernel::HLERequestContext& ctx);
+
+    /**
+     * FS_User::IsSdmcWriteable service function
+     *  Outputs:
+     *      0 : Command header 0x08180000
+     *      1 : Result of function, 0 on success, otherwise error code
+     *      2 : Whether the Sdmc is currently writeable
+     */
+    void IsSdmcWriteable(Kernel::HLERequestContext& ctx);
+
+    /**
+     * FS_User::FormatSaveData service function,
+     * formats the SaveData specified by the input path.
+     *  Inputs:
+     *      0  : 0x084C0242
+     *      1  : Archive ID
+     *      2  : Archive path type
+     *      3  : Archive path size
+     *      4  : Size in Blocks (1 block = 512 bytes)
+     *      5  : Number of directories
+     *      6  : Number of files
+     *      7  : Directory bucket count
+     *      8  : File bucket count
+     *      9  : Duplicate data
+     *      10 : (PathSize << 14) | 2
+     *      11 : Archive low path
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void FormatSaveData(Kernel::HLERequestContext& ctx);
+
+    /**
+     * FS_User::FormatThisUserSaveData service function
+     *  Inputs:
+     *      0: 0x080F0180
+     *      1  : Size in Blocks (1 block = 512 bytes)
+     *      2  : Number of directories
+     *      3  : Number of files
+     *      4  : Directory bucket count
+     *      5  : File bucket count
+     *      6  : Duplicate data
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void FormatThisUserSaveData(Kernel::HLERequestContext& ctx);
+
+    /**
+     * FS_User::GetFreeBytes service function
+     *  Inputs:
+     *      0: 0x08120080
+     *      1: Archive handle low word
+     *      2: Archive handle high word
+     *  Outputs:
+     *      1: Result of function, 0 on success, otherwise error code
+     *      2: Free byte count low word
+     *      3: Free byte count high word
+     */
+    void GetFreeBytes(Kernel::HLERequestContext& ctx);
+
+    /**
+     * FS_User::CreateExtSaveData service function
+     *  Inputs:
+     *      0 : 0x08510242
+     *      1 : Media type (NAND / SDMC)
+     *      2 : Low word of the saveid to create
+     *      3 : High word of the saveid to create
+     *      4 : Unknown
+     *      5 : Number of directories
+     *      6 : Number of files
+     *      7-8 : Size limit
+     *      9 : Size of the SMDH icon
+     *      10: (SMDH Size << 4) | 0x0000000A
+     *      11: Pointer to the SMDH icon for the new ExtSaveData
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void CreateExtSaveData(Kernel::HLERequestContext& ctx);
+
+    /**
+     * FS_User::DeleteExtSaveData service function
+     *  Inputs:
+     *      0 : 0x08520100
+     *      1 : Media type (NAND / SDMC)
+     *      2 : Low word of the saveid to create
+     *      3 : High word of the saveid to create
+     *      4 : Unknown
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void DeleteExtSaveData(Kernel::HLERequestContext& ctx);
+
+    /**
+     * FS_User::CardSlotIsInserted service function.
+     *  Inputs:
+     *      0 : 0x08210000
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     *      2 : Whether there is a game card inserted into the slot or not.
+     */
+    void CardSlotIsInserted(Kernel::HLERequestContext& ctx);
+
+    /**
+     * FS_User::DeleteSystemSaveData service function.
+     *  Inputs:
+     *      0 : 0x08570080
+     *      1 : High word of the SystemSaveData id to delete
+     *      2 : Low word of the SystemSaveData id to delete
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void DeleteSystemSaveData(Kernel::HLERequestContext& ctx);
+
+    /**
+     * FS_User::CreateSystemSaveData service function.
+     *  Inputs:
+     *      0 : 0x08560240
+     *      1 : u8 MediaType of the system save data
+     *      2 : SystemSaveData id to create
+     *      3 : Total size
+     *      4 : Block size
+     *      5 : Number of directories
+     *      6 : Number of files
+     *      7 : Directory bucket count
+     *      8 : File bucket count
+     *      9 : u8 Whether to duplicate data or not
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void CreateSystemSaveData(Kernel::HLERequestContext& ctx);
+
+    /**
+     * FS_User::CreateLegacySystemSaveData service function.
+     *  This function appears to be obsolete and seems to have been replaced by
+     *  command 0x08560240 (CreateSystemSaveData).
+     *
+     *  Inputs:
+     *      0 : 0x08100200
+     *      1 : SystemSaveData id to create
+     *      2 : Total size
+     *      3 : Block size
+     *      4 : Number of directories
+     *      5 : Number of files
+     *      6 : Directory bucket count
+     *      7 : File bucket count
+     *      8 : u8 Duplicate data
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void CreateLegacySystemSaveData(Kernel::HLERequestContext& ctx);
+
+    /**
+     * FS_User::InitializeWithSdkVersion service function.
+     *  Inputs:
+     *      0 : 0x08610042
+     *      1 : Used SDK Version
+     *      2 : ProcessId Header
+     *      3 : placeholder for ProcessId
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void InitializeWithSdkVersion(Kernel::HLERequestContext& ctx);
+
+    /**
+     * FS_User::SetPriority service function.
+     *  Inputs:
+     *      0 : 0x08620040
+     *      1 : priority
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void SetPriority(Kernel::HLERequestContext& ctx);
+
+    /**
+     * FS_User::GetPriority service function.
+     *  Inputs:
+     *      0 : 0x08630000
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     *      2 : priority
+     */
+    void GetPriority(Kernel::HLERequestContext& ctx);
+
+    /**
+     * FS_User::GetArchiveResource service function.
+     *  Inputs:
+     *      0 : 0x08490040
+     *      1 : Media type
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     *      2 : Sector byte-size
+     *      3 : Cluster byte-size
+     *      4 : Partition capacity in clusters
+     *      5 : Available free space in clusters
+     */
+    void GetArchiveResource(Kernel::HLERequestContext& ctx);
+
+    /**
+     * FS_User::GetFormatInfo service function.
+     *  Inputs:
+     *      0 : 0x084500C2
+     *      1 : Archive ID
+     *      2 : Archive path type
+     *      3 : Archive path size
+     *      4 : (PathSize << 14) | 2
+     *      5 : Archive low path
+     *  Outputs:
+     *      0 : 0x08450140
+     *      1 : Result of function, 0 on success, otherwise error code
+     *      2 : Total size
+     *      3 : Number of directories
+     *      4 : Number of files
+     *      5 : Duplicate data
+     */
+    void GetFormatInfo(Kernel::HLERequestContext& ctx);
+
+    /**
+     * FS_User::GetProgramLaunchInfo service function.
+     *  Inputs:
+     *      0 : 0x082F0040
+     *      1 : Process ID
+     *  Outputs:
+     *      0 : 0x082F0140
+     *      1 : Result of function, 0 on success, otherwise error code
+     *      2-3 : Program ID
+     *      4 : Media type
+     *      5 : Unknown
+     */
+    void GetProgramLaunchInfo(Kernel::HLERequestContext& ctx);
+
+    /**
+     * FS_User::GetNumSeeds service function.
+     *  Inputs:
+     *      0 : 0x087D0000
+     *  Outputs:
+     *      0 : 0x087D0080
+     *      1 : Result of function, 0 on success, otherwise error code
+     *      2 : Number of seeds in the SEEDDB
+     */
+    void GetNumSeeds(Kernel::HLERequestContext& ctx);
+
+    /**
+     * FS_User::SetSaveDataSecureValue service function.
+     *  Inputs:
+     *      0 : 0x08650140
+     *      1-2 : Secure Value
+     *      3 : Secure Value Slot
+     *      4 : Title Id
+     *      5 : Title Variation
+     *  Outputs:
+     *      0 : 0x08650140
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void SetSaveDataSecureValue(Kernel::HLERequestContext& ctx);
+
+    /**
+     * FS_User::GetSaveDataSecureValue service function.
+     *  Inputs:
+     *      0 : 0x086600C0
+     *      1 : Secure Value Slot
+     *      2 : Title Id
+     *      3 : Title Variation
+     *  Outputs:
+     *      0 : 0x086600C0
+     *      1 : Result of function, 0 on success, otherwise error code
+     *      2 : If Secure Value doesn't exist, 0, if it exists, 1
+     *      3-4 : Secure Value
+     */
+    void GetSaveDataSecureValue(Kernel::HLERequestContext& ctx);
+
+    u32 priority = -1; ///< For SetPriority and GetPriority service functions
 };
+
+void InstallInterfaces(SM::ServiceManager& service_manager);
 
 } // namespace FS
 } // namespace Service

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -27,6 +27,7 @@
 #include "core/hle/service/err_f.h"
 #include "core/hle/service/frd/frd.h"
 #include "core/hle/service/fs/archive.h"
+#include "core/hle/service/fs/fs_user.h"
 #include "core/hle/service/gsp/gsp.h"
 #include "core/hle/service/gsp_lcd.h"
 #include "core/hle/service/hid/hid.h"
@@ -266,6 +267,7 @@ void Init() {
     LDR::InstallInterfaces(*SM::g_service_manager);
     MIC::InstallInterfaces(*SM::g_service_manager);
 
+    FS::InstallInterfaces(*SM::g_service_manager);
     FS::ArchiveInit();
     ACT::Init();
     AM::Init();


### PR DESCRIPTION
See commit description for some details.

There are some global state in fs/archive which should be encapsulate in the FS_USER object (or a general FS object), but I didn't touch them in this PR because FS module is depended by many others including PTM, CFG and loader etc, which requires a major refactor. I leave them to a future PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3441)
<!-- Reviewable:end -->
