### PR TITLE
citra_qt: Remove obsolete application attribute

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -1446,7 +1446,6 @@ int main(int argc, char* argv[]) {
     QCoreApplication::setOrganizationName("Citra team");
     QCoreApplication::setApplicationName("Citra");
 
-    QApplication::setAttribute(Qt::AA_X11InitThreads);
     QApplication app(argc, argv);
 
     // Qt changes the locale and causes issues in float conversion using std::to_string() when


### PR DESCRIPTION
As of Qt 5 Qt::AA_X11InitThreads no longer does anything.

See http://doc.qt.io/qt-5/qt.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3913)
<!-- Reviewable:end -->
