### PR TITLE
Small fixes on software keyboard implementation

### DIFF
--- a/src/core/frontend/applets/swkbd.cpp
+++ b/src/core/frontend/applets/swkbd.cpp
@@ -130,6 +130,7 @@ ValidationError SoftwareKeyboard::Finalize(const std::string& text, u8 button) {
         return error;
     }
     data = {text, button};
+    return ValidationError::None;
 }
 
 void DefaultKeyboard::Setup(const Frontend::KeyboardConfig* config) {

--- a/src/core/hle/applets/swkbd.cpp
+++ b/src/core/hle/applets/swkbd.cpp
@@ -148,8 +148,13 @@ Frontend::KeyboardConfig SoftwareKeyboard::ToFrontendConfig(
     frontend_config.multiline_mode = config.multiline;
     frontend_config.max_text_length = config.max_text_length;
     frontend_config.max_digits = config.max_digits;
-    std::u16string buffer(config.hint_text.size(), 0);
-    std::memcpy(buffer.data(), config.hint_text.data(), config.hint_text.size() * sizeof(u16));
+
+    size_t text_size = config.hint_text.size();
+    const auto text_end = std::find(config.hint_text.begin(), config.hint_text.end(), u'\0');
+    if (text_end != config.hint_text.end())
+        text_size = std::distance(config.hint_text.begin(), text_end);
+    std::u16string buffer(text_size, 0);
+    std::memcpy(buffer.data(), config.hint_text.data(), text_size * sizeof(u16));
     frontend_config.hint_text = Common::UTF16ToUTF8(buffer);
     frontend_config.has_custom_button_text =
         !std::all_of(config.button_text.begin(), config.button_text.end(),
@@ -158,8 +163,13 @@ Frontend::KeyboardConfig SoftwareKeyboard::ToFrontendConfig(
                      });
     if (frontend_config.has_custom_button_text) {
         for (const auto& text : config.button_text) {
-            buffer.resize(text.size());
-            std::memcpy(buffer.data(), text.data(), text.size() * sizeof(u16));
+            text_size = text.size();
+            const auto text_end = std::find(text.begin(), text.end(), u'\0');
+            if (text_end != text.end())
+                text_size = std::distance(text.begin(), text_end);
+
+            buffer.resize(text_size);
+            std::memcpy(buffer.data(), text.data(), text_size * sizeof(u16));
             frontend_config.button_text.push_back(Common::UTF16ToUTF8(buffer));
         }
     }


### PR DESCRIPTION
While testing the latest revision, I encountered some problems with the software keyboard implementation (#3850).
Precisely, two problems :
- the input box show invalid characters 
![citra-softkeyboard-linux-bug](https://user-images.githubusercontent.com/8618754/42965236-b084d54a-8b99-11e8-9fb6-309eab0d5963.png)
- after validating input box, citra crash randomly ("double free or corruption")

For the first case, I don't understand why the Qt function fromStdString() would not do the job. I changed it for fromUtf8() since our labels are converted using Common::UTF16ToUTF8().
The second case, I could find it thanks to a warning coming from the compiler. Effectively, function SoftwareKeyboard::Finalize() was not returning a value in non-error path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3964)
<!-- Reviewable:end -->
