### PR TITLE
citra_qt/CMakeLists: get rid of a warning

### DIFF
--- a/src/citra_qt/CMakeLists.txt
+++ b/src/citra_qt/CMakeLists.txt
@@ -2,6 +2,9 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/CMakeModules)
+if (POLICY CMP0071)
+    cmake_policy(SET CMP0071 NEW)
+endif()
 
 add_executable(citra-qt
     Info.plist


### PR DESCRIPTION
This got rid of a warning of CMake Policy CMP0071 not set. In fact, setting it to either OLD or NEW is same for Citra (I tested on MSVC and MinGW), and the OLD option is deprecated, so I am using NEW here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4011)
<!-- Reviewable:end -->
