### PR TITLE
citra_qt: Migrate logging macros

### DIFF
--- a/src/citra_qt/compatdb.cpp
+++ b/src/citra_qt/compatdb.cpp
@@ -41,7 +41,7 @@ void CompatDB::Submit() {
         }
         break;
     case CompatDBPage::Final:
-        LOG_DEBUG(Frontend, "Compatibility Rating: %d", compatibility->checkedId());
+        NGLOG_DEBUG(Frontend, "Compatibility Rating: {}", compatibility->checkedId());
         Core::Telemetry().AddField(Telemetry::FieldType::UserFeedback, "Compatibility",
                                    compatibility->checkedId());
         // older versions of QT don't support the "NoCancelButtonOnLastPage" option, this is a
@@ -49,7 +49,7 @@ void CompatDB::Submit() {
         button(QWizard::CancelButton)->setVisible(false);
         break;
     default:
-        LOG_ERROR(Frontend, "Unexpected page: %d", currentId());
+        NGLOG_ERROR(Frontend, "Unexpected page: {}", currentId());
     }
 }
 

--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -340,7 +340,7 @@ void GameList::PopupContextMenu(const QPoint& menu_location) {
 void GameList::PopulateAsync(const QString& dir_path, bool deep_scan) {
     if (!FileUtil::Exists(dir_path.toStdString()) ||
         !FileUtil::IsDirectory(dir_path.toStdString())) {
-        LOG_ERROR(Frontend, "Could not find game list folder at %s", dir_path.toLocal8Bit().data());
+        NGLOG_ERROR(Frontend, "Could not find game list folder at {}", dir_path.toStdString());
         search_field->setFilterResult(0, 0);
         return;
     }
@@ -390,7 +390,7 @@ static bool HasSupportedFileExtension(const std::string& file_name) {
 
 void GameList::RefreshGameDirectory() {
     if (!UISettings::values.gamedir.isEmpty() && current_worker != nullptr) {
-        LOG_INFO(Frontend, "Change detected in the games directory. Reloading game list.");
+        NGLOG_INFO(Frontend, "Change detected in the games directory. Reloading game list.");
         search_field->clear();
         PopulateAsync(UISettings::values.gamedir, UISettings::values.gamedir_deepscan);
     }

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -766,7 +766,7 @@ void GMainWindow::OnGameListOpenFolder(u64 program_id, GameListOpenTarget target
         return;
     }
 
-    NGLOG_INFO(Frontend, "Opening {} path for program_id={:016}", open_target, program_id);
+    NGLOG_INFO(Frontend, "Opening {} path for program_id={:016x}", open_target, program_id);
 
     QDesktopServices::openUrl(QUrl::fromLocalFile(qpath));
 }

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -2,7 +2,6 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <cinttypes>
 #include <clocale>
 #include <memory>
 #include <thread>
@@ -470,20 +469,20 @@ void GMainWindow::OnCheckForUpdates() {
 
 void GMainWindow::CheckForUpdates() {
     if (updater->CheckForUpdates()) {
-        LOG_INFO(Frontend, "Update check started");
+        NGLOG_INFO(Frontend, "Update check started");
     } else {
-        LOG_WARNING(Frontend, "Unable to start check for updates");
+        NGLOG_WARNING(Frontend, "Unable to start check for updates");
     }
 }
 
 void GMainWindow::OnUpdateFound(bool found, bool error) {
     if (error) {
-        LOG_WARNING(Frontend, "Update check failed");
+        NGLOG_WARNING(Frontend, "Update check failed");
         return;
     }
 
     if (!found) {
-        LOG_INFO(Frontend, "No updates found");
+        NGLOG_INFO(Frontend, "No updates found");
 
         // If the user explicitly clicked the "Check for Updates" button, we are
         //  going to want to show them a prompt anyway.
@@ -495,12 +494,12 @@ void GMainWindow::OnUpdateFound(bool found, bool error) {
     }
 
     if (emulation_running && !explicit_update_check) {
-        LOG_INFO(Frontend, "Update found, deferring as game is running");
+        NGLOG_INFO(Frontend, "Update found, deferring as game is running");
         defer_update_prompt = true;
         return;
     }
 
-    LOG_INFO(Frontend, "Update found!");
+    NGLOG_INFO(Frontend, "Update found!");
     explicit_update_check = false;
 
     ShowUpdatePrompt();
@@ -552,14 +551,13 @@ bool GMainWindow::LoadROM(const QString& filename) {
     if (result != Core::System::ResultStatus::Success) {
         switch (result) {
         case Core::System::ResultStatus::ErrorGetLoader:
-            LOG_CRITICAL(Frontend, "Failed to obtain loader for %s!",
-                         filename.toStdString().c_str());
+            NGLOG_CRITICAL(Frontend, "Failed to obtain loader for {}!", filename.toStdString());
             QMessageBox::critical(this, tr("Error while loading ROM!"),
                                   tr("The ROM format is not supported."));
             break;
 
         case Core::System::ResultStatus::ErrorSystemMode:
-            LOG_CRITICAL(Frontend, "Failed to load ROM!");
+            NGLOG_CRITICAL(Frontend, "Failed to load ROM!");
             QMessageBox::critical(this, tr("Error while loading ROM!"),
                                   tr("Could not determine the system mode."));
             break;
@@ -610,7 +608,7 @@ bool GMainWindow::LoadROM(const QString& filename) {
 }
 
 void GMainWindow::BootGame(const QString& filename) {
-    LOG_INFO(Frontend, "Citra starting...");
+    NGLOG_INFO(Frontend, "Citra starting...");
     StoreRecentFile(filename); // Put the filename on top of the list
 
     if (!LoadROM(filename))
@@ -754,7 +752,7 @@ void GMainWindow::OnGameListOpenFolder(u64 program_id, GameListOpenTarget target
                "content/";
         break;
     default:
-        LOG_ERROR(Frontend, "Unexpected target %d", target);
+        NGLOG_ERROR(Frontend, "Unexpected target {}", static_cast<int>(target));
         return;
     }
 
@@ -768,8 +766,7 @@ void GMainWindow::OnGameListOpenFolder(u64 program_id, GameListOpenTarget target
         return;
     }
 
-    LOG_INFO(Frontend, "Opening %s path for program_id=%016" PRIx64, open_target.c_str(),
-             program_id);
+    NGLOG_INFO(Frontend, "Opening {} path for program_id={:#016}", open_target, program_id);
 
     QDesktopServices::openUrl(QUrl::fromLocalFile(qpath));
 }
@@ -1233,7 +1230,7 @@ void GMainWindow::UpdateUITheme() {
         QString theme_uri(":" + UISettings::values.theme + "/style.qss");
         QFile f(theme_uri);
         if (!f.exists()) {
-            LOG_ERROR(Frontend, "Unable to set style, stylesheet file not found");
+            NGLOG_ERROR(Frontend, "Unable to set style, stylesheet file not found");
         } else {
             f.open(QFile::ReadOnly | QFile::Text);
             QTextStream ts(&f);

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -766,7 +766,7 @@ void GMainWindow::OnGameListOpenFolder(u64 program_id, GameListOpenTarget target
         return;
     }
 
-    NGLOG_INFO(Frontend, "Opening {} path for program_id={:#016}", open_target, program_id);
+    NGLOG_INFO(Frontend, "Opening {} path for program_id={:016}", open_target, program_id);
 
     QDesktopServices::openUrl(QUrl::fromLocalFile(qpath));
 }

--- a/src/citra_qt/updater/updater.cpp
+++ b/src/citra_qt/updater/updater.cpp
@@ -211,8 +211,7 @@ XMLParseResult UpdaterPrivate::ParseResult(const QByteArray& output,
     }
 
     if (reader.hasError()) {
-        LOG_ERROR(Frontend, "Cannot read xml for update: %s",
-                  reader.errorString().toStdString().c_str());
+        NGLOG_ERROR(Frontend, "Cannot read xml for update: {}", reader.errorString().toStdString());
         return XMLParseResult::InvalidXML;
     }
 
@@ -276,18 +275,18 @@ void UpdaterPrivate::LaunchWithArguments(const QStringList& args) {
     QFileInfo tool_info(QCoreApplication::applicationDirPath(), tool_path);
 
     if (!QProcess::startDetached(tool_info.absoluteFilePath(), args, tool_info.absolutePath())) {
-        LOG_WARNING(Frontend, "Unable to start program %s",
-                    tool_info.absoluteFilePath().toStdString().c_str());
+        NGLOG_WARNING(Frontend, "Unable to start program {}",
+                      tool_info.absoluteFilePath().toStdString());
     }
 }
 
 void UpdaterPrivate::LaunchUI() {
-    LOG_INFO(Frontend, "Launching update UI...");
+    NGLOG_INFO(Frontend, "Launching update UI...");
     LaunchWithArguments(run_arguments);
 }
 
 void UpdaterPrivate::SilentlyUpdate() {
-    LOG_INFO(Frontend, "Launching silent update...");
+    NGLOG_INFO(Frontend, "Launching silent update...");
     LaunchWithArguments(silent_arguments);
 }
 


### PR DESCRIPTION
Follow-up of #3533

Replace prefix of all logging macros from LOG to NGLOG

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3574)
<!-- Reviewable:end -->
