### PR TITLE
sink_details: Tidy-up device listing code

### DIFF
--- a/src/audio_core/cubeb_sink.cpp
+++ b/src/audio_core/cubeb_sink.cpp
@@ -44,7 +44,7 @@ CubebSink::CubebSink(std::string target_device_name) : impl(std::make_unique<Imp
     if (cubeb_get_min_latency(impl->ctx, &params, &minimum_latency) != CUBEB_OK)
         LOG_CRITICAL(Audio_Sink, "Error getting minimum latency");
 
-    if (target_device_name != "auto" && !target_device_name.empty()) {
+    if (target_device_name != auto_device_name && !target_device_name.empty()) {
         cubeb_device_collection collection;
         if (cubeb_enumerate_devices(impl->ctx, CUBEB_DEVICE_TYPE_OUTPUT, &collection) != CUBEB_OK) {
             LOG_WARNING(Audio_Sink, "Audio output device enumeration not supported");

--- a/src/audio_core/cubeb_sink.cpp
+++ b/src/audio_core/cubeb_sink.cpp
@@ -120,8 +120,6 @@ size_t CubebSink::SamplesInQueue() const {
     return impl->queue.size() / 2;
 }
 
-void CubebSink::SetDevice(int device_id) {}
-
 long CubebSink::Impl::DataCallback(cubeb_stream* stream, void* user_data, const void* input_buffer,
                                    void* output_buffer, long num_frames) {
     Impl* impl = static_cast<Impl*>(user_data);

--- a/src/audio_core/cubeb_sink.h
+++ b/src/audio_core/cubeb_sink.h
@@ -22,7 +22,6 @@ public:
     size_t SamplesInQueue() const override;
 
     std::vector<std::string> GetDeviceList() const override;
-    void SetDevice(int device_id) override;
 
 private:
     struct Impl;

--- a/src/audio_core/cubeb_sink.h
+++ b/src/audio_core/cubeb_sink.h
@@ -12,7 +12,7 @@ namespace AudioCore {
 
 class CubebSink final : public Sink {
 public:
-    CubebSink();
+    explicit CubebSink(std::string device_id);
     ~CubebSink() override;
 
     unsigned int GetNativeSampleRate() const override;
@@ -21,11 +21,11 @@ public:
 
     size_t SamplesInQueue() const override;
 
-    std::vector<std::string> GetDeviceList() const override;
-
 private:
     struct Impl;
     std::unique_ptr<Impl> impl;
 };
+
+std::vector<std::string> ListCubebSinkDevices();
 
 } // namespace AudioCore

--- a/src/audio_core/dsp_interface.cpp
+++ b/src/audio_core/dsp_interface.cpp
@@ -18,9 +18,9 @@ DspInterface::~DspInterface() {
     }
 }
 
-void DspInterface::SetSink(const std::string& sink_id) {
+void DspInterface::SetSink(const std::string& sink_id, const std::string& audio_device) {
     const SinkDetails& sink_details = GetSinkDetails(sink_id);
-    sink = sink_details.factory();
+    sink = sink_details.factory(audio_device);
     time_stretcher.SetOutputSampleRate(sink->GetNativeSampleRate());
 }
 

--- a/src/audio_core/dsp_interface.h
+++ b/src/audio_core/dsp_interface.h
@@ -61,7 +61,7 @@ public:
     virtual std::array<u8, Memory::DSP_RAM_SIZE>& GetDspMemory() = 0;
 
     /// Select the sink to use based on sink id.
-    void SetSink(const std::string& sink_id);
+    void SetSink(const std::string& sink_id, const std::string& audio_device);
     /// Get the current sink
     Sink& GetSink();
     /// Enable/Disable audio stretching.

--- a/src/audio_core/null_sink.h
+++ b/src/audio_core/null_sink.h
@@ -12,6 +12,7 @@ namespace AudioCore {
 
 class NullSink final : public Sink {
 public:
+    NullSink(std::string) {}
     ~NullSink() override = default;
 
     unsigned int GetNativeSampleRate() const override {
@@ -22,10 +23,6 @@ public:
 
     size_t SamplesInQueue() const override {
         return 0;
-    }
-
-    std::vector<std::string> GetDeviceList() const override {
-        return {};
     }
 };
 

--- a/src/audio_core/null_sink.h
+++ b/src/audio_core/null_sink.h
@@ -24,8 +24,6 @@ public:
         return 0;
     }
 
-    void SetDevice(int device_id) override {}
-
     std::vector<std::string> GetDeviceList() const override {
         return {};
     }

--- a/src/audio_core/sdl2_sink.cpp
+++ b/src/audio_core/sdl2_sink.cpp
@@ -114,10 +114,6 @@ size_t SDL2Sink::SamplesInQueue() const {
     return total_size;
 }
 
-void SDL2Sink::SetDevice(int device_id) {
-    this->device_id = device_id;
-}
-
 void SDL2Sink::Impl::Callback(void* impl_, u8* buffer, int buffer_size_in_bytes) {
     Impl* impl = reinterpret_cast<Impl*>(impl_);
 

--- a/src/audio_core/sdl2_sink.cpp
+++ b/src/audio_core/sdl2_sink.cpp
@@ -42,7 +42,7 @@ SDL2Sink::SDL2Sink(std::string device_name) : impl(std::make_unique<Impl>()) {
     SDL_zero(obtained_audiospec);
 
     const char* device = nullptr;
-    if (device_name != "auto" && !device_name.empty()) {
+    if (device_name != auto_device_name && !device_name.empty()) {
         device = device_name.c_str();
     }
 

--- a/src/audio_core/sdl2_sink.cpp
+++ b/src/audio_core/sdl2_sink.cpp
@@ -9,7 +9,6 @@
 #include "audio_core/sdl2_sink.h"
 #include "common/assert.h"
 #include "common/logging/log.h"
-#include "core/settings.h"
 
 namespace AudioCore {
 
@@ -23,7 +22,7 @@ struct SDL2Sink::Impl {
     static void Callback(void* impl_, u8* buffer, int buffer_size_in_bytes);
 };
 
-SDL2Sink::SDL2Sink() : impl(std::make_unique<Impl>()) {
+SDL2Sink::SDL2Sink(std::string device_name) : impl(std::make_unique<Impl>()) {
     if (SDL_Init(SDL_INIT_AUDIO) < 0) {
         LOG_CRITICAL(Audio_Sink, "SDL_Init(SDL_INIT_AUDIO) failed with: {}", SDL_GetError());
         impl->audio_device_id = 0;
@@ -42,24 +41,16 @@ SDL2Sink::SDL2Sink() : impl(std::make_unique<Impl>()) {
     SDL_AudioSpec obtained_audiospec;
     SDL_zero(obtained_audiospec);
 
-    int device_count = SDL_GetNumAudioDevices(0);
-    device_list.clear();
-    for (int i = 0; i < device_count; ++i) {
-        device_list.push_back(SDL_GetAudioDeviceName(i, 0));
-    }
-
     const char* device = nullptr;
-
-    if (device_count >= 1 && Settings::values.audio_device_id != "auto" &&
-        !Settings::values.audio_device_id.empty()) {
-        device = Settings::values.audio_device_id.c_str();
+    if (device_name != "auto" && !device_name.empty()) {
+        device = device_name.c_str();
     }
 
     impl->audio_device_id = SDL_OpenAudioDevice(
         device, false, &desired_audiospec, &obtained_audiospec, SDL_AUDIO_ALLOW_FREQUENCY_CHANGE);
     if (impl->audio_device_id <= 0) {
         LOG_CRITICAL(Audio_Sink, "SDL_OpenAudioDevice failed with code {} for device \"{}\"",
-                     impl->audio_device_id, Settings::values.audio_device_id);
+                     impl->audio_device_id, device_name);
         return;
     }
 
@@ -81,10 +72,6 @@ unsigned int SDL2Sink::GetNativeSampleRate() const {
         return native_sample_rate;
 
     return impl->sample_rate;
-}
-
-std::vector<std::string> SDL2Sink::GetDeviceList() const {
-    return device_list;
 }
 
 void SDL2Sink::EnqueueSamples(const s16* samples, size_t sample_count) {
@@ -138,6 +125,23 @@ void SDL2Sink::Impl::Callback(void* impl_, u8* buffer, int buffer_size_in_bytes)
     if (remaining_size > 0) {
         memset(buffer, 0, remaining_size * sizeof(s16));
     }
+}
+
+std::vector<std::string> ListSDL2SinkDevices() {
+    if (SDL_InitSubSystem(SDL_INIT_AUDIO) < 0) {
+        LOG_CRITICAL(Audio_Sink, "SDL_InitSubSystem failed with: {}", SDL_GetError());
+        return {};
+    }
+
+    std::vector<std::string> device_list;
+    const int device_count = SDL_GetNumAudioDevices(0);
+    for (int i = 0; i < device_count; ++i) {
+        device_list.push_back(SDL_GetAudioDeviceName(i, 0));
+    }
+
+    SDL_QuitSubSystem(SDL_INIT_AUDIO);
+
+    return device_list;
 }
 
 } // namespace AudioCore

--- a/src/audio_core/sdl2_sink.h
+++ b/src/audio_core/sdl2_sink.h
@@ -22,12 +22,10 @@ public:
     size_t SamplesInQueue() const override;
 
     std::vector<std::string> GetDeviceList() const override;
-    void SetDevice(int device_id) override;
 
 private:
     struct Impl;
     std::unique_ptr<Impl> impl;
-    int device_id;
     std::vector<std::string> device_list;
 };
 

--- a/src/audio_core/sdl2_sink.h
+++ b/src/audio_core/sdl2_sink.h
@@ -12,7 +12,7 @@ namespace AudioCore {
 
 class SDL2Sink final : public Sink {
 public:
-    SDL2Sink();
+    explicit SDL2Sink(std::string device_id);
     ~SDL2Sink() override;
 
     unsigned int GetNativeSampleRate() const override;
@@ -21,12 +21,11 @@ public:
 
     size_t SamplesInQueue() const override;
 
-    std::vector<std::string> GetDeviceList() const override;
-
 private:
     struct Impl;
     std::unique_ptr<Impl> impl;
-    std::vector<std::string> device_list;
 };
+
+std::vector<std::string> ListSDL2SinkDevices();
 
 } // namespace AudioCore

--- a/src/audio_core/sink.h
+++ b/src/audio_core/sink.h
@@ -9,6 +9,8 @@
 
 namespace AudioCore {
 
+constexpr char auto_device_name[] = "auto";
+
 /**
  * This class is an interface for an audio sink. An audio sink accepts samples in stereo signed
  * PCM16 format to be output. Sinks *do not* handle resampling and expect the correct sample rate.

--- a/src/audio_core/sink.h
+++ b/src/audio_core/sink.h
@@ -32,12 +32,6 @@ public:
     /// Samples enqueued that have not been played yet.
     virtual std::size_t SamplesInQueue() const = 0;
 
-    /**
-     * Sets the desired output device.
-     * @param device_id ID of the desired device.
-     */
-    virtual void SetDevice(int device_id) = 0;
-
     /// Returns the list of available devices.
     virtual std::vector<std::string> GetDeviceList() const = 0;
 };

--- a/src/audio_core/sink.h
+++ b/src/audio_core/sink.h
@@ -31,9 +31,6 @@ public:
 
     /// Samples enqueued that have not been played yet.
     virtual std::size_t SamplesInQueue() const = 0;
-
-    /// Returns the list of available devices.
-    virtual std::vector<std::string> GetDeviceList() const = 0;
 };
 
 } // namespace AudioCore

--- a/src/audio_core/sink_details.cpp
+++ b/src/audio_core/sink_details.cpp
@@ -21,12 +21,12 @@ namespace AudioCore {
 // g_sink_details is ordered in terms of desirability, with the best choice at the top.
 const std::vector<SinkDetails> g_sink_details = {
 #ifdef HAVE_CUBEB
-    {"cubeb", []() { return std::make_unique<CubebSink>(); }},
+    {"cubeb", &std::make_unique<CubebSink>},
 #endif
 #ifdef HAVE_SDL2
-    {"sdl2", []() { return std::make_unique<SDL2Sink>(); }},
+    {"sdl2", &std::make_unique<SDL2Sink>},
 #endif
-    {"null", []() { return std::make_unique<NullSink>(); }},
+    {"null", &std::make_unique<NullSink>},
 };
 
 const SinkDetails& GetSinkDetails(std::string sink_id) {

--- a/src/audio_core/sink_details.cpp
+++ b/src/audio_core/sink_details.cpp
@@ -21,12 +21,13 @@ namespace AudioCore {
 // g_sink_details is ordered in terms of desirability, with the best choice at the top.
 const std::vector<SinkDetails> g_sink_details = {
 #ifdef HAVE_CUBEB
-    {"cubeb", &std::make_unique<CubebSink>},
+    SinkDetails{"cubeb", &std::make_unique<CubebSink, std::string>, &ListCubebSinkDevices},
 #endif
 #ifdef HAVE_SDL2
-    {"sdl2", &std::make_unique<SDL2Sink>},
+    SinkDetails{"sdl2", &std::make_unique<SDL2Sink, std::string>, &ListSDL2SinkDevices},
 #endif
-    {"null", &std::make_unique<NullSink>},
+    SinkDetails{"null", &std::make_unique<NullSink, std::string>,
+                [] { return std::vector<std::string>{"null"}; }},
 };
 
 const SinkDetails& GetSinkDetails(std::string sink_id) {

--- a/src/audio_core/sink_details.h
+++ b/src/audio_core/sink_details.h
@@ -13,13 +13,16 @@ namespace AudioCore {
 class Sink;
 
 struct SinkDetails {
-    SinkDetails(const char* id_, std::function<std::unique_ptr<Sink>()> factory_)
-        : id(id_), factory(factory_) {}
+    SinkDetails(const char* id_, std::function<std::unique_ptr<Sink>(std::string)> factory_,
+                std::function<std::vector<std::string>()> list_devices_)
+        : id(id_), factory(factory_), list_devices(list_devices_) {}
 
     /// Name for this sink.
     const char* id;
     /// A method to call to construct an instance of this type of sink.
-    std::function<std::unique_ptr<Sink>()> factory;
+    std::function<std::unique_ptr<Sink>(std::string device_id)> factory;
+    /// A method to call to list available devices.
+    std::function<std::vector<std::string>()> list_devices;
 };
 
 extern const std::vector<SinkDetails> g_sink_details;

--- a/src/citra_qt/configuration/configure_audio.cpp
+++ b/src/citra_qt/configuration/configure_audio.cpp
@@ -69,8 +69,7 @@ void ConfigureAudio::updateAudioDevices(int sink_index) {
     ui->audio_device_combo_box->addItem("auto");
 
     std::string sink_id = ui->output_sink_combo_box->itemText(sink_index).toStdString();
-    std::vector<std::string> device_list =
-        AudioCore::GetSinkDetails(sink_id).factory()->GetDeviceList();
+    std::vector<std::string> device_list = AudioCore::GetSinkDetails(sink_id).list_devices();
     for (const auto& device : device_list) {
         ui->audio_device_combo_box->addItem(device.c_str());
     }

--- a/src/citra_qt/configuration/configure_audio.cpp
+++ b/src/citra_qt/configuration/configure_audio.cpp
@@ -66,7 +66,7 @@ void ConfigureAudio::applyConfiguration() {
 
 void ConfigureAudio::updateAudioDevices(int sink_index) {
     ui->audio_device_combo_box->clear();
-    ui->audio_device_combo_box->addItem("auto");
+    ui->audio_device_combo_box->addItem(AudioCore::auto_device_name);
 
     std::string sink_id = ui->output_sink_combo_box->itemText(sink_index).toStdString();
     std::vector<std::string> device_list = AudioCore::GetSinkDetails(sink_id).list_devices();

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -166,7 +166,7 @@ System::ResultStatus System::Init(EmuWindow* emu_window, u32 system_mode) {
     }
 
     dsp_core = std::make_unique<AudioCore::DspHle>();
-    dsp_core->SetSink(Settings::values.sink_id);
+    dsp_core->SetSink(Settings::values.sink_id, Settings::values.audio_device_id);
     dsp_core->EnableStretching(Settings::values.enable_audio_stretching);
 
     telemetry_session = std::make_unique<Core::TelemetrySession>();

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -32,7 +32,7 @@ void Apply() {
     }
 
     if (Core::System::GetInstance().IsPoweredOn()) {
-        Core::DSP().SetSink(values.sink_id);
+        Core::DSP().SetSink(values.sink_id, values.audio_device_id);
         Core::DSP().EnableStretching(values.enable_audio_stretching);
     }
 


### PR DESCRIPTION
1. Remove dead code.
1. We shouldn't have to construct a sink to get a device list.
1. Remove all references to `Settings`.

We also fix changing audio device at runtime.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3909)
<!-- Reviewable:end -->
