### PR TITLE
input_common: Migrate logging macros

### DIFF
--- a/src/input_common/sdl/sdl.cpp
+++ b/src/input_common/sdl/sdl.cpp
@@ -32,7 +32,7 @@ public:
     explicit SDLJoystick(int joystick_index)
         : joystick{SDL_JoystickOpen(joystick_index), SDL_JoystickClose} {
         if (!joystick) {
-            LOG_ERROR(Input, "failed to open joystick %d", joystick_index);
+            NGLOG_ERROR(Input, "failed to open joystick {}", joystick_index);
         }
     }
 
@@ -204,7 +204,7 @@ public:
                 trigger_if_greater = false;
             } else {
                 trigger_if_greater = true;
-                LOG_ERROR(Input, "Unknown direction %s", direction_name.c_str());
+                NGLOG_ERROR(Input, "Unknown direction {}", direction_name);
             }
             return std::make_unique<SDLAxisButton>(GetJoystick(joystick_index), axis, threshold,
                                                    trigger_if_greater);
@@ -235,7 +235,7 @@ public:
 
 void Init() {
     if (SDL_Init(SDL_INIT_JOYSTICK) < 0) {
-        LOG_CRITICAL(Input, "SDL_Init(SDL_INIT_JOYSTICK) failed with: %s", SDL_GetError());
+        NGLOG_CRITICAL(Input, "SDL_Init(SDL_INIT_JOYSTICK) failed with: {}", SDL_GetError());
     } else {
         using namespace Input;
         RegisterFactory<ButtonDevice>("sdl", std::make_shared<SDLButtonFactory>());


### PR DESCRIPTION
Follow-up of #3533

Replace logging to use NGLOG instead of LOG

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3578)
<!-- Reviewable:end -->
