### PR TITLE
RomFS: add RomFSFile and RomFS::GetFile

### DIFF
--- a/src/core/hle/romfs.cpp
+++ b/src/core/hle/romfs.cpp
@@ -65,11 +65,6 @@ u64 RomFSFile::Length() const {
     return length;
 }
 
-const u8* GetFilePointer(const u8* romfs, const std::vector<std::u16string>& path) {
-    RomFSFile file = GetFile(romfs, path);
-    return file.Data();
-}
-
 const RomFSFile GetFile(const u8* romfs, const std::vector<std::u16string>& path) {
     constexpr u32 INVALID_FIELD = 0xFFFFFFFF;
 
@@ -109,8 +104,7 @@ const RomFSFile GetFile(const u8* romfs, const std::vector<std::u16string>& path
         const u8* current_file = romfs + header.file_table_offset + file_offset;
         std::memcpy(&file, current_file, sizeof(file));
         if (MatchName(current_file + sizeof(file), file.name_length, file_name)) {
-            RomFSFile res(romfs + header.data_offset + file.data_offset, file.data_length);
-            return res;
+            return RomFSFile(romfs + header.data_offset + file.data_offset, file.data_length);
         }
         file_offset = file.next_file_offset;
     }

--- a/src/core/hle/romfs.cpp
+++ b/src/core/hle/romfs.cpp
@@ -53,8 +53,6 @@ static bool MatchName(const u8* buffer, u32 name_length, const std::u16string& n
     return name == std::u16string(name_buffer.begin(), name_buffer.end());
 }
 
-RomFSFile::RomFSFile() : data(nullptr), length(0) {}
-
 RomFSFile::RomFSFile(const u8* data, u64 length) : data(data), length(length) {}
 
 const u8* RomFSFile::Data() const {

--- a/src/core/hle/romfs.h
+++ b/src/core/hle/romfs.h
@@ -12,14 +12,14 @@ namespace RomFS {
 
 class RomFSFile {
 public:
-    RomFSFile();
+    RomFSFile() = default;
     RomFSFile(const u8* data, u64 length);
     const u8* Data() const;
     u64 Length() const;
 
 private:
-    const u8* data;
-    u64 length;
+    const u8* data = nullptr;
+    u64 length = 0;
 };
 
 /**

--- a/src/core/hle/romfs.h
+++ b/src/core/hle/romfs.h
@@ -10,6 +10,18 @@
 
 namespace RomFS {
 
+class RomFSFile {
+public:
+    RomFSFile();
+    RomFSFile(const u8* data, u64 length);
+    const u8* Data() const;
+    u64 Length() const;
+
+private:
+    const u8* data;
+    u64 length;
+};
+
 /**
  * Gets the pointer to a file in a RomFS image.
  * @param romfs The pointer to the RomFS image
@@ -18,5 +30,14 @@ namespace RomFS {
  * @todo reimplement this with a full RomFS manager
  */
 const u8* GetFilePointer(const u8* romfs, const std::vector<std::u16string>& path);
+
+/**
+ * Gets a RomFSFile class to a file in a RomFS image.
+ * @param romfs The pointer to the RomFS image
+ * @param path A vector containing the directory names and file name of the path to the file
+ * @return the RomFSFile to the file
+ * @todo reimplement this with a full RomFS manager
+ */
+const RomFSFile GetFile(const u8* romfs, const std::vector<std::u16string>& path);
 
 } // namespace RomFS

--- a/src/core/hle/romfs.h
+++ b/src/core/hle/romfs.h
@@ -23,15 +23,6 @@ private:
 };
 
 /**
- * Gets the pointer to a file in a RomFS image.
- * @param romfs The pointer to the RomFS image
- * @param path A vector containing the directory names and file name of the path to the file
- * @return the pointer to the file
- * @todo reimplement this with a full RomFS manager
- */
-const u8* GetFilePointer(const u8* romfs, const std::vector<std::u16string>& path);
-
-/**
  * Gets a RomFSFile class to a file in a RomFS image.
  * @param romfs The pointer to the RomFS image
  * @param path A vector containing the directory names and file name of the path to the file

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -143,9 +143,9 @@ bool Module::LoadSharedFont() {
 
     const char16_t* file_name[4] = {u"cbf_std.bcfnt.lz", u"cbf_zh-Hans-CN.bcfnt.lz",
                                     u"cbf_ko-Hang-KR.bcfnt.lz", u"cbf_zh-Hant-TW.bcfnt.lz"};
-    const u8* font_file =
-        RomFS::GetFilePointer(romfs_buffer.data(), {file_name[font_region_code - 1]});
-    if (font_file == nullptr)
+    const RomFS::RomFSFile font_file =
+        RomFS::GetFile(romfs_buffer.data(), {file_name[font_region_code - 1]});
+    if (font_file.Data() == nullptr)
         return false;
 
     struct {
@@ -159,7 +159,7 @@ bool Module::LoadSharedFont() {
     shared_font_header.status = 2; // successfully loaded
     shared_font_header.region = font_region_code;
     shared_font_header.decompressed_size =
-        DecompressLZ11(font_file, shared_font_mem->GetPointer(0x80));
+        DecompressLZ11(font_file.Data(), shared_font_mem->GetPointer(0x80));
     std::memcpy(shared_font_mem->GetPointer(), &shared_font_header, sizeof(shared_font_header));
     *shared_font_mem->GetPointer(0x83) = 'U'; // Change the magic from "CFNT" to "CFNU"
 


### PR DESCRIPTION
Since RomFS::GetFilePointer only returns a pointer to the start address of the file but not the size but this might be necessary I added that function and a class for storing both informations. 

We could probably drop GetFilePointer() and replace it with GetFile() but for now I left both versions in the code. Also if it gets necessary to add more information to the file it's trivial to do so.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4007)
<!-- Reviewable:end -->
