### PR TITLE
Multiplayer: Send an error message when connecting to a full room

### DIFF
--- a/src/citra_qt/multiplayer/message.cpp
+++ b/src/citra_qt/multiplayer/message.cpp
@@ -22,6 +22,8 @@ const ConnectionError UNABLE_TO_CONNECT(
     QT_TR_NOOP("Unable to connect to the host. Verify that the connection settings are correct. If "
                "you still cannot connect, contact the room host and verify that the host is "
                "properly configured with the external port forwarded."));
+const ConnectionError ROOM_IS_FULL(
+    QT_TR_NOOP("Unable to connect to the room because it is already full."));
 const ConnectionError COULD_NOT_CREATE_ROOM(
     QT_TR_NOOP("Creating a room failed. Please retry. Restarting Citra might be necessary."));
 const ConnectionError HOST_BANNED(

--- a/src/citra_qt/multiplayer/message.h
+++ b/src/citra_qt/multiplayer/message.h
@@ -27,6 +27,7 @@ extern const ConnectionError IP_ADDRESS_NOT_VALID;
 extern const ConnectionError PORT_NOT_VALID;
 extern const ConnectionError NO_INTERNET;
 extern const ConnectionError UNABLE_TO_CONNECT;
+extern const ConnectionError ROOM_IS_FULL;
 extern const ConnectionError COULD_NOT_CREATE_ROOM;
 extern const ConnectionError HOST_BANNED;
 extern const ConnectionError WRONG_VERSION;

--- a/src/citra_qt/multiplayer/state.cpp
+++ b/src/citra_qt/multiplayer/state.cpp
@@ -81,6 +81,9 @@ void MultiplayerState::OnNetworkStateChanged(const Network::RoomMember::State& s
     case Network::RoomMember::State::MacCollision:
         NetworkMessage::ShowError(NetworkMessage::MAC_COLLISION);
         break;
+    case Network::RoomMember::State::RoomIsFull:
+        NetworkMessage::ShowError(NetworkMessage::ROOM_IS_FULL);
+        break;
     case Network::RoomMember::State::WrongPassword:
         NetworkMessage::ShowError(NetworkMessage::WRONG_PASSWORD);
         break;

--- a/src/network/room.cpp
+++ b/src/network/room.cpp
@@ -69,6 +69,11 @@ public:
     bool IsValidMacAddress(const MacAddress& address) const;
 
     /**
+     * Sends a ID_ROOM_IS_FULL message telling the client that the room is full.
+     */
+    void SendRoomIsFull(ENetPeer* client);
+
+    /**
      * Sends a ID_ROOM_NAME_COLLISION message telling the client that the name is invalid.
      */
     void SendNameCollision(ENetPeer* client);
@@ -193,6 +198,13 @@ void Room::RoomImpl::StartLoop() {
 }
 
 void Room::RoomImpl::HandleJoinRequest(const ENetEvent* event) {
+    {
+        std::lock_guard<std::mutex> lock(member_mutex);
+        if (members.size() >= room_information.member_slots) {
+            SendRoomIsFull(event->peer);
+            return;
+        }
+    }
     Packet packet;
     packet.Append(event->packet->data, event->packet->dataLength);
     packet.IgnoreBytes(sizeof(u8)); // Igonore the message type
@@ -288,6 +300,16 @@ void Room::RoomImpl::SendMacCollision(ENetPeer* client) {
 void Room::RoomImpl::SendWrongPassword(ENetPeer* client) {
     Packet packet;
     packet << static_cast<u8>(IdWrongPassword);
+
+    ENetPacket* enet_packet =
+        enet_packet_create(packet.GetData(), packet.GetDataSize(), ENET_PACKET_FLAG_RELIABLE);
+    enet_peer_send(client, 0, enet_packet);
+    enet_host_flush(server);
+}
+
+void Room::RoomImpl::SendRoomIsFull(ENetPeer* client) {
+    Packet packet;
+    packet << static_cast<u8>(IdRoomIsFull);
 
     ENetPacket* enet_packet =
         enet_packet_create(packet.GetData(), packet.GetDataSize(), ENET_PACKET_FLAG_RELIABLE);
@@ -527,7 +549,9 @@ bool Room::Create(const std::string& name, const std::string& server_address, u1
     }
     address.port = server_port;
 
-    room_impl->server = enet_host_create(&address, max_connections, NumChannels, 0, 0);
+    // In order to send the room is full message to the connecting client, we need to leave one slot
+    // open so enet won't reject the incoming connection without telling us
+    room_impl->server = enet_host_create(&address, max_connections + 1, NumChannels, 0, 0);
     if (!room_impl->server) {
         return false;
     }

--- a/src/network/room.h
+++ b/src/network/room.h
@@ -12,7 +12,7 @@
 
 namespace Network {
 
-constexpr u32 network_version = 2; ///< The version of this Room and RoomMember
+constexpr u32 network_version = 3; ///< The version of this Room and RoomMember
 
 constexpr u16 DefaultRoomPort = 24872;
 
@@ -57,7 +57,8 @@ enum RoomMessageTypes : u8 {
     IdMacCollision,
     IdVersionMismatch,
     IdWrongPassword,
-    IdCloseRoom
+    IdCloseRoom,
+    IdRoomIsFull,
 };
 
 /// This is what a server [person creating a server] would use.

--- a/src/network/room_member.cpp
+++ b/src/network/room_member.cpp
@@ -154,6 +154,9 @@ void RoomMember::RoomMemberImpl::MemberLoop() {
                     HandleJoinPacket(&event); // Get the MAC Address for the client
                     SetState(State::Joined);
                     break;
+                case IdRoomIsFull:
+                    SetState(State::RoomIsFull);
+                    break;
                 case IdNameCollision:
                     SetState(State::NameCollision);
                     break;

--- a/src/network/room_member.h
+++ b/src/network/room_member.h
@@ -53,11 +53,12 @@ public:
         LostConnection, ///< Connection closed
 
         // Reasons why connection was rejected
-        NameCollision,  ///< Somebody is already using this name
-        MacCollision,   ///< Somebody is already using that mac-address
-        WrongVersion,   ///< The room version is not the same as for this RoomMember
-        WrongPassword,  ///< The password doesn't match the one from the Room
-        CouldNotConnect ///< The room is not responding to a connection attempt
+        NameCollision,   ///< Somebody is already using this name
+        MacCollision,    ///< Somebody is already using that mac-address
+        WrongVersion,    ///< The room version is not the same as for this RoomMember
+        WrongPassword,   ///< The password doesn't match the one from the Room
+        CouldNotConnect, ///< The room is not responding to a connection attempt
+        RoomIsFull       ///< Room is already at the maximum number of players
     };
 
     struct MemberInformation {


### PR DESCRIPTION
Please *DO NOT* put on canary as it requires a multiplayer version bump

Previously, we had set enet's max peer limit to be equal to the size of the room that the person set, but this meant that when someone tries to connect they just get a default generic error message. In order to fix that, I added an additional status response from the server which will inform them that the room is full. This requires bumping the peer limit in enet up by 1 which lets the server send the reject message that the server is full (otherwise enet would never even tell the host that there was a peer trying to join)

I couldn't find anything in enet to suggest that there is a way to get a response for "unable to connect because the max players has been reached." If someone knows of a way, I would be fine dropping this in favor of that way (as the proposed method in the PR requires a version bump)

If we have something else to add in this version bump, now would be a good time to discuss that. The plan is to test this change locally without canary, and then merge and contact the room owners and have them update so we can have as minimum downtime as possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3677)
<!-- Reviewable:end -->
