### PR TITLE
Add two new keyboard shortcuts

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -300,7 +300,7 @@ void GMainWindow::InitializeHotkeys() {
     RegisterHotkey("Main Window", "Load File", QKeySequence::Open);
     RegisterHotkey("Main Window", "Start Emulation");
     RegisterHotkey("Main Window", "Stop Emulation", QKeySequence("CTRL+F4"));
-    RegisterHotkey("Main Window", "Reload Last File", QKeySequence("CTRL+F5"));
+    RegisterHotkey("Main Window", "Reload Last Game", QKeySequence("CTRL+F5"));
     RegisterHotkey("Main Window", "Swap Screens", QKeySequence("F9"));
     RegisterHotkey("Main Window", "Toggle Screen Layout", QKeySequence("F10"));
     RegisterHotkey("Main Window", "Fullscreen", QKeySequence::FullScreen);
@@ -318,7 +318,7 @@ void GMainWindow::InitializeHotkeys() {
             &GMainWindow::OnStartGame);
     connect(GetHotkey("Main Window", "Stop Emulation", this), &QShortcut::activated, this,
         &GMainWindow::OnStopGame);
-    connect(GetHotkey("Main Window", "Reload Last File", this), &QShortcut::activated, this,
+    connect(GetHotkey("Main Window", "Reload Last Game", this), &QShortcut::activated, this,
         &GMainWindow::OnReloadLastGame);
     connect(GetHotkey("Main Window", "Swap Screens", render_window), &QShortcut::activated,
             ui.action_Screen_Layout_Swap_Screens, &QAction::trigger);

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -936,12 +936,15 @@ void GMainWindow::OnPauseGame() {
 }
 
 void GMainWindow::OnStopGame() {
-    ShutdownGame();
+    if (emulation_running) {
+        ShutdownGame();
+    }
 }
 
 void GMainWindow::OnReloadLastGame() {
-    if (UISettings::values.recent_files.size() > 0)
+    if (UISettings::values.recent_files.size() > 0) {
         BootGame(UISettings::values.recent_files.last());
+    }
 }
 
 void GMainWindow::OnMenuReportCompatibility() {

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -317,9 +317,9 @@ void GMainWindow::InitializeHotkeys() {
     connect(GetHotkey("Main Window", "Start Emulation", this), &QShortcut::activated, this,
             &GMainWindow::OnStartGame);
     connect(GetHotkey("Main Window", "Stop Emulation", this), &QShortcut::activated, this,
-        &GMainWindow::OnStopGame);
+            &GMainWindow::OnStopGame);
     connect(GetHotkey("Main Window", "Reload Last Game", this), &QShortcut::activated, this,
-        &GMainWindow::OnReloadLastGame);
+            &GMainWindow::OnReloadLastGame);
     connect(GetHotkey("Main Window", "Swap Screens", render_window), &QShortcut::activated,
             ui.action_Screen_Layout_Swap_Screens, &QAction::trigger);
     connect(GetHotkey("Main Window", "Toggle Screen Layout", render_window), &QShortcut::activated,

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -943,7 +943,7 @@ void GMainWindow::OnStopGame() {
 
 void GMainWindow::OnReloadLastGame() {
     if (UISettings::values.recent_files.size() > 0) {
-        BootGame(UISettings::values.recent_files.last());
+        BootGame(QString(UISettings::values.recent_files.first()));
     }
 }
 

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -299,6 +299,8 @@ void GMainWindow::InitializeRecentFileMenuActions() {
 void GMainWindow::InitializeHotkeys() {
     RegisterHotkey("Main Window", "Load File", QKeySequence::Open);
     RegisterHotkey("Main Window", "Start Emulation");
+    RegisterHotkey("Main Window", "Stop Emulation", QKeySequence("CTRL+F4"));
+    RegisterHotkey("Main Window", "Reload Last File", QKeySequence("CTRL+F5"));
     RegisterHotkey("Main Window", "Swap Screens", QKeySequence("F9"));
     RegisterHotkey("Main Window", "Toggle Screen Layout", QKeySequence("F10"));
     RegisterHotkey("Main Window", "Fullscreen", QKeySequence::FullScreen);
@@ -314,6 +316,10 @@ void GMainWindow::InitializeHotkeys() {
             &GMainWindow::OnMenuLoadFile);
     connect(GetHotkey("Main Window", "Start Emulation", this), &QShortcut::activated, this,
             &GMainWindow::OnStartGame);
+    connect(GetHotkey("Main Window", "Stop Emulation", this), &QShortcut::activated, this,
+        &GMainWindow::OnStopGame);
+    connect(GetHotkey("Main Window", "Reload Last File", this), &QShortcut::activated, this,
+        &GMainWindow::OnReloadLastGame);
     connect(GetHotkey("Main Window", "Swap Screens", render_window), &QShortcut::activated,
             ui.action_Screen_Layout_Swap_Screens, &QAction::trigger);
     connect(GetHotkey("Main Window", "Toggle Screen Layout", render_window), &QShortcut::activated,
@@ -931,6 +937,11 @@ void GMainWindow::OnPauseGame() {
 
 void GMainWindow::OnStopGame() {
     ShutdownGame();
+}
+
+void GMainWindow::OnReloadLastGame() {
+    if (UISettings::values.recent_files.size() > 0)
+        BootGame(UISettings::values.recent_files.last());
 }
 
 void GMainWindow::OnMenuReportCompatibility() {

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -171,6 +171,7 @@ private slots:
     void OnCheckForUpdates();
     void OnOpenUpdater();
     void OnLanguageChanged(const QString& locale);
+    void OnReloadLastGame();
 
 private:
     void UpdateStatusBar();


### PR DESCRIPTION
I use citra to test homebrews. I often need to stop the emulation and reload the file. It's easier for me by keyboard shortcut than by the ui.

I added two shortcuts : 
 CTRL+F4 : Stop the emulation
 CTRL+F5 : Start the last game from the recent files

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3701)
<!-- Reviewable:end -->
