### PR TITLE
Frontend: Add missing translation for network error messages

### DIFF
--- a/src/citra_qt/multiplayer/message.cpp
+++ b/src/citra_qt/multiplayer/message.cpp
@@ -44,7 +44,7 @@ static bool WarnMessage(const std::string& title, const std::string& text) {
 }
 
 void ShowError(const ConnectionError& e) {
-    QMessageBox::critical(nullptr, QObject::tr("Error"), QString::fromStdString(e.GetString()));
+    QMessageBox::critical(nullptr, QObject::tr("Error"), QObject::tr(e.GetString().c_str()));
 }
 
 bool WarnCloseRoom() {


### PR DESCRIPTION
Fixes this 
![discord_2018-04-25_09-45-29](https://user-images.githubusercontent.com/952515/39256945-76d2f74c-486d-11e8-99b3-f097c3468d87.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3689)
<!-- Reviewable:end -->
