### PR TITLE
fix conversion warnings

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -931,6 +931,7 @@ void GMainWindow::OnMenuInstallCIA() {
 
     ui.action_Install_CIA->setEnabled(false);
     progress_bar->show();
+    progress_bar->setMaximum(INT_MAX);
 
     QtConcurrent::run([&, filepaths] {
         QString current_path;
@@ -948,8 +949,8 @@ void GMainWindow::OnMenuInstallCIA() {
 }
 
 void GMainWindow::OnUpdateProgress(size_t written, size_t total) {
-    progress_bar->setMaximum(total);
-    progress_bar->setValue(written);
+    progress_bar->setValue(
+        static_cast<int>(INT_MAX * (static_cast<double>(written) / static_cast<double>(total))));
 }
 
 void GMainWindow::OnCIAInstallReport(Service::AM::InstallStatus status, QString filepath) {


### PR DESCRIPTION
fixes two instances of:
`Warning	C4267	'argument': conversion from 'size_t' to 'int', possible loss of data`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3912)
<!-- Reviewable:end -->
