### PR TITLE
citra_qt: Fix image file selection dialog

### DIFF
--- a/src/citra_qt/configuration/configure_camera.cpp
+++ b/src/citra_qt/configuration/configure_camera.cpp
@@ -267,16 +267,12 @@ void ConfigureCamera::setConfiguration() {
 
 void ConfigureCamera::onToolButtonClicked() {
     stopPreviewing();
-    int camera_selection = getSelectedCameraIndex();
-    QString filter;
-    if (camera_name[camera_selection] == "image") {
-        QList<QByteArray> types = QImageReader::supportedImageFormats();
-        QList<QString> temp_filters;
-        for (const QByteArray& type : types) {
-            temp_filters << QString("*." + QString(type));
-        }
-        filter = tr("Supported image files (%1)").arg(temp_filters.join(" "));
+    QList<QByteArray> types = QImageReader::supportedImageFormats();
+    QList<QString> temp_filters;
+    for (const QByteArray& type : types) {
+        temp_filters << QString("*." + QString(type));
     }
+    QString filter = tr("Supported image files (%1)").arg(temp_filters.join(" "));
     QString path = QFileDialog::getOpenFileName(this, tr("Open File"), ".", filter);
     if (!path.isEmpty()) {
         ui->camera_file->setText(path);


### PR DESCRIPTION
Previously becasue of a bug filter will not be applied (matif reported on Discord)
![picture_from_discord](https://cdn.discordapp.com/attachments/454663283308494848/461896785359536129/unknown.png)

With this PR filters are properly applied.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3889)
<!-- Reviewable:end -->
