### PR TITLE
Migrate HTTP_C to the ServiceFramework and implement functions

### DIFF
--- a/src/core/hle/service/http_c.cpp
+++ b/src/core/hle/service/http_c.cpp
@@ -2,13 +2,33 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <string>
 #include <vector>
+#include <boost/optional.hpp>
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/ipc.h"
 #include "core/hle/service/http_c.h"
 
 namespace Service {
 namespace HTTP {
+
+enum class RequestMethod : u8 {
+    Get = 0x1,
+    Post = 0x2,
+    Head = 0x3,
+    Put = 0x4,
+    Delete = 0x5,
+    PostEmpty = 0x6,
+    PutEmpty = 0x7,
+};
+
+enum class RequestState : u8 {
+    NotStarted = 0x1,             // Request has not started yet.
+    InProgress = 0x5,             // Request in progress, sending request over the network.
+    ReadyToDownloadContent = 0x7, // Ready to download the content. (needs verification)
+    ReadyToDownload = 0x8,        // Ready to download?
+    TimedOut = 0xA,               // Request timed out?
+};
 
 /// Represents a client certificate along with its private key, stored as a byte array of DER data.
 /// There can only be at most one client certificate context attached to an HTTP context at any
@@ -30,6 +50,49 @@ struct RootCertChain {
 
     u32 handle;
     std::vector<RootCACert> certificates;
+};
+
+/// Represents an HTTP context.
+struct Context {
+    struct Proxy {
+        std::string url;
+        std::string username;
+        std::string password;
+        u16 port;
+    };
+
+    struct BasicAuth {
+        std::string username;
+        std::string password;
+    };
+
+    struct RequestHeader {
+        std::string name;
+        std::string value;
+    };
+
+    struct PostData {
+        // TODO(Subv): Support Binary and Raw POST elements.
+        std::string name;
+        std::string value;
+    };
+
+    struct SSLConfig {
+        u32 options;
+        std::weak_ptr<ClientCertContext> client_cert_ctx;
+        std::weak_ptr<RootCertChain> root_ca_chain;
+    };
+
+    u32 handle;
+    std::string url;
+    RequestMethod method;
+    RequestState state = RequestState::NotStarted;
+    boost::optional<Proxy> proxy;
+    boost::optional<BasicAuth> basic_auth;
+    SSLConfig ssl_config{};
+    u32 socket_buffer_size;
+    std::vector<RequestHeader> headers;
+    std::vector<PostData> post_data;
 };
 
 void HTTP_C::Initialize(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/http_c.cpp
+++ b/src/core/hle/service/http_c.cpp
@@ -59,14 +59,13 @@ void HTTP_C::CreateContext(Kernel::HLERequestContext& ctx) {
         return;
     }
 
-    ++context_counter;
-    contexts.emplace(context_counter, Context());
+    contexts.emplace(++context_counter, Context());
     contexts[context_counter].url = std::move(url);
     contexts[context_counter].method = method;
     contexts[context_counter].state = RequestState::NotStarted;
     // TODO(Subv): Find a correct default value for this field.
     contexts[context_counter].socket_buffer_size = 0;
-    contexts[context_counter].handle = ++context_counter;
+    contexts[context_counter].handle = context_counter;
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
     rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/http_c.cpp
+++ b/src/core/hle/service/http_c.cpp
@@ -2,71 +2,77 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "core/hle/ipc_helpers.h"
+#include "core/hle/kernel/ipc.h"
 #include "core/hle/service/http_c.h"
 
 namespace Service {
 namespace HTTP {
 
-const Interface::FunctionInfo FunctionTable[] = {
-    {0x00010044, nullptr, "Initialize"},
-    {0x00020082, nullptr, "CreateContext"},
-    {0x00030040, nullptr, "CloseContext"},
-    {0x00040040, nullptr, "CancelConnection"},
-    {0x00050040, nullptr, "GetRequestState"},
-    {0x00060040, nullptr, "GetDownloadSizeState"},
-    {0x00070040, nullptr, "GetRequestError"},
-    {0x00080042, nullptr, "InitializeConnectionSession"},
-    {0x00090040, nullptr, "BeginRequest"},
-    {0x000A0040, nullptr, "BeginRequestAsync"},
-    {0x000B0082, nullptr, "ReceiveData"},
-    {0x000C0102, nullptr, "ReceiveDataTimeout"},
-    {0x000D0146, nullptr, "SetProxy"},
-    {0x000E0040, nullptr, "SetProxyDefault"},
-    {0x000F00C4, nullptr, "SetBasicAuthorization"},
-    {0x00100080, nullptr, "SetSocketBufferSize"},
-    {0x001100C4, nullptr, "AddRequestHeader"},
-    {0x001200C4, nullptr, "AddPostDataAscii"},
-    {0x001300C4, nullptr, "AddPostDataBinary"},
-    {0x00140082, nullptr, "AddPostDataRaw"},
-    {0x00150080, nullptr, "SetPostDataType"},
-    {0x001600C4, nullptr, "SendPostDataAscii"},
-    {0x00170144, nullptr, "SendPostDataAsciiTimeout"},
-    {0x001800C4, nullptr, "SendPostDataBinary"},
-    {0x00190144, nullptr, "SendPostDataBinaryTimeout"},
-    {0x001A0082, nullptr, "SendPostDataRaw"},
-    {0x001B0102, nullptr, "SendPOSTDataRawTimeout"},
-    {0x001C0080, nullptr, "SetPostDataEncoding"},
-    {0x001D0040, nullptr, "NotifyFinishSendPostData"},
-    {0x001E00C4, nullptr, "GetResponseHeader"},
-    {0x001F0144, nullptr, "GetResponseHeaderTimeout"},
-    {0x00200082, nullptr, "GetResponseData"},
-    {0x00210102, nullptr, "GetResponseDataTimeout"},
-    {0x00220040, nullptr, "GetResponseStatusCode"},
-    {0x002300C0, nullptr, "GetResponseStatusCodeTimeout"},
-    {0x00240082, nullptr, "AddTrustedRootCA"},
-    {0x00250080, nullptr, "AddDefaultCert"},
-    {0x00260080, nullptr, "SelectRootCertChain"},
-    {0x002700C4, nullptr, "SetClientCert"},
-    {0x002B0080, nullptr, "SetSSLOpt"},
-    {0x002C0080, nullptr, "SetSSLClearOpt"},
-    {0x002D0000, nullptr, "CreateRootCertChain"},
-    {0x002E0040, nullptr, "DestroyRootCertChain"},
-    {0x002F0082, nullptr, "RootCertChainAddCert"},
-    {0x00300080, nullptr, "RootCertChainAddDefaultCert"},
-    {0x00310080, nullptr, "RootCertChainRemoveCert"},
-    {0x00320084, nullptr, "OpenClientCertContext"},
-    {0x00330040, nullptr, "OpenDefaultClientCertContext"},
-    {0x00340040, nullptr, "CloseClientCertContext"},
-    {0x00350186, nullptr, "SetDefaultProxy"},
-    {0x00360000, nullptr, "ClearDNSCache"},
-    {0x00370080, nullptr, "SetKeepAlive"},
-    {0x003800C0, nullptr, "SetPostDataTypeSize"},
-    {0x00390000, nullptr, "Finalize"},
-};
-
-HTTP_C::HTTP_C() {
-    Register(FunctionTable);
+HTTP_C::HTTP_C() : ServiceFramework("http:C", 32) {
+    static const FunctionInfo functions[] = {
+        {0x00010044, nullptr, "Initialize"},
+        {0x00020082, nullptr, "CreateContext"},
+        {0x00030040, nullptr, "CloseContext"},
+        {0x00040040, nullptr, "CancelConnection"},
+        {0x00050040, nullptr, "GetRequestState"},
+        {0x00060040, nullptr, "GetDownloadSizeState"},
+        {0x00070040, nullptr, "GetRequestError"},
+        {0x00080042, nullptr, "InitializeConnectionSession"},
+        {0x00090040, nullptr, "BeginRequest"},
+        {0x000A0040, nullptr, "BeginRequestAsync"},
+        {0x000B0082, nullptr, "ReceiveData"},
+        {0x000C0102, nullptr, "ReceiveDataTimeout"},
+        {0x000D0146, nullptr, "SetProxy"},
+        {0x000E0040, nullptr, "SetProxyDefault"},
+        {0x000F00C4, nullptr, "SetBasicAuthorization"},
+        {0x00100080, nullptr, "SetSocketBufferSize"},
+        {0x001100C4, nullptr, "AddRequestHeader"},
+        {0x001200C4, nullptr, "AddPostDataAscii"},
+        {0x001300C4, nullptr, "AddPostDataBinary"},
+        {0x00140082, nullptr, "AddPostDataRaw"},
+        {0x00150080, nullptr, "SetPostDataType"},
+        {0x001600C4, nullptr, "SendPostDataAscii"},
+        {0x00170144, nullptr, "SendPostDataAsciiTimeout"},
+        {0x001800C4, nullptr, "SendPostDataBinary"},
+        {0x00190144, nullptr, "SendPostDataBinaryTimeout"},
+        {0x001A0082, nullptr, "SendPostDataRaw"},
+        {0x001B0102, nullptr, "SendPOSTDataRawTimeout"},
+        {0x001C0080, nullptr, "SetPostDataEncoding"},
+        {0x001D0040, nullptr, "NotifyFinishSendPostData"},
+        {0x001E00C4, nullptr, "GetResponseHeader"},
+        {0x001F0144, nullptr, "GetResponseHeaderTimeout"},
+        {0x00200082, nullptr, "GetResponseData"},
+        {0x00210102, nullptr, "GetResponseDataTimeout"},
+        {0x00220040, nullptr, "GetResponseStatusCode"},
+        {0x002300C0, nullptr, "GetResponseStatusCodeTimeout"},
+        {0x00240082, nullptr, "AddTrustedRootCA"},
+        {0x00250080, nullptr, "AddDefaultCert"},
+        {0x00260080, nullptr, "SelectRootCertChain"},
+        {0x002700C4, nullptr, "SetClientCert"},
+        {0x00290080, nullptr, "SetClientCertContext"},
+        {0x002A0040, nullptr, "GetSSLError"},
+        {0x002B0080, nullptr, "SetSSLOpt"},
+        {0x002C0080, nullptr, "SetSSLClearOpt"},
+        {0x002D0000, nullptr, "CreateRootCertChain"},
+        {0x002E0040, nullptr, "DestroyRootCertChain"},
+        {0x002F0082, nullptr, "RootCertChainAddCert"},
+        {0x00300080, nullptr, "RootCertChainAddDefaultCert"},
+        {0x00310080, nullptr, "RootCertChainRemoveCert"},
+        {0x00320084, nullptr, "OpenClientCertContext"},
+        {0x00330040, nullptr, "OpenDefaultClientCertContext"},
+        {0x00340040, nullptr, "CloseClientCertContext"},
+        {0x00350186, nullptr, "SetDefaultProxy"},
+        {0x00360000, nullptr, "ClearDNSCache"},
+        {0x00370080, nullptr, "SetKeepAlive"},
+        {0x003800C0, nullptr, "SetPostDataTypeSize"},
+        {0x00390000, nullptr, "Finalize"},
+    };
+    RegisterHandlers(functions);
 }
 
+void InstallInterfaces(SM::ServiceManager& service_manager) {
+    std::make_shared<HTTP_C>()->InstallAsService(service_manager);
+}
 } // namespace HTTP
 } // namespace Service

--- a/src/core/hle/service/http_c.cpp
+++ b/src/core/hle/service/http_c.cpp
@@ -54,8 +54,7 @@ void HTTP_C::CreateContext(Kernel::HLERequestContext& ctx) {
         LOG_ERROR(Service_HTTP, "invalid request method={}", static_cast<u32>(method));
 
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-        rb.Push(ResultCode(ErrCodes::InvalidContext, ErrorModule::HTTP, ErrorSummary::InvalidState,
-                           ErrorLevel::Permanent));
+        rb.Push(ERROR_CONTEXT_ERROR);
         rb.PushMappedBuffer(buffer);
         return;
     }

--- a/src/core/hle/service/http_c.cpp
+++ b/src/core/hle/service/http_c.cpp
@@ -2,12 +2,35 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <vector>
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/ipc.h"
 #include "core/hle/service/http_c.h"
 
 namespace Service {
 namespace HTTP {
+
+/// Represents a client certificate along with its private key, stored as a byte array of DER data.
+/// There can only be at most one client certificate context attached to an HTTP context at any
+/// given time.
+struct ClientCertContext {
+    u32 handle;
+    std::vector<u8> certificate;
+    std::vector<u8> private_key;
+};
+
+/// Represents a root certificate chain, it contains a list of DER-encoded certificates for
+/// verifying HTTP requests. An HTTP context can have at most one root certificate chain attached to
+/// it, but the chain may contain an arbitrary number of certificates in it.
+struct RootCertChain {
+    struct RootCACert {
+        u32 handle;
+        std::vector<u8> certificate;
+    };
+
+    u32 handle;
+    std::vector<RootCACert> certificates;
+};
 
 void HTTP_C::Initialize(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x1, 1, 4);

--- a/src/core/hle/service/http_c.cpp
+++ b/src/core/hle/service/http_c.cpp
@@ -59,14 +59,14 @@ void HTTP_C::CreateContext(Kernel::HLERequestContext& ctx) {
         return;
     }
 
-    Context context{};
-    context.url = std::move(url);
-    context.method = method;
-    context.state = RequestState::NotStarted;
+    ++context_counter;
+    contexts.emplace(context_counter, Context());
+    contexts[context_counter].url = std::move(url);
+    contexts[context_counter].method = method;
+    contexts[context_counter].state = RequestState::NotStarted;
     // TODO(Subv): Find a correct default value for this field.
-    context.socket_buffer_size = 0;
-    context.handle = ++context_counter;
-    contexts[context_counter] = std::move(context);
+    contexts[context_counter].socket_buffer_size = 0;
+    contexts[context_counter].handle = ++context_counter;
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
     rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/http_c.cpp
+++ b/src/core/hle/service/http_c.cpp
@@ -98,29 +98,6 @@ void HTTP_C::CloseContext(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS);
 }
 
-void HTTP_C::InitializeConnectionSession(Kernel::HLERequestContext& ctx) {
-    IPC::RequestParser rp(ctx, 0x8, 1, 2);
-    const u32 context_handle = rp.Pop<u32>();
-    rp.PopPID();
-
-    auto itr = contexts.find(context_handle);
-    if (itr == contexts.end()) {
-        IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-        rb.Push(ERROR_CONTEXT_ERROR);
-        LOG_ERROR(Service_HTTP, "called, context {} not found", context_handle);
-        return;
-    }
-
-    // TODO(Subv): What happens if you try to initalize a context that's currently being used?
-    ASSERT(itr->second.state == RequestState::NotStarted);
-
-    // TODO(B3N30): Check what gets initalized
-
-    IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
-    LOG_WARNING(Service_HTTP, "(STUBBED) called, context_id={}", context_handle);
-}
-
 void HTTP_C::AddRequestHeader(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x11, 3, 4);
     const u32 context_handle = rp.Pop<u32>();
@@ -165,7 +142,7 @@ HTTP_C::HTTP_C() : ServiceFramework("http:C", 32) {
         {0x00050040, nullptr, "GetRequestState"},
         {0x00060040, nullptr, "GetDownloadSizeState"},
         {0x00070040, nullptr, "GetRequestError"},
-        {0x00080042, &HTTP_C::InitializeConnectionSession, "InitializeConnectionSession"},
+        {0x00080042, nullptr, "InitializeConnectionSession"},
         {0x00090040, nullptr, "BeginRequest"},
         {0x000A0040, nullptr, "BeginRequestAsync"},
         {0x000B0082, nullptr, "ReceiveData"},

--- a/src/core/hle/service/http_c.cpp
+++ b/src/core/hle/service/http_c.cpp
@@ -40,10 +40,11 @@ void HTTP_C::Initialize(Kernel::HLERequestContext& ctx) {
 void HTTP_C::CreateContext(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x2, 2, 2);
     const u32 url_size = rp.Pop<u32>();
-    std::string url(url_size, '\0');
     RequestMethod method = rp.PopEnum<RequestMethod>();
-
     Kernel::MappedBuffer& buffer = rp.PopMappedBuffer();
+
+    // Copy the buffer into a string without the \0 at the end of the buffer
+    std::string url(url_size, '\0');
     buffer.Read(&url[0], 0, url_size - 1);
 
     LOG_DEBUG(Service_HTTP, "called, url_size={}, url={}, method={}", url_size, url,
@@ -74,7 +75,7 @@ void HTTP_C::CreateContext(Kernel::HLERequestContext& ctx) {
 }
 
 void HTTP_C::CloseContext(Kernel::HLERequestContext& ctx) {
-    IPC::RequestParser rp(ctx, 0x3, 2, 0);
+    IPC::RequestParser rp(ctx, 0x3, 1, 0);
 
     u32 context_handle = rp.Pop<u32>();
 
@@ -104,7 +105,11 @@ void HTTP_C::AddRequestHeader(Kernel::HLERequestContext& ctx) {
     const u32 value_size = rp.Pop<u32>();
     const std::vector<u8> name_buffer = rp.PopStaticBuffer();
     Kernel::MappedBuffer& value_buffer = rp.PopMappedBuffer();
+
+    // Copy the name_buffer into a string without the \0 at the end
     const std::string name(name_buffer.begin(), name_buffer.end() - 1);
+
+    // Copy thr value_buffer into a string without the \0 at the end
     std::string value(value_size - 1, '\0');
     value_buffer.Read(&value[0], 0, value_size - 1);
 

--- a/src/core/hle/service/http_c.cpp
+++ b/src/core/hle/service/http_c.cpp
@@ -9,9 +9,26 @@
 namespace Service {
 namespace HTTP {
 
+void HTTP_C::Initialize(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp(ctx, 0x1, 1, 4);
+    const u32 shmem_size = rp.Pop<u32>();
+    rp.PopPID();
+    shared_memory = rp.PopObject<Kernel::SharedMemory>();
+    if (shared_memory) {
+        shared_memory->name = "HTTP_C:shared_memory";
+    }
+
+    IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
+    // This returns 0xd8a0a046 if no network connection is available.
+    // Just assume we are always connected.
+    rb.Push(RESULT_SUCCESS);
+
+    LOG_WARNING(Service_HTTP, "(STUBBED) called, shared memory size: {}", shmem_size);
+}
+
 HTTP_C::HTTP_C() : ServiceFramework("http:C", 32) {
     static const FunctionInfo functions[] = {
-        {0x00010044, nullptr, "Initialize"},
+        {0x00010044, &HTTP_C::Initialize, "Initialize"},
         {0x00020082, nullptr, "CreateContext"},
         {0x00030040, nullptr, "CloseContext"},
         {0x00040040, nullptr, "CancelConnection"},

--- a/src/core/hle/service/http_c.cpp
+++ b/src/core/hle/service/http_c.cpp
@@ -2,9 +2,6 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <string>
-#include <vector>
-#include <boost/optional.hpp>
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/ipc.h"
 #include "core/hle/service/http_c.h"
@@ -22,93 +19,6 @@ enum {
 const ResultCode ERROR_CONTEXT_ERROR = // 0xD8A0A066
     ResultCode(ErrCodes::InvalidContext, ErrorModule::HTTP, ErrorSummary::InvalidState,
                ErrorLevel::Permanent);
-
-enum class RequestMethod : u8 {
-    None = 0x0,
-    Get = 0x1,
-    Post = 0x2,
-    Head = 0x3,
-    Put = 0x4,
-    Delete = 0x5,
-    PostEmpty = 0x6,
-    PutEmpty = 0x7,
-};
-
-/// The number of request methods, any valid method must be less than this.
-constexpr u32 TotalRequestMethods = 8;
-
-enum class RequestState : u8 {
-    NotStarted = 0x1,             // Request has not started yet.
-    InProgress = 0x5,             // Request in progress, sending request over the network.
-    ReadyToDownloadContent = 0x7, // Ready to download the content. (needs verification)
-    ReadyToDownload = 0x8,        // Ready to download?
-    TimedOut = 0xA,               // Request timed out?
-};
-
-/// Represents a client certificate along with its private key, stored as a byte array of DER data.
-/// There can only be at most one client certificate context attached to an HTTP context at any
-/// given time.
-struct ClientCertContext {
-    u32 handle;
-    std::vector<u8> certificate;
-    std::vector<u8> private_key;
-};
-
-/// Represents a root certificate chain, it contains a list of DER-encoded certificates for
-/// verifying HTTP requests. An HTTP context can have at most one root certificate chain attached to
-/// it, but the chain may contain an arbitrary number of certificates in it.
-struct RootCertChain {
-    struct RootCACert {
-        u32 handle;
-        std::vector<u8> certificate;
-    };
-
-    u32 handle;
-    std::vector<RootCACert> certificates;
-};
-
-/// Represents an HTTP context.
-struct Context {
-    struct Proxy {
-        std::string url;
-        std::string username;
-        std::string password;
-        u16 port;
-    };
-
-    struct BasicAuth {
-        std::string username;
-        std::string password;
-    };
-
-    struct RequestHeader {
-        std::string name;
-        std::string value;
-    };
-
-    struct PostData {
-        // TODO(Subv): Support Binary and Raw POST elements.
-        std::string name;
-        std::string value;
-    };
-
-    struct SSLConfig {
-        u32 options;
-        std::weak_ptr<ClientCertContext> client_cert_ctx;
-        std::weak_ptr<RootCertChain> root_ca_chain;
-    };
-
-    u32 handle;
-    std::string url;
-    RequestMethod method;
-    RequestState state = RequestState::NotStarted;
-    boost::optional<Proxy> proxy;
-    boost::optional<BasicAuth> basic_auth;
-    SSLConfig ssl_config{};
-    u32 socket_buffer_size;
-    std::vector<RequestHeader> headers;
-    std::vector<PostData> post_data;
-};
 
 void HTTP_C::Initialize(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x1, 1, 4);

--- a/src/core/hle/service/http_c.h
+++ b/src/core/hle/service/http_c.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>

--- a/src/core/hle/service/http_c.h
+++ b/src/core/hle/service/http_c.h
@@ -4,11 +4,15 @@
 
 #pragma once
 
+#include <unordered_map>
 #include "core/hle/kernel/shared_memory.h"
 #include "core/hle/service/service.h"
 
 namespace Service {
 namespace HTTP {
+
+struct Context;
+struct ClientCertContext;
 
 class HTTP_C final : public ServiceFramework<HTTP_C> {
 public:
@@ -29,6 +33,12 @@ private:
     void Initialize(Kernel::HLERequestContext& ctx);
 
     Kernel::SharedPtr<Kernel::SharedMemory> shared_memory = nullptr;
+
+    std::unordered_map<u32, Context> contexts;
+    u32 context_counter = 0;
+
+    std::unordered_map<u32, ClientCertContext> client_certs;
+    u32 client_certs_counter = 0;
 };
 
 void InstallInterfaces(SM::ServiceManager& service_manager);

--- a/src/core/hle/service/http_c.h
+++ b/src/core/hle/service/http_c.h
@@ -9,14 +9,12 @@
 namespace Service {
 namespace HTTP {
 
-class HTTP_C final : public Interface {
+class HTTP_C final : public ServiceFramework<HTTP_C> {
 public:
     HTTP_C();
-
-    std::string GetPortName() const override {
-        return "http:C";
-    }
 };
+
+void InstallInterfaces(SM::ServiceManager& service_manager);
 
 } // namespace HTTP
 } // namespace Service

--- a/src/core/hle/service/http_c.h
+++ b/src/core/hle/service/http_c.h
@@ -142,17 +142,6 @@ private:
     void CloseContext(Kernel::HLERequestContext& ctx);
 
     /**
-     * HTTP_C::InitializeConnectionSession service function
-     *  Inputs:
-     *      1 : HTTP context handle
-     *      2 : 0x20, processID translate-header for the ARM11-kernel
-     *      3 : processID set by the ARM11-kernel
-     *  Outputs:
-     *      1 : Result of function, 0 on success, otherwise error code
-     */
-    void InitializeConnectionSession(Kernel::HLERequestContext& ctx);
-
-    /**
      * HTTP_C::AddRequestHeader service function
      *  Inputs:
      * 1 : Context handle

--- a/src/core/hle/service/http_c.h
+++ b/src/core/hle/service/http_c.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "core/hle/kernel/shared_memory.h"
 #include "core/hle/service/service.h"
 
 namespace Service {
@@ -12,6 +13,22 @@ namespace HTTP {
 class HTTP_C final : public ServiceFramework<HTTP_C> {
 public:
     HTTP_C();
+
+private:
+    /**
+     * HTTP_C::Initialize service function
+     *  Inputs:
+     *      1 : POST buffer size
+     *      2 : 0x20
+     *      3 : 0x0 (Filled with process ID by ARM11 Kernel)
+     *      4 : 0x0
+     *      5 : POST buffer memory block handle
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void Initialize(Kernel::HLERequestContext& ctx);
+
+    Kernel::SharedPtr<Kernel::SharedMemory> shared_memory = nullptr;
 };
 
 void InstallInterfaces(SM::ServiceManager& service_manager);

--- a/src/core/hle/service/http_c.h
+++ b/src/core/hle/service/http_c.h
@@ -54,6 +54,21 @@ private:
      */
     void CloseContext(Kernel::HLERequestContext& ctx);
 
+    /**
+     * HTTP_C::AddRequestHeader service function
+     *  Inputs:
+     * 1 : Context handle
+     * 2 : Header name buffer size, including null-terminator.
+     * 3 : Header value buffer size, including null-terminator.
+     * 4 : (HeaderNameSize<<14) | 0xC02
+     * 5 : Header name data pointer
+     * 6 : (HeaderValueSize<<4) | 10
+     * 7 : Header value data pointer
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void AddRequestHeader(Kernel::HLERequestContext& ctx);
+
     Kernel::SharedPtr<Kernel::SharedMemory> shared_memory = nullptr;
 
     std::unordered_map<u32, Context> contexts;

--- a/src/core/hle/service/http_c.h
+++ b/src/core/hle/service/http_c.h
@@ -142,6 +142,17 @@ private:
     void CloseContext(Kernel::HLERequestContext& ctx);
 
     /**
+     * HTTP_C::InitializeConnectionSession service function
+     *  Inputs:
+     *      1 : HTTP context handle
+     *      2 : 0x20, processID translate-header for the ARM11-kernel
+     *      3 : processID set by the ARM11-kernel
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void InitializeConnectionSession(Kernel::HLERequestContext& ctx);
+
+    /**
      * HTTP_C::AddRequestHeader service function
      *  Inputs:
      * 1 : Context handle

--- a/src/core/hle/service/http_c.h
+++ b/src/core/hle/service/http_c.h
@@ -32,6 +32,19 @@ private:
      */
     void Initialize(Kernel::HLERequestContext& ctx);
 
+    /**
+     * HTTP_C::CreateContext service function
+     *  Inputs:
+     *      1 : URL buffer size, including null-terminator
+     *      2 : RequestMethod
+     *      3 : (URLSize << 4) | 10
+     *      4 : URL data pointer
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     *      2 : HTTP context handle
+     */
+    void CreateContext(Kernel::HLERequestContext& ctx);
+
     Kernel::SharedPtr<Kernel::SharedMemory> shared_memory = nullptr;
 
     std::unordered_map<u32, Context> contexts;

--- a/src/core/hle/service/http_c.h
+++ b/src/core/hle/service/http_c.h
@@ -59,7 +59,15 @@ struct RootCertChain {
 };
 
 /// Represents an HTTP context.
-struct Context {
+class Context final {
+public:
+    Context() = default;
+    Context(const Context&) = delete;
+    Context& operator=(const Context&) = delete;
+
+    Context(Context&& other) = default;
+    Context& operator=(Context&&) = default;
+
     struct Proxy {
         std::string url;
         std::string username;
@@ -73,6 +81,7 @@ struct Context {
     };
 
     struct RequestHeader {
+        RequestHeader(std::string name, std::string value) : name(name), value(value){};
         std::string name;
         std::string value;
     };

--- a/src/core/hle/service/http_c.h
+++ b/src/core/hle/service/http_c.h
@@ -45,6 +45,15 @@ private:
      */
     void CreateContext(Kernel::HLERequestContext& ctx);
 
+    /**
+     * HTTP_C::CreateContext service function
+     *  Inputs:
+     *      1 : Context handle
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void CloseContext(Kernel::HLERequestContext& ctx);
+
     Kernel::SharedPtr<Kernel::SharedMemory> shared_memory = nullptr;
 
     std::unordered_map<u32, Context> contexts;

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -256,7 +256,7 @@ void Init(std::shared_ptr<SM::ServiceManager>& sm) {
     QTM::InstallInterfaces(*sm);
 
     CSND::InstallInterfaces(*sm);
-    AddService(new HTTP::HTTP_C);
+    HTTP::InstallInterfaces(*sm);
     PM::InstallInterfaces(*sm);
     AddService(new SOC::SOC_U);
     SSL::InstallInterfaces(*sm);


### PR DESCRIPTION
This is a team effort by @Subv and me.

Our goal is to get a fully working implementation of the http service including ssl with all the certificates. At the moment we are planning to use httplib and [libressl](https://www.libressl.org/) (which is already in citra) for the communication. 

We decided to make small PRs for easy review. 
So this one implements:

- Initialize
- CreateContext
- CloseContext
- AddRequestHeader

There is still a lot of research left so for all parts where we currently don't know how it behaves we added asserts

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3981)
<!-- Reviewable:end -->
