### PR TITLE
Added current translations from Transifex

### DIFF
--- a/dist/languages/de.ts
+++ b/dist/languages/de.ts
@@ -154,17 +154,17 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ClientRoomWindow</name>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="54"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="55"/>
         <source>Connected</source>
         <translation>Verbunden</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="65"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="63"/>
         <source>Disconnected</source>
         <translation>Nicht verbunden</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="78"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="76"/>
         <source>%1 (%2/%3 members) - connected</source>
         <translation>%1 (%2/%3 Nutzer) - verbunden</translation>
     </message>
@@ -250,7 +250,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="182"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Independent of speed or performance, how well does this game play from start to finish on this version of Citra?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"/>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Unhängig von Geschwindigkeit oder Performance - wie gut funktioniert dieses Spiel vom Anfang bis zum Ende in dieser Version von Citra?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="206"/>
@@ -312,6 +312,26 @@ p, li { white-space: pre-wrap; }
         <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="57"/>
         <source>Port:</source>
         <translation>Port:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="78"/>
+        <source>Logging</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="86"/>
+        <source>Global Log Filter</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="100"/>
+        <source>Show Log Console (Windows Only)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="107"/>
+        <source>Open Log Location</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1074,7 +1094,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="80"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Port number the host is listening on&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"/>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Port, auf dem der Host auf eingehende Verbindungen wartet&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="86"/>
@@ -1100,12 +1120,12 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DirectConnectWindow</name>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="97"/>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="103"/>
         <source>Connecting</source>
         <translation>Verbinden</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="102"/>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="108"/>
         <source>Connect</source>
         <translation>Verbinden</translation>
     </message>
@@ -1113,289 +1133,289 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GMainWindow</name>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="90"/>
+        <location filename="../../src/citra_qt/main.cpp" line="92"/>
         <source>To help improve Citra, the Citra Team collects anonymous usage data. No private or personally identifying information is collected. This data helps us to understand how people use Citra and prioritize our efforts. Furthermore, it helps us to more easily identify emulation bugs and performance issues. This data includes:&lt;ul&gt;&lt;li&gt;Information about the version of Citra you are using&lt;/li&gt;&lt;li&gt;Performance data about the games you play&lt;/li&gt;&lt;li&gt;Your configuration settings&lt;/li&gt;&lt;li&gt;Information about your computer hardware&lt;/li&gt;&lt;li&gt;Emulation errors and crash information&lt;/li&gt;&lt;/ul&gt;By default, this feature is enabled. To disable this feature, click &apos;Emulation&apos; from the menu and then select &apos;Configure...&apos;. Then, on the &apos;Web&apos; tab, uncheck &apos;Share anonymous usage data with the Citra team&apos;. &lt;br/&gt;&lt;br/&gt;By using this software, you agree to the above terms.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
         <translation>Um Citra zu verbessern, sammelt das Citra-Team anonyme Nutzungsdaten. Keine privaten oder Nutzeridentifizierenden Information werden gesammelt. Diese Daten helfen uns zu verstehen, wie Citra genutzt wird um so Prioritäten setzen zu können. Außerdem hilft es Bugs in der Emulation und Performanceprobleme leichter zu identifizieren. Diese Daten beinhalten:&lt;ul&gt;&lt;li&gt;Informationen über die Version von Citra&lt;/li&gt;&lt;li&gt;Performancedaten über deine gepsielten Spiele&lt;/li&gt;&lt;li&gt;Deine Citra-Einstellungen&lt;/li&gt;&lt;li&gt;Informationen über die Hardware deines Computers&lt;/li&gt;&lt;li&gt;Informationen über Emulationsfehler und Abstürze&lt;/li&gt;&lt;/ul&gt;Diese Funktion ist standardmäßig aktiviert. Um die Funktion auszuschalten, klicke im Menü auf &quot;Emulation&quot; und wähle dann &quot;Konfigurieren...&quot; aus. Dann, im &quot;Web&quot; Tab, entferne das Häkchen bei &quot;Anonyme Nutzungsdaten an das Citra-Team senden&quot;. &lt;br/&gt;&lt;br/&gt;Mit dem Nutzen dieser Software stimmst du den oben genannten Bedingungen zu.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Mehr erfahren&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="195"/>
+        <location filename="../../src/citra_qt/main.cpp" line="199"/>
         <source>Current emulation speed. Values higher or lower than 100% indicate emulation is running faster or slower than a 3DS.</source>
         <translation>Jetzige Emulationsgeschwindigkeit. Werte höher oder niedriger als 100% zeigen, dass die Emulation schneller oder langsamer läuft als auf einem 3DS.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="198"/>
+        <location filename="../../src/citra_qt/main.cpp" line="202"/>
         <source>How many frames per second the game is currently displaying. This will vary from game to game and scene to scene.</source>
         <translation>Die Anzahl der Bilder pro Sekunde die das Spiel gerade darstellt. Dies wird von Spiel zu Spiel und von Szene zu Szene variieren.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="202"/>
+        <location filename="../../src/citra_qt/main.cpp" line="206"/>
         <source>Time taken to emulate a 3DS frame, not counting framelimiting or v-sync. For full-speed emulation this should be at most 16.67 ms.</source>
         <translation>Die benötigte Zeit um ein 3DS-Einzelbild zu emulieren (V-Sync oder Bildratenbegrenzung nicht mitgezählt). Für eine Emulation in Echtzeit sollte dies maximal 16,67 ms betragen.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="429"/>
+        <location filename="../../src/citra_qt/main.cpp" line="434"/>
         <source>CTRL+F</source>
         <translation>STRG+F</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="538"/>
+        <location filename="../../src/citra_qt/main.cpp" line="543"/>
         <source>Update available!</source>
         <translation>Update verfügbar!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="539"/>
+        <location filename="../../src/citra_qt/main.cpp" line="544"/>
         <source>An update for Citra is available. Do you wish to install it now?&lt;br /&gt;&lt;br /&gt;This &lt;b&gt;will&lt;/b&gt; terminate emulation, if it is running.</source>
         <translation>Ein Update für Citra ist verfügbar. Möchtest du es jetzt installieren?&lt;br /&gt;&lt;br /&gt;Dies &lt;b&gt;wird&lt;/b&gt; die Emulation stoppen, falls sie läuft.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <location filename="../../src/citra_qt/main.cpp" line="555"/>
         <source>No update found</source>
         <translation>Kein Update gefunden</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <location filename="../../src/citra_qt/main.cpp" line="555"/>
         <source>No update has been found for Citra.</source>
         <translation>Kein Update für Citra wurde gefunden.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="567"/>
+        <location filename="../../src/citra_qt/main.cpp" line="572"/>
         <source>Error while initializing OpenGL 3.3 Core!</source>
         <translation>Fehler beim Initialisieren des OpenGL 3.3 Kerns!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="568"/>
+        <location filename="../../src/citra_qt/main.cpp" line="573"/>
         <source>Your GPU may not support OpenGL 3.3, or you do not have the latest graphics driver.</source>
         <translation>Deine Grafikkarte könnte OpenGL 3.3 nicht unterstützen, oder du hast nicht die neuesten Grafiktreiber.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="581"/>
-        <location filename="../../src/citra_qt/main.cpp" line="587"/>
-        <location filename="../../src/citra_qt/main.cpp" line="593"/>
-        <location filename="../../src/citra_qt/main.cpp" line="606"/>
-        <location filename="../../src/citra_qt/main.cpp" line="625"/>
+        <location filename="../../src/citra_qt/main.cpp" line="586"/>
+        <location filename="../../src/citra_qt/main.cpp" line="592"/>
+        <location filename="../../src/citra_qt/main.cpp" line="598"/>
+        <location filename="../../src/citra_qt/main.cpp" line="611"/>
+        <location filename="../../src/citra_qt/main.cpp" line="630"/>
         <source>Error while loading ROM!</source>
         <translation>Fehler beim Laden des ROMs!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="582"/>
-        <location filename="../../src/citra_qt/main.cpp" line="607"/>
+        <location filename="../../src/citra_qt/main.cpp" line="587"/>
+        <location filename="../../src/citra_qt/main.cpp" line="612"/>
         <source>The ROM format is not supported.</source>
         <translation>Das ROM Format wird nicht unterstützt.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="588"/>
+        <location filename="../../src/citra_qt/main.cpp" line="593"/>
         <source>Could not determine the system mode.</source>
         <translation>Konnte Systemmodus nicht ermitteln.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="594"/>
+        <location filename="../../src/citra_qt/main.cpp" line="599"/>
         <source>The game that you are trying to load must be decrypted before being used with Citra. A real 3DS is required.&lt;br/&gt;&lt;br/&gt;For more information on dumping and decrypting games, please see the following wiki pages: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</source>
         <translation>Das Spiel, dass du laden möchtest, muss entschlüsselt werden, bevor du es mit Citra nutzen kannst. Ein echter 3DS wird benötigt.&lt;br/&gt;&lt;br/&gt;Für mehr Informationen zum Dumpen und Entschlüsseln von  Spielen, sieh dir bitte die folgenden Wiki-Seiten an: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumpen von Spiele-Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumpen von installierten Titeln&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="612"/>
+        <location filename="../../src/citra_qt/main.cpp" line="617"/>
         <source>An error occured in the video core.</source>
         <translation>Ein Fehler ist im Videokern aufgetreten.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="613"/>
+        <location filename="../../src/citra_qt/main.cpp" line="618"/>
         <source>Citra has encountered an error while running the video core, please see the log for more details.For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.Ensure that you have the latest graphics drivers for your GPU.</source>
         <translation>Ein Fehler ist im Videokern aufgetreten. Bitte schau für mehr Details in den Log.Für mehr Informationen, wie man an den Log kommt, schau dir bitte die folgende Seite an: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;Wie man die Log-Datei hochlädt&lt;/a&gt;.Stelle sicher, dass du die neuesten Treiber für deine Grafikkarte hast.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="626"/>
+        <location filename="../../src/citra_qt/main.cpp" line="631"/>
         <source>An unknown error occured. Please see the log for more details.</source>
         <translation>Ein unbekannter Fehler ist aufgetreten. Bitte schau für mehr Details in den Log.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="699"/>
+        <location filename="../../src/citra_qt/main.cpp" line="704"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="790"/>
+        <location filename="../../src/citra_qt/main.cpp" line="795"/>
         <source>Error Opening %1 Folder</source>
         <translation>Fehler beim Öffnen des Ordners %1</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="791"/>
+        <location filename="../../src/citra_qt/main.cpp" line="796"/>
         <source>Folder does not exist!</source>
         <translation>Ordner existiert nicht!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="805"/>
+        <location filename="../../src/citra_qt/main.cpp" line="810"/>
         <source>3DS Executable</source>
         <translation>3DS-Executable</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="806"/>
-        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <location filename="../../src/citra_qt/main.cpp" line="811"/>
+        <location filename="../../src/citra_qt/main.cpp" line="833"/>
         <source>All Files (*.*)</source>
         <translation>Alle Dateien (*.*)</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="808"/>
+        <location filename="../../src/citra_qt/main.cpp" line="813"/>
         <source>Load File</source>
         <translation>Datei laden</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="818"/>
+        <location filename="../../src/citra_qt/main.cpp" line="823"/>
         <source>Select Directory</source>
         <translation>Ordner auswählen</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="827"/>
+        <location filename="../../src/citra_qt/main.cpp" line="832"/>
         <source>Load Files</source>
         <translation>Dateien laden</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <location filename="../../src/citra_qt/main.cpp" line="833"/>
         <source>3DS Installation File (*.CIA*)</source>
         <translation>3DS Installationsdatei (*.CIA*)</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="859"/>
+        <location filename="../../src/citra_qt/main.cpp" line="864"/>
         <source>%1 has been installed successfully.</source>
         <translation>%1 wurde erfolgreich installiert.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="862"/>
+        <location filename="../../src/citra_qt/main.cpp" line="867"/>
         <source>Unable to open File</source>
         <translation>Datei konnte nicht geöffnet werden</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="863"/>
+        <location filename="../../src/citra_qt/main.cpp" line="868"/>
         <source>Could not open %1</source>
         <translation>Konnte %1 nicht öffnen</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="867"/>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
         <source>Installation aborted</source>
         <translation>Installation abgebrochen</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="868"/>
+        <location filename="../../src/citra_qt/main.cpp" line="873"/>
         <source>The installation of %1 was aborted. Please see the log for more details</source>
         <translation>Die Installation von %1 wurde abgebrochen. Weitere Details dazu im Log.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <location filename="../../src/citra_qt/main.cpp" line="877"/>
         <source>Invalid File</source>
         <translation>Ungültige Datei</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <location filename="../../src/citra_qt/main.cpp" line="877"/>
         <source>%1 is not a valid CIA</source>
         <translation>%1 ist kein gültiges CIA</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="875"/>
+        <location filename="../../src/citra_qt/main.cpp" line="880"/>
         <source>Encrypted File</source>
         <translation>Verschlüsselte Datei</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="876"/>
+        <location filename="../../src/citra_qt/main.cpp" line="881"/>
         <source>%1 must be decrypted before being used with Citra. A real 3DS is required.</source>
         <translation>%1 muss entschlüsselt werden, bevor es mit Citra verwendet werden kann. Hierzu ist ein 3DS ist notwendig.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="899"/>
+        <location filename="../../src/citra_qt/main.cpp" line="904"/>
         <source>File not found</source>
         <translation>Datei nicht gefunden</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="900"/>
+        <location filename="../../src/citra_qt/main.cpp" line="905"/>
         <source>File &quot;%1&quot; not found</source>
         <translation>Datei &quot;%1&quot; nicht gefunden</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="914"/>
+        <location filename="../../src/citra_qt/main.cpp" line="919"/>
         <source>Continue</source>
         <translation>Fortsetzen</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="939"/>
+        <location filename="../../src/citra_qt/main.cpp" line="944"/>
         <source>Missing Citra Account</source>
         <translation>Fehlender Citra-Account</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="940"/>
+        <location filename="../../src/citra_qt/main.cpp" line="945"/>
         <source>In order to submit a game compatibility test case, you must link your Citra account.&lt;br&gt;&lt;br/&gt;To link your Citra account, go to Emulation &amp;gt; Configuration &amp;gt; Web.</source>
         <translation>Um einen Testfall für die Kompatibilitätsliste zu übertragen, muss der Citra-Account verknüpft sein.&lt;br&gt;&lt;br/&gt;Dieser kann unter Emulation &amp;gt; Konfiguration &amp;gt; Web konfiguriert werden.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1090"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1095"/>
         <source>Speed: %1% / %2%</source>
         <translation>Geschwindigkeit: %1% / %2%</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1094"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1099"/>
         <source>Speed: %1%</source>
         <translation>Geschwindigkeit: %1%</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1096"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1101"/>
         <source>Game: %1 FPS</source>
         <translation>Spiel: %1 FPS</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1097"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1102"/>
         <source>Frame: %1 ms</source>
         <translation>Einzelbild: %1 ms</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1108"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1113"/>
         <source>The game you are trying to load requires additional files from your 3DS to be dumped before playing.&lt;br/&gt;&lt;br/&gt;For more information on dumping these files, please see the following wiki page: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
         <translation>Das Spiel, dass du laden möchtest benötigt zusätzliche Dateien die von deinem 3DS gedumpt werden müssen, bevor du es spielen kannst.&lt;br/&gt;&lt;br/&gt;Für mehr Informationen über das Dumpen dieser Dateien, geh bitte auf die folgende Wiki-Seite: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumpen von Systemarchiven und den &quot;Shared Fonts&quot; von einer 3DS Konsole&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Möchtest du zur Spieleliste zurückkehren? Das Fortfahren der Emulation kann zu Abstürzen, beschädigten Speicherdaten oder anderen Bugs führen.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1120"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1125"/>
         <source>: %1. </source>
         <translation>: %1. </translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1126"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1131"/>
         <source>System Archive Not Found</source>
         <translation>Systemarchiv nicht gefunden</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1133"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1138"/>
         <source>Citra was unable to locate the 3DS shared fonts. </source>
         <translation>Citra konnte die &quot;3DS Shared Fonts&quot; nicht finden.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1135"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1140"/>
         <source>Shared Fonts Not Found</source>
         <translation>&quot;Shared Fonts&quot; nicht gefunden</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1143"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1148"/>
         <source>Fatal Error</source>
         <translation>Fataler Fehler</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1144"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1149"/>
         <source>Citra has encountered a fatal error, please see the log for more details. For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
         <translation>Citra hat einen schwerwiegenden Fehler festgestellt, bitte sieh dir für mehr Details das Log an. Für mehr Informationen wie man an das Log kommt, geh bitte auf die folgende Seite: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;Wie lade ich die Log-Datei hoch&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Möchtest du zur Spieleliste zurückkehren? Das Fortsetzen der Emulation kann zu Abstürzen, beschädigten Speicherdaten oder anderen Fehlern führen.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
-        <location filename="../../src/citra_qt/main.cpp" line="1245"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1183"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1250"/>
         <source>Citra</source>
         <translation>Citra</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1183"/>
         <source>Are you sure you want to close Citra?</source>
         <translation>Bist du sicher, dass du Citra schließen möchtest?</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1246"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1251"/>
         <source>Are you sure you want to stop the emulation? Any unsaved progress will be lost.</source>
         <translation>Bist du sicher, dass du die Emulation stoppen möchtest? Jeder ungespeicherte Fortschritt wird verloren gehen.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1318"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1323"/>
         <source>Citra %1| %2-%3</source>
         <translation>Citra %1| %2-%3</translation>
     </message>
@@ -1458,77 +1478,77 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GameList</name>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="117"/>
         <source>Perfect</source>
         <translation>Perfekt</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="117"/>
         <source>Game functions flawless with no audio or graphical glitches, all tested functionality works as intended without
 any workarounds needed.</source>
         <translation>Das Spiel funktioniert problemlos, ohne Grafik- oder Tonprobleme. Die getestete Funktionalität verhält sich wie gewünscht ohne Umgehungslösungen.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="118"/>
         <source>Great</source>
         <translation>Sehr gut</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="118"/>
         <source>Game functions with minor graphical or audio glitches and is playable from start to finish. May require some
 workarounds.</source>
         <translation>Das Spiel funktioniert und kann beendet werden, hat aber evtl. Grafik- oder Tonprobleme. Möglicherweise sind Umgehungslösungen notwendig.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="119"/>
         <source>Okay</source>
         <translation>Okay</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="119"/>
         <source>Game functions with major graphical or audio glitches, but game is playable from start to finish with
 workarounds.</source>
         <translation>Das Spiel funktioniert, hat aber starke Grafik- oder Tonprobleme. Das Spiel kann jedoch mit Umgehungslösungen gespielt und beendet werden.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="120"/>
         <source>Bad</source>
         <translation>Schlecht</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="120"/>
         <source>Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches
 even with workarounds.</source>
         <translation>Das Spiel funktioniert zwar, hat aber starke Grafik- oder Tonprobleme. An bestimmten Stellen ist ein Weiterkommen aufgrund von Fehlern unmöglich, auch nicht mit Umgehungslösungen.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="121"/>
         <source>Intro/Menu</source>
         <translation>Intro/Menü</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="121"/>
         <source>Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start
 Screen.</source>
         <translation>Das Spiel ist nicht spielbar aufgrund starker Grafik- oder Tonprobleme. Es ist nicht möglich, über den Startbildschirm hinaus zu kommen.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="122"/>
         <source>Won&apos;t Boot</source>
         <translation>Startet nicht</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="122"/>
         <source>The game crashes when attempting to startup.</source>
         <translation>Das Spiel stürzt beim Versuch es zu starten ab.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="123"/>
         <source>Not Tested</source>
         <translation>Nicht getestet</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="123"/>
         <source>The game has not yet been tested.</source>
         <translation>Das Spiel wurde noch nicht getestet.</translation>
     </message>
@@ -1558,17 +1578,17 @@ Screen.</source>
         <translation>Suchmuster zur Filterung eingeben</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="324"/>
+        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
         <source>Open Save Data Location</source>
         <translation>Ort der Speicherdaten öffnen</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
+        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
         <source>Open Application Location</source>
         <translation>Ort der Applikationsdaten öffnen</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
+        <location filename="../../src/citra_qt/game_list.cpp" line="327"/>
         <source>Open Update Data Location</source>
         <translation>Ort der Updatedaten öffnen</translation>
     </message>
@@ -1935,7 +1955,7 @@ Falls nein, werden die aufgenommmen Daten verworfen.</translation>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="101"/>
         <source>(Leave blank for open game)</source>
-        <translation type="unfinished"/>
+        <translation>(Leer lassen für offenes Spiel)</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="118"/>
@@ -1994,7 +2014,7 @@ Falls nein, werden die aufgenommmen Daten verworfen.</translation>
     <message>
         <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="83"/>
         <source>Hide Full Rooms</source>
-        <translation type="unfinished"/>
+        <translation>Verstecke volle Räume</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="103"/>
@@ -2002,47 +2022,42 @@ Falls nein, werden die aufgenommmen Daten verworfen.</translation>
         <translation>Lobby aktualisieren</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="73"/>
         <source>Password Required to Join</source>
         <translation>Passwort zum Beitreten benötigt</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="74"/>
         <source>Password:</source>
         <translation>Passwort:</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="77"/>
-        <source>Password</source>
-        <translation>Passwort</translation>
-    </message>
-    <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="139"/>
         <source>Room Name</source>
         <translation>Raumname</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="143"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="140"/>
         <source>Preferred Game</source>
         <translation>Bevorzugtes Spiel</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="144"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="141"/>
         <source>Host</source>
         <translation>Host</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="145"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
         <source>Players</source>
         <translation>Spieler</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="153"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="150"/>
         <source>Refreshing</source>
         <translation>Neu Laden</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="201"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="198"/>
         <source>Refresh List</source>
         <translation>Liste aktualisieren</translation>
     </message>
@@ -2406,6 +2421,57 @@ Debug Message: </source>
         <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="201"/>
         <source>%1 is playing %2</source>
         <translation>%1 spielt %2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="208"/>
+        <source>Invalid region</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Japan</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>North America</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="92"/>
+        <source>Europe</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="94"/>
+        <source>Australia</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="96"/>
+        <source>China</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="98"/>
+        <source>Korea</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="100"/>
+        <source>Taiwan</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="102"/>
+        <source>Region free</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="104"/>
+        <source>Invalid Region</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="26"/>

--- a/dist/languages/de.ts
+++ b/dist/languages/de.ts
@@ -1,0 +1,2751 @@
+<?xml version="1.0" ?><!DOCTYPE TS><TS language="de" version="2.1">
+<context>
+    <name>ARMRegisters</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="14"/>
+        <source>ARM Registers</source>
+        <translation>ARM Register</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="25"/>
+        <source>Register</source>
+        <translation>Register</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="30"/>
+        <source>Value</source>
+        <translation>Wert</translation>
+    </message>
+</context>
+<context>
+    <name>AboutDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="14"/>
+        <source>About Citra</source>
+        <translation>Über Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="30"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/citra.png&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/citra.png&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="60"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:28pt;&quot;&gt;Citra&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:28pt;&quot;&gt;Citra&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="73"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="86"/>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:12pt;&quot;&gt;Citra is a free and open source 3DS emulator licensed under GPLv2.0 or any later version.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'MS Shell Dlg 2'; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;This software should not be used to play games you have not legally obtained.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;Citra ist ein kostenloser und quelloffener 3DS-Emulator, der unter GPLv2.0 oder jeder späteren Version lizenziert ist.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;Diese Software sollte nicht genutzt werden, um Spiele zu spielen, die du nicht legal erhalten hast.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="118"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Website&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://community.citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Forum&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Source Code&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Contributors&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/blob/master/license.txt&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;License&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Website&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://community.citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Forum&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Quellcode&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Beitragende&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/blob/master/license.txt&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Lizenz&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="134"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;&amp;quot;3DS&amp;quot; is a trademark of Nintendo. Citra is not affiliated with Nintendo in any way.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;&amp;quot;3DS&amp;quot; ist eine Marke von Nintendo. Citra ist in keiner Weise mit Nintendo verbunden.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>BreakPointModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="34"/>
+        <source>Pica command loaded</source>
+        <translation>Pica-Befehl geladen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="35"/>
+        <source>Pica command processed</source>
+        <translation>Pica-Befehl verarbeitet</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="36"/>
+        <source>Incoming primitive batch</source>
+        <translation>Eingehender primitiver Stapel</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="37"/>
+        <source>Finished primitive batch</source>
+        <translation>Fertiger primitiver Stapel</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="38"/>
+        <source>Vertex shader invocation</source>
+        <translation>Vertex Shader Aufruf</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="40"/>
+        <source>Incoming display transfer</source>
+        <translation>Eingehende Anzeigeübertragung</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="41"/>
+        <source>GSP command processed</source>
+        <translation>GSP-Befehl verarbeitet</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="42"/>
+        <source>Buffers swapped</source>
+        <translation>Puffer getauscht</translation>
+    </message>
+</context>
+<context>
+    <name>ChatRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="14"/>
+        <source>Room Window</source>
+        <translation>Raum Fenster</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="40"/>
+        <source>Send Chat Message</source>
+        <translation>Chatnachricht senden</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="47"/>
+        <source>Send Message</source>
+        <translation>Nachricht senden</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.cpp" line="81"/>
+        <source>Name</source>
+        <translation>Name</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.cpp" line="82"/>
+        <source>Game</source>
+        <translation>Spiel</translation>
+    </message>
+</context>
+<context>
+    <name>ClientRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.ui" line="14"/>
+        <source>Room Window</source>
+        <translation>Raum Fenster</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.ui" line="40"/>
+        <source>Leave Room</source>
+        <translation>Raum verlassen</translation>
+    </message>
+</context>
+<context>
+    <name>ClientRoomWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="54"/>
+        <source>Connected</source>
+        <translation>Verbunden</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="65"/>
+        <source>Disconnected</source>
+        <translation>Nicht verbunden</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="78"/>
+        <source>%1 (%2/%3 members) - connected</source>
+        <translation>%1 (%2/%3 Nutzer) - verbunden</translation>
+    </message>
+</context>
+<context>
+    <name>CompatDB</name>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="20"/>
+        <source>Report Compatibility</source>
+        <translation>Kompatibilität melden</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="27"/>
+        <location filename="../../src/citra_qt/compatdb.ui" line="63"/>
+        <source>Report Game Compatibility</source>
+        <translation>Kompatibilität des Spiels melden</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="36"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;Should you choose to submit a test case to the &lt;/span&gt;&lt;a href=&quot;https://citra-emu.org/game/&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;Citra Compatibility List&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;, The following information will be collected and displayed on the site:&lt;/span&gt;&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Hardware Information (CPU / GPU / Operating System)&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Which version of Citra you are running&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The connected Citra account&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;Sollten sie sich entscheiden einen Testfall zur&lt;/span&gt;&lt;a href=&quot;https://citra-emu.org/game/&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt; Citra Kompatibilitätsliste &lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;hinzuzufügen, so werden die folgenden Informationen gesammelt und auf der Seite angezeigt:&lt;/span&gt;&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Hardware Informationen (CPU / GPU / Betriebssystem)&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Welche Citra version sie verwenden&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Den verbundenen Citra account&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="72"/>
+        <source>Perfect</source>
+        <translation>Perfekt</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="79"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions flawlessly with no audio or graphical glitches.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Spiel funktioniert makellos, ohne Audio- oder Grafikfehler.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="89"/>
+        <source>Great </source>
+        <translation>Sehr gut</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="96"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions with minor graphical or audio glitches and is playable from start to finish. May require some workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Spiel funktioniert mit minimalen Grafik und Audio Fehlern und ist von Start bis Ende spielbar. Kann Problemumgehungen benötigen&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="106"/>
+        <source>Okay</source>
+        <translation>Okay</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="113"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions with major graphical or audio glitches, but game is playable from start to finish with workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Spiel funktioniert mit starken Grafik und Audio Fehlern aber ist von Start bis Ende spielbar mit Problemumgehungen.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="123"/>
+        <source>Bad</source>
+        <translation>Schlecht</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="130"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches even with workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>Spiel funktioniert, aber mit starken Grafik und Audio Fehlern. Fortschritt ist durch Fehler selbst mit Problemumgehungen in bestimmten Bereichen nicht möglich.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="140"/>
+        <source>Intro/Menu</source>
+        <translation>Intro/Menü</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="147"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start Screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Spiel ist wegen starken Grafik und Audio Fehlern komplett unspielbar. Fortschritt über den Startbildschirm ist unmöglich.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="157"/>
+        <source>Won&apos;t Boot</source>
+        <translation>Startet nicht</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="170"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The game crashes when attempting to startup.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Das Spiel stürzt beim Starten ab.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="182"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Independent of speed or performance, how well does this game play from start to finish on this version of Citra?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="206"/>
+        <source>Thank you for your submission!</source>
+        <translation>Vielen Dank für deinen Beitrag!</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureAudio</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="10"/>
+        <source>Audio</source>
+        <translation>Audio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="18"/>
+        <source>Output Engine:</source>
+        <translation>Ausgabeengine:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="31"/>
+        <source>Enable audio stretching</source>
+        <translation>Audiodehnung aktivieren</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="34"/>
+        <source>This post-processing effect adjusts audio speed to match emulation speed and helps prevent audio stutter. This however increases audio latency.</source>
+        <translation>Dieser Nachbearbeitungseffekt passt die Audiogeschwindigkeit an die Emulationsgeschwindigkeit an und hilft Audistottern zu verhindern. Dafür vergrößert er allerdings die Audiolatenz.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="43"/>
+        <source>Audio Device:</source>
+        <translation>Audiogerät:</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureDebug</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="14"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="22"/>
+        <source>GDB</source>
+        <translation>GDB</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="28"/>
+        <source>The GDB Stub only works correctly when the CPU JIT is off.</source>
+        <translation>Der GDB-Stub funktioniert nur korrekt, wenn der CPU-JIT ausgeschaltet ist.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="37"/>
+        <source>Enable GDB Stub</source>
+        <translation>GDB-Stub aktivieren</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="57"/>
+        <source>Port:</source>
+        <translation>Port:</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="14"/>
+        <source>Citra Configuration</source>
+        <translation>Citra-Konfiguration</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="24"/>
+        <source>General</source>
+        <translation>Allgemein</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="29"/>
+        <source>System</source>
+        <translation>System</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="34"/>
+        <source>Input</source>
+        <translation>Eingabe</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="39"/>
+        <source>Graphics</source>
+        <translation>Grafik</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="44"/>
+        <source>Audio</source>
+        <translation>Audio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="49"/>
+        <source>Debug</source>
+        <translation>Debug</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="54"/>
+        <source>Web</source>
+        <translation>Web</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureGeneral</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="14"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="22"/>
+        <source>General</source>
+        <translation>Allgemein</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="30"/>
+        <source>Confirm exit while emulation is running</source>
+        <translation>Verlassen bestätigen, wenn Emulation läuft</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="37"/>
+        <source>Search sub-directories for games</source>
+        <translation>Unterverzeichnisse auf Spiele durchsuchen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="46"/>
+        <source>Interface language</source>
+        <translation>Benutzeroberflächensprache</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="63"/>
+        <source>Updates</source>
+        <translation>Updates</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="71"/>
+        <source>Check for updates on start</source>
+        <translation>Beim Start auf Updates überprüfen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="78"/>
+        <source>Silently auto update after closing</source>
+        <translation>Nach dem Beenden im Hintergrund automatisch updaten</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="90"/>
+        <source>Performance</source>
+        <translation>Leistung</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="98"/>
+        <source>Enable CPU JIT</source>
+        <translation>CPU-JIT aktivieren</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="110"/>
+        <source>Emulation</source>
+        <translation>Emulation</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="120"/>
+        <source>Region:</source>
+        <translation>Region:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="128"/>
+        <source>Auto-select</source>
+        <translation>Automatisch auswählen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="178"/>
+        <source>Theme</source>
+        <translation>Design</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="188"/>
+        <source>Theme:</source>
+        <translation>Design:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="205"/>
+        <source>Hotkeys</source>
+        <translation>Tastenkürzel</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.cpp" line="16"/>
+        <source>&lt;System&gt;</source>
+        <translation>&lt;System&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.cpp" line="17"/>
+        <source>English</source>
+        <translation>Englisch</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureGraphics</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="14"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="22"/>
+        <source>Graphics</source>
+        <translation>Grafik</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="28"/>
+        <source>Enable hardware renderer</source>
+        <translation>Hardware-Renderer aktivieren</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="35"/>
+        <source>Enable shader JIT</source>
+        <translation>Shader-JIT aktivieren</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="42"/>
+        <source>Enable V-Sync</source>
+        <translation>V-Sync aktivieren</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="51"/>
+        <source>Limit Speed Percent</source>
+        <translation>Limitiere Prozentuale Geschwindigkeit</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="58"/>
+        <source>%</source>
+        <translation>%</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="78"/>
+        <source>Internal Resolution:</source>
+        <translation>Interne Auflösung:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="86"/>
+        <source>Auto (Window Size)</source>
+        <translation>Automatisch (Fenstergröße)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="91"/>
+        <source>Native (400x240)</source>
+        <translation>Nativ (400x240)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="96"/>
+        <source>2x Native (800x480)</source>
+        <translation>2x Nativ (800x480)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="101"/>
+        <source>3x Native (1200x720)</source>
+        <translation>3x Nativ (1200x720)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="106"/>
+        <source>4x Native (1600x960)</source>
+        <translation>4x Nativ (1600x960)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="111"/>
+        <source>5x Native (2000x1200)</source>
+        <translation>5x Nativ (2000x1200)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="116"/>
+        <source>6x Native (2400x1440)</source>
+        <translation>6x Nativ (2400x1440)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="121"/>
+        <source>7x Native (2800x1680)</source>
+        <translation>7x Nativ (2800x1680)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="126"/>
+        <source>8x Native (3200x1920)</source>
+        <translation>8x Nativ (3200x1920)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="131"/>
+        <source>9x Native (3600x2160)</source>
+        <translation>9x Nativ (3600x2160)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="136"/>
+        <source>10x Native (4000x2400)</source>
+        <translation>10x Nativ (4000x2400)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="151"/>
+        <source>Layout</source>
+        <translation>Layout</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="161"/>
+        <source>Screen Layout:</source>
+        <translation>Bildschirmlayout:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="169"/>
+        <source>Default</source>
+        <translation>Standard</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="174"/>
+        <source>Single Screen</source>
+        <translation>Einzelner Bildschirm</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="179"/>
+        <source>Large Screen</source>
+        <translation>Großer Bildschrim</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="184"/>
+        <source>Side by Side</source>
+        <translation>Nebeneinander</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="194"/>
+        <source>Swap Screens</source>
+        <translation>Bildschirme tauschen</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureInput</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="14"/>
+        <source>ConfigureInput</source>
+        <translation>ConfigureInput</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="22"/>
+        <source>Face Buttons</source>
+        <translation>Face Buttons</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="36"/>
+        <source>A:</source>
+        <translation>A:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="54"/>
+        <source>B:</source>
+        <translation>B:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="72"/>
+        <source>X:</source>
+        <translation>X:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="90"/>
+        <source>Y:</source>
+        <translation>Y:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="109"/>
+        <source>Directional Pad</source>
+        <translation>Steuerkreuz</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="123"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="340"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="427"/>
+        <source>Up:</source>
+        <translation>Hoch:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="141"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="358"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="445"/>
+        <source>Down:</source>
+        <translation>Runter:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="159"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="304"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="391"/>
+        <source>Left:</source>
+        <translation>Links:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="177"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="322"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="409"/>
+        <source>Right:</source>
+        <translation>Rechts:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="196"/>
+        <source>Shoulder Buttons</source>
+        <translation>Schulterknöpfe</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="210"/>
+        <source>L:</source>
+        <translation>L:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="228"/>
+        <source>R:</source>
+        <translation>R:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="246"/>
+        <source>ZL:</source>
+        <translation>ZL:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="264"/>
+        <source>ZR:</source>
+        <translation>ZR:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="283"/>
+        <source>Circle Pad</source>
+        <translation>Schiebepad</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="295"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="461"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="232"/>
+        <source>Set Analog Stick</source>
+        <translation>Analog-Stick festlegen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="377"/>
+        <source>C-Stick</source>
+        <translation>C-Stick</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="471"/>
+        <source>Misc.</source>
+        <translation>Misc.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="485"/>
+        <source>Start:</source>
+        <translation>Start:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="503"/>
+        <source>Select:</source>
+        <translation>Select:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="521"/>
+        <source>Home:</source>
+        <translation>Home:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="539"/>
+        <source>Circle Mod:</source>
+        <translation>Schiebepad Modus:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="596"/>
+        <source>Restore Defaults</source>
+        <translation>Standardwerte wiederherstellen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="239"/>
+        <source>[press key]</source>
+        <translation>[Taste drücken]</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureSystem</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="14"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="22"/>
+        <source>System Settings</source>
+        <translation>Systemeinstellungen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="28"/>
+        <source>Username</source>
+        <translation>Nutzername</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="48"/>
+        <source>Birthday</source>
+        <translation>Geburtstag</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="58"/>
+        <source>January</source>
+        <translation>Januar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="63"/>
+        <source>February</source>
+        <translation>Februar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="68"/>
+        <source>March</source>
+        <translation>März</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="73"/>
+        <source>April</source>
+        <translation>April</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="78"/>
+        <source>May</source>
+        <translation>Mai</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="83"/>
+        <source>June</source>
+        <translation>Juni</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="88"/>
+        <source>July</source>
+        <translation>Juli</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="93"/>
+        <source>August</source>
+        <translation>August</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="98"/>
+        <source>September</source>
+        <translation>September</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="103"/>
+        <source>October</source>
+        <translation>Oktober</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="108"/>
+        <source>November</source>
+        <translation>November</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="113"/>
+        <source>December</source>
+        <translation>Dezember</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="126"/>
+        <source>Language</source>
+        <translation>Sprache</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="133"/>
+        <source>Note: this can be overridden when region setting is auto-select</source>
+        <translation>Notiz: Dies kann überschrieben werden, wenn als Region &quot;Automatisch auswählen&quot; eingestellt wurde.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="137"/>
+        <source>Japanese (日本語)</source>
+        <translation>Japanisch (日本語)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="142"/>
+        <source>English</source>
+        <translation>Englisch</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="147"/>
+        <source>French (français)</source>
+        <translation>Französisch (français)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="152"/>
+        <source>German (Deutsch)</source>
+        <translation>Deutsch</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="157"/>
+        <source>Italian (italiano)</source>
+        <translation>Italienisch (italiano)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="162"/>
+        <source>Spanish (español)</source>
+        <translation>Spanisch (español)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="167"/>
+        <source>Simplified Chinese (简体中文)</source>
+        <translation>Vereinfachtes Chinesisch (简体中文)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="172"/>
+        <source>Korean (한국어)</source>
+        <translation>Koreanisch (한국어)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="177"/>
+        <source>Dutch (Nederlands)</source>
+        <translation>Niederländisch (Nederlands)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="182"/>
+        <source>Portuguese (português)</source>
+        <translation>Portugiesisch (português)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="187"/>
+        <source>Russian (Русский)</source>
+        <translation>Russisch (Русский)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="192"/>
+        <source>Traditional Chinese (正體中文)</source>
+        <translation>Traditionelles Chinesisch (正體中文)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="200"/>
+        <source>Sound output mode</source>
+        <translation>Tonausgabemodus</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="208"/>
+        <source>Mono</source>
+        <translation>Mono</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="213"/>
+        <source>Stereo</source>
+        <translation>Stereo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="218"/>
+        <source>Surround</source>
+        <translation>Surround</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="226"/>
+        <source>Console ID:</source>
+        <translation>Konsolen-ID:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="242"/>
+        <source>Regenerate</source>
+        <translation>Regenerieren</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="252"/>
+        <source>System settings are available only when game is not running.</source>
+        <translation>Systemeinstellungen sind nur verfügbar wenn kein Spiel läuft. </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="87"/>
+        <source>Console ID: 0x%1</source>
+        <translation>Konsolen-ID: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="160"/>
+        <source>This will replace your current virtual 3DS with a new one. Your current virtual 3DS will not be recoverable. This might have unexpected effects in games. This might fail, if you use an outdated config savegame. Continue?</source>
+        <translation>Dies wird deinen jetziger virtueller 3DS wird mit einem neuen ersetzt. Dein jetziger virtueller 3DS kann nicht wiederhergestellt werden. Es könnte unerwartete Effekte in Spielen haben. Es könnte fehlschlagen, wenn du einen veralteten Konfigurationspeicherstand benutzt. Fortfahren?</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="164"/>
+        <source>Warning</source>
+        <translation>Warnung</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureWeb</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="14"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="22"/>
+        <source>Citra Web Service</source>
+        <translation>Citra Web Service</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="28"/>
+        <source>By providing your username and token, you agree to allow Citra to collect additional usage data, which may include user identifying information.</source>
+        <translation>Mit dem Bereitstellen deines Nutzernamens und Tokens, erlaubst du Citra, zusätzliche Nutzungsdaten zu sammeln. Sie können auch Informationen zur Nutzeridentifikation beinhalten.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="46"/>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="90"/>
+        <source>Verify</source>
+        <translation>Verifizieren</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="53"/>
+        <source>Sign up</source>
+        <translation>Registrieren</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="67"/>
+        <source>Token: </source>
+        <translation>Token: </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="78"/>
+        <source>Username: </source>
+        <translation>Nutzername:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="99"/>
+        <source>What is my token?</source>
+        <translation>Was ist mein Token?</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="124"/>
+        <source>Telemetry</source>
+        <translation>Telemetrie</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="130"/>
+        <source>Share anonymous usage data with the Citra team</source>
+        <translation>Anonyme Nutzungsdaten an das Citra-Team senden</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="137"/>
+        <source>Learn more</source>
+        <translation>Mehr erfahren</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="146"/>
+        <source>Telemetry ID:</source>
+        <translation>Telemetrie-ID:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="162"/>
+        <source>Regenerate</source>
+        <translation>Regenerieren</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="28"/>
+        <source>&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Mehr erfahren&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="33"/>
+        <source>&lt;a href=&apos;https://services.citra-emu.org/&apos;&gt;Sign up&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://services.citra-emu.org/&apos;&gt;Registrieren&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="36"/>
+        <source>&lt;a href=&apos;https://citra-emu.org/wiki/citra-web-service/&apos;&gt;What is my token?&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://citra-emu.org/wiki/citra-web-service/&apos;&gt;Was ist mein Token?&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="45"/>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="65"/>
+        <source>Telemetry ID: 0x%1</source>
+        <translation>Telemetrie-ID: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="55"/>
+        <source>Username and token not verified</source>
+        <translation>Benutzername und Token nicht verifiziert</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="56"/>
+        <source>Username and token were not verified. The changes to your username and/or token have not been saved.</source>
+        <translation>Nutzername und Token wurden nicht verifiziert. Die Änderungen an deinem Nutzernamen und/oder Token wurden nicht gespeichert.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="85"/>
+        <source>Verifying</source>
+        <translation>Verifiziere</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="99"/>
+        <source>Verification failed</source>
+        <translation>Verifizierung fehlgeschlagen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="100"/>
+        <source>Verification failed. Check that you have entered your username and token correctly, and that your internet connection is working.</source>
+        <translation>Verifizierung fehlgeschlagen. Überprüfe, dass du deinen Nutzernamen und  Token korrekt eingegeben hast und deine Internetverbindung funktioniert.</translation>
+    </message>
+</context>
+<context>
+    <name>DirectConnect</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="14"/>
+        <source>Direct Connect</source>
+        <translation>Direkt verbinden</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="33"/>
+        <source>IP Address</source>
+        <translation>IP-Adresse</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="56"/>
+        <source>IP</source>
+        <translation>IP</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="63"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;IPv4 address of the host&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;IPv4-Adresse des Hosts&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="73"/>
+        <source>Port</source>
+        <translation>Port</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="80"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Port number the host is listening on&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="86"/>
+        <source>24872</source>
+        <translation>24872</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="100"/>
+        <source>Nickname</source>
+        <translation>Anzeigename</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="114"/>
+        <source>Password</source>
+        <translation>Passwort</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="156"/>
+        <source>Connect</source>
+        <translation>Verbinden</translation>
+    </message>
+</context>
+<context>
+    <name>DirectConnectWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="97"/>
+        <source>Connecting</source>
+        <translation>Verbinden</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="102"/>
+        <source>Connect</source>
+        <translation>Verbinden</translation>
+    </message>
+</context>
+<context>
+    <name>GMainWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="90"/>
+        <source>To help improve Citra, the Citra Team collects anonymous usage data. No private or personally identifying information is collected. This data helps us to understand how people use Citra and prioritize our efforts. Furthermore, it helps us to more easily identify emulation bugs and performance issues. This data includes:&lt;ul&gt;&lt;li&gt;Information about the version of Citra you are using&lt;/li&gt;&lt;li&gt;Performance data about the games you play&lt;/li&gt;&lt;li&gt;Your configuration settings&lt;/li&gt;&lt;li&gt;Information about your computer hardware&lt;/li&gt;&lt;li&gt;Emulation errors and crash information&lt;/li&gt;&lt;/ul&gt;By default, this feature is enabled. To disable this feature, click &apos;Emulation&apos; from the menu and then select &apos;Configure...&apos;. Then, on the &apos;Web&apos; tab, uncheck &apos;Share anonymous usage data with the Citra team&apos;. &lt;br/&gt;&lt;br/&gt;By using this software, you agree to the above terms.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Um Citra zu verbessern, sammelt das Citra-Team anonyme Nutzungsdaten. Keine privaten oder Nutzeridentifizierenden Information werden gesammelt. Diese Daten helfen uns zu verstehen, wie Citra genutzt wird um so Prioritäten setzen zu können. Außerdem hilft es Bugs in der Emulation und Performanceprobleme leichter zu identifizieren. Diese Daten beinhalten:&lt;ul&gt;&lt;li&gt;Informationen über die Version von Citra&lt;/li&gt;&lt;li&gt;Performancedaten über deine gepsielten Spiele&lt;/li&gt;&lt;li&gt;Deine Citra-Einstellungen&lt;/li&gt;&lt;li&gt;Informationen über die Hardware deines Computers&lt;/li&gt;&lt;li&gt;Informationen über Emulationsfehler und Abstürze&lt;/li&gt;&lt;/ul&gt;Diese Funktion ist standardmäßig aktiviert. Um die Funktion auszuschalten, klicke im Menü auf &quot;Emulation&quot; und wähle dann &quot;Konfigurieren...&quot; aus. Dann, im &quot;Web&quot; Tab, entferne das Häkchen bei &quot;Anonyme Nutzungsdaten an das Citra-Team senden&quot;. &lt;br/&gt;&lt;br/&gt;Mit dem Nutzen dieser Software stimmst du den oben genannten Bedingungen zu.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Mehr erfahren&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="195"/>
+        <source>Current emulation speed. Values higher or lower than 100% indicate emulation is running faster or slower than a 3DS.</source>
+        <translation>Jetzige Emulationsgeschwindigkeit. Werte höher oder niedriger als 100% zeigen, dass die Emulation schneller oder langsamer läuft als auf einem 3DS.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="198"/>
+        <source>How many frames per second the game is currently displaying. This will vary from game to game and scene to scene.</source>
+        <translation>Die Anzahl der Bilder pro Sekunde die das Spiel gerade darstellt. Dies wird von Spiel zu Spiel und von Szene zu Szene variieren.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="202"/>
+        <source>Time taken to emulate a 3DS frame, not counting framelimiting or v-sync. For full-speed emulation this should be at most 16.67 ms.</source>
+        <translation>Die benötigte Zeit um ein 3DS-Einzelbild zu emulieren (V-Sync oder Bildratenbegrenzung nicht mitgezählt). Für eine Emulation in Echtzeit sollte dies maximal 16,67 ms betragen.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="429"/>
+        <source>CTRL+F</source>
+        <translation>STRG+F</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="538"/>
+        <source>Update available!</source>
+        <translation>Update verfügbar!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="539"/>
+        <source>An update for Citra is available. Do you wish to install it now?&lt;br /&gt;&lt;br /&gt;This &lt;b&gt;will&lt;/b&gt; terminate emulation, if it is running.</source>
+        <translation>Ein Update für Citra ist verfügbar. Möchtest du es jetzt installieren?&lt;br /&gt;&lt;br /&gt;Dies &lt;b&gt;wird&lt;/b&gt; die Emulation stoppen, falls sie läuft.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <source>No update found</source>
+        <translation>Kein Update gefunden</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <source>No update has been found for Citra.</source>
+        <translation>Kein Update für Citra wurde gefunden.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="567"/>
+        <source>Error while initializing OpenGL 3.3 Core!</source>
+        <translation>Fehler beim Initialisieren des OpenGL 3.3 Kerns!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="568"/>
+        <source>Your GPU may not support OpenGL 3.3, or you do not have the latest graphics driver.</source>
+        <translation>Deine Grafikkarte könnte OpenGL 3.3 nicht unterstützen, oder du hast nicht die neuesten Grafiktreiber.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="581"/>
+        <location filename="../../src/citra_qt/main.cpp" line="587"/>
+        <location filename="../../src/citra_qt/main.cpp" line="593"/>
+        <location filename="../../src/citra_qt/main.cpp" line="606"/>
+        <location filename="../../src/citra_qt/main.cpp" line="625"/>
+        <source>Error while loading ROM!</source>
+        <translation>Fehler beim Laden des ROMs!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="582"/>
+        <location filename="../../src/citra_qt/main.cpp" line="607"/>
+        <source>The ROM format is not supported.</source>
+        <translation>Das ROM Format wird nicht unterstützt.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="588"/>
+        <source>Could not determine the system mode.</source>
+        <translation>Konnte Systemmodus nicht ermitteln.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="594"/>
+        <source>The game that you are trying to load must be decrypted before being used with Citra. A real 3DS is required.&lt;br/&gt;&lt;br/&gt;For more information on dumping and decrypting games, please see the following wiki pages: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation>Das Spiel, dass du laden möchtest, muss entschlüsselt werden, bevor du es mit Citra nutzen kannst. Ein echter 3DS wird benötigt.&lt;br/&gt;&lt;br/&gt;Für mehr Informationen zum Dumpen und Entschlüsseln von  Spielen, sieh dir bitte die folgenden Wiki-Seiten an: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumpen von Spiele-Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumpen von installierten Titeln&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="612"/>
+        <source>An error occured in the video core.</source>
+        <translation>Ein Fehler ist im Videokern aufgetreten.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="613"/>
+        <source>Citra has encountered an error while running the video core, please see the log for more details.For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.Ensure that you have the latest graphics drivers for your GPU.</source>
+        <translation>Ein Fehler ist im Videokern aufgetreten. Bitte schau für mehr Details in den Log.Für mehr Informationen, wie man an den Log kommt, schau dir bitte die folgende Seite an: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;Wie man die Log-Datei hochlädt&lt;/a&gt;.Stelle sicher, dass du die neuesten Treiber für deine Grafikkarte hast.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="626"/>
+        <source>An unknown error occured. Please see the log for more details.</source>
+        <translation>Ein unbekannter Fehler ist aufgetreten. Bitte schau für mehr Details in den Log.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="699"/>
+        <source>Start</source>
+        <translation>Start</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="790"/>
+        <source>Error Opening %1 Folder</source>
+        <translation>Fehler beim Öffnen des Ordners %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="791"/>
+        <source>Folder does not exist!</source>
+        <translation>Ordner existiert nicht!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="805"/>
+        <source>3DS Executable</source>
+        <translation>3DS-Executable</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="806"/>
+        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <source>All Files (*.*)</source>
+        <translation>Alle Dateien (*.*)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="808"/>
+        <source>Load File</source>
+        <translation>Datei laden</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="818"/>
+        <source>Select Directory</source>
+        <translation>Ordner auswählen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="827"/>
+        <source>Load Files</source>
+        <translation>Dateien laden</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <source>3DS Installation File (*.CIA*)</source>
+        <translation>3DS Installationsdatei (*.CIA*)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="859"/>
+        <source>%1 has been installed successfully.</source>
+        <translation>%1 wurde erfolgreich installiert.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="862"/>
+        <source>Unable to open File</source>
+        <translation>Datei konnte nicht geöffnet werden</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="863"/>
+        <source>Could not open %1</source>
+        <translation>Konnte %1 nicht öffnen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="867"/>
+        <source>Installation aborted</source>
+        <translation>Installation abgebrochen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="868"/>
+        <source>The installation of %1 was aborted. Please see the log for more details</source>
+        <translation>Die Installation von %1 wurde abgebrochen. Weitere Details dazu im Log.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <source>Invalid File</source>
+        <translation>Ungültige Datei</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <source>%1 is not a valid CIA</source>
+        <translation>%1 ist kein gültiges CIA</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="875"/>
+        <source>Encrypted File</source>
+        <translation>Verschlüsselte Datei</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="876"/>
+        <source>%1 must be decrypted before being used with Citra. A real 3DS is required.</source>
+        <translation>%1 muss entschlüsselt werden, bevor es mit Citra verwendet werden kann. Hierzu ist ein 3DS ist notwendig.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="899"/>
+        <source>File not found</source>
+        <translation>Datei nicht gefunden</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="900"/>
+        <source>File &quot;%1&quot; not found</source>
+        <translation>Datei &quot;%1&quot; nicht gefunden</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="914"/>
+        <source>Continue</source>
+        <translation>Fortsetzen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="939"/>
+        <source>Missing Citra Account</source>
+        <translation>Fehlender Citra-Account</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="940"/>
+        <source>In order to submit a game compatibility test case, you must link your Citra account.&lt;br&gt;&lt;br/&gt;To link your Citra account, go to Emulation &amp;gt; Configuration &amp;gt; Web.</source>
+        <translation>Um einen Testfall für die Kompatibilitätsliste zu übertragen, muss der Citra-Account verknüpft sein.&lt;br&gt;&lt;br/&gt;Dieser kann unter Emulation &amp;gt; Konfiguration &amp;gt; Web konfiguriert werden.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1090"/>
+        <source>Speed: %1% / %2%</source>
+        <translation>Geschwindigkeit: %1% / %2%</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1094"/>
+        <source>Speed: %1%</source>
+        <translation>Geschwindigkeit: %1%</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1096"/>
+        <source>Game: %1 FPS</source>
+        <translation>Spiel: %1 FPS</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1097"/>
+        <source>Frame: %1 ms</source>
+        <translation>Einzelbild: %1 ms</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1108"/>
+        <source>The game you are trying to load requires additional files from your 3DS to be dumped before playing.&lt;br/&gt;&lt;br/&gt;For more information on dumping these files, please see the following wiki page: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
+        <translation>Das Spiel, dass du laden möchtest benötigt zusätzliche Dateien die von deinem 3DS gedumpt werden müssen, bevor du es spielen kannst.&lt;br/&gt;&lt;br/&gt;Für mehr Informationen über das Dumpen dieser Dateien, geh bitte auf die folgende Wiki-Seite: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumpen von Systemarchiven und den &quot;Shared Fonts&quot; von einer 3DS Konsole&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Möchtest du zur Spieleliste zurückkehren? Das Fortfahren der Emulation kann zu Abstürzen, beschädigten Speicherdaten oder anderen Bugs führen.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1120"/>
+        <source>: %1. </source>
+        <translation>: %1. </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1126"/>
+        <source>System Archive Not Found</source>
+        <translation>Systemarchiv nicht gefunden</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1133"/>
+        <source>Citra was unable to locate the 3DS shared fonts. </source>
+        <translation>Citra konnte die &quot;3DS Shared Fonts&quot; nicht finden.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1135"/>
+        <source>Shared Fonts Not Found</source>
+        <translation>&quot;Shared Fonts&quot; nicht gefunden</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1143"/>
+        <source>Fatal Error</source>
+        <translation>Fataler Fehler</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1144"/>
+        <source>Citra has encountered a fatal error, please see the log for more details. For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
+        <translation>Citra hat einen schwerwiegenden Fehler festgestellt, bitte sieh dir für mehr Details das Log an. Für mehr Informationen wie man an das Log kommt, geh bitte auf die folgende Seite: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;Wie lade ich die Log-Datei hoch&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Möchtest du zur Spieleliste zurückkehren? Das Fortsetzen der Emulation kann zu Abstürzen, beschädigten Speicherdaten oder anderen Fehlern führen.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1245"/>
+        <source>Citra</source>
+        <translation>Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <source>Are you sure you want to close Citra?</source>
+        <translation>Bist du sicher, dass du Citra schließen möchtest?</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1246"/>
+        <source>Are you sure you want to stop the emulation? Any unsaved progress will be lost.</source>
+        <translation>Bist du sicher, dass du die Emulation stoppen möchtest? Jeder ungespeicherte Fortschritt wird verloren gehen.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1318"/>
+        <source>Citra %1| %2-%3</source>
+        <translation>Citra %1| %2-%3</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandListModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="96"/>
+        <source>Command Name</source>
+        <translation>Befehlsname</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="98"/>
+        <source>Register</source>
+        <translation>Register</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="100"/>
+        <source>Mask</source>
+        <translation>Maske</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="102"/>
+        <source>New Value</source>
+        <translation>Neuer Wert</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandListWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="184"/>
+        <source>Pica Command List</source>
+        <translation>Pica-Kommandoliste</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="202"/>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="233"/>
+        <source>Start Tracing</source>
+        <translation>Tracing starten</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="203"/>
+        <source>Copy All</source>
+        <translation>Alle kopieren</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="229"/>
+        <source>Finish Tracing</source>
+        <translation>Tracing beenden</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandStreamWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics.cpp" line="67"/>
+        <source>Graphics Debugger</source>
+        <translation>Grafik-Debugger</translation>
+    </message>
+</context>
+<context>
+    <name>GameList</name>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <source>Perfect</source>
+        <translation>Perfekt</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <source>Game functions flawless with no audio or graphical glitches, all tested functionality works as intended without
+any workarounds needed.</source>
+        <translation>Das Spiel funktioniert problemlos, ohne Grafik- oder Tonprobleme. Die getestete Funktionalität verhält sich wie gewünscht ohne Umgehungslösungen.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <source>Great</source>
+        <translation>Sehr gut</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <source>Game functions with minor graphical or audio glitches and is playable from start to finish. May require some
+workarounds.</source>
+        <translation>Das Spiel funktioniert und kann beendet werden, hat aber evtl. Grafik- oder Tonprobleme. Möglicherweise sind Umgehungslösungen notwendig.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <source>Okay</source>
+        <translation>Okay</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <source>Game functions with major graphical or audio glitches, but game is playable from start to finish with
+workarounds.</source>
+        <translation>Das Spiel funktioniert, hat aber starke Grafik- oder Tonprobleme. Das Spiel kann jedoch mit Umgehungslösungen gespielt und beendet werden.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Bad</source>
+        <translation>Schlecht</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches
+even with workarounds.</source>
+        <translation>Das Spiel funktioniert zwar, hat aber starke Grafik- oder Tonprobleme. An bestimmten Stellen ist ein Weiterkommen aufgrund von Fehlern unmöglich, auch nicht mit Umgehungslösungen.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <source>Intro/Menu</source>
+        <translation>Intro/Menü</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <source>Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start
+Screen.</source>
+        <translation>Das Spiel ist nicht spielbar aufgrund starker Grafik- oder Tonprobleme. Es ist nicht möglich, über den Startbildschirm hinaus zu kommen.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>Won&apos;t Boot</source>
+        <translation>Startet nicht</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>The game crashes when attempting to startup.</source>
+        <translation>Das Spiel stürzt beim Versuch es zu starten ab.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <source>Not Tested</source>
+        <translation>Nicht getestet</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <source>The game has not yet been tested.</source>
+        <translation>Das Spiel wurde noch nicht getestet.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="99"/>
+        <source>of</source>
+        <translation>von</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="102"/>
+        <source>result</source>
+        <translation>Ergebnis</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="104"/>
+        <source>results</source>
+        <translation>Ergebnisse</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="125"/>
+        <source>Filter:</source>
+        <translation>Filter:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="128"/>
+        <source>Enter pattern to filter</source>
+        <translation>Suchmuster zur Filterung eingeben</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="324"/>
+        <source>Open Save Data Location</source>
+        <translation>Ort der Speicherdaten öffnen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
+        <source>Open Application Location</source>
+        <translation>Ort der Applikationsdaten öffnen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
+        <source>Open Update Data Location</source>
+        <translation>Ort der Updatedaten öffnen</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsBreakPointsWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="132"/>
+        <source>Pica Breakpoints</source>
+        <translation>Pica-Haltepunkt</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="136"/>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="198"/>
+        <source>Emulation running</source>
+        <translation>Emulation läuft</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="137"/>
+        <source>Resume</source>
+        <translation>Fortsetzen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="188"/>
+        <source>Emulation halted at breakpoint</source>
+        <translation>Emulation angehalten am Haltepunkt</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsSurfaceWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="49"/>
+        <source>Pica Surface Viewer</source>
+        <translation>Pica-Oberflächenansicht</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="54"/>
+        <source>Color Buffer</source>
+        <translation>Farbpuffer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="55"/>
+        <source>Depth Buffer</source>
+        <translation>Depth Buffer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="56"/>
+        <source>Stencil Buffer</source>
+        <translation>Stencil Buffer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="57"/>
+        <source>Texture 0</source>
+        <translation>Textur 0</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="58"/>
+        <source>Texture 1</source>
+        <translation>Textur 1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="59"/>
+        <source>Texture 2</source>
+        <translation>Textur 2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="60"/>
+        <source>Custom</source>
+        <translation>Eigener</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="103"/>
+        <source>Unknown</source>
+        <translation>Unbekannt</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="118"/>
+        <source>Save</source>
+        <translation>Speichern</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="144"/>
+        <source>Source:</source>
+        <translation>Quelle:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="150"/>
+        <source>Physical Address:</source>
+        <translation>Physikalische Addresse:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="156"/>
+        <source>Width:</source>
+        <translation>Breite:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="162"/>
+        <source>Height:</source>
+        <translation>Höhe:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="168"/>
+        <source>Format:</source>
+        <translation>Format:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="180"/>
+        <source>X:</source>
+        <translation>X:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="186"/>
+        <source>Y:</source>
+        <translation>Y:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="280"/>
+        <source>Pixel out of bounds</source>
+        <translation>Pixel außerhalb des Bereichs</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="287"/>
+        <source>(unable to access pixel data)</source>
+        <translation>(auf Pixeldaten konnte nicht zugegriffen werden)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="555"/>
+        <source>(invalid surface address)</source>
+        <translation>(ungültige Oberflächenadresse)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="565"/>
+        <source>(unknown surface format)</source>
+        <translation>(unbekanntes Oberflächenformat)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="658"/>
+        <source>Portable Network Graphic (*.png)</source>
+        <translation>Portable Network Graphic (*.png)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="659"/>
+        <source>Binary data (*.bin)</source>
+        <translation>Binärdaten (*.bin)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="663"/>
+        <source>Save Surface</source>
+        <translation>Oberfläche speichern</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsTracingWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="25"/>
+        <source>CiTrace Recorder</source>
+        <translation>CiTrace-Aufnahme</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="29"/>
+        <source>Start Recording</source>
+        <translation>Aufnahme starten</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="31"/>
+        <source>Stop and Save</source>
+        <translation>Stoppen und speichern</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="32"/>
+        <source>Abort Recording</source>
+        <translation>Aufnahme abbrechen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="112"/>
+        <source>Save CiTrace</source>
+        <translation>CI-Trace speichern</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="113"/>
+        <source>CiTrace File (*.ctf)</source>
+        <translation>CiTrace Datei (*.ctf)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="162"/>
+        <source>CiTracing still active</source>
+        <translation>CI-Trace ist noch aktiv</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="163"/>
+        <source>A CiTrace is still being recorded. Do you want to save it? If not, all recorded data will be discarded.</source>
+        <translation>Ein CI-Trace wird aktuell aufgenommen. Möchten Sie diesen speichern?
+Falls nein, werden die aufgenommmen Daten verworfen.</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsVertexShaderModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="45"/>
+        <source>Offset</source>
+        <translation>Verschiebung</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="47"/>
+        <source>Raw</source>
+        <translation>Roh</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="49"/>
+        <source>Disassembly</source>
+        <translation>Disassembly</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsVertexShaderWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="345"/>
+        <source>Save Shader Dump</source>
+        <translation>Shader-Dump speichern</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="345"/>
+        <source>Shader Binary (*.shbin)</source>
+        <translation>Shader-Binary (*.shbin)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="380"/>
+        <source>(data only available at vertex shader invocation breakpoints)</source>
+        <translation>(Daten sind nur in den Haltepunkten des Vertex-Shader-Aufrufs verfügbar)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="390"/>
+        <source>Dump</source>
+        <translation>Dump</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="412"/>
+        <source>Input Data</source>
+        <translation>Eingabedaten</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="426"/>
+        <source>Attribute %1</source>
+        <translation>Attribut %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="453"/>
+        <source>Cycle Index:</source>
+        <translation>Cycle-Index:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="558"/>
+        <source>SRC1: %1, %2, %3, %4
+</source>
+        <translation>SRC1: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="564"/>
+        <source>SRC2: %1, %2, %3, %4
+</source>
+        <translation>SRC2: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="570"/>
+        <source>SRC3: %1, %2, %3, %4
+</source>
+        <translation>SRC3: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="576"/>
+        <source>DEST_IN: %1, %2, %3, %4
+</source>
+        <translation>DEST_IN: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="582"/>
+        <source>DEST_OUT: %1, %2, %3, %4
+</source>
+        <translation>DEST_OUT: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="589"/>
+        <source>Address Registers: %1, %2
+</source>
+        <translation>Adressenregister: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="593"/>
+        <source>Compare Result: %1, %2
+</source>
+        <translation>Ergebnis vergleichen: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="598"/>
+        <source>Static Condition: %1
+</source>
+        <translation>Statische Bedingung: %1
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="600"/>
+        <source>Dynamic Conditions: %1, %2
+</source>
+        <translation>Dynamische Konditionen: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="604"/>
+        <source>Loop Parameters: %1 (repeats), %2 (initializer), %3 (increment), %4
+</source>
+        <translation>Schleifenparameter: %1 (repeats), %2 (initializer), %3 (increment), %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="611"/>
+        <source>Instruction offset: 0x%1</source>
+        <translation>Instruktionsverschiebung: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="613"/>
+        <source> -&gt; 0x%2</source>
+        <translation> -&gt; 0x%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="615"/>
+        <source> (last instruction)</source>
+        <translation> (letzte Instruktion)</translation>
+    </message>
+</context>
+<context>
+    <name>HostRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="14"/>
+        <source>Create Room</source>
+        <translation>Raum erstellen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="37"/>
+        <source>Room Name</source>
+        <translation>Raumname</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="51"/>
+        <source>Preferred Game</source>
+        <translation>Bevorzugtes Spiel</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="61"/>
+        <source>Max Players</source>
+        <translation>Maximale Spielerzahl</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="91"/>
+        <source>Username</source>
+        <translation>Anzeigename</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="101"/>
+        <source>(Leave blank for open game)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="118"/>
+        <source>Password</source>
+        <translation>Passwort</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="125"/>
+        <source>Port</source>
+        <translation>Port</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="156"/>
+        <source>Public</source>
+        <translation>Öffentlich</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="161"/>
+        <source>Unlisted</source>
+        <translation>Nicht-gelistet</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="169"/>
+        <source>Host Room</source>
+        <translation>Raum hosten</translation>
+    </message>
+</context>
+<context>
+    <name>Lobby</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="14"/>
+        <source>Public Room Browser</source>
+        <translation>Browser für Öffentliche Räume</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="32"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="39"/>
+        <source>Nickname</source>
+        <translation>Anzeigename</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="59"/>
+        <source>Filters</source>
+        <translation>Filter</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="66"/>
+        <source>Search</source>
+        <translation>Suche</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="76"/>
+        <source>Games I Own</source>
+        <translation>Spiele, die ich besitze</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="83"/>
+        <source>Hide Full Rooms</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="103"/>
+        <source>Refresh Lobby</source>
+        <translation>Lobby aktualisieren</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <source>Password Required to Join</source>
+        <translation>Passwort zum Beitreten benötigt</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <source>Password:</source>
+        <translation>Passwort:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="77"/>
+        <source>Password</source>
+        <translation>Passwort</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
+        <source>Room Name</source>
+        <translation>Raumname</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="143"/>
+        <source>Preferred Game</source>
+        <translation>Bevorzugtes Spiel</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="144"/>
+        <source>Host</source>
+        <translation>Host</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="145"/>
+        <source>Players</source>
+        <translation>Spieler</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="153"/>
+        <source>Refreshing</source>
+        <translation>Neu Laden</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="201"/>
+        <source>Refresh List</source>
+        <translation>Liste aktualisieren</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="14"/>
+        <source>Citra</source>
+        <translation>Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="53"/>
+        <source>&amp;File</source>
+        <translation>&amp;Datei</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="57"/>
+        <source>Recent Files</source>
+        <translation>Kürzliche Dateien</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="70"/>
+        <source>&amp;Emulation</source>
+        <translation>&amp;Emulation</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="80"/>
+        <source>&amp;View</source>
+        <translation>&amp;Anzeige</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="84"/>
+        <source>Debugging</source>
+        <translation>Debugging</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="91"/>
+        <source>Screen Layout</source>
+        <translation>Bildschirmanordnung</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="115"/>
+        <source>Multiplayer</source>
+        <translation>Mehrspieler</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="126"/>
+        <source>&amp;Help</source>
+        <translation>&amp;Hilfe</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="144"/>
+        <source>Load File...</source>
+        <translation>Datei laden...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="149"/>
+        <source>Install CIA...</source>
+        <translation>CIA installieren...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="154"/>
+        <source>Load Symbol Map...</source>
+        <translation>Symbolkarte laden...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="159"/>
+        <source>E&amp;xit</source>
+        <translation>V&amp;erlassen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="167"/>
+        <source>&amp;Start</source>
+        <translation>&amp;Start</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="175"/>
+        <source>&amp;Pause</source>
+        <translation>&amp;Pause</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="183"/>
+        <source>&amp;Stop</source>
+        <translation>&amp;Stop</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="188"/>
+        <source>FAQ</source>
+        <translation>FAQ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="193"/>
+        <source>About Citra</source>
+        <translation>Über Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="201"/>
+        <source>Single Window Mode</source>
+        <translation>Einzelfenstermodus</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="206"/>
+        <source>Configure...</source>
+        <translation>Konfigurieren...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="214"/>
+        <source>Display Dock Widget Headers</source>
+        <translation>Dock Widget Header anzeigen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="222"/>
+        <source>Show Filter Bar</source>
+        <translation>Filterleiste anzeigen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="230"/>
+        <source>Show Status Bar</source>
+        <translation>Statusleiste anzeigen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="235"/>
+        <source>Select Game Directory...</source>
+        <translation>Spieleverzeichnis auswählen...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="238"/>
+        <source>Selects a folder to display in the game list</source>
+        <translation>Wählt einen Ordner aus, der in der Spieleliste angezeigt werden soll.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="243"/>
+        <source>Create Pica Surface Viewer</source>
+        <translation>Pica-Oberflächenansicht</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="251"/>
+        <source>Browse Public Game Lobby</source>
+        <translation>Durchsuche Lobby für Öffentliche Spiele</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="259"/>
+        <source>Create Room</source>
+        <translation>Raum erstellen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="267"/>
+        <source>Leave Room</source>
+        <translation>Raum verlassen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="272"/>
+        <source>Direct Connect to Room</source>
+        <translation>Direkt zum Raum Verbinden</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="280"/>
+        <source>Show Current Room</source>
+        <translation>Zeige derzeitigen Raum an</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="288"/>
+        <source>Fullscreen</source>
+        <translation>Vollbild</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="293"/>
+        <source>Modify Citra Install</source>
+        <translation>Citra-Installation modifizieren</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="296"/>
+        <source>Opens the maintenance tool to modify your Citra installation</source>
+        <translation>Öffnet das Wartungstool, um deine Citra-Installation zu modifizieren</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="304"/>
+        <source>Default</source>
+        <translation>Standard</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="312"/>
+        <source>Single Screen</source>
+        <translation>Einzelner Bildschirm</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="320"/>
+        <source>Large Screen</source>
+        <translation>Großer Bildschirm</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="328"/>
+        <source>Side by Side</source>
+        <translation>Seite an Seite</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="336"/>
+        <source>Swap Screens</source>
+        <translation>Bildschirme tauschen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="341"/>
+        <source>Check for Updates</source>
+        <translation>Auf Updates prüfen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="349"/>
+        <source>Report Compatibility</source>
+        <translation>Kompatibilität melden</translation>
+    </message>
+</context>
+<context>
+    <name>MicroProfileDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/profiler.cpp" line="50"/>
+        <source>MicroProfile</source>
+        <translation>MicroProfile</translation>
+    </message>
+</context>
+<context>
+    <name>MultiplayerState</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="41"/>
+        <source>Current connection status</source>
+        <translation>Jetziger Verbindungsstatus</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="42"/>
+        <source>Not Connected. Click here to find a room!</source>
+        <translation>Nicht verbunden. Klicke hier um einen Raum zu finden</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="100"/>
+        <source>Connected</source>
+        <translation>Verbunden</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="105"/>
+        <source>Not Connected</source>
+        <translation>Nicht verbunden</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="114"/>
+        <source>Error</source>
+        <translation>Fehler</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="115"/>
+        <source>Failed to announce the room to the public lobby. In order to host a room publicly, you must have a valid Citra account configured in Emulation -&gt; Configure -&gt; Web. If you do not want to publish a room in the public lobby, then select Unlisted instead.
+Debug Message: </source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>NetworkMessage</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="12"/>
+        <source>Username is not valid. Must be 4 to 20 alphanumeric characters.</source>
+        <translation>Anzeigename ist nicht gültig. Er muss aus 4 bis 20 alphanumerischen Zeichen bestehen.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="14"/>
+        <source>Room name is not valid. Must be 4 to 20 alphanumeric characters.</source>
+        <translation>Raumname ist nicht gültig. Er muss aus 4 bis 20 alphabetischen Charakteren bestehen.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="16"/>
+        <source>Username is already in use. Please choose another.</source>
+        <translation>Anzeigename wird bereits benutzt. Bitte wähle einen anderen.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="17"/>
+        <source>IP is not a valid IPv4 address.</source>
+        <translation>IP ist keine gültige IPv4-Adresse.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="18"/>
+        <source>Port must be a number between 0 to 65535.</source>
+        <translation>Der Port muss eine Nummer zwischen 0 und 65535 sein.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="20"/>
+        <source>Unable to find an internet connection. Check your internet settings.</source>
+        <translation>Konnte keine Internetverbindung finden. Kontrollieren sie ihre Internet Einstellungen.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="22"/>
+        <source>Unable to connect to the host. Verify that the connection settings are correct. If you still cannot connect, contact the room host and verify that the host is properly configured with the external port forwarded.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="26"/>
+        <source>Creating a room failed. Please retry. Restarting Citra might be necessary.</source>
+        <translation>Fehler beim erstellen eines Raumes. Bitte versuchen sie es erneut. Citra neuzustarten kann notwendig sein.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="28"/>
+        <source>The host of the room has banned you. Speak with the host to unban you or try a different room.</source>
+        <translation>Der Ersteller des Raumes hat dich gebannt. Bitte den Ersteller dich zu entbannen oder versuche einen anderen Raum.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="31"/>
+        <source>Version mismatch! Please update to the latest version of Citra. If the problem persists, contact the room host and ask them to update the server.</source>
+        <translation>Nicht übereinstimmende Version! Bitte update auf die neueste Version von Citra. Sollte das Problem weiterhin auftreten kontaktiere den Raumersteller und bitte ihn den Server zu updaten.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="33"/>
+        <source>Incorrect password.</source>
+        <translation>Falsches Passwort.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="35"/>
+        <source>An unknown error occured. If this error continues to occur, please open an issue</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="36"/>
+        <source>Connection to room lost. Try to reconnect.</source>
+        <translation>Verbindung zum Raum verloren. Versuche dich erneut zu Verbinden.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="38"/>
+        <source>MAC address is already in use. Please choose another.</source>
+        <translation>MAC-Addresse wird bereits genutzt. Bitte wähle eine andere.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="52"/>
+        <source>Leave Room</source>
+        <translation>Raum verlassen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="53"/>
+        <source>You are about to close the room. Any network connections will be closed.</source>
+        <translation>Du bist dabei den Raum zu schliessen. Jegliche Netzwerkverbindungen werden geschlossen.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="58"/>
+        <source>Disconnect</source>
+        <translation>Verbindung trennen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="59"/>
+        <source>You are about to leave the room. Any network connections will be closed.</source>
+        <translation>Du bist dabei den Raum zu schliessen. Jegliche Netzwerkverbindungen werden geschlossen</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="47"/>
+        <source>Error</source>
+        <translation>Fehler</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="198"/>
+        <source>%1 is not playing a game</source>
+        <translation>%1 spielt kein Spiel</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="201"/>
+        <source>%1 is playing %2</source>
+        <translation>%1 spielt %2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="26"/>
+        <source>Shift</source>
+        <translation>Umschalttaste</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="28"/>
+        <source>Ctrl</source>
+        <translation>Strg</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="30"/>
+        <source>Alt</source>
+        <translation>Alt</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="51"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="75"/>
+        <source>[not set]</source>
+        <translation>[nicht gesetzt]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="55"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="83"/>
+        <source>Joystick %1</source>
+        <translation>Joystick %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="57"/>
+        <source> Hat %1 %2</source>
+        <translation> Hat %1 %2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="61"/>
+        <source> Axis %1%2</source>
+        <translation>Achse %1%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="65"/>
+        <source> Button %1</source>
+        <translation> Button %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="69"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="91"/>
+        <source>[unknown]</source>
+        <translation>[unbekannt]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="80"/>
+        <source>[unused]</source>
+        <translation>[frei]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="85"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="87"/>
+        <source> Axis %1</source>
+        <translation>Achse %1</translation>
+    </message>
+</context>
+<context>
+    <name>RegistersWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="15"/>
+        <source>Registers</source>
+        <translation>Register</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="16"/>
+        <source>VFP Registers</source>
+        <translation>VFP Register</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="18"/>
+        <source>VFP System Registers</source>
+        <translation>VFP System Register</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="167"/>
+        <source>Vector Length</source>
+        <translation>Vektorlänge</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="168"/>
+        <source>Vector Stride</source>
+        <translation>Vektor Stride</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="169"/>
+        <source>Rounding Mode</source>
+        <translation>Rundungsmodus</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="182"/>
+        <source>Vector Iteration Count</source>
+        <translation>Vektor-Iterationszähler</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeEvent</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="259"/>
+        <source>reset type = %1</source>
+        <translation>reset art = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeMutex</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="272"/>
+        <source>locked %1 times by thread:</source>
+        <translation>%1 mal durch Thread blockiert:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="275"/>
+        <source>free</source>
+        <translation>free</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeMutexList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="314"/>
+        <source>holding mutexes</source>
+        <translation>hält Mutexe</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeObjectList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="128"/>
+        <source>waiting for all objects</source>
+        <translation>wartet auf alle Objekte</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="129"/>
+        <source>waiting for one of the following objects</source>
+        <translation>Warte auf eins der folgenden Objekte</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeSemaphore</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="288"/>
+        <source>available count = %1</source>
+        <translation>Verfügbare Anzahl = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="289"/>
+        <source>max count = %1</source>
+        <translation>Maximale Anzahl = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeThread</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="146"/>
+        <source>running</source>
+        <translation>läuft</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="149"/>
+        <source>ready</source>
+        <translation>bereit</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="152"/>
+        <source>waiting for address 0x%1</source>
+        <translation>Warte auf Adresse 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="155"/>
+        <source>sleeping</source>
+        <translation>schläft</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="158"/>
+        <source>waiting for IPC response</source>
+        <translation>warten auf IPC Antwort</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="162"/>
+        <source>waiting for objects</source>
+        <translation>wartet auf Objekte</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="165"/>
+        <source>waiting for HLE return</source>
+        <translation>warten auf HLE Rückgabe</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="168"/>
+        <source>dormant</source>
+        <translation>schlafend</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="171"/>
+        <source>dead</source>
+        <translation>tot</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="174"/>
+        <source> PC = 0x%1 LR = 0x%2</source>
+        <translation> PC = 0x%1 LR = 0x%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="214"/>
+        <source>default</source>
+        <translation>Standard</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="217"/>
+        <source>all</source>
+        <translation>alle</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="220"/>
+        <source>AppCore</source>
+        <translation>AppCore</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="223"/>
+        <source>SysCore</source>
+        <translation>SysCore</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="226"/>
+        <source>Unknown processor %1</source>
+        <translation>Unbekannter Prozessor %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="230"/>
+        <source>processor = %1</source>
+        <translation>Prozessor = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="231"/>
+        <source>thread id = %1</source>
+        <translation>Thread-ID = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="232"/>
+        <source>priority = %1(current) / %2(normal)</source>
+        <translation>Priorität = %1(jetzig) / %2(normal)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="236"/>
+        <source>last running ticks = %1</source>
+        <translation>letzte laufende Ticks = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="239"/>
+        <source>not holding mutex</source>
+        <translation>hält keinen Mutex</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeThreadList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="328"/>
+        <source>waited by thread</source>
+        <translation>pausiert von Thread </translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeTimer</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="301"/>
+        <source>reset type = %1</source>
+        <translation>reset art = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="303"/>
+        <source>initial delay = %1</source>
+        <translation>anfängliches Delay = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="305"/>
+        <source>interval delay = %1</source>
+        <translation>Intervall Delay = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeWaitObject</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="76"/>
+        <source>[%1]%2 %3</source>
+        <translation>[%1]%2 %3</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="104"/>
+        <source>waited by no thread</source>
+        <translation>von keinem Thread pausiert</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="114"/>
+        <source>one shot</source>
+        <translation>one shot</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="116"/>
+        <source>sticky</source>
+        <translation>sticky</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="118"/>
+        <source>pulse</source>
+        <translation>pulse</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="399"/>
+        <source>Wait Tree</source>
+        <translation>Wartebaum</translation>
+    </message>
+</context>
+<context>
+    <name>hotkeys</name>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="14"/>
+        <source>Hotkey Settings</source>
+        <translation>Tastenkürzel-Einstellungen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="27"/>
+        <source>Action</source>
+        <translation>Aktion</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="32"/>
+        <source>Hotkey</source>
+        <translation>Tastenkürzel</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="37"/>
+        <source>Context</source>
+        <translation>Kontext</translation>
+    </message>
+</context>
+</TS>

--- a/dist/languages/es_ES.ts
+++ b/dist/languages/es_ES.ts
@@ -1,0 +1,2756 @@
+<?xml version="1.0" ?><!DOCTYPE TS><TS language="es_ES" version="2.1">
+<context>
+    <name>ARMRegisters</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="14"/>
+        <source>ARM Registers</source>
+        <translation>Registros de ARM</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="25"/>
+        <source>Register</source>
+        <translation>Registro</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="30"/>
+        <source>Value</source>
+        <translation>Valor</translation>
+    </message>
+</context>
+<context>
+    <name>AboutDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="14"/>
+        <source>About Citra</source>
+        <translation>Acerca de Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="30"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/citra.png&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/citra.png&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="60"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:28pt;&quot;&gt;Citra&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:28pt;&quot;&gt;Citra&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="73"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="86"/>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:12pt;&quot;&gt;Citra is a free and open source 3DS emulator licensed under GPLv2.0 or any later version.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'MS Shell Dlg 2'; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;This software should not be used to play games you have not legally obtained.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;Citra es un emulador de 3DS gratuito y de código abierto licenciado bajo GPLv2.0 o versiones posteriores.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;Este software no debe ser usado para jugar juegos que no tengas de manera legal.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="118"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Website&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://community.citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Forum&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Source Code&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Contributors&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/blob/master/license.txt&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;License&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Página Web&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://community.citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Foro&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Código Fuente&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Colaboradores&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/blob/master/license.txt&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Licencia&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="134"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;&amp;quot;3DS&amp;quot; is a trademark of Nintendo. Citra is not affiliated with Nintendo in any way.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;&amp;quot;3DS&amp;quot; es una marca registrada de Nintendo. Citra no está afiliada con Nintendo.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>BreakPointModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="34"/>
+        <source>Pica command loaded</source>
+        <translation>Comando de Pica cargado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="35"/>
+        <source>Pica command processed</source>
+        <translation>Comando de Pica procesado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="36"/>
+        <source>Incoming primitive batch</source>
+        <translation>Iniciando lote primitivo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="37"/>
+        <source>Finished primitive batch</source>
+        <translation>Lote primitivo terminado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="38"/>
+        <source>Vertex shader invocation</source>
+        <translation>Invocación del Sombreado de vértices</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="40"/>
+        <source>Incoming display transfer</source>
+        <translation>Iniciando transferencia de pantalla</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="41"/>
+        <source>GSP command processed</source>
+        <translation>Comando de GSP procesado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="42"/>
+        <source>Buffers swapped</source>
+        <translation>Buffers intercambiados</translation>
+    </message>
+</context>
+<context>
+    <name>ChatRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="14"/>
+        <source>Room Window</source>
+        <translation>Ventana de Sala</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="40"/>
+        <source>Send Chat Message</source>
+        <translation>Enviar Mensaje de Chat</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="47"/>
+        <source>Send Message</source>
+        <translation>Enviar Mensaje</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.cpp" line="81"/>
+        <source>Name</source>
+        <translation>Nombre</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.cpp" line="82"/>
+        <source>Game</source>
+        <translation>Juego</translation>
+    </message>
+</context>
+<context>
+    <name>ClientRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.ui" line="14"/>
+        <source>Room Window</source>
+        <translation>Ventana de Sala</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.ui" line="40"/>
+        <source>Leave Room</source>
+        <translation>Abandonar la Sala</translation>
+    </message>
+</context>
+<context>
+    <name>ClientRoomWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="54"/>
+        <source>Connected</source>
+        <translation>Conectado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="65"/>
+        <source>Disconnected</source>
+        <translation>Desconectado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="78"/>
+        <source>%1 (%2/%3 members) - connected</source>
+        <translation>%1 (%2/%3 miembros) - conectado</translation>
+    </message>
+</context>
+<context>
+    <name>CompatDB</name>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="20"/>
+        <source>Report Compatibility</source>
+        <translation>Informar de compatibilidad</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="27"/>
+        <location filename="../../src/citra_qt/compatdb.ui" line="63"/>
+        <source>Report Game Compatibility</source>
+        <translation>Informar de compatibilidad de juegos</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="36"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;Should you choose to submit a test case to the &lt;/span&gt;&lt;a href=&quot;https://citra-emu.org/game/&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;Citra Compatibility List&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;, The following information will be collected and displayed on the site:&lt;/span&gt;&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Hardware Information (CPU / GPU / Operating System)&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Which version of Citra you are running&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The connected Citra account&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;En caso de que decida enviar una prueba a &lt;/span&gt;&lt;a href=&quot;https://citra-emu.org/game/&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;Lista de compatibilidad de Citra&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;, La siguiente información será recopilada y mostrada en el sitio web:&lt;/span&gt;&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Información del Hardware (CPU / GPU / Sistema Operativo)&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Que versión de Citra está utilizando&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;La cuenta de Citra vinculada&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="72"/>
+        <source>Perfect</source>
+        <translation>Perfecto</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="79"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions flawlessly with no audio or graphical glitches.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;El juego funciona a la perfección sin problemas de audio o gráficos.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="89"/>
+        <source>Great </source>
+        <translation>Muy bien</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="96"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions with minor graphical or audio glitches and is playable from start to finish. May require some workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;El juego funciona con pequeños problemas gráficos o de audio y es jugable de principio a fin. Podría requerir de soluciones temporales.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="106"/>
+        <source>Okay</source>
+        <translation>Bien</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="113"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions with major graphical or audio glitches, but game is playable from start to finish with workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;El juego funciona con importantes problemas gráficos o de audio, pero el juego es jugable de principio a fin con soluciones temporales.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="123"/>
+        <source>Bad</source>
+        <translation>Mal</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="130"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches even with workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;El juego funciona, pero con notables problemas gráficos o de audio. Es imposible avanzar en zonas específicas debido a fallos incluso con soluciones temporales.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="140"/>
+        <source>Intro/Menu</source>
+        <translation>Intro/Menu</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="147"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start Screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;No es posible jugar al juego debido a importantes problemas gráficos o de audio. Es imposible avanzar más allá de la pantalla de inicio.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="157"/>
+        <source>Won&apos;t Boot</source>
+        <translation>No inicia</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="170"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The game crashes when attempting to startup.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;El juego se bloquea al intentar iniciarse.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="182"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Independent of speed or performance, how well does this game play from start to finish on this version of Citra?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Independientemente de la velocidad o el rendimiento, ¿cómo definiría su experiencia con el juego de principio a fin en esta versión de Citra?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="206"/>
+        <source>Thank you for your submission!</source>
+        <translation>¡Gracias por su colaboración!</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureAudio</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="10"/>
+        <source>Audio</source>
+        <translation>Audio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="18"/>
+        <source>Output Engine:</source>
+        <translation>Motor de salida:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="31"/>
+        <source>Enable audio stretching</source>
+        <translation>Activar extensión de audio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="34"/>
+        <source>This post-processing effect adjusts audio speed to match emulation speed and helps prevent audio stutter. This however increases audio latency.</source>
+        <translation>Este efecto post-procesado ajusta la velocidad del audio para igualar a la del emulador y ayuda a prevenir parones de audio, pero aumenta la latencia de éste.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="43"/>
+        <source>Audio Device:</source>
+        <translation>Dispositivo de Audio:</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureDebug</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formulario</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="22"/>
+        <source>GDB</source>
+        <translation>GDB</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="28"/>
+        <source>The GDB Stub only works correctly when the CPU JIT is off.</source>
+        <translation>El Stub de GDB sólo funciona correctamente cuando la opción CPU JIT está desactivada.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="37"/>
+        <source>Enable GDB Stub</source>
+        <translation>Activar Stub de GDB</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="57"/>
+        <source>Port:</source>
+        <translation>Puerto:</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="14"/>
+        <source>Citra Configuration</source>
+        <translation>Configuración de Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="24"/>
+        <source>General</source>
+        <translation>General</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="29"/>
+        <source>System</source>
+        <translation>Sistema</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="34"/>
+        <source>Input</source>
+        <translation>Controles</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="39"/>
+        <source>Graphics</source>
+        <translation>Gráficos</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="44"/>
+        <source>Audio</source>
+        <translation>Audio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="49"/>
+        <source>Debug</source>
+        <translation>Depuración</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="54"/>
+        <source>Web</source>
+        <translation>Web</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureGeneral</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formulario</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="22"/>
+        <source>General</source>
+        <translation>General</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="30"/>
+        <source>Confirm exit while emulation is running</source>
+        <translation>Confirmar salida durante la emulación</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="37"/>
+        <source>Search sub-directories for games</source>
+        <translation>Buscar juegos en subdirectorios</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="46"/>
+        <source>Interface language</source>
+        <translation>Interfaz de idioma</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="63"/>
+        <source>Updates</source>
+        <translation>Actualizaciones</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="71"/>
+        <source>Check for updates on start</source>
+        <translation>Buscar actualizaciones al iniciarse</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="78"/>
+        <source>Silently auto update after closing</source>
+        <translation>Actualizarse automáticamente de forma silenciosa después de cerrar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="90"/>
+        <source>Performance</source>
+        <translation>Rendimiento</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="98"/>
+        <source>Enable CPU JIT</source>
+        <translation>Activar CPU JIT</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="110"/>
+        <source>Emulation</source>
+        <translation>Emulación</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="120"/>
+        <source>Region:</source>
+        <translation>Región:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="128"/>
+        <source>Auto-select</source>
+        <translation>Auto-elegir</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="178"/>
+        <source>Theme</source>
+        <translation>Tema</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="188"/>
+        <source>Theme:</source>
+        <translation>Tema:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="205"/>
+        <source>Hotkeys</source>
+        <translation>Teclas de atajo:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.cpp" line="16"/>
+        <source>&lt;System&gt;</source>
+        <translation>&lt;System&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.cpp" line="17"/>
+        <source>English</source>
+        <translation>Inglés</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureGraphics</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formulario</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="22"/>
+        <source>Graphics</source>
+        <translation>Gráficos</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="28"/>
+        <source>Enable hardware renderer</source>
+        <translation>Activar renderizador de hardware</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="35"/>
+        <source>Enable shader JIT</source>
+        <translation>Activar sombreado JIT</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="42"/>
+        <source>Enable V-Sync</source>
+        <translation>Activar V-Sync</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="51"/>
+        <source>Limit Speed Percent</source>
+        <translation>Limitar velocidad</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="58"/>
+        <source>%</source>
+        <translation>%</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="78"/>
+        <source>Internal Resolution:</source>
+        <translation>Resolución Interna:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="86"/>
+        <source>Auto (Window Size)</source>
+        <translation>Auto (Tamaño de Ventana)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="91"/>
+        <source>Native (400x240)</source>
+        <translation>Nativo (400x240)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="96"/>
+        <source>2x Native (800x480)</source>
+        <translation>2x Nativo (800x480)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="101"/>
+        <source>3x Native (1200x720)</source>
+        <translation>3x Nativo (1200x720)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="106"/>
+        <source>4x Native (1600x960)</source>
+        <translation>4x Nativo (1600x960)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="111"/>
+        <source>5x Native (2000x1200)</source>
+        <translation>5x Nativo (2000x1200)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="116"/>
+        <source>6x Native (2400x1440)</source>
+        <translation>6x Nativo (2400x1440)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="121"/>
+        <source>7x Native (2800x1680)</source>
+        <translation>7x Nativo (2800x1680)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="126"/>
+        <source>8x Native (3200x1920)</source>
+        <translation>8x Nativo (3200x1920)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="131"/>
+        <source>9x Native (3600x2160)</source>
+        <translation>9x Nativo (3600x2160)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="136"/>
+        <source>10x Native (4000x2400)</source>
+        <translation>10x Nativo (4000x2400)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="151"/>
+        <source>Layout</source>
+        <translation>Estilo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="161"/>
+        <source>Screen Layout:</source>
+        <translation>Estilo de Pantalla:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="169"/>
+        <source>Default</source>
+        <translation>Por defecto</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="174"/>
+        <source>Single Screen</source>
+        <translation>Pantalla Única</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="179"/>
+        <source>Large Screen</source>
+        <translation>Pantalla Amplia</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="184"/>
+        <source>Side by Side</source>
+        <translation>Conjunta</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="194"/>
+        <source>Swap Screens</source>
+        <translation>Intercambiar Pantallas</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureInput</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="14"/>
+        <source>ConfigureInput</source>
+        <translation>ConfigureInput</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="22"/>
+        <source>Face Buttons</source>
+        <translation>Botones Frontales</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="36"/>
+        <source>A:</source>
+        <translation>A:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="54"/>
+        <source>B:</source>
+        <translation>B:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="72"/>
+        <source>X:</source>
+        <translation>X:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="90"/>
+        <source>Y:</source>
+        <translation>Y:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="109"/>
+        <source>Directional Pad</source>
+        <translation>Pad de Control</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="123"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="340"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="427"/>
+        <source>Up:</source>
+        <translation>Arriba:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="141"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="358"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="445"/>
+        <source>Down:</source>
+        <translation>Abajo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="159"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="304"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="391"/>
+        <source>Left:</source>
+        <translation>Izquierda:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="177"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="322"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="409"/>
+        <source>Right:</source>
+        <translation>Derecha:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="196"/>
+        <source>Shoulder Buttons</source>
+        <translation>Botones Traseros</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="210"/>
+        <source>L:</source>
+        <translation>L:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="228"/>
+        <source>R:</source>
+        <translation>R:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="246"/>
+        <source>ZL:</source>
+        <translation>ZL:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="264"/>
+        <source>ZR:</source>
+        <translation>ZR:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="283"/>
+        <source>Circle Pad</source>
+        <translation>Pad Circular</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="295"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="461"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="232"/>
+        <source>Set Analog Stick</source>
+        <translation>Configurar Palanca Analógica</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="377"/>
+        <source>C-Stick</source>
+        <translation>Palanca C</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="471"/>
+        <source>Misc.</source>
+        <translation>Varios</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="485"/>
+        <source>Start:</source>
+        <translation>Start:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="503"/>
+        <source>Select:</source>
+        <translation>Select:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="521"/>
+        <source>Home:</source>
+        <translation>Home:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="539"/>
+        <source>Circle Mod:</source>
+        <translation>Circle Mod:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="596"/>
+        <source>Restore Defaults</source>
+        <translation>Restablecer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="239"/>
+        <source>[press key]</source>
+        <translation>[pulsa un botón]</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureSystem</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formulario</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="22"/>
+        <source>System Settings</source>
+        <translation>Configuración de la Consola</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="28"/>
+        <source>Username</source>
+        <translation>Nombre</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="48"/>
+        <source>Birthday</source>
+        <translation>Cumpleaños</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="58"/>
+        <source>January</source>
+        <translation>Enero</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="63"/>
+        <source>February</source>
+        <translation>Febrero</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="68"/>
+        <source>March</source>
+        <translation>Marzo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="73"/>
+        <source>April</source>
+        <translation>Abril</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="78"/>
+        <source>May</source>
+        <translation>Mayo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="83"/>
+        <source>June</source>
+        <translation>Junio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="88"/>
+        <source>July</source>
+        <translation>Julio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="93"/>
+        <source>August</source>
+        <translation>Agosto</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="98"/>
+        <source>September</source>
+        <translation>Septiembre</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="103"/>
+        <source>October</source>
+        <translation>Octubre</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="108"/>
+        <source>November</source>
+        <translation>Noviembre</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="113"/>
+        <source>December</source>
+        <translation>Diciembre</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="126"/>
+        <source>Language</source>
+        <translation>Idioma</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="133"/>
+        <source>Note: this can be overridden when region setting is auto-select</source>
+        <translation>Nota: puede ser sobreescrito cuando la región es auto-seleccionada</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="137"/>
+        <source>Japanese (日本語)</source>
+        <translation>Japonés (日本語)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="142"/>
+        <source>English</source>
+        <translation>Inglés (English)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="147"/>
+        <source>French (français)</source>
+        <translation>Francés (français)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="152"/>
+        <source>German (Deutsch)</source>
+        <translation>Alemán (Deutsch)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="157"/>
+        <source>Italian (italiano)</source>
+        <translation>Italiano (italiano)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="162"/>
+        <source>Spanish (español)</source>
+        <translation>Español</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="167"/>
+        <source>Simplified Chinese (简体中文)</source>
+        <translation>Chino Simplificado (简体中文)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="172"/>
+        <source>Korean (한국어)</source>
+        <translation>Coreano (한국어)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="177"/>
+        <source>Dutch (Nederlands)</source>
+        <translation>Neerlandés (Nederlands)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="182"/>
+        <source>Portuguese (português)</source>
+        <translation>Portugués (português)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="187"/>
+        <source>Russian (Русский)</source>
+        <translation>Ruso (Русский)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="192"/>
+        <source>Traditional Chinese (正體中文)</source>
+        <translation>Chino Tradicional (正體中文)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="200"/>
+        <source>Sound output mode</source>
+        <translation>Modo de salida del audio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="208"/>
+        <source>Mono</source>
+        <translation>Mono</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="213"/>
+        <source>Stereo</source>
+        <translation>Estéreo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="218"/>
+        <source>Surround</source>
+        <translation>Envolvente</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="226"/>
+        <source>Console ID:</source>
+        <translation>ID de Consola:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="242"/>
+        <source>Regenerate</source>
+        <translation>Regenerar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="252"/>
+        <source>System settings are available only when game is not running.</source>
+        <translation>La Configuración de la Consola sólo está disponible cuando no se está emulando ningún juego.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="87"/>
+        <source>Console ID: 0x%1</source>
+        <translation>ID de Consola: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="160"/>
+        <source>This will replace your current virtual 3DS with a new one. Your current virtual 3DS will not be recoverable. This might have unexpected effects in games. This might fail, if you use an outdated config savegame. Continue?</source>
+        <translation>Esto reemplazará tu 3DS virtual con una nueva. Tu 3DS virtual actual será irrecuperable. Esto puede tener efectos inesperados en ciertos juegos. Si usas un archivo de configuración anticuado, esto puede fallar. ¿Desea continuar?</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="164"/>
+        <source>Warning</source>
+        <translation>Advertencia</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureWeb</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formulario</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="22"/>
+        <source>Citra Web Service</source>
+        <translation>Servicio Web de Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="28"/>
+        <source>By providing your username and token, you agree to allow Citra to collect additional usage data, which may include user identifying information.</source>
+        <translation>Al dar tu nombre de usuario y tu token, das tu consentimiento a que Citra recopile datos de uso adicionales, que pueden incluir información que identifique al usuario.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="46"/>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="90"/>
+        <source>Verify</source>
+        <translation>Verificar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="53"/>
+        <source>Sign up</source>
+        <translation>Registrarse</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="67"/>
+        <source>Token: </source>
+        <translation>Token:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="78"/>
+        <source>Username: </source>
+        <translation>Nombre de usuario:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="99"/>
+        <source>What is my token?</source>
+        <translation>¿Cuál es mi token?</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="124"/>
+        <source>Telemetry</source>
+        <translation>Telemetría</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="130"/>
+        <source>Share anonymous usage data with the Citra team</source>
+        <translation>Compartir datos de uso anónimos con el equipo de Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="137"/>
+        <source>Learn more</source>
+        <translation>Más Información</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="146"/>
+        <source>Telemetry ID:</source>
+        <translation>ID de Telemetría:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="162"/>
+        <source>Regenerate</source>
+        <translation>Regenerar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="28"/>
+        <source>&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Más Información&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="33"/>
+        <source>&lt;a href=&apos;https://services.citra-emu.org/&apos;&gt;Sign up&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://services.citra-emu.org/&apos;&gt;Registrarse&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="36"/>
+        <source>&lt;a href=&apos;https://citra-emu.org/wiki/citra-web-service/&apos;&gt;What is my token?&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://citra-emu.org/wiki/citra-web-service/&apos;&gt;¿Cuál es mi Token?&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="45"/>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="65"/>
+        <source>Telemetry ID: 0x%1</source>
+        <translation>ID de Telemetría: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="55"/>
+        <source>Username and token not verified</source>
+        <translation>Nombre de usuario y token no verificados</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="56"/>
+        <source>Username and token were not verified. The changes to your username and/or token have not been saved.</source>
+        <translation>El nombre de usuario y el token no han sido verificados. Los cambios de tu nombre de usuario y/o del token no han sido guardados.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="85"/>
+        <source>Verifying</source>
+        <translation>Verificando</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="99"/>
+        <source>Verification failed</source>
+        <translation>La verificación falló</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="100"/>
+        <source>Verification failed. Check that you have entered your username and token correctly, and that your internet connection is working.</source>
+        <translation>La verificación falló. Comprueba que has introducido tu nombre de usuario y tu token correctamente, y que tu conexión internet funcione correctamente.</translation>
+    </message>
+</context>
+<context>
+    <name>DirectConnect</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="14"/>
+        <source>Direct Connect</source>
+        <translation>Conexión Directa</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="33"/>
+        <source>IP Address</source>
+        <translation>Dirección IP</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="56"/>
+        <source>IP</source>
+        <translation>IP</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="63"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;IPv4 address of the host&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Dirección IPv4 del host&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="73"/>
+        <source>Port</source>
+        <translation>Puerto</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="80"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Port number the host is listening on&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Número de puerto que está escuchando el host&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="86"/>
+        <source>24872</source>
+        <translation>24872</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="100"/>
+        <source>Nickname</source>
+        <translation>Apodo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="114"/>
+        <source>Password</source>
+        <translation>Contraseña</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="156"/>
+        <source>Connect</source>
+        <translation>Conectar</translation>
+    </message>
+</context>
+<context>
+    <name>DirectConnectWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="97"/>
+        <source>Connecting</source>
+        <translation>Conectando</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="102"/>
+        <source>Connect</source>
+        <translation>Conectar</translation>
+    </message>
+</context>
+<context>
+    <name>GMainWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="90"/>
+        <source>To help improve Citra, the Citra Team collects anonymous usage data. No private or personally identifying information is collected. This data helps us to understand how people use Citra and prioritize our efforts. Furthermore, it helps us to more easily identify emulation bugs and performance issues. This data includes:&lt;ul&gt;&lt;li&gt;Information about the version of Citra you are using&lt;/li&gt;&lt;li&gt;Performance data about the games you play&lt;/li&gt;&lt;li&gt;Your configuration settings&lt;/li&gt;&lt;li&gt;Information about your computer hardware&lt;/li&gt;&lt;li&gt;Emulation errors and crash information&lt;/li&gt;&lt;/ul&gt;By default, this feature is enabled. To disable this feature, click &apos;Emulation&apos; from the menu and then select &apos;Configure...&apos;. Then, on the &apos;Web&apos; tab, uncheck &apos;Share anonymous usage data with the Citra team&apos;. &lt;br/&gt;&lt;br/&gt;By using this software, you agree to the above terms.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Para ayudar a mejorar Citra, el Equipo de Citra reúne datos de uso anónimos. Ningún dato personal ni privado es recogido. Esos datos nos ayuda a entender cómo la gente usa Citra y así priorizar nuestros esfuerzos. También nos ayuda a identificar bugs de emulación y problemas de rendimiento más fácilmente. Estos datos incluyen: &lt;ul&gt;&lt;li&gt;Información de la versión de Citra usada&lt;/li&gt;&lt;li&gt;Datos de rendimiento acerca del juego al que se esté jugando&lt;/li&gt;&lt;li&gt;Tu configuración&lt;/li&gt;&lt;li&gt;Información sobre tu hardware&lt;/li&gt;&lt;li&gt;Errores de emulación e información de cuelgues&lt;/li&gt;&lt;/ul&gt;Por defecto, esta característica está activada. Para desactivarla, ve a &apos;Emulación&apos; del menú y luego elige &apos;Configurar...&quot;. Luego, en la pestaña &apos;Web&apos;, desactiva la opción &apos;Compartir datos de uso anónimos con el equipo de Citra&apos;.&lt;br/&gt;&lt;br/&gt;Al usar este software, estás de acuerdo con los términos de arriba.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Más Información&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="195"/>
+        <source>Current emulation speed. Values higher or lower than 100% indicate emulation is running faster or slower than a 3DS.</source>
+        <translation>La velocidad de emulación actual. Valores mayores o menores de 100% indican que la velocidad de emulación funciona más rápida o lentamente que en un 3DS.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="198"/>
+        <source>How many frames per second the game is currently displaying. This will vary from game to game and scene to scene.</source>
+        <translation>Los fotogramas por segundo que está mostrando el juego. Variarán de juego en juego y de escena a escena.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="202"/>
+        <source>Time taken to emulate a 3DS frame, not counting framelimiting or v-sync. For full-speed emulation this should be at most 16.67 ms.</source>
+        <translation>El tiempo que lleva emular un fotograma de 3DS, sin contar el limitador de fotogramas, ni el v-sync. Para una emulación óptima, éste valor no debe superar los 16.67 ms.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="429"/>
+        <source>CTRL+F</source>
+        <translation>CTRL+F</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="538"/>
+        <source>Update available!</source>
+        <translation>¡Actualización disponible!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="539"/>
+        <source>An update for Citra is available. Do you wish to install it now?&lt;br /&gt;&lt;br /&gt;This &lt;b&gt;will&lt;/b&gt; terminate emulation, if it is running.</source>
+        <translation>Hay una actualización para Citra. ¿Quieres instalarla ahora?&lt;br /&gt;&lt;br /&gt;Esto&lt;b&gt;terminará&lt;/b&gt;la emulación, si está ejecutándose.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <source>No update found</source>
+        <translation>No se han encontrado actualizaciones</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <source>No update has been found for Citra.</source>
+        <translation>No se han encontrado actualizaciones para Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="567"/>
+        <source>Error while initializing OpenGL 3.3 Core!</source>
+        <translation>¡Error al iniciar el núcleo OpenGL 3.3!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="568"/>
+        <source>Your GPU may not support OpenGL 3.3, or you do not have the latest graphics driver.</source>
+        <translation>Tu tarjeta gráfica no soporta OpenGL 3.3, o no tienes los últimos controladores gráficos para tu tarjeta.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="581"/>
+        <location filename="../../src/citra_qt/main.cpp" line="587"/>
+        <location filename="../../src/citra_qt/main.cpp" line="593"/>
+        <location filename="../../src/citra_qt/main.cpp" line="606"/>
+        <location filename="../../src/citra_qt/main.cpp" line="625"/>
+        <source>Error while loading ROM!</source>
+        <translation>¡Error al cargar la ROM!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="582"/>
+        <location filename="../../src/citra_qt/main.cpp" line="607"/>
+        <source>The ROM format is not supported.</source>
+        <translation>Este formato de ROM no está soportado.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="588"/>
+        <source>Could not determine the system mode.</source>
+        <translation>No se pudo determinar el modo del sistema.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="594"/>
+        <source>The game that you are trying to load must be decrypted before being used with Citra. A real 3DS is required.&lt;br/&gt;&lt;br/&gt;For more information on dumping and decrypting games, please see the following wiki pages: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation>El juego que estás intentando cargar debe ser desencriptado antes de ser usado con Citra. Se necesita una 3DS real.&lt;br/&gt;&lt;br/&gt;Para más información sobre volcar y desencriptar juegos, mira las siguientes páginas de la wiki: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Volcar Cartuchos de Juego&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Volcar Títulos Instalados&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="612"/>
+        <source>An error occured in the video core.</source>
+        <translation>Un error ha ocurrido en el núcleo de vídeo.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="613"/>
+        <source>Citra has encountered an error while running the video core, please see the log for more details.For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.Ensure that you have the latest graphics drivers for your GPU.</source>
+        <translation>Citra ha encontrado un error durante la ejecución del núcleo de vídeo, por favor, mira el registro para más detalles. Para más información sobre cómo acceder al log, mira la siguiente página: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;Cómo subir el Archivo del Log&lt;/a&gt;. Asegúrate de tener los últimos drivers para tu tarjeta gráfica.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="626"/>
+        <source>An unknown error occured. Please see the log for more details.</source>
+        <translation>Un error desconocido ha ocurrido. Por favor, mira el log para más detalles.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="699"/>
+        <source>Start</source>
+        <translation>Iniciar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="790"/>
+        <source>Error Opening %1 Folder</source>
+        <translation>Error al abrir la carpeta %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="791"/>
+        <source>Folder does not exist!</source>
+        <translation>¡La carpeta no existe!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="805"/>
+        <source>3DS Executable</source>
+        <translation>Ejecutable de 3DS</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="806"/>
+        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <source>All Files (*.*)</source>
+        <translation>Todos los archivos (*.*)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="808"/>
+        <source>Load File</source>
+        <translation>Cargar Archivo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="818"/>
+        <source>Select Directory</source>
+        <translation>Seleccionar directorio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="827"/>
+        <source>Load Files</source>
+        <translation>Cargar archivos</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <source>3DS Installation File (*.CIA*)</source>
+        <translation>Archivo de Instalación de 3DS (*.CIA*)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="859"/>
+        <source>%1 has been installed successfully.</source>
+        <translation>%1 ha sido instalado con éxito.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="862"/>
+        <source>Unable to open File</source>
+        <translation>No se pudo abrir el Archivo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="863"/>
+        <source>Could not open %1</source>
+        <translation>No se pudo abrir %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="867"/>
+        <source>Installation aborted</source>
+        <translation>Instalación abortada</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="868"/>
+        <source>The installation of %1 was aborted. Please see the log for more details</source>
+        <translation>La instalación de %1 ha sido cancelada. Por favor, consulte los registros para más información.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <source>Invalid File</source>
+        <translation>Archivo no válido</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <source>%1 is not a valid CIA</source>
+        <translation>%1 no es un archivo CIA válido</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="875"/>
+        <source>Encrypted File</source>
+        <translation>Archivo Encriptado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="876"/>
+        <source>%1 must be decrypted before being used with Citra. A real 3DS is required.</source>
+        <translation>%1 debe ser desencriptado antes de ser usado en Citra. Se requiere de una 3DS real.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="899"/>
+        <source>File not found</source>
+        <translation>Archivo no encontrado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="900"/>
+        <source>File &quot;%1&quot; not found</source>
+        <translation>Archivo &quot;%1&quot; no encontrado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="914"/>
+        <source>Continue</source>
+        <translation>Continuar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="939"/>
+        <source>Missing Citra Account</source>
+        <translation>Falta la cuenta de Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="940"/>
+        <source>In order to submit a game compatibility test case, you must link your Citra account.&lt;br&gt;&lt;br/&gt;To link your Citra account, go to Emulation &amp;gt; Configuration &amp;gt; Web.</source>
+        <translation>Para enviar una prueba de compatibilidad de juegos, es necesario vincular tu cuenta de Citra.&lt;br&gt;&lt;br/&gt;Para vincular tu cuenta de Citra, ve a Emulación &amp;gt; Configuración &amp;gt; Web.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1090"/>
+        <source>Speed: %1% / %2%</source>
+        <translation>Velocidad: %1% / %2%</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1094"/>
+        <source>Speed: %1%</source>
+        <translation>Velocidad: %1%</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1096"/>
+        <source>Game: %1 FPS</source>
+        <translation>Juego: %1 FPS</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1097"/>
+        <source>Frame: %1 ms</source>
+        <translation>Frame: %1 ms</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1108"/>
+        <source>The game you are trying to load requires additional files from your 3DS to be dumped before playing.&lt;br/&gt;&lt;br/&gt;For more information on dumping these files, please see the following wiki page: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
+        <translation>El juego que estás intentando cargar requiere archivos extra que debes volcar de tu 3DS antes de jugar.&lt;br/&gt;&lt;br/&gt;Para más información sobre cómo volcar éstos, mira la siguiente página de la wiki:&lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Volcar Archivos de Sistema y las Fuentes Compartidas de una 3DS&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;¿Quieres volver a la lista de juegos? Seguir con la emulación puede resultar en cuelgues, archivos de guardado corruptos u otros bugs.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1120"/>
+        <source>: %1. </source>
+        <translation>: %1. </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1126"/>
+        <source>System Archive Not Found</source>
+        <translation>Archivo de Sistema no encontrado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1133"/>
+        <source>Citra was unable to locate the 3DS shared fonts. </source>
+        <translation>Citra no pudo encontrar las Fuentes Compartidas de la 3DS.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1135"/>
+        <source>Shared Fonts Not Found</source>
+        <translation>Fuentes Compartidas no encontradas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1143"/>
+        <source>Fatal Error</source>
+        <translation>Error Fatal</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1144"/>
+        <source>Citra has encountered a fatal error, please see the log for more details. For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
+        <translation>Citra ha encontrado un error fatal, por favor, consulte el registro para más detalles. Para más información sobre cómo acceder a los registros, por favor, mira la siguiente página: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;Cómo subir el Archivo del Log&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;¿Quieres volver a la lista de juegos? Continuar con la emulación puede provocar caídas, archivos de guardado corruptos u otros errores.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1245"/>
+        <source>Citra</source>
+        <translation>Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <source>Are you sure you want to close Citra?</source>
+        <translation>¿Estás seguro de querer cerrar Citra?</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1246"/>
+        <source>Are you sure you want to stop the emulation? Any unsaved progress will be lost.</source>
+        <translation>¿Estás seguro de querer parar la emulación? Cualquier progreso no guardado se perderá.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1318"/>
+        <source>Citra %1| %2-%3</source>
+        <translation>Citra %1| %2-%3</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandListModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="96"/>
+        <source>Command Name</source>
+        <translation>Nombre del Comando</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="98"/>
+        <source>Register</source>
+        <translation>Registro</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="100"/>
+        <source>Mask</source>
+        <translation>Máscara</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="102"/>
+        <source>New Value</source>
+        <translation>Nuevo Valor</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandListWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="184"/>
+        <source>Pica Command List</source>
+        <translation>Lista de Comandos de Pica</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="202"/>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="233"/>
+        <source>Start Tracing</source>
+        <translation>Empezar Rastreo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="203"/>
+        <source>Copy All</source>
+        <translation>Copiar Todo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="229"/>
+        <source>Finish Tracing</source>
+        <translation>Terminar el Rastreo</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandStreamWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics.cpp" line="67"/>
+        <source>Graphics Debugger</source>
+        <translation>Depurador de Gráficos</translation>
+    </message>
+</context>
+<context>
+    <name>GameList</name>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <source>Perfect</source>
+        <translation>Perfecto</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <source>Game functions flawless with no audio or graphical glitches, all tested functionality works as intended without
+any workarounds needed.</source>
+        <translation>El juego funciona a la perfección, sin problemas de audio o gráficos, todas las funcionalidades probadas funcionan según lo previsto sin
+la necesidad de soluciones temporales.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <source>Great</source>
+        <translation>Muy bien</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <source>Game functions with minor graphical or audio glitches and is playable from start to finish. May require some
+workarounds.</source>
+        <translation>El juego funciona con pequeños problemas gráficos o de audio y es jugable de principio a fin. Podría requerir de
+soluciones temporales.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <source>Okay</source>
+        <translation>Bien</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <source>Game functions with major graphical or audio glitches, but game is playable from start to finish with
+workarounds.</source>
+        <translation>El juego funciona con importantes problemas gráficos o de audio, pero el juego es jugable de principio a fin con 
+soluciones temporales.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Bad</source>
+        <translation>Mal</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches
+even with workarounds.</source>
+        <translation>El juego funciona, pero con notables problemas gráficos o de audio. Es imposible avanzar en zonas específicas debido a
+fallos incluso con soluciones temporales.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <source>Intro/Menu</source>
+        <translation>Intro/Menu</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <source>Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start
+Screen.</source>
+        <translation>No es posible jugar al juego debido a importantes problemas gráficos o de audio. Es imposible avanzar
+más allá de la pantalla de inicio.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>Won&apos;t Boot</source>
+        <translation>No carga</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>The game crashes when attempting to startup.</source>
+        <translation>El juego se bloquea al intentar iniciarse.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <source>Not Tested</source>
+        <translation>Sin probar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <source>The game has not yet been tested.</source>
+        <translation>El juego todavía no ha sido probado.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="99"/>
+        <source>of</source>
+        <translation>de</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="102"/>
+        <source>result</source>
+        <translation>resultado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="104"/>
+        <source>results</source>
+        <translation>resultados</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="125"/>
+        <source>Filter:</source>
+        <translation>Filtrar:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="128"/>
+        <source>Enter pattern to filter</source>
+        <translation>Introduzca un patrón para filtrar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="324"/>
+        <source>Open Save Data Location</source>
+        <translation>Abrir ubicación de archivos de guardado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
+        <source>Open Application Location</source>
+        <translation>Abrir ubicación de la aplicación</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
+        <source>Open Update Data Location</source>
+        <translation>Abrir ubicación de archivos de actualización</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsBreakPointsWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="132"/>
+        <source>Pica Breakpoints</source>
+        <translation>Pica Breakpoints</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="136"/>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="198"/>
+        <source>Emulation running</source>
+        <translation>Ejecutando emulación</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="137"/>
+        <source>Resume</source>
+        <translation>Reanudar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="188"/>
+        <source>Emulation halted at breakpoint</source>
+        <translation>Emulación parada en un breakpoint</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsSurfaceWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="49"/>
+        <source>Pica Surface Viewer</source>
+        <translation>Observador de Superficie de Pica</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="54"/>
+        <source>Color Buffer</source>
+        <translation>Buffer de Color</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="55"/>
+        <source>Depth Buffer</source>
+        <translation>Buffer de Profundidad</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="56"/>
+        <source>Stencil Buffer</source>
+        <translation>Buffer de Esténcil</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="57"/>
+        <source>Texture 0</source>
+        <translation>Textura 0</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="58"/>
+        <source>Texture 1</source>
+        <translation>Textura 1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="59"/>
+        <source>Texture 2</source>
+        <translation>Textura 2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="60"/>
+        <source>Custom</source>
+        <translation>Personalizada</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="103"/>
+        <source>Unknown</source>
+        <translation>Desconocido</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="118"/>
+        <source>Save</source>
+        <translation>Guardar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="144"/>
+        <source>Source:</source>
+        <translation>Fuente:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="150"/>
+        <source>Physical Address:</source>
+        <translation>Dirección Física:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="156"/>
+        <source>Width:</source>
+        <translation>Anchura:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="162"/>
+        <source>Height:</source>
+        <translation>Altura:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="168"/>
+        <source>Format:</source>
+        <translation>Formato:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="180"/>
+        <source>X:</source>
+        <translation>X:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="186"/>
+        <source>Y:</source>
+        <translation>Y:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="280"/>
+        <source>Pixel out of bounds</source>
+        <translation>Píxel fuera de los límites</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="287"/>
+        <source>(unable to access pixel data)</source>
+        <translation>(no se puede acceder a los datos del píxel)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="555"/>
+        <source>(invalid surface address)</source>
+        <translation>(dirección de superficie no válida)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="565"/>
+        <source>(unknown surface format)</source>
+        <translation>(formato de superficie desconocido)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="658"/>
+        <source>Portable Network Graphic (*.png)</source>
+        <translation>Portable Network Graphic (*.png)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="659"/>
+        <source>Binary data (*.bin)</source>
+        <translation>Archivo binario (*.bin)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="663"/>
+        <source>Save Surface</source>
+        <translation>Guardar Superficie</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsTracingWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="25"/>
+        <source>CiTrace Recorder</source>
+        <translation>Grabador CiTrace</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="29"/>
+        <source>Start Recording</source>
+        <translation>Empezar grabación</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="31"/>
+        <source>Stop and Save</source>
+        <translation>Parar y Guardar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="32"/>
+        <source>Abort Recording</source>
+        <translation>Abortar Grabación</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="112"/>
+        <source>Save CiTrace</source>
+        <translation>Guardar CiTrace</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="113"/>
+        <source>CiTrace File (*.ctf)</source>
+        <translation>Archivo CiTrace (*.ctf)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="162"/>
+        <source>CiTracing still active</source>
+        <translation>CiTracing sigue activo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="163"/>
+        <source>A CiTrace is still being recorded. Do you want to save it? If not, all recorded data will be discarded.</source>
+        <translation>Un CiTrace sigue grabándose. ¿Quieres guardarlo? Si no, todos los datos grabados serán descartados.</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsVertexShaderModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="45"/>
+        <source>Offset</source>
+        <translation>Offset</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="47"/>
+        <source>Raw</source>
+        <translation>Raw</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="49"/>
+        <source>Disassembly</source>
+        <translation>Desmontado</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsVertexShaderWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="345"/>
+        <source>Save Shader Dump</source>
+        <translation>Guardar Volcado de Sombra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="345"/>
+        <source>Shader Binary (*.shbin)</source>
+        <translation>Binario de Sombra (*.shbin)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="380"/>
+        <source>(data only available at vertex shader invocation breakpoints)</source>
+        <translation>(datos sólo disponibles en los puntos de la invocación del sombreado de vértices)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="390"/>
+        <source>Dump</source>
+        <translation>Volcar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="412"/>
+        <source>Input Data</source>
+        <translation>Datos de Entrada</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="426"/>
+        <source>Attribute %1</source>
+        <translation>Atributo %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="453"/>
+        <source>Cycle Index:</source>
+        <translation>Índice de Ciclo:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="558"/>
+        <source>SRC1: %1, %2, %3, %4
+</source>
+        <translation>SRC1: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="564"/>
+        <source>SRC2: %1, %2, %3, %4
+</source>
+        <translation>SRC2: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="570"/>
+        <source>SRC3: %1, %2, %3, %4
+</source>
+        <translation>SRC3: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="576"/>
+        <source>DEST_IN: %1, %2, %3, %4
+</source>
+        <translation>DEST_IN: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="582"/>
+        <source>DEST_OUT: %1, %2, %3, %4
+</source>
+        <translation>DEST_OUT: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="589"/>
+        <source>Address Registers: %1, %2
+</source>
+        <translation>Registros de Dirección: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="593"/>
+        <source>Compare Result: %1, %2
+</source>
+        <translation>Comparar Resultados: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="598"/>
+        <source>Static Condition: %1
+</source>
+        <translation>Condición Estática: %1
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="600"/>
+        <source>Dynamic Conditions: %1, %2
+</source>
+        <translation>Condiciones Dinámicas: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="604"/>
+        <source>Loop Parameters: %1 (repeats), %2 (initializer), %3 (increment), %4
+</source>
+        <translation>Parámetros de Bucle: %1 (repeticiones), %2 (inicializador), %3 (incremental), %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="611"/>
+        <source>Instruction offset: 0x%1</source>
+        <translation>Instrucción offset: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="613"/>
+        <source> -&gt; 0x%2</source>
+        <translation> -&gt; 0x%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="615"/>
+        <source> (last instruction)</source>
+        <translation>(última instrucción)</translation>
+    </message>
+</context>
+<context>
+    <name>HostRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="14"/>
+        <source>Create Room</source>
+        <translation>Crear Sala</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="37"/>
+        <source>Room Name</source>
+        <translation>Nombre de la Sala</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="51"/>
+        <source>Preferred Game</source>
+        <translation>Juego Preferido</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="61"/>
+        <source>Max Players</source>
+        <translation>Máxima Capacidad</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="91"/>
+        <source>Username</source>
+        <translation>Apodo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="101"/>
+        <source>(Leave blank for open game)</source>
+        <translation>(Déjalo vacío si la sala estará abierta)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="118"/>
+        <source>Password</source>
+        <translation>Contraseña</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="125"/>
+        <source>Port</source>
+        <translation>Puerto</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="156"/>
+        <source>Public</source>
+        <translation>Pública</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="161"/>
+        <source>Unlisted</source>
+        <translation>Privada</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="169"/>
+        <source>Host Room</source>
+        <translation>Hospedar Sala</translation>
+    </message>
+</context>
+<context>
+    <name>Lobby</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="14"/>
+        <source>Public Room Browser</source>
+        <translation>Navegador de Salas Públicas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="32"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="39"/>
+        <source>Nickname</source>
+        <translation>Apodo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="59"/>
+        <source>Filters</source>
+        <translation>Filtros</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="66"/>
+        <source>Search</source>
+        <translation>Buscar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="76"/>
+        <source>Games I Own</source>
+        <translation>Juegos Que Tengo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="83"/>
+        <source>Hide Full Rooms</source>
+        <translation>Ocultar Salas Llenas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="103"/>
+        <source>Refresh Lobby</source>
+        <translation>Actualizar Lobby</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <source>Password Required to Join</source>
+        <translation>Contraseña Necesaria para Unirse</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <source>Password:</source>
+        <translation>Contraseña:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="77"/>
+        <source>Password</source>
+        <translation>Contraseña</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
+        <source>Room Name</source>
+        <translation>Nombre de Sala</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="143"/>
+        <source>Preferred Game</source>
+        <translation>Juego Preferente</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="144"/>
+        <source>Host</source>
+        <translation>Host</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="145"/>
+        <source>Players</source>
+        <translation>Jugadores</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="153"/>
+        <source>Refreshing</source>
+        <translation>Actualizando</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="201"/>
+        <source>Refresh List</source>
+        <translation>Actualizar Lista</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="14"/>
+        <source>Citra</source>
+        <translation>Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="53"/>
+        <source>&amp;File</source>
+        <translation>&amp;Archivo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="57"/>
+        <source>Recent Files</source>
+        <translation>Archivos Recientes</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="70"/>
+        <source>&amp;Emulation</source>
+        <translation>&amp;Emulación</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="80"/>
+        <source>&amp;View</source>
+        <translation>&amp;Ver</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="84"/>
+        <source>Debugging</source>
+        <translation>Depuración</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="91"/>
+        <source>Screen Layout</source>
+        <translation>Estilo de pantalla</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="115"/>
+        <source>Multiplayer</source>
+        <translation>Multijugador</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="126"/>
+        <source>&amp;Help</source>
+        <translation>&amp;Ayuda</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="144"/>
+        <source>Load File...</source>
+        <translation>Cargar Archivo...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="149"/>
+        <source>Install CIA...</source>
+        <translation>Instalar CIA...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="154"/>
+        <source>Load Symbol Map...</source>
+        <translation>Cargar Mapa de Símbolos...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="159"/>
+        <source>E&amp;xit</source>
+        <translation>S&amp;alir</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="167"/>
+        <source>&amp;Start</source>
+        <translation>&amp;Iniciar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="175"/>
+        <source>&amp;Pause</source>
+        <translation>&amp;Pausar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="183"/>
+        <source>&amp;Stop</source>
+        <translation>&amp;Parar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="188"/>
+        <source>FAQ</source>
+        <translation>FAQ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="193"/>
+        <source>About Citra</source>
+        <translation>Acerca de Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="201"/>
+        <source>Single Window Mode</source>
+        <translation>Modo Ventana Única</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="206"/>
+        <source>Configure...</source>
+        <translation>Configurar...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="214"/>
+        <source>Display Dock Widget Headers</source>
+        <translation>Mostrar Títulos de Widgets del Dock</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="222"/>
+        <source>Show Filter Bar</source>
+        <translation>Mostrar Barra de Filtrado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="230"/>
+        <source>Show Status Bar</source>
+        <translation>Mostrar Barra de Estado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="235"/>
+        <source>Select Game Directory...</source>
+        <translation>Elegir Directorio de Juego...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="238"/>
+        <source>Selects a folder to display in the game list</source>
+        <translation>Elige una carpeta para mostrar en la lista de juegos</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="243"/>
+        <source>Create Pica Surface Viewer</source>
+        <translation>Crear Observador de Superficie de Pica</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="251"/>
+        <source>Browse Public Game Lobby</source>
+        <translation>Buscar Salas Públicas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="259"/>
+        <source>Create Room</source>
+        <translation>Crear Sala</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="267"/>
+        <source>Leave Room</source>
+        <translation>Abandonar Sala</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="272"/>
+        <source>Direct Connect to Room</source>
+        <translation>Conectar Directamente a Sala</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="280"/>
+        <source>Show Current Room</source>
+        <translation>Mostrar Sala Actual</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="288"/>
+        <source>Fullscreen</source>
+        <translation>Pantalla Completa</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="293"/>
+        <source>Modify Citra Install</source>
+        <translation>Modificar Instalación de Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="296"/>
+        <source>Opens the maintenance tool to modify your Citra installation</source>
+        <translation>Abre la herramienta de mantenimiento para modificar tu traducción de Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="304"/>
+        <source>Default</source>
+        <translation>Por defecto</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="312"/>
+        <source>Single Screen</source>
+        <translation>Pantalla única</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="320"/>
+        <source>Large Screen</source>
+        <translation>Pantalla amplia</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="328"/>
+        <source>Side by Side</source>
+        <translation>Conjunta</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="336"/>
+        <source>Swap Screens</source>
+        <translation>Intercambiar pantallas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="341"/>
+        <source>Check for Updates</source>
+        <translation>Comprobar Actualizaciones</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="349"/>
+        <source>Report Compatibility</source>
+        <translation>Informar de compatibilidad</translation>
+    </message>
+</context>
+<context>
+    <name>MicroProfileDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/profiler.cpp" line="50"/>
+        <source>MicroProfile</source>
+        <translation>MicroProfile</translation>
+    </message>
+</context>
+<context>
+    <name>MultiplayerState</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="41"/>
+        <source>Current connection status</source>
+        <translation>Estado actual de conexión</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="42"/>
+        <source>Not Connected. Click here to find a room!</source>
+        <translation>No estás conectado. ¡Haz clic aquí para encontrar una sala!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="100"/>
+        <source>Connected</source>
+        <translation>Conectado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="105"/>
+        <source>Not Connected</source>
+        <translation>No conectado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="114"/>
+        <source>Error</source>
+        <translation>Error</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="115"/>
+        <source>Failed to announce the room to the public lobby. In order to host a room publicly, you must have a valid Citra account configured in Emulation -&gt; Configure -&gt; Web. If you do not want to publish a room in the public lobby, then select Unlisted instead.
+Debug Message: </source>
+        <translation>No se ha podido anunciar la sala en el lobby público. Para ser el anfitrión de una sala pública, debes tener una cuenta de Citra válida configurada en Emulación -&gt; Configurar -&gt; Web. Si no deseas publicar una sala en el lobby público, entonces seleccione Privada.
+Mensaje de Depuración:</translation>
+    </message>
+</context>
+<context>
+    <name>NetworkMessage</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="12"/>
+        <source>Username is not valid. Must be 4 to 20 alphanumeric characters.</source>
+        <translation>El alias no es válido. Debe ser de 4 a 20 caracteres alfanuméricos.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="14"/>
+        <source>Room name is not valid. Must be 4 to 20 alphanumeric characters.</source>
+        <translation>El nombre de la sala no es válido. Debe ser de 4 a 20 caracteres alfanuméricos.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="16"/>
+        <source>Username is already in use. Please choose another.</source>
+        <translation>El alias está ya en uso. Por favor, elige otro.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="17"/>
+        <source>IP is not a valid IPv4 address.</source>
+        <translation>La IP no es una dirección IPv4 válida.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="18"/>
+        <source>Port must be a number between 0 to 65535.</source>
+        <translation>El puerto debe ser un número entre 0 y 65535.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="20"/>
+        <source>Unable to find an internet connection. Check your internet settings.</source>
+        <translation>No se ha podido encontrar una conexión a Internet. Revisa tu configuración de Internet.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="22"/>
+        <source>Unable to connect to the host. Verify that the connection settings are correct. If you still cannot connect, contact the room host and verify that the host is properly configured with the external port forwarded.</source>
+        <translation>No se pudo conectar con el anfitrión. Asegúrate de que la configuración de Internet es correcta. Si aún no puedes conectarte, contacta con el anfitrión de la sala y asegúrate de que éste está configurado correctamente con el puerto externo de reenvío.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="26"/>
+        <source>Creating a room failed. Please retry. Restarting Citra might be necessary.</source>
+        <translation>No se pudo crear una sala. Por favor, reinténtalo. Puede que se necesite reiniciar Citra.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="28"/>
+        <source>The host of the room has banned you. Speak with the host to unban you or try a different room.</source>
+        <translation>El anfitrión de la sala te ha baneado. Póngase en contacto con el anfitrión para que te desbanee o prueba con otra sala.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="31"/>
+        <source>Version mismatch! Please update to the latest version of Citra. If the problem persists, contact the room host and ask them to update the server.</source>
+        <translation>¡Versión incompatible! Por favor, actualice a la última versión de Citra. Si el problema persiste, póngase en contacto con el anfitrión de la sala y pide que actualicen el servidor.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="33"/>
+        <source>Incorrect password.</source>
+        <translation>Contraseña incorrecta.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="35"/>
+        <source>An unknown error occured. If this error continues to occur, please open an issue</source>
+        <translation>Error desconocido. Si el error sigue ocurriendo, por favor, repórtalo.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="36"/>
+        <source>Connection to room lost. Try to reconnect.</source>
+        <translation>Se ha perdido la conexión a la sala. Intenta reconectarte a ella.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="38"/>
+        <source>MAC address is already in use. Please choose another.</source>
+        <translation>Esta dirección MAC ya está en uso. Por favor, escoge otra.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="52"/>
+        <source>Leave Room</source>
+        <translation>Abandonar Sala</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="53"/>
+        <source>You are about to close the room. Any network connections will be closed.</source>
+        <translation>Estás a punto de cerrar la sala. Cualquier conexión de red será interrumpida.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="58"/>
+        <source>Disconnect</source>
+        <translation>Desconectar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="59"/>
+        <source>You are about to leave the room. Any network connections will be closed.</source>
+        <translation>Estás a punto de abandonar la sala. Cualquier conexión de red será interrumpida.</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="47"/>
+        <source>Error</source>
+        <translation>Error</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="198"/>
+        <source>%1 is not playing a game</source>
+        <translation>%1 no está jugando a ningún juego</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="201"/>
+        <source>%1 is playing %2</source>
+        <translation>%1 está jugando %2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="26"/>
+        <source>Shift</source>
+        <translation>Shift</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="28"/>
+        <source>Ctrl</source>
+        <translation>Ctrl</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="30"/>
+        <source>Alt</source>
+        <translation>Alt</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="51"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="75"/>
+        <source>[not set]</source>
+        <translation>[no establecido]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="55"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="83"/>
+        <source>Joystick %1</source>
+        <translation>Joystick %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="57"/>
+        <source> Hat %1 %2</source>
+        <translation> Rotación %1 %2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="61"/>
+        <source> Axis %1%2</source>
+        <translation> Axis %1%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="65"/>
+        <source> Button %1</source>
+        <translation> Botón %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="69"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="91"/>
+        <source>[unknown]</source>
+        <translation>[desconocido]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="80"/>
+        <source>[unused]</source>
+        <translation>[sin usar]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="85"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="87"/>
+        <source> Axis %1</source>
+        <translation> Axis %1</translation>
+    </message>
+</context>
+<context>
+    <name>RegistersWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="15"/>
+        <source>Registers</source>
+        <translation>Registros</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="16"/>
+        <source>VFP Registers</source>
+        <translation>Registros VFP</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="18"/>
+        <source>VFP System Registers</source>
+        <translation>Registro de Sistema VFP</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="167"/>
+        <source>Vector Length</source>
+        <translation>Longitud del Vector</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="168"/>
+        <source>Vector Stride</source>
+        <translation>Paso de Vector</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="169"/>
+        <source>Rounding Mode</source>
+        <translation>Modo Aproximado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="182"/>
+        <source>Vector Iteration Count</source>
+        <translation>Cuenta de Iteraciones del Vector</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeEvent</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="259"/>
+        <source>reset type = %1</source>
+        <translation>reset type = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeMutex</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="272"/>
+        <source>locked %1 times by thread:</source>
+        <translation>locked %1 times by thread:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="275"/>
+        <source>free</source>
+        <translation>free</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeMutexList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="314"/>
+        <source>holding mutexes</source>
+        <translation>holding mutexes</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeObjectList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="128"/>
+        <source>waiting for all objects</source>
+        <translation>waiting for all objects</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="129"/>
+        <source>waiting for one of the following objects</source>
+        <translation>waiting for one of the following objects</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeSemaphore</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="288"/>
+        <source>available count = %1</source>
+        <translation>available count = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="289"/>
+        <source>max count = %1</source>
+        <translation>max count = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeThread</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="146"/>
+        <source>running</source>
+        <translation>running</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="149"/>
+        <source>ready</source>
+        <translation>ready</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="152"/>
+        <source>waiting for address 0x%1</source>
+        <translation>waiting for address 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="155"/>
+        <source>sleeping</source>
+        <translation>sleeping</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="158"/>
+        <source>waiting for IPC response</source>
+        <translation>waiting for IPC response</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="162"/>
+        <source>waiting for objects</source>
+        <translation>waiting for objects</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="165"/>
+        <source>waiting for HLE return</source>
+        <translation>waiting for HLE return</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="168"/>
+        <source>dormant</source>
+        <translation>dormant</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="171"/>
+        <source>dead</source>
+        <translation>dead</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="174"/>
+        <source> PC = 0x%1 LR = 0x%2</source>
+        <translation> PC = 0x%1 LR = 0x%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="214"/>
+        <source>default</source>
+        <translation>default</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="217"/>
+        <source>all</source>
+        <translation>all</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="220"/>
+        <source>AppCore</source>
+        <translation>AppCore</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="223"/>
+        <source>SysCore</source>
+        <translation>SysCore</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="226"/>
+        <source>Unknown processor %1</source>
+        <translation>Unknown processor %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="230"/>
+        <source>processor = %1</source>
+        <translation>processor = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="231"/>
+        <source>thread id = %1</source>
+        <translation>thread id = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="232"/>
+        <source>priority = %1(current) / %2(normal)</source>
+        <translation>priority = %1(current) / %2(normal)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="236"/>
+        <source>last running ticks = %1</source>
+        <translation>last running ticks = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="239"/>
+        <source>not holding mutex</source>
+        <translation>not holding mutex</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeThreadList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="328"/>
+        <source>waited by thread</source>
+        <translation>waited by thread</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeTimer</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="301"/>
+        <source>reset type = %1</source>
+        <translation>reset type = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="303"/>
+        <source>initial delay = %1</source>
+        <translation>initial delay = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="305"/>
+        <source>interval delay = %1</source>
+        <translation>interval delay = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeWaitObject</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="76"/>
+        <source>[%1]%2 %3</source>
+        <translation>[%1]%2 %3</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="104"/>
+        <source>waited by no thread</source>
+        <translation>waited by no thread</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="114"/>
+        <source>one shot</source>
+        <translation>one shot</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="116"/>
+        <source>sticky</source>
+        <translation>sticky</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="118"/>
+        <source>pulse</source>
+        <translation>pulse</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="399"/>
+        <source>Wait Tree</source>
+        <translation>Árbol de Espera</translation>
+    </message>
+</context>
+<context>
+    <name>hotkeys</name>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="14"/>
+        <source>Hotkey Settings</source>
+        <translation>Configuración de Teclas de Atajo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="27"/>
+        <source>Action</source>
+        <translation>Acción</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="32"/>
+        <source>Hotkey</source>
+        <translation>Tecla de Atajo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="37"/>
+        <source>Context</source>
+        <translation>Contexto</translation>
+    </message>
+</context>
+</TS>

--- a/dist/languages/es_ES.ts
+++ b/dist/languages/es_ES.ts
@@ -154,17 +154,17 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ClientRoomWindow</name>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="54"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="55"/>
         <source>Connected</source>
         <translation>Conectado</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="65"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="63"/>
         <source>Disconnected</source>
         <translation>Desconectado</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="78"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="76"/>
         <source>%1 (%2/%3 members) - connected</source>
         <translation>%1 (%2/%3 miembros) - conectado</translation>
     </message>
@@ -230,7 +230,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="140"/>
         <source>Intro/Menu</source>
-        <translation>Intro/Menu</translation>
+        <translation>Intro/Menú</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="147"/>
@@ -312,6 +312,26 @@ p, li { white-space: pre-wrap; }
         <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="57"/>
         <source>Port:</source>
         <translation>Puerto:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="78"/>
+        <source>Logging</source>
+        <translation>Registrando</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="86"/>
+        <source>Global Log Filter</source>
+        <translation>Filtro de Registro Global</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="100"/>
+        <source>Show Log Console (Windows Only)</source>
+        <translation>Mostrar Consola del Registro (Sólo Windows)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="107"/>
+        <source>Open Log Location</source>
+        <translation>Abrir Localización del Registro</translation>
     </message>
 </context>
 <context>
@@ -475,7 +495,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="42"/>
         <source>Enable V-Sync</source>
-        <translation>Activar V-Sync</translation>
+        <translation>Activar Sincronización Vertical</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="51"/>
@@ -1100,12 +1120,12 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DirectConnectWindow</name>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="97"/>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="103"/>
         <source>Connecting</source>
         <translation>Conectando</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="102"/>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="108"/>
         <source>Connect</source>
         <translation>Conectar</translation>
     </message>
@@ -1113,289 +1133,289 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GMainWindow</name>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="90"/>
+        <location filename="../../src/citra_qt/main.cpp" line="92"/>
         <source>To help improve Citra, the Citra Team collects anonymous usage data. No private or personally identifying information is collected. This data helps us to understand how people use Citra and prioritize our efforts. Furthermore, it helps us to more easily identify emulation bugs and performance issues. This data includes:&lt;ul&gt;&lt;li&gt;Information about the version of Citra you are using&lt;/li&gt;&lt;li&gt;Performance data about the games you play&lt;/li&gt;&lt;li&gt;Your configuration settings&lt;/li&gt;&lt;li&gt;Information about your computer hardware&lt;/li&gt;&lt;li&gt;Emulation errors and crash information&lt;/li&gt;&lt;/ul&gt;By default, this feature is enabled. To disable this feature, click &apos;Emulation&apos; from the menu and then select &apos;Configure...&apos;. Then, on the &apos;Web&apos; tab, uncheck &apos;Share anonymous usage data with the Citra team&apos;. &lt;br/&gt;&lt;br/&gt;By using this software, you agree to the above terms.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
         <translation>Para ayudar a mejorar Citra, el Equipo de Citra reúne datos de uso anónimos. Ningún dato personal ni privado es recogido. Esos datos nos ayuda a entender cómo la gente usa Citra y así priorizar nuestros esfuerzos. También nos ayuda a identificar bugs de emulación y problemas de rendimiento más fácilmente. Estos datos incluyen: &lt;ul&gt;&lt;li&gt;Información de la versión de Citra usada&lt;/li&gt;&lt;li&gt;Datos de rendimiento acerca del juego al que se esté jugando&lt;/li&gt;&lt;li&gt;Tu configuración&lt;/li&gt;&lt;li&gt;Información sobre tu hardware&lt;/li&gt;&lt;li&gt;Errores de emulación e información de cuelgues&lt;/li&gt;&lt;/ul&gt;Por defecto, esta característica está activada. Para desactivarla, ve a &apos;Emulación&apos; del menú y luego elige &apos;Configurar...&quot;. Luego, en la pestaña &apos;Web&apos;, desactiva la opción &apos;Compartir datos de uso anónimos con el equipo de Citra&apos;.&lt;br/&gt;&lt;br/&gt;Al usar este software, estás de acuerdo con los términos de arriba.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Más Información&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="195"/>
+        <location filename="../../src/citra_qt/main.cpp" line="199"/>
         <source>Current emulation speed. Values higher or lower than 100% indicate emulation is running faster or slower than a 3DS.</source>
-        <translation>La velocidad de emulación actual. Valores mayores o menores de 100% indican que la velocidad de emulación funciona más rápida o lentamente que en un 3DS.</translation>
+        <translation>La velocidad de emulación actual. Valores mayores o menores de 100% indican que la velocidad de emulación funciona más rápida o lentamente que en una 3DS.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="198"/>
+        <location filename="../../src/citra_qt/main.cpp" line="202"/>
         <source>How many frames per second the game is currently displaying. This will vary from game to game and scene to scene.</source>
         <translation>Los fotogramas por segundo que está mostrando el juego. Variarán de juego en juego y de escena a escena.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="202"/>
+        <location filename="../../src/citra_qt/main.cpp" line="206"/>
         <source>Time taken to emulate a 3DS frame, not counting framelimiting or v-sync. For full-speed emulation this should be at most 16.67 ms.</source>
-        <translation>El tiempo que lleva emular un fotograma de 3DS, sin contar el limitador de fotogramas, ni el v-sync. Para una emulación óptima, éste valor no debe superar los 16.67 ms.</translation>
+        <translation>El tiempo que lleva emular un fotograma de 3DS, sin tener en cuenta el limitador de fotogramas, ni la sincronización vertical. Para una emulación óptima, este valor no debe superar los 16.67 ms.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="429"/>
+        <location filename="../../src/citra_qt/main.cpp" line="434"/>
         <source>CTRL+F</source>
         <translation>CTRL+F</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="538"/>
+        <location filename="../../src/citra_qt/main.cpp" line="543"/>
         <source>Update available!</source>
         <translation>¡Actualización disponible!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="539"/>
+        <location filename="../../src/citra_qt/main.cpp" line="544"/>
         <source>An update for Citra is available. Do you wish to install it now?&lt;br /&gt;&lt;br /&gt;This &lt;b&gt;will&lt;/b&gt; terminate emulation, if it is running.</source>
-        <translation>Hay una actualización para Citra. ¿Quieres instalarla ahora?&lt;br /&gt;&lt;br /&gt;Esto&lt;b&gt;terminará&lt;/b&gt;la emulación, si está ejecutándose.</translation>
+        <translation>Hay una actualización disponible para Citra. ¿Quieres instalarla ahora?&lt;br /&gt;&lt;br /&gt;Esto &lt;b&gt;terminará&lt;/b&gt; la emulación, si está ejecutandose.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <location filename="../../src/citra_qt/main.cpp" line="555"/>
         <source>No update found</source>
         <translation>No se han encontrado actualizaciones</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <location filename="../../src/citra_qt/main.cpp" line="555"/>
         <source>No update has been found for Citra.</source>
         <translation>No se han encontrado actualizaciones para Citra</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="567"/>
+        <location filename="../../src/citra_qt/main.cpp" line="572"/>
         <source>Error while initializing OpenGL 3.3 Core!</source>
         <translation>¡Error al iniciar el núcleo OpenGL 3.3!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="568"/>
+        <location filename="../../src/citra_qt/main.cpp" line="573"/>
         <source>Your GPU may not support OpenGL 3.3, or you do not have the latest graphics driver.</source>
         <translation>Tu tarjeta gráfica no soporta OpenGL 3.3, o no tienes los últimos controladores gráficos para tu tarjeta.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="581"/>
-        <location filename="../../src/citra_qt/main.cpp" line="587"/>
-        <location filename="../../src/citra_qt/main.cpp" line="593"/>
-        <location filename="../../src/citra_qt/main.cpp" line="606"/>
-        <location filename="../../src/citra_qt/main.cpp" line="625"/>
+        <location filename="../../src/citra_qt/main.cpp" line="586"/>
+        <location filename="../../src/citra_qt/main.cpp" line="592"/>
+        <location filename="../../src/citra_qt/main.cpp" line="598"/>
+        <location filename="../../src/citra_qt/main.cpp" line="611"/>
+        <location filename="../../src/citra_qt/main.cpp" line="630"/>
         <source>Error while loading ROM!</source>
         <translation>¡Error al cargar la ROM!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="582"/>
-        <location filename="../../src/citra_qt/main.cpp" line="607"/>
+        <location filename="../../src/citra_qt/main.cpp" line="587"/>
+        <location filename="../../src/citra_qt/main.cpp" line="612"/>
         <source>The ROM format is not supported.</source>
         <translation>Este formato de ROM no está soportado.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="588"/>
+        <location filename="../../src/citra_qt/main.cpp" line="593"/>
         <source>Could not determine the system mode.</source>
         <translation>No se pudo determinar el modo del sistema.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="594"/>
+        <location filename="../../src/citra_qt/main.cpp" line="599"/>
         <source>The game that you are trying to load must be decrypted before being used with Citra. A real 3DS is required.&lt;br/&gt;&lt;br/&gt;For more information on dumping and decrypting games, please see the following wiki pages: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</source>
         <translation>El juego que estás intentando cargar debe ser desencriptado antes de ser usado con Citra. Se necesita una 3DS real.&lt;br/&gt;&lt;br/&gt;Para más información sobre volcar y desencriptar juegos, mira las siguientes páginas de la wiki: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Volcar Cartuchos de Juego&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Volcar Títulos Instalados&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="612"/>
+        <location filename="../../src/citra_qt/main.cpp" line="617"/>
         <source>An error occured in the video core.</source>
         <translation>Un error ha ocurrido en el núcleo de vídeo.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="613"/>
+        <location filename="../../src/citra_qt/main.cpp" line="618"/>
         <source>Citra has encountered an error while running the video core, please see the log for more details.For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.Ensure that you have the latest graphics drivers for your GPU.</source>
         <translation>Citra ha encontrado un error durante la ejecución del núcleo de vídeo, por favor, mira el registro para más detalles. Para más información sobre cómo acceder al log, mira la siguiente página: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;Cómo subir el Archivo del Log&lt;/a&gt;. Asegúrate de tener los últimos drivers para tu tarjeta gráfica.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="626"/>
+        <location filename="../../src/citra_qt/main.cpp" line="631"/>
         <source>An unknown error occured. Please see the log for more details.</source>
         <translation>Un error desconocido ha ocurrido. Por favor, mira el log para más detalles.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="699"/>
+        <location filename="../../src/citra_qt/main.cpp" line="704"/>
         <source>Start</source>
         <translation>Iniciar</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="790"/>
+        <location filename="../../src/citra_qt/main.cpp" line="795"/>
         <source>Error Opening %1 Folder</source>
         <translation>Error al abrir la carpeta %1</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="791"/>
+        <location filename="../../src/citra_qt/main.cpp" line="796"/>
         <source>Folder does not exist!</source>
         <translation>¡La carpeta no existe!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="805"/>
+        <location filename="../../src/citra_qt/main.cpp" line="810"/>
         <source>3DS Executable</source>
         <translation>Ejecutable de 3DS</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="806"/>
-        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <location filename="../../src/citra_qt/main.cpp" line="811"/>
+        <location filename="../../src/citra_qt/main.cpp" line="833"/>
         <source>All Files (*.*)</source>
         <translation>Todos los archivos (*.*)</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="808"/>
+        <location filename="../../src/citra_qt/main.cpp" line="813"/>
         <source>Load File</source>
         <translation>Cargar Archivo</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="818"/>
+        <location filename="../../src/citra_qt/main.cpp" line="823"/>
         <source>Select Directory</source>
         <translation>Seleccionar directorio</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="827"/>
+        <location filename="../../src/citra_qt/main.cpp" line="832"/>
         <source>Load Files</source>
         <translation>Cargar archivos</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <location filename="../../src/citra_qt/main.cpp" line="833"/>
         <source>3DS Installation File (*.CIA*)</source>
         <translation>Archivo de Instalación de 3DS (*.CIA*)</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="859"/>
+        <location filename="../../src/citra_qt/main.cpp" line="864"/>
         <source>%1 has been installed successfully.</source>
         <translation>%1 ha sido instalado con éxito.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="862"/>
+        <location filename="../../src/citra_qt/main.cpp" line="867"/>
         <source>Unable to open File</source>
         <translation>No se pudo abrir el Archivo</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="863"/>
+        <location filename="../../src/citra_qt/main.cpp" line="868"/>
         <source>Could not open %1</source>
         <translation>No se pudo abrir %1</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="867"/>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
         <source>Installation aborted</source>
         <translation>Instalación abortada</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="868"/>
+        <location filename="../../src/citra_qt/main.cpp" line="873"/>
         <source>The installation of %1 was aborted. Please see the log for more details</source>
         <translation>La instalación de %1 ha sido cancelada. Por favor, consulte los registros para más información.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <location filename="../../src/citra_qt/main.cpp" line="877"/>
         <source>Invalid File</source>
         <translation>Archivo no válido</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <location filename="../../src/citra_qt/main.cpp" line="877"/>
         <source>%1 is not a valid CIA</source>
         <translation>%1 no es un archivo CIA válido</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="875"/>
+        <location filename="../../src/citra_qt/main.cpp" line="880"/>
         <source>Encrypted File</source>
         <translation>Archivo Encriptado</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="876"/>
+        <location filename="../../src/citra_qt/main.cpp" line="881"/>
         <source>%1 must be decrypted before being used with Citra. A real 3DS is required.</source>
         <translation>%1 debe ser desencriptado antes de ser usado en Citra. Se requiere de una 3DS real.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="899"/>
+        <location filename="../../src/citra_qt/main.cpp" line="904"/>
         <source>File not found</source>
         <translation>Archivo no encontrado</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="900"/>
+        <location filename="../../src/citra_qt/main.cpp" line="905"/>
         <source>File &quot;%1&quot; not found</source>
         <translation>Archivo &quot;%1&quot; no encontrado</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="914"/>
+        <location filename="../../src/citra_qt/main.cpp" line="919"/>
         <source>Continue</source>
         <translation>Continuar</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="939"/>
+        <location filename="../../src/citra_qt/main.cpp" line="944"/>
         <source>Missing Citra Account</source>
         <translation>Falta la cuenta de Citra</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="940"/>
+        <location filename="../../src/citra_qt/main.cpp" line="945"/>
         <source>In order to submit a game compatibility test case, you must link your Citra account.&lt;br&gt;&lt;br/&gt;To link your Citra account, go to Emulation &amp;gt; Configuration &amp;gt; Web.</source>
         <translation>Para enviar una prueba de compatibilidad de juegos, es necesario vincular tu cuenta de Citra.&lt;br&gt;&lt;br/&gt;Para vincular tu cuenta de Citra, ve a Emulación &amp;gt; Configuración &amp;gt; Web.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1090"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1095"/>
         <source>Speed: %1% / %2%</source>
         <translation>Velocidad: %1% / %2%</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1094"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1099"/>
         <source>Speed: %1%</source>
         <translation>Velocidad: %1%</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1096"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1101"/>
         <source>Game: %1 FPS</source>
         <translation>Juego: %1 FPS</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1097"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1102"/>
         <source>Frame: %1 ms</source>
         <translation>Frame: %1 ms</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1108"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1113"/>
         <source>The game you are trying to load requires additional files from your 3DS to be dumped before playing.&lt;br/&gt;&lt;br/&gt;For more information on dumping these files, please see the following wiki page: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
         <translation>El juego que estás intentando cargar requiere archivos extra que debes volcar de tu 3DS antes de jugar.&lt;br/&gt;&lt;br/&gt;Para más información sobre cómo volcar éstos, mira la siguiente página de la wiki:&lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Volcar Archivos de Sistema y las Fuentes Compartidas de una 3DS&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;¿Quieres volver a la lista de juegos? Seguir con la emulación puede resultar en cuelgues, archivos de guardado corruptos u otros bugs.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1120"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1125"/>
         <source>: %1. </source>
         <translation>: %1. </translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1126"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1131"/>
         <source>System Archive Not Found</source>
         <translation>Archivo de Sistema no encontrado</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1133"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1138"/>
         <source>Citra was unable to locate the 3DS shared fonts. </source>
         <translation>Citra no pudo encontrar las Fuentes Compartidas de la 3DS.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1135"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1140"/>
         <source>Shared Fonts Not Found</source>
         <translation>Fuentes Compartidas no encontradas</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1143"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1148"/>
         <source>Fatal Error</source>
         <translation>Error Fatal</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1144"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1149"/>
         <source>Citra has encountered a fatal error, please see the log for more details. For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
         <translation>Citra ha encontrado un error fatal, por favor, consulte el registro para más detalles. Para más información sobre cómo acceder a los registros, por favor, mira la siguiente página: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;Cómo subir el Archivo del Log&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;¿Quieres volver a la lista de juegos? Continuar con la emulación puede provocar caídas, archivos de guardado corruptos u otros errores.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
-        <location filename="../../src/citra_qt/main.cpp" line="1245"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1183"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1250"/>
         <source>Citra</source>
         <translation>Citra</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1183"/>
         <source>Are you sure you want to close Citra?</source>
         <translation>¿Estás seguro de querer cerrar Citra?</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1246"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1251"/>
         <source>Are you sure you want to stop the emulation? Any unsaved progress will be lost.</source>
         <translation>¿Estás seguro de querer parar la emulación? Cualquier progreso no guardado se perderá.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1318"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1323"/>
         <source>Citra %1| %2-%3</source>
         <translation>Citra %1| %2-%3</translation>
     </message>
@@ -1458,82 +1478,82 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GameList</name>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="117"/>
         <source>Perfect</source>
         <translation>Perfecto</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="117"/>
         <source>Game functions flawless with no audio or graphical glitches, all tested functionality works as intended without
 any workarounds needed.</source>
         <translation>El juego funciona a la perfección, sin problemas de audio o gráficos, todas las funcionalidades probadas funcionan según lo previsto sin
 la necesidad de soluciones temporales.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="118"/>
         <source>Great</source>
         <translation>Muy bien</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="118"/>
         <source>Game functions with minor graphical or audio glitches and is playable from start to finish. May require some
 workarounds.</source>
         <translation>El juego funciona con pequeños problemas gráficos o de audio y es jugable de principio a fin. Podría requerir de
 soluciones temporales.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="119"/>
         <source>Okay</source>
         <translation>Bien</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="119"/>
         <source>Game functions with major graphical or audio glitches, but game is playable from start to finish with
 workarounds.</source>
         <translation>El juego funciona con importantes problemas gráficos o de audio, pero el juego es jugable de principio a fin con 
 soluciones temporales.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="120"/>
         <source>Bad</source>
         <translation>Mal</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="120"/>
         <source>Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches
 even with workarounds.</source>
         <translation>El juego funciona, pero con notables problemas gráficos o de audio. Es imposible avanzar en zonas específicas debido a
 fallos incluso con soluciones temporales.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="121"/>
         <source>Intro/Menu</source>
-        <translation>Intro/Menu</translation>
+        <translation>Intro/Menú</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="121"/>
         <source>Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start
 Screen.</source>
         <translation>No es posible jugar al juego debido a importantes problemas gráficos o de audio. Es imposible avanzar
 más allá de la pantalla de inicio.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="122"/>
         <source>Won&apos;t Boot</source>
         <translation>No carga</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="122"/>
         <source>The game crashes when attempting to startup.</source>
         <translation>El juego se bloquea al intentar iniciarse.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="123"/>
         <source>Not Tested</source>
         <translation>Sin probar</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="123"/>
         <source>The game has not yet been tested.</source>
         <translation>El juego todavía no ha sido probado.</translation>
     </message>
@@ -1563,17 +1583,17 @@ más allá de la pantalla de inicio.</translation>
         <translation>Introduzca un patrón para filtrar</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="324"/>
+        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
         <source>Open Save Data Location</source>
         <translation>Abrir ubicación de archivos de guardado</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
+        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
         <source>Open Application Location</source>
         <translation>Abrir ubicación de la aplicación</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
+        <location filename="../../src/citra_qt/game_list.cpp" line="327"/>
         <source>Open Update Data Location</source>
         <translation>Abrir ubicación de archivos de actualización</translation>
     </message>
@@ -2006,47 +2026,42 @@ más allá de la pantalla de inicio.</translation>
         <translation>Actualizar Lobby</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="73"/>
         <source>Password Required to Join</source>
         <translation>Contraseña Necesaria para Unirse</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="74"/>
         <source>Password:</source>
         <translation>Contraseña:</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="77"/>
-        <source>Password</source>
-        <translation>Contraseña</translation>
-    </message>
-    <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="139"/>
         <source>Room Name</source>
         <translation>Nombre de Sala</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="143"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="140"/>
         <source>Preferred Game</source>
         <translation>Juego Preferente</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="144"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="141"/>
         <source>Host</source>
         <translation>Host</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="145"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
         <source>Players</source>
         <translation>Jugadores</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="153"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="150"/>
         <source>Refreshing</source>
         <translation>Actualizando</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="201"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="198"/>
         <source>Refresh List</source>
         <translation>Actualizar Lista</translation>
     </message>
@@ -2411,6 +2426,57 @@ Mensaje de Depuración:</translation>
         <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="201"/>
         <source>%1 is playing %2</source>
         <translation>%1 está jugando %2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="208"/>
+        <source>Invalid region</source>
+        <translation>Región no válida</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Japan</source>
+        <translation>Japón</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>North America</source>
+        <translation>Norteamérica</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="92"/>
+        <source>Europe</source>
+        <translation>Europa</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="94"/>
+        <source>Australia</source>
+        <translation>Australia</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="96"/>
+        <source>China</source>
+        <translation>China</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="98"/>
+        <source>Korea</source>
+        <translation>Corea</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="100"/>
+        <source>Taiwan</source>
+        <translation>Taiwán</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="102"/>
+        <source>Region free</source>
+        <translation>Region free</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="104"/>
+        <source>Invalid Region</source>
+        <translation>Región no válida</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="26"/>

--- a/dist/languages/fr.ts
+++ b/dist/languages/fr.ts
@@ -14,7 +14,7 @@
     <message>
         <location filename="../../src/citra_qt/debugger/registers.ui" line="30"/>
         <source>Value</source>
-        <translation>Value</translation>
+        <translation>Valeur</translation>
     </message>
 </context>
 <context>
@@ -154,17 +154,17 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ClientRoomWindow</name>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="54"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="55"/>
         <source>Connected</source>
         <translation>Connecté</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="65"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="63"/>
         <source>Disconnected</source>
         <translation>Déconnecté</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="78"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="76"/>
         <source>%1 (%2/%3 members) - connected</source>
         <translation>%1 (%2/%3 membres) - connecté</translation>
     </message>
@@ -240,7 +240,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="157"/>
         <source>Won&apos;t Boot</source>
-        <translation>Ne Boot Pas</translation>
+        <translation>Ne se lance pas</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="170"/>
@@ -312,6 +312,26 @@ p, li { white-space: pre-wrap; }
         <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="57"/>
         <source>Port:</source>
         <translation>Port:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="78"/>
+        <source>Logging</source>
+        <translation>Journalisation</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="86"/>
+        <source>Global Log Filter</source>
+        <translation>Filtre global des journaux</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="100"/>
+        <source>Show Log Console (Windows Only)</source>
+        <translation>Afficher la console des journaux (Windows uniquement)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="107"/>
+        <source>Open Log Location</source>
+        <translation>Ouvrir l&apos;emplacement des journaux</translation>
     </message>
 </context>
 <context>
@@ -683,7 +703,7 @@ p, li { white-space: pre-wrap; }
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="461"/>
         <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="232"/>
         <source>Set Analog Stick</source>
-        <translation>Configurer le stick analogue</translation>
+        <translation>Configurer le stick analogique</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="377"/>
@@ -901,12 +921,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.ui" line="226"/>
         <source>Console ID:</source>
-        <translation>ID de la console</translation>
+        <translation>Console ID:</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.ui" line="242"/>
         <source>Regenerate</source>
-        <translation>Régénérer </translation>
+        <translation>Regénérer </translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.ui" line="252"/>
@@ -916,7 +936,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="87"/>
         <source>Console ID: 0x%1</source>
-        <translation>ID console: 0x%1</translation>
+        <translation>Console ID: 0x%1</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="160"/>
@@ -1021,12 +1041,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="55"/>
         <source>Username and token not verified</source>
-        <translation>Nom d&apos;utilisateur et jeton non vérifiés</translation>
+        <translation>Nom d&apos;utilisateur et token non vérifiés</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="56"/>
         <source>Username and token were not verified. The changes to your username and/or token have not been saved.</source>
-        <translation>Le nom d&apos;utilisateur et le token n&apos;ont pas été vérifiés. Les modifications apportées à votre nom d&apos;utilisateur et / ou jeton n&apos;ont pas été enregistrées.</translation>
+        <translation>Le nom d&apos;utilisateur et le token n&apos;ont pas été vérifiés. Les modifications apportées à votre nom d&apos;utilisateur et / ou token n&apos;ont pas été enregistrées.</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="85"/>
@@ -1074,7 +1094,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="80"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Port number the host is listening on&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Numéro du port écouté par l&apos;hôte&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Numéro du port choisi par l&apos;hôte&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="86"/>
@@ -1100,12 +1120,12 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DirectConnectWindow</name>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="97"/>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="103"/>
         <source>Connecting</source>
         <translation>Connexion en cours</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="102"/>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="108"/>
         <source>Connect</source>
         <translation>Connecter</translation>
     </message>
@@ -1113,289 +1133,289 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GMainWindow</name>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="90"/>
+        <location filename="../../src/citra_qt/main.cpp" line="92"/>
         <source>To help improve Citra, the Citra Team collects anonymous usage data. No private or personally identifying information is collected. This data helps us to understand how people use Citra and prioritize our efforts. Furthermore, it helps us to more easily identify emulation bugs and performance issues. This data includes:&lt;ul&gt;&lt;li&gt;Information about the version of Citra you are using&lt;/li&gt;&lt;li&gt;Performance data about the games you play&lt;/li&gt;&lt;li&gt;Your configuration settings&lt;/li&gt;&lt;li&gt;Information about your computer hardware&lt;/li&gt;&lt;li&gt;Emulation errors and crash information&lt;/li&gt;&lt;/ul&gt;By default, this feature is enabled. To disable this feature, click &apos;Emulation&apos; from the menu and then select &apos;Configure...&apos;. Then, on the &apos;Web&apos; tab, uncheck &apos;Share anonymous usage data with the Citra team&apos;. &lt;br/&gt;&lt;br/&gt;By using this software, you agree to the above terms.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
         <translation>Pour aider à améliorer Citra, l&apos;équipe Citra collecte des données d&apos;utilisation anonymes. Aucune information privée ou d&apos;identification personnelle n&apos;est collectée. Ces données nous aident à comprendre comment les gens utilisent Citra et ainsi hiérarchiser nos efforts. De plus, cela nous aide à identifier plus facilement les bogues d&apos;émulation et les problèmes de performance. Ces données comprennent:&lt;ul&gt;&lt;li&gt;Informations sur la version de Citra que vous utilisez&lt;/li&gt;&lt;li&gt;Données de performance sur les jeux auxquels vous jouez&lt;/li&gt;&lt;li&gt;Vos paramètres de configuration&lt;/li&gt;&lt;li&gt;Informations sur la configuration matérielle de votre ordinateur&lt;/li&gt;&lt;li&gt;Informations sur les erreurs et crashes d&apos;émulation &lt;/li&gt;&lt;/ul&gt;Cette fonctionnalité est activée par défaut. Pour la désactiver, cliquez sur &quot;Émulation&quot; dans le menu, puis sélectionnez &quot;Configurer ...&quot;. Ensuite, dans l&apos;onglet &quot;Web&quot;, décochez &quot;Partager les données d&apos;utilisation anonymes avec l&apos;équipe Citra&quot;. &lt;br/&gt;&lt;br/&gt; En utilisant ce logiciel, vous acceptez les conditions ci-dessus.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;En savoir plus&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="195"/>
+        <location filename="../../src/citra_qt/main.cpp" line="199"/>
         <source>Current emulation speed. Values higher or lower than 100% indicate emulation is running faster or slower than a 3DS.</source>
         <translation>Vitesse actuelle d&apos;émulation. Les valeurs supérieures ou inférieures à 100% indiquent que l&apos;émulation est plus rapide ou plus lente qu&apos;une 3DS.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="198"/>
+        <location filename="../../src/citra_qt/main.cpp" line="202"/>
         <source>How many frames per second the game is currently displaying. This will vary from game to game and scene to scene.</source>
         <translation>Nombre d&apos;images par seconde le jeu affiche actuellement. Cela varie d&apos;un jeu à l&apos;autre et d&apos;une scène à l&apos;autre.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="202"/>
+        <location filename="../../src/citra_qt/main.cpp" line="206"/>
         <source>Time taken to emulate a 3DS frame, not counting framelimiting or v-sync. For full-speed emulation this should be at most 16.67 ms.</source>
         <translation>Temps nécessaire pour émuler une trame 3DS, sans compter la limitation de trame ou la synchronisation verticale V-Sync. Pour une émulation à pleine vitesse, cela ne devrait pas dépasser 16,67 ms.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="429"/>
+        <location filename="../../src/citra_qt/main.cpp" line="434"/>
         <source>CTRL+F</source>
         <translation>CTRL+F</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="538"/>
+        <location filename="../../src/citra_qt/main.cpp" line="543"/>
         <source>Update available!</source>
         <translation>Mise à jour disponible!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="539"/>
+        <location filename="../../src/citra_qt/main.cpp" line="544"/>
         <source>An update for Citra is available. Do you wish to install it now?&lt;br /&gt;&lt;br /&gt;This &lt;b&gt;will&lt;/b&gt; terminate emulation, if it is running.</source>
         <translation>Une mise à jour de Citra est disponible. Souhaitez-vous l&apos;installer maintenant?&lt;br /&gt;&lt;br /&gt;Ceci&lt;b&gt;va&lt;/b&gt;mettre fin à l&apos;émulation, si elle est en cours.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <location filename="../../src/citra_qt/main.cpp" line="555"/>
         <source>No update found</source>
         <translation>Aucune mise à jour trouvée</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <location filename="../../src/citra_qt/main.cpp" line="555"/>
         <source>No update has been found for Citra.</source>
         <translation>Aucune mise à jour n&apos;a été trouvée pour Citra.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="567"/>
+        <location filename="../../src/citra_qt/main.cpp" line="572"/>
         <source>Error while initializing OpenGL 3.3 Core!</source>
         <translation>Erreur lors de l&apos;initialisation de OpenGL 3.3!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="568"/>
+        <location filename="../../src/citra_qt/main.cpp" line="573"/>
         <source>Your GPU may not support OpenGL 3.3, or you do not have the latest graphics driver.</source>
         <translation>Votre GPU peut ne pas supporter OpenGL 3.3, ou vous n&apos;avez pas le dernier pilote graphique.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="581"/>
-        <location filename="../../src/citra_qt/main.cpp" line="587"/>
-        <location filename="../../src/citra_qt/main.cpp" line="593"/>
-        <location filename="../../src/citra_qt/main.cpp" line="606"/>
-        <location filename="../../src/citra_qt/main.cpp" line="625"/>
+        <location filename="../../src/citra_qt/main.cpp" line="586"/>
+        <location filename="../../src/citra_qt/main.cpp" line="592"/>
+        <location filename="../../src/citra_qt/main.cpp" line="598"/>
+        <location filename="../../src/citra_qt/main.cpp" line="611"/>
+        <location filename="../../src/citra_qt/main.cpp" line="630"/>
         <source>Error while loading ROM!</source>
         <translation>Erreur lors du chargement de la ROM!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="582"/>
-        <location filename="../../src/citra_qt/main.cpp" line="607"/>
+        <location filename="../../src/citra_qt/main.cpp" line="587"/>
+        <location filename="../../src/citra_qt/main.cpp" line="612"/>
         <source>The ROM format is not supported.</source>
         <translation>Le format de la ROM n&apos;est pas pris en charge.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="588"/>
+        <location filename="../../src/citra_qt/main.cpp" line="593"/>
         <source>Could not determine the system mode.</source>
         <translation>Impossible de déterminer le mode du système.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="594"/>
+        <location filename="../../src/citra_qt/main.cpp" line="599"/>
         <source>The game that you are trying to load must be decrypted before being used with Citra. A real 3DS is required.&lt;br/&gt;&lt;br/&gt;For more information on dumping and decrypting games, please see the following wiki pages: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</source>
         <translation>Le jeu que vous essayez de charger doit être décrypté avant d&apos;être utilisé avec Citra. Une 3DS est requise&lt;br/&gt;&lt;br/&gt;Pour plus d&apos;informations sur l&apos;extraction et le décryptage des jeux, veuillez consulter les pages wiki suivantes: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Extraction des cartouches de jeux&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Extraction des titres installés&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="612"/>
+        <location filename="../../src/citra_qt/main.cpp" line="617"/>
         <source>An error occured in the video core.</source>
         <translation>Une erreur est survenue dans le noyau vidéo.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="613"/>
+        <location filename="../../src/citra_qt/main.cpp" line="618"/>
         <source>Citra has encountered an error while running the video core, please see the log for more details.For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.Ensure that you have the latest graphics drivers for your GPU.</source>
         <translation>Citra a rencontré une erreur lors de l&apos;exécution du noyau vidéo, consultez le journal pour plus de détails. Pour plus d&apos;informations sur l&apos;accès au journal, consultez la page suivante: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;Comment télécharger le fichier journal&lt;/a&gt;. Assurez-vous d&apos;avoir les derniers pilotes graphiques pour votre GPU..</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="626"/>
+        <location filename="../../src/citra_qt/main.cpp" line="631"/>
         <source>An unknown error occured. Please see the log for more details.</source>
         <translation>Une erreur inconnue est survenue. Veuillez consulter le journal pour plus de détails.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="699"/>
+        <location filename="../../src/citra_qt/main.cpp" line="704"/>
         <source>Start</source>
         <translation>Démarrer</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="790"/>
+        <location filename="../../src/citra_qt/main.cpp" line="795"/>
         <source>Error Opening %1 Folder</source>
         <translation>Erreur lors de l&apos;ouverture du dossier %1</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="791"/>
+        <location filename="../../src/citra_qt/main.cpp" line="796"/>
         <source>Folder does not exist!</source>
         <translation>Le répertoire n&apos;existe pas!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="805"/>
+        <location filename="../../src/citra_qt/main.cpp" line="810"/>
         <source>3DS Executable</source>
         <translation>Fichier exécutable 3DS</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="806"/>
-        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <location filename="../../src/citra_qt/main.cpp" line="811"/>
+        <location filename="../../src/citra_qt/main.cpp" line="833"/>
         <source>All Files (*.*)</source>
         <translation>Tous les fichiers (*.*)</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="808"/>
+        <location filename="../../src/citra_qt/main.cpp" line="813"/>
         <source>Load File</source>
         <translation>Charger un fichier</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="818"/>
+        <location filename="../../src/citra_qt/main.cpp" line="823"/>
         <source>Select Directory</source>
         <translation>Sélectionner un répertoire </translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="827"/>
+        <location filename="../../src/citra_qt/main.cpp" line="832"/>
         <source>Load Files</source>
         <translation>Charger les fichiers</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <location filename="../../src/citra_qt/main.cpp" line="833"/>
         <source>3DS Installation File (*.CIA*)</source>
         <translation>Fichier d&apos;installation 3DS (*.CIA*)</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="859"/>
+        <location filename="../../src/citra_qt/main.cpp" line="864"/>
         <source>%1 has been installed successfully.</source>
         <translation>%1 a été installé avec succès.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="862"/>
+        <location filename="../../src/citra_qt/main.cpp" line="867"/>
         <source>Unable to open File</source>
         <translation>Impossible d&apos;ouvrir le fichier</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="863"/>
+        <location filename="../../src/citra_qt/main.cpp" line="868"/>
         <source>Could not open %1</source>
         <translation>Impossible d&apos;ouvrir %1</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="867"/>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
         <source>Installation aborted</source>
         <translation>Installation annulée</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="868"/>
+        <location filename="../../src/citra_qt/main.cpp" line="873"/>
         <source>The installation of %1 was aborted. Please see the log for more details</source>
-        <translation>L&apos;installation de %1 a été interrompue. Veuillez consulter le fichier journal pour plus de détails.</translation>
+        <translation>L&apos;installation de %1 a été interrompue. Veuillez consulter le fichier log pour plus de détails.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <location filename="../../src/citra_qt/main.cpp" line="877"/>
         <source>Invalid File</source>
         <translation>Fichier invalide</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <location filename="../../src/citra_qt/main.cpp" line="877"/>
         <source>%1 is not a valid CIA</source>
         <translation>%1 n&apos;est pas un CIA valide</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="875"/>
+        <location filename="../../src/citra_qt/main.cpp" line="880"/>
         <source>Encrypted File</source>
         <translation>Fichier encrypté</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="876"/>
+        <location filename="../../src/citra_qt/main.cpp" line="881"/>
         <source>%1 must be decrypted before being used with Citra. A real 3DS is required.</source>
         <translation>%1 doit être décrypté avant de fonctionner avec Citra. Une véritable 3DS est requise.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="899"/>
+        <location filename="../../src/citra_qt/main.cpp" line="904"/>
         <source>File not found</source>
         <translation>Fichier non trouvé</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="900"/>
+        <location filename="../../src/citra_qt/main.cpp" line="905"/>
         <source>File &quot;%1&quot; not found</source>
         <translation>Le fichier &quot;%1&quot; n&apos;a pas été trouvé</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="914"/>
+        <location filename="../../src/citra_qt/main.cpp" line="919"/>
         <source>Continue</source>
         <translation>Continuer</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="939"/>
+        <location filename="../../src/citra_qt/main.cpp" line="944"/>
         <source>Missing Citra Account</source>
-        <translation>Compte Citra manquant</translation>
+        <translation>Compte Citra absent</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="940"/>
+        <location filename="../../src/citra_qt/main.cpp" line="945"/>
         <source>In order to submit a game compatibility test case, you must link your Citra account.&lt;br&gt;&lt;br/&gt;To link your Citra account, go to Emulation &amp;gt; Configuration &amp;gt; Web.</source>
-        <translation>Pour pouvoir soumettre un case test de compatibilité pour un jeu, vous devez rattacher votre compte Citra.&lt;br&gt;&lt;br/&gt;Pour rattacher votre compte Citra , allez sur Emulation &amp;gt; Configuration &amp;gt; Web.</translation>
+        <translation>Pour pouvoir soumettre un cas test de compatibilité pour un jeu, vous devez rattacher votre compte Citra.&lt;br/&gt;Pour rattacher votre compte Citra , allez sur &lt;br&gt;Émulation &amp;gt; Configurer... &amp;gt; Web.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1090"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1095"/>
         <source>Speed: %1% / %2%</source>
         <translation>Vitesse: %1% / %2%</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1094"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1099"/>
         <source>Speed: %1%</source>
         <translation>Vitesse: %1%</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1096"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1101"/>
         <source>Game: %1 FPS</source>
         <translation>Jeux: %1 FPS</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1097"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1102"/>
         <source>Frame: %1 ms</source>
         <translation>Trame: %1 ms</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1108"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1113"/>
         <source>The game you are trying to load requires additional files from your 3DS to be dumped before playing.&lt;br/&gt;&lt;br/&gt;For more information on dumping these files, please see the following wiki page: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
         <translation>Le jeu que vous essayez de charger requiert que des fichiers supplémentaires soient extraits depuis votre 3DS avant de jouer.&lt;br/&gt;&lt;br/&gt;Pour plus d&apos;informations sur l&apos;extraction de ces fichiers, veuillez consulter la page wiki suivante: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Extraction des archives systèmes et des polices partagées depuis une console 3DS&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Voudriez-vous  revenir à la liste des jeux? Des crashes, des données corrompues ou d&apos;autres bogues pourraient survenir si vous choisissez de poursuivre l’émulation.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1120"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1125"/>
         <source>: %1. </source>
         <translation>: %1. </translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1126"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1131"/>
         <source>System Archive Not Found</source>
         <translation>Archive système non trouvé</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1133"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1138"/>
         <source>Citra was unable to locate the 3DS shared fonts. </source>
         <translation>Citra n&apos;a pas pu localiser les polices partagées 3DS.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1135"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1140"/>
         <source>Shared Fonts Not Found</source>
         <translation>Polices partagées non trouvées.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1143"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1148"/>
         <source>Fatal Error</source>
         <translation>Erreur fatale</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1144"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1149"/>
         <source>Citra has encountered a fatal error, please see the log for more details. For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
         <translation>Citra a rencontré une erreur fatale, veuillez consulter le journal pour plus de détails. Pour plus d&apos;informations sur l&apos;accès au journal, veuillez consulter la page suivante:&lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;Comment télécharger le fichier journal.&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Voudriez-vous revenir à la liste des jeux? Des crashes, des données corrompues ou d&apos;autres bogues pourraient survenir si vous choisissez de poursuivre l’émulation.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
-        <location filename="../../src/citra_qt/main.cpp" line="1245"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1183"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1250"/>
         <source>Citra</source>
         <translation>Citra</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1183"/>
         <source>Are you sure you want to close Citra?</source>
         <translation>Êtes-vous sûr de vouloir fermer Citra?</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1246"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1251"/>
         <source>Are you sure you want to stop the emulation? Any unsaved progress will be lost.</source>
         <translation>Êtes-vous sûr de vouloir arrêter l&apos;émulation? Tout progrès non enregistré sera perdu.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1318"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1323"/>
         <source>Citra %1| %2-%3</source>
         <translation>Citra %1| %2-%3</translation>
     </message>
@@ -1458,77 +1478,77 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GameList</name>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="117"/>
         <source>Perfect</source>
         <translation>Parfait</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="117"/>
         <source>Game functions flawless with no audio or graphical glitches, all tested functionality works as intended without
 any workarounds needed.</source>
         <translation>Le jeu fonctionne parfaitement sans bug audio ni graphique, toutes les fonctionnalités testées marchent comme prévu sans besoin de correctif. </translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="118"/>
         <source>Great</source>
         <translation>Bien</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="118"/>
         <source>Game functions with minor graphical or audio glitches and is playable from start to finish. May require some
 workarounds.</source>
         <translation>Le jeu fonctionne avec des bugs audio ou graphiques mineurs et est jouable du début à la fin. Peut nécessiter certains ajustements.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="119"/>
         <source>Okay</source>
         <translation>Ok</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="119"/>
         <source>Game functions with major graphical or audio glitches, but game is playable from start to finish with
 workarounds.</source>
         <translation>Le jeu fonctionne avec des bugs audio ou graphiques majeurs, mais il est jouable du début à la fin avec des ajustements.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="120"/>
         <source>Bad</source>
         <translation>Mauvais</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="120"/>
         <source>Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches
 even with workarounds.</source>
         <translation>Le jeu fonctionne, mais avec des bugs audio ou graphiques majeurs. Impossible de se rendre dans certaines zones à cause des bugs même avec des ajustements.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="121"/>
         <source>Intro/Menu</source>
         <translation>Intro/Menu</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="121"/>
         <source>Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start
 Screen.</source>
         <translation>Le jeu est totalement injouable à cause de bugs graphiques ou audio majeurs. Impossible de dépasser l&apos;écran titre.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="122"/>
         <source>Won&apos;t Boot</source>
         <translation>Ne se lance pas</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="122"/>
         <source>The game crashes when attempting to startup.</source>
         <translation>Le jeu plante au démarrage.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="123"/>
         <source>Not Tested</source>
         <translation>Non testé</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="123"/>
         <source>The game has not yet been tested.</source>
         <translation>Le jeu n&apos;a pas encore été testé.</translation>
     </message>
@@ -1558,17 +1578,17 @@ Screen.</source>
         <translation>Entrer l&apos;élément de filtrage</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="324"/>
+        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
         <source>Open Save Data Location</source>
         <translation>Ouvrir l&apos;emplacement des données de sauvegarde</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
+        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
         <source>Open Application Location</source>
         <translation>Ouvrir l&apos;emplacement de l&apos;application</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
+        <location filename="../../src/citra_qt/game_list.cpp" line="327"/>
         <source>Open Update Data Location</source>
         <translation>Ouvrir l&apos;emplacement des données de mise à jour</translation>
     </message>
@@ -1657,7 +1677,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="150"/>
         <source>Physical Address:</source>
-        <translation>Adresse physique</translation>
+        <translation>Adresse physique:</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="156"/>
@@ -1967,7 +1987,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="14"/>
         <source>Public Room Browser</source>
-        <translation>Navigateur de salon public</translation>
+        <translation>Explorateur de salon public</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="32"/>
@@ -2001,47 +2021,42 @@ Screen.</source>
         <translation>Rafraîchir le hall</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="73"/>
         <source>Password Required to Join</source>
         <translation>Mot de passe nécessaire pour devenir membre</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="74"/>
         <source>Password:</source>
         <translation>Mot de passe:</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="77"/>
-        <source>Password</source>
-        <translation>Mot de passe</translation>
-    </message>
-    <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="139"/>
         <source>Room Name</source>
         <translation>Nom du salon</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="143"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="140"/>
         <source>Preferred Game</source>
         <translation>Jeu préféré</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="144"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="141"/>
         <source>Host</source>
         <translation>Hôte</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="145"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
         <source>Players</source>
         <translation>Joueurs</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="153"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="150"/>
         <source>Refreshing</source>
         <translation>Rafraîchissement</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="201"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="198"/>
         <source>Refresh List</source>
         <translation>Rafraîchir la liste</translation>
     </message>
@@ -2293,7 +2308,7 @@ Screen.</source>
         <location filename="../../src/citra_qt/multiplayer/state.cpp" line="115"/>
         <source>Failed to announce the room to the public lobby. In order to host a room publicly, you must have a valid Citra account configured in Emulation -&gt; Configure -&gt; Web. If you do not want to publish a room in the public lobby, then select Unlisted instead.
 Debug Message: </source>
-        <translation>L&apos;introduction du salon dans le hall public a échoué. Pour héberger un salon public, vous devez configurer un compte Citra valide dans Emulation -&gt; Configure -&gt; Web. Si vous ne souhaitez pas publier un salon dans le hall public, choisissez Non Listé à la place.
+        <translation>L&apos;introduction du salon dans le hall public a échoué. Pour héberger un salon public, vous devez configurer un compte Citra valide dans Emulation -&gt; Configurer... -&gt; Web. Si vous ne souhaitez pas publier un salon dans le hall public, choisissez Non Listé à la place.
 Message de debug:</translation>
     </message>
 </context>
@@ -2406,6 +2421,57 @@ Message de debug:</translation>
         <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="201"/>
         <source>%1 is playing %2</source>
         <translation>%1 joue à %2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="208"/>
+        <source>Invalid region</source>
+        <translation>Région Invalide</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Japan</source>
+        <translation>Japon</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>North America</source>
+        <translation>Amérique du Nord</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="92"/>
+        <source>Europe</source>
+        <translation>Europe</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="94"/>
+        <source>Australia</source>
+        <translation>Australie</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="96"/>
+        <source>China</source>
+        <translation>Chine</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="98"/>
+        <source>Korea</source>
+        <translation>Corée</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="100"/>
+        <source>Taiwan</source>
+        <translation>Taiwan</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="102"/>
+        <source>Region free</source>
+        <translation>Dézoné</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="104"/>
+        <source>Invalid Region</source>
+        <translation>Région Invalide</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="26"/>

--- a/dist/languages/fr.ts
+++ b/dist/languages/fr.ts
@@ -1,0 +1,2751 @@
+<?xml version="1.0" ?><!DOCTYPE TS><TS language="fr" version="2.1">
+<context>
+    <name>ARMRegisters</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="14"/>
+        <source>ARM Registers</source>
+        <translation>Registres ARM</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="25"/>
+        <source>Register</source>
+        <translation>Registre</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="30"/>
+        <source>Value</source>
+        <translation>Value</translation>
+    </message>
+</context>
+<context>
+    <name>AboutDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="14"/>
+        <source>About Citra</source>
+        <translation>À propos de Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="30"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/citra.png&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/citra.png&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="60"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:28pt;&quot;&gt;Citra&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:28pt;&quot;&gt;Citra&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="73"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="86"/>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:12pt;&quot;&gt;Citra is a free and open source 3DS emulator licensed under GPLv2.0 or any later version.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'MS Shell Dlg 2'; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;This software should not be used to play games you have not legally obtained.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;Citra est un émulateur 3DS gratuit et source ouverte sous licence GPLv2.0 ou toute version ultérieure.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;Ce logiciel ne doit pas être utilisé pour jouer à des jeux que vous n&apos;avez pas obtenus légalement.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="118"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Website&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://community.citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Forum&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Source Code&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Contributors&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/blob/master/license.txt&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;License&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Site web&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://community.citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Forum&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Code source&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Contributeurs&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/blob/master/license.txt&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;License&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="134"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;&amp;quot;3DS&amp;quot; is a trademark of Nintendo. Citra is not affiliated with Nintendo in any way.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;&amp;quot;3DS&amp;quot; est une marque de commerce de Nintendo. Citra n&apos;est aucunement affilié à Nintendo.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>BreakPointModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="34"/>
+        <source>Pica command loaded</source>
+        <translation>Pica command loaded</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="35"/>
+        <source>Pica command processed</source>
+        <translation>Pica command processed </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="36"/>
+        <source>Incoming primitive batch</source>
+        <translation>Incoming primitive batch</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="37"/>
+        <source>Finished primitive batch</source>
+        <translation>Finished primitive batch</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="38"/>
+        <source>Vertex shader invocation</source>
+        <translation>Vertex shader invocation</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="40"/>
+        <source>Incoming display transfer</source>
+        <translation>Incoming display transfer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="41"/>
+        <source>GSP command processed</source>
+        <translation>GSP command processed</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="42"/>
+        <source>Buffers swapped</source>
+        <translation>Buffers swapped</translation>
+    </message>
+</context>
+<context>
+    <name>ChatRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="14"/>
+        <source>Room Window</source>
+        <translation>Fenêtre du salon</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="40"/>
+        <source>Send Chat Message</source>
+        <translation>Envoyer un message via le Chat</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="47"/>
+        <source>Send Message</source>
+        <translation>Envoyer un message</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.cpp" line="81"/>
+        <source>Name</source>
+        <translation>Nom</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.cpp" line="82"/>
+        <source>Game</source>
+        <translation>Jeu</translation>
+    </message>
+</context>
+<context>
+    <name>ClientRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.ui" line="14"/>
+        <source>Room Window</source>
+        <translation>Fenêtre du salon</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.ui" line="40"/>
+        <source>Leave Room</source>
+        <translation>Quitter le salon</translation>
+    </message>
+</context>
+<context>
+    <name>ClientRoomWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="54"/>
+        <source>Connected</source>
+        <translation>Connecté</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="65"/>
+        <source>Disconnected</source>
+        <translation>Déconnecté</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="78"/>
+        <source>%1 (%2/%3 members) - connected</source>
+        <translation>%1 (%2/%3 membres) - connecté</translation>
+    </message>
+</context>
+<context>
+    <name>CompatDB</name>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="20"/>
+        <source>Report Compatibility</source>
+        <translation>Rapporter la compatibilité</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="27"/>
+        <location filename="../../src/citra_qt/compatdb.ui" line="63"/>
+        <source>Report Game Compatibility</source>
+        <translation>Rapporter compatibilité des jeux</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="36"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;Should you choose to submit a test case to the &lt;/span&gt;&lt;a href=&quot;https://citra-emu.org/game/&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;Citra Compatibility List&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;, The following information will be collected and displayed on the site:&lt;/span&gt;&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Hardware Information (CPU / GPU / Operating System)&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Which version of Citra you are running&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The connected Citra account&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;Si vous soumettez un cas test à la &lt;/span&gt;&lt;a href=&quot;https://citra-emu.org/game/&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;Liste de compatibilité de Citra&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;, Les informations suivantes seront collectées et affichées sur le site:&lt;/span&gt;&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Informations sur le matériel (CPU / GPU / Système d&apos;exploitation)&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;La version de Citra que vous utilisez&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Le compte Citra utilisé pour la connexion&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="72"/>
+        <source>Perfect</source>
+        <translation>Parfait</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="79"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions flawlessly with no audio or graphical glitches.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Le jeu fonctionne parfaitement sans problème audio ou graphique.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="89"/>
+        <source>Great </source>
+        <translation>Bien</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="96"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions with minor graphical or audio glitches and is playable from start to finish. May require some workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Le jeu fonctionne avec des bugs audio ou graphiques mineurs et est jouable du début à la fin. Peut nécessiter quelques ajustements.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="106"/>
+        <source>Okay</source>
+        <translation>Okay</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="113"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions with major graphical or audio glitches, but game is playable from start to finish with workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Le jeu fonctionne avec des bugs audio ou graphiques majeurs, mais il est jouable du début à la fin avec des ajustements.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="123"/>
+        <source>Bad</source>
+        <translation>Mauvais</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="130"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches even with workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Le jeu fonctionne, mais avec des bugs audio ou graphiques majeurs. Impossible de se rendre dans certaines zones à cause des bugs même avec des ajustements.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="140"/>
+        <source>Intro/Menu</source>
+        <translation>Intro/Menu</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="147"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start Screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Le jeu est totalement injouable à cause de bugs graphiques ou audio majeurs. Impossible de dépasser l&apos;écran titre.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="157"/>
+        <source>Won&apos;t Boot</source>
+        <translation>Ne Boot Pas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="170"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The game crashes when attempting to startup.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Le jeu plante au démarrage.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="182"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Independent of speed or performance, how well does this game play from start to finish on this version of Citra?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Indépendamment de la vitesse et de la performance, comment ce jeu fonctionne du début à la fin sur cette version de Citra?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="206"/>
+        <source>Thank you for your submission!</source>
+        <translation>Merci pour votre contribution!</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureAudio</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="10"/>
+        <source>Audio</source>
+        <translation>Son</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="18"/>
+        <source>Output Engine:</source>
+        <translation>Moteur de sortie:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="31"/>
+        <source>Enable audio stretching</source>
+        <translation>Activer l&apos;étirement audio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="34"/>
+        <source>This post-processing effect adjusts audio speed to match emulation speed and helps prevent audio stutter. This however increases audio latency.</source>
+        <translation>Cet effet de post-traitement ajuste la vitesse audio pour correspondre à la vitesse d&apos;émulation et aide à prévenir les distorsions. Cela augmente cependant la latence du son.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="43"/>
+        <source>Audio Device:</source>
+        <translation>Périphérique Audio:</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureDebug</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="14"/>
+        <source>Form</source>
+        <translation>Forme</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="22"/>
+        <source>GDB</source>
+        <translation>GDB</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="28"/>
+        <source>The GDB Stub only works correctly when the CPU JIT is off.</source>
+        <translation>Le GDB Stub ne fonctionne correctement que lorsque le CPU JIT est désactivé.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="37"/>
+        <source>Enable GDB Stub</source>
+        <translation>Activer le GDB Stub</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="57"/>
+        <source>Port:</source>
+        <translation>Port:</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="14"/>
+        <source>Citra Configuration</source>
+        <translation>Configuration de Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="24"/>
+        <source>General</source>
+        <translation>Général</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="29"/>
+        <source>System</source>
+        <translation>Système</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="34"/>
+        <source>Input</source>
+        <translation>Contrôles</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="39"/>
+        <source>Graphics</source>
+        <translation>Graphiques</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="44"/>
+        <source>Audio</source>
+        <translation>Son</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="49"/>
+        <source>Debug</source>
+        <translation>Débug</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="54"/>
+        <source>Web</source>
+        <translation>Web</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureGeneral</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="14"/>
+        <source>Form</source>
+        <translation>Forme</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="22"/>
+        <source>General</source>
+        <translation>Général</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="30"/>
+        <source>Confirm exit while emulation is running</source>
+        <translation>Confirmer la fermeture du programme pendant l&apos;exécution de l&apos;émulation</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="37"/>
+        <source>Search sub-directories for games</source>
+        <translation>Rechercher des sous-dossiers pour les jeux</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="46"/>
+        <source>Interface language</source>
+        <translation>Langage de l&apos;interface</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="63"/>
+        <source>Updates</source>
+        <translation>Mises à Jour</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="71"/>
+        <source>Check for updates on start</source>
+        <translation>Vérifier les mises à jour au démarrage</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="78"/>
+        <source>Silently auto update after closing</source>
+        <translation>Mise à jour automatique après la fermeture</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="90"/>
+        <source>Performance</source>
+        <translation>Performance</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="98"/>
+        <source>Enable CPU JIT</source>
+        <translation>Activer le CPU JIT</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="110"/>
+        <source>Emulation</source>
+        <translation>Émulation</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="120"/>
+        <source>Region:</source>
+        <translation>Région:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="128"/>
+        <source>Auto-select</source>
+        <translation>Sélection Automatique</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="178"/>
+        <source>Theme</source>
+        <translation>Thème</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="188"/>
+        <source>Theme:</source>
+        <translation>Thème:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="205"/>
+        <source>Hotkeys</source>
+        <translation>Raccourcis</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.cpp" line="16"/>
+        <source>&lt;System&gt;</source>
+        <translation>&lt;System&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.cpp" line="17"/>
+        <source>English</source>
+        <translation>Anglais</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureGraphics</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="14"/>
+        <source>Form</source>
+        <translation>Forme</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="22"/>
+        <source>Graphics</source>
+        <translation>Graphiques</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="28"/>
+        <source>Enable hardware renderer</source>
+        <translation>Activer le rendu matériel</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="35"/>
+        <source>Enable shader JIT</source>
+        <translation>Activer le shader JIT</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="42"/>
+        <source>Enable V-Sync</source>
+        <translation>Activer le V-Sync</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="51"/>
+        <source>Limit Speed Percent</source>
+        <translation>Vitesse d&apos;émulation</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="58"/>
+        <source>%</source>
+        <translation>%</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="78"/>
+        <source>Internal Resolution:</source>
+        <translation>Résolution Interne:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="86"/>
+        <source>Auto (Window Size)</source>
+        <translation>Auto (Taille de la fenêtre)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="91"/>
+        <source>Native (400x240)</source>
+        <translation>Natif (400x240)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="96"/>
+        <source>2x Native (800x480)</source>
+        <translation>Natif x2 (800x480)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="101"/>
+        <source>3x Native (1200x720)</source>
+        <translation>Natif x3 (1200x720)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="106"/>
+        <source>4x Native (1600x960)</source>
+        <translation>Natif x4 (1600x960)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="111"/>
+        <source>5x Native (2000x1200)</source>
+        <translation>Natif x5 (2000x1200)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="116"/>
+        <source>6x Native (2400x1440)</source>
+        <translation>Natif x6 (2400x1440)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="121"/>
+        <source>7x Native (2800x1680)</source>
+        <translation>Natif x7 (2800x1680)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="126"/>
+        <source>8x Native (3200x1920)</source>
+        <translation>Natif x8 (3200x1920)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="131"/>
+        <source>9x Native (3600x2160)</source>
+        <translation>Natif x9 (3600x2160)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="136"/>
+        <source>10x Native (4000x2400)</source>
+        <translation>Natif x10 (4000x2400)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="151"/>
+        <source>Layout</source>
+        <translation>Disposition</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="161"/>
+        <source>Screen Layout:</source>
+        <translation>Disposition de l&apos;écran</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="169"/>
+        <source>Default</source>
+        <translation>Par défaut</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="174"/>
+        <source>Single Screen</source>
+        <translation>Un seul écran</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="179"/>
+        <source>Large Screen</source>
+        <translation>Écran large</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="184"/>
+        <source>Side by Side</source>
+        <translation>Côte à côte</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="194"/>
+        <source>Swap Screens</source>
+        <translation>Permuter les écrans</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureInput</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="14"/>
+        <source>ConfigureInput</source>
+        <translation>Configuration des contrôleurs</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="22"/>
+        <source>Face Buttons</source>
+        <translation>Boutons de contrôle</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="36"/>
+        <source>A:</source>
+        <translation>A</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="54"/>
+        <source>B:</source>
+        <translation>B</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="72"/>
+        <source>X:</source>
+        <translation>X</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="90"/>
+        <source>Y:</source>
+        <translation>Y</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="109"/>
+        <source>Directional Pad</source>
+        <translation>Pad directionnel</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="123"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="340"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="427"/>
+        <source>Up:</source>
+        <translation>Haut</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="141"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="358"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="445"/>
+        <source>Down:</source>
+        <translation>Bas:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="159"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="304"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="391"/>
+        <source>Left:</source>
+        <translation>Gauche</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="177"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="322"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="409"/>
+        <source>Right:</source>
+        <translation>Droit</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="196"/>
+        <source>Shoulder Buttons</source>
+        <translation>Boutons latéraux</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="210"/>
+        <source>L:</source>
+        <translation>L</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="228"/>
+        <source>R:</source>
+        <translation>R</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="246"/>
+        <source>ZL:</source>
+        <translation>ZL</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="264"/>
+        <source>ZR:</source>
+        <translation>ZR</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="283"/>
+        <source>Circle Pad</source>
+        <translation>Pad circulaire</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="295"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="461"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="232"/>
+        <source>Set Analog Stick</source>
+        <translation>Configurer le stick analogue</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="377"/>
+        <source>C-Stick</source>
+        <translation>Stick C</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="471"/>
+        <source>Misc.</source>
+        <translation>Divers</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="485"/>
+        <source>Start:</source>
+        <translation>Start</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="503"/>
+        <source>Select:</source>
+        <translation>Select</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="521"/>
+        <source>Home:</source>
+        <translation>Bouton Home</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="539"/>
+        <source>Circle Mod:</source>
+        <translation>Circle Mod:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="596"/>
+        <source>Restore Defaults</source>
+        <translation>Restaurer les paramètres par défaut</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="239"/>
+        <source>[press key]</source>
+        <translation>[appuyer sur une touche]</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureSystem</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="14"/>
+        <source>Form</source>
+        <translation>Forme</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="22"/>
+        <source>System Settings</source>
+        <translation>Paramètres système</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="28"/>
+        <source>Username</source>
+        <translation>Nom d&apos;utilisateur</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="48"/>
+        <source>Birthday</source>
+        <translation>Date de naissance</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="58"/>
+        <source>January</source>
+        <translation>Janvier</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="63"/>
+        <source>February</source>
+        <translation>Février </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="68"/>
+        <source>March</source>
+        <translation>Mars</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="73"/>
+        <source>April</source>
+        <translation>Avril</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="78"/>
+        <source>May</source>
+        <translation>Mai</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="83"/>
+        <source>June</source>
+        <translation>Juin</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="88"/>
+        <source>July</source>
+        <translation>Juillet</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="93"/>
+        <source>August</source>
+        <translation>Août </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="98"/>
+        <source>September</source>
+        <translation>Septembre</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="103"/>
+        <source>October</source>
+        <translation>Octobre</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="108"/>
+        <source>November</source>
+        <translation>Novembre</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="113"/>
+        <source>December</source>
+        <translation>Décembre</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="126"/>
+        <source>Language</source>
+        <translation>Langue</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="133"/>
+        <source>Note: this can be overridden when region setting is auto-select</source>
+        <translation>Note: ceci n&apos;est pas pris en compte quand le paramètre régional est défini sur Automatique</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="137"/>
+        <source>Japanese (日本語)</source>
+        <translation>Japonais (日本語)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="142"/>
+        <source>English</source>
+        <translation>Anglais</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="147"/>
+        <source>French (français)</source>
+        <translation>Français (français)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="152"/>
+        <source>German (Deutsch)</source>
+        <translation>Allemand (Deutsch)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="157"/>
+        <source>Italian (italiano)</source>
+        <translation>Italien (italiano)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="162"/>
+        <source>Spanish (español)</source>
+        <translation>Espagnol (español)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="167"/>
+        <source>Simplified Chinese (简体中文)</source>
+        <translation>Chinois simplifié (简体中文)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="172"/>
+        <source>Korean (한국어)</source>
+        <translation>Coréen (한국어)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="177"/>
+        <source>Dutch (Nederlands)</source>
+        <translation>Néerlandais (Nederlands)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="182"/>
+        <source>Portuguese (português)</source>
+        <translation>Portugais (português)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="187"/>
+        <source>Russian (Русский)</source>
+        <translation>Russe (Русский)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="192"/>
+        <source>Traditional Chinese (正體中文)</source>
+        <translation>Chinois traditionnel (正體中文)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="200"/>
+        <source>Sound output mode</source>
+        <translation>Mode de sortie audio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="208"/>
+        <source>Mono</source>
+        <translation>Mono</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="213"/>
+        <source>Stereo</source>
+        <translation>Stéreo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="218"/>
+        <source>Surround</source>
+        <translation>Surround </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="226"/>
+        <source>Console ID:</source>
+        <translation>ID de la console</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="242"/>
+        <source>Regenerate</source>
+        <translation>Régénérer </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="252"/>
+        <source>System settings are available only when game is not running.</source>
+        <translation>Les paramètres systèmes ne sont disponibles que lorsque l&apos;émulation n&apos;est pas en cours.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="87"/>
+        <source>Console ID: 0x%1</source>
+        <translation>ID console: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="160"/>
+        <source>This will replace your current virtual 3DS with a new one. Your current virtual 3DS will not be recoverable. This might have unexpected effects in games. This might fail, if you use an outdated config savegame. Continue?</source>
+        <translation>Ceci va remplacer votre 3DS virtuelle actuelle avec une nouvelle. Votre 3DS virtuelle actuelle ne sera plus récupérable. Cela pourrait avoir des effets inattendus pour certains jeux. Cela pourrait échouer, si vous utilisez une ancienne sauvegarde de jeu. Continuer?</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="164"/>
+        <source>Warning</source>
+        <translation>Avertissement</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureWeb</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="14"/>
+        <source>Form</source>
+        <translation>Forme</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="22"/>
+        <source>Citra Web Service</source>
+        <translation>Service web de Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="28"/>
+        <source>By providing your username and token, you agree to allow Citra to collect additional usage data, which may include user identifying information.</source>
+        <translation>En fournissant votre nom d&apos;utilisateur et votre jeton, vous acceptez d&apos;autoriser Citra à collecter des données d&apos;utilisation supplémentaires, qui peuvent inclure des informations d&apos;identification de l&apos;utilisateur.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="46"/>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="90"/>
+        <source>Verify</source>
+        <translation>Vérifier</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="53"/>
+        <source>Sign up</source>
+        <translation>S&apos;inscrire</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="67"/>
+        <source>Token: </source>
+        <translation>Token:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="78"/>
+        <source>Username: </source>
+        <translation>Nom d&apos;utilisateur</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="99"/>
+        <source>What is my token?</source>
+        <translation>Quel est mon token?</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="124"/>
+        <source>Telemetry</source>
+        <translation>Télémétrie</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="130"/>
+        <source>Share anonymous usage data with the Citra team</source>
+        <translation>Partage des données d&apos;utilisation anonymes avec l&apos;équipe Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="137"/>
+        <source>Learn more</source>
+        <translation>En savoir plus</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="146"/>
+        <source>Telemetry ID:</source>
+        <translation>ID de télémétrie:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="162"/>
+        <source>Regenerate</source>
+        <translation>Régénérer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="28"/>
+        <source>&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;En savoir plus&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="33"/>
+        <source>&lt;a href=&apos;https://services.citra-emu.org/&apos;&gt;Sign up&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://services.citra-emu.org/&apos;&gt;S&apos;inscrire&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="36"/>
+        <source>&lt;a href=&apos;https://citra-emu.org/wiki/citra-web-service/&apos;&gt;What is my token?&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://citra-emu.org/wiki/citra-web-service/&apos;&gt;Quel est mon token?&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="45"/>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="65"/>
+        <source>Telemetry ID: 0x%1</source>
+        <translation>ID de télémétrie: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="55"/>
+        <source>Username and token not verified</source>
+        <translation>Nom d&apos;utilisateur et jeton non vérifiés</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="56"/>
+        <source>Username and token were not verified. The changes to your username and/or token have not been saved.</source>
+        <translation>Le nom d&apos;utilisateur et le token n&apos;ont pas été vérifiés. Les modifications apportées à votre nom d&apos;utilisateur et / ou jeton n&apos;ont pas été enregistrées.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="85"/>
+        <source>Verifying</source>
+        <translation>Vérification en cours</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="99"/>
+        <source>Verification failed</source>
+        <translation>Échec de la vérification</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="100"/>
+        <source>Verification failed. Check that you have entered your username and token correctly, and that your internet connection is working.</source>
+        <translation>Échec de la vérification. Vérifiez que vous avez correctement entré votre nom d&apos;utilisateur et votre token, et que votre connexion Internet fonctionne.</translation>
+    </message>
+</context>
+<context>
+    <name>DirectConnect</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="14"/>
+        <source>Direct Connect</source>
+        <translation>Connexion Directe</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="33"/>
+        <source>IP Address</source>
+        <translation>Adresse IP</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="56"/>
+        <source>IP</source>
+        <translation>IP</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="63"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;IPv4 address of the host&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Adresse IPv4 de l&apos;hôte&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="73"/>
+        <source>Port</source>
+        <translation>Port</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="80"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Port number the host is listening on&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Numéro du port écouté par l&apos;hôte&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="86"/>
+        <source>24872</source>
+        <translation>24872</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="100"/>
+        <source>Nickname</source>
+        <translation>Pseudo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="114"/>
+        <source>Password</source>
+        <translation>Mot de passe</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="156"/>
+        <source>Connect</source>
+        <translation>Connecter</translation>
+    </message>
+</context>
+<context>
+    <name>DirectConnectWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="97"/>
+        <source>Connecting</source>
+        <translation>Connexion en cours</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="102"/>
+        <source>Connect</source>
+        <translation>Connecter</translation>
+    </message>
+</context>
+<context>
+    <name>GMainWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="90"/>
+        <source>To help improve Citra, the Citra Team collects anonymous usage data. No private or personally identifying information is collected. This data helps us to understand how people use Citra and prioritize our efforts. Furthermore, it helps us to more easily identify emulation bugs and performance issues. This data includes:&lt;ul&gt;&lt;li&gt;Information about the version of Citra you are using&lt;/li&gt;&lt;li&gt;Performance data about the games you play&lt;/li&gt;&lt;li&gt;Your configuration settings&lt;/li&gt;&lt;li&gt;Information about your computer hardware&lt;/li&gt;&lt;li&gt;Emulation errors and crash information&lt;/li&gt;&lt;/ul&gt;By default, this feature is enabled. To disable this feature, click &apos;Emulation&apos; from the menu and then select &apos;Configure...&apos;. Then, on the &apos;Web&apos; tab, uncheck &apos;Share anonymous usage data with the Citra team&apos;. &lt;br/&gt;&lt;br/&gt;By using this software, you agree to the above terms.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Pour aider à améliorer Citra, l&apos;équipe Citra collecte des données d&apos;utilisation anonymes. Aucune information privée ou d&apos;identification personnelle n&apos;est collectée. Ces données nous aident à comprendre comment les gens utilisent Citra et ainsi hiérarchiser nos efforts. De plus, cela nous aide à identifier plus facilement les bogues d&apos;émulation et les problèmes de performance. Ces données comprennent:&lt;ul&gt;&lt;li&gt;Informations sur la version de Citra que vous utilisez&lt;/li&gt;&lt;li&gt;Données de performance sur les jeux auxquels vous jouez&lt;/li&gt;&lt;li&gt;Vos paramètres de configuration&lt;/li&gt;&lt;li&gt;Informations sur la configuration matérielle de votre ordinateur&lt;/li&gt;&lt;li&gt;Informations sur les erreurs et crashes d&apos;émulation &lt;/li&gt;&lt;/ul&gt;Cette fonctionnalité est activée par défaut. Pour la désactiver, cliquez sur &quot;Émulation&quot; dans le menu, puis sélectionnez &quot;Configurer ...&quot;. Ensuite, dans l&apos;onglet &quot;Web&quot;, décochez &quot;Partager les données d&apos;utilisation anonymes avec l&apos;équipe Citra&quot;. &lt;br/&gt;&lt;br/&gt; En utilisant ce logiciel, vous acceptez les conditions ci-dessus.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;En savoir plus&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="195"/>
+        <source>Current emulation speed. Values higher or lower than 100% indicate emulation is running faster or slower than a 3DS.</source>
+        <translation>Vitesse actuelle d&apos;émulation. Les valeurs supérieures ou inférieures à 100% indiquent que l&apos;émulation est plus rapide ou plus lente qu&apos;une 3DS.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="198"/>
+        <source>How many frames per second the game is currently displaying. This will vary from game to game and scene to scene.</source>
+        <translation>Nombre d&apos;images par seconde le jeu affiche actuellement. Cela varie d&apos;un jeu à l&apos;autre et d&apos;une scène à l&apos;autre.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="202"/>
+        <source>Time taken to emulate a 3DS frame, not counting framelimiting or v-sync. For full-speed emulation this should be at most 16.67 ms.</source>
+        <translation>Temps nécessaire pour émuler une trame 3DS, sans compter la limitation de trame ou la synchronisation verticale V-Sync. Pour une émulation à pleine vitesse, cela ne devrait pas dépasser 16,67 ms.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="429"/>
+        <source>CTRL+F</source>
+        <translation>CTRL+F</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="538"/>
+        <source>Update available!</source>
+        <translation>Mise à jour disponible!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="539"/>
+        <source>An update for Citra is available. Do you wish to install it now?&lt;br /&gt;&lt;br /&gt;This &lt;b&gt;will&lt;/b&gt; terminate emulation, if it is running.</source>
+        <translation>Une mise à jour de Citra est disponible. Souhaitez-vous l&apos;installer maintenant?&lt;br /&gt;&lt;br /&gt;Ceci&lt;b&gt;va&lt;/b&gt;mettre fin à l&apos;émulation, si elle est en cours.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <source>No update found</source>
+        <translation>Aucune mise à jour trouvée</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <source>No update has been found for Citra.</source>
+        <translation>Aucune mise à jour n&apos;a été trouvée pour Citra.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="567"/>
+        <source>Error while initializing OpenGL 3.3 Core!</source>
+        <translation>Erreur lors de l&apos;initialisation de OpenGL 3.3!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="568"/>
+        <source>Your GPU may not support OpenGL 3.3, or you do not have the latest graphics driver.</source>
+        <translation>Votre GPU peut ne pas supporter OpenGL 3.3, ou vous n&apos;avez pas le dernier pilote graphique.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="581"/>
+        <location filename="../../src/citra_qt/main.cpp" line="587"/>
+        <location filename="../../src/citra_qt/main.cpp" line="593"/>
+        <location filename="../../src/citra_qt/main.cpp" line="606"/>
+        <location filename="../../src/citra_qt/main.cpp" line="625"/>
+        <source>Error while loading ROM!</source>
+        <translation>Erreur lors du chargement de la ROM!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="582"/>
+        <location filename="../../src/citra_qt/main.cpp" line="607"/>
+        <source>The ROM format is not supported.</source>
+        <translation>Le format de la ROM n&apos;est pas pris en charge.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="588"/>
+        <source>Could not determine the system mode.</source>
+        <translation>Impossible de déterminer le mode du système.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="594"/>
+        <source>The game that you are trying to load must be decrypted before being used with Citra. A real 3DS is required.&lt;br/&gt;&lt;br/&gt;For more information on dumping and decrypting games, please see the following wiki pages: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation>Le jeu que vous essayez de charger doit être décrypté avant d&apos;être utilisé avec Citra. Une 3DS est requise&lt;br/&gt;&lt;br/&gt;Pour plus d&apos;informations sur l&apos;extraction et le décryptage des jeux, veuillez consulter les pages wiki suivantes: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Extraction des cartouches de jeux&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Extraction des titres installés&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="612"/>
+        <source>An error occured in the video core.</source>
+        <translation>Une erreur est survenue dans le noyau vidéo.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="613"/>
+        <source>Citra has encountered an error while running the video core, please see the log for more details.For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.Ensure that you have the latest graphics drivers for your GPU.</source>
+        <translation>Citra a rencontré une erreur lors de l&apos;exécution du noyau vidéo, consultez le journal pour plus de détails. Pour plus d&apos;informations sur l&apos;accès au journal, consultez la page suivante: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;Comment télécharger le fichier journal&lt;/a&gt;. Assurez-vous d&apos;avoir les derniers pilotes graphiques pour votre GPU..</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="626"/>
+        <source>An unknown error occured. Please see the log for more details.</source>
+        <translation>Une erreur inconnue est survenue. Veuillez consulter le journal pour plus de détails.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="699"/>
+        <source>Start</source>
+        <translation>Démarrer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="790"/>
+        <source>Error Opening %1 Folder</source>
+        <translation>Erreur lors de l&apos;ouverture du dossier %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="791"/>
+        <source>Folder does not exist!</source>
+        <translation>Le répertoire n&apos;existe pas!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="805"/>
+        <source>3DS Executable</source>
+        <translation>Fichier exécutable 3DS</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="806"/>
+        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <source>All Files (*.*)</source>
+        <translation>Tous les fichiers (*.*)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="808"/>
+        <source>Load File</source>
+        <translation>Charger un fichier</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="818"/>
+        <source>Select Directory</source>
+        <translation>Sélectionner un répertoire </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="827"/>
+        <source>Load Files</source>
+        <translation>Charger les fichiers</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <source>3DS Installation File (*.CIA*)</source>
+        <translation>Fichier d&apos;installation 3DS (*.CIA*)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="859"/>
+        <source>%1 has been installed successfully.</source>
+        <translation>%1 a été installé avec succès.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="862"/>
+        <source>Unable to open File</source>
+        <translation>Impossible d&apos;ouvrir le fichier</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="863"/>
+        <source>Could not open %1</source>
+        <translation>Impossible d&apos;ouvrir %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="867"/>
+        <source>Installation aborted</source>
+        <translation>Installation annulée</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="868"/>
+        <source>The installation of %1 was aborted. Please see the log for more details</source>
+        <translation>L&apos;installation de %1 a été interrompue. Veuillez consulter le fichier journal pour plus de détails.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <source>Invalid File</source>
+        <translation>Fichier invalide</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <source>%1 is not a valid CIA</source>
+        <translation>%1 n&apos;est pas un CIA valide</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="875"/>
+        <source>Encrypted File</source>
+        <translation>Fichier encrypté</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="876"/>
+        <source>%1 must be decrypted before being used with Citra. A real 3DS is required.</source>
+        <translation>%1 doit être décrypté avant de fonctionner avec Citra. Une véritable 3DS est requise.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="899"/>
+        <source>File not found</source>
+        <translation>Fichier non trouvé</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="900"/>
+        <source>File &quot;%1&quot; not found</source>
+        <translation>Le fichier &quot;%1&quot; n&apos;a pas été trouvé</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="914"/>
+        <source>Continue</source>
+        <translation>Continuer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="939"/>
+        <source>Missing Citra Account</source>
+        <translation>Compte Citra manquant</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="940"/>
+        <source>In order to submit a game compatibility test case, you must link your Citra account.&lt;br&gt;&lt;br/&gt;To link your Citra account, go to Emulation &amp;gt; Configuration &amp;gt; Web.</source>
+        <translation>Pour pouvoir soumettre un case test de compatibilité pour un jeu, vous devez rattacher votre compte Citra.&lt;br&gt;&lt;br/&gt;Pour rattacher votre compte Citra , allez sur Emulation &amp;gt; Configuration &amp;gt; Web.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1090"/>
+        <source>Speed: %1% / %2%</source>
+        <translation>Vitesse: %1% / %2%</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1094"/>
+        <source>Speed: %1%</source>
+        <translation>Vitesse: %1%</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1096"/>
+        <source>Game: %1 FPS</source>
+        <translation>Jeux: %1 FPS</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1097"/>
+        <source>Frame: %1 ms</source>
+        <translation>Trame: %1 ms</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1108"/>
+        <source>The game you are trying to load requires additional files from your 3DS to be dumped before playing.&lt;br/&gt;&lt;br/&gt;For more information on dumping these files, please see the following wiki page: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
+        <translation>Le jeu que vous essayez de charger requiert que des fichiers supplémentaires soient extraits depuis votre 3DS avant de jouer.&lt;br/&gt;&lt;br/&gt;Pour plus d&apos;informations sur l&apos;extraction de ces fichiers, veuillez consulter la page wiki suivante: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Extraction des archives systèmes et des polices partagées depuis une console 3DS&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Voudriez-vous  revenir à la liste des jeux? Des crashes, des données corrompues ou d&apos;autres bogues pourraient survenir si vous choisissez de poursuivre l’émulation.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1120"/>
+        <source>: %1. </source>
+        <translation>: %1. </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1126"/>
+        <source>System Archive Not Found</source>
+        <translation>Archive système non trouvé</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1133"/>
+        <source>Citra was unable to locate the 3DS shared fonts. </source>
+        <translation>Citra n&apos;a pas pu localiser les polices partagées 3DS.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1135"/>
+        <source>Shared Fonts Not Found</source>
+        <translation>Polices partagées non trouvées.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1143"/>
+        <source>Fatal Error</source>
+        <translation>Erreur fatale</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1144"/>
+        <source>Citra has encountered a fatal error, please see the log for more details. For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
+        <translation>Citra a rencontré une erreur fatale, veuillez consulter le journal pour plus de détails. Pour plus d&apos;informations sur l&apos;accès au journal, veuillez consulter la page suivante:&lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;Comment télécharger le fichier journal.&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Voudriez-vous revenir à la liste des jeux? Des crashes, des données corrompues ou d&apos;autres bogues pourraient survenir si vous choisissez de poursuivre l’émulation.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1245"/>
+        <source>Citra</source>
+        <translation>Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <source>Are you sure you want to close Citra?</source>
+        <translation>Êtes-vous sûr de vouloir fermer Citra?</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1246"/>
+        <source>Are you sure you want to stop the emulation? Any unsaved progress will be lost.</source>
+        <translation>Êtes-vous sûr de vouloir arrêter l&apos;émulation? Tout progrès non enregistré sera perdu.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1318"/>
+        <source>Citra %1| %2-%3</source>
+        <translation>Citra %1| %2-%3</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandListModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="96"/>
+        <source>Command Name</source>
+        <translation>Nom de la commande</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="98"/>
+        <source>Register</source>
+        <translation>Registre</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="100"/>
+        <source>Mask</source>
+        <translation>Masque</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="102"/>
+        <source>New Value</source>
+        <translation>Nouvelle valeur</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandListWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="184"/>
+        <source>Pica Command List</source>
+        <translation>Liste de commande PICA</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="202"/>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="233"/>
+        <source>Start Tracing</source>
+        <translation>Commencer le traçage</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="203"/>
+        <source>Copy All</source>
+        <translation>Copier tout</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="229"/>
+        <source>Finish Tracing</source>
+        <translation>Arrêter le traçage</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandStreamWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics.cpp" line="67"/>
+        <source>Graphics Debugger</source>
+        <translation>Débogueur graphique</translation>
+    </message>
+</context>
+<context>
+    <name>GameList</name>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <source>Perfect</source>
+        <translation>Parfait</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <source>Game functions flawless with no audio or graphical glitches, all tested functionality works as intended without
+any workarounds needed.</source>
+        <translation>Le jeu fonctionne parfaitement sans bug audio ni graphique, toutes les fonctionnalités testées marchent comme prévu sans besoin de correctif. </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <source>Great</source>
+        <translation>Bien</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <source>Game functions with minor graphical or audio glitches and is playable from start to finish. May require some
+workarounds.</source>
+        <translation>Le jeu fonctionne avec des bugs audio ou graphiques mineurs et est jouable du début à la fin. Peut nécessiter certains ajustements.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <source>Okay</source>
+        <translation>Ok</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <source>Game functions with major graphical or audio glitches, but game is playable from start to finish with
+workarounds.</source>
+        <translation>Le jeu fonctionne avec des bugs audio ou graphiques majeurs, mais il est jouable du début à la fin avec des ajustements.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Bad</source>
+        <translation>Mauvais</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches
+even with workarounds.</source>
+        <translation>Le jeu fonctionne, mais avec des bugs audio ou graphiques majeurs. Impossible de se rendre dans certaines zones à cause des bugs même avec des ajustements.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <source>Intro/Menu</source>
+        <translation>Intro/Menu</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <source>Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start
+Screen.</source>
+        <translation>Le jeu est totalement injouable à cause de bugs graphiques ou audio majeurs. Impossible de dépasser l&apos;écran titre.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>Won&apos;t Boot</source>
+        <translation>Ne se lance pas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>The game crashes when attempting to startup.</source>
+        <translation>Le jeu plante au démarrage.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <source>Not Tested</source>
+        <translation>Non testé</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <source>The game has not yet been tested.</source>
+        <translation>Le jeu n&apos;a pas encore été testé.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="99"/>
+        <source>of</source>
+        <translation>sur</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="102"/>
+        <source>result</source>
+        <translation>résultat</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="104"/>
+        <source>results</source>
+        <translation>résultats</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="125"/>
+        <source>Filter:</source>
+        <translation>Filtre:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="128"/>
+        <source>Enter pattern to filter</source>
+        <translation>Entrer l&apos;élément de filtrage</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="324"/>
+        <source>Open Save Data Location</source>
+        <translation>Ouvrir l&apos;emplacement des données de sauvegarde</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
+        <source>Open Application Location</source>
+        <translation>Ouvrir l&apos;emplacement de l&apos;application</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
+        <source>Open Update Data Location</source>
+        <translation>Ouvrir l&apos;emplacement des données de mise à jour</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsBreakPointsWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="132"/>
+        <source>Pica Breakpoints</source>
+        <translation>Points d&apos;arrêt PICA</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="136"/>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="198"/>
+        <source>Emulation running</source>
+        <translation>Émulation en cours</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="137"/>
+        <source>Resume</source>
+        <translation>Reprendre</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="188"/>
+        <source>Emulation halted at breakpoint</source>
+        <translation>L&apos;émulation s&apos;est arrêtée au point d&apos;arrêt</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsSurfaceWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="49"/>
+        <source>Pica Surface Viewer</source>
+        <translation>Visionneuse de surface PICA</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="54"/>
+        <source>Color Buffer</source>
+        <translation>Tampon de couleur</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="55"/>
+        <source>Depth Buffer</source>
+        <translation>Tampon de profondeur</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="56"/>
+        <source>Stencil Buffer</source>
+        <translation>Template Buffer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="57"/>
+        <source>Texture 0</source>
+        <translation>Texture 0</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="58"/>
+        <source>Texture 1</source>
+        <translation>Texture 1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="59"/>
+        <source>Texture 2</source>
+        <translation>Texture 2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="60"/>
+        <source>Custom</source>
+        <translation>Custom</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="103"/>
+        <source>Unknown</source>
+        <translation>Inconnu</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="118"/>
+        <source>Save</source>
+        <translation>Enregistrer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="144"/>
+        <source>Source:</source>
+        <translation>Source:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="150"/>
+        <source>Physical Address:</source>
+        <translation>Adresse physique</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="156"/>
+        <source>Width:</source>
+        <translation>Largueur:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="162"/>
+        <source>Height:</source>
+        <translation>Hauteur:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="168"/>
+        <source>Format:</source>
+        <translation>Format</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="180"/>
+        <source>X:</source>
+        <translation>X:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="186"/>
+        <source>Y:</source>
+        <translation>Y:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="280"/>
+        <source>Pixel out of bounds</source>
+        <translation>Pixel hors champs</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="287"/>
+        <source>(unable to access pixel data)</source>
+        <translation>(impossible d&apos;accéder aux données pixels)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="555"/>
+        <source>(invalid surface address)</source>
+        <translation>(adresse de surface invalide)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="565"/>
+        <source>(unknown surface format)</source>
+        <translation>(format de surface inconnu)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="658"/>
+        <source>Portable Network Graphic (*.png)</source>
+        <translation>Portable Network Graphic (*.png)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="659"/>
+        <source>Binary data (*.bin)</source>
+        <translation>Données binaires (*.bin)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="663"/>
+        <source>Save Surface</source>
+        <translation>Sauvegarder la surface</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsTracingWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="25"/>
+        <source>CiTrace Recorder</source>
+        <translation>Enregistreur CiTrace </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="29"/>
+        <source>Start Recording</source>
+        <translation>Démarrer l&apos;enregistrement</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="31"/>
+        <source>Stop and Save</source>
+        <translation>Arrêter et enregistrer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="32"/>
+        <source>Abort Recording</source>
+        <translation>Stopper l&apos;enregistrement</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="112"/>
+        <source>Save CiTrace</source>
+        <translation>Sauvegarder CiTrace</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="113"/>
+        <source>CiTrace File (*.ctf)</source>
+        <translation>Fichier CiTrace (*.ctf)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="162"/>
+        <source>CiTracing still active</source>
+        <translation>CiTrace est actif</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="163"/>
+        <source>A CiTrace is still being recorded. Do you want to save it? If not, all recorded data will be discarded.</source>
+        <translation>Une instance CiTrace est en cours d&apos;enregistrement. Voulez vous sauvegarder ? Toutes les données non sauvegardées seront perdues.</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsVertexShaderModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="45"/>
+        <source>Offset</source>
+        <translation>Offset</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="47"/>
+        <source>Raw</source>
+        <translation>Raw</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="49"/>
+        <source>Disassembly</source>
+        <translation>Désassembleur </translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsVertexShaderWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="345"/>
+        <source>Save Shader Dump</source>
+        <translation>Sauvegarder les Shaders</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="345"/>
+        <source>Shader Binary (*.shbin)</source>
+        <translation>Fichier Shader Binaire (*.shbin)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="380"/>
+        <source>(data only available at vertex shader invocation breakpoints)</source>
+        <translation>(données uniquement disponibles aux points d&apos;arrêts de l&apos;invocation des vertex shaders)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="390"/>
+        <source>Dump</source>
+        <translation>Vidage</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="412"/>
+        <source>Input Data</source>
+        <translation>Données d&apos;entrées</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="426"/>
+        <source>Attribute %1</source>
+        <translation>Attribut %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="453"/>
+        <source>Cycle Index:</source>
+        <translation>Index du cycle:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="558"/>
+        <source>SRC1: %1, %2, %3, %4
+</source>
+        <translation>SRC1: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="564"/>
+        <source>SRC2: %1, %2, %3, %4
+</source>
+        <translation>SRC2: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="570"/>
+        <source>SRC3: %1, %2, %3, %4
+</source>
+        <translation>SRC3: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="576"/>
+        <source>DEST_IN: %1, %2, %3, %4
+</source>
+        <translation>DEST_IN: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="582"/>
+        <source>DEST_OUT: %1, %2, %3, %4
+</source>
+        <translation>DEST_OUT: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="589"/>
+        <source>Address Registers: %1, %2
+</source>
+        <translation>Adresse des Registres: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="593"/>
+        <source>Compare Result: %1, %2
+</source>
+        <translation>Comparer le résultat : %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="598"/>
+        <source>Static Condition: %1
+</source>
+        <translation>Condition Statique: %1
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="600"/>
+        <source>Dynamic Conditions: %1, %2
+</source>
+        <translation>Condition Dynamique: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="604"/>
+        <source>Loop Parameters: %1 (repeats), %2 (initializer), %3 (increment), %4
+</source>
+        <translation>Loop Parameters: %1 (repeats), %2 (initializer), %3 (increment), %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="611"/>
+        <source>Instruction offset: 0x%1</source>
+        <translation>Instruction offset: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="613"/>
+        <source> -&gt; 0x%2</source>
+        <translation>-&gt; 0x%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="615"/>
+        <source> (last instruction)</source>
+        <translation>(instruction précédente)</translation>
+    </message>
+</context>
+<context>
+    <name>HostRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="14"/>
+        <source>Create Room</source>
+        <translation>Créer un salon</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="37"/>
+        <source>Room Name</source>
+        <translation>Nom du salon</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="51"/>
+        <source>Preferred Game</source>
+        <translation>Jeu préféré</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="61"/>
+        <source>Max Players</source>
+        <translation>Nb Joueurs Max</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="91"/>
+        <source>Username</source>
+        <translation>Nom d&apos;utilisateur</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="101"/>
+        <source>(Leave blank for open game)</source>
+        <translation>(Laisser vide pour un jeu ouvert)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="118"/>
+        <source>Password</source>
+        <translation>Mot de passe</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="125"/>
+        <source>Port</source>
+        <translation>Port</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="156"/>
+        <source>Public</source>
+        <translation>Public</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="161"/>
+        <source>Unlisted</source>
+        <translation>Non listée</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="169"/>
+        <source>Host Room</source>
+        <translation>Héberger le salon</translation>
+    </message>
+</context>
+<context>
+    <name>Lobby</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="14"/>
+        <source>Public Room Browser</source>
+        <translation>Navigateur de salon public</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="32"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="39"/>
+        <source>Nickname</source>
+        <translation>Pseudo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="59"/>
+        <source>Filters</source>
+        <translation>Filtres</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="66"/>
+        <source>Search</source>
+        <translation>Rechercher</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="76"/>
+        <source>Games I Own</source>
+        <translation>Jeux que je possède</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="83"/>
+        <source>Hide Full Rooms</source>
+        <translation>Masquer les salons complets</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="103"/>
+        <source>Refresh Lobby</source>
+        <translation>Rafraîchir le hall</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <source>Password Required to Join</source>
+        <translation>Mot de passe nécessaire pour devenir membre</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <source>Password:</source>
+        <translation>Mot de passe:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="77"/>
+        <source>Password</source>
+        <translation>Mot de passe</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
+        <source>Room Name</source>
+        <translation>Nom du salon</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="143"/>
+        <source>Preferred Game</source>
+        <translation>Jeu préféré</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="144"/>
+        <source>Host</source>
+        <translation>Hôte</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="145"/>
+        <source>Players</source>
+        <translation>Joueurs</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="153"/>
+        <source>Refreshing</source>
+        <translation>Rafraîchissement</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="201"/>
+        <source>Refresh List</source>
+        <translation>Rafraîchir la liste</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="14"/>
+        <source>Citra</source>
+        <translation>Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="53"/>
+        <source>&amp;File</source>
+        <translation>&amp;Fichier</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="57"/>
+        <source>Recent Files</source>
+        <translation>Fichiers récents</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="70"/>
+        <source>&amp;Emulation</source>
+        <translation>&amp;Émulation</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="80"/>
+        <source>&amp;View</source>
+        <translation>&amp;Voir</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="84"/>
+        <source>Debugging</source>
+        <translation>Débogguer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="91"/>
+        <source>Screen Layout</source>
+        <translation>Disposition de l&apos;écran</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="115"/>
+        <source>Multiplayer</source>
+        <translation>Multijoueurs</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="126"/>
+        <source>&amp;Help</source>
+        <translation>&amp;Aide</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="144"/>
+        <source>Load File...</source>
+        <translation>Charger un fichier...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="149"/>
+        <source>Install CIA...</source>
+        <translation>Installer un fichier CIA...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="154"/>
+        <source>Load Symbol Map...</source>
+        <translation>Charger Configuration des Boutons...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="159"/>
+        <source>E&amp;xit</source>
+        <translation>A&amp;rrêter</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="167"/>
+        <source>&amp;Start</source>
+        <translation>&amp;Commencer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="175"/>
+        <source>&amp;Pause</source>
+        <translation>&amp;Pause</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="183"/>
+        <source>&amp;Stop</source>
+        <translation>&amp;Stop</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="188"/>
+        <source>FAQ</source>
+        <translation>FAQ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="193"/>
+        <source>About Citra</source>
+        <translation>À propos</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="201"/>
+        <source>Single Window Mode</source>
+        <translation>Mode fenêtre unique</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="206"/>
+        <source>Configure...</source>
+        <translation>Configurer...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="214"/>
+        <source>Display Dock Widget Headers</source>
+        <translation>Display Dock Widget Headers</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="222"/>
+        <source>Show Filter Bar</source>
+        <translation>Montrer la barre des Filtres</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="230"/>
+        <source>Show Status Bar</source>
+        <translation>Montrer la barre de Statut</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="235"/>
+        <source>Select Game Directory...</source>
+        <translation>Sélectionnez un dossier...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="238"/>
+        <source>Selects a folder to display in the game list</source>
+        <translation>Sélectionnez un dossier pour apparaître dans la liste</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="243"/>
+        <source>Create Pica Surface Viewer</source>
+        <translation>Créer une surface Pica</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="251"/>
+        <source>Browse Public Game Lobby</source>
+        <translation>Naviguer dans le hall de jeux publics</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="259"/>
+        <source>Create Room</source>
+        <translation>Créer un salon</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="267"/>
+        <source>Leave Room</source>
+        <translation>Quitter le salon</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="272"/>
+        <source>Direct Connect to Room</source>
+        <translation>Connexion directe à un salon</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="280"/>
+        <source>Show Current Room</source>
+        <translation>Afficher le salon actuel</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="288"/>
+        <source>Fullscreen</source>
+        <translation>Plein écran</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="293"/>
+        <source>Modify Citra Install</source>
+        <translation>Modifier l&apos;installation de Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="296"/>
+        <source>Opens the maintenance tool to modify your Citra installation</source>
+        <translation>Lancez l&apos;outil de maintenance pour modifier l&apos;installation de Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="304"/>
+        <source>Default</source>
+        <translation>Par défaut</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="312"/>
+        <source>Single Screen</source>
+        <translation>Un seul écran</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="320"/>
+        <source>Large Screen</source>
+        <translation>Écran large</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="328"/>
+        <source>Side by Side</source>
+        <translation>Côte à côte</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="336"/>
+        <source>Swap Screens</source>
+        <translation>Permuter les écrans</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="341"/>
+        <source>Check for Updates</source>
+        <translation>Rechercher les mises à jour</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="349"/>
+        <source>Report Compatibility</source>
+        <translation>Faire un rapport de compatibilité</translation>
+    </message>
+</context>
+<context>
+    <name>MicroProfileDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/profiler.cpp" line="50"/>
+        <source>MicroProfile</source>
+        <translation>Microprofile</translation>
+    </message>
+</context>
+<context>
+    <name>MultiplayerState</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="41"/>
+        <source>Current connection status</source>
+        <translation>État de la connexion</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="42"/>
+        <source>Not Connected. Click here to find a room!</source>
+        <translation>Vous n&apos;êtes pas connecté. Cliquez ici pour trouver un salon!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="100"/>
+        <source>Connected</source>
+        <translation>Connecté</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="105"/>
+        <source>Not Connected</source>
+        <translation>Non connecté</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="114"/>
+        <source>Error</source>
+        <translation>Erreur</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="115"/>
+        <source>Failed to announce the room to the public lobby. In order to host a room publicly, you must have a valid Citra account configured in Emulation -&gt; Configure -&gt; Web. If you do not want to publish a room in the public lobby, then select Unlisted instead.
+Debug Message: </source>
+        <translation>L&apos;introduction du salon dans le hall public a échoué. Pour héberger un salon public, vous devez configurer un compte Citra valide dans Emulation -&gt; Configure -&gt; Web. Si vous ne souhaitez pas publier un salon dans le hall public, choisissez Non Listé à la place.
+Message de debug:</translation>
+    </message>
+</context>
+<context>
+    <name>NetworkMessage</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="12"/>
+        <source>Username is not valid. Must be 4 to 20 alphanumeric characters.</source>
+        <translation>Nom d&apos;utilisateur invalide. Il doit comprendre entre 4 et 20 caractères alphanumériques.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="14"/>
+        <source>Room name is not valid. Must be 4 to 20 alphanumeric characters.</source>
+        <translation>Nom du salon invalide. Il doit comprendre de 4 à 20 caractères alphanumériques.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="16"/>
+        <source>Username is already in use. Please choose another.</source>
+        <translation>Nom d&apos;utilisateur déjà pris. Choisissez-en un autre.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="17"/>
+        <source>IP is not a valid IPv4 address.</source>
+        <translation>L&apos;IP n&apos;est pas une adresse IPv4 valide.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="18"/>
+        <source>Port must be a number between 0 to 65535.</source>
+        <translation>Le port doit être un nombre compris entre 0 et 65535.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="20"/>
+        <source>Unable to find an internet connection. Check your internet settings.</source>
+        <translation>Impossible d&apos;identifier un connexion internet. Vérifiez vos paramètres internet. </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="22"/>
+        <source>Unable to connect to the host. Verify that the connection settings are correct. If you still cannot connect, contact the room host and verify that the host is properly configured with the external port forwarded.</source>
+        <translation>Connexion à l&apos;hôte impossible. Vérifiez que les paramètres de connexion sont corrects. Si vous n&apos;arrivez toujours pas à vous connecter, contactez l&apos;hôte et vérifier que l&apos;hébergement est correctement configuré en particulier le routage du port externe.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="26"/>
+        <source>Creating a room failed. Please retry. Restarting Citra might be necessary.</source>
+        <translation>La création d&apos;un salon a échoué. Veuillez réessayer. Redémarrer Citra peut être nécessaire.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="28"/>
+        <source>The host of the room has banned you. Speak with the host to unban you or try a different room.</source>
+        <translation>L&apos;hôte du salon vous a banni. Parlez-lui pour qu&apos;il annule le bannissement ou essayez un autre salon.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="31"/>
+        <source>Version mismatch! Please update to the latest version of Citra. If the problem persists, contact the room host and ask them to update the server.</source>
+        <translation>Incompatibilité de version! Mettez à jour votre version de Citra. Si le problème persiste, contactez l&apos;hôte du salon et demandez-lui de mettre à jour le serveur.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="33"/>
+        <source>Incorrect password.</source>
+        <translation>Mot de passe incorrect.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="35"/>
+        <source>An unknown error occured. If this error continues to occur, please open an issue</source>
+        <translation>Une erreur inconnue est survenue. Si elle persiste, merci de signaler l&apos;incident.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="36"/>
+        <source>Connection to room lost. Try to reconnect.</source>
+        <translation>Connexion au salon perdue. Essayez de vous reconnecter.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="38"/>
+        <source>MAC address is already in use. Please choose another.</source>
+        <translation>Adresse MAC déjà utilisée. Choisissez-en une autre.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="52"/>
+        <source>Leave Room</source>
+        <translation>Quitter le salon</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="53"/>
+        <source>You are about to close the room. Any network connections will be closed.</source>
+        <translation>Vous êtes sur le point de fermer le salon. Toutes les connexions réseau vont être fermées.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="58"/>
+        <source>Disconnect</source>
+        <translation>Déconnecter</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="59"/>
+        <source>You are about to leave the room. Any network connections will be closed.</source>
+        <translation>Vous êtes sur le point de quitter le salon. Toutes les connexions réseau seront fermées.</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="47"/>
+        <source>Error</source>
+        <translation>Erreur</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="198"/>
+        <source>%1 is not playing a game</source>
+        <translation>%1 ne joue à aucun jeu</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="201"/>
+        <source>%1 is playing %2</source>
+        <translation>%1 joue à %2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="26"/>
+        <source>Shift</source>
+        <translation>Maj</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="28"/>
+        <source>Ctrl</source>
+        <translation>Ctrl</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="30"/>
+        <source>Alt</source>
+        <translation>Alt</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="51"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="75"/>
+        <source>[not set]</source>
+        <translation>[non défini]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="55"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="83"/>
+        <source>Joystick %1</source>
+        <translation>Joystick %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="57"/>
+        <source> Hat %1 %2</source>
+        <translation>Hat %1 %2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="61"/>
+        <source> Axis %1%2</source>
+        <translation>Axe %1%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="65"/>
+        <source> Button %1</source>
+        <translation>Boutton %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="69"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="91"/>
+        <source>[unknown]</source>
+        <translation>[inconnu]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="80"/>
+        <source>[unused]</source>
+        <translation>[inutilisé]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="85"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="87"/>
+        <source> Axis %1</source>
+        <translation>Axe %1</translation>
+    </message>
+</context>
+<context>
+    <name>RegistersWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="15"/>
+        <source>Registers</source>
+        <translation>Registres</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="16"/>
+        <source>VFP Registers</source>
+        <translation>VFP Registers</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="18"/>
+        <source>VFP System Registers</source>
+        <translation>VFP System Registers</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="167"/>
+        <source>Vector Length</source>
+        <translation>Vector Length</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="168"/>
+        <source>Vector Stride</source>
+        <translation>Vector Stride</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="169"/>
+        <source>Rounding Mode</source>
+        <translation>Rounding mode</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="182"/>
+        <source>Vector Iteration Count</source>
+        <translation>Vector Iteration Count</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeEvent</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="259"/>
+        <source>reset type = %1</source>
+        <translation>reset type = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeMutex</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="272"/>
+        <source>locked %1 times by thread:</source>
+        <translation>locked %1 times by thread: </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="275"/>
+        <source>free</source>
+        <translation>free</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeMutexList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="314"/>
+        <source>holding mutexes</source>
+        <translation>holding mutexes</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeObjectList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="128"/>
+        <source>waiting for all objects</source>
+        <translation>waiting for all objects</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="129"/>
+        <source>waiting for one of the following objects</source>
+        <translation>waiting for one of the following objects</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeSemaphore</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="288"/>
+        <source>available count = %1</source>
+        <translation>available count = 1%</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="289"/>
+        <source>max count = %1</source>
+        <translation>max count = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeThread</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="146"/>
+        <source>running</source>
+        <translation>running</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="149"/>
+        <source>ready</source>
+        <translation>ready</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="152"/>
+        <source>waiting for address 0x%1</source>
+        <translation>waiting for address 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="155"/>
+        <source>sleeping</source>
+        <translation>sleeping</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="158"/>
+        <source>waiting for IPC response</source>
+        <translation>waiting for IPC response</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="162"/>
+        <source>waiting for objects</source>
+        <translation>waiting for objects</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="165"/>
+        <source>waiting for HLE return</source>
+        <translation>waiting for HLE return</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="168"/>
+        <source>dormant</source>
+        <translation>en sommeil</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="171"/>
+        <source>dead</source>
+        <translation>dead</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="174"/>
+        <source> PC = 0x%1 LR = 0x%2</source>
+        <translation> PC = 0x%1 LR = 0x%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="214"/>
+        <source>default</source>
+        <translation>default </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="217"/>
+        <source>all</source>
+        <translation>all</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="220"/>
+        <source>AppCore</source>
+        <translation>AppCore</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="223"/>
+        <source>SysCore</source>
+        <translation>SysCore</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="226"/>
+        <source>Unknown processor %1</source>
+        <translation>Processeur inconnu %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="230"/>
+        <source>processor = %1</source>
+        <translation>processor = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="231"/>
+        <source>thread id = %1</source>
+        <translation>thread id = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="232"/>
+        <source>priority = %1(current) / %2(normal)</source>
+        <translation>priority = %1(current) / %2(normal)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="236"/>
+        <source>last running ticks = %1</source>
+        <translation>last running ticks = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="239"/>
+        <source>not holding mutex</source>
+        <translation>not holding mutex</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeThreadList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="328"/>
+        <source>waited by thread</source>
+        <translation>waited by thread</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeTimer</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="301"/>
+        <source>reset type = %1</source>
+        <translation>reset type = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="303"/>
+        <source>initial delay = %1</source>
+        <translation>initial delay = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="305"/>
+        <source>interval delay = %1</source>
+        <translation>interval delay = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeWaitObject</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="76"/>
+        <source>[%1]%2 %3</source>
+        <translation>[%1]%2 %3</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="104"/>
+        <source>waited by no thread</source>
+        <translation>waited by no thread</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="114"/>
+        <source>one shot</source>
+        <translation>one shot</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="116"/>
+        <source>sticky</source>
+        <translation>sticky</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="118"/>
+        <source>pulse</source>
+        <translation>pulse </translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="399"/>
+        <source>Wait Tree</source>
+        <translation>Arbre d&apos;instructions</translation>
+    </message>
+</context>
+<context>
+    <name>hotkeys</name>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="14"/>
+        <source>Hotkey Settings</source>
+        <translation>Réglages Raccourcis</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="27"/>
+        <source>Action</source>
+        <translation>Action</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="32"/>
+        <source>Hotkey</source>
+        <translation>Raccourcis</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="37"/>
+        <source>Context</source>
+        <translation>Contexte</translation>
+    </message>
+</context>
+</TS>

--- a/dist/languages/hu_HU.ts
+++ b/dist/languages/hu_HU.ts
@@ -1,0 +1,2750 @@
+<?xml version="1.0" ?><!DOCTYPE TS><TS language="hu_HU" version="2.1">
+<context>
+    <name>ARMRegisters</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="14"/>
+        <source>ARM Registers</source>
+        <translation>ARM Regisztrálók</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="25"/>
+        <source>Register</source>
+        <translation>Regsztráció</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="30"/>
+        <source>Value</source>
+        <translation>Érték</translation>
+    </message>
+</context>
+<context>
+    <name>AboutDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="14"/>
+        <source>About Citra</source>
+        <translation>A Citráról</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="30"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/citra.png&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/citra.png&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="60"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:28pt;&quot;&gt;Citra&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:28pt;&quot;&gt;Citra&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="73"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="86"/>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:12pt;&quot;&gt;Citra is a free and open source 3DS emulator licensed under GPLv2.0 or any later version.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'MS Shell Dlg 2'; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;This software should not be used to play games you have not legally obtained.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;Citra az egy nyílt-forráskódú 3DS emulátor a GPLv2.0 vagy bármelyik későbbi verzió alatt licenszelve.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;Ez a szoftver nem olyan játékok használatára szolgál, amire nem legálisan jutottál hozzá.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="118"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Website&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://community.citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Forum&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Source Code&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Contributors&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/blob/master/license.txt&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;License&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="134"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;&amp;quot;3DS&amp;quot; is a trademark of Nintendo. Citra is not affiliated with Nintendo in any way.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;&amp;quot;3DS&amp;quot; a Nintendo egyik védjegye. Citra semmiféle úton nincs kapcsolva a Nintendóhoz.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>BreakPointModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="34"/>
+        <source>Pica command loaded</source>
+        <translation>Pica parancs betöltve</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="35"/>
+        <source>Pica command processed</source>
+        <translation>Pica parancs feldolgozva</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="36"/>
+        <source>Incoming primitive batch</source>
+        <translation>Bejövő primitív tétel</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="37"/>
+        <source>Finished primitive batch</source>
+        <translation>Befejezett primitív tétel</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="38"/>
+        <source>Vertex shader invocation</source>
+        <translation>Vertex Shader invokáció</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="40"/>
+        <source>Incoming display transfer</source>
+        <translation>Bejövő megjelenítés átvitel</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="41"/>
+        <source>GSP command processed</source>
+        <translation>GSP parancs feldolgozva</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="42"/>
+        <source>Buffers swapped</source>
+        <translation>Pufferek cserélve</translation>
+    </message>
+</context>
+<context>
+    <name>ChatRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="14"/>
+        <source>Room Window</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="40"/>
+        <source>Send Chat Message</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="47"/>
+        <source>Send Message</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.cpp" line="81"/>
+        <source>Name</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.cpp" line="82"/>
+        <source>Game</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>ClientRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.ui" line="14"/>
+        <source>Room Window</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.ui" line="40"/>
+        <source>Leave Room</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>ClientRoomWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="54"/>
+        <source>Connected</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="65"/>
+        <source>Disconnected</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="78"/>
+        <source>%1 (%2/%3 members) - connected</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>CompatDB</name>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="20"/>
+        <source>Report Compatibility</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="27"/>
+        <location filename="../../src/citra_qt/compatdb.ui" line="63"/>
+        <source>Report Game Compatibility</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="36"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;Should you choose to submit a test case to the &lt;/span&gt;&lt;a href=&quot;https://citra-emu.org/game/&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;Citra Compatibility List&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;, The following information will be collected and displayed on the site:&lt;/span&gt;&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Hardware Information (CPU / GPU / Operating System)&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Which version of Citra you are running&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The connected Citra account&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="72"/>
+        <source>Perfect</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="79"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions flawlessly with no audio or graphical glitches.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="89"/>
+        <source>Great </source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="96"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions with minor graphical or audio glitches and is playable from start to finish. May require some workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="106"/>
+        <source>Okay</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="113"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions with major graphical or audio glitches, but game is playable from start to finish with workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="123"/>
+        <source>Bad</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="130"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches even with workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="140"/>
+        <source>Intro/Menu</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="147"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start Screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="157"/>
+        <source>Won&apos;t Boot</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="170"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The game crashes when attempting to startup.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="182"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Independent of speed or performance, how well does this game play from start to finish on this version of Citra?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="206"/>
+        <source>Thank you for your submission!</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>ConfigureAudio</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="10"/>
+        <source>Audio</source>
+        <translation>Hang</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="18"/>
+        <source>Output Engine:</source>
+        <translation>Kimeneti Motor:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="31"/>
+        <source>Enable audio stretching</source>
+        <translation>Hangnyújtás bekapcsolása</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="34"/>
+        <source>This post-processing effect adjusts audio speed to match emulation speed and helps prevent audio stutter. This however increases audio latency.</source>
+        <translation>Ez az utófeldolgozási hatás beállítja a hang sebességét, hogy az emuláció sebességével megegyezzen, és segít a hang-akadozás megakadályozásában. Azonban ez megnöveli a hang késleltetését.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="43"/>
+        <source>Audio Device:</source>
+        <translation>Hangeszköz:</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureDebug</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="14"/>
+        <source>Form</source>
+        <translation>Forma</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="22"/>
+        <source>GDB</source>
+        <translation>GDB</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="28"/>
+        <source>The GDB Stub only works correctly when the CPU JIT is off.</source>
+        <translation>A GDB Tuskó csak akkor működik megfelelően, ha a CPU JIT ki van kapcsolva.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="37"/>
+        <source>Enable GDB Stub</source>
+        <translation>GDB Tuskó bekapcsolása</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="57"/>
+        <source>Port:</source>
+        <translation>Port:</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="14"/>
+        <source>Citra Configuration</source>
+        <translation>Citra Konfiguráció</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="24"/>
+        <source>General</source>
+        <translation>Általános</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="29"/>
+        <source>System</source>
+        <translation>Rendszer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="34"/>
+        <source>Input</source>
+        <translation>Bevitel</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="39"/>
+        <source>Graphics</source>
+        <translation>Grafika</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="44"/>
+        <source>Audio</source>
+        <translation>Hang</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="49"/>
+        <source>Debug</source>
+        <translation>Debug</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="54"/>
+        <source>Web</source>
+        <translation>Web</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureGeneral</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="14"/>
+        <source>Form</source>
+        <translation>Forma</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="22"/>
+        <source>General</source>
+        <translation>Általános</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="30"/>
+        <source>Confirm exit while emulation is running</source>
+        <translation>Kilépés megerősítése amikor az emuláció fut</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="37"/>
+        <source>Search sub-directories for games</source>
+        <translation>Alkönyvtárak keresése játékokhoz</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="46"/>
+        <source>Interface language</source>
+        <translation>Kezelőfelület nyelve</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="63"/>
+        <source>Updates</source>
+        <translation>Frissítések</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="71"/>
+        <source>Check for updates on start</source>
+        <translation>Frissítések keresése induláskor</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="78"/>
+        <source>Silently auto update after closing</source>
+        <translation>Auto frissítés  a háttérben bezárás után</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="90"/>
+        <source>Performance</source>
+        <translation>Teljesítmény</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="98"/>
+        <source>Enable CPU JIT</source>
+        <translation>CPU JIT bekapcsolása</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="110"/>
+        <source>Emulation</source>
+        <translation>Emuláció</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="120"/>
+        <source>Region:</source>
+        <translation>Régió:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="128"/>
+        <source>Auto-select</source>
+        <translation>Autó-kiválasztás</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="178"/>
+        <source>Theme</source>
+        <translation>Téma</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="188"/>
+        <source>Theme:</source>
+        <translation>Téma:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="205"/>
+        <source>Hotkeys</source>
+        <translation>Gyorsbillentyűk:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.cpp" line="16"/>
+        <source>&lt;System&gt;</source>
+        <translation>&lt;System&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.cpp" line="17"/>
+        <source>English</source>
+        <translation>English</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureGraphics</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="14"/>
+        <source>Form</source>
+        <translation>Forma</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="22"/>
+        <source>Graphics</source>
+        <translation>Grafika</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="28"/>
+        <source>Enable hardware renderer</source>
+        <translation>Hardver renderer bekapcsolása</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="35"/>
+        <source>Enable shader JIT</source>
+        <translation>Shader JIT bekapcsolása</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="42"/>
+        <source>Enable V-Sync</source>
+        <translation>V-Sync bekapcsolása</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="51"/>
+        <source>Limit Speed Percent</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="58"/>
+        <source>%</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="78"/>
+        <source>Internal Resolution:</source>
+        <translation>Belső Felbontás:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="86"/>
+        <source>Auto (Window Size)</source>
+        <translation>Automatikus (ablakméret)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="91"/>
+        <source>Native (400x240)</source>
+        <translation>Natív (400x240)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="96"/>
+        <source>2x Native (800x480)</source>
+        <translation>2-szeres Natív (800x480)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="101"/>
+        <source>3x Native (1200x720)</source>
+        <translation>3-szoros Natív (1200x720)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="106"/>
+        <source>4x Native (1600x960)</source>
+        <translation>4-szeres Natív (1600x960)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="111"/>
+        <source>5x Native (2000x1200)</source>
+        <translation>5-szörös Natív (2000x1200)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="116"/>
+        <source>6x Native (2400x1440)</source>
+        <translation>6-szoros Natív (2400x1440)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="121"/>
+        <source>7x Native (2800x1680)</source>
+        <translation>7-szeres Natív (2800x1680)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="126"/>
+        <source>8x Native (3200x1920)</source>
+        <translation>8-szoros Natív (3200x1920)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="131"/>
+        <source>9x Native (3600x2160)</source>
+        <translation>9-szeres Natív (3600x2160)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="136"/>
+        <source>10x Native (4000x2400)</source>
+        <translation>10-szeres Natív (4000x2400)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="151"/>
+        <source>Layout</source>
+        <translation>Elrendezés</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="161"/>
+        <source>Screen Layout:</source>
+        <translation>Képernyő Elrendezése:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="169"/>
+        <source>Default</source>
+        <translation>Alapértelmezett</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="174"/>
+        <source>Single Screen</source>
+        <translation>Egy Képernyő</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="179"/>
+        <source>Large Screen</source>
+        <translation>Nagy Képernyő</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="184"/>
+        <source>Side by Side</source>
+        <translation>Egymás Mellett</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="194"/>
+        <source>Swap Screens</source>
+        <translation>Képernyők Cseréje</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureInput</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="14"/>
+        <source>ConfigureInput</source>
+        <translation>Bevitel Konfigurálása</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="22"/>
+        <source>Face Buttons</source>
+        <translation>Előlapi Gombok</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="36"/>
+        <source>A:</source>
+        <translation>A:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="54"/>
+        <source>B:</source>
+        <translation>B:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="72"/>
+        <source>X:</source>
+        <translation>X:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="90"/>
+        <source>Y:</source>
+        <translation>Y:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="109"/>
+        <source>Directional Pad</source>
+        <translation>Irányi pad</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="123"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="340"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="427"/>
+        <source>Up:</source>
+        <translation>Fel:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="141"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="358"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="445"/>
+        <source>Down:</source>
+        <translation>Le:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="159"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="304"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="391"/>
+        <source>Left:</source>
+        <translation>Balra:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="177"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="322"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="409"/>
+        <source>Right:</source>
+        <translation>Jobbra:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="196"/>
+        <source>Shoulder Buttons</source>
+        <translation>Hátsó Gombok</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="210"/>
+        <source>L:</source>
+        <translation>L:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="228"/>
+        <source>R:</source>
+        <translation>R:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="246"/>
+        <source>ZL:</source>
+        <translation>ZL:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="264"/>
+        <source>ZR:</source>
+        <translation>ZR:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="283"/>
+        <source>Circle Pad</source>
+        <translation>Körpad</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="295"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="461"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="232"/>
+        <source>Set Analog Stick</source>
+        <translation>Analóg Pad beállítása</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="377"/>
+        <source>C-Stick</source>
+        <translation>C-pad</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="471"/>
+        <source>Misc.</source>
+        <translation>Egyéb</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="485"/>
+        <source>Start:</source>
+        <translation>Start:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="503"/>
+        <source>Select:</source>
+        <translation>Select:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="521"/>
+        <source>Home:</source>
+        <translation>Home:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="539"/>
+        <source>Circle Mod:</source>
+        <translation>Kör Mod:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="596"/>
+        <source>Restore Defaults</source>
+        <translation>Visszaállítás Alapértelmezettre</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="239"/>
+        <source>[press key]</source>
+        <translation>[nyomj meg egy gombot]</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureSystem</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="14"/>
+        <source>Form</source>
+        <translation>Forma</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="22"/>
+        <source>System Settings</source>
+        <translation>Rendszer Beállítások</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="28"/>
+        <source>Username</source>
+        <translation>Felhasználónév</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="48"/>
+        <source>Birthday</source>
+        <translation>Születésnap</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="58"/>
+        <source>January</source>
+        <translation>Január</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="63"/>
+        <source>February</source>
+        <translation>Február</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="68"/>
+        <source>March</source>
+        <translation>Március</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="73"/>
+        <source>April</source>
+        <translation>Április</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="78"/>
+        <source>May</source>
+        <translation>Május</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="83"/>
+        <source>June</source>
+        <translation>Június</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="88"/>
+        <source>July</source>
+        <translation>Július</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="93"/>
+        <source>August</source>
+        <translation>Augusztus</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="98"/>
+        <source>September</source>
+        <translation>Szeptember</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="103"/>
+        <source>October</source>
+        <translation>Október</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="108"/>
+        <source>November</source>
+        <translation>November</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="113"/>
+        <source>December</source>
+        <translation>December</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="126"/>
+        <source>Language</source>
+        <translation>Nyelv</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="133"/>
+        <source>Note: this can be overridden when region setting is auto-select</source>
+        <translation>Megjegyzés: Ez felülírható ha a régió auto-kiválasztásra van beállítva</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="137"/>
+        <source>Japanese (日本語)</source>
+        <translation>Japán (日本語)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="142"/>
+        <source>English</source>
+        <translation>English</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="147"/>
+        <source>French (français)</source>
+        <translation>Francia (français)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="152"/>
+        <source>German (Deutsch)</source>
+        <translation>Német (Deutsch)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="157"/>
+        <source>Italian (italiano)</source>
+        <translation>Italian (Italiano)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="162"/>
+        <source>Spanish (español)</source>
+        <translation>Spanyol (español)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="167"/>
+        <source>Simplified Chinese (简体中文)</source>
+        <translation>Egyszerűsített Kínai (简体中文)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="172"/>
+        <source>Korean (한국어)</source>
+        <translation>Koreai (한국어)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="177"/>
+        <source>Dutch (Nederlands)</source>
+        <translation>Holland (Nederlands)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="182"/>
+        <source>Portuguese (português)</source>
+        <translation>Portugál (português)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="187"/>
+        <source>Russian (Русский)</source>
+        <translation>Russian (Русский)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="192"/>
+        <source>Traditional Chinese (正體中文)</source>
+        <translation>Hagyományos Kínai (正體中文)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="200"/>
+        <source>Sound output mode</source>
+        <translation>Hang kimeneteli mód</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="208"/>
+        <source>Mono</source>
+        <translation>Monó</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="213"/>
+        <source>Stereo</source>
+        <translation>Sztereó</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="218"/>
+        <source>Surround</source>
+        <translation>Surround</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="226"/>
+        <source>Console ID:</source>
+        <translation>Konzol ID:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="242"/>
+        <source>Regenerate</source>
+        <translation>Regenerálás</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="252"/>
+        <source>System settings are available only when game is not running.</source>
+        <translation>A rendszer-beállítások csak akkor érhetőek el, amikor a játék nem fut.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="87"/>
+        <source>Console ID: 0x%1</source>
+        <translation>Konzol ID: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="160"/>
+        <source>This will replace your current virtual 3DS with a new one. Your current virtual 3DS will not be recoverable. This might have unexpected effects in games. This might fail, if you use an outdated config savegame. Continue?</source>
+        <translation>Ez ki fogja cserélni a jelenlegi virtuális 3DS-edet egy újra. A jelenlegi virtuális 3DS-edetet ne lehet majd később visszaállítani. Ez lehet, hogy váratlan hatást okoz a játékokban. Ez lehet hogy nem fog sikerülni, ha egy elavult konfigurációs mentésfájlt használsz. Folytatod?</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="164"/>
+        <source>Warning</source>
+        <translation>Figyelem</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureWeb</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="14"/>
+        <source>Form</source>
+        <translation>Forma</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="22"/>
+        <source>Citra Web Service</source>
+        <translation>Citra Web-szolgáltatás</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="28"/>
+        <source>By providing your username and token, you agree to allow Citra to collect additional usage data, which may include user identifying information.</source>
+        <translation>A felhasználóneved és tokened megadásával, belegyezel abba, hogy a Citra használati adatokat gyűjtsön, ami felhasználó azonosító információt tartalmazhat.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="46"/>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="90"/>
+        <source>Verify</source>
+        <translation>Ellenőrzés</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="53"/>
+        <source>Sign up</source>
+        <translation>Regisztráció</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="67"/>
+        <source>Token: </source>
+        <translation>Token:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="78"/>
+        <source>Username: </source>
+        <translation>Felhasználónév:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="99"/>
+        <source>What is my token?</source>
+        <translation>Mi a tokenem?</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="124"/>
+        <source>Telemetry</source>
+        <translation>Telemetria</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="130"/>
+        <source>Share anonymous usage data with the Citra team</source>
+        <translation>Névtelen használati adat megosztása a Citra csapatával</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="137"/>
+        <source>Learn more</source>
+        <translation>Tudj meg többet</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="146"/>
+        <source>Telemetry ID:</source>
+        <translation>Telemetria ID:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="162"/>
+        <source>Regenerate</source>
+        <translation>Regeneráció</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="28"/>
+        <source>&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="33"/>
+        <source>&lt;a href=&apos;https://services.citra-emu.org/&apos;&gt;Sign up&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://services.citra-emu.org/&apos;&gt;Sign up&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="36"/>
+        <source>&lt;a href=&apos;https://citra-emu.org/wiki/citra-web-service/&apos;&gt;What is my token?&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://citra-emu.org/wiki/citra-web-service/&apos;&gt;What is my token?&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="45"/>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="65"/>
+        <source>Telemetry ID: 0x%1</source>
+        <translation>Telemetria ID: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="55"/>
+        <source>Username and token not verified</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="56"/>
+        <source>Username and token were not verified. The changes to your username and/or token have not been saved.</source>
+        <translation>A felhasználónév és token nem lett leellenőrizve. A felhasználóneveddel és/vagy a tokeneddel történt változások nem lettek elmentve.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="85"/>
+        <source>Verifying</source>
+        <translation>Ellenőrzés</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="99"/>
+        <source>Verification failed</source>
+        <translation>Ellenőrzés sikertelen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="100"/>
+        <source>Verification failed. Check that you have entered your username and token correctly, and that your internet connection is working.</source>
+        <translation>Ellenőrzés sikertelen. Ellenőrizd le hogy jól írtad-e a felhasználóneved és tokenedet, és hogy működik-e az internetkapcsolatod.</translation>
+    </message>
+</context>
+<context>
+    <name>DirectConnect</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="14"/>
+        <source>Direct Connect</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="33"/>
+        <source>IP Address</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="56"/>
+        <source>IP</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="63"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;IPv4 address of the host&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="73"/>
+        <source>Port</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="80"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Port number the host is listening on&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="86"/>
+        <source>24872</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="100"/>
+        <source>Nickname</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="114"/>
+        <source>Password</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="156"/>
+        <source>Connect</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>DirectConnectWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="97"/>
+        <source>Connecting</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="102"/>
+        <source>Connect</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>GMainWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="90"/>
+        <source>To help improve Citra, the Citra Team collects anonymous usage data. No private or personally identifying information is collected. This data helps us to understand how people use Citra and prioritize our efforts. Furthermore, it helps us to more easily identify emulation bugs and performance issues. This data includes:&lt;ul&gt;&lt;li&gt;Information about the version of Citra you are using&lt;/li&gt;&lt;li&gt;Performance data about the games you play&lt;/li&gt;&lt;li&gt;Your configuration settings&lt;/li&gt;&lt;li&gt;Information about your computer hardware&lt;/li&gt;&lt;li&gt;Emulation errors and crash information&lt;/li&gt;&lt;/ul&gt;By default, this feature is enabled. To disable this feature, click &apos;Emulation&apos; from the menu and then select &apos;Configure...&apos;. Then, on the &apos;Web&apos; tab, uncheck &apos;Share anonymous usage data with the Citra team&apos;. &lt;br/&gt;&lt;br/&gt;By using this software, you agree to the above terms.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
+        <translation>A Citra javulása érdekében a Citra Csapat névtelen használati adatokat gyűjt. Semmilyen privát vagy személyes azonosítási információ nem lesz begyűjtve. Ez az adat segít nekünk megérteni, hogy hogyan használják az emberek a Citrát, és hogy priorizáljuk erőfeszítéseinket. Továbbá, segít nekünk egyszerűbben észlelni az emulációs hibákat és teljesítménnyel kapcsolatos problémákat. Ezeket tartalmazza az adat: &lt;ul&gt;&lt;li&gt; Information about the version of Citra you are using&lt;/li&gt;&lt;li&gt;Performance data about the games you play&lt;/li&gt;&lt;li&gt;Your configuration settings&lt;/li&gt;&lt;li&gt;Information about your computer hardware&lt;/li&gt;&lt;li&gt;Emulation errors and crash information&lt;/li&gt;&lt;/ul&gt;Ez a funkció alapértelmezésül be van kapcsolva. Ha ki akarod kapcsolni ezt a funkciót, kattints az &quot;Emuláció&quot; gombra a menüből és válaszd ki a &quot;Konfiguráció...&quot; gombot. Ezután, a &quot;Web&quot; lapon, ürítsd ki a &quot;Névtelen használati adat megosztása a Citra csapatával&quot; négyzetet. &lt;br/&gt;&lt;br/&gt;Ennek a szoftvernek a használatával elfogadod a fenti feltételeket.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="195"/>
+        <source>Current emulation speed. Values higher or lower than 100% indicate emulation is running faster or slower than a 3DS.</source>
+        <translation>Jelenlegi emulációs sebesség. A 100%-nál nagyobb vagy kisebb értékek azt mutatják, hogy az emuláció egy 3DS-nél gyorsabban vagy lassabban fut.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="198"/>
+        <source>How many frames per second the game is currently displaying. This will vary from game to game and scene to scene.</source>
+        <translation>Mennyi képkocka/másodpercet jelez a játék jelenleg. Ez játékról játékra és helyszínről helyszínre változik.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="202"/>
+        <source>Time taken to emulate a 3DS frame, not counting framelimiting or v-sync. For full-speed emulation this should be at most 16.67 ms.</source>
+        <translation>Mennyi idő szükséges egy 3DS képkocka emulálásához, képkocka-limit vagy V-Syncet leszámítva. Teljes sebességű emulációnál ez maximum 16.67 ms-nek kéne lennie.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="429"/>
+        <source>CTRL+F</source>
+        <translation>CTRL+F</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="538"/>
+        <source>Update available!</source>
+        <translation>Frissítés elérhető!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="539"/>
+        <source>An update for Citra is available. Do you wish to install it now?&lt;br /&gt;&lt;br /&gt;This &lt;b&gt;will&lt;/b&gt; terminate emulation, if it is running.</source>
+        <translation>Egy frissítés elérhető a Citrához. Szeretnéd most feltelepíteni? &lt;br /&gt;&lt;br /&gt;Ez&lt;b&gt;meg fogja&lt;/b&gt; szakítani az emulációt, ha fut.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <source>No update found</source>
+        <translation>Nem található frissítés</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <source>No update has been found for Citra.</source>
+        <translation>Nem található frissítés a Citra számára.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="567"/>
+        <source>Error while initializing OpenGL 3.3 Core!</source>
+        <translation>Hiba az OpenGL 3.3 Mag indításakor!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="568"/>
+        <source>Your GPU may not support OpenGL 3.3, or you do not have the latest graphics driver.</source>
+        <translation>Lehet, hogy a videokártyád nem támogatja az OpenGL 3.3-mat, vagy nincs meg a legutóbbi grafikus illesztőprogramod.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="581"/>
+        <location filename="../../src/citra_qt/main.cpp" line="587"/>
+        <location filename="../../src/citra_qt/main.cpp" line="593"/>
+        <location filename="../../src/citra_qt/main.cpp" line="606"/>
+        <location filename="../../src/citra_qt/main.cpp" line="625"/>
+        <source>Error while loading ROM!</source>
+        <translation>Hiba a ROM betöltése közben!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="582"/>
+        <location filename="../../src/citra_qt/main.cpp" line="607"/>
+        <source>The ROM format is not supported.</source>
+        <translation>A ROM formátum nem támogatott.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="588"/>
+        <source>Could not determine the system mode.</source>
+        <translation>Nem lehet a rendszer módot meghatározni.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="594"/>
+        <source>The game that you are trying to load must be decrypted before being used with Citra. A real 3DS is required.&lt;br/&gt;&lt;br/&gt;For more information on dumping and decrypting games, please see the following wiki pages: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation>A játékot amit szeretnél betölteni, először vissza kell fejteni, mielőtt a Citrával lehetne használni. Ehhez egy igazi 3DS szükséges. &lt;br/&gt;&lt;br/&gt;A játékok dömpingélésével és visszafejtésével kapcsolatos információkért kérjük látogasd meg a következő wiki oldalakat: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt; Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="612"/>
+        <source>An error occured in the video core.</source>
+        <translation>Egy hiba történt a video magban.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="613"/>
+        <source>Citra has encountered an error while running the video core, please see the log for more details.For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.Ensure that you have the latest graphics drivers for your GPU.</source>
+        <translation>Citra egy hibába ütközött a video mag futása közben, kérjük nézd meg ezt a naplót több részletért. Több információért, hogy hogyan érd el a naplófájlt, kérjük nézd meg a következő oldalt: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;. Ellenőrizd, hogy a videokártyád számára a legújabb videokártya illesztőprogram van feltelepítve.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="626"/>
+        <source>An unknown error occured. Please see the log for more details.</source>
+        <translation>Egy ismeretlen hiba történt. Kérjük olvasd el a naplót több részletért.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="699"/>
+        <source>Start</source>
+        <translation>Indít</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="790"/>
+        <source>Error Opening %1 Folder</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="791"/>
+        <source>Folder does not exist!</source>
+        <translation>A mappa nem létezik!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="805"/>
+        <source>3DS Executable</source>
+        <translation>3DS Végrehajtható</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="806"/>
+        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <source>All Files (*.*)</source>
+        <translation>Minden fájl (*.*)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="808"/>
+        <source>Load File</source>
+        <translation>Fájl Betöltése</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="818"/>
+        <source>Select Directory</source>
+        <translation>Könyvtár Kiválasztása</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="827"/>
+        <source>Load Files</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <source>3DS Installation File (*.CIA*)</source>
+        <translation>3DS Telepítési Fájl (*.CIA*)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="859"/>
+        <source>%1 has been installed successfully.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="862"/>
+        <source>Unable to open File</source>
+        <translation>A fájl megnyitása sikertelen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="863"/>
+        <source>Could not open %1</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="867"/>
+        <source>Installation aborted</source>
+        <translation>Telepítés megszakítva</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="868"/>
+        <source>The installation of %1 was aborted. Please see the log for more details</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <source>Invalid File</source>
+        <translation>Ismeretlen Fájl</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <source>%1 is not a valid CIA</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="875"/>
+        <source>Encrypted File</source>
+        <translation>Titkosított Fájl</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="876"/>
+        <source>%1 must be decrypted before being used with Citra. A real 3DS is required.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="899"/>
+        <source>File not found</source>
+        <translation>A fájl nem található</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="900"/>
+        <source>File &quot;%1&quot; not found</source>
+        <translation>Fájl &quot;%1&quot; nem található</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="914"/>
+        <source>Continue</source>
+        <translation>Folytatás</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="939"/>
+        <source>Missing Citra Account</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="940"/>
+        <source>In order to submit a game compatibility test case, you must link your Citra account.&lt;br&gt;&lt;br/&gt;To link your Citra account, go to Emulation &amp;gt; Configuration &amp;gt; Web.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1090"/>
+        <source>Speed: %1% / %2%</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1094"/>
+        <source>Speed: %1%</source>
+        <translation>Sebesség: %1%</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1096"/>
+        <source>Game: %1 FPS</source>
+        <translation>Játék: %1 FPS</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1097"/>
+        <source>Frame: %1 ms</source>
+        <translation>Képkocka: %1 ms</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1108"/>
+        <source>The game you are trying to load requires additional files from your 3DS to be dumped before playing.&lt;br/&gt;&lt;br/&gt;For more information on dumping these files, please see the following wiki page: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
+        <translation>A játékot amit próbálsz betölteni, annak szüksége van további fájlokra a 3DS-edről, hogy dömpingelni tudd, mielőtt játszhatsz vele. &lt;br/&gt;&lt;br/&gt;Több információért, hogy hogyan dömpingeld ezeket a fájlokat, kérjük olvasd el a következő wiki oldalt:&lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Szeretnél visszalépni a játéklistára? Az emuláció folytatása összeomlással, hibás mentésadattal, vagy egyéb hibákkal járhat.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1120"/>
+        <source>: %1. </source>
+        <translation>: %1.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1126"/>
+        <source>System Archive Not Found</source>
+        <translation>Rendszerarchívum Nem Található</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1133"/>
+        <source>Citra was unable to locate the 3DS shared fonts. </source>
+        <translation>Citra nem volt képes a megosztott 3DS betűtípusokat megtalálni.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1135"/>
+        <source>Shared Fonts Not Found</source>
+        <translation>Megosztott Betűtípusok Nem Találhatóak</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1143"/>
+        <source>Fatal Error</source>
+        <translation>Kritikus Hiba</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1144"/>
+        <source>Citra has encountered a fatal error, please see the log for more details. For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
+        <translation>Citra egy kritikus hibába ütközött, kérjük olvasd el a naplót több részletért. Több információért, hogy hogyan érd el a naplót, kérjük olvasd el a következő oldalt: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Szeretnél visszalépni a játéklistára? Az emuláció folytatása összeomlással, hibás mentésadattal, vagy egyéb hibákkal járhat.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1245"/>
+        <source>Citra</source>
+        <translation>Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <source>Are you sure you want to close Citra?</source>
+        <translation>Biztos, hogy szeretnéd bezárni a Citrát?</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1246"/>
+        <source>Are you sure you want to stop the emulation? Any unsaved progress will be lost.</source>
+        <translation>Biztos, hogy meg akarod szakítani az emulációt? Bármilyen mentetlen állás elveszik.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1318"/>
+        <source>Citra %1| %2-%3</source>
+        <translation>Citra %1| %2-%3</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandListModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="96"/>
+        <source>Command Name</source>
+        <translation>Parancs Név</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="98"/>
+        <source>Register</source>
+        <translation>Regisztráció</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="100"/>
+        <source>Mask</source>
+        <translation>Maszk</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="102"/>
+        <source>New Value</source>
+        <translation>Új Érték</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandListWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="184"/>
+        <source>Pica Command List</source>
+        <translation>Pica Parancslista</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="202"/>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="233"/>
+        <source>Start Tracing</source>
+        <translation>Nyomkövetés indítása</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="203"/>
+        <source>Copy All</source>
+        <translation>Mind Másolása</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="229"/>
+        <source>Finish Tracing</source>
+        <translation>Nyomkövetés befejezése</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandStreamWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics.cpp" line="67"/>
+        <source>Graphics Debugger</source>
+        <translation>Grafikai Debugger</translation>
+    </message>
+</context>
+<context>
+    <name>GameList</name>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <source>Perfect</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <source>Game functions flawless with no audio or graphical glitches, all tested functionality works as intended without
+any workarounds needed.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <source>Great</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <source>Game functions with minor graphical or audio glitches and is playable from start to finish. May require some
+workarounds.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <source>Okay</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <source>Game functions with major graphical or audio glitches, but game is playable from start to finish with
+workarounds.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Bad</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches
+even with workarounds.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <source>Intro/Menu</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <source>Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start
+Screen.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>Won&apos;t Boot</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>The game crashes when attempting to startup.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <source>Not Tested</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <source>The game has not yet been tested.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="99"/>
+        <source>of</source>
+        <translation>ből</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="102"/>
+        <source>result</source>
+        <translation>eredmény</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="104"/>
+        <source>results</source>
+        <translation>eredmények</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="125"/>
+        <source>Filter:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="128"/>
+        <source>Enter pattern to filter</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="324"/>
+        <source>Open Save Data Location</source>
+        <translation>Mentésadat Helyének Megnyitása</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
+        <source>Open Application Location</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
+        <source>Open Update Data Location</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>GraphicsBreakPointsWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="132"/>
+        <source>Pica Breakpoints</source>
+        <translation>Pica Töréspontok</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="136"/>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="198"/>
+        <source>Emulation running</source>
+        <translation>Emuláció fut</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="137"/>
+        <source>Resume</source>
+        <translation>Folytatás</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="188"/>
+        <source>Emulation halted at breakpoint</source>
+        <translation>Emuláció a törésponton leállt</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsSurfaceWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="49"/>
+        <source>Pica Surface Viewer</source>
+        <translation>Pica Felülnézegető</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="54"/>
+        <source>Color Buffer</source>
+        <translation>Színpuffer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="55"/>
+        <source>Depth Buffer</source>
+        <translation>Mélységpuffer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="56"/>
+        <source>Stencil Buffer</source>
+        <translation>Patronpuffer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="57"/>
+        <source>Texture 0</source>
+        <translation>Textúra 0</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="58"/>
+        <source>Texture 1</source>
+        <translation>Textúra 1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="59"/>
+        <source>Texture 2</source>
+        <translation>Textúra 2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="60"/>
+        <source>Custom</source>
+        <translation>Egyéni</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="103"/>
+        <source>Unknown</source>
+        <translation>Ismeretlen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="118"/>
+        <source>Save</source>
+        <translation>Mentés</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="144"/>
+        <source>Source:</source>
+        <translation>Forrás:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="150"/>
+        <source>Physical Address:</source>
+        <translation>Fizikai Cím:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="156"/>
+        <source>Width:</source>
+        <translation>Szélesség:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="162"/>
+        <source>Height:</source>
+        <translation>Magasság:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="168"/>
+        <source>Format:</source>
+        <translation>Formátum:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="180"/>
+        <source>X:</source>
+        <translation>X:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="186"/>
+        <source>Y:</source>
+        <translation>Y:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="280"/>
+        <source>Pixel out of bounds</source>
+        <translation>Pixel a határokon kívül van</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="287"/>
+        <source>(unable to access pixel data)</source>
+        <translation>(pixeladat elérése sikertelen)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="555"/>
+        <source>(invalid surface address)</source>
+        <translation>(érvénytelen felszínadat)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="565"/>
+        <source>(unknown surface format)</source>
+        <translation>(ismeretlen felszínformátum)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="658"/>
+        <source>Portable Network Graphic (*.png)</source>
+        <translation>Hordozható Hálózati Grafika (*.png)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="659"/>
+        <source>Binary data (*.bin)</source>
+        <translation>Bináris adat (*.bin)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="663"/>
+        <source>Save Surface</source>
+        <translation>Felszín Elmentése</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsTracingWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="25"/>
+        <source>CiTrace Recorder</source>
+        <translation>CiTrace Felvevő</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="29"/>
+        <source>Start Recording</source>
+        <translation>Felvétel Indítása</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="31"/>
+        <source>Stop and Save</source>
+        <translation>Megállítás és Mentés</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="32"/>
+        <source>Abort Recording</source>
+        <translation>Felvétel Megszakítása</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="112"/>
+        <source>Save CiTrace</source>
+        <translation>CiTrace Mentése</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="113"/>
+        <source>CiTrace File (*.ctf)</source>
+        <translation>CiTrace Fájl (*.ctf)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="162"/>
+        <source>CiTracing still active</source>
+        <translation>CiTrace még mindig aktív</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="163"/>
+        <source>A CiTrace is still being recorded. Do you want to save it? If not, all recorded data will be discarded.</source>
+        <translation>Egy CiTrace még mindíg rögzül. Szeretnéd elmenteni? Ha nem, minden felvett adat el fog veszni.</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsVertexShaderModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="45"/>
+        <source>Offset</source>
+        <translation>Eltolás</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="47"/>
+        <source>Raw</source>
+        <translation>Dörzsölés</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="49"/>
+        <source>Disassembly</source>
+        <translation>Szétszerelés</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsVertexShaderWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="345"/>
+        <source>Save Shader Dump</source>
+        <translation>Shader Dump Elmentése</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="345"/>
+        <source>Shader Binary (*.shbin)</source>
+        <translation>Shader Bináris (*.shbin)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="380"/>
+        <source>(data only available at vertex shader invocation breakpoints)</source>
+        <translation>(adat csak a vertex shader invokáció töréspontjain elérhető)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="390"/>
+        <source>Dump</source>
+        <translation>Dump</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="412"/>
+        <source>Input Data</source>
+        <translation>Beviteli Adat</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="426"/>
+        <source>Attribute %1</source>
+        <translation>Attribútum %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="453"/>
+        <source>Cycle Index:</source>
+        <translation>Ciklus Index:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="558"/>
+        <source>SRC1: %1, %2, %3, %4
+</source>
+        <translation>SRC1: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="564"/>
+        <source>SRC2: %1, %2, %3, %4
+</source>
+        <translation>SRC2: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="570"/>
+        <source>SRC3: %1, %2, %3, %4
+</source>
+        <translation>SRC3: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="576"/>
+        <source>DEST_IN: %1, %2, %3, %4
+</source>
+        <translation>DEST_IN: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="582"/>
+        <source>DEST_OUT: %1, %2, %3, %4
+</source>
+        <translation>DEST_OUT: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="589"/>
+        <source>Address Registers: %1, %2
+</source>
+        <translation>Címregisztrációk: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="593"/>
+        <source>Compare Result: %1, %2
+</source>
+        <translation>Eredmény Összehasonlítása: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="598"/>
+        <source>Static Condition: %1
+</source>
+        <translation>Statikus Állapot: %1
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="600"/>
+        <source>Dynamic Conditions: %1, %2
+</source>
+        <translation>Dinamikus Állapotok: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="604"/>
+        <source>Loop Parameters: %1 (repeats), %2 (initializer), %3 (increment), %4
+</source>
+        <translation>Loop Paraméterek: %1 (ismétlések), %2 (inicializáló), %3 (lépés), %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="611"/>
+        <source>Instruction offset: 0x%1</source>
+        <translation>Instrukció eltolás: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="613"/>
+        <source> -&gt; 0x%2</source>
+        <translation> -&gt; 0x%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="615"/>
+        <source> (last instruction)</source>
+        <translation>(utolsó instrukció)</translation>
+    </message>
+</context>
+<context>
+    <name>HostRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="14"/>
+        <source>Create Room</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="37"/>
+        <source>Room Name</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="51"/>
+        <source>Preferred Game</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="61"/>
+        <source>Max Players</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="91"/>
+        <source>Username</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="101"/>
+        <source>(Leave blank for open game)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="118"/>
+        <source>Password</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="125"/>
+        <source>Port</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="156"/>
+        <source>Public</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="161"/>
+        <source>Unlisted</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="169"/>
+        <source>Host Room</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>Lobby</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="14"/>
+        <source>Public Room Browser</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="32"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="39"/>
+        <source>Nickname</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="59"/>
+        <source>Filters</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="66"/>
+        <source>Search</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="76"/>
+        <source>Games I Own</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="83"/>
+        <source>Hide Full Rooms</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="103"/>
+        <source>Refresh Lobby</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <source>Password Required to Join</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <source>Password:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="77"/>
+        <source>Password</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
+        <source>Room Name</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="143"/>
+        <source>Preferred Game</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="144"/>
+        <source>Host</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="145"/>
+        <source>Players</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="153"/>
+        <source>Refreshing</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="201"/>
+        <source>Refresh List</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="14"/>
+        <source>Citra</source>
+        <translation>Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="53"/>
+        <source>&amp;File</source>
+        <translation>&amp;Fájl</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="57"/>
+        <source>Recent Files</source>
+        <translation>Legutóbbi Fájlok</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="70"/>
+        <source>&amp;Emulation</source>
+        <translation>&amp;Emuláció</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="80"/>
+        <source>&amp;View</source>
+        <translation>&amp;Nézet</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="84"/>
+        <source>Debugging</source>
+        <translation>Hibakeresés</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="91"/>
+        <source>Screen Layout</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="115"/>
+        <source>Multiplayer</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="126"/>
+        <source>&amp;Help</source>
+        <translation>&amp;Segítség</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="144"/>
+        <source>Load File...</source>
+        <translation>Fájl Betöltése...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="149"/>
+        <source>Install CIA...</source>
+        <translation>CIA Telepítése...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="154"/>
+        <source>Load Symbol Map...</source>
+        <translation>Szimbólumtérkép Betöltése...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="159"/>
+        <source>E&amp;xit</source>
+        <translation>&amp;Kilépés</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="167"/>
+        <source>&amp;Start</source>
+        <translation>&amp;Indítás</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="175"/>
+        <source>&amp;Pause</source>
+        <translation>&amp;Szünet</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="183"/>
+        <source>&amp;Stop</source>
+        <translation>&amp;Megállítás</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="188"/>
+        <source>FAQ</source>
+        <translation>Gyakori Kérdések</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="193"/>
+        <source>About Citra</source>
+        <translation>A Citráról</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="201"/>
+        <source>Single Window Mode</source>
+        <translation>Egyablakos Mód</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="206"/>
+        <source>Configure...</source>
+        <translation>Konfiguráció...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="214"/>
+        <source>Display Dock Widget Headers</source>
+        <translation>Dokk Modul Fejlécek Megjelenítése</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="222"/>
+        <source>Show Filter Bar</source>
+        <translation>Filtersáv Megjelenítése</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="230"/>
+        <source>Show Status Bar</source>
+        <translation>Állapotsáv Megjelenítése</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="235"/>
+        <source>Select Game Directory...</source>
+        <translation>Játékkönyvtár Kiválasztása...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="238"/>
+        <source>Selects a folder to display in the game list</source>
+        <translation>Egy mappát választ ki, amely megjelenik a játéklistában</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="243"/>
+        <source>Create Pica Surface Viewer</source>
+        <translation>Pica Felülnézegető Létrehozása</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="251"/>
+        <source>Browse Public Game Lobby</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="259"/>
+        <source>Create Room</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="267"/>
+        <source>Leave Room</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="272"/>
+        <source>Direct Connect to Room</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="280"/>
+        <source>Show Current Room</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="288"/>
+        <source>Fullscreen</source>
+        <translation>Teljes Képernyő</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="293"/>
+        <source>Modify Citra Install</source>
+        <translation>Citra Telepítés Módosítása</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="296"/>
+        <source>Opens the maintenance tool to modify your Citra installation</source>
+        <translation>Megnyitja a karbantartási eszközt, amivel a Citra telepítést módosíthatod</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="304"/>
+        <source>Default</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="312"/>
+        <source>Single Screen</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="320"/>
+        <source>Large Screen</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="328"/>
+        <source>Side by Side</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="336"/>
+        <source>Swap Screens</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="341"/>
+        <source>Check for Updates</source>
+        <translation>Frissítések Keresése</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="349"/>
+        <source>Report Compatibility</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>MicroProfileDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/profiler.cpp" line="50"/>
+        <source>MicroProfile</source>
+        <translation>MicroProfil</translation>
+    </message>
+</context>
+<context>
+    <name>MultiplayerState</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="41"/>
+        <source>Current connection status</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="42"/>
+        <source>Not Connected. Click here to find a room!</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="100"/>
+        <source>Connected</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="105"/>
+        <source>Not Connected</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="114"/>
+        <source>Error</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="115"/>
+        <source>Failed to announce the room to the public lobby. In order to host a room publicly, you must have a valid Citra account configured in Emulation -&gt; Configure -&gt; Web. If you do not want to publish a room in the public lobby, then select Unlisted instead.
+Debug Message: </source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>NetworkMessage</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="12"/>
+        <source>Username is not valid. Must be 4 to 20 alphanumeric characters.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="14"/>
+        <source>Room name is not valid. Must be 4 to 20 alphanumeric characters.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="16"/>
+        <source>Username is already in use. Please choose another.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="17"/>
+        <source>IP is not a valid IPv4 address.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="18"/>
+        <source>Port must be a number between 0 to 65535.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="20"/>
+        <source>Unable to find an internet connection. Check your internet settings.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="22"/>
+        <source>Unable to connect to the host. Verify that the connection settings are correct. If you still cannot connect, contact the room host and verify that the host is properly configured with the external port forwarded.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="26"/>
+        <source>Creating a room failed. Please retry. Restarting Citra might be necessary.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="28"/>
+        <source>The host of the room has banned you. Speak with the host to unban you or try a different room.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="31"/>
+        <source>Version mismatch! Please update to the latest version of Citra. If the problem persists, contact the room host and ask them to update the server.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="33"/>
+        <source>Incorrect password.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="35"/>
+        <source>An unknown error occured. If this error continues to occur, please open an issue</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="36"/>
+        <source>Connection to room lost. Try to reconnect.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="38"/>
+        <source>MAC address is already in use. Please choose another.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="52"/>
+        <source>Leave Room</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="53"/>
+        <source>You are about to close the room. Any network connections will be closed.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="58"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="59"/>
+        <source>You are about to leave the room. Any network connections will be closed.</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="47"/>
+        <source>Error</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="198"/>
+        <source>%1 is not playing a game</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="201"/>
+        <source>%1 is playing %2</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="26"/>
+        <source>Shift</source>
+        <translation>Shift</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="28"/>
+        <source>Ctrl</source>
+        <translation>Ctrl</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="30"/>
+        <source>Alt</source>
+        <translation>Alt</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="51"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="75"/>
+        <source>[not set]</source>
+        <translation>[nincs megadva]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="55"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="83"/>
+        <source>Joystick %1</source>
+        <translation>Joystick %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="57"/>
+        <source> Hat %1 %2</source>
+        <translation>Fej %1 %2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="61"/>
+        <source> Axis %1%2</source>
+        <translation>Tengely %1%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="65"/>
+        <source> Button %1</source>
+        <translation>Gomb %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="69"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="91"/>
+        <source>[unknown]</source>
+        <translation>[ismeretlen]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="80"/>
+        <source>[unused]</source>
+        <translation>[nem használt]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="85"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="87"/>
+        <source> Axis %1</source>
+        <translation>Tengely %1</translation>
+    </message>
+</context>
+<context>
+    <name>RegistersWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="15"/>
+        <source>Registers</source>
+        <translation>Regisztrációk</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="16"/>
+        <source>VFP Registers</source>
+        <translation>VFP Regsztrációk</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="18"/>
+        <source>VFP System Registers</source>
+        <translation>VFP Rendszer-regisztrációk</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="167"/>
+        <source>Vector Length</source>
+        <translation>Vektorhossz</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="168"/>
+        <source>Vector Stride</source>
+        <translation>Vector Lépés</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="169"/>
+        <source>Rounding Mode</source>
+        <translation>Kerekítési Mód</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="182"/>
+        <source>Vector Iteration Count</source>
+        <translation>Vektor Ismétlés Száma</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeEvent</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="259"/>
+        <source>reset type = %1</source>
+        <translation>típus visszaállítása = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeMutex</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="272"/>
+        <source>locked %1 times by thread:</source>
+        <translation>szálak által lezárva %1 alkalommal:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="275"/>
+        <source>free</source>
+        <translation>szabad</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeMutexList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="314"/>
+        <source>holding mutexes</source>
+        <translation>mutexek tartása</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeObjectList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="128"/>
+        <source>waiting for all objects</source>
+        <translation>várakozás minden objektumra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="129"/>
+        <source>waiting for one of the following objects</source>
+        <translation>várakozás valamelyik objektumra</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeSemaphore</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="288"/>
+        <source>available count = %1</source>
+        <translation>elérhető szám = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="289"/>
+        <source>max count = %1</source>
+        <translation>maximális szám = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeThread</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="146"/>
+        <source>running</source>
+        <translation>futás</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="149"/>
+        <source>ready</source>
+        <translation>kész</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="152"/>
+        <source>waiting for address 0x%1</source>
+        <translation>várakozás a 0x%1 címre</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="155"/>
+        <source>sleeping</source>
+        <translation>alvás</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="158"/>
+        <source>waiting for IPC response</source>
+        <translation>várakozás IPC válaszra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="162"/>
+        <source>waiting for objects</source>
+        <translation>várakozás objektumokra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="165"/>
+        <source>waiting for HLE return</source>
+        <translation>várakozás HLE visszatérésre</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="168"/>
+        <source>dormant</source>
+        <translation>alvó</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="171"/>
+        <source>dead</source>
+        <translation>halott</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="174"/>
+        <source> PC = 0x%1 LR = 0x%2</source>
+        <translation> PC = 0x%1 LR = 0x%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="214"/>
+        <source>default</source>
+        <translation>alapértelmezett</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="217"/>
+        <source>all</source>
+        <translation>mind</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="220"/>
+        <source>AppCore</source>
+        <translation>AlkalmazásMag</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="223"/>
+        <source>SysCore</source>
+        <translation>RendszerMag</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="226"/>
+        <source>Unknown processor %1</source>
+        <translation>Ismeretlen processzor %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="230"/>
+        <source>processor = %1</source>
+        <translation>processzor = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="231"/>
+        <source>thread id = %1</source>
+        <translation>szál id = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="232"/>
+        <source>priority = %1(current) / %2(normal)</source>
+        <translation>prioritás = %1(jelenlegi) / %2(normál)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="236"/>
+        <source>last running ticks = %1</source>
+        <translation>utolsó futó tickek = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="239"/>
+        <source>not holding mutex</source>
+        <translation>mutexek nincsenek tartva</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeThreadList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="328"/>
+        <source>waited by thread</source>
+        <translation>várakozás a száltól</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeTimer</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="301"/>
+        <source>reset type = %1</source>
+        <translation>típus visszaállítása = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="303"/>
+        <source>initial delay = %1</source>
+        <translation>kezdeti késleltetés = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="305"/>
+        <source>interval delay = %1</source>
+        <translation>intervallum késleltetés = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeWaitObject</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="76"/>
+        <source>[%1]%2 %3</source>
+        <translation>[%1]%2 %3</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="104"/>
+        <source>waited by no thread</source>
+        <translation>semmilyen száltól várakozás</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="114"/>
+        <source>one shot</source>
+        <translation>egy lövés</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="116"/>
+        <source>sticky</source>
+        <translation>ragacsos</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="118"/>
+        <source>pulse</source>
+        <translation>pulzus</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="399"/>
+        <source>Wait Tree</source>
+        <translation>Várakozási Fa</translation>
+    </message>
+</context>
+<context>
+    <name>hotkeys</name>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="14"/>
+        <source>Hotkey Settings</source>
+        <translation>Gyorsbillentyű-beállítások</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="27"/>
+        <source>Action</source>
+        <translation>Művelet</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="32"/>
+        <source>Hotkey</source>
+        <translation>Gyorsbillentyű</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="37"/>
+        <source>Context</source>
+        <translation>Kontextus</translation>
+    </message>
+</context>
+</TS>

--- a/dist/languages/hu_HU.ts
+++ b/dist/languages/hu_HU.ts
@@ -154,17 +154,17 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ClientRoomWindow</name>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="54"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="55"/>
         <source>Connected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="65"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="63"/>
         <source>Disconnected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="78"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="76"/>
         <source>%1 (%2/%3 members) - connected</source>
         <translation type="unfinished"/>
     </message>
@@ -312,6 +312,26 @@ p, li { white-space: pre-wrap; }
         <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="57"/>
         <source>Port:</source>
         <translation>Port:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="78"/>
+        <source>Logging</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="86"/>
+        <source>Global Log Filter</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="100"/>
+        <source>Show Log Console (Windows Only)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="107"/>
+        <source>Open Log Location</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1100,12 +1120,12 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DirectConnectWindow</name>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="97"/>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="103"/>
         <source>Connecting</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="102"/>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="108"/>
         <source>Connect</source>
         <translation type="unfinished"/>
     </message>
@@ -1113,289 +1133,289 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GMainWindow</name>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="90"/>
+        <location filename="../../src/citra_qt/main.cpp" line="92"/>
         <source>To help improve Citra, the Citra Team collects anonymous usage data. No private or personally identifying information is collected. This data helps us to understand how people use Citra and prioritize our efforts. Furthermore, it helps us to more easily identify emulation bugs and performance issues. This data includes:&lt;ul&gt;&lt;li&gt;Information about the version of Citra you are using&lt;/li&gt;&lt;li&gt;Performance data about the games you play&lt;/li&gt;&lt;li&gt;Your configuration settings&lt;/li&gt;&lt;li&gt;Information about your computer hardware&lt;/li&gt;&lt;li&gt;Emulation errors and crash information&lt;/li&gt;&lt;/ul&gt;By default, this feature is enabled. To disable this feature, click &apos;Emulation&apos; from the menu and then select &apos;Configure...&apos;. Then, on the &apos;Web&apos; tab, uncheck &apos;Share anonymous usage data with the Citra team&apos;. &lt;br/&gt;&lt;br/&gt;By using this software, you agree to the above terms.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
         <translation>A Citra javulása érdekében a Citra Csapat névtelen használati adatokat gyűjt. Semmilyen privát vagy személyes azonosítási információ nem lesz begyűjtve. Ez az adat segít nekünk megérteni, hogy hogyan használják az emberek a Citrát, és hogy priorizáljuk erőfeszítéseinket. Továbbá, segít nekünk egyszerűbben észlelni az emulációs hibákat és teljesítménnyel kapcsolatos problémákat. Ezeket tartalmazza az adat: &lt;ul&gt;&lt;li&gt; Information about the version of Citra you are using&lt;/li&gt;&lt;li&gt;Performance data about the games you play&lt;/li&gt;&lt;li&gt;Your configuration settings&lt;/li&gt;&lt;li&gt;Information about your computer hardware&lt;/li&gt;&lt;li&gt;Emulation errors and crash information&lt;/li&gt;&lt;/ul&gt;Ez a funkció alapértelmezésül be van kapcsolva. Ha ki akarod kapcsolni ezt a funkciót, kattints az &quot;Emuláció&quot; gombra a menüből és válaszd ki a &quot;Konfiguráció...&quot; gombot. Ezután, a &quot;Web&quot; lapon, ürítsd ki a &quot;Névtelen használati adat megosztása a Citra csapatával&quot; négyzetet. &lt;br/&gt;&lt;br/&gt;Ennek a szoftvernek a használatával elfogadod a fenti feltételeket.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="195"/>
+        <location filename="../../src/citra_qt/main.cpp" line="199"/>
         <source>Current emulation speed. Values higher or lower than 100% indicate emulation is running faster or slower than a 3DS.</source>
         <translation>Jelenlegi emulációs sebesség. A 100%-nál nagyobb vagy kisebb értékek azt mutatják, hogy az emuláció egy 3DS-nél gyorsabban vagy lassabban fut.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="198"/>
+        <location filename="../../src/citra_qt/main.cpp" line="202"/>
         <source>How many frames per second the game is currently displaying. This will vary from game to game and scene to scene.</source>
         <translation>Mennyi képkocka/másodpercet jelez a játék jelenleg. Ez játékról játékra és helyszínről helyszínre változik.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="202"/>
+        <location filename="../../src/citra_qt/main.cpp" line="206"/>
         <source>Time taken to emulate a 3DS frame, not counting framelimiting or v-sync. For full-speed emulation this should be at most 16.67 ms.</source>
         <translation>Mennyi idő szükséges egy 3DS képkocka emulálásához, képkocka-limit vagy V-Syncet leszámítva. Teljes sebességű emulációnál ez maximum 16.67 ms-nek kéne lennie.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="429"/>
+        <location filename="../../src/citra_qt/main.cpp" line="434"/>
         <source>CTRL+F</source>
         <translation>CTRL+F</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="538"/>
+        <location filename="../../src/citra_qt/main.cpp" line="543"/>
         <source>Update available!</source>
         <translation>Frissítés elérhető!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="539"/>
+        <location filename="../../src/citra_qt/main.cpp" line="544"/>
         <source>An update for Citra is available. Do you wish to install it now?&lt;br /&gt;&lt;br /&gt;This &lt;b&gt;will&lt;/b&gt; terminate emulation, if it is running.</source>
         <translation>Egy frissítés elérhető a Citrához. Szeretnéd most feltelepíteni? &lt;br /&gt;&lt;br /&gt;Ez&lt;b&gt;meg fogja&lt;/b&gt; szakítani az emulációt, ha fut.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <location filename="../../src/citra_qt/main.cpp" line="555"/>
         <source>No update found</source>
         <translation>Nem található frissítés</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <location filename="../../src/citra_qt/main.cpp" line="555"/>
         <source>No update has been found for Citra.</source>
         <translation>Nem található frissítés a Citra számára.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="567"/>
+        <location filename="../../src/citra_qt/main.cpp" line="572"/>
         <source>Error while initializing OpenGL 3.3 Core!</source>
         <translation>Hiba az OpenGL 3.3 Mag indításakor!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="568"/>
+        <location filename="../../src/citra_qt/main.cpp" line="573"/>
         <source>Your GPU may not support OpenGL 3.3, or you do not have the latest graphics driver.</source>
         <translation>Lehet, hogy a videokártyád nem támogatja az OpenGL 3.3-mat, vagy nincs meg a legutóbbi grafikus illesztőprogramod.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="581"/>
-        <location filename="../../src/citra_qt/main.cpp" line="587"/>
-        <location filename="../../src/citra_qt/main.cpp" line="593"/>
-        <location filename="../../src/citra_qt/main.cpp" line="606"/>
-        <location filename="../../src/citra_qt/main.cpp" line="625"/>
+        <location filename="../../src/citra_qt/main.cpp" line="586"/>
+        <location filename="../../src/citra_qt/main.cpp" line="592"/>
+        <location filename="../../src/citra_qt/main.cpp" line="598"/>
+        <location filename="../../src/citra_qt/main.cpp" line="611"/>
+        <location filename="../../src/citra_qt/main.cpp" line="630"/>
         <source>Error while loading ROM!</source>
         <translation>Hiba a ROM betöltése közben!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="582"/>
-        <location filename="../../src/citra_qt/main.cpp" line="607"/>
+        <location filename="../../src/citra_qt/main.cpp" line="587"/>
+        <location filename="../../src/citra_qt/main.cpp" line="612"/>
         <source>The ROM format is not supported.</source>
         <translation>A ROM formátum nem támogatott.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="588"/>
+        <location filename="../../src/citra_qt/main.cpp" line="593"/>
         <source>Could not determine the system mode.</source>
         <translation>Nem lehet a rendszer módot meghatározni.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="594"/>
+        <location filename="../../src/citra_qt/main.cpp" line="599"/>
         <source>The game that you are trying to load must be decrypted before being used with Citra. A real 3DS is required.&lt;br/&gt;&lt;br/&gt;For more information on dumping and decrypting games, please see the following wiki pages: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</source>
         <translation>A játékot amit szeretnél betölteni, először vissza kell fejteni, mielőtt a Citrával lehetne használni. Ehhez egy igazi 3DS szükséges. &lt;br/&gt;&lt;br/&gt;A játékok dömpingélésével és visszafejtésével kapcsolatos információkért kérjük látogasd meg a következő wiki oldalakat: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt; Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="612"/>
+        <location filename="../../src/citra_qt/main.cpp" line="617"/>
         <source>An error occured in the video core.</source>
         <translation>Egy hiba történt a video magban.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="613"/>
+        <location filename="../../src/citra_qt/main.cpp" line="618"/>
         <source>Citra has encountered an error while running the video core, please see the log for more details.For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.Ensure that you have the latest graphics drivers for your GPU.</source>
         <translation>Citra egy hibába ütközött a video mag futása közben, kérjük nézd meg ezt a naplót több részletért. Több információért, hogy hogyan érd el a naplófájlt, kérjük nézd meg a következő oldalt: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;. Ellenőrizd, hogy a videokártyád számára a legújabb videokártya illesztőprogram van feltelepítve.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="626"/>
+        <location filename="../../src/citra_qt/main.cpp" line="631"/>
         <source>An unknown error occured. Please see the log for more details.</source>
         <translation>Egy ismeretlen hiba történt. Kérjük olvasd el a naplót több részletért.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="699"/>
+        <location filename="../../src/citra_qt/main.cpp" line="704"/>
         <source>Start</source>
         <translation>Indít</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="790"/>
+        <location filename="../../src/citra_qt/main.cpp" line="795"/>
         <source>Error Opening %1 Folder</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="791"/>
+        <location filename="../../src/citra_qt/main.cpp" line="796"/>
         <source>Folder does not exist!</source>
         <translation>A mappa nem létezik!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="805"/>
+        <location filename="../../src/citra_qt/main.cpp" line="810"/>
         <source>3DS Executable</source>
         <translation>3DS Végrehajtható</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="806"/>
-        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <location filename="../../src/citra_qt/main.cpp" line="811"/>
+        <location filename="../../src/citra_qt/main.cpp" line="833"/>
         <source>All Files (*.*)</source>
         <translation>Minden fájl (*.*)</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="808"/>
+        <location filename="../../src/citra_qt/main.cpp" line="813"/>
         <source>Load File</source>
         <translation>Fájl Betöltése</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="818"/>
+        <location filename="../../src/citra_qt/main.cpp" line="823"/>
         <source>Select Directory</source>
         <translation>Könyvtár Kiválasztása</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="827"/>
+        <location filename="../../src/citra_qt/main.cpp" line="832"/>
         <source>Load Files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <location filename="../../src/citra_qt/main.cpp" line="833"/>
         <source>3DS Installation File (*.CIA*)</source>
         <translation>3DS Telepítési Fájl (*.CIA*)</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="859"/>
+        <location filename="../../src/citra_qt/main.cpp" line="864"/>
         <source>%1 has been installed successfully.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="862"/>
+        <location filename="../../src/citra_qt/main.cpp" line="867"/>
         <source>Unable to open File</source>
         <translation>A fájl megnyitása sikertelen</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="863"/>
+        <location filename="../../src/citra_qt/main.cpp" line="868"/>
         <source>Could not open %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="867"/>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
         <source>Installation aborted</source>
         <translation>Telepítés megszakítva</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="868"/>
+        <location filename="../../src/citra_qt/main.cpp" line="873"/>
         <source>The installation of %1 was aborted. Please see the log for more details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <location filename="../../src/citra_qt/main.cpp" line="877"/>
         <source>Invalid File</source>
         <translation>Ismeretlen Fájl</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <location filename="../../src/citra_qt/main.cpp" line="877"/>
         <source>%1 is not a valid CIA</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="875"/>
+        <location filename="../../src/citra_qt/main.cpp" line="880"/>
         <source>Encrypted File</source>
         <translation>Titkosított Fájl</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="876"/>
+        <location filename="../../src/citra_qt/main.cpp" line="881"/>
         <source>%1 must be decrypted before being used with Citra. A real 3DS is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="899"/>
+        <location filename="../../src/citra_qt/main.cpp" line="904"/>
         <source>File not found</source>
         <translation>A fájl nem található</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="900"/>
+        <location filename="../../src/citra_qt/main.cpp" line="905"/>
         <source>File &quot;%1&quot; not found</source>
         <translation>Fájl &quot;%1&quot; nem található</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="914"/>
+        <location filename="../../src/citra_qt/main.cpp" line="919"/>
         <source>Continue</source>
         <translation>Folytatás</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="939"/>
+        <location filename="../../src/citra_qt/main.cpp" line="944"/>
         <source>Missing Citra Account</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="940"/>
+        <location filename="../../src/citra_qt/main.cpp" line="945"/>
         <source>In order to submit a game compatibility test case, you must link your Citra account.&lt;br&gt;&lt;br/&gt;To link your Citra account, go to Emulation &amp;gt; Configuration &amp;gt; Web.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1090"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1095"/>
         <source>Speed: %1% / %2%</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1094"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1099"/>
         <source>Speed: %1%</source>
         <translation>Sebesség: %1%</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1096"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1101"/>
         <source>Game: %1 FPS</source>
         <translation>Játék: %1 FPS</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1097"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1102"/>
         <source>Frame: %1 ms</source>
         <translation>Képkocka: %1 ms</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1108"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1113"/>
         <source>The game you are trying to load requires additional files from your 3DS to be dumped before playing.&lt;br/&gt;&lt;br/&gt;For more information on dumping these files, please see the following wiki page: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
         <translation>A játékot amit próbálsz betölteni, annak szüksége van további fájlokra a 3DS-edről, hogy dömpingelni tudd, mielőtt játszhatsz vele. &lt;br/&gt;&lt;br/&gt;Több információért, hogy hogyan dömpingeld ezeket a fájlokat, kérjük olvasd el a következő wiki oldalt:&lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Szeretnél visszalépni a játéklistára? Az emuláció folytatása összeomlással, hibás mentésadattal, vagy egyéb hibákkal járhat.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1120"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1125"/>
         <source>: %1. </source>
         <translation>: %1.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1126"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1131"/>
         <source>System Archive Not Found</source>
         <translation>Rendszerarchívum Nem Található</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1133"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1138"/>
         <source>Citra was unable to locate the 3DS shared fonts. </source>
         <translation>Citra nem volt képes a megosztott 3DS betűtípusokat megtalálni.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1135"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1140"/>
         <source>Shared Fonts Not Found</source>
         <translation>Megosztott Betűtípusok Nem Találhatóak</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1143"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1148"/>
         <source>Fatal Error</source>
         <translation>Kritikus Hiba</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1144"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1149"/>
         <source>Citra has encountered a fatal error, please see the log for more details. For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
         <translation>Citra egy kritikus hibába ütközött, kérjük olvasd el a naplót több részletért. Több információért, hogy hogyan érd el a naplót, kérjük olvasd el a következő oldalt: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Szeretnél visszalépni a játéklistára? Az emuláció folytatása összeomlással, hibás mentésadattal, vagy egyéb hibákkal járhat.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
-        <location filename="../../src/citra_qt/main.cpp" line="1245"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1183"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1250"/>
         <source>Citra</source>
         <translation>Citra</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1183"/>
         <source>Are you sure you want to close Citra?</source>
         <translation>Biztos, hogy szeretnéd bezárni a Citrát?</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1246"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1251"/>
         <source>Are you sure you want to stop the emulation? Any unsaved progress will be lost.</source>
         <translation>Biztos, hogy meg akarod szakítani az emulációt? Bármilyen mentetlen állás elveszik.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1318"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1323"/>
         <source>Citra %1| %2-%3</source>
         <translation>Citra %1| %2-%3</translation>
     </message>
@@ -1458,77 +1478,77 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GameList</name>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="117"/>
         <source>Perfect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="117"/>
         <source>Game functions flawless with no audio or graphical glitches, all tested functionality works as intended without
 any workarounds needed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="118"/>
         <source>Great</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="118"/>
         <source>Game functions with minor graphical or audio glitches and is playable from start to finish. May require some
 workarounds.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="119"/>
         <source>Okay</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="119"/>
         <source>Game functions with major graphical or audio glitches, but game is playable from start to finish with
 workarounds.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="120"/>
         <source>Bad</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="120"/>
         <source>Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches
 even with workarounds.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="121"/>
         <source>Intro/Menu</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="121"/>
         <source>Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start
 Screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="122"/>
         <source>Won&apos;t Boot</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="122"/>
         <source>The game crashes when attempting to startup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="123"/>
         <source>Not Tested</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="123"/>
         <source>The game has not yet been tested.</source>
         <translation type="unfinished"/>
     </message>
@@ -1558,17 +1578,17 @@ Screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="324"/>
+        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
         <source>Open Save Data Location</source>
         <translation>Mentésadat Helyének Megnyitása</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
+        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
         <source>Open Application Location</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
+        <location filename="../../src/citra_qt/game_list.cpp" line="327"/>
         <source>Open Update Data Location</source>
         <translation type="unfinished"/>
     </message>
@@ -2001,47 +2021,42 @@ Screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="73"/>
         <source>Password Required to Join</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="74"/>
         <source>Password:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="77"/>
-        <source>Password</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="139"/>
         <source>Room Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="143"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="140"/>
         <source>Preferred Game</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="144"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="141"/>
         <source>Host</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="145"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
         <source>Players</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="153"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="150"/>
         <source>Refreshing</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="201"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="198"/>
         <source>Refresh List</source>
         <translation type="unfinished"/>
     </message>
@@ -2404,6 +2419,57 @@ Debug Message: </source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="201"/>
         <source>%1 is playing %2</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="208"/>
+        <source>Invalid region</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Japan</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>North America</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="92"/>
+        <source>Europe</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="94"/>
+        <source>Australia</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="96"/>
+        <source>China</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="98"/>
+        <source>Korea</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="100"/>
+        <source>Taiwan</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="102"/>
+        <source>Region free</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="104"/>
+        <source>Invalid Region</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/dist/languages/id.ts
+++ b/dist/languages/id.ts
@@ -1,0 +1,2750 @@
+<?xml version="1.0" ?><!DOCTYPE TS><TS language="id" version="2.1">
+<context>
+    <name>ARMRegisters</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="14"/>
+        <source>ARM Registers</source>
+        <translation>Register ARM</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="25"/>
+        <source>Register</source>
+        <translation>Register</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="30"/>
+        <source>Value</source>
+        <translation>Nilai</translation>
+    </message>
+</context>
+<context>
+    <name>AboutDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="14"/>
+        <source>About Citra</source>
+        <translation>Tentang Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="30"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/citra.png&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/citra.png&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="60"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:28pt;&quot;&gt;Citra&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:28pt;&quot;&gt;Citra&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="73"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="86"/>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:12pt;&quot;&gt;Citra is a free and open source 3DS emulator licensed under GPLv2.0 or any later version.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'MS Shell Dlg 2'; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;This software should not be used to play games you have not legally obtained.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;Citra adalah emulator 3DS gratis dan open source dengan lisensi GPLv2.0 atau versi setelahnya.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;Software ini tidak digunakan untuk memainkan game yang didapatkan secara tidak legal.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="118"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Website&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://community.citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Forum&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Source Code&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Contributors&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/blob/master/license.txt&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;License&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="134"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;&amp;quot;3DS&amp;quot; is a trademark of Nintendo. Citra is not affiliated with Nintendo in any way.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;&amp;quot;3DS&amp;quot; adalah merek dagang dari Nintendo. Citra tidak berafiliasi dengan Nintendo dengan cara apapun.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>BreakPointModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="34"/>
+        <source>Pica command loaded</source>
+        <translation>Perintah Pica dimuat</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="35"/>
+        <source>Pica command processed</source>
+        <translation>Perintah Pica diproses</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="36"/>
+        <source>Incoming primitive batch</source>
+        <translation>Batch primitif masuk</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="37"/>
+        <source>Finished primitive batch</source>
+        <translation>Batch primitif selesai</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="38"/>
+        <source>Vertex shader invocation</source>
+        <translation>Menjalankan Vertex shader</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="40"/>
+        <source>Incoming display transfer</source>
+        <translation>Transfer tampilan masuk</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="41"/>
+        <source>GSP command processed</source>
+        <translation>Perintah GSP diproses</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="42"/>
+        <source>Buffers swapped</source>
+        <translation>Buffer ditukar</translation>
+    </message>
+</context>
+<context>
+    <name>ChatRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="14"/>
+        <source>Room Window</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="40"/>
+        <source>Send Chat Message</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="47"/>
+        <source>Send Message</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.cpp" line="81"/>
+        <source>Name</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.cpp" line="82"/>
+        <source>Game</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>ClientRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.ui" line="14"/>
+        <source>Room Window</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.ui" line="40"/>
+        <source>Leave Room</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>ClientRoomWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="54"/>
+        <source>Connected</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="65"/>
+        <source>Disconnected</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="78"/>
+        <source>%1 (%2/%3 members) - connected</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>CompatDB</name>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="20"/>
+        <source>Report Compatibility</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="27"/>
+        <location filename="../../src/citra_qt/compatdb.ui" line="63"/>
+        <source>Report Game Compatibility</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="36"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;Should you choose to submit a test case to the &lt;/span&gt;&lt;a href=&quot;https://citra-emu.org/game/&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;Citra Compatibility List&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;, The following information will be collected and displayed on the site:&lt;/span&gt;&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Hardware Information (CPU / GPU / Operating System)&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Which version of Citra you are running&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The connected Citra account&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="72"/>
+        <source>Perfect</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="79"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions flawlessly with no audio or graphical glitches.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="89"/>
+        <source>Great </source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="96"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions with minor graphical or audio glitches and is playable from start to finish. May require some workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="106"/>
+        <source>Okay</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="113"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions with major graphical or audio glitches, but game is playable from start to finish with workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="123"/>
+        <source>Bad</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="130"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches even with workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="140"/>
+        <source>Intro/Menu</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="147"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start Screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="157"/>
+        <source>Won&apos;t Boot</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="170"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The game crashes when attempting to startup.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="182"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Independent of speed or performance, how well does this game play from start to finish on this version of Citra?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="206"/>
+        <source>Thank you for your submission!</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>ConfigureAudio</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="10"/>
+        <source>Audio</source>
+        <translation>Audio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="18"/>
+        <source>Output Engine:</source>
+        <translation>Output Engine:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="31"/>
+        <source>Enable audio stretching</source>
+        <translation>Aktifkan peregangan audio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="34"/>
+        <source>This post-processing effect adjusts audio speed to match emulation speed and helps prevent audio stutter. This however increases audio latency.</source>
+        <translation>Pasca-pemrosesan ini dilakukan untuk menyesuaikan kecepatan audio agar sesuai dengan kecepatan emulasi dan mencegah terjadinya gagap audio. Namun proses ini meningkatkan latensi audio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="43"/>
+        <source>Audio Device:</source>
+        <translation>Perangkat Audio:</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureDebug</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formulir</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="22"/>
+        <source>GDB</source>
+        <translation>GDB</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="28"/>
+        <source>The GDB Stub only works correctly when the CPU JIT is off.</source>
+        <translation>GDB Stub hanya bekerja dengan benar jika CPU JIT mati.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="37"/>
+        <source>Enable GDB Stub</source>
+        <translation>Aktifkan GDB Stub</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="57"/>
+        <source>Port:</source>
+        <translation>Port:</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="14"/>
+        <source>Citra Configuration</source>
+        <translation>Konfigurasi Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="24"/>
+        <source>General</source>
+        <translation>Umum</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="29"/>
+        <source>System</source>
+        <translation>Sistem</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="34"/>
+        <source>Input</source>
+        <translation>Input</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="39"/>
+        <source>Graphics</source>
+        <translation>Grafik</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="44"/>
+        <source>Audio</source>
+        <translation>Audio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="49"/>
+        <source>Debug</source>
+        <translation>Debug</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="54"/>
+        <source>Web</source>
+        <translation>Web</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureGeneral</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formulir</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="22"/>
+        <source>General</source>
+        <translation>Umum</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="30"/>
+        <source>Confirm exit while emulation is running</source>
+        <translation>Konfirmasi keluar saat emulasi berjalan</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="37"/>
+        <source>Search sub-directories for games</source>
+        <translation>Cari di sub-direktori untuk game</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="46"/>
+        <source>Interface language</source>
+        <translation>Bahasa tampilan</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="63"/>
+        <source>Updates</source>
+        <translation>Update</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="71"/>
+        <source>Check for updates on start</source>
+        <translation>Periksa update ketika memulai</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="78"/>
+        <source>Silently auto update after closing</source>
+        <translation>Otomatis mengupdate ketika ditutup</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="90"/>
+        <source>Performance</source>
+        <translation>Kinerja</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="98"/>
+        <source>Enable CPU JIT</source>
+        <translation>Aktifkan CPU JIT</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="110"/>
+        <source>Emulation</source>
+        <translation>Emulasi</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="120"/>
+        <source>Region:</source>
+        <translation>Region:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="128"/>
+        <source>Auto-select</source>
+        <translation>Otomatis</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="178"/>
+        <source>Theme</source>
+        <translation>Tema</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="188"/>
+        <source>Theme:</source>
+        <translation>Tema:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="205"/>
+        <source>Hotkeys</source>
+        <translation>Hotkey</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.cpp" line="16"/>
+        <source>&lt;System&gt;</source>
+        <translation>&lt;System&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.cpp" line="17"/>
+        <source>English</source>
+        <translation>Inggris</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureGraphics</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formulir</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="22"/>
+        <source>Graphics</source>
+        <translation>Grafik</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="28"/>
+        <source>Enable hardware renderer</source>
+        <translation>Aktifkan hardware renderer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="35"/>
+        <source>Enable shader JIT</source>
+        <translation>Aktifkan shader JIT</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="42"/>
+        <source>Enable V-Sync</source>
+        <translation>Aktifkan V-Sync</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="51"/>
+        <source>Limit Speed Percent</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="58"/>
+        <source>%</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="78"/>
+        <source>Internal Resolution:</source>
+        <translation>Resolusi Internal:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="86"/>
+        <source>Auto (Window Size)</source>
+        <translation>Otomatis (Ukuran Jendela)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="91"/>
+        <source>Native (400x240)</source>
+        <translation>Asli (400x240)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="96"/>
+        <source>2x Native (800x480)</source>
+        <translation>2x Asli (800x480)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="101"/>
+        <source>3x Native (1200x720)</source>
+        <translation>3x Asli (1200x720)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="106"/>
+        <source>4x Native (1600x960)</source>
+        <translation>4x Asli (1600x960)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="111"/>
+        <source>5x Native (2000x1200)</source>
+        <translation>5x Asli (2000x1200)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="116"/>
+        <source>6x Native (2400x1440)</source>
+        <translation>6x Asli (2400x1440)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="121"/>
+        <source>7x Native (2800x1680)</source>
+        <translation>7x Asli (2800x1680)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="126"/>
+        <source>8x Native (3200x1920)</source>
+        <translation>8x Asli (3200x1920)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="131"/>
+        <source>9x Native (3600x2160)</source>
+        <translation>9x Asli (3600x2160)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="136"/>
+        <source>10x Native (4000x2400)</source>
+        <translation>10x Asli (4000x2400)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="151"/>
+        <source>Layout</source>
+        <translation>Tata letak</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="161"/>
+        <source>Screen Layout:</source>
+        <translation>Tata letak Layar:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="169"/>
+        <source>Default</source>
+        <translation>Default</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="174"/>
+        <source>Single Screen</source>
+        <translation>Satu Layar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="179"/>
+        <source>Large Screen</source>
+        <translation>Layar Besar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="184"/>
+        <source>Side by Side</source>
+        <translation>Bersebelahan</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="194"/>
+        <source>Swap Screens</source>
+        <translation>Tukar Layar</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureInput</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="14"/>
+        <source>ConfigureInput</source>
+        <translation>ConfigureInput</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="22"/>
+        <source>Face Buttons</source>
+        <translation>Face Buttons</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="36"/>
+        <source>A:</source>
+        <translation>A:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="54"/>
+        <source>B:</source>
+        <translation>B:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="72"/>
+        <source>X:</source>
+        <translation>X:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="90"/>
+        <source>Y:</source>
+        <translation>Y:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="109"/>
+        <source>Directional Pad</source>
+        <translation>Directional Pad</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="123"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="340"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="427"/>
+        <source>Up:</source>
+        <translation>Atas:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="141"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="358"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="445"/>
+        <source>Down:</source>
+        <translation>Bawah:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="159"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="304"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="391"/>
+        <source>Left:</source>
+        <translation>Kiri:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="177"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="322"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="409"/>
+        <source>Right:</source>
+        <translation>Kanan:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="196"/>
+        <source>Shoulder Buttons</source>
+        <translation>Shoulder Buttons</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="210"/>
+        <source>L:</source>
+        <translation>L:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="228"/>
+        <source>R:</source>
+        <translation>R:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="246"/>
+        <source>ZL:</source>
+        <translation>ZL:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="264"/>
+        <source>ZR:</source>
+        <translation>ZR:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="283"/>
+        <source>Circle Pad</source>
+        <translation>Circle Pad</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="295"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="461"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="232"/>
+        <source>Set Analog Stick</source>
+        <translation>Set Analog Stick</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="377"/>
+        <source>C-Stick</source>
+        <translation>C-Stick</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="471"/>
+        <source>Misc.</source>
+        <translation>Misc.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="485"/>
+        <source>Start:</source>
+        <translation>Start:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="503"/>
+        <source>Select:</source>
+        <translation>Select:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="521"/>
+        <source>Home:</source>
+        <translation>Home:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="539"/>
+        <source>Circle Mod:</source>
+        <translation>Circle Mod:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="596"/>
+        <source>Restore Defaults</source>
+        <translation>Kembali ke Default</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="239"/>
+        <source>[press key]</source>
+        <translation>[Tekan tombol]</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureSystem</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formulir</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="22"/>
+        <source>System Settings</source>
+        <translation>Pengaturan Sistem</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="28"/>
+        <source>Username</source>
+        <translation>Username</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="48"/>
+        <source>Birthday</source>
+        <translation>Ulang tahun</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="58"/>
+        <source>January</source>
+        <translation>Januari</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="63"/>
+        <source>February</source>
+        <translation>Februari</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="68"/>
+        <source>March</source>
+        <translation>Maret</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="73"/>
+        <source>April</source>
+        <translation>April</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="78"/>
+        <source>May</source>
+        <translation>Mei</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="83"/>
+        <source>June</source>
+        <translation>Juni</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="88"/>
+        <source>July</source>
+        <translation>Juli</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="93"/>
+        <source>August</source>
+        <translation>Agustus</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="98"/>
+        <source>September</source>
+        <translation>September</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="103"/>
+        <source>October</source>
+        <translation>Oktober</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="108"/>
+        <source>November</source>
+        <translation>November</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="113"/>
+        <source>December</source>
+        <translation>Desember</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="126"/>
+        <source>Language</source>
+        <translation>Bahasa</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="133"/>
+        <source>Note: this can be overridden when region setting is auto-select</source>
+        <translation>Catatan: ini akan diganti bila setting region adalah otomatis</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="137"/>
+        <source>Japanese (日本語)</source>
+        <translation>Jepang (日本語)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="142"/>
+        <source>English</source>
+        <translation>Inggris (English)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="147"/>
+        <source>French (français)</source>
+        <translation>Perancis (français)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="152"/>
+        <source>German (Deutsch)</source>
+        <translation>Jerman (Deutsch)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="157"/>
+        <source>Italian (italiano)</source>
+        <translation>Itali (italiano)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="162"/>
+        <source>Spanish (español)</source>
+        <translation>Spanyol (español)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="167"/>
+        <source>Simplified Chinese (简体中文)</source>
+        <translation>Cina Disederhanakan (简体中文)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="172"/>
+        <source>Korean (한국어)</source>
+        <translation>Korea (한국어)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="177"/>
+        <source>Dutch (Nederlands)</source>
+        <translation>Belanda (Nederlands)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="182"/>
+        <source>Portuguese (português)</source>
+        <translation>Portugis (português)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="187"/>
+        <source>Russian (Русский)</source>
+        <translation>Rusia (Русский)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="192"/>
+        <source>Traditional Chinese (正體中文)</source>
+        <translation>Cina Tradisional (正體中文)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="200"/>
+        <source>Sound output mode</source>
+        <translation>Mode output suara</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="208"/>
+        <source>Mono</source>
+        <translation>Mono</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="213"/>
+        <source>Stereo</source>
+        <translation>Stereo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="218"/>
+        <source>Surround</source>
+        <translation>Surround</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="226"/>
+        <source>Console ID:</source>
+        <translation>ID Konsol:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="242"/>
+        <source>Regenerate</source>
+        <translation>Perbarui</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="252"/>
+        <source>System settings are available only when game is not running.</source>
+        <translation>Pengaturan sistem hanya tersedia jika game tidak berjalan.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="87"/>
+        <source>Console ID: 0x%1</source>
+        <translation>ID Konsol: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="160"/>
+        <source>This will replace your current virtual 3DS with a new one. Your current virtual 3DS will not be recoverable. This might have unexpected effects in games. This might fail, if you use an outdated config savegame. Continue?</source>
+        <translation>Ini akan menggantikan 3DS virtual saat ini dengan yang baru. 3DS virtual Anda saat ini akan tidak dapat dikembalikan. Mungkin ini akan memiliki efek tak terduka dalam game. Kemungkinan ini akan gagal jika Anda menggunakan config savegame lama. Lanjutkan?</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="164"/>
+        <source>Warning</source>
+        <translation>Peringatan</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureWeb</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formulir</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="22"/>
+        <source>Citra Web Service</source>
+        <translation>Layanan Web Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="28"/>
+        <source>By providing your username and token, you agree to allow Citra to collect additional usage data, which may include user identifying information.</source>
+        <translation>Dengan memberikan username dan token, Anda setuju mengizinkan Citra mengumpulkan data penggunaan tambahan, yang termasuk informasi identifikasi pengguna.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="46"/>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="90"/>
+        <source>Verify</source>
+        <translation>Verifikasi</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="53"/>
+        <source>Sign up</source>
+        <translation>Daftar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="67"/>
+        <source>Token: </source>
+        <translation>Token: </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="78"/>
+        <source>Username: </source>
+        <translation>Username: </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="99"/>
+        <source>What is my token?</source>
+        <translation>Apa token Saya?</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="124"/>
+        <source>Telemetry</source>
+        <translation>Telemetri</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="130"/>
+        <source>Share anonymous usage data with the Citra team</source>
+        <translation>Bagikan data penggunaan anonim dengan tim Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="137"/>
+        <source>Learn more</source>
+        <translation>Pelajari lebih lanjut</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="146"/>
+        <source>Telemetry ID:</source>
+        <translation>ID Telemetri:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="162"/>
+        <source>Regenerate</source>
+        <translation>Memperbarui</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="28"/>
+        <source>&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Pelajari lebih lanjut&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="33"/>
+        <source>&lt;a href=&apos;https://services.citra-emu.org/&apos;&gt;Sign up&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://services.citra-emu.org/&apos;&gt;Daftar&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="36"/>
+        <source>&lt;a href=&apos;https://citra-emu.org/wiki/citra-web-service/&apos;&gt;What is my token?&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://citra-emu.org/wiki/citra-web-service/&apos;&gt;Apa token Saya?&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="45"/>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="65"/>
+        <source>Telemetry ID: 0x%1</source>
+        <translation>ID Telemetri: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="55"/>
+        <source>Username and token not verified</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="56"/>
+        <source>Username and token were not verified. The changes to your username and/or token have not been saved.</source>
+        <translation>Username dan token tidak terverifikasi. Perubahan pada username dan/atau token tidak disimpan.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="85"/>
+        <source>Verifying</source>
+        <translation>Memverifikasi</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="99"/>
+        <source>Verification failed</source>
+        <translation>Verifikasi gagal</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="100"/>
+        <source>Verification failed. Check that you have entered your username and token correctly, and that your internet connection is working.</source>
+        <translation>Verifikasi gagal. Pastikan username dan token yang Anda masukkan benar dan koneksi internet Anda bekerja.</translation>
+    </message>
+</context>
+<context>
+    <name>DirectConnect</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="14"/>
+        <source>Direct Connect</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="33"/>
+        <source>IP Address</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="56"/>
+        <source>IP</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="63"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;IPv4 address of the host&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="73"/>
+        <source>Port</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="80"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Port number the host is listening on&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="86"/>
+        <source>24872</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="100"/>
+        <source>Nickname</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="114"/>
+        <source>Password</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="156"/>
+        <source>Connect</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>DirectConnectWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="97"/>
+        <source>Connecting</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="102"/>
+        <source>Connect</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>GMainWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="90"/>
+        <source>To help improve Citra, the Citra Team collects anonymous usage data. No private or personally identifying information is collected. This data helps us to understand how people use Citra and prioritize our efforts. Furthermore, it helps us to more easily identify emulation bugs and performance issues. This data includes:&lt;ul&gt;&lt;li&gt;Information about the version of Citra you are using&lt;/li&gt;&lt;li&gt;Performance data about the games you play&lt;/li&gt;&lt;li&gt;Your configuration settings&lt;/li&gt;&lt;li&gt;Information about your computer hardware&lt;/li&gt;&lt;li&gt;Emulation errors and crash information&lt;/li&gt;&lt;/ul&gt;By default, this feature is enabled. To disable this feature, click &apos;Emulation&apos; from the menu and then select &apos;Configure...&apos;. Then, on the &apos;Web&apos; tab, uncheck &apos;Share anonymous usage data with the Citra team&apos;. &lt;br/&gt;&lt;br/&gt;By using this software, you agree to the above terms.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Untuk membantu memperbaiki Citra, tim Citra mengumpulkan data penggunaan anonim. Tidak ada informasi pribadi atau identifikasi personal yang dikumpulkan. Data ini membantu kami memahami bagaimana orang menggunakan Citra dan memprioritaskan usaha kami. Selain itu, data ini membantu kami lebih mudah mengidentifikasi bug emulasi dan masalah kinerja, Data ini termasuk:&lt;ul&gt;&lt;li&gt;Informasi tentang versi Citra yang digunakan&lt;/li&gt;&lt;li&gt;Data kinerja game yang dimainkan&lt;/li&gt;&lt;li&gt;Pengaturan konfigurasi&lt;/li&gt;&lt;li&gt;Informasi tentang Hardware Komputer yang digunakan&lt;/li&gt;&lt;li&gt;Error emulasi dan informasi crash&lt;/li&gt;&lt;/ul&gt;Secara default, fitur ini diaktifkan. Untuk menonaktifkan fitur ini, klik &apos;Emulasi&apos; dari menu, lalu pilih &apos;Konfigurasi...&apos;. setelah itu, pada bagian tab &apos;Web&apos;, hapus centang &apos;Bagikan data penggunaan anonim dengan tim Citra&apos;. &lt;br/&gt;&lt;br/&gt;Dengan menggunakan software ini, Anda setuju dengan pernyataan diatas.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Pelajari lebih lanjut&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="195"/>
+        <source>Current emulation speed. Values higher or lower than 100% indicate emulation is running faster or slower than a 3DS.</source>
+        <translation>Kecepatan emulasi saat ini. Nilai yang lebih tinggi atau lebih rendah dari 100% menunjukan emulasi yang lebih cepat atau lebih lambat dari 3DS.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="198"/>
+        <source>How many frames per second the game is currently displaying. This will vary from game to game and scene to scene.</source>
+        <translation>Seberapa banyak frame per detik yang ditampilkan oleh game. Tiap game dan adegan akan bervariasi.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="202"/>
+        <source>Time taken to emulate a 3DS frame, not counting framelimiting or v-sync. For full-speed emulation this should be at most 16.67 ms.</source>
+        <translation>Waktu yang dibutuhkan untuk meniru 3DS frame, tidak menghitung framelimitting atau v-sync. paling banyak 16.67 ms untuk emulasi kecepatan penuh.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="429"/>
+        <source>CTRL+F</source>
+        <translation>CTRL+F</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="538"/>
+        <source>Update available!</source>
+        <translation>Update tersedia!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="539"/>
+        <source>An update for Citra is available. Do you wish to install it now?&lt;br /&gt;&lt;br /&gt;This &lt;b&gt;will&lt;/b&gt; terminate emulation, if it is running.</source>
+        <translation>Update untuk Citra tersedia. Apakah Anda ingin menginstallnya sekarang?&lt;br /&gt;&lt;br /&gt;Ini &lt;b&gt;akan&lt;/b&gt; menghentikan emulasi, jika sedang berjalan.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <source>No update found</source>
+        <translation>Tidak ada update</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <source>No update has been found for Citra.</source>
+        <translation>Tidak ada update ditemukan untuk Citra.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="567"/>
+        <source>Error while initializing OpenGL 3.3 Core!</source>
+        <translation>Error saat menginisialisasi OpenGL 3.3 Core!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="568"/>
+        <source>Your GPU may not support OpenGL 3.3, or you do not have the latest graphics driver.</source>
+        <translation>GPU Anda tidak mendukung OpenGL 3.3, atau Anda belum mempunyai graphic driver terbaru.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="581"/>
+        <location filename="../../src/citra_qt/main.cpp" line="587"/>
+        <location filename="../../src/citra_qt/main.cpp" line="593"/>
+        <location filename="../../src/citra_qt/main.cpp" line="606"/>
+        <location filename="../../src/citra_qt/main.cpp" line="625"/>
+        <source>Error while loading ROM!</source>
+        <translation>Error saat memuat ROM!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="582"/>
+        <location filename="../../src/citra_qt/main.cpp" line="607"/>
+        <source>The ROM format is not supported.</source>
+        <translation>format ROM tidak didukung.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="588"/>
+        <source>Could not determine the system mode.</source>
+        <translation>Tidak dapat menentukan mode sistem.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="594"/>
+        <source>The game that you are trying to load must be decrypted before being used with Citra. A real 3DS is required.&lt;br/&gt;&lt;br/&gt;For more information on dumping and decrypting games, please see the following wiki pages: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation>Game yang ingin Anda muat harus sudah ter-decrypt sebelum digunakan oleh Citra. membutuhkan 3DS asli.&lt;br/&gt;&lt;br/&gt;Untuk informasi lebih lanjut tentang dumping dan decrypting game, lihat halaman wiki ini: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="612"/>
+        <source>An error occured in the video core.</source>
+        <translation>Terjadi error di video core.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="613"/>
+        <source>Citra has encountered an error while running the video core, please see the log for more details.For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.Ensure that you have the latest graphics drivers for your GPU.</source>
+        <translation>Citra mengalami error ketika menjalankan video core, lihat log untuk detail lebih lanjut. Untuk informasi lebih lanjut tentang pengaksesan log, silahkan lihat halaman ini : &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;. Pastikan Anda mempunyai graphics drivers terbaru untuk GPU Anda.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="626"/>
+        <source>An unknown error occured. Please see the log for more details.</source>
+        <translation>Terjadi error yang tidak diketahui. Lihat log untuk detail lebih lanjut.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="699"/>
+        <source>Start</source>
+        <translation>Mulai</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="790"/>
+        <source>Error Opening %1 Folder</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="791"/>
+        <source>Folder does not exist!</source>
+        <translation>Folder tidak ada!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="805"/>
+        <source>3DS Executable</source>
+        <translation>3DS Executable</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="806"/>
+        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <source>All Files (*.*)</source>
+        <translation>Semua File (*.*)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="808"/>
+        <source>Load File</source>
+        <translation>Muat File</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="818"/>
+        <source>Select Directory</source>
+        <translation>Pilih Direktori</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="827"/>
+        <source>Load Files</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <source>3DS Installation File (*.CIA*)</source>
+        <translation>3DS Installation File (*.CIA*)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="859"/>
+        <source>%1 has been installed successfully.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="862"/>
+        <source>Unable to open File</source>
+        <translation>Tidak dapat membuka File</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="863"/>
+        <source>Could not open %1</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="867"/>
+        <source>Installation aborted</source>
+        <translation>Instalasi dibatalkan</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="868"/>
+        <source>The installation of %1 was aborted. Please see the log for more details</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <source>Invalid File</source>
+        <translation>File yang tidak valid</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <source>%1 is not a valid CIA</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="875"/>
+        <source>Encrypted File</source>
+        <translation>File ter-Encrypt</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="876"/>
+        <source>%1 must be decrypted before being used with Citra. A real 3DS is required.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="899"/>
+        <source>File not found</source>
+        <translation>File tidak ditemukan</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="900"/>
+        <source>File &quot;%1&quot; not found</source>
+        <translation>File &quot;%1&quot; tidak ditemukan</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="914"/>
+        <source>Continue</source>
+        <translation>Lanjut</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="939"/>
+        <source>Missing Citra Account</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="940"/>
+        <source>In order to submit a game compatibility test case, you must link your Citra account.&lt;br&gt;&lt;br/&gt;To link your Citra account, go to Emulation &amp;gt; Configuration &amp;gt; Web.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1090"/>
+        <source>Speed: %1% / %2%</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1094"/>
+        <source>Speed: %1%</source>
+        <translation>Kecepatan: %1%</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1096"/>
+        <source>Game: %1 FPS</source>
+        <translation>Game: %1 FPS</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1097"/>
+        <source>Frame: %1 ms</source>
+        <translation>Frame: %1 ms</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1108"/>
+        <source>The game you are trying to load requires additional files from your 3DS to be dumped before playing.&lt;br/&gt;&lt;br/&gt;For more information on dumping these files, please see the following wiki page: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
+        <translation>Game yang akan Anda muat membutuhkan file tambahan dari 3DS untuk di dump sebelum dimainkan.&lt;br/&gt;&lt;br/&gt;Untuk informasi lebih lanjut tentang cara melakukan dump file tersebut, silahkan lihat halaman wiki ini: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Apakah Anda ingin keluar dan kembali ke daftar game? Melanjutkan emulasi bisa menyebabkan Crash, save data rusak, atau bug lainnya.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1120"/>
+        <source>: %1. </source>
+        <translation>: %1. </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1126"/>
+        <source>System Archive Not Found</source>
+        <translation>Arsip Sistem Tidak Ditemukan</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1133"/>
+        <source>Citra was unable to locate the 3DS shared fonts. </source>
+        <translation>Citra tidak dapat menemukan 3DS shared fonts.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1135"/>
+        <source>Shared Fonts Not Found</source>
+        <translation>Shared Fonts Tidak Ditemukan</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1143"/>
+        <source>Fatal Error</source>
+        <translation>Fatal Error</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1144"/>
+        <source>Citra has encountered a fatal error, please see the log for more details. For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
+        <translation>Citra mengalami kesalahan fatal, lihat log untuk detail lebih lanjut. Untuk informasi lebih lanjut tentang mengakses log, silahkan lihat halaman ini : &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Apakah Anda ingin keluar dan kembali ke daftar game? Melanjutkan emulasi bisa menyebabkan Crash, save data rusak, atau bug lainnya.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1245"/>
+        <source>Citra</source>
+        <translation>Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <source>Are you sure you want to close Citra?</source>
+        <translation>Apakah Anda yakin ingin menutup Citra?</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1246"/>
+        <source>Are you sure you want to stop the emulation? Any unsaved progress will be lost.</source>
+        <translation>Apakah Anda yakin ingin menghentikan emulasi? Semua perkembangan yang belum disimpan akan hilang.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1318"/>
+        <source>Citra %1| %2-%3</source>
+        <translation>Citra %1| %2-%3</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandListModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="96"/>
+        <source>Command Name</source>
+        <translation>Nama Perintah</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="98"/>
+        <source>Register</source>
+        <translation>Register</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="100"/>
+        <source>Mask</source>
+        <translation>Masker</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="102"/>
+        <source>New Value</source>
+        <translation>Nilai Baru</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandListWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="184"/>
+        <source>Pica Command List</source>
+        <translation>Daftar Perintah Pica</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="202"/>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="233"/>
+        <source>Start Tracing</source>
+        <translation>Mulai Menelusuri</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="203"/>
+        <source>Copy All</source>
+        <translation>Salin Semua</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="229"/>
+        <source>Finish Tracing</source>
+        <translation>Selesai Menelusuri</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandStreamWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics.cpp" line="67"/>
+        <source>Graphics Debugger</source>
+        <translation>Debugger Grafik</translation>
+    </message>
+</context>
+<context>
+    <name>GameList</name>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <source>Perfect</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <source>Game functions flawless with no audio or graphical glitches, all tested functionality works as intended without
+any workarounds needed.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <source>Great</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <source>Game functions with minor graphical or audio glitches and is playable from start to finish. May require some
+workarounds.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <source>Okay</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <source>Game functions with major graphical or audio glitches, but game is playable from start to finish with
+workarounds.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Bad</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches
+even with workarounds.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <source>Intro/Menu</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <source>Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start
+Screen.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>Won&apos;t Boot</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>The game crashes when attempting to startup.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <source>Not Tested</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <source>The game has not yet been tested.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="99"/>
+        <source>of</source>
+        <translation>dari</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="102"/>
+        <source>result</source>
+        <translation>hasil</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="104"/>
+        <source>results</source>
+        <translation>hasil</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="125"/>
+        <source>Filter:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="128"/>
+        <source>Enter pattern to filter</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="324"/>
+        <source>Open Save Data Location</source>
+        <translation>Buka Lokasi Save Data</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
+        <source>Open Application Location</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
+        <source>Open Update Data Location</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>GraphicsBreakPointsWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="132"/>
+        <source>Pica Breakpoints</source>
+        <translation>Pica Breakpoints</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="136"/>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="198"/>
+        <source>Emulation running</source>
+        <translation>Emulasi berjalan</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="137"/>
+        <source>Resume</source>
+        <translation>Jalankan</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="188"/>
+        <source>Emulation halted at breakpoint</source>
+        <translation>Emulasi berhenti di breakpoint</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsSurfaceWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="49"/>
+        <source>Pica Surface Viewer</source>
+        <translation>Penampil Permukaan Pica</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="54"/>
+        <source>Color Buffer</source>
+        <translation>Buffer Warna</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="55"/>
+        <source>Depth Buffer</source>
+        <translation>Buffer Kedalaman</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="56"/>
+        <source>Stencil Buffer</source>
+        <translation>Buffer Setensilan</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="57"/>
+        <source>Texture 0</source>
+        <translation>Tekstur 0</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="58"/>
+        <source>Texture 1</source>
+        <translation>Tekstur 1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="59"/>
+        <source>Texture 2</source>
+        <translation>Tekstur 2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="60"/>
+        <source>Custom</source>
+        <translation>Custom</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="103"/>
+        <source>Unknown</source>
+        <translation>Tidak diketahui</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="118"/>
+        <source>Save</source>
+        <translation>Simpan</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="144"/>
+        <source>Source:</source>
+        <translation>Sumber:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="150"/>
+        <source>Physical Address:</source>
+        <translation>Alamat Fisik:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="156"/>
+        <source>Width:</source>
+        <translation>Lebar:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="162"/>
+        <source>Height:</source>
+        <translation>Tinggi:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="168"/>
+        <source>Format:</source>
+        <translation>Format:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="180"/>
+        <source>X:</source>
+        <translation>X:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="186"/>
+        <source>Y:</source>
+        <translation>Y:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="280"/>
+        <source>Pixel out of bounds</source>
+        <translation>Pixel keluar batas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="287"/>
+        <source>(unable to access pixel data)</source>
+        <translation>(tidak dapat mengakses data pixel)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="555"/>
+        <source>(invalid surface address)</source>
+        <translation>(alamat permukaan tidak valid)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="565"/>
+        <source>(unknown surface format)</source>
+        <translation>(format permukaan tidak diketahui)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="658"/>
+        <source>Portable Network Graphic (*.png)</source>
+        <translation>Portable Network Graphic (*.png)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="659"/>
+        <source>Binary data (*.bin)</source>
+        <translation>Binary data (*.bin)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="663"/>
+        <source>Save Surface</source>
+        <translation>Simpan Permukaan</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsTracingWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="25"/>
+        <source>CiTrace Recorder</source>
+        <translation>Perekam CiTrace</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="29"/>
+        <source>Start Recording</source>
+        <translation>Mulai Perekam</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="31"/>
+        <source>Stop and Save</source>
+        <translation>Berhenti dan Simpan</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="32"/>
+        <source>Abort Recording</source>
+        <translation>Hentikan Perekam</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="112"/>
+        <source>Save CiTrace</source>
+        <translation>Simpan CiTrace</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="113"/>
+        <source>CiTrace File (*.ctf)</source>
+        <translation>CiTrace File (*.ctf)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="162"/>
+        <source>CiTracing still active</source>
+        <translation>CiTracing masih aktif</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="163"/>
+        <source>A CiTrace is still being recorded. Do you want to save it? If not, all recorded data will be discarded.</source>
+        <translation>CiTrace masih direkam. Apakah Anda ingin menyimpannya? Jika tidak, semua data yang terekam akan dibuang.</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsVertexShaderModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="45"/>
+        <source>Offset</source>
+        <translation>Offset</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="47"/>
+        <source>Raw</source>
+        <translation>Raw</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="49"/>
+        <source>Disassembly</source>
+        <translation>Membongkar</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsVertexShaderWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="345"/>
+        <source>Save Shader Dump</source>
+        <translation>Simpan Shader Dump</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="345"/>
+        <source>Shader Binary (*.shbin)</source>
+        <translation>Shader Binary (*.shbin)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="380"/>
+        <source>(data only available at vertex shader invocation breakpoints)</source>
+        <translation>(data hanya tersedia ketika vertex shader meminta breakpoints)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="390"/>
+        <source>Dump</source>
+        <translation>Dump</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="412"/>
+        <source>Input Data</source>
+        <translation>Masukkan Data</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="426"/>
+        <source>Attribute %1</source>
+        <translation>Atribut %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="453"/>
+        <source>Cycle Index:</source>
+        <translation>Indeks Siklus:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="558"/>
+        <source>SRC1: %1, %2, %3, %4
+</source>
+        <translation>SRC1: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="564"/>
+        <source>SRC2: %1, %2, %3, %4
+</source>
+        <translation>SRC2: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="570"/>
+        <source>SRC3: %1, %2, %3, %4
+</source>
+        <translation>SRC3: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="576"/>
+        <source>DEST_IN: %1, %2, %3, %4
+</source>
+        <translation>DEST_IN: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="582"/>
+        <source>DEST_OUT: %1, %2, %3, %4
+</source>
+        <translation>DEST_OUT: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="589"/>
+        <source>Address Registers: %1, %2
+</source>
+        <translation>Register Alamat: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="593"/>
+        <source>Compare Result: %1, %2
+</source>
+        <translation>Bandingkan Hasil: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="598"/>
+        <source>Static Condition: %1
+</source>
+        <translation>Kondisi Statis: %1
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="600"/>
+        <source>Dynamic Conditions: %1, %2
+</source>
+        <translation>Kondisi Dinamis: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="604"/>
+        <source>Loop Parameters: %1 (repeats), %2 (initializer), %3 (increment), %4
+</source>
+        <translation>Parameter Pengulangan: %1 (pengulangan), %2 (penginisialisasi), %3 (tambahan), %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="611"/>
+        <source>Instruction offset: 0x%1</source>
+        <translation>Instruksi offset: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="613"/>
+        <source> -&gt; 0x%2</source>
+        <translation> -&gt; 0x%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="615"/>
+        <source> (last instruction)</source>
+        <translation> (instruksi terakhir)</translation>
+    </message>
+</context>
+<context>
+    <name>HostRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="14"/>
+        <source>Create Room</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="37"/>
+        <source>Room Name</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="51"/>
+        <source>Preferred Game</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="61"/>
+        <source>Max Players</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="91"/>
+        <source>Username</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="101"/>
+        <source>(Leave blank for open game)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="118"/>
+        <source>Password</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="125"/>
+        <source>Port</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="156"/>
+        <source>Public</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="161"/>
+        <source>Unlisted</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="169"/>
+        <source>Host Room</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>Lobby</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="14"/>
+        <source>Public Room Browser</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="32"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="39"/>
+        <source>Nickname</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="59"/>
+        <source>Filters</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="66"/>
+        <source>Search</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="76"/>
+        <source>Games I Own</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="83"/>
+        <source>Hide Full Rooms</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="103"/>
+        <source>Refresh Lobby</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <source>Password Required to Join</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <source>Password:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="77"/>
+        <source>Password</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
+        <source>Room Name</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="143"/>
+        <source>Preferred Game</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="144"/>
+        <source>Host</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="145"/>
+        <source>Players</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="153"/>
+        <source>Refreshing</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="201"/>
+        <source>Refresh List</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="14"/>
+        <source>Citra</source>
+        <translation>Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="53"/>
+        <source>&amp;File</source>
+        <translation>&amp;File</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="57"/>
+        <source>Recent Files</source>
+        <translation>File Terkini</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="70"/>
+        <source>&amp;Emulation</source>
+        <translation>&amp;Emulasi</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="80"/>
+        <source>&amp;View</source>
+        <translation>&amp;Tampilan</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="84"/>
+        <source>Debugging</source>
+        <translation>Debugging</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="91"/>
+        <source>Screen Layout</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="115"/>
+        <source>Multiplayer</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="126"/>
+        <source>&amp;Help</source>
+        <translation>Ba&amp;ntuan</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="144"/>
+        <source>Load File...</source>
+        <translation>Muat File...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="149"/>
+        <source>Install CIA...</source>
+        <translation>Pasang CIA...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="154"/>
+        <source>Load Symbol Map...</source>
+        <translation>Muat Symbol Map...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="159"/>
+        <source>E&amp;xit</source>
+        <translation>&amp;Keluar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="167"/>
+        <source>&amp;Start</source>
+        <translation>&amp;Mulai</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="175"/>
+        <source>&amp;Pause</source>
+        <translation>&amp;Jeda</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="183"/>
+        <source>&amp;Stop</source>
+        <translation>&amp;Berhenti</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="188"/>
+        <source>FAQ</source>
+        <translation>FAQ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="193"/>
+        <source>About Citra</source>
+        <translation>Tentang Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="201"/>
+        <source>Single Window Mode</source>
+        <translation>Mode Satu Jendela</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="206"/>
+        <source>Configure...</source>
+        <translation>Konfigurasi...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="214"/>
+        <source>Display Dock Widget Headers</source>
+        <translation>Tampilkan Dock Widget Headers</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="222"/>
+        <source>Show Filter Bar</source>
+        <translation>Tampilkan Filter Bar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="230"/>
+        <source>Show Status Bar</source>
+        <translation>Tampilkan Status Bar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="235"/>
+        <source>Select Game Directory...</source>
+        <translation>Pilih Direktori Game...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="238"/>
+        <source>Selects a folder to display in the game list</source>
+        <translation>Pilih folder untuk ditampilkan pada daftar game</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="243"/>
+        <source>Create Pica Surface Viewer</source>
+        <translation>Buat Penampil Permukaan Pica</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="251"/>
+        <source>Browse Public Game Lobby</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="259"/>
+        <source>Create Room</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="267"/>
+        <source>Leave Room</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="272"/>
+        <source>Direct Connect to Room</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="280"/>
+        <source>Show Current Room</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="288"/>
+        <source>Fullscreen</source>
+        <translation>Layar penuh</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="293"/>
+        <source>Modify Citra Install</source>
+        <translation>Modifikasi Pemasangan Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="296"/>
+        <source>Opens the maintenance tool to modify your Citra installation</source>
+        <translation>Buka alat perbaikan untuk memodifikasi pemasangan Citra Anda</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="304"/>
+        <source>Default</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="312"/>
+        <source>Single Screen</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="320"/>
+        <source>Large Screen</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="328"/>
+        <source>Side by Side</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="336"/>
+        <source>Swap Screens</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="341"/>
+        <source>Check for Updates</source>
+        <translation>Periksa Update</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="349"/>
+        <source>Report Compatibility</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>MicroProfileDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/profiler.cpp" line="50"/>
+        <source>MicroProfile</source>
+        <translation>Profil Mikro</translation>
+    </message>
+</context>
+<context>
+    <name>MultiplayerState</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="41"/>
+        <source>Current connection status</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="42"/>
+        <source>Not Connected. Click here to find a room!</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="100"/>
+        <source>Connected</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="105"/>
+        <source>Not Connected</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="114"/>
+        <source>Error</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="115"/>
+        <source>Failed to announce the room to the public lobby. In order to host a room publicly, you must have a valid Citra account configured in Emulation -&gt; Configure -&gt; Web. If you do not want to publish a room in the public lobby, then select Unlisted instead.
+Debug Message: </source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>NetworkMessage</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="12"/>
+        <source>Username is not valid. Must be 4 to 20 alphanumeric characters.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="14"/>
+        <source>Room name is not valid. Must be 4 to 20 alphanumeric characters.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="16"/>
+        <source>Username is already in use. Please choose another.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="17"/>
+        <source>IP is not a valid IPv4 address.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="18"/>
+        <source>Port must be a number between 0 to 65535.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="20"/>
+        <source>Unable to find an internet connection. Check your internet settings.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="22"/>
+        <source>Unable to connect to the host. Verify that the connection settings are correct. If you still cannot connect, contact the room host and verify that the host is properly configured with the external port forwarded.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="26"/>
+        <source>Creating a room failed. Please retry. Restarting Citra might be necessary.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="28"/>
+        <source>The host of the room has banned you. Speak with the host to unban you or try a different room.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="31"/>
+        <source>Version mismatch! Please update to the latest version of Citra. If the problem persists, contact the room host and ask them to update the server.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="33"/>
+        <source>Incorrect password.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="35"/>
+        <source>An unknown error occured. If this error continues to occur, please open an issue</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="36"/>
+        <source>Connection to room lost. Try to reconnect.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="38"/>
+        <source>MAC address is already in use. Please choose another.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="52"/>
+        <source>Leave Room</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="53"/>
+        <source>You are about to close the room. Any network connections will be closed.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="58"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="59"/>
+        <source>You are about to leave the room. Any network connections will be closed.</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="47"/>
+        <source>Error</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="198"/>
+        <source>%1 is not playing a game</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="201"/>
+        <source>%1 is playing %2</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="26"/>
+        <source>Shift</source>
+        <translation>Shift</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="28"/>
+        <source>Ctrl</source>
+        <translation>Ctrl</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="30"/>
+        <source>Alt</source>
+        <translation>Alt</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="51"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="75"/>
+        <source>[not set]</source>
+        <translation>[tidak diatur]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="55"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="83"/>
+        <source>Joystick %1</source>
+        <translation>Joystick %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="57"/>
+        <source> Hat %1 %2</source>
+        <translation>Hat %1 %2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="61"/>
+        <source> Axis %1%2</source>
+        <translation>Axis %1%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="65"/>
+        <source> Button %1</source>
+        <translation>Tombol %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="69"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="91"/>
+        <source>[unknown]</source>
+        <translation>[tidak diketahui]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="80"/>
+        <source>[unused]</source>
+        <translation>[tidak terpakai]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="85"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="87"/>
+        <source> Axis %1</source>
+        <translation>Axis %1</translation>
+    </message>
+</context>
+<context>
+    <name>RegistersWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="15"/>
+        <source>Registers</source>
+        <translation>Register</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="16"/>
+        <source>VFP Registers</source>
+        <translation>Register VFP</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="18"/>
+        <source>VFP System Registers</source>
+        <translation>Register VFP Sistem</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="167"/>
+        <source>Vector Length</source>
+        <translation>Panjang Vektor</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="168"/>
+        <source>Vector Stride</source>
+        <translation>Langkah Vector</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="169"/>
+        <source>Rounding Mode</source>
+        <translation>Mode Pembulatan</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="182"/>
+        <source>Vector Iteration Count</source>
+        <translation>Hitungan Perulangan Vector</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeEvent</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="259"/>
+        <source>reset type = %1</source>
+        <translation>tipe reset = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeMutex</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="272"/>
+        <source>locked %1 times by thread:</source>
+        <translation>terkunci %1 kali oleh thread:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="275"/>
+        <source>free</source>
+        <translation>bebas</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeMutexList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="314"/>
+        <source>holding mutexes</source>
+        <translation>Menahan mutex</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeObjectList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="128"/>
+        <source>waiting for all objects</source>
+        <translation>menunggu semua obyek</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="129"/>
+        <source>waiting for one of the following objects</source>
+        <translation>menunggu obyek ini</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeSemaphore</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="288"/>
+        <source>available count = %1</source>
+        <translation>hitungan tersedia = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="289"/>
+        <source>max count = %1</source>
+        <translation>hitungan maksimal = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeThread</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="146"/>
+        <source>running</source>
+        <translation>berjalan</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="149"/>
+        <source>ready</source>
+        <translation>siap</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="152"/>
+        <source>waiting for address 0x%1</source>
+        <translation>menunggu alamat 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="155"/>
+        <source>sleeping</source>
+        <translation>tidur</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="158"/>
+        <source>waiting for IPC response</source>
+        <translation>menunggu respon IPC</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="162"/>
+        <source>waiting for objects</source>
+        <translation>menunggu obyek</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="165"/>
+        <source>waiting for HLE return</source>
+        <translation>menunggu HLE return</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="168"/>
+        <source>dormant</source>
+        <translation>terhenti</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="171"/>
+        <source>dead</source>
+        <translation>berhenti</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="174"/>
+        <source> PC = 0x%1 LR = 0x%2</source>
+        <translation>PC = 0x%1 LR = 0x%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="214"/>
+        <source>default</source>
+        <translation>default</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="217"/>
+        <source>all</source>
+        <translation>semua</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="220"/>
+        <source>AppCore</source>
+        <translation>AppCore</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="223"/>
+        <source>SysCore</source>
+        <translation>SysCore</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="226"/>
+        <source>Unknown processor %1</source>
+        <translation>Prosesor tidak diketahui %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="230"/>
+        <source>processor = %1</source>
+        <translation>prosesor = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="231"/>
+        <source>thread id = %1</source>
+        <translation>id thread = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="232"/>
+        <source>priority = %1(current) / %2(normal)</source>
+        <translation>prioritas = %1(saat ini) / %2(normal)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="236"/>
+        <source>last running ticks = %1</source>
+        <translation>tick yang terakhir berjalan = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="239"/>
+        <source>not holding mutex</source>
+        <translation>tidak menahan mutex</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeThreadList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="328"/>
+        <source>waited by thread</source>
+        <translation>ditunggu oleh thread</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeTimer</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="301"/>
+        <source>reset type = %1</source>
+        <translation>tipe reset = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="303"/>
+        <source>initial delay = %1</source>
+        <translation>awal delay = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="305"/>
+        <source>interval delay = %1</source>
+        <translation>delay interval = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeWaitObject</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="76"/>
+        <source>[%1]%2 %3</source>
+        <translation>[%1]%2 %3</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="104"/>
+        <source>waited by no thread</source>
+        <translation>tidak ada thread yang ditunggu</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="114"/>
+        <source>one shot</source>
+        <translation>satu kesempatan</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="116"/>
+        <source>sticky</source>
+        <translation>sticky</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="118"/>
+        <source>pulse</source>
+        <translation>pulse</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="399"/>
+        <source>Wait Tree</source>
+        <translation>Tunggu Tree</translation>
+    </message>
+</context>
+<context>
+    <name>hotkeys</name>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="14"/>
+        <source>Hotkey Settings</source>
+        <translation>Pengaturan Hotkey</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="27"/>
+        <source>Action</source>
+        <translation>Aksi</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="32"/>
+        <source>Hotkey</source>
+        <translation>Hotkey</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="37"/>
+        <source>Context</source>
+        <translation>Konteks</translation>
+    </message>
+</context>
+</TS>

--- a/dist/languages/id.ts
+++ b/dist/languages/id.ts
@@ -59,7 +59,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/aboutdialog.ui" line="118"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Website&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://community.citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Forum&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Source Code&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Contributors&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/blob/master/license.txt&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;License&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"/>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Situs Web&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://community.citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Forum&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Source Code&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Kontributor&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/blob/master/license.txt&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Lisensi&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/aboutdialog.ui" line="134"/>
@@ -120,22 +120,22 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="40"/>
         <source>Send Chat Message</source>
-        <translation type="unfinished"/>
+        <translation>Kirim Pesan Chat</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="47"/>
         <source>Send Message</source>
-        <translation type="unfinished"/>
+        <translation>Kirim Pesan</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/chat_room.cpp" line="81"/>
         <source>Name</source>
-        <translation type="unfinished"/>
+        <translation>Nama</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/chat_room.cpp" line="82"/>
         <source>Game</source>
-        <translation type="unfinished"/>
+        <translation>Permainan</translation>
     </message>
 </context>
 <context>
@@ -148,25 +148,25 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/multiplayer/client_room.ui" line="40"/>
         <source>Leave Room</source>
-        <translation type="unfinished"/>
+        <translation>Tinggalkan Ruangan</translation>
     </message>
 </context>
 <context>
     <name>ClientRoomWindow</name>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="54"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="55"/>
         <source>Connected</source>
-        <translation type="unfinished"/>
+        <translation>Terhubung</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="65"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="63"/>
         <source>Disconnected</source>
-        <translation type="unfinished"/>
+        <translation>Terputus</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="78"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="76"/>
         <source>%1 (%2/%3 members) - connected</source>
-        <translation type="unfinished"/>
+        <translation>%1 (%2/%3 anggota) - terhubung</translation>
     </message>
 </context>
 <context>
@@ -174,13 +174,13 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="20"/>
         <source>Report Compatibility</source>
-        <translation type="unfinished"/>
+        <translation>Laporkan Kompatibilitas</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="27"/>
         <location filename="../../src/citra_qt/compatdb.ui" line="63"/>
         <source>Report Game Compatibility</source>
-        <translation type="unfinished"/>
+        <translation>Laporkan Kompatibilitas Permainan</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="36"/>
@@ -190,7 +190,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="72"/>
         <source>Perfect</source>
-        <translation type="unfinished"/>
+        <translation>Sempurna</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="79"/>
@@ -220,7 +220,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="123"/>
         <source>Bad</source>
-        <translation type="unfinished"/>
+        <translation>Buruk</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="130"/>
@@ -230,7 +230,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="140"/>
         <source>Intro/Menu</source>
-        <translation type="unfinished"/>
+        <translation>Intro/Menu</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="147"/>
@@ -313,6 +313,26 @@ p, li { white-space: pre-wrap; }
         <source>Port:</source>
         <translation>Port:</translation>
     </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="78"/>
+        <source>Logging</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="86"/>
+        <source>Global Log Filter</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="100"/>
+        <source>Show Log Console (Windows Only)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="107"/>
+        <source>Open Log Location</source>
+        <translation type="unfinished"/>
+    </message>
 </context>
 <context>
     <name>ConfigureDialog</name>
@@ -339,7 +359,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure.ui" line="39"/>
         <source>Graphics</source>
-        <translation>Grafik</translation>
+        <translation>Grafis</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure.ui" line="44"/>
@@ -460,7 +480,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="22"/>
         <source>Graphics</source>
-        <translation>Grafik</translation>
+        <translation>Grafis</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="28"/>
@@ -1100,12 +1120,12 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DirectConnectWindow</name>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="97"/>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="103"/>
         <source>Connecting</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="102"/>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="108"/>
         <source>Connect</source>
         <translation type="unfinished"/>
     </message>
@@ -1113,289 +1133,289 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GMainWindow</name>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="90"/>
+        <location filename="../../src/citra_qt/main.cpp" line="92"/>
         <source>To help improve Citra, the Citra Team collects anonymous usage data. No private or personally identifying information is collected. This data helps us to understand how people use Citra and prioritize our efforts. Furthermore, it helps us to more easily identify emulation bugs and performance issues. This data includes:&lt;ul&gt;&lt;li&gt;Information about the version of Citra you are using&lt;/li&gt;&lt;li&gt;Performance data about the games you play&lt;/li&gt;&lt;li&gt;Your configuration settings&lt;/li&gt;&lt;li&gt;Information about your computer hardware&lt;/li&gt;&lt;li&gt;Emulation errors and crash information&lt;/li&gt;&lt;/ul&gt;By default, this feature is enabled. To disable this feature, click &apos;Emulation&apos; from the menu and then select &apos;Configure...&apos;. Then, on the &apos;Web&apos; tab, uncheck &apos;Share anonymous usage data with the Citra team&apos;. &lt;br/&gt;&lt;br/&gt;By using this software, you agree to the above terms.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
         <translation>Untuk membantu memperbaiki Citra, tim Citra mengumpulkan data penggunaan anonim. Tidak ada informasi pribadi atau identifikasi personal yang dikumpulkan. Data ini membantu kami memahami bagaimana orang menggunakan Citra dan memprioritaskan usaha kami. Selain itu, data ini membantu kami lebih mudah mengidentifikasi bug emulasi dan masalah kinerja, Data ini termasuk:&lt;ul&gt;&lt;li&gt;Informasi tentang versi Citra yang digunakan&lt;/li&gt;&lt;li&gt;Data kinerja game yang dimainkan&lt;/li&gt;&lt;li&gt;Pengaturan konfigurasi&lt;/li&gt;&lt;li&gt;Informasi tentang Hardware Komputer yang digunakan&lt;/li&gt;&lt;li&gt;Error emulasi dan informasi crash&lt;/li&gt;&lt;/ul&gt;Secara default, fitur ini diaktifkan. Untuk menonaktifkan fitur ini, klik &apos;Emulasi&apos; dari menu, lalu pilih &apos;Konfigurasi...&apos;. setelah itu, pada bagian tab &apos;Web&apos;, hapus centang &apos;Bagikan data penggunaan anonim dengan tim Citra&apos;. &lt;br/&gt;&lt;br/&gt;Dengan menggunakan software ini, Anda setuju dengan pernyataan diatas.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Pelajari lebih lanjut&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="195"/>
+        <location filename="../../src/citra_qt/main.cpp" line="199"/>
         <source>Current emulation speed. Values higher or lower than 100% indicate emulation is running faster or slower than a 3DS.</source>
         <translation>Kecepatan emulasi saat ini. Nilai yang lebih tinggi atau lebih rendah dari 100% menunjukan emulasi yang lebih cepat atau lebih lambat dari 3DS.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="198"/>
+        <location filename="../../src/citra_qt/main.cpp" line="202"/>
         <source>How many frames per second the game is currently displaying. This will vary from game to game and scene to scene.</source>
         <translation>Seberapa banyak frame per detik yang ditampilkan oleh game. Tiap game dan adegan akan bervariasi.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="202"/>
+        <location filename="../../src/citra_qt/main.cpp" line="206"/>
         <source>Time taken to emulate a 3DS frame, not counting framelimiting or v-sync. For full-speed emulation this should be at most 16.67 ms.</source>
         <translation>Waktu yang dibutuhkan untuk meniru 3DS frame, tidak menghitung framelimitting atau v-sync. paling banyak 16.67 ms untuk emulasi kecepatan penuh.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="429"/>
+        <location filename="../../src/citra_qt/main.cpp" line="434"/>
         <source>CTRL+F</source>
         <translation>CTRL+F</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="538"/>
+        <location filename="../../src/citra_qt/main.cpp" line="543"/>
         <source>Update available!</source>
         <translation>Update tersedia!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="539"/>
+        <location filename="../../src/citra_qt/main.cpp" line="544"/>
         <source>An update for Citra is available. Do you wish to install it now?&lt;br /&gt;&lt;br /&gt;This &lt;b&gt;will&lt;/b&gt; terminate emulation, if it is running.</source>
         <translation>Update untuk Citra tersedia. Apakah Anda ingin menginstallnya sekarang?&lt;br /&gt;&lt;br /&gt;Ini &lt;b&gt;akan&lt;/b&gt; menghentikan emulasi, jika sedang berjalan.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <location filename="../../src/citra_qt/main.cpp" line="555"/>
         <source>No update found</source>
         <translation>Tidak ada update</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <location filename="../../src/citra_qt/main.cpp" line="555"/>
         <source>No update has been found for Citra.</source>
         <translation>Tidak ada update ditemukan untuk Citra.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="567"/>
+        <location filename="../../src/citra_qt/main.cpp" line="572"/>
         <source>Error while initializing OpenGL 3.3 Core!</source>
         <translation>Error saat menginisialisasi OpenGL 3.3 Core!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="568"/>
+        <location filename="../../src/citra_qt/main.cpp" line="573"/>
         <source>Your GPU may not support OpenGL 3.3, or you do not have the latest graphics driver.</source>
         <translation>GPU Anda tidak mendukung OpenGL 3.3, atau Anda belum mempunyai graphic driver terbaru.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="581"/>
-        <location filename="../../src/citra_qt/main.cpp" line="587"/>
-        <location filename="../../src/citra_qt/main.cpp" line="593"/>
-        <location filename="../../src/citra_qt/main.cpp" line="606"/>
-        <location filename="../../src/citra_qt/main.cpp" line="625"/>
+        <location filename="../../src/citra_qt/main.cpp" line="586"/>
+        <location filename="../../src/citra_qt/main.cpp" line="592"/>
+        <location filename="../../src/citra_qt/main.cpp" line="598"/>
+        <location filename="../../src/citra_qt/main.cpp" line="611"/>
+        <location filename="../../src/citra_qt/main.cpp" line="630"/>
         <source>Error while loading ROM!</source>
         <translation>Error saat memuat ROM!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="582"/>
-        <location filename="../../src/citra_qt/main.cpp" line="607"/>
+        <location filename="../../src/citra_qt/main.cpp" line="587"/>
+        <location filename="../../src/citra_qt/main.cpp" line="612"/>
         <source>The ROM format is not supported.</source>
         <translation>format ROM tidak didukung.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="588"/>
+        <location filename="../../src/citra_qt/main.cpp" line="593"/>
         <source>Could not determine the system mode.</source>
         <translation>Tidak dapat menentukan mode sistem.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="594"/>
+        <location filename="../../src/citra_qt/main.cpp" line="599"/>
         <source>The game that you are trying to load must be decrypted before being used with Citra. A real 3DS is required.&lt;br/&gt;&lt;br/&gt;For more information on dumping and decrypting games, please see the following wiki pages: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</source>
         <translation>Game yang ingin Anda muat harus sudah ter-decrypt sebelum digunakan oleh Citra. membutuhkan 3DS asli.&lt;br/&gt;&lt;br/&gt;Untuk informasi lebih lanjut tentang dumping dan decrypting game, lihat halaman wiki ini: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="612"/>
+        <location filename="../../src/citra_qt/main.cpp" line="617"/>
         <source>An error occured in the video core.</source>
         <translation>Terjadi error di video core.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="613"/>
+        <location filename="../../src/citra_qt/main.cpp" line="618"/>
         <source>Citra has encountered an error while running the video core, please see the log for more details.For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.Ensure that you have the latest graphics drivers for your GPU.</source>
         <translation>Citra mengalami error ketika menjalankan video core, lihat log untuk detail lebih lanjut. Untuk informasi lebih lanjut tentang pengaksesan log, silahkan lihat halaman ini : &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;. Pastikan Anda mempunyai graphics drivers terbaru untuk GPU Anda.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="626"/>
+        <location filename="../../src/citra_qt/main.cpp" line="631"/>
         <source>An unknown error occured. Please see the log for more details.</source>
         <translation>Terjadi error yang tidak diketahui. Lihat log untuk detail lebih lanjut.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="699"/>
+        <location filename="../../src/citra_qt/main.cpp" line="704"/>
         <source>Start</source>
         <translation>Mulai</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="790"/>
+        <location filename="../../src/citra_qt/main.cpp" line="795"/>
         <source>Error Opening %1 Folder</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="791"/>
+        <location filename="../../src/citra_qt/main.cpp" line="796"/>
         <source>Folder does not exist!</source>
         <translation>Folder tidak ada!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="805"/>
+        <location filename="../../src/citra_qt/main.cpp" line="810"/>
         <source>3DS Executable</source>
         <translation>3DS Executable</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="806"/>
-        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <location filename="../../src/citra_qt/main.cpp" line="811"/>
+        <location filename="../../src/citra_qt/main.cpp" line="833"/>
         <source>All Files (*.*)</source>
         <translation>Semua File (*.*)</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="808"/>
+        <location filename="../../src/citra_qt/main.cpp" line="813"/>
         <source>Load File</source>
         <translation>Muat File</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="818"/>
+        <location filename="../../src/citra_qt/main.cpp" line="823"/>
         <source>Select Directory</source>
         <translation>Pilih Direktori</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="827"/>
+        <location filename="../../src/citra_qt/main.cpp" line="832"/>
         <source>Load Files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <location filename="../../src/citra_qt/main.cpp" line="833"/>
         <source>3DS Installation File (*.CIA*)</source>
         <translation>3DS Installation File (*.CIA*)</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="859"/>
+        <location filename="../../src/citra_qt/main.cpp" line="864"/>
         <source>%1 has been installed successfully.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="862"/>
+        <location filename="../../src/citra_qt/main.cpp" line="867"/>
         <source>Unable to open File</source>
         <translation>Tidak dapat membuka File</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="863"/>
+        <location filename="../../src/citra_qt/main.cpp" line="868"/>
         <source>Could not open %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="867"/>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
         <source>Installation aborted</source>
         <translation>Instalasi dibatalkan</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="868"/>
+        <location filename="../../src/citra_qt/main.cpp" line="873"/>
         <source>The installation of %1 was aborted. Please see the log for more details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <location filename="../../src/citra_qt/main.cpp" line="877"/>
         <source>Invalid File</source>
         <translation>File yang tidak valid</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <location filename="../../src/citra_qt/main.cpp" line="877"/>
         <source>%1 is not a valid CIA</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="875"/>
+        <location filename="../../src/citra_qt/main.cpp" line="880"/>
         <source>Encrypted File</source>
         <translation>File ter-Encrypt</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="876"/>
+        <location filename="../../src/citra_qt/main.cpp" line="881"/>
         <source>%1 must be decrypted before being used with Citra. A real 3DS is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="899"/>
+        <location filename="../../src/citra_qt/main.cpp" line="904"/>
         <source>File not found</source>
         <translation>File tidak ditemukan</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="900"/>
+        <location filename="../../src/citra_qt/main.cpp" line="905"/>
         <source>File &quot;%1&quot; not found</source>
         <translation>File &quot;%1&quot; tidak ditemukan</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="914"/>
+        <location filename="../../src/citra_qt/main.cpp" line="919"/>
         <source>Continue</source>
         <translation>Lanjut</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="939"/>
+        <location filename="../../src/citra_qt/main.cpp" line="944"/>
         <source>Missing Citra Account</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="940"/>
+        <location filename="../../src/citra_qt/main.cpp" line="945"/>
         <source>In order to submit a game compatibility test case, you must link your Citra account.&lt;br&gt;&lt;br/&gt;To link your Citra account, go to Emulation &amp;gt; Configuration &amp;gt; Web.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1090"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1095"/>
         <source>Speed: %1% / %2%</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1094"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1099"/>
         <source>Speed: %1%</source>
         <translation>Kecepatan: %1%</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1096"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1101"/>
         <source>Game: %1 FPS</source>
         <translation>Game: %1 FPS</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1097"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1102"/>
         <source>Frame: %1 ms</source>
         <translation>Frame: %1 ms</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1108"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1113"/>
         <source>The game you are trying to load requires additional files from your 3DS to be dumped before playing.&lt;br/&gt;&lt;br/&gt;For more information on dumping these files, please see the following wiki page: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
         <translation>Game yang akan Anda muat membutuhkan file tambahan dari 3DS untuk di dump sebelum dimainkan.&lt;br/&gt;&lt;br/&gt;Untuk informasi lebih lanjut tentang cara melakukan dump file tersebut, silahkan lihat halaman wiki ini: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Apakah Anda ingin keluar dan kembali ke daftar game? Melanjutkan emulasi bisa menyebabkan Crash, save data rusak, atau bug lainnya.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1120"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1125"/>
         <source>: %1. </source>
         <translation>: %1. </translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1126"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1131"/>
         <source>System Archive Not Found</source>
         <translation>Arsip Sistem Tidak Ditemukan</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1133"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1138"/>
         <source>Citra was unable to locate the 3DS shared fonts. </source>
         <translation>Citra tidak dapat menemukan 3DS shared fonts.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1135"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1140"/>
         <source>Shared Fonts Not Found</source>
         <translation>Shared Fonts Tidak Ditemukan</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1143"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1148"/>
         <source>Fatal Error</source>
         <translation>Fatal Error</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1144"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1149"/>
         <source>Citra has encountered a fatal error, please see the log for more details. For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
         <translation>Citra mengalami kesalahan fatal, lihat log untuk detail lebih lanjut. Untuk informasi lebih lanjut tentang mengakses log, silahkan lihat halaman ini : &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Apakah Anda ingin keluar dan kembali ke daftar game? Melanjutkan emulasi bisa menyebabkan Crash, save data rusak, atau bug lainnya.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
-        <location filename="../../src/citra_qt/main.cpp" line="1245"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1183"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1250"/>
         <source>Citra</source>
         <translation>Citra</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1183"/>
         <source>Are you sure you want to close Citra?</source>
         <translation>Apakah Anda yakin ingin menutup Citra?</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1246"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1251"/>
         <source>Are you sure you want to stop the emulation? Any unsaved progress will be lost.</source>
         <translation>Apakah Anda yakin ingin menghentikan emulasi? Semua perkembangan yang belum disimpan akan hilang.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1318"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1323"/>
         <source>Citra %1| %2-%3</source>
         <translation>Citra %1| %2-%3</translation>
     </message>
@@ -1452,83 +1472,83 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics.cpp" line="67"/>
         <source>Graphics Debugger</source>
-        <translation>Debugger Grafik</translation>
+        <translation>Debugger Grafis</translation>
     </message>
 </context>
 <context>
     <name>GameList</name>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="117"/>
         <source>Perfect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="117"/>
         <source>Game functions flawless with no audio or graphical glitches, all tested functionality works as intended without
 any workarounds needed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="118"/>
         <source>Great</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="118"/>
         <source>Game functions with minor graphical or audio glitches and is playable from start to finish. May require some
 workarounds.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="119"/>
         <source>Okay</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="119"/>
         <source>Game functions with major graphical or audio glitches, but game is playable from start to finish with
 workarounds.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="120"/>
         <source>Bad</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="120"/>
         <source>Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches
 even with workarounds.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="121"/>
         <source>Intro/Menu</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="121"/>
         <source>Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start
 Screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="122"/>
         <source>Won&apos;t Boot</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="122"/>
         <source>The game crashes when attempting to startup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="123"/>
         <source>Not Tested</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="123"/>
         <source>The game has not yet been tested.</source>
         <translation type="unfinished"/>
     </message>
@@ -1558,17 +1578,17 @@ Screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="324"/>
+        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
         <source>Open Save Data Location</source>
         <translation>Buka Lokasi Save Data</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
+        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
         <source>Open Application Location</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
+        <location filename="../../src/citra_qt/game_list.cpp" line="327"/>
         <source>Open Update Data Location</source>
         <translation type="unfinished"/>
     </message>
@@ -2001,47 +2021,42 @@ Screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="73"/>
         <source>Password Required to Join</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="74"/>
         <source>Password:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="77"/>
-        <source>Password</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="139"/>
         <source>Room Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="143"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="140"/>
         <source>Preferred Game</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="144"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="141"/>
         <source>Host</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="145"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
         <source>Players</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="153"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="150"/>
         <source>Refreshing</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="201"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="198"/>
         <source>Refresh List</source>
         <translation type="unfinished"/>
     </message>
@@ -2251,7 +2266,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="349"/>
         <source>Report Compatibility</source>
-        <translation type="unfinished"/>
+        <translation>Laporkan Kompatibilitas</translation>
     </message>
 </context>
 <context>
@@ -2267,27 +2282,27 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/state.cpp" line="41"/>
         <source>Current connection status</source>
-        <translation type="unfinished"/>
+        <translation>Status koneksi saat ini</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/state.cpp" line="42"/>
         <source>Not Connected. Click here to find a room!</source>
-        <translation type="unfinished"/>
+        <translation>Tidak Terhubung. Klik disini untuk mencari ruangan!</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/state.cpp" line="100"/>
         <source>Connected</source>
-        <translation type="unfinished"/>
+        <translation>Terhubung</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/state.cpp" line="105"/>
         <source>Not Connected</source>
-        <translation type="unfinished"/>
+        <translation>Tidak Terhubung</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/state.cpp" line="114"/>
         <source>Error</source>
-        <translation type="unfinished"/>
+        <translation>Error</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/state.cpp" line="115"/>
@@ -2301,32 +2316,32 @@ Debug Message: </source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="12"/>
         <source>Username is not valid. Must be 4 to 20 alphanumeric characters.</source>
-        <translation type="unfinished"/>
+        <translation>Username tidak valid. Harus merupakan 4 sampai 20 karakter alphanumeric</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="14"/>
         <source>Room name is not valid. Must be 4 to 20 alphanumeric characters.</source>
-        <translation type="unfinished"/>
+        <translation>Nama ruangan tidak valid. Harus merupakan 4 sampai 20 karakter alphanumeric</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="16"/>
         <source>Username is already in use. Please choose another.</source>
-        <translation type="unfinished"/>
+        <translation>Username sudah digunakan. Silahkan pilih lainnya.</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="17"/>
         <source>IP is not a valid IPv4 address.</source>
-        <translation type="unfinished"/>
+        <translation>IP bukan IPv4 address yang valid.</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="18"/>
         <source>Port must be a number between 0 to 65535.</source>
-        <translation type="unfinished"/>
+        <translation>Port harus merupakan angka antara 0 hingga 65535</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="20"/>
         <source>Unable to find an internet connection. Check your internet settings.</source>
-        <translation type="unfinished"/>
+        <translation>Tidak dapat menemukan koneksi internet. Periksa pengaturan internet anda.</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="22"/>
@@ -2336,42 +2351,42 @@ Debug Message: </source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="26"/>
         <source>Creating a room failed. Please retry. Restarting Citra might be necessary.</source>
-        <translation type="unfinished"/>
+        <translation>Pembuatan ruangan gagal. Silahkan coba lagi. Memerlukan mulai ulang Citra</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="28"/>
         <source>The host of the room has banned you. Speak with the host to unban you or try a different room.</source>
-        <translation type="unfinished"/>
+        <translation>Host ruangan telah mem-banned anda. Bicaralah pada host untuk membatalkan ban atau coba ruangan lainnya.</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="31"/>
         <source>Version mismatch! Please update to the latest version of Citra. If the problem persists, contact the room host and ask them to update the server.</source>
-        <translation type="unfinished"/>
+        <translation>Versi tidak cocok! Silahkan perbarui Citra ke versi terbaru. Jika masalah ini berlanjut, hubungi host ruangan dan minta mereka untuk memperbarui server.</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="33"/>
         <source>Incorrect password.</source>
-        <translation type="unfinished"/>
+        <translation>Password salah.</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="35"/>
         <source>An unknown error occured. If this error continues to occur, please open an issue</source>
-        <translation type="unfinished"/>
+        <translation>Terjadi Error yang tidak diketahui. Jika error ini terus terjadi, silahkan membuka masalah</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="36"/>
         <source>Connection to room lost. Try to reconnect.</source>
-        <translation type="unfinished"/>
+        <translation>Koneksi ke ruangan gagal. Coba untuk menghubungkan kembali.</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="38"/>
         <source>MAC address is already in use. Please choose another.</source>
-        <translation type="unfinished"/>
+        <translation>MAC address sudah digunakan. Silahkan pilih lainnya.</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="52"/>
         <source>Leave Room</source>
-        <translation type="unfinished"/>
+        <translation>Tinggalkan Ruangan</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="53"/>
@@ -2394,7 +2409,7 @@ Debug Message: </source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="47"/>
         <source>Error</source>
-        <translation type="unfinished"/>
+        <translation>Error</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="198"/>
@@ -2404,6 +2419,57 @@ Debug Message: </source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="201"/>
         <source>%1 is playing %2</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="208"/>
+        <source>Invalid region</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Japan</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>North America</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="92"/>
+        <source>Europe</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="94"/>
+        <source>Australia</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="96"/>
+        <source>China</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="98"/>
+        <source>Korea</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="100"/>
+        <source>Taiwan</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="102"/>
+        <source>Region free</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="104"/>
+        <source>Invalid Region</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/dist/languages/it.ts
+++ b/dist/languages/it.ts
@@ -1,0 +1,2754 @@
+<?xml version="1.0" ?><!DOCTYPE TS><TS language="it" version="2.1">
+<context>
+    <name>ARMRegisters</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="14"/>
+        <source>ARM Registers</source>
+        <translation>Registri ARM</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="25"/>
+        <source>Register</source>
+        <translation>Registro</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="30"/>
+        <source>Value</source>
+        <translation>Valore</translation>
+    </message>
+</context>
+<context>
+    <name>AboutDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="14"/>
+        <source>About Citra</source>
+        <translation>Riguardo Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="30"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/citra.png&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/citra.png&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="60"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:28pt;&quot;&gt;Citra&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:28pt;&quot;&gt;Citra&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="73"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="86"/>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:12pt;&quot;&gt;Citra is a free and open source 3DS emulator licensed under GPLv2.0 or any later version.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'MS Shell Dlg 2'; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;This software should not be used to play games you have not legally obtained.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>.&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;Citra è un emulatore del 3DS gratuito e open source sotto licenza GPLv2.0 o versioni successive.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;Questo software non dovrebbe essere usato per avviare videogiochi ottenuti illegalmente.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="118"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Website&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://community.citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Forum&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Source Code&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Contributors&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/blob/master/license.txt&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;License&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Sito Web&lt;/span&gt;&lt;/a&gt;|&lt;a href=&quot;https://community.citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Forum&lt;/span&gt;&lt;/a&gt;|&lt;a href=&quot;https://github.com/citra-emu&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Codice Sorgente&lt;/span&gt;&lt;/a&gt;|&lt;a href=&quot;https://github.com/citra-emu/citra/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Contributi&lt;/span&gt;&lt;/a&gt;|&lt;a href=&quot;https://github.com/citra-emu/citra/blob/master/license.txt&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Licenza&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="134"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;&amp;quot;3DS&amp;quot; is a trademark of Nintendo. Citra is not affiliated with Nintendo in any way.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;&amp;quot;3DS&amp;quot; è un marchio registrato di Nintendo. Citra non è affiliato in alcun modo a Nintendo.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>BreakPointModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="34"/>
+        <source>Pica command loaded</source>
+        <translation>Comando Pica caricato</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="35"/>
+        <source>Pica command processed</source>
+        <translation>Comando Pica eseguito</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="36"/>
+        <source>Incoming primitive batch</source>
+        <translation>Batch primitivo in arrivo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="37"/>
+        <source>Finished primitive batch</source>
+        <translation>Batch primitivo terminato</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="38"/>
+        <source>Vertex shader invocation</source>
+        <translation>Invocazione vertex shader</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="40"/>
+        <source>Incoming display transfer</source>
+        <translation>Trasferimento display in arrivo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="41"/>
+        <source>GSP command processed</source>
+        <translation>Comando GSP eseguito</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="42"/>
+        <source>Buffers swapped</source>
+        <translation>Buffer scambiati</translation>
+    </message>
+</context>
+<context>
+    <name>ChatRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="14"/>
+        <source>Room Window</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="40"/>
+        <source>Send Chat Message</source>
+        <translation>Invia Messaggio in Chat</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="47"/>
+        <source>Send Message</source>
+        <translation>Invia Messaggio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.cpp" line="81"/>
+        <source>Name</source>
+        <translation>Nome</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.cpp" line="82"/>
+        <source>Game</source>
+        <translation>Gioco</translation>
+    </message>
+</context>
+<context>
+    <name>ClientRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.ui" line="14"/>
+        <source>Room Window</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.ui" line="40"/>
+        <source>Leave Room</source>
+        <translation>Esci dalla Stanza</translation>
+    </message>
+</context>
+<context>
+    <name>ClientRoomWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="54"/>
+        <source>Connected</source>
+        <translation>Connesso</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="65"/>
+        <source>Disconnected</source>
+        <translation>Disconnesso</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="78"/>
+        <source>%1 (%2/%3 members) - connected</source>
+        <translation>%1 (%2/%3 membri) - connesso</translation>
+    </message>
+</context>
+<context>
+    <name>CompatDB</name>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="20"/>
+        <source>Report Compatibility</source>
+        <translation>Segnala compatibilità</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="27"/>
+        <location filename="../../src/citra_qt/compatdb.ui" line="63"/>
+        <source>Report Game Compatibility</source>
+        <translation>Segnala compatibilità gioco</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="36"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;Should you choose to submit a test case to the &lt;/span&gt;&lt;a href=&quot;https://citra-emu.org/game/&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;Citra Compatibility List&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;, The following information will be collected and displayed on the site:&lt;/span&gt;&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Hardware Information (CPU / GPU / Operating System)&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Which version of Citra you are running&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The connected Citra account&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;Se dovessi scegliere di inviare un rapporto alla &lt;/span&gt;&lt;a href=&quot;https://citra-emu.org/game/&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;Lista di Compatibilità di Citra&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;, Le seguenti informazioni saranno raccolte e visualizzate sul sito: &lt;/span&gt;&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Informazioni sull&apos;Hardware (CPU / GPU / Sistema Operativo)&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Quale versione di Citra stai utilizzando&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;L&apos;account di Citra connesso&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="72"/>
+        <source>Perfect</source>
+        <translation>Perfetto</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="79"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions flawlessly with no audio or graphical glitches.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Il gioco funziona senza problemi senza alcun glitch audio o video.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="89"/>
+        <source>Great </source>
+        <translation>Buono</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="96"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions with minor graphical or audio glitches and is playable from start to finish. May require some workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Il gioco presenta alcuni glitch audio o video minori ed è possibile giocare dall&apos;inizio alla fine. Potrebbero essere necessari dei metodi alternativi.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="106"/>
+        <source>Okay</source>
+        <translation>Okay</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="113"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions with major graphical or audio glitches, but game is playable from start to finish with workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Il gioco presenta dei glitch principali video o audio, ma è possibile giocare dall&apos;inizio alla fine con dei metodi alternativi.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="123"/>
+        <source>Bad</source>
+        <translation>Cattivo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="130"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches even with workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Il gioco presenta alcuni glitch principali audio o video. E&apos; impossibile proseguire in alcune aree a causa della presenza di glitch persino utilizzando metodi alternativi.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="140"/>
+        <source>Intro/Menu</source>
+        <translation>Intro/Menu</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="147"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start Screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Questo gioco è completamente ingiocabile a causa di glitch principali audio o video. E&apos; impossibile proseguire oltre la schermata iniziale.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="157"/>
+        <source>Won&apos;t Boot</source>
+        <translation>Non si Avvia</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="170"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The game crashes when attempting to startup.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Il gioco si blocca quando viene avviato.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="182"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Independent of speed or performance, how well does this game play from start to finish on this version of Citra?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Indipendentemente da velocità o prestazioni, come ti è sembrato giocare questo gioco dall&apos;inizio alla fine su questa versione di Citra?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="206"/>
+        <source>Thank you for your submission!</source>
+        <translation>Grazie per la segnalazione!</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureAudio</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="10"/>
+        <source>Audio</source>
+        <translation>Audio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="18"/>
+        <source>Output Engine:</source>
+        <translation>Motore di Output:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="31"/>
+        <source>Enable audio stretching</source>
+        <translation>Abilita allungamento dell&apos;audio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="34"/>
+        <source>This post-processing effect adjusts audio speed to match emulation speed and helps prevent audio stutter. This however increases audio latency.</source>
+        <translation>Questo effetto di post-processing permette di far combaciare la velocità dell&apos;emulazione con quella dell&apos;audio per prevenire lo stutter. Questo però aumenta la latenza dell&apos;audio.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="43"/>
+        <source>Audio Device:</source>
+        <translation>Dispositivo Audio:</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureDebug</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="14"/>
+        <source>Form</source>
+        <translation>Modulo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="22"/>
+        <source>GDB</source>
+        <translation>GDB</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="28"/>
+        <source>The GDB Stub only works correctly when the CPU JIT is off.</source>
+        <translation>Lo Stub GDB funziona correttamente solamente quando il JIT CPU è disabilitato.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="37"/>
+        <source>Enable GDB Stub</source>
+        <translation>Abilita Stub GDB</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="57"/>
+        <source>Port:</source>
+        <translation>Porta:</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="14"/>
+        <source>Citra Configuration</source>
+        <translation>Configurazione di Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="24"/>
+        <source>General</source>
+        <translation>Generale</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="29"/>
+        <source>System</source>
+        <translation>Sistema</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="34"/>
+        <source>Input</source>
+        <translation>Input</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="39"/>
+        <source>Graphics</source>
+        <translation>Grafica</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="44"/>
+        <source>Audio</source>
+        <translation>Audio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="49"/>
+        <source>Debug</source>
+        <translation>Debug</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="54"/>
+        <source>Web</source>
+        <translation>Web</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureGeneral</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="14"/>
+        <source>Form</source>
+        <translation>Modulo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="22"/>
+        <source>General</source>
+        <translation>Generale</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="30"/>
+        <source>Confirm exit while emulation is running</source>
+        <translation>Conferma uscita con emulazione in corso</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="37"/>
+        <source>Search sub-directories for games</source>
+        <translation>Cerca giochi nelle sottocartelle</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="46"/>
+        <source>Interface language</source>
+        <translation>Lingua dell&apos;Interfaccia</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="63"/>
+        <source>Updates</source>
+        <translation>Aggiornamenti</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="71"/>
+        <source>Check for updates on start</source>
+        <translation>Controlla aggiornamenti all&apos;avvio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="78"/>
+        <source>Silently auto update after closing</source>
+        <translation>Aggiorna automaticamente dopo la chiusura</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="90"/>
+        <source>Performance</source>
+        <translation>Prestazioni</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="98"/>
+        <source>Enable CPU JIT</source>
+        <translation>Abilita JIT CPU</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="110"/>
+        <source>Emulation</source>
+        <translation>Emulazione</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="120"/>
+        <source>Region:</source>
+        <translation>Regione:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="128"/>
+        <source>Auto-select</source>
+        <translation>Selezione automatica</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="178"/>
+        <source>Theme</source>
+        <translation>Tema</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="188"/>
+        <source>Theme:</source>
+        <translation>Tema:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="205"/>
+        <source>Hotkeys</source>
+        <translation>Hotkey:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.cpp" line="16"/>
+        <source>&lt;System&gt;</source>
+        <translation>&lt;System&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.cpp" line="17"/>
+        <source>English</source>
+        <translation>Inglese</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureGraphics</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="14"/>
+        <source>Form</source>
+        <translation>Modulo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="22"/>
+        <source>Graphics</source>
+        <translation>Grafica</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="28"/>
+        <source>Enable hardware renderer</source>
+        <translation>Abilita renderer hardware</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="35"/>
+        <source>Enable shader JIT</source>
+        <translation>Abilita shader JIT </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="42"/>
+        <source>Enable V-Sync</source>
+        <translation>Abilita V-Sync</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="51"/>
+        <source>Limit Speed Percent</source>
+        <translation>Percentuale Limite della Velocità</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="58"/>
+        <source>%</source>
+        <translation>%</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="78"/>
+        <source>Internal Resolution:</source>
+        <translation>Risoluzione Interna:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="86"/>
+        <source>Auto (Window Size)</source>
+        <translation>Automatica (Dimensione Finestra)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="91"/>
+        <source>Native (400x240)</source>
+        <translation>Nativa (400x240)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="96"/>
+        <source>2x Native (800x480)</source>
+        <translation>2x Nativa (800x480)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="101"/>
+        <source>3x Native (1200x720)</source>
+        <translation>3x Nativa (1200x720)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="106"/>
+        <source>4x Native (1600x960)</source>
+        <translation>4x Nativa (1600x960)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="111"/>
+        <source>5x Native (2000x1200)</source>
+        <translation>5x Nativa (2000x1200)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="116"/>
+        <source>6x Native (2400x1440)</source>
+        <translation>6x Nativa (2400x1440)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="121"/>
+        <source>7x Native (2800x1680)</source>
+        <translation>7x Nativa (2800x1680)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="126"/>
+        <source>8x Native (3200x1920)</source>
+        <translation>8x Nativa (3200x1920)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="131"/>
+        <source>9x Native (3600x2160)</source>
+        <translation>9x Nativa (3600x2160)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="136"/>
+        <source>10x Native (4000x2400)</source>
+        <translation>10x Nativa (4000x2400)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="151"/>
+        <source>Layout</source>
+        <translation>Disposizione</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="161"/>
+        <source>Screen Layout:</source>
+        <translation>Disposizione schermi:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="169"/>
+        <source>Default</source>
+        <translation>Default</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="174"/>
+        <source>Single Screen</source>
+        <translation>Schermo Singolo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="179"/>
+        <source>Large Screen</source>
+        <translation>Schermo Grande</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="184"/>
+        <source>Side by Side</source>
+        <translation>Affiancati</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="194"/>
+        <source>Swap Screens</source>
+        <translation>Scambia Schermi</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureInput</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="14"/>
+        <source>ConfigureInput</source>
+        <translation>ConfiguraInput</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="22"/>
+        <source>Face Buttons</source>
+        <translation>Bottoni Frontali</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="36"/>
+        <source>A:</source>
+        <translation>A:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="54"/>
+        <source>B:</source>
+        <translation>B:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="72"/>
+        <source>X:</source>
+        <translation>X:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="90"/>
+        <source>Y:</source>
+        <translation>Y:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="109"/>
+        <source>Directional Pad</source>
+        <translation>Pad Direzionale</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="123"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="340"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="427"/>
+        <source>Up:</source>
+        <translation>Su:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="141"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="358"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="445"/>
+        <source>Down:</source>
+        <translation>Giù:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="159"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="304"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="391"/>
+        <source>Left:</source>
+        <translation>Sinistra:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="177"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="322"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="409"/>
+        <source>Right:</source>
+        <translation>Destra:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="196"/>
+        <source>Shoulder Buttons</source>
+        <translation>Bottoni Dorsali:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="210"/>
+        <source>L:</source>
+        <translation>L:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="228"/>
+        <source>R:</source>
+        <translation>R:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="246"/>
+        <source>ZL:</source>
+        <translation>ZL:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="264"/>
+        <source>ZR:</source>
+        <translation>ZR:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="283"/>
+        <source>Circle Pad</source>
+        <translation>Pad Circolare</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="295"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="461"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="232"/>
+        <source>Set Analog Stick</source>
+        <translation>Imposta Stick Analogico</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="377"/>
+        <source>C-Stick</source>
+        <translation>Stick C</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="471"/>
+        <source>Misc.</source>
+        <translation>Altro</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="485"/>
+        <source>Start:</source>
+        <translation>Start:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="503"/>
+        <source>Select:</source>
+        <translation>Select:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="521"/>
+        <source>Home:</source>
+        <translation>Home:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="539"/>
+        <source>Circle Mod:</source>
+        <translation>Mod Circolare:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="596"/>
+        <source>Restore Defaults</source>
+        <translation>Reimposta Default</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="239"/>
+        <source>[press key]</source>
+        <translation>[premi pulsante]</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureSystem</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="14"/>
+        <source>Form</source>
+        <translation>Modulo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="22"/>
+        <source>System Settings</source>
+        <translation>Impostazioni di Sistema</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="28"/>
+        <source>Username</source>
+        <translation>Nome utente</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="48"/>
+        <source>Birthday</source>
+        <translation>Compleanno</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="58"/>
+        <source>January</source>
+        <translation>Gennaio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="63"/>
+        <source>February</source>
+        <translation>Febbraio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="68"/>
+        <source>March</source>
+        <translation>Marzo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="73"/>
+        <source>April</source>
+        <translation>Aprile</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="78"/>
+        <source>May</source>
+        <translation>Maggio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="83"/>
+        <source>June</source>
+        <translation>Giugno</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="88"/>
+        <source>July</source>
+        <translation>Luglio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="93"/>
+        <source>August</source>
+        <translation>Agosto</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="98"/>
+        <source>September</source>
+        <translation>Settembre</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="103"/>
+        <source>October</source>
+        <translation>Ottobre</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="108"/>
+        <source>November</source>
+        <translation>Novembre</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="113"/>
+        <source>December</source>
+        <translation>Dicembre</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="126"/>
+        <source>Language</source>
+        <translation>Lingua</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="133"/>
+        <source>Note: this can be overridden when region setting is auto-select</source>
+        <translation>Nota: questa impostazione può essere sovrascritta quando le impostazioni regionali sono su Selezione automatica</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="137"/>
+        <source>Japanese (日本語)</source>
+        <translation>Giapponese (日本語)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="142"/>
+        <source>English</source>
+        <translation>Inglese (English)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="147"/>
+        <source>French (français)</source>
+        <translation>Francese (Français)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="152"/>
+        <source>German (Deutsch)</source>
+        <translation>Tedesco (Deutsch)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="157"/>
+        <source>Italian (italiano)</source>
+        <translation>Italiano</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="162"/>
+        <source>Spanish (español)</source>
+        <translation>Spagnolo (Español)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="167"/>
+        <source>Simplified Chinese (简体中文)</source>
+        <translation>Cinese Semplificato (简体中文)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="172"/>
+        <source>Korean (한국어)</source>
+        <translation>Coreano (한국어)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="177"/>
+        <source>Dutch (Nederlands)</source>
+        <translation>Olandese (Nederlands)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="182"/>
+        <source>Portuguese (português)</source>
+        <translation>Portoghese (Português)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="187"/>
+        <source>Russian (Русский)</source>
+        <translation>Russo (Русский)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="192"/>
+        <source>Traditional Chinese (正體中文)</source>
+        <translation>Cinese Tradizionale (正體中文)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="200"/>
+        <source>Sound output mode</source>
+        <translation>Modalità di output del sonoro</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="208"/>
+        <source>Mono</source>
+        <translation>Mono</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="213"/>
+        <source>Stereo</source>
+        <translation>Stereo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="218"/>
+        <source>Surround</source>
+        <translation>Surround</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="226"/>
+        <source>Console ID:</source>
+        <translation>ID Console:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="242"/>
+        <source>Regenerate</source>
+        <translation>Rigenera</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="252"/>
+        <source>System settings are available only when game is not running.</source>
+        <translation>Le impostazioni del sistema sono disponibili solo quando non è in esecuzione nessun gioco.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="87"/>
+        <source>Console ID: 0x%1</source>
+        <translation>ID Console: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="160"/>
+        <source>This will replace your current virtual 3DS with a new one. Your current virtual 3DS will not be recoverable. This might have unexpected effects in games. This might fail, if you use an outdated config savegame. Continue?</source>
+        <translation>Questo rimpiazzerà il tuo 3DS virtuale corrente con uno nuovo. Il tuo 3DS virtuale corrente non sarà ripristinabile. Questo potrebbe causare degli effetti inaspettati sui giochi. Potrebbe inoltre fallire, se usi una configurazione di salvataggio datata. Desideri continuare?</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="164"/>
+        <source>Warning</source>
+        <translation>Attenzione</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureWeb</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="14"/>
+        <source>Form</source>
+        <translation>Modulo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="22"/>
+        <source>Citra Web Service</source>
+        <translation>Servizio Web di Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="28"/>
+        <source>By providing your username and token, you agree to allow Citra to collect additional usage data, which may include user identifying information.</source>
+        <translation>Fornendo il tuo username e token, permetti a Citra di raccogliere dati di utilizzo, che potrebbero includere informazioni di identificazione utente.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="46"/>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="90"/>
+        <source>Verify</source>
+        <translation>Verifica</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="53"/>
+        <source>Sign up</source>
+        <translation>Registrati</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="67"/>
+        <source>Token: </source>
+        <translation>Token:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="78"/>
+        <source>Username: </source>
+        <translation>Nome utente</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="99"/>
+        <source>What is my token?</source>
+        <translation>Qual è il mio token?</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="124"/>
+        <source>Telemetry</source>
+        <translation>Telemetria</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="130"/>
+        <source>Share anonymous usage data with the Citra team</source>
+        <translation>Condividi dati sull&apos;utilizzo anonimamente con il team di Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="137"/>
+        <source>Learn more</source>
+        <translation>Per saperne di più</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="146"/>
+        <source>Telemetry ID:</source>
+        <translation>ID Telemetria:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="162"/>
+        <source>Regenerate</source>
+        <translation>Rigenera</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="28"/>
+        <source>&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Per saperne di più&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="33"/>
+        <source>&lt;a href=&apos;https://services.citra-emu.org/&apos;&gt;Sign up&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://services.citra-emu.org/&apos;&gt;Registrati&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="36"/>
+        <source>&lt;a href=&apos;https://citra-emu.org/wiki/citra-web-service/&apos;&gt;What is my token?&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://citra-emu.org/wiki/citra-web-service/&apos;&gt;Qual è il mio token?&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="45"/>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="65"/>
+        <source>Telemetry ID: 0x%1</source>
+        <translation>ID Telemetria: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="55"/>
+        <source>Username and token not verified</source>
+        <translation>Nome utente e token non verificati</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="56"/>
+        <source>Username and token were not verified. The changes to your username and/or token have not been saved.</source>
+        <translation>Nome utente e token non verificati. I cambiamenti al tuo nome utente e/o token non sono stati salvati.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="85"/>
+        <source>Verifying</source>
+        <translation>Verifica in corso</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="99"/>
+        <source>Verification failed</source>
+        <translation>Verifica fallita</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="100"/>
+        <source>Verification failed. Check that you have entered your username and token correctly, and that your internet connection is working.</source>
+        <translation>Verifica fallita. Controlla di aver inserito correttamente il tuo username e token, e che la tua connessione ad internet sia funzionante.</translation>
+    </message>
+</context>
+<context>
+    <name>DirectConnect</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="14"/>
+        <source>Direct Connect</source>
+        <translation>Collegamento Diretto</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="33"/>
+        <source>IP Address</source>
+        <translation>Indirizzo IP</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="56"/>
+        <source>IP</source>
+        <translation>IP</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="63"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;IPv4 address of the host&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Indirizzo IPv4 dell&apos;host&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="73"/>
+        <source>Port</source>
+        <translation>Porta</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="80"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Port number the host is listening on&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Numero porta dell&apos;host in ascolto&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="86"/>
+        <source>24872</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="100"/>
+        <source>Nickname</source>
+        <translation>Nickname</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="114"/>
+        <source>Password</source>
+        <translation>Password</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="156"/>
+        <source>Connect</source>
+        <translation>Connetti</translation>
+    </message>
+</context>
+<context>
+    <name>DirectConnectWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="97"/>
+        <source>Connecting</source>
+        <translation>Connessione in corso</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="102"/>
+        <source>Connect</source>
+        <translation>Connetti</translation>
+    </message>
+</context>
+<context>
+    <name>GMainWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="90"/>
+        <source>To help improve Citra, the Citra Team collects anonymous usage data. No private or personally identifying information is collected. This data helps us to understand how people use Citra and prioritize our efforts. Furthermore, it helps us to more easily identify emulation bugs and performance issues. This data includes:&lt;ul&gt;&lt;li&gt;Information about the version of Citra you are using&lt;/li&gt;&lt;li&gt;Performance data about the games you play&lt;/li&gt;&lt;li&gt;Your configuration settings&lt;/li&gt;&lt;li&gt;Information about your computer hardware&lt;/li&gt;&lt;li&gt;Emulation errors and crash information&lt;/li&gt;&lt;/ul&gt;By default, this feature is enabled. To disable this feature, click &apos;Emulation&apos; from the menu and then select &apos;Configure...&apos;. Then, on the &apos;Web&apos; tab, uncheck &apos;Share anonymous usage data with the Citra team&apos;. &lt;br/&gt;&lt;br/&gt;By using this software, you agree to the above terms.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Per aiutare a migliorare Citra, il Team di Citra raccoglie dati anonimi di utilizzo. Nessuna informazione di identificazione personale è raccolta. Questi dati ci aiutano a capire come gli utenti utilizzano Citra per dare delle priorità ai nostri sforzi. Inoltre, ci aiutano ad individuare bug e problemi di prestazioni più facilmente. Questi dati includono:&lt;ul&gt;&lt;li&gt;Informazioni riguardo la versione di Citra in uso&lt;/li&gt;&lt;li&gt;Dati di prestazioni riguardo i giochi utilizzati&lt;/li&gt;&lt;li&gt;Le impostazioni di configurazione&lt;/li&gt;&lt;li&gt;Informazioni sull&apos;hardware del tuo computer&lt;/li&gt;&lt;li&gt;Informazioni su errori e crash dell&apos;emulazione&lt;/li&gt;&lt;/ul&gt;Di default, questa impostazione è abilitata. Per disabilitarla, clicca &apos;Emulazione&apos; dal menu e seleziona &apos;Configura...&apos;. Quindi nella scheda &apos;Web&apos;, togli la spunta su &apos;Condividi dati sull&apos;utilizzo anonimamente con il team di Citra&apos;.&lt;br/&gt;&lt;br/&gt;Utilizzando questo software, accetti i termini indicati sopra.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Per saperne di più&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="195"/>
+        <source>Current emulation speed. Values higher or lower than 100% indicate emulation is running faster or slower than a 3DS.</source>
+        <translation>Velocità di emulazione corrente. Valori più alti o più bassi di 100% indicano che l&apos;emulazione sta funzionando più velocemente o lentamente di un 3DS.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="198"/>
+        <source>How many frames per second the game is currently displaying. This will vary from game to game and scene to scene.</source>
+        <translation>Quanti frame al secondo il gioco visualizza attualmente. Questo varia da gioco a gioco e da situazione a situazione.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="202"/>
+        <source>Time taken to emulate a 3DS frame, not counting framelimiting or v-sync. For full-speed emulation this should be at most 16.67 ms.</source>
+        <translation>Tempo necessario per emulare un frame del 3DS, senza contare il limite al framerate o il v-sync. Per un&apos;emulazione a pieno regime questa dovrebbe essere al più 16.67 ms.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="429"/>
+        <source>CTRL+F</source>
+        <translation>CTRL+F</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="538"/>
+        <source>Update available!</source>
+        <translation>Aggiornamento disponibile!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="539"/>
+        <source>An update for Citra is available. Do you wish to install it now?&lt;br /&gt;&lt;br /&gt;This &lt;b&gt;will&lt;/b&gt; terminate emulation, if it is running.</source>
+        <translation>Un aggiornamento per Citra è disponibile. Desideri installarlo ora? &lt;br /&gt;&lt;br /&gt;Questo &lt;b&gt;terminerà&lt;/b&gt; l&apos;emulazione, se è in corso.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <source>No update found</source>
+        <translation>Nessun aggiornamento disponibile</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <source>No update has been found for Citra.</source>
+        <translation>Nessun aggiornamento per Citra è stato trovato.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="567"/>
+        <source>Error while initializing OpenGL 3.3 Core!</source>
+        <translation>Errore nell&apos;inizializzazione del Core di OpenGL 3.3!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="568"/>
+        <source>Your GPU may not support OpenGL 3.3, or you do not have the latest graphics driver.</source>
+        <translation>La tua GPU potrebbe non supportare OpenGL 3.3, o i driver della tua scheda video potrebbero non essere aggiornati.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="581"/>
+        <location filename="../../src/citra_qt/main.cpp" line="587"/>
+        <location filename="../../src/citra_qt/main.cpp" line="593"/>
+        <location filename="../../src/citra_qt/main.cpp" line="606"/>
+        <location filename="../../src/citra_qt/main.cpp" line="625"/>
+        <source>Error while loading ROM!</source>
+        <translation>Errore nel caricamento della ROM!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="582"/>
+        <location filename="../../src/citra_qt/main.cpp" line="607"/>
+        <source>The ROM format is not supported.</source>
+        <translation>Il formato di questa ROM non è supportato.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="588"/>
+        <source>Could not determine the system mode.</source>
+        <translation>Modalità di sistema non determinabile.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="594"/>
+        <source>The game that you are trying to load must be decrypted before being used with Citra. A real 3DS is required.&lt;br/&gt;&lt;br/&gt;For more information on dumping and decrypting games, please see the following wiki pages: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation>Il gioco che stai cercando di caricare deve essere decriptato prima di essere utilizzato con Citra. È necessario un 3DS reale. &lt;br/&gt;&lt;br/&gt;Per ulteriori informazioni sul dump e la decriptazione dei giochi, dai un&apos;occhiata alle seguenti pagine della wiki: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Estrazione dei giochi&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Estrazione di titoli installati&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="612"/>
+        <source>An error occured in the video core.</source>
+        <translation>Si è verificato un errore nel core video.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="613"/>
+        <source>Citra has encountered an error while running the video core, please see the log for more details.For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.Ensure that you have the latest graphics drivers for your GPU.</source>
+        <translation>Citra ha riscontrato un errore durante il processo del core video, visualizza il log per ulteriori dettagli. Per maggiori informazioni su come accedere al log, visita la seguente pagina: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;Come caricare il File di Log&lt;/a&gt;. Assicurati di avere gli ultimi driver della tua scheda video.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="626"/>
+        <source>An unknown error occured. Please see the log for more details.</source>
+        <translation>Errore sconosciuto. Visualizza il log per maggiori dettagli.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="699"/>
+        <source>Start</source>
+        <translation>Avvia</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="790"/>
+        <source>Error Opening %1 Folder</source>
+        <translation>Errore nell&apos;Apertura della Cartella %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="791"/>
+        <source>Folder does not exist!</source>
+        <translation>La cartella non esiste!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="805"/>
+        <source>3DS Executable</source>
+        <translation>Eseguibile 3DS</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="806"/>
+        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <source>All Files (*.*)</source>
+        <translation>Tutti i file (*.*)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="808"/>
+        <source>Load File</source>
+        <translation>Carica file</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="818"/>
+        <source>Select Directory</source>
+        <translation>Seleziona cartella</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="827"/>
+        <source>Load Files</source>
+        <translation>Carica File</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <source>3DS Installation File (*.CIA*)</source>
+        <translation>File di installazione 3DS (*.CIA*)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="859"/>
+        <source>%1 has been installed successfully.</source>
+        <translation>%1 è stato installato con successo.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="862"/>
+        <source>Unable to open File</source>
+        <translation>Impossibile aprire il File</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="863"/>
+        <source>Could not open %1</source>
+        <translation>Impossibile aprire %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="867"/>
+        <source>Installation aborted</source>
+        <translation>Installazione annullata</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="868"/>
+        <source>The installation of %1 was aborted. Please see the log for more details</source>
+        <translation>L&apos;installazione di %1 è stata annullata. Visualizza il log per maggiori dettagli.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <source>Invalid File</source>
+        <translation>File non valido</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <source>%1 is not a valid CIA</source>
+        <translation>%1 non è un CIA valido</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="875"/>
+        <source>Encrypted File</source>
+        <translation>File Criptato</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="876"/>
+        <source>%1 must be decrypted before being used with Citra. A real 3DS is required.</source>
+        <translation>%1 deve essere decriptato prima di poter essere usato con Citra. E&apos; necessario un 3DS fisico.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="899"/>
+        <source>File not found</source>
+        <translation>File non trovato</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="900"/>
+        <source>File &quot;%1&quot; not found</source>
+        <translation>File &quot;%1&quot; non trovato</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="914"/>
+        <source>Continue</source>
+        <translation>Continua</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="939"/>
+        <source>Missing Citra Account</source>
+        <translation>Account di Citra Mancante</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="940"/>
+        <source>In order to submit a game compatibility test case, you must link your Citra account.&lt;br&gt;&lt;br/&gt;To link your Citra account, go to Emulation &amp;gt; Configuration &amp;gt; Web.</source>
+        <translation>Per poter segnalare la compatibilità di un gioco, devi collegare il tuo Account di Citra.&lt;br&gt;&lt;br/&gt;Per collegare il tuo Account di Citra, vai su Emulazione, &amp;gt; Configurazione &amp;gt; Web</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1090"/>
+        <source>Speed: %1% / %2%</source>
+        <translation>Velocità: %1% / %2%</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1094"/>
+        <source>Speed: %1%</source>
+        <translation>Velocità: %1%</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1096"/>
+        <source>Game: %1 FPS</source>
+        <translation>Gioco: %1 FPS</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1097"/>
+        <source>Frame: %1 ms</source>
+        <translation>Frame: %1 ms</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1108"/>
+        <source>The game you are trying to load requires additional files from your 3DS to be dumped before playing.&lt;br/&gt;&lt;br/&gt;For more information on dumping these files, please see the following wiki page: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
+        <translation>Il gioco che stai tendando di caricare richiede file aggiuntivi che devi estrarre dal tuo 3DS prima di giocare.&lt;br/&gt;&lt;br/&gt;Per maggiori informazioni sull&apos;estrazione di questi file, vedi le seguenti pagine wiki: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Estrazione degli archivi del sistema e font condivisi dal 3DS&lt;/a&gt;. Desideri tornare alla lista dei giochi? Continuare l&apos;emulazione potrebbe risultare in crash, dati di salvataggio corrotti o altri bug.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1120"/>
+        <source>: %1. </source>
+        <translation>: %1. </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1126"/>
+        <source>System Archive Not Found</source>
+        <translation>Archivio di Sistema Non Trovato</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1133"/>
+        <source>Citra was unable to locate the 3DS shared fonts. </source>
+        <translation>Citra non riesce a localizzare i font condivisi del 3DS.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1135"/>
+        <source>Shared Fonts Not Found</source>
+        <translation>Font Condivisi Non Trovati</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1143"/>
+        <source>Fatal Error</source>
+        <translation>Errore fatale</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1144"/>
+        <source>Citra has encountered a fatal error, please see the log for more details. For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
+        <translation>Citra ha riscontrato un errore fatale, visualizza il log per maggiori dettagli. Per ulteriori informazioni su come accedere al log, visita la seguente pagina: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;Come Caricare il file di Log&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Vuoi tornare alla lista dei giochi? Continuare l&apos;emulazione potrebbe risultare in crash, dati di salvataggio corrotti o altri bug.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1245"/>
+        <source>Citra</source>
+        <translation>Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <source>Are you sure you want to close Citra?</source>
+        <translation>Vuoi davvero chiudere Citra?</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1246"/>
+        <source>Are you sure you want to stop the emulation? Any unsaved progress will be lost.</source>
+        <translation>Vuoi davvero terminare l&apos;emulazione? I progressi non salvati saranno persi.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1318"/>
+        <source>Citra %1| %2-%3</source>
+        <translation>Citra %1| %2-%3</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandListModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="96"/>
+        <source>Command Name</source>
+        <translation>Nome del Comando</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="98"/>
+        <source>Register</source>
+        <translation>Registro</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="100"/>
+        <source>Mask</source>
+        <translation>Mask</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="102"/>
+        <source>New Value</source>
+        <translation>Nuovo Valore</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandListWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="184"/>
+        <source>Pica Command List</source>
+        <translation>Lista Comandi Pica</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="202"/>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="233"/>
+        <source>Start Tracing</source>
+        <translation>Avvia Tracciamento</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="203"/>
+        <source>Copy All</source>
+        <translation>Copia Tutto</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="229"/>
+        <source>Finish Tracing</source>
+        <translation>Termina Tracciamento</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandStreamWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics.cpp" line="67"/>
+        <source>Graphics Debugger</source>
+        <translation>Debugger della Grafica</translation>
+    </message>
+</context>
+<context>
+    <name>GameList</name>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <source>Perfect</source>
+        <translation>Perfetto</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <source>Game functions flawless with no audio or graphical glitches, all tested functionality works as intended without
+any workarounds needed.</source>
+        <translation>Il gioco funziona alla perfezione senza alcun glitch audio o video, tutte le funzionalità testate funzionano come previsto senza
+la necessità di usare dei metodi alternativi.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <source>Great</source>
+        <translation>Buono</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <source>Game functions with minor graphical or audio glitches and is playable from start to finish. May require some
+workarounds.</source>
+        <translation>Il gioco presenta dei glitch principali video o audio, ma è possibile giocare dall&apos;inizio alla fine. Potrebbero essere necessari dei
+metodi alternativi.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <source>Okay</source>
+        <translation>Okay</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <source>Game functions with major graphical or audio glitches, but game is playable from start to finish with
+workarounds.</source>
+        <translation>Il gioco presenta dei glitch principali video o audio, ma è possibile giocare dall&apos;inizio alla fine
+con dei metodi alternativi.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Bad</source>
+        <translation>Cattivo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches
+even with workarounds.</source>
+        <translation>Il gioco presenta alcuni glitch principali audio o video. E&apos; impossibile proseguire in alcune aree a causa della presenza di glitch
+persino utilizzando metodi alternativi.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <source>Intro/Menu</source>
+        <translation>Intro/Menu</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <source>Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start
+Screen.</source>
+        <translation>Questo gioco è completamente ingiocabile a causa di glitch principali audio o video. E&apos; impossibile proseguire oltre la schermata iniziale.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>Won&apos;t Boot</source>
+        <translation>Non si Avvia</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>The game crashes when attempting to startup.</source>
+        <translation>Il gioco si blocca quando viene avviato.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <source>Not Tested</source>
+        <translation>Non Testato</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <source>The game has not yet been tested.</source>
+        <translation>Questo gioco non è stato ancora testato.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="99"/>
+        <source>of</source>
+        <translation>di</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="102"/>
+        <source>result</source>
+        <translation>risultato</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="104"/>
+        <source>results</source>
+        <translation>risultati</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="125"/>
+        <source>Filter:</source>
+        <translation>Filtro:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="128"/>
+        <source>Enter pattern to filter</source>
+        <translation>Inserisci pattern per filtrare</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="324"/>
+        <source>Open Save Data Location</source>
+        <translation>Apri Cartella dei Dati di Salvataggio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
+        <source>Open Application Location</source>
+        <translation>Apri Percorso Applicazione</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
+        <source>Open Update Data Location</source>
+        <translation>Apri Percorso Dati degli Aggiornamenti</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsBreakPointsWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="132"/>
+        <source>Pica Breakpoints</source>
+        <translation>Breakpoint Pica</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="136"/>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="198"/>
+        <source>Emulation running</source>
+        <translation>Emulazione in corso</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="137"/>
+        <source>Resume</source>
+        <translation>Riprendi</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="188"/>
+        <source>Emulation halted at breakpoint</source>
+        <translation>Emulazione arrestata al breakpoint</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsSurfaceWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="49"/>
+        <source>Pica Surface Viewer</source>
+        <translation>Visualizzatore superficie Pica</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="54"/>
+        <source>Color Buffer</source>
+        <translation>Buffer del Colore</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="55"/>
+        <source>Depth Buffer</source>
+        <translation>Buffer della Profondità</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="56"/>
+        <source>Stencil Buffer</source>
+        <translation>Buffer della Matrice</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="57"/>
+        <source>Texture 0</source>
+        <translation>Trama 0</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="58"/>
+        <source>Texture 1</source>
+        <translation>Trama 1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="59"/>
+        <source>Texture 2</source>
+        <translation>Trama 2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="60"/>
+        <source>Custom</source>
+        <translation>Personalizzato</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="103"/>
+        <source>Unknown</source>
+        <translation>Sconosciuto</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="118"/>
+        <source>Save</source>
+        <translation>Salva</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="144"/>
+        <source>Source:</source>
+        <translation>Fonte:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="150"/>
+        <source>Physical Address:</source>
+        <translation>Indirizzo fisico:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="156"/>
+        <source>Width:</source>
+        <translation>Larghezza:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="162"/>
+        <source>Height:</source>
+        <translation>Altezza:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="168"/>
+        <source>Format:</source>
+        <translation>Formato:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="180"/>
+        <source>X:</source>
+        <translation>X:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="186"/>
+        <source>Y:</source>
+        <translation>Y:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="280"/>
+        <source>Pixel out of bounds</source>
+        <translation>Pixel fuori dai margini</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="287"/>
+        <source>(unable to access pixel data)</source>
+        <translation>(impossibile accedere ai dati dei pixel)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="555"/>
+        <source>(invalid surface address)</source>
+        <translation>(indirizzo di superficie non valido)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="565"/>
+        <source>(unknown surface format)</source>
+        <translation>(formato di superficie sconosciuto)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="658"/>
+        <source>Portable Network Graphic (*.png)</source>
+        <translation>Portable Network Graphic (*.png)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="659"/>
+        <source>Binary data (*.bin)</source>
+        <translation>Binary data (*.bin)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="663"/>
+        <source>Save Surface</source>
+        <translation>Salva Superficie</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsTracingWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="25"/>
+        <source>CiTrace Recorder</source>
+        <translation>Recorder CiTrace</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="29"/>
+        <source>Start Recording</source>
+        <translation>Avvia Registrazione</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="31"/>
+        <source>Stop and Save</source>
+        <translation>Termina e Salva</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="32"/>
+        <source>Abort Recording</source>
+        <translation>Termina registrazione</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="112"/>
+        <source>Save CiTrace</source>
+        <translation>Salva CiTrace</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="113"/>
+        <source>CiTrace File (*.ctf)</source>
+        <translation>CiTrace File (*.ctf)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="162"/>
+        <source>CiTracing still active</source>
+        <translation>CiTracing ancora attivo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="163"/>
+        <source>A CiTrace is still being recorded. Do you want to save it? If not, all recorded data will be discarded.</source>
+        <translation>Un CiTrace è ancora in registrazione. Vuoi salvarlo? Se no, tutti i dati registrati saranno cancellati.</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsVertexShaderModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="45"/>
+        <source>Offset</source>
+        <translation>Offset</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="47"/>
+        <source>Raw</source>
+        <translation>Raw</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="49"/>
+        <source>Disassembly</source>
+        <translation>Smontaggio</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsVertexShaderWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="345"/>
+        <source>Save Shader Dump</source>
+        <translation>Salva Estrazione degli Shader</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="345"/>
+        <source>Shader Binary (*.shbin)</source>
+        <translation>Shader Binary (*.shbin)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="380"/>
+        <source>(data only available at vertex shader invocation breakpoints)</source>
+        <translation>(dati disponibili solo al richiamo dei vertex shader breakpoint)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="390"/>
+        <source>Dump</source>
+        <translation>Estrai</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="412"/>
+        <source>Input Data</source>
+        <translation>Dati di Input</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="426"/>
+        <source>Attribute %1</source>
+        <translation>Attributo %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="453"/>
+        <source>Cycle Index:</source>
+        <translation>Indice Ciclo:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="558"/>
+        <source>SRC1: %1, %2, %3, %4
+</source>
+        <translation>SRC1: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="564"/>
+        <source>SRC2: %1, %2, %3, %4
+</source>
+        <translation>SRC2: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="570"/>
+        <source>SRC3: %1, %2, %3, %4
+</source>
+        <translation>SRC3: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="576"/>
+        <source>DEST_IN: %1, %2, %3, %4
+</source>
+        <translation>DEST_IN: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="582"/>
+        <source>DEST_OUT: %1, %2, %3, %4
+</source>
+        <translation>DEST_OUT: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="589"/>
+        <source>Address Registers: %1, %2
+</source>
+        <translation>Registri dell&apos;indirizzo: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="593"/>
+        <source>Compare Result: %1, %2
+</source>
+        <translation>Risultato del confronto: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="598"/>
+        <source>Static Condition: %1
+</source>
+        <translation>Condizione statica: %1
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="600"/>
+        <source>Dynamic Conditions: %1, %2
+</source>
+        <translation>Condizioni dinamiche: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="604"/>
+        <source>Loop Parameters: %1 (repeats), %2 (initializer), %3 (increment), %4
+</source>
+        <translation>Parametri loop: %1 (ripetute), %2 (inizializzatore), %3 (incremento), %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="611"/>
+        <source>Instruction offset: 0x%1</source>
+        <translation>Offset istruzione: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="613"/>
+        <source> -&gt; 0x%2</source>
+        <translation> -&gt; 0x%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="615"/>
+        <source> (last instruction)</source>
+        <translation> (ultima istruzione)</translation>
+    </message>
+</context>
+<context>
+    <name>HostRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="14"/>
+        <source>Create Room</source>
+        <translation>Crea stanza</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="37"/>
+        <source>Room Name</source>
+        <translation>Nome stanza</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="51"/>
+        <source>Preferred Game</source>
+        <translation>Gioco Preferito</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="61"/>
+        <source>Max Players</source>
+        <translation>Numero max di giocatori</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="91"/>
+        <source>Username</source>
+        <translation>Nome utente</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="101"/>
+        <source>(Leave blank for open game)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="118"/>
+        <source>Password</source>
+        <translation>Password</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="125"/>
+        <source>Port</source>
+        <translation>Porta</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="156"/>
+        <source>Public</source>
+        <translation>Pubblica</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="161"/>
+        <source>Unlisted</source>
+        <translation>Non in lista</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="169"/>
+        <source>Host Room</source>
+        <translation>Stanza Host</translation>
+    </message>
+</context>
+<context>
+    <name>Lobby</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="14"/>
+        <source>Public Room Browser</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="32"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="39"/>
+        <source>Nickname</source>
+        <translation>Nickname</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="59"/>
+        <source>Filters</source>
+        <translation>Filtri</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="66"/>
+        <source>Search</source>
+        <translation>Cerca</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="76"/>
+        <source>Games I Own</source>
+        <translation>Giochi Che Possiedo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="83"/>
+        <source>Hide Full Rooms</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="103"/>
+        <source>Refresh Lobby</source>
+        <translation>Aggiorna Lobby</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <source>Password Required to Join</source>
+        <translation>Password Richiesta per Entrare</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <source>Password:</source>
+        <translation>Password:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="77"/>
+        <source>Password</source>
+        <translation>Password</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
+        <source>Room Name</source>
+        <translation>Nome Stanza</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="143"/>
+        <source>Preferred Game</source>
+        <translation>Gioco Preferito</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="144"/>
+        <source>Host</source>
+        <translation>Host</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="145"/>
+        <source>Players</source>
+        <translation>Giocatori</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="153"/>
+        <source>Refreshing</source>
+        <translation>Aggiornamento in corso</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="201"/>
+        <source>Refresh List</source>
+        <translation>Aggiorna Lista</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="14"/>
+        <source>Citra</source>
+        <translation>Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="53"/>
+        <source>&amp;File</source>
+        <translation>&amp;File</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="57"/>
+        <source>Recent Files</source>
+        <translation>File recenti</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="70"/>
+        <source>&amp;Emulation</source>
+        <translation>&amp;Emulazione</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="80"/>
+        <source>&amp;View</source>
+        <translation>&amp;Vista</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="84"/>
+        <source>Debugging</source>
+        <translation>Debugging</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="91"/>
+        <source>Screen Layout</source>
+        <translation>Disposizione schermi</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="115"/>
+        <source>Multiplayer</source>
+        <translation>Multigiocatore</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="126"/>
+        <source>&amp;Help</source>
+        <translation>&amp;Aiuto</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="144"/>
+        <source>Load File...</source>
+        <translation>Carica file...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="149"/>
+        <source>Install CIA...</source>
+        <translation>Installa CIA...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="154"/>
+        <source>Load Symbol Map...</source>
+        <translation>Carica mappa simboli...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="159"/>
+        <source>E&amp;xit</source>
+        <translation>&amp;Esci</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="167"/>
+        <source>&amp;Start</source>
+        <translation>&amp;Avvia</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="175"/>
+        <source>&amp;Pause</source>
+        <translation>&amp;Pausa</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="183"/>
+        <source>&amp;Stop</source>
+        <translation>&amp;Stop</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="188"/>
+        <source>FAQ</source>
+        <translation>FAQ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="193"/>
+        <source>About Citra</source>
+        <translation>Riguardo Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="201"/>
+        <source>Single Window Mode</source>
+        <translation>Modalità finestra singola</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="206"/>
+        <source>Configure...</source>
+        <translation>Configura</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="214"/>
+        <source>Display Dock Widget Headers</source>
+        <translation>Visualizza le intestazioni del dock dei widget</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="222"/>
+        <source>Show Filter Bar</source>
+        <translation>Mosta barra filtri</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="230"/>
+        <source>Show Status Bar</source>
+        <translation>Mostra barra stato</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="235"/>
+        <source>Select Game Directory...</source>
+        <translation>Seleziona cartella dei giochi...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="238"/>
+        <source>Selects a folder to display in the game list</source>
+        <translation>Seleziona cartella da mostrare nella lista dei giochi</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="243"/>
+        <source>Create Pica Surface Viewer</source>
+        <translation>Crea visualizzatore superficie Pica</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="251"/>
+        <source>Browse Public Game Lobby</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="259"/>
+        <source>Create Room</source>
+        <translation>Crea Stanza</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="267"/>
+        <source>Leave Room</source>
+        <translation>Esci dalla Stanza</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="272"/>
+        <source>Direct Connect to Room</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="280"/>
+        <source>Show Current Room</source>
+        <translation>Mostra Stanza Attuale</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="288"/>
+        <source>Fullscreen</source>
+        <translation>Schermo intero</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="293"/>
+        <source>Modify Citra Install</source>
+        <translation>Modifica installazione Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="296"/>
+        <source>Opens the maintenance tool to modify your Citra installation</source>
+        <translation>Accedi allo strumento di manutenzione per modificare la tua installazione di Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="304"/>
+        <source>Default</source>
+        <translation>Default</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="312"/>
+        <source>Single Screen</source>
+        <translation>Schermo Singolo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="320"/>
+        <source>Large Screen</source>
+        <translation>Schermo Grande</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="328"/>
+        <source>Side by Side</source>
+        <translation>Affiancati</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="336"/>
+        <source>Swap Screens</source>
+        <translation>Scambia Schermi</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="341"/>
+        <source>Check for Updates</source>
+        <translation>Controlla aggiornamenti</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="349"/>
+        <source>Report Compatibility</source>
+        <translation>Segnala compatibilità</translation>
+    </message>
+</context>
+<context>
+    <name>MicroProfileDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/profiler.cpp" line="50"/>
+        <source>MicroProfile</source>
+        <translation>MicroProfile</translation>
+    </message>
+</context>
+<context>
+    <name>MultiplayerState</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="41"/>
+        <source>Current connection status</source>
+        <translation>Stato connessione attuale</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="42"/>
+        <source>Not Connected. Click here to find a room!</source>
+        <translation>Non Connesso. Clicca qui per trovare una stanza!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="100"/>
+        <source>Connected</source>
+        <translation>Connesso</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="105"/>
+        <source>Not Connected</source>
+        <translation>Non Connesso</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="114"/>
+        <source>Error</source>
+        <translation>Errore</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="115"/>
+        <source>Failed to announce the room to the public lobby. In order to host a room publicly, you must have a valid Citra account configured in Emulation -&gt; Configure -&gt; Web. If you do not want to publish a room in the public lobby, then select Unlisted instead.
+Debug Message: </source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>NetworkMessage</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="12"/>
+        <source>Username is not valid. Must be 4 to 20 alphanumeric characters.</source>
+        <translation>Il tuo nome utente non è valido. Deve essere minimo 4 e massimo 20 caratteri alfanumerici.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="14"/>
+        <source>Room name is not valid. Must be 4 to 20 alphanumeric characters.</source>
+        <translation>Il nome della stanza non è valido. Deve essere minimo 4 e massimo 20 caratteri alfanumerici.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="16"/>
+        <source>Username is already in use. Please choose another.</source>
+        <translation>Il nome utente è già in uso. Scegline un altro.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="17"/>
+        <source>IP is not a valid IPv4 address.</source>
+        <translation>L&apos;IP non è un indirizzo IPv4 valido.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="18"/>
+        <source>Port must be a number between 0 to 65535.</source>
+        <translation>La porta deve essere un numero compreso tra 0 e 65535.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="20"/>
+        <source>Unable to find an internet connection. Check your internet settings.</source>
+        <translation>Impossibile trovare una connessione ad Internet. Controlla le tue impostazioni di rete.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="22"/>
+        <source>Unable to connect to the host. Verify that the connection settings are correct. If you still cannot connect, contact the room host and verify that the host is properly configured with the external port forwarded.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="26"/>
+        <source>Creating a room failed. Please retry. Restarting Citra might be necessary.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="28"/>
+        <source>The host of the room has banned you. Speak with the host to unban you or try a different room.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="31"/>
+        <source>Version mismatch! Please update to the latest version of Citra. If the problem persists, contact the room host and ask them to update the server.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="33"/>
+        <source>Incorrect password.</source>
+        <translation>Password sbagliata.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="35"/>
+        <source>An unknown error occured. If this error continues to occur, please open an issue</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="36"/>
+        <source>Connection to room lost. Try to reconnect.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="38"/>
+        <source>MAC address is already in use. Please choose another.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="52"/>
+        <source>Leave Room</source>
+        <translation>Esci dalla Stanza</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="53"/>
+        <source>You are about to close the room. Any network connections will be closed.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="58"/>
+        <source>Disconnect</source>
+        <translation>Disconnetti</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="59"/>
+        <source>You are about to leave the room. Any network connections will be closed.</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="47"/>
+        <source>Error</source>
+        <translation>Errore</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="198"/>
+        <source>%1 is not playing a game</source>
+        <translation>%1 non sta giocando ad un gioco</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="201"/>
+        <source>%1 is playing %2</source>
+        <translation>%1 sta giocando a %2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="26"/>
+        <source>Shift</source>
+        <translation>Shift</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="28"/>
+        <source>Ctrl</source>
+        <translation>Ctrl</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="30"/>
+        <source>Alt</source>
+        <translation>Alt</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="51"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="75"/>
+        <source>[not set]</source>
+        <translation>[Non impostato]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="55"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="83"/>
+        <source>Joystick %1</source>
+        <translation>Joystick %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="57"/>
+        <source> Hat %1 %2</source>
+        <translation>Hat %1 %2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="61"/>
+        <source> Axis %1%2</source>
+        <translation>Asse %1%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="65"/>
+        <source> Button %1</source>
+        <translation>Pulsante %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="69"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="91"/>
+        <source>[unknown]</source>
+        <translation>[sconosciuto]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="80"/>
+        <source>[unused]</source>
+        <translation>[inutilizzato]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="85"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="87"/>
+        <source> Axis %1</source>
+        <translation>Asse %1</translation>
+    </message>
+</context>
+<context>
+    <name>RegistersWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="15"/>
+        <source>Registers</source>
+        <translation>Registri</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="16"/>
+        <source>VFP Registers</source>
+        <translation>Registri VFP</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="18"/>
+        <source>VFP System Registers</source>
+        <translation>Registri di sistema VFP</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="167"/>
+        <source>Vector Length</source>
+        <translation>Lunghezza vettore</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="168"/>
+        <source>Vector Stride</source>
+        <translation>Andatura vettore</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="169"/>
+        <source>Rounding Mode</source>
+        <translation>Modalità di arrotondamento</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="182"/>
+        <source>Vector Iteration Count</source>
+        <translation>Conteggio dell&apos;iterazione del vettore</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeEvent</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="259"/>
+        <source>reset type = %1</source>
+        <translation>reset type = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeMutex</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="272"/>
+        <source>locked %1 times by thread:</source>
+        <translation>bloccato %1 volte da thread:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="275"/>
+        <source>free</source>
+        <translation>free</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeMutexList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="314"/>
+        <source>holding mutexes</source>
+        <translation>holding mutexes</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeObjectList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="128"/>
+        <source>waiting for all objects</source>
+        <translation>attesa di tutti gli oggetti</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="129"/>
+        <source>waiting for one of the following objects</source>
+        <translation>attesa di uno degli oggetti seguenti</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeSemaphore</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="288"/>
+        <source>available count = %1</source>
+        <translation>conteggio disponibile = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="289"/>
+        <source>max count = %1</source>
+        <translation>conteggio massimo = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeThread</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="146"/>
+        <source>running</source>
+        <translation>in esecuzione</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="149"/>
+        <source>ready</source>
+        <translation>pronto</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="152"/>
+        <source>waiting for address 0x%1</source>
+        <translation>attesa dell&apos;indirizzo 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="155"/>
+        <source>sleeping</source>
+        <translation>in sleep</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="158"/>
+        <source>waiting for IPC response</source>
+        <translation>attesa risposta IPC</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="162"/>
+        <source>waiting for objects</source>
+        <translation>attesa oggetti</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="165"/>
+        <source>waiting for HLE return</source>
+        <translation>attesa return HLE</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="168"/>
+        <source>dormant</source>
+        <translation>inattivo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="171"/>
+        <source>dead</source>
+        <translation>terminato</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="174"/>
+        <source> PC = 0x%1 LR = 0x%2</source>
+        <translation> PC = 0x%1 LR = 0x%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="214"/>
+        <source>default</source>
+        <translation>default</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="217"/>
+        <source>all</source>
+        <translation>tutti</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="220"/>
+        <source>AppCore</source>
+        <translation>AppCore</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="223"/>
+        <source>SysCore</source>
+        <translation>SysCore</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="226"/>
+        <source>Unknown processor %1</source>
+        <translation>Processore sconosciuto %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="230"/>
+        <source>processor = %1</source>
+        <translation>processore = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="231"/>
+        <source>thread id = %1</source>
+        <translation>id thread = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="232"/>
+        <source>priority = %1(current) / %2(normal)</source>
+        <translation>priorità = %1(corrente) / %2(normale)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="236"/>
+        <source>last running ticks = %1</source>
+        <translation>ultimi tick in corso = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="239"/>
+        <source>not holding mutex</source>
+        <translation>non holding mutex</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeThreadList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="328"/>
+        <source>waited by thread</source>
+        <translation>atteso dal thread</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeTimer</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="301"/>
+        <source>reset type = %1</source>
+        <translation>reset di tipo = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="303"/>
+        <source>initial delay = %1</source>
+        <translation>ritardo iniziale = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="305"/>
+        <source>interval delay = %1</source>
+        <translation>ritardo dell&apos;intervallo = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeWaitObject</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="76"/>
+        <source>[%1]%2 %3</source>
+        <translation>[%1]%2 %3</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="104"/>
+        <source>waited by no thread</source>
+        <translation>atteso da nessun thread</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="114"/>
+        <source>one shot</source>
+        <translation>one shot</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="116"/>
+        <source>sticky</source>
+        <translation>sticky</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="118"/>
+        <source>pulse</source>
+        <translation>pulse</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="399"/>
+        <source>Wait Tree</source>
+        <translation>Wait Tree</translation>
+    </message>
+</context>
+<context>
+    <name>hotkeys</name>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="14"/>
+        <source>Hotkey Settings</source>
+        <translation>Impostazioni Hotkey</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="27"/>
+        <source>Action</source>
+        <translation>Azione</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="32"/>
+        <source>Hotkey</source>
+        <translation>Hotkey</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="37"/>
+        <source>Context</source>
+        <translation>Contesto</translation>
+    </message>
+</context>
+</TS>

--- a/dist/languages/it.ts
+++ b/dist/languages/it.ts
@@ -154,17 +154,17 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ClientRoomWindow</name>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="54"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="55"/>
         <source>Connected</source>
         <translation>Connesso</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="65"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="63"/>
         <source>Disconnected</source>
         <translation>Disconnesso</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="78"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="76"/>
         <source>%1 (%2/%3 members) - connected</source>
         <translation>%1 (%2/%3 membri) - connesso</translation>
     </message>
@@ -205,7 +205,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="96"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions with minor graphical or audio glitches and is playable from start to finish. May require some workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Il gioco presenta alcuni glitch audio o video minori ed è possibile giocare dall&apos;inizio alla fine. Potrebbero essere necessari dei metodi alternativi.</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Il gioco presenta alcuni glitch audio o video minori ed è possibile giocare dall&apos;inizio alla fine. Potrebbero essere necessari dei metodi alternativi.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="106"/>
@@ -312,6 +312,26 @@ p, li { white-space: pre-wrap; }
         <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="57"/>
         <source>Port:</source>
         <translation>Porta:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="78"/>
+        <source>Logging</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="86"/>
+        <source>Global Log Filter</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="100"/>
+        <source>Show Log Console (Windows Only)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="107"/>
+        <source>Open Log Location</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1079,7 +1099,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="86"/>
         <source>24872</source>
-        <translation type="unfinished"/>
+        <translation>24872</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="100"/>
@@ -1100,12 +1120,12 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DirectConnectWindow</name>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="97"/>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="103"/>
         <source>Connecting</source>
         <translation>Connessione in corso</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="102"/>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="108"/>
         <source>Connect</source>
         <translation>Connetti</translation>
     </message>
@@ -1113,289 +1133,289 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GMainWindow</name>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="90"/>
+        <location filename="../../src/citra_qt/main.cpp" line="92"/>
         <source>To help improve Citra, the Citra Team collects anonymous usage data. No private or personally identifying information is collected. This data helps us to understand how people use Citra and prioritize our efforts. Furthermore, it helps us to more easily identify emulation bugs and performance issues. This data includes:&lt;ul&gt;&lt;li&gt;Information about the version of Citra you are using&lt;/li&gt;&lt;li&gt;Performance data about the games you play&lt;/li&gt;&lt;li&gt;Your configuration settings&lt;/li&gt;&lt;li&gt;Information about your computer hardware&lt;/li&gt;&lt;li&gt;Emulation errors and crash information&lt;/li&gt;&lt;/ul&gt;By default, this feature is enabled. To disable this feature, click &apos;Emulation&apos; from the menu and then select &apos;Configure...&apos;. Then, on the &apos;Web&apos; tab, uncheck &apos;Share anonymous usage data with the Citra team&apos;. &lt;br/&gt;&lt;br/&gt;By using this software, you agree to the above terms.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
         <translation>Per aiutare a migliorare Citra, il Team di Citra raccoglie dati anonimi di utilizzo. Nessuna informazione di identificazione personale è raccolta. Questi dati ci aiutano a capire come gli utenti utilizzano Citra per dare delle priorità ai nostri sforzi. Inoltre, ci aiutano ad individuare bug e problemi di prestazioni più facilmente. Questi dati includono:&lt;ul&gt;&lt;li&gt;Informazioni riguardo la versione di Citra in uso&lt;/li&gt;&lt;li&gt;Dati di prestazioni riguardo i giochi utilizzati&lt;/li&gt;&lt;li&gt;Le impostazioni di configurazione&lt;/li&gt;&lt;li&gt;Informazioni sull&apos;hardware del tuo computer&lt;/li&gt;&lt;li&gt;Informazioni su errori e crash dell&apos;emulazione&lt;/li&gt;&lt;/ul&gt;Di default, questa impostazione è abilitata. Per disabilitarla, clicca &apos;Emulazione&apos; dal menu e seleziona &apos;Configura...&apos;. Quindi nella scheda &apos;Web&apos;, togli la spunta su &apos;Condividi dati sull&apos;utilizzo anonimamente con il team di Citra&apos;.&lt;br/&gt;&lt;br/&gt;Utilizzando questo software, accetti i termini indicati sopra.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Per saperne di più&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="195"/>
+        <location filename="../../src/citra_qt/main.cpp" line="199"/>
         <source>Current emulation speed. Values higher or lower than 100% indicate emulation is running faster or slower than a 3DS.</source>
         <translation>Velocità di emulazione corrente. Valori più alti o più bassi di 100% indicano che l&apos;emulazione sta funzionando più velocemente o lentamente di un 3DS.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="198"/>
+        <location filename="../../src/citra_qt/main.cpp" line="202"/>
         <source>How many frames per second the game is currently displaying. This will vary from game to game and scene to scene.</source>
         <translation>Quanti frame al secondo il gioco visualizza attualmente. Questo varia da gioco a gioco e da situazione a situazione.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="202"/>
+        <location filename="../../src/citra_qt/main.cpp" line="206"/>
         <source>Time taken to emulate a 3DS frame, not counting framelimiting or v-sync. For full-speed emulation this should be at most 16.67 ms.</source>
         <translation>Tempo necessario per emulare un frame del 3DS, senza contare il limite al framerate o il v-sync. Per un&apos;emulazione a pieno regime questa dovrebbe essere al più 16.67 ms.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="429"/>
+        <location filename="../../src/citra_qt/main.cpp" line="434"/>
         <source>CTRL+F</source>
         <translation>CTRL+F</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="538"/>
+        <location filename="../../src/citra_qt/main.cpp" line="543"/>
         <source>Update available!</source>
         <translation>Aggiornamento disponibile!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="539"/>
+        <location filename="../../src/citra_qt/main.cpp" line="544"/>
         <source>An update for Citra is available. Do you wish to install it now?&lt;br /&gt;&lt;br /&gt;This &lt;b&gt;will&lt;/b&gt; terminate emulation, if it is running.</source>
         <translation>Un aggiornamento per Citra è disponibile. Desideri installarlo ora? &lt;br /&gt;&lt;br /&gt;Questo &lt;b&gt;terminerà&lt;/b&gt; l&apos;emulazione, se è in corso.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <location filename="../../src/citra_qt/main.cpp" line="555"/>
         <source>No update found</source>
         <translation>Nessun aggiornamento disponibile</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <location filename="../../src/citra_qt/main.cpp" line="555"/>
         <source>No update has been found for Citra.</source>
         <translation>Nessun aggiornamento per Citra è stato trovato.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="567"/>
+        <location filename="../../src/citra_qt/main.cpp" line="572"/>
         <source>Error while initializing OpenGL 3.3 Core!</source>
         <translation>Errore nell&apos;inizializzazione del Core di OpenGL 3.3!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="568"/>
+        <location filename="../../src/citra_qt/main.cpp" line="573"/>
         <source>Your GPU may not support OpenGL 3.3, or you do not have the latest graphics driver.</source>
         <translation>La tua GPU potrebbe non supportare OpenGL 3.3, o i driver della tua scheda video potrebbero non essere aggiornati.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="581"/>
-        <location filename="../../src/citra_qt/main.cpp" line="587"/>
-        <location filename="../../src/citra_qt/main.cpp" line="593"/>
-        <location filename="../../src/citra_qt/main.cpp" line="606"/>
-        <location filename="../../src/citra_qt/main.cpp" line="625"/>
+        <location filename="../../src/citra_qt/main.cpp" line="586"/>
+        <location filename="../../src/citra_qt/main.cpp" line="592"/>
+        <location filename="../../src/citra_qt/main.cpp" line="598"/>
+        <location filename="../../src/citra_qt/main.cpp" line="611"/>
+        <location filename="../../src/citra_qt/main.cpp" line="630"/>
         <source>Error while loading ROM!</source>
         <translation>Errore nel caricamento della ROM!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="582"/>
-        <location filename="../../src/citra_qt/main.cpp" line="607"/>
+        <location filename="../../src/citra_qt/main.cpp" line="587"/>
+        <location filename="../../src/citra_qt/main.cpp" line="612"/>
         <source>The ROM format is not supported.</source>
         <translation>Il formato di questa ROM non è supportato.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="588"/>
+        <location filename="../../src/citra_qt/main.cpp" line="593"/>
         <source>Could not determine the system mode.</source>
         <translation>Modalità di sistema non determinabile.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="594"/>
+        <location filename="../../src/citra_qt/main.cpp" line="599"/>
         <source>The game that you are trying to load must be decrypted before being used with Citra. A real 3DS is required.&lt;br/&gt;&lt;br/&gt;For more information on dumping and decrypting games, please see the following wiki pages: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</source>
-        <translation>Il gioco che stai cercando di caricare deve essere decriptato prima di essere utilizzato con Citra. È necessario un 3DS reale. &lt;br/&gt;&lt;br/&gt;Per ulteriori informazioni sul dump e la decriptazione dei giochi, dai un&apos;occhiata alle seguenti pagine della wiki: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Estrazione dei giochi&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Estrazione di titoli installati&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</translation>
+        <translation>Il gioco che stai cercando di caricare deve essere decriptato prima di essere utilizzato con Citra. È necessario un 3DS reale. &lt;br/&gt;&lt;br/&gt;Per ulteriori informazioni sull&apos;estrazione di questi file e la decriptazione dei giochi, dai un&apos;occhiata alle seguenti pagine della wiki: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Estrazione dei giochi&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Estrazione di titoli installati&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="612"/>
+        <location filename="../../src/citra_qt/main.cpp" line="617"/>
         <source>An error occured in the video core.</source>
         <translation>Si è verificato un errore nel core video.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="613"/>
+        <location filename="../../src/citra_qt/main.cpp" line="618"/>
         <source>Citra has encountered an error while running the video core, please see the log for more details.For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.Ensure that you have the latest graphics drivers for your GPU.</source>
         <translation>Citra ha riscontrato un errore durante il processo del core video, visualizza il log per ulteriori dettagli. Per maggiori informazioni su come accedere al log, visita la seguente pagina: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;Come caricare il File di Log&lt;/a&gt;. Assicurati di avere gli ultimi driver della tua scheda video.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="626"/>
+        <location filename="../../src/citra_qt/main.cpp" line="631"/>
         <source>An unknown error occured. Please see the log for more details.</source>
         <translation>Errore sconosciuto. Visualizza il log per maggiori dettagli.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="699"/>
+        <location filename="../../src/citra_qt/main.cpp" line="704"/>
         <source>Start</source>
         <translation>Avvia</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="790"/>
+        <location filename="../../src/citra_qt/main.cpp" line="795"/>
         <source>Error Opening %1 Folder</source>
         <translation>Errore nell&apos;Apertura della Cartella %1</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="791"/>
+        <location filename="../../src/citra_qt/main.cpp" line="796"/>
         <source>Folder does not exist!</source>
         <translation>La cartella non esiste!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="805"/>
+        <location filename="../../src/citra_qt/main.cpp" line="810"/>
         <source>3DS Executable</source>
         <translation>Eseguibile 3DS</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="806"/>
-        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <location filename="../../src/citra_qt/main.cpp" line="811"/>
+        <location filename="../../src/citra_qt/main.cpp" line="833"/>
         <source>All Files (*.*)</source>
         <translation>Tutti i file (*.*)</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="808"/>
+        <location filename="../../src/citra_qt/main.cpp" line="813"/>
         <source>Load File</source>
         <translation>Carica file</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="818"/>
+        <location filename="../../src/citra_qt/main.cpp" line="823"/>
         <source>Select Directory</source>
         <translation>Seleziona cartella</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="827"/>
+        <location filename="../../src/citra_qt/main.cpp" line="832"/>
         <source>Load Files</source>
         <translation>Carica File</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <location filename="../../src/citra_qt/main.cpp" line="833"/>
         <source>3DS Installation File (*.CIA*)</source>
         <translation>File di installazione 3DS (*.CIA*)</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="859"/>
+        <location filename="../../src/citra_qt/main.cpp" line="864"/>
         <source>%1 has been installed successfully.</source>
         <translation>%1 è stato installato con successo.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="862"/>
+        <location filename="../../src/citra_qt/main.cpp" line="867"/>
         <source>Unable to open File</source>
         <translation>Impossibile aprire il File</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="863"/>
+        <location filename="../../src/citra_qt/main.cpp" line="868"/>
         <source>Could not open %1</source>
         <translation>Impossibile aprire %1</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="867"/>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
         <source>Installation aborted</source>
         <translation>Installazione annullata</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="868"/>
+        <location filename="../../src/citra_qt/main.cpp" line="873"/>
         <source>The installation of %1 was aborted. Please see the log for more details</source>
         <translation>L&apos;installazione di %1 è stata annullata. Visualizza il log per maggiori dettagli.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <location filename="../../src/citra_qt/main.cpp" line="877"/>
         <source>Invalid File</source>
         <translation>File non valido</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <location filename="../../src/citra_qt/main.cpp" line="877"/>
         <source>%1 is not a valid CIA</source>
         <translation>%1 non è un CIA valido</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="875"/>
+        <location filename="../../src/citra_qt/main.cpp" line="880"/>
         <source>Encrypted File</source>
         <translation>File Criptato</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="876"/>
+        <location filename="../../src/citra_qt/main.cpp" line="881"/>
         <source>%1 must be decrypted before being used with Citra. A real 3DS is required.</source>
         <translation>%1 deve essere decriptato prima di poter essere usato con Citra. E&apos; necessario un 3DS fisico.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="899"/>
+        <location filename="../../src/citra_qt/main.cpp" line="904"/>
         <source>File not found</source>
         <translation>File non trovato</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="900"/>
+        <location filename="../../src/citra_qt/main.cpp" line="905"/>
         <source>File &quot;%1&quot; not found</source>
         <translation>File &quot;%1&quot; non trovato</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="914"/>
+        <location filename="../../src/citra_qt/main.cpp" line="919"/>
         <source>Continue</source>
         <translation>Continua</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="939"/>
+        <location filename="../../src/citra_qt/main.cpp" line="944"/>
         <source>Missing Citra Account</source>
         <translation>Account di Citra Mancante</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="940"/>
+        <location filename="../../src/citra_qt/main.cpp" line="945"/>
         <source>In order to submit a game compatibility test case, you must link your Citra account.&lt;br&gt;&lt;br/&gt;To link your Citra account, go to Emulation &amp;gt; Configuration &amp;gt; Web.</source>
-        <translation>Per poter segnalare la compatibilità di un gioco, devi collegare il tuo Account di Citra.&lt;br&gt;&lt;br/&gt;Per collegare il tuo Account di Citra, vai su Emulazione, &amp;gt; Configurazione &amp;gt; Web</translation>
+        <translation>Per poter segnalare la compatibilità di un gioco, devi collegare il tuo Account di Citra.&lt;br&gt;&lt;br/&gt;Per collegare il tuo Account di Citra, vai su Emulazione, &amp;gt; Configurazione &amp;gt; Web.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1090"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1095"/>
         <source>Speed: %1% / %2%</source>
         <translation>Velocità: %1% / %2%</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1094"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1099"/>
         <source>Speed: %1%</source>
         <translation>Velocità: %1%</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1096"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1101"/>
         <source>Game: %1 FPS</source>
         <translation>Gioco: %1 FPS</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1097"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1102"/>
         <source>Frame: %1 ms</source>
         <translation>Frame: %1 ms</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1108"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1113"/>
         <source>The game you are trying to load requires additional files from your 3DS to be dumped before playing.&lt;br/&gt;&lt;br/&gt;For more information on dumping these files, please see the following wiki page: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
         <translation>Il gioco che stai tendando di caricare richiede file aggiuntivi che devi estrarre dal tuo 3DS prima di giocare.&lt;br/&gt;&lt;br/&gt;Per maggiori informazioni sull&apos;estrazione di questi file, vedi le seguenti pagine wiki: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Estrazione degli archivi del sistema e font condivisi dal 3DS&lt;/a&gt;. Desideri tornare alla lista dei giochi? Continuare l&apos;emulazione potrebbe risultare in crash, dati di salvataggio corrotti o altri bug.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1120"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1125"/>
         <source>: %1. </source>
         <translation>: %1. </translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1126"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1131"/>
         <source>System Archive Not Found</source>
         <translation>Archivio di Sistema Non Trovato</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1133"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1138"/>
         <source>Citra was unable to locate the 3DS shared fonts. </source>
         <translation>Citra non riesce a localizzare i font condivisi del 3DS.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1135"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1140"/>
         <source>Shared Fonts Not Found</source>
         <translation>Font Condivisi Non Trovati</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1143"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1148"/>
         <source>Fatal Error</source>
         <translation>Errore fatale</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1144"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1149"/>
         <source>Citra has encountered a fatal error, please see the log for more details. For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
         <translation>Citra ha riscontrato un errore fatale, visualizza il log per maggiori dettagli. Per ulteriori informazioni su come accedere al log, visita la seguente pagina: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;Come Caricare il file di Log&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Vuoi tornare alla lista dei giochi? Continuare l&apos;emulazione potrebbe risultare in crash, dati di salvataggio corrotti o altri bug.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
-        <location filename="../../src/citra_qt/main.cpp" line="1245"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1183"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1250"/>
         <source>Citra</source>
         <translation>Citra</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1183"/>
         <source>Are you sure you want to close Citra?</source>
         <translation>Vuoi davvero chiudere Citra?</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1246"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1251"/>
         <source>Are you sure you want to stop the emulation? Any unsaved progress will be lost.</source>
         <translation>Vuoi davvero terminare l&apos;emulazione? I progressi non salvati saranno persi.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1318"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1323"/>
         <source>Citra %1| %2-%3</source>
         <translation>Citra %1| %2-%3</translation>
     </message>
@@ -1458,81 +1478,81 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GameList</name>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="117"/>
         <source>Perfect</source>
         <translation>Perfetto</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="117"/>
         <source>Game functions flawless with no audio or graphical glitches, all tested functionality works as intended without
 any workarounds needed.</source>
         <translation>Il gioco funziona alla perfezione senza alcun glitch audio o video, tutte le funzionalità testate funzionano come previsto senza
 la necessità di usare dei metodi alternativi.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="118"/>
         <source>Great</source>
         <translation>Buono</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="118"/>
         <source>Game functions with minor graphical or audio glitches and is playable from start to finish. May require some
 workarounds.</source>
         <translation>Il gioco presenta dei glitch principali video o audio, ma è possibile giocare dall&apos;inizio alla fine. Potrebbero essere necessari dei
 metodi alternativi.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="119"/>
         <source>Okay</source>
         <translation>Okay</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="119"/>
         <source>Game functions with major graphical or audio glitches, but game is playable from start to finish with
 workarounds.</source>
         <translation>Il gioco presenta dei glitch principali video o audio, ma è possibile giocare dall&apos;inizio alla fine
 con dei metodi alternativi.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="120"/>
         <source>Bad</source>
         <translation>Cattivo</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="120"/>
         <source>Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches
 even with workarounds.</source>
         <translation>Il gioco presenta alcuni glitch principali audio o video. E&apos; impossibile proseguire in alcune aree a causa della presenza di glitch
 persino utilizzando metodi alternativi.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="121"/>
         <source>Intro/Menu</source>
         <translation>Intro/Menu</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="121"/>
         <source>Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start
 Screen.</source>
         <translation>Questo gioco è completamente ingiocabile a causa di glitch principali audio o video. E&apos; impossibile proseguire oltre la schermata iniziale.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="122"/>
         <source>Won&apos;t Boot</source>
         <translation>Non si Avvia</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="122"/>
         <source>The game crashes when attempting to startup.</source>
         <translation>Il gioco si blocca quando viene avviato.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="123"/>
         <source>Not Tested</source>
         <translation>Non Testato</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="123"/>
         <source>The game has not yet been tested.</source>
         <translation>Questo gioco non è stato ancora testato.</translation>
     </message>
@@ -1562,17 +1582,17 @@ Screen.</source>
         <translation>Inserisci pattern per filtrare</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="324"/>
+        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
         <source>Open Save Data Location</source>
         <translation>Apri Cartella dei Dati di Salvataggio</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
+        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
         <source>Open Application Location</source>
         <translation>Apri Percorso Applicazione</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
+        <location filename="../../src/citra_qt/game_list.cpp" line="327"/>
         <source>Open Update Data Location</source>
         <translation>Apri Percorso Dati degli Aggiornamenti</translation>
     </message>
@@ -1928,7 +1948,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="61"/>
         <source>Max Players</source>
-        <translation>Numero max di giocatori</translation>
+        <translation>Numero Max di Giocatori</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="91"/>
@@ -1997,7 +2017,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="83"/>
         <source>Hide Full Rooms</source>
-        <translation type="unfinished"/>
+        <translation>Nascondi Stanze Piene</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="103"/>
@@ -2005,47 +2025,42 @@ Screen.</source>
         <translation>Aggiorna Lobby</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="73"/>
         <source>Password Required to Join</source>
         <translation>Password Richiesta per Entrare</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="74"/>
         <source>Password:</source>
         <translation>Password:</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="77"/>
-        <source>Password</source>
-        <translation>Password</translation>
-    </message>
-    <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="139"/>
         <source>Room Name</source>
         <translation>Nome Stanza</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="143"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="140"/>
         <source>Preferred Game</source>
         <translation>Gioco Preferito</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="144"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="141"/>
         <source>Host</source>
         <translation>Host</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="145"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
         <source>Players</source>
         <translation>Giocatori</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="153"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="150"/>
         <source>Refreshing</source>
         <translation>Aggiornamento in corso</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="201"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="198"/>
         <source>Refresh List</source>
         <translation>Aggiorna Lista</translation>
     </message>
@@ -2075,7 +2090,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="80"/>
         <source>&amp;View</source>
-        <translation>&amp;Vista</translation>
+        <translation>&amp;Visualizza</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="84"/>
@@ -2200,7 +2215,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="272"/>
         <source>Direct Connect to Room</source>
-        <translation type="unfinished"/>
+        <translation>Collegamento Diretto alla Stanza</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="280"/>
@@ -2215,12 +2230,12 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="293"/>
         <source>Modify Citra Install</source>
-        <translation>Modifica installazione Citra</translation>
+        <translation>Modifica Installazione di Citra</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="296"/>
         <source>Opens the maintenance tool to modify your Citra installation</source>
-        <translation>Accedi allo strumento di manutenzione per modificare la tua installazione di Citra</translation>
+        <translation>Accedi allo strumento di manutenzione per modificare la tua Installazione di Citra</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="304"/>
@@ -2250,12 +2265,12 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="341"/>
         <source>Check for Updates</source>
-        <translation>Controlla aggiornamenti</translation>
+        <translation>Controlla Aggiornamenti</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="349"/>
         <source>Report Compatibility</source>
-        <translation>Segnala compatibilità</translation>
+        <translation>Segnala Compatibilità</translation>
     </message>
 </context>
 <context>
@@ -2305,12 +2320,12 @@ Debug Message: </source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="12"/>
         <source>Username is not valid. Must be 4 to 20 alphanumeric characters.</source>
-        <translation>Il tuo nome utente non è valido. Deve essere minimo 4 e massimo 20 caratteri alfanumerici.</translation>
+        <translation>Il tuo nome utente non è valido. Deve essere da 4 a 20 caratteri alfanumerici.</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="14"/>
         <source>Room name is not valid. Must be 4 to 20 alphanumeric characters.</source>
-        <translation>Il nome della stanza non è valido. Deve essere minimo 4 e massimo 20 caratteri alfanumerici.</translation>
+        <translation>Il nome della stanza non è valido. Deve essere da 4 a 20 caratteri alfanumerici.</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="16"/>
@@ -2350,7 +2365,7 @@ Debug Message: </source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="31"/>
         <source>Version mismatch! Please update to the latest version of Citra. If the problem persists, contact the room host and ask them to update the server.</source>
-        <translation type="unfinished"/>
+        <translation>Versione non corrispondente! Per favore aggiorna all&apos;ultima versione di Citra. Se il problema persiste, contatta l&apos;host della stanza e chiedi di aggiornare il server.</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="33"/>
@@ -2360,17 +2375,17 @@ Debug Message: </source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="35"/>
         <source>An unknown error occured. If this error continues to occur, please open an issue</source>
-        <translation type="unfinished"/>
+        <translation>Errore sconosciuto. Se questo errore continua ad accadere, per favore, segnalalo</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="36"/>
         <source>Connection to room lost. Try to reconnect.</source>
-        <translation type="unfinished"/>
+        <translation>Collegamento alla stanza perso. Prova a riconnetterti.</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="38"/>
         <source>MAC address is already in use. Please choose another.</source>
-        <translation type="unfinished"/>
+        <translation>L&apos;indirizzo MAC è già in uso. Scegline un altro.</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="52"/>
@@ -2411,6 +2426,57 @@ Debug Message: </source>
         <translation>%1 sta giocando a %2</translation>
     </message>
     <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="208"/>
+        <source>Invalid region</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Japan</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>North America</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="92"/>
+        <source>Europe</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="94"/>
+        <source>Australia</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="96"/>
+        <source>China</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="98"/>
+        <source>Korea</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="100"/>
+        <source>Taiwan</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="102"/>
+        <source>Region free</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="104"/>
+        <source>Invalid Region</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
         <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="26"/>
         <source>Shift</source>
         <translation>Shift</translation>
@@ -2429,7 +2495,7 @@ Debug Message: </source>
         <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="51"/>
         <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="75"/>
         <source>[not set]</source>
-        <translation>[Non impostato]</translation>
+        <translation>[non impostato]</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="55"/>

--- a/dist/languages/ja_JP.ts
+++ b/dist/languages/ja_JP.ts
@@ -59,7 +59,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/aboutdialog.ui" line="118"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Website&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://community.citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Forum&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Source Code&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Contributors&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/blob/master/license.txt&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;License&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"/>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;ｳｪﾌﾞｻｲﾄ&lt;/span&gt;&lt;/a&gt;|&lt;a href=&quot;https://community.citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;ﾌｫｰﾗﾑ&lt;/span&gt;&lt;/a&gt;|&lt;a href=&quot;https://github.com/citra-emu&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;ｿｰｽｺｰﾄﾞ&lt;/span&gt;&lt;/a&gt;|&lt;a href=&quot;https://github.com/citra-emu/citra/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;貢献者&lt;/span&gt;&lt;/a&gt; |&lt;a href=&quot;https://github.com/citra-emu/citra/blob/master/license.txt&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;ﾗｲｾﾝｽ&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/aboutdialog.ui" line="134"/>
@@ -115,27 +115,27 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="14"/>
         <source>Room Window</source>
-        <translation type="unfinished"/>
+        <translation>ﾙｰﾑｳｨﾝﾄﾞｳ</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="40"/>
         <source>Send Chat Message</source>
-        <translation type="unfinished"/>
+        <translation>ﾁｬｯﾄﾒｯｾｰｼﾞ送信</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="47"/>
         <source>Send Message</source>
-        <translation type="unfinished"/>
+        <translation>ﾒｯｾｰｼﾞ送信</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/chat_room.cpp" line="81"/>
         <source>Name</source>
-        <translation type="unfinished"/>
+        <translation>名前</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/chat_room.cpp" line="82"/>
         <source>Game</source>
-        <translation type="unfinished"/>
+        <translation>ｹﾞｰﾑ</translation>
     </message>
 </context>
 <context>
@@ -143,30 +143,30 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/multiplayer/client_room.ui" line="14"/>
         <source>Room Window</source>
-        <translation type="unfinished"/>
+        <translation>ﾙｰﾑｳｨﾝﾄﾞｳ</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/client_room.ui" line="40"/>
         <source>Leave Room</source>
-        <translation type="unfinished"/>
+        <translation>退室</translation>
     </message>
 </context>
 <context>
     <name>ClientRoomWindow</name>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="54"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="55"/>
         <source>Connected</source>
-        <translation type="unfinished"/>
+        <translation>接続</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="65"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="63"/>
         <source>Disconnected</source>
-        <translation type="unfinished"/>
+        <translation>切断</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="78"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="76"/>
         <source>%1 (%2/%3 members) - connected</source>
-        <translation type="unfinished"/>
+        <translation>%1 (%2/%3 members) - 接続</translation>
     </message>
 </context>
 <context>
@@ -174,33 +174,33 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="20"/>
         <source>Report Compatibility</source>
-        <translation type="unfinished"/>
+        <translation>レポートの互換性</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="27"/>
         <location filename="../../src/citra_qt/compatdb.ui" line="63"/>
         <source>Report Game Compatibility</source>
-        <translation type="unfinished"/>
+        <translation>ｹﾞｰﾑの互換性を報告</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="36"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;Should you choose to submit a test case to the &lt;/span&gt;&lt;a href=&quot;https://citra-emu.org/game/&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;Citra Compatibility List&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;, The following information will be collected and displayed on the site:&lt;/span&gt;&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Hardware Information (CPU / GPU / Operating System)&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Which version of Citra you are running&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The connected Citra account&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"/>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;あなたはテストケースを&lt;/span&gt;&lt;a href=&quot;https://citra-emu.org/game/&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;Citra互換性ﾘｽﾄ&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;,以下の情報が収集され、サイトに表示されます。&lt;/span&gt;&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;ハードウェア情報（CPU / GPU /オペレーティングシステム）&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;実行しているCitraのバージョン&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;接続されたCitraアカウント&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="72"/>
         <source>Perfect</source>
-        <translation type="unfinished"/>
+        <translation>完全</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="79"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions flawlessly with no audio or graphical glitches.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"/>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;オーディオやグラフィカルなグリッチがなく、ゲームの機能が完璧です。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="89"/>
         <source>Great </source>
-        <translation type="unfinished"/>
+        <translation>素晴らしい</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="96"/>
@@ -210,7 +210,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="106"/>
         <source>Okay</source>
-        <translation type="unfinished"/>
+        <translation>はい</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="113"/>
@@ -220,7 +220,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="123"/>
         <source>Bad</source>
-        <translation type="unfinished"/>
+        <translation>悪い</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="130"/>
@@ -230,7 +230,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="140"/>
         <source>Intro/Menu</source>
-        <translation type="unfinished"/>
+        <translation>ｲﾝﾄﾛ/ﾒﾆｭｰ</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="147"/>
@@ -240,7 +240,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="157"/>
         <source>Won&apos;t Boot</source>
-        <translation type="unfinished"/>
+        <translation>起動しない</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="170"/>
@@ -312,6 +312,26 @@ p, li { white-space: pre-wrap; }
         <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="57"/>
         <source>Port:</source>
         <translation>ポート</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="78"/>
+        <source>Logging</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="86"/>
+        <source>Global Log Filter</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="100"/>
+        <source>Show Log Console (Windows Only)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="107"/>
+        <source>Open Log Location</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1049,27 +1069,27 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="14"/>
         <source>Direct Connect</source>
-        <translation type="unfinished"/>
+        <translation>ﾀﾞｲﾚｸﾄ接続</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="33"/>
         <source>IP Address</source>
-        <translation type="unfinished"/>
+        <translation>IPｱﾄﾞﾚｽ</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="56"/>
         <source>IP</source>
-        <translation type="unfinished"/>
+        <translation>IP</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="63"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;IPv4 address of the host&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"/>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;ﾎｽﾄのIPv4ｱﾄﾞﾚｽ&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="73"/>
         <source>Port</source>
-        <translation type="unfinished"/>
+        <translation>ﾎﾟｰﾄ</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="80"/>
@@ -1079,323 +1099,323 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="86"/>
         <source>24872</source>
-        <translation type="unfinished"/>
+        <translation>24872</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="100"/>
         <source>Nickname</source>
-        <translation type="unfinished"/>
+        <translation>ﾆｯｸﾈｰﾑ</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="114"/>
         <source>Password</source>
-        <translation type="unfinished"/>
+        <translation>ﾊﾟｽﾜｰﾄﾞ</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="156"/>
         <source>Connect</source>
-        <translation type="unfinished"/>
+        <translation>接続</translation>
     </message>
 </context>
 <context>
     <name>DirectConnectWindow</name>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="97"/>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="103"/>
         <source>Connecting</source>
-        <translation type="unfinished"/>
+        <translation>接続する</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="102"/>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="108"/>
         <source>Connect</source>
-        <translation type="unfinished"/>
+        <translation>接続</translation>
     </message>
 </context>
 <context>
     <name>GMainWindow</name>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="90"/>
+        <location filename="../../src/citra_qt/main.cpp" line="92"/>
         <source>To help improve Citra, the Citra Team collects anonymous usage data. No private or personally identifying information is collected. This data helps us to understand how people use Citra and prioritize our efforts. Furthermore, it helps us to more easily identify emulation bugs and performance issues. This data includes:&lt;ul&gt;&lt;li&gt;Information about the version of Citra you are using&lt;/li&gt;&lt;li&gt;Performance data about the games you play&lt;/li&gt;&lt;li&gt;Your configuration settings&lt;/li&gt;&lt;li&gt;Information about your computer hardware&lt;/li&gt;&lt;li&gt;Emulation errors and crash information&lt;/li&gt;&lt;/ul&gt;By default, this feature is enabled. To disable this feature, click &apos;Emulation&apos; from the menu and then select &apos;Configure...&apos;. Then, on the &apos;Web&apos; tab, uncheck &apos;Share anonymous usage data with the Citra team&apos;. &lt;br/&gt;&lt;br/&gt;By using this software, you agree to the above terms.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
         <translation>Citraを改善するために、Citraチームは匿名の使用データを収集します。 個人または個人を特定する情報は収集されません。 このデータは、人々がCitraをどのように使用しているかを理解し、私たちの努力に優先順位を付けるのに役立ちます.さらに、エミュレーションのバグやパフォーマンスの問題をより簡単に特定するのに役立ちます. このデータには次の情報が含まれます&lt;ul&gt;&lt;li&gt;使用しているシトラのバージョンに関する情報&lt;/li&gt;&lt;li&gt;プレイするゲームに関するパフォーマンスデータ&lt;/li&gt;&lt;li&gt;構成設定&lt;/li&gt;&lt;li&gt;コンピュータのハードウェアに関する情報&lt;/li&gt;&lt;li&gt;エミュレーションエラーとクラッシュ情報&lt;/li&gt;&lt;/ul&gt;デフォルトでは、この機能は有効です。 この機能を無効にするには、メニューからエミュレーションをクリックし、設定...を選択します.次に、Webタブで、Citraチームと匿名の利用状況データを共有するのチェックを外します.&lt;br/&gt;&lt;br/&gt;このソフトウェアを使用すると、上記の条件に同意したことになります&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;詳細&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="195"/>
+        <location filename="../../src/citra_qt/main.cpp" line="199"/>
         <source>Current emulation speed. Values higher or lower than 100% indicate emulation is running faster or slower than a 3DS.</source>
         <translation>現在のｴﾐｭﾚｰｼｮﾝ速度.100％より高いか低い値は、ｴﾐｭﾚｰｼｮﾝが3DS実機より高速または低速で実行されていることを示します</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="198"/>
+        <location filename="../../src/citra_qt/main.cpp" line="202"/>
         <source>How many frames per second the game is currently displaying. This will vary from game to game and scene to scene.</source>
         <translation>1秒当たりのフレーム数を表示しています. これは、ゲームによって異なります.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="202"/>
+        <location filename="../../src/citra_qt/main.cpp" line="206"/>
         <source>Time taken to emulate a 3DS frame, not counting framelimiting or v-sync. For full-speed emulation this should be at most 16.67 ms.</source>
         <translation>3DSﾌﾚｰﾑをｴﾐｭﾚｰﾄするのにかかる時間で、ﾌﾚｰﾑﾚｰﾄ制限やv-syncのときはｶｳﾝﾄしません.ﾌﾙｽﾋﾟｰﾄﾞのｴﾐｭﾚｰｼｮﾝには16.67ms以下にする必要があります.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="429"/>
+        <location filename="../../src/citra_qt/main.cpp" line="434"/>
         <source>CTRL+F</source>
         <translation>CTRL+F</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="538"/>
+        <location filename="../../src/citra_qt/main.cpp" line="543"/>
         <source>Update available!</source>
         <translation>アップデートが利用可能です！</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="539"/>
+        <location filename="../../src/citra_qt/main.cpp" line="544"/>
         <source>An update for Citra is available. Do you wish to install it now?&lt;br /&gt;&lt;br /&gt;This &lt;b&gt;will&lt;/b&gt; terminate emulation, if it is running.</source>
         <translation>Citraのアップデートが利用可能です。 今すぐインストールしますか？&lt;br /&gt;&lt;br /&gt;&lt;b&gt;エミュレーションが実行中&lt;/b&gt;の場合は、エミュレーションを終了します.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <location filename="../../src/citra_qt/main.cpp" line="555"/>
         <source>No update found</source>
         <translation>更新が見つかりません</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <location filename="../../src/citra_qt/main.cpp" line="555"/>
         <source>No update has been found for Citra.</source>
         <translation>Citraの更新は見つかりませんでした。</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="567"/>
+        <location filename="../../src/citra_qt/main.cpp" line="572"/>
         <source>Error while initializing OpenGL 3.3 Core!</source>
         <translation>OpenGL 3.3コアを初期化中にエラー!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="568"/>
+        <location filename="../../src/citra_qt/main.cpp" line="573"/>
         <source>Your GPU may not support OpenGL 3.3, or you do not have the latest graphics driver.</source>
         <translation>GPUがOpenGL 3.3に対応していないか、最新のｸﾞﾗﾌｨｯｸﾄﾞﾗｲﾊﾞがありません.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="581"/>
-        <location filename="../../src/citra_qt/main.cpp" line="587"/>
-        <location filename="../../src/citra_qt/main.cpp" line="593"/>
-        <location filename="../../src/citra_qt/main.cpp" line="606"/>
-        <location filename="../../src/citra_qt/main.cpp" line="625"/>
+        <location filename="../../src/citra_qt/main.cpp" line="586"/>
+        <location filename="../../src/citra_qt/main.cpp" line="592"/>
+        <location filename="../../src/citra_qt/main.cpp" line="598"/>
+        <location filename="../../src/citra_qt/main.cpp" line="611"/>
+        <location filename="../../src/citra_qt/main.cpp" line="630"/>
         <source>Error while loading ROM!</source>
         <translation>ROMの読込中にエラーが発生!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="582"/>
-        <location filename="../../src/citra_qt/main.cpp" line="607"/>
+        <location filename="../../src/citra_qt/main.cpp" line="587"/>
+        <location filename="../../src/citra_qt/main.cpp" line="612"/>
         <source>The ROM format is not supported.</source>
         <translation>このROMの形式に未対応.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="588"/>
+        <location filename="../../src/citra_qt/main.cpp" line="593"/>
         <source>Could not determine the system mode.</source>
         <translation>システムモードを判別できません.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="594"/>
+        <location filename="../../src/citra_qt/main.cpp" line="599"/>
         <source>The game that you are trying to load must be decrypted before being used with Citra. A real 3DS is required.&lt;br/&gt;&lt;br/&gt;For more information on dumping and decrypting games, please see the following wiki pages: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</source>
         <translation>ロードしようとしているゲームは、Citraで使用する前に復号化する必要があります.3DS実機が必要です.&lt;br/&gt;&lt;br/&gt;ゲームのダンピングと復号化の詳細については、次のwikiページを参照してください:&lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;ゲームカートリッジをダンプする&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;インストールされたタイトルのダンプ&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="612"/>
+        <location filename="../../src/citra_qt/main.cpp" line="617"/>
         <source>An error occured in the video core.</source>
         <translation>ビデオコア実行中にエラーが発生.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="613"/>
+        <location filename="../../src/citra_qt/main.cpp" line="618"/>
         <source>Citra has encountered an error while running the video core, please see the log for more details.For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.Ensure that you have the latest graphics drivers for your GPU.</source>
         <translation>ビデオコア実行中にエラーが発生. 詳細はログを確認してください. ログへのアクセスやアップロードの詳細は、&lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;ログファイルをアップロードする方法&lt;/a&gt;を参照下さい. GPUが最新のｸﾞﾗﾌｨｯｸｽﾄﾞﾗｲﾊﾞであることを確認してください.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="626"/>
+        <location filename="../../src/citra_qt/main.cpp" line="631"/>
         <source>An unknown error occured. Please see the log for more details.</source>
         <translation>不明なエラーが発生. 詳細はログを確認してください.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="699"/>
+        <location filename="../../src/citra_qt/main.cpp" line="704"/>
         <source>Start</source>
         <translation>開始</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="790"/>
+        <location filename="../../src/citra_qt/main.cpp" line="795"/>
         <source>Error Opening %1 Folder</source>
-        <translation type="unfinished"/>
+        <translation>％1ﾌｫﾙﾀﾞを開く際のｴﾗｰ</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="791"/>
+        <location filename="../../src/citra_qt/main.cpp" line="796"/>
         <source>Folder does not exist!</source>
         <translation>フォルダが見つかりません!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="805"/>
+        <location filename="../../src/citra_qt/main.cpp" line="810"/>
         <source>3DS Executable</source>
         <translation>3DS実行可能ファイル</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="806"/>
-        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <location filename="../../src/citra_qt/main.cpp" line="811"/>
+        <location filename="../../src/citra_qt/main.cpp" line="833"/>
         <source>All Files (*.*)</source>
         <translation>全てのファイル (*.*)</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="808"/>
+        <location filename="../../src/citra_qt/main.cpp" line="813"/>
         <source>Load File</source>
         <translation>ファイル読込</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="818"/>
+        <location filename="../../src/citra_qt/main.cpp" line="823"/>
         <source>Select Directory</source>
         <translation>フォルダ選択</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="827"/>
+        <location filename="../../src/citra_qt/main.cpp" line="832"/>
         <source>Load Files</source>
-        <translation type="unfinished"/>
+        <translation>ﾌｧｲﾙﾛｰﾄﾞ</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <location filename="../../src/citra_qt/main.cpp" line="833"/>
         <source>3DS Installation File (*.CIA*)</source>
         <translation>3DSインストールファイル(.CIA *)</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="859"/>
+        <location filename="../../src/citra_qt/main.cpp" line="864"/>
         <source>%1 has been installed successfully.</source>
-        <translation type="unfinished"/>
+        <translation>％1が正常にｲﾝｽﾄｰﾙされました。</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="862"/>
+        <location filename="../../src/citra_qt/main.cpp" line="867"/>
         <source>Unable to open File</source>
         <translation>ファイルを開けません</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="863"/>
+        <location filename="../../src/citra_qt/main.cpp" line="868"/>
         <source>Could not open %1</source>
-        <translation type="unfinished"/>
+        <translation>％1を開くことができませんでした</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="867"/>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
         <source>Installation aborted</source>
         <translation>インストール中止</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="868"/>
+        <location filename="../../src/citra_qt/main.cpp" line="873"/>
         <source>The installation of %1 was aborted. Please see the log for more details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <location filename="../../src/citra_qt/main.cpp" line="877"/>
         <source>Invalid File</source>
         <translation>無効なファイル</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <location filename="../../src/citra_qt/main.cpp" line="877"/>
         <source>%1 is not a valid CIA</source>
-        <translation type="unfinished"/>
+        <translation>％1は有効なCIAではありません</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="875"/>
+        <location filename="../../src/citra_qt/main.cpp" line="880"/>
         <source>Encrypted File</source>
         <translation>暗号化されたファイル</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="876"/>
+        <location filename="../../src/citra_qt/main.cpp" line="881"/>
         <source>%1 must be decrypted before being used with Citra. A real 3DS is required.</source>
-        <translation type="unfinished"/>
+        <translation>％1は、Citraで使用する前に復号化する必要があります。 3DS実機が必要です。</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="899"/>
+        <location filename="../../src/citra_qt/main.cpp" line="904"/>
         <source>File not found</source>
         <translation>ファイルが見つかりません</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="900"/>
+        <location filename="../../src/citra_qt/main.cpp" line="905"/>
         <source>File &quot;%1&quot; not found</source>
         <translation>ファイル &quot;%1&quot; が見つかりません</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="914"/>
+        <location filename="../../src/citra_qt/main.cpp" line="919"/>
         <source>Continue</source>
         <translation>続行</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="939"/>
+        <location filename="../../src/citra_qt/main.cpp" line="944"/>
         <source>Missing Citra Account</source>
-        <translation type="unfinished"/>
+        <translation>Citraアカウントがありません</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="940"/>
+        <location filename="../../src/citra_qt/main.cpp" line="945"/>
         <source>In order to submit a game compatibility test case, you must link your Citra account.&lt;br&gt;&lt;br/&gt;To link your Citra account, go to Emulation &amp;gt; Configuration &amp;gt; Web.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1090"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1095"/>
         <source>Speed: %1% / %2%</source>
-        <translation type="unfinished"/>
+        <translation>ｽﾋﾟｰﾄﾞ: %1% / %2%</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1094"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1099"/>
         <source>Speed: %1%</source>
         <translation>速度: %1%</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1096"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1101"/>
         <source>Game: %1 FPS</source>
         <translation>ｹﾞｰﾑ: %1 FPS</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1097"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1102"/>
         <source>Frame: %1 ms</source>
         <translation>ﾌﾚｰﾑ: %1 ms</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1108"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1113"/>
         <source>The game you are trying to load requires additional files from your 3DS to be dumped before playing.&lt;br/&gt;&lt;br/&gt;For more information on dumping these files, please see the following wiki page: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
         <translation>読み込もうとしているゲームは、3DS実機からダンプした追加ファイルが必要です.&lt;br/&gt;&lt;br/&gt;これらのファイルのダンプの詳細については、次のWikiページ:&lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;3DS実機からのシステムアーカイブや共有フォントのダンプ&lt;/a&gt;を参照してください.&lt;br/&gt;&lt;br/&gt;ゲームリストに戻りますか？ エミュレーションを継続すると、クラッシュ、データの破損、その他のバグが発生する可能性があります.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1120"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1125"/>
         <source>: %1. </source>
         <translation>: %1.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1126"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1131"/>
         <source>System Archive Not Found</source>
         <translation>システムアーカイブが見つかりません</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1133"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1138"/>
         <source>Citra was unable to locate the 3DS shared fonts. </source>
         <translation>Citraは3DS共有フォントを見つけることができませんでした.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1135"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1140"/>
         <source>Shared Fonts Not Found</source>
         <translation>共有フォントが見つかりません</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1143"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1148"/>
         <source>Fatal Error</source>
         <translation>致命的なエラー</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1144"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1149"/>
         <source>Citra has encountered a fatal error, please see the log for more details. For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
         <translation>致命的なエラーが発生. 詳細はログを確認してください. ログへのアクセスやアップロードの詳細は、&lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;ログファイルをアップロードする方法&lt;/a&gt;を参照下さい.&lt;br/&gt;&lt;br/&gt;ゲームリストに戻りますか？ エミュレーションを継続すると、クラッシュ、データの破損、その他のバグが発生する可能性があります.ョンを継続すると、クラッシュ、データの破損、その他のバグが発生する可能性があります.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
-        <location filename="../../src/citra_qt/main.cpp" line="1245"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1183"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1250"/>
         <source>Citra</source>
         <translation>Citra</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1183"/>
         <source>Are you sure you want to close Citra?</source>
         <translation>Citraを終了してもいいですか？</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1246"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1251"/>
         <source>Are you sure you want to stop the emulation? Any unsaved progress will be lost.</source>
         <translation>ｴﾐｭﾚｰｼｮﾝを停止してもよいですか？未保存の進行状況は失われます.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1318"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1323"/>
         <source>Citra %1| %2-%3</source>
         <translation>Citra %1| %2-%3</translation>
     </message>
@@ -1458,79 +1478,79 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GameList</name>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="117"/>
         <source>Perfect</source>
-        <translation type="unfinished"/>
+        <translation>完全</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="117"/>
         <source>Game functions flawless with no audio or graphical glitches, all tested functionality works as intended without
 any workarounds needed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="118"/>
         <source>Great</source>
-        <translation type="unfinished"/>
+        <translation>素晴らしい</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="118"/>
         <source>Game functions with minor graphical or audio glitches and is playable from start to finish. May require some
 workarounds.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="119"/>
         <source>Okay</source>
-        <translation type="unfinished"/>
+        <translation>はい</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="119"/>
         <source>Game functions with major graphical or audio glitches, but game is playable from start to finish with
 workarounds.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="120"/>
         <source>Bad</source>
-        <translation type="unfinished"/>
+        <translation>悪い</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="120"/>
         <source>Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches
 even with workarounds.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="121"/>
         <source>Intro/Menu</source>
-        <translation type="unfinished"/>
+        <translation>ｲﾝﾄﾛ/ﾒﾆｭｰ</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="121"/>
         <source>Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start
 Screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="122"/>
         <source>Won&apos;t Boot</source>
-        <translation type="unfinished"/>
+        <translation>起動しない</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="122"/>
         <source>The game crashes when attempting to startup.</source>
-        <translation type="unfinished"/>
+        <translation>起動時にゲームがクラッシュする。</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="123"/>
         <source>Not Tested</source>
-        <translation type="unfinished"/>
+        <translation>未ﾃｽﾄ</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="123"/>
         <source>The game has not yet been tested.</source>
-        <translation type="unfinished"/>
+        <translation>ゲームはまだテストされていません。</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/game_list.cpp" line="99"/>
@@ -1550,7 +1570,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/game_list.cpp" line="125"/>
         <source>Filter:</source>
-        <translation type="unfinished"/>
+        <translation>ﾌｨﾙﾀｰ</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/game_list.cpp" line="128"/>
@@ -1558,17 +1578,17 @@ Screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="324"/>
+        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
         <source>Open Save Data Location</source>
         <translation>セーブデータの保存場所を開く</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
+        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
         <source>Open Application Location</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
+        <location filename="../../src/citra_qt/game_list.cpp" line="327"/>
         <source>Open Update Data Location</source>
         <translation type="unfinished"/>
     </message>
@@ -1909,27 +1929,27 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="14"/>
         <source>Create Room</source>
-        <translation type="unfinished"/>
+        <translation>ﾙｰﾑ作成</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="37"/>
         <source>Room Name</source>
-        <translation type="unfinished"/>
+        <translation>ﾙｰﾑ名</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="51"/>
         <source>Preferred Game</source>
-        <translation type="unfinished"/>
+        <translation>優先ｹﾞｰﾑ</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="61"/>
         <source>Max Players</source>
-        <translation type="unfinished"/>
+        <translation>最大ﾌﾟﾚｲﾔｰ数</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="91"/>
         <source>Username</source>
-        <translation type="unfinished"/>
+        <translation>ﾕｰｻﾞｰ名</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="101"/>
@@ -1939,12 +1959,12 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="118"/>
         <source>Password</source>
-        <translation type="unfinished"/>
+        <translation>ﾊﾟｽﾜｰﾄﾞ</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="125"/>
         <source>Port</source>
-        <translation type="unfinished"/>
+        <translation>ﾎﾟｰﾄ</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="156"/>
@@ -1959,7 +1979,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="169"/>
         <source>Host Room</source>
-        <translation type="unfinished"/>
+        <translation>ﾎｽﾄﾙｰﾑ</translation>
     </message>
 </context>
 <context>
@@ -1973,22 +1993,22 @@ Screen.</source>
         <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="32"/>
         <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="39"/>
         <source>Nickname</source>
-        <translation type="unfinished"/>
+        <translation>ﾆｯｸﾈｰﾑ</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="59"/>
         <source>Filters</source>
-        <translation type="unfinished"/>
+        <translation>ﾌｨﾙﾀｰ</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="66"/>
         <source>Search</source>
-        <translation type="unfinished"/>
+        <translation>検索</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="76"/>
         <source>Games I Own</source>
-        <translation type="unfinished"/>
+        <translation>所持ｹﾞｰﾑ</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="83"/>
@@ -2001,49 +2021,44 @@ Screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="73"/>
         <source>Password Required to Join</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="74"/>
         <source>Password:</source>
-        <translation type="unfinished"/>
+        <translation>ﾊﾟｽﾜｰﾄﾞ</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="77"/>
-        <source>Password</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="139"/>
         <source>Room Name</source>
-        <translation type="unfinished"/>
+        <translation>ﾙｰﾑ名</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="143"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="140"/>
         <source>Preferred Game</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="144"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="141"/>
         <source>Host</source>
-        <translation type="unfinished"/>
+        <translation>ﾎｽﾄ</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="145"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
         <source>Players</source>
-        <translation type="unfinished"/>
+        <translation>ﾌﾟﾚｲﾔｰ</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="153"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="150"/>
         <source>Refreshing</source>
-        <translation type="unfinished"/>
+        <translation>更新</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="201"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="198"/>
         <source>Refresh List</source>
-        <translation type="unfinished"/>
+        <translation>ﾘｽﾄ更新</translation>
     </message>
 </context>
 <context>
@@ -2081,12 +2096,12 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="91"/>
         <source>Screen Layout</source>
-        <translation type="unfinished"/>
+        <translation>画面ﾚｲｱｳﾄ</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="115"/>
         <source>Multiplayer</source>
-        <translation type="unfinished"/>
+        <translation>ﾏﾙﾁﾌﾟﾚｲﾔｰ</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="126"/>
@@ -2186,12 +2201,12 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="259"/>
         <source>Create Room</source>
-        <translation type="unfinished"/>
+        <translation>ﾙｰﾑ作成</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="267"/>
         <source>Leave Room</source>
-        <translation type="unfinished"/>
+        <translation>退室</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="272"/>
@@ -2201,7 +2216,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="280"/>
         <source>Show Current Room</source>
-        <translation type="unfinished"/>
+        <translation>現在のﾙｰﾑを表示</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="288"/>
@@ -2221,27 +2236,27 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="304"/>
         <source>Default</source>
-        <translation type="unfinished"/>
+        <translation>ﾃﾞﾌｫﾙﾄ</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="312"/>
         <source>Single Screen</source>
-        <translation type="unfinished"/>
+        <translation>ｼﾝｸﾞﾙｽｸﾘｰﾝ</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="320"/>
         <source>Large Screen</source>
-        <translation type="unfinished"/>
+        <translation>大画面</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="328"/>
         <source>Side by Side</source>
-        <translation type="unfinished"/>
+        <translation>ｻｲﾄﾞ ﾊﾞｲ ｻｲﾄﾞ</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="336"/>
         <source>Swap Screens</source>
-        <translation type="unfinished"/>
+        <translation>画面取替</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="341"/>
@@ -2251,7 +2266,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="349"/>
         <source>Report Compatibility</source>
-        <translation type="unfinished"/>
+        <translation>レポートの互換性</translation>
     </message>
 </context>
 <context>
@@ -2277,17 +2292,17 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/state.cpp" line="100"/>
         <source>Connected</source>
-        <translation type="unfinished"/>
+        <translation>接続</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/state.cpp" line="105"/>
         <source>Not Connected</source>
-        <translation type="unfinished"/>
+        <translation>未接続</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/state.cpp" line="114"/>
         <source>Error</source>
-        <translation type="unfinished"/>
+        <translation>ｴﾗｰ</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/state.cpp" line="115"/>
@@ -2371,7 +2386,7 @@ Debug Message: </source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="52"/>
         <source>Leave Room</source>
-        <translation type="unfinished"/>
+        <translation>退室</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="53"/>
@@ -2394,7 +2409,7 @@ Debug Message: </source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="47"/>
         <source>Error</source>
-        <translation type="unfinished"/>
+        <translation>ｴﾗｰ</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="198"/>
@@ -2404,6 +2419,57 @@ Debug Message: </source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="201"/>
         <source>%1 is playing %2</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="208"/>
+        <source>Invalid region</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Japan</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>North America</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="92"/>
+        <source>Europe</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="94"/>
+        <source>Australia</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="96"/>
+        <source>China</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="98"/>
+        <source>Korea</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="100"/>
+        <source>Taiwan</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="102"/>
+        <source>Region free</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="104"/>
+        <source>Invalid Region</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/dist/languages/ja_JP.ts
+++ b/dist/languages/ja_JP.ts
@@ -1,0 +1,2750 @@
+<?xml version="1.0" ?><!DOCTYPE TS><TS language="ja_JP" version="2.1">
+<context>
+    <name>ARMRegisters</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="14"/>
+        <source>ARM Registers</source>
+        <translation>ARMﾚｼﾞｽﾀ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="25"/>
+        <source>Register</source>
+        <translation>登録</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="30"/>
+        <source>Value</source>
+        <translation>値</translation>
+    </message>
+</context>
+<context>
+    <name>AboutDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="14"/>
+        <source>About Citra</source>
+        <translation>citraについて</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="30"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/citra.png&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/citra.png&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="60"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:28pt;&quot;&gt;Citra&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:28pt;&quot;&gt;Citra&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="73"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="86"/>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:12pt;&quot;&gt;Citra is a free and open source 3DS emulator licensed under GPLv2.0 or any later version.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'MS Shell Dlg 2'; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;This software should not be used to play games you have not legally obtained.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;CitraはGPLv2.0またはそれ以降のバージョンでライセンスされたフリーのオープンソース3DSエミュレータです。&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;このソフトウェアは、法的に取得していないゲームをプレイする為に使用すべきではありません.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="118"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Website&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://community.citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Forum&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Source Code&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Contributors&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/blob/master/license.txt&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;License&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="134"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;&amp;quot;3DS&amp;quot; is a trademark of Nintendo. Citra is not affiliated with Nintendo in any way.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;「3DS」は、 任天堂の商標です。 Citraは任天堂と提携していません.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>BreakPointModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="34"/>
+        <source>Pica command loaded</source>
+        <translation>Picaｺﾏﾝﾄﾞ読込完了</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="35"/>
+        <source>Pica command processed</source>
+        <translation>Picaｺﾏﾝﾄﾞ処理完了</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="36"/>
+        <source>Incoming primitive batch</source>
+        <translation>着信ﾌﾟﾘﾐﾃｨﾌﾞﾊﾞｯﾁ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="37"/>
+        <source>Finished primitive batch</source>
+        <translation>ﾌﾟﾘﾐﾃｨﾌﾞﾊﾞｯﾁ完了</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="38"/>
+        <source>Vertex shader invocation</source>
+        <translation>頂点ｼｪｰﾀﾞｰの呼出</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="40"/>
+        <source>Incoming display transfer</source>
+        <translation>着信表示転送</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="41"/>
+        <source>GSP command processed</source>
+        <translation>GSPｺﾏﾝﾄﾞ処理完了</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="42"/>
+        <source>Buffers swapped</source>
+        <translation>ﾊﾞｯﾌｧ交換</translation>
+    </message>
+</context>
+<context>
+    <name>ChatRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="14"/>
+        <source>Room Window</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="40"/>
+        <source>Send Chat Message</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="47"/>
+        <source>Send Message</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.cpp" line="81"/>
+        <source>Name</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.cpp" line="82"/>
+        <source>Game</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>ClientRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.ui" line="14"/>
+        <source>Room Window</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.ui" line="40"/>
+        <source>Leave Room</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>ClientRoomWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="54"/>
+        <source>Connected</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="65"/>
+        <source>Disconnected</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="78"/>
+        <source>%1 (%2/%3 members) - connected</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>CompatDB</name>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="20"/>
+        <source>Report Compatibility</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="27"/>
+        <location filename="../../src/citra_qt/compatdb.ui" line="63"/>
+        <source>Report Game Compatibility</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="36"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;Should you choose to submit a test case to the &lt;/span&gt;&lt;a href=&quot;https://citra-emu.org/game/&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;Citra Compatibility List&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;, The following information will be collected and displayed on the site:&lt;/span&gt;&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Hardware Information (CPU / GPU / Operating System)&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Which version of Citra you are running&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The connected Citra account&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="72"/>
+        <source>Perfect</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="79"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions flawlessly with no audio or graphical glitches.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="89"/>
+        <source>Great </source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="96"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions with minor graphical or audio glitches and is playable from start to finish. May require some workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="106"/>
+        <source>Okay</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="113"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions with major graphical or audio glitches, but game is playable from start to finish with workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="123"/>
+        <source>Bad</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="130"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches even with workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="140"/>
+        <source>Intro/Menu</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="147"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start Screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="157"/>
+        <source>Won&apos;t Boot</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="170"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The game crashes when attempting to startup.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="182"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Independent of speed or performance, how well does this game play from start to finish on this version of Citra?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="206"/>
+        <source>Thank you for your submission!</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>ConfigureAudio</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="10"/>
+        <source>Audio</source>
+        <translation>オーディオ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="18"/>
+        <source>Output Engine:</source>
+        <translation>出力エンジン</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="31"/>
+        <source>Enable audio stretching</source>
+        <translation>音声の引き延ばしを有効</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="34"/>
+        <source>This post-processing effect adjusts audio speed to match emulation speed and helps prevent audio stutter. This however increases audio latency.</source>
+        <translation>この処理により、ｴﾐｭﾚｰｼｮﾝ速度に合わせてｵｰﾃﾞｨｵ速度を調整し、ﾉｲｽﾞの低減に役立ちます. ただし、ﾚｲﾃﾝｼが増加します.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="43"/>
+        <source>Audio Device:</source>
+        <translation>オーディオデバイス</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureDebug</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="14"/>
+        <source>Form</source>
+        <translation>フォーム</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="22"/>
+        <source>GDB</source>
+        <translation>GDB</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="28"/>
+        <source>The GDB Stub only works correctly when the CPU JIT is off.</source>
+        <translation>GDB StubはCPU JITがOFF時のみ正しく動作します.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="37"/>
+        <source>Enable GDB Stub</source>
+        <translation>GDB Stubを有効</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="57"/>
+        <source>Port:</source>
+        <translation>ポート</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="14"/>
+        <source>Citra Configuration</source>
+        <translation>Citra設定</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="24"/>
+        <source>General</source>
+        <translation>一般</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="29"/>
+        <source>System</source>
+        <translation>システム</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="34"/>
+        <source>Input</source>
+        <translation>入力</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="39"/>
+        <source>Graphics</source>
+        <translation>グラフィック</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="44"/>
+        <source>Audio</source>
+        <translation>音声</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="49"/>
+        <source>Debug</source>
+        <translation>デバッグ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="54"/>
+        <source>Web</source>
+        <translation>Web</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureGeneral</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="14"/>
+        <source>Form</source>
+        <translation>フォーム</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="22"/>
+        <source>General</source>
+        <translation>一般</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="30"/>
+        <source>Confirm exit while emulation is running</source>
+        <translation>エミュレーション実行中に終了確認</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="37"/>
+        <source>Search sub-directories for games</source>
+        <translation>ゲームのサブフォルダを検索</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="46"/>
+        <source>Interface language</source>
+        <translation>インターフェイス言語</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="63"/>
+        <source>Updates</source>
+        <translation>更新</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="71"/>
+        <source>Check for updates on start</source>
+        <translation>開始時に更新を確認する</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="78"/>
+        <source>Silently auto update after closing</source>
+        <translation>終了時に自動更新する</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="90"/>
+        <source>Performance</source>
+        <translation>パフォーマンス</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="98"/>
+        <source>Enable CPU JIT</source>
+        <translation>CPU JITを有効</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="110"/>
+        <source>Emulation</source>
+        <translation>エミュレーション</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="120"/>
+        <source>Region:</source>
+        <translation>リージョン:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="128"/>
+        <source>Auto-select</source>
+        <translation>自動選択</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="178"/>
+        <source>Theme</source>
+        <translation>テーマ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="188"/>
+        <source>Theme:</source>
+        <translation>テーマ:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="205"/>
+        <source>Hotkeys</source>
+        <translation>ホットキー</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.cpp" line="16"/>
+        <source>&lt;System&gt;</source>
+        <translation>&lt;System&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.cpp" line="17"/>
+        <source>English</source>
+        <translation>英語</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureGraphics</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="14"/>
+        <source>Form</source>
+        <translation>フォーム</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="22"/>
+        <source>Graphics</source>
+        <translation>グラフィック</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="28"/>
+        <source>Enable hardware renderer</source>
+        <translation>ハードウェアレンダラーを有効</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="35"/>
+        <source>Enable shader JIT</source>
+        <translation>シェーダーJITを有効</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="42"/>
+        <source>Enable V-Sync</source>
+        <translation>V-Syncを有効</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="51"/>
+        <source>Limit Speed Percent</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="58"/>
+        <source>%</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="78"/>
+        <source>Internal Resolution:</source>
+        <translation>内部解像度:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="86"/>
+        <source>Auto (Window Size)</source>
+        <translation>自動(ウインドウサイズ)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="91"/>
+        <source>Native (400x240)</source>
+        <translation>Native (400x240)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="96"/>
+        <source>2x Native (800x480)</source>
+        <translation>2x Native (800x480)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="101"/>
+        <source>3x Native (1200x720)</source>
+        <translation>3x Native (1200x720)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="106"/>
+        <source>4x Native (1600x960)</source>
+        <translation>4x Native (1600x960)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="111"/>
+        <source>5x Native (2000x1200)</source>
+        <translation>5x Native (2000x1200)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="116"/>
+        <source>6x Native (2400x1440)</source>
+        <translation>6x Native (2400x1440)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="121"/>
+        <source>7x Native (2800x1680)</source>
+        <translation>7x Native (2800x1680)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="126"/>
+        <source>8x Native (3200x1920)</source>
+        <translation>8x Native (3200x1920)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="131"/>
+        <source>9x Native (3600x2160)</source>
+        <translation>9x Native (3600x2160)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="136"/>
+        <source>10x Native (4000x2400)</source>
+        <translation>10x Native (4000x2400)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="151"/>
+        <source>Layout</source>
+        <translation>レイアウト</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="161"/>
+        <source>Screen Layout:</source>
+        <translation>スクリーンレイアウト:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="169"/>
+        <source>Default</source>
+        <translation>デフォルト</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="174"/>
+        <source>Single Screen</source>
+        <translation>シングルスクリーン</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="179"/>
+        <source>Large Screen</source>
+        <translation>大画面</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="184"/>
+        <source>Side by Side</source>
+        <translation>サイド バイ サイド</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="194"/>
+        <source>Swap Screens</source>
+        <translation>スクリーン切替</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureInput</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="14"/>
+        <source>ConfigureInput</source>
+        <translation>入力設定</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="22"/>
+        <source>Face Buttons</source>
+        <translation>ボタン</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="36"/>
+        <source>A:</source>
+        <translation>A:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="54"/>
+        <source>B:</source>
+        <translation>B:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="72"/>
+        <source>X:</source>
+        <translation>X:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="90"/>
+        <source>Y:</source>
+        <translation>Y:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="109"/>
+        <source>Directional Pad</source>
+        <translation>十字ボタン</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="123"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="340"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="427"/>
+        <source>Up:</source>
+        <translation>上:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="141"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="358"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="445"/>
+        <source>Down:</source>
+        <translation>下:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="159"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="304"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="391"/>
+        <source>Left:</source>
+        <translation>左:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="177"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="322"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="409"/>
+        <source>Right:</source>
+        <translation>右:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="196"/>
+        <source>Shoulder Buttons</source>
+        <translation>ショルダーボタン</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="210"/>
+        <source>L:</source>
+        <translation>L:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="228"/>
+        <source>R:</source>
+        <translation>R:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="246"/>
+        <source>ZL:</source>
+        <translation>ZL:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="264"/>
+        <source>ZR:</source>
+        <translation>ZR:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="283"/>
+        <source>Circle Pad</source>
+        <translation>スライドパッド</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="295"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="461"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="232"/>
+        <source>Set Analog Stick</source>
+        <translation>アナログスティック設定</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="377"/>
+        <source>C-Stick</source>
+        <translation>Cスティック</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="471"/>
+        <source>Misc.</source>
+        <translation>その他.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="485"/>
+        <source>Start:</source>
+        <translation>スタート:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="503"/>
+        <source>Select:</source>
+        <translation>セレクト:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="521"/>
+        <source>Home:</source>
+        <translation>ホーム:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="539"/>
+        <source>Circle Mod:</source>
+        <translation>サークルモッド:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="596"/>
+        <source>Restore Defaults</source>
+        <translation>デフォルト</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="239"/>
+        <source>[press key]</source>
+        <translation>[キーを押す]</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureSystem</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="14"/>
+        <source>Form</source>
+        <translation>フォーム</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="22"/>
+        <source>System Settings</source>
+        <translation>システム設定</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="28"/>
+        <source>Username</source>
+        <translation>ユーザー名</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="48"/>
+        <source>Birthday</source>
+        <translation>誕生日</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="58"/>
+        <source>January</source>
+        <translation>１月</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="63"/>
+        <source>February</source>
+        <translation>２月</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="68"/>
+        <source>March</source>
+        <translation>３月</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="73"/>
+        <source>April</source>
+        <translation>４月</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="78"/>
+        <source>May</source>
+        <translation>５月</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="83"/>
+        <source>June</source>
+        <translation>６月</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="88"/>
+        <source>July</source>
+        <translation>７月</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="93"/>
+        <source>August</source>
+        <translation>８月</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="98"/>
+        <source>September</source>
+        <translation>９月</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="103"/>
+        <source>October</source>
+        <translation>１０月</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="108"/>
+        <source>November</source>
+        <translation>１１月</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="113"/>
+        <source>December</source>
+        <translation>１２月</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="126"/>
+        <source>Language</source>
+        <translation>言語</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="133"/>
+        <source>Note: this can be overridden when region setting is auto-select</source>
+        <translation>注: リージョン設定が自動選択の時、無効になります。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="137"/>
+        <source>Japanese (日本語)</source>
+        <translation>日本語 (日本語)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="142"/>
+        <source>English</source>
+        <translation>英語</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="147"/>
+        <source>French (français)</source>
+        <translation>フランス語 (français)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="152"/>
+        <source>German (Deutsch)</source>
+        <translation>ドイツ語 (Deutsch)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="157"/>
+        <source>Italian (italiano)</source>
+        <translation>イタリア語 (italiano)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="162"/>
+        <source>Spanish (español)</source>
+        <translation>スペイン語 (español)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="167"/>
+        <source>Simplified Chinese (简体中文)</source>
+        <translation>中国語 簡体字 (简体中文)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="172"/>
+        <source>Korean (한국어)</source>
+        <translation>韓国語 (한국어)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="177"/>
+        <source>Dutch (Nederlands)</source>
+        <translation>オランダ語 (Nederlands)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="182"/>
+        <source>Portuguese (português)</source>
+        <translation>ポルトガル語 (português)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="187"/>
+        <source>Russian (Русский)</source>
+        <translation>ロシア語 (Русский)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="192"/>
+        <source>Traditional Chinese (正體中文)</source>
+        <translation>中国語 繁体字 (正體中文)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="200"/>
+        <source>Sound output mode</source>
+        <translation>サウンド出力モード</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="208"/>
+        <source>Mono</source>
+        <translation>モノラル</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="213"/>
+        <source>Stereo</source>
+        <translation>ステレオ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="218"/>
+        <source>Surround</source>
+        <translation>サラウンド</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="226"/>
+        <source>Console ID:</source>
+        <translation>コンソールID:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="242"/>
+        <source>Regenerate</source>
+        <translation>再生成</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="252"/>
+        <source>System settings are available only when game is not running.</source>
+        <translation>システム設定はゲームが実行されていないときのみ利用可.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="87"/>
+        <source>Console ID: 0x%1</source>
+        <translation>コンソー ル ID: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="160"/>
+        <source>This will replace your current virtual 3DS with a new one. Your current virtual 3DS will not be recoverable. This might have unexpected effects in games. This might fail, if you use an outdated config savegame. Continue?</source>
+        <translation>現在の仮想3DSを削除し、新しいものに置き換えます. 現在のものは復元できません. この変更はゲームに予期しない影響を与える可能性があります.古い設定のsavegameを使うと、失敗する可能性があります.それでも続行しますか？</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="164"/>
+        <source>Warning</source>
+        <translation>警告</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureWeb</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="14"/>
+        <source>Form</source>
+        <translation>フォーム</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="22"/>
+        <source>Citra Web Service</source>
+        <translation>Citra Web サービス</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="28"/>
+        <source>By providing your username and token, you agree to allow Citra to collect additional usage data, which may include user identifying information.</source>
+        <translation>ﾕｰｻﾞｰ名とﾄｰｸﾝを提供することで、Citraがﾕｰｻﾞｰ識別情報を含む追加の使用ﾃﾞｰﾀを収集することに同意するものとします.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="46"/>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="90"/>
+        <source>Verify</source>
+        <translation>検証</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="53"/>
+        <source>Sign up</source>
+        <translation>ｻｲﾝｱｯﾌﾟ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="67"/>
+        <source>Token: </source>
+        <translation>トークン:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="78"/>
+        <source>Username: </source>
+        <translation>ユーザー名:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="99"/>
+        <source>What is my token?</source>
+        <translation>私のﾄｰｸﾝとは?</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="124"/>
+        <source>Telemetry</source>
+        <translation>テレメトリー</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="130"/>
+        <source>Share anonymous usage data with the Citra team</source>
+        <translation>Citraチームに匿名の使用データを共有</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="137"/>
+        <source>Learn more</source>
+        <translation>詳細</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="146"/>
+        <source>Telemetry ID:</source>
+        <translation>ﾃﾚﾒﾄﾘｰID:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="162"/>
+        <source>Regenerate</source>
+        <translation>再生成</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="28"/>
+        <source>&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;詳細&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="33"/>
+        <source>&lt;a href=&apos;https://services.citra-emu.org/&apos;&gt;Sign up&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://services.citra-emu.org/&apos;&gt;ｻｲﾝｱｯﾌﾟ&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="36"/>
+        <source>&lt;a href=&apos;https://citra-emu.org/wiki/citra-web-service/&apos;&gt;What is my token?&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://citra-emu.org/wiki/citra-web-service/&apos;&gt;私のﾄｰｸﾝとは?&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="45"/>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="65"/>
+        <source>Telemetry ID: 0x%1</source>
+        <translation>ﾃﾚﾒﾄﾘｰ  ID: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="55"/>
+        <source>Username and token not verified</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="56"/>
+        <source>Username and token were not verified. The changes to your username and/or token have not been saved.</source>
+        <translation>ﾕｰｻﾞｰ名とﾄｰｸﾝは検証されませんでした. ﾕｰｻﾞｰ名やﾄｰｸﾝへの変更は保存されません.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="85"/>
+        <source>Verifying</source>
+        <translation>検証中</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="99"/>
+        <source>Verification failed</source>
+        <translation>検証失敗</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="100"/>
+        <source>Verification failed. Check that you have entered your username and token correctly, and that your internet connection is working.</source>
+        <translation>検証失敗. ﾕｰｻﾞｰ名とﾄｰｸﾝが正しく入力され、ｲﾝﾀｰﾈｯﾄ接続が機能しているか確認してください.</translation>
+    </message>
+</context>
+<context>
+    <name>DirectConnect</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="14"/>
+        <source>Direct Connect</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="33"/>
+        <source>IP Address</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="56"/>
+        <source>IP</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="63"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;IPv4 address of the host&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="73"/>
+        <source>Port</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="80"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Port number the host is listening on&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="86"/>
+        <source>24872</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="100"/>
+        <source>Nickname</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="114"/>
+        <source>Password</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="156"/>
+        <source>Connect</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>DirectConnectWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="97"/>
+        <source>Connecting</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="102"/>
+        <source>Connect</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>GMainWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="90"/>
+        <source>To help improve Citra, the Citra Team collects anonymous usage data. No private or personally identifying information is collected. This data helps us to understand how people use Citra and prioritize our efforts. Furthermore, it helps us to more easily identify emulation bugs and performance issues. This data includes:&lt;ul&gt;&lt;li&gt;Information about the version of Citra you are using&lt;/li&gt;&lt;li&gt;Performance data about the games you play&lt;/li&gt;&lt;li&gt;Your configuration settings&lt;/li&gt;&lt;li&gt;Information about your computer hardware&lt;/li&gt;&lt;li&gt;Emulation errors and crash information&lt;/li&gt;&lt;/ul&gt;By default, this feature is enabled. To disable this feature, click &apos;Emulation&apos; from the menu and then select &apos;Configure...&apos;. Then, on the &apos;Web&apos; tab, uncheck &apos;Share anonymous usage data with the Citra team&apos;. &lt;br/&gt;&lt;br/&gt;By using this software, you agree to the above terms.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Citraを改善するために、Citraチームは匿名の使用データを収集します。 個人または個人を特定する情報は収集されません。 このデータは、人々がCitraをどのように使用しているかを理解し、私たちの努力に優先順位を付けるのに役立ちます.さらに、エミュレーションのバグやパフォーマンスの問題をより簡単に特定するのに役立ちます. このデータには次の情報が含まれます&lt;ul&gt;&lt;li&gt;使用しているシトラのバージョンに関する情報&lt;/li&gt;&lt;li&gt;プレイするゲームに関するパフォーマンスデータ&lt;/li&gt;&lt;li&gt;構成設定&lt;/li&gt;&lt;li&gt;コンピュータのハードウェアに関する情報&lt;/li&gt;&lt;li&gt;エミュレーションエラーとクラッシュ情報&lt;/li&gt;&lt;/ul&gt;デフォルトでは、この機能は有効です。 この機能を無効にするには、メニューからエミュレーションをクリックし、設定...を選択します.次に、Webタブで、Citraチームと匿名の利用状況データを共有するのチェックを外します.&lt;br/&gt;&lt;br/&gt;このソフトウェアを使用すると、上記の条件に同意したことになります&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;詳細&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="195"/>
+        <source>Current emulation speed. Values higher or lower than 100% indicate emulation is running faster or slower than a 3DS.</source>
+        <translation>現在のｴﾐｭﾚｰｼｮﾝ速度.100％より高いか低い値は、ｴﾐｭﾚｰｼｮﾝが3DS実機より高速または低速で実行されていることを示します</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="198"/>
+        <source>How many frames per second the game is currently displaying. This will vary from game to game and scene to scene.</source>
+        <translation>1秒当たりのフレーム数を表示しています. これは、ゲームによって異なります.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="202"/>
+        <source>Time taken to emulate a 3DS frame, not counting framelimiting or v-sync. For full-speed emulation this should be at most 16.67 ms.</source>
+        <translation>3DSﾌﾚｰﾑをｴﾐｭﾚｰﾄするのにかかる時間で、ﾌﾚｰﾑﾚｰﾄ制限やv-syncのときはｶｳﾝﾄしません.ﾌﾙｽﾋﾟｰﾄﾞのｴﾐｭﾚｰｼｮﾝには16.67ms以下にする必要があります.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="429"/>
+        <source>CTRL+F</source>
+        <translation>CTRL+F</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="538"/>
+        <source>Update available!</source>
+        <translation>アップデートが利用可能です！</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="539"/>
+        <source>An update for Citra is available. Do you wish to install it now?&lt;br /&gt;&lt;br /&gt;This &lt;b&gt;will&lt;/b&gt; terminate emulation, if it is running.</source>
+        <translation>Citraのアップデートが利用可能です。 今すぐインストールしますか？&lt;br /&gt;&lt;br /&gt;&lt;b&gt;エミュレーションが実行中&lt;/b&gt;の場合は、エミュレーションを終了します.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <source>No update found</source>
+        <translation>更新が見つかりません</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <source>No update has been found for Citra.</source>
+        <translation>Citraの更新は見つかりませんでした。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="567"/>
+        <source>Error while initializing OpenGL 3.3 Core!</source>
+        <translation>OpenGL 3.3コアを初期化中にエラー!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="568"/>
+        <source>Your GPU may not support OpenGL 3.3, or you do not have the latest graphics driver.</source>
+        <translation>GPUがOpenGL 3.3に対応していないか、最新のｸﾞﾗﾌｨｯｸﾄﾞﾗｲﾊﾞがありません.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="581"/>
+        <location filename="../../src/citra_qt/main.cpp" line="587"/>
+        <location filename="../../src/citra_qt/main.cpp" line="593"/>
+        <location filename="../../src/citra_qt/main.cpp" line="606"/>
+        <location filename="../../src/citra_qt/main.cpp" line="625"/>
+        <source>Error while loading ROM!</source>
+        <translation>ROMの読込中にエラーが発生!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="582"/>
+        <location filename="../../src/citra_qt/main.cpp" line="607"/>
+        <source>The ROM format is not supported.</source>
+        <translation>このROMの形式に未対応.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="588"/>
+        <source>Could not determine the system mode.</source>
+        <translation>システムモードを判別できません.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="594"/>
+        <source>The game that you are trying to load must be decrypted before being used with Citra. A real 3DS is required.&lt;br/&gt;&lt;br/&gt;For more information on dumping and decrypting games, please see the following wiki pages: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation>ロードしようとしているゲームは、Citraで使用する前に復号化する必要があります.3DS実機が必要です.&lt;br/&gt;&lt;br/&gt;ゲームのダンピングと復号化の詳細については、次のwikiページを参照してください:&lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;ゲームカートリッジをダンプする&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;インストールされたタイトルのダンプ&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="612"/>
+        <source>An error occured in the video core.</source>
+        <translation>ビデオコア実行中にエラーが発生.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="613"/>
+        <source>Citra has encountered an error while running the video core, please see the log for more details.For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.Ensure that you have the latest graphics drivers for your GPU.</source>
+        <translation>ビデオコア実行中にエラーが発生. 詳細はログを確認してください. ログへのアクセスやアップロードの詳細は、&lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;ログファイルをアップロードする方法&lt;/a&gt;を参照下さい. GPUが最新のｸﾞﾗﾌｨｯｸｽﾄﾞﾗｲﾊﾞであることを確認してください.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="626"/>
+        <source>An unknown error occured. Please see the log for more details.</source>
+        <translation>不明なエラーが発生. 詳細はログを確認してください.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="699"/>
+        <source>Start</source>
+        <translation>開始</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="790"/>
+        <source>Error Opening %1 Folder</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="791"/>
+        <source>Folder does not exist!</source>
+        <translation>フォルダが見つかりません!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="805"/>
+        <source>3DS Executable</source>
+        <translation>3DS実行可能ファイル</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="806"/>
+        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <source>All Files (*.*)</source>
+        <translation>全てのファイル (*.*)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="808"/>
+        <source>Load File</source>
+        <translation>ファイル読込</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="818"/>
+        <source>Select Directory</source>
+        <translation>フォルダ選択</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="827"/>
+        <source>Load Files</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <source>3DS Installation File (*.CIA*)</source>
+        <translation>3DSインストールファイル(.CIA *)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="859"/>
+        <source>%1 has been installed successfully.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="862"/>
+        <source>Unable to open File</source>
+        <translation>ファイルを開けません</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="863"/>
+        <source>Could not open %1</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="867"/>
+        <source>Installation aborted</source>
+        <translation>インストール中止</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="868"/>
+        <source>The installation of %1 was aborted. Please see the log for more details</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <source>Invalid File</source>
+        <translation>無効なファイル</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <source>%1 is not a valid CIA</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="875"/>
+        <source>Encrypted File</source>
+        <translation>暗号化されたファイル</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="876"/>
+        <source>%1 must be decrypted before being used with Citra. A real 3DS is required.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="899"/>
+        <source>File not found</source>
+        <translation>ファイルが見つかりません</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="900"/>
+        <source>File &quot;%1&quot; not found</source>
+        <translation>ファイル &quot;%1&quot; が見つかりません</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="914"/>
+        <source>Continue</source>
+        <translation>続行</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="939"/>
+        <source>Missing Citra Account</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="940"/>
+        <source>In order to submit a game compatibility test case, you must link your Citra account.&lt;br&gt;&lt;br/&gt;To link your Citra account, go to Emulation &amp;gt; Configuration &amp;gt; Web.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1090"/>
+        <source>Speed: %1% / %2%</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1094"/>
+        <source>Speed: %1%</source>
+        <translation>速度: %1%</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1096"/>
+        <source>Game: %1 FPS</source>
+        <translation>ｹﾞｰﾑ: %1 FPS</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1097"/>
+        <source>Frame: %1 ms</source>
+        <translation>ﾌﾚｰﾑ: %1 ms</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1108"/>
+        <source>The game you are trying to load requires additional files from your 3DS to be dumped before playing.&lt;br/&gt;&lt;br/&gt;For more information on dumping these files, please see the following wiki page: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
+        <translation>読み込もうとしているゲームは、3DS実機からダンプした追加ファイルが必要です.&lt;br/&gt;&lt;br/&gt;これらのファイルのダンプの詳細については、次のWikiページ:&lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;3DS実機からのシステムアーカイブや共有フォントのダンプ&lt;/a&gt;を参照してください.&lt;br/&gt;&lt;br/&gt;ゲームリストに戻りますか？ エミュレーションを継続すると、クラッシュ、データの破損、その他のバグが発生する可能性があります.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1120"/>
+        <source>: %1. </source>
+        <translation>: %1.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1126"/>
+        <source>System Archive Not Found</source>
+        <translation>システムアーカイブが見つかりません</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1133"/>
+        <source>Citra was unable to locate the 3DS shared fonts. </source>
+        <translation>Citraは3DS共有フォントを見つけることができませんでした.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1135"/>
+        <source>Shared Fonts Not Found</source>
+        <translation>共有フォントが見つかりません</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1143"/>
+        <source>Fatal Error</source>
+        <translation>致命的なエラー</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1144"/>
+        <source>Citra has encountered a fatal error, please see the log for more details. For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
+        <translation>致命的なエラーが発生. 詳細はログを確認してください. ログへのアクセスやアップロードの詳細は、&lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;ログファイルをアップロードする方法&lt;/a&gt;を参照下さい.&lt;br/&gt;&lt;br/&gt;ゲームリストに戻りますか？ エミュレーションを継続すると、クラッシュ、データの破損、その他のバグが発生する可能性があります.ョンを継続すると、クラッシュ、データの破損、その他のバグが発生する可能性があります.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1245"/>
+        <source>Citra</source>
+        <translation>Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <source>Are you sure you want to close Citra?</source>
+        <translation>Citraを終了してもいいですか？</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1246"/>
+        <source>Are you sure you want to stop the emulation? Any unsaved progress will be lost.</source>
+        <translation>ｴﾐｭﾚｰｼｮﾝを停止してもよいですか？未保存の進行状況は失われます.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1318"/>
+        <source>Citra %1| %2-%3</source>
+        <translation>Citra %1| %2-%3</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandListModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="96"/>
+        <source>Command Name</source>
+        <translation>ｺﾏﾝﾄﾞ名</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="98"/>
+        <source>Register</source>
+        <translation>ﾚｼﾞｽﾀ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="100"/>
+        <source>Mask</source>
+        <translation>ﾏｽｸ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="102"/>
+        <source>New Value</source>
+        <translation>新しい値</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandListWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="184"/>
+        <source>Pica Command List</source>
+        <translation>Picaｺﾏﾝﾄﾞﾘｽﾄ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="202"/>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="233"/>
+        <source>Start Tracing</source>
+        <translation>ﾄﾚｰｽ開始</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="203"/>
+        <source>Copy All</source>
+        <translation>全てｺﾋﾟｰ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="229"/>
+        <source>Finish Tracing</source>
+        <translation>ﾄﾚｰｽ終了</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandStreamWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics.cpp" line="67"/>
+        <source>Graphics Debugger</source>
+        <translation>グラフィックスデバッガー</translation>
+    </message>
+</context>
+<context>
+    <name>GameList</name>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <source>Perfect</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <source>Game functions flawless with no audio or graphical glitches, all tested functionality works as intended without
+any workarounds needed.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <source>Great</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <source>Game functions with minor graphical or audio glitches and is playable from start to finish. May require some
+workarounds.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <source>Okay</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <source>Game functions with major graphical or audio glitches, but game is playable from start to finish with
+workarounds.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Bad</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches
+even with workarounds.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <source>Intro/Menu</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <source>Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start
+Screen.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>Won&apos;t Boot</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>The game crashes when attempting to startup.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <source>Not Tested</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <source>The game has not yet been tested.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="99"/>
+        <source>of</source>
+        <translation>of</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="102"/>
+        <source>result</source>
+        <translation>結果</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="104"/>
+        <source>results</source>
+        <translation>結果</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="125"/>
+        <source>Filter:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="128"/>
+        <source>Enter pattern to filter</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="324"/>
+        <source>Open Save Data Location</source>
+        <translation>セーブデータの保存場所を開く</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
+        <source>Open Application Location</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
+        <source>Open Update Data Location</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>GraphicsBreakPointsWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="132"/>
+        <source>Pica Breakpoints</source>
+        <translation>Picaブレークポイント</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="136"/>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="198"/>
+        <source>Emulation running</source>
+        <translation>ｴﾐｭﾚｰｼｮﾝ実行中</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="137"/>
+        <source>Resume</source>
+        <translation>復元</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="188"/>
+        <source>Emulation halted at breakpoint</source>
+        <translation>ﾌﾞﾚｰｸﾎﾟｲﾝﾄでｴﾐｭﾚｰｼｮﾝが停止</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsSurfaceWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="49"/>
+        <source>Pica Surface Viewer</source>
+        <translation>Pica Surfaceﾋﾞｭｰﾜｰ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="54"/>
+        <source>Color Buffer</source>
+        <translation>Colorバッファ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="55"/>
+        <source>Depth Buffer</source>
+        <translation>Depthバッファ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="56"/>
+        <source>Stencil Buffer</source>
+        <translation>Stencilバッファ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="57"/>
+        <source>Texture 0</source>
+        <translation>テクスチャ 0</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="58"/>
+        <source>Texture 1</source>
+        <translation>テクスチャ 1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="59"/>
+        <source>Texture 2</source>
+        <translation>テクスチャ 2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="60"/>
+        <source>Custom</source>
+        <translation>カスタム</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="103"/>
+        <source>Unknown</source>
+        <translation>不明</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="118"/>
+        <source>Save</source>
+        <translation>保存</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="144"/>
+        <source>Source:</source>
+        <translation>ソース:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="150"/>
+        <source>Physical Address:</source>
+        <translation>物理ｱﾄﾞﾚｽ:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="156"/>
+        <source>Width:</source>
+        <translation>幅:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="162"/>
+        <source>Height:</source>
+        <translation>高さ:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="168"/>
+        <source>Format:</source>
+        <translation>形式:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="180"/>
+        <source>X:</source>
+        <translation>X:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="186"/>
+        <source>Y:</source>
+        <translation>Y:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="280"/>
+        <source>Pixel out of bounds</source>
+        <translation>ﾋﾟｸｾﾙが範囲外</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="287"/>
+        <source>(unable to access pixel data)</source>
+        <translation>(ﾋﾟｸｾﾙﾃﾞｰﾀにｱｸｾｽできません)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="555"/>
+        <source>(invalid surface address)</source>
+        <translation>(無効surfaceｱﾄﾞﾚｽ)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="565"/>
+        <source>(unknown surface format)</source>
+        <translation>(不明surface形式)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="658"/>
+        <source>Portable Network Graphic (*.png)</source>
+        <translation>ポータブルネットワークグラフィック(.png)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="659"/>
+        <source>Binary data (*.bin)</source>
+        <translation>バイナリデータ (*.bin)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="663"/>
+        <source>Save Surface</source>
+        <translation>Surfaceの保存</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsTracingWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="25"/>
+        <source>CiTrace Recorder</source>
+        <translation>CiTraceレコーダー</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="29"/>
+        <source>Start Recording</source>
+        <translation>録音開始</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="31"/>
+        <source>Stop and Save</source>
+        <translation>保存して停止</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="32"/>
+        <source>Abort Recording</source>
+        <translation>録音を中止する</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="112"/>
+        <source>Save CiTrace</source>
+        <translation>CiTraceを保存</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="113"/>
+        <source>CiTrace File (*.ctf)</source>
+        <translation>CiTraceファイル(* .ctf)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="162"/>
+        <source>CiTracing still active</source>
+        <translation>CiTracingはまだ有効です</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="163"/>
+        <source>A CiTrace is still being recorded. Do you want to save it? If not, all recorded data will be discarded.</source>
+        <translation>CiTraceはまだ記録されています。保存しますか？ しない場合、記録されたすべてのデータは破棄されます.</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsVertexShaderModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="45"/>
+        <source>Offset</source>
+        <translation>オフセット</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="47"/>
+        <source>Raw</source>
+        <translation>Raw</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="49"/>
+        <source>Disassembly</source>
+        <translation>ﾃﾞｨｽｱｾﾝﾌﾞﾘ</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsVertexShaderWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="345"/>
+        <source>Save Shader Dump</source>
+        <translation>シェーダーダンプを保存</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="345"/>
+        <source>Shader Binary (*.shbin)</source>
+        <translation>シェーダーバイナリ (*.shbin)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="380"/>
+        <source>(data only available at vertex shader invocation breakpoints)</source>
+        <translation>(頂点ｼｪｰﾀﾞｰ呼出ﾌﾞﾚｰｸﾎﾟｲﾝﾄでのﾃﾞｰﾀのみ利用可能)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="390"/>
+        <source>Dump</source>
+        <translation>ダンプ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="412"/>
+        <source>Input Data</source>
+        <translation>入力データ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="426"/>
+        <source>Attribute %1</source>
+        <translation>属性 %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="453"/>
+        <source>Cycle Index:</source>
+        <translation>サイクルインデックス:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="558"/>
+        <source>SRC1: %1, %2, %3, %4
+</source>
+        <translation>SRC1: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="564"/>
+        <source>SRC2: %1, %2, %3, %4
+</source>
+        <translation>SRC2: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="570"/>
+        <source>SRC3: %1, %2, %3, %4
+</source>
+        <translation>SRC3: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="576"/>
+        <source>DEST_IN: %1, %2, %3, %4
+</source>
+        <translation>DEST_IN: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="582"/>
+        <source>DEST_OUT: %1, %2, %3, %4
+</source>
+        <translation>DEST_OUT: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="589"/>
+        <source>Address Registers: %1, %2
+</source>
+        <translation>アドレス登録: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="593"/>
+        <source>Compare Result: %1, %2
+</source>
+        <translation>比較結果: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="598"/>
+        <source>Static Condition: %1
+</source>
+        <translation>静的条件: %1
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="600"/>
+        <source>Dynamic Conditions: %1, %2
+</source>
+        <translation>動的条件: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="604"/>
+        <source>Loop Parameters: %1 (repeats), %2 (initializer), %3 (increment), %4
+</source>
+        <translation>ループパラメータ: %1 (ﾘﾋﾟｰﾄ), %2 (ｲﾆｼｬﾗｲｻﾞ), %3 (ｲﾝｸﾘﾒﾝﾄ), %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="611"/>
+        <source>Instruction offset: 0x%1</source>
+        <translation>命令のオフセット: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="613"/>
+        <source> -&gt; 0x%2</source>
+        <translation>-&gt; 0x%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="615"/>
+        <source> (last instruction)</source>
+        <translation>(最終指示)</translation>
+    </message>
+</context>
+<context>
+    <name>HostRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="14"/>
+        <source>Create Room</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="37"/>
+        <source>Room Name</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="51"/>
+        <source>Preferred Game</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="61"/>
+        <source>Max Players</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="91"/>
+        <source>Username</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="101"/>
+        <source>(Leave blank for open game)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="118"/>
+        <source>Password</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="125"/>
+        <source>Port</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="156"/>
+        <source>Public</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="161"/>
+        <source>Unlisted</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="169"/>
+        <source>Host Room</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>Lobby</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="14"/>
+        <source>Public Room Browser</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="32"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="39"/>
+        <source>Nickname</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="59"/>
+        <source>Filters</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="66"/>
+        <source>Search</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="76"/>
+        <source>Games I Own</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="83"/>
+        <source>Hide Full Rooms</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="103"/>
+        <source>Refresh Lobby</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <source>Password Required to Join</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <source>Password:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="77"/>
+        <source>Password</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
+        <source>Room Name</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="143"/>
+        <source>Preferred Game</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="144"/>
+        <source>Host</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="145"/>
+        <source>Players</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="153"/>
+        <source>Refreshing</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="201"/>
+        <source>Refresh List</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="14"/>
+        <source>Citra</source>
+        <translation>Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="53"/>
+        <source>&amp;File</source>
+        <translation>&amp;ファイル</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="57"/>
+        <source>Recent Files</source>
+        <translation>最近使ったﾌｧｲﾙ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="70"/>
+        <source>&amp;Emulation</source>
+        <translation>エミュレーション</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="80"/>
+        <source>&amp;View</source>
+        <translation>表示</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="84"/>
+        <source>Debugging</source>
+        <translation>デバッグ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="91"/>
+        <source>Screen Layout</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="115"/>
+        <source>Multiplayer</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="126"/>
+        <source>&amp;Help</source>
+        <translation>ヘルプ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="144"/>
+        <source>Load File...</source>
+        <translation>ファイル読込...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="149"/>
+        <source>Install CIA...</source>
+        <translation>CIAインストール...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="154"/>
+        <source>Load Symbol Map...</source>
+        <translation>シンボルマップの読込...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="159"/>
+        <source>E&amp;xit</source>
+        <translation>終了</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="167"/>
+        <source>&amp;Start</source>
+        <translation>開始</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="175"/>
+        <source>&amp;Pause</source>
+        <translation>一時停止</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="183"/>
+        <source>&amp;Stop</source>
+        <translation>停止</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="188"/>
+        <source>FAQ</source>
+        <translation>よくある質問</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="193"/>
+        <source>About Citra</source>
+        <translation>Citraについて</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="201"/>
+        <source>Single Window Mode</source>
+        <translation>シングルウィンドウモード</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="206"/>
+        <source>Configure...</source>
+        <translation>設定...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="214"/>
+        <source>Display Dock Widget Headers</source>
+        <translation>Dock Widgetヘッダの表示</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="222"/>
+        <source>Show Filter Bar</source>
+        <translation>フィルタバーを表示</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="230"/>
+        <source>Show Status Bar</source>
+        <translation>ステータスバーを表示</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="235"/>
+        <source>Select Game Directory...</source>
+        <translation>ゲームフォルダの選択</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="238"/>
+        <source>Selects a folder to display in the game list</source>
+        <translation>ｹﾞｰﾑﾘｽﾄに表示するﾌｫﾙﾀﾞを選択します</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="243"/>
+        <source>Create Pica Surface Viewer</source>
+        <translation>Pica Surfaceビューワーを表示</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="251"/>
+        <source>Browse Public Game Lobby</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="259"/>
+        <source>Create Room</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="267"/>
+        <source>Leave Room</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="272"/>
+        <source>Direct Connect to Room</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="280"/>
+        <source>Show Current Room</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="288"/>
+        <source>Fullscreen</source>
+        <translation>フルスクリーン</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="293"/>
+        <source>Modify Citra Install</source>
+        <translation>Citraのインストールを変更</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="296"/>
+        <source>Opens the maintenance tool to modify your Citra installation</source>
+        <translation>Citraのインストールを変更するためのメンテナンスツールを開きます</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="304"/>
+        <source>Default</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="312"/>
+        <source>Single Screen</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="320"/>
+        <source>Large Screen</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="328"/>
+        <source>Side by Side</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="336"/>
+        <source>Swap Screens</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="341"/>
+        <source>Check for Updates</source>
+        <translation>アップデートの確認</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="349"/>
+        <source>Report Compatibility</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>MicroProfileDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/profiler.cpp" line="50"/>
+        <source>MicroProfile</source>
+        <translation>マイクロプロファイル</translation>
+    </message>
+</context>
+<context>
+    <name>MultiplayerState</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="41"/>
+        <source>Current connection status</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="42"/>
+        <source>Not Connected. Click here to find a room!</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="100"/>
+        <source>Connected</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="105"/>
+        <source>Not Connected</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="114"/>
+        <source>Error</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="115"/>
+        <source>Failed to announce the room to the public lobby. In order to host a room publicly, you must have a valid Citra account configured in Emulation -&gt; Configure -&gt; Web. If you do not want to publish a room in the public lobby, then select Unlisted instead.
+Debug Message: </source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>NetworkMessage</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="12"/>
+        <source>Username is not valid. Must be 4 to 20 alphanumeric characters.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="14"/>
+        <source>Room name is not valid. Must be 4 to 20 alphanumeric characters.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="16"/>
+        <source>Username is already in use. Please choose another.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="17"/>
+        <source>IP is not a valid IPv4 address.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="18"/>
+        <source>Port must be a number between 0 to 65535.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="20"/>
+        <source>Unable to find an internet connection. Check your internet settings.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="22"/>
+        <source>Unable to connect to the host. Verify that the connection settings are correct. If you still cannot connect, contact the room host and verify that the host is properly configured with the external port forwarded.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="26"/>
+        <source>Creating a room failed. Please retry. Restarting Citra might be necessary.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="28"/>
+        <source>The host of the room has banned you. Speak with the host to unban you or try a different room.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="31"/>
+        <source>Version mismatch! Please update to the latest version of Citra. If the problem persists, contact the room host and ask them to update the server.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="33"/>
+        <source>Incorrect password.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="35"/>
+        <source>An unknown error occured. If this error continues to occur, please open an issue</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="36"/>
+        <source>Connection to room lost. Try to reconnect.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="38"/>
+        <source>MAC address is already in use. Please choose another.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="52"/>
+        <source>Leave Room</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="53"/>
+        <source>You are about to close the room. Any network connections will be closed.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="58"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="59"/>
+        <source>You are about to leave the room. Any network connections will be closed.</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="47"/>
+        <source>Error</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="198"/>
+        <source>%1 is not playing a game</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="201"/>
+        <source>%1 is playing %2</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="26"/>
+        <source>Shift</source>
+        <translation>Shift</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="28"/>
+        <source>Ctrl</source>
+        <translation>Ctrl</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="30"/>
+        <source>Alt</source>
+        <translation>Alt</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="51"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="75"/>
+        <source>[not set]</source>
+        <translation>[設定されてない]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="55"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="83"/>
+        <source>Joystick %1</source>
+        <translation>Joystick %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="57"/>
+        <source> Hat %1 %2</source>
+        <translation>Hat %1 %2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="61"/>
+        <source> Axis %1%2</source>
+        <translation>Axis %1%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="65"/>
+        <source> Button %1</source>
+        <translation>ボタン %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="69"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="91"/>
+        <source>[unknown]</source>
+        <translation>[不明]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="80"/>
+        <source>[unused]</source>
+        <translation>[未使用]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="85"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="87"/>
+        <source> Axis %1</source>
+        <translation> Axis %1</translation>
+    </message>
+</context>
+<context>
+    <name>RegistersWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="15"/>
+        <source>Registers</source>
+        <translation>登録</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="16"/>
+        <source>VFP Registers</source>
+        <translation>VFPﾚｼﾞｽﾀ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="18"/>
+        <source>VFP System Registers</source>
+        <translation>VFPｼｽﾃﾑﾚｼﾞｽﾀ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="167"/>
+        <source>Vector Length</source>
+        <translation>Vector長</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="168"/>
+        <source>Vector Stride</source>
+        <translation>Vectorストライド</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="169"/>
+        <source>Rounding Mode</source>
+        <translation>丸めﾓｰﾄﾞ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="182"/>
+        <source>Vector Iteration Count</source>
+        <translation>Vector反復回数</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeEvent</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="259"/>
+        <source>reset type = %1</source>
+        <translation>ﾘｾｯﾄﾀｲﾌﾟ = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeMutex</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="272"/>
+        <source>locked %1 times by thread:</source>
+        <translation>ｽﾚｯﾄﾞで %1 回ﾛｯｸ:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="275"/>
+        <source>free</source>
+        <translation>フリー</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeMutexList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="314"/>
+        <source>holding mutexes</source>
+        <translation>排他制御</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeObjectList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="128"/>
+        <source>waiting for all objects</source>
+        <translation>全てのｵﾌﾞｼﾞｪｸﾄ待機</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="129"/>
+        <source>waiting for one of the following objects</source>
+        <translation>次のｵﾌﾞｼﾞｪｸﾄ待機</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeSemaphore</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="288"/>
+        <source>available count = %1</source>
+        <translation>利用可能ｶｳﾝﾄ = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="289"/>
+        <source>max count = %1</source>
+        <translation>最大ｶｳﾝﾄ = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeThread</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="146"/>
+        <source>running</source>
+        <translation>実行中</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="149"/>
+        <source>ready</source>
+        <translation>準備</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="152"/>
+        <source>waiting for address 0x%1</source>
+        <translation>ｱﾄﾞﾚｽ待機 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="155"/>
+        <source>sleeping</source>
+        <translation>ｽﾘｰﾌﾟ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="158"/>
+        <source>waiting for IPC response</source>
+        <translation>IPC 応答待機</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="162"/>
+        <source>waiting for objects</source>
+        <translation>ｵﾌﾞｼﾞｪｸﾄ待機</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="165"/>
+        <source>waiting for HLE return</source>
+        <translation>HLEの復帰待機</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="168"/>
+        <source>dormant</source>
+        <translation>休止</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="171"/>
+        <source>dead</source>
+        <translation>終了</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="174"/>
+        <source> PC = 0x%1 LR = 0x%2</source>
+        <translation>PC = 0x%1 LR = 0x%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="214"/>
+        <source>default</source>
+        <translation>デフォルト</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="217"/>
+        <source>all</source>
+        <translation>すべて</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="220"/>
+        <source>AppCore</source>
+        <translation>Appｺｱ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="223"/>
+        <source>SysCore</source>
+        <translation>Sysｺｱ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="226"/>
+        <source>Unknown processor %1</source>
+        <translation>不明ﾌﾟﾛｾｯｻ %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="230"/>
+        <source>processor = %1</source>
+        <translation>ﾌﾟﾛｾｯｻ = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="231"/>
+        <source>thread id = %1</source>
+        <translation>ｽﾚｯﾄﾞid = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="232"/>
+        <source>priority = %1(current) / %2(normal)</source>
+        <translation>優先度 = %1(現在) / %2(通常)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="236"/>
+        <source>last running ticks = %1</source>
+        <translation>最終実行ticks = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="239"/>
+        <source>not holding mutex</source>
+        <translation>非排他制御</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeThreadList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="328"/>
+        <source>waited by thread</source>
+        <translation>ｽﾚｯﾄﾞで待機</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeTimer</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="301"/>
+        <source>reset type = %1</source>
+        <translation>ﾘｾｯﾄﾀｲﾌﾟ = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="303"/>
+        <source>initial delay = %1</source>
+        <translation>初期遅延 = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="305"/>
+        <source>interval delay = %1</source>
+        <translation>ｲﾝﾀｰﾊﾞﾙ遅延 = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeWaitObject</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="76"/>
+        <source>[%1]%2 %3</source>
+        <translation>[%1]%2 %3</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="104"/>
+        <source>waited by no thread</source>
+        <translation>ｽﾚｯﾄﾞ無で待機</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="114"/>
+        <source>one shot</source>
+        <translation>1回限りの</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="116"/>
+        <source>sticky</source>
+        <translation>難しい</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="118"/>
+        <source>pulse</source>
+        <translation>パルス</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="399"/>
+        <source>Wait Tree</source>
+        <translation>待機ツリー</translation>
+    </message>
+</context>
+<context>
+    <name>hotkeys</name>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="14"/>
+        <source>Hotkey Settings</source>
+        <translation>ホットキーの設定</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="27"/>
+        <source>Action</source>
+        <translation>動作</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="32"/>
+        <source>Hotkey</source>
+        <translation>ホットキー</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="37"/>
+        <source>Context</source>
+        <translation>コンテキスト</translation>
+    </message>
+</context>
+</TS>

--- a/dist/languages/ko_KR.ts
+++ b/dist/languages/ko_KR.ts
@@ -1,0 +1,2755 @@
+<?xml version="1.0" ?><!DOCTYPE TS><TS language="ko_KR" version="2.1">
+<context>
+    <name>ARMRegisters</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="14"/>
+        <source>ARM Registers</source>
+        <translation>ARM 레지스터</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="25"/>
+        <source>Register</source>
+        <translation>레지스터</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="30"/>
+        <source>Value</source>
+        <translation>Value</translation>
+    </message>
+</context>
+<context>
+    <name>AboutDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="14"/>
+        <source>About Citra</source>
+        <translation>Citra에 대하여</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="30"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/citra.png&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/citra.png&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="60"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:28pt;&quot;&gt;Citra&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:28pt;&quot;&gt;Citra&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt; </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="73"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="86"/>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:12pt;&quot;&gt;Citra is a free and open source 3DS emulator licensed under GPLv2.0 or any later version.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'MS Shell Dlg 2'; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;This software should not be used to play games you have not legally obtained.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;Citra는 GPL 2.0 이상의 버전으로 라이센스가 부여된 무료 오픈 소스 3DS에뮬레이터입니다&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;이 소프트웨어는 합법적으로 얻지 않은 게임을 플레이하는 데 사용할 수 없습니다.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="118"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Website&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://community.citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Forum&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Source Code&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Contributors&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/blob/master/license.txt&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;License&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;웹사이트&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://community.citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;포럼&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;소스코드&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;기여자들&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/blob/master/license.txt&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;라이센스&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="134"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;&amp;quot;3DS&amp;quot; is a trademark of Nintendo. Citra is not affiliated with Nintendo in any way.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;&amp;quot;3DS&amp;quot; 는 닌텐도의 트레이드 마크입니다. Citra는 닌텐도와 아무런 관련이 없습니다&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>BreakPointModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="34"/>
+        <source>Pica command loaded</source>
+        <translation>Pica command loaded</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="35"/>
+        <source>Pica command processed</source>
+        <translation>Pica command processed</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="36"/>
+        <source>Incoming primitive batch</source>
+        <translation>Incoming primitive batch</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="37"/>
+        <source>Finished primitive batch</source>
+        <translation>Finished primitive batch</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="38"/>
+        <source>Vertex shader invocation</source>
+        <translation>Vertex shader invocation</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="40"/>
+        <source>Incoming display transfer</source>
+        <translation>Incoming display transfer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="41"/>
+        <source>GSP command processed</source>
+        <translation>GSP command processed</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="42"/>
+        <source>Buffers swapped</source>
+        <translation>Buffers swapped</translation>
+    </message>
+</context>
+<context>
+    <name>ChatRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="14"/>
+        <source>Room Window</source>
+        <translation>Room Window</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="40"/>
+        <source>Send Chat Message</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="47"/>
+        <source>Send Message</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.cpp" line="81"/>
+        <source>Name</source>
+        <translation>이름</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.cpp" line="82"/>
+        <source>Game</source>
+        <translation>게임</translation>
+    </message>
+</context>
+<context>
+    <name>ClientRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.ui" line="14"/>
+        <source>Room Window</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.ui" line="40"/>
+        <source>Leave Room</source>
+        <translation>방 나가기</translation>
+    </message>
+</context>
+<context>
+    <name>ClientRoomWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="54"/>
+        <source>Connected</source>
+        <translation>연결됨</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="65"/>
+        <source>Disconnected</source>
+        <translation>연결되지 않음</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="78"/>
+        <source>%1 (%2/%3 members) - connected</source>
+        <translation>%1 (%2/%3 멤버) - 연결됨</translation>
+    </message>
+</context>
+<context>
+    <name>CompatDB</name>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="20"/>
+        <source>Report Compatibility</source>
+        <translation>호환성 보고하기</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="27"/>
+        <location filename="../../src/citra_qt/compatdb.ui" line="63"/>
+        <source>Report Game Compatibility</source>
+        <translation>게임 호환성 보고하기</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="36"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;Should you choose to submit a test case to the &lt;/span&gt;&lt;a href=&quot;https://citra-emu.org/game/&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;Citra Compatibility List&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;, The following information will be collected and displayed on the site:&lt;/span&gt;&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Hardware Information (CPU / GPU / Operating System)&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Which version of Citra you are running&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The connected Citra account&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="72"/>
+        <source>Perfect</source>
+        <translation>완벽함</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="79"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions flawlessly with no audio or graphical glitches.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;오디오 또는 그래픽 글리치가 없이 게임이 완벽하게 작동합니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="89"/>
+        <source>Great </source>
+        <translation>좋음</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="96"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions with minor graphical or audio glitches and is playable from start to finish. May require some workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;게임은 사소한 그래픽문제나 오디오 글리치와 함께 처음부터 끝까지 진행가능합니다. 몇가지 해결방안이 필요할 수 있습니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="106"/>
+        <source>Okay</source>
+        <translation>양호</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="113"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions with major graphical or audio glitches, but game is playable from start to finish with workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;게임에 주요 그래픽문제가 오디오 글리치가 있지만 몇가지 해결방안과 함께 처음부터 끝까지 플레이 할 수있습니다&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="123"/>
+        <source>Bad</source>
+        <translation>나쁨</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="130"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches even with workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;게임은 작동하지만 주요 그래픽이나 오디오 글리치가 있습니다. 특별한 해결방안에도 불구하고 특정한 지역에서 글리치로 인해 진행이 불가능합니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="140"/>
+        <source>Intro/Menu</source>
+        <translation>인트로/메뉴</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="147"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start Screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;주요 그래픽 또는 오디오 결함으로 인해 게임을 완전히 재생할 수 없습니다. 시작화면을 지날 수 없습니다&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="157"/>
+        <source>Won&apos;t Boot</source>
+        <translation>실행불가</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="170"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The game crashes when attempting to startup.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>시작할 때 게임이 충돌합니다.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="182"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Independent of speed or performance, how well does this game play from start to finish on this version of Citra?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;속도나 성능에 관계없이 Citra가 이 게임이 현재버전에서 처음부터 끝까지 얼마나 잘 실행됩니까?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="206"/>
+        <source>Thank you for your submission!</source>
+        <translation>당신의 제출에 대해 감사합니다!</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureAudio</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="10"/>
+        <source>Audio</source>
+        <translation>오디오</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="18"/>
+        <source>Output Engine:</source>
+        <translation>출력 엔진:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="31"/>
+        <source>Enable audio stretching</source>
+        <translation>오디오 스트레칭 사용</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="34"/>
+        <source>This post-processing effect adjusts audio speed to match emulation speed and helps prevent audio stutter. This however increases audio latency.</source>
+        <translation>이 후처리 효과는 오디오 속도를 에뮬레이션 속도와 일치시키고 오디오 떨림을 방지하는 데 도움이 됩니다. 하지만 이렇게 되면 오디오 지연 시간이 늘어납니다.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="43"/>
+        <source>Audio Device:</source>
+        <translation>오디오 디바이스:</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureDebug</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="14"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="22"/>
+        <source>GDB</source>
+        <translation>GDB</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="28"/>
+        <source>The GDB Stub only works correctly when the CPU JIT is off.</source>
+        <translation>GDB Stub은 CPU JIT이 꺼져있을 때만 올바르게 작동합니다.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="37"/>
+        <source>Enable GDB Stub</source>
+        <translation>GDB Stub 사용</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="57"/>
+        <source>Port:</source>
+        <translation>포트:</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="14"/>
+        <source>Citra Configuration</source>
+        <translation>Citra 설정</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="24"/>
+        <source>General</source>
+        <translation>일반</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="29"/>
+        <source>System</source>
+        <translation>시스템</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="34"/>
+        <source>Input</source>
+        <translation>입력</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="39"/>
+        <source>Graphics</source>
+        <translation>그래픽</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="44"/>
+        <source>Audio</source>
+        <translation>오디오</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="49"/>
+        <source>Debug</source>
+        <translation>디버그</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="54"/>
+        <source>Web</source>
+        <translation>웹</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureGeneral</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="14"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="22"/>
+        <source>General</source>
+        <translation>일반</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="30"/>
+        <source>Confirm exit while emulation is running</source>
+        <translation>에뮬레이션이 실행되는 동안 종료확인</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="37"/>
+        <source>Search sub-directories for games</source>
+        <translation>게임을 위해 서브 디렉토리 탐색</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="46"/>
+        <source>Interface language</source>
+        <translation>인터페이스 언어</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="63"/>
+        <source>Updates</source>
+        <translation>업데이트</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="71"/>
+        <source>Check for updates on start</source>
+        <translation>시작시 업데이트 확인</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="78"/>
+        <source>Silently auto update after closing</source>
+        <translation>종료후 자동으로 업데이트</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="90"/>
+        <source>Performance</source>
+        <translation>퍼포먼스</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="98"/>
+        <source>Enable CPU JIT</source>
+        <translation>CPU JIT 사용</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="110"/>
+        <source>Emulation</source>
+        <translation>에뮬레이션</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="120"/>
+        <source>Region:</source>
+        <translation>지역:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="128"/>
+        <source>Auto-select</source>
+        <translation>자동</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="178"/>
+        <source>Theme</source>
+        <translation>테마</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="188"/>
+        <source>Theme:</source>
+        <translation>테마:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="205"/>
+        <source>Hotkeys</source>
+        <translation>단축키</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.cpp" line="16"/>
+        <source>&lt;System&gt;</source>
+        <translation>&lt;시스템&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.cpp" line="17"/>
+        <source>English</source>
+        <translation>영어</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureGraphics</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="14"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="22"/>
+        <source>Graphics</source>
+        <translation>그래픽</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="28"/>
+        <source>Enable hardware renderer</source>
+        <translation>하드웨어 렌더러 사용</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="35"/>
+        <source>Enable shader JIT</source>
+        <translation>쉐이더 JIT 사용</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="42"/>
+        <source>Enable V-Sync</source>
+        <translation>V-Sync 사용</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="51"/>
+        <source>Limit Speed Percent</source>
+        <translation>스피드 퍼센트 제한</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="58"/>
+        <source>%</source>
+        <translation>%</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="78"/>
+        <source>Internal Resolution:</source>
+        <translation>내부 해상도:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="86"/>
+        <source>Auto (Window Size)</source>
+        <translation>자동 (화면크기)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="91"/>
+        <source>Native (400x240)</source>
+        <translation>네이티브 (400x240)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="96"/>
+        <source>2x Native (800x480)</source>
+        <translation>2x 네이티브 (800x480)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="101"/>
+        <source>3x Native (1200x720)</source>
+        <translation>3x 네이티브 (1200x720)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="106"/>
+        <source>4x Native (1600x960)</source>
+        <translation>4x 네이티브 (1600x960)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="111"/>
+        <source>5x Native (2000x1200)</source>
+        <translation>5x 네이티브 (2000x1200)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="116"/>
+        <source>6x Native (2400x1440)</source>
+        <translation>6x 네이티브 (2400x1440)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="121"/>
+        <source>7x Native (2800x1680)</source>
+        <translation>7x 네이티브 (2800x1680)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="126"/>
+        <source>8x Native (3200x1920)</source>
+        <translation>8x 네이티브 (3200x1920)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="131"/>
+        <source>9x Native (3600x2160)</source>
+        <translation>9x 네이티브 (3600x2160)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="136"/>
+        <source>10x Native (4000x2400)</source>
+        <translation>10x 네이티브 (4000x2400)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="151"/>
+        <source>Layout</source>
+        <translation>레이아웃</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="161"/>
+        <source>Screen Layout:</source>
+        <translation>스크린 레이아웃:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="169"/>
+        <source>Default</source>
+        <translation>기본</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="174"/>
+        <source>Single Screen</source>
+        <translation>단일화면</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="179"/>
+        <source>Large Screen</source>
+        <translation>큰 화면</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="184"/>
+        <source>Side by Side</source>
+        <translation>좌우화면 (Side by Side)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="194"/>
+        <source>Swap Screens</source>
+        <translation>스크린 바꾸기</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureInput</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="14"/>
+        <source>ConfigureInput</source>
+        <translation>ConfigureInput</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="22"/>
+        <source>Face Buttons</source>
+        <translation>A/B/X/Y 버튼</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="36"/>
+        <source>A:</source>
+        <translation>A:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="54"/>
+        <source>B:</source>
+        <translation>B:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="72"/>
+        <source>X:</source>
+        <translation>X:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="90"/>
+        <source>Y:</source>
+        <translation>Y:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="109"/>
+        <source>Directional Pad</source>
+        <translation>방향패드</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="123"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="340"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="427"/>
+        <source>Up:</source>
+        <translation>위:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="141"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="358"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="445"/>
+        <source>Down:</source>
+        <translation>아래:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="159"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="304"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="391"/>
+        <source>Left:</source>
+        <translation>왼쪽:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="177"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="322"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="409"/>
+        <source>Right:</source>
+        <translation>오른쪽:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="196"/>
+        <source>Shoulder Buttons</source>
+        <translation>L/R 버튼</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="210"/>
+        <source>L:</source>
+        <translation>L:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="228"/>
+        <source>R:</source>
+        <translation>R:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="246"/>
+        <source>ZL:</source>
+        <translation>ZL:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="264"/>
+        <source>ZR:</source>
+        <translation>ZR:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="283"/>
+        <source>Circle Pad</source>
+        <translation>슬라이드 패드</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="295"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="461"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="232"/>
+        <source>Set Analog Stick</source>
+        <translation>아날로그 스틱 설정</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="377"/>
+        <source>C-Stick</source>
+        <translation>C 스틱</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="471"/>
+        <source>Misc.</source>
+        <translation>기타</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="485"/>
+        <source>Start:</source>
+        <translation>Start:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="503"/>
+        <source>Select:</source>
+        <translation>Select:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="521"/>
+        <source>Home:</source>
+        <translation>Home:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="539"/>
+        <source>Circle Mod:</source>
+        <translation>슬라이드 수정:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="596"/>
+        <source>Restore Defaults</source>
+        <translation>기본값으로 재설정</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="239"/>
+        <source>[press key]</source>
+        <translation>[키 입력]</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureSystem</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="14"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="22"/>
+        <source>System Settings</source>
+        <translation>시스템 설정</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="28"/>
+        <source>Username</source>
+        <translation>사용자 이름</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="48"/>
+        <source>Birthday</source>
+        <translation>생일</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="58"/>
+        <source>January</source>
+        <translation>1월</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="63"/>
+        <source>February</source>
+        <translation>2월</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="68"/>
+        <source>March</source>
+        <translation>3월</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="73"/>
+        <source>April</source>
+        <translation>4월</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="78"/>
+        <source>May</source>
+        <translation>5월</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="83"/>
+        <source>June</source>
+        <translation>6월</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="88"/>
+        <source>July</source>
+        <translation>7월</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="93"/>
+        <source>August</source>
+        <translation>8월</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="98"/>
+        <source>September</source>
+        <translation>9월</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="103"/>
+        <source>October</source>
+        <translation>10월</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="108"/>
+        <source>November</source>
+        <translation>11월</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="113"/>
+        <source>December</source>
+        <translation>12월</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="126"/>
+        <source>Language</source>
+        <translation>언어</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="133"/>
+        <source>Note: this can be overridden when region setting is auto-select</source>
+        <translation>Note: 이 설정은 언어설정이 자동일경우 무시될수 있습니다</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="137"/>
+        <source>Japanese (日本語)</source>
+        <translation>일본어 (日本語)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="142"/>
+        <source>English</source>
+        <translation>영어 (English)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="147"/>
+        <source>French (français)</source>
+        <translation>프랑스어 (français)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="152"/>
+        <source>German (Deutsch)</source>
+        <translation>독일어 (Deutsch)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="157"/>
+        <source>Italian (italiano)</source>
+        <translation>이탈리아어 (italiano)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="162"/>
+        <source>Spanish (español)</source>
+        <translation>스페인어 (español)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="167"/>
+        <source>Simplified Chinese (简体中文)</source>
+        <translation>간체 (简体中文)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="172"/>
+        <source>Korean (한국어)</source>
+        <translation>한국어</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="177"/>
+        <source>Dutch (Nederlands)</source>
+        <translation>네덜란드어 (Nederlands)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="182"/>
+        <source>Portuguese (português)</source>
+        <translation>포르투갈어 (português)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="187"/>
+        <source>Russian (Русский)</source>
+        <translation>러시아어 (Русский)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="192"/>
+        <source>Traditional Chinese (正體中文)</source>
+        <translation>번체 (正體中文)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="200"/>
+        <source>Sound output mode</source>
+        <translation>사운드 출력모드</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="208"/>
+        <source>Mono</source>
+        <translation>모노</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="213"/>
+        <source>Stereo</source>
+        <translation>스테레오</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="218"/>
+        <source>Surround</source>
+        <translation>서라운드</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="226"/>
+        <source>Console ID:</source>
+        <translation>콘솔 ID:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="242"/>
+        <source>Regenerate</source>
+        <translation>재생성</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="252"/>
+        <source>System settings are available only when game is not running.</source>
+        <translation>시스템 설정은 게임이 실행되고 있지 않을 때만 사용할 수 있습니다.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="87"/>
+        <source>Console ID: 0x%1</source>
+        <translation>콘솔 ID: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="160"/>
+        <source>This will replace your current virtual 3DS with a new one. Your current virtual 3DS will not be recoverable. This might have unexpected effects in games. This might fail, if you use an outdated config savegame. Continue?</source>
+        <translation>현재의 가상 3DS를 새로운 시스템으로 교체합니다. 당신의 현재 가상 3DS는 복구 할 수 없습니다. 이러한 변경은 게임에 예기치 않은 영향을 미칠 수 있습니다. 이 작업은 오래된 config savegame을 사용하는 경우 실패할 수 있습니다. 계속하시겠습니까?</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="164"/>
+        <source>Warning</source>
+        <translation>경고</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureWeb</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="14"/>
+        <source>Form</source>
+        <translation>Form</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="22"/>
+        <source>Citra Web Service</source>
+        <translation>Citra 웹 서비스</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="28"/>
+        <source>By providing your username and token, you agree to allow Citra to collect additional usage data, which may include user identifying information.</source>
+        <translation>사용자 이름과 토큰을 제공하므로써 Citra가 사용자 식별 정보를 포함하는 추가 사용 데이터를 수집하도록 허용하는 데 동의하게 됩니다.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="46"/>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="90"/>
+        <source>Verify</source>
+        <translation>인증</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="53"/>
+        <source>Sign up</source>
+        <translation>가입</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="67"/>
+        <source>Token: </source>
+        <translation>토큰:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="78"/>
+        <source>Username: </source>
+        <translation>사용자 이름:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="99"/>
+        <source>What is my token?</source>
+        <translation>나의 토큰이 무엇인가요?</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="124"/>
+        <source>Telemetry</source>
+        <translation>텔레메트리</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="130"/>
+        <source>Share anonymous usage data with the Citra team</source>
+        <translation>Citra팀과 익명 사용 데이터 공유하겠습니다</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="137"/>
+        <source>Learn more</source>
+        <translation>자세히 알아보기</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="146"/>
+        <source>Telemetry ID:</source>
+        <translation>Telemetry ID:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="162"/>
+        <source>Regenerate</source>
+        <translation>재생성</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="28"/>
+        <source>&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;자세히 알아보기&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="33"/>
+        <source>&lt;a href=&apos;https://services.citra-emu.org/&apos;&gt;Sign up&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://services.citra-emu.org/&apos;&gt;가입&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="36"/>
+        <source>&lt;a href=&apos;https://citra-emu.org/wiki/citra-web-service/&apos;&gt;What is my token?&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://citra-emu.org/wiki/citra-web-service/&apos;&gt;나의 토큰이 무엇인가요?&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="45"/>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="65"/>
+        <source>Telemetry ID: 0x%1</source>
+        <translation>Telemetry ID: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="55"/>
+        <source>Username and token not verified</source>
+        <translation>사용자 이름과 토큰이 확인되지 않았습니다</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="56"/>
+        <source>Username and token were not verified. The changes to your username and/or token have not been saved.</source>
+        <translation>사용자 이름 및 토큰을 확인하지 못했습니다. 사용자 이름 및 토큰에 대한 변경 내용이 저장되지 않습니다.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="85"/>
+        <source>Verifying</source>
+        <translation>확인중</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="99"/>
+        <source>Verification failed</source>
+        <translation>인증 실패</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="100"/>
+        <source>Verification failed. Check that you have entered your username and token correctly, and that your internet connection is working.</source>
+        <translation>인증에 실패했습니다. 사용자 이름과 토큰을 올바르게 입력했으며 인터넷 연결이 작동하는지 확인하십시오.</translation>
+    </message>
+</context>
+<context>
+    <name>DirectConnect</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="14"/>
+        <source>Direct Connect</source>
+        <translation>직접 연결</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="33"/>
+        <source>IP Address</source>
+        <translation>IP 주소</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="56"/>
+        <source>IP</source>
+        <translation>IP</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="63"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;IPv4 address of the host&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;호스트의 IPv4 주소&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="73"/>
+        <source>Port</source>
+        <translation>포트</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="80"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Port number the host is listening on&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;호스트가 수신 대기중인 포트 번호&lt;/p&gt;&lt;/body&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="86"/>
+        <source>24872</source>
+        <translation>24872</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="100"/>
+        <source>Nickname</source>
+        <translation>닉네임</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="114"/>
+        <source>Password</source>
+        <translation>비밀번호</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="156"/>
+        <source>Connect</source>
+        <translation>연결</translation>
+    </message>
+</context>
+<context>
+    <name>DirectConnectWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="97"/>
+        <source>Connecting</source>
+        <translation>연결중</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="102"/>
+        <source>Connect</source>
+        <translation>연결</translation>
+    </message>
+</context>
+<context>
+    <name>GMainWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="90"/>
+        <source>To help improve Citra, the Citra Team collects anonymous usage data. No private or personally identifying information is collected. This data helps us to understand how people use Citra and prioritize our efforts. Furthermore, it helps us to more easily identify emulation bugs and performance issues. This data includes:&lt;ul&gt;&lt;li&gt;Information about the version of Citra you are using&lt;/li&gt;&lt;li&gt;Performance data about the games you play&lt;/li&gt;&lt;li&gt;Your configuration settings&lt;/li&gt;&lt;li&gt;Information about your computer hardware&lt;/li&gt;&lt;li&gt;Emulation errors and crash information&lt;/li&gt;&lt;/ul&gt;By default, this feature is enabled. To disable this feature, click &apos;Emulation&apos; from the menu and then select &apos;Configure...&apos;. Then, on the &apos;Web&apos; tab, uncheck &apos;Share anonymous usage data with the Citra team&apos;. &lt;br/&gt;&lt;br/&gt;By using this software, you agree to the above terms.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Citra를 개선하기 위해 Citra팀은 익명데이터를 수집합니다. 어떠한 개인적인 혹은 개인적으로 식별될 수 있는 정보는 수집되지 않습니다. 이 데이터는 어떤 사람이 Citra를 사용하는지 이해하고 우리의 노력을 우선시하는데 도움을 줍니다. 게다가, 이것은 에뮬레이션 버그와 퍼포먼스 이슈를 파악하는데 도움을 줍니다. 이 정보는 다음을 포함합니다:&lt;ul&gt;&lt;li&gt;이용하는 Citra의 버전&lt;/li&gt;&lt;li&gt;플레이하는 게임의 퍼포먼스 데이터&lt;/li&gt;&lt;li&gt;설정 &lt;/li&gt;&lt;li&gt;하드웨어 종류&lt;/li&gt;&lt;li&gt;에뮬레이션 에러와 크래시 정보&lt;/li&gt;&lt;/ul&gt;기본적으로, 이 기능은 활성화 되어 있습니다. 이 기능을 비활성화하기 위해서 메뉴에서 &apos;에뮬레이션&apos;을 클릭하고 &apos;설정...&apos;을 선택하세요.  그리고 &apos;웹&apos; 탭에서, &apos;Citra팀과 익명 사용 데이터 공유하겠습니다&apos;를 체크를 해제하세요. &lt;br/&gt;&lt;br/&gt;이 소프트웨어를 사용하므로써, 당신은 이 조항에 동의합니다.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;더 알아보기&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="195"/>
+        <source>Current emulation speed. Values higher or lower than 100% indicate emulation is running faster or slower than a 3DS.</source>
+        <translation>현재 에뮬레이션 속도. 100%보다 높거나 낮은 값은 에뮬레이션이 3DS보다 빠르거나 느린 것을 나타냅니다.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="198"/>
+        <source>How many frames per second the game is currently displaying. This will vary from game to game and scene to scene.</source>
+        <translation>게임이 현재 표시하고있는 초당 프레임 수입니다. 이것은 게임마다 다르며 장면마다 다릅니다.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="202"/>
+        <source>Time taken to emulate a 3DS frame, not counting framelimiting or v-sync. For full-speed emulation this should be at most 16.67 ms.</source>
+        <translation>3DS 프레임을 에뮬레이션 하는 데 걸린 시간, 프레임제한 또는 v-동기화를 카운트하지 않음. 최대 속도 에뮬레이션의 경우, 이는 최대 16.67 ms여야 합니다.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="429"/>
+        <source>CTRL+F</source>
+        <translation>CTRL+F</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="538"/>
+        <source>Update available!</source>
+        <translation>업데이트가 사용가능합니다!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="539"/>
+        <source>An update for Citra is available. Do you wish to install it now?&lt;br /&gt;&lt;br /&gt;This &lt;b&gt;will&lt;/b&gt; terminate emulation, if it is running.</source>
+        <translation>Citra에 대한 업데이트를 사용할 수 있습니다. 지금 설치하시겠습니까? 만약 에뮬레이션을 실행중이면 에뮬레이션이 종료됩니다.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <source>No update found</source>
+        <translation>업데이트를 찾을 수 없음</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <source>No update has been found for Citra.</source>
+        <translation>Citra의 업데이트를 찾을 수 없습니다</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="567"/>
+        <source>Error while initializing OpenGL 3.3 Core!</source>
+        <translation>OpenGL 3.3 Core를 초기화하는 동안 오류가 발생했습니다!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="568"/>
+        <source>Your GPU may not support OpenGL 3.3, or you do not have the latest graphics driver.</source>
+        <translation>GPU가 OpenGL 3.3을 지원하지 않거나 최신 그래픽 드라이버가 설치되지 않았을 수 있습니다.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="581"/>
+        <location filename="../../src/citra_qt/main.cpp" line="587"/>
+        <location filename="../../src/citra_qt/main.cpp" line="593"/>
+        <location filename="../../src/citra_qt/main.cpp" line="606"/>
+        <location filename="../../src/citra_qt/main.cpp" line="625"/>
+        <source>Error while loading ROM!</source>
+        <translation>ROM을 로드하는 중 오류가 발생했습니다!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="582"/>
+        <location filename="../../src/citra_qt/main.cpp" line="607"/>
+        <source>The ROM format is not supported.</source>
+        <translation>지원되지 않는 ROM 형식입니다</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="588"/>
+        <source>Could not determine the system mode.</source>
+        <translation>시스템 모드를 결정할 수 없습니다.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="594"/>
+        <source>The game that you are trying to load must be decrypted before being used with Citra. A real 3DS is required.&lt;br/&gt;&lt;br/&gt;For more information on dumping and decrypting games, please see the following wiki pages: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation>당신이 로드하고자 하는 게임은 CItra에서 사용되기전에 암호화가 해독되어야합니다. 실제 3DS가 필요합니다.&lt;br/&gt;&lt;br/&gt;게임 덤프 및 암호 해독에 대한 자세한 내용은 다음 위키 페이지를 참조하십시오:&lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="612"/>
+        <source>An error occured in the video core.</source>
+        <translation>비디오 코어에 오류가 발생했습니다.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="613"/>
+        <source>Citra has encountered an error while running the video core, please see the log for more details.For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.Ensure that you have the latest graphics drivers for your GPU.</source>
+        <translation>Citra에 치명적인 오류가 발생했습니다. 자세한 내용은 로그를 참조하십시오. 로그 액세스에 대한 자세한 내용은 다음 페이지를 참조하십시오.&lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt; 로그 파일 업로드 방법:&lt;/a&gt;&lt;br/&gt;&lt;br/&gt;게임 목록으로 다시 돌아가시겠습니까? 지속적인 에뮬레이션을 수행하면 충돌, 손상된 저장 데이터 또는 기타 버그가 발생할 수 있습니다.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="626"/>
+        <source>An unknown error occured. Please see the log for more details.</source>
+        <translation>알 수 없는 오류가 발생했습니다. 자세한 내용은 로그를 참조하십시오.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="699"/>
+        <source>Start</source>
+        <translation>시작</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="790"/>
+        <source>Error Opening %1 Folder</source>
+        <translation>%1  폴더 오픈 에러</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="791"/>
+        <source>Folder does not exist!</source>
+        <translation>폴더가 존재하지 않습니다!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="805"/>
+        <source>3DS Executable</source>
+        <translation>3DS 실행파일</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="806"/>
+        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <source>All Files (*.*)</source>
+        <translation>모든파일 (*.*)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="808"/>
+        <source>Load File</source>
+        <translation>파일 열기</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="818"/>
+        <source>Select Directory</source>
+        <translation>디렉토리 선택</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="827"/>
+        <source>Load Files</source>
+        <translation>파일 열기</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <source>3DS Installation File (*.CIA*)</source>
+        <translation>3DS 설치파일 (*.CIA*)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="859"/>
+        <source>%1 has been installed successfully.</source>
+        <translation>%1가 성공적으로 설치되었습니다.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="862"/>
+        <source>Unable to open File</source>
+        <translation>파일을 열 수 없음</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="863"/>
+        <source>Could not open %1</source>
+        <translation>%1를 열수 없음</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="867"/>
+        <source>Installation aborted</source>
+        <translation>설치가 중단됨</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="868"/>
+        <source>The installation of %1 was aborted. Please see the log for more details</source>
+        <translation>%1의 설치가 중단되었습니다. 자세한 내용은 로그를 참조하십시오.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <source>Invalid File</source>
+        <translation>올바르지 않은 파일</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <source>%1 is not a valid CIA</source>
+        <translation>%1은 올바른 CIA가 아닙니다</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="875"/>
+        <source>Encrypted File</source>
+        <translation>암호화된 파일</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="876"/>
+        <source>%1 must be decrypted before being used with Citra. A real 3DS is required.</source>
+        <translation>%1 은 Citra에서 사용되기전에 디크립트되어야 합니다. 실제 3DS가 필요합니다.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="899"/>
+        <source>File not found</source>
+        <translation>파일을 찾을 수 없음</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="900"/>
+        <source>File &quot;%1&quot; not found</source>
+        <translation>파일 &quot;%1&quot;을 찾을 수 없음</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="914"/>
+        <source>Continue</source>
+        <translation>계속</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="939"/>
+        <source>Missing Citra Account</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="940"/>
+        <source>In order to submit a game compatibility test case, you must link your Citra account.&lt;br&gt;&lt;br/&gt;To link your Citra account, go to Emulation &amp;gt; Configuration &amp;gt; Web.</source>
+        <translation>게임 호환성 테스트 케이스를 제출하려면 Citra 계정을 연결해야합니다.&lt;br/&gt;Citra 계정을 연결하려면, 에뮬레이션&amp;gt; 설정&amp;gt; 웹으로 이동하세요.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1090"/>
+        <source>Speed: %1% / %2%</source>
+        <translation>스피드: %1% / %2%</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1094"/>
+        <source>Speed: %1%</source>
+        <translation>스피드: %1%</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1096"/>
+        <source>Game: %1 FPS</source>
+        <translation>게임: %1 FPS</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1097"/>
+        <source>Frame: %1 ms</source>
+        <translation>프레임: %1 ms</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1108"/>
+        <source>The game you are trying to load requires additional files from your 3DS to be dumped before playing.&lt;br/&gt;&lt;br/&gt;For more information on dumping these files, please see the following wiki page: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
+        <translation>로드하려는 게임을 실행하려면 먼저 3DS의 추가 파일을 덤프 해야 합니다.&lt;br/&gt;&lt;br/&gt;이러한 파일 덤프에 대한 자세한 내용은 다음 위키 페이지를 참조하십시오: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;게임 목록으로 돌아가시겠습니까? 지속적인 에뮬레이션을 수행하면 충돌, 손상된 저장 데이터 또는 기타 버그가 발생할 수 있습니다.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1120"/>
+        <source>: %1. </source>
+        <translation>: %1. </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1126"/>
+        <source>System Archive Not Found</source>
+        <translation>System Archive를 찾을수 없음 </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1133"/>
+        <source>Citra was unable to locate the 3DS shared fonts. </source>
+        <translation>Citra는 3DS shared fonts를 찾을 수 없었습니다.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1135"/>
+        <source>Shared Fonts Not Found</source>
+        <translation>Shared Fonts를 찾을수 없음 </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1143"/>
+        <source>Fatal Error</source>
+        <translation>치명적인 에러</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1144"/>
+        <source>Citra has encountered a fatal error, please see the log for more details. For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
+        <translation>Citra에 치명적인 오류가 발생했습니다. 자세한 내용은 로그를 참조하십시오. 로그 액세스에 대한 자세한 내용은 다음 페이지를 참조하십시오.&lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt; 로그 파일 업로드 방법:&lt;/a&gt;&lt;br/&gt;&lt;br/&gt;게임 목록으로 다시 돌아가시겠습니까? 지속적인 에뮬레이션을 수행하면 충돌, 손상된 저장 데이터 또는 기타 버그가 발생할 수 있습니다.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1245"/>
+        <source>Citra</source>
+        <translation>Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <source>Are you sure you want to close Citra?</source>
+        <translation>Citra를 종료하시겠습니까?</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1246"/>
+        <source>Are you sure you want to stop the emulation? Any unsaved progress will be lost.</source>
+        <translation>에뮬레이션을 중지하시겠습니까? 저장되지 않은 진행이 손실됩니다.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1318"/>
+        <source>Citra %1| %2-%3</source>
+        <translation>Citra %1| %2-%3</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandListModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="96"/>
+        <source>Command Name</source>
+        <translation>커맨드 이름</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="98"/>
+        <source>Register</source>
+        <translation>레지스터</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="100"/>
+        <source>Mask</source>
+        <translation>마스크</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="102"/>
+        <source>New Value</source>
+        <translation>새 값</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandListWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="184"/>
+        <source>Pica Command List</source>
+        <translation>Pica Command List</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="202"/>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="233"/>
+        <source>Start Tracing</source>
+        <translation>트레이싱 시작</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="203"/>
+        <source>Copy All</source>
+        <translation>모두 복사</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="229"/>
+        <source>Finish Tracing</source>
+        <translation>트레이싱 종료</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandStreamWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics.cpp" line="67"/>
+        <source>Graphics Debugger</source>
+        <translation>그래픽 디버거</translation>
+    </message>
+</context>
+<context>
+    <name>GameList</name>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <source>Perfect</source>
+        <translation>완벽함</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <source>Game functions flawless with no audio or graphical glitches, all tested functionality works as intended without
+any workarounds needed.</source>
+        <translation>오디오 또는 그래픽 글리치가 없이 게임이 완벽하게 작동하며, 테스트된 모든 기능이 특별한 해결방안 없이 의도대로 작동합니다.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <source>Great</source>
+        <translation>좋음</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <source>Game functions with minor graphical or audio glitches and is playable from start to finish. May require some
+workarounds.</source>
+        <translation>게임은 사소한 그래픽문제나 오디오 글리치와 함꼐 처음부터 끝까지 진행가능합니다. 
+몇가지 해결방안이 필요할 수 있습니다.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <source>Okay</source>
+        <translation>양호</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <source>Game functions with major graphical or audio glitches, but game is playable from start to finish with
+workarounds.</source>
+        <translation>게임은 주요 그래픽문제나 오디오 글리치와 함꼐 처음부터 끝까지 진행가능합니다. 
+몇가지 해결방안이 필요할 수 있습니다.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Bad</source>
+        <translation>나쁨</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches
+even with workarounds.</source>
+        <translation>게임은 작동하지만 주요 그래픽이나 오디오 글리치가 있습니다. 특별한 해결방안에도 불구하고 
+특정한 지역에서 글리치로 인해 진행이 불가능합니다</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <source>Intro/Menu</source>
+        <translation>인트로/메뉴</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <source>Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start
+Screen.</source>
+        <translation>주요 그래픽 또는 오디오 결함으로 인해 게임을 완전히 재생할 수 없습니다. 시작화면을 
+지날 수 없습니다</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>Won&apos;t Boot</source>
+        <translation>실행불가</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>The game crashes when attempting to startup.</source>
+        <translation>시작할 때 게임이 충돌합니다.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <source>Not Tested</source>
+        <translation>테스트되지 않음</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <source>The game has not yet been tested.</source>
+        <translation>이 게임은 아직 테스트되지 않았습니다.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="99"/>
+        <source>of</source>
+        <translation>of</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="102"/>
+        <source>result</source>
+        <translation>result</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="104"/>
+        <source>results</source>
+        <translation>result</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="125"/>
+        <source>Filter:</source>
+        <translation>필터:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="128"/>
+        <source>Enter pattern to filter</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="324"/>
+        <source>Open Save Data Location</source>
+        <translation>세이브 데이터 위치 열기</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
+        <source>Open Application Location</source>
+        <translation>어플리케이션 위치 열기</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
+        <source>Open Update Data Location</source>
+        <translation>업데이트 데이터 위치 열기</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsBreakPointsWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="132"/>
+        <source>Pica Breakpoints</source>
+        <translation>Pica 중단점</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="136"/>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="198"/>
+        <source>Emulation running</source>
+        <translation>에뮬레이션 실행중</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="137"/>
+        <source>Resume</source>
+        <translation>Resume</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="188"/>
+        <source>Emulation halted at breakpoint</source>
+        <translation>에뮬레이션이 중단점에서 정지했습니다</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsSurfaceWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="49"/>
+        <source>Pica Surface Viewer</source>
+        <translation>Pica Surface Viewer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="54"/>
+        <source>Color Buffer</source>
+        <translation>컬러 버퍼</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="55"/>
+        <source>Depth Buffer</source>
+        <translation>깊이 버퍼</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="56"/>
+        <source>Stencil Buffer</source>
+        <translation>스텐실 버퍼</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="57"/>
+        <source>Texture 0</source>
+        <translation>텍스처 0</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="58"/>
+        <source>Texture 1</source>
+        <translation>텍스처 1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="59"/>
+        <source>Texture 2</source>
+        <translation>텍스처 2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="60"/>
+        <source>Custom</source>
+        <translation>커스텀</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="103"/>
+        <source>Unknown</source>
+        <translation>알 수없는</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="118"/>
+        <source>Save</source>
+        <translation>저장</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="144"/>
+        <source>Source:</source>
+        <translation>출처:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="150"/>
+        <source>Physical Address:</source>
+        <translation>물리 주소:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="156"/>
+        <source>Width:</source>
+        <translation>너비:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="162"/>
+        <source>Height:</source>
+        <translation>높이:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="168"/>
+        <source>Format:</source>
+        <translation>포맷:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="180"/>
+        <source>X:</source>
+        <translation>X:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="186"/>
+        <source>Y:</source>
+        <translation>Y:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="280"/>
+        <source>Pixel out of bounds</source>
+        <translation>픽셀이 경계를 벗어남</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="287"/>
+        <source>(unable to access pixel data)</source>
+        <translation>(픽셀 데이터에 액세스 할 수 없음)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="555"/>
+        <source>(invalid surface address)</source>
+        <translation>(잘못된 surface 주소)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="565"/>
+        <source>(unknown surface format)</source>
+        <translation>(알 수 없는 surface 형식)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="658"/>
+        <source>Portable Network Graphic (*.png)</source>
+        <translation>포터블 네트워크 그래픽 (*.png)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="659"/>
+        <source>Binary data (*.bin)</source>
+        <translation>바이너리 데이터 (*.bin)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="663"/>
+        <source>Save Surface</source>
+        <translation>Surface 저장</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsTracingWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="25"/>
+        <source>CiTrace Recorder</source>
+        <translation>CiTrace Recorder</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="29"/>
+        <source>Start Recording</source>
+        <translation>레코딩 시작</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="31"/>
+        <source>Stop and Save</source>
+        <translation>저장하고 종료</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="32"/>
+        <source>Abort Recording</source>
+        <translation>레코딩 중단</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="112"/>
+        <source>Save CiTrace</source>
+        <translation>CiTrace 저장</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="113"/>
+        <source>CiTrace File (*.ctf)</source>
+        <translation>CiTrace 파일 (*.ctf)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="162"/>
+        <source>CiTracing still active</source>
+        <translation>CiTracing 실행중</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="163"/>
+        <source>A CiTrace is still being recorded. Do you want to save it? If not, all recorded data will be discarded.</source>
+        <translation>CiTrace는 계속 레코딩중입니다. 저장하시겠습니까? 그렇지 않으면, 모든 레코딩된 데이터는 버려집니다.</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsVertexShaderModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="45"/>
+        <source>Offset</source>
+        <translation>오프셋</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="47"/>
+        <source>Raw</source>
+        <translation>Raw</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="49"/>
+        <source>Disassembly</source>
+        <translation>디스어셈블리</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsVertexShaderWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="345"/>
+        <source>Save Shader Dump</source>
+        <translation>쉐이더 덤프 저장</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="345"/>
+        <source>Shader Binary (*.shbin)</source>
+        <translation>쉐이더 바이너리 (*.shbin)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="380"/>
+        <source>(data only available at vertex shader invocation breakpoints)</source>
+        <translation>(버텍스 쉐이더 호출 중단 점에서만 데이터 사용 가능)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="390"/>
+        <source>Dump</source>
+        <translation>덤프</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="412"/>
+        <source>Input Data</source>
+        <translation>입력 데이터</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="426"/>
+        <source>Attribute %1</source>
+        <translation>Attribute %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="453"/>
+        <source>Cycle Index:</source>
+        <translation>Cycle Index:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="558"/>
+        <source>SRC1: %1, %2, %3, %4
+</source>
+        <translation>SRC1: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="564"/>
+        <source>SRC2: %1, %2, %3, %4
+</source>
+        <translation>SRC2: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="570"/>
+        <source>SRC3: %1, %2, %3, %4
+</source>
+        <translation>SRC3: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="576"/>
+        <source>DEST_IN: %1, %2, %3, %4
+</source>
+        <translation>DEST_IN: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="582"/>
+        <source>DEST_OUT: %1, %2, %3, %4
+</source>
+        <translation>DEST_OUT: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="589"/>
+        <source>Address Registers: %1, %2
+</source>
+        <translation>Address Registers: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="593"/>
+        <source>Compare Result: %1, %2
+</source>
+        <translation>Compare Result: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="598"/>
+        <source>Static Condition: %1
+</source>
+        <translation>Static Condition: %1
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="600"/>
+        <source>Dynamic Conditions: %1, %2
+</source>
+        <translation>Dynamic Conditions: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="604"/>
+        <source>Loop Parameters: %1 (repeats), %2 (initializer), %3 (increment), %4
+</source>
+        <translation>Loop Parameters: %1 (repeats), %2 (initializer), %3 (increment), %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="611"/>
+        <source>Instruction offset: 0x%1</source>
+        <translation>Instruction offset: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="613"/>
+        <source> -&gt; 0x%2</source>
+        <translation> -&gt; 0x%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="615"/>
+        <source> (last instruction)</source>
+        <translation> (last instruction)</translation>
+    </message>
+</context>
+<context>
+    <name>HostRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="14"/>
+        <source>Create Room</source>
+        <translation>방 만들기</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="37"/>
+        <source>Room Name</source>
+        <translation>방 이름</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="51"/>
+        <source>Preferred Game</source>
+        <translation>선호되는 게임</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="61"/>
+        <source>Max Players</source>
+        <translation>최대 플레이어</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="91"/>
+        <source>Username</source>
+        <translation>사용자 이름</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="101"/>
+        <source>(Leave blank for open game)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="118"/>
+        <source>Password</source>
+        <translation>비밀번호</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="125"/>
+        <source>Port</source>
+        <translation>포트</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="156"/>
+        <source>Public</source>
+        <translation>공개</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="161"/>
+        <source>Unlisted</source>
+        <translation>비공개</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="169"/>
+        <source>Host Room</source>
+        <translation>방 호스트</translation>
+    </message>
+</context>
+<context>
+    <name>Lobby</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="14"/>
+        <source>Public Room Browser</source>
+        <translation>공개 방 브라우저</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="32"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="39"/>
+        <source>Nickname</source>
+        <translation>닉네임</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="59"/>
+        <source>Filters</source>
+        <translation>필터</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="66"/>
+        <source>Search</source>
+        <translation>검색</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="76"/>
+        <source>Games I Own</source>
+        <translation>소유하고 있는 게임</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="83"/>
+        <source>Hide Full Rooms</source>
+        <translation>가득찬 방 숨기기</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="103"/>
+        <source>Refresh Lobby</source>
+        <translation>로비 새로고침</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <source>Password Required to Join</source>
+        <translation>참가시 비밀번호 필요</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <source>Password:</source>
+        <translation>비밀번호:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="77"/>
+        <source>Password</source>
+        <translation>비밀번호</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
+        <source>Room Name</source>
+        <translation>방 이름</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="143"/>
+        <source>Preferred Game</source>
+        <translation>선호되는 게임</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="144"/>
+        <source>Host</source>
+        <translation>호스트</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="145"/>
+        <source>Players</source>
+        <translation>플레이어들</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="153"/>
+        <source>Refreshing</source>
+        <translation>새로고침중</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="201"/>
+        <source>Refresh List</source>
+        <translation>리스트 새로고침</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="14"/>
+        <source>Citra</source>
+        <translation>Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="53"/>
+        <source>&amp;File</source>
+        <translation>파일(&amp;F)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="57"/>
+        <source>Recent Files</source>
+        <translation>최근 파일</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="70"/>
+        <source>&amp;Emulation</source>
+        <translation>에뮬레이션(&amp;E)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="80"/>
+        <source>&amp;View</source>
+        <translation>보기(&amp;V)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="84"/>
+        <source>Debugging</source>
+        <translation>디버깅</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="91"/>
+        <source>Screen Layout</source>
+        <translation>스크린 레이아웃</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="115"/>
+        <source>Multiplayer</source>
+        <translation>멀티플레이어</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="126"/>
+        <source>&amp;Help</source>
+        <translation>도움말(&amp;H)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="144"/>
+        <source>Load File...</source>
+        <translation>파일 열기...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="149"/>
+        <source>Install CIA...</source>
+        <translation>CIA 설치...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="154"/>
+        <source>Load Symbol Map...</source>
+        <translation>Symbol Map 열기...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="159"/>
+        <source>E&amp;xit</source>
+        <translation>종료(&amp;X)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="167"/>
+        <source>&amp;Start</source>
+        <translation>시작(&amp;S)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="175"/>
+        <source>&amp;Pause</source>
+        <translation>중지(&amp;P)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="183"/>
+        <source>&amp;Stop</source>
+        <translation>정지(&amp;S)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="188"/>
+        <source>FAQ</source>
+        <translation>FAQ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="193"/>
+        <source>About Citra</source>
+        <translation>Citra에 대하여</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="201"/>
+        <source>Single Window Mode</source>
+        <translation>싱글 윈도우 모드</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="206"/>
+        <source>Configure...</source>
+        <translation>설정...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="214"/>
+        <source>Display Dock Widget Headers</source>
+        <translation>Dock 위젯 보이기</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="222"/>
+        <source>Show Filter Bar</source>
+        <translation>필터바 보이기</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="230"/>
+        <source>Show Status Bar</source>
+        <translation>스테이스바 보이기</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="235"/>
+        <source>Select Game Directory...</source>
+        <translation>게임 디렉토리 선택...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="238"/>
+        <source>Selects a folder to display in the game list</source>
+        <translation>게임 리스트를 보여줄 디렉토리 선택</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="243"/>
+        <source>Create Pica Surface Viewer</source>
+        <translation>Pica Surface Viewer 생성</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="251"/>
+        <source>Browse Public Game Lobby</source>
+        <translation>공개 방 찾아보기</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="259"/>
+        <source>Create Room</source>
+        <translation>방 만들기</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="267"/>
+        <source>Leave Room</source>
+        <translation>방 나가기</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="272"/>
+        <source>Direct Connect to Room</source>
+        <translation>방에 직접 연결</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="280"/>
+        <source>Show Current Room</source>
+        <translation>현재 방 보이기</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="288"/>
+        <source>Fullscreen</source>
+        <translation>전체화면</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="293"/>
+        <source>Modify Citra Install</source>
+        <translation>Citra 설치 수정</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="296"/>
+        <source>Opens the maintenance tool to modify your Citra installation</source>
+        <translation>Citra 설치 수정을 위한 유지보수 도구 열기</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="304"/>
+        <source>Default</source>
+        <translation>기본</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="312"/>
+        <source>Single Screen</source>
+        <translation>단일화면</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="320"/>
+        <source>Large Screen</source>
+        <translation>큰 화면</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="328"/>
+        <source>Side by Side</source>
+        <translation>좌우화면 (Side by Side)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="336"/>
+        <source>Swap Screens</source>
+        <translation>스크린 바꾸기</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="341"/>
+        <source>Check for Updates</source>
+        <translation>업데이트 체크</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="349"/>
+        <source>Report Compatibility</source>
+        <translation>호환성 보고하기</translation>
+    </message>
+</context>
+<context>
+    <name>MicroProfileDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/profiler.cpp" line="50"/>
+        <source>MicroProfile</source>
+        <translation>MicroProfile</translation>
+    </message>
+</context>
+<context>
+    <name>MultiplayerState</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="41"/>
+        <source>Current connection status</source>
+        <translation>현재 연결 정보</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="42"/>
+        <source>Not Connected. Click here to find a room!</source>
+        <translation>연결되지 않았습니다.  방을 찾으려면 여기를 클릭하십시오!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="100"/>
+        <source>Connected</source>
+        <translation>연결됨</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="105"/>
+        <source>Not Connected</source>
+        <translation>연결되지 않음</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="114"/>
+        <source>Error</source>
+        <translation>오류</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="115"/>
+        <source>Failed to announce the room to the public lobby. In order to host a room publicly, you must have a valid Citra account configured in Emulation -&gt; Configure -&gt; Web. If you do not want to publish a room in the public lobby, then select Unlisted instead.
+Debug Message: </source>
+        <translation>공개로비에 방을 알리는데 실패했습니다. 방을 공개적으로 호스트하기 위해서는 에뮬레이션 -&gt; 설정 -&gt; 웹 에서 유효한 Citra 계정을 설정해야합니다.
+Debug Message: </translation>
+    </message>
+</context>
+<context>
+    <name>NetworkMessage</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="12"/>
+        <source>Username is not valid. Must be 4 to 20 alphanumeric characters.</source>
+        <translation>사용자 이름이 올바르지 않습니다. 4자에서 20자의 알피벳 글자여야 합니다.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="14"/>
+        <source>Room name is not valid. Must be 4 to 20 alphanumeric characters.</source>
+        <translation>방 이름이 올바르지 않습니다. 4자에서 20자의 알파벳 글자여야 합니다.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="16"/>
+        <source>Username is already in use. Please choose another.</source>
+        <translation>사용자 이름이 이미 사용중입니다. 다른 이름을 선택해주세요.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="17"/>
+        <source>IP is not a valid IPv4 address.</source>
+        <translation>IP는 올바른 IPv4 주소가 아닙니다.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="18"/>
+        <source>Port must be a number between 0 to 65535.</source>
+        <translation>포트는 0에서 65535사이에 숫자여야 합니다.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="20"/>
+        <source>Unable to find an internet connection. Check your internet settings.</source>
+        <translation>인터넷 연결을 찾을 수 없습니다. 당신의 인터넷 세팅을 확인해주세요.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="22"/>
+        <source>Unable to connect to the host. Verify that the connection settings are correct. If you still cannot connect, contact the room host and verify that the host is properly configured with the external port forwarded.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="26"/>
+        <source>Creating a room failed. Please retry. Restarting Citra might be necessary.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="28"/>
+        <source>The host of the room has banned you. Speak with the host to unban you or try a different room.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="31"/>
+        <source>Version mismatch! Please update to the latest version of Citra. If the problem persists, contact the room host and ask them to update the server.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="33"/>
+        <source>Incorrect password.</source>
+        <translation>올바르지않은 비밀번호</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="35"/>
+        <source>An unknown error occured. If this error continues to occur, please open an issue</source>
+        <translation>알 수없는 오류가 발생했습니다. 이 오류가 계속 발생하면 issue를 열어주세요.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="36"/>
+        <source>Connection to room lost. Try to reconnect.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="38"/>
+        <source>MAC address is already in use. Please choose another.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="52"/>
+        <source>Leave Room</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="53"/>
+        <source>You are about to close the room. Any network connections will be closed.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="58"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="59"/>
+        <source>You are about to leave the room. Any network connections will be closed.</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="47"/>
+        <source>Error</source>
+        <translation>오류</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="198"/>
+        <source>%1 is not playing a game</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="201"/>
+        <source>%1 is playing %2</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="26"/>
+        <source>Shift</source>
+        <translation>Shift</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="28"/>
+        <source>Ctrl</source>
+        <translation>Ctrl</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="30"/>
+        <source>Alt</source>
+        <translation>Alt</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="51"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="75"/>
+        <source>[not set]</source>
+        <translation>[설정 안함]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="55"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="83"/>
+        <source>Joystick %1</source>
+        <translation>조이스틱 %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="57"/>
+        <source> Hat %1 %2</source>
+        <translation>방향키 %1 %2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="61"/>
+        <source> Axis %1%2</source>
+        <translation> Axis %1%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="65"/>
+        <source> Button %1</source>
+        <translation> 버튼 %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="69"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="91"/>
+        <source>[unknown]</source>
+        <translation>[알수없는]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="80"/>
+        <source>[unused]</source>
+        <translation>[사용되지않음]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="85"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="87"/>
+        <source> Axis %1</source>
+        <translation> Axis %1</translation>
+    </message>
+</context>
+<context>
+    <name>RegistersWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="15"/>
+        <source>Registers</source>
+        <translation>레지스터</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="16"/>
+        <source>VFP Registers</source>
+        <translation>VFP 레지스터</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="18"/>
+        <source>VFP System Registers</source>
+        <translation>VFP 시스템 레지스터</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="167"/>
+        <source>Vector Length</source>
+        <translation>Vector Length</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="168"/>
+        <source>Vector Stride</source>
+        <translation>Vector Stride</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="169"/>
+        <source>Rounding Mode</source>
+        <translation>Rounding Mode</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="182"/>
+        <source>Vector Iteration Count</source>
+        <translation>Vector Iteration Count</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeEvent</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="259"/>
+        <source>reset type = %1</source>
+        <translation>reset type = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeMutex</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="272"/>
+        <source>locked %1 times by thread:</source>
+        <translation>locked %1 times by thread:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="275"/>
+        <source>free</source>
+        <translation>free</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeMutexList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="314"/>
+        <source>holding mutexes</source>
+        <translation>holding mutexes</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeObjectList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="128"/>
+        <source>waiting for all objects</source>
+        <translation>waiting for all objects</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="129"/>
+        <source>waiting for one of the following objects</source>
+        <translation>waiting for one of the following objects</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeSemaphore</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="288"/>
+        <source>available count = %1</source>
+        <translation>available count = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="289"/>
+        <source>max count = %1</source>
+        <translation>max count = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeThread</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="146"/>
+        <source>running</source>
+        <translation>running</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="149"/>
+        <source>ready</source>
+        <translation>ready</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="152"/>
+        <source>waiting for address 0x%1</source>
+        <translation>waiting for address 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="155"/>
+        <source>sleeping</source>
+        <translation>sleeping</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="158"/>
+        <source>waiting for IPC response</source>
+        <translation>waiting for IPC response</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="162"/>
+        <source>waiting for objects</source>
+        <translation>waiting for objects</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="165"/>
+        <source>waiting for HLE return</source>
+        <translation>waiting for HLE return</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="168"/>
+        <source>dormant</source>
+        <translation>dormant</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="171"/>
+        <source>dead</source>
+        <translation>dead</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="174"/>
+        <source> PC = 0x%1 LR = 0x%2</source>
+        <translation> PC = 0x%1 LR = 0x%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="214"/>
+        <source>default</source>
+        <translation>default</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="217"/>
+        <source>all</source>
+        <translation>all</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="220"/>
+        <source>AppCore</source>
+        <translation>AppCore</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="223"/>
+        <source>SysCore</source>
+        <translation>SysCore</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="226"/>
+        <source>Unknown processor %1</source>
+        <translation>Unknown processor %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="230"/>
+        <source>processor = %1</source>
+        <translation>processor = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="231"/>
+        <source>thread id = %1</source>
+        <translation>thread id = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="232"/>
+        <source>priority = %1(current) / %2(normal)</source>
+        <translation>priority = %1(current) / %2(normal)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="236"/>
+        <source>last running ticks = %1</source>
+        <translation>last running ticks = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="239"/>
+        <source>not holding mutex</source>
+        <translation>not holding mutex</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeThreadList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="328"/>
+        <source>waited by thread</source>
+        <translation>waited by thread</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeTimer</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="301"/>
+        <source>reset type = %1</source>
+        <translation>reset type = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="303"/>
+        <source>initial delay = %1</source>
+        <translation>initial delay = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="305"/>
+        <source>interval delay = %1</source>
+        <translation>interval delay = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeWaitObject</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="76"/>
+        <source>[%1]%2 %3</source>
+        <translation>[%1]%2 %3</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="104"/>
+        <source>waited by no thread</source>
+        <translation>waited by no thread</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="114"/>
+        <source>one shot</source>
+        <translation>one shot</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="116"/>
+        <source>sticky</source>
+        <translation>sticky</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="118"/>
+        <source>pulse</source>
+        <translation>pulse</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="399"/>
+        <source>Wait Tree</source>
+        <translation>Wait Tree</translation>
+    </message>
+</context>
+<context>
+    <name>hotkeys</name>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="14"/>
+        <source>Hotkey Settings</source>
+        <translation>단축키 설정</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="27"/>
+        <source>Action</source>
+        <translation>액션</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="32"/>
+        <source>Hotkey</source>
+        <translation>단축키</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="37"/>
+        <source>Context</source>
+        <translation>컨텍스트</translation>
+    </message>
+</context>
+</TS>

--- a/dist/languages/ko_KR.ts
+++ b/dist/languages/ko_KR.ts
@@ -120,12 +120,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="40"/>
         <source>Send Chat Message</source>
-        <translation type="unfinished"/>
+        <translation>보내는 채팅 메시지</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="47"/>
         <source>Send Message</source>
-        <translation type="unfinished"/>
+        <translation>메시지 보내기</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/chat_room.cpp" line="81"/>
@@ -143,7 +143,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/multiplayer/client_room.ui" line="14"/>
         <source>Room Window</source>
-        <translation type="unfinished"/>
+        <translation>Room Window</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/client_room.ui" line="40"/>
@@ -154,17 +154,17 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ClientRoomWindow</name>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="54"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="55"/>
         <source>Connected</source>
         <translation>연결됨</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="65"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="63"/>
         <source>Disconnected</source>
         <translation>연결되지 않음</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="78"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="76"/>
         <source>%1 (%2/%3 members) - connected</source>
         <translation>%1 (%2/%3 멤버) - 연결됨</translation>
     </message>
@@ -185,7 +185,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="36"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;Should you choose to submit a test case to the &lt;/span&gt;&lt;a href=&quot;https://citra-emu.org/game/&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;Citra Compatibility List&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;, The following information will be collected and displayed on the site:&lt;/span&gt;&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Hardware Information (CPU / GPU / Operating System)&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Which version of Citra you are running&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The connected Citra account&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"/>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;&lt;a href=&quot;https://citra-emu.org/game/&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;Citra 호환성 리스트에&lt;/span&gt;&lt;/a&gt; 제출할 테스트 케이스를 선택해야 합니다&lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;, 다음 정보가 수집되어 사이트에 표시됩니다:&lt;/span&gt;&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;하드웨어 정보 (CPU/GPU/운영 체제)&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;당신이 실행중인 Citra의 버전&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;연결된 Citra 계정&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="72"/>
@@ -255,7 +255,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="206"/>
         <source>Thank you for your submission!</source>
-        <translation>당신의 제출에 대해 감사합니다!</translation>
+        <translation>제출해주셔서 감사합니다!</translation>
     </message>
 </context>
 <context>
@@ -312,6 +312,26 @@ p, li { white-space: pre-wrap; }
         <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="57"/>
         <source>Port:</source>
         <translation>포트:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="78"/>
+        <source>Logging</source>
+        <translation>로깅</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="86"/>
+        <source>Global Log Filter</source>
+        <translation>글로벌 로그 필터</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="100"/>
+        <source>Show Log Console (Windows Only)</source>
+        <translation>로그 콘솔 표시 (Windows에만 해당)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="107"/>
+        <source>Open Log Location</source>
+        <translation>로그 위치 열기</translation>
     </message>
 </context>
 <context>
@@ -447,7 +467,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_general.cpp" line="17"/>
         <source>English</source>
-        <translation>영어</translation>
+        <translation>English</translation>
     </message>
 </context>
 <context>
@@ -480,7 +500,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="51"/>
         <source>Limit Speed Percent</source>
-        <translation>스피드 퍼센트 제한</translation>
+        <translation>속도 퍼센트 제한</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="58"/>
@@ -1100,12 +1120,12 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DirectConnectWindow</name>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="97"/>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="103"/>
         <source>Connecting</source>
         <translation>연결중</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="102"/>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="108"/>
         <source>Connect</source>
         <translation>연결</translation>
     </message>
@@ -1113,289 +1133,289 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GMainWindow</name>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="90"/>
+        <location filename="../../src/citra_qt/main.cpp" line="92"/>
         <source>To help improve Citra, the Citra Team collects anonymous usage data. No private or personally identifying information is collected. This data helps us to understand how people use Citra and prioritize our efforts. Furthermore, it helps us to more easily identify emulation bugs and performance issues. This data includes:&lt;ul&gt;&lt;li&gt;Information about the version of Citra you are using&lt;/li&gt;&lt;li&gt;Performance data about the games you play&lt;/li&gt;&lt;li&gt;Your configuration settings&lt;/li&gt;&lt;li&gt;Information about your computer hardware&lt;/li&gt;&lt;li&gt;Emulation errors and crash information&lt;/li&gt;&lt;/ul&gt;By default, this feature is enabled. To disable this feature, click &apos;Emulation&apos; from the menu and then select &apos;Configure...&apos;. Then, on the &apos;Web&apos; tab, uncheck &apos;Share anonymous usage data with the Citra team&apos;. &lt;br/&gt;&lt;br/&gt;By using this software, you agree to the above terms.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
         <translation>Citra를 개선하기 위해 Citra팀은 익명데이터를 수집합니다. 어떠한 개인적인 혹은 개인적으로 식별될 수 있는 정보는 수집되지 않습니다. 이 데이터는 어떤 사람이 Citra를 사용하는지 이해하고 우리의 노력을 우선시하는데 도움을 줍니다. 게다가, 이것은 에뮬레이션 버그와 퍼포먼스 이슈를 파악하는데 도움을 줍니다. 이 정보는 다음을 포함합니다:&lt;ul&gt;&lt;li&gt;이용하는 Citra의 버전&lt;/li&gt;&lt;li&gt;플레이하는 게임의 퍼포먼스 데이터&lt;/li&gt;&lt;li&gt;설정 &lt;/li&gt;&lt;li&gt;하드웨어 종류&lt;/li&gt;&lt;li&gt;에뮬레이션 에러와 크래시 정보&lt;/li&gt;&lt;/ul&gt;기본적으로, 이 기능은 활성화 되어 있습니다. 이 기능을 비활성화하기 위해서 메뉴에서 &apos;에뮬레이션&apos;을 클릭하고 &apos;설정...&apos;을 선택하세요.  그리고 &apos;웹&apos; 탭에서, &apos;Citra팀과 익명 사용 데이터 공유하겠습니다&apos;를 체크를 해제하세요. &lt;br/&gt;&lt;br/&gt;이 소프트웨어를 사용하므로써, 당신은 이 조항에 동의합니다.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;더 알아보기&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="195"/>
+        <location filename="../../src/citra_qt/main.cpp" line="199"/>
         <source>Current emulation speed. Values higher or lower than 100% indicate emulation is running faster or slower than a 3DS.</source>
         <translation>현재 에뮬레이션 속도. 100%보다 높거나 낮은 값은 에뮬레이션이 3DS보다 빠르거나 느린 것을 나타냅니다.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="198"/>
+        <location filename="../../src/citra_qt/main.cpp" line="202"/>
         <source>How many frames per second the game is currently displaying. This will vary from game to game and scene to scene.</source>
         <translation>게임이 현재 표시하고있는 초당 프레임 수입니다. 이것은 게임마다 다르며 장면마다 다릅니다.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="202"/>
+        <location filename="../../src/citra_qt/main.cpp" line="206"/>
         <source>Time taken to emulate a 3DS frame, not counting framelimiting or v-sync. For full-speed emulation this should be at most 16.67 ms.</source>
         <translation>3DS 프레임을 에뮬레이션 하는 데 걸린 시간, 프레임제한 또는 v-동기화를 카운트하지 않음. 최대 속도 에뮬레이션의 경우, 이는 최대 16.67 ms여야 합니다.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="429"/>
+        <location filename="../../src/citra_qt/main.cpp" line="434"/>
         <source>CTRL+F</source>
         <translation>CTRL+F</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="538"/>
+        <location filename="../../src/citra_qt/main.cpp" line="543"/>
         <source>Update available!</source>
         <translation>업데이트가 사용가능합니다!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="539"/>
+        <location filename="../../src/citra_qt/main.cpp" line="544"/>
         <source>An update for Citra is available. Do you wish to install it now?&lt;br /&gt;&lt;br /&gt;This &lt;b&gt;will&lt;/b&gt; terminate emulation, if it is running.</source>
         <translation>Citra에 대한 업데이트를 사용할 수 있습니다. 지금 설치하시겠습니까? 만약 에뮬레이션을 실행중이면 에뮬레이션이 종료됩니다.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <location filename="../../src/citra_qt/main.cpp" line="555"/>
         <source>No update found</source>
         <translation>업데이트를 찾을 수 없음</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <location filename="../../src/citra_qt/main.cpp" line="555"/>
         <source>No update has been found for Citra.</source>
         <translation>Citra의 업데이트를 찾을 수 없습니다</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="567"/>
+        <location filename="../../src/citra_qt/main.cpp" line="572"/>
         <source>Error while initializing OpenGL 3.3 Core!</source>
         <translation>OpenGL 3.3 Core를 초기화하는 동안 오류가 발생했습니다!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="568"/>
+        <location filename="../../src/citra_qt/main.cpp" line="573"/>
         <source>Your GPU may not support OpenGL 3.3, or you do not have the latest graphics driver.</source>
         <translation>GPU가 OpenGL 3.3을 지원하지 않거나 최신 그래픽 드라이버가 설치되지 않았을 수 있습니다.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="581"/>
-        <location filename="../../src/citra_qt/main.cpp" line="587"/>
-        <location filename="../../src/citra_qt/main.cpp" line="593"/>
-        <location filename="../../src/citra_qt/main.cpp" line="606"/>
-        <location filename="../../src/citra_qt/main.cpp" line="625"/>
+        <location filename="../../src/citra_qt/main.cpp" line="586"/>
+        <location filename="../../src/citra_qt/main.cpp" line="592"/>
+        <location filename="../../src/citra_qt/main.cpp" line="598"/>
+        <location filename="../../src/citra_qt/main.cpp" line="611"/>
+        <location filename="../../src/citra_qt/main.cpp" line="630"/>
         <source>Error while loading ROM!</source>
         <translation>ROM을 로드하는 중 오류가 발생했습니다!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="582"/>
-        <location filename="../../src/citra_qt/main.cpp" line="607"/>
+        <location filename="../../src/citra_qt/main.cpp" line="587"/>
+        <location filename="../../src/citra_qt/main.cpp" line="612"/>
         <source>The ROM format is not supported.</source>
         <translation>지원되지 않는 ROM 형식입니다</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="588"/>
+        <location filename="../../src/citra_qt/main.cpp" line="593"/>
         <source>Could not determine the system mode.</source>
         <translation>시스템 모드를 결정할 수 없습니다.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="594"/>
+        <location filename="../../src/citra_qt/main.cpp" line="599"/>
         <source>The game that you are trying to load must be decrypted before being used with Citra. A real 3DS is required.&lt;br/&gt;&lt;br/&gt;For more information on dumping and decrypting games, please see the following wiki pages: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</source>
         <translation>당신이 로드하고자 하는 게임은 CItra에서 사용되기전에 암호화가 해독되어야합니다. 실제 3DS가 필요합니다.&lt;br/&gt;&lt;br/&gt;게임 덤프 및 암호 해독에 대한 자세한 내용은 다음 위키 페이지를 참조하십시오:&lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="612"/>
+        <location filename="../../src/citra_qt/main.cpp" line="617"/>
         <source>An error occured in the video core.</source>
         <translation>비디오 코어에 오류가 발생했습니다.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="613"/>
+        <location filename="../../src/citra_qt/main.cpp" line="618"/>
         <source>Citra has encountered an error while running the video core, please see the log for more details.For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.Ensure that you have the latest graphics drivers for your GPU.</source>
         <translation>Citra에 치명적인 오류가 발생했습니다. 자세한 내용은 로그를 참조하십시오. 로그 액세스에 대한 자세한 내용은 다음 페이지를 참조하십시오.&lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt; 로그 파일 업로드 방법:&lt;/a&gt;&lt;br/&gt;&lt;br/&gt;게임 목록으로 다시 돌아가시겠습니까? 지속적인 에뮬레이션을 수행하면 충돌, 손상된 저장 데이터 또는 기타 버그가 발생할 수 있습니다.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="626"/>
+        <location filename="../../src/citra_qt/main.cpp" line="631"/>
         <source>An unknown error occured. Please see the log for more details.</source>
         <translation>알 수 없는 오류가 발생했습니다. 자세한 내용은 로그를 참조하십시오.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="699"/>
+        <location filename="../../src/citra_qt/main.cpp" line="704"/>
         <source>Start</source>
         <translation>시작</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="790"/>
+        <location filename="../../src/citra_qt/main.cpp" line="795"/>
         <source>Error Opening %1 Folder</source>
         <translation>%1  폴더 오픈 에러</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="791"/>
+        <location filename="../../src/citra_qt/main.cpp" line="796"/>
         <source>Folder does not exist!</source>
         <translation>폴더가 존재하지 않습니다!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="805"/>
+        <location filename="../../src/citra_qt/main.cpp" line="810"/>
         <source>3DS Executable</source>
         <translation>3DS 실행파일</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="806"/>
-        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <location filename="../../src/citra_qt/main.cpp" line="811"/>
+        <location filename="../../src/citra_qt/main.cpp" line="833"/>
         <source>All Files (*.*)</source>
         <translation>모든파일 (*.*)</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="808"/>
+        <location filename="../../src/citra_qt/main.cpp" line="813"/>
         <source>Load File</source>
         <translation>파일 열기</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="818"/>
+        <location filename="../../src/citra_qt/main.cpp" line="823"/>
         <source>Select Directory</source>
         <translation>디렉토리 선택</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="827"/>
+        <location filename="../../src/citra_qt/main.cpp" line="832"/>
         <source>Load Files</source>
         <translation>파일 열기</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <location filename="../../src/citra_qt/main.cpp" line="833"/>
         <source>3DS Installation File (*.CIA*)</source>
         <translation>3DS 설치파일 (*.CIA*)</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="859"/>
+        <location filename="../../src/citra_qt/main.cpp" line="864"/>
         <source>%1 has been installed successfully.</source>
         <translation>%1가 성공적으로 설치되었습니다.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="862"/>
+        <location filename="../../src/citra_qt/main.cpp" line="867"/>
         <source>Unable to open File</source>
         <translation>파일을 열 수 없음</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="863"/>
+        <location filename="../../src/citra_qt/main.cpp" line="868"/>
         <source>Could not open %1</source>
         <translation>%1를 열수 없음</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="867"/>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
         <source>Installation aborted</source>
         <translation>설치가 중단됨</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="868"/>
+        <location filename="../../src/citra_qt/main.cpp" line="873"/>
         <source>The installation of %1 was aborted. Please see the log for more details</source>
         <translation>%1의 설치가 중단되었습니다. 자세한 내용은 로그를 참조하십시오.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <location filename="../../src/citra_qt/main.cpp" line="877"/>
         <source>Invalid File</source>
         <translation>올바르지 않은 파일</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <location filename="../../src/citra_qt/main.cpp" line="877"/>
         <source>%1 is not a valid CIA</source>
         <translation>%1은 올바른 CIA가 아닙니다</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="875"/>
+        <location filename="../../src/citra_qt/main.cpp" line="880"/>
         <source>Encrypted File</source>
         <translation>암호화된 파일</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="876"/>
+        <location filename="../../src/citra_qt/main.cpp" line="881"/>
         <source>%1 must be decrypted before being used with Citra. A real 3DS is required.</source>
         <translation>%1 은 Citra에서 사용되기전에 디크립트되어야 합니다. 실제 3DS가 필요합니다.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="899"/>
+        <location filename="../../src/citra_qt/main.cpp" line="904"/>
         <source>File not found</source>
         <translation>파일을 찾을 수 없음</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="900"/>
+        <location filename="../../src/citra_qt/main.cpp" line="905"/>
         <source>File &quot;%1&quot; not found</source>
         <translation>파일 &quot;%1&quot;을 찾을 수 없음</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="914"/>
+        <location filename="../../src/citra_qt/main.cpp" line="919"/>
         <source>Continue</source>
         <translation>계속</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="939"/>
+        <location filename="../../src/citra_qt/main.cpp" line="944"/>
         <source>Missing Citra Account</source>
-        <translation type="unfinished"/>
+        <translation>Citra 계정 없음</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="940"/>
+        <location filename="../../src/citra_qt/main.cpp" line="945"/>
         <source>In order to submit a game compatibility test case, you must link your Citra account.&lt;br&gt;&lt;br/&gt;To link your Citra account, go to Emulation &amp;gt; Configuration &amp;gt; Web.</source>
         <translation>게임 호환성 테스트 케이스를 제출하려면 Citra 계정을 연결해야합니다.&lt;br/&gt;Citra 계정을 연결하려면, 에뮬레이션&amp;gt; 설정&amp;gt; 웹으로 이동하세요.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1090"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1095"/>
         <source>Speed: %1% / %2%</source>
-        <translation>스피드: %1% / %2%</translation>
+        <translation>속도: %1% / %2%</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1094"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1099"/>
         <source>Speed: %1%</source>
-        <translation>스피드: %1%</translation>
+        <translation>속도: %1%</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1096"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1101"/>
         <source>Game: %1 FPS</source>
         <translation>게임: %1 FPS</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1097"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1102"/>
         <source>Frame: %1 ms</source>
         <translation>프레임: %1 ms</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1108"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1113"/>
         <source>The game you are trying to load requires additional files from your 3DS to be dumped before playing.&lt;br/&gt;&lt;br/&gt;For more information on dumping these files, please see the following wiki page: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
         <translation>로드하려는 게임을 실행하려면 먼저 3DS의 추가 파일을 덤프 해야 합니다.&lt;br/&gt;&lt;br/&gt;이러한 파일 덤프에 대한 자세한 내용은 다음 위키 페이지를 참조하십시오: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;게임 목록으로 돌아가시겠습니까? 지속적인 에뮬레이션을 수행하면 충돌, 손상된 저장 데이터 또는 기타 버그가 발생할 수 있습니다.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1120"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1125"/>
         <source>: %1. </source>
         <translation>: %1. </translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1126"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1131"/>
         <source>System Archive Not Found</source>
         <translation>System Archive를 찾을수 없음 </translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1133"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1138"/>
         <source>Citra was unable to locate the 3DS shared fonts. </source>
         <translation>Citra는 3DS shared fonts를 찾을 수 없었습니다.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1135"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1140"/>
         <source>Shared Fonts Not Found</source>
         <translation>Shared Fonts를 찾을수 없음 </translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1143"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1148"/>
         <source>Fatal Error</source>
         <translation>치명적인 에러</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1144"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1149"/>
         <source>Citra has encountered a fatal error, please see the log for more details. For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
         <translation>Citra에 치명적인 오류가 발생했습니다. 자세한 내용은 로그를 참조하십시오. 로그 액세스에 대한 자세한 내용은 다음 페이지를 참조하십시오.&lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt; 로그 파일 업로드 방법:&lt;/a&gt;&lt;br/&gt;&lt;br/&gt;게임 목록으로 다시 돌아가시겠습니까? 지속적인 에뮬레이션을 수행하면 충돌, 손상된 저장 데이터 또는 기타 버그가 발생할 수 있습니다.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
-        <location filename="../../src/citra_qt/main.cpp" line="1245"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1183"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1250"/>
         <source>Citra</source>
         <translation>Citra</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1183"/>
         <source>Are you sure you want to close Citra?</source>
         <translation>Citra를 종료하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1246"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1251"/>
         <source>Are you sure you want to stop the emulation? Any unsaved progress will be lost.</source>
         <translation>에뮬레이션을 중지하시겠습니까? 저장되지 않은 진행이 손실됩니다.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1318"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1323"/>
         <source>Citra %1| %2-%3</source>
         <translation>Citra %1| %2-%3</translation>
     </message>
@@ -1458,81 +1478,81 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GameList</name>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="117"/>
         <source>Perfect</source>
         <translation>완벽함</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="117"/>
         <source>Game functions flawless with no audio or graphical glitches, all tested functionality works as intended without
 any workarounds needed.</source>
         <translation>오디오 또는 그래픽 글리치가 없이 게임이 완벽하게 작동하며, 테스트된 모든 기능이 특별한 해결방안 없이 의도대로 작동합니다.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="118"/>
         <source>Great</source>
         <translation>좋음</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="118"/>
         <source>Game functions with minor graphical or audio glitches and is playable from start to finish. May require some
 workarounds.</source>
-        <translation>게임은 사소한 그래픽문제나 오디오 글리치와 함꼐 처음부터 끝까지 진행가능합니다. 
+        <translation>게임은 사소한 그래픽문제나 오디오 글리치와 함께 처음부터 끝까지 진행가능합니다. 
 몇가지 해결방안이 필요할 수 있습니다.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="119"/>
         <source>Okay</source>
         <translation>양호</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="119"/>
         <source>Game functions with major graphical or audio glitches, but game is playable from start to finish with
 workarounds.</source>
-        <translation>게임은 주요 그래픽문제나 오디오 글리치와 함꼐 처음부터 끝까지 진행가능합니다. 
+        <translation>게임은 주요 그래픽문제나 오디오 글리치와 함께 처음부터 끝까지 진행가능합니다. 
 몇가지 해결방안이 필요할 수 있습니다.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="120"/>
         <source>Bad</source>
         <translation>나쁨</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="120"/>
         <source>Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches
 even with workarounds.</source>
         <translation>게임은 작동하지만 주요 그래픽이나 오디오 글리치가 있습니다. 특별한 해결방안에도 불구하고 
 특정한 지역에서 글리치로 인해 진행이 불가능합니다</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="121"/>
         <source>Intro/Menu</source>
         <translation>인트로/메뉴</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="121"/>
         <source>Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start
 Screen.</source>
         <translation>주요 그래픽 또는 오디오 결함으로 인해 게임을 완전히 재생할 수 없습니다. 시작화면을 
 지날 수 없습니다</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="122"/>
         <source>Won&apos;t Boot</source>
         <translation>실행불가</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="122"/>
         <source>The game crashes when attempting to startup.</source>
         <translation>시작할 때 게임이 충돌합니다.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="123"/>
         <source>Not Tested</source>
         <translation>테스트되지 않음</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="123"/>
         <source>The game has not yet been tested.</source>
         <translation>이 게임은 아직 테스트되지 않았습니다.</translation>
     </message>
@@ -1559,20 +1579,20 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/game_list.cpp" line="128"/>
         <source>Enter pattern to filter</source>
-        <translation type="unfinished"/>
+        <translation>검색 필터 입력</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="324"/>
+        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
         <source>Open Save Data Location</source>
         <translation>세이브 데이터 위치 열기</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
+        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
         <source>Open Application Location</source>
         <translation>어플리케이션 위치 열기</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
+        <location filename="../../src/citra_qt/game_list.cpp" line="327"/>
         <source>Open Update Data Location</source>
         <translation>업데이트 데이터 위치 열기</translation>
     </message>
@@ -1938,7 +1958,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="101"/>
         <source>(Leave blank for open game)</source>
-        <translation type="unfinished"/>
+        <translation>(공개된 게임을 원하면 비워두세요)</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="118"/>
@@ -2005,47 +2025,42 @@ Screen.</source>
         <translation>로비 새로고침</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="73"/>
         <source>Password Required to Join</source>
         <translation>참가시 비밀번호 필요</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="74"/>
         <source>Password:</source>
         <translation>비밀번호:</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="77"/>
-        <source>Password</source>
-        <translation>비밀번호</translation>
-    </message>
-    <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="139"/>
         <source>Room Name</source>
         <translation>방 이름</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="143"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="140"/>
         <source>Preferred Game</source>
         <translation>선호되는 게임</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="144"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="141"/>
         <source>Host</source>
         <translation>호스트</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="145"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
         <source>Players</source>
-        <translation>플레이어들</translation>
+        <translation>플레이어</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="153"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="150"/>
         <source>Refreshing</source>
         <translation>새로고침중</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="201"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="198"/>
         <source>Refresh List</source>
         <translation>리스트 새로고침</translation>
     </message>
@@ -2215,12 +2230,12 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="293"/>
         <source>Modify Citra Install</source>
-        <translation>Citra 설치 수정</translation>
+        <translation>Citra 설치 변경</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="296"/>
         <source>Opens the maintenance tool to modify your Citra installation</source>
-        <translation>Citra 설치 수정을 위한 유지보수 도구 열기</translation>
+        <translation>Citra 설치 변경을 위한 유지보수 도구 열기</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="304"/>
@@ -2336,27 +2351,27 @@ Debug Message: </translation>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="22"/>
         <source>Unable to connect to the host. Verify that the connection settings are correct. If you still cannot connect, contact the room host and verify that the host is properly configured with the external port forwarded.</source>
-        <translation type="unfinished"/>
+        <translation>호스트에 연결할 수 없습니다. 연결 설정이 올바른지 확인하십시오. 그래도 연결할 수 없으면 방의 호스트에게 문의하여 호스트가 외부 포트포워딩을 올바르게 구성되었는지 확인하십시오.</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="26"/>
         <source>Creating a room failed. Please retry. Restarting Citra might be necessary.</source>
-        <translation type="unfinished"/>
+        <translation>방 생성해 실패하였습니다. 다시 시도해주세요. Citra를 다시 시작해야 할 수 있습니다.</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="28"/>
         <source>The host of the room has banned you. Speak with the host to unban you or try a different room.</source>
-        <translation type="unfinished"/>
+        <translation>방의 호스트가 당신을 밴했습니다. 호스트에게 언밴을 요청하거나 다른 방을 시도하세요.</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="31"/>
         <source>Version mismatch! Please update to the latest version of Citra. If the problem persists, contact the room host and ask them to update the server.</source>
-        <translation type="unfinished"/>
+        <translation>버전 불일치! Citra의 최신 버전으로 업데이트하십시오. 문제가 계속되면 방의 호스트에게 문의하여 서버를 업데이트하도록 요청하십시오.</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="33"/>
         <source>Incorrect password.</source>
-        <translation>올바르지않은 비밀번호</translation>
+        <translation>올바르지 않은 비밀번호</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="35"/>
@@ -2366,32 +2381,32 @@ Debug Message: </translation>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="36"/>
         <source>Connection to room lost. Try to reconnect.</source>
-        <translation type="unfinished"/>
+        <translation>방 연결이 끊어졌습니다. 다시 연결하십시오.</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="38"/>
         <source>MAC address is already in use. Please choose another.</source>
-        <translation type="unfinished"/>
+        <translation>MAC 어드레스가 이미 사용되고 있습니다. 다른 것을 선택해 주세요.</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="52"/>
         <source>Leave Room</source>
-        <translation type="unfinished"/>
+        <translation>방 나가기</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="53"/>
         <source>You are about to close the room. Any network connections will be closed.</source>
-        <translation type="unfinished"/>
+        <translation>방을 닫으려고 합니다. 모든 네트워크 연결이 닫힙니다.</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="58"/>
         <source>Disconnect</source>
-        <translation type="unfinished"/>
+        <translation>연결끊기</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="59"/>
         <source>You are about to leave the room. Any network connections will be closed.</source>
-        <translation type="unfinished"/>
+        <translation>방을 닫으려고 합니다. 모든 네트워크 연결이 닫힙니다.</translation>
     </message>
 </context>
 <context>
@@ -2404,11 +2419,62 @@ Debug Message: </translation>
     <message>
         <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="198"/>
         <source>%1 is not playing a game</source>
-        <translation type="unfinished"/>
+        <translation>%1 은 게임을 플레이 중이지 않음</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="201"/>
         <source>%1 is playing %2</source>
+        <translation>%1 는 %2를 플레이중</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="208"/>
+        <source>Invalid region</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Japan</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>North America</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="92"/>
+        <source>Europe</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="94"/>
+        <source>Australia</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="96"/>
+        <source>China</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="98"/>
+        <source>Korea</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="100"/>
+        <source>Taiwan</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="102"/>
+        <source>Region free</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="104"/>
+        <source>Invalid Region</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/dist/languages/lt_LT.ts
+++ b/dist/languages/lt_LT.ts
@@ -1,0 +1,2751 @@
+<?xml version="1.0" ?><!DOCTYPE TS><TS language="lt_LT" version="2.1">
+<context>
+    <name>ARMRegisters</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="14"/>
+        <source>ARM Registers</source>
+        <translation>ARM registrai</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="25"/>
+        <source>Register</source>
+        <translation>Registras</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="30"/>
+        <source>Value</source>
+        <translation>Vertė</translation>
+    </message>
+</context>
+<context>
+    <name>AboutDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="14"/>
+        <source>About Citra</source>
+        <translation>Apie „Citra“</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="30"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/citra.png&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/citra.png&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="60"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:28pt;&quot;&gt;Citra&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:28pt;&quot;&gt;Citra&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="73"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="86"/>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:12pt;&quot;&gt;Citra is a free and open source 3DS emulator licensed under GPLv2.0 or any later version.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'MS Shell Dlg 2'; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;This software should not be used to play games you have not legally obtained.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;„Citra“ yra nemokamas ir atvirojo kodo 3DS emuliatorius, licencijuotas GPL v2.0 arba aukščiau.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;Ši programa neturėtų būti naudojama žaisti žaidimus, kurių jūs nesate įsigijęs legaliai.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="118"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Website&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://community.citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Forum&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Source Code&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Contributors&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/blob/master/license.txt&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;License&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Svetainė&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://community.citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Forumas&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Išeitinis kodas&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Pagalbininkai&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/blob/master/license.txt&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Licencija&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="134"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;&amp;quot;3DS&amp;quot; is a trademark of Nintendo. Citra is not affiliated with Nintendo in any way.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;&amp;quot;3DS&amp;quot; yra „Nintendo“ prekės ženklas. „Citra“ jokiu būdu nėra susijusi su „Nintendo“.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>BreakPointModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="34"/>
+        <source>Pica command loaded</source>
+        <translation>„Pica“ komanda įkrauta</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="35"/>
+        <source>Pica command processed</source>
+        <translation>„Pica“ komanda apdorota</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="36"/>
+        <source>Incoming primitive batch</source>
+        <translation>Įeinanti primityvi partija</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="37"/>
+        <source>Finished primitive batch</source>
+        <translation>Primityvi partija užbaigta</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="38"/>
+        <source>Vertex shader invocation</source>
+        <translation>Vertekso šešėliuoklės iškvietimas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="40"/>
+        <source>Incoming display transfer</source>
+        <translation>Įeinantis vaizdo perdavimas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="41"/>
+        <source>GSP command processed</source>
+        <translation>GSP komanda apdorota</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="42"/>
+        <source>Buffers swapped</source>
+        <translation>Buferiai apkeisti</translation>
+    </message>
+</context>
+<context>
+    <name>ChatRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="14"/>
+        <source>Room Window</source>
+        <translation>Serverio langas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="40"/>
+        <source>Send Chat Message</source>
+        <translation>Siųsti pokalbio žinutę</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="47"/>
+        <source>Send Message</source>
+        <translation>Siųsti žinutę</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.cpp" line="81"/>
+        <source>Name</source>
+        <translation>Pavadinimas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.cpp" line="82"/>
+        <source>Game</source>
+        <translation>Žaidimas</translation>
+    </message>
+</context>
+<context>
+    <name>ClientRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.ui" line="14"/>
+        <source>Room Window</source>
+        <translation>Serverio langas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.ui" line="40"/>
+        <source>Leave Room</source>
+        <translation>Palikti serverį</translation>
+    </message>
+</context>
+<context>
+    <name>ClientRoomWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="54"/>
+        <source>Connected</source>
+        <translation>Prisijungta</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="65"/>
+        <source>Disconnected</source>
+        <translation>Atsijungta</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="78"/>
+        <source>%1 (%2/%3 members) - connected</source>
+        <translation>%1 (%2/%3 vartotojai) - prisijungę</translation>
+    </message>
+</context>
+<context>
+    <name>CompatDB</name>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="20"/>
+        <source>Report Compatibility</source>
+        <translation>Pranešti suderinamumą</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="27"/>
+        <location filename="../../src/citra_qt/compatdb.ui" line="63"/>
+        <source>Report Game Compatibility</source>
+        <translation>Pranešti žaidimo suderinamumą</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="36"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;Should you choose to submit a test case to the &lt;/span&gt;&lt;a href=&quot;https://citra-emu.org/game/&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;Citra Compatibility List&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;, The following information will be collected and displayed on the site:&lt;/span&gt;&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Hardware Information (CPU / GPU / Operating System)&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Which version of Citra you are running&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The connected Citra account&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;Jeigu jūs norite pateikti savo testavimus į &lt;/span&gt;&lt;a href=&quot;https://citra-emu.org/game/&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;„Citra&quot; suderinamumo sąrašą&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;, ši informacija bus surinkta ir parodyta svetainėje:&lt;/span&gt;&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Kompiuterinės įrangos informacija (CPU / GPU / operacinė sistema)&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Kokią „Citra&quot; versiją naudojate&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Prijungta „Citra&quot; paskyra&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="72"/>
+        <source>Perfect</source>
+        <translation>Puikiai</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="79"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions flawlessly with no audio or graphical glitches.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Žaidimas veikia nuostabiai be jokių garso ar vaizdo trikdžių.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="89"/>
+        <source>Great </source>
+        <translation>Labai gerai</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="96"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions with minor graphical or audio glitches and is playable from start to finish. May require some workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Žaidimas veikia su mažais garso arba vaizdo trikdžiais ir gali būti žaidžiamas nuo pradžios iki galo. Gali reikalauti keletą apėjimų.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="106"/>
+        <source>Okay</source>
+        <translation>Gerai</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="113"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions with major graphical or audio glitches, but game is playable from start to finish with workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Žaidimas veikia su dideliais garso arba vaizdo trikdžiais, bet žaidimas gali būti žaidžiamas nuo pradžios iki galo su apėjimais.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="123"/>
+        <source>Bad</source>
+        <translation>Blogai</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="130"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches even with workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Žaidimas veikia, bet su dideliais garso arba vaizdo trikdžiais. Neįmanoma pereiti keletos vietų net ir su apėjimais.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="140"/>
+        <source>Intro/Menu</source>
+        <translation>Rodo tik pradžios ekraną</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="147"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start Screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Žaidimas yra visiškai neveikiantis dėl didelių garso arba vaizdo trikdžių. Neįmanoma pratęsti žaidimo toliau kaip nuo pradžios ekrano.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="157"/>
+        <source>Won&apos;t Boot</source>
+        <translation>Nepasileidžia</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="170"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The game crashes when attempting to startup.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Žaidimas netikėtai išsijungia pasileidžiant.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="182"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Independent of speed or performance, how well does this game play from start to finish on this version of Citra?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Neskaitant jūsų greičio ar FPS, kaip šis žaidimas žaidžiasi nuo pradžios iki galo šitoje „Citra&quot; versijoje?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="206"/>
+        <source>Thank you for your submission!</source>
+        <translation>Ačiū už jūsų pateikimą!</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureAudio</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="10"/>
+        <source>Audio</source>
+        <translation>Garsas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="18"/>
+        <source>Output Engine:</source>
+        <translation>Išvesties variklis:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="31"/>
+        <source>Enable audio stretching</source>
+        <translation>Įjungti garso tęstinumą</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="34"/>
+        <source>This post-processing effect adjusts audio speed to match emulation speed and helps prevent audio stutter. This however increases audio latency.</source>
+        <translation>Šis efektas suderina garso greitį su emuliacijos greičiu ir padeda išvengti garso trūkinėjimų. Bet tai kartu pailgina garso latenciją.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="43"/>
+        <source>Audio Device:</source>
+        <translation>Garso įrenginys:</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureDebug</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="14"/>
+        <source>Form</source>
+        <translation>Forma</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="22"/>
+        <source>GDB</source>
+        <translation>GDB</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="28"/>
+        <source>The GDB Stub only works correctly when the CPU JIT is off.</source>
+        <translation>GDB „kelmas“ veikia tik tada, kai procesoriaus JIT yra išjungtas.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="37"/>
+        <source>Enable GDB Stub</source>
+        <translation>Įjungti GDB „kelmą“</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="57"/>
+        <source>Port:</source>
+        <translation>Įvadas:</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="14"/>
+        <source>Citra Configuration</source>
+        <translation>„Citra“ konfigūracija</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="24"/>
+        <source>General</source>
+        <translation>Pagrindinis</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="29"/>
+        <source>System</source>
+        <translation>Sistema</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="34"/>
+        <source>Input</source>
+        <translation>Įvestis</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="39"/>
+        <source>Graphics</source>
+        <translation>Grafika</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="44"/>
+        <source>Audio</source>
+        <translation>Garsas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="49"/>
+        <source>Debug</source>
+        <translation>Derinimas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="54"/>
+        <source>Web</source>
+        <translation>Tinklo tarnyba</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureGeneral</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="14"/>
+        <source>Form</source>
+        <translation>Forma</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="22"/>
+        <source>General</source>
+        <translation>Pagrindinis</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="30"/>
+        <source>Confirm exit while emulation is running</source>
+        <translation>Patvirtinti išėjimą veikiant emuliacijai</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="37"/>
+        <source>Search sub-directories for games</source>
+        <translation>Ieškoti poaplankiuose žaidimų</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="46"/>
+        <source>Interface language</source>
+        <translation>Sąsajos kalba</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="63"/>
+        <source>Updates</source>
+        <translation>Atnaujinimai</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="71"/>
+        <source>Check for updates on start</source>
+        <translation>Paieškoti atnaujinimų paleidžiant programą</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="78"/>
+        <source>Silently auto update after closing</source>
+        <translation>Tyliai atsinaujinti išjungus programą</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="90"/>
+        <source>Performance</source>
+        <translation>Našumas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="98"/>
+        <source>Enable CPU JIT</source>
+        <translation>Įjungti procesoriaus JIT</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="110"/>
+        <source>Emulation</source>
+        <translation>Emuliacija</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="120"/>
+        <source>Region:</source>
+        <translation>Regionas:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="128"/>
+        <source>Auto-select</source>
+        <translation>Automatiškai pasirinkti</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="178"/>
+        <source>Theme</source>
+        <translation>Tema</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="188"/>
+        <source>Theme:</source>
+        <translation>Tema:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="205"/>
+        <source>Hotkeys</source>
+        <translation>Spartieji klavišai</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.cpp" line="16"/>
+        <source>&lt;System&gt;</source>
+        <translation>&lt;System&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.cpp" line="17"/>
+        <source>English</source>
+        <translation>Anglų</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureGraphics</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="14"/>
+        <source>Form</source>
+        <translation>Forma</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="22"/>
+        <source>Graphics</source>
+        <translation>Grafika</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="28"/>
+        <source>Enable hardware renderer</source>
+        <translation>Įjungti techninės įrangos atvaizduotoją</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="35"/>
+        <source>Enable shader JIT</source>
+        <translation>Įjungti šešėliuoklės JIT</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="42"/>
+        <source>Enable V-Sync</source>
+        <translation>Įjungti V-Sync</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="51"/>
+        <source>Limit Speed Percent</source>
+        <translation>Riboti emuliacijos greitį</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="58"/>
+        <source>%</source>
+        <translation>%</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="78"/>
+        <source>Internal Resolution:</source>
+        <translation>Vidinė skiriamoji geba:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="86"/>
+        <source>Auto (Window Size)</source>
+        <translation>Automatiška (lango dydis)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="91"/>
+        <source>Native (400x240)</source>
+        <translation>Normali (400x240)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="96"/>
+        <source>2x Native (800x480)</source>
+        <translation>2x didesnė (800x480)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="101"/>
+        <source>3x Native (1200x720)</source>
+        <translation>3x didesnė (1200x720)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="106"/>
+        <source>4x Native (1600x960)</source>
+        <translation>4x didesnė (1600x960)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="111"/>
+        <source>5x Native (2000x1200)</source>
+        <translation>5x didesnė (2000x1200)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="116"/>
+        <source>6x Native (2400x1440)</source>
+        <translation>6x didesnė (2400x1440)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="121"/>
+        <source>7x Native (2800x1680)</source>
+        <translation>7x didesnė (2800x1680)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="126"/>
+        <source>8x Native (3200x1920)</source>
+        <translation>8x didesnė (3200x1920)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="131"/>
+        <source>9x Native (3600x2160)</source>
+        <translation>9x didesnė (3600x2160)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="136"/>
+        <source>10x Native (4000x2400)</source>
+        <translation>10x didesnė (4000x2400)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="151"/>
+        <source>Layout</source>
+        <translation>Išdėstymas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="161"/>
+        <source>Screen Layout:</source>
+        <translation>Ekranų išdėstymas:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="169"/>
+        <source>Default</source>
+        <translation>Numatytasis</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="174"/>
+        <source>Single Screen</source>
+        <translation>Vienas ekranas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="179"/>
+        <source>Large Screen</source>
+        <translation>Didelis ekranas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="184"/>
+        <source>Side by Side</source>
+        <translation>Vienas prie kito šonu</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="194"/>
+        <source>Swap Screens</source>
+        <translation>Apkeisti ekranus</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureInput</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="14"/>
+        <source>ConfigureInput</source>
+        <translation>Konfigūruoti įvestį</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="22"/>
+        <source>Face Buttons</source>
+        <translation>Priekiniai mygtukai</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="36"/>
+        <source>A:</source>
+        <translation>A:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="54"/>
+        <source>B:</source>
+        <translation>B:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="72"/>
+        <source>X:</source>
+        <translation>X:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="90"/>
+        <source>Y:</source>
+        <translation>Y:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="109"/>
+        <source>Directional Pad</source>
+        <translation>Valdymo mygtukai</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="123"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="340"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="427"/>
+        <source>Up:</source>
+        <translation>Aukštyn:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="141"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="358"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="445"/>
+        <source>Down:</source>
+        <translation>Žemyn:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="159"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="304"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="391"/>
+        <source>Left:</source>
+        <translation>Kairėn:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="177"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="322"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="409"/>
+        <source>Right:</source>
+        <translation>Dešinėn:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="196"/>
+        <source>Shoulder Buttons</source>
+        <translation>Galiniai mygtukai</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="210"/>
+        <source>L:</source>
+        <translation>L:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="228"/>
+        <source>R:</source>
+        <translation>R:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="246"/>
+        <source>ZL:</source>
+        <translation>ZL:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="264"/>
+        <source>ZR:</source>
+        <translation>ZR:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="283"/>
+        <source>Circle Pad</source>
+        <translation>Judesių apskritimas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="295"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="461"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="232"/>
+        <source>Set Analog Stick</source>
+        <translation>Nustatyti analoginį valdiklį</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="377"/>
+        <source>C-Stick</source>
+        <translation>Apžvalgos valdiklis</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="471"/>
+        <source>Misc.</source>
+        <translation>Įvairūs</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="485"/>
+        <source>Start:</source>
+        <translation>Pradėti:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="503"/>
+        <source>Select:</source>
+        <translation>Pasirinkti:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="521"/>
+        <source>Home:</source>
+        <translation>Meniu mygtukas:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="539"/>
+        <source>Circle Mod:</source>
+        <translation>Sumažinti valdiklių jautrą:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="596"/>
+        <source>Restore Defaults</source>
+        <translation>Atkurti numatytuosius</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="239"/>
+        <source>[press key]</source>
+        <translation>[paspauskite klavišą]</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureSystem</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="14"/>
+        <source>Form</source>
+        <translation>Forma</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="22"/>
+        <source>System Settings</source>
+        <translation>Sistemos nustatymai</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="28"/>
+        <source>Username</source>
+        <translation>Vartotojo vardas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="48"/>
+        <source>Birthday</source>
+        <translation>Gimtadienis</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="58"/>
+        <source>January</source>
+        <translation>Sausio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="63"/>
+        <source>February</source>
+        <translation>Vasario</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="68"/>
+        <source>March</source>
+        <translation>Kovo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="73"/>
+        <source>April</source>
+        <translation>Balandžio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="78"/>
+        <source>May</source>
+        <translation>Gegužės</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="83"/>
+        <source>June</source>
+        <translation>Birželio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="88"/>
+        <source>July</source>
+        <translation>Liepos</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="93"/>
+        <source>August</source>
+        <translation>Rugpjūčio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="98"/>
+        <source>September</source>
+        <translation>Rugsėjo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="103"/>
+        <source>October</source>
+        <translation>Spalio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="108"/>
+        <source>November</source>
+        <translation>Lapkričio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="113"/>
+        <source>December</source>
+        <translation>Gruodžio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="126"/>
+        <source>Language</source>
+        <translation>Kalba</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="133"/>
+        <source>Note: this can be overridden when region setting is auto-select</source>
+        <translation>Pastaba: šis nustatymas bus ignoruojamas jeigu regionas nustatytas į &quot;Automatiškai pasirinkti&quot;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="137"/>
+        <source>Japanese (日本語)</source>
+        <translation>Japonų (日本語)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="142"/>
+        <source>English</source>
+        <translation>Anglų (English)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="147"/>
+        <source>French (français)</source>
+        <translation>Prancūzų (français)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="152"/>
+        <source>German (Deutsch)</source>
+        <translation>Vokiečių (Deutsch)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="157"/>
+        <source>Italian (italiano)</source>
+        <translation>Italų (italiano)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="162"/>
+        <source>Spanish (español)</source>
+        <translation>Ispanų (español)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="167"/>
+        <source>Simplified Chinese (简体中文)</source>
+        <translation>Supaprastinta kinų (简体中文)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="172"/>
+        <source>Korean (한국어)</source>
+        <translation>Korėjiečių (한국어)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="177"/>
+        <source>Dutch (Nederlands)</source>
+        <translation>Olandų (Nederlands)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="182"/>
+        <source>Portuguese (português)</source>
+        <translation>Portugalų (português)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="187"/>
+        <source>Russian (Русский)</source>
+        <translation>Rusų (Русский)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="192"/>
+        <source>Traditional Chinese (正體中文)</source>
+        <translation>Tradicinė kinų (正體中文)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="200"/>
+        <source>Sound output mode</source>
+        <translation>Garso išvesties režimas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="208"/>
+        <source>Mono</source>
+        <translation>Mono</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="213"/>
+        <source>Stereo</source>
+        <translation>Stereo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="218"/>
+        <source>Surround</source>
+        <translation>Erdvinis</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="226"/>
+        <source>Console ID:</source>
+        <translation>Konsolės ID:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="242"/>
+        <source>Regenerate</source>
+        <translation>Regeneruoti</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="252"/>
+        <source>System settings are available only when game is not running.</source>
+        <translation>Sistemos nustatymai yra prieinami, tik kai žaidimai nepaleisti.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="87"/>
+        <source>Console ID: 0x%1</source>
+        <translation>Konsolės ID: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="160"/>
+        <source>This will replace your current virtual 3DS with a new one. Your current virtual 3DS will not be recoverable. This might have unexpected effects in games. This might fail, if you use an outdated config savegame. Continue?</source>
+        <translation>Tai pakeis jūsų dabartinį virtualų 3DS nauju. Jūsų dabartinis virtualus 3DS bus nebeatkuriamas. Tai gali padaryti netikėtų pokyčių žaidimuose. Tęsti?</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="164"/>
+        <source>Warning</source>
+        <translation>Įspėjimas</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureWeb</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="14"/>
+        <source>Form</source>
+        <translation>Forma</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="22"/>
+        <source>Citra Web Service</source>
+        <translation>„Citra“ interneto tarnyba</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="28"/>
+        <source>By providing your username and token, you agree to allow Citra to collect additional usage data, which may include user identifying information.</source>
+        <translation>Įrašydami jūsų vartotojo vardą ir simbolinį ID, jūs sutinkate, kad „Citra“ rinktų papildomus naudojimo duomenis, tarp kurių gali būti informacija, skirta atpažinti vartotoją.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="46"/>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="90"/>
+        <source>Verify</source>
+        <translation>Patikrinti</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="53"/>
+        <source>Sign up</source>
+        <translation>Užsiregistruoti</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="67"/>
+        <source>Token: </source>
+        <translation>Simbolinis ID:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="78"/>
+        <source>Username: </source>
+        <translation>Vartotojo vardas:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="99"/>
+        <source>What is my token?</source>
+        <translation>Koks yra mano simbolinis ID?</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="124"/>
+        <source>Telemetry</source>
+        <translation>Telemetrija</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="130"/>
+        <source>Share anonymous usage data with the Citra team</source>
+        <translation>Pasidalinti anonimiškais naudojimo duomenimis su „Citra“ komanda</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="137"/>
+        <source>Learn more</source>
+        <translation>Sužinoti daugiau</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="146"/>
+        <source>Telemetry ID:</source>
+        <translation>Telemetrijos ID:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="162"/>
+        <source>Regenerate</source>
+        <translation>Regeneruoti</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="28"/>
+        <source>&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Sužinoti daugiau&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="33"/>
+        <source>&lt;a href=&apos;https://services.citra-emu.org/&apos;&gt;Sign up&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://services.citra-emu.org/&apos;&gt;Užsiregistruoti&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="36"/>
+        <source>&lt;a href=&apos;https://citra-emu.org/wiki/citra-web-service/&apos;&gt;What is my token?&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://citra-emu.org/wiki/citra-web-service/&apos;&gt;Koks yra mano simbolinis ID?&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="45"/>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="65"/>
+        <source>Telemetry ID: 0x%1</source>
+        <translation>Telemetrijos ID: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="55"/>
+        <source>Username and token not verified</source>
+        <translation>Vartotojo vardas ir simbolinis ID nėra patikrinti</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="56"/>
+        <source>Username and token were not verified. The changes to your username and/or token have not been saved.</source>
+        <translation>Vartotojo vardas ir simbolinis ID nebuvo patikrinti. Pakeitimai nebuvo išsaugoti.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="85"/>
+        <source>Verifying</source>
+        <translation>Tikrinama</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="99"/>
+        <source>Verification failed</source>
+        <translation>Tikrinimas nepavyko</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="100"/>
+        <source>Verification failed. Check that you have entered your username and token correctly, and that your internet connection is working.</source>
+        <translation>Tikrinimas nepavyko. Įsitikinkite, ar įvedėte duomenis teisingai ir kad jūsų interneto ryšys veikia.</translation>
+    </message>
+</context>
+<context>
+    <name>DirectConnect</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="14"/>
+        <source>Direct Connect</source>
+        <translation>Tiesioginis prisijungimas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="33"/>
+        <source>IP Address</source>
+        <translation>IP adresas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="56"/>
+        <source>IP</source>
+        <translation>IP</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="63"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;IPv4 address of the host&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Serverio IPv4 adresas&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="73"/>
+        <source>Port</source>
+        <translation>Prievadas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="80"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Port number the host is listening on&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Prievado numeris kuris klauso serverio&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="86"/>
+        <source>24872</source>
+        <translation>24872</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="100"/>
+        <source>Nickname</source>
+        <translation>Vartotojo vardas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="114"/>
+        <source>Password</source>
+        <translation>Slaptažodis</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="156"/>
+        <source>Connect</source>
+        <translation>Prisijungti</translation>
+    </message>
+</context>
+<context>
+    <name>DirectConnectWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="97"/>
+        <source>Connecting</source>
+        <translation>Jungiamasi</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="102"/>
+        <source>Connect</source>
+        <translation>Prisijungti</translation>
+    </message>
+</context>
+<context>
+    <name>GMainWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="90"/>
+        <source>To help improve Citra, the Citra Team collects anonymous usage data. No private or personally identifying information is collected. This data helps us to understand how people use Citra and prioritize our efforts. Furthermore, it helps us to more easily identify emulation bugs and performance issues. This data includes:&lt;ul&gt;&lt;li&gt;Information about the version of Citra you are using&lt;/li&gt;&lt;li&gt;Performance data about the games you play&lt;/li&gt;&lt;li&gt;Your configuration settings&lt;/li&gt;&lt;li&gt;Information about your computer hardware&lt;/li&gt;&lt;li&gt;Emulation errors and crash information&lt;/li&gt;&lt;/ul&gt;By default, this feature is enabled. To disable this feature, click &apos;Emulation&apos; from the menu and then select &apos;Configure...&apos;. Then, on the &apos;Web&apos; tab, uncheck &apos;Share anonymous usage data with the Citra team&apos;. &lt;br/&gt;&lt;br/&gt;By using this software, you agree to the above terms.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Kad padėti patobulinti „Citra“, „Citra“ komanda renka anonimiškus naudojimo duomenis. Jokia privati ar asmeninė informacija nėra renkama. Šie duomenys mums padeda sužinoti, kaip vartotojai naudoja „Citra“ ir teikia pirmenybę mūsų pastangoms. Ji taip pat padeda lengviau išsiaiškinti emuliacijos klaidas ir našumo problemas. Šie duomenys yra sudaryti iš:&lt;ul&gt;&lt;li&gt;Informacijos apie jūsų „Citra“ versiją&lt;/li&gt;&lt;li&gt;Našumo duomenų iš žaidimų, kuriuos žaidžiate&lt;/li&gt;&lt;li&gt;Jūsų konfigūracijos nustatymų&lt;/li&gt;&lt;li&gt;Informacijos apie jūsų kompiuterio įrangą&lt;/li&gt;&lt;li&gt;Emuliacijos klaidų ir netikėtų išjungimų informacijos&lt;/li&gt;&lt;/ul&gt;Ši funkcija yra šiuo metu įjungta. Kad išjungti, paspauskite „Emuliacija“ meniu viršuje ir pasirinkite „Konfigūruoti...“. Tada, „Tinklo tarnyba“ skiltyje atžymėkite „Pasidalinti anonimiškais naudojimo duomenimis su „Citra“ komanda“.&lt;br/&gt;&lt;br/&gt;Naudodami šią programą, jūs sutinkate su aukščiau pateiktomis sąlygomis.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Sužinoti daugiau&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="195"/>
+        <source>Current emulation speed. Values higher or lower than 100% indicate emulation is running faster or slower than a 3DS.</source>
+        <translation>Dabartinės emuliacijos greitis. Reikšmės žemiau ar aukščiau 100% parodo, kad emuliacija veikia greičiau ar lėčiau negu 3DS.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="198"/>
+        <source>How many frames per second the game is currently displaying. This will vary from game to game and scene to scene.</source>
+        <translation>Kiek FPS žaidimas šiuo metu atvaizduoja. Tai gali keistis nuo žaidimo ir scenos.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="202"/>
+        <source>Time taken to emulate a 3DS frame, not counting framelimiting or v-sync. For full-speed emulation this should be at most 16.67 ms.</source>
+        <translation>Laikas, kuris buvo sunaudotas atvaizduoti 1 3DS kadrą, neskaičiuojant FPS ribojimo ar V-Sync. Pilno greičio emuliacijai reikalinga daugiausia 16.67 ms reikšmė.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="429"/>
+        <source>CTRL+F</source>
+        <translation>Ctrl+F</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="538"/>
+        <source>Update available!</source>
+        <translation>Pasiekiamas atnaujinimas!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="539"/>
+        <source>An update for Citra is available. Do you wish to install it now?&lt;br /&gt;&lt;br /&gt;This &lt;b&gt;will&lt;/b&gt; terminate emulation, if it is running.</source>
+        <translation>Pasiekiamas „Citra“ atnaujinimas. Ar norite atnaujinti programą dabar?&lt;br /&gt;&lt;br /&gt;Tai &lt;b&gt;sustabdys emuliaciją&lt;/b&gt;, jeigu ji veikia. </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <source>No update found</source>
+        <translation>Atnaujinimų nerasta</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <source>No update has been found for Citra.</source>
+        <translation>„Citra“ atnaujinimų nebuvo rasta.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="567"/>
+        <source>Error while initializing OpenGL 3.3 Core!</source>
+        <translation>Klaida inicijuojant OpenGL 3.3 branduolį!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="568"/>
+        <source>Your GPU may not support OpenGL 3.3, or you do not have the latest graphics driver.</source>
+        <translation>Jūsų vaizdo plokštė nepalaiko OpenGL 3.3, arba neturite naujausių vaizdo tvarkyklių.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="581"/>
+        <location filename="../../src/citra_qt/main.cpp" line="587"/>
+        <location filename="../../src/citra_qt/main.cpp" line="593"/>
+        <location filename="../../src/citra_qt/main.cpp" line="606"/>
+        <location filename="../../src/citra_qt/main.cpp" line="625"/>
+        <source>Error while loading ROM!</source>
+        <translation>Klaida įkraunant atvaizdą!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="582"/>
+        <location filename="../../src/citra_qt/main.cpp" line="607"/>
+        <source>The ROM format is not supported.</source>
+        <translation>Atvaizdo formatas nepalaikomas.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="588"/>
+        <source>Could not determine the system mode.</source>
+        <translation>Klaida nustatant sisteminį režimą.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="594"/>
+        <source>The game that you are trying to load must be decrypted before being used with Citra. A real 3DS is required.&lt;br/&gt;&lt;br/&gt;For more information on dumping and decrypting games, please see the following wiki pages: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation>Žaidimas, kurį įkraunate, turi būti iššifruotas prieš naudojant jį su „Citra“. Tikra 3DS konsolė yra būtina.&lt;br/&gt;&lt;br/&gt;Jei reikia daugiau informacijos apie žaidimų kopijavimą ir iššifravimą, pasižiūrėkite wiki puslapius: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Žaidimų kortelių kopijavimas&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Įdiegtų žaidimų kopijavimas&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="612"/>
+        <source>An error occured in the video core.</source>
+        <translation>Klaida vaizdo branduolyje.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="613"/>
+        <source>Citra has encountered an error while running the video core, please see the log for more details.For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.Ensure that you have the latest graphics drivers for your GPU.</source>
+        <translation>„Citra“ susidūrė su klaida vaizdo branduolyje, pasižiūrėkite į žurnalą dėl daugiau informacijos. Jei reikia daugiau informacijos apie žurnalo pasiekiamumą, pasižiūrėkite šį puslapį: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;Kaip įkelti žurnalo failą&lt;/a&gt;. Įsitikinkite, kad turite naujausias vaizdo tvarkykles jūsų vaizdo plokštei.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="626"/>
+        <source>An unknown error occured. Please see the log for more details.</source>
+        <translation>Įvyko nežinoma klaida. Pasižiūrėkite į žurnalą dėl daugiau informacijos.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="699"/>
+        <source>Start</source>
+        <translation>Pradėti</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="790"/>
+        <source>Error Opening %1 Folder</source>
+        <translation>Klaida atidarant %1 aplanką</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="791"/>
+        <source>Folder does not exist!</source>
+        <translation>Aplankas neegzistuoja!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="805"/>
+        <source>3DS Executable</source>
+        <translation>3DS taik. programa</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="806"/>
+        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <source>All Files (*.*)</source>
+        <translation>Visi failai (*.*)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="808"/>
+        <source>Load File</source>
+        <translation>Įkrauti failą</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="818"/>
+        <source>Select Directory</source>
+        <translation>Pasirinkti katalogą</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="827"/>
+        <source>Load Files</source>
+        <translation>Įkrauti failus</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <source>3DS Installation File (*.CIA*)</source>
+        <translation>3DS instaliacijos failas (*.cia*)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="859"/>
+        <source>%1 has been installed successfully.</source>
+        <translation>%1 buvo įdiegtas sėkmingai.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="862"/>
+        <source>Unable to open File</source>
+        <translation>Negalima atverti failo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="863"/>
+        <source>Could not open %1</source>
+        <translation>Negalima atverti %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="867"/>
+        <source>Installation aborted</source>
+        <translation>Instaliacija nutraukta</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="868"/>
+        <source>The installation of %1 was aborted. Please see the log for more details</source>
+        <translation>Failo %1 instaliacija buvo nutraukta. Pasižiūrėkite į žurnalą dėl daugiau informacijos</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <source>Invalid File</source>
+        <translation>Klaidingas failas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <source>%1 is not a valid CIA</source>
+        <translation>%1 nėra tinkamas CIA</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="875"/>
+        <source>Encrypted File</source>
+        <translation>Šifruotas failas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="876"/>
+        <source>%1 must be decrypted before being used with Citra. A real 3DS is required.</source>
+        <translation>%1 turi būti iššifruotas prieš naudojant jį su „Citra“. Tikra 3DS konsolė yra būtina. </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="899"/>
+        <source>File not found</source>
+        <translation>Failas nerastas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="900"/>
+        <source>File &quot;%1&quot; not found</source>
+        <translation>Failas &quot;%1&quot; nerastas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="914"/>
+        <source>Continue</source>
+        <translation>Tęsti</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="939"/>
+        <source>Missing Citra Account</source>
+        <translation>Nėra „Citra“ paskyros</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="940"/>
+        <source>In order to submit a game compatibility test case, you must link your Citra account.&lt;br&gt;&lt;br/&gt;To link your Citra account, go to Emulation &amp;gt; Configuration &amp;gt; Web.</source>
+        <translation>Jūs turite prijungti savo „Citra“ paskyrą prieš pateikiant savo žaidimo suderinamumo testavimą.&lt;br&gt;&lt;br/&gt;Kad tai padarytumėte, eikite į Emuliacija &amp;gt; Konfigūracija &amp;gt; Tinklo tarnyba.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1090"/>
+        <source>Speed: %1% / %2%</source>
+        <translation>Greitis: %1% / %2%</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1094"/>
+        <source>Speed: %1%</source>
+        <translation>Greitis: %1%</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1096"/>
+        <source>Game: %1 FPS</source>
+        <translation>Žaidimas: %1 FPS</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1097"/>
+        <source>Frame: %1 ms</source>
+        <translation>Kadras: %1 ms</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1108"/>
+        <source>The game you are trying to load requires additional files from your 3DS to be dumped before playing.&lt;br/&gt;&lt;br/&gt;For more information on dumping these files, please see the following wiki page: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
+        <translation>Žaidimas, kurį bandote įkrauti, reikalauja papildomų kopijuotų failų iš 3DS prieš žaidžiant.&lt;br/&gt;&lt;br/&gt;Jei reikia daugiau informacijos apie šių failų kopijavimą, pasižiūrėkite šį wiki puslapį: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Sisteminių archyvų ir bendrų šriftų kopijavimas iš 3DS konsolės&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Ar norite išeiti į žaidimų sąrašą? Tęsdami emuliaciją, galite susidurti su netikėtais išjungimais, sugadintais išsaugojimais ar kitomis klaidomis.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1120"/>
+        <source>: %1. </source>
+        <translation>: %1.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1126"/>
+        <source>System Archive Not Found</source>
+        <translation>Sisteminis archyvas nerastas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1133"/>
+        <source>Citra was unable to locate the 3DS shared fonts. </source>
+        <translation>„Citra“ negalėjo surasti bendrų 3DS šriftų.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1135"/>
+        <source>Shared Fonts Not Found</source>
+        <translation>Bendri šriftai nerasti</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1143"/>
+        <source>Fatal Error</source>
+        <translation>Nepataisoma klaida</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1144"/>
+        <source>Citra has encountered a fatal error, please see the log for more details. For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
+        <translation>„Citra“ susidūrė su nepataisoma klaida, pasižiūrėkite į žurnalą dėl daugiau informacijos. Jei reikia daugiau informacijos apie žurnalo pasiekiamumą, pasižiūrėkite šį puslapį: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;Kaip įkelti žurnalo failą&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Ar norite išeiti į žaidimų sąrašą? Tęsdami emuliaciją, galite susidurti su netikėtais išjungimais, sugadintais išsaugojimais ar kitomis klaidomis.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1245"/>
+        <source>Citra</source>
+        <translation>„Citra“</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <source>Are you sure you want to close Citra?</source>
+        <translation>Ar tikrai norite uždaryti „Citra“?</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1246"/>
+        <source>Are you sure you want to stop the emulation? Any unsaved progress will be lost.</source>
+        <translation>Ar tikrai norite sustabdyti emuliaciją? Visi neišsaugoti duomenys bus prarasti.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1318"/>
+        <source>Citra %1| %2-%3</source>
+        <translation>„Citra“ %1| %2-%3</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandListModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="96"/>
+        <source>Command Name</source>
+        <translation>Komandos pavadinimas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="98"/>
+        <source>Register</source>
+        <translation>Registras</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="100"/>
+        <source>Mask</source>
+        <translation>Kaukė</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="102"/>
+        <source>New Value</source>
+        <translation>Nauja vertė</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandListWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="184"/>
+        <source>Pica Command List</source>
+        <translation>„Pica“ komandų sąrašas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="202"/>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="233"/>
+        <source>Start Tracing</source>
+        <translation>Pradėti sekti</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="203"/>
+        <source>Copy All</source>
+        <translation>Kopijuoti viską</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="229"/>
+        <source>Finish Tracing</source>
+        <translation>Užbaigti sekimą</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandStreamWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics.cpp" line="67"/>
+        <source>Graphics Debugger</source>
+        <translation>Grafikos derinimas</translation>
+    </message>
+</context>
+<context>
+    <name>GameList</name>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <source>Perfect</source>
+        <translation>Puikiai</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <source>Game functions flawless with no audio or graphical glitches, all tested functionality works as intended without
+any workarounds needed.</source>
+        <translation>Žaidimas veikia nuostabiai be jokių garso ar vaizdo trikdžių, visos išbandytos funkcijos veikia kaip buvo numatyta be apėjimų.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <source>Great</source>
+        <translation>Labai gerai</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <source>Game functions with minor graphical or audio glitches and is playable from start to finish. May require some
+workarounds.</source>
+        <translation>Žaidimas veikia su mažais garso arba vaizdo trikdžiais ir gali būti pereitas nuo pradžios iki galo. Gali reikalauti keletą apėjimų.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <source>Okay</source>
+        <translation>Gerai</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <source>Game functions with major graphical or audio glitches, but game is playable from start to finish with
+workarounds.</source>
+        <translation>Žaidimas veikia su dideliais garso arba vaizdo trikdžiais, bet žaidimas gali būti pereitas nuo pradžios iki galo su apėjimais.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Bad</source>
+        <translation>Blogai</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches
+even with workarounds.</source>
+        <translation>Žaidimas veikia, bet su dideliais garso arba vaizdo trikdžiais. Neįmanoma pereiti keletos vietų net su apėjimais.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <source>Intro/Menu</source>
+        <translation>Rodo tik pradžios ekraną</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <source>Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start
+Screen.</source>
+        <translation>Žaidimas yra pilnai nepereinamas dėl didelių garso ar vaizdo trikdžių. Neįmanoma žaisti pratęsti žaidimo toliau kaip pradžios ekranas.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>Won&apos;t Boot</source>
+        <translation>Nepasileidžia</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>The game crashes when attempting to startup.</source>
+        <translation>Žaidimas netikėtai išsijungia pasileidžiant.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <source>Not Tested</source>
+        <translation>Neišbandytas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <source>The game has not yet been tested.</source>
+        <translation>Žaidimas dar nebuvo testuotas.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="99"/>
+        <source>of</source>
+        <translation>iš</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="102"/>
+        <source>result</source>
+        <translation>rezultatas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="104"/>
+        <source>results</source>
+        <translation>rezultatai</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="125"/>
+        <source>Filter:</source>
+        <translation>Filtras:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="128"/>
+        <source>Enter pattern to filter</source>
+        <translation>Įveskite raktinius žodžius filtravimui</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="324"/>
+        <source>Open Save Data Location</source>
+        <translation>Atidaryti išsaugojimo duomenų vietą</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
+        <source>Open Application Location</source>
+        <translation>Atidaryti programos vietą</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
+        <source>Open Update Data Location</source>
+        <translation>Atidaryti atnaujinimo duomenų vietą</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsBreakPointsWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="132"/>
+        <source>Pica Breakpoints</source>
+        <translation>„Pica“ nutrūkimo taškai</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="136"/>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="198"/>
+        <source>Emulation running</source>
+        <translation>Emuliacija veikia</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="137"/>
+        <source>Resume</source>
+        <translation>Pratęsti</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="188"/>
+        <source>Emulation halted at breakpoint</source>
+        <translation>Emuliacija sustabdyta nutrūkimo taške</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsSurfaceWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="49"/>
+        <source>Pica Surface Viewer</source>
+        <translation>„Pica“ pagrindo žiūryklė</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="54"/>
+        <source>Color Buffer</source>
+        <translation>Spalvos buferis</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="55"/>
+        <source>Depth Buffer</source>
+        <translation>Gylio buferis</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="56"/>
+        <source>Stencil Buffer</source>
+        <translation>Šablono buferis</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="57"/>
+        <source>Texture 0</source>
+        <translation>Tekstūra 0</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="58"/>
+        <source>Texture 1</source>
+        <translation>Tekstūra 1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="59"/>
+        <source>Texture 2</source>
+        <translation>Tekstūra 2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="60"/>
+        <source>Custom</source>
+        <translation>Pasirinktinis</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="103"/>
+        <source>Unknown</source>
+        <translation>Nežinoma</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="118"/>
+        <source>Save</source>
+        <translation>Išsaugoti</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="144"/>
+        <source>Source:</source>
+        <translation>Šaltinis:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="150"/>
+        <source>Physical Address:</source>
+        <translation>Fizinis adresas:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="156"/>
+        <source>Width:</source>
+        <translation>Plotis:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="162"/>
+        <source>Height:</source>
+        <translation>Aukštis:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="168"/>
+        <source>Format:</source>
+        <translation>Formatas:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="180"/>
+        <source>X:</source>
+        <translation>X:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="186"/>
+        <source>Y:</source>
+        <translation>Y:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="280"/>
+        <source>Pixel out of bounds</source>
+        <translation>Pikseliai už ribų</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="287"/>
+        <source>(unable to access pixel data)</source>
+        <translation>(negalima pasiekti pikselių duomenų)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="555"/>
+        <source>(invalid surface address)</source>
+        <translation>(netinkamas paviršiaus adresas)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="565"/>
+        <source>(unknown surface format)</source>
+        <translation>(nežinomas paviršiaus formatas)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="658"/>
+        <source>Portable Network Graphic (*.png)</source>
+        <translation>Kilnojama tinklo grafika (*.png)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="659"/>
+        <source>Binary data (*.bin)</source>
+        <translation>Dvejetainiai duomenys (*.bin)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="663"/>
+        <source>Save Surface</source>
+        <translation>Išsaugoti paviršių</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsTracingWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="25"/>
+        <source>CiTrace Recorder</source>
+        <translation>CiTrace įrašymas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="29"/>
+        <source>Start Recording</source>
+        <translation>Pradėti įrašymą</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="31"/>
+        <source>Stop and Save</source>
+        <translation>Sustabdyti ir išsaugoti</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="32"/>
+        <source>Abort Recording</source>
+        <translation>Nutraukti įrašymą</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="112"/>
+        <source>Save CiTrace</source>
+        <translation>Išsaugoti CiTrace</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="113"/>
+        <source>CiTrace File (*.ctf)</source>
+        <translation>CiTrace failas (*.ctf)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="162"/>
+        <source>CiTracing still active</source>
+        <translation>CiTracing vis dar veikia</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="163"/>
+        <source>A CiTrace is still being recorded. Do you want to save it? If not, all recorded data will be discarded.</source>
+        <translation>CiTrace vis dar įrašomas. Ar norite išsaugoti įrašymą? Jeigu ne, visi įrašyti duomenys bus atmesti.</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsVertexShaderModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="45"/>
+        <source>Offset</source>
+        <translation>Ofsetas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="47"/>
+        <source>Raw</source>
+        <translation>Neapdorotas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="49"/>
+        <source>Disassembly</source>
+        <translation>Išardymas</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsVertexShaderWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="345"/>
+        <source>Save Shader Dump</source>
+        <translation>Išsaugoti šešėliuoklės kopiją</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="345"/>
+        <source>Shader Binary (*.shbin)</source>
+        <translation>Šešėliuoklės kodas (*.shbin)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="380"/>
+        <source>(data only available at vertex shader invocation breakpoints)</source>
+        <translation>(duomenys prieinami tik vertekso šešėliuoklės iškvietimo sustabdymo taškuose)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="390"/>
+        <source>Dump</source>
+        <translation>Kopijuoti</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="412"/>
+        <source>Input Data</source>
+        <translation>Įvesties duomenys</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="426"/>
+        <source>Attribute %1</source>
+        <translation>Atributas %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="453"/>
+        <source>Cycle Index:</source>
+        <translation>Rato indeksas:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="558"/>
+        <source>SRC1: %1, %2, %3, %4
+</source>
+        <translation>SRC1: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="564"/>
+        <source>SRC2: %1, %2, %3, %4
+</source>
+        <translation>SRC2: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="570"/>
+        <source>SRC3: %1, %2, %3, %4
+</source>
+        <translation>SRC3: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="576"/>
+        <source>DEST_IN: %1, %2, %3, %4
+</source>
+        <translation>DEST_IN: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="582"/>
+        <source>DEST_OUT: %1, %2, %3, %4
+</source>
+        <translation>DEST_OUT: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="589"/>
+        <source>Address Registers: %1, %2
+</source>
+        <translation>Adreso registrai: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="593"/>
+        <source>Compare Result: %1, %2
+</source>
+        <translation>Palyginti rezultatus: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="598"/>
+        <source>Static Condition: %1
+</source>
+        <translation>Statinė sąlyga %1
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="600"/>
+        <source>Dynamic Conditions: %1, %2
+</source>
+        <translation>Dinaminės sąlygos: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="604"/>
+        <source>Loop Parameters: %1 (repeats), %2 (initializer), %3 (increment), %4
+</source>
+        <translation>Ciklo parametrai: %1 (pasikartoja), %2 (inicijuoja), %3 (didina), %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="611"/>
+        <source>Instruction offset: 0x%1</source>
+        <translation>Instrukcijos ofsetas: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="613"/>
+        <source> -&gt; 0x%2</source>
+        <translation>-&gt; 0x%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="615"/>
+        <source> (last instruction)</source>
+        <translation>(paskutinė instrukcija)</translation>
+    </message>
+</context>
+<context>
+    <name>HostRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="14"/>
+        <source>Create Room</source>
+        <translation>Sukurti serverį</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="37"/>
+        <source>Room Name</source>
+        <translation>Serverio pavadinimas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="51"/>
+        <source>Preferred Game</source>
+        <translation>Pageidautinas žaidimas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="61"/>
+        <source>Max Players</source>
+        <translation>Daugiausiai žaidėjų</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="91"/>
+        <source>Username</source>
+        <translation>Vartotojo vardas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="101"/>
+        <source>(Leave blank for open game)</source>
+        <translation>(palikite tuščią jei nesvarbu)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="118"/>
+        <source>Password</source>
+        <translation>Slaptažodis</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="125"/>
+        <source>Port</source>
+        <translation>Prievadas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="156"/>
+        <source>Public</source>
+        <translation>Viešas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="161"/>
+        <source>Unlisted</source>
+        <translation>Nematomas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="169"/>
+        <source>Host Room</source>
+        <translation>Paskelbti serverį</translation>
+    </message>
+</context>
+<context>
+    <name>Lobby</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="14"/>
+        <source>Public Room Browser</source>
+        <translation>Viešų serverių naršyklė</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="32"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="39"/>
+        <source>Nickname</source>
+        <translation>Vartotojo vardas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="59"/>
+        <source>Filters</source>
+        <translation>Filtrai</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="66"/>
+        <source>Search</source>
+        <translation>Paieška</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="76"/>
+        <source>Games I Own</source>
+        <translation>Žaidimai kuriuos turiu</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="83"/>
+        <source>Hide Full Rooms</source>
+        <translation>Slėpti pilnus serverius</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="103"/>
+        <source>Refresh Lobby</source>
+        <translation>Atnaujinti serverius</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <source>Password Required to Join</source>
+        <translation>Reikalingas slaptažodis</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <source>Password:</source>
+        <translation>Slaptažodis:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="77"/>
+        <source>Password</source>
+        <translation>Slaptažodis</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
+        <source>Room Name</source>
+        <translation>Serverio pavadinimas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="143"/>
+        <source>Preferred Game</source>
+        <translation>Pageidautinas žaidimas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="144"/>
+        <source>Host</source>
+        <translation>Vartotojas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="145"/>
+        <source>Players</source>
+        <translation>Žaidėjų skaičius</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="153"/>
+        <source>Refreshing</source>
+        <translation>Atnaujinama</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="201"/>
+        <source>Refresh List</source>
+        <translation>Atnaujinti sąrašą</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="14"/>
+        <source>Citra</source>
+        <translation>„Citra“</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="53"/>
+        <source>&amp;File</source>
+        <translation>&amp;Failas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="57"/>
+        <source>Recent Files</source>
+        <translation>Neseniai įkrauti failai</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="70"/>
+        <source>&amp;Emulation</source>
+        <translation>&amp;Emuliacija</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="80"/>
+        <source>&amp;View</source>
+        <translation>&amp;Žiūrėti</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="84"/>
+        <source>Debugging</source>
+        <translation>Derinimas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="91"/>
+        <source>Screen Layout</source>
+        <translation>Ekranų išdėstymas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="115"/>
+        <source>Multiplayer</source>
+        <translation>Multiplayer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="126"/>
+        <source>&amp;Help</source>
+        <translation>&amp;Pagalba</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="144"/>
+        <source>Load File...</source>
+        <translation>Įkrauti failą...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="149"/>
+        <source>Install CIA...</source>
+        <translation>Diegti CIA...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="154"/>
+        <source>Load Symbol Map...</source>
+        <translation>Įkrauti simbolių žemėlapį...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="159"/>
+        <source>E&amp;xit</source>
+        <translation>Į&amp;šeiti</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="167"/>
+        <source>&amp;Start</source>
+        <translation>&amp;Pradėti</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="175"/>
+        <source>&amp;Pause</source>
+        <translation>&amp;Pauzė</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="183"/>
+        <source>&amp;Stop</source>
+        <translation>&amp;Sustabdyti</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="188"/>
+        <source>FAQ</source>
+        <translation>DUK</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="193"/>
+        <source>About Citra</source>
+        <translation>Apie „Citra“</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="201"/>
+        <source>Single Window Mode</source>
+        <translation>Vieno lango režimas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="206"/>
+        <source>Configure...</source>
+        <translation>Konfigūruoti...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="214"/>
+        <source>Display Dock Widget Headers</source>
+        <translation>Rodyti ikonėles apačioje</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="222"/>
+        <source>Show Filter Bar</source>
+        <translation>Rodyti paieškos juostą</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="230"/>
+        <source>Show Status Bar</source>
+        <translation>Rodyti būsenos juostą</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="235"/>
+        <source>Select Game Directory...</source>
+        <translation>Pasirinkti žaidimo katalogą...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="238"/>
+        <source>Selects a folder to display in the game list</source>
+        <translation>Pasirenka aplanką, kuris rodomas žaidimų saraše</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="243"/>
+        <source>Create Pica Surface Viewer</source>
+        <translation>Sukurti „Pica“ pagrindo žiūryklę</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="251"/>
+        <source>Browse Public Game Lobby</source>
+        <translation>Peržiūrėti viešus žaidimų serverius</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="259"/>
+        <source>Create Room</source>
+        <translation>Sukurti serverį</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="267"/>
+        <source>Leave Room</source>
+        <translation>Palikti serverį</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="272"/>
+        <source>Direct Connect to Room</source>
+        <translation>Tiesioginis prisijungimas prie serverio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="280"/>
+        <source>Show Current Room</source>
+        <translation>Rodyti dabartinį serverį</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="288"/>
+        <source>Fullscreen</source>
+        <translation>Per visą ekraną</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="293"/>
+        <source>Modify Citra Install</source>
+        <translation>Modifikuoti „Citra“ instaliaciją</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="296"/>
+        <source>Opens the maintenance tool to modify your Citra installation</source>
+        <translation>Atidaro priežiūros įrankį modifikuoti jūsų „Citra“ instaliaciją</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="304"/>
+        <source>Default</source>
+        <translation>Numatytasis</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="312"/>
+        <source>Single Screen</source>
+        <translation>Vienas ekranas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="320"/>
+        <source>Large Screen</source>
+        <translation>Didelis ekranas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="328"/>
+        <source>Side by Side</source>
+        <translation>Vienas prie kito šonu</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="336"/>
+        <source>Swap Screens</source>
+        <translation>Apkeisti ekranus</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="341"/>
+        <source>Check for Updates</source>
+        <translation>Tikrinti, ar yra naujinimų</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="349"/>
+        <source>Report Compatibility</source>
+        <translation>Pranešti suderinamumą</translation>
+    </message>
+</context>
+<context>
+    <name>MicroProfileDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/profiler.cpp" line="50"/>
+        <source>MicroProfile</source>
+        <translation>Mikroprofilis</translation>
+    </message>
+</context>
+<context>
+    <name>MultiplayerState</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="41"/>
+        <source>Current connection status</source>
+        <translation>Dabartinis ryšio statusas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="42"/>
+        <source>Not Connected. Click here to find a room!</source>
+        <translation>Neprisijungta. Paspausk čia kad susirastum serverį!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="100"/>
+        <source>Connected</source>
+        <translation>Prisijungta</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="105"/>
+        <source>Not Connected</source>
+        <translation>Neprisijungta</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="114"/>
+        <source>Error</source>
+        <translation>Klaida</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="115"/>
+        <source>Failed to announce the room to the public lobby. In order to host a room publicly, you must have a valid Citra account configured in Emulation -&gt; Configure -&gt; Web. If you do not want to publish a room in the public lobby, then select Unlisted instead.
+Debug Message: </source>
+        <translation>Nepavyko paskelbti serverio viešai. Norint paskelbti viešai jus privalote turėti tinkamą „Citra“ paskyrą, sukonfigūruotą Emuliacija -&gt; Konfigūruoti -&gt; Tinklo tarnyba. Jeigu nenorite kurti serverio viešai, pasirinkite Nematomas.
+Derinimo pranešimas:</translation>
+    </message>
+</context>
+<context>
+    <name>NetworkMessage</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="12"/>
+        <source>Username is not valid. Must be 4 to 20 alphanumeric characters.</source>
+        <translation>Vartotojo vardas negalimas. Jis turi būti sudarytas iš 4-20 raidžių / skaičių.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="14"/>
+        <source>Room name is not valid. Must be 4 to 20 alphanumeric characters.</source>
+        <translation>Serverio pavadinimas negalimas. Jis turi būti sudarytas iš 4-20 raidžių / skaičių.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="16"/>
+        <source>Username is already in use. Please choose another.</source>
+        <translation>Vartotojo vardas jau naudojamas. Pasirinkite kitokį.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="17"/>
+        <source>IP is not a valid IPv4 address.</source>
+        <translation>Jūsų IP nėra tinkamas IPv4 adresas.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="18"/>
+        <source>Port must be a number between 0 to 65535.</source>
+        <translation>Prievadas turi būti numeris nuo 0 iki 65535.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="20"/>
+        <source>Unable to find an internet connection. Check your internet settings.</source>
+        <translation>Jūs nesate prisijungę prie interneto. Patikrinkite savo interneto nustatymus.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="22"/>
+        <source>Unable to connect to the host. Verify that the connection settings are correct. If you still cannot connect, contact the room host and verify that the host is properly configured with the external port forwarded.</source>
+        <translation>Nepavyko prisijungti prie serverio. Patikrinkite ar prisijungimo nustatymai yra teisingi. Jeigu vis tiek negalite prisijungti, susisiekite su serverio administratoriumi ir patikrinkite, ar serveris tinkamai sukonfigūruotas ir paskleistas prievadas (port forward).</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="26"/>
+        <source>Creating a room failed. Please retry. Restarting Citra might be necessary.</source>
+        <translation>Nepavyko sukurti serverio. Pabandykite iš naujo. Gali tekti perkrauti Citra.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="28"/>
+        <source>The host of the room has banned you. Speak with the host to unban you or try a different room.</source>
+        <translation>Serverio administratorius jus užblokavo. Pasikalbėkite su administratoriumi dėl atblokavimo, arba bandykite kitą serverį.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="31"/>
+        <source>Version mismatch! Please update to the latest version of Citra. If the problem persists, contact the room host and ask them to update the server.</source>
+        <translation>Versijų nesutapimas! Prašome atnaujinti Citra į naujausią versiją. Jeigu problema išlieka, susisiekite su serverio administratoriumi ir pasakykite kad atnaujintų serverį.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="33"/>
+        <source>Incorrect password.</source>
+        <translation>Neteisingas slaptažodis.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="35"/>
+        <source>An unknown error occured. If this error continues to occur, please open an issue</source>
+        <translation>Įvyko nežinoma klaida. Jeigu problema išlieka, parašykite problemos ataskaitą.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="36"/>
+        <source>Connection to room lost. Try to reconnect.</source>
+        <translation>Prarastas ryšys tarp serverio. Pabandykite prisijungti iš naujo.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="38"/>
+        <source>MAC address is already in use. Please choose another.</source>
+        <translation>MAC adresas jau naudojamas. Pasirinkite kitokį.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="52"/>
+        <source>Leave Room</source>
+        <translation>Palikti serverį</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="53"/>
+        <source>You are about to close the room. Any network connections will be closed.</source>
+        <translation>Jūs netrukus uždarysite serverį. Visa su serveriu susijusi informacija bus prarasta.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="58"/>
+        <source>Disconnect</source>
+        <translation>Atsijungti</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="59"/>
+        <source>You are about to leave the room. Any network connections will be closed.</source>
+        <translation>Jūs netrukus paliksite serverį. Visa su serveriu susijusi informacija bus prarasta.</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="47"/>
+        <source>Error</source>
+        <translation>Klaida</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="198"/>
+        <source>%1 is not playing a game</source>
+        <translation>%1 nežaidžia žaidimo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="201"/>
+        <source>%1 is playing %2</source>
+        <translation>%1 žaidžia %2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="26"/>
+        <source>Shift</source>
+        <translation>Shift</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="28"/>
+        <source>Ctrl</source>
+        <translation>Ctrl</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="30"/>
+        <source>Alt</source>
+        <translation>Alt</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="51"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="75"/>
+        <source>[not set]</source>
+        <translation>[nenustatytas]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="55"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="83"/>
+        <source>Joystick %1</source>
+        <translation>Valdiklis %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="57"/>
+        <source> Hat %1 %2</source>
+        <translation>Pusė %1 %2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="61"/>
+        <source> Axis %1%2</source>
+        <translation>Ašis %1%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="65"/>
+        <source> Button %1</source>
+        <translation>Mygtukas %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="69"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="91"/>
+        <source>[unknown]</source>
+        <translation>[nežinomas]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="80"/>
+        <source>[unused]</source>
+        <translation>[nenaudojamas]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="85"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="87"/>
+        <source> Axis %1</source>
+        <translation>Ašis %1</translation>
+    </message>
+</context>
+<context>
+    <name>RegistersWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="15"/>
+        <source>Registers</source>
+        <translation>Registrai</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="16"/>
+        <source>VFP Registers</source>
+        <translation>VFP registrai</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="18"/>
+        <source>VFP System Registers</source>
+        <translation>VFP sistemos registrai</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="167"/>
+        <source>Vector Length</source>
+        <translation>Vektoriaus ilgis</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="168"/>
+        <source>Vector Stride</source>
+        <translation>Vektoriaus žingsnis</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="169"/>
+        <source>Rounding Mode</source>
+        <translation>Apvalinimo režimas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="182"/>
+        <source>Vector Iteration Count</source>
+        <translation>Vektoriaus iteracijos skaičiavimas</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeEvent</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="259"/>
+        <source>reset type = %1</source>
+        <translation>perkrovimo tipas = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeMutex</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="272"/>
+        <source>locked %1 times by thread:</source>
+        <translation>užrakintas = %1 kartų gijoje:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="275"/>
+        <source>free</source>
+        <translation>laisvas</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeMutexList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="314"/>
+        <source>holding mutexes</source>
+        <translation>laiko muteksus</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeObjectList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="128"/>
+        <source>waiting for all objects</source>
+        <translation>laukia visų objektų</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="129"/>
+        <source>waiting for one of the following objects</source>
+        <translation>laukia vieno iš išvardintų objektų</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeSemaphore</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="288"/>
+        <source>available count = %1</source>
+        <translation>galimas skaičiavimas = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="289"/>
+        <source>max count = %1</source>
+        <translation>maksimalus skaičiavimas = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeThread</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="146"/>
+        <source>running</source>
+        <translation>veikia</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="149"/>
+        <source>ready</source>
+        <translation>pasiruošęs</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="152"/>
+        <source>waiting for address 0x%1</source>
+        <translation>laukia adreso 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="155"/>
+        <source>sleeping</source>
+        <translation>miega</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="158"/>
+        <source>waiting for IPC response</source>
+        <translation>laukia IPC atsakymo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="162"/>
+        <source>waiting for objects</source>
+        <translation>laukia objektų</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="165"/>
+        <source>waiting for HLE return</source>
+        <translation>laukia HLE atsakymo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="168"/>
+        <source>dormant</source>
+        <translation>neveikiantis</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="171"/>
+        <source>dead</source>
+        <translation>numiręs</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="174"/>
+        <source> PC = 0x%1 LR = 0x%2</source>
+        <translation>PC = 0x%1 LR = 0x%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="214"/>
+        <source>default</source>
+        <translation>numatytasis</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="217"/>
+        <source>all</source>
+        <translation>visi</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="220"/>
+        <source>AppCore</source>
+        <translation>AppCore</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="223"/>
+        <source>SysCore</source>
+        <translation>SysCore</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="226"/>
+        <source>Unknown processor %1</source>
+        <translation>Nežinomas procesorius %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="230"/>
+        <source>processor = %1</source>
+        <translation>procesorius = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="231"/>
+        <source>thread id = %1</source>
+        <translation>gijos id = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="232"/>
+        <source>priority = %1(current) / %2(normal)</source>
+        <translation>prioritetas = %1(dabartinis) / %2(normalus)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="236"/>
+        <source>last running ticks = %1</source>
+        <translation>paskutinis veikia tiksėjimu = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="239"/>
+        <source>not holding mutex</source>
+        <translation>nelaiko mutekso</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeThreadList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="328"/>
+        <source>waited by thread</source>
+        <translation>laukiamas gijos</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeTimer</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="301"/>
+        <source>reset type = %1</source>
+        <translation>perkrovimo tipas = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="303"/>
+        <source>initial delay = %1</source>
+        <translation>pradinis laukimas = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="305"/>
+        <source>interval delay = %1</source>
+        <translation>intervalo laukimas = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeWaitObject</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="76"/>
+        <source>[%1]%2 %3</source>
+        <translation>[%1]%2 %3</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="104"/>
+        <source>waited by no thread</source>
+        <translation>nelaukiamas nė vienos gijos</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="114"/>
+        <source>one shot</source>
+        <translation>vieną kartą</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="116"/>
+        <source>sticky</source>
+        <translation>lipnus</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="118"/>
+        <source>pulse</source>
+        <translation>pulsas</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="399"/>
+        <source>Wait Tree</source>
+        <translation>Laukimo gijų medis</translation>
+    </message>
+</context>
+<context>
+    <name>hotkeys</name>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="14"/>
+        <source>Hotkey Settings</source>
+        <translation>Sparčiųjų klavišų nustatymai</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="27"/>
+        <source>Action</source>
+        <translation>Veiksmas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="32"/>
+        <source>Hotkey</source>
+        <translation>Spartusis klavišas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="37"/>
+        <source>Context</source>
+        <translation>Kontekstas</translation>
+    </message>
+</context>
+</TS>

--- a/dist/languages/lt_LT.ts
+++ b/dist/languages/lt_LT.ts
@@ -154,19 +154,19 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ClientRoomWindow</name>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="54"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="55"/>
         <source>Connected</source>
         <translation>Prisijungta</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="65"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="63"/>
         <source>Disconnected</source>
         <translation>Atsijungta</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="78"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="76"/>
         <source>%1 (%2/%3 members) - connected</source>
-        <translation>%1 (%2/%3 vartotojai) - prisijungę</translation>
+        <translation>%1 (%2/%3 vartotojai) - prisijungta</translation>
     </message>
 </context>
 <context>
@@ -190,22 +190,22 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="72"/>
         <source>Perfect</source>
-        <translation>Puikiai</translation>
+        <translation>Tobulai</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="79"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions flawlessly with no audio or graphical glitches.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Žaidimas veikia nuostabiai be jokių garso ar vaizdo trikdžių.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Žaidimas veikia nuostabiai, be jokių garso ar vaizdo trikdžių.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="89"/>
         <source>Great </source>
-        <translation>Labai gerai</translation>
+        <translation>Puikiai</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="96"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions with minor graphical or audio glitches and is playable from start to finish. May require some workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Žaidimas veikia su mažais garso arba vaizdo trikdžiais ir gali būti žaidžiamas nuo pradžios iki galo. Gali reikalauti keletą apėjimų.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Žaidimas veikia su smulkiais garso arba vaizdo trikdžiais ir yra galimas žaisti nuo pradžios iki galo. Gali reikalauti keleto problemų apėjimų.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="106"/>
@@ -215,7 +215,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="113"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions with major graphical or audio glitches, but game is playable from start to finish with workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Žaidimas veikia su dideliais garso arba vaizdo trikdžiais, bet žaidimas gali būti žaidžiamas nuo pradžios iki galo su apėjimais.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Žaidimas veikia su dideliais garso arba vaizdo trikdžiais, bet žaidimas galimas žaisti nuo pradžios iki galo su problemų apėjimais.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="123"/>
@@ -225,7 +225,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="130"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches even with workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Žaidimas veikia, bet su dideliais garso arba vaizdo trikdžiais. Neįmanoma pereiti keletos vietų net ir su apėjimais.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Žaidimas veikia, bet su dideliais garso arba vaizdo trikdžiais. Neįmanoma pereiti keleto vietų net ir su problemų apėjimais.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="140"/>
@@ -245,12 +245,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="170"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The game crashes when attempting to startup.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Žaidimas netikėtai išsijungia pasileidžiant.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Žaidimas netikėtai išsijungia jam bandant pasileisti.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="182"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Independent of speed or performance, how well does this game play from start to finish on this version of Citra?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Neskaitant jūsų greičio ar FPS, kaip šis žaidimas žaidžiasi nuo pradžios iki galo šitoje „Citra&quot; versijoje?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Neįskaitant jūsų greičio ar FPS, kaip šis žaidimas žaidžiasi nuo pradžios iki galo šitoje „Citra&quot; versijoje?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="206"/>
@@ -312,6 +312,26 @@ p, li { white-space: pre-wrap; }
         <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="57"/>
         <source>Port:</source>
         <translation>Įvadas:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="78"/>
+        <source>Logging</source>
+        <translation>Žurnalas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="86"/>
+        <source>Global Log Filter</source>
+        <translation>Žurnalo filtras</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="100"/>
+        <source>Show Log Console (Windows Only)</source>
+        <translation>Rodyti žurnalo langą (tik Windows sistemoms)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="107"/>
+        <source>Open Log Location</source>
+        <translation>Atidaryti žurnalo vietą</translation>
     </message>
 </context>
 <context>
@@ -480,7 +500,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="51"/>
         <source>Limit Speed Percent</source>
-        <translation>Riboti emuliacijos greitį</translation>
+        <translation>Riboti emuliacijos greitį procentais</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="58"/>
@@ -1074,7 +1094,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="80"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Port number the host is listening on&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Prievado numeris kuris klauso serverio&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Prievado numeris, kuris klauso serverio&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="86"/>
@@ -1100,12 +1120,12 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DirectConnectWindow</name>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="97"/>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="103"/>
         <source>Connecting</source>
         <translation>Jungiamasi</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="102"/>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="108"/>
         <source>Connect</source>
         <translation>Prisijungti</translation>
     </message>
@@ -1113,289 +1133,289 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GMainWindow</name>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="90"/>
+        <location filename="../../src/citra_qt/main.cpp" line="92"/>
         <source>To help improve Citra, the Citra Team collects anonymous usage data. No private or personally identifying information is collected. This data helps us to understand how people use Citra and prioritize our efforts. Furthermore, it helps us to more easily identify emulation bugs and performance issues. This data includes:&lt;ul&gt;&lt;li&gt;Information about the version of Citra you are using&lt;/li&gt;&lt;li&gt;Performance data about the games you play&lt;/li&gt;&lt;li&gt;Your configuration settings&lt;/li&gt;&lt;li&gt;Information about your computer hardware&lt;/li&gt;&lt;li&gt;Emulation errors and crash information&lt;/li&gt;&lt;/ul&gt;By default, this feature is enabled. To disable this feature, click &apos;Emulation&apos; from the menu and then select &apos;Configure...&apos;. Then, on the &apos;Web&apos; tab, uncheck &apos;Share anonymous usage data with the Citra team&apos;. &lt;br/&gt;&lt;br/&gt;By using this software, you agree to the above terms.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
         <translation>Kad padėti patobulinti „Citra“, „Citra“ komanda renka anonimiškus naudojimo duomenis. Jokia privati ar asmeninė informacija nėra renkama. Šie duomenys mums padeda sužinoti, kaip vartotojai naudoja „Citra“ ir teikia pirmenybę mūsų pastangoms. Ji taip pat padeda lengviau išsiaiškinti emuliacijos klaidas ir našumo problemas. Šie duomenys yra sudaryti iš:&lt;ul&gt;&lt;li&gt;Informacijos apie jūsų „Citra“ versiją&lt;/li&gt;&lt;li&gt;Našumo duomenų iš žaidimų, kuriuos žaidžiate&lt;/li&gt;&lt;li&gt;Jūsų konfigūracijos nustatymų&lt;/li&gt;&lt;li&gt;Informacijos apie jūsų kompiuterio įrangą&lt;/li&gt;&lt;li&gt;Emuliacijos klaidų ir netikėtų išjungimų informacijos&lt;/li&gt;&lt;/ul&gt;Ši funkcija yra šiuo metu įjungta. Kad išjungti, paspauskite „Emuliacija“ meniu viršuje ir pasirinkite „Konfigūruoti...“. Tada, „Tinklo tarnyba“ skiltyje atžymėkite „Pasidalinti anonimiškais naudojimo duomenimis su „Citra“ komanda“.&lt;br/&gt;&lt;br/&gt;Naudodami šią programą, jūs sutinkate su aukščiau pateiktomis sąlygomis.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Sužinoti daugiau&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="195"/>
+        <location filename="../../src/citra_qt/main.cpp" line="199"/>
         <source>Current emulation speed. Values higher or lower than 100% indicate emulation is running faster or slower than a 3DS.</source>
         <translation>Dabartinės emuliacijos greitis. Reikšmės žemiau ar aukščiau 100% parodo, kad emuliacija veikia greičiau ar lėčiau negu 3DS.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="198"/>
+        <location filename="../../src/citra_qt/main.cpp" line="202"/>
         <source>How many frames per second the game is currently displaying. This will vary from game to game and scene to scene.</source>
         <translation>Kiek FPS žaidimas šiuo metu atvaizduoja. Tai gali keistis nuo žaidimo ir scenos.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="202"/>
+        <location filename="../../src/citra_qt/main.cpp" line="206"/>
         <source>Time taken to emulate a 3DS frame, not counting framelimiting or v-sync. For full-speed emulation this should be at most 16.67 ms.</source>
         <translation>Laikas, kuris buvo sunaudotas atvaizduoti 1 3DS kadrą, neskaičiuojant FPS ribojimo ar V-Sync. Pilno greičio emuliacijai reikalinga daugiausia 16.67 ms reikšmė.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="429"/>
+        <location filename="../../src/citra_qt/main.cpp" line="434"/>
         <source>CTRL+F</source>
         <translation>Ctrl+F</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="538"/>
+        <location filename="../../src/citra_qt/main.cpp" line="543"/>
         <source>Update available!</source>
         <translation>Pasiekiamas atnaujinimas!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="539"/>
+        <location filename="../../src/citra_qt/main.cpp" line="544"/>
         <source>An update for Citra is available. Do you wish to install it now?&lt;br /&gt;&lt;br /&gt;This &lt;b&gt;will&lt;/b&gt; terminate emulation, if it is running.</source>
         <translation>Pasiekiamas „Citra“ atnaujinimas. Ar norite atnaujinti programą dabar?&lt;br /&gt;&lt;br /&gt;Tai &lt;b&gt;sustabdys emuliaciją&lt;/b&gt;, jeigu ji veikia. </translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <location filename="../../src/citra_qt/main.cpp" line="555"/>
         <source>No update found</source>
         <translation>Atnaujinimų nerasta</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <location filename="../../src/citra_qt/main.cpp" line="555"/>
         <source>No update has been found for Citra.</source>
         <translation>„Citra“ atnaujinimų nebuvo rasta.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="567"/>
+        <location filename="../../src/citra_qt/main.cpp" line="572"/>
         <source>Error while initializing OpenGL 3.3 Core!</source>
         <translation>Klaida inicijuojant OpenGL 3.3 branduolį!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="568"/>
+        <location filename="../../src/citra_qt/main.cpp" line="573"/>
         <source>Your GPU may not support OpenGL 3.3, or you do not have the latest graphics driver.</source>
         <translation>Jūsų vaizdo plokštė nepalaiko OpenGL 3.3, arba neturite naujausių vaizdo tvarkyklių.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="581"/>
-        <location filename="../../src/citra_qt/main.cpp" line="587"/>
-        <location filename="../../src/citra_qt/main.cpp" line="593"/>
-        <location filename="../../src/citra_qt/main.cpp" line="606"/>
-        <location filename="../../src/citra_qt/main.cpp" line="625"/>
+        <location filename="../../src/citra_qt/main.cpp" line="586"/>
+        <location filename="../../src/citra_qt/main.cpp" line="592"/>
+        <location filename="../../src/citra_qt/main.cpp" line="598"/>
+        <location filename="../../src/citra_qt/main.cpp" line="611"/>
+        <location filename="../../src/citra_qt/main.cpp" line="630"/>
         <source>Error while loading ROM!</source>
         <translation>Klaida įkraunant atvaizdą!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="582"/>
-        <location filename="../../src/citra_qt/main.cpp" line="607"/>
+        <location filename="../../src/citra_qt/main.cpp" line="587"/>
+        <location filename="../../src/citra_qt/main.cpp" line="612"/>
         <source>The ROM format is not supported.</source>
         <translation>Atvaizdo formatas nepalaikomas.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="588"/>
+        <location filename="../../src/citra_qt/main.cpp" line="593"/>
         <source>Could not determine the system mode.</source>
         <translation>Klaida nustatant sisteminį režimą.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="594"/>
+        <location filename="../../src/citra_qt/main.cpp" line="599"/>
         <source>The game that you are trying to load must be decrypted before being used with Citra. A real 3DS is required.&lt;br/&gt;&lt;br/&gt;For more information on dumping and decrypting games, please see the following wiki pages: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</source>
         <translation>Žaidimas, kurį įkraunate, turi būti iššifruotas prieš naudojant jį su „Citra“. Tikra 3DS konsolė yra būtina.&lt;br/&gt;&lt;br/&gt;Jei reikia daugiau informacijos apie žaidimų kopijavimą ir iššifravimą, pasižiūrėkite wiki puslapius: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Žaidimų kortelių kopijavimas&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Įdiegtų žaidimų kopijavimas&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="612"/>
+        <location filename="../../src/citra_qt/main.cpp" line="617"/>
         <source>An error occured in the video core.</source>
         <translation>Klaida vaizdo branduolyje.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="613"/>
+        <location filename="../../src/citra_qt/main.cpp" line="618"/>
         <source>Citra has encountered an error while running the video core, please see the log for more details.For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.Ensure that you have the latest graphics drivers for your GPU.</source>
         <translation>„Citra“ susidūrė su klaida vaizdo branduolyje, pasižiūrėkite į žurnalą dėl daugiau informacijos. Jei reikia daugiau informacijos apie žurnalo pasiekiamumą, pasižiūrėkite šį puslapį: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;Kaip įkelti žurnalo failą&lt;/a&gt;. Įsitikinkite, kad turite naujausias vaizdo tvarkykles jūsų vaizdo plokštei.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="626"/>
+        <location filename="../../src/citra_qt/main.cpp" line="631"/>
         <source>An unknown error occured. Please see the log for more details.</source>
         <translation>Įvyko nežinoma klaida. Pasižiūrėkite į žurnalą dėl daugiau informacijos.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="699"/>
+        <location filename="../../src/citra_qt/main.cpp" line="704"/>
         <source>Start</source>
         <translation>Pradėti</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="790"/>
+        <location filename="../../src/citra_qt/main.cpp" line="795"/>
         <source>Error Opening %1 Folder</source>
         <translation>Klaida atidarant %1 aplanką</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="791"/>
+        <location filename="../../src/citra_qt/main.cpp" line="796"/>
         <source>Folder does not exist!</source>
         <translation>Aplankas neegzistuoja!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="805"/>
+        <location filename="../../src/citra_qt/main.cpp" line="810"/>
         <source>3DS Executable</source>
         <translation>3DS taik. programa</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="806"/>
-        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <location filename="../../src/citra_qt/main.cpp" line="811"/>
+        <location filename="../../src/citra_qt/main.cpp" line="833"/>
         <source>All Files (*.*)</source>
         <translation>Visi failai (*.*)</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="808"/>
+        <location filename="../../src/citra_qt/main.cpp" line="813"/>
         <source>Load File</source>
         <translation>Įkrauti failą</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="818"/>
+        <location filename="../../src/citra_qt/main.cpp" line="823"/>
         <source>Select Directory</source>
         <translation>Pasirinkti katalogą</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="827"/>
+        <location filename="../../src/citra_qt/main.cpp" line="832"/>
         <source>Load Files</source>
         <translation>Įkrauti failus</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <location filename="../../src/citra_qt/main.cpp" line="833"/>
         <source>3DS Installation File (*.CIA*)</source>
         <translation>3DS instaliacijos failas (*.cia*)</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="859"/>
+        <location filename="../../src/citra_qt/main.cpp" line="864"/>
         <source>%1 has been installed successfully.</source>
         <translation>%1 buvo įdiegtas sėkmingai.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="862"/>
+        <location filename="../../src/citra_qt/main.cpp" line="867"/>
         <source>Unable to open File</source>
         <translation>Negalima atverti failo</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="863"/>
+        <location filename="../../src/citra_qt/main.cpp" line="868"/>
         <source>Could not open %1</source>
-        <translation>Negalima atverti %1</translation>
+        <translation>Nepavyko atverti %1</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="867"/>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
         <source>Installation aborted</source>
         <translation>Instaliacija nutraukta</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="868"/>
+        <location filename="../../src/citra_qt/main.cpp" line="873"/>
         <source>The installation of %1 was aborted. Please see the log for more details</source>
         <translation>Failo %1 instaliacija buvo nutraukta. Pasižiūrėkite į žurnalą dėl daugiau informacijos</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <location filename="../../src/citra_qt/main.cpp" line="877"/>
         <source>Invalid File</source>
         <translation>Klaidingas failas</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <location filename="../../src/citra_qt/main.cpp" line="877"/>
         <source>%1 is not a valid CIA</source>
         <translation>%1 nėra tinkamas CIA</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="875"/>
+        <location filename="../../src/citra_qt/main.cpp" line="880"/>
         <source>Encrypted File</source>
         <translation>Šifruotas failas</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="876"/>
+        <location filename="../../src/citra_qt/main.cpp" line="881"/>
         <source>%1 must be decrypted before being used with Citra. A real 3DS is required.</source>
         <translation>%1 turi būti iššifruotas prieš naudojant jį su „Citra“. Tikra 3DS konsolė yra būtina. </translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="899"/>
+        <location filename="../../src/citra_qt/main.cpp" line="904"/>
         <source>File not found</source>
         <translation>Failas nerastas</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="900"/>
+        <location filename="../../src/citra_qt/main.cpp" line="905"/>
         <source>File &quot;%1&quot; not found</source>
         <translation>Failas &quot;%1&quot; nerastas</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="914"/>
+        <location filename="../../src/citra_qt/main.cpp" line="919"/>
         <source>Continue</source>
         <translation>Tęsti</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="939"/>
+        <location filename="../../src/citra_qt/main.cpp" line="944"/>
         <source>Missing Citra Account</source>
         <translation>Nėra „Citra“ paskyros</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="940"/>
+        <location filename="../../src/citra_qt/main.cpp" line="945"/>
         <source>In order to submit a game compatibility test case, you must link your Citra account.&lt;br&gt;&lt;br/&gt;To link your Citra account, go to Emulation &amp;gt; Configuration &amp;gt; Web.</source>
         <translation>Jūs turite prijungti savo „Citra“ paskyrą prieš pateikiant savo žaidimo suderinamumo testavimą.&lt;br&gt;&lt;br/&gt;Kad tai padarytumėte, eikite į Emuliacija &amp;gt; Konfigūracija &amp;gt; Tinklo tarnyba.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1090"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1095"/>
         <source>Speed: %1% / %2%</source>
         <translation>Greitis: %1% / %2%</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1094"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1099"/>
         <source>Speed: %1%</source>
         <translation>Greitis: %1%</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1096"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1101"/>
         <source>Game: %1 FPS</source>
         <translation>Žaidimas: %1 FPS</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1097"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1102"/>
         <source>Frame: %1 ms</source>
         <translation>Kadras: %1 ms</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1108"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1113"/>
         <source>The game you are trying to load requires additional files from your 3DS to be dumped before playing.&lt;br/&gt;&lt;br/&gt;For more information on dumping these files, please see the following wiki page: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
         <translation>Žaidimas, kurį bandote įkrauti, reikalauja papildomų kopijuotų failų iš 3DS prieš žaidžiant.&lt;br/&gt;&lt;br/&gt;Jei reikia daugiau informacijos apie šių failų kopijavimą, pasižiūrėkite šį wiki puslapį: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Sisteminių archyvų ir bendrų šriftų kopijavimas iš 3DS konsolės&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Ar norite išeiti į žaidimų sąrašą? Tęsdami emuliaciją, galite susidurti su netikėtais išjungimais, sugadintais išsaugojimais ar kitomis klaidomis.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1120"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1125"/>
         <source>: %1. </source>
         <translation>: %1.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1126"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1131"/>
         <source>System Archive Not Found</source>
         <translation>Sisteminis archyvas nerastas</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1133"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1138"/>
         <source>Citra was unable to locate the 3DS shared fonts. </source>
         <translation>„Citra“ negalėjo surasti bendrų 3DS šriftų.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1135"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1140"/>
         <source>Shared Fonts Not Found</source>
         <translation>Bendri šriftai nerasti</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1143"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1148"/>
         <source>Fatal Error</source>
         <translation>Nepataisoma klaida</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1144"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1149"/>
         <source>Citra has encountered a fatal error, please see the log for more details. For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
         <translation>„Citra“ susidūrė su nepataisoma klaida, pasižiūrėkite į žurnalą dėl daugiau informacijos. Jei reikia daugiau informacijos apie žurnalo pasiekiamumą, pasižiūrėkite šį puslapį: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;Kaip įkelti žurnalo failą&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Ar norite išeiti į žaidimų sąrašą? Tęsdami emuliaciją, galite susidurti su netikėtais išjungimais, sugadintais išsaugojimais ar kitomis klaidomis.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
-        <location filename="../../src/citra_qt/main.cpp" line="1245"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1183"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1250"/>
         <source>Citra</source>
         <translation>„Citra“</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1183"/>
         <source>Are you sure you want to close Citra?</source>
         <translation>Ar tikrai norite uždaryti „Citra“?</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1246"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1251"/>
         <source>Are you sure you want to stop the emulation? Any unsaved progress will be lost.</source>
         <translation>Ar tikrai norite sustabdyti emuliaciją? Visi neišsaugoti duomenys bus prarasti.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1318"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1323"/>
         <source>Citra %1| %2-%3</source>
         <translation>„Citra“ %1| %2-%3</translation>
     </message>
@@ -1458,77 +1478,77 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GameList</name>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="117"/>
         <source>Perfect</source>
+        <translation>Tobulai</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="117"/>
+        <source>Game functions flawless with no audio or graphical glitches, all tested functionality works as intended without
+any workarounds needed.</source>
+        <translation>Žaidimas veikia nuostabiai be jokių garso ar vaizdo trikdžių, visos išbandytos funkcijos veikia kaip numatyta be problemų apėjimų.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="118"/>
+        <source>Great</source>
         <translation>Puikiai</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
-        <source>Game functions flawless with no audio or graphical glitches, all tested functionality works as intended without
-any workarounds needed.</source>
-        <translation>Žaidimas veikia nuostabiai be jokių garso ar vaizdo trikdžių, visos išbandytos funkcijos veikia kaip buvo numatyta be apėjimų.</translation>
-    </message>
-    <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
-        <source>Great</source>
-        <translation>Labai gerai</translation>
-    </message>
-    <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="118"/>
         <source>Game functions with minor graphical or audio glitches and is playable from start to finish. May require some
 workarounds.</source>
-        <translation>Žaidimas veikia su mažais garso arba vaizdo trikdžiais ir gali būti pereitas nuo pradžios iki galo. Gali reikalauti keletą apėjimų.</translation>
+        <translation>Žaidimas veikia su smulkiais garso arba vaizdo trikdžiais ir gali būti pereitas nuo pradžios iki galo. Gali reikalauti keleto problemų apėjimų.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="119"/>
         <source>Okay</source>
         <translation>Gerai</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="119"/>
         <source>Game functions with major graphical or audio glitches, but game is playable from start to finish with
 workarounds.</source>
-        <translation>Žaidimas veikia su dideliais garso arba vaizdo trikdžiais, bet žaidimas gali būti pereitas nuo pradžios iki galo su apėjimais.</translation>
+        <translation>Žaidimas veikia su dideliais garso arba vaizdo trikdžiais, bet žaidimas gali būti pereitas nuo pradžios iki galo su problemų apėjimais.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="120"/>
         <source>Bad</source>
         <translation>Blogai</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="120"/>
         <source>Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches
 even with workarounds.</source>
-        <translation>Žaidimas veikia, bet su dideliais garso arba vaizdo trikdžiais. Neįmanoma pereiti keletos vietų net su apėjimais.</translation>
+        <translation>Žaidimas veikia, bet su dideliais garso arba vaizdo trikdžiais. Neįmanoma pereiti keleto vietų net su problemų apėjimais.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="121"/>
         <source>Intro/Menu</source>
         <translation>Rodo tik pradžios ekraną</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="121"/>
         <source>Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start
 Screen.</source>
-        <translation>Žaidimas yra pilnai nepereinamas dėl didelių garso ar vaizdo trikdžių. Neįmanoma žaisti pratęsti žaidimo toliau kaip pradžios ekranas.</translation>
+        <translation>Žaidimas yra visiškai negalimas žaisti dėl didelių garso ar vaizdo trikdžių. Neįmanoma pratęsti žaidimo toliau negu pradžios ekranas.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="122"/>
         <source>Won&apos;t Boot</source>
         <translation>Nepasileidžia</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="122"/>
         <source>The game crashes when attempting to startup.</source>
         <translation>Žaidimas netikėtai išsijungia pasileidžiant.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="123"/>
         <source>Not Tested</source>
         <translation>Neišbandytas</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="123"/>
         <source>The game has not yet been tested.</source>
         <translation>Žaidimas dar nebuvo testuotas.</translation>
     </message>
@@ -1558,17 +1578,17 @@ Screen.</source>
         <translation>Įveskite raktinius žodžius filtravimui</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="324"/>
+        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
         <source>Open Save Data Location</source>
         <translation>Atidaryti išsaugojimo duomenų vietą</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
+        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
         <source>Open Application Location</source>
         <translation>Atidaryti programos vietą</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
+        <location filename="../../src/citra_qt/game_list.cpp" line="327"/>
         <source>Open Update Data Location</source>
         <translation>Atidaryti atnaujinimo duomenų vietą</translation>
     </message>
@@ -1924,7 +1944,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="61"/>
         <source>Max Players</source>
-        <translation>Daugiausiai žaidėjų</translation>
+        <translation>Daugiausia žaidėjų</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="91"/>
@@ -1934,7 +1954,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="101"/>
         <source>(Leave blank for open game)</source>
-        <translation>(palikite tuščią jei nesvarbu)</translation>
+        <translation>(palikite tuščią, jei nesvarbu)</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="118"/>
@@ -1988,7 +2008,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="76"/>
         <source>Games I Own</source>
-        <translation>Žaidimai kuriuos turiu</translation>
+        <translation>Žaidimai, kuriuos turiu</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="83"/>
@@ -1998,50 +2018,45 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="103"/>
         <source>Refresh Lobby</source>
-        <translation>Atnaujinti serverius</translation>
+        <translation>Atnaujinti sąrašą</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="73"/>
         <source>Password Required to Join</source>
         <translation>Reikalingas slaptažodis</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="74"/>
         <source>Password:</source>
         <translation>Slaptažodis:</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="77"/>
-        <source>Password</source>
-        <translation>Slaptažodis</translation>
-    </message>
-    <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="139"/>
         <source>Room Name</source>
         <translation>Serverio pavadinimas</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="143"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="140"/>
         <source>Preferred Game</source>
         <translation>Pageidautinas žaidimas</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="144"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="141"/>
         <source>Host</source>
         <translation>Vartotojas</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="145"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
         <source>Players</source>
         <translation>Žaidėjų skaičius</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="153"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="150"/>
         <source>Refreshing</source>
         <translation>Atnaujinama</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="201"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="198"/>
         <source>Refresh List</source>
         <translation>Atnaujinti sąrašą</translation>
     </message>
@@ -2086,7 +2101,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="115"/>
         <source>Multiplayer</source>
-        <translation>Multiplayer</translation>
+        <translation>Kelių žaidėjų režimas</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="126"/>
@@ -2272,7 +2287,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/state.cpp" line="42"/>
         <source>Not Connected. Click here to find a room!</source>
-        <translation>Neprisijungta. Paspausk čia kad susirastum serverį!</translation>
+        <translation>Neprisijungta. Paspauskite čia, kad susirastumėte serverį!</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/state.cpp" line="100"/>
@@ -2337,7 +2352,7 @@ Derinimo pranešimas:</translation>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="26"/>
         <source>Creating a room failed. Please retry. Restarting Citra might be necessary.</source>
-        <translation>Nepavyko sukurti serverio. Pabandykite iš naujo. Gali tekti perkrauti Citra.</translation>
+        <translation>Nepavyko sukurti serverio. Pabandykite iš naujo. Gali tekti perkrauti „Citra“.</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="28"/>
@@ -2347,7 +2362,7 @@ Derinimo pranešimas:</translation>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="31"/>
         <source>Version mismatch! Please update to the latest version of Citra. If the problem persists, contact the room host and ask them to update the server.</source>
-        <translation>Versijų nesutapimas! Prašome atnaujinti Citra į naujausią versiją. Jeigu problema išlieka, susisiekite su serverio administratoriumi ir pasakykite kad atnaujintų serverį.</translation>
+        <translation>Versijų nesutapimas! Prašome atnaujinti „Citra“ į naujausią versiją. Jeigu problema išlieka, susisiekite su serverio administratoriumi ir pasakykite kad atnaujintų serverį.</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="33"/>
@@ -2406,6 +2421,57 @@ Derinimo pranešimas:</translation>
         <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="201"/>
         <source>%1 is playing %2</source>
         <translation>%1 žaidžia %2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="208"/>
+        <source>Invalid region</source>
+        <translation>Klaidingas regionas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Japan</source>
+        <translation>Japonija</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>North America</source>
+        <translation>Šiaurės Amerika</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="92"/>
+        <source>Europe</source>
+        <translation>Europa</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="94"/>
+        <source>Australia</source>
+        <translation>Australija</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="96"/>
+        <source>China</source>
+        <translation>Kinija</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="98"/>
+        <source>Korea</source>
+        <translation>Korėja</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="100"/>
+        <source>Taiwan</source>
+        <translation>Taivanas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="102"/>
+        <source>Region free</source>
+        <translation>Be regiono</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="104"/>
+        <source>Invalid Region</source>
+        <translation>Klaidingas regionas</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="26"/>

--- a/dist/languages/nl.ts
+++ b/dist/languages/nl.ts
@@ -1,0 +1,2750 @@
+<?xml version="1.0" ?><!DOCTYPE TS><TS language="nl" version="2.1">
+<context>
+    <name>ARMRegisters</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="14"/>
+        <source>ARM Registers</source>
+        <translation>ARM Registers</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="25"/>
+        <source>Register</source>
+        <translation>Register</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="30"/>
+        <source>Value</source>
+        <translation>Waarde</translation>
+    </message>
+</context>
+<context>
+    <name>AboutDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="14"/>
+        <source>About Citra</source>
+        <translation>Over Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="30"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/citra.png&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/citra.png&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="60"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:28pt;&quot;&gt;Citra&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:28pt;&quot;&gt;Citra&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="73"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="86"/>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:12pt;&quot;&gt;Citra is a free and open source 3DS emulator licensed under GPLv2.0 or any later version.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'MS Shell Dlg 2'; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;This software should not be used to play games you have not legally obtained.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;Citra is een gratis en open source 3DS emulator gelicentieerd onder GPLv2.0 of een latere versie.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;Deze software is niet bedoeld om spellen te spelen die je niet legaal verkregen hebt.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="118"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Website&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://community.citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Forum&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Source Code&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Contributors&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/blob/master/license.txt&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;License&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="134"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;&amp;quot;3DS&amp;quot; is a trademark of Nintendo. Citra is not affiliated with Nintendo in any way.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;&amp;quot;3DS&amp;quot; is een handelsmerk van Nintendo. Citra is op geen enkele manier aan Nintendo verbonden.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>BreakPointModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="34"/>
+        <source>Pica command loaded</source>
+        <translation>Pica opdracht geladen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="35"/>
+        <source>Pica command processed</source>
+        <translation>Pica opdracht verwerkt</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="36"/>
+        <source>Incoming primitive batch</source>
+        <translation>Inkomende primitieve batch</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="37"/>
+        <source>Finished primitive batch</source>
+        <translation>Klaar met primitieve batch</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="38"/>
+        <source>Vertex shader invocation</source>
+        <translation>Vertex shader-aanroep</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="40"/>
+        <source>Incoming display transfer</source>
+        <translation>Inkomende schermoverdracht</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="41"/>
+        <source>GSP command processed</source>
+        <translation>GSP opdracht verwerkt</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="42"/>
+        <source>Buffers swapped</source>
+        <translation>Buffers verwisseld</translation>
+    </message>
+</context>
+<context>
+    <name>ChatRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="14"/>
+        <source>Room Window</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="40"/>
+        <source>Send Chat Message</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="47"/>
+        <source>Send Message</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.cpp" line="81"/>
+        <source>Name</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.cpp" line="82"/>
+        <source>Game</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>ClientRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.ui" line="14"/>
+        <source>Room Window</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.ui" line="40"/>
+        <source>Leave Room</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>ClientRoomWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="54"/>
+        <source>Connected</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="65"/>
+        <source>Disconnected</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="78"/>
+        <source>%1 (%2/%3 members) - connected</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>CompatDB</name>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="20"/>
+        <source>Report Compatibility</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="27"/>
+        <location filename="../../src/citra_qt/compatdb.ui" line="63"/>
+        <source>Report Game Compatibility</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="36"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;Should you choose to submit a test case to the &lt;/span&gt;&lt;a href=&quot;https://citra-emu.org/game/&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;Citra Compatibility List&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;, The following information will be collected and displayed on the site:&lt;/span&gt;&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Hardware Information (CPU / GPU / Operating System)&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Which version of Citra you are running&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The connected Citra account&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="72"/>
+        <source>Perfect</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="79"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions flawlessly with no audio or graphical glitches.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="89"/>
+        <source>Great </source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="96"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions with minor graphical or audio glitches and is playable from start to finish. May require some workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="106"/>
+        <source>Okay</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="113"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions with major graphical or audio glitches, but game is playable from start to finish with workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="123"/>
+        <source>Bad</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="130"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches even with workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="140"/>
+        <source>Intro/Menu</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="147"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start Screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="157"/>
+        <source>Won&apos;t Boot</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="170"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The game crashes when attempting to startup.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="182"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Independent of speed or performance, how well does this game play from start to finish on this version of Citra?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="206"/>
+        <source>Thank you for your submission!</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>ConfigureAudio</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="10"/>
+        <source>Audio</source>
+        <translation>Geluid</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="18"/>
+        <source>Output Engine:</source>
+        <translation>Uitvoer Engine:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="31"/>
+        <source>Enable audio stretching</source>
+        <translation>Geluid vervorming inschakelen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="34"/>
+        <source>This post-processing effect adjusts audio speed to match emulation speed and helps prevent audio stutter. This however increases audio latency.</source>
+        <translation>Dit post-processing effect past de geluidssnelheid aan om gelijk te zijn aan de emulatiesnelheid en helpt geluidsonderbrekingen te voorkomen. Dit zorgt wel voor vertraging in het geluid.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="43"/>
+        <source>Audio Device:</source>
+        <translation>Geluidsapparaat:</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureDebug</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formulier</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="22"/>
+        <source>GDB</source>
+        <translation>GDB</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="28"/>
+        <source>The GDB Stub only works correctly when the CPU JIT is off.</source>
+        <translation>De GDB Stub werkt alleen correct als de CPU JIT is uitgeschakeld.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="37"/>
+        <source>Enable GDB Stub</source>
+        <translation>GBD Stub inschakelen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="57"/>
+        <source>Port:</source>
+        <translation>Poort:</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="14"/>
+        <source>Citra Configuration</source>
+        <translation>Citra configuratie</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="24"/>
+        <source>General</source>
+        <translation>Algemeen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="29"/>
+        <source>System</source>
+        <translation>Systeem</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="34"/>
+        <source>Input</source>
+        <translation>Invoer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="39"/>
+        <source>Graphics</source>
+        <translation>Beeldkwaliteit</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="44"/>
+        <source>Audio</source>
+        <translation>Geluid</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="49"/>
+        <source>Debug</source>
+        <translation>Fouten opsporen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="54"/>
+        <source>Web</source>
+        <translation>Website</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureGeneral</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formulier</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="22"/>
+        <source>General</source>
+        <translation>Algemeen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="30"/>
+        <source>Confirm exit while emulation is running</source>
+        <translation>Bevestig afsluiten terwijl emulatie bezig is</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="37"/>
+        <source>Search sub-directories for games</source>
+        <translation>Zoeken in onderliggende folders voor spellen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="46"/>
+        <source>Interface language</source>
+        <translation>Interfacetaal</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="63"/>
+        <source>Updates</source>
+        <translation>Updates</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="71"/>
+        <source>Check for updates on start</source>
+        <translation>Zoeken naar updates bij opstarten</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="78"/>
+        <source>Silently auto update after closing</source>
+        <translation>Auto update na sluiten in de achtergrond</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="90"/>
+        <source>Performance</source>
+        <translation>Prestaties</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="98"/>
+        <source>Enable CPU JIT</source>
+        <translation>CPU JIT inschakelen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="110"/>
+        <source>Emulation</source>
+        <translation>Emulatie</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="120"/>
+        <source>Region:</source>
+        <translation>Regio:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="128"/>
+        <source>Auto-select</source>
+        <translation>Automatisch selecteren</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="178"/>
+        <source>Theme</source>
+        <translation>Thema</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="188"/>
+        <source>Theme:</source>
+        <translation>Thema:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="205"/>
+        <source>Hotkeys</source>
+        <translation>Sneltoetsen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.cpp" line="16"/>
+        <source>&lt;System&gt;</source>
+        <translation>&lt;System&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.cpp" line="17"/>
+        <source>English</source>
+        <translation>Engels</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureGraphics</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formulier</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="22"/>
+        <source>Graphics</source>
+        <translation>Beeldkwaliteit</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="28"/>
+        <source>Enable hardware renderer</source>
+        <translation>Hardware renderer inschakelen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="35"/>
+        <source>Enable shader JIT</source>
+        <translation>Shader JIT inschakelen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="42"/>
+        <source>Enable V-Sync</source>
+        <translation>V-Sync inschakelen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="51"/>
+        <source>Limit Speed Percent</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="58"/>
+        <source>%</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="78"/>
+        <source>Internal Resolution:</source>
+        <translation>Interne Resolutie:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="86"/>
+        <source>Auto (Window Size)</source>
+        <translation>Automatisch (Schermgrootte)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="91"/>
+        <source>Native (400x240)</source>
+        <translation>Native (400x240)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="96"/>
+        <source>2x Native (800x480)</source>
+        <translation>2x Native (800x480)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="101"/>
+        <source>3x Native (1200x720)</source>
+        <translation>3x Native (1200x720)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="106"/>
+        <source>4x Native (1600x960)</source>
+        <translation>4x Native (1600x960)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="111"/>
+        <source>5x Native (2000x1200)</source>
+        <translation>5x Native (2000x1200)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="116"/>
+        <source>6x Native (2400x1440)</source>
+        <translation>6x Native (2400x1440)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="121"/>
+        <source>7x Native (2800x1680)</source>
+        <translation>7x Native (2800x1680)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="126"/>
+        <source>8x Native (3200x1920)</source>
+        <translation>8x Native (3200x1920)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="131"/>
+        <source>9x Native (3600x2160)</source>
+        <translation>9x Native (3600x2160)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="136"/>
+        <source>10x Native (4000x2400)</source>
+        <translation>10x Native (4000x2400)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="151"/>
+        <source>Layout</source>
+        <translation>Indeling</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="161"/>
+        <source>Screen Layout:</source>
+        <translation>Schermindeling:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="169"/>
+        <source>Default</source>
+        <translation>Standaard</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="174"/>
+        <source>Single Screen</source>
+        <translation>Enkel Scherm</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="179"/>
+        <source>Large Screen</source>
+        <translation>Groot Scherm</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="184"/>
+        <source>Side by Side</source>
+        <translation>Naast Elkaar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="194"/>
+        <source>Swap Screens</source>
+        <translation>Scherm Verwisselen</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureInput</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="14"/>
+        <source>ConfigureInput</source>
+        <translation>Invoer Configureren</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="22"/>
+        <source>Face Buttons</source>
+        <translation>Actieknoppen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="36"/>
+        <source>A:</source>
+        <translation>A:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="54"/>
+        <source>B:</source>
+        <translation>B:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="72"/>
+        <source>X:</source>
+        <translation>X:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="90"/>
+        <source>Y:</source>
+        <translation>Y:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="109"/>
+        <source>Directional Pad</source>
+        <translation>Richtingsknoppen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="123"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="340"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="427"/>
+        <source>Up:</source>
+        <translation>Omhoog:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="141"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="358"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="445"/>
+        <source>Down:</source>
+        <translation>Omlaag:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="159"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="304"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="391"/>
+        <source>Left:</source>
+        <translation>Links:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="177"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="322"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="409"/>
+        <source>Right:</source>
+        <translation>Rechts:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="196"/>
+        <source>Shoulder Buttons</source>
+        <translation>Schouderknoppen:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="210"/>
+        <source>L:</source>
+        <translation>L:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="228"/>
+        <source>R:</source>
+        <translation>R:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="246"/>
+        <source>ZL:</source>
+        <translation>ZL:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="264"/>
+        <source>ZR:</source>
+        <translation>ZR:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="283"/>
+        <source>Circle Pad</source>
+        <translation>Circle Pad</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="295"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="461"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="232"/>
+        <source>Set Analog Stick</source>
+        <translation>Analog Stick instellen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="377"/>
+        <source>C-Stick</source>
+        <translation>C-Stick</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="471"/>
+        <source>Misc.</source>
+        <translation>Diversen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="485"/>
+        <source>Start:</source>
+        <translation>Start:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="503"/>
+        <source>Select:</source>
+        <translation>Select:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="521"/>
+        <source>Home:</source>
+        <translation>Home:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="539"/>
+        <source>Circle Mod:</source>
+        <translation>Circle Mod:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="596"/>
+        <source>Restore Defaults</source>
+        <translation>Standaardwaarde herstellen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="239"/>
+        <source>[press key]</source>
+        <translation>[Druk op een toets]</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureSystem</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formulier</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="22"/>
+        <source>System Settings</source>
+        <translation>Systeeminstellingen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="28"/>
+        <source>Username</source>
+        <translation>Gebruikersnaam</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="48"/>
+        <source>Birthday</source>
+        <translation>Geboortedatum</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="58"/>
+        <source>January</source>
+        <translation>Januari</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="63"/>
+        <source>February</source>
+        <translation>Februari</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="68"/>
+        <source>March</source>
+        <translation>Maart</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="73"/>
+        <source>April</source>
+        <translation>April</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="78"/>
+        <source>May</source>
+        <translation>Mei</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="83"/>
+        <source>June</source>
+        <translation>Juni</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="88"/>
+        <source>July</source>
+        <translation>Juli</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="93"/>
+        <source>August</source>
+        <translation>Augustus</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="98"/>
+        <source>September</source>
+        <translation>September</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="103"/>
+        <source>October</source>
+        <translation>Oktober</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="108"/>
+        <source>November</source>
+        <translation>November</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="113"/>
+        <source>December</source>
+        <translation>December</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="126"/>
+        <source>Language</source>
+        <translation>Taal</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="133"/>
+        <source>Note: this can be overridden when region setting is auto-select</source>
+        <translation>Opmerking: dit kan overschreven worden wanneer regio instelling op automatisch selecteren staat</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="137"/>
+        <source>Japanese (日本語)</source>
+        <translation>Japans (日本語)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="142"/>
+        <source>English</source>
+        <translation>Engels</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="147"/>
+        <source>French (français)</source>
+        <translation>Frans (français)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="152"/>
+        <source>German (Deutsch)</source>
+        <translation>Duits (Deutsch)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="157"/>
+        <source>Italian (italiano)</source>
+        <translation>Italiaans (italiano)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="162"/>
+        <source>Spanish (español)</source>
+        <translation>Spaans (español)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="167"/>
+        <source>Simplified Chinese (简体中文)</source>
+        <translation>Versimpeld Chinees (简体中文)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="172"/>
+        <source>Korean (한국어)</source>
+        <translation>Koreaans (한국어)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="177"/>
+        <source>Dutch (Nederlands)</source>
+        <translation>Nederlands (Nederlands)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="182"/>
+        <source>Portuguese (português)</source>
+        <translation>Portugees (português)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="187"/>
+        <source>Russian (Русский)</source>
+        <translation>Russisch (Русский)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="192"/>
+        <source>Traditional Chinese (正體中文)</source>
+        <translation>Traditioneel Chinees (正體中文)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="200"/>
+        <source>Sound output mode</source>
+        <translation>Geluidsuitvoer modus</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="208"/>
+        <source>Mono</source>
+        <translation>Mono</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="213"/>
+        <source>Stereo</source>
+        <translation>Stereo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="218"/>
+        <source>Surround</source>
+        <translation>Surround</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="226"/>
+        <source>Console ID:</source>
+        <translation>Console ID:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="242"/>
+        <source>Regenerate</source>
+        <translation>Herstellen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="252"/>
+        <source>System settings are available only when game is not running.</source>
+        <translation>Systeeminstellingen zijn alleen beschikbaar wanneer er geen spel actief is.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="87"/>
+        <source>Console ID: 0x%1</source>
+        <translation>Console ID: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="160"/>
+        <source>This will replace your current virtual 3DS with a new one. Your current virtual 3DS will not be recoverable. This might have unexpected effects in games. This might fail, if you use an outdated config savegame. Continue?</source>
+        <translation>Dit zal je huidige virtuele 3DS vervangen met een nieuwe. Je huidige virtuele 3DS is niet herstelbaar. Dit kan onverwachte effecten hebben in spellen. Dit kan mislukken, als je een verouderd configuratie opslagbestand gebruikt. Doorgaan?</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="164"/>
+        <source>Warning</source>
+        <translation>Waarschuwing</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureWeb</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formulier</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="22"/>
+        <source>Citra Web Service</source>
+        <translation>Citra Web Service</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="28"/>
+        <source>By providing your username and token, you agree to allow Citra to collect additional usage data, which may include user identifying information.</source>
+        <translation>Door het voorzien van je gebruikersnaam en token, ga je akkoord dat Citra aanvullende gebruiksdata verzameld, wat gebruikersinformatie kan bevatten.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="46"/>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="90"/>
+        <source>Verify</source>
+        <translation>Verifiëren </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="53"/>
+        <source>Sign up</source>
+        <translation>Registreren</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="67"/>
+        <source>Token: </source>
+        <translation>Token:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="78"/>
+        <source>Username: </source>
+        <translation>Gebruikersnaam:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="99"/>
+        <source>What is my token?</source>
+        <translation>Wat is mijn token?</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="124"/>
+        <source>Telemetry</source>
+        <translation>Telemetrie</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="130"/>
+        <source>Share anonymous usage data with the Citra team</source>
+        <translation>Deel anonieme gebruiksdata met het Citra team</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="137"/>
+        <source>Learn more</source>
+        <translation>Leer meer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="146"/>
+        <source>Telemetry ID:</source>
+        <translation>Telemetrie ID:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="162"/>
+        <source>Regenerate</source>
+        <translation>Herstellen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="28"/>
+        <source>&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Leer meer&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="33"/>
+        <source>&lt;a href=&apos;https://services.citra-emu.org/&apos;&gt;Sign up&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://services.citra-emu.org/&apos;&gt;Registreren&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="36"/>
+        <source>&lt;a href=&apos;https://citra-emu.org/wiki/citra-web-service/&apos;&gt;What is my token?&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://citra-emu.org/wiki/citra-web-service/&apos;&gt;Wat is mijn token?&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="45"/>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="65"/>
+        <source>Telemetry ID: 0x%1</source>
+        <translation>Telemetrie ID: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="55"/>
+        <source>Username and token not verified</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="56"/>
+        <source>Username and token were not verified. The changes to your username and/or token have not been saved.</source>
+        <translation>Gebruikersnaam en token zijn niet geverifieerd. De veranderingen aan je gebruikersnaam en/of token zijn niet opgeslagen.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="85"/>
+        <source>Verifying</source>
+        <translation>Verifiëren </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="99"/>
+        <source>Verification failed</source>
+        <translation>Verificatie mislukt</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="100"/>
+        <source>Verification failed. Check that you have entered your username and token correctly, and that your internet connection is working.</source>
+        <translation>Verificatie mislukt. Kijk of je je gebruikersnaam en token goed hebt ingevuld, en dat je internetverbinding werkt.</translation>
+    </message>
+</context>
+<context>
+    <name>DirectConnect</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="14"/>
+        <source>Direct Connect</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="33"/>
+        <source>IP Address</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="56"/>
+        <source>IP</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="63"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;IPv4 address of the host&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="73"/>
+        <source>Port</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="80"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Port number the host is listening on&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="86"/>
+        <source>24872</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="100"/>
+        <source>Nickname</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="114"/>
+        <source>Password</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="156"/>
+        <source>Connect</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>DirectConnectWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="97"/>
+        <source>Connecting</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="102"/>
+        <source>Connect</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>GMainWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="90"/>
+        <source>To help improve Citra, the Citra Team collects anonymous usage data. No private or personally identifying information is collected. This data helps us to understand how people use Citra and prioritize our efforts. Furthermore, it helps us to more easily identify emulation bugs and performance issues. This data includes:&lt;ul&gt;&lt;li&gt;Information about the version of Citra you are using&lt;/li&gt;&lt;li&gt;Performance data about the games you play&lt;/li&gt;&lt;li&gt;Your configuration settings&lt;/li&gt;&lt;li&gt;Information about your computer hardware&lt;/li&gt;&lt;li&gt;Emulation errors and crash information&lt;/li&gt;&lt;/ul&gt;By default, this feature is enabled. To disable this feature, click &apos;Emulation&apos; from the menu and then select &apos;Configure...&apos;. Then, on the &apos;Web&apos; tab, uncheck &apos;Share anonymous usage data with the Citra team&apos;. &lt;br/&gt;&lt;br/&gt;By using this software, you agree to the above terms.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Om Citra te verbeteren, zal het Citra team anonieme gebruiksdata verzamelen. Geen privé of persoonlijk identificerende informatie zal worden verzameld. Deze data zal ons helpen begrijpen hoe de mensen Citra gebruiken en onze inspanningen te prioriteren. Daarnaast zal het ons helpen makkelijker emulatiebugs en prestatieproblemen te identificeren. Onder deze data valt:&lt;ul&gt;&lt;li&gt;Informatie over de versie van Citra die je gebruikt&lt;/li&gt;&lt;li&gt;Prestatiedata over de spellen die je speelt&lt;/li&gt;&lt;li&gt;Je configuratieinstellingen&lt;/li&gt;&lt;li&gt;Informatie over je computerhardware&lt;/li&gt;&lt;li&gt;Emulatie errors en crashinformatie&lt;/li&gt;&lt;/ul&gt;Standaard is deze optie ingeschakeld. Om deze optie uit te schakelen, klik op &apos;Emulatie&apos; vanuit het menu en kies &apos;Configuratie...&apos;. Dan in de &apos;Web&apos; tab, deselecteer &apos;Deel anonieme gebruiksdata met het Citra team&apos;. &lt;br/&gt;&lt;br/&gt;Door deze software te gebruiker, ga je akkoord met de bovenstaande voorwaardes.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Leer meer&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="195"/>
+        <source>Current emulation speed. Values higher or lower than 100% indicate emulation is running faster or slower than a 3DS.</source>
+        <translation>Huidige emulatiesnelheid.  Waardes hoger of lager dan 100% geven aan dat de emulatie sneller of langzamer gaat dan een 3DS.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="198"/>
+        <source>How many frames per second the game is currently displaying. This will vary from game to game and scene to scene.</source>
+        <translation>Hoeveel frames per seconde het spel nu momenteel laat zien. Dit kan variëren van spel tot spel en scene tot scene.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="202"/>
+        <source>Time taken to emulate a 3DS frame, not counting framelimiting or v-sync. For full-speed emulation this should be at most 16.67 ms.</source>
+        <translation>Tijd verstrekt om één 3DS frame te emuleren, zonder framelimitatie of V-Sync te tellen. Voor volledige snelheid emulatie zal dit maximaal 16.67 ms moeten zijn.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="429"/>
+        <source>CTRL+F</source>
+        <translation>CTRL+F</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="538"/>
+        <source>Update available!</source>
+        <translation>Update beschikbaar!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="539"/>
+        <source>An update for Citra is available. Do you wish to install it now?&lt;br /&gt;&lt;br /&gt;This &lt;b&gt;will&lt;/b&gt; terminate emulation, if it is running.</source>
+        <translation>Een update voor Citra is beschikbaar. Wil je die nu installeren?&lt;br /&gt;&lt;br /&gt;Dit &lt;b&gt;zal&lt;/b&gt; de huidige emulatie stoppen, als deze bezig is.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <source>No update found</source>
+        <translation>Geen update gevonden</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <source>No update has been found for Citra.</source>
+        <translation>Geen update voor Citra is gevonden.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="567"/>
+        <source>Error while initializing OpenGL 3.3 Core!</source>
+        <translation>Fout bij het initialiseren van OpenGL 3.3 Core!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="568"/>
+        <source>Your GPU may not support OpenGL 3.3, or you do not have the latest graphics driver.</source>
+        <translation>Je GPU ondersteunt OpenGL 3.3 misschien niet, of je hebt niet de laatste grafische stuurprogramma&apos;s.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="581"/>
+        <location filename="../../src/citra_qt/main.cpp" line="587"/>
+        <location filename="../../src/citra_qt/main.cpp" line="593"/>
+        <location filename="../../src/citra_qt/main.cpp" line="606"/>
+        <location filename="../../src/citra_qt/main.cpp" line="625"/>
+        <source>Error while loading ROM!</source>
+        <translation>Fout tijdens het laden van de ROM!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="582"/>
+        <location filename="../../src/citra_qt/main.cpp" line="607"/>
+        <source>The ROM format is not supported.</source>
+        <translation>De ROM-formaat is niet ondersteund.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="588"/>
+        <source>Could not determine the system mode.</source>
+        <translation>Kon de systeemmodus niet vaststellen.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="594"/>
+        <source>The game that you are trying to load must be decrypted before being used with Citra. A real 3DS is required.&lt;br/&gt;&lt;br/&gt;For more information on dumping and decrypting games, please see the following wiki pages: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation>Het spel dat je probeert te laden moet eerst gedecodeerd worden voordat je het kan gebruiken met Citra. Een echte 3DS is vereist.&lt;br/&gt;&lt;br/&gt;Voor meer informatie over dumping en decoderen van spellen, zie de volgende wiki-pagina&apos;s: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="612"/>
+        <source>An error occured in the video core.</source>
+        <translation>Een fout in de video core is opgetreden.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="613"/>
+        <source>Citra has encountered an error while running the video core, please see the log for more details.For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.Ensure that you have the latest graphics drivers for your GPU.</source>
+        <translation>Citra heeft een fout aangetroffen tijdens het uitvoeren van de video core, raadpleeg het logboek voor meer informatie. Raadpleeg de volgende pagina voor meer informatie over het openen van het logboek: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;. Zorg dat je beschikt over de nieuwste grafische stuurprogramma&apos;s voor uw GPU.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="626"/>
+        <source>An unknown error occured. Please see the log for more details.</source>
+        <translation>Er is een onbekende fout opgetreden. Zie het logboek voor meer details.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="699"/>
+        <source>Start</source>
+        <translation>Start</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="790"/>
+        <source>Error Opening %1 Folder</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="791"/>
+        <source>Folder does not exist!</source>
+        <translation>Map bestaat niet!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="805"/>
+        <source>3DS Executable</source>
+        <translation>3DS Executable</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="806"/>
+        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <source>All Files (*.*)</source>
+        <translation>Alle bestanden (*.*)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="808"/>
+        <source>Load File</source>
+        <translation>Laad bestand</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="818"/>
+        <source>Select Directory</source>
+        <translation>Selecteer Folder</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="827"/>
+        <source>Load Files</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <source>3DS Installation File (*.CIA*)</source>
+        <translation>3DS Installatie bestand (*.CIA*)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="859"/>
+        <source>%1 has been installed successfully.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="862"/>
+        <source>Unable to open File</source>
+        <translation>Kan bestand niet openen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="863"/>
+        <source>Could not open %1</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="867"/>
+        <source>Installation aborted</source>
+        <translation>Installatie onderbroken</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="868"/>
+        <source>The installation of %1 was aborted. Please see the log for more details</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <source>Invalid File</source>
+        <translation>Ongeldig bestand</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <source>%1 is not a valid CIA</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="875"/>
+        <source>Encrypted File</source>
+        <translation>Versleuterd bestand</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="876"/>
+        <source>%1 must be decrypted before being used with Citra. A real 3DS is required.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="899"/>
+        <source>File not found</source>
+        <translation>Bestand niet gevonden</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="900"/>
+        <source>File &quot;%1&quot; not found</source>
+        <translation>Bestand &quot;%1&quot; niet gevonden</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="914"/>
+        <source>Continue</source>
+        <translation>Doorgaan</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="939"/>
+        <source>Missing Citra Account</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="940"/>
+        <source>In order to submit a game compatibility test case, you must link your Citra account.&lt;br&gt;&lt;br/&gt;To link your Citra account, go to Emulation &amp;gt; Configuration &amp;gt; Web.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1090"/>
+        <source>Speed: %1% / %2%</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1094"/>
+        <source>Speed: %1%</source>
+        <translation>Snelheid: %1%</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1096"/>
+        <source>Game: %1 FPS</source>
+        <translation>Spel: %1 FPS</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1097"/>
+        <source>Frame: %1 ms</source>
+        <translation>Frame: %1 ms</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1108"/>
+        <source>The game you are trying to load requires additional files from your 3DS to be dumped before playing.&lt;br/&gt;&lt;br/&gt;For more information on dumping these files, please see the following wiki page: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
+        <translation>Het spel dat je probeert te laden vereist dat er extra bestanden van uw 3DS worden gedumpt voordat je kan spelen.&lt;br/&gt;&lt;br/&gt;Voor meer informatie over dumping van deze bestanden, kijk dan naar de volgende wiki pagina: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Wil je afsluiten en terug gaan naar de lijst met spellen? Doorgaan met de emulatie kan crashes, beschadigde save data of andere bugs veroorzaken.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1120"/>
+        <source>: %1. </source>
+        <translation>: %1. </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1126"/>
+        <source>System Archive Not Found</source>
+        <translation>Systeem archief niet gevonden</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1133"/>
+        <source>Citra was unable to locate the 3DS shared fonts. </source>
+        <translation>Citra was kon de locatie van de 3DS gedeelde fonts niet vinden.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1135"/>
+        <source>Shared Fonts Not Found</source>
+        <translation>Gedeelde Fonts Niet Gevonden</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1143"/>
+        <source>Fatal Error</source>
+        <translation>Fatale Fout</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1144"/>
+        <source>Citra has encountered a fatal error, please see the log for more details. For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
+        <translation>Citra heeft een fatale fout aangetroffen, raadpleeg het logboek voor meer informatie. Raadpleeg de volgende pagina voor meer informatie over het openen van het logboek: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Wil je afsluiten en terug gaan naar de lijst met spellen? Doorgaan met de emulatie kan crashes, beschadigde save data of andere bugs veroorzaken. </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1245"/>
+        <source>Citra</source>
+        <translation>Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <source>Are you sure you want to close Citra?</source>
+        <translation>Weet je zeker dat je Citra wilt afsluiten?</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1246"/>
+        <source>Are you sure you want to stop the emulation? Any unsaved progress will be lost.</source>
+        <translation>Weet je zeker dat je de emulatie wilt stoppen? Alle niet opgeslagen voortgang zal verloren gaan.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1318"/>
+        <source>Citra %1| %2-%3</source>
+        <translation>Citra %1| %2-%3</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandListModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="96"/>
+        <source>Command Name</source>
+        <translation>Opdracht Naam</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="98"/>
+        <source>Register</source>
+        <translation>Register</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="100"/>
+        <source>Mask</source>
+        <translation>Maskeren</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="102"/>
+        <source>New Value</source>
+        <translation>Nieuwe Waarde</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandListWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="184"/>
+        <source>Pica Command List</source>
+        <translation>Pica Opdrachten Lijst</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="202"/>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="233"/>
+        <source>Start Tracing</source>
+        <translation>Start Traceren</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="203"/>
+        <source>Copy All</source>
+        <translation>Alles kopiëren</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="229"/>
+        <source>Finish Tracing</source>
+        <translation>Traceren voltooien</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandStreamWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics.cpp" line="67"/>
+        <source>Graphics Debugger</source>
+        <translation>Grafische Foutopsporing</translation>
+    </message>
+</context>
+<context>
+    <name>GameList</name>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <source>Perfect</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <source>Game functions flawless with no audio or graphical glitches, all tested functionality works as intended without
+any workarounds needed.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <source>Great</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <source>Game functions with minor graphical or audio glitches and is playable from start to finish. May require some
+workarounds.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <source>Okay</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <source>Game functions with major graphical or audio glitches, but game is playable from start to finish with
+workarounds.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Bad</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches
+even with workarounds.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <source>Intro/Menu</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <source>Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start
+Screen.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>Won&apos;t Boot</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>The game crashes when attempting to startup.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <source>Not Tested</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <source>The game has not yet been tested.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="99"/>
+        <source>of</source>
+        <translation>van de</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="102"/>
+        <source>result</source>
+        <translation>Resultaat</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="104"/>
+        <source>results</source>
+        <translation>Resultaten</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="125"/>
+        <source>Filter:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="128"/>
+        <source>Enter pattern to filter</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="324"/>
+        <source>Open Save Data Location</source>
+        <translation>Open opslag data locatie</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
+        <source>Open Application Location</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
+        <source>Open Update Data Location</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>GraphicsBreakPointsWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="132"/>
+        <source>Pica Breakpoints</source>
+        <translation>Pica breekpunten</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="136"/>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="198"/>
+        <source>Emulation running</source>
+        <translation>Emulatie loopt</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="137"/>
+        <source>Resume</source>
+        <translation>Hervatten</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="188"/>
+        <source>Emulation halted at breakpoint</source>
+        <translation>Emulatie gestopt op breekpunt</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsSurfaceWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="49"/>
+        <source>Pica Surface Viewer</source>
+        <translation>Pica Surface Viewer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="54"/>
+        <source>Color Buffer</source>
+        <translation>Kleur Buffer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="55"/>
+        <source>Depth Buffer</source>
+        <translation>Diepte Buffer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="56"/>
+        <source>Stencil Buffer</source>
+        <translation>Stencil Buffer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="57"/>
+        <source>Texture 0</source>
+        <translation>Structuur 0</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="58"/>
+        <source>Texture 1</source>
+        <translation>Structuur 1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="59"/>
+        <source>Texture 2</source>
+        <translation>Structuur 2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="60"/>
+        <source>Custom</source>
+        <translation>Aangepast</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="103"/>
+        <source>Unknown</source>
+        <translation>Onbekend</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="118"/>
+        <source>Save</source>
+        <translation>Opslaan</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="144"/>
+        <source>Source:</source>
+        <translation>Bron:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="150"/>
+        <source>Physical Address:</source>
+        <translation>Fysiek Adres:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="156"/>
+        <source>Width:</source>
+        <translation>Breedte:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="162"/>
+        <source>Height:</source>
+        <translation>Hoogte:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="168"/>
+        <source>Format:</source>
+        <translation>Formaat:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="180"/>
+        <source>X:</source>
+        <translation>X:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="186"/>
+        <source>Y:</source>
+        <translation>Y:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="280"/>
+        <source>Pixel out of bounds</source>
+        <translation>Pixel buiten bereik</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="287"/>
+        <source>(unable to access pixel data)</source>
+        <translation>(geen toegang tot pixel data)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="555"/>
+        <source>(invalid surface address)</source>
+        <translation>(ongeldig surface adres)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="565"/>
+        <source>(unknown surface format)</source>
+        <translation>(onbekend surface formaat)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="658"/>
+        <source>Portable Network Graphic (*.png)</source>
+        <translation>Portable Network Graphic (*.png)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="659"/>
+        <source>Binary data (*.bin)</source>
+        <translation>Binary data (*.bin)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="663"/>
+        <source>Save Surface</source>
+        <translation>Surface opslaan</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsTracingWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="25"/>
+        <source>CiTrace Recorder</source>
+        <translation>CiTrace Opnemer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="29"/>
+        <source>Start Recording</source>
+        <translation>Start Opname</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="31"/>
+        <source>Stop and Save</source>
+        <translation>Stop en Opslaan</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="32"/>
+        <source>Abort Recording</source>
+        <translation>Opname Onderbreken</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="112"/>
+        <source>Save CiTrace</source>
+        <translation>CiTrace Opslaan</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="113"/>
+        <source>CiTrace File (*.ctf)</source>
+        <translation>CiTrace File (*.ctf)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="162"/>
+        <source>CiTracing still active</source>
+        <translation>CiTracing nog steeds actief</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="163"/>
+        <source>A CiTrace is still being recorded. Do you want to save it? If not, all recorded data will be discarded.</source>
+        <translation>Een CiTrace wordt nog steeds opgenomen. Wil je deze opslaan? Zo niet, dan zal alle data worden verwijderd.</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsVertexShaderModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="45"/>
+        <source>Offset</source>
+        <translation>Compenseren</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="47"/>
+        <source>Raw</source>
+        <translation>Rauw</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="49"/>
+        <source>Disassembly</source>
+        <translation>Demontage</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsVertexShaderWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="345"/>
+        <source>Save Shader Dump</source>
+        <translation>Shader Dump Opslaan</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="345"/>
+        <source>Shader Binary (*.shbin)</source>
+        <translation>Shader Binary (*.shbin)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="380"/>
+        <source>(data only available at vertex shader invocation breakpoints)</source>
+        <translation>(data alleen beschikbaar bij vertex shader-aanroep breekpunten)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="390"/>
+        <source>Dump</source>
+        <translation>Dump</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="412"/>
+        <source>Input Data</source>
+        <translation>Invoer Data</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="426"/>
+        <source>Attribute %1</source>
+        <translation>Attribuut %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="453"/>
+        <source>Cycle Index:</source>
+        <translation>Cyclus Index:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="558"/>
+        <source>SRC1: %1, %2, %3, %4
+</source>
+        <translation>SRC1: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="564"/>
+        <source>SRC2: %1, %2, %3, %4
+</source>
+        <translation>SRC2: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="570"/>
+        <source>SRC3: %1, %2, %3, %4
+</source>
+        <translation>SRC3: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="576"/>
+        <source>DEST_IN: %1, %2, %3, %4
+</source>
+        <translation>DEST_IN: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="582"/>
+        <source>DEST_OUT: %1, %2, %3, %4
+</source>
+        <translation>DEST_OUT: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="589"/>
+        <source>Address Registers: %1, %2
+</source>
+        <translation>Adres Registers: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="593"/>
+        <source>Compare Result: %1, %2
+</source>
+        <translation>Vergelijkings-resultaten: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="598"/>
+        <source>Static Condition: %1
+</source>
+        <translation>Statische Toestand: %1
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="600"/>
+        <source>Dynamic Conditions: %1, %2
+</source>
+        <translation>Dynamische Toestand: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="604"/>
+        <source>Loop Parameters: %1 (repeats), %2 (initializer), %3 (increment), %4
+</source>
+        <translation>Loop Parameters: %1 (Herhaaldelijk), %2 (Tot stand brengen), %3 (Ophoging), %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="611"/>
+        <source>Instruction offset: 0x%1</source>
+        <translation>Instructie compenseren: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="613"/>
+        <source> -&gt; 0x%2</source>
+        <translation> -&gt; 0x%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="615"/>
+        <source> (last instruction)</source>
+        <translation> (laatste instructie)</translation>
+    </message>
+</context>
+<context>
+    <name>HostRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="14"/>
+        <source>Create Room</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="37"/>
+        <source>Room Name</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="51"/>
+        <source>Preferred Game</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="61"/>
+        <source>Max Players</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="91"/>
+        <source>Username</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="101"/>
+        <source>(Leave blank for open game)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="118"/>
+        <source>Password</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="125"/>
+        <source>Port</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="156"/>
+        <source>Public</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="161"/>
+        <source>Unlisted</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="169"/>
+        <source>Host Room</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>Lobby</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="14"/>
+        <source>Public Room Browser</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="32"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="39"/>
+        <source>Nickname</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="59"/>
+        <source>Filters</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="66"/>
+        <source>Search</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="76"/>
+        <source>Games I Own</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="83"/>
+        <source>Hide Full Rooms</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="103"/>
+        <source>Refresh Lobby</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <source>Password Required to Join</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <source>Password:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="77"/>
+        <source>Password</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
+        <source>Room Name</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="143"/>
+        <source>Preferred Game</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="144"/>
+        <source>Host</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="145"/>
+        <source>Players</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="153"/>
+        <source>Refreshing</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="201"/>
+        <source>Refresh List</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="14"/>
+        <source>Citra</source>
+        <translation>Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="53"/>
+        <source>&amp;File</source>
+        <translation>&amp;Bestand</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="57"/>
+        <source>Recent Files</source>
+        <translation>Recente Bestanden</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="70"/>
+        <source>&amp;Emulation</source>
+        <translation>&amp;Emulatie</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="80"/>
+        <source>&amp;View</source>
+        <translation>&amp;Beeld</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="84"/>
+        <source>Debugging</source>
+        <translation>Foutopsporing</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="91"/>
+        <source>Screen Layout</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="115"/>
+        <source>Multiplayer</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="126"/>
+        <source>&amp;Help</source>
+        <translation>&amp;Help</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="144"/>
+        <source>Load File...</source>
+        <translation>Laad Bestand...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="149"/>
+        <source>Install CIA...</source>
+        <translation>CIA Installeren...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="154"/>
+        <source>Load Symbol Map...</source>
+        <translation>Symbool Map Laden...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="159"/>
+        <source>E&amp;xit</source>
+        <translation>&amp;Afsluiten</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="167"/>
+        <source>&amp;Start</source>
+        <translation>&amp;Start</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="175"/>
+        <source>&amp;Pause</source>
+        <translation>&amp;Pauzeren</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="183"/>
+        <source>&amp;Stop</source>
+        <translation>&amp;Stop</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="188"/>
+        <source>FAQ</source>
+        <translation>FAQ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="193"/>
+        <source>About Citra</source>
+        <translation>Over Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="201"/>
+        <source>Single Window Mode</source>
+        <translation>Enkel Scherm Modus</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="206"/>
+        <source>Configure...</source>
+        <translation>Configureren...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="214"/>
+        <source>Display Dock Widget Headers</source>
+        <translation>Dock Widget Headers Tonen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="222"/>
+        <source>Show Filter Bar</source>
+        <translation>Filter Bar Tonen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="230"/>
+        <source>Show Status Bar</source>
+        <translation>Status Bar Tonen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="235"/>
+        <source>Select Game Directory...</source>
+        <translation>Selecteer Spel Folder...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="238"/>
+        <source>Selects a folder to display in the game list</source>
+        <translation>Selecteert een folder om te tonen in de spellen lijst</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="243"/>
+        <source>Create Pica Surface Viewer</source>
+        <translation>Pica Surface Viewer Maken</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="251"/>
+        <source>Browse Public Game Lobby</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="259"/>
+        <source>Create Room</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="267"/>
+        <source>Leave Room</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="272"/>
+        <source>Direct Connect to Room</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="280"/>
+        <source>Show Current Room</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="288"/>
+        <source>Fullscreen</source>
+        <translation>Volledig Scherm</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="293"/>
+        <source>Modify Citra Install</source>
+        <translation>Citra Installatie Aanpassen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="296"/>
+        <source>Opens the maintenance tool to modify your Citra installation</source>
+        <translation>Opent de onderhouds-tool om de Citra installatie aan te passen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="304"/>
+        <source>Default</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="312"/>
+        <source>Single Screen</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="320"/>
+        <source>Large Screen</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="328"/>
+        <source>Side by Side</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="336"/>
+        <source>Swap Screens</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="341"/>
+        <source>Check for Updates</source>
+        <translation>Zoeken naar Updates</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="349"/>
+        <source>Report Compatibility</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>MicroProfileDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/profiler.cpp" line="50"/>
+        <source>MicroProfile</source>
+        <translation>MicroProfiel</translation>
+    </message>
+</context>
+<context>
+    <name>MultiplayerState</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="41"/>
+        <source>Current connection status</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="42"/>
+        <source>Not Connected. Click here to find a room!</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="100"/>
+        <source>Connected</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="105"/>
+        <source>Not Connected</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="114"/>
+        <source>Error</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="115"/>
+        <source>Failed to announce the room to the public lobby. In order to host a room publicly, you must have a valid Citra account configured in Emulation -&gt; Configure -&gt; Web. If you do not want to publish a room in the public lobby, then select Unlisted instead.
+Debug Message: </source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>NetworkMessage</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="12"/>
+        <source>Username is not valid. Must be 4 to 20 alphanumeric characters.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="14"/>
+        <source>Room name is not valid. Must be 4 to 20 alphanumeric characters.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="16"/>
+        <source>Username is already in use. Please choose another.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="17"/>
+        <source>IP is not a valid IPv4 address.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="18"/>
+        <source>Port must be a number between 0 to 65535.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="20"/>
+        <source>Unable to find an internet connection. Check your internet settings.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="22"/>
+        <source>Unable to connect to the host. Verify that the connection settings are correct. If you still cannot connect, contact the room host and verify that the host is properly configured with the external port forwarded.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="26"/>
+        <source>Creating a room failed. Please retry. Restarting Citra might be necessary.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="28"/>
+        <source>The host of the room has banned you. Speak with the host to unban you or try a different room.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="31"/>
+        <source>Version mismatch! Please update to the latest version of Citra. If the problem persists, contact the room host and ask them to update the server.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="33"/>
+        <source>Incorrect password.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="35"/>
+        <source>An unknown error occured. If this error continues to occur, please open an issue</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="36"/>
+        <source>Connection to room lost. Try to reconnect.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="38"/>
+        <source>MAC address is already in use. Please choose another.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="52"/>
+        <source>Leave Room</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="53"/>
+        <source>You are about to close the room. Any network connections will be closed.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="58"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="59"/>
+        <source>You are about to leave the room. Any network connections will be closed.</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="47"/>
+        <source>Error</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="198"/>
+        <source>%1 is not playing a game</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="201"/>
+        <source>%1 is playing %2</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="26"/>
+        <source>Shift</source>
+        <translation>Shift</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="28"/>
+        <source>Ctrl</source>
+        <translation>Ctrl</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="30"/>
+        <source>Alt</source>
+        <translation>Alt</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="51"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="75"/>
+        <source>[not set]</source>
+        <translation>[niet ingesteld]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="55"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="83"/>
+        <source>Joystick %1</source>
+        <translation>Joystick %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="57"/>
+        <source> Hat %1 %2</source>
+        <translation> Hat %1 %2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="61"/>
+        <source> Axis %1%2</source>
+        <translation> Axis %1%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="65"/>
+        <source> Button %1</source>
+        <translation>Knop %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="69"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="91"/>
+        <source>[unknown]</source>
+        <translation>[onbekend]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="80"/>
+        <source>[unused]</source>
+        <translation>[ongebruikt]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="85"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="87"/>
+        <source> Axis %1</source>
+        <translation> Axis %1</translation>
+    </message>
+</context>
+<context>
+    <name>RegistersWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="15"/>
+        <source>Registers</source>
+        <translation>Registers</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="16"/>
+        <source>VFP Registers</source>
+        <translation>VFP Registers</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="18"/>
+        <source>VFP System Registers</source>
+        <translation>VFP Systeem Registers</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="167"/>
+        <source>Vector Length</source>
+        <translation>Vector Lengte</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="168"/>
+        <source>Vector Stride</source>
+        <translation>Vector Schrede</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="169"/>
+        <source>Rounding Mode</source>
+        <translation>Afronding Modus</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="182"/>
+        <source>Vector Iteration Count</source>
+        <translation>Vector Iteratieteller</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeEvent</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="259"/>
+        <source>reset type = %1</source>
+        <translation>reset type = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeMutex</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="272"/>
+        <source>locked %1 times by thread:</source>
+        <translation>%1 keer gesloten door thread:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="275"/>
+        <source>free</source>
+        <translation>vrij</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeMutexList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="314"/>
+        <source>holding mutexes</source>
+        <translation>mutexes worden vasthouden</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeObjectList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="128"/>
+        <source>waiting for all objects</source>
+        <translation>wachten op alle objecten</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="129"/>
+        <source>waiting for one of the following objects</source>
+        <translation>wachten op een van de volgende objecten</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeSemaphore</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="288"/>
+        <source>available count = %1</source>
+        <translation>beschikbare aantal = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="289"/>
+        <source>max count = %1</source>
+        <translation>maximale aantal = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeThread</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="146"/>
+        <source>running</source>
+        <translation>lopend</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="149"/>
+        <source>ready</source>
+        <translation>Gereed</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="152"/>
+        <source>waiting for address 0x%1</source>
+        <translation>Wachten op adres 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="155"/>
+        <source>sleeping</source>
+        <translation>sluimeren</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="158"/>
+        <source>waiting for IPC response</source>
+        <translation>wachten op IPC antwoord</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="162"/>
+        <source>waiting for objects</source>
+        <translation>wachten op objecten</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="165"/>
+        <source>waiting for HLE return</source>
+        <translation>wachten op HLE teruggave</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="168"/>
+        <source>dormant</source>
+        <translation>slapend</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="171"/>
+        <source>dead</source>
+        <translation>dood</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="174"/>
+        <source> PC = 0x%1 LR = 0x%2</source>
+        <translation> PC = 0x%1 LR = 0x%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="214"/>
+        <source>default</source>
+        <translation>standaard</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="217"/>
+        <source>all</source>
+        <translation>alle</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="220"/>
+        <source>AppCore</source>
+        <translation>AppCore</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="223"/>
+        <source>SysCore</source>
+        <translation>SysCore</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="226"/>
+        <source>Unknown processor %1</source>
+        <translation>Onbekende processor %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="230"/>
+        <source>processor = %1</source>
+        <translation>processor = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="231"/>
+        <source>thread id = %1</source>
+        <translation>thread id = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="232"/>
+        <source>priority = %1(current) / %2(normal)</source>
+        <translation>prioriteit = %1(huidige) / %2(normaal)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="236"/>
+        <source>last running ticks = %1</source>
+        <translation>laatste lopende tikken = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="239"/>
+        <source>not holding mutex</source>
+        <translation>geen mutex wordt vastgehouden</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeThreadList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="328"/>
+        <source>waited by thread</source>
+        <translation>gepauzeerd door thread</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeTimer</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="301"/>
+        <source>reset type = %1</source>
+        <translation>reset type = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="303"/>
+        <source>initial delay = %1</source>
+        <translation>Initiële vertraging = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="305"/>
+        <source>interval delay = %1</source>
+        <translation>interval vertraging = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeWaitObject</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="76"/>
+        <source>[%1]%2 %3</source>
+        <translation>[%1]%2 %3</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="104"/>
+        <source>waited by no thread</source>
+        <translation>gepauzeerd door geen thread</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="114"/>
+        <source>one shot</source>
+        <translation>one shot</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="116"/>
+        <source>sticky</source>
+        <translation>sticky</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="118"/>
+        <source>pulse</source>
+        <translation>pulse</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="399"/>
+        <source>Wait Tree</source>
+        <translation>Wait Tree</translation>
+    </message>
+</context>
+<context>
+    <name>hotkeys</name>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="14"/>
+        <source>Hotkey Settings</source>
+        <translation>Sneltoets instellingen</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="27"/>
+        <source>Action</source>
+        <translation>Actie</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="32"/>
+        <source>Hotkey</source>
+        <translation>Sneltoets</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="37"/>
+        <source>Context</source>
+        <translation>Context</translation>
+    </message>
+</context>
+</TS>

--- a/dist/languages/nl.ts
+++ b/dist/languages/nl.ts
@@ -154,17 +154,17 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ClientRoomWindow</name>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="54"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="55"/>
         <source>Connected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="65"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="63"/>
         <source>Disconnected</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="78"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="76"/>
         <source>%1 (%2/%3 members) - connected</source>
         <translation type="unfinished"/>
     </message>
@@ -312,6 +312,26 @@ p, li { white-space: pre-wrap; }
         <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="57"/>
         <source>Port:</source>
         <translation>Poort:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="78"/>
+        <source>Logging</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="86"/>
+        <source>Global Log Filter</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="100"/>
+        <source>Show Log Console (Windows Only)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="107"/>
+        <source>Open Log Location</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1100,12 +1120,12 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DirectConnectWindow</name>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="97"/>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="103"/>
         <source>Connecting</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="102"/>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="108"/>
         <source>Connect</source>
         <translation type="unfinished"/>
     </message>
@@ -1113,289 +1133,289 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GMainWindow</name>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="90"/>
+        <location filename="../../src/citra_qt/main.cpp" line="92"/>
         <source>To help improve Citra, the Citra Team collects anonymous usage data. No private or personally identifying information is collected. This data helps us to understand how people use Citra and prioritize our efforts. Furthermore, it helps us to more easily identify emulation bugs and performance issues. This data includes:&lt;ul&gt;&lt;li&gt;Information about the version of Citra you are using&lt;/li&gt;&lt;li&gt;Performance data about the games you play&lt;/li&gt;&lt;li&gt;Your configuration settings&lt;/li&gt;&lt;li&gt;Information about your computer hardware&lt;/li&gt;&lt;li&gt;Emulation errors and crash information&lt;/li&gt;&lt;/ul&gt;By default, this feature is enabled. To disable this feature, click &apos;Emulation&apos; from the menu and then select &apos;Configure...&apos;. Then, on the &apos;Web&apos; tab, uncheck &apos;Share anonymous usage data with the Citra team&apos;. &lt;br/&gt;&lt;br/&gt;By using this software, you agree to the above terms.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
         <translation>Om Citra te verbeteren, zal het Citra team anonieme gebruiksdata verzamelen. Geen privé of persoonlijk identificerende informatie zal worden verzameld. Deze data zal ons helpen begrijpen hoe de mensen Citra gebruiken en onze inspanningen te prioriteren. Daarnaast zal het ons helpen makkelijker emulatiebugs en prestatieproblemen te identificeren. Onder deze data valt:&lt;ul&gt;&lt;li&gt;Informatie over de versie van Citra die je gebruikt&lt;/li&gt;&lt;li&gt;Prestatiedata over de spellen die je speelt&lt;/li&gt;&lt;li&gt;Je configuratieinstellingen&lt;/li&gt;&lt;li&gt;Informatie over je computerhardware&lt;/li&gt;&lt;li&gt;Emulatie errors en crashinformatie&lt;/li&gt;&lt;/ul&gt;Standaard is deze optie ingeschakeld. Om deze optie uit te schakelen, klik op &apos;Emulatie&apos; vanuit het menu en kies &apos;Configuratie...&apos;. Dan in de &apos;Web&apos; tab, deselecteer &apos;Deel anonieme gebruiksdata met het Citra team&apos;. &lt;br/&gt;&lt;br/&gt;Door deze software te gebruiker, ga je akkoord met de bovenstaande voorwaardes.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Leer meer&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="195"/>
+        <location filename="../../src/citra_qt/main.cpp" line="199"/>
         <source>Current emulation speed. Values higher or lower than 100% indicate emulation is running faster or slower than a 3DS.</source>
         <translation>Huidige emulatiesnelheid.  Waardes hoger of lager dan 100% geven aan dat de emulatie sneller of langzamer gaat dan een 3DS.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="198"/>
+        <location filename="../../src/citra_qt/main.cpp" line="202"/>
         <source>How many frames per second the game is currently displaying. This will vary from game to game and scene to scene.</source>
         <translation>Hoeveel frames per seconde het spel nu momenteel laat zien. Dit kan variëren van spel tot spel en scene tot scene.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="202"/>
+        <location filename="../../src/citra_qt/main.cpp" line="206"/>
         <source>Time taken to emulate a 3DS frame, not counting framelimiting or v-sync. For full-speed emulation this should be at most 16.67 ms.</source>
         <translation>Tijd verstrekt om één 3DS frame te emuleren, zonder framelimitatie of V-Sync te tellen. Voor volledige snelheid emulatie zal dit maximaal 16.67 ms moeten zijn.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="429"/>
+        <location filename="../../src/citra_qt/main.cpp" line="434"/>
         <source>CTRL+F</source>
         <translation>CTRL+F</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="538"/>
+        <location filename="../../src/citra_qt/main.cpp" line="543"/>
         <source>Update available!</source>
         <translation>Update beschikbaar!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="539"/>
+        <location filename="../../src/citra_qt/main.cpp" line="544"/>
         <source>An update for Citra is available. Do you wish to install it now?&lt;br /&gt;&lt;br /&gt;This &lt;b&gt;will&lt;/b&gt; terminate emulation, if it is running.</source>
         <translation>Een update voor Citra is beschikbaar. Wil je die nu installeren?&lt;br /&gt;&lt;br /&gt;Dit &lt;b&gt;zal&lt;/b&gt; de huidige emulatie stoppen, als deze bezig is.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <location filename="../../src/citra_qt/main.cpp" line="555"/>
         <source>No update found</source>
         <translation>Geen update gevonden</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <location filename="../../src/citra_qt/main.cpp" line="555"/>
         <source>No update has been found for Citra.</source>
         <translation>Geen update voor Citra is gevonden.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="567"/>
+        <location filename="../../src/citra_qt/main.cpp" line="572"/>
         <source>Error while initializing OpenGL 3.3 Core!</source>
         <translation>Fout bij het initialiseren van OpenGL 3.3 Core!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="568"/>
+        <location filename="../../src/citra_qt/main.cpp" line="573"/>
         <source>Your GPU may not support OpenGL 3.3, or you do not have the latest graphics driver.</source>
         <translation>Je GPU ondersteunt OpenGL 3.3 misschien niet, of je hebt niet de laatste grafische stuurprogramma&apos;s.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="581"/>
-        <location filename="../../src/citra_qt/main.cpp" line="587"/>
-        <location filename="../../src/citra_qt/main.cpp" line="593"/>
-        <location filename="../../src/citra_qt/main.cpp" line="606"/>
-        <location filename="../../src/citra_qt/main.cpp" line="625"/>
+        <location filename="../../src/citra_qt/main.cpp" line="586"/>
+        <location filename="../../src/citra_qt/main.cpp" line="592"/>
+        <location filename="../../src/citra_qt/main.cpp" line="598"/>
+        <location filename="../../src/citra_qt/main.cpp" line="611"/>
+        <location filename="../../src/citra_qt/main.cpp" line="630"/>
         <source>Error while loading ROM!</source>
         <translation>Fout tijdens het laden van de ROM!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="582"/>
-        <location filename="../../src/citra_qt/main.cpp" line="607"/>
+        <location filename="../../src/citra_qt/main.cpp" line="587"/>
+        <location filename="../../src/citra_qt/main.cpp" line="612"/>
         <source>The ROM format is not supported.</source>
         <translation>De ROM-formaat is niet ondersteund.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="588"/>
+        <location filename="../../src/citra_qt/main.cpp" line="593"/>
         <source>Could not determine the system mode.</source>
         <translation>Kon de systeemmodus niet vaststellen.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="594"/>
+        <location filename="../../src/citra_qt/main.cpp" line="599"/>
         <source>The game that you are trying to load must be decrypted before being used with Citra. A real 3DS is required.&lt;br/&gt;&lt;br/&gt;For more information on dumping and decrypting games, please see the following wiki pages: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</source>
         <translation>Het spel dat je probeert te laden moet eerst gedecodeerd worden voordat je het kan gebruiken met Citra. Een echte 3DS is vereist.&lt;br/&gt;&lt;br/&gt;Voor meer informatie over dumping en decoderen van spellen, zie de volgende wiki-pagina&apos;s: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="612"/>
+        <location filename="../../src/citra_qt/main.cpp" line="617"/>
         <source>An error occured in the video core.</source>
         <translation>Een fout in de video core is opgetreden.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="613"/>
+        <location filename="../../src/citra_qt/main.cpp" line="618"/>
         <source>Citra has encountered an error while running the video core, please see the log for more details.For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.Ensure that you have the latest graphics drivers for your GPU.</source>
         <translation>Citra heeft een fout aangetroffen tijdens het uitvoeren van de video core, raadpleeg het logboek voor meer informatie. Raadpleeg de volgende pagina voor meer informatie over het openen van het logboek: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;. Zorg dat je beschikt over de nieuwste grafische stuurprogramma&apos;s voor uw GPU.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="626"/>
+        <location filename="../../src/citra_qt/main.cpp" line="631"/>
         <source>An unknown error occured. Please see the log for more details.</source>
         <translation>Er is een onbekende fout opgetreden. Zie het logboek voor meer details.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="699"/>
+        <location filename="../../src/citra_qt/main.cpp" line="704"/>
         <source>Start</source>
         <translation>Start</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="790"/>
+        <location filename="../../src/citra_qt/main.cpp" line="795"/>
         <source>Error Opening %1 Folder</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="791"/>
+        <location filename="../../src/citra_qt/main.cpp" line="796"/>
         <source>Folder does not exist!</source>
         <translation>Map bestaat niet!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="805"/>
+        <location filename="../../src/citra_qt/main.cpp" line="810"/>
         <source>3DS Executable</source>
         <translation>3DS Executable</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="806"/>
-        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <location filename="../../src/citra_qt/main.cpp" line="811"/>
+        <location filename="../../src/citra_qt/main.cpp" line="833"/>
         <source>All Files (*.*)</source>
         <translation>Alle bestanden (*.*)</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="808"/>
+        <location filename="../../src/citra_qt/main.cpp" line="813"/>
         <source>Load File</source>
         <translation>Laad bestand</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="818"/>
+        <location filename="../../src/citra_qt/main.cpp" line="823"/>
         <source>Select Directory</source>
         <translation>Selecteer Folder</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="827"/>
+        <location filename="../../src/citra_qt/main.cpp" line="832"/>
         <source>Load Files</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <location filename="../../src/citra_qt/main.cpp" line="833"/>
         <source>3DS Installation File (*.CIA*)</source>
         <translation>3DS Installatie bestand (*.CIA*)</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="859"/>
+        <location filename="../../src/citra_qt/main.cpp" line="864"/>
         <source>%1 has been installed successfully.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="862"/>
+        <location filename="../../src/citra_qt/main.cpp" line="867"/>
         <source>Unable to open File</source>
         <translation>Kan bestand niet openen</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="863"/>
+        <location filename="../../src/citra_qt/main.cpp" line="868"/>
         <source>Could not open %1</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="867"/>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
         <source>Installation aborted</source>
         <translation>Installatie onderbroken</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="868"/>
+        <location filename="../../src/citra_qt/main.cpp" line="873"/>
         <source>The installation of %1 was aborted. Please see the log for more details</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <location filename="../../src/citra_qt/main.cpp" line="877"/>
         <source>Invalid File</source>
         <translation>Ongeldig bestand</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <location filename="../../src/citra_qt/main.cpp" line="877"/>
         <source>%1 is not a valid CIA</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="875"/>
+        <location filename="../../src/citra_qt/main.cpp" line="880"/>
         <source>Encrypted File</source>
         <translation>Versleuterd bestand</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="876"/>
+        <location filename="../../src/citra_qt/main.cpp" line="881"/>
         <source>%1 must be decrypted before being used with Citra. A real 3DS is required.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="899"/>
+        <location filename="../../src/citra_qt/main.cpp" line="904"/>
         <source>File not found</source>
         <translation>Bestand niet gevonden</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="900"/>
+        <location filename="../../src/citra_qt/main.cpp" line="905"/>
         <source>File &quot;%1&quot; not found</source>
         <translation>Bestand &quot;%1&quot; niet gevonden</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="914"/>
+        <location filename="../../src/citra_qt/main.cpp" line="919"/>
         <source>Continue</source>
         <translation>Doorgaan</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="939"/>
+        <location filename="../../src/citra_qt/main.cpp" line="944"/>
         <source>Missing Citra Account</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="940"/>
+        <location filename="../../src/citra_qt/main.cpp" line="945"/>
         <source>In order to submit a game compatibility test case, you must link your Citra account.&lt;br&gt;&lt;br/&gt;To link your Citra account, go to Emulation &amp;gt; Configuration &amp;gt; Web.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1090"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1095"/>
         <source>Speed: %1% / %2%</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1094"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1099"/>
         <source>Speed: %1%</source>
         <translation>Snelheid: %1%</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1096"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1101"/>
         <source>Game: %1 FPS</source>
         <translation>Spel: %1 FPS</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1097"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1102"/>
         <source>Frame: %1 ms</source>
         <translation>Frame: %1 ms</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1108"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1113"/>
         <source>The game you are trying to load requires additional files from your 3DS to be dumped before playing.&lt;br/&gt;&lt;br/&gt;For more information on dumping these files, please see the following wiki page: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
         <translation>Het spel dat je probeert te laden vereist dat er extra bestanden van uw 3DS worden gedumpt voordat je kan spelen.&lt;br/&gt;&lt;br/&gt;Voor meer informatie over dumping van deze bestanden, kijk dan naar de volgende wiki pagina: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Wil je afsluiten en terug gaan naar de lijst met spellen? Doorgaan met de emulatie kan crashes, beschadigde save data of andere bugs veroorzaken.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1120"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1125"/>
         <source>: %1. </source>
         <translation>: %1. </translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1126"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1131"/>
         <source>System Archive Not Found</source>
         <translation>Systeem archief niet gevonden</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1133"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1138"/>
         <source>Citra was unable to locate the 3DS shared fonts. </source>
         <translation>Citra was kon de locatie van de 3DS gedeelde fonts niet vinden.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1135"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1140"/>
         <source>Shared Fonts Not Found</source>
         <translation>Gedeelde Fonts Niet Gevonden</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1143"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1148"/>
         <source>Fatal Error</source>
         <translation>Fatale Fout</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1144"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1149"/>
         <source>Citra has encountered a fatal error, please see the log for more details. For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
         <translation>Citra heeft een fatale fout aangetroffen, raadpleeg het logboek voor meer informatie. Raadpleeg de volgende pagina voor meer informatie over het openen van het logboek: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Wil je afsluiten en terug gaan naar de lijst met spellen? Doorgaan met de emulatie kan crashes, beschadigde save data of andere bugs veroorzaken. </translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
-        <location filename="../../src/citra_qt/main.cpp" line="1245"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1183"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1250"/>
         <source>Citra</source>
         <translation>Citra</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1183"/>
         <source>Are you sure you want to close Citra?</source>
         <translation>Weet je zeker dat je Citra wilt afsluiten?</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1246"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1251"/>
         <source>Are you sure you want to stop the emulation? Any unsaved progress will be lost.</source>
         <translation>Weet je zeker dat je de emulatie wilt stoppen? Alle niet opgeslagen voortgang zal verloren gaan.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1318"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1323"/>
         <source>Citra %1| %2-%3</source>
         <translation>Citra %1| %2-%3</translation>
     </message>
@@ -1458,77 +1478,77 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GameList</name>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="117"/>
         <source>Perfect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="117"/>
         <source>Game functions flawless with no audio or graphical glitches, all tested functionality works as intended without
 any workarounds needed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="118"/>
         <source>Great</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="118"/>
         <source>Game functions with minor graphical or audio glitches and is playable from start to finish. May require some
 workarounds.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="119"/>
         <source>Okay</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="119"/>
         <source>Game functions with major graphical or audio glitches, but game is playable from start to finish with
 workarounds.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="120"/>
         <source>Bad</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="120"/>
         <source>Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches
 even with workarounds.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="121"/>
         <source>Intro/Menu</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="121"/>
         <source>Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start
 Screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="122"/>
         <source>Won&apos;t Boot</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="122"/>
         <source>The game crashes when attempting to startup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="123"/>
         <source>Not Tested</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="123"/>
         <source>The game has not yet been tested.</source>
         <translation type="unfinished"/>
     </message>
@@ -1558,17 +1578,17 @@ Screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="324"/>
+        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
         <source>Open Save Data Location</source>
         <translation>Open opslag data locatie</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
+        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
         <source>Open Application Location</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
+        <location filename="../../src/citra_qt/game_list.cpp" line="327"/>
         <source>Open Update Data Location</source>
         <translation type="unfinished"/>
     </message>
@@ -2001,47 +2021,42 @@ Screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="73"/>
         <source>Password Required to Join</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="74"/>
         <source>Password:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="77"/>
-        <source>Password</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="139"/>
         <source>Room Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="143"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="140"/>
         <source>Preferred Game</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="144"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="141"/>
         <source>Host</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="145"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
         <source>Players</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="153"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="150"/>
         <source>Refreshing</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="201"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="198"/>
         <source>Refresh List</source>
         <translation type="unfinished"/>
     </message>
@@ -2404,6 +2419,57 @@ Debug Message: </source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="201"/>
         <source>%1 is playing %2</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="208"/>
+        <source>Invalid region</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Japan</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>North America</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="92"/>
+        <source>Europe</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="94"/>
+        <source>Australia</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="96"/>
+        <source>China</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="98"/>
+        <source>Korea</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="100"/>
+        <source>Taiwan</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="102"/>
+        <source>Region free</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="104"/>
+        <source>Invalid Region</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/dist/languages/pt_BR.ts
+++ b/dist/languages/pt_BR.ts
@@ -154,17 +154,17 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ClientRoomWindow</name>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="54"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="55"/>
         <source>Connected</source>
         <translation>Conectado</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="65"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="63"/>
         <source>Disconnected</source>
         <translation>Desconectado</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="78"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="76"/>
         <source>%1 (%2/%3 members) - connected</source>
         <translation>%1 (%2/%3 membros) - conectado</translation>
     </message>
@@ -185,7 +185,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="36"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;Should you choose to submit a test case to the &lt;/span&gt;&lt;a href=&quot;https://citra-emu.org/game/&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;Citra Compatibility List&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;, The following information will be collected and displayed on the site:&lt;/span&gt;&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Hardware Information (CPU / GPU / Operating System)&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Which version of Citra you are running&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The connected Citra account&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;Ao enviar um caso de teste à&lt;/span&gt;&lt;a href=&quot;https://citra-emu.org/game/&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;lista de compatibilidade do Citra&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;, as seguintes informações serão coletadas e exibidas no site:&lt;/span&gt;&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Informações de hardware (CPU / GPU / sistema operacional)&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Qual versão do Citra você está usando&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A conta do Citra conectada&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;Ao enviar um caso de teste à&lt;/span&gt;&lt;a href=&quot;https://citra-emu.org/game/&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;Lista de compatibilidade do Citra&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;, as seguintes informações serão coletadas e exibidas no site:&lt;/span&gt;&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Informações de hardware (CPU / GPU / sistema operacional)&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Qual versão do Citra você está usando&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A conta do Citra conectada&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="72"/>
@@ -195,7 +195,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="79"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions flawlessly with no audio or graphical glitches.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;O jogo funciona perfeitamente sem falhas no áudio ou gráficos.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;O jogo funciona perfeitamente sem falhas no áudio ou nos gráficos.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="89"/>
@@ -245,7 +245,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="170"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The game crashes when attempting to startup.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;O jogo trava ou se encerra abruptamente ao tentar iniciá-lo.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;O jogo trava ou se encerra abruptamente ao tentar o iniciar.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="182"/>
@@ -312,6 +312,26 @@ p, li { white-space: pre-wrap; }
         <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="57"/>
         <source>Port:</source>
         <translation>Porta:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="78"/>
+        <source>Logging</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="86"/>
+        <source>Global Log Filter</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="100"/>
+        <source>Show Log Console (Windows Only)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="107"/>
+        <source>Open Log Location</source>
+        <translation type="unfinished"/>
     </message>
 </context>
 <context>
@@ -1100,12 +1120,12 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DirectConnectWindow</name>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="97"/>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="103"/>
         <source>Connecting</source>
         <translation>Conectando</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="102"/>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="108"/>
         <source>Connect</source>
         <translation>Conectar</translation>
     </message>
@@ -1113,290 +1133,290 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GMainWindow</name>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="90"/>
+        <location filename="../../src/citra_qt/main.cpp" line="92"/>
         <source>To help improve Citra, the Citra Team collects anonymous usage data. No private or personally identifying information is collected. This data helps us to understand how people use Citra and prioritize our efforts. Furthermore, it helps us to more easily identify emulation bugs and performance issues. This data includes:&lt;ul&gt;&lt;li&gt;Information about the version of Citra you are using&lt;/li&gt;&lt;li&gt;Performance data about the games you play&lt;/li&gt;&lt;li&gt;Your configuration settings&lt;/li&gt;&lt;li&gt;Information about your computer hardware&lt;/li&gt;&lt;li&gt;Emulation errors and crash information&lt;/li&gt;&lt;/ul&gt;By default, this feature is enabled. To disable this feature, click &apos;Emulation&apos; from the menu and then select &apos;Configure...&apos;. Then, on the &apos;Web&apos; tab, uncheck &apos;Share anonymous usage data with the Citra team&apos;. &lt;br/&gt;&lt;br/&gt;By using this software, you agree to the above terms.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
         <translation>Para ajudar a melhorar o Citra, a Equipe do Citra coleta anonimamente dados de uso. Nenhuma informação privada ou de identificação pessoal é coletada. Esses dados nos ajudam a entender como as pessoas utilizam o Citra e priorizar nossos esforços. Além disso, isso nos ajuda a identificar mais facilmente bugs de emulação e problemas de performance. Nesses dados incluem: &lt;ul&gt;&lt;li&gt;Informação sobre a versão do Citra que está utilizando&lt;/li&gt;&lt;li&gt;Dados de performance dos jogos que você joga&lt;/li&gt;&lt;li&gt;Sua configurações&lt;/li&gt;&lt;li&gt;Informação sobre hardware do computador&lt;/li&gt;&lt;li&gt;Erros de emulação e Informação de travamento&lt;/li&gt;&lt;/ul&gt;Por padrão, essa funcionalidade está ativa. Para desativar essa funcionalidade, clique &apos;Emulação&apos; no menu e então selecione &apos;Configurar...&apos;. Então, na aba &apos;Rede&apos; desmarque &apos;Compartilhar anonimamente dados de uso com a equipe do Citra&apos;.&lt;br/&gt;&lt;br/&gt;Ao usar este software você concorda com os termos acima.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Saiba mais&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="195"/>
+        <location filename="../../src/citra_qt/main.cpp" line="199"/>
         <source>Current emulation speed. Values higher or lower than 100% indicate emulation is running faster or slower than a 3DS.</source>
         <translation>Atual velocidade de emulação. Valores maiores ou menores que 100% indicam que a emulação está rodando mais rápida ou lentamente que um 3DS.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="198"/>
+        <location filename="../../src/citra_qt/main.cpp" line="202"/>
         <source>How many frames per second the game is currently displaying. This will vary from game to game and scene to scene.</source>
         <translation>Quantos quadros por segundo o jogo está atualmente mostrando. Isto vai variar de jogo para jogo e cena para cena.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="202"/>
+        <location filename="../../src/citra_qt/main.cpp" line="206"/>
         <source>Time taken to emulate a 3DS frame, not counting framelimiting or v-sync. For full-speed emulation this should be at most 16.67 ms.</source>
         <translation>Tempo levado para emular um quadro do 3DS, não contando o limitador de framerate ou o v-sync. Para emulação em velocidade total isso deve ser pelo menos 16.67 ms.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="429"/>
+        <location filename="../../src/citra_qt/main.cpp" line="434"/>
         <source>CTRL+F</source>
         <translation>CTRL+F</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="538"/>
+        <location filename="../../src/citra_qt/main.cpp" line="543"/>
         <source>Update available!</source>
         <translation>Atualização disponível!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="539"/>
+        <location filename="../../src/citra_qt/main.cpp" line="544"/>
         <source>An update for Citra is available. Do you wish to install it now?&lt;br /&gt;&lt;br /&gt;This &lt;b&gt;will&lt;/b&gt; terminate emulation, if it is running.</source>
         <translation>Uma atualização do Citra está disponível. Você gostaria de instalar agora?&lt;br /&gt;&lt;br /&gt;Isto&lt;b&gt;vai&lt;/b&gt;encerrar a emulação, se estiver rodando.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <location filename="../../src/citra_qt/main.cpp" line="555"/>
         <source>No update found</source>
         <translation>Nenhuma atualização encontrada</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <location filename="../../src/citra_qt/main.cpp" line="555"/>
         <source>No update has been found for Citra.</source>
         <translation>Nenhuma atualização foi encontrada para o Citra.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="567"/>
+        <location filename="../../src/citra_qt/main.cpp" line="572"/>
         <source>Error while initializing OpenGL 3.3 Core!</source>
         <translation>Erro ao inicializar núcleo de OpenGL 3.3!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="568"/>
+        <location filename="../../src/citra_qt/main.cpp" line="573"/>
         <source>Your GPU may not support OpenGL 3.3, or you do not have the latest graphics driver.</source>
         <translation>Sua placa de vídeo (GPU) pode não suportar OpenGL 3.3 ou você não tem a ultima versão do driver. </translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="581"/>
-        <location filename="../../src/citra_qt/main.cpp" line="587"/>
-        <location filename="../../src/citra_qt/main.cpp" line="593"/>
-        <location filename="../../src/citra_qt/main.cpp" line="606"/>
-        <location filename="../../src/citra_qt/main.cpp" line="625"/>
+        <location filename="../../src/citra_qt/main.cpp" line="586"/>
+        <location filename="../../src/citra_qt/main.cpp" line="592"/>
+        <location filename="../../src/citra_qt/main.cpp" line="598"/>
+        <location filename="../../src/citra_qt/main.cpp" line="611"/>
+        <location filename="../../src/citra_qt/main.cpp" line="630"/>
         <source>Error while loading ROM!</source>
         <translation>Erro ao carregar ROM!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="582"/>
-        <location filename="../../src/citra_qt/main.cpp" line="607"/>
+        <location filename="../../src/citra_qt/main.cpp" line="587"/>
+        <location filename="../../src/citra_qt/main.cpp" line="612"/>
         <source>The ROM format is not supported.</source>
         <translation>O formato da ROM não é suportado.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="588"/>
+        <location filename="../../src/citra_qt/main.cpp" line="593"/>
         <source>Could not determine the system mode.</source>
         <translation>Não conseguiu determinar o modo de sistema!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="594"/>
+        <location filename="../../src/citra_qt/main.cpp" line="599"/>
         <source>The game that you are trying to load must be decrypted before being used with Citra. A real 3DS is required.&lt;br/&gt;&lt;br/&gt;For more information on dumping and decrypting games, please see the following wiki pages: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</source>
         <translation>O jogo que você está tentando carregar deve ser descriptografado antes de ser utilizado no Citra. Um 3DS real é necessário. &lt;br/&gt;&lt;br/&gt;Para mais informações sobre extrair e descriptografar jogos, por favor veja as seguintes páginas da wiki: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Extraindo de Cartuchos de Jogos&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Extraindo Títulos Instalados&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="612"/>
+        <location filename="../../src/citra_qt/main.cpp" line="617"/>
         <source>An error occured in the video core.</source>
         <translation>Um erro ocorreu no núcleo de vídeo.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="613"/>
+        <location filename="../../src/citra_qt/main.cpp" line="618"/>
         <source>Citra has encountered an error while running the video core, please see the log for more details.For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.Ensure that you have the latest graphics drivers for your GPU.</source>
         <translation>Citra encontrou um erro ao rodar o núcleo de vídeo, por favor veja o log para mais detalhes. Para mais informações sobre acessar o log, por favor veja a seguinte página: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;Como enviar o arquivo de Log&lt;/a&gt;. Tenha certeza que você está utilizando os drivers atualizados de sua GPU.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="626"/>
+        <location filename="../../src/citra_qt/main.cpp" line="631"/>
         <source>An unknown error occured. Please see the log for more details.</source>
         <translation>Um erro desconhecido ocorreu. Por favor veja o log para mais detalhes.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="699"/>
+        <location filename="../../src/citra_qt/main.cpp" line="704"/>
         <source>Start</source>
         <translation>Iniciar</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="790"/>
+        <location filename="../../src/citra_qt/main.cpp" line="795"/>
         <source>Error Opening %1 Folder</source>
         <translation>Erro ao abrir a pasta %1</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="791"/>
+        <location filename="../../src/citra_qt/main.cpp" line="796"/>
         <source>Folder does not exist!</source>
         <translation>Pasta não existe!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="805"/>
+        <location filename="../../src/citra_qt/main.cpp" line="810"/>
         <source>3DS Executable</source>
         <translation>Executável 3DS</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="806"/>
-        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <location filename="../../src/citra_qt/main.cpp" line="811"/>
+        <location filename="../../src/citra_qt/main.cpp" line="833"/>
         <source>All Files (*.*)</source>
         <translation>Todos os arquivos (*.*)</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="808"/>
+        <location filename="../../src/citra_qt/main.cpp" line="813"/>
         <source>Load File</source>
         <translation>Carregar Arquivo</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="818"/>
+        <location filename="../../src/citra_qt/main.cpp" line="823"/>
         <source>Select Directory</source>
         <translation>Selecionar Diretório</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="827"/>
+        <location filename="../../src/citra_qt/main.cpp" line="832"/>
         <source>Load Files</source>
         <translation>Carregar Arquivos</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <location filename="../../src/citra_qt/main.cpp" line="833"/>
         <source>3DS Installation File (*.CIA*)</source>
         <translation>Arquivo de Instalação 3DS (*.CIA*)</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="859"/>
+        <location filename="../../src/citra_qt/main.cpp" line="864"/>
         <source>%1 has been installed successfully.</source>
         <translation>%1 foi instalado com sucesso.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="862"/>
+        <location filename="../../src/citra_qt/main.cpp" line="867"/>
         <source>Unable to open File</source>
         <translation>Não foi possível abrir o arquivo</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="863"/>
+        <location filename="../../src/citra_qt/main.cpp" line="868"/>
         <source>Could not open %1</source>
         <translation>Não foi possível abrir %1</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="867"/>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
         <source>Installation aborted</source>
         <translation>Instalação cancelada</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="868"/>
+        <location filename="../../src/citra_qt/main.cpp" line="873"/>
         <source>The installation of %1 was aborted. Please see the log for more details</source>
         <translation>A instalação de %1 foi abortada. Verifique o log para mais detalhes</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <location filename="../../src/citra_qt/main.cpp" line="877"/>
         <source>Invalid File</source>
         <translation>Arquivo inválido</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <location filename="../../src/citra_qt/main.cpp" line="877"/>
         <source>%1 is not a valid CIA</source>
         <translation>%1 não é um CIA válido</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="875"/>
+        <location filename="../../src/citra_qt/main.cpp" line="880"/>
         <source>Encrypted File</source>
         <translation>Arquivo criptografado</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="876"/>
+        <location filename="../../src/citra_qt/main.cpp" line="881"/>
         <source>%1 must be decrypted before being used with Citra. A real 3DS is required.</source>
         <translation>%1 deve ser decriptado antes de ser usado no Citra.
 É necessário um 3DS de verdade.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="899"/>
+        <location filename="../../src/citra_qt/main.cpp" line="904"/>
         <source>File not found</source>
         <translation>Arquivo não encontrado</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="900"/>
+        <location filename="../../src/citra_qt/main.cpp" line="905"/>
         <source>File &quot;%1&quot; not found</source>
         <translation>Arquivo &quot;%1&quot; não encontrado</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="914"/>
+        <location filename="../../src/citra_qt/main.cpp" line="919"/>
         <source>Continue</source>
         <translation>Continuar</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="939"/>
+        <location filename="../../src/citra_qt/main.cpp" line="944"/>
         <source>Missing Citra Account</source>
         <translation>Conta do Citra Faltando</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="940"/>
+        <location filename="../../src/citra_qt/main.cpp" line="945"/>
         <source>In order to submit a game compatibility test case, you must link your Citra account.&lt;br&gt;&lt;br/&gt;To link your Citra account, go to Emulation &amp;gt; Configuration &amp;gt; Web.</source>
         <translation>Para poder enviar um caso de teste de compatibilidade para um jogo, você precisa antes entrar com sua conta do Citra.&lt;br&gt;&lt;br/&gt;Para entrar usando sua conta do Citra, vá para Emulação &amp;gt; Configurar... &amp;gt; Rede.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1090"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1095"/>
         <source>Speed: %1% / %2%</source>
         <translation>Velocidade: %1% / %2%</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1094"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1099"/>
         <source>Speed: %1%</source>
         <translation>Velocidade: %1%</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1096"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1101"/>
         <source>Game: %1 FPS</source>
         <translation>Jogo: %1 FPS</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1097"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1102"/>
         <source>Frame: %1 ms</source>
         <translation>Quadro: %1 ms</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1108"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1113"/>
         <source>The game you are trying to load requires additional files from your 3DS to be dumped before playing.&lt;br/&gt;&lt;br/&gt;For more information on dumping these files, please see the following wiki page: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
         <translation>O jogo que você está tentando carregar requer arquivos adicionais de seu 3DS que precisam ser extraídos antes de jogar. &lt;br/&gt;&lt;br/&gt;Para mais informações sobre como extrair esses arquivos, por favor veja a seguinte página da wiki: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Extraindo Arquivos de Sistema e o Shared Fonts de um console 3DS&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Você gostaria de retornar a lista de jogos ? Continuar a emulação pode resultar em travamentos, dados salvos corruptos, ou outros bugs.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1120"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1125"/>
         <source>: %1. </source>
         <translation>: %1. </translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1126"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1131"/>
         <source>System Archive Not Found</source>
         <translation>Arquivo de Sistema não Encontrado</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1133"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1138"/>
         <source>Citra was unable to locate the 3DS shared fonts. </source>
         <translation>Citra não conseguiu localizar o shared fonts do 3DS. </translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1135"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1140"/>
         <source>Shared Fonts Not Found</source>
         <translation>Shared Fonts Não Encontrado</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1143"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1148"/>
         <source>Fatal Error</source>
         <translation>Erro Fatal</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1144"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1149"/>
         <source>Citra has encountered a fatal error, please see the log for more details. For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
         <translation>Citra encontrou um erro fatal, por favor veja o log para mais detalhes. Para mais informações para o acesso do log, por favor veja a seguinte página: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;Como enviar o arquivo Log&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt; Você gostaria de voltar para lista de jogos? Continuar a emulação pode resultar em travamentos, arquivos salvos corrompidos, ou outros bugs.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
-        <location filename="../../src/citra_qt/main.cpp" line="1245"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1183"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1250"/>
         <source>Citra</source>
         <translation>Citra</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1183"/>
         <source>Are you sure you want to close Citra?</source>
         <translation>Tem certeza que deseja encerrar o Citra?</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1246"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1251"/>
         <source>Are you sure you want to stop the emulation? Any unsaved progress will be lost.</source>
         <translation>Tem certeza que deseja parar a emulação ? Qualquer progresso não salvo será perdido.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1318"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1323"/>
         <source>Citra %1| %2-%3</source>
         <translation>Citra %1| %2-%3</translation>
     </message>
@@ -1459,82 +1479,82 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GameList</name>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="117"/>
         <source>Perfect</source>
         <translation>Perfeito</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="117"/>
         <source>Game functions flawless with no audio or graphical glitches, all tested functionality works as intended without
 any workarounds needed.</source>
         <translation>O jogo funciona impecavelmente, sem nenhum problema no áudio ou nos gráficos. Todos os recursos testados
 do jogo funcionam como deveriam, sem precisar de nenhuma solução alternativa.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="118"/>
         <source>Great</source>
         <translation>Ótimo</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="118"/>
         <source>Game functions with minor graphical or audio glitches and is playable from start to finish. May require some
 workarounds.</source>
         <translation>O jogo funciona com pequenos problemas nos gráficos ou no áudio e é jogável do início ao fim. Pode exigir
 algumas soluções alternativas.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="119"/>
         <source>Okay</source>
         <translation>Razoável</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="119"/>
         <source>Game functions with major graphical or audio glitches, but game is playable from start to finish with
 workarounds.</source>
         <translation>O jogo funciona com grandes problemas nos gráficos ou no áudio, mas é jogável do início ao fim com o uso
 de soluções alternativas.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="120"/>
         <source>Bad</source>
         <translation>Ruim</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="120"/>
         <source>Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches
 even with workarounds.</source>
         <translation>O jogo funciona, só que com problemas significativos nos gráficos ou no áudio. Não é possível progredir em áreas 
 específicas por conta de tais problemas, mesmo com soluções alternativas.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="121"/>
         <source>Intro/Menu</source>
         <translation>Intro/Menu</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="121"/>
         <source>Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start
 Screen.</source>
         <translation>É impossível jogar o jogo devido a grandes problemas nos gráficos ou no áudio. Não é possível passar da
 tela inicial do jogo.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="122"/>
         <source>Won&apos;t Boot</source>
         <translation>Não inicia</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="122"/>
         <source>The game crashes when attempting to startup.</source>
-        <translation>O jogo trava ou se encerra abruptamente ao tentar iniciá-lo.</translation>
+        <translation>O jogo trava ou se encerra abruptamente ao tentar o iniciar.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="123"/>
         <source>Not Tested</source>
         <translation>Não testado</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="123"/>
         <source>The game has not yet been tested.</source>
         <translation>O jogo ainda não foi testado.</translation>
     </message>
@@ -1564,17 +1584,17 @@ tela inicial do jogo.</translation>
         <translation>Digite o padrão para filtrar</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="324"/>
+        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
         <source>Open Save Data Location</source>
         <translation>Abrir Local dos Dados Salvos</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
+        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
         <source>Open Application Location</source>
         <translation>Abrir Local do Aplicativo</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
+        <location filename="../../src/citra_qt/game_list.cpp" line="327"/>
         <source>Open Update Data Location</source>
         <translation>Abrir Local dos Dados de Atualizações</translation>
     </message>
@@ -1999,7 +2019,7 @@ tela inicial do jogo.</translation>
     <message>
         <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="83"/>
         <source>Hide Full Rooms</source>
-        <translation type="unfinished"/>
+        <translation>Esconder salas cheias</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="103"/>
@@ -2007,47 +2027,42 @@ tela inicial do jogo.</translation>
         <translation>Atualizar Lobby</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="73"/>
         <source>Password Required to Join</source>
         <translation>É necessária uma senha para entrar</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="74"/>
         <source>Password:</source>
         <translation>Senha:</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="77"/>
-        <source>Password</source>
-        <translation>Senha</translation>
-    </message>
-    <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="139"/>
         <source>Room Name</source>
         <translation>Nome da Sala</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="143"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="140"/>
         <source>Preferred Game</source>
         <translation>Jogo Preferido</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="144"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="141"/>
         <source>Host</source>
         <translation>Host</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="145"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
         <source>Players</source>
         <translation>Jogadores</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="153"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="150"/>
         <source>Refreshing</source>
         <translation>Atualizando</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="201"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="198"/>
         <source>Refresh List</source>
         <translation>Atualizar Lista</translation>
     </message>
@@ -2202,7 +2217,7 @@ tela inicial do jogo.</translation>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="272"/>
         <source>Direct Connect to Room</source>
-        <translation>Conectar-se Diretamente a uma Sala</translation>
+        <translation>Conectar-se diretamente a uma Sala</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="280"/>
@@ -2368,7 +2383,7 @@ Mensagem para depuração: </translation>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="36"/>
         <source>Connection to room lost. Try to reconnect.</source>
-        <translation>A conexão com a sala foi perdida. Tente reconectar-se.</translation>
+        <translation>A conexão com a sala foi perdida. Tente se reconectar.</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="38"/>
@@ -2412,6 +2427,57 @@ Mensagem para depuração: </translation>
         <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="201"/>
         <source>%1 is playing %2</source>
         <translation>%1 está jogando %2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="208"/>
+        <source>Invalid region</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Japan</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>North America</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="92"/>
+        <source>Europe</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="94"/>
+        <source>Australia</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="96"/>
+        <source>China</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="98"/>
+        <source>Korea</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="100"/>
+        <source>Taiwan</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="102"/>
+        <source>Region free</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="104"/>
+        <source>Invalid Region</source>
+        <translation type="unfinished"/>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="26"/>

--- a/dist/languages/pt_BR.ts
+++ b/dist/languages/pt_BR.ts
@@ -1,0 +1,2757 @@
+<?xml version="1.0" ?><!DOCTYPE TS><TS language="pt_BR" version="2.1">
+<context>
+    <name>ARMRegisters</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="14"/>
+        <source>ARM Registers</source>
+        <translation>Registradores ARM</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="25"/>
+        <source>Register</source>
+        <translation>Registrador</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="30"/>
+        <source>Value</source>
+        <translation>Valor</translation>
+    </message>
+</context>
+<context>
+    <name>AboutDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="14"/>
+        <source>About Citra</source>
+        <translation>Sobre o Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="30"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/citra.png&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/citra.png&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="60"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:28pt;&quot;&gt;Citra&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:28pt;&quot;&gt;Citra&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="73"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="86"/>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:12pt;&quot;&gt;Citra is a free and open source 3DS emulator licensed under GPLv2.0 or any later version.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'MS Shell Dlg 2'; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;This software should not be used to play games you have not legally obtained.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;Citra é um emulador de 3DS livre e de código aberto sob licença GPLv2.0 ou qualquer versão posterior.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;Este programa não deve ser utilizado para jogar jogos que você não obteve legalmente.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="118"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Website&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://community.citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Forum&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Source Code&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Contributors&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/blob/master/license.txt&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;License&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Site&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://community.citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Fórum&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Código fonte&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Contribuidores&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/blob/master/license.txt&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Licença&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="134"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;&amp;quot;3DS&amp;quot; is a trademark of Nintendo. Citra is not affiliated with Nintendo in any way.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;&amp;quot;3DS&amp;quot; é uma marca da Nintendo. Citra não é afiliado com a Nintendo de nenhuma forma.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>BreakPointModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="34"/>
+        <source>Pica command loaded</source>
+        <translation>Comando Pica carregado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="35"/>
+        <source>Pica command processed</source>
+        <translation>Comando Pica processado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="36"/>
+        <source>Incoming primitive batch</source>
+        <translation>Recebendo Primitive batch</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="37"/>
+        <source>Finished primitive batch</source>
+        <translation>Primitive batch finalizado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="38"/>
+        <source>Vertex shader invocation</source>
+        <translation>Invocação de Vertex Shader</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="40"/>
+        <source>Incoming display transfer</source>
+        <translation>Transferência de display iminente</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="41"/>
+        <source>GSP command processed</source>
+        <translation>Comando GSP processado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="42"/>
+        <source>Buffers swapped</source>
+        <translation>Buffers trocados</translation>
+    </message>
+</context>
+<context>
+    <name>ChatRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="14"/>
+        <source>Room Window</source>
+        <translation>Janela da sala</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="40"/>
+        <source>Send Chat Message</source>
+        <translation>Enviar mensagem no chat</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="47"/>
+        <source>Send Message</source>
+        <translation>Enviar mensagem</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.cpp" line="81"/>
+        <source>Name</source>
+        <translation>Nome</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.cpp" line="82"/>
+        <source>Game</source>
+        <translation>Jogo</translation>
+    </message>
+</context>
+<context>
+    <name>ClientRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.ui" line="14"/>
+        <source>Room Window</source>
+        <translation>Janela da sala</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.ui" line="40"/>
+        <source>Leave Room</source>
+        <translation>Sair da sala</translation>
+    </message>
+</context>
+<context>
+    <name>ClientRoomWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="54"/>
+        <source>Connected</source>
+        <translation>Conectado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="65"/>
+        <source>Disconnected</source>
+        <translation>Desconectado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="78"/>
+        <source>%1 (%2/%3 members) - connected</source>
+        <translation>%1 (%2/%3 membros) - conectado</translation>
+    </message>
+</context>
+<context>
+    <name>CompatDB</name>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="20"/>
+        <source>Report Compatibility</source>
+        <translation>Informar compatibilidade</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="27"/>
+        <location filename="../../src/citra_qt/compatdb.ui" line="63"/>
+        <source>Report Game Compatibility</source>
+        <translation>Informar compatibilidade de jogo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="36"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;Should you choose to submit a test case to the &lt;/span&gt;&lt;a href=&quot;https://citra-emu.org/game/&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;Citra Compatibility List&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;, The following information will be collected and displayed on the site:&lt;/span&gt;&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Hardware Information (CPU / GPU / Operating System)&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Which version of Citra you are running&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The connected Citra account&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;Ao enviar um caso de teste à&lt;/span&gt;&lt;a href=&quot;https://citra-emu.org/game/&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;lista de compatibilidade do Citra&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;, as seguintes informações serão coletadas e exibidas no site:&lt;/span&gt;&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Informações de hardware (CPU / GPU / sistema operacional)&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Qual versão do Citra você está usando&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;A conta do Citra conectada&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="72"/>
+        <source>Perfect</source>
+        <translation>Perfeito</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="79"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions flawlessly with no audio or graphical glitches.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;O jogo funciona perfeitamente sem falhas no áudio ou gráficos.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="89"/>
+        <source>Great </source>
+        <translation>Ótimo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="96"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions with minor graphical or audio glitches and is playable from start to finish. May require some workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;O jogo funciona com pequenas falhas gráficas ou de áudio e é jogável do início ao fim. Pode exigir algumas soluções alternativas.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="106"/>
+        <source>Okay</source>
+        <translation>Razoável</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="113"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions with major graphical or audio glitches, but game is playable from start to finish with workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;O jogo funciona com grandes falhas gráficas ou de áudio, mas o jogo é jogável do início ao fim com soluções alternativas.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="123"/>
+        <source>Bad</source>
+        <translation>Ruim</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="130"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches even with workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;O jogo funciona, só que com problemas significativos nos gráficos ou no áudio. Não é possível progredir em áreas específicas por conta de tais problemas, mesmo com soluções alternativas.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="140"/>
+        <source>Intro/Menu</source>
+        <translation>Intro/Menu</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="147"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start Screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;É impossível jogar o jogo devido a grandes problemas nos gráficos ou no áudio. Não é possível passar da tela inicial do jogo.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="157"/>
+        <source>Won&apos;t Boot</source>
+        <translation>Não inicia</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="170"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The game crashes when attempting to startup.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;O jogo trava ou se encerra abruptamente ao tentar iniciá-lo.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="182"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Independent of speed or performance, how well does this game play from start to finish on this version of Citra?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Deixando de lado velocidade e desempenho, quão bem o jogo se comporta, do início ao fim, nesta versão do Citra?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="206"/>
+        <source>Thank you for your submission!</source>
+        <translation>Agradecemos pelo seu relatório!</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureAudio</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="10"/>
+        <source>Audio</source>
+        <translation>Áudio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="18"/>
+        <source>Output Engine:</source>
+        <translation>Engine de Saída:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="31"/>
+        <source>Enable audio stretching</source>
+        <translation>Habilitar alongamento de áudio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="34"/>
+        <source>This post-processing effect adjusts audio speed to match emulation speed and helps prevent audio stutter. This however increases audio latency.</source>
+        <translation>Este efeito de pós-processamento ajusta a velocidade do áudio para acompanhar a velocidade de emulação e ajuda prevenir cortes no áudio. Isso entretanto aumenta a latência do áudio.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="43"/>
+        <source>Audio Device:</source>
+        <translation>Dispositivo de Áudio:</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureDebug</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formulário</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="22"/>
+        <source>GDB</source>
+        <translation>GDB</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="28"/>
+        <source>The GDB Stub only works correctly when the CPU JIT is off.</source>
+        <translation>O GDB Stub funciona corretamente apenas quando o CPU JIT está desligado.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="37"/>
+        <source>Enable GDB Stub</source>
+        <translation>Ativar GDB Stub</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="57"/>
+        <source>Port:</source>
+        <translation>Porta:</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="14"/>
+        <source>Citra Configuration</source>
+        <translation>Configurações do Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="24"/>
+        <source>General</source>
+        <translation>Geral</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="29"/>
+        <source>System</source>
+        <translation>Sistema</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="34"/>
+        <source>Input</source>
+        <translation>Controle</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="39"/>
+        <source>Graphics</source>
+        <translation>Gráficos</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="44"/>
+        <source>Audio</source>
+        <translation>Áudio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="49"/>
+        <source>Debug</source>
+        <translation>Debug</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="54"/>
+        <source>Web</source>
+        <translation>Rede</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureGeneral</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formulário</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="22"/>
+        <source>General</source>
+        <translation>Geral</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="30"/>
+        <source>Confirm exit while emulation is running</source>
+        <translation>Confirmar saída quando a emulação estiver rodando</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="37"/>
+        <source>Search sub-directories for games</source>
+        <translation>Pesquisar por jogos em subdiretórios</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="46"/>
+        <source>Interface language</source>
+        <translation>Idioma da interface</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="63"/>
+        <source>Updates</source>
+        <translation>Atualizações</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="71"/>
+        <source>Check for updates on start</source>
+        <translation>Verificar atualizações ao iniciar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="78"/>
+        <source>Silently auto update after closing</source>
+        <translation>Atualizar silenciosamente ao fechar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="90"/>
+        <source>Performance</source>
+        <translation>Performance</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="98"/>
+        <source>Enable CPU JIT</source>
+        <translation>Habilitar CPU JIT</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="110"/>
+        <source>Emulation</source>
+        <translation>Emulação</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="120"/>
+        <source>Region:</source>
+        <translation>Região:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="128"/>
+        <source>Auto-select</source>
+        <translation>Seleção automática</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="178"/>
+        <source>Theme</source>
+        <translation>Tema</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="188"/>
+        <source>Theme:</source>
+        <translation>Tema:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="205"/>
+        <source>Hotkeys</source>
+        <translation>Teclas de atalho</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.cpp" line="16"/>
+        <source>&lt;System&gt;</source>
+        <translation>&lt;Sistema&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.cpp" line="17"/>
+        <source>English</source>
+        <translation>Inglês</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureGraphics</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formulário</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="22"/>
+        <source>Graphics</source>
+        <translation>Gráficos</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="28"/>
+        <source>Enable hardware renderer</source>
+        <translation>Habilitar hardware renderer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="35"/>
+        <source>Enable shader JIT</source>
+        <translation>Habilitar shader JIT</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="42"/>
+        <source>Enable V-Sync</source>
+        <translation>Habilitar V-Sync</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="51"/>
+        <source>Limit Speed Percent</source>
+        <translation>Limitar Porcentagem de Velocidade</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="58"/>
+        <source>%</source>
+        <translation>%</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="78"/>
+        <source>Internal Resolution:</source>
+        <translation>Resolução Interna</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="86"/>
+        <source>Auto (Window Size)</source>
+        <translation>Automática (Tamanho da Janela)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="91"/>
+        <source>Native (400x240)</source>
+        <translation>Nativa (400x240)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="96"/>
+        <source>2x Native (800x480)</source>
+        <translation>2x Nativa (800x480)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="101"/>
+        <source>3x Native (1200x720)</source>
+        <translation>3x Nativa (1200x720)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="106"/>
+        <source>4x Native (1600x960)</source>
+        <translation>4x Nativa (1600x960)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="111"/>
+        <source>5x Native (2000x1200)</source>
+        <translation>5x Nativa (2000x1200)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="116"/>
+        <source>6x Native (2400x1440)</source>
+        <translation>6x Nativa (2400x1440)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="121"/>
+        <source>7x Native (2800x1680)</source>
+        <translation>7x Nativa (2800x1680)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="126"/>
+        <source>8x Native (3200x1920)</source>
+        <translation>8x Nativa (3200x1920)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="131"/>
+        <source>9x Native (3600x2160)</source>
+        <translation>9x Nativa (3600x2160)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="136"/>
+        <source>10x Native (4000x2400)</source>
+        <translation>10x Nativa (4000x2400)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="151"/>
+        <source>Layout</source>
+        <translation>Layout</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="161"/>
+        <source>Screen Layout:</source>
+        <translation>Layout de tela:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="169"/>
+        <source>Default</source>
+        <translation>Padrão</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="174"/>
+        <source>Single Screen</source>
+        <translation>Tela única</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="179"/>
+        <source>Large Screen</source>
+        <translation>Tela grande</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="184"/>
+        <source>Side by Side</source>
+        <translation>Lado a lado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="194"/>
+        <source>Swap Screens</source>
+        <translation>Trocar Telas</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureInput</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="14"/>
+        <source>ConfigureInput</source>
+        <translation>Configurar controles</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="22"/>
+        <source>Face Buttons</source>
+        <translation>Botões frontais</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="36"/>
+        <source>A:</source>
+        <translation>A:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="54"/>
+        <source>B:</source>
+        <translation>B:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="72"/>
+        <source>X:</source>
+        <translation>X:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="90"/>
+        <source>Y:</source>
+        <translation>Y:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="109"/>
+        <source>Directional Pad</source>
+        <translation>Direcionais</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="123"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="340"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="427"/>
+        <source>Up:</source>
+        <translation>Cima:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="141"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="358"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="445"/>
+        <source>Down:</source>
+        <translation>Baixo:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="159"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="304"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="391"/>
+        <source>Left:</source>
+        <translation>Esquerda:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="177"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="322"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="409"/>
+        <source>Right:</source>
+        <translation>Direita:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="196"/>
+        <source>Shoulder Buttons</source>
+        <translation>Botões laterais</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="210"/>
+        <source>L:</source>
+        <translation>L:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="228"/>
+        <source>R:</source>
+        <translation>R:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="246"/>
+        <source>ZL:</source>
+        <translation>ZL:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="264"/>
+        <source>ZR:</source>
+        <translation>ZR:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="283"/>
+        <source>Circle Pad</source>
+        <translation>Circle Pad</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="295"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="461"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="232"/>
+        <source>Set Analog Stick</source>
+        <translation>Definir Analog Stick</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="377"/>
+        <source>C-Stick</source>
+        <translation>C-Stick</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="471"/>
+        <source>Misc.</source>
+        <translation>Misc.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="485"/>
+        <source>Start:</source>
+        <translation>Start:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="503"/>
+        <source>Select:</source>
+        <translation>Select:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="521"/>
+        <source>Home:</source>
+        <translation>Home:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="539"/>
+        <source>Circle Mod:</source>
+        <translation>Circle Mod:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="596"/>
+        <source>Restore Defaults</source>
+        <translation>Restaurar padrões</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="239"/>
+        <source>[press key]</source>
+        <translation>[pressione uma tecla]</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureSystem</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formulário</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="22"/>
+        <source>System Settings</source>
+        <translation>Configurações de Sistema</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="28"/>
+        <source>Username</source>
+        <translation>Usuário</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="48"/>
+        <source>Birthday</source>
+        <translation>Aniversário</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="58"/>
+        <source>January</source>
+        <translation>Janeiro</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="63"/>
+        <source>February</source>
+        <translation>Fevereiro</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="68"/>
+        <source>March</source>
+        <translation>Março</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="73"/>
+        <source>April</source>
+        <translation>Abril</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="78"/>
+        <source>May</source>
+        <translation>Maio</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="83"/>
+        <source>June</source>
+        <translation>Junho</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="88"/>
+        <source>July</source>
+        <translation>Julho</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="93"/>
+        <source>August</source>
+        <translation>Agosto</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="98"/>
+        <source>September</source>
+        <translation>Setembro</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="103"/>
+        <source>October</source>
+        <translation>Outubro</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="108"/>
+        <source>November</source>
+        <translation>Novembro</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="113"/>
+        <source>December</source>
+        <translation>Dezembro</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="126"/>
+        <source>Language</source>
+        <translation>Idioma</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="133"/>
+        <source>Note: this can be overridden when region setting is auto-select</source>
+        <translation>Nota: isso pode ser sobrescrito quando a configuração de região for seleção automática</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="137"/>
+        <source>Japanese (日本語)</source>
+        <translation>Japonês (日本語)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="142"/>
+        <source>English</source>
+        <translation>Inglês (English)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="147"/>
+        <source>French (français)</source>
+        <translation>Francês (français)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="152"/>
+        <source>German (Deutsch)</source>
+        <translation>Alemão (Deutsch)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="157"/>
+        <source>Italian (italiano)</source>
+        <translation>Italiano (italiano)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="162"/>
+        <source>Spanish (español)</source>
+        <translation>Espanhol (español)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="167"/>
+        <source>Simplified Chinese (简体中文)</source>
+        <translation>Chinês Simplificado (简体中文)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="172"/>
+        <source>Korean (한국어)</source>
+        <translation>Coreano (한국어)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="177"/>
+        <source>Dutch (Nederlands)</source>
+        <translation>Holandês (Nederlands)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="182"/>
+        <source>Portuguese (português)</source>
+        <translation>Português</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="187"/>
+        <source>Russian (Русский)</source>
+        <translation>Russo (Русский)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="192"/>
+        <source>Traditional Chinese (正體中文)</source>
+        <translation>Chinês Tradicional (正體中文)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="200"/>
+        <source>Sound output mode</source>
+        <translation>Modo de saída de som</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="208"/>
+        <source>Mono</source>
+        <translation>Mono</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="213"/>
+        <source>Stereo</source>
+        <translation>Estéreo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="218"/>
+        <source>Surround</source>
+        <translation>Surround</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="226"/>
+        <source>Console ID:</source>
+        <translation>ID do console:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="242"/>
+        <source>Regenerate</source>
+        <translation>Regerar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="252"/>
+        <source>System settings are available only when game is not running.</source>
+        <translation>Configurações de sistema estão disponíveis apenas quando o game não estiver rodando.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="87"/>
+        <source>Console ID: 0x%1</source>
+        <translation>ID do console: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="160"/>
+        <source>This will replace your current virtual 3DS with a new one. Your current virtual 3DS will not be recoverable. This might have unexpected effects in games. This might fail, if you use an outdated config savegame. Continue?</source>
+        <translation>Isso vai substituir seu atual 3DS virtual por um novo. Seu atual 3DS virtual não será recuperável. Isso pode causar efeitos inesperados em jogos. Isso pode falhar se você utilizar uma configuração de jogo salvo desatualizada. Continuar ?   </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="164"/>
+        <source>Warning</source>
+        <translation>Alerta</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureWeb</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formulário</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="22"/>
+        <source>Citra Web Service</source>
+        <translation>Citra Web Service</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="28"/>
+        <source>By providing your username and token, you agree to allow Citra to collect additional usage data, which may include user identifying information.</source>
+        <translation>Ao preencher seu usuário e token, você concorda em permitir ao Citra coletar dados de uso adicionais, que podem incluir informações de identificação de usuário.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="46"/>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="90"/>
+        <source>Verify</source>
+        <translation>Verificar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="53"/>
+        <source>Sign up</source>
+        <translation>Cadastrar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="67"/>
+        <source>Token: </source>
+        <translation>Token:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="78"/>
+        <source>Username: </source>
+        <translation>Usuário:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="99"/>
+        <source>What is my token?</source>
+        <translation>O que é meu token?</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="124"/>
+        <source>Telemetry</source>
+        <translation>Telemetria</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="130"/>
+        <source>Share anonymous usage data with the Citra team</source>
+        <translation>Compartilhar anonimamente dados de uso com a equipe do Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="137"/>
+        <source>Learn more</source>
+        <translation>Saiba mais</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="146"/>
+        <source>Telemetry ID:</source>
+        <translation>ID de Telemetria:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="162"/>
+        <source>Regenerate</source>
+        <translation>Regerar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="28"/>
+        <source>&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Saiba mais&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="33"/>
+        <source>&lt;a href=&apos;https://services.citra-emu.org/&apos;&gt;Sign up&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://services.citra-emu.org/&apos;&gt;Cadastrar-se&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="36"/>
+        <source>&lt;a href=&apos;https://citra-emu.org/wiki/citra-web-service/&apos;&gt;What is my token?&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://citra-emu.org/wiki/citra-web-service/&apos;&gt;O que é o meu token ?&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="45"/>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="65"/>
+        <source>Telemetry ID: 0x%1</source>
+        <translation>ID de Telemetria: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="55"/>
+        <source>Username and token not verified</source>
+        <translation>Nome de usuário e token não verificados</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="56"/>
+        <source>Username and token were not verified. The changes to your username and/or token have not been saved.</source>
+        <translation>Usuário e token não foram verificados. As mudanças de seu usuário e/ou token não foram salvas.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="85"/>
+        <source>Verifying</source>
+        <translation>Verificando</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="99"/>
+        <source>Verification failed</source>
+        <translation>Verificação falhou</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="100"/>
+        <source>Verification failed. Check that you have entered your username and token correctly, and that your internet connection is working.</source>
+        <translation>A verificação falhou. Verifique se você colocou seu usuário e token corretamente, e se sua conexão com a internet está funcionando.</translation>
+    </message>
+</context>
+<context>
+    <name>DirectConnect</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="14"/>
+        <source>Direct Connect</source>
+        <translation>Conectar-se Diretamente</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="33"/>
+        <source>IP Address</source>
+        <translation>Endereço IP</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="56"/>
+        <source>IP</source>
+        <translation>IP</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="63"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;IPv4 address of the host&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Endereço IPv4 do host&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="73"/>
+        <source>Port</source>
+        <translation>Porta</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="80"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Port number the host is listening on&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;O número da porta que o host está escutando&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="86"/>
+        <source>24872</source>
+        <translation>24872</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="100"/>
+        <source>Nickname</source>
+        <translation>Apelido</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="114"/>
+        <source>Password</source>
+        <translation>Senha</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="156"/>
+        <source>Connect</source>
+        <translation>Conectar</translation>
+    </message>
+</context>
+<context>
+    <name>DirectConnectWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="97"/>
+        <source>Connecting</source>
+        <translation>Conectando</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="102"/>
+        <source>Connect</source>
+        <translation>Conectar</translation>
+    </message>
+</context>
+<context>
+    <name>GMainWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="90"/>
+        <source>To help improve Citra, the Citra Team collects anonymous usage data. No private or personally identifying information is collected. This data helps us to understand how people use Citra and prioritize our efforts. Furthermore, it helps us to more easily identify emulation bugs and performance issues. This data includes:&lt;ul&gt;&lt;li&gt;Information about the version of Citra you are using&lt;/li&gt;&lt;li&gt;Performance data about the games you play&lt;/li&gt;&lt;li&gt;Your configuration settings&lt;/li&gt;&lt;li&gt;Information about your computer hardware&lt;/li&gt;&lt;li&gt;Emulation errors and crash information&lt;/li&gt;&lt;/ul&gt;By default, this feature is enabled. To disable this feature, click &apos;Emulation&apos; from the menu and then select &apos;Configure...&apos;. Then, on the &apos;Web&apos; tab, uncheck &apos;Share anonymous usage data with the Citra team&apos;. &lt;br/&gt;&lt;br/&gt;By using this software, you agree to the above terms.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Para ajudar a melhorar o Citra, a Equipe do Citra coleta anonimamente dados de uso. Nenhuma informação privada ou de identificação pessoal é coletada. Esses dados nos ajudam a entender como as pessoas utilizam o Citra e priorizar nossos esforços. Além disso, isso nos ajuda a identificar mais facilmente bugs de emulação e problemas de performance. Nesses dados incluem: &lt;ul&gt;&lt;li&gt;Informação sobre a versão do Citra que está utilizando&lt;/li&gt;&lt;li&gt;Dados de performance dos jogos que você joga&lt;/li&gt;&lt;li&gt;Sua configurações&lt;/li&gt;&lt;li&gt;Informação sobre hardware do computador&lt;/li&gt;&lt;li&gt;Erros de emulação e Informação de travamento&lt;/li&gt;&lt;/ul&gt;Por padrão, essa funcionalidade está ativa. Para desativar essa funcionalidade, clique &apos;Emulação&apos; no menu e então selecione &apos;Configurar...&apos;. Então, na aba &apos;Rede&apos; desmarque &apos;Compartilhar anonimamente dados de uso com a equipe do Citra&apos;.&lt;br/&gt;&lt;br/&gt;Ao usar este software você concorda com os termos acima.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Saiba mais&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="195"/>
+        <source>Current emulation speed. Values higher or lower than 100% indicate emulation is running faster or slower than a 3DS.</source>
+        <translation>Atual velocidade de emulação. Valores maiores ou menores que 100% indicam que a emulação está rodando mais rápida ou lentamente que um 3DS.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="198"/>
+        <source>How many frames per second the game is currently displaying. This will vary from game to game and scene to scene.</source>
+        <translation>Quantos quadros por segundo o jogo está atualmente mostrando. Isto vai variar de jogo para jogo e cena para cena.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="202"/>
+        <source>Time taken to emulate a 3DS frame, not counting framelimiting or v-sync. For full-speed emulation this should be at most 16.67 ms.</source>
+        <translation>Tempo levado para emular um quadro do 3DS, não contando o limitador de framerate ou o v-sync. Para emulação em velocidade total isso deve ser pelo menos 16.67 ms.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="429"/>
+        <source>CTRL+F</source>
+        <translation>CTRL+F</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="538"/>
+        <source>Update available!</source>
+        <translation>Atualização disponível!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="539"/>
+        <source>An update for Citra is available. Do you wish to install it now?&lt;br /&gt;&lt;br /&gt;This &lt;b&gt;will&lt;/b&gt; terminate emulation, if it is running.</source>
+        <translation>Uma atualização do Citra está disponível. Você gostaria de instalar agora?&lt;br /&gt;&lt;br /&gt;Isto&lt;b&gt;vai&lt;/b&gt;encerrar a emulação, se estiver rodando.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <source>No update found</source>
+        <translation>Nenhuma atualização encontrada</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <source>No update has been found for Citra.</source>
+        <translation>Nenhuma atualização foi encontrada para o Citra.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="567"/>
+        <source>Error while initializing OpenGL 3.3 Core!</source>
+        <translation>Erro ao inicializar núcleo de OpenGL 3.3!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="568"/>
+        <source>Your GPU may not support OpenGL 3.3, or you do not have the latest graphics driver.</source>
+        <translation>Sua placa de vídeo (GPU) pode não suportar OpenGL 3.3 ou você não tem a ultima versão do driver. </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="581"/>
+        <location filename="../../src/citra_qt/main.cpp" line="587"/>
+        <location filename="../../src/citra_qt/main.cpp" line="593"/>
+        <location filename="../../src/citra_qt/main.cpp" line="606"/>
+        <location filename="../../src/citra_qt/main.cpp" line="625"/>
+        <source>Error while loading ROM!</source>
+        <translation>Erro ao carregar ROM!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="582"/>
+        <location filename="../../src/citra_qt/main.cpp" line="607"/>
+        <source>The ROM format is not supported.</source>
+        <translation>O formato da ROM não é suportado.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="588"/>
+        <source>Could not determine the system mode.</source>
+        <translation>Não conseguiu determinar o modo de sistema!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="594"/>
+        <source>The game that you are trying to load must be decrypted before being used with Citra. A real 3DS is required.&lt;br/&gt;&lt;br/&gt;For more information on dumping and decrypting games, please see the following wiki pages: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation>O jogo que você está tentando carregar deve ser descriptografado antes de ser utilizado no Citra. Um 3DS real é necessário. &lt;br/&gt;&lt;br/&gt;Para mais informações sobre extrair e descriptografar jogos, por favor veja as seguintes páginas da wiki: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Extraindo de Cartuchos de Jogos&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Extraindo Títulos Instalados&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="612"/>
+        <source>An error occured in the video core.</source>
+        <translation>Um erro ocorreu no núcleo de vídeo.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="613"/>
+        <source>Citra has encountered an error while running the video core, please see the log for more details.For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.Ensure that you have the latest graphics drivers for your GPU.</source>
+        <translation>Citra encontrou um erro ao rodar o núcleo de vídeo, por favor veja o log para mais detalhes. Para mais informações sobre acessar o log, por favor veja a seguinte página: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;Como enviar o arquivo de Log&lt;/a&gt;. Tenha certeza que você está utilizando os drivers atualizados de sua GPU.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="626"/>
+        <source>An unknown error occured. Please see the log for more details.</source>
+        <translation>Um erro desconhecido ocorreu. Por favor veja o log para mais detalhes.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="699"/>
+        <source>Start</source>
+        <translation>Iniciar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="790"/>
+        <source>Error Opening %1 Folder</source>
+        <translation>Erro ao abrir a pasta %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="791"/>
+        <source>Folder does not exist!</source>
+        <translation>Pasta não existe!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="805"/>
+        <source>3DS Executable</source>
+        <translation>Executável 3DS</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="806"/>
+        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <source>All Files (*.*)</source>
+        <translation>Todos os arquivos (*.*)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="808"/>
+        <source>Load File</source>
+        <translation>Carregar Arquivo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="818"/>
+        <source>Select Directory</source>
+        <translation>Selecionar Diretório</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="827"/>
+        <source>Load Files</source>
+        <translation>Carregar Arquivos</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <source>3DS Installation File (*.CIA*)</source>
+        <translation>Arquivo de Instalação 3DS (*.CIA*)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="859"/>
+        <source>%1 has been installed successfully.</source>
+        <translation>%1 foi instalado com sucesso.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="862"/>
+        <source>Unable to open File</source>
+        <translation>Não foi possível abrir o arquivo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="863"/>
+        <source>Could not open %1</source>
+        <translation>Não foi possível abrir %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="867"/>
+        <source>Installation aborted</source>
+        <translation>Instalação cancelada</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="868"/>
+        <source>The installation of %1 was aborted. Please see the log for more details</source>
+        <translation>A instalação de %1 foi abortada. Verifique o log para mais detalhes</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <source>Invalid File</source>
+        <translation>Arquivo inválido</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <source>%1 is not a valid CIA</source>
+        <translation>%1 não é um CIA válido</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="875"/>
+        <source>Encrypted File</source>
+        <translation>Arquivo criptografado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="876"/>
+        <source>%1 must be decrypted before being used with Citra. A real 3DS is required.</source>
+        <translation>%1 deve ser decriptado antes de ser usado no Citra.
+É necessário um 3DS de verdade.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="899"/>
+        <source>File not found</source>
+        <translation>Arquivo não encontrado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="900"/>
+        <source>File &quot;%1&quot; not found</source>
+        <translation>Arquivo &quot;%1&quot; não encontrado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="914"/>
+        <source>Continue</source>
+        <translation>Continuar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="939"/>
+        <source>Missing Citra Account</source>
+        <translation>Conta do Citra Faltando</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="940"/>
+        <source>In order to submit a game compatibility test case, you must link your Citra account.&lt;br&gt;&lt;br/&gt;To link your Citra account, go to Emulation &amp;gt; Configuration &amp;gt; Web.</source>
+        <translation>Para poder enviar um caso de teste de compatibilidade para um jogo, você precisa antes entrar com sua conta do Citra.&lt;br&gt;&lt;br/&gt;Para entrar usando sua conta do Citra, vá para Emulação &amp;gt; Configurar... &amp;gt; Rede.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1090"/>
+        <source>Speed: %1% / %2%</source>
+        <translation>Velocidade: %1% / %2%</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1094"/>
+        <source>Speed: %1%</source>
+        <translation>Velocidade: %1%</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1096"/>
+        <source>Game: %1 FPS</source>
+        <translation>Jogo: %1 FPS</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1097"/>
+        <source>Frame: %1 ms</source>
+        <translation>Quadro: %1 ms</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1108"/>
+        <source>The game you are trying to load requires additional files from your 3DS to be dumped before playing.&lt;br/&gt;&lt;br/&gt;For more information on dumping these files, please see the following wiki page: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
+        <translation>O jogo que você está tentando carregar requer arquivos adicionais de seu 3DS que precisam ser extraídos antes de jogar. &lt;br/&gt;&lt;br/&gt;Para mais informações sobre como extrair esses arquivos, por favor veja a seguinte página da wiki: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Extraindo Arquivos de Sistema e o Shared Fonts de um console 3DS&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Você gostaria de retornar a lista de jogos ? Continuar a emulação pode resultar em travamentos, dados salvos corruptos, ou outros bugs.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1120"/>
+        <source>: %1. </source>
+        <translation>: %1. </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1126"/>
+        <source>System Archive Not Found</source>
+        <translation>Arquivo de Sistema não Encontrado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1133"/>
+        <source>Citra was unable to locate the 3DS shared fonts. </source>
+        <translation>Citra não conseguiu localizar o shared fonts do 3DS. </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1135"/>
+        <source>Shared Fonts Not Found</source>
+        <translation>Shared Fonts Não Encontrado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1143"/>
+        <source>Fatal Error</source>
+        <translation>Erro Fatal</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1144"/>
+        <source>Citra has encountered a fatal error, please see the log for more details. For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
+        <translation>Citra encontrou um erro fatal, por favor veja o log para mais detalhes. Para mais informações para o acesso do log, por favor veja a seguinte página: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;Como enviar o arquivo Log&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt; Você gostaria de voltar para lista de jogos? Continuar a emulação pode resultar em travamentos, arquivos salvos corrompidos, ou outros bugs.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1245"/>
+        <source>Citra</source>
+        <translation>Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <source>Are you sure you want to close Citra?</source>
+        <translation>Tem certeza que deseja encerrar o Citra?</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1246"/>
+        <source>Are you sure you want to stop the emulation? Any unsaved progress will be lost.</source>
+        <translation>Tem certeza que deseja parar a emulação ? Qualquer progresso não salvo será perdido.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1318"/>
+        <source>Citra %1| %2-%3</source>
+        <translation>Citra %1| %2-%3</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandListModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="96"/>
+        <source>Command Name</source>
+        <translation>Nome do Comando</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="98"/>
+        <source>Register</source>
+        <translation>Registrador</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="100"/>
+        <source>Mask</source>
+        <translation>Máscara</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="102"/>
+        <source>New Value</source>
+        <translation>Novo Valor</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandListWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="184"/>
+        <source>Pica Command List</source>
+        <translation>Lista de Comandos Pica</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="202"/>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="233"/>
+        <source>Start Tracing</source>
+        <translation>Iniciar Tracing</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="203"/>
+        <source>Copy All</source>
+        <translation>Copiar todos</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="229"/>
+        <source>Finish Tracing</source>
+        <translation>Finalizar Tracing</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandStreamWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics.cpp" line="67"/>
+        <source>Graphics Debugger</source>
+        <translation>Debugger Gráfico</translation>
+    </message>
+</context>
+<context>
+    <name>GameList</name>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <source>Perfect</source>
+        <translation>Perfeito</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <source>Game functions flawless with no audio or graphical glitches, all tested functionality works as intended without
+any workarounds needed.</source>
+        <translation>O jogo funciona impecavelmente, sem nenhum problema no áudio ou nos gráficos. Todos os recursos testados
+do jogo funcionam como deveriam, sem precisar de nenhuma solução alternativa.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <source>Great</source>
+        <translation>Ótimo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <source>Game functions with minor graphical or audio glitches and is playable from start to finish. May require some
+workarounds.</source>
+        <translation>O jogo funciona com pequenos problemas nos gráficos ou no áudio e é jogável do início ao fim. Pode exigir
+algumas soluções alternativas.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <source>Okay</source>
+        <translation>Razoável</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <source>Game functions with major graphical or audio glitches, but game is playable from start to finish with
+workarounds.</source>
+        <translation>O jogo funciona com grandes problemas nos gráficos ou no áudio, mas é jogável do início ao fim com o uso
+de soluções alternativas.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Bad</source>
+        <translation>Ruim</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches
+even with workarounds.</source>
+        <translation>O jogo funciona, só que com problemas significativos nos gráficos ou no áudio. Não é possível progredir em áreas 
+específicas por conta de tais problemas, mesmo com soluções alternativas.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <source>Intro/Menu</source>
+        <translation>Intro/Menu</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <source>Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start
+Screen.</source>
+        <translation>É impossível jogar o jogo devido a grandes problemas nos gráficos ou no áudio. Não é possível passar da
+tela inicial do jogo.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>Won&apos;t Boot</source>
+        <translation>Não inicia</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>The game crashes when attempting to startup.</source>
+        <translation>O jogo trava ou se encerra abruptamente ao tentar iniciá-lo.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <source>Not Tested</source>
+        <translation>Não testado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <source>The game has not yet been tested.</source>
+        <translation>O jogo ainda não foi testado.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="99"/>
+        <source>of</source>
+        <translation>de</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="102"/>
+        <source>result</source>
+        <translation>resultado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="104"/>
+        <source>results</source>
+        <translation>resultados</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="125"/>
+        <source>Filter:</source>
+        <translation>Filtro:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="128"/>
+        <source>Enter pattern to filter</source>
+        <translation>Digite o padrão para filtrar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="324"/>
+        <source>Open Save Data Location</source>
+        <translation>Abrir Local dos Dados Salvos</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
+        <source>Open Application Location</source>
+        <translation>Abrir Local do Aplicativo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
+        <source>Open Update Data Location</source>
+        <translation>Abrir Local dos Dados de Atualizações</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsBreakPointsWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="132"/>
+        <source>Pica Breakpoints</source>
+        <translation>Pica Breakpoints</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="136"/>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="198"/>
+        <source>Emulation running</source>
+        <translation>Emulação rodando</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="137"/>
+        <source>Resume</source>
+        <translation>Retomar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="188"/>
+        <source>Emulation halted at breakpoint</source>
+        <translation>Emulação interrompida no breakpoint</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsSurfaceWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="49"/>
+        <source>Pica Surface Viewer</source>
+        <translation>Visualizador de Superfície Pica</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="54"/>
+        <source>Color Buffer</source>
+        <translation>Buffer de Cor</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="55"/>
+        <source>Depth Buffer</source>
+        <translation>Buffer de Profundidade</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="56"/>
+        <source>Stencil Buffer</source>
+        <translation>Stencil Buffer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="57"/>
+        <source>Texture 0</source>
+        <translation>Textura 0</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="58"/>
+        <source>Texture 1</source>
+        <translation>Textura 1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="59"/>
+        <source>Texture 2</source>
+        <translation>Textura 2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="60"/>
+        <source>Custom</source>
+        <translation>Personalizado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="103"/>
+        <source>Unknown</source>
+        <translation>Desconhecido</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="118"/>
+        <source>Save</source>
+        <translation>Salvar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="144"/>
+        <source>Source:</source>
+        <translation>Fonte:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="150"/>
+        <source>Physical Address:</source>
+        <translation>Endereço físico:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="156"/>
+        <source>Width:</source>
+        <translation>Largura:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="162"/>
+        <source>Height:</source>
+        <translation>Altura:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="168"/>
+        <source>Format:</source>
+        <translation>Formato:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="180"/>
+        <source>X:</source>
+        <translation>X:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="186"/>
+        <source>Y:</source>
+        <translation>Y:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="280"/>
+        <source>Pixel out of bounds</source>
+        <translation>Pixel fora dos limites</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="287"/>
+        <source>(unable to access pixel data)</source>
+        <translation>(incapaz de acessar dado de pixel)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="555"/>
+        <source>(invalid surface address)</source>
+        <translation>(endereço inválido de superfície)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="565"/>
+        <source>(unknown surface format)</source>
+        <translation>(formato de superfície desconhecido)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="658"/>
+        <source>Portable Network Graphic (*.png)</source>
+        <translation>Portable Network Graphic (*.png)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="659"/>
+        <source>Binary data (*.bin)</source>
+        <translation>Dado binário (*.bin)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="663"/>
+        <source>Save Surface</source>
+        <translation>Salvar Superfície</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsTracingWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="25"/>
+        <source>CiTrace Recorder</source>
+        <translation>Gravador CiTrace</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="29"/>
+        <source>Start Recording</source>
+        <translation>Iniciar Gravação</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="31"/>
+        <source>Stop and Save</source>
+        <translation>Parar e Salvar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="32"/>
+        <source>Abort Recording</source>
+        <translation>Interromper Gravação</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="112"/>
+        <source>Save CiTrace</source>
+        <translation>Salvar CiTrace</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="113"/>
+        <source>CiTrace File (*.ctf)</source>
+        <translation>Arquivo CiTrace (*.ctf)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="162"/>
+        <source>CiTracing still active</source>
+        <translation>CiTracing ainda ativo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="163"/>
+        <source>A CiTrace is still being recorded. Do you want to save it? If not, all recorded data will be discarded.</source>
+        <translation>Um CiTrace ainda está sendo gravado. Deseja salva-lo ? Se não, todos os dados gravados serão descartados.</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsVertexShaderModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="45"/>
+        <source>Offset</source>
+        <translation>Offset</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="47"/>
+        <source>Raw</source>
+        <translation>Raw</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="49"/>
+        <source>Disassembly</source>
+        <translation>Disassembly</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsVertexShaderWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="345"/>
+        <source>Save Shader Dump</source>
+        <translation>Salvar Extração de Shader</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="345"/>
+        <source>Shader Binary (*.shbin)</source>
+        <translation>Shader Binary (*.shbin)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="380"/>
+        <source>(data only available at vertex shader invocation breakpoints)</source>
+        <translation>(dados apenas disponíveis nos breakpoints de invocação do vertex shader)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="390"/>
+        <source>Dump</source>
+        <translation>Extração</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="412"/>
+        <source>Input Data</source>
+        <translation>Dado de Entrada</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="426"/>
+        <source>Attribute %1</source>
+        <translation>Atributo %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="453"/>
+        <source>Cycle Index:</source>
+        <translation>Índice Cíclico:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="558"/>
+        <source>SRC1: %1, %2, %3, %4
+</source>
+        <translation>SRC1: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="564"/>
+        <source>SRC2: %1, %2, %3, %4
+</source>
+        <translation>SRC2: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="570"/>
+        <source>SRC3: %1, %2, %3, %4
+</source>
+        <translation>SRC3: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="576"/>
+        <source>DEST_IN: %1, %2, %3, %4
+</source>
+        <translation>DEST_IN: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="582"/>
+        <source>DEST_OUT: %1, %2, %3, %4
+</source>
+        <translation>DEST_OUT: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="589"/>
+        <source>Address Registers: %1, %2
+</source>
+        <translation>Registradores de Endereço: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="593"/>
+        <source>Compare Result: %1, %2
+</source>
+        <translation>Comparar Resultado: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="598"/>
+        <source>Static Condition: %1
+</source>
+        <translation>Condição Estática: %1
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="600"/>
+        <source>Dynamic Conditions: %1, %2
+</source>
+        <translation>Condições Dinâmicas: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="604"/>
+        <source>Loop Parameters: %1 (repeats), %2 (initializer), %3 (increment), %4
+</source>
+        <translation>Parametros de loop: %1 (repetições), %2 (inicializador), %3 (incremento), %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="611"/>
+        <source>Instruction offset: 0x%1</source>
+        <translation>Offset de instrução: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="613"/>
+        <source> -&gt; 0x%2</source>
+        <translation> -&gt; 0x%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="615"/>
+        <source> (last instruction)</source>
+        <translation>(última instrução)</translation>
+    </message>
+</context>
+<context>
+    <name>HostRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="14"/>
+        <source>Create Room</source>
+        <translation>Criar Sala</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="37"/>
+        <source>Room Name</source>
+        <translation>Nome da Sala</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="51"/>
+        <source>Preferred Game</source>
+        <translation>Jogo Preferido</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="61"/>
+        <source>Max Players</source>
+        <translation>Máximo de Jogadores</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="91"/>
+        <source>Username</source>
+        <translation>Nome de Usuário</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="101"/>
+        <source>(Leave blank for open game)</source>
+        <translation>(Deixe em branco para deixar a sala aberta)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="118"/>
+        <source>Password</source>
+        <translation>Senha</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="125"/>
+        <source>Port</source>
+        <translation>Porta</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="156"/>
+        <source>Public</source>
+        <translation>Pública</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="161"/>
+        <source>Unlisted</source>
+        <translation>Não Listada</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="169"/>
+        <source>Host Room</source>
+        <translation>Hospedar Sala</translation>
+    </message>
+</context>
+<context>
+    <name>Lobby</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="14"/>
+        <source>Public Room Browser</source>
+        <translation>Navegador de Salas Públicas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="32"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="39"/>
+        <source>Nickname</source>
+        <translation>Apelido</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="59"/>
+        <source>Filters</source>
+        <translation>Filtros</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="66"/>
+        <source>Search</source>
+        <translation>Busca</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="76"/>
+        <source>Games I Own</source>
+        <translation>Jogos que eu tenho</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="83"/>
+        <source>Hide Full Rooms</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="103"/>
+        <source>Refresh Lobby</source>
+        <translation>Atualizar Lobby</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <source>Password Required to Join</source>
+        <translation>É necessária uma senha para entrar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <source>Password:</source>
+        <translation>Senha:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="77"/>
+        <source>Password</source>
+        <translation>Senha</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
+        <source>Room Name</source>
+        <translation>Nome da Sala</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="143"/>
+        <source>Preferred Game</source>
+        <translation>Jogo Preferido</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="144"/>
+        <source>Host</source>
+        <translation>Host</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="145"/>
+        <source>Players</source>
+        <translation>Jogadores</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="153"/>
+        <source>Refreshing</source>
+        <translation>Atualizando</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="201"/>
+        <source>Refresh List</source>
+        <translation>Atualizar Lista</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="14"/>
+        <source>Citra</source>
+        <translation>Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="53"/>
+        <source>&amp;File</source>
+        <translation>&amp;Arquivo</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="57"/>
+        <source>Recent Files</source>
+        <translation>Arquivos recentes</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="70"/>
+        <source>&amp;Emulation</source>
+        <translation>&amp;Emulação</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="80"/>
+        <source>&amp;View</source>
+        <translation>&amp;Exibir</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="84"/>
+        <source>Debugging</source>
+        <translation>Debugging</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="91"/>
+        <source>Screen Layout</source>
+        <translation>Layout da tela</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="115"/>
+        <source>Multiplayer</source>
+        <translation>Multiplayer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="126"/>
+        <source>&amp;Help</source>
+        <translation>A&amp;juda</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="144"/>
+        <source>Load File...</source>
+        <translation>Carregar arquivo...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="149"/>
+        <source>Install CIA...</source>
+        <translation>Instalar CIA...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="154"/>
+        <source>Load Symbol Map...</source>
+        <translation>Carregar Mapa de Símbolos...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="159"/>
+        <source>E&amp;xit</source>
+        <translation>&amp;Sair</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="167"/>
+        <source>&amp;Start</source>
+        <translation>&amp;Iniciar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="175"/>
+        <source>&amp;Pause</source>
+        <translation>&amp;Pausar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="183"/>
+        <source>&amp;Stop</source>
+        <translation>P&amp;arar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="188"/>
+        <source>FAQ</source>
+        <translation>FAQ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="193"/>
+        <source>About Citra</source>
+        <translation>Sobre o Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="201"/>
+        <source>Single Window Mode</source>
+        <translation>Modo Janela Única</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="206"/>
+        <source>Configure...</source>
+        <translation>Configurar...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="214"/>
+        <source>Display Dock Widget Headers</source>
+        <translation>Exibir Cabeçalhos do Widget do Dock</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="222"/>
+        <source>Show Filter Bar</source>
+        <translation>Mostrar barra de filtro</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="230"/>
+        <source>Show Status Bar</source>
+        <translation>Mostrar barra de status</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="235"/>
+        <source>Select Game Directory...</source>
+        <translation>Selecionar diretório de jogos...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="238"/>
+        <source>Selects a folder to display in the game list</source>
+        <translation>Selecionar a pasta para exibir na lista de jogos</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="243"/>
+        <source>Create Pica Surface Viewer</source>
+        <translation>Visualizador do Criador de Superfície Pica</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="251"/>
+        <source>Browse Public Game Lobby</source>
+        <translation>Navegar pelas Salas Públicas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="259"/>
+        <source>Create Room</source>
+        <translation>Criar Sala</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="267"/>
+        <source>Leave Room</source>
+        <translation>Sair da Sala</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="272"/>
+        <source>Direct Connect to Room</source>
+        <translation>Conectar-se Diretamente a uma Sala</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="280"/>
+        <source>Show Current Room</source>
+        <translation>Mostrar Sala Atual</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="288"/>
+        <source>Fullscreen</source>
+        <translation>Tela cheia</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="293"/>
+        <source>Modify Citra Install</source>
+        <translation>Modificar instalação do Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="296"/>
+        <source>Opens the maintenance tool to modify your Citra installation</source>
+        <translation>Abre a ferramenta de manutenção para modificar sua instalação do Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="304"/>
+        <source>Default</source>
+        <translation>Padrão</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="312"/>
+        <source>Single Screen</source>
+        <translation>Tela única</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="320"/>
+        <source>Large Screen</source>
+        <translation>Tela grande</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="328"/>
+        <source>Side by Side</source>
+        <translation>Lado a lado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="336"/>
+        <source>Swap Screens</source>
+        <translation>Trocar telas</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="341"/>
+        <source>Check for Updates</source>
+        <translation>Verificar atualizações</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="349"/>
+        <source>Report Compatibility</source>
+        <translation>Informar compatibilidade</translation>
+    </message>
+</context>
+<context>
+    <name>MicroProfileDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/profiler.cpp" line="50"/>
+        <source>MicroProfile</source>
+        <translation>MicroProfile</translation>
+    </message>
+</context>
+<context>
+    <name>MultiplayerState</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="41"/>
+        <source>Current connection status</source>
+        <translation>Status atual de conexão</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="42"/>
+        <source>Not Connected. Click here to find a room!</source>
+        <translation>Não conectado. Clique aqui para encontrar uma sala!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="100"/>
+        <source>Connected</source>
+        <translation>Conectado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="105"/>
+        <source>Not Connected</source>
+        <translation>Não conectado</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="114"/>
+        <source>Error</source>
+        <translation>Erro</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="115"/>
+        <source>Failed to announce the room to the public lobby. In order to host a room publicly, you must have a valid Citra account configured in Emulation -&gt; Configure -&gt; Web. If you do not want to publish a room in the public lobby, then select Unlisted instead.
+Debug Message: </source>
+        <translation>Falha ao anunciar a sala no lobby público. Para poder hospedar uma sala publicamente, você deve ter uma conta válida do Citra configurada em Emulação &gt; Configurar... &gt; Rede. Se você não quiser publicar uma sala no lobby público, deixe-a como Não Listada.
+Mensagem para depuração: </translation>
+    </message>
+</context>
+<context>
+    <name>NetworkMessage</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="12"/>
+        <source>Username is not valid. Must be 4 to 20 alphanumeric characters.</source>
+        <translation>Nome de usuário não é válido. Deve conter entre 4 e 20 caracteres alfanuméricos.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="14"/>
+        <source>Room name is not valid. Must be 4 to 20 alphanumeric characters.</source>
+        <translation>Nome da sala não é válido. Deve conter entre 4 e 20 caracteres alfanuméricos.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="16"/>
+        <source>Username is already in use. Please choose another.</source>
+        <translation>Esse nome de usuário já está em uso. Por favor, escolha outro.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="17"/>
+        <source>IP is not a valid IPv4 address.</source>
+        <translation>O IP não é um endereço IPv4 válido.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="18"/>
+        <source>Port must be a number between 0 to 65535.</source>
+        <translation>Porta deve ser um número entre 0 e 65535.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="20"/>
+        <source>Unable to find an internet connection. Check your internet settings.</source>
+        <translation>Não foi possível encontrar uma conexão com a internet. Verifique suas configurações de internet.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="22"/>
+        <source>Unable to connect to the host. Verify that the connection settings are correct. If you still cannot connect, contact the room host and verify that the host is properly configured with the external port forwarded.</source>
+        <translation>Não foi possível se conectar ao host. Verifique se as configurações de conexão estão corretas. Se você ainda não puder se conectar, entre em contato com o dono da sala e verifique se as configurações da sala e o encaminhamento externo da porta estão corretos.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="26"/>
+        <source>Creating a room failed. Please retry. Restarting Citra might be necessary.</source>
+        <translation>Falha ao criar uma sala. Tente novamente. Pode ser necessário reiniciar o Citra.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="28"/>
+        <source>The host of the room has banned you. Speak with the host to unban you or try a different room.</source>
+        <translation>O dono da sala baniu você. Fale com o dono para retirar seu banimento ou tente uma sala diferente.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="31"/>
+        <source>Version mismatch! Please update to the latest version of Citra. If the problem persists, contact the room host and ask them to update the server.</source>
+        <translation>Incompatibilidade de versões! Por favor, atualize seu Citra para a última versão. Se o problema persistir, entre em contato com o dono da sala e peça para que atualize o servidor.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="33"/>
+        <source>Incorrect password.</source>
+        <translation>Senha incorreta.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="35"/>
+        <source>An unknown error occured. If this error continues to occur, please open an issue</source>
+        <translation>Ocorreu um erro desconhecido. Se esse erro persistir, abra uma issue no GitHub</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="36"/>
+        <source>Connection to room lost. Try to reconnect.</source>
+        <translation>A conexão com a sala foi perdida. Tente reconectar-se.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="38"/>
+        <source>MAC address is already in use. Please choose another.</source>
+        <translation>Este endereço MAC já está em uso. Por favor, escolha outro.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="52"/>
+        <source>Leave Room</source>
+        <translation>Sair da Sala</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="53"/>
+        <source>You are about to close the room. Any network connections will be closed.</source>
+        <translation>Você está prestes a fechar a sala. Quaisquer conexões de rede existentes serão fechadas.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="58"/>
+        <source>Disconnect</source>
+        <translation>Desconectar</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="59"/>
+        <source>You are about to leave the room. Any network connections will be closed.</source>
+        <translation>Você está prestes a sair da sala. Quaisquer conexões de rede existentes serão fechadas.</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="47"/>
+        <source>Error</source>
+        <translation>Erro</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="198"/>
+        <source>%1 is not playing a game</source>
+        <translation>%1 não está jogando</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="201"/>
+        <source>%1 is playing %2</source>
+        <translation>%1 está jogando %2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="26"/>
+        <source>Shift</source>
+        <translation>Shift</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="28"/>
+        <source>Ctrl</source>
+        <translation>Ctrl</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="30"/>
+        <source>Alt</source>
+        <translation>Alt</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="51"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="75"/>
+        <source>[not set]</source>
+        <translation>[não definido]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="55"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="83"/>
+        <source>Joystick %1</source>
+        <translation>Controle %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="57"/>
+        <source> Hat %1 %2</source>
+        <translation>Chapéu %1 %2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="61"/>
+        <source> Axis %1%2</source>
+        <translation>Eixo %1%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="65"/>
+        <source> Button %1</source>
+        <translation>Botão %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="69"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="91"/>
+        <source>[unknown]</source>
+        <translation>[desconhecido]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="80"/>
+        <source>[unused]</source>
+        <translation>[não usado]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="85"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="87"/>
+        <source> Axis %1</source>
+        <translation>Eixo %1</translation>
+    </message>
+</context>
+<context>
+    <name>RegistersWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="15"/>
+        <source>Registers</source>
+        <translation>Registradores</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="16"/>
+        <source>VFP Registers</source>
+        <translation>Registradores VFP</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="18"/>
+        <source>VFP System Registers</source>
+        <translation>Registradores de Sistema VFP</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="167"/>
+        <source>Vector Length</source>
+        <translation>Comprimento de Vetor</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="168"/>
+        <source>Vector Stride</source>
+        <translation>Passo de Vetor</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="169"/>
+        <source>Rounding Mode</source>
+        <translation>Modo de Arredondamento</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="182"/>
+        <source>Vector Iteration Count</source>
+        <translation>Contagem de Iterações de Vetor</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeEvent</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="259"/>
+        <source>reset type = %1</source>
+        <translation>tipo de reset = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeMutex</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="272"/>
+        <source>locked %1 times by thread:</source>
+        <translation>bloqueado %1 vezes pela thread:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="275"/>
+        <source>free</source>
+        <translation>livre</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeMutexList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="314"/>
+        <source>holding mutexes</source>
+        <translation>holding mutexes</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeObjectList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="128"/>
+        <source>waiting for all objects</source>
+        <translation>esperando por todos os objetos</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="129"/>
+        <source>waiting for one of the following objects</source>
+        <translation>Esperando por um dos seguintes objetos</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeSemaphore</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="288"/>
+        <source>available count = %1</source>
+        <translation>contagem disponível = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="289"/>
+        <source>max count = %1</source>
+        <translation>contagem máxima = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeThread</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="146"/>
+        <source>running</source>
+        <translation>rodando</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="149"/>
+        <source>ready</source>
+        <translation>pronto</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="152"/>
+        <source>waiting for address 0x%1</source>
+        <translation>esperando pelo endereço 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="155"/>
+        <source>sleeping</source>
+        <translation>adormecido</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="158"/>
+        <source>waiting for IPC response</source>
+        <translation>esperando por resposta IPC</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="162"/>
+        <source>waiting for objects</source>
+        <translation>esperando por objetos</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="165"/>
+        <source>waiting for HLE return</source>
+        <translation>esperando pelo retorno HLE</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="168"/>
+        <source>dormant</source>
+        <translation>dormente</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="171"/>
+        <source>dead</source>
+        <translation>morto</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="174"/>
+        <source> PC = 0x%1 LR = 0x%2</source>
+        <translation> PC = 0x%1 LR = 0x%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="214"/>
+        <source>default</source>
+        <translation>padrão</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="217"/>
+        <source>all</source>
+        <translation>todos</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="220"/>
+        <source>AppCore</source>
+        <translation>AppCore</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="223"/>
+        <source>SysCore</source>
+        <translation>SysCore</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="226"/>
+        <source>Unknown processor %1</source>
+        <translation>Processador desconhecido %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="230"/>
+        <source>processor = %1</source>
+        <translation>processador = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="231"/>
+        <source>thread id = %1</source>
+        <translation>thread id = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="232"/>
+        <source>priority = %1(current) / %2(normal)</source>
+        <translation>prioridade = %1(atual) / %2(normal)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="236"/>
+        <source>last running ticks = %1</source>
+        <translation>últimos ticks executados = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="239"/>
+        <source>not holding mutex</source>
+        <translation>not holding mutex</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeThreadList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="328"/>
+        <source>waited by thread</source>
+        <translation>esperado pela thread</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeTimer</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="301"/>
+        <source>reset type = %1</source>
+        <translation>tipo de reset = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="303"/>
+        <source>initial delay = %1</source>
+        <translation>atraso inicial = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="305"/>
+        <source>interval delay = %1</source>
+        <translation>intervalo de atraso = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeWaitObject</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="76"/>
+        <source>[%1]%2 %3</source>
+        <translation>[%1]%2 %3</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="104"/>
+        <source>waited by no thread</source>
+        <translation>esperado por nenhuma thread</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="114"/>
+        <source>one shot</source>
+        <translation>one shot</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="116"/>
+        <source>sticky</source>
+        <translation>sticky</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="118"/>
+        <source>pulse</source>
+        <translation>pulso</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="399"/>
+        <source>Wait Tree</source>
+        <translation>Árvore de espera</translation>
+    </message>
+</context>
+<context>
+    <name>hotkeys</name>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="14"/>
+        <source>Hotkey Settings</source>
+        <translation>Configurações de teclas de atalho</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="27"/>
+        <source>Action</source>
+        <translation>Ação</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="32"/>
+        <source>Hotkey</source>
+        <translation>Teclas de atalho</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="37"/>
+        <source>Context</source>
+        <translation>Contexto</translation>
+    </message>
+</context>
+</TS>

--- a/dist/languages/ru_RU.ts
+++ b/dist/languages/ru_RU.ts
@@ -4,7 +4,7 @@
     <message>
         <location filename="../../src/citra_qt/debugger/registers.ui" line="14"/>
         <source>ARM Registers</source>
-        <translation>ARM Registers</translation>
+        <translation>Регистры ARM</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/debugger/registers.ui" line="25"/>
@@ -14,7 +14,7 @@
     <message>
         <location filename="../../src/citra_qt/debugger/registers.ui" line="30"/>
         <source>Value</source>
-        <translation>Value</translation>
+        <translation>Значение</translation>
     </message>
 </context>
 <context>
@@ -59,7 +59,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/aboutdialog.ui" line="118"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Website&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://community.citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Forum&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Source Code&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Contributors&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/blob/master/license.txt&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;License&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"/>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Веб-сайт&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://community.citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Форум&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Исходный код&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Участники&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/blob/master/license.txt&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Лицензия&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/aboutdialog.ui" line="134"/>
@@ -82,12 +82,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="36"/>
         <source>Incoming primitive batch</source>
-        <translation>Следующая загрузка примитива</translation>
+        <translation>Поступающий пакет примитивов</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="37"/>
         <source>Finished primitive batch</source>
-        <translation>Загрузка примитива готова</translation>
+        <translation>Загрузка пакета примитивов завершена</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="38"/>
@@ -102,7 +102,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="41"/>
         <source>GSP command processed</source>
-        <translation>Обработана команда GSP</translation>
+        <translation>Команда GSP обработана</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="42"/>
@@ -115,27 +115,27 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="14"/>
         <source>Room Window</source>
-        <translation type="unfinished"/>
+        <translation>Окно комнаты</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="40"/>
         <source>Send Chat Message</source>
-        <translation type="unfinished"/>
+        <translation>Отправить сообщение для чата</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="47"/>
         <source>Send Message</source>
-        <translation type="unfinished"/>
+        <translation>Отправить сообщение</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/chat_room.cpp" line="81"/>
         <source>Name</source>
-        <translation type="unfinished"/>
+        <translation>Имя</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/chat_room.cpp" line="82"/>
         <source>Game</source>
-        <translation type="unfinished"/>
+        <translation>Игра</translation>
     </message>
 </context>
 <context>
@@ -143,30 +143,30 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/multiplayer/client_room.ui" line="14"/>
         <source>Room Window</source>
-        <translation type="unfinished"/>
+        <translation>Окно комнаты</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/client_room.ui" line="40"/>
         <source>Leave Room</source>
-        <translation type="unfinished"/>
+        <translation>Покинуть комнату</translation>
     </message>
 </context>
 <context>
     <name>ClientRoomWindow</name>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="54"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="55"/>
         <source>Connected</source>
-        <translation type="unfinished"/>
+        <translation>Подключился</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="65"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="63"/>
         <source>Disconnected</source>
-        <translation type="unfinished"/>
+        <translation>Отключился</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="78"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="76"/>
         <source>%1 (%2/%3 members) - connected</source>
-        <translation type="unfinished"/>
+        <translation>%1 (%2/%3 участников) - подключено</translation>
     </message>
 </context>
 <context>
@@ -174,13 +174,13 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="20"/>
         <source>Report Compatibility</source>
-        <translation type="unfinished"/>
+        <translation>Сообщить о совместимости</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="27"/>
         <location filename="../../src/citra_qt/compatdb.ui" line="63"/>
         <source>Report Game Compatibility</source>
-        <translation type="unfinished"/>
+        <translation>Сообщить о совместимости игры</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="36"/>
@@ -190,7 +190,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="72"/>
         <source>Perfect</source>
-        <translation type="unfinished"/>
+        <translation>Идеально</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="79"/>
@@ -200,7 +200,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="89"/>
         <source>Great </source>
-        <translation type="unfinished"/>
+        <translation>Хорошо</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="96"/>
@@ -210,7 +210,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="106"/>
         <source>Okay</source>
-        <translation type="unfinished"/>
+        <translation>Средне</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="113"/>
@@ -220,7 +220,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="123"/>
         <source>Bad</source>
-        <translation type="unfinished"/>
+        <translation>Плохо</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="130"/>
@@ -230,7 +230,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="140"/>
         <source>Intro/Menu</source>
-        <translation type="unfinished"/>
+        <translation>Меню/Интро</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="147"/>
@@ -240,7 +240,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="157"/>
         <source>Won&apos;t Boot</source>
-        <translation type="unfinished"/>
+        <translation>Не запускается</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="170"/>
@@ -255,7 +255,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="206"/>
         <source>Thank you for your submission!</source>
-        <translation type="unfinished"/>
+        <translation>Благодарим за предоставленную информацию!</translation>
     </message>
 </context>
 <context>
@@ -301,7 +301,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="28"/>
         <source>The GDB Stub only works correctly when the CPU JIT is off.</source>
-        <translation>Заглушка GDB работает правильно только если отключёна Динамическая рекомпиляция. </translation>
+        <translation>Заглушка GDB работает правильно лишь когда отключёна JIT-компиляция ЦПУ. </translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="37"/>
@@ -312,6 +312,26 @@ p, li { white-space: pre-wrap; }
         <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="57"/>
         <source>Port:</source>
         <translation>Порт:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="78"/>
+        <source>Logging</source>
+        <translation>Логирование</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="86"/>
+        <source>Global Log Filter</source>
+        <translation>Глобальный фильтр логирования</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="100"/>
+        <source>Show Log Console (Windows Only)</source>
+        <translation>Показать консоль логов (Только для Windows)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="107"/>
+        <source>Open Log Location</source>
+        <translation>Открыть местоположение логов</translation>
     </message>
 </context>
 <context>
@@ -397,7 +417,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_general.ui" line="78"/>
         <source>Silently auto update after closing</source>
-        <translation>Тихо автообновлять после закрытия</translation>
+        <translation>Тихое автообновление после закрытия</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_general.ui" line="90"/>
@@ -407,7 +427,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_general.ui" line="98"/>
         <source>Enable CPU JIT</source>
-        <translation>Включить Динамическую рекомпиляцию</translation>
+        <translation>Включить JIT-компиляцию ЦПУ</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_general.ui" line="110"/>
@@ -470,7 +490,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="35"/>
         <source>Enable shader JIT</source>
-        <translation>Включить динамическую рекомпиляцию шейдеров</translation>
+        <translation>Включить JIT-компиляцию шейдеров</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="42"/>
@@ -480,12 +500,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="51"/>
         <source>Limit Speed Percent</source>
-        <translation type="unfinished"/>
+        <translation>Ограничение скорости в процентах</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="58"/>
         <source>%</source>
-        <translation type="unfinished"/>
+        <translation>%</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="78"/>
@@ -618,7 +638,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="109"/>
         <source>Directional Pad</source>
-        <translation>Крестовина</translation>
+        <translation>Кнопки направлений</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="123"/>
@@ -651,7 +671,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="196"/>
         <source>Shoulder Buttons</source>
-        <translation>Рычажки</translation>
+        <translation>Краевые кнопки</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="210"/>
@@ -676,7 +696,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="283"/>
         <source>Circle Pad</source>
-        <translation>Аналоговый стик</translation>
+        <translation>Кнопка движения</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="295"/>
@@ -688,7 +708,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="377"/>
         <source>C-Stick</source>
-        <translation>C-Stick</translation>
+        <translation>Стик C</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="471"/>
@@ -718,12 +738,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="596"/>
         <source>Restore Defaults</source>
-        <translation>Восстановить умолчания</translation>
+        <translation>Восстановить по умолчанию</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="239"/>
         <source>[press key]</source>
-        <translation>[нажмите клавишу]</translation>
+        <translation>[нажмите кнопку]</translation>
     </message>
 </context>
 <context>
@@ -821,62 +841,62 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.ui" line="137"/>
         <source>Japanese (日本語)</source>
-        <translation>Японский (日本語)</translation>
+        <translation>Japanese (日本語)</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.ui" line="142"/>
         <source>English</source>
-        <translation>Английский</translation>
+        <translation>English</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.ui" line="147"/>
         <source>French (français)</source>
-        <translation>Французский (français)</translation>
+        <translation>French (français)</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.ui" line="152"/>
         <source>German (Deutsch)</source>
-        <translation>Немецкий (Deutsch)</translation>
+        <translation>German (Deutsch)</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.ui" line="157"/>
         <source>Italian (italiano)</source>
-        <translation>Итальянский (italiano)</translation>
+        <translation>Italian (italiano)</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.ui" line="162"/>
         <source>Spanish (español)</source>
-        <translation>Испанский (español)</translation>
+        <translation>Spanish (español)</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.ui" line="167"/>
         <source>Simplified Chinese (简体中文)</source>
-        <translation>Упрощённый Китайский (简体中文)</translation>
+        <translation>Simplified Chinese (简体中文)</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.ui" line="172"/>
         <source>Korean (한국어)</source>
-        <translation>Корейский (한국어)</translation>
+        <translation>Korean (한국어)</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.ui" line="177"/>
         <source>Dutch (Nederlands)</source>
-        <translation>Голландский (Nederlands)</translation>
+        <translation>Dutch (Nederlands)</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.ui" line="182"/>
         <source>Portuguese (português)</source>
-        <translation>Португальский (português)</translation>
+        <translation>Portuguese (português)</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.ui" line="187"/>
         <source>Russian (Русский)</source>
-        <translation>Русский (Россия)</translation>
+        <translation>Russian (Русский)</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.ui" line="192"/>
         <source>Traditional Chinese (正體中文)</source>
-        <translation>Традиционный Китайский (正體中文)</translation>
+        <translation>Traditional Chinese (正體中文)</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.ui" line="200"/>
@@ -906,7 +926,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.ui" line="242"/>
         <source>Regenerate</source>
-        <translation>Сгенерировать</translation>
+        <translation>Регенерировать</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.ui" line="252"/>
@@ -921,7 +941,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="160"/>
         <source>This will replace your current virtual 3DS with a new one. Your current virtual 3DS will not be recoverable. This might have unexpected effects in games. This might fail, if you use an outdated config savegame. Continue?</source>
-        <translation>Это заменит вашу нынешнюю виртуальную 3DS новой. Вашу текущую виртуальную 3DS нельзя будет вернуть. Это может иметь неожиданные эффекты в играх. Это может не сработать, если вы используете сохранения устаревшей конфигурации. Продолжить?</translation>
+        <translation>Это заменит вашу нынешнюю виртуальную 3DS новой. Вашу текущую виртуальную 3DS нельзя будет вернуть. Это может иметь неожиданные эффекты в играх. Генерация может не сработать, если вы используете устаревший &quot;Config Savegame&quot;. Продолжить?</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="164"/>
@@ -995,7 +1015,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_web.ui" line="162"/>
         <source>Regenerate</source>
-        <translation>Сгенерировать</translation>
+        <translation>Регенерировать</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="28"/>
@@ -1021,27 +1041,27 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="55"/>
         <source>Username and token not verified</source>
-        <translation type="unfinished"/>
+        <translation>Имя пользователя и Токен не верифицированы</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="56"/>
         <source>Username and token were not verified. The changes to your username and/or token have not been saved.</source>
-        <translation>Имя пользователя и токен не были подтверждены. Изменения в имени пользователя и/или токене не были сохранены.</translation>
+        <translation>Имя пользователя и токен не были верифицированы. Изменения в имени пользователя и/или токене не были сохранены.</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="85"/>
         <source>Verifying</source>
-        <translation>Проверка</translation>
+        <translation>Верификация</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="99"/>
         <source>Verification failed</source>
-        <translation>Проверка не удалась</translation>
+        <translation>Верификация не удалась</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="100"/>
         <source>Verification failed. Check that you have entered your username and token correctly, and that your internet connection is working.</source>
-        <translation>Ошибка проверки. Убедитесь, что вы правильно ввели свое имя пользователя и токен и что ваше интернет-соединение работает.</translation>
+        <translation>Ошибка верификации. Убедитесь, что вы правильно ввели свое имя пользователя и Токен и что ваше интернет-соединение работает.</translation>
     </message>
 </context>
 <context>
@@ -1049,354 +1069,354 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="14"/>
         <source>Direct Connect</source>
-        <translation type="unfinished"/>
+        <translation>Прямое подключение</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="33"/>
         <source>IP Address</source>
-        <translation type="unfinished"/>
+        <translation>IP адрес</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="56"/>
         <source>IP</source>
-        <translation type="unfinished"/>
+        <translation>IP</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="63"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;IPv4 address of the host&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"/>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;IPv4 адрес хоста&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="73"/>
         <source>Port</source>
-        <translation type="unfinished"/>
+        <translation>Порт</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="80"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Port number the host is listening on&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"/>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Номер порта хоста прослушивается на&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="86"/>
         <source>24872</source>
-        <translation type="unfinished"/>
+        <translation>24872</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="100"/>
         <source>Nickname</source>
-        <translation type="unfinished"/>
+        <translation>Псевдоним</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="114"/>
         <source>Password</source>
-        <translation type="unfinished"/>
+        <translation>Пароль</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="156"/>
         <source>Connect</source>
-        <translation type="unfinished"/>
+        <translation>Подключиться</translation>
     </message>
 </context>
 <context>
     <name>DirectConnectWindow</name>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="97"/>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="103"/>
         <source>Connecting</source>
-        <translation type="unfinished"/>
+        <translation>Подключение</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="102"/>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="108"/>
         <source>Connect</source>
-        <translation type="unfinished"/>
+        <translation>Подключиться</translation>
     </message>
 </context>
 <context>
     <name>GMainWindow</name>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="90"/>
+        <location filename="../../src/citra_qt/main.cpp" line="92"/>
         <source>To help improve Citra, the Citra Team collects anonymous usage data. No private or personally identifying information is collected. This data helps us to understand how people use Citra and prioritize our efforts. Furthermore, it helps us to more easily identify emulation bugs and performance issues. This data includes:&lt;ul&gt;&lt;li&gt;Information about the version of Citra you are using&lt;/li&gt;&lt;li&gt;Performance data about the games you play&lt;/li&gt;&lt;li&gt;Your configuration settings&lt;/li&gt;&lt;li&gt;Information about your computer hardware&lt;/li&gt;&lt;li&gt;Emulation errors and crash information&lt;/li&gt;&lt;/ul&gt;By default, this feature is enabled. To disable this feature, click &apos;Emulation&apos; from the menu and then select &apos;Configure...&apos;. Then, on the &apos;Web&apos; tab, uncheck &apos;Share anonymous usage data with the Citra team&apos;. &lt;br/&gt;&lt;br/&gt;By using this software, you agree to the above terms.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
-        <translation>Чтобы помочь улучшить Citra, Citra Team собирает анонимные данные об использовании. Частная информация или информация идентифицирующая личность не собирается. Эти данные помогают нам понять, как люди используют Citra и приоритизировать наши усилия. Кроме того, это помогает нам более легко идентифицировать ошибки эмуляции и проблемы с производительностью. Эти данные включают:&lt;ul&gt;&lt;li&gt; Информация о версии Citra, которую вы используете&lt;/li&gt;&lt;li&gt; Данные о производительности игр, в которые вы играете&lt;/li&gt;&lt;li&gt; Ваши настройки конфигурации &lt;/li&gt;&lt;li&gt;Информацию об аппаратной части вашего компьютера&lt;/li&gt;&lt;li&gt; Ошибки эмуляции и информация о сбоях&lt;/li&gt;&lt;/ul&gt;
+        <translation>Чтобы помочь улучшить Citra, команда Citra собирает анонимные данные об использовании. Частная информация или информация идентифицирующая личность не собирается. Эти данные помогают нам понять, как люди используют Citra и приоритизировать наши усилия. Кроме того, это помогает нам более легко идентифицировать ошибки эмуляции и проблемы с производительностью. Эти данные включают:&lt;ul&gt;&lt;li&gt; Информация о версии Citra, которую вы используете&lt;/li&gt;&lt;li&gt; Данные о производительности игр, в которые вы играете&lt;/li&gt;&lt;li&gt; Ваши настройки конфигурации &lt;/li&gt;&lt;li&gt;Информацию об аппаратной части вашего компьютера&lt;/li&gt;&lt;li&gt; Ошибки эмуляции и информация о сбоях&lt;/li&gt;&lt;/ul&gt;
 По умолчанию эта функция включена. Чтобы отключить эту функцию, нажмите «Эмуляция» в меню, а затем выберите «Настроить ...». Затем на вкладке «Веб» снимите флажок «Поделиться анонимными данными использования с командой Citra». &lt;br/&gt;&lt;br/&gt;Используя это программное обеспечение, вы соглашаетесь с вышеуказанными условиями.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt; Узнать больше&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="195"/>
+        <location filename="../../src/citra_qt/main.cpp" line="199"/>
         <source>Current emulation speed. Values higher or lower than 100% indicate emulation is running faster or slower than a 3DS.</source>
         <translation>Текущая скорость эмуляции. Значения выше или ниже 100% указывают, что эмуляция работает быстрее или медленнее, чем 3DS.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="198"/>
+        <location filename="../../src/citra_qt/main.cpp" line="202"/>
         <source>How many frames per second the game is currently displaying. This will vary from game to game and scene to scene.</source>
         <translation>Сколько кадров в секунду сейчас отображается в игре. Это будет варьироваться от игры к игре и от сцены к сцене.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="202"/>
+        <location filename="../../src/citra_qt/main.cpp" line="206"/>
         <source>Time taken to emulate a 3DS frame, not counting framelimiting or v-sync. For full-speed emulation this should be at most 16.67 ms.</source>
         <translation>Время, затраченное на эмуляцию кадра 3DS, не считая ограничения кадров или Вертикальной синхронизации. Для полноскоростной эмуляции это значение должно быть не более 16,67 мс.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="429"/>
+        <location filename="../../src/citra_qt/main.cpp" line="434"/>
         <source>CTRL+F</source>
         <translation>CTRL+F</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="538"/>
+        <location filename="../../src/citra_qt/main.cpp" line="543"/>
         <source>Update available!</source>
         <translation>Доступно обновление!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="539"/>
+        <location filename="../../src/citra_qt/main.cpp" line="544"/>
         <source>An update for Citra is available. Do you wish to install it now?&lt;br /&gt;&lt;br /&gt;This &lt;b&gt;will&lt;/b&gt; terminate emulation, if it is running.</source>
         <translation>Доступно обновление для Citra. Вы хотите установить его сейчас?&lt;br /&gt;&lt;br /&gt;Это &lt;b&gt;остановит эмуляцию&lt;/b&gt; , если она запущена. </translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <location filename="../../src/citra_qt/main.cpp" line="555"/>
         <source>No update found</source>
         <translation>Обновления не найдены</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <location filename="../../src/citra_qt/main.cpp" line="555"/>
         <source>No update has been found for Citra.</source>
         <translation>Для Citra не найдено обновлений.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="567"/>
+        <location filename="../../src/citra_qt/main.cpp" line="572"/>
         <source>Error while initializing OpenGL 3.3 Core!</source>
         <translation>Ошибка при инициализации ядра OpenGL 3.3!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="568"/>
+        <location filename="../../src/citra_qt/main.cpp" line="573"/>
         <source>Your GPU may not support OpenGL 3.3, or you do not have the latest graphics driver.</source>
-        <translation>Ваш GPU может не поддерживать OpenGL 3.3, или у вас нет последнего графического драйвера.</translation>
+        <translation>Ваша видеокарта не поддерживает OpenGL 3.3, либо у вас не установлен последний графический драйвер.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="581"/>
-        <location filename="../../src/citra_qt/main.cpp" line="587"/>
-        <location filename="../../src/citra_qt/main.cpp" line="593"/>
-        <location filename="../../src/citra_qt/main.cpp" line="606"/>
-        <location filename="../../src/citra_qt/main.cpp" line="625"/>
+        <location filename="../../src/citra_qt/main.cpp" line="586"/>
+        <location filename="../../src/citra_qt/main.cpp" line="592"/>
+        <location filename="../../src/citra_qt/main.cpp" line="598"/>
+        <location filename="../../src/citra_qt/main.cpp" line="611"/>
+        <location filename="../../src/citra_qt/main.cpp" line="630"/>
         <source>Error while loading ROM!</source>
         <translation>Ошибка при загрузке рома!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="582"/>
-        <location filename="../../src/citra_qt/main.cpp" line="607"/>
+        <location filename="../../src/citra_qt/main.cpp" line="587"/>
+        <location filename="../../src/citra_qt/main.cpp" line="612"/>
         <source>The ROM format is not supported.</source>
         <translation>Этот формат рома не поддерживается.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="588"/>
+        <location filename="../../src/citra_qt/main.cpp" line="593"/>
         <source>Could not determine the system mode.</source>
         <translation>Не удалось определить режим системы.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="594"/>
+        <location filename="../../src/citra_qt/main.cpp" line="599"/>
         <source>The game that you are trying to load must be decrypted before being used with Citra. A real 3DS is required.&lt;br/&gt;&lt;br/&gt;For more information on dumping and decrypting games, please see the following wiki pages: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</source>
         <translation>Игра, которую вы пытаетесь загрузить, должна быть расшифрована перед использованием с Citra. Требуется реальная 3DS.&lt;br/&gt;&lt;br/&gt;Для получения дополнительной информации о дампинге и дешифровке игр см. следующие страницы вики: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="612"/>
+        <location filename="../../src/citra_qt/main.cpp" line="617"/>
         <source>An error occured in the video core.</source>
-        <translation>В ядре видео произошла ошибка.</translation>
+        <translation>В видео ядре произошла ошибка.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="613"/>
+        <location filename="../../src/citra_qt/main.cpp" line="618"/>
         <source>Citra has encountered an error while running the video core, please see the log for more details.For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.Ensure that you have the latest graphics drivers for your GPU.</source>
-        <translation>Citra столкнулась с ошибкой при работе с ядром видео. Дополнительную информацию о доступе к логу можно найти на следующей странице: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;. Убедитесь, что у вас есть последние графические драйверы для вашего графического процессора.</translation>
+        <translation>Citra столкнулась с ошибкой во время запуска видео ядра. Дополнительную информацию о доступе к логу можно найти на следующей странице: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;. Убедитесь, что у вас установлены последние графические драйверы для вашей видеокарты.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="626"/>
+        <location filename="../../src/citra_qt/main.cpp" line="631"/>
         <source>An unknown error occured. Please see the log for more details.</source>
         <translation>Произошла неизвестная ошибка. Более подробную информацию см. в Журнале.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="699"/>
+        <location filename="../../src/citra_qt/main.cpp" line="704"/>
         <source>Start</source>
         <translation>Старт</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="790"/>
+        <location filename="../../src/citra_qt/main.cpp" line="795"/>
         <source>Error Opening %1 Folder</source>
-        <translation type="unfinished"/>
+        <translation>Ошибка открытия папки %1 </translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="791"/>
+        <location filename="../../src/citra_qt/main.cpp" line="796"/>
         <source>Folder does not exist!</source>
         <translation>Папка не существует!</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="805"/>
+        <location filename="../../src/citra_qt/main.cpp" line="810"/>
         <source>3DS Executable</source>
         <translation>Исполняемый файл 3DS</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="806"/>
-        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <location filename="../../src/citra_qt/main.cpp" line="811"/>
+        <location filename="../../src/citra_qt/main.cpp" line="833"/>
         <source>All Files (*.*)</source>
         <translation>Все файлы (*.*)</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="808"/>
+        <location filename="../../src/citra_qt/main.cpp" line="813"/>
         <source>Load File</source>
         <translation>Загрузить файл</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="818"/>
+        <location filename="../../src/citra_qt/main.cpp" line="823"/>
         <source>Select Directory</source>
         <translation>Выбрать каталог</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="827"/>
+        <location filename="../../src/citra_qt/main.cpp" line="832"/>
         <source>Load Files</source>
-        <translation type="unfinished"/>
+        <translation>Загрузка файлов</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <location filename="../../src/citra_qt/main.cpp" line="833"/>
         <source>3DS Installation File (*.CIA*)</source>
-        <translation>Файл установки 3DS (*.CIA*)</translation>
+        <translation>Установочный файл 3DS (*.CIA*)</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="859"/>
+        <location filename="../../src/citra_qt/main.cpp" line="864"/>
         <source>%1 has been installed successfully.</source>
-        <translation type="unfinished"/>
+        <translation>%1 был успешно установлен.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="862"/>
+        <location filename="../../src/citra_qt/main.cpp" line="867"/>
         <source>Unable to open File</source>
         <translation>Невозможно открыть файл</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="863"/>
+        <location filename="../../src/citra_qt/main.cpp" line="868"/>
         <source>Could not open %1</source>
-        <translation type="unfinished"/>
+        <translation>Не смог открыть %1</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="867"/>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
         <source>Installation aborted</source>
         <translation>Установка прервана</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="868"/>
+        <location filename="../../src/citra_qt/main.cpp" line="873"/>
         <source>The installation of %1 was aborted. Please see the log for more details</source>
-        <translation type="unfinished"/>
+        <translation>Установка %1 была прервана. Более подробную информацию см. в Журнале.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <location filename="../../src/citra_qt/main.cpp" line="877"/>
         <source>Invalid File</source>
-        <translation>Неверный файл</translation>
+        <translation>Неправильный файл</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <location filename="../../src/citra_qt/main.cpp" line="877"/>
         <source>%1 is not a valid CIA</source>
-        <translation type="unfinished"/>
+        <translation>%1 не является правильным CIA</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="875"/>
+        <location filename="../../src/citra_qt/main.cpp" line="880"/>
         <source>Encrypted File</source>
         <translation>Зашифрованный файл</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="876"/>
+        <location filename="../../src/citra_qt/main.cpp" line="881"/>
         <source>%1 must be decrypted before being used with Citra. A real 3DS is required.</source>
-        <translation type="unfinished"/>
+        <translation>%1 должен быть расшифрован перед использованием с Citra. Требуется реальная 3DS.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="899"/>
+        <location filename="../../src/citra_qt/main.cpp" line="904"/>
         <source>File not found</source>
         <translation>Файл не найден</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="900"/>
+        <location filename="../../src/citra_qt/main.cpp" line="905"/>
         <source>File &quot;%1&quot; not found</source>
         <translation>Файл &quot;%1&quot; не найден</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="914"/>
+        <location filename="../../src/citra_qt/main.cpp" line="919"/>
         <source>Continue</source>
         <translation>Продолжить</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="939"/>
+        <location filename="../../src/citra_qt/main.cpp" line="944"/>
         <source>Missing Citra Account</source>
-        <translation type="unfinished"/>
+        <translation>Аккаунт Citra не найден</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="940"/>
+        <location filename="../../src/citra_qt/main.cpp" line="945"/>
         <source>In order to submit a game compatibility test case, you must link your Citra account.&lt;br&gt;&lt;br/&gt;To link your Citra account, go to Emulation &amp;gt; Configuration &amp;gt; Web.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1090"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1095"/>
         <source>Speed: %1% / %2%</source>
-        <translation type="unfinished"/>
+        <translation>Скорость: %1% / %2%</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1094"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1099"/>
         <source>Speed: %1%</source>
         <translation>Скорость: %1%</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1096"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1101"/>
         <source>Game: %1 FPS</source>
         <translation>Игра: %1 FPS</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1097"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1102"/>
         <source>Frame: %1 ms</source>
         <translation>Кадр: %1 ms</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1108"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1113"/>
         <source>The game you are trying to load requires additional files from your 3DS to be dumped before playing.&lt;br/&gt;&lt;br/&gt;For more information on dumping these files, please see the following wiki page: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
-        <translation>Игра, которую вы пытаетесь загрузить, требует дополнительных файлов из вашей 3DS, которые нужно сбросить перед игрой.&lt;br/&gt;&lt;br/&gt; Для получения дополнительной информации о дампинге этих файлов см. следующую страницу вики: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Вы хотите вернуться к списку игр? Продолжение эмуляции может привести к сбоям, повреждению данных и другим ошибкам.</translation>
+        <translation>Игра, которую вы пытаетесь загрузить, требует дополнительных файлов из вашей 3DS, которые нужно задампить перед игрой.&lt;br/&gt;&lt;br/&gt; Для получения дополнительной информации о дампинге этих файлов см. следующую страницу вики: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Вы хотите вернуться к списку игр? Продолжение эмуляции может привести к сбоям, повреждению данных и другим ошибкам.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1120"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1125"/>
         <source>: %1. </source>
         <translation>: %1. </translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1126"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1131"/>
         <source>System Archive Not Found</source>
         <translation>Системный архив не найден</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1133"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1138"/>
         <source>Citra was unable to locate the 3DS shared fonts. </source>
-        <translation>Citra не удалось найти общие шрифты 3DS.</translation>
+        <translation>Citra не удалось найти 3DS shared fonts.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1135"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1140"/>
         <source>Shared Fonts Not Found</source>
-        <translation>Шрифты не найдены</translation>
+        <translation>Shared fonts не найдены</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1143"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1148"/>
         <source>Fatal Error</source>
         <translation>Критическая ошибка</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1144"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1149"/>
         <source>Citra has encountered a fatal error, please see the log for more details. For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
         <translation>Citra столкнулась с критической ошибкой, см. Журнал для получения более подробной информации. Дополнительную информацию о доступе к журналу см. на следующей странице: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Вы хотите вернуться к списку игр? Продолжение эмуляции может привести к сбоям, повреждению данных и другим ошибкам.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
-        <location filename="../../src/citra_qt/main.cpp" line="1245"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1183"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1250"/>
         <source>Citra</source>
         <translation>Citra</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1183"/>
         <source>Are you sure you want to close Citra?</source>
         <translation>Вы уверены, что хотите закрыть Citra?</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1246"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1251"/>
         <source>Are you sure you want to stop the emulation? Any unsaved progress will be lost.</source>
         <translation>Вы действительно хотите остановить эмуляцию? Любой несохраненный прогресс будет потерян.</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1318"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1323"/>
         <source>Citra %1| %2-%3</source>
         <translation>Citra %1| %2-%3</translation>
     </message>
@@ -1459,77 +1479,77 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GameList</name>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="117"/>
         <source>Perfect</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="117"/>
         <source>Game functions flawless with no audio or graphical glitches, all tested functionality works as intended without
 any workarounds needed.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="118"/>
         <source>Great</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="118"/>
         <source>Game functions with minor graphical or audio glitches and is playable from start to finish. May require some
 workarounds.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="119"/>
         <source>Okay</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="119"/>
         <source>Game functions with major graphical or audio glitches, but game is playable from start to finish with
 workarounds.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="120"/>
         <source>Bad</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="120"/>
         <source>Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches
 even with workarounds.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="121"/>
         <source>Intro/Menu</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="121"/>
         <source>Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start
 Screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="122"/>
         <source>Won&apos;t Boot</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="122"/>
         <source>The game crashes when attempting to startup.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="123"/>
         <source>Not Tested</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="123"/>
         <source>The game has not yet been tested.</source>
         <translation type="unfinished"/>
     </message>
@@ -1551,7 +1571,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/game_list.cpp" line="125"/>
         <source>Filter:</source>
-        <translation type="unfinished"/>
+        <translation>Фильтр:</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/game_list.cpp" line="128"/>
@@ -1559,19 +1579,19 @@ Screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="324"/>
-        <source>Open Save Data Location</source>
-        <translation>Открыть место нахождения данных сохранений</translation>
-    </message>
-    <message>
         <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
-        <source>Open Application Location</source>
-        <translation type="unfinished"/>
+        <source>Open Save Data Location</source>
+        <translation>Открыть местоположение данных сохранений</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
+        <source>Open Application Location</source>
+        <translation>Открыть местоположение приложения</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="327"/>
         <source>Open Update Data Location</source>
-        <translation type="unfinished"/>
+        <translation>Открыть местоположение обновления</translation>
     </message>
 </context>
 <context>
@@ -1585,7 +1605,7 @@ Screen.</source>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="136"/>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="198"/>
         <source>Emulation running</source>
-        <translation>Эмуляция работает</translation>
+        <translation>Эмуляция запущена</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="137"/>
@@ -1638,7 +1658,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="60"/>
         <source>Custom</source>
-        <translation>Custom</translation>
+        <translation>Пользовательское</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="103"/>
@@ -1910,42 +1930,42 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="14"/>
         <source>Create Room</source>
-        <translation type="unfinished"/>
+        <translation>Создать комнату</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="37"/>
         <source>Room Name</source>
-        <translation type="unfinished"/>
+        <translation>Имя комнаты</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="51"/>
         <source>Preferred Game</source>
-        <translation type="unfinished"/>
+        <translation>Предпочтительная игра</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="61"/>
         <source>Max Players</source>
-        <translation type="unfinished"/>
+        <translation>Максимум игроков</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="91"/>
         <source>Username</source>
-        <translation type="unfinished"/>
+        <translation>Имя пользователя</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="101"/>
         <source>(Leave blank for open game)</source>
-        <translation type="unfinished"/>
+        <translation>(Оставьте пустым для открытой игры)</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="118"/>
         <source>Password</source>
-        <translation type="unfinished"/>
+        <translation>Пароль</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="125"/>
         <source>Port</source>
-        <translation type="unfinished"/>
+        <translation>Порт</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="156"/>
@@ -2002,47 +2022,42 @@ Screen.</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="73"/>
         <source>Password Required to Join</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="74"/>
         <source>Password:</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="77"/>
-        <source>Password</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="139"/>
         <source>Room Name</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="143"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="140"/>
         <source>Preferred Game</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="144"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="141"/>
         <source>Host</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="145"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
         <source>Players</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="153"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="150"/>
         <source>Refreshing</source>
         <translation type="unfinished"/>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="201"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="198"/>
         <source>Refresh List</source>
         <translation type="unfinished"/>
     </message>
@@ -2405,6 +2420,57 @@ Debug Message: </source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="201"/>
         <source>%1 is playing %2</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="208"/>
+        <source>Invalid region</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Japan</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>North America</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="92"/>
+        <source>Europe</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="94"/>
+        <source>Australia</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="96"/>
+        <source>China</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="98"/>
+        <source>Korea</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="100"/>
+        <source>Taiwan</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="102"/>
+        <source>Region free</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="104"/>
+        <source>Invalid Region</source>
         <translation type="unfinished"/>
     </message>
     <message>

--- a/dist/languages/ru_RU.ts
+++ b/dist/languages/ru_RU.ts
@@ -1,0 +1,2751 @@
+<?xml version="1.0" ?><!DOCTYPE TS><TS language="ru_RU" version="2.1">
+<context>
+    <name>ARMRegisters</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="14"/>
+        <source>ARM Registers</source>
+        <translation>ARM Registers</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="25"/>
+        <source>Register</source>
+        <translation>Регистр</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="30"/>
+        <source>Value</source>
+        <translation>Value</translation>
+    </message>
+</context>
+<context>
+    <name>AboutDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="14"/>
+        <source>About Citra</source>
+        <translation>О Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="30"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/citra.png&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/citra.png&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="60"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:28pt;&quot;&gt;Citra&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:28pt;&quot;&gt;Citra&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="73"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="86"/>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:12pt;&quot;&gt;Citra is a free and open source 3DS emulator licensed under GPLv2.0 or any later version.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'MS Shell Dlg 2'; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;This software should not be used to play games you have not legally obtained.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;Citra - бесплатный эмулятор 3DS с открытым исходным кодом, лицензированный под GPLv2.0 или любой более поздней версией.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;Это программное обеспечение не должно использоваться для игр, которые вы не получили на законных основаниях.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="118"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Website&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://community.citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Forum&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Source Code&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Contributors&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/blob/master/license.txt&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;License&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="134"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;&amp;quot;3DS&amp;quot; is a trademark of Nintendo. Citra is not affiliated with Nintendo in any way.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;&amp;quot;3DS&amp;quot; является торговой маркой Nintendo. Citra никоим образом не связан с Nintendo.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>BreakPointModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="34"/>
+        <source>Pica command loaded</source>
+        <translation>Команда Pica загружена</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="35"/>
+        <source>Pica command processed</source>
+        <translation>Команда Pica выполнена</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="36"/>
+        <source>Incoming primitive batch</source>
+        <translation>Следующая загрузка примитива</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="37"/>
+        <source>Finished primitive batch</source>
+        <translation>Загрузка примитива готова</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="38"/>
+        <source>Vertex shader invocation</source>
+        <translation>Вызов вершинного шейдера</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="40"/>
+        <source>Incoming display transfer</source>
+        <translation>Передача входящего отображения</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="41"/>
+        <source>GSP command processed</source>
+        <translation>Обработана команда GSP</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="42"/>
+        <source>Buffers swapped</source>
+        <translation>Буферы заменены</translation>
+    </message>
+</context>
+<context>
+    <name>ChatRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="14"/>
+        <source>Room Window</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="40"/>
+        <source>Send Chat Message</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="47"/>
+        <source>Send Message</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.cpp" line="81"/>
+        <source>Name</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.cpp" line="82"/>
+        <source>Game</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>ClientRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.ui" line="14"/>
+        <source>Room Window</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.ui" line="40"/>
+        <source>Leave Room</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>ClientRoomWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="54"/>
+        <source>Connected</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="65"/>
+        <source>Disconnected</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="78"/>
+        <source>%1 (%2/%3 members) - connected</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>CompatDB</name>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="20"/>
+        <source>Report Compatibility</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="27"/>
+        <location filename="../../src/citra_qt/compatdb.ui" line="63"/>
+        <source>Report Game Compatibility</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="36"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;Should you choose to submit a test case to the &lt;/span&gt;&lt;a href=&quot;https://citra-emu.org/game/&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;Citra Compatibility List&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;, The following information will be collected and displayed on the site:&lt;/span&gt;&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Hardware Information (CPU / GPU / Operating System)&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Which version of Citra you are running&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The connected Citra account&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="72"/>
+        <source>Perfect</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="79"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions flawlessly with no audio or graphical glitches.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="89"/>
+        <source>Great </source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="96"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions with minor graphical or audio glitches and is playable from start to finish. May require some workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="106"/>
+        <source>Okay</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="113"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions with major graphical or audio glitches, but game is playable from start to finish with workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="123"/>
+        <source>Bad</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="130"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches even with workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="140"/>
+        <source>Intro/Menu</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="147"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start Screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="157"/>
+        <source>Won&apos;t Boot</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="170"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The game crashes when attempting to startup.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="182"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Independent of speed or performance, how well does this game play from start to finish on this version of Citra?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="206"/>
+        <source>Thank you for your submission!</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>ConfigureAudio</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="10"/>
+        <source>Audio</source>
+        <translation>Аудио</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="18"/>
+        <source>Output Engine:</source>
+        <translation>Библиотека вывода:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="31"/>
+        <source>Enable audio stretching</source>
+        <translation>Включить растяжение аудио</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="34"/>
+        <source>This post-processing effect adjusts audio speed to match emulation speed and helps prevent audio stutter. This however increases audio latency.</source>
+        <translation>Этот эффект пост-процессинга помогает предотвратить заикание звука и корректирует скорость аудио так, чтобы она совпадала со скоростью эмуляции. Однако это увеличивает задержку звука.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="43"/>
+        <source>Audio Device:</source>
+        <translation>Звуковое устройство:</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureDebug</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="14"/>
+        <source>Form</source>
+        <translation>Форма</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="22"/>
+        <source>GDB</source>
+        <translation>GDB</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="28"/>
+        <source>The GDB Stub only works correctly when the CPU JIT is off.</source>
+        <translation>Заглушка GDB работает правильно только если отключёна Динамическая рекомпиляция. </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="37"/>
+        <source>Enable GDB Stub</source>
+        <translation>Включить заглушку GDB</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="57"/>
+        <source>Port:</source>
+        <translation>Порт:</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="14"/>
+        <source>Citra Configuration</source>
+        <translation>Настройки Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="24"/>
+        <source>General</source>
+        <translation>Общие</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="29"/>
+        <source>System</source>
+        <translation>Система</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="34"/>
+        <source>Input</source>
+        <translation>Управление</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="39"/>
+        <source>Graphics</source>
+        <translation>Графика</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="44"/>
+        <source>Audio</source>
+        <translation>Аудио</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="49"/>
+        <source>Debug</source>
+        <translation>Отладка</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="54"/>
+        <source>Web</source>
+        <translation>Веб</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureGeneral</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="14"/>
+        <source>Form</source>
+        <translation>Форма</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="22"/>
+        <source>General</source>
+        <translation>Общие</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="30"/>
+        <source>Confirm exit while emulation is running</source>
+        <translation>Подтверждать выход при запущенной эмуляции</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="37"/>
+        <source>Search sub-directories for games</source>
+        <translation>Искать игры в подкаталогах</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="46"/>
+        <source>Interface language</source>
+        <translation>Язык интерфейса</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="63"/>
+        <source>Updates</source>
+        <translation>Обновления</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="71"/>
+        <source>Check for updates on start</source>
+        <translation>Проверять обновления при запуске</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="78"/>
+        <source>Silently auto update after closing</source>
+        <translation>Тихо автообновлять после закрытия</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="90"/>
+        <source>Performance</source>
+        <translation>Производительность</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="98"/>
+        <source>Enable CPU JIT</source>
+        <translation>Включить Динамическую рекомпиляцию</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="110"/>
+        <source>Emulation</source>
+        <translation>Эмуляция</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="120"/>
+        <source>Region:</source>
+        <translation>Регион:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="128"/>
+        <source>Auto-select</source>
+        <translation>Автоматически</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="178"/>
+        <source>Theme</source>
+        <translation>Тема</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="188"/>
+        <source>Theme:</source>
+        <translation>Тема:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="205"/>
+        <source>Hotkeys</source>
+        <translation>Горячие клавиши</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.cpp" line="16"/>
+        <source>&lt;System&gt;</source>
+        <translation>&lt;System&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.cpp" line="17"/>
+        <source>English</source>
+        <translation>Английский</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureGraphics</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="14"/>
+        <source>Form</source>
+        <translation>Форма</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="22"/>
+        <source>Graphics</source>
+        <translation>Графика</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="28"/>
+        <source>Enable hardware renderer</source>
+        <translation>Включить аппаратный рендеринг</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="35"/>
+        <source>Enable shader JIT</source>
+        <translation>Включить динамическую рекомпиляцию шейдеров</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="42"/>
+        <source>Enable V-Sync</source>
+        <translation>Включить вертикальную синхронизацию</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="51"/>
+        <source>Limit Speed Percent</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="58"/>
+        <source>%</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="78"/>
+        <source>Internal Resolution:</source>
+        <translation>Внутреннее разрешение:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="86"/>
+        <source>Auto (Window Size)</source>
+        <translation>Авто (По размеру окна)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="91"/>
+        <source>Native (400x240)</source>
+        <translation>Родное (400x240)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="96"/>
+        <source>2x Native (800x480)</source>
+        <translation>Родное 2x (800x480)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="101"/>
+        <source>3x Native (1200x720)</source>
+        <translation>Родное 3x (1200x720)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="106"/>
+        <source>4x Native (1600x960)</source>
+        <translation>Родное 4x (1600x960)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="111"/>
+        <source>5x Native (2000x1200)</source>
+        <translation>Родное 5x (2000x1200)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="116"/>
+        <source>6x Native (2400x1440)</source>
+        <translation>Родное 6x (2400x1440)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="121"/>
+        <source>7x Native (2800x1680)</source>
+        <translation>Родное 7x (2800x1680)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="126"/>
+        <source>8x Native (3200x1920)</source>
+        <translation>Родное 8x (3200x1920)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="131"/>
+        <source>9x Native (3600x2160)</source>
+        <translation>Родное 9x (3600x2160)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="136"/>
+        <source>10x Native (4000x2400)</source>
+        <translation>Родное 10x (4000x2400)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="151"/>
+        <source>Layout</source>
+        <translation>Расположение</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="161"/>
+        <source>Screen Layout:</source>
+        <translation>Расположение экрана:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="169"/>
+        <source>Default</source>
+        <translation>Стандартное</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="174"/>
+        <source>Single Screen</source>
+        <translation>Один экран</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="179"/>
+        <source>Large Screen</source>
+        <translation>Большой экран</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="184"/>
+        <source>Side by Side</source>
+        <translation>Бок о бок</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="194"/>
+        <source>Swap Screens</source>
+        <translation>Поменять экраны местами</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureInput</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="14"/>
+        <source>ConfigureInput</source>
+        <translation>КонфигурацияУправления</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="22"/>
+        <source>Face Buttons</source>
+        <translation>Лицевые кнопки</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="36"/>
+        <source>A:</source>
+        <translation>A:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="54"/>
+        <source>B:</source>
+        <translation>B:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="72"/>
+        <source>X:</source>
+        <translation>X:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="90"/>
+        <source>Y:</source>
+        <translation>Y:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="109"/>
+        <source>Directional Pad</source>
+        <translation>Крестовина</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="123"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="340"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="427"/>
+        <source>Up:</source>
+        <translation>Вверх:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="141"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="358"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="445"/>
+        <source>Down:</source>
+        <translation>Вниз:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="159"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="304"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="391"/>
+        <source>Left:</source>
+        <translation>Влево:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="177"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="322"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="409"/>
+        <source>Right:</source>
+        <translation>Вправо:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="196"/>
+        <source>Shoulder Buttons</source>
+        <translation>Рычажки</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="210"/>
+        <source>L:</source>
+        <translation>L:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="228"/>
+        <source>R:</source>
+        <translation>R:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="246"/>
+        <source>ZL:</source>
+        <translation>ZL:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="264"/>
+        <source>ZR:</source>
+        <translation>ZR:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="283"/>
+        <source>Circle Pad</source>
+        <translation>Аналоговый стик</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="295"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="461"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="232"/>
+        <source>Set Analog Stick</source>
+        <translation>Назначить аналоговый стик</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="377"/>
+        <source>C-Stick</source>
+        <translation>C-Stick</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="471"/>
+        <source>Misc.</source>
+        <translation>Прочее</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="485"/>
+        <source>Start:</source>
+        <translation>Start:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="503"/>
+        <source>Select:</source>
+        <translation>Select:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="521"/>
+        <source>Home:</source>
+        <translation>Home:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="539"/>
+        <source>Circle Mod:</source>
+        <translation>Circle Mod:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="596"/>
+        <source>Restore Defaults</source>
+        <translation>Восстановить умолчания</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="239"/>
+        <source>[press key]</source>
+        <translation>[нажмите клавишу]</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureSystem</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="14"/>
+        <source>Form</source>
+        <translation>Форма</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="22"/>
+        <source>System Settings</source>
+        <translation>Настройки системы</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="28"/>
+        <source>Username</source>
+        <translation>Имя пользователя</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="48"/>
+        <source>Birthday</source>
+        <translation>Дата рождения</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="58"/>
+        <source>January</source>
+        <translation>Январь</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="63"/>
+        <source>February</source>
+        <translation>Февраль</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="68"/>
+        <source>March</source>
+        <translation>Март</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="73"/>
+        <source>April</source>
+        <translation>Апрель</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="78"/>
+        <source>May</source>
+        <translation>Май</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="83"/>
+        <source>June</source>
+        <translation>Июнь</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="88"/>
+        <source>July</source>
+        <translation>Июль</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="93"/>
+        <source>August</source>
+        <translation>Август</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="98"/>
+        <source>September</source>
+        <translation>Сентябрь</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="103"/>
+        <source>October</source>
+        <translation>Октябрь</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="108"/>
+        <source>November</source>
+        <translation>Ноябрь</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="113"/>
+        <source>December</source>
+        <translation>Декабрь</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="126"/>
+        <source>Language</source>
+        <translation>Язык</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="133"/>
+        <source>Note: this can be overridden when region setting is auto-select</source>
+        <translation>Примечание: это может быть перезаписано если включён автовыбор региона.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="137"/>
+        <source>Japanese (日本語)</source>
+        <translation>Японский (日本語)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="142"/>
+        <source>English</source>
+        <translation>Английский</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="147"/>
+        <source>French (français)</source>
+        <translation>Французский (français)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="152"/>
+        <source>German (Deutsch)</source>
+        <translation>Немецкий (Deutsch)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="157"/>
+        <source>Italian (italiano)</source>
+        <translation>Итальянский (italiano)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="162"/>
+        <source>Spanish (español)</source>
+        <translation>Испанский (español)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="167"/>
+        <source>Simplified Chinese (简体中文)</source>
+        <translation>Упрощённый Китайский (简体中文)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="172"/>
+        <source>Korean (한국어)</source>
+        <translation>Корейский (한국어)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="177"/>
+        <source>Dutch (Nederlands)</source>
+        <translation>Голландский (Nederlands)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="182"/>
+        <source>Portuguese (português)</source>
+        <translation>Португальский (português)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="187"/>
+        <source>Russian (Русский)</source>
+        <translation>Русский (Россия)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="192"/>
+        <source>Traditional Chinese (正體中文)</source>
+        <translation>Традиционный Китайский (正體中文)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="200"/>
+        <source>Sound output mode</source>
+        <translation>Режим вывода звука</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="208"/>
+        <source>Mono</source>
+        <translation>Моно</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="213"/>
+        <source>Stereo</source>
+        <translation>Стерео</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="218"/>
+        <source>Surround</source>
+        <translation>Объёмный</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="226"/>
+        <source>Console ID:</source>
+        <translation>ID консоли:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="242"/>
+        <source>Regenerate</source>
+        <translation>Сгенерировать</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="252"/>
+        <source>System settings are available only when game is not running.</source>
+        <translation>Настройки системы доступны только когда игра не запущена.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="87"/>
+        <source>Console ID: 0x%1</source>
+        <translation>ID консоли: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="160"/>
+        <source>This will replace your current virtual 3DS with a new one. Your current virtual 3DS will not be recoverable. This might have unexpected effects in games. This might fail, if you use an outdated config savegame. Continue?</source>
+        <translation>Это заменит вашу нынешнюю виртуальную 3DS новой. Вашу текущую виртуальную 3DS нельзя будет вернуть. Это может иметь неожиданные эффекты в играх. Это может не сработать, если вы используете сохранения устаревшей конфигурации. Продолжить?</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="164"/>
+        <source>Warning</source>
+        <translation>Предупреждение</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureWeb</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="14"/>
+        <source>Form</source>
+        <translation>Форма</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="22"/>
+        <source>Citra Web Service</source>
+        <translation>Веб-сервис Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="28"/>
+        <source>By providing your username and token, you agree to allow Citra to collect additional usage data, which may include user identifying information.</source>
+        <translation>Предоставляя свое имя пользователя и токен, вы соглашаетесь разрешать Citra собирать дополнительные данные об использовании, которые могут включать информацию, идентифицирующую пользователя.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="46"/>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="90"/>
+        <source>Verify</source>
+        <translation>Подтвердить</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="53"/>
+        <source>Sign up</source>
+        <translation>Регистрация</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="67"/>
+        <source>Token: </source>
+        <translation>Токен:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="78"/>
+        <source>Username: </source>
+        <translation>Имя пользователя:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="99"/>
+        <source>What is my token?</source>
+        <translation>Что такое Токен?</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="124"/>
+        <source>Telemetry</source>
+        <translation>Телеметрия</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="130"/>
+        <source>Share anonymous usage data with the Citra team</source>
+        <translation>Поделиться анонимными данными использования с командой Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="137"/>
+        <source>Learn more</source>
+        <translation>Узнайте больше</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="146"/>
+        <source>Telemetry ID:</source>
+        <translation>ID телеметрии:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="162"/>
+        <source>Regenerate</source>
+        <translation>Сгенерировать</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="28"/>
+        <source>&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Узнайте больше&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="33"/>
+        <source>&lt;a href=&apos;https://services.citra-emu.org/&apos;&gt;Sign up&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://services.citra-emu.org/&apos;&gt;Регистрация&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="36"/>
+        <source>&lt;a href=&apos;https://citra-emu.org/wiki/citra-web-service/&apos;&gt;What is my token?&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://citra-emu.org/wiki/citra-web-service/&apos;&gt;Что такое Токен?&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="45"/>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="65"/>
+        <source>Telemetry ID: 0x%1</source>
+        <translation>ID телеметрии: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="55"/>
+        <source>Username and token not verified</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="56"/>
+        <source>Username and token were not verified. The changes to your username and/or token have not been saved.</source>
+        <translation>Имя пользователя и токен не были подтверждены. Изменения в имени пользователя и/или токене не были сохранены.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="85"/>
+        <source>Verifying</source>
+        <translation>Проверка</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="99"/>
+        <source>Verification failed</source>
+        <translation>Проверка не удалась</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="100"/>
+        <source>Verification failed. Check that you have entered your username and token correctly, and that your internet connection is working.</source>
+        <translation>Ошибка проверки. Убедитесь, что вы правильно ввели свое имя пользователя и токен и что ваше интернет-соединение работает.</translation>
+    </message>
+</context>
+<context>
+    <name>DirectConnect</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="14"/>
+        <source>Direct Connect</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="33"/>
+        <source>IP Address</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="56"/>
+        <source>IP</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="63"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;IPv4 address of the host&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="73"/>
+        <source>Port</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="80"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Port number the host is listening on&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="86"/>
+        <source>24872</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="100"/>
+        <source>Nickname</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="114"/>
+        <source>Password</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="156"/>
+        <source>Connect</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>DirectConnectWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="97"/>
+        <source>Connecting</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="102"/>
+        <source>Connect</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>GMainWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="90"/>
+        <source>To help improve Citra, the Citra Team collects anonymous usage data. No private or personally identifying information is collected. This data helps us to understand how people use Citra and prioritize our efforts. Furthermore, it helps us to more easily identify emulation bugs and performance issues. This data includes:&lt;ul&gt;&lt;li&gt;Information about the version of Citra you are using&lt;/li&gt;&lt;li&gt;Performance data about the games you play&lt;/li&gt;&lt;li&gt;Your configuration settings&lt;/li&gt;&lt;li&gt;Information about your computer hardware&lt;/li&gt;&lt;li&gt;Emulation errors and crash information&lt;/li&gt;&lt;/ul&gt;By default, this feature is enabled. To disable this feature, click &apos;Emulation&apos; from the menu and then select &apos;Configure...&apos;. Then, on the &apos;Web&apos; tab, uncheck &apos;Share anonymous usage data with the Citra team&apos;. &lt;br/&gt;&lt;br/&gt;By using this software, you agree to the above terms.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Чтобы помочь улучшить Citra, Citra Team собирает анонимные данные об использовании. Частная информация или информация идентифицирующая личность не собирается. Эти данные помогают нам понять, как люди используют Citra и приоритизировать наши усилия. Кроме того, это помогает нам более легко идентифицировать ошибки эмуляции и проблемы с производительностью. Эти данные включают:&lt;ul&gt;&lt;li&gt; Информация о версии Citra, которую вы используете&lt;/li&gt;&lt;li&gt; Данные о производительности игр, в которые вы играете&lt;/li&gt;&lt;li&gt; Ваши настройки конфигурации &lt;/li&gt;&lt;li&gt;Информацию об аппаратной части вашего компьютера&lt;/li&gt;&lt;li&gt; Ошибки эмуляции и информация о сбоях&lt;/li&gt;&lt;/ul&gt;
+По умолчанию эта функция включена. Чтобы отключить эту функцию, нажмите «Эмуляция» в меню, а затем выберите «Настроить ...». Затем на вкладке «Веб» снимите флажок «Поделиться анонимными данными использования с командой Citra». &lt;br/&gt;&lt;br/&gt;Используя это программное обеспечение, вы соглашаетесь с вышеуказанными условиями.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt; Узнать больше&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="195"/>
+        <source>Current emulation speed. Values higher or lower than 100% indicate emulation is running faster or slower than a 3DS.</source>
+        <translation>Текущая скорость эмуляции. Значения выше или ниже 100% указывают, что эмуляция работает быстрее или медленнее, чем 3DS.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="198"/>
+        <source>How many frames per second the game is currently displaying. This will vary from game to game and scene to scene.</source>
+        <translation>Сколько кадров в секунду сейчас отображается в игре. Это будет варьироваться от игры к игре и от сцены к сцене.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="202"/>
+        <source>Time taken to emulate a 3DS frame, not counting framelimiting or v-sync. For full-speed emulation this should be at most 16.67 ms.</source>
+        <translation>Время, затраченное на эмуляцию кадра 3DS, не считая ограничения кадров или Вертикальной синхронизации. Для полноскоростной эмуляции это значение должно быть не более 16,67 мс.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="429"/>
+        <source>CTRL+F</source>
+        <translation>CTRL+F</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="538"/>
+        <source>Update available!</source>
+        <translation>Доступно обновление!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="539"/>
+        <source>An update for Citra is available. Do you wish to install it now?&lt;br /&gt;&lt;br /&gt;This &lt;b&gt;will&lt;/b&gt; terminate emulation, if it is running.</source>
+        <translation>Доступно обновление для Citra. Вы хотите установить его сейчас?&lt;br /&gt;&lt;br /&gt;Это &lt;b&gt;остановит эмуляцию&lt;/b&gt; , если она запущена. </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <source>No update found</source>
+        <translation>Обновления не найдены</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <source>No update has been found for Citra.</source>
+        <translation>Для Citra не найдено обновлений.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="567"/>
+        <source>Error while initializing OpenGL 3.3 Core!</source>
+        <translation>Ошибка при инициализации ядра OpenGL 3.3!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="568"/>
+        <source>Your GPU may not support OpenGL 3.3, or you do not have the latest graphics driver.</source>
+        <translation>Ваш GPU может не поддерживать OpenGL 3.3, или у вас нет последнего графического драйвера.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="581"/>
+        <location filename="../../src/citra_qt/main.cpp" line="587"/>
+        <location filename="../../src/citra_qt/main.cpp" line="593"/>
+        <location filename="../../src/citra_qt/main.cpp" line="606"/>
+        <location filename="../../src/citra_qt/main.cpp" line="625"/>
+        <source>Error while loading ROM!</source>
+        <translation>Ошибка при загрузке рома!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="582"/>
+        <location filename="../../src/citra_qt/main.cpp" line="607"/>
+        <source>The ROM format is not supported.</source>
+        <translation>Этот формат рома не поддерживается.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="588"/>
+        <source>Could not determine the system mode.</source>
+        <translation>Не удалось определить режим системы.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="594"/>
+        <source>The game that you are trying to load must be decrypted before being used with Citra. A real 3DS is required.&lt;br/&gt;&lt;br/&gt;For more information on dumping and decrypting games, please see the following wiki pages: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation>Игра, которую вы пытаетесь загрузить, должна быть расшифрована перед использованием с Citra. Требуется реальная 3DS.&lt;br/&gt;&lt;br/&gt;Для получения дополнительной информации о дампинге и дешифровке игр см. следующие страницы вики: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="612"/>
+        <source>An error occured in the video core.</source>
+        <translation>В ядре видео произошла ошибка.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="613"/>
+        <source>Citra has encountered an error while running the video core, please see the log for more details.For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.Ensure that you have the latest graphics drivers for your GPU.</source>
+        <translation>Citra столкнулась с ошибкой при работе с ядром видео. Дополнительную информацию о доступе к логу можно найти на следующей странице: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;. Убедитесь, что у вас есть последние графические драйверы для вашего графического процессора.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="626"/>
+        <source>An unknown error occured. Please see the log for more details.</source>
+        <translation>Произошла неизвестная ошибка. Более подробную информацию см. в Журнале.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="699"/>
+        <source>Start</source>
+        <translation>Старт</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="790"/>
+        <source>Error Opening %1 Folder</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="791"/>
+        <source>Folder does not exist!</source>
+        <translation>Папка не существует!</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="805"/>
+        <source>3DS Executable</source>
+        <translation>Исполняемый файл 3DS</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="806"/>
+        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <source>All Files (*.*)</source>
+        <translation>Все файлы (*.*)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="808"/>
+        <source>Load File</source>
+        <translation>Загрузить файл</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="818"/>
+        <source>Select Directory</source>
+        <translation>Выбрать каталог</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="827"/>
+        <source>Load Files</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <source>3DS Installation File (*.CIA*)</source>
+        <translation>Файл установки 3DS (*.CIA*)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="859"/>
+        <source>%1 has been installed successfully.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="862"/>
+        <source>Unable to open File</source>
+        <translation>Невозможно открыть файл</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="863"/>
+        <source>Could not open %1</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="867"/>
+        <source>Installation aborted</source>
+        <translation>Установка прервана</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="868"/>
+        <source>The installation of %1 was aborted. Please see the log for more details</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <source>Invalid File</source>
+        <translation>Неверный файл</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <source>%1 is not a valid CIA</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="875"/>
+        <source>Encrypted File</source>
+        <translation>Зашифрованный файл</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="876"/>
+        <source>%1 must be decrypted before being used with Citra. A real 3DS is required.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="899"/>
+        <source>File not found</source>
+        <translation>Файл не найден</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="900"/>
+        <source>File &quot;%1&quot; not found</source>
+        <translation>Файл &quot;%1&quot; не найден</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="914"/>
+        <source>Continue</source>
+        <translation>Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="939"/>
+        <source>Missing Citra Account</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="940"/>
+        <source>In order to submit a game compatibility test case, you must link your Citra account.&lt;br&gt;&lt;br/&gt;To link your Citra account, go to Emulation &amp;gt; Configuration &amp;gt; Web.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1090"/>
+        <source>Speed: %1% / %2%</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1094"/>
+        <source>Speed: %1%</source>
+        <translation>Скорость: %1%</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1096"/>
+        <source>Game: %1 FPS</source>
+        <translation>Игра: %1 FPS</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1097"/>
+        <source>Frame: %1 ms</source>
+        <translation>Кадр: %1 ms</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1108"/>
+        <source>The game you are trying to load requires additional files from your 3DS to be dumped before playing.&lt;br/&gt;&lt;br/&gt;For more information on dumping these files, please see the following wiki page: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
+        <translation>Игра, которую вы пытаетесь загрузить, требует дополнительных файлов из вашей 3DS, которые нужно сбросить перед игрой.&lt;br/&gt;&lt;br/&gt; Для получения дополнительной информации о дампинге этих файлов см. следующую страницу вики: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Вы хотите вернуться к списку игр? Продолжение эмуляции может привести к сбоям, повреждению данных и другим ошибкам.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1120"/>
+        <source>: %1. </source>
+        <translation>: %1. </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1126"/>
+        <source>System Archive Not Found</source>
+        <translation>Системный архив не найден</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1133"/>
+        <source>Citra was unable to locate the 3DS shared fonts. </source>
+        <translation>Citra не удалось найти общие шрифты 3DS.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1135"/>
+        <source>Shared Fonts Not Found</source>
+        <translation>Шрифты не найдены</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1143"/>
+        <source>Fatal Error</source>
+        <translation>Критическая ошибка</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1144"/>
+        <source>Citra has encountered a fatal error, please see the log for more details. For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
+        <translation>Citra столкнулась с критической ошибкой, см. Журнал для получения более подробной информации. Дополнительную информацию о доступе к журналу см. на следующей странице: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Вы хотите вернуться к списку игр? Продолжение эмуляции может привести к сбоям, повреждению данных и другим ошибкам.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1245"/>
+        <source>Citra</source>
+        <translation>Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <source>Are you sure you want to close Citra?</source>
+        <translation>Вы уверены, что хотите закрыть Citra?</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1246"/>
+        <source>Are you sure you want to stop the emulation? Any unsaved progress will be lost.</source>
+        <translation>Вы действительно хотите остановить эмуляцию? Любой несохраненный прогресс будет потерян.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1318"/>
+        <source>Citra %1| %2-%3</source>
+        <translation>Citra %1| %2-%3</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandListModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="96"/>
+        <source>Command Name</source>
+        <translation>Имя команды</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="98"/>
+        <source>Register</source>
+        <translation>Регистр</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="100"/>
+        <source>Mask</source>
+        <translation>Маска</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="102"/>
+        <source>New Value</source>
+        <translation>Новое значение</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandListWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="184"/>
+        <source>Pica Command List</source>
+        <translation>Список команд Pica</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="202"/>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="233"/>
+        <source>Start Tracing</source>
+        <translation>Начать трассировку</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="203"/>
+        <source>Copy All</source>
+        <translation>Копировать всё</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="229"/>
+        <source>Finish Tracing</source>
+        <translation>Закончить трассировку</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandStreamWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics.cpp" line="67"/>
+        <source>Graphics Debugger</source>
+        <translation>Графический отладчик</translation>
+    </message>
+</context>
+<context>
+    <name>GameList</name>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <source>Perfect</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <source>Game functions flawless with no audio or graphical glitches, all tested functionality works as intended without
+any workarounds needed.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <source>Great</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <source>Game functions with minor graphical or audio glitches and is playable from start to finish. May require some
+workarounds.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <source>Okay</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <source>Game functions with major graphical or audio glitches, but game is playable from start to finish with
+workarounds.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Bad</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches
+even with workarounds.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <source>Intro/Menu</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <source>Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start
+Screen.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>Won&apos;t Boot</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>The game crashes when attempting to startup.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <source>Not Tested</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <source>The game has not yet been tested.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="99"/>
+        <source>of</source>
+        <translation>из</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="102"/>
+        <source>result</source>
+        <translation>результат</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="104"/>
+        <source>results</source>
+        <translation>результаты</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="125"/>
+        <source>Filter:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="128"/>
+        <source>Enter pattern to filter</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="324"/>
+        <source>Open Save Data Location</source>
+        <translation>Открыть место нахождения данных сохранений</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
+        <source>Open Application Location</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
+        <source>Open Update Data Location</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>GraphicsBreakPointsWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="132"/>
+        <source>Pica Breakpoints</source>
+        <translation>Точки прерывания Pica</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="136"/>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="198"/>
+        <source>Emulation running</source>
+        <translation>Эмуляция работает</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="137"/>
+        <source>Resume</source>
+        <translation>Продолжить</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="188"/>
+        <source>Emulation halted at breakpoint</source>
+        <translation>Эмуляция остановлена ​​в точке прерывания</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsSurfaceWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="49"/>
+        <source>Pica Surface Viewer</source>
+        <translation>Pica Surface Viewer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="54"/>
+        <source>Color Buffer</source>
+        <translation>Цветовой буфер</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="55"/>
+        <source>Depth Buffer</source>
+        <translation>Буфер глубины</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="56"/>
+        <source>Stencil Buffer</source>
+        <translation>Буфер трафарета</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="57"/>
+        <source>Texture 0</source>
+        <translation>Текстура 0</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="58"/>
+        <source>Texture 1</source>
+        <translation>Текстура 1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="59"/>
+        <source>Texture 2</source>
+        <translation>Текстура 2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="60"/>
+        <source>Custom</source>
+        <translation>Custom</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="103"/>
+        <source>Unknown</source>
+        <translation>Неизвестно</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="118"/>
+        <source>Save</source>
+        <translation>Сохранить</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="144"/>
+        <source>Source:</source>
+        <translation>Источник:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="150"/>
+        <source>Physical Address:</source>
+        <translation>Физический адрес:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="156"/>
+        <source>Width:</source>
+        <translation>Ширина:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="162"/>
+        <source>Height:</source>
+        <translation>Высота:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="168"/>
+        <source>Format:</source>
+        <translation>Формат:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="180"/>
+        <source>X:</source>
+        <translation>X:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="186"/>
+        <source>Y:</source>
+        <translation>Y:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="280"/>
+        <source>Pixel out of bounds</source>
+        <translation>Пиксель за гранью</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="287"/>
+        <source>(unable to access pixel data)</source>
+        <translation>(не удается получить доступ к данным о пикселях)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="555"/>
+        <source>(invalid surface address)</source>
+        <translation>(неверный адрес поверхности)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="565"/>
+        <source>(unknown surface format)</source>
+        <translation>(неизвестный формат поверхности)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="658"/>
+        <source>Portable Network Graphic (*.png)</source>
+        <translation>Portable Network Graphic (*.png)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="659"/>
+        <source>Binary data (*.bin)</source>
+        <translation>Binary data (*.bin)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="663"/>
+        <source>Save Surface</source>
+        <translation>Сохранить поверхность</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsTracingWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="25"/>
+        <source>CiTrace Recorder</source>
+        <translation>CiTrace Recorder</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="29"/>
+        <source>Start Recording</source>
+        <translation>Начать запись</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="31"/>
+        <source>Stop and Save</source>
+        <translation>Остановить и сохранить</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="32"/>
+        <source>Abort Recording</source>
+        <translation>Отменить запись</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="112"/>
+        <source>Save CiTrace</source>
+        <translation>Сохранить CiTrace</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="113"/>
+        <source>CiTrace File (*.ctf)</source>
+        <translation>CiTrace File (*.ctf)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="162"/>
+        <source>CiTracing still active</source>
+        <translation>CiTracing ещё активен</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="163"/>
+        <source>A CiTrace is still being recorded. Do you want to save it? If not, all recorded data will be discarded.</source>
+        <translation>CiTrace все еще записывается. Вы хотите сохранить его? Если нет, все записанные данные будут отброшены.</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsVertexShaderModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="45"/>
+        <source>Offset</source>
+        <translation>Смещение</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="47"/>
+        <source>Raw</source>
+        <translation>Сырой</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="49"/>
+        <source>Disassembly</source>
+        <translation>Разборка</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsVertexShaderWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="345"/>
+        <source>Save Shader Dump</source>
+        <translation>Сохранить Shader Dump</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="345"/>
+        <source>Shader Binary (*.shbin)</source>
+        <translation>Shader Binary (*.shbin)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="380"/>
+        <source>(data only available at vertex shader invocation breakpoints)</source>
+        <translation>(данные доступны только в контрольных точках вызова вершинного шейдера)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="390"/>
+        <source>Dump</source>
+        <translation>Дамп</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="412"/>
+        <source>Input Data</source>
+        <translation>Входные данные</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="426"/>
+        <source>Attribute %1</source>
+        <translation>Аттрибут %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="453"/>
+        <source>Cycle Index:</source>
+        <translation>Индекс цикла:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="558"/>
+        <source>SRC1: %1, %2, %3, %4
+</source>
+        <translation>SRC1: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="564"/>
+        <source>SRC2: %1, %2, %3, %4
+</source>
+        <translation>SRC2: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="570"/>
+        <source>SRC3: %1, %2, %3, %4
+</source>
+        <translation>SRC3: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="576"/>
+        <source>DEST_IN: %1, %2, %3, %4
+</source>
+        <translation>DEST_IN: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="582"/>
+        <source>DEST_OUT: %1, %2, %3, %4
+</source>
+        <translation>DEST_OUT: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="589"/>
+        <source>Address Registers: %1, %2
+</source>
+        <translation>Регистры адресов: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="593"/>
+        <source>Compare Result: %1, %2
+</source>
+        <translation>Сравнить результат: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="598"/>
+        <source>Static Condition: %1
+</source>
+        <translation>Статическое состояние: %1
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="600"/>
+        <source>Dynamic Conditions: %1, %2
+</source>
+        <translation>Динамические состояния: %1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="604"/>
+        <source>Loop Parameters: %1 (repeats), %2 (initializer), %3 (increment), %4
+</source>
+        <translation>Параметры петли:% 1 (повторы),% 2 (инициализатор),% 3 (приращение),% 4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="611"/>
+        <source>Instruction offset: 0x%1</source>
+        <translation>Смещение команды: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="613"/>
+        <source> -&gt; 0x%2</source>
+        <translation> -&gt; 0x%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="615"/>
+        <source> (last instruction)</source>
+        <translation>(последняя инструкция)</translation>
+    </message>
+</context>
+<context>
+    <name>HostRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="14"/>
+        <source>Create Room</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="37"/>
+        <source>Room Name</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="51"/>
+        <source>Preferred Game</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="61"/>
+        <source>Max Players</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="91"/>
+        <source>Username</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="101"/>
+        <source>(Leave blank for open game)</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="118"/>
+        <source>Password</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="125"/>
+        <source>Port</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="156"/>
+        <source>Public</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="161"/>
+        <source>Unlisted</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="169"/>
+        <source>Host Room</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>Lobby</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="14"/>
+        <source>Public Room Browser</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="32"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="39"/>
+        <source>Nickname</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="59"/>
+        <source>Filters</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="66"/>
+        <source>Search</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="76"/>
+        <source>Games I Own</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="83"/>
+        <source>Hide Full Rooms</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="103"/>
+        <source>Refresh Lobby</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <source>Password Required to Join</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <source>Password:</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="77"/>
+        <source>Password</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
+        <source>Room Name</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="143"/>
+        <source>Preferred Game</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="144"/>
+        <source>Host</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="145"/>
+        <source>Players</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="153"/>
+        <source>Refreshing</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="201"/>
+        <source>Refresh List</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="14"/>
+        <source>Citra</source>
+        <translation>Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="53"/>
+        <source>&amp;File</source>
+        <translation>&amp;Файл</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="57"/>
+        <source>Recent Files</source>
+        <translation>Недавние файлы</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="70"/>
+        <source>&amp;Emulation</source>
+        <translation>&amp;Эмуляция</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="80"/>
+        <source>&amp;View</source>
+        <translation>&amp;Вид</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="84"/>
+        <source>Debugging</source>
+        <translation>Отладка</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="91"/>
+        <source>Screen Layout</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="115"/>
+        <source>Multiplayer</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="126"/>
+        <source>&amp;Help</source>
+        <translation>&amp;Помощь</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="144"/>
+        <source>Load File...</source>
+        <translation>Загрузить файл...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="149"/>
+        <source>Install CIA...</source>
+        <translation>Установить CIA...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="154"/>
+        <source>Load Symbol Map...</source>
+        <translation>Загрузить карту символов...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="159"/>
+        <source>E&amp;xit</source>
+        <translation>В&amp;ыход</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="167"/>
+        <source>&amp;Start</source>
+        <translation>&amp;Старт</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="175"/>
+        <source>&amp;Pause</source>
+        <translation>&amp;Пауза</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="183"/>
+        <source>&amp;Stop</source>
+        <translation>&amp;Стоп</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="188"/>
+        <source>FAQ</source>
+        <translation>FAQ</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="193"/>
+        <source>About Citra</source>
+        <translation>О Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="201"/>
+        <source>Single Window Mode</source>
+        <translation>Режим одиночного окна</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="206"/>
+        <source>Configure...</source>
+        <translation>Настроить...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="214"/>
+        <source>Display Dock Widget Headers</source>
+        <translation>Отображать заголовки виджетов дока</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="222"/>
+        <source>Show Filter Bar</source>
+        <translation>Показать панель фильтров</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="230"/>
+        <source>Show Status Bar</source>
+        <translation>Показать строку состояния</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="235"/>
+        <source>Select Game Directory...</source>
+        <translation>Выбрать каталог с играми...</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="238"/>
+        <source>Selects a folder to display in the game list</source>
+        <translation>Выбор папки для отображения в списке игр</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="243"/>
+        <source>Create Pica Surface Viewer</source>
+        <translation>Создание Pica Surface Viewer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="251"/>
+        <source>Browse Public Game Lobby</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="259"/>
+        <source>Create Room</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="267"/>
+        <source>Leave Room</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="272"/>
+        <source>Direct Connect to Room</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="280"/>
+        <source>Show Current Room</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="288"/>
+        <source>Fullscreen</source>
+        <translation>Полный экран</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="293"/>
+        <source>Modify Citra Install</source>
+        <translation>Изменить установку Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="296"/>
+        <source>Opens the maintenance tool to modify your Citra installation</source>
+        <translation>Открывает инструмент обслуживания, чтобы изменить установку Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="304"/>
+        <source>Default</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="312"/>
+        <source>Single Screen</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="320"/>
+        <source>Large Screen</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="328"/>
+        <source>Side by Side</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="336"/>
+        <source>Swap Screens</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="341"/>
+        <source>Check for Updates</source>
+        <translation>Проверить наличие обновлений</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="349"/>
+        <source>Report Compatibility</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>MicroProfileDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/profiler.cpp" line="50"/>
+        <source>MicroProfile</source>
+        <translation>МикроПрофиль</translation>
+    </message>
+</context>
+<context>
+    <name>MultiplayerState</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="41"/>
+        <source>Current connection status</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="42"/>
+        <source>Not Connected. Click here to find a room!</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="100"/>
+        <source>Connected</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="105"/>
+        <source>Not Connected</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="114"/>
+        <source>Error</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="115"/>
+        <source>Failed to announce the room to the public lobby. In order to host a room publicly, you must have a valid Citra account configured in Emulation -&gt; Configure -&gt; Web. If you do not want to publish a room in the public lobby, then select Unlisted instead.
+Debug Message: </source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>NetworkMessage</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="12"/>
+        <source>Username is not valid. Must be 4 to 20 alphanumeric characters.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="14"/>
+        <source>Room name is not valid. Must be 4 to 20 alphanumeric characters.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="16"/>
+        <source>Username is already in use. Please choose another.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="17"/>
+        <source>IP is not a valid IPv4 address.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="18"/>
+        <source>Port must be a number between 0 to 65535.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="20"/>
+        <source>Unable to find an internet connection. Check your internet settings.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="22"/>
+        <source>Unable to connect to the host. Verify that the connection settings are correct. If you still cannot connect, contact the room host and verify that the host is properly configured with the external port forwarded.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="26"/>
+        <source>Creating a room failed. Please retry. Restarting Citra might be necessary.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="28"/>
+        <source>The host of the room has banned you. Speak with the host to unban you or try a different room.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="31"/>
+        <source>Version mismatch! Please update to the latest version of Citra. If the problem persists, contact the room host and ask them to update the server.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="33"/>
+        <source>Incorrect password.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="35"/>
+        <source>An unknown error occured. If this error continues to occur, please open an issue</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="36"/>
+        <source>Connection to room lost. Try to reconnect.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="38"/>
+        <source>MAC address is already in use. Please choose another.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="52"/>
+        <source>Leave Room</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="53"/>
+        <source>You are about to close the room. Any network connections will be closed.</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="58"/>
+        <source>Disconnect</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="59"/>
+        <source>You are about to leave the room. Any network connections will be closed.</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="47"/>
+        <source>Error</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="198"/>
+        <source>%1 is not playing a game</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="201"/>
+        <source>%1 is playing %2</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="26"/>
+        <source>Shift</source>
+        <translation>Shift</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="28"/>
+        <source>Ctrl</source>
+        <translation>Ctrl</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="30"/>
+        <source>Alt</source>
+        <translation>Alt</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="51"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="75"/>
+        <source>[not set]</source>
+        <translation>[не задано]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="55"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="83"/>
+        <source>Joystick %1</source>
+        <translation>Джойстик %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="57"/>
+        <source> Hat %1 %2</source>
+        <translation>Hat %1 %2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="61"/>
+        <source> Axis %1%2</source>
+        <translation>Ось %1%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="65"/>
+        <source> Button %1</source>
+        <translation>Кнопка %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="69"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="91"/>
+        <source>[unknown]</source>
+        <translation>[Неизвестно]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="80"/>
+        <source>[unused]</source>
+        <translation>[не использовано]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="85"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="87"/>
+        <source> Axis %1</source>
+        <translation>Ось %1</translation>
+    </message>
+</context>
+<context>
+    <name>RegistersWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="15"/>
+        <source>Registers</source>
+        <translation>Регистры</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="16"/>
+        <source>VFP Registers</source>
+        <translation>Регистры VFP</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="18"/>
+        <source>VFP System Registers</source>
+        <translation>Системные регистры VFP</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="167"/>
+        <source>Vector Length</source>
+        <translation>Длина вектора</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="168"/>
+        <source>Vector Stride</source>
+        <translation>Векторный шаг</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="169"/>
+        <source>Rounding Mode</source>
+        <translation>Режим округления</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="182"/>
+        <source>Vector Iteration Count</source>
+        <translation>Количество векторных итераций</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeEvent</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="259"/>
+        <source>reset type = %1</source>
+        <translation>тип сброса = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeMutex</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="272"/>
+        <source>locked %1 times by thread:</source>
+        <translation>заблокировано %1 раз по потоку:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="275"/>
+        <source>free</source>
+        <translation>свободно</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeMutexList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="314"/>
+        <source>holding mutexes</source>
+        <translation>удержание мьютексов</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeObjectList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="128"/>
+        <source>waiting for all objects</source>
+        <translation>ожидание всех объектов</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="129"/>
+        <source>waiting for one of the following objects</source>
+        <translation>ожидание одного из следующих объектов</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeSemaphore</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="288"/>
+        <source>available count = %1</source>
+        <translation>доступный счет = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="289"/>
+        <source>max count = %1</source>
+        <translation>максимальный счет = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeThread</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="146"/>
+        <source>running</source>
+        <translation>работает</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="149"/>
+        <source>ready</source>
+        <translation>готово</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="152"/>
+        <source>waiting for address 0x%1</source>
+        <translation>ожидание адреса 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="155"/>
+        <source>sleeping</source>
+        <translation>сон</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="158"/>
+        <source>waiting for IPC response</source>
+        <translation>Ожидание ответа IPC</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="162"/>
+        <source>waiting for objects</source>
+        <translation>ожидание объектов</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="165"/>
+        <source>waiting for HLE return</source>
+        <translation>ожидание возвращения HLE</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="168"/>
+        <source>dormant</source>
+        <translation>бездействующий</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="171"/>
+        <source>dead</source>
+        <translation>мёртвый</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="174"/>
+        <source> PC = 0x%1 LR = 0x%2</source>
+        <translation> PC = 0x%1 LR = 0x%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="214"/>
+        <source>default</source>
+        <translation>по умолчанию</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="217"/>
+        <source>all</source>
+        <translation>все</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="220"/>
+        <source>AppCore</source>
+        <translation>AppCore</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="223"/>
+        <source>SysCore</source>
+        <translation>SysCore</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="226"/>
+        <source>Unknown processor %1</source>
+        <translation>Неизвестный процессор %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="230"/>
+        <source>processor = %1</source>
+        <translation>процессор = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="231"/>
+        <source>thread id = %1</source>
+        <translation>id потока = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="232"/>
+        <source>priority = %1(current) / %2(normal)</source>
+        <translation>приоритет = %1(текущий) / %2(нормальный)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="236"/>
+        <source>last running ticks = %1</source>
+        <translation>последние тики = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="239"/>
+        <source>not holding mutex</source>
+        <translation>не удерживать мьютексы</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeThreadList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="328"/>
+        <source>waited by thread</source>
+        <translation>ожидаемый потоком</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeTimer</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="301"/>
+        <source>reset type = %1</source>
+        <translation>тип сброса = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="303"/>
+        <source>initial delay = %1</source>
+        <translation>начальная задержка = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="305"/>
+        <source>interval delay = %1</source>
+        <translation>задержка интервала = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeWaitObject</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="76"/>
+        <source>[%1]%2 %3</source>
+        <translation>[%1]%2 %3</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="104"/>
+        <source>waited by no thread</source>
+        <translation>не ожидаемый потоком</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="114"/>
+        <source>one shot</source>
+        <translation>один выстрел</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="116"/>
+        <source>sticky</source>
+        <translation>липкий</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="118"/>
+        <source>pulse</source>
+        <translation>пульс</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="399"/>
+        <source>Wait Tree</source>
+        <translation>Дерево ожиданий</translation>
+    </message>
+</context>
+<context>
+    <name>hotkeys</name>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="14"/>
+        <source>Hotkey Settings</source>
+        <translation>Настройки хоткеев</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="27"/>
+        <source>Action</source>
+        <translation>Действие</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="32"/>
+        <source>Hotkey</source>
+        <translation>Хоткей</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="37"/>
+        <source>Context</source>
+        <translation>Контекст</translation>
+    </message>
+</context>
+</TS>

--- a/dist/languages/zh_CN.ts
+++ b/dist/languages/zh_CN.ts
@@ -4,7 +4,7 @@
     <message>
         <location filename="../../src/citra_qt/debugger/registers.ui" line="14"/>
         <source>ARM Registers</source>
-        <translation>ARM寄存器</translation>
+        <translation>ARM 寄存器</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/debugger/registers.ui" line="25"/>
@@ -22,7 +22,7 @@
     <message>
         <location filename="../../src/citra_qt/aboutdialog.ui" line="14"/>
         <source>About Citra</source>
-        <translation>关于Citra</translation>
+        <translation>关于 Citra</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/aboutdialog.ui" line="30"/>
@@ -52,9 +52,9 @@ p, li { white-space: pre-wrap; }
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;Citra是一个免费且开源的3DS模拟器，使用GPL2.0或者更新的版本授权。&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;Citra是一个免费且开源的3DS模拟器，以GPLv2.0+授权。&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;这个软件不应该用在非合法取得的游戏上。&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;这个软件不应该用来运行非法取得的游戏。&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/aboutdialog.ui" line="118"/>
@@ -64,7 +64,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/aboutdialog.ui" line="134"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;&amp;quot;3DS&amp;quot; is a trademark of Nintendo. Citra is not affiliated with Nintendo in any way.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;“3DS”是任天堂的商标。Citra与任天堂没有任何联系。&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;“3DS”是任天堂的商标。Citra 与任天堂没有任何关系。&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
 </context>
 <context>
@@ -72,37 +72,37 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="34"/>
         <source>Pica command loaded</source>
-        <translation>已加载Pica命令</translation>
+        <translation>已加载 Pica 命令</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="35"/>
         <source>Pica command processed</source>
-        <translation>已处理Pica命令</translation>
+        <translation>已处理 Pica 命令</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="36"/>
         <source>Incoming primitive batch</source>
-        <translation>正传入原始批次</translation>
+        <translation>正传入的原始批处理任务</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="37"/>
         <source>Finished primitive batch</source>
-        <translation>已完成原始批次</translation>
+        <translation>已完成的原始批处理任务</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="38"/>
         <source>Vertex shader invocation</source>
-        <translation>调用顶点着色器</translation>
+        <translation>顶点着色器调用</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="40"/>
         <source>Incoming display transfer</source>
-        <translation>正传入显示调用</translation>
+        <translation>正传入的显示调用</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="41"/>
         <source>GSP command processed</source>
-        <translation>已处理GSP命令</translation>
+        <translation>已处理的 GSP 命令</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="42"/>
@@ -154,19 +154,19 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ClientRoomWindow</name>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="54"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="55"/>
         <source>Connected</source>
         <translation>已连接</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="65"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="63"/>
         <source>Disconnected</source>
         <translation>已断开连接</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="78"/>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="76"/>
         <source>%1 (%2/%3 members) - connected</source>
-        <translation>%1 (%2/%3 人数)已连接</translation>
+        <translation>%1 (%2/%3 人) 已连接</translation>
     </message>
 </context>
 <context>
@@ -200,17 +200,17 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="89"/>
         <source>Great </source>
-        <translation>好极了</translation>
+        <translation>良好</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="96"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions with minor graphical or audio glitches and is playable from start to finish. May require some workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;游戏运行时会有非常轻微的图像或音频问题，但是能从头玩到尾。可能需要一些技巧处理图像或音频问题。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;游戏运行时会有非常轻微的图像或音频问题，但是能从头玩到尾。可能需要一些技巧才能完成游戏。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="106"/>
         <source>Okay</source>
-        <translation>还行</translation>
+        <translation>一般</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="113"/>
@@ -220,7 +220,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="123"/>
         <source>Bad</source>
-        <translation>比较差</translation>
+        <translation>较差</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="130"/>
@@ -230,7 +230,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="140"/>
         <source>Intro/Menu</source>
-        <translation>开场/菜单</translation>
+        <translation>开场 / 菜单</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="147"/>
@@ -240,7 +240,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="157"/>
         <source>Won&apos;t Boot</source>
-        <translation>打不开</translation>
+        <translation>无法打开</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/compatdb.ui" line="170"/>
@@ -301,17 +301,37 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="28"/>
         <source>The GDB Stub only works correctly when the CPU JIT is off.</source>
-        <translation>GDB 存根仅在CPU JIT关闭时正常工作。</translation>
+        <translation>GDB 桩仅在 CPU JIT 关闭时正常工作。</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="37"/>
         <source>Enable GDB Stub</source>
-        <translation>开启GDB 存根</translation>
+        <translation>开启 GDB 调试</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="57"/>
         <source>Port:</source>
         <translation>端口:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="78"/>
+        <source>Logging</source>
+        <translation>日志</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="86"/>
+        <source>Global Log Filter</source>
+        <translation>全局日志过滤器</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="100"/>
+        <source>Show Log Console (Windows Only)</source>
+        <translation>显示日志窗口（仅限 Windows）</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="107"/>
+        <source>Open Log Location</source>
+        <translation>打开日志位置</translation>
     </message>
 </context>
 <context>
@@ -319,12 +339,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure.ui" line="14"/>
         <source>Citra Configuration</source>
-        <translation>Citra设置</translation>
+        <translation>Citra 设置</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure.ui" line="24"/>
         <source>General</source>
-        <translation>一般</translation>
+        <translation>通用</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure.ui" line="29"/>
@@ -354,7 +374,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure.ui" line="54"/>
         <source>Web</source>
-        <translation>网页</translation>
+        <translation>网络</translation>
     </message>
 </context>
 <context>
@@ -372,7 +392,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_general.ui" line="30"/>
         <source>Confirm exit while emulation is running</source>
-        <translation>确认在运行模拟时退出</translation>
+        <translation>在游戏运行时退出需要确认</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_general.ui" line="37"/>
@@ -407,7 +427,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_general.ui" line="98"/>
         <source>Enable CPU JIT</source>
-        <translation>开启CPU JIT</translation>
+        <translation>开启 CPU JIT</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_general.ui" line="110"/>
@@ -447,7 +467,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_general.cpp" line="17"/>
         <source>English</source>
-        <translation>英语</translation>
+        <translation>English</translation>
     </message>
 </context>
 <context>
@@ -470,7 +490,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="35"/>
         <source>Enable shader JIT</source>
-        <translation>开启shader JIT</translation>
+        <translation>开启着色器 JIT</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="42"/>
@@ -480,7 +500,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="51"/>
         <source>Limit Speed Percent</source>
-        <translation>限制速度百分比</translation>
+        <translation>运行速度限制</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="58"/>
@@ -495,57 +515,57 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="86"/>
         <source>Auto (Window Size)</source>
-        <translation>自动(窗口大小)</translation>
+        <translation>自动 (窗口大小)</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="91"/>
         <source>Native (400x240)</source>
-        <translation>原生(400x240)</translation>
+        <translation>原生 (400x240)</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="96"/>
         <source>2x Native (800x480)</source>
-        <translation>2倍于原生(800x480)</translation>
+        <translation>2倍 (800x480)</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="101"/>
         <source>3x Native (1200x720)</source>
-        <translation>3倍于原生(1200x720)</translation>
+        <translation>3倍 (1200x720)</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="106"/>
         <source>4x Native (1600x960)</source>
-        <translation>4倍于原生(1600x960)</translation>
+        <translation>4倍 (1600x960)</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="111"/>
         <source>5x Native (2000x1200)</source>
-        <translation>5倍于原生(2000x1200)</translation>
+        <translation>5倍 (2000x1200)</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="116"/>
         <source>6x Native (2400x1440)</source>
-        <translation>6倍于原生(2400x1440)</translation>
+        <translation>6倍 (2400x1440)</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="121"/>
         <source>7x Native (2800x1680)</source>
-        <translation>7倍于原生(2800x1680)</translation>
+        <translation>7倍 (2800x1680)</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="126"/>
         <source>8x Native (3200x1920)</source>
-        <translation>8倍于原生(3200x1920)</translation>
+        <translation>8倍 (3200x1920)</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="131"/>
         <source>9x Native (3600x2160)</source>
-        <translation>9倍于原生(3600x2160)</translation>
+        <translation>9倍 (3600x2160)</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="136"/>
         <source>10x Native (4000x2400)</source>
-        <translation>10倍于原生(4000x2400)</translation>
+        <translation>10倍 (4000x2400)</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="151"/>
@@ -570,7 +590,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="179"/>
         <source>Large Screen</source>
-        <translation>大屏显示在左边，小屏显示在右边</translation>
+        <translation>大屏</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="184"/>
@@ -580,7 +600,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="194"/>
         <source>Swap Screens</source>
-        <translation>交换屏幕</translation>
+        <translation>交换上下屏</translation>
     </message>
 </context>
 <context>
@@ -598,22 +618,22 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="36"/>
         <source>A:</source>
-        <translation>A键：</translation>
+        <translation>A：</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="54"/>
         <source>B:</source>
-        <translation>B键:</translation>
+        <translation>B:</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="72"/>
         <source>X:</source>
-        <translation>X键:</translation>
+        <translation>X:</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="90"/>
         <source>Y:</source>
-        <translation>Y键:</translation>
+        <translation>Y:</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="109"/>
@@ -625,28 +645,28 @@ p, li { white-space: pre-wrap; }
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="340"/>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="427"/>
         <source>Up:</source>
-        <translation>上键:</translation>
+        <translation>上:</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="141"/>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="358"/>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="445"/>
         <source>Down:</source>
-        <translation>下键:</translation>
+        <translation>下:</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="159"/>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="304"/>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="391"/>
         <source>Left:</source>
-        <translation>左键:</translation>
+        <translation>左:</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="177"/>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="322"/>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="409"/>
         <source>Right:</source>
-        <translation>右键:</translation>
+        <translation>右:</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="196"/>
@@ -656,22 +676,22 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="210"/>
         <source>L:</source>
-        <translation>L键:</translation>
+        <translation>L:</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="228"/>
         <source>R:</source>
-        <translation>R键:</translation>
+        <translation>R:</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="246"/>
         <source>ZL:</source>
-        <translation>ZL键:</translation>
+        <translation>ZL:</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="264"/>
         <source>ZR:</source>
-        <translation>ZR键:</translation>
+        <translation>ZR:</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="283"/>
@@ -688,7 +708,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="377"/>
         <source>C-Stick</source>
-        <translation>C摇杆</translation>
+        <translation>C 摇杆</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="471"/>
@@ -698,17 +718,17 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="485"/>
         <source>Start:</source>
-        <translation> 开始键：</translation>
+        <translation> 开始：</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="503"/>
         <source>Select:</source>
-        <translation>选择键：</translation>
+        <translation>选择：</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="521"/>
         <source>Home:</source>
-        <translation>Home键：</translation>
+        <translation>Home:</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="539"/>
@@ -718,7 +738,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.ui" line="596"/>
         <source>Restore Defaults</source>
-        <translation>恢复默认按键</translation>
+        <translation>恢复默认设置</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="239"/>
@@ -816,7 +836,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.ui" line="133"/>
         <source>Note: this can be overridden when region setting is auto-select</source>
-        <translation>注意：当“地区”设置是自动选择时，可以重写此设置。</translation>
+        <translation>注意：当“地区”设置是自动选择时，此设置会被覆盖。</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.ui" line="137"/>
@@ -831,7 +851,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.ui" line="147"/>
         <source>French (français)</source>
-        <translation>法语 (français)</translation>
+        <translation>法语 (Français)</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.ui" line="152"/>
@@ -841,12 +861,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.ui" line="157"/>
         <source>Italian (italiano)</source>
-        <translation>意大利语 (italiano)</translation>
+        <translation>意大利语 (Italiano)</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.ui" line="162"/>
         <source>Spanish (español)</source>
-        <translation>西班牙语 (español)</translation>
+        <translation>西班牙语 (Español)</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.ui" line="167"/>
@@ -866,7 +886,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.ui" line="182"/>
         <source>Portuguese (português)</source>
-        <translation>葡萄牙语 (português)</translation>
+        <translation>葡萄牙语 (Português)</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.ui" line="187"/>
@@ -911,12 +931,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.ui" line="252"/>
         <source>System settings are available only when game is not running.</source>
-        <translation>只有当游戏不运行时，系统设置才可用。</translation>
+        <translation>只有当游戏不在运行时，系统设置才可用。</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="87"/>
         <source>Console ID: 0x%1</source>
-        <translation>设备ID: 0x%1</translation>
+        <translation>设备 ID: 0x%1</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="160"/>
@@ -939,12 +959,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_web.ui" line="22"/>
         <source>Citra Web Service</source>
-        <translation>Citra网络服务</translation>
+        <translation>Citra 网络服务</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_web.ui" line="28"/>
         <source>By providing your username and token, you agree to allow Citra to collect additional usage data, which may include user identifying information.</source>
-        <translation>提供您的用户名和令牌意味着您同意让Citra收集额外的使用数据，其中可能包括用户识别信息。</translation>
+        <translation>提供您的用户名和令牌意味着您同意让 Citra 收集额外的使用数据，其中可能包括用户识别信息。</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_web.ui" line="46"/>
@@ -960,7 +980,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_web.ui" line="67"/>
         <source>Token: </source>
-        <translation>令牌：</translation>
+        <translation>凭证：</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_web.ui" line="78"/>
@@ -975,12 +995,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_web.ui" line="124"/>
         <source>Telemetry</source>
-        <translation>遥测</translation>
+        <translation>使用数据共享</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_web.ui" line="130"/>
         <source>Share anonymous usage data with the Citra team</source>
-        <translation>与Citra团队共享匿名使用数据</translation>
+        <translation>与 Citra 团队共享匿名使用数据</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_web.ui" line="137"/>
@@ -990,7 +1010,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_web.ui" line="146"/>
         <source>Telemetry ID:</source>
-        <translation>遥测ID：</translation>
+        <translation>数据 ID：</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_web.ui" line="162"/>
@@ -1010,13 +1030,13 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="36"/>
         <source>&lt;a href=&apos;https://citra-emu.org/wiki/citra-web-service/&apos;&gt;What is my token?&lt;/a&gt;</source>
-        <translation>&lt;a href=&apos;https://citra-emu.org/wiki/citra-web-service/&apos;&gt;我的令牌是什么？&lt;/a&gt;</translation>
+        <translation>&lt;a href=&apos;https://citra-emu.org/wiki/citra-web-service/&apos;&gt;我的凭证是什么？&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="45"/>
         <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="65"/>
         <source>Telemetry ID: 0x%1</source>
-        <translation>遥测ID：0x%1</translation>
+        <translation>数据 ID：0x%1</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="55"/>
@@ -1054,7 +1074,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="33"/>
         <source>IP Address</source>
-        <translation>IP地址</translation>
+        <translation>IP 地址</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="56"/>
@@ -1064,7 +1084,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="63"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;IPv4 address of the host&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;主机IPv4地址&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;主机 IPv4 地址&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="73"/>
@@ -1100,12 +1120,12 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>DirectConnectWindow</name>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="97"/>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="103"/>
         <source>Connecting</source>
         <translation>连接中</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="102"/>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="108"/>
         <source>Connect</source>
         <translation>连接</translation>
     </message>
@@ -1113,290 +1133,290 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GMainWindow</name>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="90"/>
+        <location filename="../../src/citra_qt/main.cpp" line="92"/>
         <source>To help improve Citra, the Citra Team collects anonymous usage data. No private or personally identifying information is collected. This data helps us to understand how people use Citra and prioritize our efforts. Furthermore, it helps us to more easily identify emulation bugs and performance issues. This data includes:&lt;ul&gt;&lt;li&gt;Information about the version of Citra you are using&lt;/li&gt;&lt;li&gt;Performance data about the games you play&lt;/li&gt;&lt;li&gt;Your configuration settings&lt;/li&gt;&lt;li&gt;Information about your computer hardware&lt;/li&gt;&lt;li&gt;Emulation errors and crash information&lt;/li&gt;&lt;/ul&gt;By default, this feature is enabled. To disable this feature, click &apos;Emulation&apos; from the menu and then select &apos;Configure...&apos;. Then, on the &apos;Web&apos; tab, uncheck &apos;Share anonymous usage data with the Citra team&apos;. &lt;br/&gt;&lt;br/&gt;By using this software, you agree to the above terms.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
-        <translation>为了帮助改进Citra，Citra团队收集匿名使用数据。不收集任何私人或个人身份资料。这些数据帮助我们理解人们如何使用Citra，并确定我们的工作重点。此外，它帮助我们更容易地识别模拟错误和性能问题。这些数据包括:&lt;ul&gt;&lt;li&gt;有关您正在使用的Citra版本的信息&lt;/li&gt;&lt;li&gt;你玩的游戏的性能数据&lt;/li&gt;&lt;li&gt;你的配置设置&lt;li&gt;您电脑的硬件信息&lt;/li&gt;&lt;li&gt;模拟错误和崩溃信息&lt;/li&gt;&lt;/ul&gt;
-默认情况下，启用此功能。若要禁用此功能，请单击菜单中的“模拟”，然后选择“配置...”。然后，在“网页”选项卡上，取消选中“与Citra团队共享匿名使用数据”。&lt;br/&gt;&lt;br/&gt;使用本软件，您同意上述条款。&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;了解更多&lt;/a&gt;</translation>
+        <translation>为了帮助改进 Citra，Citra 团队收集匿名使用数据。我们不会收集任何私人或个人身份资料。这些数据帮助我们理解人们如何使用 Citra，并确定我们的工作重点。此外，它帮助我们更容易地识别模拟错误和性能问题。这些数据包括:&lt;ul&gt;&lt;li&gt;有关您正在使用的 Citra 版本的信息&lt;/li&gt;&lt;li&gt;您玩的游戏的性能数据&lt;/li&gt;&lt;li&gt;您的配置设置&lt;li&gt;您电脑的硬件信息&lt;/li&gt;&lt;li&gt;模拟错误和崩溃信息&lt;/li&gt;&lt;/ul&gt;
+默认情况下，此功能已启用。若要禁用此功能，请单击菜单中的“模拟”，然后选择“配置...”。然后，在“网络”选项卡，取消选中“与 Citra 团队共享匿名使用数据”。&lt;br/&gt;&lt;br/&gt;您使用本软件，即视为同意上述条款。&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;了解更多&lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="195"/>
+        <location filename="../../src/citra_qt/main.cpp" line="199"/>
         <source>Current emulation speed. Values higher or lower than 100% indicate emulation is running faster or slower than a 3DS.</source>
-        <translation>当前模拟速度。高于或低于100%的值表示模拟正在运行得比3DS更快或更慢。</translation>
-    </message>
-    <message>
-        <location filename="../../src/citra_qt/main.cpp" line="198"/>
-        <source>How many frames per second the game is currently displaying. This will vary from game to game and scene to scene.</source>
-        <translation>游戏当前显示的每秒有多少帧。这将因游戏和场景的不同而有所不同。</translation>
+        <translation>当前模拟速度。高于或低于 100% 的值表示模拟正在运行得比 实际 3DS 更快或更慢。</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.cpp" line="202"/>
-        <source>Time taken to emulate a 3DS frame, not counting framelimiting or v-sync. For full-speed emulation this should be at most 16.67 ms.</source>
-        <translation>在不计算锁帧或垂直同步的情况下全速模拟一个3DS帧的实际时间最多16.67毫秒。</translation>
+        <source>How many frames per second the game is currently displaying. This will vary from game to game and scene to scene.</source>
+        <translation>游戏当前显示的帧率 FPS 。这将因游戏和场景的不同而有所不同。</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="429"/>
+        <location filename="../../src/citra_qt/main.cpp" line="206"/>
+        <source>Time taken to emulate a 3DS frame, not counting framelimiting or v-sync. For full-speed emulation this should be at most 16.67 ms.</source>
+        <translation>在不计算速度限制和垂直同步的情况下，模拟一个 3DS 帧的实际时间。若要进行全速模拟，这个数值不应超过 16.67 毫秒。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="434"/>
         <source>CTRL+F</source>
         <translation>CTRL+F</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="538"/>
+        <location filename="../../src/citra_qt/main.cpp" line="543"/>
         <source>Update available!</source>
         <translation>更新可用！</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="539"/>
+        <location filename="../../src/citra_qt/main.cpp" line="544"/>
         <source>An update for Citra is available. Do you wish to install it now?&lt;br /&gt;&lt;br /&gt;This &lt;b&gt;will&lt;/b&gt; terminate emulation, if it is running.</source>
-        <translation>发现一个更新。你需要安装它吗？&lt;br /&gt;&lt;br /&gt;如果在&lt;b&gt;运行游戏&lt;/b&gt;的时候更新将会终止模拟。</translation>
+        <translation>有更新版本的 Citra 可用。您要安装吗？&lt;br /&gt;&lt;br /&gt;如果在运行游戏的时候更新，&lt;b&gt;将会终止模拟&lt;/b&gt;。</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <location filename="../../src/citra_qt/main.cpp" line="555"/>
         <source>No update found</source>
         <translation>没有找到更新</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <location filename="../../src/citra_qt/main.cpp" line="555"/>
         <source>No update has been found for Citra.</source>
-        <translation>没有找到更新。</translation>
+        <translation>没有找到 Citra 的更新。</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="567"/>
+        <location filename="../../src/citra_qt/main.cpp" line="572"/>
         <source>Error while initializing OpenGL 3.3 Core!</source>
-        <translation>初始化OpenGL 3.3内核时出错！</translation>
+        <translation>初始化 OpenGL 3.3 内核时出错！</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="568"/>
+        <location filename="../../src/citra_qt/main.cpp" line="573"/>
         <source>Your GPU may not support OpenGL 3.3, or you do not have the latest graphics driver.</source>
-        <translation>您的GPU可能不支持OpenGL 3.3，或者您没有最新的图形驱动程序。</translation>
+        <translation>您的 GPU 可能不支持 OpenGL 3.3，或者您没有最新的图形驱动程序。</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="581"/>
-        <location filename="../../src/citra_qt/main.cpp" line="587"/>
-        <location filename="../../src/citra_qt/main.cpp" line="593"/>
-        <location filename="../../src/citra_qt/main.cpp" line="606"/>
-        <location filename="../../src/citra_qt/main.cpp" line="625"/>
+        <location filename="../../src/citra_qt/main.cpp" line="586"/>
+        <location filename="../../src/citra_qt/main.cpp" line="592"/>
+        <location filename="../../src/citra_qt/main.cpp" line="598"/>
+        <location filename="../../src/citra_qt/main.cpp" line="611"/>
+        <location filename="../../src/citra_qt/main.cpp" line="630"/>
         <source>Error while loading ROM!</source>
-        <translation>加载ROM时出错！</translation>
+        <translation>加载游戏时出错！</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="582"/>
-        <location filename="../../src/citra_qt/main.cpp" line="607"/>
+        <location filename="../../src/citra_qt/main.cpp" line="587"/>
+        <location filename="../../src/citra_qt/main.cpp" line="612"/>
         <source>The ROM format is not supported.</source>
-        <translation>这个ROM格式不支持。</translation>
+        <translation>这个 ROM 格式不被支持。</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="588"/>
+        <location filename="../../src/citra_qt/main.cpp" line="593"/>
         <source>Could not determine the system mode.</source>
         <translation>无法确定系统模式。</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="594"/>
+        <location filename="../../src/citra_qt/main.cpp" line="599"/>
         <source>The game that you are trying to load must be decrypted before being used with Citra. A real 3DS is required.&lt;br/&gt;&lt;br/&gt;For more information on dumping and decrypting games, please see the following wiki pages: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</source>
-        <translation>这个游戏需要解密才能被Citra识别。解密过程需要一台实体 3DS 游戏机。&lt;br/&gt;&lt;br/&gt;更多有关转储和解密游戏的信息，请参见以下wiki页面：&lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;转储游戏卡带&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;转储已安装的游戏&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</translation>
+        <translation>这个游戏需要解密才能被 Citra 识别。解密过程需要一台实体 3DS 游戏机。&lt;br/&gt;&lt;br/&gt;更多有关转储和解密游戏的信息，请参见以下 wiki 页面：&lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;转储游戏卡带&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;转储已安装的游戏&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="612"/>
+        <location filename="../../src/citra_qt/main.cpp" line="617"/>
         <source>An error occured in the video core.</source>
         <translation>视频核心出现错误。</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="613"/>
+        <location filename="../../src/citra_qt/main.cpp" line="618"/>
         <source>Citra has encountered an error while running the video core, please see the log for more details.For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.Ensure that you have the latest graphics drivers for your GPU.</source>
-        <translation>Citra在运行时视频核心时遇到错误，请看日志文件。有关访问日志的更多信息，请参见以下网页：&lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;如何上传日志文件。&lt;/a&gt;确保你有最新的显卡驱动。</translation>
+        <translation>Citra 在运行时视频核心遇到错误，请参看日志文件。若想了解如何查看日志，请参见以下 wiki 页面：&lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;如何上传日志文件&lt;/a&gt;。请确保您安装了最新的显卡驱动。</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="626"/>
+        <location filename="../../src/citra_qt/main.cpp" line="631"/>
         <source>An unknown error occured. Please see the log for more details.</source>
         <translation>发生了一个未知的错误。详情请参阅日志。</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="699"/>
+        <location filename="../../src/citra_qt/main.cpp" line="704"/>
         <source>Start</source>
         <translation>开始</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="790"/>
+        <location filename="../../src/citra_qt/main.cpp" line="795"/>
         <source>Error Opening %1 Folder</source>
-        <translation>无法打开%1文件夹 </translation>
+        <translation>无法打开 %1</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="791"/>
+        <location filename="../../src/citra_qt/main.cpp" line="796"/>
         <source>Folder does not exist!</source>
         <translation>文件夹不存在！</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="805"/>
+        <location filename="../../src/citra_qt/main.cpp" line="810"/>
         <source>3DS Executable</source>
-        <translation>3DS可执行文件</translation>
+        <translation>3DS 可执行文件</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="806"/>
-        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <location filename="../../src/citra_qt/main.cpp" line="811"/>
+        <location filename="../../src/citra_qt/main.cpp" line="833"/>
         <source>All Files (*.*)</source>
-        <translation>所有文件(*.*)</translation>
+        <translation>所有文件 (*.*)</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="808"/>
+        <location filename="../../src/citra_qt/main.cpp" line="813"/>
         <source>Load File</source>
         <translation>加载文件</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="818"/>
+        <location filename="../../src/citra_qt/main.cpp" line="823"/>
         <source>Select Directory</source>
         <translation>选择目录</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="827"/>
+        <location filename="../../src/citra_qt/main.cpp" line="832"/>
         <source>Load Files</source>
         <translation>加载多个文件</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <location filename="../../src/citra_qt/main.cpp" line="833"/>
         <source>3DS Installation File (*.CIA*)</source>
-        <translation>3DS安装文件(*.CIA*)</translation>
+        <translation>3DS 安装文件 (*.CIA*)</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="859"/>
+        <location filename="../../src/citra_qt/main.cpp" line="864"/>
         <source>%1 has been installed successfully.</source>
         <translation>%1 已成功安装。</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="862"/>
+        <location filename="../../src/citra_qt/main.cpp" line="867"/>
         <source>Unable to open File</source>
         <translation>无法打开文件</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="863"/>
+        <location filename="../../src/citra_qt/main.cpp" line="868"/>
         <source>Could not open %1</source>
         <translation>无法打开 %1</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="867"/>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
         <source>Installation aborted</source>
         <translation>安装失败</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="868"/>
+        <location filename="../../src/citra_qt/main.cpp" line="873"/>
         <source>The installation of %1 was aborted. Please see the log for more details</source>
-        <translation>%1 的安装过程被取消。详情请检查日志</translation>
+        <translation>%1 的安装过程被取消。详情请参看日志</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <location filename="../../src/citra_qt/main.cpp" line="877"/>
         <source>Invalid File</source>
         <translation>文件无效</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <location filename="../../src/citra_qt/main.cpp" line="877"/>
         <source>%1 is not a valid CIA</source>
         <translation>%1 不是有效的 CIA 文件</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="875"/>
+        <location filename="../../src/citra_qt/main.cpp" line="880"/>
         <source>Encrypted File</source>
-        <translation>被加密的文件</translation>
+        <translation>文件已加密</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="876"/>
+        <location filename="../../src/citra_qt/main.cpp" line="881"/>
         <source>%1 must be decrypted before being used with Citra. A real 3DS is required.</source>
-        <translation>%1 需要在用于 Citra 前先解密。你需要一个真的 3DS 设备。</translation>
+        <translation>%1 需要解密才能被 Citra 识别。解密过程需要一台实体 3DS 游戏机。</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="899"/>
+        <location filename="../../src/citra_qt/main.cpp" line="904"/>
         <source>File not found</source>
         <translation>找不到文件</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="900"/>
+        <location filename="../../src/citra_qt/main.cpp" line="905"/>
         <source>File &quot;%1&quot; not found</source>
         <translation>文件 &quot;%1&quot; 未找到</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="914"/>
+        <location filename="../../src/citra_qt/main.cpp" line="919"/>
         <source>Continue</source>
         <translation>继续</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="939"/>
+        <location filename="../../src/citra_qt/main.cpp" line="944"/>
         <source>Missing Citra Account</source>
         <translation>没有 Citra 帐号</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="940"/>
+        <location filename="../../src/citra_qt/main.cpp" line="945"/>
         <source>In order to submit a game compatibility test case, you must link your Citra account.&lt;br&gt;&lt;br/&gt;To link your Citra account, go to Emulation &amp;gt; Configuration &amp;gt; Web.</source>
         <translation>为了提交游戏兼容性信息, 您必须关联您的 Citra 帐号。&lt;br&gt;&lt;br/&gt;请前往 模拟 &amp;gt; 设置 &amp;gt; 网络 关联您的帐户。</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1090"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1095"/>
         <source>Speed: %1% / %2%</source>
         <translation>速度: %1% / %2%</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1094"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1099"/>
         <source>Speed: %1%</source>
         <translation>速度: %1%</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1096"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1101"/>
         <source>Game: %1 FPS</source>
-        <translation>游戏: %1 FPS</translation>
+        <translation>FPS: %1</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1097"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1102"/>
         <source>Frame: %1 ms</source>
         <translation>帧延迟：%1 毫秒</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1108"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1113"/>
         <source>The game you are trying to load requires additional files from your 3DS to be dumped before playing.&lt;br/&gt;&lt;br/&gt;For more information on dumping these files, please see the following wiki page: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
-        <translation>你想要加载的游戏需要从你的3DS转储附加文件后才能玩。&lt;br/&gt;&lt;br/&gt;有关转储文件的更多信息，请参见下面的wiki页面：&lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;从3DS控制台转储系统档案和共享字体&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;你想退出到游戏列表吗？继续模拟可能导致崩溃，损坏保存数据或其他错误。</translation>
+        <translation>您想要加载的游戏需要来自 3DS 的附加文件才能运行。&lt;br/&gt;&lt;br/&gt;有关转储文件的更多信息，请参见以下 wiki 页面：&lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;从 3DS 控制台转储系统档案和共享字体&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;您想退出并返回游戏列表吗？继续模拟可能导致崩溃，存档损坏或其他错误。</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1120"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1125"/>
         <source>: %1. </source>
         <translation>: %1. </translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1126"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1131"/>
         <source>System Archive Not Found</source>
         <translation>未找到系统档案</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1133"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1138"/>
         <source>Citra was unable to locate the 3DS shared fonts. </source>
-        <translation>Citra无法定位3DS的字体文件。 </translation>
+        <translation>Citra 无法定位 3DS 的字体文件。 </translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1135"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1140"/>
         <source>Shared Fonts Not Found</source>
         <translation>找不到字体文件</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1143"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1148"/>
         <source>Fatal Error</source>
         <translation>致命错误</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1144"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1149"/>
         <source>Citra has encountered a fatal error, please see the log for more details. For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
-        <translation>Citra遇到了一个致命的错误，请看日志文件。有关访问日志的更多信息，请参见下面的页面&lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;如何上传日志文件&lt;/a&gt;。&lt;br/&gt;&lt;br/&gt;你想退出并返回到游戏列表吗？继续模拟可能导致崩溃，存档损坏或其他错误。</translation>
+        <translation>Citra遇到了一个致命的错误，请看日志文件。若想了解如何查看日志，请参见以下 wiki 页面：&lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;如何上传日志文件&lt;/a&gt;。&lt;br/&gt;&lt;br/&gt;您想退出并返回游戏列表吗？继续模拟可能导致崩溃，存档损坏或其他错误。</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
-        <location filename="../../src/citra_qt/main.cpp" line="1245"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1183"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1250"/>
         <source>Citra</source>
         <translation>Citra</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1183"/>
         <source>Are you sure you want to close Citra?</source>
-        <translation>你确定要关闭Citra吗？</translation>
+        <translation>你确定要关闭 Citra 吗？</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1246"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1251"/>
         <source>Are you sure you want to stop the emulation? Any unsaved progress will be lost.</source>
         <translation>您确定要停止模拟吗？任何未保存的进度将会丢失。</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/main.cpp" line="1318"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1323"/>
         <source>Citra %1| %2-%3</source>
         <translation>Citra %1| %2-%3</translation>
     </message>
@@ -1416,7 +1436,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="100"/>
         <source>Mask</source>
-        <translation>伪装</translation>
+        <translation>掩码</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="102"/>
@@ -1429,7 +1449,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="184"/>
         <source>Pica Command List</source>
-        <translation>Pica命令列表</translation>
+        <translation>Pica 命令列表</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="202"/>
@@ -1445,7 +1465,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="229"/>
         <source>Finish Tracing</source>
-        <translation>完成追踪</translation>
+        <translation>结束追踪</translation>
     </message>
 </context>
 <context>
@@ -1459,77 +1479,77 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>GameList</name>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="117"/>
         <source>Perfect</source>
         <translation>完美</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="117"/>
         <source>Game functions flawless with no audio or graphical glitches, all tested functionality works as intended without
 any workarounds needed.</source>
-        <translation>游戏功能完美无音频或图形故障，所有测试功能的工作，没有任何解决方案需要。</translation>
+        <translation>游戏功能完美，没有音频或图形问题。所有测试的功能均能工作，不需要任何额外的技巧。</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="118"/>
         <source>Great</source>
-        <translation>好极了</translation>
+        <translation>良好</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="118"/>
         <source>Game functions with minor graphical or audio glitches and is playable from start to finish. May require some
 workarounds.</source>
-        <translation>游戏运行时会有非常轻微的图像或音频问题，但是能从头玩到尾。可能需要一些技巧处理图像或音频问题。</translation>
+        <translation>游戏运行时会有非常轻微的图像或音频问题，但是能从头玩到尾。可能需要一些技巧才能完成游戏。</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="119"/>
         <source>Okay</source>
-        <translation>还行</translation>
+        <translation>一般</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="119"/>
         <source>Game functions with major graphical or audio glitches, but game is playable from start to finish with
 workarounds.</source>
         <translation>游戏运行时会有很多图像或音频错误，但是在使用一些特殊技巧之后能完整地完成游戏。</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="120"/>
         <source>Bad</source>
-        <translation>比较差</translation>
+        <translation>较差</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="120"/>
         <source>Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches
 even with workarounds.</source>
         <translation>游戏能运行，但是会有大量图像或音频错误。即使使用一些技巧仍无法通过游戏的某些区域。</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="121"/>
         <source>Intro/Menu</source>
-        <translation>开场/菜单</translation>
+        <translation>开场 / 菜单</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="121"/>
         <source>Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start
 Screen.</source>
         <translation>游戏完全没法玩，图像或音频有重大错误。无法通过开场菜单。</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="122"/>
         <source>Won&apos;t Boot</source>
-        <translation>打不开</translation>
+        <translation>无法打开</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="122"/>
         <source>The game crashes when attempting to startup.</source>
         <translation>在启动游戏时直接崩溃了。</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="123"/>
         <source>Not Tested</source>
         <translation>未测试</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="123"/>
         <source>The game has not yet been tested.</source>
         <translation>游戏尚未经过测试。</translation>
     </message>
@@ -1551,7 +1571,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/game_list.cpp" line="125"/>
         <source>Filter:</source>
-        <translation>过滤器：</translation>
+        <translation>过滤器</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/game_list.cpp" line="128"/>
@@ -1559,19 +1579,19 @@ Screen.</source>
         <translation>输入样式进行过滤</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/game_list.cpp" line="324"/>
-        <source>Open Save Data Location</source>
-        <translation>打开保存数据位置</translation>
-    </message>
-    <message>
         <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
-        <source>Open Application Location</source>
-        <translation>打开应用位置</translation>
+        <source>Open Save Data Location</source>
+        <translation>打开存档位置</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
+        <source>Open Application Location</source>
+        <translation>打开应用程序位置</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="327"/>
         <source>Open Update Data Location</source>
-        <translation>打开数据更新位置</translation>
+        <translation>打开更新数据位置</translation>
     </message>
 </context>
 <context>
@@ -1579,7 +1599,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="132"/>
         <source>Pica Breakpoints</source>
-        <translation>Pica断点</translation>
+        <translation>Pica 断点</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="136"/>
@@ -1603,7 +1623,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="49"/>
         <source>Pica Surface Viewer</source>
-        <translation>Pica表面浏览器</translation>
+        <translation>Pica 表面浏览器</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="54"/>
@@ -1726,7 +1746,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="25"/>
         <source>CiTrace Recorder</source>
-        <translation>CiTrace录制器</translation>
+        <translation>CiTrace 录制器</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="29"/>
@@ -1746,22 +1766,22 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="112"/>
         <source>Save CiTrace</source>
-        <translation>保存CiTracer</translation>
+        <translation>保存 CiTrace</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="113"/>
         <source>CiTrace File (*.ctf)</source>
-        <translation>CiTrace文件 (*.ctf)</translation>
+        <translation>CiTrace 文件 (*.ctf)</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="162"/>
         <source>CiTracing still active</source>
-        <translation>CiTracing依然活跃</translation>
+        <translation>CiTrace 仍在运行</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="163"/>
         <source>A CiTrace is still being recorded. Do you want to save it? If not, all recorded data will be discarded.</source>
-        <translation>一个CiTrace仍被记录。你想保存它吗？如果不保存，所有记录的数据将丢失。</translation>
+        <translation>当前正在记录 CiTrace。您想保存它吗？如果不保存，所有记录的数据将丢失。</translation>
     </message>
 </context>
 <context>
@@ -1792,7 +1812,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="345"/>
         <source>Shader Binary (*.shbin)</source>
-        <translation>着色器二进制文件(*.shbin)</translation>
+        <translation>着色器二进制文件 (*.shbin)</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="380"/>
@@ -1910,7 +1930,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="14"/>
         <source>Create Room</source>
-        <translation>建立房间</translation>
+        <translation>创建房间</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="37"/>
@@ -1935,7 +1955,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="101"/>
         <source>(Leave blank for open game)</source>
-        <translation>（为开放游戏留下空白）</translation>
+        <translation>（无密码请留白）</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="118"/>
@@ -1950,17 +1970,17 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="156"/>
         <source>Public</source>
-        <translation>公开房间</translation>
+        <translation>公开</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="161"/>
         <source>Unlisted</source>
-        <translation>不公开房间</translation>
+        <translation>私有</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="169"/>
         <source>Host Room</source>
-        <translation>房间主机</translation>
+        <translation>创建房间</translation>
     </message>
 </context>
 <context>
@@ -1968,7 +1988,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="14"/>
         <source>Public Room Browser</source>
-        <translation>公共房间浏览器</translation>
+        <translation>公共房间列表</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="32"/>
@@ -1989,12 +2009,12 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="76"/>
         <source>Games I Own</source>
-        <translation>我拥有的游戏</translation>
+        <translation>仅显示拥有的游戏</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="83"/>
         <source>Hide Full Rooms</source>
-        <translation>屏蔽满员房间</translation>
+        <translation>隐藏满员房间</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="103"/>
@@ -2002,47 +2022,42 @@ Screen.</source>
         <translation>刷新大厅</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="73"/>
         <source>Password Required to Join</source>
-        <translation>连接所需密码</translation>
+        <translation>需要密码</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="74"/>
         <source>Password:</source>
         <translation>密码:</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="77"/>
-        <source>Password</source>
-        <translation>密码</translation>
-    </message>
-    <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="139"/>
         <source>Room Name</source>
         <translation>房间名称</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="143"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="140"/>
         <source>Preferred Game</source>
         <translation>首选游戏</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="144"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="141"/>
         <source>Host</source>
-        <translation>主机</translation>
+        <translation>创建者</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="145"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
         <source>Players</source>
         <translation>玩家</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="153"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="150"/>
         <source>Refreshing</source>
         <translation>正在刷新</translation>
     </message>
     <message>
-        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="201"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="198"/>
         <source>Refresh List</source>
         <translation>刷新列表</translation>
     </message>
@@ -2057,7 +2072,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="53"/>
         <source>&amp;File</source>
-        <translation>文件(&amp;F)</translation>
+        <translation>文件</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="57"/>
@@ -2067,22 +2082,22 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="70"/>
         <source>&amp;Emulation</source>
-        <translation>模拟(&amp;E)</translation>
+        <translation>模拟</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="80"/>
         <source>&amp;View</source>
-        <translation>视图(&amp;V)</translation>
+        <translation>视图</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="84"/>
         <source>Debugging</source>
-        <translation>正在调试</translation>
+        <translation>调试</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="91"/>
         <source>Screen Layout</source>
-        <translation>屏幕排版</translation>
+        <translation>屏幕布局</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="115"/>
@@ -2092,7 +2107,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="126"/>
         <source>&amp;Help</source>
-        <translation>帮助(&amp;H)</translation>
+        <translation>帮助</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="144"/>
@@ -2102,7 +2117,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="149"/>
         <source>Install CIA...</source>
-        <translation>安装CIA…</translation>
+        <translation>安装 CIA…</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="154"/>
@@ -2112,22 +2127,22 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="159"/>
         <source>E&amp;xit</source>
-        <translation>退出(&amp;X)</translation>
+        <translation>退出</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="167"/>
         <source>&amp;Start</source>
-        <translation>开始(&amp;S)</translation>
+        <translation>开始</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="175"/>
         <source>&amp;Pause</source>
-        <translation>暂停(&amp;P)</translation>
+        <translation>暂停</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="183"/>
         <source>&amp;Stop</source>
-        <translation>停止(&amp;S)</translation>
+        <translation>停止</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="188"/>
@@ -2137,7 +2152,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="193"/>
         <source>About Citra</source>
-        <translation>关于Citra</translation>
+        <translation>关于 Citra</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="201"/>
@@ -2177,7 +2192,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="243"/>
         <source>Create Pica Surface Viewer</source>
-        <translation>新建Pica表面浏览器</translation>
+        <translation>新建 Pica 表面浏览器</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="251"/>
@@ -2187,7 +2202,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="259"/>
         <source>Create Room</source>
-        <translation>建立房间</translation>
+        <translation>创建房间</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="267"/>
@@ -2212,12 +2227,12 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="293"/>
         <source>Modify Citra Install</source>
-        <translation>更改Citra安装包</translation>
+        <translation>更改 Citra 安装</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="296"/>
         <source>Opens the maintenance tool to modify your Citra installation</source>
-        <translation>打开维护工具以修改Citra安装</translation>
+        <translation>打开维护工具修改 Citra 安装</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="304"/>
@@ -2232,7 +2247,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="320"/>
         <source>Large Screen</source>
-        <translation>大屏显示在左边，小屏显示在右边</translation>
+        <translation>大屏</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="328"/>
@@ -2242,12 +2257,12 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="336"/>
         <source>Swap Screens</source>
-        <translation>交换屏幕</translation>
+        <translation>交换上下屏</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="341"/>
         <source>Check for Updates</source>
-        <translation>检查新版本</translation>
+        <translation>检查更新</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/main.ui" line="349"/>
@@ -2260,7 +2275,7 @@ Screen.</source>
     <message>
         <location filename="../../src/citra_qt/debugger/profiler.cpp" line="50"/>
         <source>MicroProfile</source>
-        <translation>微配置文件</translation>
+        <translation>MicroProfile</translation>
     </message>
 </context>
 <context>
@@ -2294,7 +2309,7 @@ Screen.</source>
         <location filename="../../src/citra_qt/multiplayer/state.cpp" line="115"/>
         <source>Failed to announce the room to the public lobby. In order to host a room publicly, you must have a valid Citra account configured in Emulation -&gt; Configure -&gt; Web. If you do not want to publish a room in the public lobby, then select Unlisted instead.
 Debug Message: </source>
-        <translation>未能向公众大厅宣布房间。 为了公开托管房间，您必须在模拟 - &gt;配置 - &gt; Web中配置有效的Citra帐户。 如果您不想在公共大厅中发布房间，请选择“不公开”。
+        <translation>未能创建公开房间。您必须在模拟 - 设置 - 网络中配置有效的 Citra 账户。如果您不希望您的房间在公共游戏大厅中显示，请选择“私有”。
 调试消息：</translation>
     </message>
 </context>
@@ -2313,42 +2328,42 @@ Debug Message: </source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="16"/>
         <source>Username is already in use. Please choose another.</source>
-        <translation>用户名已存在。 请选择另一个。</translation>
+        <translation>用户名已存在。请重新选择。</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="17"/>
         <source>IP is not a valid IPv4 address.</source>
-        <translation>这不是一个有效的IPv4地址。</translation>
+        <translation>这不是一个有效的 IPv4 地址。</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="18"/>
         <source>Port must be a number between 0 to 65535.</source>
-        <translation>端口必须是介于0到65535之间的数字。</translation>
+        <translation>端口必须是介于 0 到 65535 之间的数字。</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="20"/>
         <source>Unable to find an internet connection. Check your internet settings.</source>
-        <translation>无法找到互联网连接。 请检查你的网络设置。</translation>
+        <translation>无法连接到互联网。请检查你的网络设置。</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="22"/>
         <source>Unable to connect to the host. Verify that the connection settings are correct. If you still cannot connect, contact the room host and verify that the host is properly configured with the external port forwarded.</source>
-        <translation>连接到主机失败。请校验连接设置是否正确。 如果你还是不能连接， 请联系房主核实主机是否正确配置了外部端口转发。</translation>
+        <translation>连接房间失败。请校验连接设置是否正确。如果您还是不能连接， 请联系房主核实服务器是否正确配置了外部端口转发。</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="26"/>
         <source>Creating a room failed. Please retry. Restarting Citra might be necessary.</source>
-        <translation>建立一个房间失败。 请重试。 如果仍然失败， 请重新运行citra。</translation>
+        <translation>创建房间失败，请重试。如果仍然失败，请尝试重新启动 Citra。</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="28"/>
         <source>The host of the room has banned you. Speak with the host to unban you or try a different room.</source>
-        <translation>这个房间的房主把你封禁了。 请跟房主联系取消封禁或者尝试登陆别的房间。</translation>
+        <translation>这个房间的房主把你封禁了。请跟联系房主取消封禁或者尝试加入别的房间。</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="31"/>
         <source>Version mismatch! Please update to the latest version of Citra. If the problem persists, contact the room host and ask them to update the server.</source>
-        <translation>版本号不匹配。 请更新最新版本的citra。 如果问题仍然存在， 请联系房主更新服务器。</translation>
+        <translation>版本不匹配！请更新到最新版本的 Citra。如果问题仍然存在，请联系房主更新服务器。</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="33"/>
@@ -2358,17 +2373,17 @@ Debug Message: </source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="35"/>
         <source>An unknown error occured. If this error continues to occur, please open an issue</source>
-        <translation>发生了一个未知的错误。 如果这个错误继续发生， 请开启一个议题。</translation>
+        <translation>发生了一个未知的错误。 如果这个错误继续发生，请到 Github 上发布 Issue。</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="36"/>
         <source>Connection to room lost. Try to reconnect.</source>
-        <translation>到房间的连接信号丢失。正在重新登录。</translation>
+        <translation>与房间的连接断开。正在尝试重新连接。</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="38"/>
         <source>MAC address is already in use. Please choose another.</source>
-        <translation>mac地址已经被使用。请重新选择其他的mac地址</translation>
+        <translation>MAC 地址已经被使用。请选择其他 MAC 地址。</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="52"/>
@@ -2378,7 +2393,7 @@ Debug Message: </source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="53"/>
         <source>You are about to close the room. Any network connections will be closed.</source>
-        <translation>你准备关闭这个房间。所有的网络连接将会被关闭。</translation>
+        <translation>您正准备关闭房间。所有的网络连接将会被关闭。</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="58"/>
@@ -2388,7 +2403,7 @@ Debug Message: </source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/message.cpp" line="59"/>
         <source>You are about to leave the room. Any network connections will be closed.</source>
-        <translation>你准备离开这个房间。 所有的网络连接将会被关闭。</translation>
+        <translation>您正准备离开房间。所有的网络连接将会被关闭。</translation>
     </message>
 </context>
 <context>
@@ -2401,27 +2416,78 @@ Debug Message: </source>
     <message>
         <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="198"/>
         <source>%1 is not playing a game</source>
-        <translation>%1不在玩游戏</translation>
+        <translation>%1 不在玩游戏</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="201"/>
         <source>%1 is playing %2</source>
-        <translation>%1在玩%2</translation>
+        <translation>%1 在玩 %2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <location filename="../../src/citra_qt/game_list_p.h" line="208"/>
+        <source>Invalid region</source>
+        <translation>无效的地区</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Japan</source>
+        <translation>日本</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>North America</source>
+        <translation>北美洲</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="92"/>
+        <source>Europe</source>
+        <translation>欧洲</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="94"/>
+        <source>Australia</source>
+        <translation>澳大利亚</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="96"/>
+        <source>China</source>
+        <translation>中国</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="98"/>
+        <source>Korea</source>
+        <translation>朝鲜</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="100"/>
+        <source>Taiwan</source>
+        <translation>台湾</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="102"/>
+        <source>Region free</source>
+        <translation>不锁区</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="104"/>
+        <source>Invalid Region</source>
+        <translation>无效的地区</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="26"/>
         <source>Shift</source>
-        <translation>Shift键</translation>
+        <translation>Shift</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="28"/>
         <source>Ctrl</source>
-        <translation>Ctrl键</translation>
+        <translation>Ctrl</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="30"/>
         <source>Alt</source>
-        <translation>Alt键</translation>
+        <translation>Alt</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="51"/>
@@ -2478,12 +2544,12 @@ Debug Message: </source>
     <message>
         <location filename="../../src/citra_qt/debugger/registers.cpp" line="16"/>
         <source>VFP Registers</source>
-        <translation>VFP寄存器</translation>
+        <translation>VFP 寄存器</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/debugger/registers.cpp" line="18"/>
         <source>VFP System Registers</source>
-        <translation>VFP系统寄存器</translation>
+        <translation>VFP 系统寄存器</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/debugger/registers.cpp" line="167"/>
@@ -2511,7 +2577,7 @@ Debug Message: </source>
     <message>
         <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="259"/>
         <source>reset type = %1</source>
-        <translation>复位类型= %1</translation>
+        <translation>复位类型 %1</translation>
     </message>
 </context>
 <context>
@@ -2519,7 +2585,7 @@ Debug Message: </source>
     <message>
         <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="272"/>
         <source>locked %1 times by thread:</source>
-        <translation>线程被锁定了%1次：</translation>
+        <translation>线程被锁定了 %1 次：</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="275"/>
@@ -2532,7 +2598,7 @@ Debug Message: </source>
     <message>
         <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="314"/>
         <source>holding mutexes</source>
-        <translation>持有互斥体</translation>
+        <translation>持有互斥锁</translation>
     </message>
 </context>
 <context>
@@ -2576,7 +2642,7 @@ Debug Message: </source>
     <message>
         <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="152"/>
         <source>waiting for address 0x%1</source>
-        <translation>等待解决0x%1</translation>
+        <translation>等待地址 0x%1</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="155"/>
@@ -2586,7 +2652,7 @@ Debug Message: </source>
     <message>
         <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="158"/>
         <source>waiting for IPC response</source>
-        <translation>等待IPC响应</translation>
+        <translation>等待 IPC 响应</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="162"/>
@@ -2596,7 +2662,7 @@ Debug Message: </source>
     <message>
         <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="165"/>
         <source>waiting for HLE return</source>
-        <translation>等待高级模拟返回</translation>
+        <translation>等待 HLE 返回</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="168"/>
@@ -2646,7 +2712,7 @@ Debug Message: </source>
     <message>
         <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="231"/>
         <source>thread id = %1</source>
-        <translation>线程ID = %1</translation>
+        <translation>线程 ID = %1</translation>
     </message>
     <message>
         <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="232"/>
@@ -2661,7 +2727,7 @@ Debug Message: </source>
     <message>
         <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="239"/>
         <source>not holding mutex</source>
-        <translation>未持有互斥体</translation>
+        <translation>未持有互斥锁</translation>
     </message>
 </context>
 <context>

--- a/dist/languages/zh_CN.ts
+++ b/dist/languages/zh_CN.ts
@@ -1,0 +1,2752 @@
+<?xml version="1.0" ?><!DOCTYPE TS><TS language="zh_CN" version="2.1">
+<context>
+    <name>ARMRegisters</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="14"/>
+        <source>ARM Registers</source>
+        <translation>ARM寄存器</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="25"/>
+        <source>Register</source>
+        <translation>寄存器</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.ui" line="30"/>
+        <source>Value</source>
+        <translation>值</translation>
+    </message>
+</context>
+<context>
+    <name>AboutDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="14"/>
+        <source>About Citra</source>
+        <translation>关于Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="30"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/citra.png&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/citra.png&quot;/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="60"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:28pt;&quot;&gt;Citra&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:28pt;&quot;&gt;Citra&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="73"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="86"/>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'MS Shell Dlg 2'; font-size:12pt;&quot;&gt;Citra is a free and open source 3DS emulator licensed under GPLv2.0 or any later version.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:'MS Shell Dlg 2'; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;This software should not be used to play games you have not legally obtained.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;Citra是一个免费且开源的3DS模拟器，使用GPL2.0或者更新的版本授权。&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:12pt;&quot;&gt;这个软件不应该用在非合法取得的游戏上。&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="118"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Website&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://community.citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Forum&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Source Code&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Contributors&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/blob/master/license.txt&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;License&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;网站&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://community.citra-emu.org/&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;论坛&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;源代码&lt;/span&gt;&lt;/a&gt; | &lt;a href=&quot;https://github.com/citra-emu/citra/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;贡献者&lt;/span&gt; &lt;/a&gt;| &lt;a href=&quot;https://github.com/citra-emu/citra/blob/master/license.txt&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;许可证&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/aboutdialog.ui" line="134"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;&amp;quot;3DS&amp;quot; is a trademark of Nintendo. Citra is not affiliated with Nintendo in any way.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:7pt;&quot;&gt;“3DS”是任天堂的商标。Citra与任天堂没有任何联系。&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>BreakPointModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="34"/>
+        <source>Pica command loaded</source>
+        <translation>已加载Pica命令</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="35"/>
+        <source>Pica command processed</source>
+        <translation>已处理Pica命令</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="36"/>
+        <source>Incoming primitive batch</source>
+        <translation>正传入原始批次</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="37"/>
+        <source>Finished primitive batch</source>
+        <translation>已完成原始批次</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="38"/>
+        <source>Vertex shader invocation</source>
+        <translation>调用顶点着色器</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="40"/>
+        <source>Incoming display transfer</source>
+        <translation>正传入显示调用</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="41"/>
+        <source>GSP command processed</source>
+        <translation>已处理GSP命令</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="42"/>
+        <source>Buffers swapped</source>
+        <translation>交换缓冲区</translation>
+    </message>
+</context>
+<context>
+    <name>ChatRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="14"/>
+        <source>Room Window</source>
+        <translation>房间窗口</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="40"/>
+        <source>Send Chat Message</source>
+        <translation>发送聊天消息</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.ui" line="47"/>
+        <source>Send Message</source>
+        <translation>发送信息</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.cpp" line="81"/>
+        <source>Name</source>
+        <translation>名称</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/chat_room.cpp" line="82"/>
+        <source>Game</source>
+        <translation>游戏</translation>
+    </message>
+</context>
+<context>
+    <name>ClientRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.ui" line="14"/>
+        <source>Room Window</source>
+        <translation>房间窗口</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.ui" line="40"/>
+        <source>Leave Room</source>
+        <translation>离开房间</translation>
+    </message>
+</context>
+<context>
+    <name>ClientRoomWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="54"/>
+        <source>Connected</source>
+        <translation>已连接</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="65"/>
+        <source>Disconnected</source>
+        <translation>已断开连接</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/client_room.cpp" line="78"/>
+        <source>%1 (%2/%3 members) - connected</source>
+        <translation>%1 (%2/%3 人数)已连接</translation>
+    </message>
+</context>
+<context>
+    <name>CompatDB</name>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="20"/>
+        <source>Report Compatibility</source>
+        <translation>报告兼容性</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="27"/>
+        <location filename="../../src/citra_qt/compatdb.ui" line="63"/>
+        <source>Report Game Compatibility</source>
+        <translation>报告游戏兼容性</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="36"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;Should you choose to submit a test case to the &lt;/span&gt;&lt;a href=&quot;https://citra-emu.org/game/&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;Citra Compatibility List&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;, The following information will be collected and displayed on the site:&lt;/span&gt;&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Hardware Information (CPU / GPU / Operating System)&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Which version of Citra you are running&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The connected Citra account&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;如果您选择向&lt;/span&gt;&lt;a href=&quot;https://citra-emu.org/game/&quot;&gt;&lt;span style=&quot; font-size:10pt; text-decoration: underline; color:#0000ff;&quot;&gt;Citra 兼容性列表&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;提交项目的话，以下信息将会被收集并显示在网站上：&lt;/span&gt;&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;设备硬件信息 (CPU / GPU / 操作系统)&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;您正在使用的 Citra 版本&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;已关联的 Citra 帐户信息&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="72"/>
+        <source>Perfect</source>
+        <translation>完美</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="79"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions flawlessly with no audio or graphical glitches.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;p&gt;&lt;html&gt;&lt;head/&gt;&lt;body&gt;游戏功能完美，没有音频或图形问题。&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="89"/>
+        <source>Great </source>
+        <translation>好极了</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="96"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions with minor graphical or audio glitches and is playable from start to finish. May require some workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;游戏运行时会有非常轻微的图像或音频问题，但是能从头玩到尾。可能需要一些技巧处理图像或音频问题。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="106"/>
+        <source>Okay</source>
+        <translation>还行</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="113"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions with major graphical or audio glitches, but game is playable from start to finish with workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;游戏运行时会有很多图像或音频错误，但是在使用一些特殊技巧之后能完整地完成游戏。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="123"/>
+        <source>Bad</source>
+        <translation>比较差</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="130"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches even with workarounds.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;游戏能运行，但是会有大量图像或音频错误。即使使用一些技巧也无法通过游戏的某些区域。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="140"/>
+        <source>Intro/Menu</source>
+        <translation>开场/菜单</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="147"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start Screen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;游戏完全没法玩，图像或音频有重大错误。无法通过开场菜单。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="157"/>
+        <source>Won&apos;t Boot</source>
+        <translation>打不开</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="170"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The game crashes when attempting to startup.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;在启动游戏时直接崩溃了。&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="182"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Independent of speed or performance, how well does this game play from start to finish on this version of Citra?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;在不考虑速度或帧率的情况下，使用此版本 Citra 玩这款游戏的情况如何？&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/compatdb.ui" line="206"/>
+        <source>Thank you for your submission!</source>
+        <translation>感谢您向我们提交信息！</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureAudio</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="10"/>
+        <source>Audio</source>
+        <translation>声音</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="18"/>
+        <source>Output Engine:</source>
+        <translation>输出引擎：</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="31"/>
+        <source>Enable audio stretching</source>
+        <translation>启动音频拉伸</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="34"/>
+        <source>This post-processing effect adjusts audio speed to match emulation speed and helps prevent audio stutter. This however increases audio latency.</source>
+        <translation>这种后处理效果可以调整音频速度以匹配模拟速度，并有助于防止音频断断续续。 但是会增加音频延迟。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_audio.ui" line="43"/>
+        <source>Audio Device:</source>
+        <translation>音频设备:</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureDebug</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="14"/>
+        <source>Form</source>
+        <translation>格式</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="22"/>
+        <source>GDB</source>
+        <translation>GDB</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="28"/>
+        <source>The GDB Stub only works correctly when the CPU JIT is off.</source>
+        <translation>GDB 存根仅在CPU JIT关闭时正常工作。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="37"/>
+        <source>Enable GDB Stub</source>
+        <translation>开启GDB 存根</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_debug.ui" line="57"/>
+        <source>Port:</source>
+        <translation>端口:</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="14"/>
+        <source>Citra Configuration</source>
+        <translation>Citra设置</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="24"/>
+        <source>General</source>
+        <translation>一般</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="29"/>
+        <source>System</source>
+        <translation>系统</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="34"/>
+        <source>Input</source>
+        <translation>输入</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="39"/>
+        <source>Graphics</source>
+        <translation>图形</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="44"/>
+        <source>Audio</source>
+        <translation>声音</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="49"/>
+        <source>Debug</source>
+        <translation>调试</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure.ui" line="54"/>
+        <source>Web</source>
+        <translation>网页</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureGeneral</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="14"/>
+        <source>Form</source>
+        <translation>格式</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="22"/>
+        <source>General</source>
+        <translation>常规</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="30"/>
+        <source>Confirm exit while emulation is running</source>
+        <translation>确认在运行模拟时退出</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="37"/>
+        <source>Search sub-directories for games</source>
+        <translation>搜索子目录中的游戏</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="46"/>
+        <source>Interface language</source>
+        <translation>界面语言</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="63"/>
+        <source>Updates</source>
+        <translation>更新</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="71"/>
+        <source>Check for updates on start</source>
+        <translation>启动时检查更新</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="78"/>
+        <source>Silently auto update after closing</source>
+        <translation>关闭后静默自动更新</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="90"/>
+        <source>Performance</source>
+        <translation>性能</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="98"/>
+        <source>Enable CPU JIT</source>
+        <translation>开启CPU JIT</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="110"/>
+        <source>Emulation</source>
+        <translation>模拟</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="120"/>
+        <source>Region:</source>
+        <translation>地区：</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="128"/>
+        <source>Auto-select</source>
+        <translation>自动选择</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="178"/>
+        <source>Theme</source>
+        <translation>主题</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="188"/>
+        <source>Theme:</source>
+        <translation>主题：</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.ui" line="205"/>
+        <source>Hotkeys</source>
+        <translation>热键</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.cpp" line="16"/>
+        <source>&lt;System&gt;</source>
+        <translation>&lt;System&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_general.cpp" line="17"/>
+        <source>English</source>
+        <translation>英语</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureGraphics</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="14"/>
+        <source>Form</source>
+        <translation>格式</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="22"/>
+        <source>Graphics</source>
+        <translation>图形</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="28"/>
+        <source>Enable hardware renderer</source>
+        <translation>启用硬件渲染器</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="35"/>
+        <source>Enable shader JIT</source>
+        <translation>开启shader JIT</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="42"/>
+        <source>Enable V-Sync</source>
+        <translation>开启垂直同步</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="51"/>
+        <source>Limit Speed Percent</source>
+        <translation>限制速度百分比</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="58"/>
+        <source>%</source>
+        <translation>%</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="78"/>
+        <source>Internal Resolution:</source>
+        <translation>内部分辨率：</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="86"/>
+        <source>Auto (Window Size)</source>
+        <translation>自动(窗口大小)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="91"/>
+        <source>Native (400x240)</source>
+        <translation>原生(400x240)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="96"/>
+        <source>2x Native (800x480)</source>
+        <translation>2倍于原生(800x480)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="101"/>
+        <source>3x Native (1200x720)</source>
+        <translation>3倍于原生(1200x720)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="106"/>
+        <source>4x Native (1600x960)</source>
+        <translation>4倍于原生(1600x960)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="111"/>
+        <source>5x Native (2000x1200)</source>
+        <translation>5倍于原生(2000x1200)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="116"/>
+        <source>6x Native (2400x1440)</source>
+        <translation>6倍于原生(2400x1440)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="121"/>
+        <source>7x Native (2800x1680)</source>
+        <translation>7倍于原生(2800x1680)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="126"/>
+        <source>8x Native (3200x1920)</source>
+        <translation>8倍于原生(3200x1920)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="131"/>
+        <source>9x Native (3600x2160)</source>
+        <translation>9倍于原生(3600x2160)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="136"/>
+        <source>10x Native (4000x2400)</source>
+        <translation>10倍于原生(4000x2400)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="151"/>
+        <source>Layout</source>
+        <translation>布局</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="161"/>
+        <source>Screen Layout:</source>
+        <translation>屏幕布局：</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="169"/>
+        <source>Default</source>
+        <translation>默认</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="174"/>
+        <source>Single Screen</source>
+        <translation>单屏</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="179"/>
+        <source>Large Screen</source>
+        <translation>大屏显示在左边，小屏显示在右边</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="184"/>
+        <source>Side by Side</source>
+        <translation>横屏</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_graphics.ui" line="194"/>
+        <source>Swap Screens</source>
+        <translation>交换屏幕</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureInput</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="14"/>
+        <source>ConfigureInput</source>
+        <translation>输入设置</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="22"/>
+        <source>Face Buttons</source>
+        <translation>主要按键</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="36"/>
+        <source>A:</source>
+        <translation>A键：</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="54"/>
+        <source>B:</source>
+        <translation>B键:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="72"/>
+        <source>X:</source>
+        <translation>X键:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="90"/>
+        <source>Y:</source>
+        <translation>Y键:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="109"/>
+        <source>Directional Pad</source>
+        <translation>十字方向键</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="123"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="340"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="427"/>
+        <source>Up:</source>
+        <translation>上键:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="141"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="358"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="445"/>
+        <source>Down:</source>
+        <translation>下键:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="159"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="304"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="391"/>
+        <source>Left:</source>
+        <translation>左键:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="177"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="322"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="409"/>
+        <source>Right:</source>
+        <translation>右键:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="196"/>
+        <source>Shoulder Buttons</source>
+        <translation>肩部按键</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="210"/>
+        <source>L:</source>
+        <translation>L键:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="228"/>
+        <source>R:</source>
+        <translation>R键:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="246"/>
+        <source>ZL:</source>
+        <translation>ZL键:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="264"/>
+        <source>ZR:</source>
+        <translation>ZR键:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="283"/>
+        <source>Circle Pad</source>
+        <translation>方向摇杆</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="295"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="461"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="232"/>
+        <source>Set Analog Stick</source>
+        <translation>设置摇杆</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="377"/>
+        <source>C-Stick</source>
+        <translation>C摇杆</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="471"/>
+        <source>Misc.</source>
+        <translation>杂项.</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="485"/>
+        <source>Start:</source>
+        <translation> 开始键：</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="503"/>
+        <source>Select:</source>
+        <translation>选择键：</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="521"/>
+        <source>Home:</source>
+        <translation>Home键：</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="539"/>
+        <source>Circle Mod:</source>
+        <translation>方向摇杆：</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.ui" line="596"/>
+        <source>Restore Defaults</source>
+        <translation>恢复默认按键</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="239"/>
+        <source>[press key]</source>
+        <translation>[请按一个键]</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureSystem</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="14"/>
+        <source>Form</source>
+        <translation>格式</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="22"/>
+        <source>System Settings</source>
+        <translation>系统设置</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="28"/>
+        <source>Username</source>
+        <translation>用户名</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="48"/>
+        <source>Birthday</source>
+        <translation>生日</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="58"/>
+        <source>January</source>
+        <translation>一月</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="63"/>
+        <source>February</source>
+        <translation>二月</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="68"/>
+        <source>March</source>
+        <translation>三月</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="73"/>
+        <source>April</source>
+        <translation>四月</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="78"/>
+        <source>May</source>
+        <translation>五月</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="83"/>
+        <source>June</source>
+        <translation>六月</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="88"/>
+        <source>July</source>
+        <translation>七月</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="93"/>
+        <source>August</source>
+        <translation>八月</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="98"/>
+        <source>September</source>
+        <translation>九月</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="103"/>
+        <source>October</source>
+        <translation>十月</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="108"/>
+        <source>November</source>
+        <translation>十一月</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="113"/>
+        <source>December</source>
+        <translation>十二月</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="126"/>
+        <source>Language</source>
+        <translation>语言</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="133"/>
+        <source>Note: this can be overridden when region setting is auto-select</source>
+        <translation>注意：当“地区”设置是自动选择时，可以重写此设置。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="137"/>
+        <source>Japanese (日本語)</source>
+        <translation>日语 (日本語)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="142"/>
+        <source>English</source>
+        <translation>英语</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="147"/>
+        <source>French (français)</source>
+        <translation>法语 (français)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="152"/>
+        <source>German (Deutsch)</source>
+        <translation>德语 (Deutsch)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="157"/>
+        <source>Italian (italiano)</source>
+        <translation>意大利语 (italiano)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="162"/>
+        <source>Spanish (español)</source>
+        <translation>西班牙语 (español)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="167"/>
+        <source>Simplified Chinese (简体中文)</source>
+        <translation>简体中文 (简体中文)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="172"/>
+        <source>Korean (한국어)</source>
+        <translation>朝鲜语 (한국어)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="177"/>
+        <source>Dutch (Nederlands)</source>
+        <translation>荷兰语 (Nederlands)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="182"/>
+        <source>Portuguese (português)</source>
+        <translation>葡萄牙语 (português)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="187"/>
+        <source>Russian (Русский)</source>
+        <translation>俄语 (Русский)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="192"/>
+        <source>Traditional Chinese (正體中文)</source>
+        <translation>繁体中文 (正體中文)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="200"/>
+        <source>Sound output mode</source>
+        <translation>声音输出模式</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="208"/>
+        <source>Mono</source>
+        <translation>单声道</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="213"/>
+        <source>Stereo</source>
+        <translation>立体声</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="218"/>
+        <source>Surround</source>
+        <translation>环绕声</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="226"/>
+        <source>Console ID:</source>
+        <translation>设备ID：</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="242"/>
+        <source>Regenerate</source>
+        <translation>重置ID</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.ui" line="252"/>
+        <source>System settings are available only when game is not running.</source>
+        <translation>只有当游戏不运行时，系统设置才可用。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="87"/>
+        <source>Console ID: 0x%1</source>
+        <translation>设备ID: 0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="160"/>
+        <source>This will replace your current virtual 3DS with a new one. Your current virtual 3DS will not be recoverable. This might have unexpected effects in games. This might fail, if you use an outdated config savegame. Continue?</source>
+        <translation>这将使用一个新的虚拟 3DS 取代你当前的虚拟 3DS。您当前的虚拟 3DS 将无法恢复。在部分游戏中可能会出现意外效果。如果你使用一个过时的配置存档这可能会失败。确定要继续吗？</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_system.cpp" line="164"/>
+        <source>Warning</source>
+        <translation>警告</translation>
+    </message>
+</context>
+<context>
+    <name>ConfigureWeb</name>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="14"/>
+        <source>Form</source>
+        <translation>格式</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="22"/>
+        <source>Citra Web Service</source>
+        <translation>Citra网络服务</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="28"/>
+        <source>By providing your username and token, you agree to allow Citra to collect additional usage data, which may include user identifying information.</source>
+        <translation>提供您的用户名和令牌意味着您同意让Citra收集额外的使用数据，其中可能包括用户识别信息。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="46"/>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="90"/>
+        <source>Verify</source>
+        <translation>验证</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="53"/>
+        <source>Sign up</source>
+        <translation>注册</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="67"/>
+        <source>Token: </source>
+        <translation>令牌：</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="78"/>
+        <source>Username: </source>
+        <translation>用户名：</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="99"/>
+        <source>What is my token?</source>
+        <translation>我的令牌是什么？</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="124"/>
+        <source>Telemetry</source>
+        <translation>遥测</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="130"/>
+        <source>Share anonymous usage data with the Citra team</source>
+        <translation>与Citra团队共享匿名使用数据</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="137"/>
+        <source>Learn more</source>
+        <translation>了解更多</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="146"/>
+        <source>Telemetry ID:</source>
+        <translation>遥测ID：</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.ui" line="162"/>
+        <source>Regenerate</source>
+        <translation>重新生成</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="28"/>
+        <source>&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;了解更多&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="33"/>
+        <source>&lt;a href=&apos;https://services.citra-emu.org/&apos;&gt;Sign up&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://services.citra-emu.org/&apos;&gt;注册&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="36"/>
+        <source>&lt;a href=&apos;https://citra-emu.org/wiki/citra-web-service/&apos;&gt;What is my token?&lt;/a&gt;</source>
+        <translation>&lt;a href=&apos;https://citra-emu.org/wiki/citra-web-service/&apos;&gt;我的令牌是什么？&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="45"/>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="65"/>
+        <source>Telemetry ID: 0x%1</source>
+        <translation>遥测ID：0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="55"/>
+        <source>Username and token not verified</source>
+        <translation>用户名和令牌未被验证</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="56"/>
+        <source>Username and token were not verified. The changes to your username and/or token have not been saved.</source>
+        <translation>用户名和令牌未被验证。对用户名和/或令牌的更改尚未保存。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="85"/>
+        <source>Verifying</source>
+        <translation>验证中</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="99"/>
+        <source>Verification failed</source>
+        <translation>验证失败</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_web.cpp" line="100"/>
+        <source>Verification failed. Check that you have entered your username and token correctly, and that your internet connection is working.</source>
+        <translation>验证失败。检查您输入的用户名和令牌是否正确，并且您的互联网连接是否正常。</translation>
+    </message>
+</context>
+<context>
+    <name>DirectConnect</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="14"/>
+        <source>Direct Connect</source>
+        <translation>直接连接</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="33"/>
+        <source>IP Address</source>
+        <translation>IP地址</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="56"/>
+        <source>IP</source>
+        <translation>IP</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="63"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;IPv4 address of the host&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;主机IPv4地址&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="73"/>
+        <source>Port</source>
+        <translation>端口</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="80"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Port number the host is listening on&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;主机侦听端口&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="86"/>
+        <source>24872</source>
+        <translation>24872</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="100"/>
+        <source>Nickname</source>
+        <translation>名称</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="114"/>
+        <source>Password</source>
+        <translation>密码</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.ui" line="156"/>
+        <source>Connect</source>
+        <translation>连接</translation>
+    </message>
+</context>
+<context>
+    <name>DirectConnectWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="97"/>
+        <source>Connecting</source>
+        <translation>连接中</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/direct_connect.cpp" line="102"/>
+        <source>Connect</source>
+        <translation>连接</translation>
+    </message>
+</context>
+<context>
+    <name>GMainWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="90"/>
+        <source>To help improve Citra, the Citra Team collects anonymous usage data. No private or personally identifying information is collected. This data helps us to understand how people use Citra and prioritize our efforts. Furthermore, it helps us to more easily identify emulation bugs and performance issues. This data includes:&lt;ul&gt;&lt;li&gt;Information about the version of Citra you are using&lt;/li&gt;&lt;li&gt;Performance data about the games you play&lt;/li&gt;&lt;li&gt;Your configuration settings&lt;/li&gt;&lt;li&gt;Information about your computer hardware&lt;/li&gt;&lt;li&gt;Emulation errors and crash information&lt;/li&gt;&lt;/ul&gt;By default, this feature is enabled. To disable this feature, click &apos;Emulation&apos; from the menu and then select &apos;Configure...&apos;. Then, on the &apos;Web&apos; tab, uncheck &apos;Share anonymous usage data with the Citra team&apos;. &lt;br/&gt;&lt;br/&gt;By using this software, you agree to the above terms.&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;Learn more&lt;/a&gt;</source>
+        <translation>为了帮助改进Citra，Citra团队收集匿名使用数据。不收集任何私人或个人身份资料。这些数据帮助我们理解人们如何使用Citra，并确定我们的工作重点。此外，它帮助我们更容易地识别模拟错误和性能问题。这些数据包括:&lt;ul&gt;&lt;li&gt;有关您正在使用的Citra版本的信息&lt;/li&gt;&lt;li&gt;你玩的游戏的性能数据&lt;/li&gt;&lt;li&gt;你的配置设置&lt;li&gt;您电脑的硬件信息&lt;/li&gt;&lt;li&gt;模拟错误和崩溃信息&lt;/li&gt;&lt;/ul&gt;
+默认情况下，启用此功能。若要禁用此功能，请单击菜单中的“模拟”，然后选择“配置...”。然后，在“网页”选项卡上，取消选中“与Citra团队共享匿名使用数据”。&lt;br/&gt;&lt;br/&gt;使用本软件，您同意上述条款。&lt;br/&gt;&lt;br/&gt;&lt;a href=&apos;https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/&apos;&gt;了解更多&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="195"/>
+        <source>Current emulation speed. Values higher or lower than 100% indicate emulation is running faster or slower than a 3DS.</source>
+        <translation>当前模拟速度。高于或低于100%的值表示模拟正在运行得比3DS更快或更慢。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="198"/>
+        <source>How many frames per second the game is currently displaying. This will vary from game to game and scene to scene.</source>
+        <translation>游戏当前显示的每秒有多少帧。这将因游戏和场景的不同而有所不同。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="202"/>
+        <source>Time taken to emulate a 3DS frame, not counting framelimiting or v-sync. For full-speed emulation this should be at most 16.67 ms.</source>
+        <translation>在不计算锁帧或垂直同步的情况下全速模拟一个3DS帧的实际时间最多16.67毫秒。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="429"/>
+        <source>CTRL+F</source>
+        <translation>CTRL+F</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="538"/>
+        <source>Update available!</source>
+        <translation>更新可用！</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="539"/>
+        <source>An update for Citra is available. Do you wish to install it now?&lt;br /&gt;&lt;br /&gt;This &lt;b&gt;will&lt;/b&gt; terminate emulation, if it is running.</source>
+        <translation>发现一个更新。你需要安装它吗？&lt;br /&gt;&lt;br /&gt;如果在&lt;b&gt;运行游戏&lt;/b&gt;的时候更新将会终止模拟。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <source>No update found</source>
+        <translation>没有找到更新</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="550"/>
+        <source>No update has been found for Citra.</source>
+        <translation>没有找到更新。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="567"/>
+        <source>Error while initializing OpenGL 3.3 Core!</source>
+        <translation>初始化OpenGL 3.3内核时出错！</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="568"/>
+        <source>Your GPU may not support OpenGL 3.3, or you do not have the latest graphics driver.</source>
+        <translation>您的GPU可能不支持OpenGL 3.3，或者您没有最新的图形驱动程序。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="581"/>
+        <location filename="../../src/citra_qt/main.cpp" line="587"/>
+        <location filename="../../src/citra_qt/main.cpp" line="593"/>
+        <location filename="../../src/citra_qt/main.cpp" line="606"/>
+        <location filename="../../src/citra_qt/main.cpp" line="625"/>
+        <source>Error while loading ROM!</source>
+        <translation>加载ROM时出错！</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="582"/>
+        <location filename="../../src/citra_qt/main.cpp" line="607"/>
+        <source>The ROM format is not supported.</source>
+        <translation>这个ROM格式不支持。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="588"/>
+        <source>Could not determine the system mode.</source>
+        <translation>无法确定系统模式。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="594"/>
+        <source>The game that you are trying to load must be decrypted before being used with Citra. A real 3DS is required.&lt;br/&gt;&lt;br/&gt;For more information on dumping and decrypting games, please see the following wiki pages: &lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;Dumping Game Cartridges&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;Dumping Installed Titles&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</source>
+        <translation>这个游戏需要解密才能被Citra识别。解密过程需要一台实体 3DS 游戏机。&lt;br/&gt;&lt;br/&gt;更多有关转储和解密游戏的信息，请参见以下wiki页面：&lt;ul&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-game-cartridges/&apos;&gt;转储游戏卡带&lt;/a&gt;&lt;/li&gt;&lt;li&gt;&lt;a href=&apos;https://citra-emu.org/wiki/dumping-installed-titles/&apos;&gt;转储已安装的游戏&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="612"/>
+        <source>An error occured in the video core.</source>
+        <translation>视频核心出现错误。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="613"/>
+        <source>Citra has encountered an error while running the video core, please see the log for more details.For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.Ensure that you have the latest graphics drivers for your GPU.</source>
+        <translation>Citra在运行时视频核心时遇到错误，请看日志文件。有关访问日志的更多信息，请参见以下网页：&lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;如何上传日志文件。&lt;/a&gt;确保你有最新的显卡驱动。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="626"/>
+        <source>An unknown error occured. Please see the log for more details.</source>
+        <translation>发生了一个未知的错误。详情请参阅日志。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="699"/>
+        <source>Start</source>
+        <translation>开始</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="790"/>
+        <source>Error Opening %1 Folder</source>
+        <translation>无法打开%1文件夹 </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="791"/>
+        <source>Folder does not exist!</source>
+        <translation>文件夹不存在！</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="805"/>
+        <source>3DS Executable</source>
+        <translation>3DS可执行文件</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="806"/>
+        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <source>All Files (*.*)</source>
+        <translation>所有文件(*.*)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="808"/>
+        <source>Load File</source>
+        <translation>加载文件</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="818"/>
+        <source>Select Directory</source>
+        <translation>选择目录</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="827"/>
+        <source>Load Files</source>
+        <translation>加载多个文件</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="828"/>
+        <source>3DS Installation File (*.CIA*)</source>
+        <translation>3DS安装文件(*.CIA*)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="859"/>
+        <source>%1 has been installed successfully.</source>
+        <translation>%1 已成功安装。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="862"/>
+        <source>Unable to open File</source>
+        <translation>无法打开文件</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="863"/>
+        <source>Could not open %1</source>
+        <translation>无法打开 %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="867"/>
+        <source>Installation aborted</source>
+        <translation>安装失败</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="868"/>
+        <source>The installation of %1 was aborted. Please see the log for more details</source>
+        <translation>%1 的安装过程被取消。详情请检查日志</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <source>Invalid File</source>
+        <translation>文件无效</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="872"/>
+        <source>%1 is not a valid CIA</source>
+        <translation>%1 不是有效的 CIA 文件</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="875"/>
+        <source>Encrypted File</source>
+        <translation>被加密的文件</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="876"/>
+        <source>%1 must be decrypted before being used with Citra. A real 3DS is required.</source>
+        <translation>%1 需要在用于 Citra 前先解密。你需要一个真的 3DS 设备。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="899"/>
+        <source>File not found</source>
+        <translation>找不到文件</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="900"/>
+        <source>File &quot;%1&quot; not found</source>
+        <translation>文件 &quot;%1&quot; 未找到</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="914"/>
+        <source>Continue</source>
+        <translation>继续</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="939"/>
+        <source>Missing Citra Account</source>
+        <translation>没有 Citra 帐号</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="940"/>
+        <source>In order to submit a game compatibility test case, you must link your Citra account.&lt;br&gt;&lt;br/&gt;To link your Citra account, go to Emulation &amp;gt; Configuration &amp;gt; Web.</source>
+        <translation>为了提交游戏兼容性信息, 您必须关联您的 Citra 帐号。&lt;br&gt;&lt;br/&gt;请前往 模拟 &amp;gt; 设置 &amp;gt; 网络 关联您的帐户。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1090"/>
+        <source>Speed: %1% / %2%</source>
+        <translation>速度: %1% / %2%</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1094"/>
+        <source>Speed: %1%</source>
+        <translation>速度: %1%</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1096"/>
+        <source>Game: %1 FPS</source>
+        <translation>游戏: %1 FPS</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1097"/>
+        <source>Frame: %1 ms</source>
+        <translation>帧延迟：%1 毫秒</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1108"/>
+        <source>The game you are trying to load requires additional files from your 3DS to be dumped before playing.&lt;br/&gt;&lt;br/&gt;For more information on dumping these files, please see the following wiki page: &lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;Dumping System Archives and the Shared Fonts from a 3DS Console&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
+        <translation>你想要加载的游戏需要从你的3DS转储附加文件后才能玩。&lt;br/&gt;&lt;br/&gt;有关转储文件的更多信息，请参见下面的wiki页面：&lt;a href=&apos;https://citra-emu.org/wiki/dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/&apos;&gt;从3DS控制台转储系统档案和共享字体&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;你想退出到游戏列表吗？继续模拟可能导致崩溃，损坏保存数据或其他错误。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1120"/>
+        <source>: %1. </source>
+        <translation>: %1. </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1126"/>
+        <source>System Archive Not Found</source>
+        <translation>未找到系统档案</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1133"/>
+        <source>Citra was unable to locate the 3DS shared fonts. </source>
+        <translation>Citra无法定位3DS的字体文件。 </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1135"/>
+        <source>Shared Fonts Not Found</source>
+        <translation>找不到字体文件</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1143"/>
+        <source>Fatal Error</source>
+        <translation>致命错误</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1144"/>
+        <source>Citra has encountered a fatal error, please see the log for more details. For more information on accessing the log, please see the following page: &lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;How to Upload the Log File&lt;/a&gt;.&lt;br/&gt;&lt;br/&gt;Would you like to quit back to the game list? Continuing emulation may result in crashes, corrupted save data, or other bugs.</source>
+        <translation>Citra遇到了一个致命的错误，请看日志文件。有关访问日志的更多信息，请参见下面的页面&lt;a href=&apos;https://community.citra-emu.org/t/how-to-upload-the-log-file/296&apos;&gt;如何上传日志文件&lt;/a&gt;。&lt;br/&gt;&lt;br/&gt;你想退出并返回到游戏列表吗？继续模拟可能导致崩溃，存档损坏或其他错误。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <location filename="../../src/citra_qt/main.cpp" line="1245"/>
+        <source>Citra</source>
+        <translation>Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1178"/>
+        <source>Are you sure you want to close Citra?</source>
+        <translation>你确定要关闭Citra吗？</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1246"/>
+        <source>Are you sure you want to stop the emulation? Any unsaved progress will be lost.</source>
+        <translation>您确定要停止模拟吗？任何未保存的进度将会丢失。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.cpp" line="1318"/>
+        <source>Citra %1| %2-%3</source>
+        <translation>Citra %1| %2-%3</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandListModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="96"/>
+        <source>Command Name</source>
+        <translation>命令名称</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="98"/>
+        <source>Register</source>
+        <translation>寄存器</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="100"/>
+        <source>Mask</source>
+        <translation>伪装</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="102"/>
+        <source>New Value</source>
+        <translation>新参数</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandListWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="184"/>
+        <source>Pica Command List</source>
+        <translation>Pica命令列表</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="202"/>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="233"/>
+        <source>Start Tracing</source>
+        <translation>开始追踪</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="203"/>
+        <source>Copy All</source>
+        <translation>复制所有</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_cmdlists.cpp" line="229"/>
+        <source>Finish Tracing</source>
+        <translation>完成追踪</translation>
+    </message>
+</context>
+<context>
+    <name>GPUCommandStreamWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics.cpp" line="67"/>
+        <source>Graphics Debugger</source>
+        <translation>图形调试工具</translation>
+    </message>
+</context>
+<context>
+    <name>GameList</name>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <source>Perfect</source>
+        <translation>完美</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="85"/>
+        <source>Game functions flawless with no audio or graphical glitches, all tested functionality works as intended without
+any workarounds needed.</source>
+        <translation>游戏功能完美无音频或图形故障，所有测试功能的工作，没有任何解决方案需要。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <source>Great</source>
+        <translation>好极了</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="86"/>
+        <source>Game functions with minor graphical or audio glitches and is playable from start to finish. May require some
+workarounds.</source>
+        <translation>游戏运行时会有非常轻微的图像或音频问题，但是能从头玩到尾。可能需要一些技巧处理图像或音频问题。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <source>Okay</source>
+        <translation>还行</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="87"/>
+        <source>Game functions with major graphical or audio glitches, but game is playable from start to finish with
+workarounds.</source>
+        <translation>游戏运行时会有很多图像或音频错误，但是在使用一些特殊技巧之后能完整地完成游戏。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Bad</source>
+        <translation>比较差</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="88"/>
+        <source>Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches
+even with workarounds.</source>
+        <translation>游戏能运行，但是会有大量图像或音频错误。即使使用一些技巧仍无法通过游戏的某些区域。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <source>Intro/Menu</source>
+        <translation>开场/菜单</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="89"/>
+        <source>Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start
+Screen.</source>
+        <translation>游戏完全没法玩，图像或音频有重大错误。无法通过开场菜单。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>Won&apos;t Boot</source>
+        <translation>打不开</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="90"/>
+        <source>The game crashes when attempting to startup.</source>
+        <translation>在启动游戏时直接崩溃了。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <source>Not Tested</source>
+        <translation>未测试</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list_p.h" line="91"/>
+        <source>The game has not yet been tested.</source>
+        <translation>游戏尚未经过测试。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="99"/>
+        <source>of</source>
+        <translation>于</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="102"/>
+        <source>result</source>
+        <translation>结果</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="104"/>
+        <source>results</source>
+        <translation>结果</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="125"/>
+        <source>Filter:</source>
+        <translation>过滤器：</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="128"/>
+        <source>Enter pattern to filter</source>
+        <translation>输入样式进行过滤</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="324"/>
+        <source>Open Save Data Location</source>
+        <translation>打开保存数据位置</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="325"/>
+        <source>Open Application Location</source>
+        <translation>打开应用位置</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/game_list.cpp" line="326"/>
+        <source>Open Update Data Location</source>
+        <translation>打开数据更新位置</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsBreakPointsWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="132"/>
+        <source>Pica Breakpoints</source>
+        <translation>Pica断点</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="136"/>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="198"/>
+        <source>Emulation running</source>
+        <translation>模拟正在运行</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="137"/>
+        <source>Resume</source>
+        <translation>继续</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_breakpoints.cpp" line="188"/>
+        <source>Emulation halted at breakpoint</source>
+        <translation>模拟停止在断点处</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsSurfaceWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="49"/>
+        <source>Pica Surface Viewer</source>
+        <translation>Pica表面浏览器</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="54"/>
+        <source>Color Buffer</source>
+        <translation>彩色缓冲器</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="55"/>
+        <source>Depth Buffer</source>
+        <translation>深度缓冲器</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="56"/>
+        <source>Stencil Buffer</source>
+        <translation>模板缓冲器</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="57"/>
+        <source>Texture 0</source>
+        <translation>贴图 0</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="58"/>
+        <source>Texture 1</source>
+        <translation>贴图 1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="59"/>
+        <source>Texture 2</source>
+        <translation>贴图 2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="60"/>
+        <source>Custom</source>
+        <translation>自定义</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="103"/>
+        <source>Unknown</source>
+        <translation>未知</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="118"/>
+        <source>Save</source>
+        <translation>保存</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="144"/>
+        <source>Source:</source>
+        <translation>来源：</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="150"/>
+        <source>Physical Address:</source>
+        <translation>物理地址：</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="156"/>
+        <source>Width:</source>
+        <translation>宽度：</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="162"/>
+        <source>Height:</source>
+        <translation>高度：</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="168"/>
+        <source>Format:</source>
+        <translation>格式：</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="180"/>
+        <source>X:</source>
+        <translation>X:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="186"/>
+        <source>Y:</source>
+        <translation>Y:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="280"/>
+        <source>Pixel out of bounds</source>
+        <translation>像素越界</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="287"/>
+        <source>(unable to access pixel data)</source>
+        <translation>(无法访问像素数据)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="555"/>
+        <source>(invalid surface address)</source>
+        <translation>(非法表层地址)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="565"/>
+        <source>(unknown surface format)</source>
+        <translation>(未知表层格式)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="658"/>
+        <source>Portable Network Graphic (*.png)</source>
+        <translation>便携式网络图形 (*.png)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="659"/>
+        <source>Binary data (*.bin)</source>
+        <translation>二进制文件 (*.bin)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_surface.cpp" line="663"/>
+        <source>Save Surface</source>
+        <translation>保存表层</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsTracingWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="25"/>
+        <source>CiTrace Recorder</source>
+        <translation>CiTrace录制器</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="29"/>
+        <source>Start Recording</source>
+        <translation>开始录制</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="31"/>
+        <source>Stop and Save</source>
+        <translation>停止并保存</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="32"/>
+        <source>Abort Recording</source>
+        <translation>停止录制</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="112"/>
+        <source>Save CiTrace</source>
+        <translation>保存CiTracer</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="113"/>
+        <source>CiTrace File (*.ctf)</source>
+        <translation>CiTrace文件 (*.ctf)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="162"/>
+        <source>CiTracing still active</source>
+        <translation>CiTracing依然活跃</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_tracing.cpp" line="163"/>
+        <source>A CiTrace is still being recorded. Do you want to save it? If not, all recorded data will be discarded.</source>
+        <translation>一个CiTrace仍被记录。你想保存它吗？如果不保存，所有记录的数据将丢失。</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsVertexShaderModel</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="45"/>
+        <source>Offset</source>
+        <translation>偏移</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="47"/>
+        <source>Raw</source>
+        <translation>原内容</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="49"/>
+        <source>Disassembly</source>
+        <translation>反汇编</translation>
+    </message>
+</context>
+<context>
+    <name>GraphicsVertexShaderWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="345"/>
+        <source>Save Shader Dump</source>
+        <translation>保存着色器转储</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="345"/>
+        <source>Shader Binary (*.shbin)</source>
+        <translation>着色器二进制文件(*.shbin)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="380"/>
+        <source>(data only available at vertex shader invocation breakpoints)</source>
+        <translation>(数据仅在顶点着色器调用断点时可用)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="390"/>
+        <source>Dump</source>
+        <translation>转储</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="412"/>
+        <source>Input Data</source>
+        <translation>输入数据</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="426"/>
+        <source>Attribute %1</source>
+        <translation>属性 %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="453"/>
+        <source>Cycle Index:</source>
+        <translation>循环索引：</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="558"/>
+        <source>SRC1: %1, %2, %3, %4
+</source>
+        <translation>SRC1: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="564"/>
+        <source>SRC2: %1, %2, %3, %4
+</source>
+        <translation>SRC2: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="570"/>
+        <source>SRC3: %1, %2, %3, %4
+</source>
+        <translation>SRC3: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="576"/>
+        <source>DEST_IN: %1, %2, %3, %4
+</source>
+        <translation>DEST_IN: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="582"/>
+        <source>DEST_OUT: %1, %2, %3, %4
+</source>
+        <translation>DEST_OUT: %1, %2, %3, %4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="589"/>
+        <source>Address Registers: %1, %2
+</source>
+        <translation>地址寄存器：%1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="593"/>
+        <source>Compare Result: %1, %2
+</source>
+        <translation>比较结果：%1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="598"/>
+        <source>Static Condition: %1
+</source>
+        <translation>静态状态：%1
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="600"/>
+        <source>Dynamic Conditions: %1, %2
+</source>
+        <translation>动态状态：%1, %2
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="604"/>
+        <source>Loop Parameters: %1 (repeats), %2 (initializer), %3 (increment), %4
+</source>
+        <translation>循环参数：%1(循环)，%2(初始值)，%3(增量)，%4
+</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="611"/>
+        <source>Instruction offset: 0x%1</source>
+        <translation>指令偏移量：0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="613"/>
+        <source> -&gt; 0x%2</source>
+        <translation> -&gt; 0x%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp" line="615"/>
+        <source> (last instruction)</source>
+        <translation>(最后指令)</translation>
+    </message>
+</context>
+<context>
+    <name>HostRoom</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="14"/>
+        <source>Create Room</source>
+        <translation>建立房间</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="37"/>
+        <source>Room Name</source>
+        <translation>房间名称</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="51"/>
+        <source>Preferred Game</source>
+        <translation>首选游戏</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="61"/>
+        <source>Max Players</source>
+        <translation>最大玩家数</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="91"/>
+        <source>Username</source>
+        <translation>用户名</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="101"/>
+        <source>(Leave blank for open game)</source>
+        <translation>（为开放游戏留下空白）</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="118"/>
+        <source>Password</source>
+        <translation>密码</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="125"/>
+        <source>Port</source>
+        <translation>端口</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="156"/>
+        <source>Public</source>
+        <translation>公开房间</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="161"/>
+        <source>Unlisted</source>
+        <translation>不公开房间</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/host_room.ui" line="169"/>
+        <source>Host Room</source>
+        <translation>房间主机</translation>
+    </message>
+</context>
+<context>
+    <name>Lobby</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="14"/>
+        <source>Public Room Browser</source>
+        <translation>公共房间浏览器</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="32"/>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="39"/>
+        <source>Nickname</source>
+        <translation>昵称</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="59"/>
+        <source>Filters</source>
+        <translation>过滤器</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="66"/>
+        <source>Search</source>
+        <translation>搜索</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="76"/>
+        <source>Games I Own</source>
+        <translation>我拥有的游戏</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="83"/>
+        <source>Hide Full Rooms</source>
+        <translation>屏蔽满员房间</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.ui" line="103"/>
+        <source>Refresh Lobby</source>
+        <translation>刷新大厅</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <source>Password Required to Join</source>
+        <translation>连接所需密码</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="76"/>
+        <source>Password:</source>
+        <translation>密码:</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="77"/>
+        <source>Password</source>
+        <translation>密码</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="142"/>
+        <source>Room Name</source>
+        <translation>房间名称</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="143"/>
+        <source>Preferred Game</source>
+        <translation>首选游戏</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="144"/>
+        <source>Host</source>
+        <translation>主机</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="145"/>
+        <source>Players</source>
+        <translation>玩家</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="153"/>
+        <source>Refreshing</source>
+        <translation>正在刷新</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby.cpp" line="201"/>
+        <source>Refresh List</source>
+        <translation>刷新列表</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="14"/>
+        <source>Citra</source>
+        <translation>Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="53"/>
+        <source>&amp;File</source>
+        <translation>文件(&amp;F)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="57"/>
+        <source>Recent Files</source>
+        <translation>最近文件</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="70"/>
+        <source>&amp;Emulation</source>
+        <translation>模拟(&amp;E)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="80"/>
+        <source>&amp;View</source>
+        <translation>视图(&amp;V)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="84"/>
+        <source>Debugging</source>
+        <translation>正在调试</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="91"/>
+        <source>Screen Layout</source>
+        <translation>屏幕排版</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="115"/>
+        <source>Multiplayer</source>
+        <translation>多人游戏</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="126"/>
+        <source>&amp;Help</source>
+        <translation>帮助(&amp;H)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="144"/>
+        <source>Load File...</source>
+        <translation>加载文件…</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="149"/>
+        <source>Install CIA...</source>
+        <translation>安装CIA…</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="154"/>
+        <source>Load Symbol Map...</source>
+        <translation>加载符号表…</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="159"/>
+        <source>E&amp;xit</source>
+        <translation>退出(&amp;X)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="167"/>
+        <source>&amp;Start</source>
+        <translation>开始(&amp;S)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="175"/>
+        <source>&amp;Pause</source>
+        <translation>暂停(&amp;P)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="183"/>
+        <source>&amp;Stop</source>
+        <translation>停止(&amp;S)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="188"/>
+        <source>FAQ</source>
+        <translation>常见问题</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="193"/>
+        <source>About Citra</source>
+        <translation>关于Citra</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="201"/>
+        <source>Single Window Mode</source>
+        <translation>单窗口模式</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="206"/>
+        <source>Configure...</source>
+        <translation>设置…</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="214"/>
+        <source>Display Dock Widget Headers</source>
+        <translation>显示停靠小部件的标题</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="222"/>
+        <source>Show Filter Bar</source>
+        <translation>显示过滤栏</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="230"/>
+        <source>Show Status Bar</source>
+        <translation>显示状态栏</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="235"/>
+        <source>Select Game Directory...</source>
+        <translation>选择游戏路径…</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="238"/>
+        <source>Selects a folder to display in the game list</source>
+        <translation>选择一个文件夹在游戏列表中显示 </translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="243"/>
+        <source>Create Pica Surface Viewer</source>
+        <translation>新建Pica表面浏览器</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="251"/>
+        <source>Browse Public Game Lobby</source>
+        <translation>浏览公共游戏大厅</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="259"/>
+        <source>Create Room</source>
+        <translation>建立房间</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="267"/>
+        <source>Leave Room</source>
+        <translation>离开房间</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="272"/>
+        <source>Direct Connect to Room</source>
+        <translation>直接连接到房间</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="280"/>
+        <source>Show Current Room</source>
+        <translation>显示当前房间</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="288"/>
+        <source>Fullscreen</source>
+        <translation>全屏</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="293"/>
+        <source>Modify Citra Install</source>
+        <translation>更改Citra安装包</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="296"/>
+        <source>Opens the maintenance tool to modify your Citra installation</source>
+        <translation>打开维护工具以修改Citra安装</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="304"/>
+        <source>Default</source>
+        <translation>默认</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="312"/>
+        <source>Single Screen</source>
+        <translation>单屏</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="320"/>
+        <source>Large Screen</source>
+        <translation>大屏显示在左边，小屏显示在右边</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="328"/>
+        <source>Side by Side</source>
+        <translation>横屏</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="336"/>
+        <source>Swap Screens</source>
+        <translation>交换屏幕</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="341"/>
+        <source>Check for Updates</source>
+        <translation>检查新版本</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/main.ui" line="349"/>
+        <source>Report Compatibility</source>
+        <translation>报告兼容性</translation>
+    </message>
+</context>
+<context>
+    <name>MicroProfileDialog</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/profiler.cpp" line="50"/>
+        <source>MicroProfile</source>
+        <translation>微配置文件</translation>
+    </message>
+</context>
+<context>
+    <name>MultiplayerState</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="41"/>
+        <source>Current connection status</source>
+        <translation>当前连接状态</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="42"/>
+        <source>Not Connected. Click here to find a room!</source>
+        <translation>未连接。点击此处查找一个房间！</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="100"/>
+        <source>Connected</source>
+        <translation>已连接</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="105"/>
+        <source>Not Connected</source>
+        <translation>未连接</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="114"/>
+        <source>Error</source>
+        <translation>错误</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/state.cpp" line="115"/>
+        <source>Failed to announce the room to the public lobby. In order to host a room publicly, you must have a valid Citra account configured in Emulation -&gt; Configure -&gt; Web. If you do not want to publish a room in the public lobby, then select Unlisted instead.
+Debug Message: </source>
+        <translation>未能向公众大厅宣布房间。 为了公开托管房间，您必须在模拟 - &gt;配置 - &gt; Web中配置有效的Citra帐户。 如果您不想在公共大厅中发布房间，请选择“不公开”。
+调试消息：</translation>
+    </message>
+</context>
+<context>
+    <name>NetworkMessage</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="12"/>
+        <source>Username is not valid. Must be 4 to 20 alphanumeric characters.</source>
+        <translation>用户名无效。 必须是4至20个字母数字字符。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="14"/>
+        <source>Room name is not valid. Must be 4 to 20 alphanumeric characters.</source>
+        <translation>房间名称无效。 必须是4至20个字母数字字符。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="16"/>
+        <source>Username is already in use. Please choose another.</source>
+        <translation>用户名已存在。 请选择另一个。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="17"/>
+        <source>IP is not a valid IPv4 address.</source>
+        <translation>这不是一个有效的IPv4地址。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="18"/>
+        <source>Port must be a number between 0 to 65535.</source>
+        <translation>端口必须是介于0到65535之间的数字。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="20"/>
+        <source>Unable to find an internet connection. Check your internet settings.</source>
+        <translation>无法找到互联网连接。 请检查你的网络设置。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="22"/>
+        <source>Unable to connect to the host. Verify that the connection settings are correct. If you still cannot connect, contact the room host and verify that the host is properly configured with the external port forwarded.</source>
+        <translation>连接到主机失败。请校验连接设置是否正确。 如果你还是不能连接， 请联系房主核实主机是否正确配置了外部端口转发。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="26"/>
+        <source>Creating a room failed. Please retry. Restarting Citra might be necessary.</source>
+        <translation>建立一个房间失败。 请重试。 如果仍然失败， 请重新运行citra。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="28"/>
+        <source>The host of the room has banned you. Speak with the host to unban you or try a different room.</source>
+        <translation>这个房间的房主把你封禁了。 请跟房主联系取消封禁或者尝试登陆别的房间。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="31"/>
+        <source>Version mismatch! Please update to the latest version of Citra. If the problem persists, contact the room host and ask them to update the server.</source>
+        <translation>版本号不匹配。 请更新最新版本的citra。 如果问题仍然存在， 请联系房主更新服务器。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="33"/>
+        <source>Incorrect password.</source>
+        <translation>密码错误。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="35"/>
+        <source>An unknown error occured. If this error continues to occur, please open an issue</source>
+        <translation>发生了一个未知的错误。 如果这个错误继续发生， 请开启一个议题。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="36"/>
+        <source>Connection to room lost. Try to reconnect.</source>
+        <translation>到房间的连接信号丢失。正在重新登录。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="38"/>
+        <source>MAC address is already in use. Please choose another.</source>
+        <translation>mac地址已经被使用。请重新选择其他的mac地址</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="52"/>
+        <source>Leave Room</source>
+        <translation>离开房间</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="53"/>
+        <source>You are about to close the room. Any network connections will be closed.</source>
+        <translation>你准备关闭这个房间。所有的网络连接将会被关闭。</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="58"/>
+        <source>Disconnect</source>
+        <translation>断开</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="59"/>
+        <source>You are about to leave the room. Any network connections will be closed.</source>
+        <translation>你准备离开这个房间。 所有的网络连接将会被关闭。</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/message.cpp" line="47"/>
+        <source>Error</source>
+        <translation>错误</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="198"/>
+        <source>%1 is not playing a game</source>
+        <translation>%1不在玩游戏</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/multiplayer/lobby_p.h" line="201"/>
+        <source>%1 is playing %2</source>
+        <translation>%1在玩%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="26"/>
+        <source>Shift</source>
+        <translation>Shift键</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="28"/>
+        <source>Ctrl</source>
+        <translation>Ctrl键</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="30"/>
+        <source>Alt</source>
+        <translation>Alt键</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="51"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="75"/>
+        <source>[not set]</source>
+        <translation>[未设置]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="55"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="83"/>
+        <source>Joystick %1</source>
+        <translation>摇杆 %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="57"/>
+        <source> Hat %1 %2</source>
+        <translation>帽子开关 %1 %2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="61"/>
+        <source> Axis %1%2</source>
+        <translation>轴 %1%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="65"/>
+        <source> Button %1</source>
+        <translation>按键 %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="69"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="91"/>
+        <source>[unknown]</source>
+        <translation>[未知]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="80"/>
+        <source>[unused]</source>
+        <translation>[未使用]</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="85"/>
+        <location filename="../../src/citra_qt/configuration/configure_input.cpp" line="87"/>
+        <source> Axis %1</source>
+        <translation>轴 %1</translation>
+    </message>
+</context>
+<context>
+    <name>RegistersWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="15"/>
+        <source>Registers</source>
+        <translation>寄存器</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="16"/>
+        <source>VFP Registers</source>
+        <translation>VFP寄存器</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="18"/>
+        <source>VFP System Registers</source>
+        <translation>VFP系统寄存器</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="167"/>
+        <source>Vector Length</source>
+        <translation>矢量长度</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="168"/>
+        <source>Vector Stride</source>
+        <translation>矢量步长</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="169"/>
+        <source>Rounding Mode</source>
+        <translation>回合模式</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/registers.cpp" line="182"/>
+        <source>Vector Iteration Count</source>
+        <translation>矢量重复演算计数</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeEvent</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="259"/>
+        <source>reset type = %1</source>
+        <translation>复位类型= %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeMutex</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="272"/>
+        <source>locked %1 times by thread:</source>
+        <translation>线程被锁定了%1次：</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="275"/>
+        <source>free</source>
+        <translation>空闲</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeMutexList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="314"/>
+        <source>holding mutexes</source>
+        <translation>持有互斥体</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeObjectList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="128"/>
+        <source>waiting for all objects</source>
+        <translation>等待所有对象</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="129"/>
+        <source>waiting for one of the following objects</source>
+        <translation>等待下面的对象之一</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeSemaphore</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="288"/>
+        <source>available count = %1</source>
+        <translation>可用数 = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="289"/>
+        <source>max count = %1</source>
+        <translation>最大数 = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeThread</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="146"/>
+        <source>running</source>
+        <translation>运行中</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="149"/>
+        <source>ready</source>
+        <translation>准备</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="152"/>
+        <source>waiting for address 0x%1</source>
+        <translation>等待解决0x%1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="155"/>
+        <source>sleeping</source>
+        <translation>休眠</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="158"/>
+        <source>waiting for IPC response</source>
+        <translation>等待IPC响应</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="162"/>
+        <source>waiting for objects</source>
+        <translation>等待对象</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="165"/>
+        <source>waiting for HLE return</source>
+        <translation>等待高级模拟返回</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="168"/>
+        <source>dormant</source>
+        <translation>休眠</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="171"/>
+        <source>dead</source>
+        <translation>死亡</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="174"/>
+        <source> PC = 0x%1 LR = 0x%2</source>
+        <translation> PC = 0x%1 LR = 0x%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="214"/>
+        <source>default</source>
+        <translation>默认</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="217"/>
+        <source>all</source>
+        <translation>所有</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="220"/>
+        <source>AppCore</source>
+        <translation>软件核心</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="223"/>
+        <source>SysCore</source>
+        <translation>系统核心</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="226"/>
+        <source>Unknown processor %1</source>
+        <translation>未知处理器 %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="230"/>
+        <source>processor = %1</source>
+        <translation>处理器 = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="231"/>
+        <source>thread id = %1</source>
+        <translation>线程ID = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="232"/>
+        <source>priority = %1(current) / %2(normal)</source>
+        <translation>优先 = %1(实时) / %2(正常)</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="236"/>
+        <source>last running ticks = %1</source>
+        <translation>最后运行频率 = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="239"/>
+        <source>not holding mutex</source>
+        <translation>未持有互斥体</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeThreadList</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="328"/>
+        <source>waited by thread</source>
+        <translation>等待线程</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeTimer</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="301"/>
+        <source>reset type = %1</source>
+        <translation>复位类型 = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="303"/>
+        <source>initial delay = %1</source>
+        <translation>初始延迟 = %1</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="305"/>
+        <source>interval delay = %1</source>
+        <translation>区间延迟 = %1</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeWaitObject</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="76"/>
+        <source>[%1]%2 %3</source>
+        <translation>[%1]%2 %3</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="104"/>
+        <source>waited by no thread</source>
+        <translation>没有等待的线程</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="114"/>
+        <source>one shot</source>
+        <translation>一个镜头</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="116"/>
+        <source>sticky</source>
+        <translation>粘性</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="118"/>
+        <source>pulse</source>
+        <translation>脉冲</translation>
+    </message>
+</context>
+<context>
+    <name>WaitTreeWidget</name>
+    <message>
+        <location filename="../../src/citra_qt/debugger/wait_tree.cpp" line="399"/>
+        <source>Wait Tree</source>
+        <translation>等待树</translation>
+    </message>
+</context>
+<context>
+    <name>hotkeys</name>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="14"/>
+        <source>Hotkey Settings</source>
+        <translation>热键设置</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="27"/>
+        <source>Action</source>
+        <translation>作用</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="32"/>
+        <source>Hotkey</source>
+        <translation>热键</translation>
+    </message>
+    <message>
+        <location filename="../../src/citra_qt/hotkeys.ui" line="37"/>
+        <source>Context</source>
+        <translation>Context</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
This PR adds the current translations (2018-04-25) to the main Citra repo from the Transifex project. I accepted translations that were at least 50% translated and reviewed with some exceptions.

Language list: German, Spanish, French, Hungarian, Indonesian, Italian, Japanese, Korean, Lithuanian, Dutch, Brazillian, Russian, Chinese.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3688)
<!-- Reviewable:end -->
