### PR TITLE
Services/HTTP: Corrected some error codes and added a few new ones.

### DIFF
--- a/src/core/hle/service/http_c.cpp
+++ b/src/core/hle/service/http_c.cpp
@@ -42,6 +42,7 @@ void HTTP_C::Initialize(Kernel::HLERequestContext& ctx) {
     ASSERT(session_data);
 
     if (session_data->initialized) {
+        LOG_ERROR(Service_HTTP, "Tried to initialize an already initialized session");
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
         rb.Push(ERROR_STATE_ERROR);
         return;
@@ -64,6 +65,7 @@ void HTTP_C::InitializeConnectionSession(Kernel::HLERequestContext& ctx) {
     ASSERT(session_data);
 
     if (session_data->initialized) {
+        LOG_ERROR(Service_HTTP, "Tried to initialize an already initialized session");
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
         rb.Push(ERROR_STATE_ERROR);
         return;
@@ -104,6 +106,7 @@ void HTTP_C::CreateContext(Kernel::HLERequestContext& ctx) {
     ASSERT(session_data);
 
     if (!session_data->initialized) {
+        LOG_ERROR(Service_HTTP, "Tried to create a context on an uninitialized session");
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
         rb.Push(ERROR_STATE_ERROR);
         rb.PushMappedBuffer(buffer);
@@ -170,6 +173,7 @@ void HTTP_C::CloseContext(Kernel::HLERequestContext& ctx) {
     ASSERT(session_data);
 
     if (!session_data->initialized) {
+        LOG_ERROR(Service_HTTP, "Tried to close a context on an uninitialized session");
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
         rb.Push(ERROR_STATE_ERROR);
         return;
@@ -218,6 +222,7 @@ void HTTP_C::AddRequestHeader(Kernel::HLERequestContext& ctx) {
     ASSERT(session_data);
 
     if (!session_data->initialized) {
+        LOG_ERROR(Service_HTTP, "Tried to add a request header on an uninitialized session");
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
         rb.Push(ERROR_STATE_ERROR);
         rb.PushMappedBuffer(value_buffer);
@@ -236,6 +241,10 @@ void HTTP_C::AddRequestHeader(Kernel::HLERequestContext& ctx) {
     }
 
     if (session_data->current_http_context != context_handle) {
+        LOG_ERROR(Service_HTTP,
+                  "Tried to add a request header on a mismatched session input context={} session "
+                  "context={}",
+                  context_handle, session_data->current_http_context.get());
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
         rb.Push(ERROR_STATE_ERROR);
         rb.PushMappedBuffer(value_buffer);
@@ -246,6 +255,8 @@ void HTTP_C::AddRequestHeader(Kernel::HLERequestContext& ctx) {
     ASSERT(itr != contexts.end());
 
     if (itr->second.state != RequestState::NotStarted) {
+        LOG_ERROR(Service_HTTP,
+                  "Tried to add a request header on a context that has already been started.");
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
         rb.Push(ResultCode(ErrCodes::InvalidRequestState, ErrorModule::HTTP,
                            ErrorSummary::InvalidState, ErrorLevel::Permanent));

--- a/src/core/hle/service/http_c.cpp
+++ b/src/core/hle/service/http_c.cpp
@@ -36,7 +36,7 @@ void HTTP_C::Initialize(Kernel::HLERequestContext& ctx) {
         shared_memory->name = "HTTP_C:shared_memory";
     }
 
-    LOG_WARNING(Service_HTTP, "(STUBBED) called, shared memory size: {}", shmem_size);
+    LOG_WARNING(Service_HTTP, "(STUBBED) called, shared memory size: {} pid: {}", shmem_size, pid);
 
     auto* session_data = GetSessionData(ctx.Session());
     ASSERT(session_data);
@@ -57,7 +57,7 @@ void HTTP_C::Initialize(Kernel::HLERequestContext& ctx) {
 
 void HTTP_C::InitializeConnectionSession(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x8, 1, 2);
-    const u32 context_handle = rp.Pop<u32>();
+    const Context::Handle context_handle = rp.Pop<u32>();
     u32 pid = rp.PopPID();
 
     auto* session_data = GetSessionData(ctx.Session());
@@ -84,7 +84,7 @@ void HTTP_C::InitializeConnectionSession(Kernel::HLERequestContext& ctx) {
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     rb.Push(RESULT_SUCCESS);
-    LOG_DEBUG(Service_HTTP, "called, context_id={}", context_handle);
+    LOG_DEBUG(Service_HTTP, "called, context_id={} pid={}", context_handle, pid);
 }
 
 void HTTP_C::CreateContext(Kernel::HLERequestContext& ctx) {
@@ -265,7 +265,7 @@ void HTTP_C::AddRequestHeader(Kernel::HLERequestContext& ctx) {
     rb.PushMappedBuffer(value_buffer);
 
     LOG_DEBUG(Service_HTTP, "called, name={}, value={}, context_handle={}", name, value,
-                context_handle);
+              context_handle);
 }
 
 HTTP_C::HTTP_C() : ServiceFramework("http:C", 32) {

--- a/src/core/hle/service/http_c.h
+++ b/src/core/hle/service/http_c.h
@@ -172,6 +172,17 @@ private:
     void CloseContext(Kernel::HLERequestContext& ctx);
 
     /**
+     * HTTP_C::InitializeConnectionSession service function
+     *  Inputs:
+     *      1 : HTTP context handle
+     *      2 : 0x20, processID translate-header for the ARM11-kernel
+     *      3 : processID set by the ARM11-kernel
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void InitializeConnectionSession(Kernel::HLERequestContext& ctx);
+
+    /**
      * HTTP_C::AddRequestHeader service function
      *  Inputs:
      * 1 : Context handle


### PR DESCRIPTION
Use the session data to store information about the HTTP session state.
This is based on reverse engineering of the HTTP module.

~~The AddRequestHeader function is still mostly incorrect, this will be fixed in follow up PRs~~

AddRequestHeader's behavior has been corrected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4001)
<!-- Reviewable:end -->
