### PR TITLE
Implement Pull #87 from yuzu: game_list: Add missing override specifier for KeyReleaseEater's eventFilter function

### DIFF
--- a/src/citra_qt/game_list.h
+++ b/src/citra_qt/game_list.h
@@ -51,7 +51,7 @@ public:
             QString edit_filter_text_old;
 
         protected:
-            bool eventFilter(QObject* obj, QEvent* event);
+            bool eventFilter(QObject* obj, QEvent* event) override;
         };
         QHBoxLayout* layout_filter = nullptr;
         QTreeView* tree_view = nullptr;


### PR DESCRIPTION
This is a straightforward port of https://github.com/yuzu-emu/yuzu/pull/87.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3582)
<!-- Reviewable:end -->
