### PR TITLE
citra-room: Use the default OpenGL loader instead of SDL_GL_GetProcAddress

### DIFF
--- a/src/dedicated_room/CMakeLists.txt
+++ b/src/dedicated_room/CMakeLists.txt
@@ -12,7 +12,7 @@ target_link_libraries(citra-room PRIVATE glad)
 if (MSVC)
     target_link_libraries(citra-room PRIVATE getopt)
 endif()
-target_link_libraries(citra-room PRIVATE ${PLATFORM_LIBRARIES} SDL2 Threads::Threads)
+target_link_libraries(citra-room PRIVATE ${PLATFORM_LIBRARIES} Threads::Threads)
 
 if(UNIX AND NOT APPLE)
     install(TARGETS citra-room RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")

--- a/src/dedicated_room/citra-room.cpp
+++ b/src/dedicated_room/citra-room.cpp
@@ -8,8 +8,6 @@
 #include <regex>
 #include <string>
 #include <thread>
-#define SDL_MAIN_HANDLED
-#include <SDL.h>
 #include <glad/glad.h>
 
 #ifdef _MSC_VER
@@ -60,7 +58,7 @@ int main(int argc, char** argv) {
     char* endarg;
 
     // This is just to be able to link against core
-    gladLoadGLLoader(static_cast<GLADloadproc>(SDL_GL_GetProcAddress));
+    gladLoadGL();
 
     std::string room_name;
     std::string password;


### PR DESCRIPTION
Fixes #3538

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3634)
<!-- Reviewable:end -->
