### PR TITLE
citra-qt: Add build date in about dialog

### DIFF
--- a/src/citra_qt/aboutdialog.cpp
+++ b/src/citra_qt/aboutdialog.cpp
@@ -12,8 +12,9 @@ AboutDialog::AboutDialog(QWidget* parent)
       ui(new Ui::AboutDialog) {
     ui->setupUi(this);
     ui->labelLogo->setPixmap(QIcon::fromTheme("citra").pixmap(200));
-    ui->labelBuildInfo->setText(ui->labelBuildInfo->text().arg(
-        Common::g_build_name, Common::g_scm_branch, Common::g_scm_desc));
+    ui->labelBuildInfo->setText(
+        ui->labelBuildInfo->text().arg(Common::g_build_name, Common::g_scm_branch,
+                                       Common::g_scm_desc, QString(Common::g_build_date).left(10)));
 }
 
 AboutDialog::~AboutDialog() {

--- a/src/citra_qt/aboutdialog.ui
+++ b/src/citra_qt/aboutdialog.ui
@@ -70,7 +70,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3 (%4)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/21307832/41536388-0d364d0c-7338-11e8-8466-43026c534682.png)

This is just some random PR.. If you don't think it necessary I will close.

But.. It's nice to let the users know how old their builds are, isn't it?

It's not good to put this in the titlebar, as that way the title bar text will be too long when game is running. (#3804)

Note: I did not include full date string in the dialog as it is not user-friendly (contains `T` and `Z` like `2018-06-18T12:39:22Z`), and has problems with time zones.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3837)
<!-- Reviewable:end -->
