### PR TITLE
[Don't merge] gl_rasterizer: implement shadow map 2D

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -807,6 +807,7 @@ bool RasterizerOpenGL::Draw(bool accelerate, bool is_indexed) {
         state.texture_units[texture_index].texture_2d = 0;
     }
     state.texture_cube_unit.texture_cube = 0;
+    state.texture_shadow_unit.texture_2d = 0;
     state.Apply();
 
     // Mark framebuffer surfaces as dirty

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -72,6 +72,10 @@ private:
         u32 border_color;
     };
 
+    struct ShadowSamplerInfo : public SamplerInfo {
+        void Create();
+    };
+
     /// Structure that the hardware rendered vertices are composed of
     struct HardwareVertex {
         HardwareVertex() = default;
@@ -287,6 +291,7 @@ private:
     size_t uniform_size_aligned_fs;
 
     SamplerInfo texture_cube_sampler;
+    ShadowSamplerInfo texture_shadow_sampler;
 
     OGLBuffer lighting_lut_buffer;
     OGLTexture lighting_lut;

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -1112,6 +1112,89 @@ void RasterizerCacheOpenGL::ConvertD24S8toABGR(GLuint src_tex,
     glBindTexture(GL_TEXTURE_BUFFER, 0);
 }
 
+void RasterizerCacheOpenGL::ConvertShadowtoABGR(GLuint src_tex,
+                                                const MathUtil::Rectangle<u32>& src_rect,
+                                                GLuint dst_tex,
+                                                const MathUtil::Rectangle<u32>& dst_rect) {
+    ASSERT(src_rect.GetWidth() == dst_rect.GetWidth());
+    ASSERT(src_rect.GetHeight() == dst_rect.GetHeight());
+
+    OpenGLState prev_state = OpenGLState::GetCurState();
+    SCOPE_EXIT({ prev_state.Apply(); });
+
+    OpenGLState state;
+    state.draw.read_framebuffer = read_framebuffer.handle;
+    state.draw.draw_framebuffer = draw_framebuffer.handle;
+    state.Apply();
+
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, d24s8_abgr_buffer.handle);
+
+    GLsizeiptr target_pbo_size = src_rect.GetWidth() * src_rect.GetHeight() * 4;
+    if (target_pbo_size > d24s8_abgr_buffer_size) {
+        d24s8_abgr_buffer_size = target_pbo_size * 2;
+        glBufferData(GL_PIXEL_PACK_BUFFER, d24s8_abgr_buffer_size, nullptr, GL_STREAM_COPY);
+    }
+
+    glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, 0, 0);
+    glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, src_tex,
+                           0);
+    glReadPixels(static_cast<GLint>(src_rect.left), static_cast<GLint>(src_rect.bottom),
+                 static_cast<GLsizei>(src_rect.GetWidth()),
+                 static_cast<GLsizei>(src_rect.GetHeight()), GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8,
+                 0);
+
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+
+    state.texture_units[0].texture_2d = dst_tex;
+    state.Apply();
+    glActiveTexture(GL_TEXTURE0);
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, d24s8_abgr_buffer.handle);
+    glTexSubImage2D(GL_TEXTURE_2D, 0, dst_rect.left, dst_rect.bottom, dst_rect.GetWidth(),
+                    dst_rect.GetHeight(), GL_RGBA, GL_UNSIGNED_INT_8_8_8_8_REV, 0);
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+}
+
+void RasterizerCacheOpenGL::ConvertABGRtoShadow(GLuint src_tex,
+                                                const MathUtil::Rectangle<u32>& src_rect,
+                                                GLuint dst_tex,
+                                                const MathUtil::Rectangle<u32>& dst_rect) {
+    ASSERT(src_rect.GetWidth() == dst_rect.GetWidth());
+    ASSERT(src_rect.GetHeight() == dst_rect.GetHeight());
+
+    OpenGLState prev_state = OpenGLState::GetCurState();
+    SCOPE_EXIT({ prev_state.Apply(); });
+
+    OpenGLState state;
+    state.draw.read_framebuffer = read_framebuffer.handle;
+    state.draw.draw_framebuffer = draw_framebuffer.handle;
+    state.Apply();
+
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, d24s8_abgr_buffer.handle);
+
+    GLsizeiptr target_pbo_size = src_rect.GetWidth() * src_rect.GetHeight() * 4;
+    if (target_pbo_size > d24s8_abgr_buffer_size) {
+        d24s8_abgr_buffer_size = target_pbo_size * 2;
+        glBufferData(GL_PIXEL_PACK_BUFFER, d24s8_abgr_buffer_size, nullptr, GL_STREAM_COPY);
+    }
+
+    glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, src_tex, 0);
+    glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, 0, 0);
+    glReadPixels(static_cast<GLint>(src_rect.left), static_cast<GLint>(src_rect.bottom),
+                 static_cast<GLsizei>(src_rect.GetWidth()),
+                 static_cast<GLsizei>(src_rect.GetHeight()), GL_RGBA, GL_UNSIGNED_INT_8_8_8_8_REV,
+                 0);
+
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+
+    state.texture_units[0].texture_2d = dst_tex;
+    state.Apply();
+    glActiveTexture(GL_TEXTURE0);
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, d24s8_abgr_buffer.handle);
+    glTexSubImage2D(GL_TEXTURE_2D, 0, dst_rect.left, dst_rect.bottom, dst_rect.GetWidth(),
+                    dst_rect.GetHeight(), GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, 0);
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+}
+
 Surface RasterizerCacheOpenGL::GetSurface(const SurfaceParams& params, ScaleMatch match_res_scale,
                                           bool load_if_create) {
     if (params.addr == 0 || params.height * params.width == 0) {
@@ -1571,7 +1654,7 @@ void RasterizerCacheOpenGL::ValidateSurface(const Surface& surface, PAddr addr, 
             continue;
         }
 
-        // D24S8 to RGBA8
+        // D24S8 or Shadow to RGBA8
         if (surface->pixel_format == PixelFormat::RGBA8) {
             params.pixel_format = PixelFormat::D24S8;
             Surface reinterpret_surface =
@@ -1586,6 +1669,45 @@ void RasterizerCacheOpenGL::ValidateSurface(const Surface& surface, PAddr addr, 
 
                 ConvertD24S8toABGR(reinterpret_surface->texture.handle, src_rect,
                                    surface->texture.handle, dest_rect);
+
+                surface->invalid_regions.erase(convert_interval);
+                continue;
+            }
+
+            params.pixel_format = PixelFormat::Shadow;
+            reinterpret_surface =
+                FindMatch<MatchFlags::Copy>(surface_cache, params, ScaleMatch::Exact, interval);
+            if (reinterpret_surface != nullptr) {
+                ASSERT(reinterpret_surface->pixel_format == PixelFormat::Shadow);
+
+                SurfaceInterval convert_interval = params.GetCopyableInterval(reinterpret_surface);
+                SurfaceParams convert_params = surface->FromInterval(convert_interval);
+                auto src_rect = reinterpret_surface->GetScaledSubRect(convert_params);
+                auto dest_rect = surface->GetScaledSubRect(convert_params);
+
+                ConvertShadowtoABGR(reinterpret_surface->texture.handle, src_rect,
+                                    surface->texture.handle, dest_rect);
+
+                surface->invalid_regions.erase(convert_interval);
+                continue;
+            }
+        }
+
+        // RGBA8 to Shadow
+        if (surface->pixel_format == PixelFormat::Shadow) {
+            params.pixel_format = PixelFormat::RGBA8;
+            Surface reinterpret_surface =
+                FindMatch<MatchFlags::Copy>(surface_cache, params, ScaleMatch::Exact, interval);
+            if (reinterpret_surface != nullptr) {
+                ASSERT(reinterpret_surface->pixel_format == PixelFormat::RGBA8);
+
+                SurfaceInterval convert_interval = params.GetCopyableInterval(reinterpret_surface);
+                SurfaceParams convert_params = surface->FromInterval(convert_interval);
+                auto src_rect = reinterpret_surface->GetScaledSubRect(convert_params);
+                auto dest_rect = surface->GetScaledSubRect(convert_params);
+
+                ConvertABGRtoShadow(reinterpret_surface->texture.handle, src_rect,
+                                    surface->texture.handle, dest_rect);
 
                 surface->invalid_regions.erase(convert_interval);
                 continue;

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -81,6 +81,8 @@ struct SurfaceParams {
         D24 = 16,
         D24S8 = 17,
 
+        Shadow = 18,
+
         Invalid = 255,
     };
 
@@ -89,12 +91,13 @@ struct SurfaceParams {
         Texture = 1,
         Depth = 2,
         DepthStencil = 3,
-        Fill = 4,
-        Invalid = 5
+        Shadow = 4,
+        Fill = 5,
+        Invalid = 6
     };
 
     static constexpr unsigned int GetFormatBpp(PixelFormat format) {
-        constexpr std::array<unsigned int, 18> bpp_table = {
+        constexpr std::array<unsigned int, 19> bpp_table = {
             32, // RGBA8
             24, // RGB8
             16, // RGB5A1
@@ -113,6 +116,7 @@ struct SurfaceParams {
             0,
             24, // D24
             32, // D24S8
+            32, // Shadow
         };
 
         assert(static_cast<size_t>(format) < bpp_table.size());
@@ -164,6 +168,10 @@ struct SurfaceParams {
             return true;
         }
 
+        if (a_type == SurfaceType::Shadow && b_type == SurfaceType::Shadow) {
+            return true;
+        }
+
         return false;
     }
 
@@ -182,6 +190,10 @@ struct SurfaceParams {
 
         if (pixel_format == PixelFormat::D24S8) {
             return SurfaceType::DepthStencil;
+        }
+
+        if (pixel_format == PixelFormat::Shadow) {
+            return SurfaceType::Shadow;
         }
 
         return SurfaceType::Invalid;
@@ -427,7 +439,7 @@ public:
 
     /// Get a surface based on the texture configuration
     Surface GetTextureSurface(const Pica::TexturingRegs::FullTextureConfig& config);
-    Surface GetTextureSurface(const Pica::Texture::TextureInfo& info);
+    Surface GetTextureSurface(const Pica::Texture::TextureInfo& info, bool shadow = false);
 
     /// Get a texture cube based on the texture configuration
     const CachedTextureCube& GetTextureCube(const TextureCubeConfig& config);

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -424,6 +424,12 @@ public:
     void ConvertD24S8toABGR(GLuint src_tex, const MathUtil::Rectangle<u32>& src_rect,
                             GLuint dst_tex, const MathUtil::Rectangle<u32>& dst_rect);
 
+    void ConvertShadowtoABGR(GLuint src_tex, const MathUtil::Rectangle<u32>& src_rect,
+                             GLuint dst_tex, const MathUtil::Rectangle<u32>& dst_rect);
+
+    void ConvertABGRtoShadow(GLuint src_tex, const MathUtil::Rectangle<u32>& src_rect,
+                             GLuint dst_tex, const MathUtil::Rectangle<u32>& dst_rect);
+
     /// Copy one surface's region to another
     void CopySurface(const Surface& src_surface, const Surface& dst_surface,
                      SurfaceInterval copy_interval);

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -220,6 +220,9 @@ PicaFSConfig PicaFSConfig::BuildFromRegs(const Pica::Regs& regs) {
         state.proctex.lut_filter = regs.texturing.proctex_lut.filter;
     }
 
+    state.shadow_texture_orthographic = regs.texturing.shadow.orthographic != 0;
+    state.shadow_texture_bias = (regs.texturing.shadow.bias << 1) / 16777215.0f; // 2^24 - 1
+
     return res;
 }
 
@@ -300,6 +303,7 @@ static std::string SampleTexture(const PicaFSConfig& config, unsigned texture_un
         case TexturingRegs::TextureConfig::TextureCube:
             return "texture(tex_cube, vec3(texcoord0, texcoord0_w))";
         case TexturingRegs::TextureConfig::Shadow2D:
+            return "shadowTexture(texcoord0, texcoord0_w)";
         case TexturingRegs::TextureConfig::ShadowCube:
             NGLOG_CRITICAL(HW_GPU, "Unhandled shadow texture");
             UNIMPLEMENTED();
@@ -1197,6 +1201,7 @@ uniform sampler2D tex0;
 uniform sampler2D tex1;
 uniform sampler2D tex2;
 uniform samplerCube tex_cube;
+uniform sampler2DShadow tex_shadow;
 uniform samplerBuffer lighting_lut;
 uniform samplerBuffer fog_lut;
 uniform samplerBuffer proctex_noise_lut;
@@ -1249,6 +1254,14 @@ vec4 byteround(vec4 x) {
 }
 
 )";
+
+    out += "vec4 shadowTexture(vec2 uv, float w) {\n";
+    out += "    float z = min(abs(w), 1.0) - " + std::to_string(state.shadow_texture_bias) + ";\n";
+    if (state.shadow_texture_orthographic) {
+        out += "    return vec4(texture(tex_shadow, vec3(uv, z)));\n}\n";
+    } else {
+        out += "    return vec4(texture(tex_shadow, vec3(uv / w, z)));\n}\n";
+    }
 
     if (config.state.proctex.enable)
         AppendProcTexSampler(out, config);

--- a/src/video_core/renderer_opengl/gl_shader_gen.h
+++ b/src/video_core/renderer_opengl/gl_shader_gen.h
@@ -110,6 +110,9 @@ struct PicaFSConfigState {
         u32 lut_offset;
         Pica::TexturingRegs::ProcTexFilter lut_filter;
     } proctex;
+
+    bool shadow_texture_orthographic;
+    float shadow_texture_bias;
 };
 
 /**

--- a/src/video_core/renderer_opengl/gl_shader_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_manager.cpp
@@ -46,6 +46,7 @@ static void SetShaderSamplerBindings(GLuint shader) {
     SetShaderSamplerBinding(shader, "tex1", TextureUnits::PicaTexture(1));
     SetShaderSamplerBinding(shader, "tex2", TextureUnits::PicaTexture(2));
     SetShaderSamplerBinding(shader, "tex_cube", TextureUnits::TextureCube);
+    SetShaderSamplerBinding(shader, "tex_shadow", TextureUnits::TextureShadow);
 
     // Set the texture samplers to correspond to different lookup table texture units
     SetShaderSamplerBinding(shader, "lighting_lut", TextureUnits::LightingLUT);

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -55,6 +55,9 @@ OpenGLState::OpenGLState() {
     texture_cube_unit.texture_cube = 0;
     texture_cube_unit.sampler = 0;
 
+    texture_shadow_unit.texture_2d = 0;
+    texture_shadow_unit.sampler = 0;
+
     lighting_lut.texture_buffer = 0;
 
     fog_lut.texture_buffer = 0;
@@ -213,6 +216,14 @@ void OpenGLState::Apply() const {
         glBindSampler(TextureUnits::TextureCube.id, texture_cube_unit.sampler);
     }
 
+    if (texture_shadow_unit.texture_2d != cur_state.texture_shadow_unit.texture_2d) {
+        glActiveTexture(TextureUnits::TextureShadow.Enum());
+        glBindTexture(GL_TEXTURE_2D, texture_shadow_unit.texture_2d);
+    }
+    if (texture_shadow_unit.sampler != cur_state.texture_shadow_unit.sampler) {
+        glBindSampler(TextureUnits::TextureShadow.id, texture_shadow_unit.sampler);
+    }
+
     // Lighting LUTs
     if (lighting_lut.texture_buffer != cur_state.lighting_lut.texture_buffer) {
         glActiveTexture(TextureUnits::LightingLUT.Enum());
@@ -330,6 +341,8 @@ OpenGLState& OpenGLState::ResetTexture(GLuint handle) {
     }
     if (texture_cube_unit.texture_cube == handle)
         texture_cube_unit.texture_cube = 0;
+    if (texture_shadow_unit.texture_2d == handle)
+        texture_shadow_unit.texture_2d = 0;
     if (lighting_lut.texture_buffer == handle)
         lighting_lut.texture_buffer = 0;
     if (fog_lut.texture_buffer == handle)
@@ -355,6 +368,9 @@ OpenGLState& OpenGLState::ResetSampler(GLuint handle) {
     }
     if (texture_cube_unit.sampler == handle) {
         texture_cube_unit.sampler = 0;
+    }
+    if (texture_shadow_unit.sampler == handle) {
+        texture_shadow_unit.sampler = 0;
     }
     return *this;
 }

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -28,6 +28,7 @@ constexpr TextureUnit ProcTexAlphaMap{7};
 constexpr TextureUnit ProcTexLUT{8};
 constexpr TextureUnit ProcTexDiffLUT{9};
 constexpr TextureUnit TextureCube{10};
+constexpr TextureUnit TextureShadow{11};
 
 } // namespace TextureUnits
 
@@ -92,6 +93,11 @@ public:
         GLuint texture_cube; // GL_TEXTURE_BINDING_CUBE_MAP
         GLuint sampler;      // GL_SAMPLER_BINDING
     } texture_cube_unit;
+
+    struct {
+        GLuint texture_2d; // GL_TEXTURE_BINDING_2D
+        GLuint sampler;    // GL_SAMPLER_BINDING
+    } texture_shadow_unit;
 
     struct {
         GLuint texture_buffer; // GL_TEXTURE_BINDING_BUFFER


### PR DESCRIPTION
This is the hardware renderer counterpart of #3516 (the last two commits there).

This implementation uses OpenGL native shadow sampler, which is impossible to implement soft shadow (PICA's custom shadow intense control). Another alternative to implement shadow map rendering & sampling is to use `ARB_shader_image_load_store` extension, which enables the possibility to implement soft shadow. I also have a finished branch for that. I went through some comparison and eventually decided to use the native shadow map implementation for now.

Some comparison between the two alternatives

|                                                      | Native shadow sampler                | Image load/store              |
|------------------------------------------------------|-------------------------------|-------------------------------|
| OpenGL version                                       | No requirement                | 4.2 or extension              |
| Soft shadow                                          | Impossible                    | Possible                      |
| Percentage Closer Filtering (matches PICA behaviour) | Free                          | Possible, but need extra code |
| Performance                                          | A little bit better, probably | OK                            |
| Shadow cubemap                                       | Free in GLSL part             | Possible, but need extra code |

Overall the native shadow sampler method has more advantages, and there is still no known use case of soft shadow in commercial games. We can also have the third alternative if necessary, which is to implementing both method, but that would be in a future PR.

The shadow cubemap, although not difficult, is not implemented in this PR, due to lack of test case and in order to minimize the amount of code change in one PR. 

A special surface format `Shadow` is added to the texture cache, which is treated as D24S8 format in general, but has special behaviour on downloading/uploading. The framebuffer/texture retriever is also modified to match this special format when the register is configured in the shadow map mode. 
 
![image](https://user-images.githubusercontent.com/4592895/39834236-fab3f04e-53d4-11e8-89d5-fe02f11c741d.png)
(image from Monster Hunter XX)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3729)
<!-- Reviewable:end -->
