### PR TITLE
service: remove deprecated service interface

### DIFF
--- a/src/core/hle/ipc.h
+++ b/src/core/hle/ipc.h
@@ -28,18 +28,6 @@ inline u32* GetCommandBuffer(const int offset = 0) {
                                     offset);
 }
 
-/// Offset into static buffers, relative to command buffer header
-static const int kStaticBuffersOffset = 0x100;
-
-/**
- * Returns a pointer to the static buffers area in the current thread's TLS
- * TODO(Subv): cf. GetCommandBuffer
- * @param offset Optional offset into static buffers area (in bytes)
- * @return Pointer to static buffers area
- */
-inline u32* GetStaticBuffers(const int offset = 0) {
-    return GetCommandBuffer(kStaticBuffersOffset + offset);
-}
 } // namespace Kernel
 
 namespace IPC {

--- a/src/core/hle/service/frd/frd.h
+++ b/src/core/hle/service/frd/frd.h
@@ -10,8 +10,6 @@
 
 namespace Service {
 
-class Interface;
-
 namespace FRD {
 
 struct FriendKey {

--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -33,87 +33,6 @@ static const int kMaxPortSize = 8; ///< Maximum size of a port name (8 character
 static const u32 DefaultMaxSessions = 10;
 
 /**
- * Framework for implementing HLE service handlers which dispatch incoming SyncRequests based on a
- * table mapping header ids to handler functions.
- *
- * @deprecated Use ServiceFramework for new services instead. It allows services to be stateful and
- *     is more extensible going forward.
- */
-class Interface : public Kernel::SessionRequestHandler {
-public:
-    /**
-     * Creates an HLE interface with the specified max sessions.
-     * @param max_sessions Maximum number of sessions that can be
-     * connected to this service at the same time.
-     */
-    Interface(u32 max_sessions = DefaultMaxSessions);
-
-    virtual ~Interface();
-
-    std::string GetName() const {
-        return GetPortName();
-    }
-
-    virtual void SetVersion(u32 raw_version) {
-        version.raw = raw_version;
-    }
-
-    /**
-     * Gets the maximum allowed number of sessions that can be connected to this service
-     * at the same time.
-     * @returns The maximum number of connections allowed.
-     */
-    u32 GetMaxSessions() const {
-        return max_sessions;
-    }
-
-    typedef void (*Function)(Interface*);
-
-    struct FunctionInfo {
-        u32 id;
-        Function func;
-        const char* name;
-    };
-
-    /**
-     * Gets the string name used by CTROS for a service
-     * @return Port name of service
-     */
-    virtual std::string GetPortName() const {
-        return "[UNKNOWN SERVICE PORT]";
-    }
-
-protected:
-    void HandleSyncRequest(Kernel::SharedPtr<Kernel::ServerSession> server_session) override;
-
-    std::unique_ptr<SessionDataBase> MakeSessionData() const override {
-        return nullptr;
-    }
-
-    /**
-     * Registers the functions in the service
-     */
-    template <size_t N>
-    inline void Register(const FunctionInfo (&functions)[N]) {
-        Register(functions, N);
-    }
-
-    void Register(const FunctionInfo* functions, size_t n);
-
-    union {
-        u32 raw;
-        BitField<0, 8, u32> major;
-        BitField<8, 8, u32> minor;
-        BitField<16, 8, u32> build;
-        BitField<24, 8, u32> revision;
-    } version = {};
-
-private:
-    u32 max_sessions; ///< Maximum number of concurrent sessions that this service can handle.
-    boost::container::flat_map<u32, FunctionInfo> m_functions;
-};
-
-/**
  * This is an non-templated base of ServiceFramework to reduce code bloat and compilation times, it
  * is not meant to be used directly.
  *
@@ -272,7 +191,5 @@ extern std::unordered_map<std::string, Kernel::SharedPtr<Kernel::ClientPort>> g_
 
 /// Adds a port to the named port table
 void AddNamedPort(std::string name, Kernel::SharedPtr<Kernel::ClientPort> port);
-/// Adds a service to the services table
-void AddService(Interface* interface_);
 
 } // namespace Service


### PR DESCRIPTION
Just deletes unused stuff. Closes #2531.

`GetCommandBuffer` is not removed because it is still used by svc and HLE command buffer translation, and removing it requires some large refactor there. This is put to later PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4014)
<!-- Reviewable:end -->
