### PR TITLE
gl_rasterizer: Cache framebuffer attachments.

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -591,24 +591,25 @@ bool RasterizerOpenGL::Draw(bool accelerate, bool is_indexed) {
     state.draw.draw_framebuffer = framebuffer.handle;
     state.Apply();
 
-    glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
-                           color_surface != nullptr ? color_surface->texture.handle : 0, 0);
-    if (depth_surface != nullptr) {
-        if (has_stencil) {
-            // attach both depth and stencil
-            glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D,
-                                   depth_surface->texture.handle, 0);
-        } else {
-            // attach depth
-            glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D,
-                                   depth_surface->texture.handle, 0);
-            // clear stencil attachment
-            glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_TEXTURE_2D, 0, 0);
-        }
-    } else {
-        // clear both depth and stencil attachment
-        glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, 0,
-                               0);
+    GLuint attachment = color_surface != nullptr ? color_surface->texture.handle : 0;
+    if (attachment != color_attachment) {
+        color_attachment = attachment;
+        glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+                               color_attachment, 0);
+    }
+
+    attachment = depth_surface != nullptr ? depth_surface->texture.handle : 0;
+    if (attachment != depth_attachment) {
+        depth_attachment = attachment;
+        glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D,
+                               depth_attachment, 0);
+    }
+
+    attachment = (depth_surface != nullptr && has_stencil) ? depth_surface->texture.handle : 0;
+    if (attachment != stencil_attachment) {
+        stencil_attachment = attachment;
+        glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_TEXTURE_2D,
+                               stencil_attachment, 0);
     }
 
     // Sync the viewport

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -286,6 +286,11 @@ private:
     size_t uniform_size_aligned_gs;
     size_t uniform_size_aligned_fs;
 
+    // framebuffer attachment
+    GLuint color_attachment = 0;
+    GLuint depth_attachment = 0;
+    GLuint stencil_attachment = 0;
+
     SamplerInfo texture_cube_sampler;
 
     OGLBuffer lighting_lut_buffer;


### PR DESCRIPTION
This framebuffer is only used here, so reemiting the GL state
is highly redundant. This patch caches the framebuffer state
and only emit GL calls on changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3738)
<!-- Reviewable:end -->
