### PR TITLE
UDS: fix RecvBeaconBroadcastData response header

### DIFF
--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -613,7 +613,7 @@ void NWM_UDS::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
     data_reply_header.total_size = cur_buffer_size;
     out_buffer.Write(&data_reply_header, 0, sizeof(BeaconDataReplyHeader));
 
-    IPC::RequestBuilder rb = rp.MakeBuilder(1, 1);
+    IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
     rb.Push(RESULT_SUCCESS);
     rb.PushMappedBuffer(out_buffer);
 


### PR DESCRIPTION
The mapped buffer descriptor consists of two words

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3803)
<!-- Reviewable:end -->
