### PR TITLE
applet_manager: disable loading LLE applets

### DIFF
--- a/src/core/hle/service/apt/applet_manager.cpp
+++ b/src/core/hle/service/apt/applet_manager.cpp
@@ -321,10 +321,13 @@ ResultCode AppletManager::PrepareToStartLibraryApplet(AppletId applet_id) {
                           ErrorSummary::InvalidState, ErrorLevel::Status);
     }
 
-    auto process = NS::LaunchTitle(FS::MediaType::NAND, GetTitleIdForApplet(applet_id));
-    if (process) {
-        return RESULT_SUCCESS;
-    }
+    // There are some problems with LLE applets. The rasterizer cache gets out of sync
+    // when the applet is closed. To avoid breaking applications because of the issue,
+    // we are going to disable loading LLE applets before further fixes are done.
+    //    auto process = NS::LaunchTitle(FS::MediaType::NAND, GetTitleIdForApplet(applet_id));
+    //    if (process) {
+    //        return RESULT_SUCCESS;
+    //    }
 
     // If we weren't able to load the native applet title, try to fallback to an HLE implementation.
     auto applet = HLE::Applets::Applet::Get(applet_id);
@@ -345,10 +348,13 @@ ResultCode AppletManager::PreloadLibraryApplet(AppletId applet_id) {
                           ErrorSummary::InvalidState, ErrorLevel::Status);
     }
 
-    auto process = NS::LaunchTitle(FS::MediaType::NAND, GetTitleIdForApplet(applet_id));
-    if (process) {
-        return RESULT_SUCCESS;
-    }
+    // There are some problems with LLE applets. The rasterizer cache gets out of sync
+    // when the applet is closed. To avoid breaking applications because of the issue,
+    // we are going to disable loading LLE applets before further fixes are done.
+    //    auto process = NS::LaunchTitle(FS::MediaType::NAND, GetTitleIdForApplet(applet_id));
+    //    if (process) {
+    //        return RESULT_SUCCESS;
+    //    }
 
     // If we weren't able to load the native applet title, try to fallback to an HLE implementation.
     auto applet = HLE::Applets::Applet::Get(applet_id);


### PR DESCRIPTION
Currently LLE applets cannot exit properly in Citra and causes Citra to hang. We are already providing HLE for applets, and the LLE applets are preventing users who dumped their system files from using the applets correctly. Before the further fix is done, I think we should temporaily disable loading LLE applets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/3991)
<!-- Reviewable:end -->
