### PR TITLE
swrasterizer, gl_shader_gen: return 0.0 for Disabled texture unit 0

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -319,6 +319,8 @@ static std::string SampleTexture(const PicaFSConfig& config, unsigned texture_un
             return "shadowTexture(texcoord0, texcoord0_w)";
         case TexturingRegs::TextureConfig::ShadowCube:
             return "shadowTextureCube(texcoord0, texcoord0_w)";
+        case TexturingRegs::TextureConfig::Disabled:
+            return "vec4(0.0)";
         default:
             LOG_CRITICAL(HW_GPU, "Unhandled texture type {:x}",
                          static_cast<int>(state.texture0_type));

--- a/src/video_core/swrasterizer/rasterizer.cpp
+++ b/src/video_core/swrasterizer/rasterizer.cpp
@@ -361,9 +361,10 @@ static void ProcessTriangleInternal(const Vertex& v0, const Vertex& v1, const Ve
                         shadow_z = float24::FromFloat32(std::abs(tc0_w.ToFloat32()));
                         break;
                     }
+                    case TexturingRegs::TextureConfig::Disabled:
+                        continue; // skip this unit and continue to the next unit
                     default:
-                        // TODO: Change to LOG_ERROR when more types are handled.
-                        LOG_DEBUG(HW_GPU, "Unhandled texture type {:x}", (int)texture.config.type);
+                        LOG_ERROR(HW_GPU, "Unhandled texture type {:x}", (int)texture.config.type);
                         UNIMPLEMENTED();
                         break;
                     }


### PR DESCRIPTION
Similar to #3851, games only use this texture type when they actually disable it. This texture type can be referenced during the shader generation but would typically end up in dead code, so it is harmless to silently return a 0. ~~Furthermore, it indeed returns 0 on real 3DS.~~

The behavior on 3DS is that Disabled texture would return the last texel color it fetched when it was not disabled. This is not possible to emulate in our current code.

All known texture type are handled so far.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3898)
<!-- Reviewable:end -->
