### PR TITLE
Add missing std::string import in text_formatter

### DIFF
--- a/src/common/logging/text_formatter.h
+++ b/src/common/logging/text_formatter.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstddef>
+#include <string>
 
 namespace Log {
 


### PR DESCRIPTION
The text formatter doesn't include std::string by itself, erroneously relying on the includes from parent files.

This PR adds this.

... describing one line of changes isn't easy, is it?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3758)
<!-- Reviewable:end -->
