### PR TITLE
citra_qt: Improve Game List Item display

### DIFF
--- a/src/citra_qt/game_list_p.h
+++ b/src/citra_qt/game_list_p.h
@@ -182,8 +182,9 @@ public:
                     .replace("\\", "\\\\"));
             if (installed_system_pattern.exactMatch(QString::fromStdString(path))) {
                 // Use a different mechanism for system / installed titles showing program ID
-                second_name =
-                    "000" + QString::number(data(ProgramIdRole).toULongLong(), 16).toUpper();
+                second_name = "000" +
+                              QString::number(data(ProgramIdRole).toULongLong(), 16).toUpper() +
+                              "-" + QString::fromStdString(filename);
             }
             return title + (title.isEmpty() ? "" : "\n     ") + second_name;
         } else {

--- a/src/citra_qt/game_list_p.h
+++ b/src/citra_qt/game_list_p.h
@@ -15,6 +15,7 @@
 #include <QStandardItem>
 #include <QString>
 #include "citra_qt/util/util.h"
+#include "common/file_util.h"
 #include "common/logging/log.h"
 #include "common/string_util.h"
 #include "core/loader/smdh.h"
@@ -167,11 +168,24 @@ public:
 
     QVariant data(int role) const override {
         if (role == Qt::DisplayRole) {
-            std::string filename;
-            Common::SplitPath(data(FullPathRole).toString().toStdString(), nullptr, &filename,
-                              nullptr);
+            std::string path, filename, extension;
+            Common::SplitPath(data(FullPathRole).toString().toStdString(), &path, &filename,
+                              &extension);
             QString title = data(TitleRole).toString();
-            return QString::fromStdString(filename) + (title.isEmpty() ? "" : "\n    " + title);
+            QString second_name = QString::fromStdString(filename + extension);
+            QRegExp installed_system_pattern(
+                QString::fromStdString(
+                    FileUtil::GetUserPath(D_SDMC_IDX) +
+                    "Nintendo "
+                    "3DS/00000000000000000000000000000000/00000000000000000000000000000000/"
+                    "title/000400(0|1)0/[0-9a-f]{8}/content/")
+                    .replace("\\", "\\\\"));
+            if (installed_system_pattern.exactMatch(QString::fromStdString(path))) {
+                // Use a different mechanism for system / installed titles showing program ID
+                second_name =
+                    "000" + QString::number(data(ProgramIdRole).toULongLong(), 16).toUpper();
+            }
+            return title + (title.isEmpty() ? "" : "\n     ") + second_name;
         } else {
             return GameListItem::data(role);
         }

--- a/src/citra_qt/game_list_p.h
+++ b/src/citra_qt/game_list_p.h
@@ -173,7 +173,7 @@ public:
                               &extension);
             QString title = data(TitleRole).toString();
             QString second_name = QString::fromStdString(filename + extension);
-            QRegExp installed_system_pattern(
+            static QRegExp installed_system_pattern(
                 QString::fromStdString(
                     FileUtil::GetUserPath(D_SDMC_IDX) +
                     "Nintendo "
@@ -182,9 +182,10 @@ public:
                     .replace("\\", "\\\\"));
             if (installed_system_pattern.exactMatch(QString::fromStdString(path))) {
                 // Use a different mechanism for system / installed titles showing program ID
-                second_name = "000" +
-                              QString::number(data(ProgramIdRole).toULongLong(), 16).toUpper() +
-                              "-" + QString::fromStdString(filename);
+                second_name = QString("%1-%2")
+                                  .arg(data(ProgramIdRole).toULongLong(), 16, 16, QChar('0'))
+                                  .toUpper()
+                                  .arg(QString::fromStdString(filename));
             }
             return title + (title.isEmpty() ? "" : "\n     ") + second_name;
         } else {


### PR DESCRIPTION
I think Citra's game list items does not look very nice, so I made this..
I swapped the positions of the game title and file name, as I think game title is more important.
And, I think file name is incomplete without extension, so I added it.
For Installed titles & System titles, it makes no sense to display the file name (usually it's 00000000.app or something similar), so I display the program ID.

This is what Installed Titles look like (with multiple game dir PR merged)
![Installed Titles](https://user-images.githubusercontent.com/21307832/40267186-1ac8673a-5b8b-11e8-8476-263c9294f784.png)

And this is what a usual game directory looks like..
![Game Dir](https://user-images.githubusercontent.com/21307832/40267221-d100ea4a-5b8b-11e8-9be5-e16874a7922d.png)

With (not latest) Canary it will look like this..
![Installed Titles Canary](https://user-images.githubusercontent.com/21307832/40267229-f2ad1c18-5b8b-11e8-8ef8-d0dc8f223a42.png)
![Game Dir Canary](https://user-images.githubusercontent.com/21307832/40267235-020c9b98-5b8c-11e8-87ad-a2528cae53d4.png)

What do you think?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3757)
<!-- Reviewable:end -->
