### PR TITLE
pica/lighting: compute highlight clamp after one-/two-sided diffuse pass

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -562,6 +562,8 @@ static void WriteLighting(std::string& out, const PicaShaderConfig& config) {
            "vec3 refl_value = vec3(0.0);\n"
            "vec3 spot_dir = vec3(0.0);\n"
            "vec3 half_vector = vec3(0.0);\n"
+           "float dot_product = 0.0;\n"
+           "float clamp_highlights = 1.0;\n"
            "float geo_factor = 1.0;\n";
 
     // Compute fragment normals and tangents
@@ -680,9 +682,14 @@ static void WriteLighting(std::string& out, const PicaShaderConfig& config) {
 
         // Compute dot product of light_vector and normal, adjust if lighting is one-sided or
         // two-sided
-        std::string dot_product = light_config.two_sided_diffuse
-                                      ? "abs(dot(light_vector, normal))"
-                                      : "max(dot(light_vector, normal), 0.0)";
+        out += std::string("dot_product = ") + (light_config.two_sided_diffuse
+                                                    ? "abs(dot(light_vector, normal));\n"
+                                                    : "max(dot(light_vector, normal), 0.0);\n");
+
+        // If enabled, clamp specular component if lighting result is zero
+        if (lighting.clamp_highlights) {
+            out += "clamp_highlights = dot_product == 0.0 ? 0.0 : 1.0;\n";
+        }
 
         // If enabled, compute spot light attenuation value
         std::string spot_atten = "1.0";
@@ -706,14 +713,10 @@ static void WriteLighting(std::string& out, const PicaShaderConfig& config) {
                          std::to_string(static_cast<unsigned>(sampler)) + "," + index + ")";
         }
 
-        // If enabled, clamp specular component if lighting result is negative
-        std::string clamp_highlights =
-            lighting.clamp_highlights ? "(dot(light_vector, normal) <= 0.0 ? 0.0 : 1.0)" : "1.0";
-
         if (light_config.geometric_factor_0 || light_config.geometric_factor_1) {
             out += "geo_factor = dot(half_vector, half_vector);\n"
-                   "geo_factor = geo_factor == 0.0 ? 0.0 : min(" +
-                   dot_product + " / geo_factor, 1.0);\n";
+                   "geo_factor = geo_factor == 0.0 ? 0.0 : min("
+                   "dot_product / geo_factor, 1.0);\n";
         }
 
         // Specular 0 component
@@ -814,12 +817,12 @@ static void WriteLighting(std::string& out, const PicaShaderConfig& config) {
         }
 
         // Compute primary fragment color (diffuse lighting) function
-        out += "diffuse_sum.rgb += ((" + light_src + ".diffuse * " + dot_product + ") + " +
-               light_src + ".ambient) * " + dist_atten + " * " + spot_atten + ";\n";
+        out += "diffuse_sum.rgb += ((" + light_src + ".diffuse * dot_product) + " + light_src +
+               ".ambient) * " + dist_atten + " * " + spot_atten + ";\n";
 
         // Compute secondary fragment color (specular lighting) function
-        out += "specular_sum.rgb += (" + specular_0 + " + " + specular_1 + ") * " +
-               clamp_highlights + " * " + dist_atten + " * " + spot_atten + ";\n";
+        out += "specular_sum.rgb += (" + specular_0 + " + " + specular_1 +
+               ") * clamp_highlights * " + dist_atten + " * " + spot_atten + ";\n";
     }
 
     // Sum final lighting result

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -688,7 +688,7 @@ static void WriteLighting(std::string& out, const PicaShaderConfig& config) {
 
         // If enabled, clamp specular component if lighting result is zero
         if (lighting.clamp_highlights) {
-            out += "clamp_highlights = dot_product == 0.0 ? 0.0 : 1.0;\n";
+            out += "clamp_highlights = sign(dot_product);\n";
         }
 
         // If enabled, compute spot light attenuation value

--- a/src/video_core/swrasterizer/lighting.cpp
+++ b/src/video_core/swrasterizer/lighting.cpp
@@ -256,21 +256,15 @@ std::tuple<Math::Vec4<u8>, Math::Vec4<u8>> ComputeFragmentsColors(
         }
 
         auto dot_product = Math::Dot(light_vector, normal);
-
-        // Calculate clamp highlights before applying the two-sided diffuse configuration to the dot
-        // product.
-        float clamp_highlights = 1.0f;
-        if (lighting.config0.clamp_highlights) {
-            if (dot_product <= 0.0f)
-                clamp_highlights = 0.0f;
-            else
-                clamp_highlights = 1.0f;
-        }
-
         if (light_config.config.two_sided_diffuse)
             dot_product = std::abs(dot_product);
         else
             dot_product = std::max(dot_product, 0.0f);
+
+        float clamp_highlights = 1.0f;
+        if (lighting.config0.clamp_highlights) {
+            clamp_highlights = dot_product == 0.0f ? 0.0f : 1.0f;
+        }
 
         if (light_config.config.geometric_factor_0 || light_config.config.geometric_factor_1) {
             float geo_factor = half_vector.Length2();


### PR DESCRIPTION
Fixes #3482

I hwtested the two side diffuse and highlights clamping behaviour and there is a summary table

|           |                           |       |         |       |         | 
|-----------|---------------------------|-------|---------|-------|---------| 
| \         | Two side diffuse          | FALSE | TRUE    | FALSE | TRUE    | 
|           | Clamp highlights          | FALSE | FALSE   | TRUE  | TRUE    | 
| L * N > 0 | dot product =             | L * N | L * N   | L * N | L * N   | 
|           | clamp highlights factor = | 1     | 1       | 1     | 1       | 
| L * N = 0 | dot product =             | 0     | 0       | 0     | 0       | 
|           | clamp highlights factor = | 1     | 1       | 0     | 0       | 
| L * N < 0 | dot product =             | 0     | - L * N | 0     | - L * N | 
|           | clamp highlights factor = | 1     | 1       | 0     | 1      :warning:  | 

:warning: is where it was not correctly implemented, which is fixed in this PR

The new implementation relies on equality comparison against zero on float type. I am not sure if this is a defined behaviour (especially for the GLSL part), so I would appreciate if someone can find me the standard about it or come up with a better solution. Note that when two side diffuse enabled, highlights clamping happens exactly when L * N = 0, so equality comparison against zero is probably unavoidable.

I changed `dot_product` and `clamp_highlights` in the shader generator from string macros to real GLSL variables, to avoid redundant computation on the same formula. Please do fact check that this won't change other behaviours when reviewing, thank you!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3484)
<!-- Reviewable:end -->
