### PR TITLE
gl_rasterizer_cache: cache texture cube

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -44,7 +44,6 @@ RasterizerOpenGL::RasterizerOpenGL()
     // Create cubemap texture and sampler objects
     texture_cube_sampler.Create();
     state.texture_cube_unit.sampler = texture_cube_sampler.sampler.handle;
-    texture_cube.Create();
 
     // Generate VBO, VAO and UBO
     vertex_array.Create();
@@ -392,19 +391,18 @@ void RasterizerOpenGL::DrawTriangles() {
                 switch (texture.config.type.Value()) {
                 case TextureType::TextureCube:
                     using CubeFace = Pica::TexturingRegs::CubeFace;
-                    if (res_cache.FillTextureCube(
-                            texture_cube.handle, texture,
-                            regs.texturing.GetCubePhysicalAddress(CubeFace::PositiveX),
-                            regs.texturing.GetCubePhysicalAddress(CubeFace::NegativeX),
-                            regs.texturing.GetCubePhysicalAddress(CubeFace::PositiveY),
-                            regs.texturing.GetCubePhysicalAddress(CubeFace::NegativeY),
-                            regs.texturing.GetCubePhysicalAddress(CubeFace::PositiveZ),
-                            regs.texturing.GetCubePhysicalAddress(CubeFace::NegativeZ))) {
-                        state.texture_cube_unit.texture_cube = texture_cube.handle;
-                    } else {
-                        // Can occur when texture addr is null or its memory is unmapped/invalid
-                        state.texture_cube_unit.texture_cube = 0;
-                    }
+                    TextureCubeConfig config;
+                    config.px = regs.texturing.GetCubePhysicalAddress(CubeFace::PositiveX);
+                    config.nx = regs.texturing.GetCubePhysicalAddress(CubeFace::NegativeX);
+                    config.py = regs.texturing.GetCubePhysicalAddress(CubeFace::PositiveY);
+                    config.ny = regs.texturing.GetCubePhysicalAddress(CubeFace::NegativeY);
+                    config.pz = regs.texturing.GetCubePhysicalAddress(CubeFace::PositiveZ);
+                    config.nz = regs.texturing.GetCubePhysicalAddress(CubeFace::NegativeZ);
+                    config.width = texture.config.width;
+                    config.format = texture.format;
+                    state.texture_cube_unit.texture_cube =
+                        res_cache.GetTextureCube(config).texture.handle;
+
                     texture_cube_sampler.SyncWithConfig(texture.config);
                     state.texture_units[texture_index].texture_2d = 0;
                     continue; // Texture unit 0 setup finished. Continue to next unit

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -244,8 +244,6 @@ private:
     OGLBuffer uniform_buffer;
     OGLFramebuffer framebuffer;
 
-    // TODO (wwylele): consider caching texture cube in the rasterizer cache
-    OGLTexture texture_cube;
     SamplerInfo texture_cube_sampler;
 
     OGLBuffer lighting_lut_buffer;

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -28,7 +28,6 @@
 #include "video_core/pica_state.h"
 #include "video_core/renderer_opengl/gl_rasterizer_cache.h"
 #include "video_core/renderer_opengl/gl_state.h"
-#include "video_core/texture/texture_decode.h"
 #include "video_core/utils.h"
 #include "video_core/video_core.h"
 
@@ -228,6 +227,32 @@ static void AllocateSurfaceTexture(GLuint texture, const FormatTuple& format_tup
 
     // Restore previous texture bindings
     cur_state.texture_units[0].texture_2d = old_tex;
+    cur_state.Apply();
+}
+
+static void AllocateTextureCube(GLuint texture, const FormatTuple& format_tuple, u32 width) {
+    OpenGLState cur_state = OpenGLState::GetCurState();
+
+    // Keep track of previous texture bindings
+    GLuint old_tex = cur_state.texture_cube_unit.texture_cube;
+    cur_state.texture_cube_unit.texture_cube = texture;
+    cur_state.Apply();
+    glActiveTexture(TextureUnits::TextureCube.Enum());
+
+    for (auto faces : {
+             GL_TEXTURE_CUBE_MAP_POSITIVE_X,
+             GL_TEXTURE_CUBE_MAP_POSITIVE_Y,
+             GL_TEXTURE_CUBE_MAP_POSITIVE_Z,
+             GL_TEXTURE_CUBE_MAP_NEGATIVE_X,
+             GL_TEXTURE_CUBE_MAP_NEGATIVE_Y,
+             GL_TEXTURE_CUBE_MAP_NEGATIVE_Z,
+         }) {
+        glTexImage2D(faces, 0, format_tuple.internal_format, width, width, 0, format_tuple.format,
+                     format_tuple.type, nullptr);
+    }
+
+    // Restore previous texture bindings
+    cur_state.texture_cube_unit.texture_cube = old_tex;
     cur_state.Apply();
 }
 
@@ -761,6 +786,8 @@ void CachedSurface::UploadGLTexture(const MathUtil::Rectangle<u32>& rect, GLuint
         BlitTextures(unscaled_tex.handle, {0, rect.GetHeight(), rect.GetWidth(), 0}, texture.handle,
                      scaled_rect, type, read_fb_handle, draw_fb_handle);
     }
+
+    InvalidateAllWatcher();
 }
 
 MICROPROFILE_DEFINE(OpenGL_TextureDL, "OpenGL", "Texture Download", MP_RGB(128, 192, 64));
@@ -1193,14 +1220,13 @@ SurfaceRect_Tuple RasterizerCacheOpenGL::GetSurfaceSubRect(const SurfaceParams& 
 }
 
 Surface RasterizerCacheOpenGL::GetTextureSurface(
-    const Pica::TexturingRegs::FullTextureConfig& config, PAddr addr_override) {
+    const Pica::TexturingRegs::FullTextureConfig& config) {
     Pica::Texture::TextureInfo info =
         Pica::Texture::TextureInfo::FromPicaRegister(config.config, config.format);
+    return GetTextureSurface(info);
+}
 
-    if (addr_override != 0) {
-        info.physical_address = addr_override;
-    }
-
+Surface RasterizerCacheOpenGL::GetTextureSurface(const Pica::Texture::TextureInfo& info) {
     SurfaceParams params;
     params.addr = info.physical_address;
     params.width = info.width;
@@ -1228,80 +1254,94 @@ Surface RasterizerCacheOpenGL::GetTextureSurface(
     return GetSurface(params, ScaleMatch::Ignore, true);
 }
 
-bool RasterizerCacheOpenGL::FillTextureCube(GLuint dest_handle,
-                                            const Pica::TexturingRegs::FullTextureConfig& config,
-                                            PAddr px, PAddr nx, PAddr py, PAddr ny, PAddr pz,
-                                            PAddr nz) {
-    ASSERT(config.config.width == config.config.height);
-    struct FaceTuple {
+const CachedTextureCube& RasterizerCacheOpenGL::GetTextureCube(const TextureCubeConfig& config) {
+    auto& cube = texture_cube_cache[config];
+
+    struct Face {
+        Face(std::shared_ptr<SurfaceWatcher>& watcher, PAddr address, GLenum gl_face)
+            : watcher(watcher), address(address), gl_face(gl_face) {}
+        std::shared_ptr<SurfaceWatcher>& watcher;
         PAddr address;
         GLenum gl_face;
-        Surface surface;
     };
-    std::array<FaceTuple, 6> faces{{
-        {px, GL_TEXTURE_CUBE_MAP_POSITIVE_X},
-        {nx, GL_TEXTURE_CUBE_MAP_NEGATIVE_X},
-        {py, GL_TEXTURE_CUBE_MAP_POSITIVE_Y},
-        {ny, GL_TEXTURE_CUBE_MAP_NEGATIVE_Y},
-        {pz, GL_TEXTURE_CUBE_MAP_POSITIVE_Z},
-        {nz, GL_TEXTURE_CUBE_MAP_NEGATIVE_Z},
+
+    const std::array<Face, 6> faces{{
+        {cube.px, config.px, GL_TEXTURE_CUBE_MAP_POSITIVE_X},
+        {cube.nx, config.nx, GL_TEXTURE_CUBE_MAP_NEGATIVE_X},
+        {cube.py, config.py, GL_TEXTURE_CUBE_MAP_POSITIVE_Y},
+        {cube.ny, config.ny, GL_TEXTURE_CUBE_MAP_NEGATIVE_Y},
+        {cube.pz, config.pz, GL_TEXTURE_CUBE_MAP_POSITIVE_Z},
+        {cube.nz, config.nz, GL_TEXTURE_CUBE_MAP_NEGATIVE_Z},
     }};
 
-    u16 res_scale = 1;
-    for (auto& face : faces) {
-        face.surface = GetTextureSurface(config, face.address);
-        if (face.surface == nullptr)
-            return false;
-        res_scale = std::max(res_scale, face.surface->res_scale);
+    for (const Face& face : faces) {
+        if (!face.watcher || !face.watcher->Get()) {
+            Pica::Texture::TextureInfo info;
+            info.physical_address = face.address;
+            info.height = info.width = config.width;
+            info.format = config.format;
+            info.SetDefaultStride();
+            auto surface = GetTextureSurface(info);
+            if (surface) {
+                face.watcher = surface->CreateWatcher();
+            } else {
+                // Can occur when texture address is invalid. We mark the watcher with nullptr in
+                // this case and the content of the face wouldn't get updated. These are usually
+                // leftover setup in the texture unit and games are not supposed to draw using them.
+                face.watcher = nullptr;
+            }
+        }
     }
 
-    u32 scaled_size = res_scale * config.config.width;
+    if (cube.texture.handle == 0) {
+        for (const Face& face : faces) {
+            if (face.watcher) {
+                auto surface = face.watcher->Get();
+                cube.res_scale = std::max(cube.res_scale, surface->res_scale);
+            }
+        }
+
+        cube.texture.Create();
+        AllocateTextureCube(
+            cube.texture.handle,
+            GetFormatTuple(CachedSurface::PixelFormatFromTextureFormat(config.format)),
+            cube.res_scale * config.width);
+    }
+
+    u32 scaled_size = cube.res_scale * config.width;
 
     OpenGLState state = OpenGLState::GetCurState();
 
     OpenGLState prev_state = state;
     SCOPE_EXIT({ prev_state.Apply(); });
 
-    state.texture_cube_unit.texture_cube = dest_handle;
-    state.Apply();
-    glActiveTexture(TextureUnits::TextureCube.Enum());
-    FormatTuple format_tuple = GetFormatTuple(faces[0].surface->pixel_format);
+    state.draw.read_framebuffer = read_framebuffer.handle;
+    state.draw.draw_framebuffer = draw_framebuffer.handle;
+    state.ResetTexture(cube.texture.handle);
 
-    GLint cur_size, cur_format;
-    glGetTexLevelParameteriv(GL_TEXTURE_CUBE_MAP_POSITIVE_X, 0, GL_TEXTURE_WIDTH, &cur_size);
-    glGetTexLevelParameteriv(GL_TEXTURE_CUBE_MAP_POSITIVE_X, 0, GL_TEXTURE_INTERNAL_FORMAT,
-                             &cur_format);
+    for (const Face& face : faces) {
+        if (face.watcher && !face.watcher->IsValid()) {
+            auto surface = face.watcher->Get();
+            state.ResetTexture(surface->texture.handle);
+            state.Apply();
+            glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+                                   surface->texture.handle, 0);
+            glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D,
+                                   0, 0);
 
-    if (cur_size != scaled_size || cur_format != format_tuple.internal_format) {
-        for (auto& face : faces) {
-            glTexImage2D(face.gl_face, 0, format_tuple.internal_format, scaled_size, scaled_size, 0,
-                         format_tuple.format, format_tuple.type, nullptr);
+            glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, face.gl_face,
+                                   cube.texture.handle, 0);
+            glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D,
+                                   0, 0);
+
+            auto src_rect = surface->GetScaledRect();
+            glBlitFramebuffer(src_rect.left, src_rect.bottom, src_rect.right, src_rect.top, 0, 0,
+                              scaled_size, scaled_size, GL_COLOR_BUFFER_BIT, GL_LINEAR);
+            face.watcher->Validate();
         }
     }
 
-    state.draw.read_framebuffer = read_framebuffer.handle;
-    state.draw.draw_framebuffer = draw_framebuffer.handle;
-    state.ResetTexture(dest_handle);
-
-    for (auto& face : faces) {
-        state.ResetTexture(face.surface->texture.handle);
-        state.Apply();
-        glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
-                               face.surface->texture.handle, 0);
-        glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, 0,
-                               0);
-
-        glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, face.gl_face, dest_handle,
-                               0);
-        glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, 0,
-                               0);
-
-        auto src_rect = face.surface->GetScaledRect();
-        glBlitFramebuffer(src_rect.left, src_rect.bottom, src_rect.right, src_rect.top, 0, 0,
-                          scaled_size, scaled_size, GL_COLOR_BUFFER_BIT, GL_LINEAR);
-    }
-
-    return true;
+    return cube;
 }
 
 SurfaceSurfaceRect_Tuple RasterizerCacheOpenGL::GetFramebufferSurfaces(
@@ -1316,6 +1356,7 @@ SurfaceSurfaceRect_Tuple RasterizerCacheOpenGL::GetFramebufferSurfaces(
         FlushAll();
         while (!surface_cache.empty())
             UnregisterSurface(*surface_cache.begin()->second.begin());
+        texture_cube_cache.clear();
     }
 
     MathUtil::Rectangle<u32> viewport_clamped{


### PR DESCRIPTION
This is to reduce the performance impact of texture cube. Previously the texture cube is copied from texture surfaces on every draw batch, and for example in some area in Monster Hunter XX this is about 36 texture copies per frame.

Now with the cached texture cube, the texture copy only happens when the content of texture is changed, which in theory means: 6 copy on first draw and 0 copy per frame for static cubemap (= games load the cube from binary. The 0 copy per frame statistics is tested in MHXX), and 6 copies per frame for dynamic cubemap (= games renders environment to cube then do shading using the cube)

The cache is implemented such that, for each cached texture cube object, it has six watchers linked with the six referenced surfaces. When the texture cube is used, it checks if the referenced surface has been changed, and update the content if so. The "watcher" structure can be also useful for mipmaps and shadow map cubes in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3700)
<!-- Reviewable:end -->
