### PR TITLE
Service/NWM: convert to ServiceFramwework

### DIFF
--- a/src/core/hle/service/nwm/nwm.cpp
+++ b/src/core/hle/service/nwm/nwm.cpp
@@ -2,7 +2,6 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <cryptopp/osrng.h>
 #include "core/hle/service/nwm/nwm.h"
 #include "core/hle/service/nwm/nwm_cec.h"
 #include "core/hle/service/nwm/nwm_ext.h"
@@ -11,35 +10,17 @@
 #include "core/hle/service/nwm/nwm_soc.h"
 #include "core/hle/service/nwm/nwm_tst.h"
 #include "core/hle/service/nwm/nwm_uds.h"
-#include "core/hle/shared_page.h"
-#include "network/network.h"
 
 namespace Service {
 namespace NWM {
 
-void Init() {
-    AddService(new NWM_CEC);
-    AddService(new NWM_EXT);
-    AddService(new NWM_INF);
-    AddService(new NWM_SAP);
-    AddService(new NWM_SOC);
-    AddService(new NWM_TST);
-
-    CryptoPP::AutoSeededRandomPool rng;
-    auto mac = SharedPage::DefaultMac;
-    // Keep the Nintendo 3DS MAC header and randomly generate the last 3 bytes
-    rng.GenerateBlock(static_cast<CryptoPP::byte*>(mac.data() + 3), 3);
-
-    if (auto room_member = Network::GetRoomMember().lock()) {
-        if (room_member->IsConnected()) {
-            mac = room_member->GetMacAddress();
-        }
-    }
-    SharedPage::SetMacAddress(mac);
-    SharedPage::SetWifiLinkLevel(SharedPage::WifiLinkLevel::BEST);
-}
-
 void InstallInterfaces(SM::ServiceManager& service_manager) {
+    std::make_shared<NWM_CEC>()->InstallAsService(service_manager);
+    std::make_shared<NWM_EXT>()->InstallAsService(service_manager);
+    std::make_shared<NWM_INF>()->InstallAsService(service_manager);
+    std::make_shared<NWM_SAP>()->InstallAsService(service_manager);
+    std::make_shared<NWM_SOC>()->InstallAsService(service_manager);
+    std::make_shared<NWM_TST>()->InstallAsService(service_manager);
     std::make_shared<NWM_UDS>()->InstallAsService(service_manager);
 }
 

--- a/src/core/hle/service/nwm/nwm.h
+++ b/src/core/hle/service/nwm/nwm.h
@@ -10,7 +10,6 @@ namespace Service {
 namespace NWM {
 
 /// Initialize all NWM services
-void Init();
 void InstallInterfaces(SM::ServiceManager& service_manager);
 
 } // namespace NWM

--- a/src/core/hle/service/nwm/nwm_cec.cpp
+++ b/src/core/hle/service/nwm/nwm_cec.cpp
@@ -7,12 +7,11 @@
 namespace Service {
 namespace NWM {
 
-const Interface::FunctionInfo FunctionTable[] = {
-    {0x000D0082, nullptr, "SendProbeRequest"},
-};
-
-NWM_CEC::NWM_CEC() {
-    Register(FunctionTable);
+NWM_CEC::NWM_CEC() : ServiceFramework("nwm::CEC") {
+    static const FunctionInfo functions[] = {
+        {0x000D0082, nullptr, "SendProbeRequest"},
+    };
+    RegisterHandlers(functions);
 }
 
 } // namespace NWM

--- a/src/core/hle/service/nwm/nwm_cec.h
+++ b/src/core/hle/service/nwm/nwm_cec.h
@@ -9,13 +9,9 @@
 namespace Service {
 namespace NWM {
 
-class NWM_CEC final : public Interface {
+class NWM_CEC final : public ServiceFramework<NWM_CEC> {
 public:
     NWM_CEC();
-
-    std::string GetPortName() const override {
-        return "nwm::CEC";
-    }
 };
 
 } // namespace NWM

--- a/src/core/hle/service/nwm/nwm_ext.cpp
+++ b/src/core/hle/service/nwm/nwm_ext.cpp
@@ -7,12 +7,11 @@
 namespace Service {
 namespace NWM {
 
-const Interface::FunctionInfo FunctionTable[] = {
-    {0x00080040, nullptr, "ControlWirelessEnabled"},
-};
-
-NWM_EXT::NWM_EXT() {
-    Register(FunctionTable);
+NWM_EXT::NWM_EXT() : ServiceFramework("nwm::EXT") {
+    static const FunctionInfo functions[] = {
+        {0x00080040, nullptr, "ControlWirelessEnabled"},
+    };
+    RegisterHandlers(functions);
 }
 
 } // namespace NWM

--- a/src/core/hle/service/nwm/nwm_ext.h
+++ b/src/core/hle/service/nwm/nwm_ext.h
@@ -9,13 +9,9 @@
 namespace Service {
 namespace NWM {
 
-class NWM_EXT final : public Interface {
+class NWM_EXT final : public ServiceFramework<NWM_EXT> {
 public:
     NWM_EXT();
-
-    std::string GetPortName() const override {
-        return "nwm::EXT";
-    }
 };
 
 } // namespace NWM

--- a/src/core/hle/service/nwm/nwm_inf.cpp
+++ b/src/core/hle/service/nwm/nwm_inf.cpp
@@ -7,14 +7,13 @@
 namespace Service {
 namespace NWM {
 
-const Interface::FunctionInfo FunctionTable[] = {
-    {0x000603C4, nullptr, "RecvBeaconBroadcastData"},
-    {0x00070742, nullptr, "ConnectToEncryptedAP"},
-    {0x00080302, nullptr, "ConnectToAP"},
-};
-
-NWM_INF::NWM_INF() {
-    Register(FunctionTable);
+NWM_INF::NWM_INF() : ServiceFramework("nwm::INF") {
+    static const FunctionInfo functions[] = {
+        {0x000603C4, nullptr, "RecvBeaconBroadcastData"},
+        {0x00070742, nullptr, "ConnectToEncryptedAP"},
+        {0x00080302, nullptr, "ConnectToAP"},
+    };
+    RegisterHandlers(functions);
 }
 
 } // namespace NWM

--- a/src/core/hle/service/nwm/nwm_inf.h
+++ b/src/core/hle/service/nwm/nwm_inf.h
@@ -9,13 +9,9 @@
 namespace Service {
 namespace NWM {
 
-class NWM_INF final : public Interface {
+class NWM_INF final : public ServiceFramework<NWM_INF> {
 public:
     NWM_INF();
-
-    std::string GetPortName() const override {
-        return "nwm::INF";
-    }
 };
 
 } // namespace NWM

--- a/src/core/hle/service/nwm/nwm_sap.cpp
+++ b/src/core/hle/service/nwm/nwm_sap.cpp
@@ -7,13 +7,12 @@
 namespace Service {
 namespace NWM {
 
-/*
-const Interface::FunctionInfo FunctionTable[] = {
-};
-*/
-
-NWM_SAP::NWM_SAP() {
-    // Register(FunctionTable);
+NWM_SAP::NWM_SAP() : ServiceFramework("nwm::SAP") {
+    /*
+    static const FunctionInfo functions[] = {
+    };
+    RegisterHandlers(functions);
+    */
 }
 
 } // namespace NWM

--- a/src/core/hle/service/nwm/nwm_sap.h
+++ b/src/core/hle/service/nwm/nwm_sap.h
@@ -9,13 +9,9 @@
 namespace Service {
 namespace NWM {
 
-class NWM_SAP final : public Interface {
+class NWM_SAP final : public ServiceFramework<NWM_SAP> {
 public:
     NWM_SAP();
-
-    std::string GetPortName() const override {
-        return "nwm::SAP";
-    }
 };
 
 } // namespace NWM

--- a/src/core/hle/service/nwm/nwm_soc.cpp
+++ b/src/core/hle/service/nwm/nwm_soc.cpp
@@ -7,13 +7,12 @@
 namespace Service {
 namespace NWM {
 
-/*
-const Interface::FunctionInfo FunctionTable[] = {
-};
-*/
-
-NWM_SOC::NWM_SOC() {
-    // Register(FunctionTable);
+NWM_SOC::NWM_SOC() : ServiceFramework("nwm::SOC") {
+    /*
+    static const FunctionInfo functions[] = {
+    };
+    RegisterHandlers(functions);
+    */
 }
 
 } // namespace NWM

--- a/src/core/hle/service/nwm/nwm_soc.h
+++ b/src/core/hle/service/nwm/nwm_soc.h
@@ -9,13 +9,9 @@
 namespace Service {
 namespace NWM {
 
-class NWM_SOC final : public Interface {
+class NWM_SOC final : public ServiceFramework<NWM_SOC> {
 public:
     NWM_SOC();
-
-    std::string GetPortName() const override {
-        return "nwm::SOC";
-    }
 };
 
 } // namespace NWM

--- a/src/core/hle/service/nwm/nwm_tst.cpp
+++ b/src/core/hle/service/nwm/nwm_tst.cpp
@@ -7,13 +7,12 @@
 namespace Service {
 namespace NWM {
 
-/*
-const Interface::FunctionInfo FunctionTable[] = {
-};
-*/
-
-NWM_TST::NWM_TST() {
-    // Register(FunctionTable);
+NWM_TST::NWM_TST() : ServiceFramework("nwm::TST") {
+    /*
+    static const FunctionInfo functions[] = {
+    };
+    RegisterHandlers(functions);
+    */
 }
 
 } // namespace NWM

--- a/src/core/hle/service/nwm/nwm_tst.h
+++ b/src/core/hle/service/nwm/nwm_tst.h
@@ -9,13 +9,9 @@
 namespace Service {
 namespace NWM {
 
-class NWM_TST final : public Interface {
+class NWM_TST final : public ServiceFramework<NWM_TST> {
 public:
     NWM_TST();
-
-    std::string GetPortName() const override {
-        return "nwm::TST";
-    }
 };
 
 } // namespace NWM

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -252,7 +252,6 @@ void Init(std::shared_ptr<SM::ServiceManager>& sm) {
     NEWS::InstallInterfaces(*sm);
     NFC::InstallInterfaces(*sm);
     NIM::InstallInterfaces(*sm);
-    NWM::Init();
     PTM::InstallInterfaces(*sm);
     QTM::Init();
 


### PR DESCRIPTION
Also moved the MAC initialization from `NWM::Init()` to `NWM_UDS::NWM_UDS()`. A better place for this would be a central NWM module shared by all service. But for now UDS is the only functioning service which acts like a single-service module, so I put it there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3873)
<!-- Reviewable:end -->
