### PR TITLE
Fix formatting of mac address in error log

### DIFF
--- a/src/network/room.cpp
+++ b/src/network/room.cpp
@@ -16,22 +16,6 @@
 
 namespace Network {
 
-std::string MacAddressToString(const MacAddress& address) {
-    std::stringstream result;
-    bool is_start = true;
-    for (const auto& octal : address) {
-        if (!is_start) {
-            result << ":";
-        }
-
-        result << std::hex << octal;
-
-        is_start = false;
-    }
-
-    return result.str();
-}
-
 class Room::RoomImpl {
 public:
     // This MAC address is used to generate a 'Nintendo' like Mac address.
@@ -424,9 +408,10 @@ void Room::RoomImpl::HandleWifiPacket(const ENetEvent* event) {
         if (member != members.end()) {
             enet_peer_send(member->peer, 0, enet_packet);
         } else {
-            std::string formatted_address = MacAddressToString(destination_address);
-            LOG_ERROR(Network, "Attempting to send to unknown MAC address: %s",
-                      formatted_address.c_str());
+            LOG_ERROR(Network,
+                      "Attempting to send to unknown MAC address: %02X:%02X:%02X:%02X:%02X:%02X",
+                      destination_address[0], destination_address[1], destination_address[2],
+                      destination_address[3], destination_address[4], destination_address[5]);
             enet_packet_destroy(enet_packet);
         }
     }

--- a/src/network/room.h
+++ b/src/network/room.h
@@ -45,9 +45,6 @@ constexpr MacAddress NoPreferredMac = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 // 802.11 broadcast MAC address
 constexpr MacAddress BroadcastMac = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
-/// Converts a MAC address to a string representation.
-std::string MacAddressToString(const MacAddress& address);
-
 // The different types of messages that can be sent. The first byte of each packet defines the type
 enum RoomMessageTypes : u8 {
     IdJoinRequest = 1,


### PR DESCRIPTION
stringstream interpreted u8 as char and thus stopped printing on a 0 byte. 
Also the width of each octal was just 1 if a leading 0 was required.

Blame me, since I suggested stringstream in the first place.
Thx for @wwylele for finding that error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3515)
<!-- Reviewable:end -->
