### PR TITLE
boss: Return buff_size in parameter 2 of ReceiveProperty.

### DIFF
--- a/src/core/hle/service/boss/boss.cpp
+++ b/src/core/hle/service/boss/boss.cpp
@@ -404,7 +404,7 @@ void ReceiveProperty(Service::Interface* self) {
 
     cmd_buff[0] = IPC::MakeHeader(0x16, 0x2, 0x2);
     cmd_buff[1] = RESULT_SUCCESS.raw;
-    cmd_buff[2] = 0; // stub 0 (32 bit value)
+    cmd_buff[2] = buff_size; // Should be actual number of read bytes.
     cmd_buff[3] = (buff_size << 4 | 0xC);
     cmd_buff[4] = buff_addr;
 


### PR DESCRIPTION
Changes output parameter 2 to buff_size as a placeholder for the actual number of read bytes, as per [3dbrew](http://3dbrew.org/wiki/BOSSU:ReceiveProperty) documentation.

Probably the most inconsequential title ever, but this at least fixes the Ambassador Certificate app. Before, it would throw a fatal error on boot with result code 0xD860F82C.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3826)
<!-- Reviewable:end -->
