### PR TITLE
citra_qt: disable hw shader by default for macos

### DIFF
--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -95,7 +95,14 @@ void Config::ReadValues() {
 
     // Renderer
     Settings::values.use_hw_renderer = sdl2_config->GetBoolean("Renderer", "use_hw_renderer", true);
+#ifdef __APPLE__
+    // Hardware shader is broken on macos thanks to poor drivers.
+    // We still want to provide this option for test/development purposes, but disable it by
+    // default.
+    Settings::values.use_hw_shader = sdl2_config->GetBoolean("Renderer", "use_hw_shader", false);
+#else
     Settings::values.use_hw_shader = sdl2_config->GetBoolean("Renderer", "use_hw_shader", true);
+#endif
     Settings::values.shaders_accurate_gs =
         sdl2_config->GetBoolean("Renderer", "shaders_accurate_gs", true);
     Settings::values.shaders_accurate_mul =

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -83,7 +83,14 @@ void Config::ReadValues() {
 
     qt_config->beginGroup("Renderer");
     Settings::values.use_hw_renderer = qt_config->value("use_hw_renderer", true).toBool();
+#ifdef __APPLE__
+    // Hardware shader is broken on macos thanks to poor drivers.
+    // We still want to provide this option for test/development purposes, but disable it by
+    // default.
+    Settings::values.use_hw_shader = qt_config->value("use_hw_shader", false).toBool();
+#else
     Settings::values.use_hw_shader = qt_config->value("use_hw_shader", true).toBool();
+#endif
     Settings::values.shaders_accurate_gs = qt_config->value("shaders_accurate_gs", true).toBool();
     Settings::values.shaders_accurate_mul =
         qt_config->value("shaders_accurate_mul", false).toBool();

--- a/src/citra_qt/configuration/configure_graphics.cpp
+++ b/src/citra_qt/configuration/configure_graphics.cpp
@@ -2,6 +2,9 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#ifdef __APPLE__
+#include <QMessageBox>
+#endif
 #include "citra_qt/configuration/configure_graphics.h"
 #include "core/core.h"
 #include "core/settings.h"
@@ -26,6 +29,18 @@ ConfigureGraphics::ConfigureGraphics(QWidget* parent)
     ui->hw_shader_group->setEnabled(ui->toggle_hw_shader->isChecked());
     connect(ui->toggle_hw_shader, &QCheckBox::stateChanged, ui->hw_shader_group,
             &QWidget::setEnabled);
+#ifdef __APPLE__
+    connect(ui->toggle_hw_shader, &QCheckBox::stateChanged, this, [this](int state) {
+        if (state == Qt::Checked) {
+            QMessageBox::warning(
+                this, tr("Hardware Shader Warning"),
+                tr("Hardware Shader support is broken on macOS, and will cause graphical issues "
+                   "like showing a black screen.<br><br>The option is only there for "
+                   "test/development purposes. If you experience graphical issues with Hardware "
+                   "Shader, please turn it off."));
+        }
+    });
+#endif
 }
 
 ConfigureGraphics::~ConfigureGraphics() {}


### PR DESCRIPTION
Also show an warning when turning it on.

This is because I've seen several issues/forum topics where users enabled hw shader on macos (or just used default settings) and got black screen.

AFAIK the option was left there for test/development purposes, but I think at least we can disable it by default and provide a warning when users turn it on.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3946)
<!-- Reviewable:end -->
