### PR TITLE
citra_qt: multiplayer password dialog fix

### DIFF
--- a/src/citra_qt/multiplayer/lobby.cpp
+++ b/src/citra_qt/multiplayer/lobby.cpp
@@ -70,9 +70,8 @@ Lobby::Lobby(QWidget* parent, QStandardItemModel* list,
 
 QString Lobby::PasswordPrompt() {
     bool ok;
-    const QString text =
-        QInputDialog::getText(this, tr("Password Required to Join"), tr("Password:"),
-                              QLineEdit::Password, "", &ok);
+    const QString text = QInputDialog::getText(this, tr("Password Required to Join"),
+                                               tr("Password:"), QLineEdit::Password, "", &ok);
     return ok ? text : QString();
 }
 

--- a/src/citra_qt/multiplayer/lobby.cpp
+++ b/src/citra_qt/multiplayer/lobby.cpp
@@ -72,7 +72,7 @@ QString Lobby::PasswordPrompt() {
     bool ok;
     const QString text =
         QInputDialog::getText(this, tr("Password Required to Join"), tr("Password:"),
-                              QLineEdit::Normal, tr("Password"), &ok);
+                              QLineEdit::Password, "", &ok);
     return ok ? text : QString();
 }
 


### PR DESCRIPTION
This would be quite a quick fix.
Old (canary):
Default
![canary](https://user-images.githubusercontent.com/21307832/39459854-22281772-4d31-11e8-90f0-5e01ced08b1d.png)

Entered something
![canary-edited](https://user-images.githubusercontent.com/21307832/39459856-22683d34-4d31-11e8-96c8-578c1b321169.png)

PR:
Default
![pr_new_first](https://user-images.githubusercontent.com/21307832/39459865-32e6dc42-4d31-11e8-863e-5a4badb10468.png)

Entered something
![pr_new](https://user-images.githubusercontent.com/21307832/39459871-37b79c02-4d31-11e8-87ac-bd2908e3f2f9.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3705)
<!-- Reviewable:end -->
