### PR TITLE
citra_qt: Settings (configuration) default value fix

### DIFF
--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -45,8 +45,7 @@ void Config::ReadValues() {
     for (int i = 0; i < Settings::NativeButton::NumButtons; ++i) {
         std::string default_param = InputCommon::GenerateKeyboardParam(default_buttons[i]);
         Settings::values.buttons[i] =
-            qt_config
-                ->value(Settings::NativeButton::mapping[i], QString::fromStdString(default_param))
+            ReadSetting(Settings::NativeButton::mapping[i], QString::fromStdString(default_param))
                 .toString()
                 .toStdString();
         if (Settings::values.buttons[i].empty())
@@ -58,8 +57,7 @@ void Config::ReadValues() {
             default_analogs[i][0], default_analogs[i][1], default_analogs[i][2],
             default_analogs[i][3], default_analogs[i][4], 0.5f);
         Settings::values.analogs[i] =
-            qt_config
-                ->value(Settings::NativeAnalog::mapping[i], QString::fromStdString(default_param))
+            ReadSetting(Settings::NativeAnalog::mapping[i], QString::fromStdString(default_param))
                 .toString()
                 .toStdString();
         if (Settings::values.analogs[i].empty())
@@ -67,166 +65,161 @@ void Config::ReadValues() {
     }
 
     Settings::values.motion_device =
-        qt_config
-            ->value("motion_device",
+        ReadSetting("motion_device",
                     "engine:motion_emu,update_period:100,sensitivity:0.01,tilt_clamp:90.0")
             .toString()
             .toStdString();
     Settings::values.touch_device =
-        qt_config->value("touch_device", "engine:emu_window").toString().toStdString();
+        ReadSetting("touch_device", "engine:emu_window").toString().toStdString();
 
     qt_config->endGroup();
 
     qt_config->beginGroup("Core");
-    Settings::values.use_cpu_jit = qt_config->value("use_cpu_jit", true).toBool();
+    Settings::values.use_cpu_jit = ReadSetting("use_cpu_jit", true).toBool();
     qt_config->endGroup();
 
     qt_config->beginGroup("Renderer");
-    Settings::values.use_hw_renderer = qt_config->value("use_hw_renderer", true).toBool();
+    Settings::values.use_hw_renderer = ReadSetting("use_hw_renderer", true).toBool();
 #ifdef __APPLE__
     // Hardware shader is broken on macos thanks to poor drivers.
     // We still want to provide this option for test/development purposes, but disable it by
     // default.
-    Settings::values.use_hw_shader = qt_config->value("use_hw_shader", false).toBool();
+    Settings::values.use_hw_shader = ReadSetting("use_hw_shader", false).toBool();
 #else
-    Settings::values.use_hw_shader = qt_config->value("use_hw_shader", true).toBool();
+    Settings::values.use_hw_shader = ReadSetting("use_hw_shader", true).toBool();
 #endif
-    Settings::values.shaders_accurate_gs = qt_config->value("shaders_accurate_gs", true).toBool();
-    Settings::values.shaders_accurate_mul =
-        qt_config->value("shaders_accurate_mul", false).toBool();
-    Settings::values.use_shader_jit = qt_config->value("use_shader_jit", true).toBool();
+    Settings::values.shaders_accurate_gs = ReadSetting("shaders_accurate_gs", true).toBool();
+    Settings::values.shaders_accurate_mul = ReadSetting("shaders_accurate_mul", false).toBool();
+    Settings::values.use_shader_jit = ReadSetting("use_shader_jit", true).toBool();
     Settings::values.resolution_factor =
-        static_cast<u16>(qt_config->value("resolution_factor", 1).toInt());
-    Settings::values.use_vsync = qt_config->value("use_vsync", false).toBool();
-    Settings::values.use_frame_limit = qt_config->value("use_frame_limit", true).toBool();
-    Settings::values.frame_limit = qt_config->value("frame_limit", 100).toInt();
+        static_cast<u16>(ReadSetting("resolution_factor", 1).toInt());
+    Settings::values.use_vsync = ReadSetting("use_vsync", false).toBool();
+    Settings::values.use_frame_limit = ReadSetting("use_frame_limit", true).toBool();
+    Settings::values.frame_limit = ReadSetting("frame_limit", 100).toInt();
 
-    Settings::values.bg_red = qt_config->value("bg_red", 0.0).toFloat();
-    Settings::values.bg_green = qt_config->value("bg_green", 0.0).toFloat();
-    Settings::values.bg_blue = qt_config->value("bg_blue", 0.0).toFloat();
+    Settings::values.bg_red = ReadSetting("bg_red", 0.0).toFloat();
+    Settings::values.bg_green = ReadSetting("bg_green", 0.0).toFloat();
+    Settings::values.bg_blue = ReadSetting("bg_blue", 0.0).toFloat();
     qt_config->endGroup();
 
     qt_config->beginGroup("Layout");
-    Settings::values.toggle_3d = qt_config->value("toggle_3d", false).toBool();
-    Settings::values.factor_3d = qt_config->value("factor_3d", 0).toInt();
+    Settings::values.toggle_3d = ReadSetting("toggle_3d", false).toBool();
+    Settings::values.factor_3d = ReadSetting("factor_3d", 0).toInt();
     Settings::values.layout_option =
-        static_cast<Settings::LayoutOption>(qt_config->value("layout_option").toInt());
-    Settings::values.swap_screen = qt_config->value("swap_screen", false).toBool();
-    Settings::values.custom_layout = qt_config->value("custom_layout", false).toBool();
-    Settings::values.custom_top_left = qt_config->value("custom_top_left", 0).toInt();
-    Settings::values.custom_top_top = qt_config->value("custom_top_top", 0).toInt();
-    Settings::values.custom_top_right = qt_config->value("custom_top_right", 400).toInt();
-    Settings::values.custom_top_bottom = qt_config->value("custom_top_bottom", 240).toInt();
-    Settings::values.custom_bottom_left = qt_config->value("custom_bottom_left", 40).toInt();
-    Settings::values.custom_bottom_top = qt_config->value("custom_bottom_top", 240).toInt();
-    Settings::values.custom_bottom_right = qt_config->value("custom_bottom_right", 360).toInt();
-    Settings::values.custom_bottom_bottom = qt_config->value("custom_bottom_bottom", 480).toInt();
+        static_cast<Settings::LayoutOption>(ReadSetting("layout_option").toInt());
+    Settings::values.swap_screen = ReadSetting("swap_screen", false).toBool();
+    Settings::values.custom_layout = ReadSetting("custom_layout", false).toBool();
+    Settings::values.custom_top_left = ReadSetting("custom_top_left", 0).toInt();
+    Settings::values.custom_top_top = ReadSetting("custom_top_top", 0).toInt();
+    Settings::values.custom_top_right = ReadSetting("custom_top_right", 400).toInt();
+    Settings::values.custom_top_bottom = ReadSetting("custom_top_bottom", 240).toInt();
+    Settings::values.custom_bottom_left = ReadSetting("custom_bottom_left", 40).toInt();
+    Settings::values.custom_bottom_top = ReadSetting("custom_bottom_top", 240).toInt();
+    Settings::values.custom_bottom_right = ReadSetting("custom_bottom_right", 360).toInt();
+    Settings::values.custom_bottom_bottom = ReadSetting("custom_bottom_bottom", 480).toInt();
     qt_config->endGroup();
 
     qt_config->beginGroup("Audio");
-    Settings::values.sink_id = qt_config->value("output_engine", "auto").toString().toStdString();
+    Settings::values.sink_id = ReadSetting("output_engine", "auto").toString().toStdString();
     Settings::values.enable_audio_stretching =
-        qt_config->value("enable_audio_stretching", true).toBool();
+        ReadSetting("enable_audio_stretching", true).toBool();
     Settings::values.audio_device_id =
-        qt_config->value("output_device", "auto").toString().toStdString();
-    Settings::values.volume = qt_config->value("volume", 1).toFloat();
+        ReadSetting("output_device", "auto").toString().toStdString();
+    Settings::values.volume = ReadSetting("volume", 1).toFloat();
     qt_config->endGroup();
 
     using namespace Service::CAM;
     qt_config->beginGroup("Camera");
     Settings::values.camera_name[OuterRightCamera] =
-        qt_config->value("camera_outer_right_name", "blank").toString().toStdString();
+        ReadSetting("camera_outer_right_name", "blank").toString().toStdString();
     Settings::values.camera_config[OuterRightCamera] =
-        qt_config->value("camera_outer_right_config", "").toString().toStdString();
+        ReadSetting("camera_outer_right_config", "").toString().toStdString();
     Settings::values.camera_flip[OuterRightCamera] =
-        qt_config->value("camera_outer_right_flip", "0").toInt();
+        ReadSetting("camera_outer_right_flip", "0").toInt();
     Settings::values.camera_name[InnerCamera] =
-        qt_config->value("camera_inner_name", "blank").toString().toStdString();
+        ReadSetting("camera_inner_name", "blank").toString().toStdString();
     Settings::values.camera_config[InnerCamera] =
-        qt_config->value("camera_inner_config", "").toString().toStdString();
-    Settings::values.camera_flip[InnerCamera] = qt_config->value("camera_inner_flip", "").toInt();
+        ReadSetting("camera_inner_config", "").toString().toStdString();
+    Settings::values.camera_flip[InnerCamera] = ReadSetting("camera_inner_flip", "").toInt();
     Settings::values.camera_name[OuterLeftCamera] =
-        qt_config->value("camera_outer_left_name", "blank").toString().toStdString();
+        ReadSetting("camera_outer_left_name", "blank").toString().toStdString();
     Settings::values.camera_config[OuterLeftCamera] =
-        qt_config->value("camera_outer_left_config", "").toString().toStdString();
+        ReadSetting("camera_outer_left_config", "").toString().toStdString();
     Settings::values.camera_flip[OuterLeftCamera] =
-        qt_config->value("camera_outer_left_flip", "").toInt();
+        ReadSetting("camera_outer_left_flip", "").toInt();
     qt_config->endGroup();
 
     qt_config->beginGroup("Data Storage");
-    Settings::values.use_virtual_sd = qt_config->value("use_virtual_sd", true).toBool();
+    Settings::values.use_virtual_sd = ReadSetting("use_virtual_sd", true).toBool();
     qt_config->endGroup();
 
     qt_config->beginGroup("System");
-    Settings::values.is_new_3ds = qt_config->value("is_new_3ds", false).toBool();
+    Settings::values.is_new_3ds = ReadSetting("is_new_3ds", false).toBool();
     Settings::values.region_value =
-        qt_config->value("region_value", Settings::REGION_VALUE_AUTO_SELECT).toInt();
+        ReadSetting("region_value", Settings::REGION_VALUE_AUTO_SELECT).toInt();
     qt_config->endGroup();
 
     qt_config->beginGroup("Miscellaneous");
-    Settings::values.log_filter = qt_config->value("log_filter", "*:Info").toString().toStdString();
+    Settings::values.log_filter = ReadSetting("log_filter", "*:Info").toString().toStdString();
     qt_config->endGroup();
 
     qt_config->beginGroup("Debugging");
-    Settings::values.use_gdbstub = qt_config->value("use_gdbstub", false).toBool();
-    Settings::values.gdbstub_port = qt_config->value("gdbstub_port", 24689).toInt();
+    Settings::values.use_gdbstub = ReadSetting("use_gdbstub", false).toBool();
+    Settings::values.gdbstub_port = ReadSetting("gdbstub_port", 24689).toInt();
     qt_config->endGroup();
 
     qt_config->beginGroup("WebService");
-    Settings::values.enable_telemetry = qt_config->value("enable_telemetry", true).toBool();
+    Settings::values.enable_telemetry = ReadSetting("enable_telemetry", true).toBool();
     Settings::values.telemetry_endpoint_url =
-        qt_config->value("telemetry_endpoint_url", "https://services.citra-emu.org/api/telemetry")
+        ReadSetting("telemetry_endpoint_url", "https://services.citra-emu.org/api/telemetry")
             .toString()
             .toStdString();
     Settings::values.verify_endpoint_url =
-        qt_config->value("verify_endpoint_url", "https://services.citra-emu.org/api/profile")
+        ReadSetting("verify_endpoint_url", "https://services.citra-emu.org/api/profile")
             .toString()
             .toStdString();
     Settings::values.announce_multiplayer_room_endpoint_url =
-        qt_config
-            ->value("announce_multiplayer_room_endpoint_url",
+        ReadSetting("announce_multiplayer_room_endpoint_url",
                     "https://services.citra-emu.org/api/multiplayer/rooms")
             .toString()
             .toStdString();
-    Settings::values.citra_username = qt_config->value("citra_username").toString().toStdString();
-    Settings::values.citra_token = qt_config->value("citra_token").toString().toStdString();
+    Settings::values.citra_username = ReadSetting("citra_username").toString().toStdString();
+    Settings::values.citra_token = ReadSetting("citra_token").toString().toStdString();
     qt_config->endGroup();
 
     qt_config->beginGroup("UI");
-    UISettings::values.theme = qt_config->value("theme", UISettings::themes[0].second).toString();
+    UISettings::values.theme = ReadSetting("theme", UISettings::themes[0].second).toString();
 
     qt_config->beginGroup("Updater");
     UISettings::values.check_for_update_on_start =
-        qt_config->value("check_for_update_on_start", true).toBool();
-    UISettings::values.update_on_close = qt_config->value("update_on_close", false).toBool();
+        ReadSetting("check_for_update_on_start", true).toBool();
+    UISettings::values.update_on_close = ReadSetting("update_on_close", false).toBool();
     qt_config->endGroup();
 
     qt_config->beginGroup("UILayout");
-    UISettings::values.geometry = qt_config->value("geometry").toByteArray();
-    UISettings::values.state = qt_config->value("state").toByteArray();
-    UISettings::values.renderwindow_geometry =
-        qt_config->value("geometryRenderWindow").toByteArray();
-    UISettings::values.gamelist_header_state =
-        qt_config->value("gameListHeaderState").toByteArray();
+    UISettings::values.geometry = ReadSetting("geometry").toByteArray();
+    UISettings::values.state = ReadSetting("state").toByteArray();
+    UISettings::values.renderwindow_geometry = ReadSetting("geometryRenderWindow").toByteArray();
+    UISettings::values.gamelist_header_state = ReadSetting("gameListHeaderState").toByteArray();
     UISettings::values.microprofile_geometry =
-        qt_config->value("microProfileDialogGeometry").toByteArray();
+        ReadSetting("microProfileDialogGeometry").toByteArray();
     UISettings::values.microprofile_visible =
-        qt_config->value("microProfileDialogVisible", false).toBool();
+        ReadSetting("microProfileDialogVisible", false).toBool();
     qt_config->endGroup();
 
     qt_config->beginGroup("Paths");
-    UISettings::values.roms_path = qt_config->value("romsPath").toString();
-    UISettings::values.symbols_path = qt_config->value("symbolsPath").toString();
-    UISettings::values.game_dir_deprecated = qt_config->value("gameListRootDir", ".").toString();
+    UISettings::values.roms_path = ReadSetting("romsPath").toString();
+    UISettings::values.symbols_path = ReadSetting("symbolsPath").toString();
+    UISettings::values.game_dir_deprecated = ReadSetting("gameListRootDir", ".").toString();
     UISettings::values.game_dir_deprecated_deepscan =
-        qt_config->value("gameListDeepScan", false).toBool();
+        ReadSetting("gameListDeepScan", false).toBool();
     int size = qt_config->beginReadArray("gamedirs");
     for (int i = 0; i < size; ++i) {
         qt_config->setArrayIndex(i);
         UISettings::GameDir game_dir;
-        game_dir.path = qt_config->value("path").toString();
-        game_dir.deep_scan = qt_config->value("deep_scan", false).toBool();
-        game_dir.expanded = qt_config->value("expanded", true).toBool();
+        game_dir.path = ReadSetting("path").toString();
+        game_dir.deep_scan = ReadSetting("deep_scan", false).toBool();
+        game_dir.expanded = ReadSetting("expanded", true).toBool();
         UISettings::values.game_dirs.append(game_dir);
     }
     qt_config->endArray();
@@ -245,8 +238,8 @@ void Config::ReadValues() {
             UISettings::values.game_dirs.append(game_dir);
         }
     }
-    UISettings::values.recent_files = qt_config->value("recentFiles").toStringList();
-    UISettings::values.language = qt_config->value("language", "").toString();
+    UISettings::values.recent_files = ReadSetting("recentFiles").toStringList();
+    UISettings::values.language = ReadSetting("language", "").toString();
     qt_config->endGroup();
 
     qt_config->beginGroup("Shortcuts");
@@ -259,8 +252,8 @@ void Config::ReadValues() {
             qt_config->beginGroup(hotkey);
             UISettings::values.shortcuts.emplace_back(UISettings::Shortcut(
                 group + "/" + hotkey,
-                UISettings::ContextualShortcut(qt_config->value("KeySeq").toString(),
-                                               qt_config->value("Context").toInt())));
+                UISettings::ContextualShortcut(ReadSetting("KeySeq").toString(),
+                                               ReadSetting("Context").toInt())));
             qt_config->endGroup();
         }
 
@@ -268,30 +261,30 @@ void Config::ReadValues() {
     }
     qt_config->endGroup();
 
-    UISettings::values.single_window_mode = qt_config->value("singleWindowMode", true).toBool();
-    UISettings::values.fullscreen = qt_config->value("fullscreen", false).toBool();
-    UISettings::values.display_titlebar = qt_config->value("displayTitleBars", true).toBool();
-    UISettings::values.show_filter_bar = qt_config->value("showFilterBar", true).toBool();
-    UISettings::values.show_status_bar = qt_config->value("showStatusBar", true).toBool();
-    UISettings::values.confirm_before_closing = qt_config->value("confirmClose", true).toBool();
-    UISettings::values.first_start = qt_config->value("firstStart", true).toBool();
-    UISettings::values.callout_flags = qt_config->value("calloutFlags", 0).toUInt();
-    UISettings::values.show_console = qt_config->value("showConsole", false).toBool();
+    UISettings::values.single_window_mode = ReadSetting("singleWindowMode", true).toBool();
+    UISettings::values.fullscreen = ReadSetting("fullscreen", false).toBool();
+    UISettings::values.display_titlebar = ReadSetting("displayTitleBars", true).toBool();
+    UISettings::values.show_filter_bar = ReadSetting("showFilterBar", true).toBool();
+    UISettings::values.show_status_bar = ReadSetting("showStatusBar", true).toBool();
+    UISettings::values.confirm_before_closing = ReadSetting("confirmClose", true).toBool();
+    UISettings::values.first_start = ReadSetting("firstStart", true).toBool();
+    UISettings::values.callout_flags = ReadSetting("calloutFlags", 0).toUInt();
+    UISettings::values.show_console = ReadSetting("showConsole", false).toBool();
 
     qt_config->beginGroup("Multiplayer");
-    UISettings::values.nickname = qt_config->value("nickname", "").toString();
-    UISettings::values.ip = qt_config->value("ip", "").toString();
-    UISettings::values.port = qt_config->value("port", Network::DefaultRoomPort).toString();
-    UISettings::values.room_nickname = qt_config->value("room_nickname", "").toString();
-    UISettings::values.room_name = qt_config->value("room_name", "").toString();
-    UISettings::values.room_port = qt_config->value("room_port", "24872").toString();
+    UISettings::values.nickname = ReadSetting("nickname", "").toString();
+    UISettings::values.ip = ReadSetting("ip", "").toString();
+    UISettings::values.port = ReadSetting("port", Network::DefaultRoomPort).toString();
+    UISettings::values.room_nickname = ReadSetting("room_nickname", "").toString();
+    UISettings::values.room_name = ReadSetting("room_name", "").toString();
+    UISettings::values.room_port = ReadSetting("room_port", "24872").toString();
     bool ok;
-    UISettings::values.host_type = qt_config->value("host_type", 0).toUInt(&ok);
+    UISettings::values.host_type = ReadSetting("host_type", 0).toUInt(&ok);
     if (!ok) {
         UISettings::values.host_type = 0;
     }
-    UISettings::values.max_player = qt_config->value("max_player", 8).toUInt();
-    UISettings::values.game_id = qt_config->value("game_id", 0).toULongLong();
+    UISettings::values.max_player = ReadSetting("max_player", 8).toUInt();
+    UISettings::values.game_id = ReadSetting("game_id", 0).toULongLong();
     qt_config->endGroup();
 
     qt_config->endGroup();
@@ -300,178 +293,215 @@ void Config::ReadValues() {
 void Config::SaveValues() {
     qt_config->beginGroup("Controls");
     for (int i = 0; i < Settings::NativeButton::NumButtons; ++i) {
-        qt_config->setValue(QString::fromStdString(Settings::NativeButton::mapping[i]),
-                            QString::fromStdString(Settings::values.buttons[i]));
+        std::string default_param = InputCommon::GenerateKeyboardParam(default_buttons[i]);
+        WriteSetting(QString::fromStdString(Settings::NativeButton::mapping[i]),
+                     QString::fromStdString(Settings::values.buttons[i]),
+                     QString::fromStdString(default_param));
     }
     for (int i = 0; i < Settings::NativeAnalog::NumAnalogs; ++i) {
-        qt_config->setValue(QString::fromStdString(Settings::NativeAnalog::mapping[i]),
-                            QString::fromStdString(Settings::values.analogs[i]));
+        std::string default_param = InputCommon::GenerateAnalogParamFromKeys(
+            default_analogs[i][0], default_analogs[i][1], default_analogs[i][2],
+            default_analogs[i][3], default_analogs[i][4], 0.5f);
+        WriteSetting(QString::fromStdString(Settings::NativeAnalog::mapping[i]),
+                     QString::fromStdString(Settings::values.analogs[i]),
+                     QString::fromStdString(default_param));
     }
-    qt_config->setValue("motion_device", QString::fromStdString(Settings::values.motion_device));
-    qt_config->setValue("touch_device", QString::fromStdString(Settings::values.touch_device));
+    WriteSetting("motion_device", QString::fromStdString(Settings::values.motion_device),
+                 "engine:motion_emu,update_period:100,sensitivity:0.01,tilt_clamp:90.0");
+    WriteSetting("touch_device", QString::fromStdString(Settings::values.touch_device),
+                 "engine:emu_window");
     qt_config->endGroup();
 
     qt_config->beginGroup("Core");
-    qt_config->setValue("use_cpu_jit", Settings::values.use_cpu_jit);
+    WriteSetting("use_cpu_jit", Settings::values.use_cpu_jit, true);
     qt_config->endGroup();
 
     qt_config->beginGroup("Renderer");
-    qt_config->setValue("use_hw_renderer", Settings::values.use_hw_renderer);
-    qt_config->setValue("use_hw_shader", Settings::values.use_hw_shader);
-    qt_config->setValue("shaders_accurate_gs", Settings::values.shaders_accurate_gs);
-    qt_config->setValue("shaders_accurate_mul", Settings::values.shaders_accurate_mul);
-    qt_config->setValue("use_shader_jit", Settings::values.use_shader_jit);
-    qt_config->setValue("resolution_factor", Settings::values.resolution_factor);
-    qt_config->setValue("use_vsync", Settings::values.use_vsync);
-    qt_config->setValue("use_frame_limit", Settings::values.use_frame_limit);
-    qt_config->setValue("frame_limit", Settings::values.frame_limit);
+    WriteSetting("use_hw_renderer", Settings::values.use_hw_renderer, true);
+    WriteSetting("use_hw_shader", Settings::values.use_hw_shader, true);
+    WriteSetting("shaders_accurate_gs", Settings::values.shaders_accurate_gs, true);
+    WriteSetting("shaders_accurate_mul", Settings::values.shaders_accurate_mul, false);
+    WriteSetting("use_shader_jit", Settings::values.use_shader_jit, true);
+    WriteSetting("resolution_factor", Settings::values.resolution_factor, 1);
+    WriteSetting("use_vsync", Settings::values.use_vsync, false);
+    WriteSetting("use_frame_limit", Settings::values.use_frame_limit, true);
+    WriteSetting("frame_limit", Settings::values.frame_limit, 100);
 
     // Cast to double because Qt's written float values are not human-readable
-    qt_config->setValue("bg_red", (double)Settings::values.bg_red);
-    qt_config->setValue("bg_green", (double)Settings::values.bg_green);
-    qt_config->setValue("bg_blue", (double)Settings::values.bg_blue);
+    WriteSetting("bg_red", (double)Settings::values.bg_red, 0.0);
+    WriteSetting("bg_green", (double)Settings::values.bg_green, 0.0);
+    WriteSetting("bg_blue", (double)Settings::values.bg_blue, 0.0);
     qt_config->endGroup();
 
     qt_config->beginGroup("Layout");
-    qt_config->setValue("toggle_3d", Settings::values.toggle_3d);
-    qt_config->setValue("factor_3d", Settings::values.factor_3d);
-    qt_config->setValue("layout_option", static_cast<int>(Settings::values.layout_option));
-    qt_config->setValue("swap_screen", Settings::values.swap_screen);
-    qt_config->setValue("custom_layout", Settings::values.custom_layout);
-    qt_config->setValue("custom_top_left", Settings::values.custom_top_left);
-    qt_config->setValue("custom_top_top", Settings::values.custom_top_top);
-    qt_config->setValue("custom_top_right", Settings::values.custom_top_right);
-    qt_config->setValue("custom_top_bottom", Settings::values.custom_top_bottom);
-    qt_config->setValue("custom_bottom_left", Settings::values.custom_bottom_left);
-    qt_config->setValue("custom_bottom_top", Settings::values.custom_bottom_top);
-    qt_config->setValue("custom_bottom_right", Settings::values.custom_bottom_right);
-    qt_config->setValue("custom_bottom_bottom", Settings::values.custom_bottom_bottom);
+    WriteSetting("toggle_3d", Settings::values.toggle_3d, false);
+    WriteSetting("factor_3d", Settings::values.factor_3d, 0);
+    WriteSetting("layout_option", static_cast<int>(Settings::values.layout_option));
+    WriteSetting("swap_screen", Settings::values.swap_screen, false);
+    WriteSetting("custom_layout", Settings::values.custom_layout, false);
+    WriteSetting("custom_top_left", Settings::values.custom_top_left, 0);
+    WriteSetting("custom_top_top", Settings::values.custom_top_top, 0);
+    WriteSetting("custom_top_right", Settings::values.custom_top_right, 400);
+    WriteSetting("custom_top_bottom", Settings::values.custom_top_bottom, 240);
+    WriteSetting("custom_bottom_left", Settings::values.custom_bottom_left, 40);
+    WriteSetting("custom_bottom_top", Settings::values.custom_bottom_top, 240);
+    WriteSetting("custom_bottom_right", Settings::values.custom_bottom_right, 360);
+    WriteSetting("custom_bottom_bottom", Settings::values.custom_bottom_bottom, 480);
     qt_config->endGroup();
 
     qt_config->beginGroup("Audio");
-    qt_config->setValue("output_engine", QString::fromStdString(Settings::values.sink_id));
-    qt_config->setValue("enable_audio_stretching", Settings::values.enable_audio_stretching);
-    qt_config->setValue("output_device", QString::fromStdString(Settings::values.audio_device_id));
-    qt_config->setValue("volume", Settings::values.volume);
+    WriteSetting("output_engine", QString::fromStdString(Settings::values.sink_id), "auto");
+    WriteSetting("enable_audio_stretching", Settings::values.enable_audio_stretching, true);
+    WriteSetting("output_device", QString::fromStdString(Settings::values.audio_device_id), "auto");
+    WriteSetting("volume", Settings::values.volume, 1.0f);
     qt_config->endGroup();
 
     using namespace Service::CAM;
     qt_config->beginGroup("Camera");
-    qt_config->setValue("camera_outer_right_name",
-                        QString::fromStdString(Settings::values.camera_name[OuterRightCamera]));
-    qt_config->setValue("camera_outer_right_config",
-                        QString::fromStdString(Settings::values.camera_config[OuterRightCamera]));
-    qt_config->setValue("camera_outer_right_flip", Settings::values.camera_flip[OuterRightCamera]);
-    qt_config->setValue("camera_inner_name",
-                        QString::fromStdString(Settings::values.camera_name[InnerCamera]));
-    qt_config->setValue("camera_inner_config",
-                        QString::fromStdString(Settings::values.camera_config[InnerCamera]));
-    qt_config->setValue("camera_inner_flip", Settings::values.camera_flip[InnerCamera]);
-    qt_config->setValue("camera_outer_left_name",
-                        QString::fromStdString(Settings::values.camera_name[OuterLeftCamera]));
-    qt_config->setValue("camera_outer_left_config",
-                        QString::fromStdString(Settings::values.camera_config[OuterLeftCamera]));
-    qt_config->setValue("camera_outer_left_flip", Settings::values.camera_flip[OuterLeftCamera]);
+    WriteSetting("camera_outer_right_name",
+                 QString::fromStdString(Settings::values.camera_name[OuterRightCamera]), "blank");
+    WriteSetting("camera_outer_right_config",
+                 QString::fromStdString(Settings::values.camera_config[OuterRightCamera]), "");
+    WriteSetting("camera_outer_right_flip", Settings::values.camera_flip[OuterRightCamera], 0);
+    WriteSetting("camera_inner_name",
+                 QString::fromStdString(Settings::values.camera_name[InnerCamera]), "blank");
+    WriteSetting("camera_inner_config",
+                 QString::fromStdString(Settings::values.camera_config[InnerCamera]), "");
+    WriteSetting("camera_inner_flip", Settings::values.camera_flip[InnerCamera], 0);
+    WriteSetting("camera_outer_left_name",
+                 QString::fromStdString(Settings::values.camera_name[OuterLeftCamera]), "blank");
+    WriteSetting("camera_outer_left_config",
+                 QString::fromStdString(Settings::values.camera_config[OuterLeftCamera]), "");
+    WriteSetting("camera_outer_left_flip", Settings::values.camera_flip[OuterLeftCamera], 0);
     qt_config->endGroup();
 
     qt_config->beginGroup("Data Storage");
-    qt_config->setValue("use_virtual_sd", Settings::values.use_virtual_sd);
+    WriteSetting("use_virtual_sd", Settings::values.use_virtual_sd, true);
     qt_config->endGroup();
 
     qt_config->beginGroup("System");
-    qt_config->setValue("is_new_3ds", Settings::values.is_new_3ds);
-    qt_config->setValue("region_value", Settings::values.region_value);
+    WriteSetting("is_new_3ds", Settings::values.is_new_3ds, false);
+    WriteSetting("region_value", Settings::values.region_value, Settings::REGION_VALUE_AUTO_SELECT);
     qt_config->endGroup();
 
     qt_config->beginGroup("Miscellaneous");
-    qt_config->setValue("log_filter", QString::fromStdString(Settings::values.log_filter));
+    WriteSetting("log_filter", QString::fromStdString(Settings::values.log_filter), "*:Info");
     qt_config->endGroup();
 
     qt_config->beginGroup("Debugging");
-    qt_config->setValue("use_gdbstub", Settings::values.use_gdbstub);
-    qt_config->setValue("gdbstub_port", Settings::values.gdbstub_port);
+    WriteSetting("use_gdbstub", Settings::values.use_gdbstub, false);
+    WriteSetting("gdbstub_port", Settings::values.gdbstub_port, 24689);
     qt_config->endGroup();
 
     qt_config->beginGroup("WebService");
-    qt_config->setValue("enable_telemetry", Settings::values.enable_telemetry);
-    qt_config->setValue("telemetry_endpoint_url",
-                        QString::fromStdString(Settings::values.telemetry_endpoint_url));
-    qt_config->setValue("verify_endpoint_url",
-                        QString::fromStdString(Settings::values.verify_endpoint_url));
-    qt_config->setValue(
-        "announce_multiplayer_room_endpoint_url",
-        QString::fromStdString(Settings::values.announce_multiplayer_room_endpoint_url));
-    qt_config->setValue("citra_username", QString::fromStdString(Settings::values.citra_username));
-    qt_config->setValue("citra_token", QString::fromStdString(Settings::values.citra_token));
+    WriteSetting("enable_telemetry", Settings::values.enable_telemetry, true);
+    WriteSetting("telemetry_endpoint_url",
+                 QString::fromStdString(Settings::values.telemetry_endpoint_url),
+                 "https://services.citra-emu.org/api/telemetry");
+    WriteSetting("verify_endpoint_url",
+                 QString::fromStdString(Settings::values.verify_endpoint_url),
+                 "https://services.citra-emu.org/api/profile");
+    WriteSetting("announce_multiplayer_room_endpoint_url",
+                 QString::fromStdString(Settings::values.announce_multiplayer_room_endpoint_url),
+                 "https://services.citra-emu.org/"
+                 "api/multiplayer/rooms");
+    WriteSetting("citra_username", QString::fromStdString(Settings::values.citra_username));
+    WriteSetting("citra_token", QString::fromStdString(Settings::values.citra_token));
     qt_config->endGroup();
 
     qt_config->beginGroup("UI");
-    qt_config->setValue("theme", UISettings::values.theme);
+    WriteSetting("theme", UISettings::values.theme, UISettings::themes[0].second);
 
     qt_config->beginGroup("Updater");
-    qt_config->setValue("check_for_update_on_start", UISettings::values.check_for_update_on_start);
-    qt_config->setValue("update_on_close", UISettings::values.update_on_close);
+    WriteSetting("check_for_update_on_start", UISettings::values.check_for_update_on_start, true);
+    WriteSetting("update_on_close", UISettings::values.update_on_close, false);
     qt_config->endGroup();
 
     qt_config->beginGroup("UILayout");
-    qt_config->setValue("geometry", UISettings::values.geometry);
-    qt_config->setValue("state", UISettings::values.state);
-    qt_config->setValue("geometryRenderWindow", UISettings::values.renderwindow_geometry);
-    qt_config->setValue("gameListHeaderState", UISettings::values.gamelist_header_state);
-    qt_config->setValue("microProfileDialogGeometry", UISettings::values.microprofile_geometry);
-    qt_config->setValue("microProfileDialogVisible", UISettings::values.microprofile_visible);
+    WriteSetting("geometry", UISettings::values.geometry);
+    WriteSetting("state", UISettings::values.state);
+    WriteSetting("geometryRenderWindow", UISettings::values.renderwindow_geometry);
+    WriteSetting("gameListHeaderState", UISettings::values.gamelist_header_state);
+    WriteSetting("microProfileDialogGeometry", UISettings::values.microprofile_geometry);
+    WriteSetting("microProfileDialogVisible", UISettings::values.microprofile_visible, false);
     qt_config->endGroup();
 
     qt_config->beginGroup("Paths");
-    qt_config->setValue("romsPath", UISettings::values.roms_path);
-    qt_config->setValue("symbolsPath", UISettings::values.symbols_path);
+    WriteSetting("romsPath", UISettings::values.roms_path);
+    WriteSetting("symbolsPath", UISettings::values.symbols_path);
     qt_config->beginWriteArray("gamedirs");
     for (int i = 0; i < UISettings::values.game_dirs.size(); ++i) {
         qt_config->setArrayIndex(i);
         const auto& game_dir = UISettings::values.game_dirs.at(i);
-        qt_config->setValue("path", game_dir.path);
-        qt_config->setValue("deep_scan", game_dir.deep_scan);
-        qt_config->setValue("expanded", game_dir.expanded);
+        WriteSetting("path", game_dir.path);
+        WriteSetting("deep_scan", game_dir.deep_scan, false);
+        WriteSetting("expanded", game_dir.expanded, true);
     }
     qt_config->endArray();
-    qt_config->setValue("recentFiles", UISettings::values.recent_files);
-    qt_config->setValue("language", UISettings::values.language);
+    WriteSetting("recentFiles", UISettings::values.recent_files);
+    WriteSetting("language", UISettings::values.language, "");
     qt_config->endGroup();
 
     qt_config->beginGroup("Shortcuts");
     for (auto shortcut : UISettings::values.shortcuts) {
-        qt_config->setValue(shortcut.first + "/KeySeq", shortcut.second.first);
-        qt_config->setValue(shortcut.first + "/Context", shortcut.second.second);
+        WriteSetting(shortcut.first + "/KeySeq", shortcut.second.first);
+        WriteSetting(shortcut.first + "/Context", shortcut.second.second);
     }
     qt_config->endGroup();
 
-    qt_config->setValue("singleWindowMode", UISettings::values.single_window_mode);
-    qt_config->setValue("fullscreen", UISettings::values.fullscreen);
-    qt_config->setValue("displayTitleBars", UISettings::values.display_titlebar);
-    qt_config->setValue("showFilterBar", UISettings::values.show_filter_bar);
-    qt_config->setValue("showStatusBar", UISettings::values.show_status_bar);
-    qt_config->setValue("confirmClose", UISettings::values.confirm_before_closing);
-    qt_config->setValue("firstStart", UISettings::values.first_start);
-    qt_config->setValue("calloutFlags", UISettings::values.callout_flags);
-    qt_config->setValue("showConsole", UISettings::values.show_console);
+    WriteSetting("singleWindowMode", UISettings::values.single_window_mode, true);
+    WriteSetting("fullscreen", UISettings::values.fullscreen, false);
+    WriteSetting("displayTitleBars", UISettings::values.display_titlebar, true);
+    WriteSetting("showFilterBar", UISettings::values.show_filter_bar, true);
+    WriteSetting("showStatusBar", UISettings::values.show_status_bar, true);
+    WriteSetting("confirmClose", UISettings::values.confirm_before_closing, true);
+    WriteSetting("firstStart", UISettings::values.first_start, true);
+    WriteSetting("calloutFlags", UISettings::values.callout_flags, 0);
+    WriteSetting("showConsole", UISettings::values.show_console, false);
 
     qt_config->beginGroup("Multiplayer");
-    qt_config->setValue("nickname", UISettings::values.nickname);
-    qt_config->setValue("ip", UISettings::values.ip);
-    qt_config->setValue("port", UISettings::values.port);
-    qt_config->setValue("room_nickname", UISettings::values.room_nickname);
-    qt_config->setValue("room_name", UISettings::values.room_name);
-    qt_config->setValue("room_port", UISettings::values.room_port);
-    qt_config->setValue("host_type", UISettings::values.host_type);
-    qt_config->setValue("max_player", UISettings::values.max_player);
-    qt_config->setValue("game_id", UISettings::values.game_id);
+    WriteSetting("nickname", UISettings::values.nickname, "");
+    WriteSetting("ip", UISettings::values.ip, "");
+    WriteSetting("port", UISettings::values.port, Network::DefaultRoomPort);
+    WriteSetting("room_nickname", UISettings::values.room_nickname, "");
+    WriteSetting("room_name", UISettings::values.room_name, "");
+    WriteSetting("room_port", UISettings::values.room_port, "24872");
+    WriteSetting("host_type", UISettings::values.host_type, 0);
+    WriteSetting("max_player", UISettings::values.max_player, 8);
+    WriteSetting("game_id", UISettings::values.game_id, 0);
     qt_config->endGroup();
 
     qt_config->endGroup();
 }
 
+QVariant Config::ReadSetting(const QString& name) {
+    return qt_config->value(name);
+}
+
+QVariant Config::ReadSetting(const QString& name, const QVariant& default_value) {
+    QVariant result;
+    if (qt_config->value(name + "/default", false).toBool()) {
+        result = default_value;
+    } else {
+        result = qt_config->value(name, default_value);
+    }
+    return result;
+}
+
+void Config::WriteSetting(const QString& name, const QVariant& value) {
+    qt_config->setValue(name, value);
+}
+
+void Config::WriteSetting(const QString& name, const QVariant& value,
+                          const QVariant& default_value) {
+    qt_config->setValue(name + "/default", value == default_value);
+    qt_config->setValue(name, value);
+}
+
 void Config::Reload() {
     ReadValues();
+    // To apply default value changes
+    SaveValues();
     Settings::Apply();
 }
 

--- a/src/citra_qt/configuration/config.h
+++ b/src/citra_qt/configuration/config.h
@@ -17,6 +17,10 @@ class Config {
 
     void ReadValues();
     void SaveValues();
+    QVariant ReadSetting(const QString& name);
+    QVariant ReadSetting(const QString& name, const QVariant& default_value);
+    void WriteSetting(const QString& name, const QVariant& value);
+    void WriteSetting(const QString& name, const QVariant& value, const QVariant& default_value);
 
 public:
     Config();


### PR DESCRIPTION
This is to fix #3531.
Design:
1. When a setting does not has a default value, it is stored in the same way as before. (Simple QSettings  entry)
1. When a setting has a default value, it is separated into two entries: `xxxxx\default` and `xxxxx`. If `xxxxx\default` = true, it means that the setting is using its default value, and when the configuration is loaded, the setting will be automatically replaced with the new default value (if any). The `xxxxx` entry stores the setting value, however it is only used when `xxxxx\default` = false. See the `ReadSetting` and `WriteSetting` functions for more detail.
1. In this way the new config file will be compatible with the old file.
1. I did not make any changes to the core/settings part. It remained as-is.

Advantages:
1. We can tell if a user is using the default setting or not and upgrade them to the new defaults when any is changed.
1. Well, I can't think of more.

Concerns:
1. ~~Do we really want to upgrade users to new default settings silently? What if I intentionally set it to some value, and the value happened to be the default value? But~~ I think for a common user it is good enough to use the default settings most of the time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3924)
<!-- Reviewable:end -->
