### PR TITLE
Fix QGLWidget viewport resize on macOS

### DIFF
--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -128,13 +128,14 @@ void GRenderWindow::moveContext() {
 }
 
 void GRenderWindow::SwapBuffers() {
-#if !defined(QT_NO_DEBUG)
-    // Qt debug runtime prints a bogus warning on the console if you haven't called makeCurrent
-    // since the last time you called swapBuffers. This presumably means something if you're using
-    // QGLWidget the "regular" way, but in our multi-threaded use case is harmless since we never
-    // call doneCurrent in this thread.
+    // In our multi-threaded QGLWidget use case we shouldn't need to call `makeCurrent`,
+    // since we never call `doneCurrent` in this thread.
+    // However:
+    // - The Qt debug runtime prints a bogus warning on the console if `makeCurrent` wasn't called
+    // since the last time `swapBuffers` was executed;
+    // - On macOS, if `makeCurrent` isn't called explicitely, resizing the buffer breaks.
     child->makeCurrent();
-#endif
+
     child->swapBuffers();
 }
 


### PR DESCRIPTION
This fixes #2092, a long-standing bug where on macOS resizing the window results in a garbled display.

It seems the seemingly optional `child()->makeCurrent` call is actually required on macOS. Enabling it in all cases fixes the resize issue.

I couldn't observe any effect on performances. However it should be possible to perform this call only if the buffer was resized since last swap (at the cost of added complexity).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3505)
<!-- Reviewable:end -->
