### PR TITLE
UDS: Add non zero mac address to the shared page

### DIFF
--- a/src/core/hle/service/nwm/nwm.cpp
+++ b/src/core/hle/service/nwm/nwm.cpp
@@ -32,7 +32,7 @@ void Init() {
 
     if (auto room_member = Network::GetRoomMember().lock()) {
         if (room_member->IsConnected()) {
-            mac = static_cast<SharedPage::MacAddress>(room_member->GetMacAddress());
+            mac = room_member->GetMacAddress();
         }
     }
     SharedPage::SetMacAddress(mac);

--- a/src/core/hle/service/nwm/nwm.cpp
+++ b/src/core/hle/service/nwm/nwm.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <random>
 #include "core/hle/service/nwm/nwm.h"
 #include "core/hle/service/nwm/nwm_cec.h"
 #include "core/hle/service/nwm/nwm_ext.h"
@@ -10,6 +11,8 @@
 #include "core/hle/service/nwm/nwm_soc.h"
 #include "core/hle/service/nwm/nwm_tst.h"
 #include "core/hle/service/nwm/nwm_uds.h"
+#include "core/hle/shared_page.h"
+#include "network/network.h"
 
 namespace Service {
 namespace NWM {
@@ -21,6 +24,21 @@ void Init() {
     AddService(new NWM_SAP);
     AddService(new NWM_SOC);
     AddService(new NWM_TST);
+
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<> dis(0, std::numeric_limits<u8>::max());
+    auto mac = SharedPage::DefaultMac;
+    for (int i = 3; i < sizeof(SharedPage::MacAddress); ++i) {
+        mac[i] = static_cast<u8>(dis(gen));
+    }
+    if (auto room_member = Network::GetRoomMember().lock()) {
+        if (room_member->IsConnected()) {
+            mac = static_cast<SharedPage::MacAddress>(room_member->GetMacAddress());
+        }
+    }
+    SharedPage::SetMacAddress(mac);
+    SharedPage::SetWifiLinkLevel(SharedPage::WifiLinkLevel::BEST);
 }
 
 void InstallInterfaces(SM::ServiceManager& service_manager) {

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -554,9 +554,8 @@ void NWM_UDS::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS);
     rb.PushMappedBuffer(out_buffer);
 
-    LOG_DEBUG(Service_NWM,
-              "called out_buffer_size=0x%08X, wlan_comm_id=0x%08X, id=0x%08X,"
-              "unk1=0x%08X, unk2=0x%08X, offset=%zu",
+    LOG_DEBUG(Service_NWM, "called out_buffer_size=0x%08X, wlan_comm_id=0x%08X, id=0x%08X,"
+                           "unk1=0x%08X, unk2=0x%08X, offset=%zu",
               out_buffer_size, wlan_comm_id, id, unk1, unk2, cur_buffer_size);
 }
 

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -23,6 +23,7 @@
 #include "core/hle/service/nwm/uds_beacon.h"
 #include "core/hle/service/nwm/uds_connection.h"
 #include "core/hle/service/nwm/uds_data.h"
+#include "core/hle/shared_page.h"
 #include "core/memory.h"
 #include "network/network.h"
 
@@ -590,6 +591,12 @@ void NWM_UDS::InitializeWithVersion(Kernel::HLERequestContext& ctx) {
         connection_status.status = static_cast<u32>(NetworkStatus::NotConnected);
         node_info.clear();
         node_info.push_back(current_node);
+    }
+
+    if (auto room_member = Network::GetRoomMember().lock()) {
+        if (room_member->IsConnected()) {
+            SharedPage::SetMacAddress(static_cast<SharedPage::MacAddress>(room_member->GetMacAddress()));
+        }
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -23,7 +23,6 @@
 #include "core/hle/service/nwm/uds_beacon.h"
 #include "core/hle/service/nwm/uds_connection.h"
 #include "core/hle/service/nwm/uds_data.h"
-#include "core/hle/shared_page.h"
 #include "core/memory.h"
 #include "network/network.h"
 
@@ -555,8 +554,9 @@ void NWM_UDS::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS);
     rb.PushMappedBuffer(out_buffer);
 
-    LOG_DEBUG(Service_NWM, "called out_buffer_size=0x%08X, wlan_comm_id=0x%08X, id=0x%08X,"
-                           "unk1=0x%08X, unk2=0x%08X, offset=%zu",
+    LOG_DEBUG(Service_NWM,
+              "called out_buffer_size=0x%08X, wlan_comm_id=0x%08X, id=0x%08X,"
+              "unk1=0x%08X, unk2=0x%08X, offset=%zu",
               out_buffer_size, wlan_comm_id, id, unk1, unk2, cur_buffer_size);
 }
 

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -593,12 +593,6 @@ void NWM_UDS::InitializeWithVersion(Kernel::HLERequestContext& ctx) {
         node_info.push_back(current_node);
     }
 
-    if (auto room_member = Network::GetRoomMember().lock()) {
-        if (room_member->IsConnected()) {
-            SharedPage::SetMacAddress(static_cast<SharedPage::MacAddress>(room_member->GetMacAddress()));
-        }
-    }
-
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
     rb.Push(RESULT_SUCCESS);
     rb.PushCopyObjects(connection_status_event);

--- a/src/core/hle/shared_page.cpp
+++ b/src/core/hle/shared_page.cpp
@@ -83,6 +83,17 @@ void Init() {
     update_time_event =
         CoreTiming::RegisterEvent("SharedPage::UpdateTimeCallback", UpdateTimeCallback);
     CoreTiming::ScheduleEvent(0, update_time_event);
+
+    SetWifiLinkLevel(WifiLinkLevel::POOR);
+    SetMacAddress(DefaultMac);
+}
+
+void SetMacAddress(const MacAddress& addr) {
+    std::memcpy(shared_page.wifi_macaddr, addr.data(), sizeof(MacAddress));
+}
+
+void SetWifiLinkLevel(WifiLinkLevel level) {
+    shared_page.wifi_link_level = static_cast<u8>(level);
 }
 
 } // namespace

--- a/src/core/hle/shared_page.cpp
+++ b/src/core/hle/shared_page.cpp
@@ -83,9 +83,6 @@ void Init() {
     update_time_event =
         CoreTiming::RegisterEvent("SharedPage::UpdateTimeCallback", UpdateTimeCallback);
     CoreTiming::ScheduleEvent(0, update_time_event);
-
-    SetWifiLinkLevel(WifiLinkLevel::POOR);
-    SetMacAddress(DefaultMac);
 }
 
 void SetMacAddress(const MacAddress& addr) {
@@ -96,4 +93,4 @@ void SetWifiLinkLevel(WifiLinkLevel level) {
     shared_page.wifi_link_level = static_cast<u8>(level);
 }
 
-} // namespace
+} // namespace SharedPage

--- a/src/core/hle/shared_page.h
+++ b/src/core/hle/shared_page.h
@@ -37,6 +37,17 @@ union BatteryState {
     BitField<2, 3, u8> charge_level;
 };
 
+using MacAddress = std::array<u8, 6>;
+
+// Default MAC address in the nintendo 3ds range
+constexpr MacAddress DefaultMac = { 0x40, 0xF4, 0x07, 0x00, 0x00, 0x00 };
+
+enum class WifiLinkLevel : u8 {
+    POOR = 0,
+    GOOD = 1,
+    BEST = 2,
+};
+
 struct SharedPageDef {
     // Most of these names are taken from the 3dbrew page linked above.
     u32_le date_time_counter; // 0
@@ -65,5 +76,9 @@ static_assert(sizeof(SharedPageDef) == Memory::SHARED_PAGE_SIZE,
 extern SharedPageDef shared_page;
 
 void Init();
+
+void SetMacAddress(const MacAddress&);
+
+void SetWifiLinkLevel(WifiLinkLevel);
 
 } // namespace

--- a/src/core/hle/shared_page.h
+++ b/src/core/hle/shared_page.h
@@ -39,13 +39,14 @@ union BatteryState {
 
 using MacAddress = std::array<u8, 6>;
 
-// Default MAC address in the nintendo 3ds range
-constexpr MacAddress DefaultMac = { 0x40, 0xF4, 0x07, 0x00, 0x00, 0x00 };
+// Default MAC address in the Nintendo 3DS range
+constexpr MacAddress DefaultMac = {0x40, 0xF4, 0x07, 0x00, 0x00, 0x00};
 
 enum class WifiLinkLevel : u8 {
-    POOR = 0,
-    GOOD = 1,
-    BEST = 2,
+    OFF = 0,
+    POOR = 1,
+    GOOD = 2,
+    BEST = 3,
 };
 
 struct SharedPageDef {
@@ -81,4 +82,4 @@ void SetMacAddress(const MacAddress&);
 
 void SetWifiLinkLevel(WifiLinkLevel);
 
-} // namespace
+} // namespace SharedPage


### PR DESCRIPTION
Apparently several games check the shared page mac address and wifi
link level values, and will refuse to start UDS if they are not correct.
This change gives a default value (in case you aren't connected to a
network) and will read the value from Room if you are connected.

This pr is known to fix Tri Force Heroes multiplayer. Please test other games that used to have the "Cannot connect" issue when starting a lobby, and report success here. Some games that I know are on that list are:  Mario Party Star Rush, The Legend of Zelda: TriForce Heroes, Monster Hunter Generations, Monster Hunter X, Monster Hunter XX, Dragon Quest Monsters: Terry, PokemonXY, and VirtualConsole games (such as pokemon red/blue/gold/silver)

clang format will likely bark at me.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3444)
<!-- Reviewable:end -->
