### PR TITLE
Revert "CMake: Avoid non-compliant standard library extensions in MSVC"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,8 +120,6 @@ if (NOT MSVC)
 else()
     # Silence "deprecation" warnings
     add_definitions(/D_CRT_SECURE_NO_WARNINGS /D_CRT_NONSTDC_NO_DEPRECATE /D_SCL_SECURE_NO_WARNINGS)
-    # Avoid non-compliant standard library extensions
-    add_definitions(/D_CRT_DECLARE_NONSTDC_NAMES)
     # Avoid windows.h junk
     add_definitions(/DNOMINMAX)
     # Avoid windows.h from including some usually unused libs like winsocks.h, since this might cause some redefinition errors.


### PR DESCRIPTION
Reverts citra-emu/citra#3773

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3935)
<!-- Reviewable:end -->
