### PR TITLE
Unbreak install

### DIFF
--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -81,5 +81,5 @@ endif()
 # Cubeb
 if(ENABLE_CUBEB)
     set(BUILD_TESTS OFF CACHE BOOL "")
-    add_subdirectory(cubeb)
+    add_subdirectory(cubeb EXCLUDE_FROM_ALL)
 endif()


### PR DESCRIPTION
Regressed by #3776. See [error log](https://ptpb.pw/v3YL).

```
$ cmake -DENABLE_QT=off -DCMAKE_INSTALL_PREFIX=/prefix /path/to/citra
$ gmake
$ gmake install
[...]
[100%] Built target citra
[100%] Built target citra-room
Install the project...
-- Install configuration: "Release"
-- Installing: /prefix/share/man/man6/citra.6
CMake Error at externals/cubeb/cmake_install.cmake:44 (file):
  file INSTALL cannot find "/path/to/citra/include".
Call Stack (most recent call first):
  externals/cmake_install.cmake:46 (include)
  cmake_install.cmake:49 (include)

gmake: *** [Makefile:74: install] Error 1
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3805)
<!-- Reviewable:end -->
