### PR TITLE
game_list: Remove unnecessary QString initialization in KeyReleaseEater

### DIFF
--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -31,10 +31,7 @@
 #include "core/hle/service/fs/archive.h"
 #include "core/loader/loader.h"
 
-GameList::SearchField::KeyReleaseEater::KeyReleaseEater(GameList* gamelist) {
-    this->gamelist = gamelist;
-    edit_filter_text_old = "";
-}
+GameList::SearchField::KeyReleaseEater::KeyReleaseEater(GameList* gamelist) : gamelist{gamelist} {}
 
 // EventFilter in order to process systemkeys while editing the searchfield
 bool GameList::SearchField::KeyReleaseEater::eventFilter(QObject* obj, QEvent* event) {


### PR DESCRIPTION
QString initializes to an empty string by default, so this does nothing meaningful. While we're at it, use a constructor initializer list for initializing the gamelist member variable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3957)
<!-- Reviewable:end -->
