### PR TITLE
gl_rasterizer_cache: exit FillTextureCube when address is invalid

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -1228,7 +1228,7 @@ Surface RasterizerCacheOpenGL::GetTextureSurface(
     return GetSurface(params, ScaleMatch::Ignore, true);
 }
 
-void RasterizerCacheOpenGL::FillTextureCube(GLuint dest_handle,
+bool RasterizerCacheOpenGL::FillTextureCube(GLuint dest_handle,
                                             const Pica::TexturingRegs::FullTextureConfig& config,
                                             PAddr px, PAddr nx, PAddr py, PAddr ny, PAddr pz,
                                             PAddr nz) {
@@ -1250,6 +1250,8 @@ void RasterizerCacheOpenGL::FillTextureCube(GLuint dest_handle,
     u16 res_scale = 1;
     for (auto& face : faces) {
         face.surface = GetTextureSurface(config, face.address);
+        if (face.surface == nullptr)
+            return false;
         res_scale = std::max(res_scale, face.surface->res_scale);
     }
 
@@ -1298,6 +1300,8 @@ void RasterizerCacheOpenGL::FillTextureCube(GLuint dest_handle,
         glBlitFramebuffer(src_rect.left, src_rect.bottom, src_rect.right, src_rect.top, 0, 0,
                           scaled_size, scaled_size, GL_COLOR_BUFFER_BIT, GL_LINEAR);
     }
+
+    return true;
 }
 
 SurfaceSurfaceRect_Tuple RasterizerCacheOpenGL::GetFramebufferSurfaces(

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -326,7 +326,7 @@ public:
                               PAddr addr_override = 0);
 
     /// Copy surfaces to a cubemap texture based on the texture configuration
-    void FillTextureCube(GLuint dest_handle, const Pica::TexturingRegs::FullTextureConfig& config,
+    bool FillTextureCube(GLuint dest_handle, const Pica::TexturingRegs::FullTextureConfig& config,
                          PAddr px, PAddr nx, PAddr py, PAddr ny, PAddr pz, PAddr nz);
 
     /// Get the color and depth surfaces based on the framebuffer configuration


### PR DESCRIPTION
Game can feed the texture address register an invalid value and doesn't use the texture in the rendering pipeline. In this case we should just ignore the invalid texture. We already do this for normal texture units, and it should also be done fore the texture cube.

The texture cube is also changed such that it is not bound to the texture unit from the rasterizer initialization, but only bound when in use, just in the same way as normal textures. It will not be bound when texture cube is not used or when the address is invalid.

Aim to fix #3635.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3639)
<!-- Reviewable:end -->
