### PR TITLE
GSP_GPU: Release the GPU right if the active session closes the gpu session

### DIFF
--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -52,14 +52,14 @@ public:
      * associated ServerSession alive for the duration of the connection.
      * @param server_session Owning pointer to the ServerSession associated with the connection.
      */
-    void ClientConnected(SharedPtr<ServerSession> server_session);
+    virtual void ClientConnected(SharedPtr<ServerSession> server_session);
 
     /**
      * Signals that a client has just disconnected from this HLE handler and releases the
      * associated ServerSession.
      * @param server_session ServerSession associated with the connection.
      */
-    void ClientDisconnected(SharedPtr<ServerSession> server_session);
+    virtual void ClientDisconnected(SharedPtr<ServerSession> server_session);
 
     /// Empty placeholder structure for services with no per-session data. The session data classes
     /// in each service must inherit from this.

--- a/src/core/hle/service/gsp/gsp_gpu.h
+++ b/src/core/hle/service/gsp/gsp_gpu.h
@@ -196,6 +196,8 @@ public:
     GSP_GPU();
     ~GSP_GPU() = default;
 
+    void ClientDisconnected(Kernel::SharedPtr<Kernel::ServerSession> server_session) override;
+
     /**
      * Signals that the specified interrupt type has occurred to userland code
      * @param interrupt_id ID of interrupt that is being signalled
@@ -333,6 +335,12 @@ private:
      *      1: Result code
      */
     void ReleaseRight(Kernel::HLERequestContext& ctx);
+
+    /**
+     * Releases rights to the GPU.
+     * Will fail if the session_data doesn't have the GPU right
+     */
+    void ReleaseRight(SessionData* session_data);
 
     /**
      * GSP_GPU::ImportDisplayCaptureInfo service function


### PR DESCRIPTION
This was HW tested behavior

To enabled service specific behavior on closing the session the according SessionRequestHandler::ClientDisconnected had to be virtual.
Since SessionRequestHandler is just an interface and out of consistency I decided to make the ClientConnected virtual too. It isn't needed atm, but we might reach a point where it is useful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3461)
<!-- Reviewable:end -->
