### PR TITLE
citra_qt: retranslate status bar

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -1415,6 +1415,7 @@ void GMainWindow::OnLanguageChanged(const QString& locale) {
     UISettings::values.language = locale;
     LoadTranslation();
     ui.retranslateUi(this);
+    RetranslateStatusBar();
     SetupUIStrings();
 }
 
@@ -1436,6 +1437,21 @@ void GMainWindow::SyncMenuUISettings() {
     ui.action_Screen_Layout_Side_by_Side->setChecked(Settings::values.layout_option ==
                                                      Settings::LayoutOption::SideScreen);
     ui.action_Screen_Layout_Swap_Screens->setChecked(Settings::values.swap_screen);
+}
+
+void GMainWindow::RetranslateStatusBar() {
+    if (emu_thread)
+        UpdateStatusBar();
+
+    emu_speed_label->setToolTip(tr("Current emulation speed. Values higher or lower than 100% "
+                                   "indicate emulation is running faster or slower than a 3DS."));
+    game_fps_label->setToolTip(tr("How many frames per second the game is currently displaying. "
+                                  "This will vary from game to game and scene to scene."));
+    emu_frametime_label->setToolTip(
+        tr("Time taken to emulate a 3DS frame, not counting framelimiting or v-sync. For "
+           "full-speed emulation this should be at most 16.67 ms."));
+
+    multiplayer_state->retranslateUi();
 }
 
 #ifdef main

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -181,6 +181,7 @@ private:
     void UpdateStatusBar();
     void LoadTranslation();
     void SetupUIStrings();
+    void RetranslateStatusBar();
 
     Ui::MainWindow ui;
 

--- a/src/citra_qt/multiplayer/state.cpp
+++ b/src/citra_qt/multiplayer/state.cpp
@@ -65,6 +65,18 @@ void MultiplayerState::Close() {
         lobby->close();
 }
 
+void MultiplayerState::retranslateUi() {
+    status_text->setToolTip(tr("Current connection status"));
+
+    if (current_state == Network::RoomMember::State::Uninitialized) {
+        status_text->setText(tr("Not Connected. Click here to find a room!"));
+    } else if (current_state == Network::RoomMember::State::Joined) {
+        status_text->setText(tr("Connected"));
+    } else {
+        status_text->setText(tr("Not Connected"));
+    }
+}
+
 void MultiplayerState::OnNetworkStateChanged(const Network::RoomMember::State& state) {
     LOG_DEBUG(Frontend, "Network State: {}", Network::GetStateStr(state));
     bool is_connected = false;
@@ -106,6 +118,8 @@ void MultiplayerState::OnNetworkStateChanged(const Network::RoomMember::State& s
         leave_room->setEnabled(false);
         show_room->setEnabled(false);
     }
+
+    current_state = state;
 }
 
 void MultiplayerState::OnAnnounceFailed(const Common::WebResult& result) {

--- a/src/citra_qt/multiplayer/state.h
+++ b/src/citra_qt/multiplayer/state.h
@@ -36,6 +36,8 @@ public:
         return status_icon;
     }
 
+    void retranslateUi();
+
 public slots:
     void OnNetworkStateChanged(const Network::RoomMember::State& state);
     void OnViewLobby();
@@ -60,6 +62,7 @@ private:
     QAction* leave_room;
     QAction* show_room;
     std::shared_ptr<Core::AnnounceMultiplayerSession> announce_multiplayer_session;
+    Network::RoomMember::State current_state = Network::RoomMember::State::Uninitialized;
     Network::RoomMember::CallbackHandle<Network::RoomMember::State> state_callback_handle;
 };
 

--- a/src/network/room_member.h
+++ b/src/network/room_member.h
@@ -46,10 +46,11 @@ struct ChatEntry {
 class RoomMember final {
 public:
     enum class State : u8 {
-        Idle,    ///< Default state
-        Error,   ///< Some error [permissions to network device missing or something]
-        Joining, ///< The client is attempting to join a room.
-        Joined,  ///< The client is connected to the room and is ready to send/receive packets.
+        Uninitialized, ///< Not initialized
+        Idle,          ///< Default state
+        Error,         ///< Some error [permissions to network device missing or something]
+        Joining,       ///< The client is attempting to join a room.
+        Joined, ///< The client is connected to the room and is ready to send/receive packets.
         LostConnection, ///< Connection closed
 
         // Reasons why connection was rejected


### PR DESCRIPTION
As the status bar does not have an UI file, it has to be manually retranslated by setting the text again.

I had to add a `Network::RoomMember::State` to provide the same behaviour ("Not Connected. Click here to find a room" by default, and "Not Connected" once you join a room and quit)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3989)
<!-- Reviewable:end -->
