### PR TITLE
core/loader: avoid "different type" warning for .app

### DIFF
--- a/src/core/loader/loader.cpp
+++ b/src/core/loader/loader.cpp
@@ -57,7 +57,7 @@ FileType GuessFromExtension(const std::string& extension_) {
     if (extension == ".cci" || extension == ".3ds")
         return FileType::CCI;
 
-    if (extension == ".cxi")
+    if (extension == ".cxi" || extension == ".app")
         return FileType::CXI;
 
     if (extension == ".3dsx")


### PR DESCRIPTION
Previously for installed titles, the file type would be NCCH (assumed as CXI) and the extension would be ".app". This would trigger a warning of the file "having a different type than its extension", which is actually not true here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3978)
<!-- Reviewable:end -->
