### PR TITLE
Rewrite texture_buffer_object handling.

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -806,49 +806,8 @@ bool RasterizerOpenGL::Draw(bool accelerate, bool is_indexed) {
         shader_dirty = false;
     }
 
-    // Sync the lighting luts
-    for (unsigned index = 0; index < uniform_block_data.lut_dirty.size(); index++) {
-        if (uniform_block_data.lut_dirty[index]) {
-            SyncLightingLUT(index);
-            uniform_block_data.lut_dirty[index] = false;
-        }
-    }
-
-    // Sync the fog lut
-    if (uniform_block_data.fog_lut_dirty) {
-        SyncFogLUT();
-        uniform_block_data.fog_lut_dirty = false;
-    }
-
-    // Sync the proctex noise lut
-    if (uniform_block_data.proctex_noise_lut_dirty) {
-        SyncProcTexNoiseLUT();
-        uniform_block_data.proctex_noise_lut_dirty = false;
-    }
-
-    // Sync the proctex color map
-    if (uniform_block_data.proctex_color_map_dirty) {
-        SyncProcTexColorMap();
-        uniform_block_data.proctex_color_map_dirty = false;
-    }
-
-    // Sync the proctex alpha map
-    if (uniform_block_data.proctex_alpha_map_dirty) {
-        SyncProcTexAlphaMap();
-        uniform_block_data.proctex_alpha_map_dirty = false;
-    }
-
-    // Sync the proctex lut
-    if (uniform_block_data.proctex_lut_dirty) {
-        SyncProcTexLUT();
-        uniform_block_data.proctex_lut_dirty = false;
-    }
-
-    // Sync the proctex difference lut
-    if (uniform_block_data.proctex_diff_lut_dirty) {
-        SyncProcTexDiffLUT();
-        uniform_block_data.proctex_diff_lut_dirty = false;
-    }
+    // Sync the LUTs within the texture buffer
+    SyncAndUploadLUTs();
 
     // Sync the uniform data
     const bool use_gs = regs.pipeline.use_gs == Pica::PipelineRegs::UseGS::Yes;
@@ -2062,6 +2021,52 @@ void RasterizerOpenGL::SyncShadowBias() {
         uniform_block_data.data.shadow_bias_constant = constant;
         uniform_block_data.data.shadow_bias_linear = linear;
         uniform_block_data.dirty = true;
+    }
+}
+
+void RasterizerOpenGL::SyncAndUploadLUTs() {
+    // Sync the lighting luts
+    for (unsigned index = 0; index < uniform_block_data.lut_dirty.size(); index++) {
+        if (uniform_block_data.lut_dirty[index]) {
+            SyncLightingLUT(index);
+            uniform_block_data.lut_dirty[index] = false;
+        }
+    }
+
+    // Sync the fog lut
+    if (uniform_block_data.fog_lut_dirty) {
+        SyncFogLUT();
+        uniform_block_data.fog_lut_dirty = false;
+    }
+
+    // Sync the proctex noise lut
+    if (uniform_block_data.proctex_noise_lut_dirty) {
+        SyncProcTexNoiseLUT();
+        uniform_block_data.proctex_noise_lut_dirty = false;
+    }
+
+    // Sync the proctex color map
+    if (uniform_block_data.proctex_color_map_dirty) {
+        SyncProcTexColorMap();
+        uniform_block_data.proctex_color_map_dirty = false;
+    }
+
+    // Sync the proctex alpha map
+    if (uniform_block_data.proctex_alpha_map_dirty) {
+        SyncProcTexAlphaMap();
+        uniform_block_data.proctex_alpha_map_dirty = false;
+    }
+
+    // Sync the proctex lut
+    if (uniform_block_data.proctex_lut_dirty) {
+        SyncProcTexLUT();
+        uniform_block_data.proctex_lut_dirty = false;
+    }
+
+    // Sync the proctex difference lut
+    if (uniform_block_data.proctex_diff_lut_dirty) {
+        SyncProcTexDiffLUT();
+        uniform_block_data.proctex_diff_lut_dirty = false;
     }
 }
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -1725,21 +1725,6 @@ void RasterizerOpenGL::SyncFogColor() {
     uniform_block_data.dirty = true;
 }
 
-void RasterizerOpenGL::SyncFogLUT() {
-    std::array<GLvec2, 128> new_data;
-
-    std::transform(Pica::g_state.fog.lut.begin(), Pica::g_state.fog.lut.end(), new_data.begin(),
-                   [](const auto& entry) {
-                       return GLvec2{entry.ToFloat(), entry.DiffToFloat()};
-                   });
-
-    if (new_data != fog_lut_data) {
-        fog_lut_data = new_data;
-        glBindBuffer(GL_TEXTURE_BUFFER, fog_lut_buffer.handle);
-        glBufferSubData(GL_TEXTURE_BUFFER, 0, new_data.size() * sizeof(GLvec2), new_data.data());
-    }
-}
-
 void RasterizerOpenGL::SyncProcTexNoise() {
     const auto& regs = Pica::g_state.regs.texturing;
     uniform_block_data.data.proctex_noise_f = {
@@ -1756,70 +1741,6 @@ void RasterizerOpenGL::SyncProcTexNoise() {
     };
 
     uniform_block_data.dirty = true;
-}
-
-// helper function for SyncProcTexNoiseLUT/ColorMap/AlphaMap
-static void SyncProcTexValueLUT(const std::array<Pica::State::ProcTex::ValueEntry, 128>& lut,
-                                std::array<GLvec2, 128>& lut_data, GLuint buffer) {
-    std::array<GLvec2, 128> new_data;
-    std::transform(lut.begin(), lut.end(), new_data.begin(), [](const auto& entry) {
-        return GLvec2{entry.ToFloat(), entry.DiffToFloat()};
-    });
-
-    if (new_data != lut_data) {
-        lut_data = new_data;
-        glBindBuffer(GL_TEXTURE_BUFFER, buffer);
-        glBufferSubData(GL_TEXTURE_BUFFER, 0, new_data.size() * sizeof(GLvec2), new_data.data());
-    }
-}
-
-void RasterizerOpenGL::SyncProcTexNoiseLUT() {
-    SyncProcTexValueLUT(Pica::g_state.proctex.noise_table, proctex_noise_lut_data,
-                        proctex_noise_lut_buffer.handle);
-}
-
-void RasterizerOpenGL::SyncProcTexColorMap() {
-    SyncProcTexValueLUT(Pica::g_state.proctex.color_map_table, proctex_color_map_data,
-                        proctex_color_map_buffer.handle);
-}
-
-void RasterizerOpenGL::SyncProcTexAlphaMap() {
-    SyncProcTexValueLUT(Pica::g_state.proctex.alpha_map_table, proctex_alpha_map_data,
-                        proctex_alpha_map_buffer.handle);
-}
-
-void RasterizerOpenGL::SyncProcTexLUT() {
-    std::array<GLvec4, 256> new_data;
-
-    std::transform(Pica::g_state.proctex.color_table.begin(),
-                   Pica::g_state.proctex.color_table.end(), new_data.begin(),
-                   [](const auto& entry) {
-                       auto rgba = entry.ToVector() / 255.0f;
-                       return GLvec4{rgba.r(), rgba.g(), rgba.b(), rgba.a()};
-                   });
-
-    if (new_data != proctex_lut_data) {
-        proctex_lut_data = new_data;
-        glBindBuffer(GL_TEXTURE_BUFFER, proctex_lut_buffer.handle);
-        glBufferSubData(GL_TEXTURE_BUFFER, 0, new_data.size() * sizeof(GLvec4), new_data.data());
-    }
-}
-
-void RasterizerOpenGL::SyncProcTexDiffLUT() {
-    std::array<GLvec4, 256> new_data;
-
-    std::transform(Pica::g_state.proctex.color_diff_table.begin(),
-                   Pica::g_state.proctex.color_diff_table.end(), new_data.begin(),
-                   [](const auto& entry) {
-                       auto rgba = entry.ToVector() / 255.0f;
-                       return GLvec4{rgba.r(), rgba.g(), rgba.b(), rgba.a()};
-                   });
-
-    if (new_data != proctex_diff_lut_data) {
-        proctex_diff_lut_data = new_data;
-        glBindBuffer(GL_TEXTURE_BUFFER, proctex_diff_lut_buffer.handle);
-        glBufferSubData(GL_TEXTURE_BUFFER, 0, new_data.size() * sizeof(GLvec4), new_data.data());
-    }
 }
 
 void RasterizerOpenGL::SyncAlphaTest() {
@@ -1919,21 +1840,6 @@ void RasterizerOpenGL::SyncGlobalAmbient() {
     }
 }
 
-void RasterizerOpenGL::SyncLightingLUT(unsigned lut_index) {
-    std::array<GLvec2, 256> new_data;
-    const auto& source_lut = Pica::g_state.lighting.luts[lut_index];
-    std::transform(source_lut.begin(), source_lut.end(), new_data.begin(), [](const auto& entry) {
-        return GLvec2{entry.ToFloat(), entry.DiffToFloat()};
-    });
-
-    if (new_data != lighting_lut_data[lut_index]) {
-        lighting_lut_data[lut_index] = new_data;
-        glBindBuffer(GL_TEXTURE_BUFFER, lighting_lut_buffer.handle);
-        glBufferSubData(GL_TEXTURE_BUFFER, lut_index * new_data.size() * sizeof(GLvec2),
-                        new_data.size() * sizeof(GLvec2), new_data.data());
-    }
-}
-
 void RasterizerOpenGL::SyncLightSpecular0(int light_index) {
     auto color = PicaToGL::LightColor(Pica::g_state.regs.lighting.light[light_index].specular_0);
     if (color != uniform_block_data.data.light_src[light_index].specular_0) {
@@ -2028,44 +1934,115 @@ void RasterizerOpenGL::SyncAndUploadLUTs() {
     // Sync the lighting luts
     for (unsigned index = 0; index < uniform_block_data.lut_dirty.size(); index++) {
         if (uniform_block_data.lut_dirty[index]) {
-            SyncLightingLUT(index);
+            std::array<GLvec2, 256> new_data;
+            const auto& source_lut = Pica::g_state.lighting.luts[index];
+            std::transform(source_lut.begin(), source_lut.end(), new_data.begin(),
+                           [](const auto& entry) {
+                               return GLvec2{entry.ToFloat(), entry.DiffToFloat()};
+                           });
+
+            if (new_data != lighting_lut_data[index]) {
+                lighting_lut_data[index] = new_data;
+                glBindBuffer(GL_TEXTURE_BUFFER, lighting_lut_buffer.handle);
+                glBufferSubData(GL_TEXTURE_BUFFER, index * new_data.size() * sizeof(GLvec2),
+                                new_data.size() * sizeof(GLvec2), new_data.data());
+            }
             uniform_block_data.lut_dirty[index] = false;
         }
     }
 
     // Sync the fog lut
     if (uniform_block_data.fog_lut_dirty) {
-        SyncFogLUT();
+        std::array<GLvec2, 128> new_data;
+
+        std::transform(Pica::g_state.fog.lut.begin(), Pica::g_state.fog.lut.end(), new_data.begin(),
+                       [](const auto& entry) {
+                           return GLvec2{entry.ToFloat(), entry.DiffToFloat()};
+                       });
+
+        if (new_data != fog_lut_data) {
+            fog_lut_data = new_data;
+            glBindBuffer(GL_TEXTURE_BUFFER, fog_lut_buffer.handle);
+            glBufferSubData(GL_TEXTURE_BUFFER, 0, new_data.size() * sizeof(GLvec2),
+                            new_data.data());
+        }
         uniform_block_data.fog_lut_dirty = false;
     }
 
+    // helper function for SyncProcTexNoiseLUT/ColorMap/AlphaMap
+    auto SyncProcTexValueLUT = [](const std::array<Pica::State::ProcTex::ValueEntry, 128>& lut,
+                                  std::array<GLvec2, 128>& lut_data, GLuint buffer) {
+        std::array<GLvec2, 128> new_data;
+        std::transform(lut.begin(), lut.end(), new_data.begin(), [](const auto& entry) {
+            return GLvec2{entry.ToFloat(), entry.DiffToFloat()};
+        });
+
+        if (new_data != lut_data) {
+            lut_data = new_data;
+            glBindBuffer(GL_TEXTURE_BUFFER, buffer);
+            glBufferSubData(GL_TEXTURE_BUFFER, 0, new_data.size() * sizeof(GLvec2),
+                            new_data.data());
+        }
+    };
+
     // Sync the proctex noise lut
     if (uniform_block_data.proctex_noise_lut_dirty) {
-        SyncProcTexNoiseLUT();
+        SyncProcTexValueLUT(Pica::g_state.proctex.noise_table, proctex_noise_lut_data,
+                            proctex_noise_lut_buffer.handle);
         uniform_block_data.proctex_noise_lut_dirty = false;
     }
 
     // Sync the proctex color map
     if (uniform_block_data.proctex_color_map_dirty) {
-        SyncProcTexColorMap();
+        SyncProcTexValueLUT(Pica::g_state.proctex.color_map_table, proctex_color_map_data,
+                            proctex_color_map_buffer.handle);
         uniform_block_data.proctex_color_map_dirty = false;
     }
 
     // Sync the proctex alpha map
     if (uniform_block_data.proctex_alpha_map_dirty) {
-        SyncProcTexAlphaMap();
+        SyncProcTexValueLUT(Pica::g_state.proctex.alpha_map_table, proctex_alpha_map_data,
+                            proctex_alpha_map_buffer.handle);
         uniform_block_data.proctex_alpha_map_dirty = false;
     }
 
     // Sync the proctex lut
     if (uniform_block_data.proctex_lut_dirty) {
-        SyncProcTexLUT();
+        std::array<GLvec4, 256> new_data;
+
+        std::transform(Pica::g_state.proctex.color_table.begin(),
+                       Pica::g_state.proctex.color_table.end(), new_data.begin(),
+                       [](const auto& entry) {
+                           auto rgba = entry.ToVector() / 255.0f;
+                           return GLvec4{rgba.r(), rgba.g(), rgba.b(), rgba.a()};
+                       });
+
+        if (new_data != proctex_lut_data) {
+            proctex_lut_data = new_data;
+            glBindBuffer(GL_TEXTURE_BUFFER, proctex_lut_buffer.handle);
+            glBufferSubData(GL_TEXTURE_BUFFER, 0, new_data.size() * sizeof(GLvec4),
+                            new_data.data());
+        }
         uniform_block_data.proctex_lut_dirty = false;
     }
 
     // Sync the proctex difference lut
     if (uniform_block_data.proctex_diff_lut_dirty) {
-        SyncProcTexDiffLUT();
+        std::array<GLvec4, 256> new_data;
+
+        std::transform(Pica::g_state.proctex.color_diff_table.begin(),
+                       Pica::g_state.proctex.color_diff_table.end(), new_data.begin(),
+                       [](const auto& entry) {
+                           auto rgba = entry.ToVector() / 255.0f;
+                           return GLvec4{rgba.r(), rgba.g(), rgba.b(), rgba.a()};
+                       });
+
+        if (new_data != proctex_diff_lut_data) {
+            proctex_diff_lut_data = new_data;
+            glBindBuffer(GL_TEXTURE_BUFFER, proctex_diff_lut_buffer.handle);
+            glBufferSubData(GL_TEXTURE_BUFFER, 0, new_data.size() * sizeof(GLvec4),
+                            new_data.data());
+        }
         uniform_block_data.proctex_diff_lut_dirty = false;
     }
 }

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -76,6 +76,9 @@ RasterizerOpenGL::RasterizerOpenGL()
     uniform_block_data.proctex_lut_dirty = true;
     uniform_block_data.proctex_diff_lut_dirty = true;
 
+    for (int i = 0; i < 24; i++)
+      uniform_block_data.data.lighting_lut_offset[i / 4][i % 4] = 256 * i;
+
     glGetIntegerv(GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT, &uniform_buffer_alignment);
     uniform_size_aligned_vs =
         Common::AlignUp<size_t>(sizeof(VSUniformData), uniform_buffer_alignment);

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -291,17 +291,8 @@ private:
 
     std::array<std::array<GLvec2, 256>, Pica::LightingRegs::NumLightingSampler> lighting_lut_data{};
     std::array<GLvec2, 128> fog_lut_data{};
-
-    OGLBuffer proctex_noise_lut_buffer;
-    OGLTexture proctex_noise_lut;
     std::array<GLvec2, 128> proctex_noise_lut_data{};
-
-    OGLBuffer proctex_color_map_buffer;
-    OGLTexture proctex_color_map;
     std::array<GLvec2, 128> proctex_color_map_data{};
-
-    OGLBuffer proctex_alpha_map_buffer;
-    OGLTexture proctex_alpha_map;
     std::array<GLvec2, 128> proctex_alpha_map_data{};
 
     OGLBuffer proctex_lut_buffer;

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -148,17 +148,9 @@ private:
 
     /// Syncs the fog states to match the PICA register
     void SyncFogColor();
-    void SyncFogLUT();
 
     /// Sync the procedural texture noise configuration to match the PICA register
     void SyncProcTexNoise();
-
-    /// Sync the procedural texture lookup tables
-    void SyncProcTexNoiseLUT();
-    void SyncProcTexColorMap();
-    void SyncProcTexAlphaMap();
-    void SyncProcTexLUT();
-    void SyncProcTexDiffLUT();
 
     /// Syncs the alpha test states to match the PICA register
     void SyncAlphaTest();
@@ -189,9 +181,6 @@ private:
 
     /// Syncs the lighting global ambient color to match the PICA register
     void SyncGlobalAmbient();
-
-    /// Syncs the lighting lookup tables
-    void SyncLightingLUT(unsigned index);
 
     /// Syncs the specified light's specular 0 color to match the PICA register
     void SyncLightSpecular0(int light_index);

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -290,9 +290,6 @@ private:
     OGLTexture texture_buffer_lut_rgba;
 
     std::array<std::array<GLvec2, 256>, Pica::LightingRegs::NumLightingSampler> lighting_lut_data{};
-
-    OGLBuffer fog_lut_buffer;
-    OGLTexture fog_lut;
     std::array<GLvec2, 128> fog_lut_data{};
 
     OGLBuffer proctex_noise_lut_buffer;

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -289,8 +289,6 @@ private:
     OGLTexture texture_buffer_lut_rg;
     OGLTexture texture_buffer_lut_rgba;
 
-    OGLBuffer lighting_lut_buffer;
-    OGLTexture lighting_lut;
     std::array<std::array<GLvec2, 256>, Pica::LightingRegs::NumLightingSampler> lighting_lut_data{};
 
     OGLBuffer fog_lut_buffer;

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -220,6 +220,9 @@ private:
     /// Syncs the shadow rendering bias to match the PICA register
     void SyncShadowBias();
 
+    /// Syncs and uploads the lighting, fog and proctex LUTs
+    void SyncAndUploadLUTs();
+
     /// Upload the uniform blocks to the uniform buffer object
     void UploadUniforms(bool accelerate_draw, bool use_gs);
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -294,13 +294,7 @@ private:
     std::array<GLvec2, 128> proctex_noise_lut_data{};
     std::array<GLvec2, 128> proctex_color_map_data{};
     std::array<GLvec2, 128> proctex_alpha_map_data{};
-
-    OGLBuffer proctex_lut_buffer;
-    OGLTexture proctex_lut;
     std::array<GLvec4, 256> proctex_lut_data{};
-
-    OGLBuffer proctex_diff_lut_buffer;
-    OGLTexture proctex_diff_lut;
     std::array<GLvec4, 256> proctex_diff_lut_data{};
 
     bool allow_shadow;

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -266,6 +266,7 @@ private:
     static constexpr size_t VERTEX_BUFFER_SIZE = 32 * 1024 * 1024;
     static constexpr size_t INDEX_BUFFER_SIZE = 1 * 1024 * 1024;
     static constexpr size_t UNIFORM_BUFFER_SIZE = 2 * 1024 * 1024;
+    static constexpr size_t TEXTURE_BUFFER_SIZE = 1 * 1024 * 1024;
 
     OGLVertexArray sw_vao; // VAO for software shader draw
     OGLVertexArray hw_vao; // VAO for hardware shader / accelerate draw
@@ -275,6 +276,7 @@ private:
     OGLStreamBuffer vertex_buffer;
     OGLStreamBuffer uniform_buffer;
     OGLStreamBuffer index_buffer;
+    OGLStreamBuffer texture_buffer;
     OGLFramebuffer framebuffer;
     GLint uniform_buffer_alignment;
     size_t uniform_size_aligned_vs;
@@ -282,6 +284,9 @@ private:
     size_t uniform_size_aligned_fs;
 
     SamplerInfo texture_cube_sampler;
+
+    OGLTexture texture_buffer_lut_rg;
+    OGLTexture texture_buffer_lut_rgba;
 
     OGLBuffer lighting_lut_buffer;
     OGLTexture lighting_lut;

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -250,7 +250,8 @@ private:
 
     struct {
         UniformData data;
-        std::array<bool, Pica::LightingRegs::NumLightingSampler> lut_dirty;
+        std::array<bool, Pica::LightingRegs::NumLightingSampler> lighting_lut_dirty;
+        bool lighting_lut_dirty_any;
         bool fog_lut_dirty;
         bool proctex_noise_lut_dirty;
         bool proctex_color_map_dirty;

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -1224,7 +1224,6 @@ uniform sampler2D tex2;
 uniform samplerCube tex_cube;
 uniform samplerBuffer texture_buffer_lut_rg;
 uniform samplerBuffer texture_buffer_lut_rgba;
-uniform samplerBuffer fog_lut;
 uniform samplerBuffer proctex_noise_lut;
 uniform samplerBuffer proctex_color_map;
 uniform samplerBuffer proctex_alpha_map;
@@ -1494,7 +1493,8 @@ vec4 secondary_fragment_color = vec4(0.0);
         // Generate clamped fog factor from LUT for given fog index
         out += "float fog_i = clamp(floor(fog_index), 0.0, 127.0);\n";
         out += "float fog_f = fog_index - fog_i;\n";
-        out += "vec2 fog_lut_entry = texelFetch(fog_lut, int(fog_i) + fog_lut_offset).rg;\n";
+        out += "vec2 fog_lut_entry = texelFetch(texture_buffer_lut_rg, int(fog_i) + "
+               "fog_lut_offset).rg;\n";
         out += "float fog_factor = fog_lut_entry.r + fog_lut_entry.g * fog_f;\n";
         out += "fog_factor = clamp(fog_factor, 0.0, 1.0);\n";
 

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -1171,15 +1171,16 @@ float ProcTexNoiseCoef(vec2 x) {
         out += "int lut_index_i = int(lut_coord) + " +
                std::to_string(config.state.proctex.lut_offset) + ";\n";
         out += "float lut_index_f = fract(lut_coord);\n";
-        out += "vec4 final_color = texelFetch(proctex_lut, lut_index_i + proctex_lut_offset) + "
+        out += "vec4 final_color = texelFetch(texture_buffer_lut_rgba, lut_index_i + "
+               "proctex_lut_offset) + "
                "lut_index_f * "
-               "texelFetch(proctex_diff_lut, lut_index_i + proctex_diff_lut_offset);\n";
+               "texelFetch(texture_buffer_lut_rgba, lut_index_i + proctex_diff_lut_offset);\n";
         break;
     case ProcTexFilter::Nearest:
     case ProcTexFilter::NearestMipmapLinear:
     case ProcTexFilter::NearestMipmapNearest:
         out += "lut_coord += " + std::to_string(config.state.proctex.lut_offset) + ";\n";
-        out += "vec4 final_color = texelFetch(proctex_lut, int(round(lut_coord)) + "
+        out += "vec4 final_color = texelFetch(texture_buffer_lut_rgba, int(round(lut_coord)) + "
                "proctex_lut_offset);\n";
         break;
     }
@@ -1224,8 +1225,6 @@ uniform sampler2D tex2;
 uniform samplerCube tex_cube;
 uniform samplerBuffer texture_buffer_lut_rg;
 uniform samplerBuffer texture_buffer_lut_rgba;
-uniform samplerBuffer proctex_lut;
-uniform samplerBuffer proctex_diff_lut;
 
 #if ALLOW_SHADOW
 layout(r32ui) uniform readonly uimage2D shadow_texture_px;

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -1222,6 +1222,8 @@ uniform sampler2D tex0;
 uniform sampler2D tex1;
 uniform sampler2D tex2;
 uniform samplerCube tex_cube;
+uniform samplerBuffer texture_buffer_lut_rg;
+uniform samplerBuffer texture_buffer_lut_rgba;
 uniform samplerBuffer lighting_lut;
 uniform samplerBuffer fog_lut;
 uniform samplerBuffer proctex_noise_lut;

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -1113,8 +1113,8 @@ float ProcTexNoiseCoef(vec2 x) {
     float g2 = ProcTexNoiseRand2D(point + vec2(0.0, 1.0)) * (frac.x + frac.y - 1.0);
     float g3 = ProcTexNoiseRand2D(point + vec2(1.0, 1.0)) * (frac.x + frac.y - 2.0);
 
-    float x_noise = ProcTexLookupLUT(proctex_noise_lut, proctex_noise_lut_offset, frac.x);
-    float y_noise = ProcTexLookupLUT(proctex_noise_lut, proctex_noise_lut_offset, frac.y);
+    float x_noise = ProcTexLookupLUT(texture_buffer_lut_rg, proctex_noise_lut_offset, frac.x);
+    float y_noise = ProcTexLookupLUT(texture_buffer_lut_rg, proctex_noise_lut_offset, frac.y);
     float x0 = mix(g0, g1, x_noise);
     float x1 = mix(g2, g3, x_noise);
     return mix(x0, x1, y_noise);
@@ -1156,7 +1156,7 @@ float ProcTexNoiseCoef(vec2 x) {
 
     // Combine and map
     out += "float lut_coord = ";
-    AppendProcTexCombineAndMap(out, config.state.proctex.color_combiner, "proctex_color_map",
+    AppendProcTexCombineAndMap(out, config.state.proctex.color_combiner, "texture_buffer_lut_rg",
                                "proctex_color_map_offset");
     out += ";\n";
 
@@ -1188,8 +1188,8 @@ float ProcTexNoiseCoef(vec2 x) {
         // Note: in separate alpha mode, the alpha channel skips the color LUT look up stage. It
         // uses the output of CombineAndMap directly instead.
         out += "float final_alpha = ";
-        AppendProcTexCombineAndMap(out, config.state.proctex.alpha_combiner, "proctex_alpha_map",
-                                   "proctex_alpha_map_offset");
+        AppendProcTexCombineAndMap(out, config.state.proctex.alpha_combiner,
+                                   "texture_buffer_lut_rg", "proctex_alpha_map_offset");
         out += ";\n";
         out += "return vec4(final_color.xyz, final_alpha);\n}\n";
     } else {
@@ -1224,9 +1224,6 @@ uniform sampler2D tex2;
 uniform samplerCube tex_cube;
 uniform samplerBuffer texture_buffer_lut_rg;
 uniform samplerBuffer texture_buffer_lut_rgba;
-uniform samplerBuffer proctex_noise_lut;
-uniform samplerBuffer proctex_color_map;
-uniform samplerBuffer proctex_alpha_map;
 uniform samplerBuffer proctex_lut;
 uniform samplerBuffer proctex_diff_lut;
 

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -32,6 +32,7 @@ namespace GLShader {
 static const std::string UniformBlockDef = R"(
 #define NUM_TEV_STAGES 6
 #define NUM_LIGHTS 8
+#define NUM_LIGHTING_SAMPLERS 24
 
 struct LightSrc {
     vec3 specular_0;
@@ -55,6 +56,13 @@ layout (std140) uniform shader_data {
     int scissor_y1;
     int scissor_x2;
     int scissor_y2;
+    int fog_lut_offset;
+    int proctex_noise_lut_offset;
+    int proctex_color_map_offset;
+    int proctex_alpha_map_offset;
+    int proctex_lut_offset;
+    int proctex_diff_lut_offset;
+    ivec4 lighting_lut_offset[NUM_LIGHTING_SAMPLERS / 4];
     vec3 fog_color;
     vec2 proctex_noise_f;
     vec2 proctex_noise_a;
@@ -1017,7 +1025,7 @@ void AppendProcTexClamp(std::string& out, const std::string& var, ProcTexClamp m
 }
 
 void AppendProcTexCombineAndMap(std::string& out, ProcTexCombiner combiner,
-                                const std::string& map_lut) {
+                                const std::string& map_lut, const std::string& offset) {
     std::string combined;
     switch (combiner) {
     case ProcTexCombiner::U:
@@ -1055,7 +1063,7 @@ void AppendProcTexCombineAndMap(std::string& out, ProcTexCombiner combiner,
         combined = "0.0";
         break;
     }
-    out += "ProcTexLookupLUT(" + map_lut + ", " + combined + ")";
+    out += "ProcTexLookupLUT(" + map_lut + ", " + offset + ", " + combined + ")";
 }
 
 void AppendProcTexSampler(std::string& out, const PicaFSConfig& config) {
@@ -1064,12 +1072,12 @@ void AppendProcTexSampler(std::string& out, const PicaFSConfig& config) {
     // coord=1.0 is lut[127]+lut_diff[127]. For other indices, the result is interpolated using
     // value entries and difference entries.
     out += R"(
-float ProcTexLookupLUT(samplerBuffer lut, float coord) {
+float ProcTexLookupLUT(samplerBuffer lut, int offset, float coord) {
     coord *= 128;
     float index_i = clamp(floor(coord), 0.0, 127.0);
     float index_f = coord - index_i; // fract() cannot be used here because 128.0 needs to be
                                      // extracted as index_i = 127.0 and index_f = 1.0
-    vec2 entry = texelFetch(lut, int(index_i)).rg;
+    vec2 entry = texelFetch(lut, int(index_i) + offset).rg;
     return clamp(entry.r + entry.g * index_f, 0.0, 1.0);
 }
     )";
@@ -1105,8 +1113,8 @@ float ProcTexNoiseCoef(vec2 x) {
     float g2 = ProcTexNoiseRand2D(point + vec2(0.0, 1.0)) * (frac.x + frac.y - 1.0);
     float g3 = ProcTexNoiseRand2D(point + vec2(1.0, 1.0)) * (frac.x + frac.y - 2.0);
 
-    float x_noise = ProcTexLookupLUT(proctex_noise_lut, frac.x);
-    float y_noise = ProcTexLookupLUT(proctex_noise_lut, frac.y);
+    float x_noise = ProcTexLookupLUT(proctex_noise_lut, proctex_noise_lut_offset, frac.x);
+    float y_noise = ProcTexLookupLUT(proctex_noise_lut, proctex_noise_lut_offset, frac.y);
     float x0 = mix(g0, g1, x_noise);
     float x1 = mix(g2, g3, x_noise);
     return mix(x0, x1, y_noise);
@@ -1148,7 +1156,8 @@ float ProcTexNoiseCoef(vec2 x) {
 
     // Combine and map
     out += "float lut_coord = ";
-    AppendProcTexCombineAndMap(out, config.state.proctex.color_combiner, "proctex_color_map");
+    AppendProcTexCombineAndMap(out, config.state.proctex.color_combiner, "proctex_color_map",
+                               "proctex_color_map_offset");
     out += ";\n";
 
     // Look up color
@@ -1162,14 +1171,16 @@ float ProcTexNoiseCoef(vec2 x) {
         out += "int lut_index_i = int(lut_coord) + " +
                std::to_string(config.state.proctex.lut_offset) + ";\n";
         out += "float lut_index_f = fract(lut_coord);\n";
-        out += "vec4 final_color = texelFetch(proctex_lut, lut_index_i) + lut_index_f * "
-               "texelFetch(proctex_diff_lut, lut_index_i);\n";
+        out += "vec4 final_color = texelFetch(proctex_lut, lut_index_i + proctex_lut_offset) + "
+               "lut_index_f * "
+               "texelFetch(proctex_diff_lut, lut_index_i + proctex_diff_lut_offset);\n";
         break;
     case ProcTexFilter::Nearest:
     case ProcTexFilter::NearestMipmapLinear:
     case ProcTexFilter::NearestMipmapNearest:
         out += "lut_coord += " + std::to_string(config.state.proctex.lut_offset) + ";\n";
-        out += "vec4 final_color = texelFetch(proctex_lut, int(round(lut_coord)));\n";
+        out += "vec4 final_color = texelFetch(proctex_lut, int(round(lut_coord)) + "
+               "proctex_lut_offset);\n";
         break;
     }
 
@@ -1177,7 +1188,8 @@ float ProcTexNoiseCoef(vec2 x) {
         // Note: in separate alpha mode, the alpha channel skips the color LUT look up stage. It
         // uses the output of CombineAndMap directly instead.
         out += "float final_alpha = ";
-        AppendProcTexCombineAndMap(out, config.state.proctex.alpha_combiner, "proctex_alpha_map");
+        AppendProcTexCombineAndMap(out, config.state.proctex.alpha_combiner, "proctex_alpha_map",
+                                   "proctex_alpha_map_offset");
         out += ";\n";
         out += "return vec4(final_color.xyz, final_alpha);\n}\n";
     } else {
@@ -1238,7 +1250,7 @@ vec3 quaternion_rotate(vec4 q, vec3 v) {
 }
 
 float LookupLightingLUT(int lut_index, int index, float delta) {
-    vec2 entry = texelFetch(lighting_lut, lut_index * 256 + index).rg;
+    vec2 entry = texelFetch(lighting_lut, lighting_lut_offset[lut_index >> 2][lut_index & 3] + index).rg;
     return entry.r + entry.g * delta;
 }
 
@@ -1481,7 +1493,7 @@ vec4 secondary_fragment_color = vec4(0.0);
         // Generate clamped fog factor from LUT for given fog index
         out += "float fog_i = clamp(floor(fog_index), 0.0, 127.0);\n";
         out += "float fog_f = fog_index - fog_i;\n";
-        out += "vec2 fog_lut_entry = texelFetch(fog_lut, int(fog_i)).rg;\n";
+        out += "vec2 fog_lut_entry = texelFetch(fog_lut, int(fog_i) + fog_lut_offset).rg;\n";
         out += "float fog_factor = fog_lut_entry.r + fog_lut_entry.g * fog_f;\n";
         out += "fog_factor = clamp(fog_factor, 0.0, 1.0);\n";
 

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -1224,7 +1224,6 @@ uniform sampler2D tex2;
 uniform samplerCube tex_cube;
 uniform samplerBuffer texture_buffer_lut_rg;
 uniform samplerBuffer texture_buffer_lut_rgba;
-uniform samplerBuffer lighting_lut;
 uniform samplerBuffer fog_lut;
 uniform samplerBuffer proctex_noise_lut;
 uniform samplerBuffer proctex_color_map;
@@ -1252,7 +1251,7 @@ vec3 quaternion_rotate(vec4 q, vec3 v) {
 }
 
 float LookupLightingLUT(int lut_index, int index, float delta) {
-    vec2 entry = texelFetch(lighting_lut, lighting_lut_offset[lut_index >> 2][lut_index & 3] + index).rg;
+    vec2 entry = texelFetch(texture_buffer_lut_rg, lighting_lut_offset[lut_index >> 2][lut_index & 3] + index).rg;
     return entry.r + entry.g * delta;
 }
 

--- a/src/video_core/renderer_opengl/gl_shader_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_manager.cpp
@@ -57,8 +57,6 @@ static void SetShaderSamplerBindings(GLuint shader) {
     // Set the texture samplers to correspond to different lookup table texture units
     SetShaderSamplerBinding(shader, "texture_buffer_lut_rg", TextureUnits::TextureBufferLUT_RG);
     SetShaderSamplerBinding(shader, "texture_buffer_lut_rgba", TextureUnits::TextureBufferLUT_RGBA);
-    SetShaderSamplerBinding(shader, "proctex_lut", TextureUnits::ProcTexLUT);
-    SetShaderSamplerBinding(shader, "proctex_diff_lut", TextureUnits::ProcTexDiffLUT);
 
     SetShaderImageBinding(shader, "shadow_buffer", ImageUnits::ShadowBuffer);
     SetShaderImageBinding(shader, "shadow_texture_px", ImageUnits::ShadowTexturePX);

--- a/src/video_core/renderer_opengl/gl_shader_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_manager.cpp
@@ -55,6 +55,8 @@ static void SetShaderSamplerBindings(GLuint shader) {
     SetShaderSamplerBinding(shader, "tex_cube", TextureUnits::TextureCube);
 
     // Set the texture samplers to correspond to different lookup table texture units
+    SetShaderSamplerBinding(shader, "texture_buffer_lut_rg", TextureUnits::TextureBufferLUT_RG);
+    SetShaderSamplerBinding(shader, "texture_buffer_lut_rgba", TextureUnits::TextureBufferLUT_RGBA);
     SetShaderSamplerBinding(shader, "lighting_lut", TextureUnits::LightingLUT);
     SetShaderSamplerBinding(shader, "fog_lut", TextureUnits::FogLUT);
     SetShaderSamplerBinding(shader, "proctex_noise_lut", TextureUnits::ProcTexNoiseLUT);

--- a/src/video_core/renderer_opengl/gl_shader_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_manager.cpp
@@ -57,9 +57,6 @@ static void SetShaderSamplerBindings(GLuint shader) {
     // Set the texture samplers to correspond to different lookup table texture units
     SetShaderSamplerBinding(shader, "texture_buffer_lut_rg", TextureUnits::TextureBufferLUT_RG);
     SetShaderSamplerBinding(shader, "texture_buffer_lut_rgba", TextureUnits::TextureBufferLUT_RGBA);
-    SetShaderSamplerBinding(shader, "proctex_noise_lut", TextureUnits::ProcTexNoiseLUT);
-    SetShaderSamplerBinding(shader, "proctex_color_map", TextureUnits::ProcTexColorMap);
-    SetShaderSamplerBinding(shader, "proctex_alpha_map", TextureUnits::ProcTexAlphaMap);
     SetShaderSamplerBinding(shader, "proctex_lut", TextureUnits::ProcTexLUT);
     SetShaderSamplerBinding(shader, "proctex_diff_lut", TextureUnits::ProcTexDiffLUT);
 

--- a/src/video_core/renderer_opengl/gl_shader_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_manager.cpp
@@ -57,7 +57,6 @@ static void SetShaderSamplerBindings(GLuint shader) {
     // Set the texture samplers to correspond to different lookup table texture units
     SetShaderSamplerBinding(shader, "texture_buffer_lut_rg", TextureUnits::TextureBufferLUT_RG);
     SetShaderSamplerBinding(shader, "texture_buffer_lut_rgba", TextureUnits::TextureBufferLUT_RGBA);
-    SetShaderSamplerBinding(shader, "lighting_lut", TextureUnits::LightingLUT);
     SetShaderSamplerBinding(shader, "fog_lut", TextureUnits::FogLUT);
     SetShaderSamplerBinding(shader, "proctex_noise_lut", TextureUnits::ProcTexNoiseLUT);
     SetShaderSamplerBinding(shader, "proctex_color_map", TextureUnits::ProcTexColorMap);

--- a/src/video_core/renderer_opengl/gl_shader_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_manager.cpp
@@ -57,7 +57,6 @@ static void SetShaderSamplerBindings(GLuint shader) {
     // Set the texture samplers to correspond to different lookup table texture units
     SetShaderSamplerBinding(shader, "texture_buffer_lut_rg", TextureUnits::TextureBufferLUT_RG);
     SetShaderSamplerBinding(shader, "texture_buffer_lut_rgba", TextureUnits::TextureBufferLUT_RGBA);
-    SetShaderSamplerBinding(shader, "fog_lut", TextureUnits::FogLUT);
     SetShaderSamplerBinding(shader, "proctex_noise_lut", TextureUnits::ProcTexNoiseLUT);
     SetShaderSamplerBinding(shader, "proctex_color_map", TextureUnits::ProcTexColorMap);
     SetShaderSamplerBinding(shader, "proctex_alpha_map", TextureUnits::ProcTexAlphaMap);

--- a/src/video_core/renderer_opengl/gl_shader_manager.h
+++ b/src/video_core/renderer_opengl/gl_shader_manager.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <glad/glad.h>
+#include "video_core/regs_lighting.h"
 #include "video_core/renderer_opengl/gl_resource_manager.h"
 #include "video_core/renderer_opengl/gl_shader_gen.h"
 #include "video_core/renderer_opengl/pica_to_gl.h"
@@ -38,6 +39,13 @@ struct UniformData {
     GLint scissor_y1;
     GLint scissor_x2;
     GLint scissor_y2;
+    GLint fog_lut_offset;
+    GLint proctex_noise_lut_offset;
+    GLint proctex_color_map_offset;
+    GLint proctex_alpha_map_offset;
+    GLint proctex_lut_offset;
+    GLint proctex_diff_lut_offset;
+    alignas(16) GLivec4 lighting_lut_offset[Pica::LightingRegs::NumLightingSampler / 4];
     alignas(16) GLvec3 fog_color;
     alignas(8) GLvec2 proctex_noise_f;
     alignas(8) GLvec2 proctex_noise_a;
@@ -50,7 +58,7 @@ struct UniformData {
 };
 
 static_assert(
-    sizeof(UniformData) == 0x470,
+    sizeof(UniformData) == 0x4e0,
     "The size of the UniformData structure has changed, update the structure in the shader");
 static_assert(sizeof(UniformData) < 16384,
               "UniformData structure must be less than 16kb as per the OpenGL spec");

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -55,6 +55,9 @@ OpenGLState::OpenGLState() {
     texture_cube_unit.texture_cube = 0;
     texture_cube_unit.sampler = 0;
 
+    texture_buffer_lut_rg.texture_buffer = 0;
+    texture_buffer_lut_rgba.texture_buffer = 0;
+
     lighting_lut.texture_buffer = 0;
 
     fog_lut.texture_buffer = 0;
@@ -221,6 +224,19 @@ void OpenGLState::Apply() const {
         glBindSampler(TextureUnits::TextureCube.id, texture_cube_unit.sampler);
     }
 
+    // Texture buffer LUTs
+    if (texture_buffer_lut_rg.texture_buffer != cur_state.texture_buffer_lut_rg.texture_buffer) {
+        glActiveTexture(TextureUnits::TextureBufferLUT_RG.Enum());
+        glBindTexture(GL_TEXTURE_BUFFER, texture_buffer_lut_rg.texture_buffer);
+    }
+
+    // Texture buffer LUTs
+    if (texture_buffer_lut_rgba.texture_buffer !=
+        cur_state.texture_buffer_lut_rgba.texture_buffer) {
+        glActiveTexture(TextureUnits::TextureBufferLUT_RGBA.Enum());
+        glBindTexture(GL_TEXTURE_BUFFER, texture_buffer_lut_rgba.texture_buffer);
+    }
+
     // Lighting LUTs
     if (lighting_lut.texture_buffer != cur_state.lighting_lut.texture_buffer) {
         glActiveTexture(TextureUnits::LightingLUT.Enum());
@@ -374,6 +390,10 @@ OpenGLState& OpenGLState::ResetTexture(GLuint handle) {
     }
     if (texture_cube_unit.texture_cube == handle)
         texture_cube_unit.texture_cube = 0;
+    if (texture_buffer_lut_rg.texture_buffer == handle)
+        texture_buffer_lut_rg.texture_buffer = 0;
+    if (texture_buffer_lut_rgba.texture_buffer == handle)
+        texture_buffer_lut_rgba.texture_buffer = 0;
     if (lighting_lut.texture_buffer == handle)
         lighting_lut.texture_buffer = 0;
     if (fog_lut.texture_buffer == handle)

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -60,9 +60,6 @@ OpenGLState::OpenGLState() {
 
     proctex_lut.texture_buffer = 0;
     proctex_diff_lut.texture_buffer = 0;
-    proctex_color_map.texture_buffer = 0;
-    proctex_alpha_map.texture_buffer = 0;
-    proctex_noise_lut.texture_buffer = 0;
 
     image_shadow_buffer = 0;
     image_shadow_texture_px = 0;
@@ -233,24 +230,6 @@ void OpenGLState::Apply() const {
         glBindTexture(GL_TEXTURE_BUFFER, texture_buffer_lut_rgba.texture_buffer);
     }
 
-    // ProcTex Noise LUT
-    if (proctex_noise_lut.texture_buffer != cur_state.proctex_noise_lut.texture_buffer) {
-        glActiveTexture(TextureUnits::ProcTexNoiseLUT.Enum());
-        glBindTexture(GL_TEXTURE_BUFFER, proctex_noise_lut.texture_buffer);
-    }
-
-    // ProcTex Color Map
-    if (proctex_color_map.texture_buffer != cur_state.proctex_color_map.texture_buffer) {
-        glActiveTexture(TextureUnits::ProcTexColorMap.Enum());
-        glBindTexture(GL_TEXTURE_BUFFER, proctex_color_map.texture_buffer);
-    }
-
-    // ProcTex Alpha Map
-    if (proctex_alpha_map.texture_buffer != cur_state.proctex_alpha_map.texture_buffer) {
-        glActiveTexture(TextureUnits::ProcTexAlphaMap.Enum());
-        glBindTexture(GL_TEXTURE_BUFFER, proctex_alpha_map.texture_buffer);
-    }
-
     // ProcTex LUT
     if (proctex_lut.texture_buffer != cur_state.proctex_lut.texture_buffer) {
         glActiveTexture(TextureUnits::ProcTexLUT.Enum());
@@ -378,12 +357,6 @@ OpenGLState& OpenGLState::ResetTexture(GLuint handle) {
         texture_buffer_lut_rg.texture_buffer = 0;
     if (texture_buffer_lut_rgba.texture_buffer == handle)
         texture_buffer_lut_rgba.texture_buffer = 0;
-    if (proctex_noise_lut.texture_buffer == handle)
-        proctex_noise_lut.texture_buffer = 0;
-    if (proctex_color_map.texture_buffer == handle)
-        proctex_color_map.texture_buffer = 0;
-    if (proctex_alpha_map.texture_buffer == handle)
-        proctex_alpha_map.texture_buffer = 0;
     if (proctex_lut.texture_buffer == handle)
         proctex_lut.texture_buffer = 0;
     if (proctex_diff_lut.texture_buffer == handle)

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -58,9 +58,6 @@ OpenGLState::OpenGLState() {
     texture_buffer_lut_rg.texture_buffer = 0;
     texture_buffer_lut_rgba.texture_buffer = 0;
 
-    proctex_lut.texture_buffer = 0;
-    proctex_diff_lut.texture_buffer = 0;
-
     image_shadow_buffer = 0;
     image_shadow_texture_px = 0;
     image_shadow_texture_nx = 0;
@@ -230,18 +227,6 @@ void OpenGLState::Apply() const {
         glBindTexture(GL_TEXTURE_BUFFER, texture_buffer_lut_rgba.texture_buffer);
     }
 
-    // ProcTex LUT
-    if (proctex_lut.texture_buffer != cur_state.proctex_lut.texture_buffer) {
-        glActiveTexture(TextureUnits::ProcTexLUT.Enum());
-        glBindTexture(GL_TEXTURE_BUFFER, proctex_lut.texture_buffer);
-    }
-
-    // ProcTex Diff LUT
-    if (proctex_diff_lut.texture_buffer != cur_state.proctex_diff_lut.texture_buffer) {
-        glActiveTexture(TextureUnits::ProcTexDiffLUT.Enum());
-        glBindTexture(GL_TEXTURE_BUFFER, proctex_diff_lut.texture_buffer);
-    }
-
     // Shadow Images
     if (image_shadow_buffer != cur_state.image_shadow_buffer) {
         glBindImageTexture(ImageUnits::ShadowBuffer, image_shadow_buffer, 0, GL_FALSE, 0,
@@ -357,10 +342,6 @@ OpenGLState& OpenGLState::ResetTexture(GLuint handle) {
         texture_buffer_lut_rg.texture_buffer = 0;
     if (texture_buffer_lut_rgba.texture_buffer == handle)
         texture_buffer_lut_rgba.texture_buffer = 0;
-    if (proctex_lut.texture_buffer == handle)
-        proctex_lut.texture_buffer = 0;
-    if (proctex_diff_lut.texture_buffer == handle)
-        proctex_diff_lut.texture_buffer = 0;
     if (image_shadow_buffer == handle)
         image_shadow_buffer = 0;
     if (image_shadow_texture_px == handle)

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -58,8 +58,6 @@ OpenGLState::OpenGLState() {
     texture_buffer_lut_rg.texture_buffer = 0;
     texture_buffer_lut_rgba.texture_buffer = 0;
 
-    lighting_lut.texture_buffer = 0;
-
     fog_lut.texture_buffer = 0;
 
     proctex_lut.texture_buffer = 0;
@@ -237,12 +235,6 @@ void OpenGLState::Apply() const {
         glBindTexture(GL_TEXTURE_BUFFER, texture_buffer_lut_rgba.texture_buffer);
     }
 
-    // Lighting LUTs
-    if (lighting_lut.texture_buffer != cur_state.lighting_lut.texture_buffer) {
-        glActiveTexture(TextureUnits::LightingLUT.Enum());
-        glBindTexture(GL_TEXTURE_BUFFER, lighting_lut.texture_buffer);
-    }
-
     // Fog LUT
     if (fog_lut.texture_buffer != cur_state.fog_lut.texture_buffer) {
         glActiveTexture(TextureUnits::FogLUT.Enum());
@@ -394,8 +386,6 @@ OpenGLState& OpenGLState::ResetTexture(GLuint handle) {
         texture_buffer_lut_rg.texture_buffer = 0;
     if (texture_buffer_lut_rgba.texture_buffer == handle)
         texture_buffer_lut_rgba.texture_buffer = 0;
-    if (lighting_lut.texture_buffer == handle)
-        lighting_lut.texture_buffer = 0;
     if (fog_lut.texture_buffer == handle)
         fog_lut.texture_buffer = 0;
     if (proctex_noise_lut.texture_buffer == handle)

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -58,8 +58,6 @@ OpenGLState::OpenGLState() {
     texture_buffer_lut_rg.texture_buffer = 0;
     texture_buffer_lut_rgba.texture_buffer = 0;
 
-    fog_lut.texture_buffer = 0;
-
     proctex_lut.texture_buffer = 0;
     proctex_diff_lut.texture_buffer = 0;
     proctex_color_map.texture_buffer = 0;
@@ -235,12 +233,6 @@ void OpenGLState::Apply() const {
         glBindTexture(GL_TEXTURE_BUFFER, texture_buffer_lut_rgba.texture_buffer);
     }
 
-    // Fog LUT
-    if (fog_lut.texture_buffer != cur_state.fog_lut.texture_buffer) {
-        glActiveTexture(TextureUnits::FogLUT.Enum());
-        glBindTexture(GL_TEXTURE_BUFFER, fog_lut.texture_buffer);
-    }
-
     // ProcTex Noise LUT
     if (proctex_noise_lut.texture_buffer != cur_state.proctex_noise_lut.texture_buffer) {
         glActiveTexture(TextureUnits::ProcTexNoiseLUT.Enum());
@@ -386,8 +378,6 @@ OpenGLState& OpenGLState::ResetTexture(GLuint handle) {
         texture_buffer_lut_rg.texture_buffer = 0;
     if (texture_buffer_lut_rgba.texture_buffer == handle)
         texture_buffer_lut_rgba.texture_buffer = 0;
-    if (fog_lut.texture_buffer == handle)
-        fog_lut.texture_buffer = 0;
     if (proctex_noise_lut.texture_buffer == handle)
         proctex_noise_lut.texture_buffer = 0;
     if (proctex_color_map.texture_buffer == handle)

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -20,9 +20,9 @@ constexpr TextureUnit PicaTexture(int unit) {
     return TextureUnit{unit};
 }
 
-constexpr TextureUnit TextureCube{10};
-constexpr TextureUnit TextureBufferLUT_RG{11};
-constexpr TextureUnit TextureBufferLUT_RGBA{12};
+constexpr TextureUnit TextureCube{3};
+constexpr TextureUnit TextureBufferLUT_RG{4};
+constexpr TextureUnit TextureBufferLUT_RGBA{5};
 
 } // namespace TextureUnits
 

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -20,9 +20,6 @@ constexpr TextureUnit PicaTexture(int unit) {
     return TextureUnit{unit};
 }
 
-constexpr TextureUnit ProcTexNoiseLUT{5};
-constexpr TextureUnit ProcTexColorMap{6};
-constexpr TextureUnit ProcTexAlphaMap{7};
 constexpr TextureUnit ProcTexLUT{8};
 constexpr TextureUnit ProcTexDiffLUT{9};
 constexpr TextureUnit TextureCube{10};
@@ -110,18 +107,6 @@ public:
     struct {
         GLuint texture_buffer; // GL_TEXTURE_BINDING_BUFFER
     } texture_buffer_lut_rgba;
-
-    struct {
-        GLuint texture_buffer; // GL_TEXTURE_BINDING_BUFFER
-    } proctex_noise_lut;
-
-    struct {
-        GLuint texture_buffer; // GL_TEXTURE_BINDING_BUFFER
-    } proctex_color_map;
-
-    struct {
-        GLuint texture_buffer; // GL_TEXTURE_BINDING_BUFFER
-    } proctex_alpha_map;
 
     struct {
         GLuint texture_buffer; // GL_TEXTURE_BINDING_BUFFER

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -20,7 +20,6 @@ constexpr TextureUnit PicaTexture(int unit) {
     return TextureUnit{unit};
 }
 
-constexpr TextureUnit LightingLUT{3};
 constexpr TextureUnit FogLUT{4};
 constexpr TextureUnit ProcTexNoiseLUT{5};
 constexpr TextureUnit ProcTexColorMap{6};
@@ -112,10 +111,6 @@ public:
     struct {
         GLuint texture_buffer; // GL_TEXTURE_BINDING_BUFFER
     } texture_buffer_lut_rgba;
-
-    struct {
-        GLuint texture_buffer; // GL_TEXTURE_BINDING_BUFFER
-    } lighting_lut;
 
     struct {
         GLuint texture_buffer; // GL_TEXTURE_BINDING_BUFFER

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -28,6 +28,8 @@ constexpr TextureUnit ProcTexAlphaMap{7};
 constexpr TextureUnit ProcTexLUT{8};
 constexpr TextureUnit ProcTexDiffLUT{9};
 constexpr TextureUnit TextureCube{10};
+constexpr TextureUnit TextureBufferLUT_RG{11};
+constexpr TextureUnit TextureBufferLUT_RGBA{12};
 
 } // namespace TextureUnits
 
@@ -102,6 +104,14 @@ public:
         GLuint texture_cube; // GL_TEXTURE_BINDING_CUBE_MAP
         GLuint sampler;      // GL_SAMPLER_BINDING
     } texture_cube_unit;
+
+    struct {
+        GLuint texture_buffer; // GL_TEXTURE_BINDING_BUFFER
+    } texture_buffer_lut_rg;
+
+    struct {
+        GLuint texture_buffer; // GL_TEXTURE_BINDING_BUFFER
+    } texture_buffer_lut_rgba;
 
     struct {
         GLuint texture_buffer; // GL_TEXTURE_BINDING_BUFFER

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -20,8 +20,6 @@ constexpr TextureUnit PicaTexture(int unit) {
     return TextureUnit{unit};
 }
 
-constexpr TextureUnit ProcTexLUT{8};
-constexpr TextureUnit ProcTexDiffLUT{9};
 constexpr TextureUnit TextureCube{10};
 constexpr TextureUnit TextureBufferLUT_RG{11};
 constexpr TextureUnit TextureBufferLUT_RGBA{12};
@@ -107,14 +105,6 @@ public:
     struct {
         GLuint texture_buffer; // GL_TEXTURE_BINDING_BUFFER
     } texture_buffer_lut_rgba;
-
-    struct {
-        GLuint texture_buffer; // GL_TEXTURE_BINDING_BUFFER
-    } proctex_lut;
-
-    struct {
-        GLuint texture_buffer; // GL_TEXTURE_BINDING_BUFFER
-    } proctex_diff_lut;
 
     // GL_IMAGE_BINDING_NAME
     GLuint image_shadow_buffer;

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -20,7 +20,6 @@ constexpr TextureUnit PicaTexture(int unit) {
     return TextureUnit{unit};
 }
 
-constexpr TextureUnit FogLUT{4};
 constexpr TextureUnit ProcTexNoiseLUT{5};
 constexpr TextureUnit ProcTexColorMap{6};
 constexpr TextureUnit ProcTexAlphaMap{7};
@@ -111,10 +110,6 @@ public:
     struct {
         GLuint texture_buffer; // GL_TEXTURE_BINDING_BUFFER
     } texture_buffer_lut_rgba;
-
-    struct {
-        GLuint texture_buffer; // GL_TEXTURE_BINDING_BUFFER
-    } fog_lut;
 
     struct {
         GLuint texture_buffer; // GL_TEXTURE_BINDING_BUFFER

--- a/src/video_core/renderer_opengl/gl_stream_buffer.cpp
+++ b/src/video_core/renderer_opengl/gl_stream_buffer.cpp
@@ -87,7 +87,7 @@ std::tuple<u8*, GLintptr, bool> OGLStreamBuffer::Map(GLsizeiptr size, GLintptr a
 void OGLStreamBuffer::Unmap(GLsizeiptr size) {
     ASSERT(size <= mapped_size);
 
-    if (!coherent) {
+    if (!coherent && size > 0) {
         glFlushMappedBufferRange(gl_target, buffer_pos - mapped_offset, size);
     }
 

--- a/src/video_core/renderer_opengl/pica_to_gl.h
+++ b/src/video_core/renderer_opengl/pica_to_gl.h
@@ -23,6 +23,10 @@ using GLuvec2 = std::array<GLuint, 2>;
 using GLuvec3 = std::array<GLuint, 3>;
 using GLuvec4 = std::array<GLuint, 4>;
 
+using GLivec2 = std::array<GLint, 2>;
+using GLivec3 = std::array<GLint, 3>;
+using GLivec4 = std::array<GLint, 4>;
+
 namespace PicaToGL {
 
 inline GLenum TextureFilterMode(Pica::TexturingRegs::TextureConfig::TextureFilter mode) {


### PR DESCRIPTION
This PR rewrites all of the TBO usage of the main draw calls:
Instead of having one binding per LUT with is updated by glBufferSubData, upload all TBO data within one buffer. To address in this big buffer, one offset per LUT is stored within the UBO.

The indirect addressing adds a small overhead for the GPU per pixel, but UBO access is usually very fast.
However skipping the glBufferSubData call decrease both the CPU and GPU overhead.
So for high upscaling factors, this PR makes the GPU performance slower. For low upscaling factors, this PR should make the emulation faster.

As a small dicussion about how to upload our LUTs:
The big part of our LUTs are our 24 lighting LUTs with each 2kB. I don't want to reupload all of them if one has changed to save memory bandwidth, and we can't use one binding point per LUT. So we have two ways to upload the LUTs, both with their drawbacks. The way on master uses glBufferSubData, which assumes that the driver will emit a glCopy, which ends in a second memcpy on the GPU and a GPU context switch. But the driver may also decide to stall the GPU (i965...). The other way (implemented here) accesses the LUTs within the shader in an indirect way. This is the fastest one for the CPU, but it has a GPU overhead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3759)
<!-- Reviewable:end -->
