### PR TITLE
game_list: fix system title display

### DIFF
--- a/src/citra_qt/game_list_p.h
+++ b/src/citra_qt/game_list_p.h
@@ -173,14 +173,20 @@ public:
                               &extension);
             QString title = data(TitleRole).toString();
             QString second_name = QString::fromStdString(filename + extension);
-            static QRegExp installed_system_pattern(
+            static QRegExp installed_pattern(
                 QString::fromStdString(
                     FileUtil::GetUserPath(D_SDMC_IDX) +
                     "Nintendo "
                     "3DS/00000000000000000000000000000000/00000000000000000000000000000000/"
-                    "title/000400(0|1)0/[0-9a-f]{8}/content/")
+                    "title/0004000(0|e)/[0-9a-f]{8}/content/")
                     .replace("\\", "\\\\"));
-            if (installed_system_pattern.exactMatch(QString::fromStdString(path))) {
+            static QRegExp system_pattern(
+                QString::fromStdString(FileUtil::GetUserPath(D_NAND_IDX) +
+                                       "00000000000000000000000000000000/"
+                                       "title/00040010/[0-9a-f]{8}/content/")
+                    .replace("\\", "\\\\"));
+            if (installed_pattern.exactMatch(QString::fromStdString(path)) ||
+                system_pattern.exactMatch(QString::fromStdString(path))) {
                 // Use a different mechanism for system / installed titles showing program ID
                 second_name = QString("%1-%2")
                                   .arg(data(ProgramIdRole).toULongLong(), 16, 16, QChar('0'))


### PR DESCRIPTION
Fixed system titles (they are stored in NAND)
Also, hide "-00000000" from the ID. (it is ugly).
Now only filename other than "00000000" will be displayed.

![image](https://user-images.githubusercontent.com/21307832/41092709-1554b1be-6a7c-11e8-84c2-6f0d4b3d33d4.png)

In the example, "AR Games" has a filename of 00000000 so it is hidden.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3819)
<!-- Reviewable:end -->
