### PR TITLE
Fix build on OpenBSD

### DIFF
--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -21,6 +21,7 @@ endif()
 
 # libfmt
 add_subdirectory(fmt)
+add_library(fmt::fmt ALIAS fmt)
 
 # getopt
 if (MSVC)

--- a/src/common/swap.h
+++ b/src/common/swap.h
@@ -103,7 +103,19 @@ inline __attribute__((always_inline)) u64 swap64(u64 _data) {
     return __builtin_bswap64(_data);
 }
 #elif defined(__Bitrig__) || defined(__OpenBSD__)
-// swap16, swap32, swap64 are left as is
+// redefine swap16, swap32, swap64 as inline functions
+#undef swap16
+#undef swap32
+#undef swap64
+inline u16 swap16(u16 _data) {
+    return __swap16(_data);
+}
+inline u32 swap32(u32 _data) {
+    return __swap32(_data);
+}
+inline u64 swap64(u64 _data) {
+    return __swap64(_data);
+}
 #elif defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__)
 inline u16 swap16(u16 _data) {
     return bswap16(_data);

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -150,15 +150,15 @@ void ServiceFrameworkBase::ReportUnimplementedFunction(u32* cmd_buf, const Funct
     int num_params = header.normal_params_size + header.translate_params_size;
     std::string function_name = info == nullptr ? fmt::format("{:#08x}", cmd_buf[0]) : info->name;
 
-    fmt::MemoryWriter w;
-    w.write("function '{}': port='{}' cmd_buf={{[0]={:#x}", function_name, service_name,
-            cmd_buf[0]);
+    fmt::memory_buffer buf;
+    fmt::format_to(buf, "function '{}': port='{}' cmd_buf={{[0]={:#x}", function_name, service_name,
+                   cmd_buf[0]);
     for (int i = 1; i <= num_params; ++i) {
-        w.write(", [{}]={:#x}", i, cmd_buf[i]);
+        fmt::format_to(buf, ", [{}]={:#x}", i, cmd_buf[i]);
     }
-    w << '}';
+    buf.push_back('}');
 
-    LOG_ERROR(Service, "unknown / unimplemented %s", w.c_str());
+    LOG_ERROR(Service, "unknown / unimplemented %s", fmt::to_string(buf).c_str());
     // TODO(bunnei): Hack - ignore error
     cmd_buf[1] = 0;
 }

--- a/src/core/hle/service/soc_u.cpp
+++ b/src/core/hle/service/soc_u.cpp
@@ -94,7 +94,9 @@ static const std::unordered_map<int, int> error_map = {{
     {ERRNO(EMFILE), 33},
     {EMLINK, 34},
     {ERRNO(EMSGSIZE), 35},
+#ifdef EMULTIHOP
     {ERRNO(EMULTIHOP), 36},
+#endif
     {ERRNO(ENAMETOOLONG), 37},
     {ERRNO(ENETDOWN), 38},
     {ERRNO(ENETRESET), 39},

--- a/src/web_service/announce_room_json.cpp
+++ b/src/web_service/announce_room_json.cpp
@@ -3,9 +3,9 @@
 // Refer to the license.txt file included.
 
 #include <future>
-#include <json.hpp>
 #include "common/logging/log.h"
 #include "web_service/announce_room_json.h"
+#include "web_service/json.h"
 #include "web_service/web_backend.h"
 
 namespace AnnounceMultiplayerRoom {

--- a/src/web_service/json.h
+++ b/src/web_service/json.h
@@ -1,0 +1,18 @@
+// Copyright 2018 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+// This hack is needed to support json.hpp on platforms where the C++17 stdlib
+// lacks std::string_view. See https://github.com/nlohmann/json/issues/735.
+// clang-format off
+#if !__has_include(<string_view>) && __has_include(<experimental/string_view>)
+# include <experimental/string_view>
+# define string_view experimental::string_view
+# include <json.hpp>
+# undef string_view
+#else
+# include <json.hpp>
+#endif
+// clang-format on

--- a/src/web_service/telemetry_json.h
+++ b/src/web_service/telemetry_json.h
@@ -7,9 +7,9 @@
 #include <array>
 #include <future>
 #include <string>
-#include <json.hpp>
 #include "common/announce_multiplayer_room.h"
 #include "common/telemetry.h"
+#include "web_service/json.h"
 
 namespace WebService {
 

--- a/src/web_service/verify_login.cpp
+++ b/src/web_service/verify_login.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <json.hpp>
+#include "web_service/json.h"
 #include "web_service/verify_login.h"
 #include "web_service/web_backend.h"
 


### PR DESCRIPTION
Refer to the commit messages for details.

The first (fix swap functions on Bitrig and OpenBSD) and last (use std::experimental::string_view in json) changes are particularly hacky, but unless the project is willing to rename the entire Common::swap* function family, I can't think of a better way to do the former. The latter can just be dropped if it's viewed as too hacky; it's understandable if the project doesn't want to cater to incomplete c++17 stdlib implementations.

With these changes, citra compiles on OpenBSD with the following commands:
```
mkdir build && cd build
export Qt5_DIR=/usr/local/lib/qt5/cmake/Qt5
cmake \
    -DCMAKE_CXX_FLAGS='-I/usr/local/include -O2' \
    -DCMAKE_EXE_LINKER_FLAGS=-zwxneeded \
    -DUSE_SYSTEM_CURL=1 ..
make
```

As an aside, I noticed that compiling with `-DCMAKE_BUILD_TYPE=Release` produces a very slow build on OpenBSD; is this a symptom of the default compiler being Clang? I have to compile with `-O` manually set to >=2 to get playable games.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3456)
<!-- Reviewable:end -->
