### PR TITLE
gl_rasterizer: Fix incorrect comparison against src_surface in AccelerateTextureCopy()

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -1093,7 +1093,7 @@ bool RasterizerOpenGL::AccelerateTextureCopy(const GPU::Regs::DisplayTransferCon
     Surface dst_surface;
     std::tie(dst_surface, dst_rect) =
         res_cache.GetSurfaceSubRect(dst_params, ScaleMatch::Upscale, load_gap);
-    if (src_surface == nullptr) {
+    if (dst_surface == nullptr) {
         return false;
     }
 


### PR DESCRIPTION
This should actually be comparing the validity of the destination surface.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3601)
<!-- Reviewable:end -->
