### PR TITLE
Minor multiplayer ui fixes

### DIFF
--- a/src/citra_qt/multiplayer/client_room.cpp
+++ b/src/citra_qt/multiplayer/client_room.cpp
@@ -13,6 +13,7 @@
 #include "citra_qt/game_list_p.h"
 #include "citra_qt/multiplayer/client_room.h"
 #include "citra_qt/multiplayer/message.h"
+#include "citra_qt/multiplayer/state.h"
 #include "common/logging/log.h"
 #include "core/announce_multiplayer_session.h"
 #include "ui_client_room.h"
@@ -57,11 +58,8 @@ void ClientRoomWindow::OnStateChange(const Network::RoomMember::State& state) {
 }
 
 void ClientRoomWindow::Disconnect() {
-    if (!NetworkMessage::WarnDisconnect()) {
-        return;
-    }
-    if (auto member = Network::GetRoomMember().lock()) {
-        member->Leave();
+    auto parent = static_cast<MultiplayerState*>(parentWidget());
+    if (!parent->OnCloseRoom()) {
         ui->chat->AppendStatusMessage(tr("Disconnected"));
         close();
     }

--- a/src/citra_qt/multiplayer/direct_connect.cpp
+++ b/src/citra_qt/multiplayer/direct_connect.cpp
@@ -51,8 +51,14 @@ void DirectConnectWindow::Connect() {
         return;
     }
     if (const auto member = Network::GetRoomMember().lock()) {
-        if (member->IsConnected() && !NetworkMessage::WarnDisconnect()) {
+        // Prevent the user from trying to join a room while they are already joining.
+        if (member->GetState() == Network::RoomMember::State::Joining) {
             return;
+        } else if (member->GetState() == Network::RoomMember::State::Joined) {
+            // And ask if they want to leave the room if they are already in one.
+            if (!NetworkMessage::WarnDisconnect()) {
+                return;
+            }
         }
     }
     switch (static_cast<ConnectionType>(ui->connection_type->currentIndex())) {

--- a/src/citra_qt/multiplayer/host_room.cpp
+++ b/src/citra_qt/multiplayer/host_room.cpp
@@ -74,7 +74,9 @@ void HostRoomWindow::Host() {
         return;
     }
     if (auto member = Network::GetRoomMember().lock()) {
-        if (member->IsConnected()) {
+        if (member->GetState() == Network::RoomMember::State::Joining) {
+            return;
+        } else if (member->GetState() == Network::RoomMember::State::Joined) {
             auto parent = static_cast<MultiplayerState*>(parentWidget());
             if (!parent->OnCloseRoom()) {
                 close();

--- a/src/citra_qt/multiplayer/lobby.h
+++ b/src/citra_qt/multiplayer/lobby.h
@@ -89,7 +89,6 @@ private:
     std::unique_ptr<Ui::Lobby> ui;
     QFutureWatcher<void>* watcher;
     Validation validation;
-    bool joining = false;
 };
 
 /**

--- a/src/citra_qt/multiplayer/state.cpp
+++ b/src/citra_qt/multiplayer/state.cpp
@@ -147,6 +147,7 @@ bool MultiplayerState::OnCloseRoom() {
         // if you are in a room, leave it
         if (auto member = Network::GetRoomMember().lock()) {
             member->Leave();
+            NGLOG_DEBUG(Frontend, "Left the room (as a client)");
         }
 
         // if you are hosting a room, also stop hosting
@@ -155,6 +156,7 @@ bool MultiplayerState::OnCloseRoom() {
         }
         room->Destroy();
         announce_multiplayer_session->Stop();
+        NGLOG_DEBUG(Frontend, "Closed the room (as a server)");
     }
     return true;
 }

--- a/src/citra_qt/multiplayer/state.h
+++ b/src/citra_qt/multiplayer/state.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <QWidget>
+#include "core/announce_multiplayer_session.h"
 #include "network/network.h"
 
 class QStandardItemModel;


### PR DESCRIPTION
One bug was found and reported on discord today where if you attempt to direct connect to a room that doesn't exist, and simultaneously try to join a room in the lobby, citra would pop up a message about "do you want to close the current network connection?" and if you choose yes, citra would crash. The first commit fixes this by preventing any join (through the lobby, direct connect, or hosting a new room) from happening while the network state is "Joining". The old behavior where citra pops up a message still happens if you've successfully joined a room.

The second commit was a bug I found while fixing the first. If you host a room and close it using the disconnect button in the client room, it wouldn't stop the server (as it was using the old close handler). This commit moves the Disconnect button to call the new, centralized close room handler in MultiplayerState