### PR TITLE
Handle ENet packet destruction if the packet is not sent anywhere

### DIFF
--- a/src/network/room.h
+++ b/src/network/room.h
@@ -45,6 +45,9 @@ constexpr MacAddress NoPreferredMac = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 // 802.11 broadcast MAC address
 constexpr MacAddress BroadcastMac = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
+/// Converts a MAC address to a string representation.
+std::string MacAddressToString(const MacAddress& address);
+
 // The different types of messages that can be sent. The first byte of each packet defines the type
 enum RoomMessageTypes : u8 {
     IdJoinRequest = 1,


### PR DESCRIPTION
Currently, we are leaking memory from our HandleWifiPacket() implementation. This PR adds some sanity checks that will log a error and free that memory if a situation like this is hit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3503)
<!-- Reviewable:end -->
