### PR TITLE
citra-room: Fix always false case in main() related to port range

### DIFF
--- a/src/dedicated_room/citra-room.cpp
+++ b/src/dedicated_room/citra-room.cpp
@@ -69,7 +69,7 @@ int main(int argc, char** argv) {
     std::string token;
     std::string announce_url;
     u64 preferred_game_id = 0;
-    u16 port = Network::DefaultRoomPort;
+    u32 port = Network::DefaultRoomPort;
     u32 max_members = 16;
 
     static struct option long_options[] = {


### PR DESCRIPTION
If the variable we're checking is a u16, then there can never be values outside of the 0-65535 range. This is bad because an arbitrary larger value can be truncated down into a valid value (as we use strtoul, which operates on unsigned longs), making otherwise malformed argument well-formed.

Change it to use u32 to allow the check to function properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3603)
<!-- Reviewable:end -->
