### PR TITLE
common: Migrate logging macros

### DIFF
--- a/src/audio_core/hle/mixers.cpp
+++ b/src/audio_core/hle/mixers.cpp
@@ -132,7 +132,7 @@ void Mixers::DownmixAndMixIntoCurrentFrame(float gain, const QuadFrame32& sample
         return;
     }
 
-    UNREACHABLE_MSG("Invalid output_format %zu", static_cast<size_t>(state.output_format));
+    UNREACHABLE_MSG("Invalid output_format {}", static_cast<size_t>(state.output_format));
 }
 
 void Mixers::AuxReturn(const IntermediateMixSamples& read_samples) {

--- a/src/citra_qt/debugger/graphics/graphics_surface.cpp
+++ b/src/citra_qt/debugger/graphics/graphics_surface.cpp
@@ -708,7 +708,7 @@ unsigned int GraphicsSurfaceWidget::NibblesPerPixel(GraphicsSurfaceWidget::Forma
     default:
         UNREACHABLE_MSG("GraphicsSurfaceWidget::BytesPerPixel: this should not be reached as this "
                         "function should be given a format which is in "
-                        "GraphicsSurfaceWidget::Format. Instead got %i",
+                        "GraphicsSurfaceWidget::Format. Instead got {}",
                         static_cast<int>(format));
         return 0;
     }

--- a/src/common/assert.h
+++ b/src/common/assert.h
@@ -30,14 +30,14 @@ __declspec(noinline, noreturn)
 #define ASSERT(_a_)                                                                                \
     do                                                                                             \
         if (!(_a_)) {                                                                              \
-            assert_noinline_call([] { LOG_CRITICAL(Debug, "Assertion Failed!"); });                \
+            assert_noinline_call([] { NGLOG_CRITICAL(Debug, "Assertion Failed!"); });              \
         }                                                                                          \
     while (0)
 
 #define ASSERT_MSG(_a_, ...)                                                                       \
     do                                                                                             \
         if (!(_a_)) {                                                                              \
-            assert_noinline_call([&] { LOG_CRITICAL(Debug, "Assertion Failed!\n" __VA_ARGS__); }); \
+            assert_noinline_call([&] { NGLOG_CRITICAL(Debug, "Assertion Failed!" __VA_ARGS__); }); \
         }                                                                                          \
     while (0)
 
@@ -52,5 +52,5 @@ __declspec(noinline, noreturn)
 #define DEBUG_ASSERT_MSG(_a_, _desc_, ...)
 #endif
 
-#define UNIMPLEMENTED() LOG_CRITICAL(Debug, "Unimplemented code!")
+#define UNIMPLEMENTED() NGLOG_CRITICAL(Debug, "Unimplemented code!")
 #define UNIMPLEMENTED_MSG(_a_, ...) ASSERT_MSG(false, _a_, __VA_ARGS__)

--- a/src/common/assert.h
+++ b/src/common/assert.h
@@ -37,7 +37,8 @@ __declspec(noinline, noreturn)
 #define ASSERT_MSG(_a_, ...)                                                                       \
     do                                                                                             \
         if (!(_a_)) {                                                                              \
-            assert_noinline_call([&] { NGLOG_CRITICAL(Debug, "Assertion Failed!" __VA_ARGS__); }); \
+            assert_noinline_call(                                                                  \
+                [&] { NGLOG_CRITICAL(Debug, "Assertion Failed!\n" __VA_ARGS__); });                \
         }                                                                                          \
     while (0)
 

--- a/src/common/chunk_file.h
+++ b/src/common/chunk_file.h
@@ -159,8 +159,8 @@ public:
             Do(foundVersion);
 
         if (error == ERROR_FAILURE || foundVersion < minVer || foundVersion > ver) {
-            LOG_ERROR(Common, "Savestate failure: wrong version %d found for %s", foundVersion,
-                      title);
+            NGLOG_ERROR(Common, "Savestate failure: wrong version {} found for {}", foundVersion,
+                        title);
             SetError(ERROR_FAILURE);
             return PointerWrapSection(*this, -1, title);
         }
@@ -466,7 +466,7 @@ public:
         } break;
 
         default:
-            LOG_ERROR(Common, "Savestate error: invalid mode %d.", mode);
+            NGLOG_ERROR(Common, "Savestate error: invalid mode {}.", mode);
         }
     }
 
@@ -607,10 +607,10 @@ public:
         u32 cookie = arbitraryNumber;
         Do(cookie);
         if (mode == PointerWrap::MODE_READ && cookie != arbitraryNumber) {
-            LOG_ERROR(Common,
-                      "After \"%s\", found %d (0x%X) instead of save marker %d (0x%X). "
-                      "Aborting savestate load...",
-                      prevName, cookie, cookie, arbitraryNumber, arbitraryNumber);
+            NGLOG_ERROR(Common,
+                        "After \"{}\", found {} ({:#X}) instead of save marker {} ({:#X}). "
+                        "Aborting savestate load...",
+                        prevName, cookie, cookie, arbitraryNumber, arbitraryNumber);
             SetError(ERROR_FAILURE);
         }
     }

--- a/src/common/chunk_file.h
+++ b/src/common/chunk_file.h
@@ -198,7 +198,7 @@ public:
             for (int i = 0; i < size; i++) {
                 DEBUG_ASSERT_MSG(
                     ((u8*)data)[i] == (*ptr)[i],
-                    "Savestate verification failure: %d (0x%X) (at %p) != %d (0x%X) (at %p).\n",
+                    "Savestate verification failure: {} ({:#X}) (at {}) != {} ({:#X}) (at {}).\n",
                     ((u8*)data)[i], ((u8*)data)[i], &((u8*)data)[i], (*ptr)[i], (*ptr)[i],
                     &(*ptr)[i]);
             }
@@ -224,7 +224,7 @@ public:
             for (int i = 0; i < size; i++) {
                 DEBUG_ASSERT_MSG(
                     ((u8*)data)[i] == (*ptr)[i],
-                    "Savestate verification failure: %d (0x%X) (at %p) != %d (0x%X) (at %p).\n",
+                    "Savestate verification failure: {} ({#:X}) (at {}) != {} ({:#X}) (at {}).\n",
                     ((u8*)data)[i], ((u8*)data)[i], &((u8*)data)[i], (*ptr)[i], (*ptr)[i],
                     &(*ptr)[i]);
             }
@@ -486,8 +486,8 @@ public:
             break;
         case MODE_VERIFY:
             DEBUG_ASSERT_MSG((x == (char*)*ptr),
-                             "Savestate verification failure: \"%s\" != \"%s\" (at %p).\n",
-                             x.c_str(), (char*)*ptr, ptr);
+                             "Savestate verification failure: \"{}\" != \"{}\" (at {}).\n", x,
+                             (char*)*ptr, ptr);
             break;
         }
         (*ptr) += stringLen;
@@ -508,8 +508,8 @@ public:
             break;
         case MODE_VERIFY:
             DEBUG_ASSERT_MSG((x == (wchar_t*)*ptr),
-                             "Savestate verification failure: \"%ls\" != \"%ls\" (at %p).\n",
-                             x.c_str(), (wchar_t*)*ptr, ptr);
+                             "Savestate verification failure: \"{}\" != \"{}\" (at {}).\n", x,
+                             (wchar_t*)*ptr, ptr);
             break;
         }
         (*ptr) += stringLen;

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -651,12 +651,12 @@ static const std::string GetUserDirectory(const std::string& envvar) {
         else if (envvar == "XDG_CACHE_HOME")
             subdirectory = DIR_SEP ".cache";
         else
-            ASSERT_MSG(false, "Unknown XDG variable %s.", envvar.c_str());
+            ASSERT_MSG(false, "Unknown XDG variable {}.", envvar);
         user_dir = GetHomeDirectory() + subdirectory;
     }
 
-    ASSERT_MSG(!user_dir.empty(), "User directory %s musn’t be empty.", envvar.c_str());
-    ASSERT_MSG(user_dir[0] == '/', "User directory %s must be absolute.", envvar.c_str());
+    ASSERT_MSG(!user_dir.empty(), "User directory {} musn’t be empty.", envvar);
+    ASSERT_MSG(user_dir[0] == '/', "User directory {} must be absolute.", envvar);
 
     return user_dir;
 }

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -348,7 +348,7 @@ u64 GetSize(const std::string& filename) {
     if (stat(filename.c_str(), &buf) == 0)
 #endif
     {
-        NGLOG_TRACE(Common_Filesystem, "{}: {}", filename, (long long)buf.st_size);
+        NGLOG_TRACE(Common_Filesystem, "{}: {}", filename, buf.st_size);
         return buf.st_size;
     }
 

--- a/src/common/logging/filter.cpp
+++ b/src/common/logging/filter.cpp
@@ -65,14 +65,14 @@ bool Filter::ParseFilterRule(const std::string::const_iterator begin,
                              const std::string::const_iterator end) {
     auto level_separator = std::find(begin, end, ':');
     if (level_separator == end) {
-        LOG_ERROR(Log, "Invalid log filter. Must specify a log level after `:`: %s",
-                  std::string(begin, end).c_str());
+        NGLOG_ERROR(Log, "Invalid log filter. Must specify a log level after `:`: {}",
+                    std::string(begin, end));
         return false;
     }
 
     const Level level = GetLevelByName(level_separator + 1, end);
     if (level == Level::Count) {
-        LOG_ERROR(Log, "Unknown log level in filter: %s", std::string(begin, end).c_str());
+        NGLOG_ERROR(Log, "Unknown log level in filter: {}", std::string(begin, end));
         return false;
     }
 
@@ -83,7 +83,7 @@ bool Filter::ParseFilterRule(const std::string::const_iterator begin,
 
     const Class log_class = GetClassByName(begin, level_separator);
     if (log_class == Class::Count) {
-        LOG_ERROR(Log, "Unknown log class in filter: %s", std::string(begin, end).c_str());
+        NGLOG_ERROR(Log, "Unknown log class in filter: {}", std::string(begin, end));
         return false;
     }
 

--- a/src/common/memory_util.cpp
+++ b/src/common/memory_util.cpp
@@ -55,7 +55,7 @@ void* AllocateExecutableMemory(size_t size, bool low) {
     if (ptr == MAP_FAILED) {
         ptr = nullptr;
 #endif
-        LOG_ERROR(Common_Memory, "Failed to allocate executable memory");
+        NGLOG_ERROR(Common_Memory, "Failed to allocate executable memory");
     }
 #if !defined(_WIN32) && defined(ARCHITECTURE_X64) && !defined(MAP_32BIT)
     else {
@@ -68,7 +68,7 @@ void* AllocateExecutableMemory(size_t size, bool low) {
 
 #if EMU_ARCH_BITS == 64
     if ((u64)ptr >= 0x80000000 && low == true)
-        LOG_ERROR(Common_Memory, "Executable memory ended up above 2GB!");
+        NGLOG_ERROR(Common_Memory, "Executable memory ended up above 2GB!");
 #endif
 
     return ptr;
@@ -85,7 +85,7 @@ void* AllocateMemoryPages(size_t size) {
 #endif
 
     if (ptr == nullptr)
-        LOG_ERROR(Common_Memory, "Failed to allocate raw memory");
+        NGLOG_ERROR(Common_Memory, "Failed to allocate raw memory");
 
     return ptr;
 }
@@ -99,12 +99,12 @@ void* AllocateAlignedMemory(size_t size, size_t alignment) {
     ptr = memalign(alignment, size);
 #else
     if (posix_memalign(&ptr, alignment, size) != 0)
-        LOG_ERROR(Common_Memory, "Failed to allocate aligned memory");
+        NGLOG_ERROR(Common_Memory, "Failed to allocate aligned memory");
 #endif
 #endif
 
     if (ptr == nullptr)
-        LOG_ERROR(Common_Memory, "Failed to allocate aligned memory");
+        NGLOG_ERROR(Common_Memory, "Failed to allocate aligned memory");
 
     return ptr;
 }
@@ -113,7 +113,7 @@ void FreeMemoryPages(void* ptr, size_t size) {
     if (ptr) {
 #ifdef _WIN32
         if (!VirtualFree(ptr, 0, MEM_RELEASE))
-            LOG_ERROR(Common_Memory, "FreeMemoryPages failed!\n%s", GetLastErrorMsg());
+            NGLOG_ERROR(Common_Memory, "FreeMemoryPages failed!\n{}", GetLastErrorMsg());
 #else
         munmap(ptr, size);
 #endif
@@ -134,7 +134,7 @@ void WriteProtectMemory(void* ptr, size_t size, bool allowExecute) {
 #ifdef _WIN32
     DWORD oldValue;
     if (!VirtualProtect(ptr, size, allowExecute ? PAGE_EXECUTE_READ : PAGE_READONLY, &oldValue))
-        LOG_ERROR(Common_Memory, "WriteProtectMemory failed!\n%s", GetLastErrorMsg());
+        NGLOG_ERROR(Common_Memory, "WriteProtectMemory failed!\n{}", GetLastErrorMsg());
 #else
     mprotect(ptr, size, allowExecute ? (PROT_READ | PROT_EXEC) : PROT_READ);
 #endif
@@ -145,7 +145,7 @@ void UnWriteProtectMemory(void* ptr, size_t size, bool allowExecute) {
     DWORD oldValue;
     if (!VirtualProtect(ptr, size, allowExecute ? PAGE_EXECUTE_READWRITE : PAGE_READWRITE,
                         &oldValue))
-        LOG_ERROR(Common_Memory, "UnWriteProtectMemory failed!\n%s", GetLastErrorMsg());
+        NGLOG_ERROR(Common_Memory, "UnWriteProtectMemory failed!\n{}", GetLastErrorMsg());
 #else
     mprotect(ptr, size,
              allowExecute ? (PROT_READ | PROT_WRITE | PROT_EXEC) : PROT_WRITE | PROT_READ);

--- a/src/common/param_package.cpp
+++ b/src/common/param_package.cpp
@@ -25,7 +25,7 @@ ParamPackage::ParamPackage(const std::string& serialized) {
         std::vector<std::string> key_value;
         Common::SplitString(pair, KEY_VALUE_SEPARATOR, key_value);
         if (key_value.size() != 2) {
-            LOG_ERROR(Common, "invalid key pair %s", pair.c_str());
+            NGLOG_ERROR(Common, "invalid key pair {}", pair);
             continue;
         }
 
@@ -64,7 +64,7 @@ std::string ParamPackage::Serialize() const {
 std::string ParamPackage::Get(const std::string& key, const std::string& default_value) const {
     auto pair = data.find(key);
     if (pair == data.end()) {
-        LOG_DEBUG(Common, "key %s not found", key.c_str());
+        NGLOG_DEBUG(Common, "key {} not found", key);
         return default_value;
     }
 
@@ -74,14 +74,14 @@ std::string ParamPackage::Get(const std::string& key, const std::string& default
 int ParamPackage::Get(const std::string& key, int default_value) const {
     auto pair = data.find(key);
     if (pair == data.end()) {
-        LOG_DEBUG(Common, "key %s not found", key.c_str());
+        NGLOG_DEBUG(Common, "key {} not found", key);
         return default_value;
     }
 
     try {
         return std::stoi(pair->second);
     } catch (const std::logic_error&) {
-        LOG_ERROR(Common, "failed to convert %s to int", pair->second.c_str());
+        NGLOG_ERROR(Common, "failed to convert {} to int", pair->second);
         return default_value;
     }
 }
@@ -89,14 +89,14 @@ int ParamPackage::Get(const std::string& key, int default_value) const {
 float ParamPackage::Get(const std::string& key, float default_value) const {
     auto pair = data.find(key);
     if (pair == data.end()) {
-        LOG_DEBUG(Common, "key %s not found", key.c_str());
+        NGLOG_DEBUG(Common, "key {} not found", key);
         return default_value;
     }
 
     try {
         return std::stof(pair->second);
     } catch (const std::logic_error&) {
-        LOG_ERROR(Common, "failed to convert %s to float", pair->second.c_str());
+        NGLOG_ERROR(Common, "failed to convert {} to float", pair->second);
         return default_value;
     }
 }

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -107,7 +107,7 @@ std::string StringFromFormat(const char* format, ...) {
 #else
     va_start(args, format);
     if (vasprintf(&buf, format, args) < 0)
-        LOG_ERROR(Common, "Unable to allocate memory for string");
+        NGLOG_ERROR(Common, "Unable to allocate memory for string");
     va_end(args);
 
     std::string temp = buf;
@@ -347,7 +347,7 @@ static std::string CodeToUTF8(const char* fromcode, const std::basic_string<T>& 
 
     iconv_t const conv_desc = iconv_open("UTF-8", fromcode);
     if ((iconv_t)(-1) == conv_desc) {
-        LOG_ERROR(Common, "Iconv initialization failure [%s]: %s", fromcode, strerror(errno));
+        NGLOG_ERROR(Common, "Iconv initialization failure [{}]: {}", fromcode, strerror(errno));
         iconv_close(conv_desc);
         return {};
     }
@@ -376,7 +376,7 @@ static std::string CodeToUTF8(const char* fromcode, const std::basic_string<T>& 
                     ++src_buffer;
                 }
             } else {
-                LOG_ERROR(Common, "iconv failure [%s]: %s", fromcode, strerror(errno));
+                NGLOG_ERROR(Common, "iconv failure [{}]: {}", fromcode, strerror(errno));
                 break;
             }
         }
@@ -395,7 +395,7 @@ std::u16string UTF8ToUTF16(const std::string& input) {
 
     iconv_t const conv_desc = iconv_open("UTF-16LE", "UTF-8");
     if ((iconv_t)(-1) == conv_desc) {
-        LOG_ERROR(Common, "Iconv initialization failure [UTF-8]: %s", strerror(errno));
+        NGLOG_ERROR(Common, "Iconv initialization failure [UTF-8]: {}", strerror(errno));
         iconv_close(conv_desc);
         return {};
     }
@@ -424,7 +424,7 @@ std::u16string UTF8ToUTF16(const std::string& input) {
                     ++src_buffer;
                 }
             } else {
-                LOG_ERROR(Common, "iconv failure [UTF-8]: %s", strerror(errno));
+                NGLOG_ERROR(Common, "iconv failure [UTF-8]: {}", strerror(errno));
                 break;
             }
         }

--- a/src/core/core_timing.cpp
+++ b/src/core/core_timing.cpp
@@ -74,9 +74,9 @@ EventType* RegisterEvent(const std::string& name, TimedCallback callback) {
     // check for existing type with same name.
     // we want event type names to remain unique so that we can use them for serialization.
     ASSERT_MSG(event_types.find(name) == event_types.end(),
-               "CoreTiming Event \"%s\" is already registered. Events should only be registered "
+               "CoreTiming Event \"{}\" is already registered. Events should only be registered "
                "during Init to avoid breaking save states.",
-               name.c_str());
+               name);
 
     auto info = event_types.emplace(name, EventType{callback, nullptr});
     EventType* event_type = &info.first->second;

--- a/src/core/hle/applets/applet.cpp
+++ b/src/core/hle/applets/applet.cpp
@@ -82,7 +82,7 @@ std::shared_ptr<Applet> Applet::Get(Service::APT::AppletId id) {
 static void AppletUpdateEvent(u64 applet_id, int cycles_late) {
     Service::APT::AppletId id = static_cast<Service::APT::AppletId>(applet_id);
     std::shared_ptr<Applet> applet = Applet::Get(id);
-    ASSERT_MSG(applet != nullptr, "Applet doesn't exist! applet_id={:#X}", static_cast<u32>(id));
+    ASSERT_MSG(applet != nullptr, "Applet doesn't exist! applet_id={:#08X}", static_cast<u32>(id));
 
     applet->Update();
 

--- a/src/core/hle/applets/applet.cpp
+++ b/src/core/hle/applets/applet.cpp
@@ -82,7 +82,7 @@ std::shared_ptr<Applet> Applet::Get(Service::APT::AppletId id) {
 static void AppletUpdateEvent(u64 applet_id, int cycles_late) {
     Service::APT::AppletId id = static_cast<Service::APT::AppletId>(applet_id);
     std::shared_ptr<Applet> applet = Applet::Get(id);
-    ASSERT_MSG(applet != nullptr, "Applet doesn't exist! applet_id=%08X", static_cast<u32>(id));
+    ASSERT_MSG(applet != nullptr, "Applet doesn't exist! applet_id={:#X}", static_cast<u32>(id));
 
     applet->Update();
 

--- a/src/core/hle/applets/applet.cpp
+++ b/src/core/hle/applets/applet.cpp
@@ -82,7 +82,7 @@ std::shared_ptr<Applet> Applet::Get(Service::APT::AppletId id) {
 static void AppletUpdateEvent(u64 applet_id, int cycles_late) {
     Service::APT::AppletId id = static_cast<Service::APT::AppletId>(applet_id);
     std::shared_ptr<Applet> applet = Applet::Get(id);
-    ASSERT_MSG(applet != nullptr, "Applet doesn't exist! applet_id={:#08X}", static_cast<u32>(id));
+    ASSERT_MSG(applet != nullptr, "Applet doesn't exist! applet_id={:08X}", static_cast<u32>(id));
 
     applet->Update();
 

--- a/src/core/hle/ipc_helpers.h
+++ b/src/core/hle/ipc_helpers.h
@@ -32,7 +32,7 @@ public:
     }
 
     void ValidateHeader() {
-        DEBUG_ASSERT_MSG(index == TotalSize(), "Operations do not match the header (cmd 0x%x)",
+        DEBUG_ASSERT_MSG(index == TotalSize(), "Operations do not match the header (cmd {:#x})",
                          header.raw);
     }
 

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -154,7 +154,7 @@ ResultCode HLERequestContext::PopulateFromIncomingCommandBuffer(const u32_le* sr
             break;
         }
         default:
-            UNIMPLEMENTED_MSG("Unsupported handle translation: 0x%08X", descriptor);
+            UNIMPLEMENTED_MSG("Unsupported handle translation: {:#X}", descriptor);
         }
     }
 
@@ -218,7 +218,7 @@ ResultCode HLERequestContext::WriteToOutgoingCommandBuffer(u32_le* dst_cmdbuf, P
             break;
         }
         default:
-            UNIMPLEMENTED_MSG("Unsupported handle translation: 0x%08X", descriptor);
+            UNIMPLEMENTED_MSG("Unsupported handle translation: {:#X}", descriptor);
         }
     }
 

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -154,7 +154,7 @@ ResultCode HLERequestContext::PopulateFromIncomingCommandBuffer(const u32_le* sr
             break;
         }
         default:
-            UNIMPLEMENTED_MSG("Unsupported handle translation: {:#X}", descriptor);
+            UNIMPLEMENTED_MSG("Unsupported handle translation: {:#010X}", descriptor);
         }
     }
 
@@ -218,7 +218,7 @@ ResultCode HLERequestContext::WriteToOutgoingCommandBuffer(u32_le* dst_cmdbuf, P
             break;
         }
         default:
-            UNIMPLEMENTED_MSG("Unsupported handle translation: {:#X}", descriptor);
+            UNIMPLEMENTED_MSG("Unsupported handle translation: {:#010X}", descriptor);
         }
     }
 

--- a/src/core/hle/kernel/ipc.cpp
+++ b/src/core/hle/kernel/ipc.cpp
@@ -199,7 +199,7 @@ ResultCode TranslateCommandBuffer(SharedPtr<Thread> src_thread, SharedPtr<Thread
             break;
         }
         default:
-            UNIMPLEMENTED_MSG("Unsupported handle translation: 0x%08X", descriptor);
+            UNIMPLEMENTED_MSG("Unsupported handle translation: {:#X}", descriptor);
         }
     }
 

--- a/src/core/hle/kernel/ipc.cpp
+++ b/src/core/hle/kernel/ipc.cpp
@@ -199,7 +199,7 @@ ResultCode TranslateCommandBuffer(SharedPtr<Thread> src_thread, SharedPtr<Thread
             break;
         }
         default:
-            UNIMPLEMENTED_MSG("Unsupported handle translation: {:#X}", descriptor);
+            UNIMPLEMENTED_MSG("Unsupported handle translation: {:#010X}", descriptor);
         }
     }
 

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -751,7 +751,7 @@ static ResultCode CreateThread(Handle* out_handle, u32 priority, u32 entry_point
         break;
     default:
         // TODO(bunnei): Implement support for other processor IDs
-        ASSERT_MSG(false, "Unsupported thread processor ID: %d", processor_id);
+        ASSERT_MSG(false, "Unsupported thread processor ID: {}", processor_id);
         break;
     }
 
@@ -865,7 +865,7 @@ static ResultCode GetProcessIdOfThread(u32* process_id, Handle thread_handle) {
 
     const SharedPtr<Process> process = thread->owner_process;
 
-    ASSERT_MSG(process != nullptr, "Invalid parent process for thread=0x%08X", thread_handle);
+    ASSERT_MSG(process != nullptr, "Invalid parent process for thread={:#X}", thread_handle);
 
     *process_id = process->process_id;
     return RESULT_SUCCESS;

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -865,7 +865,7 @@ static ResultCode GetProcessIdOfThread(u32* process_id, Handle thread_handle) {
 
     const SharedPtr<Process> process = thread->owner_process;
 
-    ASSERT_MSG(process != nullptr, "Invalid parent process for thread={:#X}", thread_handle);
+    ASSERT_MSG(process != nullptr, "Invalid parent process for thread={:#010X}", thread_handle);
 
     *process_id = process->process_id;
     return RESULT_SUCCESS;

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -242,11 +242,11 @@ void Thread::ResumeFromWait() {
         return;
 
     case THREADSTATUS_RUNNING:
-        DEBUG_ASSERT_MSG(false, "Thread with object id %u has already resumed.", GetObjectId());
+        DEBUG_ASSERT_MSG(false, "Thread with object id {} has already resumed.", GetObjectId());
         return;
     case THREADSTATUS_DEAD:
         // This should never happen, as threads must complete before being stopped.
-        DEBUG_ASSERT_MSG(false, "Thread with object id %u cannot be resumed because it's DEAD.",
+        DEBUG_ASSERT_MSG(false, "Thread with object id {} cannot be resumed because it's DEAD.",
                          GetObjectId());
         return;
     }

--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -276,8 +276,8 @@ VMManager::VMAIter VMManager::StripIterConstness(const VMAHandle& iter) {
 }
 
 ResultVal<VMManager::VMAIter> VMManager::CarveVMA(VAddr base, u32 size) {
-    ASSERT_MSG((size & Memory::PAGE_MASK) == 0, "non-page aligned size: 0x%8X", size);
-    ASSERT_MSG((base & Memory::PAGE_MASK) == 0, "non-page aligned base: 0x%08X", base);
+    ASSERT_MSG((size & Memory::PAGE_MASK) == 0, "non-page aligned size: {:#8X}", size);
+    ASSERT_MSG((base & Memory::PAGE_MASK) == 0, "non-page aligned base: {:#010X}", base);
 
     VMAIter vma_handle = StripIterConstness(FindVMA(base));
     if (vma_handle == vma_map.end()) {
@@ -312,8 +312,8 @@ ResultVal<VMManager::VMAIter> VMManager::CarveVMA(VAddr base, u32 size) {
 }
 
 ResultVal<VMManager::VMAIter> VMManager::CarveVMARange(VAddr target, u32 size) {
-    ASSERT_MSG((size & Memory::PAGE_MASK) == 0, "non-page aligned size: 0x%8X", size);
-    ASSERT_MSG((target & Memory::PAGE_MASK) == 0, "non-page aligned base: 0x%08X", target);
+    ASSERT_MSG((size & Memory::PAGE_MASK) == 0, "non-page aligned size: {:#8X}", size);
+    ASSERT_MSG((target & Memory::PAGE_MASK) == 0, "non-page aligned base: {:#010X}", target);
 
     VAddr target_end = target + size;
     ASSERT(target_end >= target);

--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -276,7 +276,7 @@ VMManager::VMAIter VMManager::StripIterConstness(const VMAHandle& iter) {
 }
 
 ResultVal<VMManager::VMAIter> VMManager::CarveVMA(VAddr base, u32 size) {
-    ASSERT_MSG((size & Memory::PAGE_MASK) == 0, "non-page aligned size: {:#8X}", size);
+    ASSERT_MSG((size & Memory::PAGE_MASK) == 0, "non-page aligned size: {:#10X}", size);
     ASSERT_MSG((base & Memory::PAGE_MASK) == 0, "non-page aligned base: {:#010X}", base);
 
     VMAIter vma_handle = StripIterConstness(FindVMA(base));
@@ -312,7 +312,7 @@ ResultVal<VMManager::VMAIter> VMManager::CarveVMA(VAddr base, u32 size) {
 }
 
 ResultVal<VMManager::VMAIter> VMManager::CarveVMARange(VAddr target, u32 size) {
-    ASSERT_MSG((size & Memory::PAGE_MASK) == 0, "non-page aligned size: {:#8X}", size);
+    ASSERT_MSG((size & Memory::PAGE_MASK) == 0, "non-page aligned size: {:#10X}", size);
     ASSERT_MSG((target & Memory::PAGE_MASK) == 0, "non-page aligned base: {:#010X}", target);
 
     VAddr target_end = target + size;

--- a/src/core/hle/service/apt/applet_manager.cpp
+++ b/src/core/hle/service/apt/applet_manager.cpp
@@ -77,7 +77,7 @@ static u64 GetTitleIdForApplet(AppletId id) {
                                 return data.applet_ids[0] == id || data.applet_ids[1] == id;
                             });
 
-    ASSERT_MSG(itr != applet_titleids.end(), "Unknown applet id 0x%03X", static_cast<u32>(id));
+    ASSERT_MSG(itr != applet_titleids.end(), "Unknown applet id 0x{:#05X}", static_cast<u32>(id));
 
     return itr->title_ids[CFG::GetCurrentModule()->GetRegionValue()];
 }

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -653,7 +653,7 @@ void Module::Interface::Wrap(Kernel::HLERequestContext& ctx) {
     // Note: real 3DS still returns SUCCESS when the sizes don't match. It seems that it doesn't
     // check the buffer size and writes data with potential overflow.
     ASSERT_MSG(output_size == input_size + HW::AES::CCM_MAC_SIZE,
-               "input_size (%d) doesn't match to output_size (%d)", input_size, output_size);
+               "input_size ({}) doesn't match to output_size ({})", input_size, output_size);
 
     LOG_DEBUG(Service_APT, "called, output_size=%u, input_size=%u, nonce_offset=%u, nonce_size=%u",
               output_size, input_size, nonce_offset, nonce_size);
@@ -698,7 +698,7 @@ void Module::Interface::Unwrap(Kernel::HLERequestContext& ctx) {
     // Note: real 3DS still returns SUCCESS when the sizes don't match. It seems that it doesn't
     // check the buffer size and writes data with potential overflow.
     ASSERT_MSG(output_size == input_size - HW::AES::CCM_MAC_SIZE,
-               "input_size (%d) doesn't match to output_size (%d)", input_size, output_size);
+               "input_size ({}) doesn't match to output_size ({})", input_size, output_size);
 
     LOG_DEBUG(Service_APT, "called, output_size=%u, input_size=%u, nonce_offset=%u, nonce_size=%u",
               output_size, input_size, nonce_offset, nonce_size);

--- a/src/core/hle/service/dsp_dsp.cpp
+++ b/src/core/hle/service/dsp_dsp.cpp
@@ -51,7 +51,7 @@ public:
         }
         }
 
-        UNREACHABLE_MSG("Invalid interrupt type = %zu", static_cast<size_t>(type));
+        UNREACHABLE_MSG("Invalid interrupt type = {}", static_cast<size_t>(type));
     }
 
     bool HasTooManyEventsRegistered() const {
@@ -219,7 +219,7 @@ static void RegisterInterruptEvents(Service::Interface* self) {
     u32 event_handle = cmd_buff[4];
 
     ASSERT_MSG(type_index < NUM_INTERRUPT_TYPE && pipe_index < AudioCore::num_dsp_pipe,
-               "Invalid type or pipe: type = %u, pipe = %u", type_index, pipe_index);
+               "Invalid type or pipe: type = {}, pipe = {}", type_index, pipe_index);
 
     InterruptType type = static_cast<InterruptType>(cmd_buff[1]);
     DspPipe pipe = static_cast<DspPipe>(cmd_buff[2]);
@@ -305,7 +305,7 @@ static void WriteProcessPipe(Service::Interface* self) {
     }
 
     ASSERT_MSG(Memory::IsValidVirtualAddress(buffer),
-               "Invalid Buffer: pipe=%u, size=0x%X, buffer=0x%08X", pipe_index, size, buffer);
+               "Invalid Buffer: pipe={}, size={:#X}, buffer={:#010X}", pipe_index, size, buffer);
 
     std::vector<u8> message(size);
     for (u32 i = 0; i < size; i++) {
@@ -363,8 +363,8 @@ static void ReadPipeIfPossible(Service::Interface* self) {
     AudioCore::DspPipe pipe = static_cast<AudioCore::DspPipe>(pipe_index);
 
     ASSERT_MSG(Memory::IsValidVirtualAddress(addr),
-               "Invalid addr: pipe=0x%08X, unknown=0x%08X, size=0x%X, buffer=0x%08X", pipe_index,
-               unknown, size, addr);
+               "Invalid addr: pipe={:#010X}, unknown={:#010X}, size={:#X}, buffer={:#010X}",
+               pipe_index, unknown, size, addr);
 
     cmd_buff[0] = IPC::MakeHeader(0x10, 1, 2);
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
@@ -407,8 +407,8 @@ static void ReadPipe(Service::Interface* self) {
     AudioCore::DspPipe pipe = static_cast<AudioCore::DspPipe>(pipe_index);
 
     ASSERT_MSG(Memory::IsValidVirtualAddress(addr),
-               "Invalid addr: pipe=0x%08X, unknown=0x%08X, size=0x%X, buffer=0x%08X", pipe_index,
-               unknown, size, addr);
+               "Invalid addr: pipe={:#010X}, unknown={:#010X}, size={:#X}, buffer={:#010X}",
+               pipe_index, unknown, size, addr);
 
     if (Core::DSP().GetPipeReadableSize(pipe) >= size) {
         std::vector<u8> response = Core::DSP().PipeRead(pipe, size);
@@ -508,7 +508,7 @@ static void RecvData(Service::Interface* self) {
 
     u32 register_number = cmd_buff[1];
 
-    ASSERT_MSG(register_number == 0, "Unknown register_number %u", register_number);
+    ASSERT_MSG(register_number == 0, "Unknown register_number {}", register_number);
 
     // Application reads this after requesting DSP shutdown, to verify the DSP has indeed shutdown
     // or slept.
@@ -547,7 +547,7 @@ static void RecvDataIsReady(Service::Interface* self) {
 
     u32 register_number = cmd_buff[1];
 
-    ASSERT_MSG(register_number == 0, "Unknown register_number %u", register_number);
+    ASSERT_MSG(register_number == 0, "Unknown register_number {}", register_number);
 
     cmd_buff[0] = IPC::MakeHeader(0x2, 2, 0);
     cmd_buff[1] = RESULT_SUCCESS.raw;

--- a/src/core/hle/service/sm/srv.cpp
+++ b/src/core/hle/service/sm/srv.cpp
@@ -118,7 +118,7 @@ void SRV::GetServiceHandle(Kernel::HLERequestContext& ctx) {
     } else if (session.Code() == Kernel::ERR_MAX_CONNECTIONS_REACHED && wait_until_available) {
         LOG_WARNING(Service_SRV, "called service=%s -> ERR_MAX_CONNECTIONS_REACHED", name.c_str());
         // TODO(Subv): Put the caller guest thread to sleep until this port becomes available again.
-        UNIMPLEMENTED_MSG("Unimplemented wait until port %s is available.", name.c_str());
+        UNIMPLEMENTED_MSG("Unimplemented wait until port {} is available.", name);
     } else {
         LOG_ERROR(Service_SRV, "called service=%s -> error 0x%08X", name.c_str(),
                   session.Code().raw);

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -46,7 +46,7 @@ static void MapPages(PageTable& page_table, u32 base, u32 size, u8* memory, Page
 
     u32 end = base + size;
     while (base != end) {
-        ASSERT_MSG(base < PAGE_TABLE_NUM_ENTRIES, "out of range mapping at {:#010X}", base);
+        ASSERT_MSG(base < PAGE_TABLE_NUM_ENTRIES, "out of range mapping at {:08X}", base);
 
         page_table.attributes[base] = type;
         page_table.pointers[base] = memory;
@@ -58,22 +58,22 @@ static void MapPages(PageTable& page_table, u32 base, u32 size, u8* memory, Page
 }
 
 void MapMemoryRegion(PageTable& page_table, VAddr base, u32 size, u8* target) {
-    ASSERT_MSG((size & PAGE_MASK) == 0, "non-page aligned size: {:#010X}", size);
-    ASSERT_MSG((base & PAGE_MASK) == 0, "non-page aligned base: {:#010X}", base);
+    ASSERT_MSG((size & PAGE_MASK) == 0, "non-page aligned size: {:08X}", size);
+    ASSERT_MSG((base & PAGE_MASK) == 0, "non-page aligned base: {:08X}", base);
     MapPages(page_table, base / PAGE_SIZE, size / PAGE_SIZE, target, PageType::Memory);
 }
 
 void MapIoRegion(PageTable& page_table, VAddr base, u32 size, MMIORegionPointer mmio_handler) {
-    ASSERT_MSG((size & PAGE_MASK) == 0, "non-page aligned size: {:#010X}", size);
-    ASSERT_MSG((base & PAGE_MASK) == 0, "non-page aligned base: {:#010X}", base);
+    ASSERT_MSG((size & PAGE_MASK) == 0, "non-page aligned size: {:08X}", size);
+    ASSERT_MSG((base & PAGE_MASK) == 0, "non-page aligned base: {:08X}", base);
     MapPages(page_table, base / PAGE_SIZE, size / PAGE_SIZE, nullptr, PageType::Special);
 
     page_table.special_regions.emplace_back(SpecialRegion{base, size, mmio_handler});
 }
 
 void UnmapRegion(PageTable& page_table, VAddr base, u32 size) {
-    ASSERT_MSG((size & PAGE_MASK) == 0, "non-page aligned size: {:#010X}", size);
-    ASSERT_MSG((base & PAGE_MASK) == 0, "non-page aligned base: {:#010X}", base);
+    ASSERT_MSG((size & PAGE_MASK) == 0, "non-page aligned size: {:08X}", size);
+    ASSERT_MSG((base & PAGE_MASK) == 0, "non-page aligned base: {:08X}", base);
     MapPages(page_table, base / PAGE_SIZE, size / PAGE_SIZE, nullptr, PageType::Unmapped);
 }
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -46,7 +46,7 @@ static void MapPages(PageTable& page_table, u32 base, u32 size, u8* memory, Page
 
     u32 end = base + size;
     while (base != end) {
-        ASSERT_MSG(base < PAGE_TABLE_NUM_ENTRIES, "out of range mapping at %08X", base);
+        ASSERT_MSG(base < PAGE_TABLE_NUM_ENTRIES, "out of range mapping at {:#010X}", base);
 
         page_table.attributes[base] = type;
         page_table.pointers[base] = memory;
@@ -58,22 +58,22 @@ static void MapPages(PageTable& page_table, u32 base, u32 size, u8* memory, Page
 }
 
 void MapMemoryRegion(PageTable& page_table, VAddr base, u32 size, u8* target) {
-    ASSERT_MSG((size & PAGE_MASK) == 0, "non-page aligned size: %08X", size);
-    ASSERT_MSG((base & PAGE_MASK) == 0, "non-page aligned base: %08X", base);
+    ASSERT_MSG((size & PAGE_MASK) == 0, "non-page aligned size: {:#010X}", size);
+    ASSERT_MSG((base & PAGE_MASK) == 0, "non-page aligned base: {:#010X}", base);
     MapPages(page_table, base / PAGE_SIZE, size / PAGE_SIZE, target, PageType::Memory);
 }
 
 void MapIoRegion(PageTable& page_table, VAddr base, u32 size, MMIORegionPointer mmio_handler) {
-    ASSERT_MSG((size & PAGE_MASK) == 0, "non-page aligned size: %08X", size);
-    ASSERT_MSG((base & PAGE_MASK) == 0, "non-page aligned base: %08X", base);
+    ASSERT_MSG((size & PAGE_MASK) == 0, "non-page aligned size: {:#010X}", size);
+    ASSERT_MSG((base & PAGE_MASK) == 0, "non-page aligned base: {:#010X}", base);
     MapPages(page_table, base / PAGE_SIZE, size / PAGE_SIZE, nullptr, PageType::Special);
 
     page_table.special_regions.emplace_back(SpecialRegion{base, size, mmio_handler});
 }
 
 void UnmapRegion(PageTable& page_table, VAddr base, u32 size) {
-    ASSERT_MSG((size & PAGE_MASK) == 0, "non-page aligned size: %08X", size);
-    ASSERT_MSG((base & PAGE_MASK) == 0, "non-page aligned base: %08X", base);
+    ASSERT_MSG((size & PAGE_MASK) == 0, "non-page aligned size: {:#010X}", size);
+    ASSERT_MSG((base & PAGE_MASK) == 0, "non-page aligned base: {:#010X}", base);
     MapPages(page_table, base / PAGE_SIZE, size / PAGE_SIZE, nullptr, PageType::Unmapped);
 }
 
@@ -123,7 +123,7 @@ static MMIORegionPointer GetMMIOHandler(const PageTable& page_table, VAddr vaddr
             return region.handler;
         }
     }
-    ASSERT_MSG(false, "Mapped IO page without a handler @ %08X", vaddr);
+    ASSERT_MSG(false, "Mapped IO page without a handler @ {:08X}", vaddr);
     return nullptr; // Should never happen
 }
 
@@ -154,7 +154,7 @@ T Read(const VAddr vaddr) {
         LOG_ERROR(HW_Memory, "unmapped Read%lu @ 0x%08X", sizeof(T) * 8, vaddr);
         return 0;
     case PageType::Memory:
-        ASSERT_MSG(false, "Mapped memory page without a pointer @ %08X", vaddr);
+        ASSERT_MSG(false, "Mapped memory page without a pointer @ {:08X}", vaddr);
         break;
     case PageType::RasterizerCachedMemory: {
         RasterizerFlushVirtualRegion(vaddr, sizeof(T), FlushMode::Flush);
@@ -192,7 +192,7 @@ void Write(const VAddr vaddr, const T data) {
                   vaddr);
         return;
     case PageType::Memory:
-        ASSERT_MSG(false, "Mapped memory page without a pointer @ %08X", vaddr);
+        ASSERT_MSG(false, "Mapped memory page without a pointer @ {:08X}", vaddr);
         break;
     case PageType::RasterizerCachedMemory: {
         RasterizerFlushVirtualRegion(vaddr, sizeof(T), FlushMode::Invalidate);

--- a/src/video_core/regs_framebuffer.h
+++ b/src/video_core/regs_framebuffer.h
@@ -258,7 +258,7 @@ struct FramebufferRegs {
             return 4;
         }
 
-        ASSERT_MSG(false, "Unknown depth format %u", static_cast<u32>(format));
+        ASSERT_MSG(false, "Unknown depth format {}", static_cast<u32>(format));
     }
 
     // Returns the number of bits per depth component of the specified depth format
@@ -271,7 +271,7 @@ struct FramebufferRegs {
             return 24;
         }
 
-        ASSERT_MSG(false, "Unknown depth format %u", static_cast<u32>(format));
+        ASSERT_MSG(false, "Unknown depth format {}", static_cast<u32>(format));
     }
 
     INSERT_PADDING_WORDS(0x20);

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -1281,7 +1281,7 @@ void RasterizerOpenGL::SetShader() {
             glGetActiveUniformBlockiv(current_shader->shader.handle, block_index,
                                       GL_UNIFORM_BLOCK_DATA_SIZE, &block_size);
             ASSERT_MSG(block_size == sizeof(UniformData),
-                       "Uniform block size did not match! Got %d, expected %zu",
+                       "Uniform block size did not match! Got {}, expected {}",
                        static_cast<int>(block_size), sizeof(UniformData));
             glUniformBlockBinding(current_shader->shader.handle, block_index, 0);
 

--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -30,7 +30,7 @@ void OutputVertex::ValidateSemantics(const RasterizerRegs& regs) {
         for (size_t comp = 0; comp < 4; ++comp) {
             u32 semantic = (output_register_map >> (8 * comp)) & 0x1F;
             ASSERT_MSG(semantic < 24 || semantic == RasterizerRegs::VSOutputAttributes::INVALID,
-                       "Invalid/unknown semantic id: %" PRIu32, semantic);
+                       "Invalid/unknown semantic id: {}", semantic);
         }
     }
 }

--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -2,7 +2,6 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <cinttypes>
 #include <cmath>
 #include <cstring>
 #include "common/bit_set.h"


### PR DESCRIPTION
Follow-up of #3533

Replace logging to use `NGLOG` instead of `LOG`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3580)
<!-- Reviewable:end -->
