### PR TITLE
regs_pipeline: use proper unsigned type where applicable

### DIFF
--- a/src/video_core/regs_pipeline.h
+++ b/src/video_core/regs_pipeline.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <array>
-
 #include "common/assert.h"
 #include "common/bit_field.h"
 #include "common/common_funcs.h"
@@ -64,35 +63,35 @@ struct PipelineRegs {
             BitField<28, 4, u32> max_attribute_index;
         };
 
-        inline VertexAttributeFormat GetFormat(int n) const {
+        VertexAttributeFormat GetFormat(std::size_t n) const {
             VertexAttributeFormat formats[] = {format0, format1, format2,  format3,
                                                format4, format5, format6,  format7,
                                                format8, format9, format10, format11};
             return formats[n];
         }
 
-        inline int GetNumElements(int n) const {
+        u32 GetNumElements(std::size_t n) const {
             u32 sizes[] = {size0, size1, size2, size3, size4,  size5,
                            size6, size7, size8, size9, size10, size11};
-            return (int)sizes[n] + 1;
+            return sizes[n] + 1;
         }
 
-        inline int GetElementSizeInBytes(int n) const {
+        u32 GetElementSizeInBytes(std::size_t n) const {
             return (GetFormat(n) == VertexAttributeFormat::FLOAT)
                        ? 4
                        : (GetFormat(n) == VertexAttributeFormat::SHORT) ? 2 : 1;
         }
 
-        inline int GetStride(int n) const {
+        u32 GetStride(std::size_t n) const {
             return GetNumElements(n) * GetElementSizeInBytes(n);
         }
 
-        inline bool IsDefaultAttribute(int id) const {
+        bool IsDefaultAttribute(std::size_t id) const {
             return (id >= 12) || (attribute_mask & (1ULL << id)) != 0;
         }
 
-        inline int GetNumTotalAttributes() const {
-            return (int)max_attribute_index + 1;
+        u32 GetNumTotalAttributes() const {
+            return max_attribute_index + 1;
         }
 
         // Attribute loaders map the source vertex data to input attributes
@@ -124,10 +123,10 @@ struct PipelineRegs {
                 BitField<28, 4, u32> component_count;
             };
 
-            inline int GetComponent(int n) const {
+            u32 GetComponent(std::size_t n) const {
                 u32 components[] = {comp0, comp1, comp2, comp3, comp4,  comp5,
                                     comp6, comp7, comp8, comp9, comp10, comp11};
-                return (int)components[n];
+                return components[n];
             }
         } attribute_loaders[12];
     } vertex_attributes;


### PR DESCRIPTION
These utility functions for loaders have common issues:
 - `inline` is unnecessary as it is already defined in-class (implicitly inline)
 - input parameter are used as array index, which should be size_t
 - output are converted from u32 to int. Their only user is video_core/vertex_loader, where they are then converted back to unsigned values, making the type `int` meaningless

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3719)
<!-- Reviewable:end -->
