### PR TITLE
NWM_UDS:: Check flags in SendTo

### DIFF
--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -937,8 +937,20 @@ void NWM_UDS::SendTo(Kernel::HLERequestContext& ctx) {
         dest_address = Network::BroadcastMac;
     } else {
         if (connection_status.status == static_cast<u32>(NetworkStatus::ConnectedAsHost)) {
-            ASSERT_MSG(false, "Direct messages from the host to one client aren't implemented yet");
+            // Send from host to specific client
+            auto destination =
+                std::find_if(node_map.begin(), node_map.end(), [dest_node_id](const auto& node) {
+                    return node.second == dest_node_id;
+                });
+            if (destination != node_map.end()) {
+                rb.Push(ResultCode(ErrorDescription::NotFound, ErrorModule::UDS,
+                                   ErrorSummary::WrongArgument, ErrorLevel::Status));
+                return;
+            }
+            dest_address = destination->first;
         } else if (dest_node_id != 0) {
+            // TODO(B3N30): Find a way to store the mac address together with the node id on the clients
+            // if necessary
             ASSERT_MSG(
                 false,
                 "Direct messages from the one client to another client aren't implemented yet");

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -926,7 +926,27 @@ void NWM_UDS::SendTo(Kernel::HLERequestContext& ctx) {
         return;
     }
 
-    // TODO(B3N30): Do something with the flags.
+    Network::MacAddress dest_address;
+
+    if (!(flags & 0x1) || (flags >> 2)) {
+        LOG_ERROR(Service_NWM, "Unexpected flags 0x%08X", flags);
+    }
+
+    if (flags & (0x1 << 1)) {
+        // Broadcast and don't listen to the dest node id
+        dest_address = Network::BroadcastMac;
+    } else {
+        if (connection_status.status == static_cast<u32>(NetworkStatus::ConnectedAsHost)) {
+            ASSERT_MSG(false, "Direct messages from the host to one client aren't implemented yet");
+        } else if (dest_node_id != 0) {
+            ASSERT_MSG(
+                false,
+                "Direct messages from the one client to another client aren't implemented yet");
+        } else {
+            // Send message to host
+            dest_address = network_info.host_mac_address;
+        }
+    }
 
     constexpr size_t MaxSize = 0x5C6;
     if (data_size > MaxSize) {
@@ -945,12 +965,8 @@ void NWM_UDS::SendTo(Kernel::HLERequestContext& ctx) {
     // and encapsulate the payload.
 
     Network::WifiPacket packet;
-    // Data frames are sent to the host, who then decides where to route it to. If we're the host,
-    // just directly broadcast the frame.
-    if (connection_status.status == static_cast<u32>(NetworkStatus::ConnectedAsHost))
-        packet.destination_address = Network::BroadcastMac;
-    else
-        packet.destination_address = network_info.host_mac_address;
+
+    packet.destination_address = dest_address;
     packet.channel = network_channel;
     packet.data = std::move(data_payload);
     packet.type = Network::WifiPacket::PacketType::Data;

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -904,7 +904,7 @@ void NWM_UDS::SendTo(Kernel::HLERequestContext& ctx) {
     u8 data_channel = rp.Pop<u8>();
     rp.Skip(1, false);
     u32 data_size = rp.Pop<u32>();
-    u32 flags = rp.Pop<u32>();
+    u8 flags = rp.Pop<u8>();
 
     std::vector<u8> input_buffer = rp.PopStaticBuffer();
     ASSERT(input_buffer.size() >= data_size);
@@ -929,7 +929,7 @@ void NWM_UDS::SendTo(Kernel::HLERequestContext& ctx) {
     Network::MacAddress dest_address;
 
     if (!(flags & 0x1) || (flags >> 2)) {
-        LOG_ERROR(Service_NWM, "Unexpected flags 0x%08X", flags);
+        LOG_ERROR(Service_NWM, "Unexpected flags 0x%02X", flags);
     }
 
     if (flags & (0x1 << 1)) {

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -162,7 +162,7 @@ static void BroadcastNodeMap() {
     packet.data.resize(sizeof(size) + (sizeof(Network::MacAddress) + sizeof(u32)) * size);
     std::memcpy(packet.data.data(), &size, sizeof(size));
     size_t offset = sizeof(size);
-    for (auto node : node_map) {
+    for (const auto& node : node_map) {
         std::memcpy(packet.data.data() + offset, node.first.data(), sizeof(node.first));
         std::memcpy(packet.data.data() + offset + sizeof(node.first), &node.second,
                     sizeof(node.second));

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -266,7 +266,7 @@ static void HandleEAPoLPacket(const Network::WifiPacket& packet) {
 
         network_info.total_nodes++;
 
-        node_map[packet.transmitter_address] = node_id;
+        node_map[packet.transmitter_address] = node.network_node_id;
 
         // Send the EAPoL-Logoff packet.
         using Network::WifiPacket;
@@ -470,12 +470,12 @@ void HandleDeauthenticationFrame(const Network::WifiPacket& packet) {
 
     u16 node_id = node_map[packet.transmitter_address];
     auto node = std::find_if(node_info.begin(), node_info.end(), [&node_id](const NodeInfo& info) {
-        return info.network_node_id == node_id + 1;
+        return info.network_node_id == node_id;
     });
     ASSERT(node != node_info.end());
 
-    connection_status.node_bitmask &= ~(1 << node_id);
-    connection_status.changed_nodes |= 1 << node_id;
+    connection_status.node_bitmask &= ~(1 << (node_id-1));
+    connection_status.changed_nodes |= 1 << (node_id-1);
     connection_status.total_nodes--;
 
     network_info.total_nodes--;
@@ -986,7 +986,7 @@ void NWM_UDS::SendTo(Kernel::HLERequestContext& ctx) {
         // Send to specific client
         auto destination =
             std::find_if(node_map.begin(), node_map.end(), [dest_node_id](const auto& node) {
-                return node.second == dest_node_id - 1;
+                return node.second == dest_node_id;
             });
         if (destination == node_map.end()) {
             LOG_ERROR(Service_NWM, "tried to send packet to unknown dest id %u", dest_node_id);

--- a/src/network/room.h
+++ b/src/network/room.h
@@ -12,7 +12,7 @@
 
 namespace Network {
 
-constexpr u32 network_version = 1; ///< The version of this Room and RoomMember
+constexpr u32 network_version = 2; ///< The version of this Room and RoomMember
 
 constexpr u16 DefaultRoomPort = 24872;
 

--- a/src/network/room_member.h
+++ b/src/network/room_member.h
@@ -21,7 +21,8 @@ struct WifiPacket {
         Data,
         Authentication,
         AssociationResponse,
-        Deauthentication
+        Deauthentication,
+        NodeMap
     };
     PacketType type;      ///< The type of 802.11 frame.
     std::vector<u8> data; ///< Raw 802.11 frame data, starting at the management frame header


### PR DESCRIPTION
This checks the flags in SendTo and tries to sand the packets according to the flags. 
This wasn't HW-Tested by me, but just taken from 3dbrew
~~Some variants are currently unimplemented and will assert. I didn't observe any game using that mode yet. If we find such games I'll implement them.~~

I want this PR to stay in canary some time to see if some games (especially games with more then 2 players) get fixed by that, ~~or if the hit the unimplemented scenarios.~~

Note: Since this PR also touches libnetwork I increased the libnetwork version. This makes future builds incompatible with old builds

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3481)
<!-- Reviewable:end -->
