### PR TITLE
citra_qt: Refactor game list compatibility system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ configure_file(${CMAKE_SOURCE_DIR}/dist/compatibility_list/compatibility_list.qr
 if (ENABLE_COMPATIBILITY_LIST_DOWNLOAD AND NOT EXISTS ${CMAKE_BINARY_DIR}/dist/compatibility_list/compatibility_list.json)
     message(STATUS "Downloading compatibility list for citra...")
     file(DOWNLOAD
-        https://api.citra-emu.org/gamedb/titleid/
+        https://api.citra-emu.org/gamedb/
         "${CMAKE_BINARY_DIR}/dist/compatibility_list/compatibility_list.json" SHOW_PROGRESS)
 endif()
 

--- a/src/citra_qt/game_list.h
+++ b/src/citra_qt/game_list.h
@@ -85,6 +85,9 @@ signals:
     void GameChosen(QString game_path);
     void ShouldCancelWorker();
     void OpenFolderRequested(u64 program_id, GameListOpenTarget target);
+    void NavigateToGamedbEntryRequested(
+        u64 program_id,
+        std::unordered_map<std::string, std::pair<QString, QString>>& compatibility_list);
 
 private slots:
     void onTextChanged(const QString& newText);
@@ -106,7 +109,7 @@ private:
     QStandardItemModel* item_model = nullptr;
     GameListWorker* current_worker = nullptr;
     QFileSystemWatcher* watcher = nullptr;
-    std::unordered_map<std::string, QString> compatibility_list;
+    std::unordered_map<std::string, std::pair<QString, QString>> compatibility_list;
 };
 
 Q_DECLARE_METATYPE(GameListOpenTarget);

--- a/src/citra_qt/game_list_p.h
+++ b/src/citra_qt/game_list_p.h
@@ -260,8 +260,9 @@ class GameListWorker : public QObject, public QRunnable {
     Q_OBJECT
 
 public:
-    GameListWorker(QString dir_path, bool deep_scan,
-                   const std::unordered_map<std::string, QString>& compatibility_list)
+    GameListWorker(
+        QString dir_path, bool deep_scan,
+        const std::unordered_map<std::string, std::pair<QString, QString>>& compatibility_list)
         : QObject(), QRunnable(), dir_path(dir_path), deep_scan(deep_scan),
           compatibility_list(compatibility_list) {}
 
@@ -289,7 +290,7 @@ private:
     QStringList watch_list;
     QString dir_path;
     bool deep_scan;
-    const std::unordered_map<std::string, QString>& compatibility_list;
+    const std::unordered_map<std::string, std::pair<QString, QString>>& compatibility_list;
     std::atomic_bool stop_processing;
 
     void AddFstEntriesToGameList(const std::string& dir_path, unsigned int recursion = 0);

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -7,6 +7,7 @@
 #include <thread>
 #include <glad/glad.h>
 #define QT_NO_OPENGL
+#include <cinttypes>
 #include <QDesktopWidget>
 #include <QFileDialog>
 #include <QFutureWatcher>
@@ -397,6 +398,8 @@ void GMainWindow::RestoreUIState() {
 void GMainWindow::ConnectWidgetEvents() {
     connect(game_list, &GameList::GameChosen, this, &GMainWindow::OnGameListLoadFile);
     connect(game_list, &GameList::OpenFolderRequested, this, &GMainWindow::OnGameListOpenFolder);
+    connect(game_list, &GameList::NavigateToGamedbEntryRequested, this,
+            &GMainWindow::OnGameListNavigateToGamedbEntry);
 
     connect(this, &GMainWindow::EmulationStarting, render_window,
             &GRenderWindow::OnEmulationStarting);
@@ -800,6 +803,25 @@ void GMainWindow::OnGameListOpenFolder(u64 program_id, GameListOpenTarget target
     NGLOG_INFO(Frontend, "Opening {} path for program_id={:016x}", open_target, program_id);
 
     QDesktopServices::openUrl(QUrl::fromLocalFile(qpath));
+}
+
+void GMainWindow::OnGameListNavigateToGamedbEntry(
+    u64 program_id,
+    std::unordered_map<std::string, std::pair<QString, QString>>& compatibility_list) {
+
+    auto it = std::find_if(
+        compatibility_list.begin(), compatibility_list.end(),
+        [program_id](const std::pair<std::string, std::pair<QString, QString>>& element) {
+            std::string pid = Common::StringFromFormat("%016" PRIX64, program_id);
+            return element.first == pid;
+        });
+
+    QString directory = "";
+
+    if (it != compatibility_list.end())
+        directory = it->second.second;
+
+    QDesktopServices::openUrl(QUrl("https://citra-emu.org/game/" + directory));
 }
 
 void GMainWindow::OnMenuLoadFile() {

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -145,6 +145,9 @@ private slots:
     /// Called whenever a user selects a game in the game list widget.
     void OnGameListLoadFile(QString game_path);
     void OnGameListOpenFolder(u64 program_id, GameListOpenTarget target);
+    void OnGameListNavigateToGamedbEntry(
+        u64 program_id,
+        std::unordered_map<std::string, std::pair<QString, QString>>& compatibility_list);
     void OnMenuLoadFile();
     void OnMenuInstallCIA();
     void OnUpdateProgress(size_t written, size_t total);


### PR DESCRIPTION
I made this PR, because @chris062689 wanted to make some changes to the API endpoint used for the compatibility list.
The only functional change in this PR should be the introduction of a new context menu option when you right-click a game. It is called "Navigate to GameDB entry" and opens the game wiki page of the game in your browser. 
![bild](https://user-images.githubusercontent.com/20753089/39847795-ce1cd79c-5403-11e8-91b9-1be393171946.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3730)
<!-- Reviewable:end -->
