### PR TITLE
use nvidia graphics automatically on laptops with optimus

### DIFF
--- a/src/citra/citra.cpp
+++ b/src/citra/citra.cpp
@@ -40,6 +40,12 @@
 #include "core/settings.h"
 #include "network/network.h"
 
+#ifdef _WIN32
+extern "C" {
+__declspec(dllexport) unsigned long NvOptimusEnablement = 0x00000001;
+}
+#endif
+
 static void PrintHelp(const char* argv0) {
     std::cout << "Usage: " << argv0
               << " [options] <filename>\n"

--- a/src/citra/citra.cpp
+++ b/src/citra/citra.cpp
@@ -42,6 +42,7 @@
 
 #ifdef _WIN32
 extern "C" {
+// tells Nvidia drivers to use the dedicated GPU by default on laptops with switchable graphics
 __declspec(dllexport) unsigned long NvOptimusEnablement = 0x00000001;
 }
 #endif

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -56,6 +56,7 @@ Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
 
 #ifdef _WIN32
 extern "C" {
+// tells Nvidia drivers to use the dedicated GPU by default on laptops with switchable graphics
 __declspec(dllexport) unsigned long NvOptimusEnablement = 0x00000001;
 }
 #endif

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -54,6 +54,12 @@
 Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
 #endif
 
+#ifdef _WIN32
+extern "C" {
+__declspec(dllexport) unsigned long NvOptimusEnablement = 0x00000001;
+}
+#endif
+
 /**
  * "Callouts" are one-time instructional messages shown to the user. In the config settings, there
  * is a bitfield "callout_flags" options, used to track if a message has already been shown to the


### PR DESCRIPTION
https://stackoverflow.com/a/39047129
basically copied this^
I held off on AMD because I have no way to test that, and AMD GPUs sometimes have more issues than Intel integrated graphics in the current PICA->GLSL implementation.
(this can of course be overridden by custom control panel profiles)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3528)
<!-- Reviewable:end -->
