### PR TITLE
web_service: Migrate logging macros

### DIFF
--- a/src/web_service/announce_room_json.cpp
+++ b/src/web_service/announce_room_json.cpp
@@ -50,7 +50,7 @@ void from_json(const nlohmann::json& json, Room& room) {
     try {
         room.members = json.at("players").get<std::vector<Room::Member>>();
     } catch (const nlohmann::detail::out_of_range& e) {
-        LOG_DEBUG(Network, "Out of range %s", e.what());
+        NGLOG_DEBUG(Network, "Out of range {}", e.what());
     }
 }
 

--- a/src/web_service/web_backend.cpp
+++ b/src/web_service/web_backend.cpp
@@ -40,7 +40,7 @@ std::unique_ptr<httplib::Client> GetClientFor(const LUrlParser::clParseURL& pars
         return std::make_unique<hl::SSLClient>(parsedUrl.m_Host.c_str(), port, TIMEOUT_SECONDS,
                                                hl::HttpVersion::v1_1);
     } else {
-        LOG_ERROR(WebService, "Bad URL scheme %s", parsedUrl.m_Scheme.c_str());
+        NGLOG_ERROR(WebService, "Bad URL scheme {}", parsedUrl.m_Scheme);
         return nullptr;
     }
 }
@@ -54,7 +54,7 @@ std::future<Common::WebResult> PostJson(const std::string& url, const std::strin
     lup parsedUrl = lup::ParseURL(url);
 
     if (url.empty() || !parsedUrl.IsValid()) {
-        LOG_ERROR(WebService, "URL is invalid");
+        NGLOG_ERROR(WebService, "URL is invalid");
         return std::async(std::launch::deferred, []() {
             return Common::WebResult{Common::WebResult::Code::InvalidURL, "URL is invalid"};
         });
@@ -62,7 +62,7 @@ std::future<Common::WebResult> PostJson(const std::string& url, const std::strin
 
     const bool are_credentials_provided{!token.empty() && !username.empty()};
     if (!allow_anonymous && !are_credentials_provided) {
-        LOG_ERROR(WebService, "Credentials must be provided for authenticated requests");
+        NGLOG_ERROR(WebService, "Credentials must be provided for authenticated requests");
         return std::async(std::launch::deferred, []() {
             return Common::WebResult{Common::WebResult::Code::CredentialsMissing,
                                      "Credentials needed"};
@@ -100,13 +100,13 @@ std::future<Common::WebResult> PostJson(const std::string& url, const std::strin
         hl::Response response;
 
         if (!cli->send(request, response)) {
-            LOG_ERROR(WebService, "POST to %s returned null", url.c_str());
+            NGLOG_ERROR(WebService, "POST to {} returned null", url);
             return Common::WebResult{Common::WebResult::Code::LibError, "Null response"};
         }
 
         if (response.status >= 400) {
-            LOG_ERROR(WebService, "POST to %s returned error status code: %u", url.c_str(),
-                      response.status);
+            NGLOG_ERROR(WebService, "POST to {} returned error status code: {}", url,
+                        response.status);
             return Common::WebResult{Common::WebResult::Code::HttpError,
                                      std::to_string(response.status)};
         }
@@ -115,8 +115,8 @@ std::future<Common::WebResult> PostJson(const std::string& url, const std::strin
 
         if (content_type == response.headers.end() ||
             content_type->second.find("application/json") == std::string::npos) {
-            LOG_ERROR(WebService, "POST to %s returned wrong content: %s", url.c_str(),
-                      content_type->second.c_str());
+            NGLOG_ERROR(WebService, "POST to {} returned wrong content: {}", url,
+                        content_type->second);
             return Common::WebResult{Common::WebResult::Code::WrongContent, content_type->second};
         }
 
@@ -134,13 +134,13 @@ std::future<T> GetJson(std::function<T(const std::string&)> func, const std::str
     lup parsedUrl = lup::ParseURL(url);
 
     if (url.empty() || !parsedUrl.IsValid()) {
-        LOG_ERROR(WebService, "URL is invalid");
+        NGLOG_ERROR(WebService, "URL is invalid");
         return std::async(std::launch::deferred, [func{std::move(func)}]() { return func(""); });
     }
 
     const bool are_credentials_provided{!token.empty() && !username.empty()};
     if (!allow_anonymous && !are_credentials_provided) {
-        LOG_ERROR(WebService, "Credentials must be provided for authenticated requests");
+        NGLOG_ERROR(WebService, "Credentials must be provided for authenticated requests");
         return std::async(std::launch::deferred, [func{std::move(func)}]() { return func(""); });
     }
 
@@ -172,13 +172,13 @@ std::future<T> GetJson(std::function<T(const std::string&)> func, const std::str
         hl::Response response;
 
         if (!cli->send(request, response)) {
-            LOG_ERROR(WebService, "GET to %s returned null", url.c_str());
+            NGLOG_ERROR(WebService, "GET to {} returned null", url);
             return func("");
         }
 
         if (response.status >= 400) {
-            LOG_ERROR(WebService, "GET to %s returned error status code: %u", url.c_str(),
-                      response.status);
+            NGLOG_ERROR(WebService, "GET to {} returned error status code: {}", url,
+                        response.status);
             return func("");
         }
 
@@ -186,8 +186,8 @@ std::future<T> GetJson(std::function<T(const std::string&)> func, const std::str
 
         if (content_type == response.headers.end() ||
             content_type->second.find("application/json") == std::string::npos) {
-            LOG_ERROR(WebService, "GET to %s returned wrong content: %s", url.c_str(),
-                      content_type->second.c_str());
+            NGLOG_ERROR(WebService, "GET to {} returned wrong content: {}", url,
+                        content_type->second);
             return func("");
         }
 
@@ -211,13 +211,13 @@ void DeleteJson(const std::string& url, const std::string& data, const std::stri
     lup parsedUrl = lup::ParseURL(url);
 
     if (url.empty() || !parsedUrl.IsValid()) {
-        LOG_ERROR(WebService, "URL is invalid");
+        NGLOG_ERROR(WebService, "URL is invalid");
         return;
     }
 
     const bool are_credentials_provided{!token.empty() && !username.empty()};
     if (!are_credentials_provided) {
-        LOG_ERROR(WebService, "Credentials must be provided for authenticated requests");
+        NGLOG_ERROR(WebService, "Credentials must be provided for authenticated requests");
         return;
     }
 
@@ -244,13 +244,13 @@ void DeleteJson(const std::string& url, const std::string& data, const std::stri
         hl::Response response;
 
         if (!cli->send(request, response)) {
-            LOG_ERROR(WebService, "DELETE to %s returned null", url.c_str());
+            NGLOG_ERROR(WebService, "DELETE to {} returned null", url);
             return;
         }
 
         if (response.status >= 400) {
-            LOG_ERROR(WebService, "DELETE to %s returned error status code: %u", url.c_str(),
-                      response.status);
+            NGLOG_ERROR(WebService, "DELETE to {} returned error status code: {}", url,
+                        response.status);
             return;
         }
 
@@ -258,8 +258,8 @@ void DeleteJson(const std::string& url, const std::string& data, const std::stri
 
         if (content_type == response.headers.end() ||
             content_type->second.find("application/json") == std::string::npos) {
-            LOG_ERROR(WebService, "DELETE to %s returned wrong content: %s", url.c_str(),
-                      content_type->second.c_str());
+            NGLOG_ERROR(WebService, "DELETE to {} returned wrong content: {}", url,
+                        content_type->second);
             return;
         }
 


### PR DESCRIPTION
Follow-up of #3533

Replace prefix of all logging macros from LOG to NGLOG

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3577)
<!-- Reviewable:end -->
