### PR TITLE
core/loader: Migrate logging macros

### DIFF
--- a/src/core/loader/3dsx.cpp
+++ b/src/core/loader/3dsx.cpp
@@ -172,8 +172,8 @@ static THREEDSX_Error Load3DSXFile(FileUtil::IOFile& file, u32 base_addr,
                 for (unsigned current_inprogress = 0;
                      current_inprogress < remaining && pos < end_pos; current_inprogress++) {
                     const auto& table = reloc_table[current_inprogress];
-                    LOG_TRACE(Loader, "(t=%d,skip=%u,patch=%u)", current_segment_reloc_table,
-                              static_cast<u32>(table.skip), static_cast<u32>(table.patch));
+                    NGLOG_TRACE(Loader, "(t={},skip={},patch={})", current_segment_reloc_table,
+                                static_cast<u32>(table.skip), static_cast<u32>(table.patch));
                     pos += table.skip;
                     s32 num_patches = table.patch;
                     while (0 < num_patches && pos < end_pos) {
@@ -182,8 +182,8 @@ static THREEDSX_Error Load3DSXFile(FileUtil::IOFile& file, u32 base_addr,
                         u32 orig_data = *pos;
                         u32 sub_type = orig_data >> (32 - 4);
                         u32 addr = TranslateAddr(orig_data & ~0xF0000000, &loadinfo, offsets);
-                        LOG_TRACE(Loader, "Patching %08X <-- rel(%08X,%d) (%08X)", in_addr, addr,
-                                  current_segment_reloc_table, *pos);
+                        NGLOG_TRACE(Loader, "Patching {:08X} <-- rel({:08X},{}) ({:08X})", in_addr,
+                                    addr, current_segment_reloc_table, *pos);
                         switch (current_segment_reloc_table) {
                         case 0: {
                             if (sub_type != 0)
@@ -234,10 +234,10 @@ static THREEDSX_Error Load3DSXFile(FileUtil::IOFile& file, u32 base_addr,
     code_set->entrypoint = code_set->code.addr;
     code_set->memory = std::make_shared<std::vector<u8>>(std::move(program_image));
 
-    LOG_DEBUG(Loader, "code size:   0x%X", loadinfo.seg_sizes[0]);
-    LOG_DEBUG(Loader, "rodata size: 0x%X", loadinfo.seg_sizes[1]);
-    LOG_DEBUG(Loader, "data size:   0x%X (including 0x%X of bss)", loadinfo.seg_sizes[2],
-              hdr.bss_size);
+    NGLOG_DEBUG(Loader, "code size:   {:#X}", loadinfo.seg_sizes[0]);
+    NGLOG_DEBUG(Loader, "rodata size: {:#X}", loadinfo.seg_sizes[1]);
+    NGLOG_DEBUG(Loader, "data size:   {:#X} (including {:#X} of bss)", loadinfo.seg_sizes[2],
+                hdr.bss_size);
 
     *out_codeset = code_set;
     return ERROR_NONE;
@@ -303,8 +303,8 @@ ResultStatus AppLoader_THREEDSX::ReadRomFS(std::shared_ptr<FileUtil::IOFile>& ro
         u32 romfs_offset = hdr.fs_offset;
         u32 romfs_size = static_cast<u32>(file.GetSize()) - hdr.fs_offset;
 
-        LOG_DEBUG(Loader, "RomFS offset:           0x%08X", romfs_offset);
-        LOG_DEBUG(Loader, "RomFS size:             0x%08X", romfs_size);
+        NGLOG_DEBUG(Loader, "RomFS offset:           {:#010X}", romfs_offset);
+        NGLOG_DEBUG(Loader, "RomFS size:             {:#010X}", romfs_size);
 
         // We reopen the file, to allow its position to be independent from file's
         romfs_file = std::make_shared<FileUtil::IOFile>(filepath, "rb");
@@ -316,7 +316,7 @@ ResultStatus AppLoader_THREEDSX::ReadRomFS(std::shared_ptr<FileUtil::IOFile>& ro
 
         return ResultStatus::Success;
     }
-    LOG_DEBUG(Loader, "3DSX has no RomFS");
+    NGLOG_DEBUG(Loader, "3DSX has no RomFS");
     return ResultStatus::ErrorNotUsed;
 }
 

--- a/src/core/loader/elf.cpp
+++ b/src/core/loader/elf.cpp
@@ -272,18 +272,18 @@ const char* ElfReader::GetSectionName(int section) const {
 }
 
 SharedPtr<CodeSet> ElfReader::LoadInto(u32 vaddr) {
-    LOG_DEBUG(Loader, "String section: %i", header->e_shstrndx);
+    NGLOG_DEBUG(Loader, "String section: {}", header->e_shstrndx);
 
     // Should we relocate?
     relocate = (header->e_type != ET_EXEC);
 
     if (relocate) {
-        LOG_DEBUG(Loader, "Relocatable module");
+        NGLOG_DEBUG(Loader, "Relocatable module");
         entryPoint += vaddr;
     } else {
-        LOG_DEBUG(Loader, "Prerelocated executable");
+        NGLOG_DEBUG(Loader, "Prerelocated executable");
     }
-    LOG_DEBUG(Loader, "%i segments:", header->e_phnum);
+    NGLOG_DEBUG(Loader, "{} segments:", header->e_phnum);
 
     // First pass : Get the bits into RAM
     u32 base_addr = relocate ? vaddr : 0;
@@ -303,8 +303,8 @@ SharedPtr<CodeSet> ElfReader::LoadInto(u32 vaddr) {
 
     for (unsigned int i = 0; i < header->e_phnum; ++i) {
         Elf32_Phdr* p = &segments[i];
-        LOG_DEBUG(Loader, "Type: %i Vaddr: %08X Filesz: %8X Memsz: %8X ", p->p_type, p->p_vaddr,
-                  p->p_filesz, p->p_memsz);
+        NGLOG_DEBUG(Loader, "Type: {} Vaddr: {:08X} Filesz: {:08X} Memsz: {:08X} ", p->p_type,
+                    p->p_vaddr, p->p_filesz, p->p_memsz);
 
         if (p->p_type == PT_LOAD) {
             CodeSet::Segment* codeset_segment;
@@ -316,16 +316,16 @@ SharedPtr<CodeSet> ElfReader::LoadInto(u32 vaddr) {
             } else if (permission_flags == (PF_R | PF_W)) {
                 codeset_segment = &codeset->data;
             } else {
-                LOG_ERROR(Loader, "Unexpected ELF PT_LOAD segment id %u with flags %X", i,
-                          p->p_flags);
+                NGLOG_ERROR(Loader, "Unexpected ELF PT_LOAD segment id {} with flags {:X}", i,
+                            p->p_flags);
                 continue;
             }
 
             if (codeset_segment->size != 0) {
-                LOG_ERROR(Loader,
-                          "ELF has more than one segment of the same type. Skipping extra "
-                          "segment (id %i)",
-                          i);
+                NGLOG_ERROR(Loader,
+                            "ELF has more than one segment of the same type. Skipping extra "
+                            "segment (id {})",
+                            i);
                 continue;
             }
 
@@ -344,7 +344,7 @@ SharedPtr<CodeSet> ElfReader::LoadInto(u32 vaddr) {
     codeset->entrypoint = base_addr + header->e_entry;
     codeset->memory = std::make_shared<std::vector<u8>>(std::move(program_image));
 
-    LOG_DEBUG(Loader, "Done loading.");
+    NGLOG_DEBUG(Loader, "Done loading.");
 
     return codeset;
 }

--- a/src/core/loader/loader.cpp
+++ b/src/core/loader/loader.cpp
@@ -41,7 +41,7 @@ FileType IdentifyFile(FileUtil::IOFile& file) {
 FileType IdentifyFile(const std::string& file_name) {
     FileUtil::IOFile file(file_name, "rb");
     if (!file.IsOpen()) {
-        LOG_ERROR(Loader, "Failed to load file %s", file_name.c_str());
+        NGLOG_ERROR(Loader, "Failed to load file {}", file_name);
         return FileType::Unknown;
     }
 
@@ -123,7 +123,7 @@ static std::unique_ptr<AppLoader> GetFileLoader(FileUtil::IOFile&& file, FileTyp
 std::unique_ptr<AppLoader> GetLoader(const std::string& filename) {
     FileUtil::IOFile file(filename, "rb");
     if (!file.IsOpen()) {
-        LOG_ERROR(Loader, "Failed to load file %s", filename.c_str());
+        NGLOG_ERROR(Loader, "Failed to load file {}", filename);
         return nullptr;
     }
 
@@ -134,12 +134,12 @@ std::unique_ptr<AppLoader> GetLoader(const std::string& filename) {
     FileType filename_type = GuessFromExtension(filename_extension);
 
     if (type != filename_type) {
-        LOG_WARNING(Loader, "File %s has a different type than its extension.", filename.c_str());
+        NGLOG_WARNING(Loader, "File {} has a different type than its extension.", filename);
         if (FileType::Unknown == type)
             type = filename_type;
     }
 
-    LOG_DEBUG(Loader, "Loading file %s as %s...", filename.c_str(), GetFileTypeString(type));
+    NGLOG_DEBUG(Loader, "Loading file {} as {}...", filename, GetFileTypeString(type));
 
     return GetFileLoader(std::move(file), type, filename_filename, filename);
 }

--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -156,7 +156,7 @@ ResultStatus AppLoader_NCCH::Load(Kernel::SharedPtr<Kernel::Process>& process) {
     ReadProgramId(ncch_program_id);
     std::string program_id{Common::StringFromFormat("%016" PRIX64, ncch_program_id)};
 
-    LOG_INFO(Loader, "Program ID: %s", program_id.c_str());
+    NGLOG_INFO(Loader, "Program ID: {}", program_id);
 
     update_ncch.OpenFile(Service::AM::GetTitleContentPath(Service::FS::MediaType::SDMC,
                                                           ncch_program_id | UPDATE_MASK));


### PR DESCRIPTION
Replace logging to use `NGLOG` instead of `LOG`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3593)
<!-- Reviewable:end -->
