### PR TITLE
drone.io: add config files and build scripts

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,16 @@
+pipeline:
+  build:
+    image: citraemu/build-environments:linux-${}
+    commands:
+      - ./.drone/linux-${}/build.sh
+
+matrix:
+  BUILD_NAME:
+    - transifex
+    - fresh
+    - frozen
+    - mingw
+
+cache:
+  mount:
+    - /drone/.ccache

--- a/.drone/linux-fresh/build.sh
+++ b/.drone/linux-fresh/build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -ex
+
+cd /citra
+
+mkdir build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/lib/ccache/gcc -DCMAKE_CXX_COMPILER=/usr/lib/ccache/g++ -DENABLE_QT_TRANSLATION=ON -DCITRA_ENABLE_COMPATIBILITY_REPORTING=${ENABLE_COMPATIBILITY_REPORTING:-"OFF"} -DENABLE_COMPATIBILITY_LIST_DOWNLOAD=ON
+make -j4
+
+ctest -VV -C Release

--- a/.drone/linux-frozen
+++ b/.drone/linux-frozen
@@ -1,0 +1,1 @@
+linux-fresh/

--- a/.drone/linux-mingw/build.sh
+++ b/.drone/linux-mingw/build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash -ex
+
+cd /citra
+
+mkdir build && cd build
+cmake .. -DCMAKE_TOOLCHAIN_FILE="$(pwd)/../CMakeModules/MinGWCross.cmake" -DUSE_CCACHE=ON -DCMAKE_BUILD_TYPE=Release -DENABLE_QT_TRANSLATION=ON -DCITRA_ENABLE_COMPATIBILITY_REPORTING=${ENABLE_COMPATIBILITY_REPORTING:-"OFF"} -DENABLE_COMPATIBILITY_LIST_DOWNLOAD=ON
+make -j4
+
+echo "Tests skipped"
+#ctest -VV -C Release
+
+ccache -s
+
+echo 'Prepare binaries...'
+cd ..
+mkdir package
+
+QT_PLATFORM_DLL_PATH='/usr/x86_64-w64-mingw32/lib/qt5/plugins/platforms/'
+find build/ -name "citra*.exe" -exec cp {} 'package' \;
+
+mkdir package/platforms
+cp "${QT_PLATFORM_DLL_PATH}/qwindows.dll" package/platforms/
+cp -r "${QT_PLATFORM_DLL_PATH}/../mediaservice/" package/
+
+
+for i in package/*.exe; do
+  # we need to process pdb here, however, cv2pdb
+  # does not work here, so we just simply strip all the debug symbols
+  x86_64-w64-mingw32-strip "${i}"
+done
+
+pip3 install pefile
+python3 .travis/linux-mingw/scan_dll.py package/*.exe "package/"

--- a/.drone/linux-transifex/build.sh
+++ b/.drone/linux-transifex/build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+
+if [[ "x$DRONE_BRANCH" == 'xmaster' && "x$DRONE_PULL_REQUEST" == 'x' ]]; then
+  echo 'Skipped Transifex uploading as required'
+  exit 0
+fi
+
+# Setup RC file for tx
+echo $'[https://www.transifex.com]\nhostname = https://www.transifex.com\nusername = api\npassword = '"$TRANSIFEX_API_TOKEN"$'\n' > ~/.transifexrc
+
+set -x
+echo -e "\e[1m\e[33mBuild tools information:\e[0m"
+cmake --version
+gcc -v
+tx --version
+
+cd /citra
+mkdir build && cd build
+cmake .. -DENABLE_QT_TRANSLATION=ON -DGENERATE_QT_TRANSLATION=ON -DCMAKE_BUILD_TYPE=Release -DENABLE_SDL2=OFF
+make translation
+cd ..
+
+cd dist/languages
+tx push -s


### PR DESCRIPTION
Experimental configuration files for drone.io instance, problems can arise.

Currently does not include deploy and release pipeline steps.

`.drone/linux-frozen` is a symbolic link to `.drone/linux-fresh`. This is to simplify the syntax of `.drone.yml` of utilizing the build matrix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3813)
<!-- Reviewable:end -->
