### PR TITLE
.gitignore: Add CMakeLists.txt.user to Project/editor files, citra_qt: Sync menu UI settings after changing the layout with F10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ src/common/scm_rev.cpp
 .idea/
 .vs/
 .vscode/
+CMakeLists.txt.user
 
 # *nix related
 # Common convention for backup or temporary files

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -1011,6 +1011,7 @@ void GMainWindow::ToggleScreenLayout() {
     }
 
     Settings::values.layout_option = new_layout;
+    SyncMenuUISettings();
     Settings::Apply();
 }
 


### PR DESCRIPTION
Fixes that the menu layout option is not updated after changing layout with F10

-----------------------
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3513)
<!-- Reviewable:end -->
