### PR TITLE
video_core/command_processor: correctly handles 0xFFFF index as a normal index

### DIFF
--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -323,12 +323,12 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
         // Simple circular-replacement vertex cache
         // The size has been tuned for optimal balance between hit-rate and the cost of lookup
         const size_t VERTEX_CACHE_SIZE = 32;
+        std::array<bool, VERTEX_CACHE_SIZE> vertex_cache_valid{};
         std::array<u16, VERTEX_CACHE_SIZE> vertex_cache_ids;
         std::array<Shader::AttributeBuffer, VERTEX_CACHE_SIZE> vertex_cache;
         Shader::AttributeBuffer vs_output;
 
         unsigned int vertex_cache_pos = 0;
-        vertex_cache_ids.fill(-1);
 
         auto* shader_engine = Shader::GetEngine();
         Shader::UnitState shader_unit;
@@ -346,10 +346,6 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
                 is_indexed ? (index_u16 ? index_address_16[index] : index_address_8[index])
                            : (index + regs.pipeline.vertex_offset);
 
-            // -1 is a common special value used for primitive restart. Since it's unknown if
-            // the PICA supports it, and it would mess up the caching, guard against it here.
-            ASSERT(vertex != -1);
-
             bool vertex_cache_hit = false;
 
             if (is_indexed) {
@@ -365,7 +361,7 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
                 }
 
                 for (unsigned int i = 0; i < VERTEX_CACHE_SIZE; ++i) {
-                    if (vertex == vertex_cache_ids[i]) {
+                    if (vertex_cache_valid[i] && vertex == vertex_cache_ids[i]) {
                         vs_output = vertex_cache[i];
                         vertex_cache_hit = true;
                         break;
@@ -388,6 +384,7 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
 
                 if (is_indexed) {
                     vertex_cache[vertex_cache_pos] = vs_output;
+                    vertex_cache_valid[vertex_cache_pos] = true;
                     vertex_cache_ids[vertex_cache_pos] = vertex;
                     vertex_cache_pos = (vertex_cache_pos + 1) % VERTEX_CACHE_SIZE;
                 }


### PR DESCRIPTION
A random stuff that @Phanto-m made in #3499 

The ASSERT on `vertex != -1` have several issues:
 - `vertex` is `unsigned int` type. When getting assigned with a `(u16)-1`/`0xFFFF`, it keeps the value `0xFFFF` which is not equal to `(unsigned int)-1`/`0xFFFFFFFF`. So this guard has never been functioning.
 - A [hwtest](https://gist.github.com/wwylele/3261647c72105f96c460bb89be3408c4) shows that PICA does not support index -1 as primitive restart; instead it treats it as a normal index and reads the 0xFFFF-th vertex in the vertex buffer.

To correct the implementation, the vertex cache now doesn't use magic -1 as the uninitialized value; instead an explicit initialization bit array is used.