### PR TITLE
citra_qt/configuration: retranslate hotkey widget on language change

### DIFF
--- a/src/citra_qt/configuration/configure_general.cpp
+++ b/src/citra_qt/configuration/configure_general.cpp
@@ -79,4 +79,5 @@ void ConfigureGeneral::onLanguageChanged(int index) {
 
 void ConfigureGeneral::retranslateUi() {
     ui->retranslateUi(this);
+    ui->hotkeysDialog->retranslateUi();
 }

--- a/src/citra_qt/configuration/configure_general.ui
+++ b/src/citra_qt/configuration/configure_general.ui
@@ -201,7 +201,7 @@
         <item>
          <layout class="QVBoxLayout" name="verticalLayout_4">
           <item>
-           <widget class="GHotkeysDialog" name="widget" native="true"/>
+           <widget class="GHotkeysDialog" name="hotkeysDialog" native="true"/>
           </item>
          </layout>
         </item>

--- a/src/citra_qt/hotkeys.cpp
+++ b/src/citra_qt/hotkeys.cpp
@@ -88,3 +88,7 @@ GHotkeysDialog::GHotkeysDialog(QWidget* parent) : QWidget(parent) {
     ui.treeWidget->resizeColumnToContents(0);
     ui.treeWidget->resizeColumnToContents(1);
 }
+
+void GHotkeysDialog::retranslateUi() {
+    ui.retranslateUi(this);
+}

--- a/src/citra_qt/hotkeys.h
+++ b/src/citra_qt/hotkeys.h
@@ -58,6 +58,7 @@ class GHotkeysDialog : public QWidget {
 
 public:
     explicit GHotkeysDialog(QWidget* parent = nullptr);
+    void retranslateUi();
 
 private:
     Ui::hotkeys ui;


### PR DESCRIPTION
The hotkey widget has a separate class defined for it, and qt cannot automatically retranslate it when retranslateUi is called. This commit explicitly calls the function to retranslate the hotkey dialog.

Side note: the name for the hotkey dialog widget: "widget" is too bad, so I changed it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3987)
<!-- Reviewable:end -->
