### PR TITLE
game_list: Make containsAllWords() a non-member function

### DIFF
--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -166,10 +166,12 @@ GameList::SearchField::SearchField(GameList* parent) : QWidget{parent} {
  * @param String containing all words getting checked
  * @return true if the haystack contains all words of userinput
  */
-bool GameList::containsAllWords(QString haystack, QString userinput) {
-    QStringList userinput_split = userinput.split(" ", QString::SplitBehavior::SkipEmptyParts);
+static bool ContainsAllWords(const QString& haystack, const QString& userinput) {
+    const QStringList userinput_split =
+        userinput.split(' ', QString::SplitBehavior::SkipEmptyParts);
+
     return std::all_of(userinput_split.begin(), userinput_split.end(),
-                       [haystack](QString s) { return haystack.contains(s); });
+                       [&haystack](const QString& s) { return haystack.contains(s); });
 }
 
 // Syncs the expanded state of Game Directories with settings to persist across sessions
@@ -223,7 +225,7 @@ void GameList::onTextChanged(const QString& newText) {
                 // The search is case insensitive because of toLower()
                 // I decided not to use Qt::CaseInsensitive in containsAllWords to prevent
                 // multiple conversions of edit_filter_text for each game in the gamelist
-                if (containsAllWords(file_name.append(" ").append(file_title), edit_filter_text) ||
+                if (ContainsAllWords(file_name.append(' ').append(file_title), edit_filter_text) ||
                     (file_programmid.count() == 16 && edit_filter_text.contains(file_programmid))) {
                     tree_view->setRowHidden(j, folder_index, false);
                     ++result_count;

--- a/src/citra_qt/game_list.h
+++ b/src/citra_qt/game_list.h
@@ -115,7 +115,6 @@ private:
     void DonePopulating(QStringList watch_list);
 
     void RefreshGameDirectory();
-    bool containsAllWords(QString haystack, QString userinput);
 
     void PopupContextMenu(const QPoint& menu_location);
     void AddGamePopup(QMenu& context_menu, u64 program_id);


### PR DESCRIPTION
This doesn't depend on class state at all, so this can be made internal. While we're at it, amend the function to take its arguments by const reference.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3958)
<!-- Reviewable:end -->
