### PR TITLE
citra_qt: use Citra Web Service username as default multiplayer nickname

### DIFF
--- a/src/citra_qt/multiplayer/direct_connect.cpp
+++ b/src/citra_qt/multiplayer/direct_connect.cpp
@@ -33,6 +33,10 @@ DirectConnectWindow::DirectConnectWindow(QWidget* parent)
 
     ui->nickname->setValidator(validation.GetNickname());
     ui->nickname->setText(UISettings::values.nickname);
+    if (ui->nickname->text().isEmpty() && !Settings::values.citra_username.empty()) {
+        // Use Citra Web Service user name as nickname by default
+        ui->nickname->setText(QString::fromStdString(Settings::values.citra_username));
+    }
     ui->ip->setValidator(validation.GetIP());
     ui->ip->setText(UISettings::values.ip);
     ui->port->setValidator(validation.GetPort());

--- a/src/citra_qt/multiplayer/host_room.cpp
+++ b/src/citra_qt/multiplayer/host_room.cpp
@@ -54,6 +54,10 @@ HostRoomWindow::HostRoomWindow(QWidget* parent, QStandardItemModel* list,
 
     // Restore the settings:
     ui->username->setText(UISettings::values.room_nickname);
+    if (ui->username->text().isEmpty() && !Settings::values.citra_username.empty()) {
+        // Use Citra Web Service user name as nickname by default
+        ui->username->setText(QString::fromStdString(Settings::values.citra_username));
+    }
     ui->room_name->setText(UISettings::values.room_name);
     ui->port->setText(UISettings::values.room_port);
     ui->max_player->setValue(UISettings::values.max_player);

--- a/src/citra_qt/multiplayer/lobby.cpp
+++ b/src/citra_qt/multiplayer/lobby.cpp
@@ -48,6 +48,10 @@ Lobby::Lobby(QWidget* parent, QStandardItemModel* list,
 
     ui->nickname->setValidator(validation.GetNickname());
     ui->nickname->setText(UISettings::values.nickname);
+    if (ui->nickname->text().isEmpty() && !Settings::values.citra_username.empty()) {
+        // Use Citra Web Service user name as nickname by default
+        ui->nickname->setText(QString::fromStdString(Settings::values.citra_username));
+    }
 
     // UI Buttons
     connect(ui->refresh_list, &QPushButton::pressed, this, &Lobby::RefreshLobby);


### PR DESCRIPTION
fix #3945

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3947)
<!-- Reviewable:end -->
