### PR TITLE
Memory: remove RasterizerCachedSpecial page type

### DIFF
--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -37,9 +37,6 @@ enum class PageType {
     RasterizerCachedMemory,
     /// Page is mapped to a I/O region. Writing and reading to this page is handled by functions.
     Special,
-    /// Page is mapped to a I/O region, but also needs to check for rasterizer cache flushing and
-    /// invalidation
-    RasterizerCachedSpecial,
 };
 
 struct SpecialRegion {


### PR DESCRIPTION
This page type is not used, and is not expected to be used at any time. Rasterizer only caches on linear heap and VRAM, which has no overlap with I/O region.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3487)
<!-- Reviewable:end -->
