### PR TITLE
configure_system: fix an untranslated text

### DIFF
--- a/src/citra_qt/configuration/configure_system.cpp
+++ b/src/citra_qt/configuration/configure_system.cpp
@@ -170,7 +170,8 @@ void ConfigureSystem::refreshConsoleID() {
     cfg->GenerateConsoleUniqueId(random_number, console_id);
     cfg->SetConsoleUniqueId(random_number, console_id);
     cfg->UpdateConfigNANDSavegame();
-    ui->label_console_id->setText("Console ID: 0x" + QString::number(console_id, 16).toUpper());
+    ui->label_console_id->setText(
+        tr("Console ID: 0x%1").arg(QString::number(console_id, 16).toUpper()));
 }
 
 void ConfigureSystem::retranslateUi() {


### PR DESCRIPTION
The "Console ID: " text is untranslated once you regenerate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3952)
<!-- Reviewable:end -->
