### PR TITLE
Remove PICA image dumping, burn libpng

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,11 +166,6 @@ set_property(DIRECTORY APPEND PROPERTY
 # System imported libraries
 # ======================
 
-find_package(PNG QUIET)
-if (NOT PNG_FOUND)
-    message(STATUS "libpng not found. Some debugging features have been disabled.")
-endif()
-
 find_package(Boost 1.63.0 QUIET)
 if (NOT Boost_FOUND)
     message(STATUS "Boost 1.63.0 or newer not found, falling back to externals")

--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -86,8 +86,3 @@ target_link_libraries(video_core PRIVATE glad nihstro-headers)
 if (ARCHITECTURE_x86_64)
     target_link_libraries(video_core PUBLIC xbyak)
 endif()
-
-if (PNG_FOUND)
-    target_link_libraries(video_core PRIVATE PNG::PNG)
-    target_compile_definitions(video_core PRIVATE HAVE_PNG)
-endif()

--- a/src/video_core/debug_utils/debug_utils.h
+++ b/src/video_core/debug_utils/debug_utils.h
@@ -207,8 +207,6 @@ inline bool IsPicaTracing() {
 void OnPicaRegWrite(PicaTrace::Write write);
 std::unique_ptr<PicaTrace> FinishPicaTracing();
 
-void DumpTexture(const TexturingRegs::TextureConfig& texture_config, u8* data);
-
 std::string GetTevStageConfigColorCombinerString(const TexturingRegs::TevStageConfig& tev_stage);
 std::string GetTevStageConfigAlphaCombinerString(const TexturingRegs::TevStageConfig& tev_stage);
 

--- a/src/video_core/debug_utils/debug_utils.h
+++ b/src/video_core/debug_utils/debug_utils.h
@@ -181,7 +181,6 @@ extern std::shared_ptr<DebugContext> g_debug_context; // TODO: Get rid of this g
 
 namespace DebugUtils {
 
-#define PICA_DUMP_TEXTURES 0
 #define PICA_LOG_TEV 0
 
 void DumpShader(const std::string& filename, const ShaderRegs& config,

--- a/src/video_core/swrasterizer/rasterizer.cpp
+++ b/src/video_core/swrasterizer/rasterizer.cpp
@@ -393,9 +393,6 @@ static void ProcessTriangleInternal(const Vertex& v0, const Vertex& v1, const Ve
 
                     // TODO: Apply the min and mag filters to the texture
                     texture_color[i] = Texture::LookupTexture(texture_data, s, t, info);
-#if PICA_DUMP_TEXTURES
-                    DebugUtils::DumpTexture(texture.config, texture_data);
-#endif
                 }
             }
 


### PR DESCRIPTION
Backport from LibRetro.

Libpng is only currently used in [one place in Citra](https://github.com/citra-emu/citra/blob/443bb3d522916f9be2d27fc8b3d7b5cc942213df/src/video_core/debug_utils/debug_utils.cpp#L322), which is [never reached by code ordinarily](https://github.com/citra-emu/citra/blob/ae7240a2cb6ebcf703df52f086d57a26551e4761/src/video_core/swrasterizer/rasterizer.cpp#L397) as PICA_DUMP_TEXTURES is [disabled](https://github.com/citra-emu/citra/blob/0cb52ee74a8255eb0320c882bc9e70700317d16a/src/video_core/debug_utils/debug_utils.h#L184). It is a dependency which is generally hard to bring around and literally doesn't add any functionality to regular, release Citra builds at all.

This PR disables libpng integration by default, and gates it behind a CMake option. It should be trivial for developers to enable it on a case by case basis.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3478)
<!-- Reviewable:end -->
