### PR TITLE
video-core: Migrate logging macros

### DIFF
--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -68,8 +68,8 @@ static void WriteUniformIntReg(Shader::ShaderSetup& setup, unsigned index,
                                const Math::Vec4<u8>& values) {
     ASSERT(index < setup.uniforms.i.size());
     setup.uniforms.i[index] = values;
-    LOG_TRACE(HW_GPU, "Set %s integer uniform %d to %02x %02x %02x %02x",
-              GetShaderSetupTypeName(setup), index, values.x, values.y, values.z, values.w);
+    NGLOG_TRACE(HW_GPU, "Set {} integer uniform {} to {:02x} {:02x} {:02x} {:02x}",
+                GetShaderSetupTypeName(setup), index, values.x, values.y, values.z, values.w);
 }
 
 static void WriteUniformFloatReg(ShaderRegs& config, Shader::ShaderSetup& setup,
@@ -90,8 +90,8 @@ static void WriteUniformFloatReg(ShaderRegs& config, Shader::ShaderSetup& setup,
         auto& uniform = setup.uniforms.f[uniform_setup.index];
 
         if (uniform_setup.index >= 96) {
-            LOG_ERROR(HW_GPU, "Invalid %s float uniform index %d", GetShaderSetupTypeName(setup),
-                      (int)uniform_setup.index);
+            NGLOG_ERROR(HW_GPU, "Invalid {} float uniform index {}", GetShaderSetupTypeName(setup),
+                        (int)uniform_setup.index);
         } else {
 
             // NOTE: The destination component order indeed is "backwards"
@@ -108,10 +108,10 @@ static void WriteUniformFloatReg(ShaderRegs& config, Shader::ShaderSetup& setup,
                 uniform.x = float24::FromRaw(uniform_write_buffer[2] & 0xFFFFFF);
             }
 
-            LOG_TRACE(HW_GPU, "Set %s float uniform %x to (%f %f %f %f)",
-                      GetShaderSetupTypeName(setup), (int)uniform_setup.index,
-                      uniform.x.ToFloat32(), uniform.y.ToFloat32(), uniform.z.ToFloat32(),
-                      uniform.w.ToFloat32());
+            NGLOG_TRACE(HW_GPU, "Set {} float uniform {:x} to ({} {} {} {})",
+                        GetShaderSetupTypeName(setup), (int)uniform_setup.index,
+                        uniform.x.ToFloat32(), uniform.y.ToFloat32(), uniform.z.ToFloat32(),
+                        uniform.w.ToFloat32());
 
             // TODO: Verify that this actually modifies the register!
             uniform_setup.index.Assign(uniform_setup.index + 1);
@@ -123,9 +123,10 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
     auto& regs = g_state.regs;
 
     if (id >= Regs::NUM_REGS) {
-        LOG_ERROR(HW_GPU,
-                  "Commandlist tried to write to invalid register 0x%03X (value: %08X, mask: %X)",
-                  id, value, mask);
+        NGLOG_ERROR(
+            HW_GPU,
+            "Commandlist tried to write to invalid register 0x{:03X} (value: {:08X}, mask: {:X})",
+            id, value, mask);
         return;
     }
 
@@ -183,7 +184,7 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
             auto& setup = regs.pipeline.vs_default_attributes_setup;
 
             if (setup.index >= 16) {
-                LOG_ERROR(HW_GPU, "Invalid VS default attribute index %d", (int)setup.index);
+                NGLOG_ERROR(HW_GPU, "Invalid VS default attribute index {}", (int)setup.index);
                 break;
             }
 
@@ -197,9 +198,9 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
                                            ((default_attr_write_buffer[2] >> 24) & 0xFF));
             attribute.x = float24::FromRaw(default_attr_write_buffer[2] & 0xFFFFFF);
 
-            LOG_TRACE(HW_GPU, "Set default VS attribute %x to (%f %f %f %f)", (int)setup.index,
-                      attribute.x.ToFloat32(), attribute.y.ToFloat32(), attribute.z.ToFloat32(),
-                      attribute.w.ToFloat32());
+            NGLOG_TRACE(HW_GPU, "Set default VS attribute {:x} to ({} {} {} {})", (int)setup.index,
+                        attribute.x.ToFloat32(), attribute.y.ToFloat32(), attribute.z.ToFloat32(),
+                        attribute.w.ToFloat32());
 
             // TODO: Verify that this actually modifies the register!
             if (setup.index < 15) {
@@ -473,7 +474,7 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
     case PICA_REG_INDEX_WORKAROUND(gs.program.set_word[7], 0x2a3): {
         u32& offset = g_state.regs.gs.program.offset;
         if (offset >= 4096) {
-            LOG_ERROR(HW_GPU, "Invalid GS program offset %u", offset);
+            NGLOG_ERROR(HW_GPU, "Invalid GS program offset {}", offset);
         } else {
             g_state.gs.program_code[offset] = value;
             g_state.gs.MarkProgramCodeDirty();
@@ -492,7 +493,7 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
     case PICA_REG_INDEX_WORKAROUND(gs.swizzle_patterns.set_word[7], 0x2ad): {
         u32& offset = g_state.regs.gs.swizzle_patterns.offset;
         if (offset >= g_state.gs.swizzle_data.size()) {
-            LOG_ERROR(HW_GPU, "Invalid GS swizzle pattern offset %u", offset);
+            NGLOG_ERROR(HW_GPU, "Invalid GS swizzle pattern offset {}", offset);
         } else {
             g_state.gs.swizzle_data[offset] = value;
             g_state.gs.MarkSwizzleDataDirty();
@@ -542,7 +543,7 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
     case PICA_REG_INDEX_WORKAROUND(vs.program.set_word[7], 0x2d3): {
         u32& offset = g_state.regs.vs.program.offset;
         if (offset >= 512) {
-            LOG_ERROR(HW_GPU, "Invalid VS program offset %u", offset);
+            NGLOG_ERROR(HW_GPU, "Invalid VS program offset {}", offset);
         } else {
             g_state.vs.program_code[offset] = value;
             g_state.vs.MarkProgramCodeDirty();
@@ -565,7 +566,7 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
     case PICA_REG_INDEX_WORKAROUND(vs.swizzle_patterns.set_word[7], 0x2dd): {
         u32& offset = g_state.regs.vs.swizzle_patterns.offset;
         if (offset >= g_state.vs.swizzle_data.size()) {
-            LOG_ERROR(HW_GPU, "Invalid VS swizzle pattern offset %u", offset);
+            NGLOG_ERROR(HW_GPU, "Invalid VS swizzle pattern offset {}", offset);
         } else {
             g_state.vs.swizzle_data[offset] = value;
             g_state.vs.MarkSwizzleDataDirty();

--- a/src/video_core/debug_utils/debug_utils.cpp
+++ b/src/video_core/debug_utils/debug_utils.cpp
@@ -178,11 +178,12 @@ void DumpShader(const std::string& filename, const ShaderRegs& config,
                 }
             } catch (const std::out_of_range&) {
                 DEBUG_ASSERT_MSG(false, "Unknown output attribute mapping");
-                LOG_ERROR(HW_GPU, "Unknown output attribute mapping: %03x, %03x, %03x, %03x",
-                          (int)output_attributes[i].map_x.Value(),
-                          (int)output_attributes[i].map_y.Value(),
-                          (int)output_attributes[i].map_z.Value(),
-                          (int)output_attributes[i].map_w.Value());
+                NGLOG_ERROR(HW_GPU,
+                            "Unknown output attribute mapping: {:03x}, {:03x}, {:03x}, {:03x}",
+                            (int)output_attributes[i].map_x.Value(),
+                            (int)output_attributes[i].map_y.Value(),
+                            (int)output_attributes[i].map_z.Value(),
+                            (int)output_attributes[i].map_w.Value());
             }
         }
     }
@@ -277,7 +278,7 @@ bool g_is_pica_tracing = false;
 
 void StartPicaTracing() {
     if (g_is_pica_tracing) {
-        LOG_WARNING(HW_GPU, "StartPicaTracing called even though tracing already running!");
+        NGLOG_WARNING(HW_GPU, "StartPicaTracing called even though tracing already running!");
         return;
     }
 
@@ -298,7 +299,7 @@ void OnPicaRegWrite(PicaTrace::Write write) {
 
 std::unique_ptr<PicaTrace> FinishPicaTracing() {
     if (!g_is_pica_tracing) {
-        LOG_WARNING(HW_GPU, "FinishPicaTracing called even though tracing isn't running!");
+        NGLOG_WARNING(HW_GPU, "FinishPicaTracing called even though tracing isn't running!");
         return {};
     }
 
@@ -456,7 +457,7 @@ void DumpTevStageConfig(const std::array<TexturingRegs::TevStageConfig, 6>& stag
                       GetTevStageConfigColorCombinerString(tev_stage) + "   " +
                       GetTevStageConfigAlphaCombinerString(tev_stage) + "\n";
     }
-    LOG_TRACE(HW_GPU, "%s", stage_info.c_str());
+    NGLOG_TRACE(HW_GPU, "{}", stage_info);
 }
 
 } // namespace DebugUtils

--- a/src/video_core/gpu_debugger.h
+++ b/src/video_core/gpu_debugger.h
@@ -30,7 +30,7 @@ public:
         virtual void GXCommandProcessed(int total_command_count) {
             const Service::GSP::Command& cmd =
                 observed->ReadGXCommandHistory(total_command_count - 1);
-            LOG_TRACE(Debug_GPU, "Received command: id=%x", (int)cmd.id.Value());
+            NGLOG_TRACE(Debug_GPU, "Received command: id={:x}", (int)cmd.id.Value());
         }
 
     protected:

--- a/src/video_core/primitive_assembly.cpp
+++ b/src/video_core/primitive_assembly.cpp
@@ -48,7 +48,7 @@ void PrimitiveAssembler<VertexType>::SubmitVertex(const VertexType& vtx,
         break;
 
     default:
-        LOG_ERROR(HW_GPU, "Unknown triangle topology %x:", (int)topology);
+        NGLOG_ERROR(HW_GPU, "Unknown triangle topology {:x}:", (int)topology);
         break;
     }
 }

--- a/src/video_core/regs_framebuffer.h
+++ b/src/video_core/regs_framebuffer.h
@@ -200,7 +200,7 @@ struct FramebufferRegs {
         case ColorFormat::RGBA4:
             return 2;
         default:
-            LOG_CRITICAL(HW_GPU, "Unknown color format %u", static_cast<u32>(format));
+            NGLOG_CRITICAL(HW_GPU, "Unknown color format {}", static_cast<u32>(format));
             UNIMPLEMENTED();
         }
     }

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -1600,8 +1600,8 @@ void RasterizerOpenGL::SyncCullMode() {
         break;
 
     default:
-        LOG_CRITICAL(Render_OpenGL, "Unknown cull mode %u",
-                     static_cast<u32>(regs.rasterizer.cull_mode.Value()));
+        NGLOG_CRITICAL(Render_OpenGL, "Unknown cull mode {}",
+                       static_cast<u32>(regs.rasterizer.cull_mode.Value()));
         UNIMPLEMENTED();
         break;
     }

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -1390,8 +1390,8 @@ SurfaceSurfaceRect_Tuple RasterizerCacheOpenGL::GetFramebufferSurfaces(
     // Make sure that framebuffers don't overlap if both color and depth are being used
     if (using_color_fb && using_depth_fb &&
         boost::icl::length(color_vp_interval & depth_vp_interval)) {
-        LOG_CRITICAL(Render_OpenGL, "Color and depth framebuffer memory regions overlap; "
-                                    "overlapping framebuffers not supported!");
+        NGLOG_CRITICAL(Render_OpenGL, "Color and depth framebuffer memory regions overlap; "
+                                      "overlapping framebuffers not supported!");
         using_depth_fb = false;
     }
 

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -546,9 +546,9 @@ private:
                 const CompareOp op_y = instr.common.compare_op.y.Value();
 
                 if (cmp_ops.find(op_x) == cmp_ops.end()) {
-                    LOG_ERROR(HW_GPU, "Unknown compare mode %x", static_cast<int>(op_x));
+                    NGLOG_ERROR(HW_GPU, "Unknown compare mode {:x}", static_cast<int>(op_x));
                 } else if (cmp_ops.find(op_y) == cmp_ops.end()) {
-                    LOG_ERROR(HW_GPU, "Unknown compare mode %x", static_cast<int>(op_y));
+                    NGLOG_ERROR(HW_GPU, "Unknown compare mode {:x}", static_cast<int>(op_y));
                 } else if (op_x != op_y) {
                     shader.AddLine("conditional_code.x = " + src1 + ".x " +
                                    cmp_ops.find(op_x)->second.first + " " + src2 + ".x;");
@@ -572,9 +572,9 @@ private:
             }
 
             default: {
-                LOG_ERROR(HW_GPU, "Unhandled arithmetic instruction: 0x%02x (%s): 0x%08x",
-                          (int)instr.opcode.Value().EffectiveOpCode(),
-                          instr.opcode.Value().GetInfo().name, instr.hex);
+                NGLOG_ERROR(HW_GPU, "Unhandled arithmetic instruction: 0x{:02x} ({}): 0x{:08x}",
+                            (int)instr.opcode.Value().EffectiveOpCode(),
+                            instr.opcode.Value().GetInfo().name, instr.hex);
                 throw DecompileFail("Unhandled instruction");
                 break;
             }
@@ -616,9 +616,9 @@ private:
                     SetDest(swizzle, dest_reg, src1 + " * " + src2 + " + " + src3, 4, 4);
                 }
             } else {
-                LOG_ERROR(HW_GPU, "Unhandled multiply-add instruction: 0x%02x (%s): 0x%08x",
-                          (int)instr.opcode.Value().EffectiveOpCode(),
-                          instr.opcode.Value().GetInfo().name, instr.hex);
+                NGLOG_ERROR(HW_GPU, "Unhandled multiply-add instruction: 0x{:02x} ({}): 0x{:08x}",
+                            (int)instr.opcode.Value().EffectiveOpCode(),
+                            instr.opcode.Value().GetInfo().name, instr.hex);
                 throw DecompileFail("Unhandled instruction");
             }
             break;
@@ -770,9 +770,9 @@ private:
             }
 
             default: {
-                LOG_ERROR(HW_GPU, "Unhandled instruction: 0x%02x (%s): 0x%08x",
-                          (int)instr.opcode.Value().EffectiveOpCode(),
-                          instr.opcode.Value().GetInfo().name, instr.hex);
+                NGLOG_ERROR(HW_GPU, "Unhandled instruction: 0x{:02x} ({}): 0x{:08x}",
+                            (int)instr.opcode.Value().EffectiveOpCode(),
+                            instr.opcode.Value().GetInfo().name, instr.hex);
                 throw DecompileFail("Unhandled instruction");
                 break;
             }
@@ -921,7 +921,7 @@ boost::optional<std::string> DecompileProgram(const ProgramCode& program_code,
                                 inputreg_getter, outputreg_getter, sanitize_mul, is_gs);
         return generator.MoveShaderCode();
     } catch (const DecompileFail& exception) {
-        LOG_INFO(HW_GPU, "Shader decompilation failed: %s", exception.what());
+        NGLOG_INFO(HW_GPU, "Shader decompilation failed: {}", exception.what());
         return boost::none;
     }
 }

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -320,8 +320,8 @@ static std::string SampleTexture(const PicaFSConfig& config, unsigned texture_un
         case TexturingRegs::TextureConfig::ShadowCube:
             return "shadowTextureCube(texcoord0, texcoord0_w)";
         default:
-            LOG_CRITICAL(HW_GPU, "Unhandled texture type %x",
-                         static_cast<int>(state.texture0_type));
+            NGLOG_CRITICAL(HW_GPU, "Unhandled texture type {:x}",
+                           static_cast<int>(state.texture0_type));
             UNIMPLEMENTED();
             return "texture(tex0, texcoord0)";
         }
@@ -336,7 +336,7 @@ static std::string SampleTexture(const PicaFSConfig& config, unsigned texture_un
         if (state.proctex.enable) {
             return "ProcTex()";
         } else {
-            LOG_ERROR(Render_OpenGL, "Using Texture3 without enabling it");
+            NGLOG_ERROR(Render_OpenGL, "Using Texture3 without enabling it");
             return "vec4(0.0)";
         }
     default:
@@ -383,7 +383,7 @@ static void AppendSource(std::string& out, const PicaFSConfig& config,
         break;
     default:
         out += "vec4(0.0)";
-        LOG_CRITICAL(Render_OpenGL, "Unknown source op %u", static_cast<u32>(source));
+        NGLOG_CRITICAL(Render_OpenGL, "Unknown source op {}", static_cast<u32>(source));
         break;
     }
 }
@@ -441,7 +441,7 @@ static void AppendColorModifier(std::string& out, const PicaFSConfig& config,
         break;
     default:
         out += "vec3(0.0)";
-        LOG_CRITICAL(Render_OpenGL, "Unknown color modifier op %u", static_cast<u32>(modifier));
+        NGLOG_CRITICAL(Render_OpenGL, "Unknown color modifier op {}", static_cast<u32>(modifier));
         break;
     }
 }
@@ -490,7 +490,7 @@ static void AppendAlphaModifier(std::string& out, const PicaFSConfig& config,
         break;
     default:
         out += "0.0";
-        LOG_CRITICAL(Render_OpenGL, "Unknown alpha modifier op %u", static_cast<u32>(modifier));
+        NGLOG_CRITICAL(Render_OpenGL, "Unknown alpha modifier op {}", static_cast<u32>(modifier));
         break;
     }
 }
@@ -534,8 +534,8 @@ static void AppendColorCombiner(std::string& out, TevStageConfig::Operation oper
         break;
     default:
         out += "vec3(0.0)";
-        LOG_CRITICAL(Render_OpenGL, "Unknown color combiner operation: %u",
-                     static_cast<u32>(operation));
+        NGLOG_CRITICAL(Render_OpenGL, "Unknown color combiner operation: {}",
+                       static_cast<u32>(operation));
         break;
     }
     out += ", vec3(0.0), vec3(1.0))"; // Clamp result to 0.0, 1.0
@@ -575,8 +575,8 @@ static void AppendAlphaCombiner(std::string& out, TevStageConfig::Operation oper
         break;
     default:
         out += "0.0";
-        LOG_CRITICAL(Render_OpenGL, "Unknown alpha combiner operation: %u",
-                     static_cast<u32>(operation));
+        NGLOG_CRITICAL(Render_OpenGL, "Unknown alpha combiner operation: {}",
+                       static_cast<u32>(operation));
         break;
     }
     out += ", 0.0, 1.0)";
@@ -606,7 +606,7 @@ static void AppendAlphaTestCondition(std::string& out, FramebufferRegs::CompareF
 
     default:
         out += "false";
-        LOG_CRITICAL(Render_OpenGL, "Unknown alpha test condition %u", static_cast<u32>(func));
+        NGLOG_CRITICAL(Render_OpenGL, "Unknown alpha test condition {}", static_cast<u32>(func));
         break;
     }
 }
@@ -776,7 +776,7 @@ static void WriteLighting(std::string& out, const PicaFSConfig& config) {
             break;
 
         default:
-            LOG_CRITICAL(HW_GPU, "Unknown lighting LUT input %d\n", (int)input);
+            NGLOG_CRITICAL(HW_GPU, "Unknown lighting LUT input {}\n", (int)input);
             UNIMPLEMENTED();
             index = "0.0";
             break;
@@ -992,7 +992,7 @@ void AppendProcTexShiftOffset(std::string& out, const std::string& v, ProcTexShi
         out += offset + " * (((int(" + v + ") + 1) / 2) % 2)";
         break;
     default:
-        LOG_CRITICAL(HW_GPU, "Unknown shift mode %u", static_cast<u32>(mode));
+        NGLOG_CRITICAL(HW_GPU, "Unknown shift mode {}", static_cast<u32>(mode));
         out += "0";
         break;
     }
@@ -1018,7 +1018,7 @@ void AppendProcTexClamp(std::string& out, const std::string& var, ProcTexClamp m
         out += var + " = " + var + " > 0.5 ? 1.0 : 0.0;\n";
         break;
     default:
-        LOG_CRITICAL(HW_GPU, "Unknown clamp mode %u", static_cast<u32>(mode));
+        NGLOG_CRITICAL(HW_GPU, "Unknown clamp mode {}", static_cast<u32>(mode));
         out += var + " = " + "min(" + var + ", 1.0);\n";
         break;
     }
@@ -1059,7 +1059,7 @@ void AppendProcTexCombineAndMap(std::string& out, ProcTexCombiner combiner,
         combined = "min(((u + v) * 0.5 + sqrt(u * u + v * v)) * 0.5, 1.0)";
         break;
     default:
-        LOG_CRITICAL(HW_GPU, "Unknown combiner %u", static_cast<u32>(combiner));
+        NGLOG_CRITICAL(HW_GPU, "Unknown combiner {}", static_cast<u32>(combiner));
         combined = "0.0";
         break;
     }
@@ -1499,7 +1499,7 @@ vec4 secondary_fragment_color = vec4(0.0);
     } else if (state.fog_mode == TexturingRegs::FogMode::Gas) {
         Core::Telemetry().AddField(Telemetry::FieldType::Session, "VideoCore_Pica_UseGasMode",
                                    true);
-        LOG_CRITICAL(Render_OpenGL, "Unimplemented gas mode");
+        NGLOG_CRITICAL(Render_OpenGL, "Unimplemented gas mode");
         out += "discard; }";
         return out;
     }

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -494,8 +494,8 @@ static void APIENTRY DebugHandler(GLenum source, GLenum type, GLuint id, GLenum 
         level = Log::Level::Debug;
         break;
     }
-    LOG_GENERIC(Log::Class::Render_OpenGL, level, "%s %s %d: %s", GetSource(source), GetType(type),
-                id, message);
+    NGLOG_GENERIC(Log::Class::Render_OpenGL, level, "{} {} {}: {}", GetSource(source),
+                  GetType(type), id, message);
 }
 
 /// Initialize the renderer

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -171,9 +171,9 @@ void RendererOpenGL::LoadFBToScreenInfo(const GPU::Regs::FramebufferConfig& fram
             ? (!right_eye ? framebuffer.address_left1 : framebuffer.address_right1)
             : (!right_eye ? framebuffer.address_left2 : framebuffer.address_right2);
 
-    LOG_TRACE(Render_OpenGL, "0x%08x bytes from 0x%08x(%dx%d), fmt %x",
-              framebuffer.stride * framebuffer.height, framebuffer_addr, (int)framebuffer.width,
-              (int)framebuffer.height, (int)framebuffer.format);
+    NGLOG_TRACE(Render_OpenGL, "0x{:08x} bytes from 0x{:08x}({}x{}), fmt {:x}",
+                framebuffer.stride * framebuffer.height, framebuffer_addr, (int)framebuffer.width,
+                (int)framebuffer.height, (int)framebuffer.format);
 
     int bpp = GPU::Regs::BytesPerPixel(framebuffer.color_format);
     size_t pixel_stride = framebuffer.stride / bpp;
@@ -511,9 +511,9 @@ bool RendererOpenGL::Init() {
     const char* gpu_vendor{reinterpret_cast<char const*>(glGetString(GL_VENDOR))};
     const char* gpu_model{reinterpret_cast<char const*>(glGetString(GL_RENDERER))};
 
-    LOG_INFO(Render_OpenGL, "GL_VERSION: %s", gl_version);
-    LOG_INFO(Render_OpenGL, "GL_VENDOR: %s", gpu_vendor);
-    LOG_INFO(Render_OpenGL, "GL_RENDERER: %s", gpu_model);
+    NGLOG_INFO(Render_OpenGL, "GL_VERSION: {}", gl_version);
+    NGLOG_INFO(Render_OpenGL, "GL_VENDOR: {}", gpu_vendor);
+    NGLOG_INFO(Render_OpenGL, "GL_RENDERER: {}", gpu_model);
 
     Core::Telemetry().AddField(Telemetry::FieldType::UserSystem, "GPU_Vendor", gpu_vendor);
     Core::Telemetry().AddField(Telemetry::FieldType::UserSystem, "GPU_Model", gpu_model);

--- a/src/video_core/shader/shader.cpp
+++ b/src/video_core/shader/shader.cpp
@@ -65,15 +65,15 @@ OutputVertex OutputVertex::FromAttributeBuffer(const RasterizerRegs& regs,
         ret.color[i] = float24::FromFloat32(c < 1.0f ? c : 1.0f);
     }
 
-    LOG_TRACE(HW_GPU,
-              "Output vertex: pos(%.2f, %.2f, %.2f, %.2f), quat(%.2f, %.2f, %.2f, %.2f), "
-              "col(%.2f, %.2f, %.2f, %.2f), tc0(%.2f, %.2f), view(%.2f, %.2f, %.2f)",
-              ret.pos.x.ToFloat32(), ret.pos.y.ToFloat32(), ret.pos.z.ToFloat32(),
-              ret.pos.w.ToFloat32(), ret.quat.x.ToFloat32(), ret.quat.y.ToFloat32(),
-              ret.quat.z.ToFloat32(), ret.quat.w.ToFloat32(), ret.color.x.ToFloat32(),
-              ret.color.y.ToFloat32(), ret.color.z.ToFloat32(), ret.color.w.ToFloat32(),
-              ret.tc0.u().ToFloat32(), ret.tc0.v().ToFloat32(), ret.view.x.ToFloat32(),
-              ret.view.y.ToFloat32(), ret.view.z.ToFloat32());
+    NGLOG_TRACE(HW_GPU,
+                "Output vertex: pos({:.2}, {:.2}, {:.2}, {:.2}), quat({:.2}, {:.2}, {:.2}, {:.2}), "
+                "col({:.2}, {:.2}, {:.2}, {:.2}), tc0({:.2}, {:.2}), view({:.2}, {:.2}, {:.2})",
+                ret.pos.x.ToFloat32(), ret.pos.y.ToFloat32(), ret.pos.z.ToFloat32(),
+                ret.pos.w.ToFloat32(), ret.quat.x.ToFloat32(), ret.quat.y.ToFloat32(),
+                ret.quat.z.ToFloat32(), ret.quat.w.ToFloat32(), ret.color.x.ToFloat32(),
+                ret.color.y.ToFloat32(), ret.color.z.ToFloat32(), ret.color.w.ToFloat32(),
+                ret.tc0.u().ToFloat32(), ret.tc0.v().ToFloat32(), ret.view.x.ToFloat32(),
+                ret.view.y.ToFloat32(), ret.view.z.ToFloat32());
 
     return ret;
 }

--- a/src/video_core/shader/shader_interpreter.cpp
+++ b/src/video_core/shader/shader_interpreter.cpp
@@ -404,7 +404,7 @@ static void RunInterpreter(const ShaderSetup& setup, UnitState& state, DebugData
                         break;
 
                     default:
-                        LOG_ERROR(HW_GPU, "Unknown compare mode %x", static_cast<int>(op));
+                        NGLOG_ERROR(HW_GPU, "Unknown compare mode {:x}", static_cast<int>(op));
                         break;
                     }
                 }
@@ -446,9 +446,9 @@ static void RunInterpreter(const ShaderSetup& setup, UnitState& state, DebugData
             }
 
             default:
-                LOG_ERROR(HW_GPU, "Unhandled arithmetic instruction: 0x%02x (%s): 0x%08x",
-                          (int)instr.opcode.Value().EffectiveOpCode(),
-                          instr.opcode.Value().GetInfo().name, instr.hex);
+                NGLOG_ERROR(HW_GPU, "Unhandled arithmetic instruction: 0x{:02x} ({}): 0x{:08x}",
+                            (int)instr.opcode.Value().EffectiveOpCode(),
+                            instr.opcode.Value().GetInfo().name, instr.hex);
                 DEBUG_ASSERT(false);
                 break;
             }
@@ -535,9 +535,9 @@ static void RunInterpreter(const ShaderSetup& setup, UnitState& state, DebugData
                 }
                 Record<DebugDataRecord::DEST_OUT>(debug_data, iteration, dest);
             } else {
-                LOG_ERROR(HW_GPU, "Unhandled multiply-add instruction: 0x%02x (%s): 0x%08x",
-                          (int)instr.opcode.Value().EffectiveOpCode(),
-                          instr.opcode.Value().GetInfo().name, instr.hex);
+                NGLOG_ERROR(HW_GPU, "Unhandled multiply-add instruction: 0x{:02x} ({}): 0x{:08x}",
+                            (int)instr.opcode.Value().EffectiveOpCode(),
+                            instr.opcode.Value().GetInfo().name, instr.hex);
             }
             break;
         }
@@ -653,9 +653,9 @@ static void RunInterpreter(const ShaderSetup& setup, UnitState& state, DebugData
             }
 
             default:
-                LOG_ERROR(HW_GPU, "Unhandled instruction: 0x%02x (%s): 0x%08x",
-                          (int)instr.opcode.Value().EffectiveOpCode(),
-                          instr.opcode.Value().GetInfo().name, instr.hex);
+                NGLOG_ERROR(HW_GPU, "Unhandled instruction: 0x{:02x} ({}): 0x{:08x}",
+                            (int)instr.opcode.Value().EffectiveOpCode(),
+                            instr.opcode.Value().GetInfo().name, instr.hex);
                 break;
             }
 

--- a/src/video_core/shader/shader_jit_x64_compiler.cpp
+++ b/src/video_core/shader/shader_jit_x64_compiler.cpp
@@ -161,7 +161,7 @@ static const u8 NO_SRC_REG_SWIZZLE = 0x1b;
 static const u8 NO_DEST_REG_MASK = 0xf;
 
 static void LogCritical(const char* msg) {
-    LOG_CRITICAL(HW_GPU, "%s", msg);
+    NGLOG_CRITICAL(HW_GPU, "{}", msg);
 }
 
 void JitShader::Compile_Assert(bool condition, const char* msg) {
@@ -858,8 +858,8 @@ void JitShader::Compile_NextInstr() {
         ((*this).*instr_func)(instr);
     } else {
         // Unhandled instruction
-        LOG_CRITICAL(HW_GPU, "Unhandled instruction: 0x%02x (0x%08x)",
-                     static_cast<u32>(instr.opcode.Value().EffectiveOpCode()), instr.hex);
+        NGLOG_CRITICAL(HW_GPU, "Unhandled instruction: 0x{:02x} (0x{:08x})",
+                       static_cast<u32>(instr.opcode.Value().EffectiveOpCode()), instr.hex);
     }
 }
 
@@ -945,7 +945,7 @@ void JitShader::Compile(const std::array<u32, MAX_PROGRAM_CODE_LENGTH>* program_
     ready();
 
     ASSERT_MSG(getSize() <= MAX_SHADER_SIZE, "Compiled a shader that exceeds the allocated size!");
-    LOG_DEBUG(HW_GPU, "Compiled shader size=%lu", getSize());
+    NGLOG_DEBUG(HW_GPU, "Compiled shader size={}", getSize());
 }
 
 JitShader::JitShader() : Xbyak::CodeGenerator(MAX_SHADER_SIZE) {

--- a/src/video_core/swrasterizer/clipper.cpp
+++ b/src/video_core/swrasterizer/clipper.cpp
@@ -173,19 +173,20 @@ void ProcessTriangle(const OutputVertex& v0, const OutputVertex& v1, const Outpu
 
         InitScreenCoordinates(vtx2);
 
-        LOG_TRACE(Render_Software,
-                  "Triangle %lu/%lu at position (%.3f, %.3f, %.3f, %.3f), "
-                  "(%.3f, %.3f, %.3f, %.3f), (%.3f, %.3f, %.3f, %.3f) and "
-                  "screen position (%.2f, %.2f, %.2f), (%.2f, %.2f, %.2f), (%.2f, %.2f, %.2f)",
-                  i + 1, output_list->size() - 2, vtx0.pos.x.ToFloat32(), vtx0.pos.y.ToFloat32(),
-                  vtx0.pos.z.ToFloat32(), vtx0.pos.w.ToFloat32(), vtx1.pos.x.ToFloat32(),
-                  vtx1.pos.y.ToFloat32(), vtx1.pos.z.ToFloat32(), vtx1.pos.w.ToFloat32(),
-                  vtx2.pos.x.ToFloat32(), vtx2.pos.y.ToFloat32(), vtx2.pos.z.ToFloat32(),
-                  vtx2.pos.w.ToFloat32(), vtx0.screenpos.x.ToFloat32(),
-                  vtx0.screenpos.y.ToFloat32(), vtx0.screenpos.z.ToFloat32(),
-                  vtx1.screenpos.x.ToFloat32(), vtx1.screenpos.y.ToFloat32(),
-                  vtx1.screenpos.z.ToFloat32(), vtx2.screenpos.x.ToFloat32(),
-                  vtx2.screenpos.y.ToFloat32(), vtx2.screenpos.z.ToFloat32());
+        NGLOG_TRACE(
+            Render_Software,
+            "Triangle {}/{} at position ({:.3}, {:.3}, {:.3}, {:.3f}), "
+            "({:.3}, {:.3}, {:.3}, {:.3}), ({:.3}, {:.3}, {:.3}, {:.3}) and "
+            "screen position ({:.2}, {:.2}, {:.2}), ({:.2}, {:.2}, {:.2}), ({:.2}, {:.2}, {:.2})",
+            i + 1, output_list->size() - 2, vtx0.pos.x.ToFloat32(), vtx0.pos.y.ToFloat32(),
+            vtx0.pos.z.ToFloat32(), vtx0.pos.w.ToFloat32(), vtx1.pos.x.ToFloat32(),
+            vtx1.pos.y.ToFloat32(), vtx1.pos.z.ToFloat32(), vtx1.pos.w.ToFloat32(),
+            vtx2.pos.x.ToFloat32(), vtx2.pos.y.ToFloat32(), vtx2.pos.z.ToFloat32(),
+            vtx2.pos.w.ToFloat32(), vtx0.screenpos.x.ToFloat32(),
+            vtx0.screenpos.y.ToFloat32(), vtx0.screenpos.z.ToFloat32(),
+            vtx1.screenpos.x.ToFloat32(), vtx1.screenpos.y.ToFloat32(),
+            vtx1.screenpos.z.ToFloat32(), vtx2.screenpos.x.ToFloat32(),
+            vtx2.screenpos.y.ToFloat32(), vtx2.screenpos.z.ToFloat32());
 
         Rasterizer::ProcessTriangle(vtx0, vtx1, vtx2);
     }

--- a/src/video_core/swrasterizer/clipper.cpp
+++ b/src/video_core/swrasterizer/clipper.cpp
@@ -182,11 +182,11 @@ void ProcessTriangle(const OutputVertex& v0, const OutputVertex& v1, const Outpu
             vtx0.pos.z.ToFloat32(), vtx0.pos.w.ToFloat32(), vtx1.pos.x.ToFloat32(),
             vtx1.pos.y.ToFloat32(), vtx1.pos.z.ToFloat32(), vtx1.pos.w.ToFloat32(),
             vtx2.pos.x.ToFloat32(), vtx2.pos.y.ToFloat32(), vtx2.pos.z.ToFloat32(),
-            vtx2.pos.w.ToFloat32(), vtx0.screenpos.x.ToFloat32(),
-            vtx0.screenpos.y.ToFloat32(), vtx0.screenpos.z.ToFloat32(),
-            vtx1.screenpos.x.ToFloat32(), vtx1.screenpos.y.ToFloat32(),
-            vtx1.screenpos.z.ToFloat32(), vtx2.screenpos.x.ToFloat32(),
-            vtx2.screenpos.y.ToFloat32(), vtx2.screenpos.z.ToFloat32());
+            vtx2.pos.w.ToFloat32(), vtx0.screenpos.x.ToFloat32(), vtx0.screenpos.y.ToFloat32(),
+            vtx0.screenpos.z.ToFloat32(), vtx1.screenpos.x.ToFloat32(),
+            vtx1.screenpos.y.ToFloat32(), vtx1.screenpos.z.ToFloat32(),
+            vtx2.screenpos.x.ToFloat32(), vtx2.screenpos.y.ToFloat32(),
+            vtx2.screenpos.z.ToFloat32());
 
         Rasterizer::ProcessTriangle(vtx0, vtx1, vtx2);
     }

--- a/src/video_core/swrasterizer/framebuffer.cpp
+++ b/src/video_core/swrasterizer/framebuffer.cpp
@@ -57,8 +57,8 @@ void DrawPixel(int x, int y, const Math::Vec4<u8>& color) {
         break;
 
     default:
-        LOG_CRITICAL(Render_Software, "Unknown framebuffer color format %x",
-                     static_cast<u32>(framebuffer.color_format.Value()));
+        NGLOG_CRITICAL(Render_Software, "Unknown framebuffer color format {:x}",
+                       static_cast<u32>(framebuffer.color_format.Value()));
         UNIMPLEMENTED();
     }
 }
@@ -93,8 +93,8 @@ const Math::Vec4<u8> GetPixel(int x, int y) {
         return Color::DecodeRGBA4(src_pixel);
 
     default:
-        LOG_CRITICAL(Render_Software, "Unknown framebuffer color format %x",
-                     static_cast<u32>(framebuffer.color_format.Value()));
+        NGLOG_CRITICAL(Render_Software, "Unknown framebuffer color format {:x}",
+                       static_cast<u32>(framebuffer.color_format.Value()));
         UNIMPLEMENTED();
     }
 
@@ -123,8 +123,8 @@ u32 GetDepth(int x, int y) {
     case FramebufferRegs::DepthFormat::D24S8:
         return Color::DecodeD24S8(src_pixel).x;
     default:
-        LOG_CRITICAL(HW_GPU, "Unimplemented depth format %u",
-                     static_cast<u32>(framebuffer.depth_format.Value()));
+        NGLOG_CRITICAL(HW_GPU, "Unimplemented depth format {}",
+                       static_cast<u32>(framebuffer.depth_format.Value()));
         UNIMPLEMENTED();
         return 0;
     }
@@ -149,9 +149,9 @@ u8 GetStencil(int x, int y) {
         return Color::DecodeD24S8(src_pixel).y;
 
     default:
-        LOG_WARNING(
+        NGLOG_WARNING(
             HW_GPU,
-            "GetStencil called for function which doesn't have a stencil component (format %u)",
+            "GetStencil called for function which doesn't have a stencil component (format {})",
             static_cast<u32>(framebuffer.depth_format.Value()));
         return 0;
     }
@@ -185,8 +185,8 @@ void SetDepth(int x, int y, u32 value) {
         break;
 
     default:
-        LOG_CRITICAL(HW_GPU, "Unimplemented depth format %u",
-                     static_cast<u32>(framebuffer.depth_format.Value()));
+        NGLOG_CRITICAL(HW_GPU, "Unimplemented depth format {}",
+                       static_cast<u32>(framebuffer.depth_format.Value()));
         UNIMPLEMENTED();
         break;
     }
@@ -217,8 +217,8 @@ void SetStencil(int x, int y, u8 value) {
         break;
 
     default:
-        LOG_CRITICAL(HW_GPU, "Unimplemented depth format %u",
-                     static_cast<u32>(framebuffer.depth_format.Value()));
+        NGLOG_CRITICAL(HW_GPU, "Unimplemented depth format {}",
+                       static_cast<u32>(framebuffer.depth_format.Value()));
         UNIMPLEMENTED();
         break;
     }
@@ -253,7 +253,7 @@ u8 PerformStencilAction(FramebufferRegs::StencilAction action, u8 old_stencil, u
         return old_stencil - 1;
 
     default:
-        LOG_CRITICAL(HW_GPU, "Unknown stencil action %x", (int)action);
+        NGLOG_CRITICAL(HW_GPU, "Unknown stencil action {:x}", (int)action);
         UNIMPLEMENTED();
         return 0;
     }
@@ -297,7 +297,7 @@ Math::Vec4<u8> EvaluateBlendEquation(const Math::Vec4<u8>& src, const Math::Vec4
         break;
 
     default:
-        LOG_CRITICAL(HW_GPU, "Unknown RGB blend equation 0x%x", static_cast<u8>(equation));
+        NGLOG_CRITICAL(HW_GPU, "Unknown RGB blend equation 0x{:x}", static_cast<u8>(equation));
         UNIMPLEMENTED();
     }
 

--- a/src/video_core/swrasterizer/lighting.cpp
+++ b/src/video_core/swrasterizer/lighting.cpp
@@ -53,8 +53,8 @@ std::tuple<Math::Vec4<u8>, Math::Vec4<u8>> ComputeFragmentsColors(
             surface_normal = Math::MakeVec(0.0f, 0.0f, 1.0f);
             surface_tangent = perturbation;
         } else {
-            LOG_ERROR(HW_GPU, "Unknown bump mode %u",
-                      static_cast<u32>(lighting.config0.bump_mode.Value()));
+            NGLOG_ERROR(HW_GPU, "Unknown bump mode {}",
+                        static_cast<u32>(lighting.config0.bump_mode.Value()));
         }
     } else {
         surface_normal = Math::MakeVec(0.0f, 0.0f, 1.0f);
@@ -143,7 +143,7 @@ std::tuple<Math::Vec4<u8>, Math::Vec4<u8>> ComputeFragmentsColors(
                 }
                 break;
             default:
-                LOG_CRITICAL(HW_GPU, "Unknown lighting LUT input %u\n", static_cast<u32>(input));
+                NGLOG_CRITICAL(HW_GPU, "Unknown lighting LUT input {}\n", static_cast<u32>(input));
                 UNIMPLEMENTED();
                 result = 0.0f;
             }

--- a/src/video_core/swrasterizer/proctex.cpp
+++ b/src/video_core/swrasterizer/proctex.cpp
@@ -77,7 +77,7 @@ static float GetShiftOffset(float v, ProcTexShift mode, ProcTexClamp clamp_mode)
     case ProcTexShift::Even:
         return offset * ((((int)v + 1) / 2) % 2);
     default:
-        LOG_CRITICAL(HW_GPU, "Unknown shift mode %u", static_cast<u32>(mode));
+        NGLOG_CRITICAL(HW_GPU, "Unknown shift mode {}", static_cast<u32>(mode));
         return 0;
     }
 };
@@ -107,7 +107,7 @@ static void ClampCoord(float& coord, ProcTexClamp mode) {
             coord = 1.0f;
         break;
     default:
-        LOG_CRITICAL(HW_GPU, "Unknown clamp mode %u", static_cast<u32>(mode));
+        NGLOG_CRITICAL(HW_GPU, "Unknown clamp mode {}", static_cast<u32>(mode));
         coord = std::min(coord, 1.0f);
         break;
     }
@@ -148,7 +148,7 @@ float CombineAndMap(float u, float v, ProcTexCombiner combiner,
         f = std::min(((u + v) * 0.5f + std::sqrt(u * u + v * v)) * 0.5f, 1.0f);
         break;
     default:
-        LOG_CRITICAL(HW_GPU, "Unknown combiner %u", static_cast<u32>(combiner));
+        NGLOG_CRITICAL(HW_GPU, "Unknown combiner {}", static_cast<u32>(combiner));
         f = 0.0f;
         break;
     }

--- a/src/video_core/swrasterizer/rasterizer.cpp
+++ b/src/video_core/swrasterizer/rasterizer.cpp
@@ -363,7 +363,8 @@ static void ProcessTriangleInternal(const Vertex& v0, const Vertex& v1, const Ve
                     }
                     default:
                         // TODO: Change to LOG_ERROR when more types are handled.
-                        LOG_DEBUG(HW_GPU, "Unhandled texture type %x", (int)texture.config.type);
+                        NGLOG_DEBUG(HW_GPU, "Unhandled texture type {:x}",
+                                    (int)texture.config.type);
                         UNIMPLEMENTED();
                         break;
                     }
@@ -512,7 +513,7 @@ static void ProcessTriangleInternal(const Vertex& v0, const Vertex& v1, const Ve
                         return combiner_output;
 
                     default:
-                        LOG_ERROR(HW_GPU, "Unknown color combiner source %d", (int)source);
+                        NGLOG_ERROR(HW_GPU, "Unknown color combiner source {}", (int)source);
                         UNIMPLEMENTED();
                         return {0, 0, 0, 0};
                     }
@@ -843,7 +844,8 @@ static void ProcessTriangleInternal(const Vertex& v0, const Vertex& v1, const Ve
                         return std::min(combiner_output.a(), static_cast<u8>(255 - dest.a()));
 
                     default:
-                        LOG_CRITICAL(HW_GPU, "Unknown blend factor %x", static_cast<u32>(factor));
+                        NGLOG_CRITICAL(HW_GPU, "Unknown blend factor {:x}",
+                                       static_cast<u32>(factor));
                         UNIMPLEMENTED();
                         break;
                     }

--- a/src/video_core/swrasterizer/texturing.cpp
+++ b/src/video_core/swrasterizer/texturing.cpp
@@ -48,7 +48,7 @@ int GetWrappedTexCoord(TexturingRegs::TextureConfig::WrapMode mode, int val, uns
     }
 
     default:
-        LOG_ERROR(HW_GPU, "Unknown texture coordinate wrapping mode %x", (int)mode);
+        NGLOG_ERROR(HW_GPU, "Unknown texture coordinate wrapping mode {:x}", (int)mode);
         UNIMPLEMENTED();
         return 0;
     }
@@ -197,7 +197,7 @@ Math::Vec3<u8> ColorCombine(TevStageConfig::Operation op, const Math::Vec3<u8> i
         return {(u8)result, (u8)result, (u8)result};
     }
     default:
-        LOG_ERROR(HW_GPU, "Unknown color combiner operation %d", (int)op);
+        NGLOG_ERROR(HW_GPU, "Unknown color combiner operation {}", (int)op);
         UNIMPLEMENTED();
         return {0, 0, 0};
     }
@@ -234,7 +234,7 @@ u8 AlphaCombine(TevStageConfig::Operation op, const std::array<u8, 3>& input) {
         return (std::min(255, (input[0] + input[1])) * input[2]) / 255;
 
     default:
-        LOG_ERROR(HW_GPU, "Unknown alpha combiner operation %d", (int)op);
+        NGLOG_ERROR(HW_GPU, "Unknown alpha combiner operation {}", (int)op);
         UNIMPLEMENTED();
         return 0;
     }

--- a/src/video_core/texture/texture_decode.cpp
+++ b/src/video_core/texture/texture_decode.cpp
@@ -206,7 +206,7 @@ Math::Vec4<u8> LookupTexelInTile(const u8* source, unsigned int x, unsigned int 
     }
 
     default:
-        LOG_ERROR(HW_GPU, "Unknown texture format: %x", (u32)info.format);
+        NGLOG_ERROR(HW_GPU, "Unknown texture format: {:x}", (u32)info.format);
         DEBUG_ASSERT(false);
         return {};
     }

--- a/src/video_core/vertex_loader.cpp
+++ b/src/video_core/vertex_loader.cpp
@@ -37,9 +37,10 @@ void VertexLoader::Setup(const PipelineRegs& regs) {
         // TODO: What happens if a loader overwrites a previous one's data?
         for (unsigned component = 0; component < loader_config.component_count; ++component) {
             if (component >= 12) {
-                LOG_ERROR(HW_GPU,
-                          "Overflow in the vertex attribute loader %u trying to load component %u",
-                          loader, component);
+                NGLOG_ERROR(
+                    HW_GPU,
+                    "Overflow in the vertex attribute loader {} trying to load component {}",
+                    loader, component);
                 continue;
             }
 
@@ -136,20 +137,21 @@ void VertexLoader::LoadVertex(u32 base_address, int index, int vertex,
                     comp == 3 ? float24::FromFloat32(1.0f) : float24::FromFloat32(0.0f);
             }
 
-            LOG_TRACE(HW_GPU,
-                      "Loaded %d components of attribute %x for vertex %x (index %x) from "
-                      "0x%08x + 0x%08x + 0x%04x: %f %f %f %f",
-                      vertex_attribute_elements[i], i, vertex, index, base_address,
-                      vertex_attribute_sources[i], vertex_attribute_strides[i] * vertex,
-                      input.attr[i][0].ToFloat32(), input.attr[i][1].ToFloat32(),
-                      input.attr[i][2].ToFloat32(), input.attr[i][3].ToFloat32());
+            NGLOG_TRACE(HW_GPU,
+                        "Loaded {} components of attribute {:x} for vertex {:x} (index {:x}) from "
+                        "0x{:08x} + 0x{:08x} + 0x{:04x}: {} {} {} {}",
+                        vertex_attribute_elements[i], i, vertex, index, base_address,
+                        vertex_attribute_sources[i], vertex_attribute_strides[i] * vertex,
+                        input.attr[i][0].ToFloat32(), input.attr[i][1].ToFloat32(),
+                        input.attr[i][2].ToFloat32(), input.attr[i][3].ToFloat32());
         } else if (vertex_attribute_is_default[i]) {
             // Load the default attribute if we're configured to do so
             input.attr[i] = g_state.input_default_attributes.attr[i];
-            LOG_TRACE(HW_GPU,
-                      "Loaded default attribute %x for vertex %x (index %x): (%f, %f, %f, %f)", i,
-                      vertex, index, input.attr[i][0].ToFloat32(), input.attr[i][1].ToFloat32(),
-                      input.attr[i][2].ToFloat32(), input.attr[i][3].ToFloat32());
+            NGLOG_TRACE(
+                HW_GPU,
+                "Loaded default attribute {:x} for vertex {:x} (index {:x}): ({}, {}, {}, {})", i,
+                vertex, index, input.attr[i][0].ToFloat32(), input.attr[i][1].ToFloat32(),
+                input.attr[i][2].ToFloat32(), input.attr[i][3].ToFloat32());
         } else {
             // TODO(yuriks): In this case, no data gets loaded and the vertex
             // remains with the last value it had. This isn't currently maintained

--- a/src/video_core/video_core.cpp
+++ b/src/video_core/video_core.cpp
@@ -31,9 +31,9 @@ bool Init(EmuWindow* emu_window) {
     g_renderer = std::make_unique<RendererOpenGL>();
     g_renderer->SetWindow(g_emu_window);
     if (g_renderer->Init()) {
-        LOG_DEBUG(Render, "initialized OK");
+        NGLOG_DEBUG(Render, "initialized OK");
     } else {
-        LOG_ERROR(Render, "initialization failed !");
+        NGLOG_ERROR(Render, "initialization failed !");
         return false;
     }
     return true;
@@ -45,7 +45,7 @@ void Shutdown() {
 
     g_renderer.reset();
 
-    LOG_DEBUG(Render, "shutdown OK");
+    NGLOG_DEBUG(Render, "shutdown OK");
 }
 
 } // namespace VideoCore


### PR DESCRIPTION
There is still one `LOG_GENERIC` left in renderer_opengl.cpp. I can do that after `NGLOG_GENERIC` is added in my hle/kernel pr.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3878)
<!-- Reviewable:end -->
