### PR TITLE
citra_qt/multiplayer: allow blocking other players in chat room

### DIFF
--- a/src/citra_qt/multiplayer/chat_room.h
+++ b/src/citra_qt/multiplayer/chat_room.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <memory>
+#include <unordered_set>
 #include <QDialog>
 #include <QSortFilterProxyModel>
 #include <QStandardItemModel>
@@ -39,6 +40,7 @@ public slots:
     void OnChatReceive(const Network::ChatEntry&);
     void OnSendChat();
     void OnChatTextChanged();
+    void PopupContextMenu(const QPoint& menu_location);
     void Disable();
     void Enable();
 
@@ -51,6 +53,7 @@ private:
     bool ValidateMessage(const std::string&);
     QStandardItemModel* player_list;
     std::unique_ptr<Ui::ChatRoom> ui;
+    std::unordered_set<std::string> block_list;
 };
 
 Q_DECLARE_METATYPE(Network::ChatEntry);


### PR DESCRIPTION
@adityaruplaha says such feature is needed, and @wwylele suggested it
This is an example GIF
![spamming](https://user-images.githubusercontent.com/21307832/43123135-d394954c-8f55-11e8-8f1a-2e8b4625a2fc.gif)

Note that the GIF was recorded on a earlier version of the code and now I have added a question to explain what a Block is and confirm they want to block the user.
![blockingplayer](https://user-images.githubusercontent.com/21307832/43123186-f4ec5950-8f55-11e8-8a03-f6a7eac4a263.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3988)
<!-- Reviewable:end -->
