### PR TITLE
travis: use cmake in official repository

### DIFF
--- a/.travis/linux-frozen/docker.sh
+++ b/.travis/linux-frozen/docker.sh
@@ -16,12 +16,8 @@ apt-get install -y build-essential wget git python-launchpadlib ccache
     qt5-qmltooling-plugins 5.9.3-0ubuntu1 bionic     \
     qtdeclarative5-dev 5.9.3-0ubuntu1 bionic         \
     qtmultimedia5-dev 5.9.3-0ubuntu3 bionic          \
-    libicu57 57.1-6ubuntu0.2 bionic
-
-# Get a recent version of CMake
-wget https://cmake.org/files/v3.10/cmake-3.10.1-Linux-x86_64.sh
-echo y | sh cmake-3.10.1-Linux-x86_64.sh --prefix=cmake
-export PATH=/citra/cmake/cmake-3.10.1-Linux-x86_64/bin:$PATH
+    libicu57 57.1-6ubuntu0.2 bionic                  \
+    cmake 3.10.2-1ubuntu2 bionic
 
 mkdir build && cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/lib/ccache/gcc -DCMAKE_CXX_COMPILER=/usr/lib/ccache/g++ -DCITRA_ENABLE_COMPATIBILITY_REPORTING=${ENABLE_COMPATIBILITY_REPORTING:-"OFF"} -DENABLE_COMPATIBILITY_LIST_DOWNLOAD=ON

--- a/.travis/linux-frozen/install_package.py
+++ b/.travis/linux-frozen/install_package.py
@@ -1,30 +1,42 @@
 #!/usr/bin/python
 
-import sys, re, subprocess
+import sys
+import re
+import subprocess
 from launchpadlib.launchpad import Launchpad
 
+if sys.version_info[0] > 2:
+    xrange = range
+
 cachedir = '/.launchpadlib/cache/'
-launchpad = Launchpad.login_anonymously('grab build info', 'production', cachedir, version='devel')
+launchpad = Launchpad.login_anonymously(
+    'grab build info', 'production', cachedir, version='devel')
 
 processed_packages = []
 deb_file_list = []
 
+
 def get_url(pkg, distro):
-    build_link = launchpad.archives.getByReference(reference='ubuntu').getPublishedBinaries(binary_name=pkg[0], distro_arch_series='https://api.launchpad.net/devel/ubuntu/'+distro+'/amd64', version=pkg[1], exact_match=True, order_by_date=True).entries[0]['build_link']
-    deb_name = pkg[0] + '_' + pkg[1] + '_amd64.deb'
+    build_ref = launchpad.archives.getByReference(reference='ubuntu').getPublishedBinaries(
+        binary_name=pkg[0], distro_arch_series='https://api.launchpad.net/devel/ubuntu/' + distro + '/amd64', version=pkg[1], exact_match=True, order_by_date=True).entries[0]
+    build_link = build_ref['build_link']
+    deb_name = '{}_{}_{}.deb'.format(pkg[0], pkg[1], 'amd64' if build_ref['architecture_specific'] else 'all')
     deb_link = build_link + '/+files/' + deb_name
     return [deb_link, deb_name]
 
+
 def list_dependencies(deb_file):
-    t=subprocess.check_output(['bash', '-c', 'dpkg -I ' + deb_file + ' | grep -oP "^ Depends\: \K.*$"'])
-    deps=[i.strip() for i in t.split(',')]
+    t = subprocess.check_output(
+        ['bash', '-c', '(dpkg -I {} | grep -oP "^ Depends\: \K.*$") || true'.format(deb_file)])
+    deps = [i.strip() for i in t.split(',')]
     equals_re = re.compile(r'^(.*) \(= (.*)\)$')
     return [equals_re.sub(r'\1=\2', i).split('=') for i in filter(equals_re.match, deps)]
+
 
 def get_package(pkg, distro):
     if pkg in processed_packages:
         return
-    print 'Getting ' + pkg[0] + '...'
+    print('Getting {}...'.format(pkg[0]))
     url = get_url(pkg, distro)
     subprocess.check_call(['wget', '--quiet', url[0], '-O', url[1]])
     for dep in list_dependencies(url[1]):
@@ -32,7 +44,9 @@ def get_package(pkg, distro):
     processed_packages.append(pkg)
     deb_file_list.append('./' + url[1])
 
+
 for i in xrange(1, len(sys.argv), 3):
     get_package([sys.argv[i], sys.argv[i + 1]], sys.argv[i + 2])
 
-subprocess.check_call(['apt-get', 'install', '-y', '--force-yes'] + deb_file_list)
+subprocess.check_call(
+    ['apt-get', 'install', '-y', '--force-yes'] + deb_file_list)

--- a/.travis/linux/docker.sh
+++ b/.travis/linux/docker.sh
@@ -3,12 +3,7 @@
 cd /citra
 
 apt-get update
-apt-get install -y build-essential libsdl2-dev qtbase5-dev libqt5opengl5-dev qtmultimedia5-dev qttools5-dev qttools5-dev-tools wget git ccache
-
-# Get a recent version of CMake
-wget https://cmake.org/files/v3.10/cmake-3.10.1-Linux-x86_64.sh
-echo y | sh cmake-3.10.1-Linux-x86_64.sh --prefix=cmake
-export PATH=/citra/cmake/cmake-3.10.1-Linux-x86_64/bin:$PATH
+apt-get install -y build-essential libsdl2-dev qtbase5-dev libqt5opengl5-dev qtmultimedia5-dev qttools5-dev qttools5-dev-tools wget git ccache cmake
 
 mkdir build && cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/lib/ccache/gcc -DCMAKE_CXX_COMPILER=/usr/lib/ccache/g++ -DENABLE_QT_TRANSLATION=ON -DCITRA_ENABLE_COMPATIBILITY_REPORTING=${ENABLE_COMPATIBILITY_REPORTING:-"OFF"} -DENABLE_COMPATIBILITY_LIST_DOWNLOAD=ON


### PR DESCRIPTION
Recently Ubuntu 18.04 updated their `cmake` package to 3.10.x. This PR will remove the explicit download of `cmake`.

The changes to the installation Python script were that:

- Script hardcoded the architecture to be `amd64`, the data package `cmake-data` is not an architecture-specific package, so I have changed that.
- I've heard that Python Foundation has been planning to drop Python 2 support, so I added some checks to make the script Python 3 ready.