### PR TITLE
gl_shader_gen: lower log level of using disabled proctex

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -321,7 +321,7 @@ static std::string SampleTexture(const PicaFSConfig& config, unsigned texture_un
         if (state.proctex.enable) {
             return "ProcTex()";
         } else {
-            LOG_ERROR(Render_OpenGL, "Using Texture3 without enabling it");
+            NGLOG_DEBUG(Render_OpenGL, "Using Texture3 without enabling it");
             return "vec4(0.0)";
         }
     default:


### PR DESCRIPTION
This log turns out to be usually a false positive and can be annoying. An example of this is Monster Hunter X/XX/Gen. The game always has tev stage 0 source 2 set to texture 3 (proctex), but only actually use it for some specific models. For other models, proctex is disabled, and the tev stage 0 operation is configured to one that doesn't use source 2 (anything other than lerp or multiply-and-add). Our shader generator would still go through source 2 in this case and generate dead code for it

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3851)
<!-- Reviewable:end -->
