### PR TITLE
citra_qt/configuration: fix input configuration disappearing after changing languages

### DIFF
--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -289,4 +289,5 @@ void ConfigureInput::keyPressEvent(QKeyEvent* event) {
 
 void ConfigureInput::retranslateUi() {
     ui->retranslateUi(this);
+    updateButtonLabels();
 }


### PR DESCRIPTION
Previously, once you change language, the texts in the buttons in the Input tab will disappear. It is because the default text in the buttons are empty, and we did not update the text after translations are reloaded, aka texts are reset. This PR fixed the issue.

Again, one line diff took 4 lines of description.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3986)
<!-- Reviewable:end -->
