### PR TITLE
citra_qt: UI text improvements

### DIFF
--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -102,7 +102,7 @@ private:
     void BootGame(const QString& filename);
     void ShutdownGame();
 
-    void ShowCallouts();
+    void ShowTelemetryCallout();
     void ShowUpdaterWidgets();
     void ShowUpdatePrompt();
     void ShowNoUpdatePrompt();


### PR DESCRIPTION
Changed a few texts that are not so good in the UI according to @neobrain.

This should just be a Part 1.

# Principles I follow:
1. Users do not read long text, so text should be as simple and short as possible
1. Title should be in title case, and should not be sentences
1. Provide some help/action for the users. For example I guided users to redump their games when the ROM is invalid, instead of just displaying the error message.

# Major changes:
## Telemetry
### Old:
![image](https://user-images.githubusercontent.com/21307832/43351143-774567ce-9240-11e8-850f-66389bb75958.png)
### New:
![image](https://user-images.githubusercontent.com/21307832/43351197-48683c6e-9241-11e8-9ed9-029342c4988a.png)
### Note:
1. Text too long.
1. Not actionable.
1. opt-out, not opt-in. 

although 2 and 3 seems to be @bunnei's design
## Missing System Archives
### Old:
![image](https://user-images.githubusercontent.com/21307832/43351162-d00d36a2-9240-11e8-83fc-033e9e993eb8.png)
### New:
![image](https://user-images.githubusercontent.com/21307832/43351209-73099bc0-9241-11e8-9e0f-8b843279844c.png)
### Note:
1. Text too long.
1. Icon not proper.
## Fatal Error
### Old:
![image](https://user-images.githubusercontent.com/21307832/43351178-2e5317b8-9241-11e8-9db9-4abbd45addbb.png)
### New:
![image](https://user-images.githubusercontent.com/21307832/43351214-78ea2f14-9241-11e8-98d5-2e2f54e91536.png)
### Note:
1. Text too long.
1. Icon not proper.
## Invalid ROM Format
### Old:
![image](https://user-images.githubusercontent.com/21307832/43351252-dbb6f4f6-9241-11e8-8aad-998941d33bd3.png)
### New:
![image](https://user-images.githubusercontent.com/21307832/43351255-e6d70664-9241-11e8-89d5-68ad35594d77.png)
### Note:
1. No guidance on how to solve the problem.
1. Title is not in title case.
## Could not determine system mode
### Old:
![image](https://user-images.githubusercontent.com/21307832/43351267-097713da-9242-11e8-9089-e957940c553a.png)
### New:
![image](https://user-images.githubusercontent.com/21307832/43351271-10716fd2-9242-11e8-9fa1-599a0f23c66a.png)
### Note:
1. Users would not know what is "system mode"
1. No guidance on how to solve the problem
1. Title is not in title case.
## Encrypted ROM
Similar to the above two, I guided the users to redump their ROMs with a short message.
## OpenGL 3.3
Changed the title. The message seems ok.
## Video Core Error
Edited the message to something similar to "Fatal Error". Changed the title to title case.
## Misc.
There are also some other minor changes to the texts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4012)
<!-- Reviewable:end -->
