### PR TITLE
APT: don't skip translation parameters

### DIFF
--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -202,7 +202,8 @@ void Module::Interface::GetSharedFont(Kernel::HLERequestContext& ctx) {
         } else {
             LOG_ERROR(Service_APT, "shared font file missing - go dump it from your 3ds");
             rb.Push<u32>(-1); // TODO: Find the right error code
-            rb.Skip(1 + 2, true);
+            rb.Push<u32>(0);
+            rb.PushCopyObjects<Kernel::Object>(nullptr);
             Core::System::GetInstance().SetStatus(Core::System::ResultStatus::ErrorSharedFont);
             return;
         }


### PR DESCRIPTION
This is a abuse of `Skip` which conflicts with the new hle_ipc framework and which is revealed by #3421 . Currently if the shared font fails to load, hle_ipc will ASSERT on the handle because it is skipped and their is no corresponding objects being send (even though it is just a null object). The object should be send by calling PushCopy/MoveObjects regardless.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3448)
<!-- Reviewable:end -->
