### PR TITLE
gl_rasterizer_cache: add missing watcher invalidation

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -334,6 +334,8 @@ static bool FillSurface(const Surface& surface, const u8* fill_data,
     state.draw.draw_framebuffer = draw_fb_handle;
     state.Apply();
 
+    surface->InvalidateAllWatcher();
+
     if (surface->type == SurfaceType::Color || surface->type == SurfaceType::Texture) {
         glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
                                surface->texture.handle, 0);
@@ -1029,6 +1031,8 @@ bool RasterizerCacheOpenGL::BlitSurfaces(const Surface& src_surface,
     if (!SurfaceParams::CheckFormatsBlittable(src_surface->pixel_format, dst_surface->pixel_format))
         return false;
 
+    dst_surface->InvalidateAllWatcher();
+
     return BlitTextures(src_surface->texture.handle, src_rect, dst_surface->texture.handle,
                         dst_rect, src_surface->type, read_framebuffer.handle,
                         draw_framebuffer.handle);
@@ -1427,10 +1431,12 @@ SurfaceSurfaceRect_Tuple RasterizerCacheOpenGL::GetFramebufferSurfaces(
     if (color_surface != nullptr) {
         ValidateSurface(color_surface, boost::icl::first(color_vp_interval),
                         boost::icl::length(color_vp_interval));
+        color_surface->InvalidateAllWatcher();
     }
     if (depth_surface != nullptr) {
         ValidateSurface(depth_surface, boost::icl::first(depth_vp_interval),
                         boost::icl::length(depth_vp_interval));
+        depth_surface->InvalidateAllWatcher();
     }
 
     return std::make_tuple(color_surface, depth_surface, fb_rect);


### PR DESCRIPTION
A fixup to #3700. The watcher invalidation there is only placed in `UploadGLTexture`, which is called when the game upload the texture from CPU side. However, there are more cases where a texture surface can be modified. Specifically, they are:
 - when cleared (GPU accelerate surface clear)
 - when copied from other texture (GPU accelerate display transfer / texture copy)
 - when rendered by framebuffer 

In all this cases, the watcher should notify that the holder/cubemap should update the content.

For whoever is wondering, this would have performance impact on dynamic environment cube mapping, but wouldn't affect games with static cubemap (tested monster hunter).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3750)
<!-- Reviewable:end -->
