### PR TITLE
gl_rasterizer: move shader uniform sync from SetShader() to ctor

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -174,6 +174,12 @@ RasterizerOpenGL::RasterizerOpenGL() : shader_dirty(true) {
 
     glEnable(GL_BLEND);
 
+    SyncEntireState();
+}
+
+RasterizerOpenGL::~RasterizerOpenGL() {}
+
+void RasterizerOpenGL::SyncEntireState() {
     // Sync fixed function OpenGL state
     SyncClipEnabled();
     SyncCullMode();
@@ -211,8 +217,6 @@ RasterizerOpenGL::RasterizerOpenGL() : shader_dirty(true) {
     SyncFogColor();
     SyncProcTexNoise();
 }
-
-RasterizerOpenGL::~RasterizerOpenGL() {}
 
 /**
  * This is a helper function to resolve an issue when interpolating opposite quaternions. See below

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -162,6 +162,9 @@ private:
     static_assert(sizeof(UniformData) < 16384,
                   "UniformData structure must be less than 16kb as per the OpenGL spec");
 
+    /// Syncs entire status to match PICA registers
+    void SyncEntireState();
+
     /// Syncs the clip enabled status to match the PICA register
     void SyncClipEnabled();
 


### PR DESCRIPTION
This is a question come up from #3499 (["`// TODO: why is this here ???`"](https://github.com/citra-emu/citra/pull/3499/files#diff-d1b91c65951bd9733c0e7d924161e57dR1742)), and it hinders further refactor for preparing vertex/geometry shader. All the SyncXXX functions called here share the following patterns:
 - Their implementation all follows this form:
```
some_value = Pica::g_state.regs.some_register
if (some_value != uniform_block_data.data.some_value) {
    uniform_block_data.data.some_value = some_value;
    uniform_block_data.dirty = true;
}
```
 - They are all called in exactly two places: `SetShader` (here) and `NotifyPicaRegisterChanged`

It can be seen that only when the register value and uniform value mismatch, these function can do something instead of no-op. The only possibilities of the mismatch happening are:
 - They are not the same at the beginning. Happens on initialization.
 - `uniform_block_data.data.some_value` changed. There is no code explicitly doing this. Only re-initialization (changing from swrasterizer to hwrasterizer) can change this value.
 - `Pica::g_state.regs.some_register` changed. This should be captured by `NotifyPicaRegisterChanged`

The first two cases can be captured well by the constructor, and the sync in `SetShader` is unnecessary.

----

I did some retrospective work to find the source of these code. The SyncXXX pattern was introduced when HW renderer was first implemented (#789). At that time, these functions were called only in `NotifyPicaRegisterChanged` and `Reset` (effectively the constructor nowadays). Later, they were moved to `SetShader` (which is still called by `Reset`) in #1187. And at some point later, `Reset` was removed and this ended up being in `SetShader`. I feel that this was a refactor flaw, and I basically changed it back to the original idea.

----

Also moved `SyncClipCoef()` to the "sync uniform" group as it also follows the same pattern.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3624)
<!-- Reviewable:end -->
