### PR TITLE
core: clean up warnings

### DIFF
--- a/src/audio_core/dsp_interface.cpp
+++ b/src/audio_core/dsp_interface.cpp
@@ -45,7 +45,7 @@ void DspInterface::OutputFrame(StereoFrame16& frame) {
         return;
 
     // Implementation of the hardware volume slider with a dynamic range of 60 dB
-    float volume_scale_factor = std::exp(6.90775 * Settings::values.volume) * 0.001;
+    double volume_scale_factor = std::exp(6.90775 * Settings::values.volume) * 0.001;
     for (size_t i = 0; i < frame.size(); i++) {
         frame[i][0] = static_cast<s16>(frame[i][0] * volume_scale_factor);
         frame[i][1] = static_cast<s16>(frame[i][1] * volume_scale_factor);

--- a/src/audio_core/hle/hle.cpp
+++ b/src/audio_core/hle/hle.cpp
@@ -43,7 +43,7 @@ private:
 
     StereoFrame16 GenerateCurrentFrame();
     bool Tick();
-    void AudioTickCallback(int cycles_late);
+    void AudioTickCallback(s64 cycles_late);
 
     DspState dsp_state = DspState::Off;
     std::array<std::vector<u8>, num_dsp_pipe> pipe_data;
@@ -66,7 +66,7 @@ DspHle::Impl::Impl(DspHle& parent_) : parent(parent_) {
     dsp_memory.raw_memory.fill(0);
 
     tick_event =
-        CoreTiming::RegisterEvent("AudioCore::DspHle::tick_event", [this](u64, int cycles_late) {
+        CoreTiming::RegisterEvent("AudioCore::DspHle::tick_event", [this](u64, s64 cycles_late) {
             this->AudioTickCallback(cycles_late);
         });
     CoreTiming::ScheduleEvent(audio_frame_ticks, tick_event);
@@ -304,7 +304,7 @@ bool DspHle::Impl::Tick() {
     return true;
 }
 
-void DspHle::Impl::AudioTickCallback(int cycles_late) {
+void DspHle::Impl::AudioTickCallback(s64 cycles_late) {
     if (Tick()) {
         // TODO(merry): Signal all the other interrupts as appropriate.
         Service::DSP::SignalPipeInterrupt(DspPipe::Audio);

--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -110,7 +110,7 @@ template <typename... Args>
 void FmtLogMessage(Class log_class, Level log_level, const char* filename, unsigned int line_num,
                    const char* function, const char* format, const Args&... args) {
     FmtLogMessageImpl(log_class, log_level, filename, line_num, function, format,
-                      fmt::make_args(args...));
+                      fmt::make_format_args(args...));
 }
 
 } // namespace Log

--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -99,7 +99,7 @@ static void AddTicks(u64 ticks) {
 }
 
 static u64 GetTicksRemaining() {
-    int ticks = CoreTiming::GetDowncount();
+    s64 ticks = CoreTiming::GetDowncount();
     return static_cast<u64>(ticks <= 0 ? 0 : ticks);
 }
 

--- a/src/core/arm/dyncom/arm_dyncom.cpp
+++ b/src/core/arm/dyncom/arm_dyncom.cpp
@@ -75,7 +75,7 @@ ARM_DynCom::ARM_DynCom(PrivilegeMode initial_mode) {
 ARM_DynCom::~ARM_DynCom() {}
 
 void ARM_DynCom::Run() {
-    ExecuteInstructions(std::max(CoreTiming::GetDowncount(), 0));
+    ExecuteInstructions(std::max<s64>(CoreTiming::GetDowncount(), 0));
 }
 
 void ARM_DynCom::Step() {
@@ -143,7 +143,7 @@ void ARM_DynCom::SetCP15Register(CP15Register reg, u32 value) {
     state->CP15[reg] = value;
 }
 
-void ARM_DynCom::ExecuteInstructions(int num_instructions) {
+void ARM_DynCom::ExecuteInstructions(u64 num_instructions) {
     state->NumInstrsToExecute = num_instructions;
     unsigned ticks_executed = InterpreterMainLoop(state.get());
     CoreTiming::AddTicks(ticks_executed);

--- a/src/core/arm/dyncom/arm_dyncom.h
+++ b/src/core/arm/dyncom/arm_dyncom.h
@@ -42,7 +42,7 @@ public:
     void PrepareReschedule() override;
 
 private:
-    void ExecuteInstructions(int num_instructions);
+    void ExecuteInstructions(u64 num_instructions);
 
     std::unique_ptr<ARMul_State> state;
 };

--- a/src/core/arm/dyncom/arm_dyncom_trans.h
+++ b/src/core/arm/dyncom/arm_dyncom_trans.h
@@ -1,4 +1,8 @@
 #pragma once
+#ifdef _MSC_VER
+// nonstandard extension used: zero-sized array in struct/union
+#pragma warning(disable : 4200)
+#endif
 
 #include <cstddef>
 #include "common/common_types.h"

--- a/src/core/arm/skyeye_common/armstate.h
+++ b/src/core/arm/skyeye_common/armstate.h
@@ -221,7 +221,7 @@ public:
     u32 TFlag; // Thumb state
 
     unsigned long long NumInstrs; // The number of instructions executed
-    unsigned NumInstrsToExecute;
+    u64 NumInstrsToExecute;
 
     unsigned NresetSig; // Reset the processor
     unsigned NfiqSig;

--- a/src/core/core_timing.cpp
+++ b/src/core/core_timing.cpp
@@ -19,8 +19,8 @@
 namespace CoreTiming {
 
 static s64 global_timer;
-static int slice_length;
-static int downcount;
+static s64 slice_length;
+static s64 downcount;
 
 struct EventType {
     TimedCallback callback;
@@ -180,10 +180,8 @@ void RemoveNormalAndThreadsafeEvent(const EventType* event_type) {
 void ForceExceptionCheck(s64 cycles) {
     cycles = std::max<s64>(0, cycles);
     if (downcount > cycles) {
-        // downcount is always (much) smaller than MAX_INT so we can safely cast cycles to an int
-        // here. Account for cycles already executed by adjusting the g.slice_length
-        slice_length -= downcount - static_cast<int>(cycles);
-        downcount = static_cast<int>(cycles);
+        slice_length -= downcount - cycles;
+        downcount = cycles;
     }
 }
 
@@ -198,7 +196,7 @@ void MoveEvents() {
 void Advance() {
     MoveEvents();
 
-    int cycles_executed = slice_length - downcount;
+    s64 cycles_executed = slice_length - downcount;
     global_timer += cycles_executed;
     slice_length = MAX_SLICE_LENGTH;
 
@@ -231,7 +229,7 @@ u64 GetGlobalTimeUs() {
     return GetTicks() * 1000000 / BASE_CLOCK_RATE_ARM11;
 }
 
-int GetDowncount() {
+s64 GetDowncount() {
     return downcount;
 }
 

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -128,7 +128,7 @@ namespace CoreTiming {
 void Init();
 void Shutdown();
 
-typedef std::function<void(u64 userdata, int cycles_late)> TimedCallback;
+typedef std::function<void(u64 userdata, s64 cycles_late)> TimedCallback;
 
 /**
  * This should only be called from the emu thread, if you are calling it any other thread, you are
@@ -186,6 +186,6 @@ void ForceExceptionCheck(s64 cycles);
 
 u64 GetGlobalTimeUs();
 
-int GetDowncount();
+s64 GetDowncount();
 
 } // namespace CoreTiming

--- a/src/core/file_sys/title_metadata.cpp
+++ b/src/core/file_sys/title_metadata.cpp
@@ -73,7 +73,7 @@ Loader::ResultStatus TitleMetadata::Load(const std::vector<u8> file_data, size_t
     memcpy(&tmd_body, &file_data[offset + body_start], sizeof(TitleMetadata::Body));
 
     size_t expected_size =
-        body_start + sizeof(Body) + tmd_body.content_count * sizeof(ContentChunk);
+        body_start + sizeof(Body) + static_cast<u16>(tmd_body.content_count) * sizeof(ContentChunk);
     if (total_size < expected_size) {
         LOG_ERROR(Service_FS, "Malformed TMD, expected size 0x{:x}, got 0x{:x}!", expected_size,
                   total_size);

--- a/src/core/hle/applets/applet.cpp
+++ b/src/core/hle/applets/applet.cpp
@@ -79,7 +79,7 @@ std::shared_ptr<Applet> Applet::Get(Service::APT::AppletId id) {
 }
 
 /// Handles updating the current Applet every time it's called.
-static void AppletUpdateEvent(u64 applet_id, int cycles_late) {
+static void AppletUpdateEvent(u64 applet_id, s64 cycles_late) {
     Service::APT::AppletId id = static_cast<Service::APT::AppletId>(applet_id);
     std::shared_ptr<Applet> applet = Applet::Get(id);
     ASSERT_MSG(applet != nullptr, "Applet doesn't exist! applet_id={:08X}", static_cast<u32>(id));

--- a/src/core/hle/ipc_helpers.h
+++ b/src/core/hle/ipc_helpers.h
@@ -423,7 +423,7 @@ inline const std::vector<u8>& RequestParser::PopStaticBuffer() {
     Pop<VAddr>();
 
     StaticBufferDescInfo buffer_info{sbuffer_descriptor};
-    return context->GetStaticBuffer(buffer_info.buffer_id);
+    return context->GetStaticBuffer(static_cast<u8>(buffer_info.buffer_id));
 }
 
 inline Kernel::MappedBuffer& RequestParser::PopMappedBuffer() {

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -240,13 +240,13 @@ MappedBuffer::MappedBuffer(const Process& process, u32 descriptor, VAddr address
 void MappedBuffer::Read(void* dest_buffer, size_t offset, size_t size) {
     ASSERT(perms & IPC::R);
     ASSERT(offset + size <= this->size);
-    Memory::ReadBlock(*process, address + offset, dest_buffer, size);
+    Memory::ReadBlock(*process, address + static_cast<VAddr>(offset), dest_buffer, size);
 }
 
 void MappedBuffer::Write(const void* src_buffer, size_t offset, size_t size) {
     ASSERT(perms & IPC::W);
     ASSERT(offset + size <= this->size);
-    Memory::WriteBlock(*process, address + offset, src_buffer, size);
+    Memory::WriteBlock(*process, address + static_cast<VAddr>(offset), src_buffer, size);
 }
 
 } // namespace Kernel

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -188,7 +188,7 @@ void ExitCurrentThread() {
  * @param thread_handle The handle of the thread that's been awoken
  * @param cycles_late The number of CPU cycles that have passed since the desired wakeup time
  */
-static void ThreadWakeupCallback(u64 thread_handle, int cycles_late) {
+static void ThreadWakeupCallback(u64 thread_handle, s64 cycles_late) {
     SharedPtr<Thread> thread = wakeup_callback_handle_table.Get<Thread>((Handle)thread_handle);
     if (thread == nullptr) {
         LOG_CRITICAL(Kernel, "Callback fired for invalid thread {:08X}", (Handle)thread_handle);

--- a/src/core/hle/kernel/timer.cpp
+++ b/src/core/hle/kernel/timer.cpp
@@ -76,7 +76,7 @@ void Timer::WakeupAllWaitingThreads() {
         signaled = false;
 }
 
-void Timer::Signal(int cycles_late) {
+void Timer::Signal(s64 cycles_late) {
     LOG_TRACE(Kernel, "Timer {} fired", GetObjectId());
 
     signaled = true;
@@ -92,7 +92,7 @@ void Timer::Signal(int cycles_late) {
 }
 
 /// The timer callback event, called when a timer is fired
-static void TimerCallback(u64 timer_handle, int cycles_late) {
+static void TimerCallback(u64 timer_handle, s64 cycles_late) {
     SharedPtr<Timer> timer =
         timer_callback_handle_table.Get<Timer>(static_cast<Handle>(timer_handle));
 

--- a/src/core/hle/kernel/timer.h
+++ b/src/core/hle/kernel/timer.h
@@ -65,7 +65,7 @@ public:
      * This method should not be called from outside the timer callback handler,
      * lest multiple callback events get scheduled.
      */
-    void Signal(int cycles_late);
+    void Signal(s64 cycles_late);
 
 private:
     Timer();

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -232,7 +232,7 @@ bool CIAFile::SetSize(u64 size) const {
 bool CIAFile::Close() const {
     bool complete = true;
     for (size_t i = 0; i < container.GetTitleMetadata().GetContentCount(); i++) {
-        if (content_written[i] < container.GetContentSize(i))
+        if (content_written[i] < container.GetContentSize(static_cast<u16>(i)))
             complete = false;
     }
 
@@ -294,7 +294,7 @@ InstallStatus InstallCIA(const std::string& path,
             Service::AM::GetTitleMediaType(container.GetTitleMetadata().GetTitleID()));
 
         for (size_t i = 0; i < container.GetTitleMetadata().GetContentCount(); i++) {
-            if (container.GetTitleMetadata().GetContentTypeByIndex(i) &
+            if (container.GetTitleMetadata().GetContentTypeByIndex(static_cast<u16>(i)) &
                 FileSys::TMDContentTypeFlag::Encrypted) {
                 LOG_ERROR(Service_AM, "File {} is encrypted! Aborting...", path);
                 return InstallStatus::ErrorEncrypted;
@@ -493,7 +493,7 @@ void Module::Interface::GetNumPrograms(Kernel::HLERequestContext& ctx) {
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
     rb.Push(RESULT_SUCCESS);
-    rb.Push<u32>(am->am_title_list[media_type].size());
+    rb.Push<u32>(static_cast<u32>(am->am_title_list[media_type].size()));
 }
 
 void Module::Interface::FindDLCContentInfos(Kernel::HLERequestContext& ctx) {
@@ -877,7 +877,7 @@ void Module::Interface::GetDLCContentInfoCount(Kernel::HLERequestContext& ctx) {
 
     FileSys::TitleMetadata tmd;
     if (tmd.Load(tmd_path) == Loader::ResultStatus::Success) {
-        rb.Push<u32>(tmd.GetContentCount());
+        rb.Push<u32>(static_cast<u32>(tmd.GetContentCount()));
     } else {
         rb.Push<u32>(1); // Number of content infos plus one
         LOG_WARNING(Service_AM, "(STUBBED) called media_type={}, title_id=0x{:016x}",

--- a/src/core/hle/service/cam/cam.cpp
+++ b/src/core/hle/service/cam/cam.cpp
@@ -74,7 +74,7 @@ void Module::PortConfig::Clear() {
     transfer_bytes = 256;
 }
 
-void Module::CompletionEventCallBack(u64 port_id, int) {
+void Module::CompletionEventCallBack(u64 port_id, s64) {
     PortConfig& port = ports[port_id];
     const CameraConfig& camera = cameras[port.camera_id];
     const auto buffer = port.capture_result.get();
@@ -1028,7 +1028,7 @@ Module::Module() {
     }
     completion_event_callback = CoreTiming::RegisterEvent(
         "CAM::CompletionEventCallBack",
-        [this](u64 userdata, int cycles_late) { CompletionEventCallBack(userdata, cycles_late); });
+        [this](u64 userdata, s64 cycles_late) { CompletionEventCallBack(userdata, cycles_late); });
 }
 
 Module::~Module() {

--- a/src/core/hle/service/cam/cam.h
+++ b/src/core/hle/service/cam/cam.h
@@ -710,7 +710,7 @@ public:
     };
 
 private:
-    void CompletionEventCallBack(u64 port_id, int);
+    void CompletionEventCallBack(u64 port_id, s64);
 
     // Starts a receiving process on the specified port. This can only be called when is_busy = true
     // and is_receiving = false.

--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -184,7 +184,7 @@ void Module::Interface::SecureInfoGetRegion(Kernel::HLERequestContext& ctx, u16 
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
     rb.Push(RESULT_SUCCESS);
-    rb.Push<u8>(cfg->GetRegionValue());
+    rb.Push<u8>(static_cast<u8>(cfg->GetRegionValue()));
 }
 
 void Module::Interface::GenHashConsoleUnique(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -79,7 +79,7 @@ void File::Read(Kernel::HLERequestContext& ctx) {
 
     if (file->subfile && length > file->size) {
         LOG_WARNING(Service_FS, "Trying to read beyond the subfile size, truncating");
-        length = file->size;
+        length = static_cast<u32>(file->size);
     }
 
     // This file session might have a specific offset from where to start reading, apply it.
@@ -101,7 +101,7 @@ void File::Read(Kernel::HLERequestContext& ctx) {
     } else {
         buffer.Write(data.data(), 0, *read);
         rb.Push(RESULT_SUCCESS);
-        rb.Push<u32>(*read);
+        rb.Push<u32>(static_cast<u32>(*read));
     }
     rb.PushMappedBuffer(buffer);
 
@@ -142,7 +142,7 @@ void File::Write(Kernel::HLERequestContext& ctx) {
         rb.Push<u32>(0);
     } else {
         rb.Push(RESULT_SUCCESS);
-        rb.Push<u32>(*written);
+        rb.Push<u32>(static_cast<u32>(*written));
     }
     rb.PushMappedBuffer(buffer);
 }

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -71,7 +71,7 @@ void Module::LoadInputDevices() {
     touch_device = Input::CreateDevice<Input::TouchDevice>(Settings::values.touch_device);
 }
 
-void Module::UpdatePadCallback(u64 userdata, int cycles_late) {
+void Module::UpdatePadCallback(u64 userdata, s64 cycles_late) {
     SharedMem* mem = reinterpret_cast<SharedMem*>(shared_mem->GetPointer());
 
     if (is_device_reload_pending.exchange(false))
@@ -166,7 +166,7 @@ void Module::UpdatePadCallback(u64 userdata, int cycles_late) {
     CoreTiming::ScheduleEvent(pad_update_ticks - cycles_late, pad_update_event);
 }
 
-void Module::UpdateAccelerometerCallback(u64 userdata, int cycles_late) {
+void Module::UpdateAccelerometerCallback(u64 userdata, s64 cycles_late) {
     SharedMem* mem = reinterpret_cast<SharedMem*>(shared_mem->GetPointer());
 
     mem->accelerometer.index = next_accelerometer_index;
@@ -210,7 +210,7 @@ void Module::UpdateAccelerometerCallback(u64 userdata, int cycles_late) {
     CoreTiming::ScheduleEvent(accelerometer_update_ticks - cycles_late, accelerometer_update_event);
 }
 
-void Module::UpdateGyroscopeCallback(u64 userdata, int cycles_late) {
+void Module::UpdateGyroscopeCallback(u64 userdata, s64 cycles_late) {
     SharedMem* mem = reinterpret_cast<SharedMem*>(shared_mem->GetPointer());
 
     mem->gyroscope.index = next_gyroscope_index;
@@ -371,16 +371,16 @@ Module::Module() {
 
     // Register update callbacks
     pad_update_event =
-        CoreTiming::RegisterEvent("HID::UpdatePadCallback", [this](u64 userdata, int cycles_late) {
+        CoreTiming::RegisterEvent("HID::UpdatePadCallback", [this](u64 userdata, s64 cycles_late) {
             UpdatePadCallback(userdata, cycles_late);
         });
     accelerometer_update_event = CoreTiming::RegisterEvent(
-        "HID::UpdateAccelerometerCallback", [this](u64 userdata, int cycles_late) {
+        "HID::UpdateAccelerometerCallback", [this](u64 userdata, s64 cycles_late) {
             UpdateAccelerometerCallback(userdata, cycles_late);
         });
     gyroscope_update_event = CoreTiming::RegisterEvent(
         "HID::UpdateGyroscopeCallback",
-        [this](u64 userdata, int cycles_late) { UpdateGyroscopeCallback(userdata, cycles_late); });
+        [this](u64 userdata, s64 cycles_late) { UpdateGyroscopeCallback(userdata, cycles_late); });
 
     CoreTiming::ScheduleEvent(pad_update_ticks, pad_update_event);
 }

--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -24,7 +24,7 @@ class SharedMemory;
 } // namespace Kernel
 
 namespace CoreTiming {
-class EventType;
+struct EventType;
 };
 
 namespace Service {
@@ -297,9 +297,9 @@ public:
 
 private:
     void LoadInputDevices();
-    void UpdatePadCallback(u64 userdata, int cycles_late);
-    void UpdateAccelerometerCallback(u64 userdata, int cycles_late);
-    void UpdateGyroscopeCallback(u64 userdata, int cycles_late);
+    void UpdatePadCallback(u64 userdata, s64 cycles_late);
+    void UpdateAccelerometerCallback(u64 userdata, s64 cycles_late);
+    void UpdateGyroscopeCallback(u64 userdata, s64 cycles_late);
 
     // Handle to shared memory region designated to HID_User service
     Kernel::SharedPtr<Kernel::SharedMemory> shared_mem;

--- a/src/core/hle/service/ir/extra_hid.cpp
+++ b/src/core/hle/service/ir/extra_hid.cpp
@@ -146,7 +146,7 @@ ExtraHID::ExtraHID(SendFunc send_func) : IRDevice(send_func) {
     }};
 
     hid_polling_callback_id =
-        CoreTiming::RegisterEvent("ExtraHID::SendHIDStatus", [this](u64, int cycles_late) {
+        CoreTiming::RegisterEvent("ExtraHID::SendHIDStatus", [this](u64, s64 cycles_late) {
             SendHIDStatus();
             CoreTiming::ScheduleEvent(msToCycles(hid_period) - cycles_late,
                                       hid_polling_callback_id);

--- a/src/core/hle/service/ir/ir_rst.cpp
+++ b/src/core/hle/service/ir/ir_rst.cpp
@@ -48,7 +48,7 @@ void IR_RST::UnloadInputDevices() {
     c_stick = nullptr;
 }
 
-void IR_RST::UpdateCallback(u64 userdata, int cycles_late) {
+void IR_RST::UpdateCallback(u64 userdata, s64 cycles_late) {
     SharedMem* mem = reinterpret_cast<SharedMem*>(shared_memory->GetPointer());
 
     if (is_device_reload_pending.exchange(false))
@@ -155,7 +155,7 @@ IR_RST::IR_RST() : ServiceFramework("ir:rst", 1) {
     update_event = Event::Create(ResetType::OneShot, "IRRST:UpdateEvent");
 
     update_callback_id =
-        CoreTiming::RegisterEvent("IRRST:UpdateCallBack", [this](u64 userdata, int cycles_late) {
+        CoreTiming::RegisterEvent("IRRST:UpdateCallBack", [this](u64 userdata, s64 cycles_late) {
             UpdateCallback(userdata, cycles_late);
         });
 

--- a/src/core/hle/service/ir/ir_rst.h
+++ b/src/core/hle/service/ir/ir_rst.h
@@ -19,7 +19,7 @@ class SharedMemory;
 } // namespace Kernel
 
 namespace CoreTiming {
-class EventType;
+struct EventType;
 };
 
 namespace Service {
@@ -76,7 +76,7 @@ private:
 
     void LoadInputDevices();
     void UnloadInputDevices();
-    void UpdateCallback(u64 userdata, int cycles_late);
+    void UpdateCallback(u64 userdata, s64 cycles_late);
 
     Kernel::SharedPtr<Kernel::Event> update_event;
     Kernel::SharedPtr<Kernel::SharedMemory> shared_memory;

--- a/src/core/hle/service/ir/ir_user.h
+++ b/src/core/hle/service/ir/ir_user.h
@@ -15,7 +15,7 @@ class SharedMemory;
 } // namespace Kernel
 
 namespace CoreTiming {
-class EventType;
+struct EventType;
 };
 
 namespace Service {

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -80,7 +80,7 @@ static u8 network_channel = DefaultNetworkChannel;
 static NetworkInfo network_info;
 
 // Mapping of mac addresses to their respective node_ids.
-static std::map<MacAddress, u32> node_map;
+static std::map<MacAddress, u16> node_map;
 
 // Event that will generate and send the 802.11 beacon frames.
 static CoreTiming::EventType* beacon_broadcast_event;
@@ -179,7 +179,7 @@ static void HandleNodeMapPacket(const Network::WifiPacket& packet) {
     node_map.clear();
     size_t num_entries;
     Network::MacAddress address;
-    u32 id;
+    u16 id;
     std::memcpy(&num_entries, packet.data.data(), sizeof(num_entries));
     size_t offset = sizeof(num_entries);
     for (size_t i = 0; i < num_entries; ++i) {
@@ -612,7 +612,7 @@ void NWM_UDS::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
     }
 
     // Update the total size in the structure and write it to the buffer again.
-    data_reply_header.total_size = cur_buffer_size;
+    data_reply_header.total_size = static_cast<u32>(cur_buffer_size);
     out_buffer.Write(&data_reply_header, 0, sizeof(BeaconDataReplyHeader));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
@@ -1189,7 +1189,7 @@ void NWM_UDS::SetApplicationData(Kernel::HLERequestContext& ctx) {
         return;
     }
 
-    network_info.application_data_size = size;
+    network_info.application_data_size = static_cast<u8>(size);
     std::memcpy(network_info.application_data.data(), application_data.data(), size);
 
     rb.Push(RESULT_SUCCESS);
@@ -1262,7 +1262,7 @@ void NWM_UDS::DecryptBeaconData(Kernel::HLERequestContext& ctx) {
 }
 
 // Sends a 802.11 beacon frame with information about the current network.
-static void BeaconBroadcastCallback(u64 userdata, int cycles_late) {
+static void BeaconBroadcastCallback(u64 userdata, s64 cycles_late) {
     // Don't do anything if we're not actually hosting a network
     if (connection_status.status != static_cast<u32>(NetworkStatus::ConnectedAsHost))
         return;

--- a/src/core/hle/service/ptm/ptm.cpp
+++ b/src/core/hle/service/ptm/ptm.cpp
@@ -77,7 +77,6 @@ void Module::Interface::GetStepHistory(Kernel::HLERequestContext& ctx) {
 
     u32 hours = rp.Pop<u32>();
     u64 start_time = rp.Pop<u64>();
-    size_t steps_buff_size;
     auto& buffer = rp.PopMappedBuffer();
     ASSERT_MSG(sizeof(u16) * hours == buffer.GetSize(),
                "Buffer for steps count has incorrect size");

--- a/src/core/hle/service/soc_u.cpp
+++ b/src/core/hle/service/soc_u.cpp
@@ -796,8 +796,8 @@ void SOC_U::SetSockOpt(Kernel::HLERequestContext& ctx) {
 #endif
     } else {
         const char* optval_data = reinterpret_cast<const char*>(optval.data());
-        err = static_cast<u32>(
-            ::setsockopt(socket_handle, level, optname, optval_data, optval.size()));
+        err = static_cast<u32>(::setsockopt(socket_handle, level, optname, optval_data,
+                                            static_cast<socklen_t>(optval.size())));
         if (err == SOCKET_ERROR_VALUE) {
             err = TranslateError(GET_ERRNO);
         }

--- a/src/core/hle/shared_page.cpp
+++ b/src/core/hle/shared_page.cpp
@@ -52,7 +52,7 @@ static u64 GetSystemTime() {
     return console_time;
 }
 
-static void UpdateTimeCallback(u64 userdata, int cycles_late) {
+static void UpdateTimeCallback(u64 userdata, s64 cycles_late) {
     DateTime& date_time =
         shared_page.date_time_counter % 2 ? shared_page.date_time_0 : shared_page.date_time_1;
 

--- a/src/core/hw/gpu.cpp
+++ b/src/core/hw/gpu.cpp
@@ -510,7 +510,7 @@ template void Write<u16>(u32 addr, const u16 data);
 template void Write<u8>(u32 addr, const u8 data);
 
 /// Update hardware
-static void VBlankCallback(u64 userdata, int cycles_late) {
+static void VBlankCallback(u64 userdata, s64 cycles_late) {
     VideoCore::g_renderer->SwapBuffers();
 
     // Signal to GSP that GPU interrupt has occurred

--- a/src/core/movie.cpp
+++ b/src/core/movie.cpp
@@ -242,12 +242,15 @@ void Movie::Play(Service::IR::ExtraHIDResponse& extra_hid_response) {
         return;
     }
 
-    extra_hid_response.buttons.battery_level.Assign(s.extra_hid_response.battery_level);
+    extra_hid_response.buttons.battery_level.Assign(
+        static_cast<u8>(s.extra_hid_response.battery_level));
     extra_hid_response.c_stick.c_stick_x.Assign(s.extra_hid_response.c_stick_x);
     extra_hid_response.c_stick.c_stick_y.Assign(s.extra_hid_response.c_stick_y);
-    extra_hid_response.buttons.r_not_held.Assign(s.extra_hid_response.r_not_held);
-    extra_hid_response.buttons.zl_not_held.Assign(s.extra_hid_response.zl_not_held);
-    extra_hid_response.buttons.zr_not_held.Assign(s.extra_hid_response.zr_not_held);
+    extra_hid_response.buttons.r_not_held.Assign(static_cast<u8>(s.extra_hid_response.r_not_held));
+    extra_hid_response.buttons.zl_not_held.Assign(
+        static_cast<u8>(s.extra_hid_response.zl_not_held));
+    extra_hid_response.buttons.zr_not_held.Assign(
+        static_cast<u8>(s.extra_hid_response.zr_not_held));
 }
 
 void Movie::Record(const ControllerState& controller_state) {


### PR DESCRIPTION
cleans up all the errors encountered in core using MSVC ~~except a copious number of
`Warning	C4244	'initializing': conversion from 'const wchar_t' to 'char', possible loss of data	core	c:\program files (x86)\microsoft visual studio\2017\community\vc\tools\msvc\14.14.26428\include\xmemory0	228	`~~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3985)
<!-- Reviewable:end -->
