### PR TITLE
Round TEV outputs and the final fragment output in GLSL

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -1101,19 +1101,19 @@ float LookupLightingLUTSigned(int lut_index, float pos) {
 }
 
 float byteround(float x) {
-    return round(x * 255.0) / 255.0;
+    return round(x * 255.0) * (1.0 / 255.0);
 }
 
 vec2 byteround(vec2 x) {
-    return round(x * 255.0) / 255.0;
+    return round(x * 255.0) * (1.0 / 255.0);
 }
 
 vec3 byteround(vec3 x) {
-    return round(x * 255.0) / 255.0;
+    return round(x * 255.0) * (1.0 / 255.0);
 }
 
 vec4 byteround(vec4 x) {
-    return round(x * 255.0) / 255.0;
+    return round(x * 255.0) * (1.0 / 255.0);
 }
 
 )";


### PR DESCRIPTION
Adds a function to the generated GLSL called byteround for floats and vec2-vec4.

Fixes water effect in SM3DL.

![image](https://user-images.githubusercontent.com/2268005/38460201-30b70fb6-3a83-11e8-9f48-b7c8316417d2.png)

Closes #2791

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3638)
<!-- Reviewable:end -->
