### PR TITLE
 citra-qt: add gpu shader emulation related configurations 

### DIFF
--- a/src/citra_qt/configuration/configure_graphics.cpp
+++ b/src/citra_qt/configuration/configure_graphics.cpp
@@ -19,13 +19,22 @@ ConfigureGraphics::ConfigureGraphics(QWidget* parent)
             &QSpinBox::setEnabled);
 
     ui->layoutBox->setEnabled(!Settings::values.custom_layout);
+
+    ui->hw_renderer_group->setEnabled(ui->toggle_hw_renderer->isChecked());
+    connect(ui->toggle_hw_renderer, &QCheckBox::stateChanged, ui->hw_renderer_group,
+            &QWidget::setEnabled);
+    ui->hw_shader_group->setEnabled(ui->toggle_hw_shader->isChecked());
+    connect(ui->toggle_hw_shader, &QCheckBox::stateChanged, ui->hw_shader_group,
+            &QWidget::setEnabled);
 }
 
 ConfigureGraphics::~ConfigureGraphics() {}
 
 void ConfigureGraphics::setConfiguration() {
     ui->toggle_hw_renderer->setChecked(Settings::values.use_hw_renderer);
-    ui->resolution_factor_combobox->setEnabled(Settings::values.use_hw_renderer);
+    ui->toggle_hw_shader->setChecked(Settings::values.use_hw_shader);
+    ui->toggle_accurate_gs->setChecked(Settings::values.shaders_accurate_gs);
+    ui->toggle_accurate_mul->setChecked(Settings::values.shaders_accurate_mul);
     ui->toggle_shader_jit->setChecked(Settings::values.use_shader_jit);
     ui->resolution_factor_combobox->setCurrentIndex(Settings::values.resolution_factor);
     ui->toggle_vsync->setChecked(Settings::values.use_vsync);
@@ -37,6 +46,9 @@ void ConfigureGraphics::setConfiguration() {
 
 void ConfigureGraphics::applyConfiguration() {
     Settings::values.use_hw_renderer = ui->toggle_hw_renderer->isChecked();
+    Settings::values.use_hw_shader = ui->toggle_hw_shader->isChecked();
+    Settings::values.shaders_accurate_gs = ui->toggle_accurate_gs->isChecked();
+    Settings::values.shaders_accurate_mul = ui->toggle_accurate_mul->isChecked();
     Settings::values.use_shader_jit = ui->toggle_shader_jit->isChecked();
     Settings::values.resolution_factor =
         static_cast<u16>(ui->resolution_factor_combobox->currentIndex());

--- a/src/citra_qt/configuration/configure_graphics.ui
+++ b/src/citra_qt/configuration/configure_graphics.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>300</height>
+    <height>427</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,187 +15,245 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QVBoxLayout" name="verticalLayout_3">
-     <item>
-      <widget class="QGroupBox" name="groupBox">
-       <property name="title">
-        <string>Graphics</string>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout_2">
+    <widget class="QGroupBox" name="generalBox">
+     <property name="title">
+      <string>General</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QCheckBox" name="toggle_vsync">
+        <property name="text">
+         <string>Enable V-Sync</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
-         <widget class="QCheckBox" name="toggle_hw_renderer">
+         <widget class="QCheckBox" name="toggle_frame_limit">
           <property name="text">
-           <string>Enable hardware renderer</string>
+           <string>Limit Speed Percent</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QCheckBox" name="toggle_shader_jit">
-          <property name="text">
-           <string>Enable shader JIT</string>
+         <widget class="QSpinBox" name="frame_limit">
+          <property name="suffix">
+           <string>%</string>
+          </property>
+          <property name="minimum">
+           <number>1</number>
+          </property>
+          <property name="maximum">
+           <number>9999</number>
+          </property>
+          <property name="value">
+           <number>100</number>
           </property>
          </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="toggle_vsync">
-          <property name="text">
-           <string>Enable V-Sync</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_2">
-          <item>
-           <widget class="QCheckBox" name="toggle_frame_limit">
-            <property name="text">
-             <string>Limit Speed Percent</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QSpinBox" name="frame_limit">
-            <property name="suffix">
-             <string>%</string>
-            </property>
-            <property name="minimum">
-             <number>1</number>
-            </property>
-            <property name="maximum">
-             <number>9999</number>
-            </property>
-            <property name="value">
-             <number>100</number>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout">
-          <item>
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>Internal Resolution:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QComboBox" name="resolution_factor_combobox">
-            <item>
-             <property name="text">
-              <string>Auto (Window Size)</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Native (400x240)</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>2x Native (800x480)</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>3x Native (1200x720)</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>4x Native (1600x960)</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>5x Native (2000x1200)</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>6x Native (2400x1440)</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>7x Native (2800x1680)</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>8x Native (3200x1920)</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>9x Native (3600x2160)</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>10x Native (4000x2400)</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-         </layout>
         </item>
        </layout>
-      </widget>
-     </item>
-    </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="rendererBox">
+     <property name="title">
+      <string>Renderer</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_6">
+      <item>
+       <widget class="QCheckBox" name="toggle_hw_renderer">
+        <property name="text">
+         <string>Enable Hardware Renderer</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QWidget" name="hw_renderer_group" native="true">
+        <layout class="QVBoxLayout" name="verticalLayout_5">
+         <property name="leftMargin">
+          <number>16</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout">
+           <item>
+            <widget class="QLabel" name="label">
+             <property name="text">
+              <string>Internal Resolution</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="resolution_factor_combobox">
+             <item>
+              <property name="text">
+               <string>Auto (Window Size)</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Native (400x240)</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>2x Native (800x480)</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>3x Native (1200x720)</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>4x Native (1600x960)</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>5x Native (2000x1200)</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>6x Native (2400x1440)</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>7x Native (2800x1680)</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>8x Native (3200x1920)</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>9x Native (3600x2160)</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>10x Native (4000x2400)</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="toggle_hw_shader">
+           <property name="text">
+            <string>Enable Hardware Shader</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QWidget" name="hw_shader_group" native="true">
+           <layout class="QVBoxLayout" name="verticalLayout_7">
+            <property name="leftMargin">
+             <number>16</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QCheckBox" name="toggle_accurate_mul">
+              <property name="text">
+               <string>Accurate Multiplication</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="toggle_accurate_gs">
+              <property name="text">
+               <string>Accurate Geometry Shader</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="toggle_shader_jit">
+        <property name="text">
+         <string>Enable Shader JIT</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item>
     <widget class="QGroupBox" name="layoutBox">
      <property name="title">
       <string>Layout</string>
      </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <layout class="QVBoxLayout" name="verticalLayout_3">
       <item>
-       <layout class="QVBoxLayout" name="verticalLayout_4">
+       <layout class="QHBoxLayout" name="horizontalLayout_4">
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_4">
-          <item>
-           <widget class="QLabel" name="label1">
-            <property name="text">
-             <string>Screen Layout:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QComboBox" name="layout_combobox">
-            <item>
-             <property name="text">
-              <string>Default</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Single Screen</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Large Screen</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Side by Side</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="swap_screen">
+         <widget class="QLabel" name="label1">
           <property name="text">
-           <string>Swap Screens</string>
+           <string>Screen Layout:</string>
           </property>
          </widget>
         </item>
+        <item>
+         <widget class="QComboBox" name="layout_combobox">
+          <item>
+           <property name="text">
+            <string>Default</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Single Screen</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Large Screen</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Side by Side</string>
+           </property>
+          </item>
+         </widget>
+        </item>
        </layout>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="swap_screen">
+        <property name="text">
+         <string>Swap Screens</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -216,12 +274,5 @@
   </layout>
  </widget>
  <resources/>
- <connections>
-  <connection>
-   <sender>toggle_hw_renderer</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>resolution_factor_combobox</receiver>
-   <slot>setEnabled(bool)</slot>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/src/citra_qt/configuration/configure_graphics.ui
+++ b/src/citra_qt/configuration/configure_graphics.ui
@@ -65,6 +65,9 @@
      <layout class="QVBoxLayout" name="verticalLayout_6">
       <item>
        <widget class="QCheckBox" name="toggle_hw_renderer">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use OpenGL to accelerate rendering.&lt;/p&gt;&lt;p&gt;Disable to debug graphics-related problem.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
         <property name="text">
          <string>Enable Hardware Renderer</string>
         </property>
@@ -157,6 +160,9 @@
          </item>
          <item>
           <widget class="QCheckBox" name="toggle_hw_shader">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use OpenGL to accelerate shader emulation.&lt;/p&gt;&lt;p&gt;Requires a relatively powerful GPU for better performance.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
            <property name="text">
             <string>Enable Hardware Shader</string>
            </property>
@@ -179,6 +185,9 @@
             </property>
             <item>
              <widget class="QCheckBox" name="toggle_accurate_mul">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Correctly handle all edge cases in multiplication operation in shaders. &lt;/p&gt;&lt;p&gt;Some games requires this to be enabled for the hardware shader to render properly.&lt;/p&gt;&lt;p&gt;However this would reduce performance in most games.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
               <property name="text">
                <string>Accurate Multiplication</string>
               </property>
@@ -186,6 +195,9 @@
             </item>
             <item>
              <widget class="QCheckBox" name="toggle_accurate_gs">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Force to fall back to software shader emulation when geometry shaders are used. &lt;/p&gt;&lt;p&gt;Some games require this to be enabled for the hardware shader to render properly.&lt;/p&gt;&lt;p&gt;However this might reduce performance in some games&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
               <property name="text">
                <string>Accurate Geometry Shader</string>
               </property>
@@ -199,6 +211,9 @@
       </item>
       <item>
        <widget class="QCheckBox" name="toggle_shader_jit">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use the JIT engine instead of the interpreter for software shader emulation. &lt;/p&gt;&lt;p&gt;Enable this for better performance.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
         <property name="text">
          <string>Enable Shader JIT</string>
         </property>

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -107,6 +107,9 @@ struct Values {
 
     // Renderer
     bool use_hw_renderer;
+    bool use_hw_shader;
+    bool shaders_accurate_gs;
+    bool shaders_accurate_mul;
     bool use_shader_jit;
     u16 resolution_factor;
     bool use_vsync;


### PR DESCRIPTION
This is the frontend part of #3499. I am not very happy with the UI design (either the original one or current one), but I am running out of idea. Currently the core problem we have is

Our shader emulation implementation is not good enough yet to eliminate the need of manual configuration from users, so we have to expose multiple options in the UI. 

My excuse is that the default settings should be good for most games and users, so users don't need to go over these options. These are here for debug purpose when an issue is found and dev asks the user to try different settings and report.

![image](https://user-images.githubusercontent.com/4592895/39965351-d4c26528-569f-11e8-85a2-0e54800cf7d2.png)

The layout is rearranged to incorporate with the new options. Some of them is put into a hierarchy, where disabling the top level option would also disable all sub-options. The hierarchy is indicated by the indentation in the UI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3742)
<!-- Reviewable:end -->
