### PR TITLE
renderer_opengl: Rewrite stream buffer.

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -239,8 +239,8 @@ private:
 
     std::array<SamplerInfo, 3> texture_samplers;
     OGLVertexArray vertex_array;
-    static constexpr size_t VERTEX_BUFFER_SIZE = 128 * 1024 * 1024;
-    std::unique_ptr<OGLStreamBuffer> vertex_buffer;
+    static constexpr size_t VERTEX_BUFFER_SIZE = 32 * 1024 * 1024;
+    OGLStreamBuffer vertex_buffer;
     OGLBuffer uniform_buffer;
     OGLFramebuffer framebuffer;
 

--- a/src/video_core/renderer_opengl/gl_resource_manager.h
+++ b/src/video_core/renderer_opengl/gl_resource_manager.h
@@ -225,39 +225,6 @@ public:
     GLuint handle = 0;
 };
 
-class OGLSync : private NonCopyable {
-public:
-    OGLSync() = default;
-
-    OGLSync(OGLSync&& o) : handle(std::exchange(o.handle, nullptr)) {}
-
-    ~OGLSync() {
-        Release();
-    }
-    OGLSync& operator=(OGLSync&& o) {
-        Release();
-        handle = std::exchange(o.handle, nullptr);
-        return *this;
-    }
-
-    /// Creates a new internal OpenGL resource and stores the handle
-    void Create() {
-        if (handle != 0)
-            return;
-        handle = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
-    }
-
-    /// Deletes the internal OpenGL resource
-    void Release() {
-        if (handle == 0)
-            return;
-        glDeleteSync(handle);
-        handle = 0;
-    }
-
-    GLsync handle = 0;
-};
-
 class OGLVertexArray : private NonCopyable {
 public:
     OGLVertexArray() = default;


### PR DESCRIPTION
This is a followup to #3504 .

The idea of this rewrite is to orphan the buffer when it is full instead of syncing. This allows the driver to allocate many buffer objects and so to increase/decrease the size of the ring buffer. This however needs a glMapBufferRange call on orphaning, which likely synchronize the drivers worker thread once a frame.

On rewriting the implementation, I've also updated the API to flush the used buffer space on unmapping. This allows to generate the vertex data in-place and to flush the generated data afterwards. The new API also returns if the old allocations are still valid. This might allow us to use this kind of buffer for uniforms and texture buffers. In this way, we just need to reupload all of them on orphaning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3666)
<!-- Reviewable:end -->
