### PR TITLE
Add system time configuration

### DIFF
--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -2,8 +2,10 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <iomanip>
 #include <memory>
 #include <unordered_map>
+#include <sstream>
 #include <SDL.h>
 #include <inih/cpp/INIReader.h>
 #include "citra/config.h"
@@ -167,6 +169,25 @@ void Config::ReadValues() {
     Settings::values.is_new_3ds = sdl2_config->GetBoolean("System", "is_new_3ds", false);
     Settings::values.region_value =
         sdl2_config->GetInteger("System", "region_value", Settings::REGION_VALUE_AUTO_SELECT);
+    Settings::values.init_clock =
+        static_cast<Settings::InitClock>(sdl2_config->GetInteger("System", "init_clock", 1));
+    {
+        std::tm t;
+        t.tm_sec = 1;
+        t.tm_min = 0;
+        t.tm_hour = 0;
+        t.tm_mday = 1;
+        t.tm_mon = 0;
+        t.tm_year = 100;
+        t.tm_isdst = 0;
+        std::istringstream string_stream(
+            sdl2_config->Get("System", "init_time", "2000-01-01 00:00:01"));
+        string_stream >> std::get_time(&t, "%Y-%m-%d %H:%M:%S");
+        if (string_stream.fail()) {
+            LOG_ERROR(Config, "Failed To parse init_time. Using 2000-01-01 00:00:01");
+        }
+        Settings::values.init_time = std::mktime(&t);
+    }
 
     // Camera
     using namespace Service::CAM;

--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -4,8 +4,8 @@
 
 #include <iomanip>
 #include <memory>
-#include <unordered_map>
 #include <sstream>
+#include <unordered_map>
 #include <SDL.h>
 #include <inih/cpp/INIReader.h>
 #include "citra/config.h"

--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -186,7 +186,10 @@ void Config::ReadValues() {
         if (string_stream.fail()) {
             LOG_ERROR(Config, "Failed To parse init_time. Using 2000-01-01 00:00:01");
         }
-        Settings::values.init_time = std::mktime(&t);
+        Settings::values.init_time =
+            std::chrono::duration_cast<std::chrono::seconds>(
+                std::chrono::system_clock::from_time_t(std::mktime(&t)).time_since_epoch())
+                .count();
     }
 
     // Camera

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -199,6 +199,15 @@ is_new_3ds =
 # -1: Auto-select (default), 0: Japan, 1: USA, 2: Europe, 3: Australia, 4: China, 5: Korea, 6: Taiwan
 region_value =
 
+# The clock to use when citra starts
+# 0: System clock (default), 1: fixed time
+init_clock =
+
+# Time used when init_clock is set to fixed_time in the format %Y-%m-%d %H:%M:%S
+# set to fixed time. Default 2000-01-01 00:00:01
+# Note: 3DS can only handle times later then Jan 1 2000
+init_time =
+
 [Camera]
 # Which camera engine to use for the right outer camera
 # blank (default): a dummy camera that always returns black image

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -203,8 +203,8 @@ region_value =
 # 0: System clock (default), 1: fixed time
 init_clock =
 
-# Time used when init_clock is set to fixed_time in seconds since epoch
-# set to fixed time. Default 946681277
+# Time used when init_clock is set to fixed_time in the format %Y-%m-%d %H:%M:%S
+# set to fixed time. Default 2000-01-01 00:00:01
 # Note: 3DS can only handle times later then Jan 1 2000
 init_time =
 

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -203,8 +203,8 @@ region_value =
 # 0: System clock (default), 1: fixed time
 init_clock =
 
-# Time used when init_clock is set to fixed_time in the format %Y-%m-%d %H:%M:%S
-# set to fixed time. Default 2000-01-01 00:00:01
+# Time used when init_clock is set to fixed_time in seconds since epoch
+# set to fixed time. Default 946681277
 # Note: 3DS can only handle times later then Jan 1 2000
 init_time =
 

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -410,7 +410,8 @@ void Config::SaveValues() {
     WriteSetting("region_value", Settings::values.region_value, Settings::REGION_VALUE_AUTO_SELECT);
     WriteSetting("init_clock", static_cast<u32>(Settings::values.init_clock),
                  static_cast<u32>(Settings::InitClock::SystemTime));
-    WriteSetting("init_time", static_cast<u64>(Settings::values.init_time), 946681277ULL);
+    WriteSetting("init_time", static_cast<unsigned long long>(Settings::values.init_time),
+                 946681277ULL);
     qt_config->endGroup();
 
     qt_config->beginGroup("Miscellaneous");

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -168,6 +168,9 @@ void Config::ReadValues() {
     Settings::values.is_new_3ds = ReadSetting("is_new_3ds", false).toBool();
     Settings::values.region_value =
         ReadSetting("region_value", Settings::REGION_VALUE_AUTO_SELECT).toInt();
+    Settings::values.init_clock =
+        static_cast<Settings::InitClock>(ReadSetting("init_clock", static_cast<u32>(Settings::InitClock::SystemTime)).toInt());
+    Settings::values.init_time = ReadSetting("init_time", 946681277ULL).toULongLong();
     qt_config->endGroup();
 
     qt_config->beginGroup("Miscellaneous");
@@ -405,6 +408,8 @@ void Config::SaveValues() {
     qt_config->beginGroup("System");
     WriteSetting("is_new_3ds", Settings::values.is_new_3ds, false);
     WriteSetting("region_value", Settings::values.region_value, Settings::REGION_VALUE_AUTO_SELECT);
+    WriteSetting("init_clock", static_cast<u32>(Settings::values.init_clock), static_cast<u32>(Settings::InitClock::SystemTime));
+    WriteSetting("init_time", static_cast<u64>(Settings::values.init_time), 946681277ULL);
     qt_config->endGroup();
 
     qt_config->beginGroup("Miscellaneous");

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -168,8 +168,8 @@ void Config::ReadValues() {
     Settings::values.is_new_3ds = ReadSetting("is_new_3ds", false).toBool();
     Settings::values.region_value =
         ReadSetting("region_value", Settings::REGION_VALUE_AUTO_SELECT).toInt();
-    Settings::values.init_clock =
-        static_cast<Settings::InitClock>(ReadSetting("init_clock", static_cast<u32>(Settings::InitClock::SystemTime)).toInt());
+    Settings::values.init_clock = static_cast<Settings::InitClock>(
+        ReadSetting("init_clock", static_cast<u32>(Settings::InitClock::SystemTime)).toInt());
     Settings::values.init_time = ReadSetting("init_time", 946681277ULL).toULongLong();
     qt_config->endGroup();
 
@@ -408,7 +408,8 @@ void Config::SaveValues() {
     qt_config->beginGroup("System");
     WriteSetting("is_new_3ds", Settings::values.is_new_3ds, false);
     WriteSetting("region_value", Settings::values.region_value, Settings::REGION_VALUE_AUTO_SELECT);
-    WriteSetting("init_clock", static_cast<u32>(Settings::values.init_clock), static_cast<u32>(Settings::InitClock::SystemTime));
+    WriteSetting("init_clock", static_cast<u32>(Settings::values.init_clock),
+                 static_cast<u32>(Settings::InitClock::SystemTime));
     WriteSetting("init_time", static_cast<u64>(Settings::values.init_time), 946681277ULL);
     qt_config->endGroup();
 

--- a/src/citra_qt/configuration/configure_system.h
+++ b/src/citra_qt/configuration/configure_system.h
@@ -31,10 +31,12 @@ public:
 
 public slots:
     void updateBirthdayComboBox(int birthmonth_index);
+    void updateInitTime(int init_clock);
     void refreshConsoleID();
 
 private:
     void ReadSystemSettings();
+    void ConfigureTime();
 
     std::unique_ptr<Ui::ConfigureSystem> ui;
     bool enabled;

--- a/src/citra_qt/configuration/configure_system.ui
+++ b/src/citra_qt/configuration/configure_system.ui
@@ -232,13 +232,45 @@
          </widget>
         </item>
         <item row="5" column="0">
+         <widget class="QLabel" name="label_init_clock">
+          <property name="text">
+           <string>Clock</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1">
+         <widget class="QComboBox" name="combo_init_clock">
+          <item>
+           <property name="text">
+            <string>System Clock</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Fixed Time</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="6" column="0">
+         <widget class="QLabel" name="label_init_time">
+          <property name="text">
+           <string>Startup time</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="1">
+         <widget class="QDateTimeEdit" name="edit_init_time">
+         </widget>
+        </item>
+        <item row="7" column="0">
          <widget class="QLabel" name="label_console_id">
           <property name="text">
            <string>Console ID:</string>
           </property>
          </widget>
         </item>
-        <item row="5" column="1">
+        <item row="7" column="1">
          <widget class="QPushButton" name="button_regenerate_console_id">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -171,6 +171,7 @@ System::ResultStatus System::Init(EmuWindow* emu_window, u32 system_mode) {
 
     telemetry_session = std::make_unique<Core::TelemetrySession>();
     service_manager = std::make_shared<Service::SM::ServiceManager>();
+    shared_page_handler = std::make_shared<SharedPage::Handler>();
 
     HW::Init();
     Kernel::Init(system_mode);

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -8,6 +8,7 @@
 #include <string>
 #include "common/common_types.h"
 #include "core/frontend/applets/swkbd.h"
+#include "core/hle/shared_page.h"
 #include "core/loader/loader.h"
 #include "core/memory.h"
 #include "core/perf_stats.h"
@@ -159,6 +160,10 @@ public:
         return registered_swkbd;
     }
 
+    std::shared_ptr<SharedPage::Handler> GetSharedPageHandler() const {
+        return shared_page_handler;
+    }
+
 private:
     /**
      * Initialize the emulated system.
@@ -191,6 +196,9 @@ private:
 
     /// Frontend applets
     std::shared_ptr<Frontend::SoftwareKeyboard> registered_swkbd;
+
+    /// Shared PAge
+    std::shared_ptr<SharedPage::Handler> shared_page_handler;
 
     static System s_instance;
 

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -197,7 +197,7 @@ private:
     /// Frontend applets
     std::shared_ptr<Frontend::SoftwareKeyboard> registered_swkbd;
 
-    /// Shared PAge
+    /// Shared Page
     std::shared_ptr<SharedPage::Handler> shared_page_handler;
 
     static System s_instance;

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -19,7 +19,6 @@ unsigned int Object::next_object_id;
 /// Initialize the kernel
 void Init(u32 system_mode) {
     ConfigMem::Init();
-    SharedPage::Init();
 
     Kernel::MemoryInit(system_mode);
 

--- a/src/core/hle/kernel/memory.cpp
+++ b/src/core/hle/kernel/memory.cpp
@@ -11,11 +11,11 @@
 #include "common/assert.h"
 #include "common/common_types.h"
 #include "common/logging/log.h"
+#include "core/core.h"
 #include "core/hle/config_mem.h"
 #include "core/hle/kernel/memory.h"
 #include "core/hle/kernel/vm_manager.h"
 #include "core/hle/result.h"
-#include "core/hle/shared_page.h"
 #include "core/memory.h"
 #include "core/memory_setup.h"
 
@@ -80,7 +80,6 @@ void MemoryShutdown() {
         region.used = 0;
         region.linear_heap_memory = nullptr;
     }
-    SharedPage::Reset();
 }
 
 MemoryRegionInfo* GetMemoryRegion(MemoryRegion region) {
@@ -161,12 +160,13 @@ void MapSharedPages(VMManager& address_space) {
                            .Unwrap();
     address_space.Reprotect(cfg_mem_vma, VMAPermission::Read);
 
-    auto shared_page_handler = SharedPage::GetHandler().lock();
     auto shared_page_vma =
         address_space
-            .MapBackingMemory(Memory::SHARED_PAGE_VADDR,
-                              reinterpret_cast<u8*>(&shared_page_handler->GetSharedPage()),
-                              Memory::SHARED_PAGE_SIZE, MemoryState::Shared)
+            .MapBackingMemory(
+                Memory::SHARED_PAGE_VADDR,
+                reinterpret_cast<u8*>(
+                    &Core::System::GetInstance().GetSharedPageHandler()->GetSharedPage()),
+                Memory::SHARED_PAGE_SIZE, MemoryState::Shared)
             .Unwrap();
     address_space.Reprotect(shared_page_vma, VMAPermission::Read);
 }

--- a/src/core/hle/kernel/memory.cpp
+++ b/src/core/hle/kernel/memory.cpp
@@ -80,6 +80,7 @@ void MemoryShutdown() {
         region.used = 0;
         region.linear_heap_memory = nullptr;
     }
+    SharedPage::Reset();
 }
 
 MemoryRegionInfo* GetMemoryRegion(MemoryRegion region) {
@@ -160,11 +161,13 @@ void MapSharedPages(VMManager& address_space) {
                            .Unwrap();
     address_space.Reprotect(cfg_mem_vma, VMAPermission::Read);
 
-    auto shared_page_vma = address_space
-                               .MapBackingMemory(Memory::SHARED_PAGE_VADDR,
-                                                 reinterpret_cast<u8*>(&SharedPage::shared_page),
-                                                 Memory::SHARED_PAGE_SIZE, MemoryState::Shared)
-                               .Unwrap();
+    auto shared_page_handler = SharedPage::GetHandler().lock();
+    auto shared_page_vma =
+        address_space
+            .MapBackingMemory(Memory::SHARED_PAGE_VADDR,
+                              reinterpret_cast<u8*>(&shared_page_handler->GetSharedPage()),
+                              Memory::SHARED_PAGE_SIZE, MemoryState::Shared)
+            .Unwrap();
     address_space.Reprotect(shared_page_vma, VMAPermission::Read);
 }
 

--- a/src/core/hle/service/gsp/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp/gsp_gpu.cpp
@@ -13,7 +13,6 @@
 #include "core/hle/kernel/shared_memory.h"
 #include "core/hle/result.h"
 #include "core/hle/service/gsp/gsp_gpu.h"
-#include "core/hle/shared_page.h"
 #include "core/hw/gpu.h"
 #include "core/hw/hw.h"
 #include "core/hw/lcd.h"
@@ -733,8 +732,7 @@ void GSP_GPU::SetLedForceOff(Kernel::HLERequestContext& ctx) {
 
     u8 state = rp.Pop<u8>();
 
-    auto shared_page_handler = SharedPage::GetHandler().lock();
-    shared_page_handler->Set3DLed(state);
+    Core::System::GetInstance().GetSharedPageHandler()->Set3DLed(state);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/gsp/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp/gsp_gpu.cpp
@@ -732,7 +732,9 @@ void GSP_GPU::SetLedForceOff(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x1C, 1, 0);
 
     u8 state = rp.Pop<u8>();
-    SharedPage::Set3DLed(state);
+
+    auto shared_page_handler = SharedPage::GetHandler().lock();
+    shared_page_handler->Set3DLed(state);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -14,6 +14,7 @@
 #include <cryptopp/osrng.h>
 #include "common/common_types.h"
 #include "common/logging/log.h"
+#include "core/core.h"
 #include "core/core_timing.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/event.h"
@@ -24,7 +25,6 @@
 #include "core/hle/service/nwm/uds_beacon.h"
 #include "core/hle/service/nwm/uds_connection.h"
 #include "core/hle/service/nwm/uds_data.h"
-#include "core/hle/shared_page.h"
 #include "core/memory.h"
 #include "network/network.h"
 
@@ -1334,9 +1334,9 @@ NWM_UDS::NWM_UDS() : ServiceFramework("nwm::UDS") {
         }
     }
 
-    auto shared_page_handler = SharedPage::GetHandler().lock();
-    shared_page_handler->SetMacAddress(mac);
-    shared_page_handler->SetWifiLinkLevel(SharedPage::WifiLinkLevel::BEST);
+    Core::System::GetInstance().GetSharedPageHandler()->SetMacAddress(mac);
+    Core::System::GetInstance().GetSharedPageHandler()->SetWifiLinkLevel(
+        SharedPage::WifiLinkLevel::BEST);
 }
 
 NWM_UDS::~NWM_UDS() {

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -1333,8 +1333,10 @@ NWM_UDS::NWM_UDS() : ServiceFramework("nwm::UDS") {
             mac = room_member->GetMacAddress();
         }
     }
-    SharedPage::SetMacAddress(mac);
-    SharedPage::SetWifiLinkLevel(SharedPage::WifiLinkLevel::BEST);
+
+    auto shared_page_handler = SharedPage::GetHandler().lock();
+    shared_page_handler->SetMacAddress(mac);
+    shared_page_handler->SetWifiLinkLevel(SharedPage::WifiLinkLevel::BEST);
 }
 
 NWM_UDS::~NWM_UDS() {

--- a/src/core/hle/shared_page.cpp
+++ b/src/core/hle/shared_page.cpp
@@ -4,7 +4,6 @@
 
 #include <chrono>
 #include <cstring>
-#include <ctime>
 #include "core/core_timing.h"
 #include "core/hle/service/ptm/ptm.h"
 #include "core/hle/shared_page.h"
@@ -14,13 +13,63 @@
 
 namespace SharedPage {
 
-SharedPageDef shared_page;
+static std::shared_ptr<Handler> handler;
 
-static CoreTiming::EventType* update_time_event;
+static std::time_t GetInitTime() {
+    switch (Settings::values.init_clock) {
+    case Settings::InitClock::SystemTime: {
+        auto now = std::chrono::system_clock::now();
+        // If the system time is in daylight saving, we give an additional hour to console time
+        std::time_t now_time_t = std::chrono::system_clock::to_time_t(now);
+        std::tm* now_tm = std::localtime(&now_time_t);
+        if (now_tm && now_tm->tm_isdst > 0)
+            now_time_t += 60 * 60 * 1000;
+        return now_time_t;
+    }
+    case Settings::InitClock::FixedTime:
+        return Settings::values.init_time;
+    }
+}
+
+Handler::Handler() {
+    std::memset(&shared_page, 0, sizeof(shared_page));
+
+    shared_page.running_hw = 0x1; // product
+
+    // Some games wait until this value becomes 0x1, before asking running_hw
+    shared_page.unknown_value = 0x1;
+
+    // Set to a completely full battery
+    shared_page.battery_state.charge_level.Assign(
+        static_cast<u8>(Service::PTM::ChargeLevels::CompletelyFull));
+    shared_page.battery_state.is_adapter_connected.Assign(1);
+    shared_page.battery_state.is_charging.Assign(1);
+
+    init_time = GetInitTime();
+
+    using namespace std::placeholders;
+    update_time_event = CoreTiming::RegisterEvent(
+        "SharedPage::UpdateTimeCallback", std::bind(&Handler::UpdateTimeCallback, this, _1, _2));
+    CoreTiming::ScheduleEvent(0, update_time_event);
+
+    float slidestate =
+        Settings::values.toggle_3d ? (float_le)Settings::values.factor_3d / 100 : 0.0f;
+    shared_page.sliderstate_3d = slidestate;
+}
+
+std::weak_ptr<Handler> GetHandler() {
+    if (handler == nullptr)
+        handler = std::make_shared<Handler>();
+    return handler;
+}
+
+void Reset() {
+    handler.reset();
+}
 
 /// Gets system time in 3DS format. The epoch is Jan 1900, and the unit is millisecond.
-static u64 GetSystemTime() {
-    auto now = std::chrono::system_clock::now();
+u64 Handler::GetSystemTime() const {
+    std::time_t now = init_time * 1000 + CoreTiming::GetGlobalTimeUs() / 1000;
 
     // 3DS system does't allow user to set a time before Jan 1 2000,
     // so we use it as an auxiliary epoch to calculate the console time.
@@ -32,7 +81,7 @@ static u64 GetSystemTime() {
     epoch_tm.tm_mon = 0;
     epoch_tm.tm_year = 100;
     epoch_tm.tm_isdst = 0;
-    auto epoch = std::chrono::system_clock::from_time_t(std::mktime(&epoch_tm));
+    std::time_t epoch = std::mktime(&epoch_tm);
 
     // 3DS console time uses Jan 1 1900 as internal epoch,
     // so we use the milliseconds between 1900 and 2000 as base console time
@@ -40,19 +89,13 @@ static u64 GetSystemTime() {
 
     // Only when system time is after 2000, we set it as 3DS system time
     if (now > epoch) {
-        console_time += std::chrono::duration_cast<std::chrono::milliseconds>(now - epoch).count();
+        console_time += (now - epoch * 1000);
     }
-
-    // If the system time is in daylight saving, we give an additional hour to console time
-    std::time_t now_time_t = std::chrono::system_clock::to_time_t(now);
-    std::tm* now_tm = std::localtime(&now_time_t);
-    if (now_tm && now_tm->tm_isdst > 0)
-        console_time += 60 * 60 * 1000;
 
     return console_time;
 }
 
-static void UpdateTimeCallback(u64 userdata, s64 cycles_late) {
+void Handler::UpdateTimeCallback(u64 userdata, int cycles_late) {
     DateTime& date_time =
         shared_page.date_time_counter % 2 ? shared_page.date_time_0 : shared_page.date_time_1;
 
@@ -67,39 +110,20 @@ static void UpdateTimeCallback(u64 userdata, s64 cycles_late) {
     CoreTiming::ScheduleEvent(msToCycles(60 * 60 * 1000) - cycles_late, update_time_event);
 }
 
-void Init() {
-    std::memset(&shared_page, 0, sizeof(shared_page));
-
-    shared_page.running_hw = 0x1; // product
-
-    // Some games wait until this value becomes 0x1, before asking running_hw
-    shared_page.unknown_value = 0x1;
-
-    // Set to a completely full battery
-    shared_page.battery_state.charge_level.Assign(
-        static_cast<u8>(Service::PTM::ChargeLevels::CompletelyFull));
-    shared_page.battery_state.is_adapter_connected.Assign(1);
-    shared_page.battery_state.is_charging.Assign(1);
-
-    update_time_event =
-        CoreTiming::RegisterEvent("SharedPage::UpdateTimeCallback", UpdateTimeCallback);
-    CoreTiming::ScheduleEvent(0, update_time_event);
-
-    float slidestate =
-        Settings::values.toggle_3d ? (float_le)Settings::values.factor_3d / 100 : 0.0f;
-    shared_page.sliderstate_3d = slidestate;
-}
-
-void SetMacAddress(const MacAddress& addr) {
+void Handler::SetMacAddress(const MacAddress& addr) {
     std::memcpy(shared_page.wifi_macaddr, addr.data(), sizeof(MacAddress));
 }
 
-void SetWifiLinkLevel(WifiLinkLevel level) {
+void Handler::SetWifiLinkLevel(WifiLinkLevel level) {
     shared_page.wifi_link_level = static_cast<u8>(level);
 }
 
-void Set3DLed(u8 state) {
+void Handler::Set3DLed(u8 state) {
     shared_page.ledstate_3d = state;
+}
+
+SharedPageDef& Handler::GetSharedPage() {
+    return shared_page;
 }
 
 } // namespace SharedPage

--- a/src/core/hle/shared_page.cpp
+++ b/src/core/hle/shared_page.cpp
@@ -13,7 +13,7 @@
 
 namespace SharedPage {
 
-static std::time_t GetInitTime() {
+static std::chrono::seconds GetInitTime() {
     switch (Settings::values.init_clock) {
     case Settings::InitClock::SystemTime: {
         auto now = std::chrono::system_clock::now();
@@ -21,11 +21,11 @@ static std::time_t GetInitTime() {
         std::time_t now_time_t = std::chrono::system_clock::to_time_t(now);
         std::tm* now_tm = std::localtime(&now_time_t);
         if (now_tm && now_tm->tm_isdst > 0)
-            now_time_t += 60 * 60 * 1000;
-        return now_time_t;
+            now = now + std::chrono::hours(1);
+        return std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch());
     }
     case Settings::InitClock::FixedTime:
-        return Settings::values.init_time;
+        return std::chrono::seconds(Settings::values.init_time);
     }
 }
 
@@ -57,7 +57,8 @@ Handler::Handler() {
 
 /// Gets system time in 3DS format. The epoch is Jan 1900, and the unit is millisecond.
 u64 Handler::GetSystemTime() const {
-    u64 now = init_time * 1000 + CoreTiming::GetGlobalTimeUs() / 1000;
+    std::chrono::milliseconds now =
+        init_time + std::chrono::milliseconds(CoreTiming::GetGlobalTimeUs() / 1000);
 
     // 3DS system does't allow user to set a time before Jan 1 2000,
     // so we use it as an auxiliary epoch to calculate the console time.
@@ -76,8 +77,8 @@ u64 Handler::GetSystemTime() const {
     u64 console_time = 3155673600000ULL;
 
     // Only when system time is after 2000, we set it as 3DS system time
-    if (now > epoch) {
-        console_time += (now - epoch);
+    if (now.count() > epoch) {
+        console_time += (now.count() - epoch);
     }
 
     return console_time;

--- a/src/core/hle/shared_page.cpp
+++ b/src/core/hle/shared_page.cpp
@@ -58,7 +58,8 @@ Handler::Handler() {
 /// Gets system time in 3DS format. The epoch is Jan 1900, and the unit is millisecond.
 u64 Handler::GetSystemTime() const {
     std::chrono::milliseconds now =
-        init_time + std::chrono::milliseconds(CoreTiming::GetGlobalTimeUs() / 1000);
+        init_time +
+        std::chrono::duration_cast<std::chrono::milliseconds>(CoreTiming::GetGlobalTimeUs());
 
     // 3DS system does't allow user to set a time before Jan 1 2000,
     // so we use it as an auxiliary epoch to calculate the console time.

--- a/src/core/hle/shared_page.cpp
+++ b/src/core/hle/shared_page.cpp
@@ -13,8 +13,6 @@
 
 namespace SharedPage {
 
-static std::shared_ptr<Handler> handler;
-
 static std::time_t GetInitTime() {
     switch (Settings::values.init_clock) {
     case Settings::InitClock::SystemTime: {
@@ -57,19 +55,9 @@ Handler::Handler() {
     shared_page.sliderstate_3d = slidestate;
 }
 
-std::weak_ptr<Handler> GetHandler() {
-    if (handler == nullptr)
-        handler = std::make_shared<Handler>();
-    return handler;
-}
-
-void Reset() {
-    handler.reset();
-}
-
 /// Gets system time in 3DS format. The epoch is Jan 1900, and the unit is millisecond.
 u64 Handler::GetSystemTime() const {
-    std::time_t now = init_time * 1000 + CoreTiming::GetGlobalTimeUs() / 1000;
+    u64 now = init_time * 1000 + CoreTiming::GetGlobalTimeUs() / 1000;
 
     // 3DS system does't allow user to set a time before Jan 1 2000,
     // so we use it as an auxiliary epoch to calculate the console time.
@@ -81,7 +69,7 @@ u64 Handler::GetSystemTime() const {
     epoch_tm.tm_mon = 0;
     epoch_tm.tm_year = 100;
     epoch_tm.tm_isdst = 0;
-    std::time_t epoch = std::mktime(&epoch_tm);
+    u64 epoch = std::mktime(&epoch_tm) * 1000;
 
     // 3DS console time uses Jan 1 1900 as internal epoch,
     // so we use the milliseconds between 1900 and 2000 as base console time
@@ -89,7 +77,7 @@ u64 Handler::GetSystemTime() const {
 
     // Only when system time is after 2000, we set it as 3DS system time
     if (now > epoch) {
-        console_time += (now - epoch * 1000);
+        console_time += (now - epoch);
     }
 
     return console_time;

--- a/src/core/hle/shared_page.h
+++ b/src/core/hle/shared_page.h
@@ -101,7 +101,4 @@ private:
     SharedPageDef shared_page;
 };
 
-std::weak_ptr<Handler> GetHandler();
-void Reset();
-
 } // namespace SharedPage

--- a/src/core/hle/shared_page.h
+++ b/src/core/hle/shared_page.h
@@ -10,6 +10,8 @@
  * write access, according to 3dbrew; this is not emulated)
  */
 
+#include <ctime>
+#include <memory>
 #include "common/bit_field.h"
 #include "common/common_funcs.h"
 #include "common/common_types.h"
@@ -17,6 +19,10 @@
 #include "core/memory.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace CoreTiming {
+struct EventType;
+}
 
 namespace SharedPage {
 
@@ -74,14 +80,28 @@ struct SharedPageDef {
 static_assert(sizeof(SharedPageDef) == Memory::SHARED_PAGE_SIZE,
               "Shared page structure size is wrong");
 
-extern SharedPageDef shared_page;
+class Handler {
+public:
+    Handler();
 
-void Init();
+    void SetMacAddress(const MacAddress&);
 
-void SetMacAddress(const MacAddress&);
+    void SetWifiLinkLevel(WifiLinkLevel);
 
-void SetWifiLinkLevel(WifiLinkLevel);
+    void Set3DLed(u8);
 
-void Set3DLed(u8);
+    SharedPageDef& GetSharedPage();
+
+private:
+    u64 GetSystemTime() const;
+    void UpdateTimeCallback(u64 userdata, int cycles_late);
+    CoreTiming::EventType* update_time_event;
+    std::time_t init_time;
+
+    SharedPageDef shared_page;
+};
+
+std::weak_ptr<Handler> GetHandler();
+void Reset();
 
 } // namespace SharedPage

--- a/src/core/hle/shared_page.h
+++ b/src/core/hle/shared_page.h
@@ -10,6 +10,7 @@
  * write access, according to 3dbrew; this is not emulated)
  */
 
+#include <chrono>
 #include <ctime>
 #include <memory>
 #include "common/bit_field.h"
@@ -96,7 +97,7 @@ private:
     u64 GetSystemTime() const;
     void UpdateTimeCallback(u64 userdata, int cycles_late);
     CoreTiming::EventType* update_time_event;
-    std::time_t init_time;
+    std::chrono::seconds init_time;
 
     SharedPageDef shared_page;
 };

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -12,6 +12,11 @@
 
 namespace Settings {
 
+enum class InitClock {
+    SystemTime = 0,
+    FixedTime = 1,
+};
+
 enum class LayoutOption {
     Default,
     SingleScreen,
@@ -106,8 +111,10 @@ struct Values {
     // Data Storage
     bool use_virtual_sd;
 
-    // System Region
+    // System
     int region_value;
+    InitClock init_clock;
+    time_t init_time;
 
     // Renderer
     bool use_hw_renderer;

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -114,7 +114,7 @@ struct Values {
     // System
     int region_value;
     InitClock init_clock;
-    time_t init_time;
+    u64 init_time;
 
     // Renderer
     bool use_hw_renderer;

--- a/src/tests/core/memory/memory.cpp
+++ b/src/tests/core/memory/memory.cpp
@@ -5,6 +5,7 @@
 #include <catch.hpp>
 #include "core/hle/kernel/memory.h"
 #include "core/hle/kernel/process.h"
+#include "core/hle/shared_page.h"
 #include "core/memory.h"
 
 TEST_CASE("Memory::IsValidVirtualAddress", "[core][memory]") {


### PR DESCRIPTION
This is take two based on #3507. I hope I addressed all the comments 

This adds the possibility to set a fixed time for the emulated GetSystemTime.
It also synchronises the advance of the clock with the executed ticks like mentioned in #1963

Options are provided for SDL and for qt the settings are added to the config dialog.

I didn't add new screenshots since the one from the old PR are still how it looks like.

Minor design change: I had to add a SharedPage handler class

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4043)
<!-- Reviewable:end -->
