### PR TITLE
Revert "Kernel/Threads: Add a new thread status that will allow using a Kernel::Event to put a guest thread to sleep inside an HLE handler until said event is signaled"

### DIFF
--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -9,7 +9,6 @@
 #include "common/string_util.h"
 #include "core/hle/ipc.h"
 #include "core/hle/kernel/client_port.h"
-#include "core/hle/kernel/event.h"
 #include "core/hle/kernel/process.h"
 #include "core/hle/kernel/server_port.h"
 #include "core/hle/kernel/server_session.h"
@@ -220,47 +219,6 @@ void AddService(Interface* interface_) {
     server_port->SetHleHandler(std::shared_ptr<Interface>(interface_));
 }
 
-bool ThreadContinuationToken::IsValid() {
-    return thread != nullptr && event != nullptr;
-}
-
-ThreadContinuationToken SleepClientThread(const std::string& reason,
-                                          ThreadContinuationToken::Callback callback) {
-    auto thread = Kernel::GetCurrentThread();
-
-    ASSERT(thread->status == THREADSTATUS_RUNNING);
-
-    ThreadContinuationToken token;
-
-    token.event = Kernel::Event::Create(Kernel::ResetType::OneShot, "HLE Pause Event: " + reason);
-    token.thread = thread;
-    token.callback = std::move(callback);
-    token.pause_reason = std::move(reason);
-
-    // Make the thread wait on our newly created event, it will be signaled when
-    // ContinueClientThread is called.
-    thread->status = THREADSTATUS_WAIT_HLE_EVENT;
-    thread->wait_objects = {token.event};
-    token.event->AddWaitingThread(thread);
-
-    return token;
-}
-
-void ContinueClientThread(ThreadContinuationToken& token) {
-    ASSERT_MSG(token.IsValid(), "Invalid continuation token");
-    ASSERT(token.thread->status == THREADSTATUS_WAIT_HLE_EVENT);
-
-    // Signal the event to wake up the thread
-    token.event->Signal();
-    ASSERT(token.thread->status == THREADSTATUS_READY);
-
-    token.callback(token.thread);
-
-    token.event = nullptr;
-    token.thread = nullptr;
-    token.callback = nullptr;
-}
-
 /// Initialize ServiceManager
 void Init() {
     SM::g_service_manager = std::make_shared<SM::ServiceManager>();
@@ -327,4 +285,4 @@ void Shutdown() {
     g_kernel_named_ports.clear();
     LOG_DEBUG(Service, "shutdown OK");
 }
-} // namespace Service
+}

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -285,4 +285,4 @@ void Shutdown() {
     g_kernel_named_ports.clear();
     LOG_DEBUG(Service, "shutdown OK");
 }
-}
+} // namespace Service

--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -20,7 +20,7 @@ namespace Kernel {
 class ClientPort;
 class ServerPort;
 class ServerSession;
-}
+} // namespace Kernel
 
 namespace Service {
 
@@ -275,4 +275,4 @@ void AddNamedPort(std::string name, Kernel::SharedPtr<Kernel::ClientPort> port);
 /// Adds a service to the services table
 void AddService(Interface* interface_);
 
-} // namespace
+} // namespace Service

--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -20,8 +20,7 @@ namespace Kernel {
 class ClientPort;
 class ServerPort;
 class ServerSession;
-class Event;
-} // namespace Kernel
+}
 
 namespace Service {
 
@@ -262,45 +261,6 @@ private:
     }
 };
 
-/*
- * Token representing a pause request for a guest thread from an HLE service function.
- * Using this token a function can put a guest thread to sleep to defer returning a result from
- * SendSyncRequest until an async operation completes on the host. To use it, call SleepClientThread
- * to create a specific continuation token for the current thread, perform your async operation, and
- * then call ContinueClientThread passing in the returned token as a parameter.
- */
-class ThreadContinuationToken {
-public:
-    using Callback = std::function<void(Kernel::SharedPtr<Kernel::Thread> thread)>;
-    friend ThreadContinuationToken SleepClientThread(const std::string& reason, Callback callback);
-    friend void ContinueClientThread(ThreadContinuationToken& token);
-
-    bool IsValid();
-
-private:
-    Kernel::SharedPtr<Kernel::Event> event;
-    Kernel::SharedPtr<Kernel::Thread> thread;
-    Callback callback;
-    std::string pause_reason;
-};
-
-/*
- * Puts the current guest thread to sleep and returns a ThreadContinuationToken to be used with
- * ContinueClientThread.
- * @param reason Reason for pausing the thread, to be used for debugging purposes.
- * @param callback Callback to be invoked when the thread is resumed by ContinueClientThread.
- * @returns ThreadContinuationToken representing the pause request.
- */
-ThreadContinuationToken SleepClientThread(const std::string& reason,
-                                          ThreadContinuationToken::Callback callback);
-
-/*
- * Completes a continuation request and resumes the associated guest thread.
- * This function invalidates the token.
- * @param token The continuation token associated with the continuation request.
- */
-void ContinueClientThread(ThreadContinuationToken& token);
-
 /// Initialize ServiceManager
 void Init();
 
@@ -315,4 +275,4 @@ void AddNamedPort(std::string name, Kernel::SharedPtr<Kernel::ClientPort> port);
 /// Adds a service to the services table
 void AddService(Interface* interface_);
 
-} // namespace Service
+} // namespace


### PR DESCRIPTION
Reverts citra-emu/citra#2968
Deprecated by #3101

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3455)
<!-- Reviewable:end -->
