### PR TITLE
arm: Clear exclusive state after service call

### DIFF
--- a/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
+++ b/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
@@ -3866,6 +3866,8 @@ SWI_INST : {
             num_instrs >= cpu->NumInstrsToExecute ? 0 : cpu->NumInstrsToExecute - num_instrs;
         num_instrs = 0;
         Kernel::CallSVC(inst_cream->num & 0xFFFF);
+        // The kernel would call ERET to get here, which clears exclusive memory state.
+        cpu->UnsetExclusiveMemoryAddress();
     }
 
     cpu->Reg[15] += cpu->GetInstructionSize();


### PR DESCRIPTION
The ERET instruction (called by the kernel on return to userland) clears exclusive state.

It was a bug for exclusive state to be maintained across a SVC call.

This PR fixes both dynarmic and skyeye.

Closes #3806.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3810)
<!-- Reviewable:end -->
