### PR TITLE
Move factory to a new file in common

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(common STATIC
     common_funcs.h
     common_paths.h
     common_types.h
+    factory.h
     file_util.cpp
     file_util.h
     hash.h

--- a/src/common/factory.h
+++ b/src/common/factory.h
@@ -1,0 +1,85 @@
+// Copyright 2018 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include "common/logging/log.h"
+#include "common/param_package.h"
+
+namespace Common {
+/// An abstract class template for a factory that can create devices.
+template <typename Type>
+class Factory {
+public:
+    virtual ~Factory() = default;
+    virtual std::unique_ptr<Type> Create(const Common::ParamPackage&) = 0;
+};
+
+namespace Impl {
+
+template <typename Type>
+using FactoryListType = std::unordered_map<std::string, std::shared_ptr<Factory<Type>>>;
+
+template <typename Type>
+struct FactoryList {
+    static FactoryListType<Type> list;
+};
+
+template <typename Type>
+FactoryListType<Type> FactoryList<Type>::list;
+
+} // namespace Impl
+
+/**
+ * Registers a device factory.
+ * @tparam Type the type of devices the factory can create
+ * @param name the name of the factory. Will be used to match the "engine" parameter when creating
+ *     a device
+ * @param factory the factory object to register
+ */
+template <typename Type>
+void RegisterFactory(const std::string& name, std::shared_ptr<Factory<Type>> factory) {
+    auto pair = std::make_pair(name, std::move(factory));
+    if (!Impl::FactoryList<Type>::list.insert(std::move(pair)).second) {
+        LOG_ERROR(Frontend, "Factory %s already registered", name.c_str());
+    }
+}
+
+/**
+ * Unregisters a device factory.
+ * @tparam Type the type of input devices the factory can create
+ * @param name the name of the factory to unregister
+ */
+template <typename Type>
+void UnregisterFactory(const std::string& name) {
+    if (Impl::FactoryList<Type>::list.erase(name) == 0) {
+        LOG_ERROR(Frontend, "Factory %s not registered", name.c_str());
+    }
+}
+
+/**
+ * Create a device from given paramters.
+ * @tparam Type the type of devices to create
+ * @param params a serialized ParamPackage string contains all parameters for creating the device
+ */
+template <typename Type>
+std::unique_ptr<Type> CreateDevice(const std::string& params) {
+    const Common::ParamPackage package(params);
+    const std::string engine = package.Get("engine", "null");
+    const auto& factory_list = Impl::FactoryList<Type>::list;
+    const auto pair = factory_list.find(engine);
+    if (pair == factory_list.end()) {
+        if (engine != "null") {
+            LOG_ERROR(Frontend, "Unknown engine name: %s", engine.c_str());
+        }
+        return std::make_unique<Type>();
+    }
+    return pair->second->Create(package);
+}
+
+} // namespace Common

--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -4,11 +4,12 @@
 
 #include <cmath>
 #include <mutex>
+#include "common/factory.h"
 #include "core/frontend/emu_window.h"
 #include "core/frontend/input.h"
 #include "core/settings.h"
 
-class EmuWindow::TouchState : public Input::Factory<Input::TouchDevice>,
+class EmuWindow::TouchState : public Common::Factory<Input::TouchDevice>,
                               public std::enable_shared_from_this<TouchState> {
 public:
     std::unique_ptr<Input::TouchDevice> Create(const Common::ParamPackage&) override {
@@ -44,11 +45,11 @@ EmuWindow::EmuWindow() {
     config.min_client_area_size = std::make_pair(400u, 480u);
     active_config = config;
     touch_state = std::make_shared<TouchState>();
-    Input::RegisterFactory<Input::TouchDevice>("emu_window", touch_state);
+    Common::RegisterFactory<Input::TouchDevice>("emu_window", touch_state);
 }
 
 EmuWindow::~EmuWindow() {
-    Input::UnregisterFactory<Input::TouchDevice>("emu_window");
+    Common::UnregisterFactory<Input::TouchDevice>("emu_window");
 }
 
 /**

--- a/src/core/frontend/input.h
+++ b/src/core/frontend/input.h
@@ -4,13 +4,7 @@
 
 #pragma once
 
-#include <memory>
-#include <string>
 #include <tuple>
-#include <unordered_map>
-#include <utility>
-#include "common/logging/log.h"
-#include "common/param_package.h"
 #include "common/vector_math.h"
 
 namespace Input {
@@ -24,76 +18,6 @@ public:
         return {};
     }
 };
-
-/// An abstract class template for a factory that can create input devices.
-template <typename InputDeviceType>
-class Factory {
-public:
-    virtual ~Factory() = default;
-    virtual std::unique_ptr<InputDeviceType> Create(const Common::ParamPackage&) = 0;
-};
-
-namespace Impl {
-
-template <typename InputDeviceType>
-using FactoryListType = std::unordered_map<std::string, std::shared_ptr<Factory<InputDeviceType>>>;
-
-template <typename InputDeviceType>
-struct FactoryList {
-    static FactoryListType<InputDeviceType> list;
-};
-
-template <typename InputDeviceType>
-FactoryListType<InputDeviceType> FactoryList<InputDeviceType>::list;
-
-} // namespace Impl
-
-/**
- * Registers an input device factory.
- * @tparam InputDeviceType the type of input devices the factory can create
- * @param name the name of the factory. Will be used to match the "engine" parameter when creating
- *     a device
- * @param factory the factory object to register
- */
-template <typename InputDeviceType>
-void RegisterFactory(const std::string& name, std::shared_ptr<Factory<InputDeviceType>> factory) {
-    auto pair = std::make_pair(name, std::move(factory));
-    if (!Impl::FactoryList<InputDeviceType>::list.insert(std::move(pair)).second) {
-        LOG_ERROR(Input, "Factory %s already registered", name.c_str());
-    }
-}
-
-/**
- * Unregisters an input device factory.
- * @tparam InputDeviceType the type of input devices the factory can create
- * @param name the name of the factory to unregister
- */
-template <typename InputDeviceType>
-void UnregisterFactory(const std::string& name) {
-    if (Impl::FactoryList<InputDeviceType>::list.erase(name) == 0) {
-        LOG_ERROR(Input, "Factory %s not registered", name.c_str());
-    }
-}
-
-/**
- * Create an input device from given paramters.
- * @tparam InputDeviceType the type of input devices to create
- * @param params a serialized ParamPackage string contains all parameters for creating the device
- */
-template <typename InputDeviceType>
-std::unique_ptr<InputDeviceType> CreateDevice(const std::string& params) {
-    const Common::ParamPackage package(params);
-    const std::string engine = package.Get("engine", "null");
-    const auto& factory_list = Impl::FactoryList<InputDeviceType>::list;
-    const auto pair = factory_list.find(engine);
-    if (pair == factory_list.end()) {
-        if (engine != "null") {
-            LOG_ERROR(Input, "Unknown engine name: %s", engine.c_str());
-        }
-        return std::make_unique<InputDeviceType>();
-    }
-    return pair->second->Create(package);
-}
 
 /**
  * A button device is an input device that returns bool as status.

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include "common/factory.h"
 #include "common/logging/log.h"
 #include "core/3ds.h"
 #include "core/core.h"
@@ -64,11 +65,11 @@ DirectionState GetStickDirectionState(s16 circle_pad_x, s16 circle_pad_y) {
 void Module::LoadInputDevices() {
     std::transform(Settings::values.buttons.begin() + Settings::NativeButton::BUTTON_HID_BEGIN,
                    Settings::values.buttons.begin() + Settings::NativeButton::BUTTON_HID_END,
-                   buttons.begin(), Input::CreateDevice<Input::ButtonDevice>);
-    circle_pad = Input::CreateDevice<Input::AnalogDevice>(
+                   buttons.begin(), Common::CreateDevice<Input::ButtonDevice>);
+    circle_pad = Common::CreateDevice<Input::AnalogDevice>(
         Settings::values.analogs[Settings::NativeAnalog::CirclePad]);
-    motion_device = Input::CreateDevice<Input::MotionDevice>(Settings::values.motion_device);
-    touch_device = Input::CreateDevice<Input::TouchDevice>(Settings::values.touch_device);
+    motion_device = Common::CreateDevice<Input::MotionDevice>(Settings::values.motion_device);
+    touch_device = Common::CreateDevice<Input::TouchDevice>(Settings::values.touch_device);
 }
 
 void Module::UpdatePadCallback(u64 userdata, int cycles_late) {

--- a/src/core/hle/service/ir/extra_hid.cpp
+++ b/src/core/hle/service/ir/extra_hid.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "common/alignment.h"
+#include "common/factory.h"
 #include "common/string_util.h"
 #include "core/core_timing.h"
 #include "core/hle/service/ir/extra_hid.h"
@@ -262,11 +263,11 @@ void ExtraHID::RequestInputDevicesReload() {
 }
 
 void ExtraHID::LoadInputDevices() {
-    zl = Input::CreateDevice<Input::ButtonDevice>(
+    zl = Common::CreateDevice<Input::ButtonDevice>(
         Settings::values.buttons[Settings::NativeButton::ZL]);
-    zr = Input::CreateDevice<Input::ButtonDevice>(
+    zr = Common::CreateDevice<Input::ButtonDevice>(
         Settings::values.buttons[Settings::NativeButton::ZR]);
-    c_stick = Input::CreateDevice<Input::AnalogDevice>(
+    c_stick = Common::CreateDevice<Input::AnalogDevice>(
         Settings::values.analogs[Settings::NativeAnalog::CStick]);
 }
 

--- a/src/core/hle/service/ir/ir_rst.cpp
+++ b/src/core/hle/service/ir/ir_rst.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "common/factory.h"
 #include "core/core_timing.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/event.h"
@@ -34,11 +35,11 @@ struct SharedMem {
 static_assert(sizeof(SharedMem) == 0x98, "SharedMem has wrong size!");
 
 void IR_RST::LoadInputDevices() {
-    zl_button = Input::CreateDevice<Input::ButtonDevice>(
+    zl_button = Common::CreateDevice<Input::ButtonDevice>(
         Settings::values.buttons[Settings::NativeButton::ZL]);
-    zr_button = Input::CreateDevice<Input::ButtonDevice>(
+    zr_button = Common::CreateDevice<Input::ButtonDevice>(
         Settings::values.buttons[Settings::NativeButton::ZR]);
-    c_stick = Input::CreateDevice<Input::AnalogDevice>(
+    c_stick = Common::CreateDevice<Input::AnalogDevice>(
         Settings::values.analogs[Settings::NativeAnalog::CStick]);
 }
 

--- a/src/input_common/analog_from_button.cpp
+++ b/src/input_common/analog_from_button.cpp
@@ -45,11 +45,11 @@ private:
 
 std::unique_ptr<Input::AnalogDevice> AnalogFromButton::Create(const Common::ParamPackage& params) {
     const std::string null_engine = Common::ParamPackage{{"engine", "null"}}.Serialize();
-    auto up = Input::CreateDevice<Input::ButtonDevice>(params.Get("up", null_engine));
-    auto down = Input::CreateDevice<Input::ButtonDevice>(params.Get("down", null_engine));
-    auto left = Input::CreateDevice<Input::ButtonDevice>(params.Get("left", null_engine));
-    auto right = Input::CreateDevice<Input::ButtonDevice>(params.Get("right", null_engine));
-    auto modifier = Input::CreateDevice<Input::ButtonDevice>(params.Get("modifier", null_engine));
+    auto up = Common::CreateDevice<Input::ButtonDevice>(params.Get("up", null_engine));
+    auto down = Common::CreateDevice<Input::ButtonDevice>(params.Get("down", null_engine));
+    auto left = Common::CreateDevice<Input::ButtonDevice>(params.Get("left", null_engine));
+    auto right = Common::CreateDevice<Input::ButtonDevice>(params.Get("right", null_engine));
+    auto modifier = Common::CreateDevice<Input::ButtonDevice>(params.Get("modifier", null_engine));
     auto modifier_scale = params.Get("modifier_scale", 0.5f);
     return std::make_unique<Analog>(std::move(up), std::move(down), std::move(left),
                                     std::move(right), std::move(modifier), modifier_scale);

--- a/src/input_common/analog_from_button.h
+++ b/src/input_common/analog_from_button.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <memory>
+#include "common/factory.h"
 #include "core/frontend/input.h"
 
 namespace InputCommon {
@@ -13,7 +14,7 @@ namespace InputCommon {
  * An analog device factory that takes direction button devices and combines them into a analog
  * device.
  */
-class AnalogFromButton final : public Input::Factory<Input::AnalogDevice> {
+class AnalogFromButton final : public Common::Factory<Input::AnalogDevice> {
 public:
     /**
      * Creates an analog device from direction button devices

--- a/src/input_common/keyboard.h
+++ b/src/input_common/keyboard.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <memory>
+#include "common/factory.h"
 #include "core/frontend/input.h"
 
 namespace InputCommon {
@@ -15,7 +16,7 @@ class KeyButtonList;
  * A button device factory representing a keyboard. It receives keyboard events and forward them
  * to all button devices it created.
  */
-class Keyboard final : public Input::Factory<Input::ButtonDevice> {
+class Keyboard final : public Common::Factory<Input::ButtonDevice> {
 public:
     Keyboard();
 

--- a/src/input_common/main.cpp
+++ b/src/input_common/main.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <memory>
+#include "common/factory.h"
 #include "common/param_package.h"
 #include "input_common/analog_from_button.h"
 #include "input_common/keyboard.h"
@@ -19,11 +20,11 @@ static std::shared_ptr<MotionEmu> motion_emu;
 
 void Init() {
     keyboard = std::make_shared<Keyboard>();
-    Input::RegisterFactory<Input::ButtonDevice>("keyboard", keyboard);
-    Input::RegisterFactory<Input::AnalogDevice>("analog_from_button",
-                                                std::make_shared<AnalogFromButton>());
+    Common::RegisterFactory<Input::ButtonDevice>("keyboard", keyboard);
+    Common::RegisterFactory<Input::AnalogDevice>("analog_from_button",
+                                                 std::make_shared<AnalogFromButton>());
     motion_emu = std::make_shared<MotionEmu>();
-    Input::RegisterFactory<Input::MotionDevice>("motion_emu", motion_emu);
+    Common::RegisterFactory<Input::MotionDevice>("motion_emu", motion_emu);
 
 #ifdef HAVE_SDL2
     SDL::Init();
@@ -31,10 +32,10 @@ void Init() {
 }
 
 void Shutdown() {
-    Input::UnregisterFactory<Input::ButtonDevice>("keyboard");
+    Common::UnregisterFactory<Input::ButtonDevice>("keyboard");
     keyboard.reset();
-    Input::UnregisterFactory<Input::AnalogDevice>("analog_from_button");
-    Input::UnregisterFactory<Input::MotionDevice>("motion_emu");
+    Common::UnregisterFactory<Input::AnalogDevice>("analog_from_button");
+    Common::UnregisterFactory<Input::MotionDevice>("motion_emu");
     motion_emu.reset();
 
 #ifdef HAVE_SDL2

--- a/src/input_common/motion_emu.h
+++ b/src/input_common/motion_emu.h
@@ -4,13 +4,14 @@
 
 #pragma once
 
+#include "common/factory.h"
 #include "core/frontend/input.h"
 
 namespace InputCommon {
 
 class MotionEmuDevice;
 
-class MotionEmu : public Input::Factory<Input::MotionDevice> {
+class MotionEmu : public Common::Factory<Input::MotionDevice> {
 public:
     /**
      * Creates a motion device emulated from mouse input

--- a/src/input_common/sdl/sdl.cpp
+++ b/src/input_common/sdl/sdl.cpp
@@ -8,6 +8,7 @@
 #include <unordered_map>
 #include <utility>
 #include <SDL.h>
+#include "common/factory.h"
 #include "common/logging/log.h"
 #include "common/math_util.h"
 #include "common/param_package.h"
@@ -154,7 +155,7 @@ static std::shared_ptr<SDLJoystick> GetJoystick(int joystick_index) {
 }
 
 /// A button device factory that creates button devices from SDL joystick
-class SDLButtonFactory final : public Input::Factory<Input::ButtonDevice> {
+class SDLButtonFactory final : public Common::Factory<Input::ButtonDevice> {
 public:
     /**
      * Creates a button device from a joystick button
@@ -216,7 +217,7 @@ public:
 };
 
 /// An analog device factory that creates analog devices from SDL joystick
-class SDLAnalogFactory final : public Input::Factory<Input::AnalogDevice> {
+class SDLAnalogFactory final : public Common::Factory<Input::AnalogDevice> {
 public:
     /**
      * Creates analog device from joystick axes
@@ -238,8 +239,8 @@ void Init() {
         LOG_CRITICAL(Input, "SDL_Init(SDL_INIT_JOYSTICK) failed with: %s", SDL_GetError());
     } else {
         using namespace Input;
-        RegisterFactory<ButtonDevice>("sdl", std::make_shared<SDLButtonFactory>());
-        RegisterFactory<AnalogDevice>("sdl", std::make_shared<SDLAnalogFactory>());
+        Common::RegisterFactory<ButtonDevice>("sdl", std::make_shared<SDLButtonFactory>());
+        Common::RegisterFactory<AnalogDevice>("sdl", std::make_shared<SDLAnalogFactory>());
         initialized = true;
     }
 }
@@ -247,8 +248,8 @@ void Init() {
 void Shutdown() {
     if (initialized) {
         using namespace Input;
-        UnregisterFactory<ButtonDevice>("sdl");
-        UnregisterFactory<AnalogDevice>("sdl");
+        Common::UnregisterFactory<ButtonDevice>("sdl");
+        Common::UnregisterFactory<AnalogDevice>("sdl");
         SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
     }
 }


### PR DESCRIPTION
As we add more devices and different types of factories, its useful to
not repeat the same plumbing code for factories, so this refactors the
input factory to common.

This commit did not change the factory for cameras as that is handled
slightly differently and would be fine to put in a follow up after the
still camera is merged. See #3451 for the still camera.

This is the first PR in relation to adding a frontend HLE applet interface. I plan to extend this code to add support for frontend driven applets, and wanted to reuse the existing factory code. Please review quickly so I can push out the other code as well.

The goal is to allow frontends to define their own applet callbacks, for instance, the QT frontend can have a software keyboard that allows users to type text with their keyboard, or any other frontend can draw a keyboard to the screen and use controller input to choose the keys.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3553)
<!-- Reviewable:end -->
