### PR TITLE
CI: add imageformats plugins

### DIFF
--- a/CMakeModules/CopyCitraQt5Deps.cmake
+++ b/CMakeModules/CopyCitraQt5Deps.cmake
@@ -5,9 +5,11 @@ function(copy_citra_Qt5_deps target_dir)
     set(Qt5_PLATFORMS_DIR "${Qt5_DIR}/../../../plugins/platforms/")
     set(Qt5_MEDIASERVICE_DIR "${Qt5_DIR}/../../../plugins/mediaservice/")
     set(Qt5_STYLES_DIR "${Qt5_DIR}/../../../plugins/styles/")
+    set(Qt5_IMAGEFORMATS_DIR "${Qt5_DIR}/../../../plugins/imageformats/")
     set(PLATFORMS ${DLL_DEST}platforms/)
     set(MEDIASERVICE ${DLL_DEST}mediaservice/)
     set(STYLES ${DLL_DEST}styles/)
+    set(IMAGEFORMATS ${DLL_DEST}imageformats/)
     windows_copy_files(${target_dir} ${Qt5_DLL_DIR} ${DLL_DEST}
         icudt*.dll
         icuin*.dll
@@ -25,4 +27,15 @@ function(copy_citra_Qt5_deps target_dir)
         wmfengine$<$<CONFIG:Debug>:d>.*
     )
     windows_copy_files(citra-qt ${Qt5_STYLES_DIR} ${STYLES} qwindowsvistastyle$<$<CONFIG:Debug>:d>.*)
+    windows_copy_files(${target_dir} ${Qt5_IMAGEFORMATS_DIR} ${IMAGEFORMATS}
+        qgif$<$<CONFIG:Debug>:d>.dll
+        qicns$<$<CONFIG:Debug>:d>.dll
+        qico$<$<CONFIG:Debug>:d>.dll
+        qjpeg$<$<CONFIG:Debug>:d>.dll
+        qsvg$<$<CONFIG:Debug>:d>.dll
+        qtga$<$<CONFIG:Debug>:d>.dll
+        qtiff$<$<CONFIG:Debug>:d>.dll
+        qwbmp$<$<CONFIG:Debug>:d>.dll
+        qwebp$<$<CONFIG:Debug>:d>.dll
+    )
 endfunction(copy_citra_Qt5_deps)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -113,6 +113,7 @@ after_build:
           mkdir $RELEASE_DIST/platforms
           mkdir $RELEASE_DIST/mediaservice
           mkdir $RELEASE_DIST/styles
+          mkdir $RELEASE_DIST/imageformats
 
           # copy the compiled binaries and other release files to the release folder
           Get-ChildItem "$CMAKE_BINARY_DIR" -Recurse -Filter "citra*.exe" | Copy-Item -destination $RELEASE_DIST
@@ -138,6 +139,9 @@ after_build:
 
           # copy the qt windows vista style dll to platforms
           Copy-Item -path "C:/msys64/mingw64/share/qt5/plugins/styles/qwindowsvistastyle.dll" -force -destination "$RELEASE_DIST/styles"
+
+          # copy the qt imageformats plugin dlls to imageformats
+          Get-ChildItem "C:/msys64/mingw64/share/qt5/plugins/imageformats" -Exclude "*d.dll" | Copy-Item -force -destination "$RELEASE_DIST/imageformats"
 
           # process PDBs
           . "./.appveyor/ProcessPdb.ps1"


### PR DESCRIPTION
This adds a lot of extra supported formats to qt.
MSVC:
![image](https://user-images.githubusercontent.com/21307832/42066967-4d2564ca-7b76-11e8-9e26-806b709d6a7f.png)

Mingw:
![image](https://user-images.githubusercontent.com/21307832/42066969-52d4ae08-7b76-11e8-9df6-43fbd42a5ef8.png)

The above pictures come from Appveyor builds of my repo.

pinging #3706

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3891)
<!-- Reviewable:end -->
