### PR TITLE
service/cecd: Migrate logging macros

### DIFF
--- a/src/core/hle/service/cecd/cecd.cpp
+++ b/src/core/hle/service/cecd/cecd.cpp
@@ -25,7 +25,7 @@ void GetCecStateAbbreviated(Service::Interface* self) {
     cmd_buff[1] = RESULT_SUCCESS.raw; // No error
     cmd_buff[2] = static_cast<u32>(CecStateAbbreviated::CEC_STATE_ABBREV_IDLE);
 
-    LOG_WARNING(Service_CECD, "(STUBBED) called");
+    NGLOG_WARNING(Service_CECD, "(STUBBED) called");
 }
 
 void GetCecInfoEventHandle(Service::Interface* self) {
@@ -34,7 +34,7 @@ void GetCecInfoEventHandle(Service::Interface* self) {
     cmd_buff[1] = RESULT_SUCCESS.raw;                                    // No error
     cmd_buff[3] = Kernel::g_handle_table.Create(cecinfo_event).Unwrap(); // Event handle
 
-    LOG_WARNING(Service_CECD, "(STUBBED) called");
+    NGLOG_WARNING(Service_CECD, "(STUBBED) called");
 }
 
 void GetChangeStateEventHandle(Service::Interface* self) {
@@ -43,7 +43,7 @@ void GetChangeStateEventHandle(Service::Interface* self) {
     cmd_buff[1] = RESULT_SUCCESS.raw;                                         // No error
     cmd_buff[3] = Kernel::g_handle_table.Create(change_state_event).Unwrap(); // Event handle
 
-    LOG_WARNING(Service_CECD, "(STUBBED) called");
+    NGLOG_WARNING(Service_CECD, "(STUBBED) called");
 }
 
 void Init() {


### PR DESCRIPTION
Not much to say for this one. Just some "(Stubbed) called" warnings migrated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3842)
<!-- Reviewable:end -->
