### PR TITLE
Fix clang-format CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,8 @@ matrix:
       addons:
         apt:
           sources:
-            - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-6.0 main'
-              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
-            - sourceline: 'deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu trusty main'
+            - llvm-toolchain-trusty-6.0
+            - ubuntu-toolchain-r-test
           packages:
             - clang-format-6.0
       script: "./.travis/clang-format/script.sh"


### PR DESCRIPTION
I don't know why this fixed it.
It seems that the gpg key is only added in this way.
Anyway, it is simpler and fixes the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3923)
<!-- Reviewable:end -->
