### PR TITLE
gl_rasterizer: implement mipmap for procedural texture

### DIFF
--- a/src/video_core/regs_texturing.h
+++ b/src/video_core/regs_texturing.h
@@ -251,11 +251,18 @@ struct TexturingRegs {
 
     union {
         BitField<0, 3, ProcTexFilter> filter;
+        BitField<3, 4, u32> lod_min;
+        BitField<7, 4, u32> lod_max;
         BitField<11, 8, u32> width;
         BitField<19, 8, u32> bias_high; // TODO: unimplemented
     } proctex_lut;
 
-    BitField<0, 8, u32> proctex_lut_offset;
+    union {
+        BitField<0, 8, u32> level0;
+        BitField<8, 8, u32> level1;
+        BitField<16, 8, u32> level2;
+        BitField<24, 8, u32> level3;
+    } proctex_lut_offset;
 
     INSERT_PADDING_WORDS(0x1);
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -186,6 +186,7 @@ void RasterizerOpenGL::SyncEntireState() {
 
     SyncFogColor();
     SyncProcTexNoise();
+    SyncProcTexBias();
     SyncShadowBias();
 }
 
@@ -894,6 +895,7 @@ void RasterizerOpenGL::NotifyPicaRegisterChanged(u32 id) {
     case PICA_REG_INDEX(texturing.proctex):
     case PICA_REG_INDEX(texturing.proctex_lut):
     case PICA_REG_INDEX(texturing.proctex_lut_offset):
+        SyncProcTexBias();
         shader_dirty = true;
         break;
 
@@ -1677,6 +1679,15 @@ void RasterizerOpenGL::SyncProcTexNoise() {
         Pica::float16::FromRaw(regs.proctex_noise_u.phase).ToFloat32(),
         Pica::float16::FromRaw(regs.proctex_noise_v.phase).ToFloat32(),
     };
+
+    uniform_block_data.dirty = true;
+}
+
+void RasterizerOpenGL::SyncProcTexBias() {
+    const auto& regs = Pica::g_state.regs.texturing;
+    uniform_block_data.data.proctex_bias =
+        Pica::float16::FromRaw(regs.proctex.bias_low | (regs.proctex_lut.bias_high << 8))
+            .ToFloat32();
 
     uniform_block_data.dirty = true;
 }

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -152,6 +152,9 @@ private:
     /// Sync the procedural texture noise configuration to match the PICA register
     void SyncProcTexNoise();
 
+    /// Sync the procedural texture bias configuration to match the PICA register
+    void SyncProcTexBias();
+
     /// Syncs the alpha test states to match the PICA register
     void SyncAlphaTest();
 

--- a/src/video_core/renderer_opengl/gl_shader_gen.h
+++ b/src/video_core/renderer_opengl/gl_shader_gen.h
@@ -107,7 +107,12 @@ struct PicaFSConfigState {
         bool noise_enable;
         Pica::TexturingRegs::ProcTexShift u_shift, v_shift;
         u32 lut_width;
-        u32 lut_offset;
+        u32 lut_offset0;
+        u32 lut_offset1;
+        u32 lut_offset2;
+        u32 lut_offset3;
+        u32 lod_min;
+        u32 lod_max;
         Pica::TexturingRegs::ProcTexFilter lut_filter;
     } proctex;
 

--- a/src/video_core/renderer_opengl/gl_shader_manager.h
+++ b/src/video_core/renderer_opengl/gl_shader_manager.h
@@ -45,6 +45,7 @@ struct UniformData {
     GLint proctex_alpha_map_offset;
     GLint proctex_lut_offset;
     GLint proctex_diff_lut_offset;
+    GLfloat proctex_bias;
     alignas(16) GLivec4 lighting_lut_offset[Pica::LightingRegs::NumLightingSampler / 4];
     alignas(16) GLvec3 fog_color;
     alignas(8) GLvec2 proctex_noise_f;
@@ -58,7 +59,7 @@ struct UniformData {
 };
 
 static_assert(
-    sizeof(UniformData) == 0x4e0,
+    sizeof(UniformData) == 0x4F0,
     "The size of the UniformData structure has changed, update the structure in the shader");
 static_assert(sizeof(UniformData) < 16384,
               "UniformData structure must be less than 16kb as per the OpenGL spec");

--- a/src/video_core/swrasterizer/proctex.cpp
+++ b/src/video_core/swrasterizer/proctex.cpp
@@ -185,7 +185,7 @@ Math::Vec4<u8> ProcTex(float u, float v, TexturingRegs regs, State::ProcTex stat
 
     // Look up the color
     // For the color lut, coord=0.0 is lut[offset] and coord=1.0 is lut[offset+width-1]
-    const u32 offset = regs.proctex_lut_offset;
+    const u32 offset = regs.proctex_lut_offset.level0;
     const u32 width = regs.proctex_lut.width;
     const float index = offset + (lut_coord * (width - 1));
     Math::Vec4<u8> final_color;


### PR DESCRIPTION
Parallel to #3910, this is the special mipmap mechanism for procedural texture. The mipmap look up happens at the last step of proctex: sampling the color map LUT. The color map works like a 1D texture with mipmap. Games uploads all mipmap levels to the LUT buffer and specifies the offsets for each level. However the last four offsets seem to be hardcoded, and the first four are also always 0, 0x80, 0xC0, and 0xE0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3916)
<!-- Reviewable:end -->
