### PR TITLE
citra_qt: Add a volume slider

### DIFF
--- a/src/audio_core/dsp_interface.h
+++ b/src/audio_core/dsp_interface.h
@@ -68,7 +68,7 @@ public:
     void EnableStretching(bool enable);
 
 protected:
-    void OutputFrame(const StereoFrame16& frame);
+    void OutputFrame(StereoFrame16& frame);
 
 private:
     void FlushResidualStretcherAudio();

--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -143,6 +143,7 @@ void Config::ReadValues() {
     Settings::values.enable_audio_stretching =
         sdl2_config->GetBoolean("Audio", "enable_audio_stretching", true);
     Settings::values.audio_device_id = sdl2_config->Get("Audio", "output_device", "auto");
+    Settings::values.volume = sdl2_config->GetReal("Audio", "volume", 1);
 
     // Data Storage
     Settings::values.use_virtual_sd =

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -164,6 +164,10 @@ enable_audio_stretching =
 # auto (default): Auto-select
 output_device =
 
+# Output volume.
+# 1.0 (default): 100%, 0.0; mute
+volume =
+
 [Data Storage]
 # Whether to create a virtual SD card.
 # 1 (default): Yes, 0: No

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -122,6 +122,7 @@ void Config::ReadValues() {
         qt_config->value("enable_audio_stretching", true).toBool();
     Settings::values.audio_device_id =
         qt_config->value("output_device", "auto").toString().toStdString();
+    Settings::values.volume = qt_config->value("volume", 1).toFloat();
     qt_config->endGroup();
 
     using namespace Service::CAM;
@@ -344,6 +345,7 @@ void Config::SaveValues() {
     qt_config->setValue("output_engine", QString::fromStdString(Settings::values.sink_id));
     qt_config->setValue("enable_audio_stretching", Settings::values.enable_audio_stretching);
     qt_config->setValue("output_device", QString::fromStdString(Settings::values.audio_device_id));
+    qt_config->setValue("volume", Settings::values.volume);
     qt_config->endGroup();
 
     using namespace Service::CAM;

--- a/src/citra_qt/configuration/configure_audio.cpp
+++ b/src/citra_qt/configuration/configure_audio.cpp
@@ -19,6 +19,10 @@ ConfigureAudio::ConfigureAudio(QWidget* parent)
         ui->output_sink_combo_box->addItem(sink_detail.id);
     }
 
+    connect(ui->volume_slider, &QSlider::valueChanged, [this] {
+        ui->volume_indicator->setText(tr("%1 %").arg(ui->volume_slider->sliderPosition()));
+    });
+
     this->setConfiguration();
     connect(ui->output_sink_combo_box,
             static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
@@ -51,6 +55,9 @@ void ConfigureAudio::setConfiguration() {
         }
     }
     ui->audio_device_combo_box->setCurrentIndex(new_device_index);
+
+    ui->volume_slider->setValue(Settings::values.volume * ui->volume_slider->maximum());
+    ui->volume_indicator->setText(tr("%1 %").arg(ui->volume_slider->sliderPosition()));
 }
 
 void ConfigureAudio::applyConfiguration() {
@@ -61,6 +68,8 @@ void ConfigureAudio::applyConfiguration() {
     Settings::values.audio_device_id =
         ui->audio_device_combo_box->itemText(ui->audio_device_combo_box->currentIndex())
             .toStdString();
+    Settings::values.volume =
+        static_cast<float>(ui->volume_slider->sliderPosition()) / ui->volume_slider->maximum();
 }
 
 void ConfigureAudio::updateAudioDevices(int sink_index) {

--- a/src/citra_qt/configuration/configure_audio.ui
+++ b/src/citra_qt/configuration/configure_audio.ui
@@ -1,11 +1,18 @@
-<?xml version="1.0" encoding="utf-8"?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>ConfigureAudio</class>
  <widget class="QWidget" name="ConfigureAudio">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>188</width>
+    <height>246</height>
+   </rect>
+  </property>
   <layout class="QVBoxLayout">
    <item>
-    <widget class="QGroupBox">
+    <widget class="QGroupBox" name="groupBox">
      <property name="title">
       <string>Audio</string>
      </property>
@@ -13,39 +20,90 @@
       <item>
        <layout class="QHBoxLayout">
         <item>
-         <widget class="QLabel">
+         <widget class="QLabel" name="label">
           <property name="text">
            <string>Output Engine:</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QComboBox" name="output_sink_combo_box">
-         </widget>
+         <widget class="QComboBox" name="output_sink_combo_box"/>
         </item>
        </layout>
       </item>
       <item>
        <widget class="QCheckBox" name="toggle_audio_stretching">
-        <property name="text">
-         <string>Enable audio stretching</string>
-        </property>
         <property name="toolTip">
          <string>This post-processing effect adjusts audio speed to match emulation speed and helps prevent audio stutter. This however increases audio latency.</string>
+        </property>
+        <property name="text">
+         <string>Enable audio stretching</string>
         </property>
        </widget>
       </item>
       <item>
        <layout class="QHBoxLayout">
         <item>
-         <widget class="QLabel">
+         <widget class="QLabel" name="label">
           <property name="text">
            <string>Audio Device:</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QComboBox" name="audio_device_combo_box">
+         <widget class="QComboBox" name="audio_device_combo_box"/>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Volume:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QSlider" name="volume_slider">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximum">
+           <number>100</number>
+          </property>
+          <property name="pageStep">
+           <number>10</number>
+          </property>
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="volume_indicator">
+          <property name="text">
+           <string>0 %</string>
+          </property>
          </widget>
         </item>
        </layout>
@@ -60,14 +118,14 @@
      </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>20</width>
-       <height>40</height>
+       <width>167</width>
+       <height>55</height>
       </size>
      </property>
     </spacer>
    </item>
   </layout>
  </widget>
- <resources />
- <connections />
+ <resources/>
+ <connections/>
 </ui>

--- a/src/citra_qt/configuration/configure_audio.ui
+++ b/src/citra_qt/configuration/configure_audio.ui
@@ -101,8 +101,17 @@
         </item>
         <item>
          <widget class="QLabel" name="volume_indicator">
+          <property name="minimumSize">
+           <size>
+            <width>32</width>
+            <height>0</height>
+           </size>
+          </property>
           <property name="text">
            <string>0 %</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
           </property>
          </widget>
         </item>

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -345,13 +345,11 @@ void Module::Interface::GetGyroscopeLowCalibrateParam(Kernel::HLERequestContext&
 void Module::Interface::GetSoundVolume(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx, 0x17, 0, 0};
 
-    const u8 volume = 0x3F; // TODO(purpasmart): Find out if this is the max value for the volume
+    const u8 volume = static_cast<u8>(0x3F * Settings::values.volume);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
     rb.Push(RESULT_SUCCESS);
     rb.Push(volume);
-
-    LOG_WARNING(Service_HID, "(STUBBED) called");
 }
 
 Module::Interface::Interface(std::shared_ptr<Module> hid, const char* name, u32 max_session)

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -139,6 +139,7 @@ struct Values {
     std::string sink_id;
     bool enable_audio_stretching;
     std::string audio_device_id;
+    float volume;
 
     // Camera
     std::array<std::string, Service::CAM::NumCameras> camera_name;


### PR DESCRIPTION
This PR adds a volume slider to Citra, which uses a logarithmic scale. 
It also implements Hid:GetSoundVolume.

UI Screenshot:
![slider](https://user-images.githubusercontent.com/20753089/41202642-7f18381c-6ccc-11e8-931a-dff3567acd3d.PNG)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3831)
<!-- Reviewable:end -->
