### PR TITLE
gl_rasterizer: implement shadow map 2D/Cube - Image load/store version

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -38,6 +38,15 @@ RasterizerOpenGL::RasterizerOpenGL()
     : shader_dirty(true), vertex_buffer(GL_ARRAY_BUFFER, VERTEX_BUFFER_SIZE),
       uniform_buffer(GL_UNIFORM_BUFFER, UNIFORM_BUFFER_SIZE),
       index_buffer(GL_ELEMENT_ARRAY_BUFFER, INDEX_BUFFER_SIZE) {
+
+    allow_shadow = GLAD_GL_ARB_shader_image_load_store && GLAD_GL_ARB_shader_image_size &&
+                   GLAD_GL_ARB_framebuffer_no_attachments;
+    if (!allow_shadow) {
+        NGLOG_WARNING(
+            Render_OpenGL,
+            "Shadow might not be able to render because of unsupported OpenGL extensions.");
+    }
+
     // Clipping plane 0 is always enabled for PICA fixed clip plane z <= 0
     state.clip_distance[0] = true;
 
@@ -237,6 +246,7 @@ void RasterizerOpenGL::SyncEntireState() {
 
     SyncFogColor();
     SyncProcTexNoise();
+    SyncShadowBias();
 }
 
 /**
@@ -533,12 +543,16 @@ bool RasterizerOpenGL::Draw(bool accelerate, bool is_indexed) {
     MICROPROFILE_SCOPE(OpenGL_Drawing);
     const auto& regs = Pica::g_state.regs;
 
+    bool shadow_rendering = regs.framebuffer.output_merger.fragment_operation_mode ==
+                            Pica::FramebufferRegs::FragmentOperationMode::Shadow;
+
     const bool has_stencil =
         regs.framebuffer.framebuffer.depth_format == Pica::FramebufferRegs::DepthFormat::D24S8;
 
-    const bool write_color_fb =
-        state.color_mask.red_enabled == GL_TRUE || state.color_mask.green_enabled == GL_TRUE ||
-        state.color_mask.blue_enabled == GL_TRUE || state.color_mask.alpha_enabled == GL_TRUE;
+    const bool write_color_fb = shadow_rendering || state.color_mask.red_enabled == GL_TRUE ||
+                                state.color_mask.green_enabled == GL_TRUE ||
+                                state.color_mask.blue_enabled == GL_TRUE ||
+                                state.color_mask.alpha_enabled == GL_TRUE;
 
     const bool write_depth_fb =
         (state.depth.test_enabled && state.depth.write_mask == GL_TRUE) ||
@@ -547,7 +561,7 @@ bool RasterizerOpenGL::Draw(bool accelerate, bool is_indexed) {
     const bool using_color_fb =
         regs.framebuffer.framebuffer.GetColorBufferPhysicalAddress() != 0 && write_color_fb;
     const bool using_depth_fb =
-        regs.framebuffer.framebuffer.GetDepthBufferPhysicalAddress() != 0 &&
+        !shadow_rendering && regs.framebuffer.framebuffer.GetDepthBufferPhysicalAddress() != 0 &&
         (write_depth_fb || regs.framebuffer.output_merger.depth_test_enable != 0 ||
          (has_stencil && state.stencil.test_enabled));
 
@@ -591,24 +605,39 @@ bool RasterizerOpenGL::Draw(bool accelerate, bool is_indexed) {
     state.draw.draw_framebuffer = framebuffer.handle;
     state.Apply();
 
-    glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
-                           color_surface != nullptr ? color_surface->texture.handle : 0, 0);
-    if (depth_surface != nullptr) {
-        if (has_stencil) {
-            // attach both depth and stencil
-            glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D,
-                                   depth_surface->texture.handle, 0);
-        } else {
-            // attach depth
-            glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D,
-                                   depth_surface->texture.handle, 0);
-            // clear stencil attachment
-            glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_TEXTURE_2D, 0, 0);
+    if (shadow_rendering) {
+        if (!allow_shadow || color_surface == nullptr) {
+            return true;
         }
-    } else {
-        // clear both depth and stencil attachment
+        glFramebufferParameteri(GL_DRAW_FRAMEBUFFER, GL_FRAMEBUFFER_DEFAULT_WIDTH,
+                                color_surface->width * color_surface->res_scale);
+        glFramebufferParameteri(GL_DRAW_FRAMEBUFFER, GL_FRAMEBUFFER_DEFAULT_HEIGHT,
+                                color_surface->height * color_surface->res_scale);
+        glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, 0, 0);
         glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, 0,
                                0);
+        state.image_shadow_buffer = color_surface->texture.handle;
+    } else {
+        glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+                               color_surface != nullptr ? color_surface->texture.handle : 0, 0);
+        if (depth_surface != nullptr) {
+            if (has_stencil) {
+                // attach both depth and stencil
+                glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT,
+                                       GL_TEXTURE_2D, depth_surface->texture.handle, 0);
+            } else {
+                // attach depth
+                glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D,
+                                       depth_surface->texture.handle, 0);
+                // clear stencil attachment
+                glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_TEXTURE_2D, 0,
+                                       0);
+            }
+        } else {
+            // clear both depth and stencil attachment
+            glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D,
+                                   0, 0);
+        }
     }
 
     // Sync the viewport
@@ -658,6 +687,82 @@ bool RasterizerOpenGL::Draw(bool accelerate, bool is_indexed) {
             if (texture_index == 0) {
                 using TextureType = Pica::TexturingRegs::TextureConfig::TextureType;
                 switch (texture.config.type.Value()) {
+                case TextureType::Shadow2D: {
+                    if (!allow_shadow)
+                        continue;
+
+                    Surface surface = res_cache.GetTextureSurface(texture);
+                    if (surface != nullptr) {
+                        state.image_shadow_texture_px = surface->texture.handle;
+                    } else {
+                        state.image_shadow_texture_px = 0;
+                    }
+                    continue;
+                }
+                case TextureType::ShadowCube: {
+                    if (!allow_shadow)
+                        continue;
+                    Pica::Texture::TextureInfo info = Pica::Texture::TextureInfo::FromPicaRegister(
+                        texture.config, texture.format);
+                    Surface surface;
+
+                    using CubeFace = Pica::TexturingRegs::CubeFace;
+                    info.physical_address =
+                        regs.texturing.GetCubePhysicalAddress(CubeFace::PositiveX);
+                    surface = res_cache.GetTextureSurface(info);
+                    if (surface != nullptr) {
+                        state.image_shadow_texture_px = surface->texture.handle;
+                    } else {
+                        state.image_shadow_texture_px = 0;
+                    }
+
+                    info.physical_address =
+                        regs.texturing.GetCubePhysicalAddress(CubeFace::NegativeX);
+                    surface = res_cache.GetTextureSurface(info);
+                    if (surface != nullptr) {
+                        state.image_shadow_texture_nx = surface->texture.handle;
+                    } else {
+                        state.image_shadow_texture_nx = 0;
+                    }
+
+                    info.physical_address =
+                        regs.texturing.GetCubePhysicalAddress(CubeFace::PositiveY);
+                    surface = res_cache.GetTextureSurface(info);
+                    if (surface != nullptr) {
+                        state.image_shadow_texture_py = surface->texture.handle;
+                    } else {
+                        state.image_shadow_texture_py = 0;
+                    }
+
+                    info.physical_address =
+                        regs.texturing.GetCubePhysicalAddress(CubeFace::NegativeY);
+                    surface = res_cache.GetTextureSurface(info);
+                    if (surface != nullptr) {
+                        state.image_shadow_texture_ny = surface->texture.handle;
+                    } else {
+                        state.image_shadow_texture_ny = 0;
+                    }
+
+                    info.physical_address =
+                        regs.texturing.GetCubePhysicalAddress(CubeFace::PositiveZ);
+                    surface = res_cache.GetTextureSurface(info);
+                    if (surface != nullptr) {
+                        state.image_shadow_texture_pz = surface->texture.handle;
+                    } else {
+                        state.image_shadow_texture_pz = 0;
+                    }
+
+                    info.physical_address =
+                        regs.texturing.GetCubePhysicalAddress(CubeFace::NegativeZ);
+                    surface = res_cache.GetTextureSurface(info);
+                    if (surface != nullptr) {
+                        state.image_shadow_texture_nz = surface->texture.handle;
+                    } else {
+                        state.image_shadow_texture_nz = 0;
+                    }
+
+                    continue;
+                }
                 case TextureType::TextureCube:
                     using CubeFace = Pica::TexturingRegs::CubeFace;
                     TextureCubeConfig config;
@@ -791,7 +896,21 @@ bool RasterizerOpenGL::Draw(bool accelerate, bool is_indexed) {
         state.texture_units[texture_index].texture_2d = 0;
     }
     state.texture_cube_unit.texture_cube = 0;
+    if (allow_shadow) {
+        state.image_shadow_texture_px = 0;
+        state.image_shadow_texture_nx = 0;
+        state.image_shadow_texture_py = 0;
+        state.image_shadow_texture_ny = 0;
+        state.image_shadow_texture_pz = 0;
+        state.image_shadow_texture_nz = 0;
+        state.image_shadow_buffer = 0;
+    }
     state.Apply();
+
+    if (shadow_rendering) {
+        glMemoryBarrier(GL_TEXTURE_FETCH_BARRIER_BIT | GL_SHADER_IMAGE_ACCESS_BARRIER_BIT |
+                        GL_TEXTURE_UPDATE_BARRIER_BIT | GL_FRAMEBUFFER_BARRIER_BIT);
+    }
 
     // Mark framebuffer surfaces as dirty
     MathUtil::Rectangle<u32> draw_rect_unscaled{
@@ -949,6 +1068,10 @@ void RasterizerOpenGL::NotifyPicaRegisterChanged(u32 id) {
     // (This is a dedicated color write-enable register)
     case PICA_REG_INDEX(framebuffer.framebuffer.allow_color_write):
         SyncColorWriteMask();
+        break;
+
+    case PICA_REG_INDEX(framebuffer.shadow):
+        SyncShadowBias();
         break;
 
     // Scissor test
@@ -1922,6 +2045,19 @@ void RasterizerOpenGL::SyncLightDistanceAttenuationScale(int light_index) {
 
     if (dist_atten_scale != uniform_block_data.data.light_src[light_index].dist_atten_scale) {
         uniform_block_data.data.light_src[light_index].dist_atten_scale = dist_atten_scale;
+        uniform_block_data.dirty = true;
+    }
+}
+
+void RasterizerOpenGL::SyncShadowBias() {
+    const auto& shadow = Pica::g_state.regs.framebuffer.shadow;
+    GLfloat constant = Pica::float16::FromRaw(shadow.constant).ToFloat32();
+    GLfloat linear = Pica::float16::FromRaw(shadow.linear).ToFloat32();
+
+    if (constant != uniform_block_data.data.shadow_bias_constant ||
+        linear != uniform_block_data.data.shadow_bias_linear) {
+        uniform_block_data.data.shadow_bias_constant = constant;
+        uniform_block_data.data.shadow_bias_linear = linear;
         uniform_block_data.dirty = true;
     }
 }

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -217,6 +217,9 @@ private:
     /// Syncs the specified light's distance attenuation scale to match the PICA register
     void SyncLightDistanceAttenuationScale(int light_index);
 
+    /// Syncs the shadow rendering bias to match the PICA register
+    void SyncShadowBias();
+
     /// Upload the uniform blocks to the uniform buffer object
     void UploadUniforms(bool accelerate_draw, bool use_gs);
 
@@ -315,4 +318,6 @@ private:
     OGLBuffer proctex_diff_lut_buffer;
     OGLTexture proctex_diff_lut;
     std::array<GLvec4, 256> proctex_diff_lut_data{};
+
+    bool allow_shadow;
 };

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -303,6 +303,11 @@ static bool BlitTextures(GLuint src_tex, const MathUtil::Rectangle<u32>& src_rec
         buffers = GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT;
     }
 
+    // TODO (wwylele): use GL_NEAREST for shadow map texture
+    // Note: shadow map is treated as RGBA8 format in PICA, as well as in the rasterizer cache, but
+    // doing linear intepolation componentwise would cause incorrect value. However, for a
+    // well-programmed game this code path should be rarely executed for shadow map with
+    // inconsistent scale.
     glBlitFramebuffer(src_rect.left, src_rect.bottom, src_rect.right, src_rect.top, dst_rect.left,
                       dst_rect.bottom, dst_rect.right, dst_rect.top, buffers,
                       buffers == GL_COLOR_BUFFER_BIT ? GL_LINEAR : GL_NEAREST);

--- a/src/video_core/renderer_opengl/gl_shader_gen.h
+++ b/src/video_core/renderer_opengl/gl_shader_gen.h
@@ -110,6 +110,10 @@ struct PicaFSConfigState {
         u32 lut_offset;
         Pica::TexturingRegs::ProcTexFilter lut_filter;
     } proctex;
+
+    bool shadow_rendering;
+    bool shadow_texture_orthographic;
+    u32 shadow_texture_bias;
 };
 
 /**

--- a/src/video_core/renderer_opengl/gl_shader_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_manager.cpp
@@ -36,6 +36,13 @@ static void SetShaderSamplerBinding(GLuint shader, const char* name,
     }
 }
 
+static void SetShaderImageBinding(GLuint shader, const char* name, GLuint binding) {
+    GLint uniform_tex = glGetUniformLocation(shader, name);
+    if (uniform_tex != -1) {
+        glUniform1i(uniform_tex, static_cast<GLint>(binding));
+    }
+}
+
 static void SetShaderSamplerBindings(GLuint shader) {
     OpenGLState cur_state = OpenGLState::GetCurState();
     GLuint old_program = std::exchange(cur_state.draw.shader_program, shader);
@@ -55,6 +62,14 @@ static void SetShaderSamplerBindings(GLuint shader) {
     SetShaderSamplerBinding(shader, "proctex_alpha_map", TextureUnits::ProcTexAlphaMap);
     SetShaderSamplerBinding(shader, "proctex_lut", TextureUnits::ProcTexLUT);
     SetShaderSamplerBinding(shader, "proctex_diff_lut", TextureUnits::ProcTexDiffLUT);
+
+    SetShaderImageBinding(shader, "shadow_buffer", ImageUnits::ShadowBuffer);
+    SetShaderImageBinding(shader, "shadow_texture_px", ImageUnits::ShadowTexturePX);
+    SetShaderImageBinding(shader, "shadow_texture_nx", ImageUnits::ShadowTextureNX);
+    SetShaderImageBinding(shader, "shadow_texture_py", ImageUnits::ShadowTexturePY);
+    SetShaderImageBinding(shader, "shadow_texture_ny", ImageUnits::ShadowTextureNY);
+    SetShaderImageBinding(shader, "shadow_texture_pz", ImageUnits::ShadowTexturePZ);
+    SetShaderImageBinding(shader, "shadow_texture_nz", ImageUnits::ShadowTextureNZ);
 
     cur_state.draw.shader_program = old_program;
     cur_state.Apply();

--- a/src/video_core/renderer_opengl/gl_shader_manager.h
+++ b/src/video_core/renderer_opengl/gl_shader_manager.h
@@ -32,6 +32,8 @@ struct UniformData {
     GLint alphatest_ref;
     GLfloat depth_scale;
     GLfloat depth_offset;
+    GLfloat shadow_bias_constant;
+    GLfloat shadow_bias_linear;
     GLint scissor_x1;
     GLint scissor_y1;
     GLint scissor_x2;
@@ -48,7 +50,7 @@ struct UniformData {
 };
 
 static_assert(
-    sizeof(UniformData) == 0x460,
+    sizeof(UniformData) == 0x470,
     "The size of the UniformData structure has changed, update the structure in the shader");
 static_assert(sizeof(UniformData) < 16384,
               "UniformData structure must be less than 16kb as per the OpenGL spec");

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -65,6 +65,14 @@ OpenGLState::OpenGLState() {
     proctex_alpha_map.texture_buffer = 0;
     proctex_noise_lut.texture_buffer = 0;
 
+    image_shadow_buffer = 0;
+    image_shadow_texture_px = 0;
+    image_shadow_texture_nx = 0;
+    image_shadow_texture_py = 0;
+    image_shadow_texture_ny = 0;
+    image_shadow_texture_pz = 0;
+    image_shadow_texture_nz = 0;
+
     draw.read_framebuffer = 0;
     draw.draw_framebuffer = 0;
     draw.vertex_array = 0;
@@ -255,6 +263,42 @@ void OpenGLState::Apply() const {
         glBindTexture(GL_TEXTURE_BUFFER, proctex_diff_lut.texture_buffer);
     }
 
+    // Shadow Images
+    if (image_shadow_buffer != cur_state.image_shadow_buffer) {
+        glBindImageTexture(ImageUnits::ShadowBuffer, image_shadow_buffer, 0, GL_FALSE, 0,
+                           GL_READ_WRITE, GL_R32UI);
+    }
+
+    if (image_shadow_texture_px != cur_state.image_shadow_texture_px) {
+        glBindImageTexture(ImageUnits::ShadowTexturePX, image_shadow_texture_px, 0, GL_FALSE, 0,
+                           GL_READ_ONLY, GL_R32UI);
+    }
+
+    if (image_shadow_texture_nx != cur_state.image_shadow_texture_nx) {
+        glBindImageTexture(ImageUnits::ShadowTextureNX, image_shadow_texture_nx, 0, GL_FALSE, 0,
+                           GL_READ_ONLY, GL_R32UI);
+    }
+
+    if (image_shadow_texture_py != cur_state.image_shadow_texture_py) {
+        glBindImageTexture(ImageUnits::ShadowTexturePY, image_shadow_texture_py, 0, GL_FALSE, 0,
+                           GL_READ_ONLY, GL_R32UI);
+    }
+
+    if (image_shadow_texture_ny != cur_state.image_shadow_texture_ny) {
+        glBindImageTexture(ImageUnits::ShadowTextureNY, image_shadow_texture_ny, 0, GL_FALSE, 0,
+                           GL_READ_ONLY, GL_R32UI);
+    }
+
+    if (image_shadow_texture_pz != cur_state.image_shadow_texture_pz) {
+        glBindImageTexture(ImageUnits::ShadowTexturePZ, image_shadow_texture_pz, 0, GL_FALSE, 0,
+                           GL_READ_ONLY, GL_R32UI);
+    }
+
+    if (image_shadow_texture_nz != cur_state.image_shadow_texture_nz) {
+        glBindImageTexture(ImageUnits::ShadowTextureNZ, image_shadow_texture_nz, 0, GL_FALSE, 0,
+                           GL_READ_ONLY, GL_R32UI);
+    }
+
     // Framebuffer
     if (draw.read_framebuffer != cur_state.draw.read_framebuffer) {
         glBindFramebuffer(GL_READ_FRAMEBUFFER, draw.read_framebuffer);
@@ -344,6 +388,20 @@ OpenGLState& OpenGLState::ResetTexture(GLuint handle) {
         proctex_lut.texture_buffer = 0;
     if (proctex_diff_lut.texture_buffer == handle)
         proctex_diff_lut.texture_buffer = 0;
+    if (image_shadow_buffer == handle)
+        image_shadow_buffer = 0;
+    if (image_shadow_texture_px == handle)
+        image_shadow_texture_px = 0;
+    if (image_shadow_texture_nx == handle)
+        image_shadow_texture_nx = 0;
+    if (image_shadow_texture_py == handle)
+        image_shadow_texture_py = 0;
+    if (image_shadow_texture_ny == handle)
+        image_shadow_texture_ny = 0;
+    if (image_shadow_texture_pz == handle)
+        image_shadow_texture_pz = 0;
+    if (image_shadow_texture_nz == handle)
+        image_shadow_texture_nz = 0;
     return *this;
 }
 

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -31,6 +31,16 @@ constexpr TextureUnit TextureCube{10};
 
 } // namespace TextureUnits
 
+namespace ImageUnits {
+constexpr GLuint ShadowBuffer = 0;
+constexpr GLuint ShadowTexturePX = 1;
+constexpr GLuint ShadowTextureNX = 2;
+constexpr GLuint ShadowTexturePY = 3;
+constexpr GLuint ShadowTextureNY = 4;
+constexpr GLuint ShadowTexturePZ = 5;
+constexpr GLuint ShadowTextureNZ = 6;
+} // namespace ImageUnits
+
 class OpenGLState {
 public:
     struct {
@@ -120,6 +130,15 @@ public:
     struct {
         GLuint texture_buffer; // GL_TEXTURE_BINDING_BUFFER
     } proctex_diff_lut;
+
+    // GL_IMAGE_BINDING_NAME
+    GLuint image_shadow_buffer;
+    GLuint image_shadow_texture_px;
+    GLuint image_shadow_texture_nx;
+    GLuint image_shadow_texture_py;
+    GLuint image_shadow_texture_ny;
+    GLuint image_shadow_texture_pz;
+    GLuint image_shadow_texture_nz;
 
     struct {
         GLuint read_framebuffer; // GL_READ_FRAMEBUFFER_BINDING


### PR DESCRIPTION
This is the other alternative to implement shadow map, mentioned in #3729. 

The downside of this method so-far:
 - requires extension ARB_shader_image_load_store (and some other trivial extension). Many modern GPUs have this implemented tho. The overall support rate is 70% reported by @jroweboy 
 -  has more potentially overhead due to atomic read/write in the fragment shader. The largest performance impact I have been reported is from nightly 110%+ speed -> this branch 105% speed, running monster hunter gen/x/xx on Nvidia GPU.

The advantage of this method:
 - Accurate soft shadow emulation
 - No texture reinterpretation between RGBA8 and D24S8. The format reinterpretation and decoding is done natively by image load/store and shader program.
   - In #3729 the reinterpretation caused huge performance impact. To mitigate it an ugly workaround is added, which however still involves pixel downloading/uploading, and cause serious issue on most AMD and some Intel GPU
   - D24S8 shadow sampler still has an unexplained issue in AMD.
   - In general D24S8 is a danger area where GPU driver likely to make mistakes, because it is not a usual texture format - different GPU might split it into two textures and transfer data in a special (not well-tested) way. By avoiding D24S8, we get defined GPU behavior - either do it correctly, or do not render shadow at all (in case of unsupported extensions)
 - No change made in the rasterizer. Treat shadow map as RGBA8 in the same way as PICA does
   - However there is a small flaw. See the comment in the code

Note that this solution is parallel with #3729. If needed, #3729 can still be added as a fallback path.

----

In an extreme edge case this doesn't guarantee accurate emulation though. GPU is allowed to reorder primitives and the values rendered to the same pixel might have a different order from the intended order. Recall the PICA shadow map framebuffer combiner:
```
if (color == 0)
    depth = min(depth, fragment_depth);
else
    if (fragment_depth < depth)
         stencil = min(stencil, f(color));
```
which is *almost* order-neutral, if viewed as a double MIN blending. The order only matters when fragments with both color==0 and color!=0 are mixed in one primitive branch, which shouldn't happen in a normal program design: color!=0 is usually in a second pass after color==0 to "decorate" the soft shadow region. If we want to take care of this extreme case, another OpenGL extension, ARB_fragment_shader_interlock, is required. Unfortunately, it has a base OpenGL version requirement of 4.2, and it is not supported by many GPUs. 

---

For anyone that finds the format reinterpretation/decoding confusing in this code, here is a simple explanation:

The native PICA RGBA8 format is {A, B, G, R} in bytes layout.
The native PICA shadow map format is {Dh, Dm, Dl, S} in bytes layout (D = depth, S = stencil, h = high byte, m = medium, l = low). Note that his is different from PICA D24S8 format ({Dl, Dm, Dh, S})
So we can say, in PICA, A=Dh, B=Dm, G=Dl, S=R

PICA RGBA8 textures is uploaded to OpenGL as RGBA8. This OpenGL texture is then bound to shader as a r32ui image. According to the format conversion rule of image load/store, the data is transferred as if the pixel is downloaded to client with the corresponding external format of the source format, then uploaded with the corresponding external format of the destination format. The "external format" here specified for RGBA8 is {GL_RGBA, GL_BYTE}, meaning that the downloaded pixel would be {R, G, B, A}={S, Dl, Dm, Dh} in bytes layout; the destination format is a u32 integer. Assuming little-endian platform, the destination value, viewed by the shader, would be ABGR = DhDmDlS in u32 layout (left = most significant byte).  Therefore to decode the shadow map in the shader, one just needs to do Depth = DhDmDl = DhDmDlS >> 8; Stencil = DhDmDlS & 0xFF;

Granted, this relies on the assumption of little-endian platform. On big-endian platform, byte swapping needs to be done in the shader. We can leave this until we actually support big-endian platforms.

----

~~I didn't add the state tracking boilerplate of image binding in gl_state, because it is only used in the rasterizer main rendering, and it itself has too many state to track (format, readonly/writeonly...), which doesn't worth to do it.~~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3778)
<!-- Reviewable:end -->
