### PR TITLE
Unbreak build with Qt 5.9.4 (at least on FreeBSD)

### DIFF
--- a/src/citra_qt/game_list_p.h
+++ b/src/citra_qt/game_list_p.h
@@ -7,6 +7,7 @@
 #include <atomic>
 #include <map>
 #include <unordered_map>
+#include <QCoreApplication>
 #include <QImage>
 #include <QObject>
 #include <QPainter>


### PR DESCRIPTION
#3663 regression. Not sure how the header is bootlegged on Travis CI but...
```
$ pkg info -x qt5
qt5-buildtools-5.9.4_1
qt5-concurrent-5.9.4_1
qt5-core-5.9.4_2
qt5-dbus-5.9.4_1
qt5-gui-5.9.4_4
qt5-network-5.9.4_3
qt5-opengl-5.9.4_1
qt5-qmake-5.9.4_1
qt5-widgets-5.9.4_1

$ rg QCoreApplication::translate /usr/local/include
/usr/local/include/qt5/QtCore/qcoreapplication.h
244:        { return QCoreApplication::translate(#context, sourceText, disambiguation, n); }
250:        { return QCoreApplication::translate(#context, sourceText, disambiguation, n); } \
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3670)
<!-- Reviewable:end -->
