### PR TITLE
citra_qt: add restart hotkey & menu option

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -309,6 +309,7 @@ void GMainWindow::InitializeHotkeys() {
     RegisterHotkey("Main Window", "Load File", QKeySequence::Open);
     RegisterHotkey("Main Window", "Start Emulation");
     RegisterHotkey("Main Window", "Continue/Pause", QKeySequence(Qt::Key_F4));
+    RegisterHotkey("Main Window", "Restart", QKeySequence(Qt::Key_F5));
     RegisterHotkey("Main Window", "Swap Screens", QKeySequence(tr("F9")));
     RegisterHotkey("Main Window", "Toggle Screen Layout", QKeySequence(tr("F10")));
     RegisterHotkey("Main Window", "Fullscreen", QKeySequence::FullScreen);
@@ -334,6 +335,11 @@ void GMainWindow::InitializeHotkeys() {
                 OnStartGame();
             }
         }
+    });
+    connect(GetHotkey("Main Window", "Restart", this), &QShortcut::activated, this, [&] {
+        if (!Core::System::GetInstance().IsPoweredOn())
+            return;
+        BootGame(QString(UISettings::values.recent_files.first()));
     });
     connect(GetHotkey("Main Window", "Swap Screens", render_window), &QShortcut::activated,
             ui.action_Screen_Layout_Swap_Screens, &QAction::trigger);
@@ -450,6 +456,8 @@ void GMainWindow::ConnectMenuEvents() {
     connect(ui.action_Start, &QAction::triggered, this, &GMainWindow::OnStartGame);
     connect(ui.action_Pause, &QAction::triggered, this, &GMainWindow::OnPauseGame);
     connect(ui.action_Stop, &QAction::triggered, this, &GMainWindow::OnStopGame);
+    connect(ui.action_Restart, &QAction::triggered, this,
+            [&] { BootGame(QString(UISettings::values.recent_files.first())); });
     connect(ui.action_Report_Compatibility, &QAction::triggered, this,
             &GMainWindow::OnMenuReportCompatibility);
     connect(ui.action_Configure, &QAction::triggered, this, &GMainWindow::OnConfigure);
@@ -740,6 +748,7 @@ void GMainWindow::ShutdownGame() {
     ui.action_Start->setText(tr("Start"));
     ui.action_Pause->setEnabled(false);
     ui.action_Stop->setEnabled(false);
+    ui.action_Restart->setEnabled(false);
     ui.action_Report_Compatibility->setEnabled(false);
     render_window->hide();
     if (game_list->isEmpty())
@@ -1016,6 +1025,7 @@ void GMainWindow::OnStartGame() {
 
     ui.action_Pause->setEnabled(true);
     ui.action_Stop->setEnabled(true);
+    ui.action_Restart->setEnabled(true);
     ui.action_Report_Compatibility->setEnabled(true);
 }
 

--- a/src/citra_qt/main.ui
+++ b/src/citra_qt/main.ui
@@ -71,6 +71,7 @@
     <addaction name="action_Start"/>
     <addaction name="action_Pause"/>
     <addaction name="action_Stop"/>
+    <addaction name="action_Restart"/>
     <addaction name="separator"/>
     <addaction name="action_Configure"/>
    </widget>
@@ -349,6 +350,14 @@
    </property>
    <property name="visible">
     <bool>false</bool>
+   </property>
+  </action>
+  <action name="action_Restart">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Restart</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Hotkey is F5

Screenshot:
![image](https://user-images.githubusercontent.com/22228082/42127662-7288d386-7c62-11e8-80db-17b2fae6e2dc.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3902)
<!-- Reviewable:end -->
