### PR TITLE
citra-qt: service: add convenient LLE service module configuration

### DIFF
--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -193,8 +193,8 @@ void Config::ReadValues() {
         static_cast<u16>(sdl2_config->GetInteger("Debugging", "gdbstub_port", 24689));
 
     for (const auto& service_module : Service::service_module_map) {
-        bool use_lle = sdl2_config->GetBoolean("Debugging", "LLE\\" + service_module.first, false);
-        Settings::values.lle_modules.emplace(service_module.first, use_lle);
+        bool use_lle = sdl2_config->GetBoolean("Debugging", "LLE\\" + service_module.name, false);
+        Settings::values.lle_modules.emplace(service_module.name, use_lle);
     }
 
     // Web Service

--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <memory>
+#include <unordered_map>
 #include <SDL.h>
 #include <inih/cpp/INIReader.h>
 #include "citra/config.h"
@@ -10,6 +11,7 @@
 #include "common/file_util.h"
 #include "common/logging/log.h"
 #include "common/param_package.h"
+#include "core/hle/service/service.h"
 #include "core/settings.h"
 #include "input_common/main.h"
 
@@ -189,6 +191,11 @@ void Config::ReadValues() {
     Settings::values.use_gdbstub = sdl2_config->GetBoolean("Debugging", "use_gdbstub", false);
     Settings::values.gdbstub_port =
         static_cast<u16>(sdl2_config->GetInteger("Debugging", "gdbstub_port", 24689));
+
+    for (const auto& service_module : Service::service_module_map) {
+        bool use_lle = sdl2_config->GetBoolean("Debugging", "LLE\\" + service_module.first, false);
+        Settings::values.lle_modules.emplace(service_module.first, use_lle);
+    }
 
     // Web Service
     Settings::values.enable_telemetry =

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -213,6 +213,7 @@ log_filter = *:Info
 # Port for listening to GDB connections.
 use_gdbstub=false
 gdbstub_port=24689
+# To LLE a service module add "LLE\<module name>=true"
 
 [WebService]
 # Whether or not to enable telemetry

--- a/src/citra_qt/CMakeLists.txt
+++ b/src/citra_qt/CMakeLists.txt
@@ -60,6 +60,8 @@ add_executable(citra-qt
     debugger/graphics/graphics_tracing.h
     debugger/graphics/graphics_vertex_shader.cpp
     debugger/graphics/graphics_vertex_shader.h
+    debugger/lle_service_modules.cpp
+    debugger/lle_service_modules.h
     debugger/profiler.cpp
     debugger/profiler.h
     debugger/registers.cpp

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -2,10 +2,12 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <unordered_map>
 #include <QSettings>
 #include "citra_qt/configuration/config.h"
 #include "citra_qt/ui_settings.h"
 #include "common/file_util.h"
+#include "core/hle/service/service.h"
 #include "input_common/main.h"
 #include "network/network.h"
 
@@ -166,6 +168,13 @@ void Config::ReadValues() {
     qt_config->beginGroup("Debugging");
     Settings::values.use_gdbstub = ReadSetting("use_gdbstub", false).toBool();
     Settings::values.gdbstub_port = ReadSetting("gdbstub_port", 24689).toInt();
+
+    qt_config->beginGroup("LLE");
+    for (const auto& service_module : Service::service_module_map) {
+        bool use_lle = ReadSetting(QString::fromStdString(service_module.name), false).toBool();
+        Settings::values.lle_modules.emplace(service_module.name, use_lle);
+    }
+    qt_config->endGroup();
     qt_config->endGroup();
 
     qt_config->beginGroup("WebService");
@@ -391,6 +400,12 @@ void Config::SaveValues() {
     qt_config->beginGroup("Debugging");
     WriteSetting("use_gdbstub", Settings::values.use_gdbstub, false);
     WriteSetting("gdbstub_port", Settings::values.gdbstub_port, 24689);
+
+    qt_config->beginGroup("LLE");
+    for (const auto& service_module : Settings::values.lle_modules) {
+        WriteSetting(QString::fromStdString(service_module.first), service_module.second);
+    }
+    qt_config->endGroup();
     qt_config->endGroup();
 
     qt_config->beginGroup("WebService");

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -403,7 +403,7 @@ void Config::SaveValues() {
 
     qt_config->beginGroup("LLE");
     for (const auto& service_module : Settings::values.lle_modules) {
-        WriteSetting(QString::fromStdString(service_module.first), service_module.second);
+        WriteSetting(QString::fromStdString(service_module.first), service_module.second, false);
     }
     qt_config->endGroup();
     qt_config->endGroup();

--- a/src/citra_qt/debugger/lle_service_modules.cpp
+++ b/src/citra_qt/debugger/lle_service_modules.cpp
@@ -1,0 +1,32 @@
+// Copyright 2018 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <QCheckBox>
+#include <QLabel>
+#include <QLayout>
+#include <QScrollArea>
+#include "citra_qt/debugger/lle_service_modules.h"
+#include "core/settings.h"
+
+LLEServiceModulesWidget::LLEServiceModulesWidget(QWidget* parent)
+    : QDockWidget(tr("Toggle LLE Service Modules"), parent) {
+    QScrollArea* scroll_area = new QScrollArea;
+    QLayout* scroll_layout = new QVBoxLayout;
+    for (const auto& service_module : Settings::values.lle_modules) {
+        QCheckBox* check_box =
+            new QCheckBox(QString::fromStdString(service_module.first), scroll_area);
+        check_box->setChecked(service_module.second);
+        connect(check_box, &QCheckBox::toggled, [check_box] {
+            Settings::values.lle_modules.find(check_box->text().toStdString())->second =
+                check_box->isChecked();
+        });
+        scroll_layout->addWidget(check_box);
+    }
+    QWidget* scroll_area_contents = new QWidget;
+    scroll_area_contents->setLayout(scroll_layout);
+    scroll_area->setWidget(scroll_area_contents);
+    setWidget(scroll_area);
+}
+
+LLEServiceModulesWidget::~LLEServiceModulesWidget() = default;

--- a/src/citra_qt/debugger/lle_service_modules.h
+++ b/src/citra_qt/debugger/lle_service_modules.h
@@ -1,0 +1,15 @@
+// Copyright 2018 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QDockWidget>
+
+class LLEServiceModulesWidget : public QDockWidget {
+    Q_OBJECT
+
+public:
+    explicit LLEServiceModulesWidget(QWidget* parent = nullptr);
+    ~LLEServiceModulesWidget();
+};

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -30,6 +30,7 @@
 #include "citra_qt/debugger/graphics/graphics_surface.h"
 #include "citra_qt/debugger/graphics/graphics_tracing.h"
 #include "citra_qt/debugger/graphics/graphics_vertex_shader.h"
+#include "citra_qt/debugger/lle_service_modules.h"
 #include "citra_qt/debugger/profiler.h"
 #include "citra_qt/debugger/registers.h"
 #include "citra_qt/debugger/wait_tree.h"
@@ -302,6 +303,15 @@ void GMainWindow::InitializeDebugWidgets() {
             &WaitTreeWidget::OnEmulationStarting);
     connect(this, &GMainWindow::EmulationStopping, waitTreeWidget,
             &WaitTreeWidget::OnEmulationStopping);
+
+    lleServiceModulesWidget = new LLEServiceModulesWidget(this);
+    addDockWidget(Qt::RightDockWidgetArea, lleServiceModulesWidget);
+    lleServiceModulesWidget->hide();
+    debug_menu->addAction(lleServiceModulesWidget->toggleViewAction());
+    connect(this, &GMainWindow::EmulationStarting,
+            [this] { lleServiceModulesWidget->setDisabled(true); });
+    connect(this, &GMainWindow::EmulationStopping, waitTreeWidget,
+            [this] { lleServiceModulesWidget->setDisabled(false); });
 }
 
 void GMainWindow::InitializeRecentFileMenuActions() {

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -28,6 +28,7 @@ class GraphicsBreakPointsWidget;
 class GraphicsTracingWidget;
 class GraphicsVertexShaderWidget;
 class GRenderWindow;
+class LLEServiceModulesWidget;
 class MicroProfileDialog;
 class MultiplayerState;
 class ProfilerWidget;
@@ -215,6 +216,7 @@ private:
     GraphicsBreakPointsWidget* graphicsBreakpointsWidget;
     GraphicsVertexShaderWidget* graphicsVertexShaderWidget;
     GraphicsTracingWidget* graphicsTracingWidget;
+    LLEServiceModulesWidget* lleServiceModulesWidget;
     WaitTreeWidget* waitTreeWidget;
     Updater* updater;
 

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -64,6 +64,58 @@ namespace Service {
 
 std::unordered_map<std::string, SharedPtr<ClientPort>> g_kernel_named_ports;
 
+const std::array<ServiceModuleInfo, 40> service_module_map{
+    {{"FS", 0x00040130'00001102, FS::InstallInterfaces},
+     {"PM", 0x00040130'00001202, PM::InstallInterfaces},
+     {"LDR", 0x00040130'00003702, LDR::InstallInterfaces},
+     {"PXI", 0x00040130'00001402, PXI::InstallInterfaces},
+
+     {"ERR", 0x00040030'00008A02, [](SM::ServiceManager& sm) { ERR::InstallInterfaces(); }},
+     {"AC", 0x00040130'00002402, AC::InstallInterfaces},
+     {"ACT", 0x00040130'00003802, ACT::InstallInterfaces},
+     {"AM", 0x00040130'00001502, AM::InstallInterfaces},
+     {"BOSS", 0x00040130'00003402, BOSS::InstallInterfaces},
+     {"CAM", 0x00040130'00001602,
+      [](SM::ServiceManager& sm) {
+          CAM::InstallInterfaces(sm);
+          Y2R::InstallInterfaces(sm);
+      }},
+     {"CECD", 0x00040130'00002602, CECD::InstallInterfaces},
+     {"CFG", 0x00040130'00001702, CFG::InstallInterfaces},
+     {"DLP", 0x00040130'00002802, DLP::InstallInterfaces},
+     {"DSP", 0x00040130'00001A02, DSP::InstallInterfaces},
+     {"FRD", 0x00040130'00003202, FRD::InstallInterfaces},
+     {"GSP", 0x00040130'00001C02, GSP::InstallInterfaces},
+     {"HID", 0x00040130'00001D02, HID::InstallInterfaces},
+     {"IR", 0x00040130'00003302, IR::InstallInterfaces},
+     {"MIC", 0x00040130'00002002, MIC::InstallInterfaces},
+     {"MVD", 0x00040130'20004102, MVD::InstallInterfaces},
+     {"NDM", 0x00040130'00002B02, NDM::InstallInterfaces},
+     {"NEWS", 0x00040130'00003502, NEWS::InstallInterfaces},
+     {"NFC", 0x00040130'00004002, NFC::InstallInterfaces},
+     {"NIM", 0x00040130'00002C02, NIM::InstallInterfaces},
+     {"NS", 0x00040130'00008002,
+      [](SM::ServiceManager& sm) {
+          NS::InstallInterfaces(sm);
+          APT::InstallInterfaces(sm);
+      }},
+     {"NWM", 0x00040130'00002D02, NWM::InstallInterfaces},
+     {"PTM", 0x00040130'00002202, PTM::InstallInterfaces},
+     {"QTM", 0x00040130'00004202, QTM::InstallInterfaces},
+     {"CSND", 0x00040130'00002702, CSND::InstallInterfaces},
+     {"HTTP", 0x00040130'00002902, HTTP::InstallInterfaces},
+     {"SOC", 0x00040130'00002E02, SOC::InstallInterfaces},
+     {"SSL", 0x00040130'00002F02, SSL::InstallInterfaces},
+     // no HLE implementation
+     {"CDC", 0x00040130'00001802, nullptr},
+     {"GPIO", 0x00040130'00001B02, nullptr},
+     {"I2C", 0x00040130'00001E02, nullptr},
+     {"MCU", 0x00040130'00001F02, nullptr},
+     {"MP", 0x00040130'00002A02, nullptr},
+     {"PDN", 0x00040130'00002102, nullptr},
+     {"PS", 0x00040130'00003102, nullptr},
+     {"SPI", 0x00040130'00002302, nullptr}}};
+
 /**
  * Creates a function string for logging, complete with the name (or header code, depending
  * on what's passed in) the port name, and all the cmd_buff arguments.
@@ -149,9 +201,9 @@ void ServiceFrameworkBase::HandleSyncRequest(SharedPtr<ServerSession> server_ses
 
     auto thread = Kernel::GetCurrentThread();
     ASSERT(thread->status == THREADSTATUS_RUNNING || thread->status == THREADSTATUS_WAIT_HLE_EVENT);
-    // Only write the response immediately if the thread is still running. If the HLE handler put
-    // the thread to sleep then the writing of the command buffer will be deferred to the wakeup
-    // callback.
+    // Only write the response immediately if the thread is still running. If the HLE
+    // handler put the thread to sleep then the writing of the command buffer will be
+    // deferred to the wakeup callback.
     if (thread->status == THREADSTATUS_RUNNING) {
         context.WriteToOutgoingCommandBuffer(cmd_buf, *Kernel::g_current_process,
                                              Kernel::g_handle_table);
@@ -168,49 +220,31 @@ void AddNamedPort(std::string name, SharedPtr<ClientPort> port) {
 
 /// Initialize ServiceManager
 void Init(std::shared_ptr<SM::ServiceManager>& sm) {
+    FS::ArchiveInit();
     SM::ServiceManager::InstallInterfaces(sm);
 
-    ERR::InstallInterfaces();
-
-    PS::InstallInterfaces(*sm);
-    PXI::InstallInterfaces(*sm);
-    NS::InstallInterfaces(*sm);
-    AC::InstallInterfaces(*sm);
-    LDR::InstallInterfaces(*sm);
-    MIC::InstallInterfaces(*sm);
-    NWM::InstallInterfaces(*sm);
-
-    FS::InstallInterfaces(*sm);
-    FS::ArchiveInit();
-    ACT::InstallInterfaces(*sm);
-    AM::InstallInterfaces(*sm);
-    APT::InstallInterfaces(*sm);
-    BOSS::InstallInterfaces(*sm);
-    CAM::InstallInterfaces(*sm);
-    CECD::InstallInterfaces(*sm);
-    CFG::InstallInterfaces(*sm);
-    DLP::InstallInterfaces(*sm);
-    DSP::InstallInterfaces(*sm);
-    FRD::InstallInterfaces(*sm);
-    GSP::InstallInterfaces(*sm);
-    HID::InstallInterfaces(*sm);
-    IR::InstallInterfaces(*sm);
-    MVD::InstallInterfaces(*sm);
-    NDM::InstallInterfaces(*sm);
-    NEWS::InstallInterfaces(*sm);
-    NFC::InstallInterfaces(*sm);
-    NIM::InstallInterfaces(*sm);
-    PTM::InstallInterfaces(*sm);
-    QTM::InstallInterfaces(*sm);
-
-    CSND::InstallInterfaces(*sm);
-    HTTP::InstallInterfaces(*sm);
-    PM::InstallInterfaces(*sm);
-    SOC::InstallInterfaces(*sm);
-    SSL::InstallInterfaces(*sm);
-    Y2R::InstallInterfaces(*sm);
-
+    for (const auto& service_module : service_module_map) {
+        if (!AttemptLLE(service_module) && service_module.init_function != nullptr)
+            service_module.init_function(*sm);
+    }
     LOG_DEBUG(Service, "initialized OK");
+}
+
+bool AttemptLLE(const ServiceModuleInfo& service_module) {
+    if (!Settings::values.lle_modules.at(service_module.name))
+        return false;
+    std::unique_ptr<Loader::AppLoader> loader =
+        Loader::GetLoader(AM::GetTitleContentPath(FS::MediaType::NAND, service_module.title_id));
+    if (!loader) {
+        LOG_ERROR(Service,
+                  "Service module \"{}\" could not be loaded; Defaulting to HLE implementation.",
+                  service_module.name);
+        return false;
+    }
+    SharedPtr<Kernel::Process> process;
+    loader->Load(process);
+    LOG_DEBUG(Service, "Service module \"{}\" has been successfully loaded.", service_module.name);
+    return true;
 }
 
 /// Shutdown ServiceManager

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -218,18 +218,6 @@ void AddNamedPort(std::string name, SharedPtr<ClientPort> port) {
     g_kernel_named_ports.emplace(std::move(name), std::move(port));
 }
 
-/// Initialize ServiceManager
-void Init(std::shared_ptr<SM::ServiceManager>& sm) {
-    FS::ArchiveInit();
-    SM::ServiceManager::InstallInterfaces(sm);
-
-    for (const auto& service_module : service_module_map) {
-        if (!AttemptLLE(service_module) && service_module.init_function != nullptr)
-            service_module.init_function(*sm);
-    }
-    LOG_DEBUG(Service, "initialized OK");
-}
-
 bool AttemptLLE(const ServiceModuleInfo& service_module) {
     if (!Settings::values.lle_modules.at(service_module.name))
         return false;
@@ -245,6 +233,18 @@ bool AttemptLLE(const ServiceModuleInfo& service_module) {
     loader->Load(process);
     LOG_DEBUG(Service, "Service module \"{}\" has been successfully loaded.", service_module.name);
     return true;
+}
+
+/// Initialize ServiceManager
+void Init(std::shared_ptr<SM::ServiceManager>& sm) {
+    FS::ArchiveInit();
+    SM::ServiceManager::InstallInterfaces(sm);
+
+    for (const auto& service_module : service_module_map) {
+        if (!AttemptLLE(service_module) && service_module.init_function != nullptr)
+            service_module.init_function(*sm);
+    }
+    LOG_DEBUG(Service, "initialized OK");
 }
 
 /// Shutdown ServiceManager

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -201,9 +201,9 @@ void ServiceFrameworkBase::HandleSyncRequest(SharedPtr<ServerSession> server_ses
 
     auto thread = Kernel::GetCurrentThread();
     ASSERT(thread->status == THREADSTATUS_RUNNING || thread->status == THREADSTATUS_WAIT_HLE_EVENT);
-    // Only write the response immediately if the thread is still running. If the HLE
-    // handler put the thread to sleep then the writing of the command buffer will be
-    // deferred to the wakeup callback.
+    // Only write the response immediately if the thread is still running. If the HLE handler put
+    // the thread to sleep then the writing of the command buffer will be deferred to the wakeup
+    // callback.
     if (thread->status == THREADSTATUS_RUNNING) {
         context.WriteToOutgoingCommandBuffer(cmd_buf, *Kernel::g_current_process,
                                              Kernel::g_handle_table);

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -218,7 +218,7 @@ void AddNamedPort(std::string name, SharedPtr<ClientPort> port) {
     g_kernel_named_ports.emplace(std::move(name), std::move(port));
 }
 
-bool AttemptLLE(const ServiceModuleInfo& service_module) {
+static bool AttemptLLE(const ServiceModuleInfo& service_module) {
     if (!Settings::values.lle_modules.at(service_module.name))
         return false;
     std::unique_ptr<Loader::AppLoader> loader =

--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -201,9 +201,6 @@ struct ServiceModuleInfo {
 
 extern const std::array<ServiceModuleInfo, 40> service_module_map;
 
-/// Atempt to load an LLE service
-static bool AttemptLLE(const ServiceModuleInfo& service_module);
-
 /// Adds a port to the named port table
 void AddNamedPort(std::string name, Kernel::SharedPtr<Kernel::ClientPort> port);
 

--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -4,12 +4,11 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include <functional>
-#include <map>
 #include <string>
 #include <unordered_map>
-#include <utility>
 #include <boost/container/flat_map.hpp>
 #include "common/bit_field.h"
 #include "common/common_types.h"

--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -5,13 +5,17 @@
 #pragma once
 
 #include <cstddef>
+#include <functional>
+#include <map>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <boost/container/flat_map.hpp>
 #include "common/bit_field.h"
 #include "common/common_types.h"
 #include "core/hle/kernel/hle_ipc.h"
 #include "core/hle/kernel/kernel.h"
+#include "core/hle/service/sm/sm.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Namespace Service
@@ -188,6 +192,17 @@ void Shutdown();
 
 /// Map of named ports managed by the kernel, which can be retrieved using the ConnectToPort SVC.
 extern std::unordered_map<std::string, Kernel::SharedPtr<Kernel::ClientPort>> g_kernel_named_ports;
+
+struct ServiceModuleInfo {
+    std::string name;
+    u64 title_id;
+    std::function<void(SM::ServiceManager&)> init_function;
+};
+
+extern const std::array<ServiceModuleInfo, 40> service_module_map;
+
+/// Atempt to load an LLE service
+static bool AttemptLLE(const ServiceModuleInfo& service_module);
 
 /// Adds a port to the named port table
 void AddNamedPort(std::string name, Kernel::SharedPtr<Kernel::ClientPort> port);

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <string>
+#include <unordered_map>
 #include "common/common_types.h"
 #include "core/hle/service/cam/cam.h"
 
@@ -150,6 +151,7 @@ struct Values {
     bool use_gdbstub;
     u16 gdbstub_port;
     std::string log_filter;
+    std::unordered_map<std::string, bool> lle_modules;
 
     // Movie
     std::string movie_play;


### PR DESCRIPTION
Allows developers to easily toggle low level emulation of installed service modules.
As requested by @Subv 
# UI
![image](https://user-images.githubusercontent.com/28246325/42976560-c4fe2b8c-8b87-11e8-9e61-6c416b6b17a1.png)
# Config file example
```[Debugging]
use_gdbstub=false
gdbstub_port=24689
LLE\SSL=false
LLE\AC=false
LLE\AM=false
LLE\CDC=true
LLE\ACT=false
LLE\CAM=false
etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3967)
<!-- Reviewable:end -->
