### PR TITLE
citra-qt: optimize settings application

### DIFF
--- a/src/citra_qt/configuration/configure_audio.cpp
+++ b/src/citra_qt/configuration/configure_audio.cpp
@@ -61,7 +61,6 @@ void ConfigureAudio::applyConfiguration() {
     Settings::values.audio_device_id =
         ui->audio_device_combo_box->itemText(ui->audio_device_combo_box->currentIndex())
             .toStdString();
-    Settings::Apply();
 }
 
 void ConfigureAudio::updateAudioDevices(int sink_index) {

--- a/src/citra_qt/configuration/configure_camera.cpp
+++ b/src/citra_qt/configuration/configure_camera.cpp
@@ -285,7 +285,6 @@ void ConfigureCamera::applyConfiguration() {
     Settings::values.camera_name = camera_name;
     Settings::values.camera_config = camera_config;
     Settings::values.camera_flip = camera_flip;
-    Settings::Apply();
 }
 
 ConfigureCamera::CameraPosition ConfigureCamera::getCameraSelection() {

--- a/src/citra_qt/configuration/configure_debug.cpp
+++ b/src/citra_qt/configuration/configure_debug.cpp
@@ -44,7 +44,6 @@ void ConfigureDebug::applyConfiguration() {
     Log::Filter filter;
     filter.ParseFilterString(Settings::values.log_filter);
     Log::SetGlobalFilter(filter);
-    Settings::Apply();
 }
 
 void ConfigureDebug::retranslateUi() {

--- a/src/citra_qt/configuration/configure_general.cpp
+++ b/src/citra_qt/configuration/configure_general.cpp
@@ -68,7 +68,6 @@ void ConfigureGeneral::applyConfiguration() {
 
     Settings::values.region_value = ui->region_combobox->currentIndex() - 1;
     Settings::values.use_cpu_jit = ui->toggle_cpu_jit->isChecked();
-    Settings::Apply();
 }
 
 void ConfigureGeneral::onLanguageChanged(int index) {

--- a/src/citra_qt/configuration/configure_graphics.cpp
+++ b/src/citra_qt/configuration/configure_graphics.cpp
@@ -62,7 +62,6 @@ void ConfigureGraphics::applyConfiguration() {
     Settings::values.layout_option =
         static_cast<Settings::LayoutOption>(ui->layout_combobox->currentIndex());
     Settings::values.swap_screen = ui->swap_screen->isChecked();
-    Settings::Apply();
 }
 
 void ConfigureGraphics::retranslateUi() {

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -186,8 +186,6 @@ void ConfigureInput::applyConfiguration() {
                    [](const Common::ParamPackage& param) { return param.Serialize(); });
     std::transform(analogs_param.begin(), analogs_param.end(), Settings::values.analogs.begin(),
                    [](const Common::ParamPackage& param) { return param.Serialize(); });
-
-    Settings::Apply();
 }
 
 void ConfigureInput::loadConfiguration() {

--- a/src/citra_qt/configuration/configure_web.cpp
+++ b/src/citra_qt/configuration/configure_web.cpp
@@ -61,7 +61,6 @@ void ConfigureWeb::applyConfiguration() {
                              tr("Username and token were not verified. The changes to your "
                                 "username and/or token have not been saved."));
     }
-    Settings::Apply();
 }
 
 void ConfigureWeb::RefreshTelemetryID() {

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -1154,10 +1154,12 @@ void GMainWindow::OnConfigure() {
     ConfigureDialog configureDialog(this);
     connect(&configureDialog, &ConfigureDialog::languageChanged, this,
             &GMainWindow::OnLanguageChanged);
+    auto old_theme = UISettings::values.theme;
     auto result = configureDialog.exec();
     if (result == QDialog::Accepted) {
         configureDialog.applyConfiguration();
-        UpdateUITheme();
+        if (UISettings::values.theme != old_theme)
+            UpdateUITheme();
         emit UpdateThemedIcons();
         SyncMenuUISettings();
         config->Save();


### PR DESCRIPTION
In an attempt to relieve issue #3049, I profiled the time between closing the configuration dialog and the end of `GMainWindow::OnConfigure`. I unfortunately could not recreate the freeze on command, but I noticed that, even while a game was running, a large percentage of CPU time was spent applying the theme, regardless of whether the theme was changed:
![image](https://user-images.githubusercontent.com/28246325/42188504-c372c28a-7e19-11e8-94dc-6b57feb14657.png)
With this change, the theme is only applied if changed.
I also removed redundant calls to `Settings::Apply` as it only needs to be called once for the entire configuration dialog.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3911)
<!-- Reviewable:end -->
