### PR TITLE
QT: add themed icon update signal

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -112,6 +112,9 @@ GMainWindow::GMainWindow() : config(new Config()), emu_thread(nullptr) {
     ui.setupUi(this);
     statusBar()->hide();
 
+    default_theme_paths = QIcon::themeSearchPaths();
+    UpdateUITheme();
+
     InitializeWidgets();
     InitializeDebugWidgets();
     InitializeRecentFileMenuActions();
@@ -129,9 +132,6 @@ GMainWindow::GMainWindow() : config(new Config()), emu_thread(nullptr) {
     show();
 
     game_list->PopulateAsync(UISettings::values.gamedir, UISettings::values.gamedir_deepscan);
-
-    default_theme_paths = QIcon::themeSearchPaths();
-    UpdateUITheme();
 
     // Show one-time "callout" messages to the user
     ShowCallouts();
@@ -1249,6 +1249,7 @@ void GMainWindow::UpdateUITheme() {
         QIcon::setThemeName(":/icons/default");
     }
     QIcon::setThemeSearchPaths(theme_paths);
+    emit UpdateThemedIcons();
 }
 
 void GMainWindow::LoadTranslation() {

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -74,6 +74,8 @@ signals:
     void UpdateProgress(size_t written, size_t total);
     void CIAInstallReport(Service::AM::InstallStatus status, QString filepath);
     void CIAInstallFinished();
+    // Signal that tells widgets to update icons to use the current theme
+    void UpdateThemedIcons();
 
 private:
     void InitializeWidgets();


### PR DESCRIPTION
adds a signal to tell widgets to update icons to match the current theme
also moves UpdateUITheme() before widget initialization so widgets properly inherit the icon theme

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3610)
<!-- Reviewable:end -->
