### PR TITLE
citra_qt: only update title from game after ensuring loaded successfully

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -606,10 +606,6 @@ bool GMainWindow::LoadROM(const QString& filename) {
     Core::System& system{Core::System::GetInstance()};
 
     const Core::System::ResultStatus result{system.Load(render_window, filename.toStdString())};
-    std::string title;
-    system.GetAppLoader().ReadTitle(title);
-    game_title = QString::fromStdString(title);
-    SetupUIStrings();
 
     if (result != Core::System::ResultStatus::Success) {
         switch (result) {
@@ -665,6 +661,11 @@ bool GMainWindow::LoadROM(const QString& filename) {
         }
         return false;
     }
+
+    std::string title;
+    system.GetAppLoader().ReadTitle(title);
+    game_title = QString::fromStdString(title);
+    SetupUIStrings();
 
     Core::Telemetry().AddField(Telemetry::FieldType::App, "Frontend", "Qt");
     return true;


### PR DESCRIPTION
A bug introduced in #3804, citra would crash on any invalid ROM.

This also affect the shortcut created by the installer, which forwards the filename from command line. When no file specified, it would forward an empty filename (= invalid ROM), causing guaranteed crash from opening citra from the shortcut.  

cc @zhaowenlan1779

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3880)
<!-- Reviewable:end -->
