### PR TITLE
citra_qt: minor retranslation fix

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -1416,6 +1416,9 @@ void GMainWindow::OnLanguageChanged(const QString& locale) {
     LoadTranslation();
     ui.retranslateUi(this);
     SetupUIStrings();
+
+    if (emulation_running)
+        ui.action_Start->setText(tr("Continue"));
 }
 
 void GMainWindow::SetupUIStrings() {


### PR DESCRIPTION
When you change the language when a game is running, the "Continue" action in the "Emulation" menu would become "Start". This PR fixes the issue by checking and setting it if it should be "Continue". It seems that this is the only place with this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3990)
<!-- Reviewable:end -->
