### PR TITLE
Camera translation

### DIFF
--- a/src/citra_qt/camera/qt_camera_factory.cpp
+++ b/src/citra_qt/camera/qt_camera_factory.cpp
@@ -15,8 +15,7 @@ std::unique_ptr<CameraInterface> QtCameraFactory::CreatePreview(const std::strin
         return camera;
     }
     QMessageBox::critical(nullptr, QObject::tr("Error"),
-                          QObject::tr("Couldn't load ") +
-                              (config.empty() ? QObject::tr("the camera") : "") +
+                          (config.empty() ? QObject::tr("Couldn't load the camera ") : QObject::tr("Couldn't load ")) +
                               QString::fromStdString(config));
     return nullptr;
 }

--- a/src/citra_qt/camera/qt_camera_factory.cpp
+++ b/src/citra_qt/camera/qt_camera_factory.cpp
@@ -14,9 +14,10 @@ std::unique_ptr<CameraInterface> QtCameraFactory::CreatePreview(const std::strin
     if (camera->IsPreviewAvailable()) {
         return camera;
     }
-    QMessageBox::critical(nullptr, QObject::tr("Error"),
-                          (config.empty() ? QObject::tr("Couldn't load the camera ") : QObject::tr("Couldn't load ")) +
-                              QString::fromStdString(config));
+    QMessageBox::critical(
+        nullptr, QObject::tr("Error"),
+        (config.empty() ? QObject::tr("Couldn't load the camera")
+                        : QObject::tr("Couldn't load %1").arg(QString::fromStdString(config))));
     return nullptr;
 }
 

--- a/src/citra_qt/camera/still_image_camera.cpp
+++ b/src/citra_qt/camera/still_image_camera.cpp
@@ -52,7 +52,7 @@ const std::string StillImageCameraFactory::getFilePath() {
         temp_filters << QString("*." + QString(type));
     }
 
-    QString filter = QObject::tr("Supported image files (") + temp_filters.join(" ") + ")";
+    QString filter = QObject::tr("Supported image files (%1)").arg(temp_filters.join(" "));
 
     return QFileDialog::getOpenFileName(nullptr, QObject::tr("Open File"), ".", filter)
         .toStdString();

--- a/src/citra_qt/configuration/configure_camera.ui
+++ b/src/citra_qt/configuration/configure_camera.ui
@@ -117,7 +117,7 @@
                 <item>
                   <widget class="QLabel" name="image_source_label">
                     <property name="toolTip">
-                      <string>Select where the image of the emulated camera come from. It may be an image or a real camera.</string>
+                      <string>Select where the image of the emulated camera comes from. It may be an image or a real camera.</string>
                     </property>
                     <property name="text">
                       <string>Camera Image Source:</string>


### PR DESCRIPTION
Correct the translation of some things in the camera module I found while translating.

When the config in ``QtCameraFactory::CreatePreview()`` couldn't be loaded the translation would sound very messed up in some languages (like German) where the wording does not correspond to "Couldn't load" and "the camera".
Also there is a missing "s" in the ``.ui`` file (come -> comes).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3747)
<!-- Reviewable:end -->
