### PR TITLE
CMake: Avoid non-compliant standard library extensions in MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,8 @@ if (NOT MSVC)
 else()
     # Silence "deprecation" warnings
     add_definitions(/D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_DEPRECATE /D_SCL_SECURE_NO_WARNINGS)
+    # Avoid non-compliant standard library extensions
+    add_definitions(/D_CRT_DECLARE_NONSTDC_NAMES)
     # Avoid windows.h junk
     add_definitions(/DNOMINMAX)
     # Avoid windows.h from including some usually unused libs like winsocks.h, since this might cause some redefinition errors.


### PR DESCRIPTION
Some preliminary work has already been done a while ago in https://github.com/citra-emu/citra/commit/bf12f270b3c74f694c789a57cc69f414753ca080.

Among other things, [`/DNOMINMAX` was defined for MSVC](https://github.com/citra-emu/citra/commit/bf12f270b3c74f694c789a57cc69f414753ca080#diff-af3b638bc2a3e6c650974192a53c7291R14) to avoid Microsoft's lowercase `min` and `max` macros. It turns out that this is *not* enough to avoid these macros. Even worse, there are a lot of unneeded macros that MSVC will still define.

Grepping through the most recent Windows headers reveals that the `min` and `max` macros are actually defined in four places:

1) ntdef.h:3280
2) minmax.h:17
3) minwindef.h:197
4) stdlib.h:1290

None of the Windows headers includes `ntdef.h` (1) or `minmax.h` (2), so let's disregard these two for now.

Let's inspect `minwindef.h` (3) first:

```c
190 #ifndef NOMINMAX
191
192 #ifndef max
193 #define max(a,b)            (((a) > (b)) ? (a) : (b))
194 #endif
195
196 #ifndef min
197 #define min(a,b)            (((a) < (b)) ? (a) : (b))
198 #endif
```

This is covered by `/DNOMINMAX`, so we're good.

Lastly, let's inspect **`stdlib.h`** (4):
```c
1286 #if _CRT_INTERNAL_NONSTDC_NAMES
1287
1288     #ifndef __cplusplus
1289         #define max(a,b) (((a) > (b)) ? (a) : (b))
1290         #define min(a,b) (((a) < (b)) ? (a) : (b))
1291     #endif
```
To my surprise, **`stdlib.h`** (4) is **not** covered by `/DNOMINMAX`. Instead, Microsoft relies on the `_CRT_INTERNAL_NONSTDC_NAMES` macro, which in turn is defined in `corecrt.h`, which they include in numerous standard library headers (**`stdlib.h`** (4) being among which). This macro's definition is:

```c
 287 //-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 288 //
 289 // Deprecation
 290 //
 291 //-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 292 #define _CRT_INTERNAL_NONSTDC_NAMES                                            \
 293     (                                                                          \
 294         ( defined _CRT_DECLARE_NONSTDC_NAMES && _CRT_DECLARE_NONSTDC_NAMES) || \
 295         (!defined _CRT_DECLARE_NONSTDC_NAMES && !__STDC__                 )    \
 296     )
```
Now, none of the Windows headers defines `_CRT_DECLARE_NONSTDC_NAMES`; hence it is left to be defined by the annoyed user.

This PR defines `/D_CRT_DECLARE_NONSTDC_NAMES=0` such that its dependent macro `_CRT_INTERNAL_NONSTDC_NAMES` becomes `0`, which skips the definition of Microsoft's `min`/`max` macros.

More importantly, **this removes a plethora of other Microsoft-specific macros**, as both `_CRT_DECLARE_NONSTDC_NAMES` as well as `_CRT_INTERNAL_NONSTDC_NAMES` are used in lots of other places. An exhaustive, sorted list of their 55 occurences in Microsoft's headers can be viewed below.

<details>

 <summary>(List of skipped macro definitions affected by this PR.)</summary>

- conio.h:430
- conio.h:510
- corecrt.h:292
- corecrt.h:294
- corecrt.h:295
- corecrt_io.h:435
- corecrt_io.h:565
- corecrt_math.h:44
- corecrt_math.h:963
- corecrt_math.h:989
- corecrt_memory.h:76
- corecrt_memory.h:93
- corecrt_search.h:188
- corecrt_search.h:208
- corecrt_share.h:21
- corecrt_wstring.h:573
- corecrt_wstring.h:643
- crtdbg.h:319
- ctype.h:224
- direct.h:120
- direct.h:85
- dos.h:52
- fcntl.h:44
- float.h:328
- float.h:398
- malloc.h:173
- process.h:232
- process.h:364
- stdio.h:2437
- stdio.h:2466
- stdio.h:378
- stdlib.h:1286
- stdlib.h:1362
- stdlib.h:79
- string.h:531
- string.h:588
- sys/locking.h:18
- sys/stat.h:120
- sys/stat.h:217
- sys/stat.h:87
- sys/timeb.h:37
- sys/timeb.h:86
- sys/types.h:17
- sys/types.h:29
- sys/types.h:41
- sys/utime.h:138
- sys/utime.h:41
- tchar.h:1267
- tchar.h:1275
- tchar.h:178
- tchar.h:186
- tchar.h:2105
- tchar.h:2113
- time.h:589
- time.h:597
</details>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3773)
<!-- Reviewable:end -->
