### PR TITLE
travis: add missing dependency for transifex push job

### DIFF
--- a/.travis/transifex/docker.sh
+++ b/.travis/transifex/docker.sh
@@ -7,7 +7,7 @@ set -x
 
 echo -e "\e[1m\e[33mInstalling dependencies...\e[0m"
 apk update
-apk add build-base cmake python3-dev qt5-qttools-dev
+apk add build-base cmake python3-dev qt5-qttools-dev qtmultimedia5-dev
 
 pip3 install transifex-client
 


### PR DESCRIPTION
The Qt multimedia dependency was added in #3566, but didn't added to the transfex push job. Although it really doesn't have anything to do translation, the CI on master still errored anyway: https://travis-ci.org/citra-emu/citra/jobs/377846806

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3734)
<!-- Reviewable:end -->
