### PR TITLE
CMake: Actually avoid MSVC non-standard definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ else()
     # Silence "deprecation" warnings
     add_definitions(/D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_DEPRECATE /D_SCL_SECURE_NO_WARNINGS)
     # Avoid non-compliant standard library extensions
-    add_definitions(/D_CRT_DECLARE_NONSTDC_NAMES)
+    add_definitions(/D_CRT_DECLARE_NONSTDC_NAMES=0)
     # Avoid windows.h junk
     add_definitions(/DNOMINMAX)
     # Avoid windows.h from including some usually unused libs like winsocks.h, since this might cause some redefinition errors.


### PR DESCRIPTION
As @yuriks pointed out, this fixes an error in #3773 making it actually doing the opposite of what it meant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3933)
<!-- Reviewable:end -->
