### PR TITLE
gl_rasterizer: Don't flip the texture bindings.

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -676,6 +676,7 @@ bool RasterizerOpenGL::Draw(bool accelerate, bool is_indexed) {
                     state.texture_units[texture_index].texture_2d = 0;
                     continue; // Texture unit 0 setup finished. Continue to next unit
                 }
+                state.texture_cube_unit.texture_cube = 0;
             }
 
             texture_samplers[texture_index].SyncWithConfig(texture.config);
@@ -784,13 +785,6 @@ bool RasterizerOpenGL::Draw(bool accelerate, bool is_indexed) {
     }
 
     vertex_batch.clear();
-
-    // Unbind textures for potential future use as framebuffer attachments
-    for (unsigned texture_index = 0; texture_index < pica_textures.size(); ++texture_index) {
-        state.texture_units[texture_index].texture_2d = 0;
-    }
-    state.texture_cube_unit.texture_cube = 0;
-    state.Apply();
 
     // Mark framebuffer surfaces as dirty
     MathUtil::Rectangle<u32> draw_rect_unscaled{


### PR DESCRIPTION
The state object isn't used anywhere else, so there is no need to revert the state.
And the comment is just wrong: It doesn't matter which textures are bound on framebuffer binding, it only matters at draw time. And we reset all bindings before the draw call. So let's use gl_state as it is designed to avoid flipping states.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3789)
<!-- Reviewable:end -->
