### PR TITLE
travis: fix tx push (again)

### DIFF
--- a/.travis/transifex/docker.sh
+++ b/.travis/transifex/docker.sh
@@ -9,7 +9,21 @@ echo -e "\e[1m\e[33mInstalling dependencies...\e[0m"
 apk update
 apk add build-base cmake python3-dev qt5-qttools-dev qt5-qtmultimedia-dev
 
-pip3 install transifex-client
+pip3 install --upgrade pip transifex-client
+
+cat << 'EOF' > /usr/bin/tx
+#!/usr/bin/python3
+
+# -*- coding: utf-8 -*-
+import re
+import sys
+
+from txclib.cmdline import main
+
+if __name__ == '__main__':
+    sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
+    sys.exit(main())
+EOF
 
 echo -e "\e[1m\e[33mBuild tools information:\e[0m"
 cmake --version


### PR DESCRIPTION
This PR fixes tx push by replacing `/usr/bin/tx` with the original executable instead of the `easy_install` generated one (which can cause problems)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3828)
<!-- Reviewable:end -->
