### PR TITLE
citra_qt: only toggle console if the setting has been changed

### DIFF
--- a/src/citra_qt/debugger/console.cpp
+++ b/src/citra_qt/debugger/console.cpp
@@ -14,16 +14,13 @@
 
 namespace Debugger {
 void ToggleConsole() {
-    static bool first_call = true, console_shown = true;
-    if (!first_call) {
-        if (console_shown == UISettings::values.show_console) {
-            return;
-        } else {
-            console_shown = UISettings::values.show_console;
-        }
+    static bool console_shown = false;
+    if (console_shown == UISettings::values.show_console) {
+        return;
     } else {
-        first_call = false;
+        console_shown = UISettings::values.show_console;
     }
+    
 #ifdef _WIN32
     FILE* temp;
     if (UISettings::values.show_console) {

--- a/src/citra_qt/debugger/console.cpp
+++ b/src/citra_qt/debugger/console.cpp
@@ -20,7 +20,7 @@ void ToggleConsole() {
     } else {
         console_shown = UISettings::values.show_console;
     }
-    
+
 #ifdef _WIN32
     FILE* temp;
     if (UISettings::values.show_console) {

--- a/src/citra_qt/debugger/console.cpp
+++ b/src/citra_qt/debugger/console.cpp
@@ -14,6 +14,16 @@
 
 namespace Debugger {
 void ToggleConsole() {
+    static bool first_call = true, console_shown = true;
+    if (!first_call) {
+        if (console_shown == UISettings::values.show_console) {
+            return;
+        } else {
+            console_shown = UISettings::values.show_console;
+        }
+    } else {
+        first_call = false;
+    }
 #ifdef _WIN32
     FILE* temp;
     if (UISettings::values.show_console) {


### PR DESCRIPTION
There was a bug that on linux/macOS, opening and closing configuration window would duplicate all the following log. This is due to `ToggleConsole` being called and `Log::AddBackend` being called twice. This PR prevents log backend changing if the setting value hasn't been changed.

cc @jroweboy

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3899)
<!-- Reviewable:end -->
