### PR TITLE
Service::HTTP_C: Add decryption of the ClCertA

### DIFF
--- a/src/core/file_sys/archive_ncch.cpp
+++ b/src/core/file_sys/archive_ncch.cpp
@@ -27,12 +27,6 @@
 
 namespace FileSys {
 
-enum class NCCHFilePathType : u32 {
-    RomFS = 0,
-    Code = 1,
-    ExeFS = 2,
-};
-
 struct NCCHArchivePath {
     u64_le tid;
     u32_le media_type;
@@ -47,6 +41,28 @@ struct NCCHFilePath {
     std::array<char, 8> exefs_filepath;
 };
 static_assert(sizeof(NCCHFilePath) == 0x14, "NCCHFilePath has wrong size!");
+
+Path MakeNCCHArchivePath(u64 tid, Service::FS::MediaType media_type) {
+    NCCHArchivePath path;
+    path.tid = static_cast<u64_le>(tid);
+    path.media_type = static_cast<u32_le>(media_type);
+    path.unknown = 0;
+    std::vector<u8> archive(sizeof(path));
+    std::memcpy(&archive[0], &path, sizeof(path));
+    return FileSys::Path(archive);
+}
+
+Path MakeNCCHFilePath(NCCHFileOpenType open_type, u32 content_index, NCCHFilePathType filepath_type,
+                      std::array<char, 8>& exefs_filepath) {
+    NCCHFilePath path;
+    path.open_type = static_cast<u32_le>(open_type);
+    path.content_index = static_cast<u32_le>(content_index);
+    path.filepath_type = static_cast<u32_le>(filepath_type);
+    path.exefs_filepath = exefs_filepath;
+    std::vector<u8> file(sizeof(path));
+    std::memcpy(&file[0], &path, sizeof(path));
+    return FileSys::Path(file);
+}
 
 ResultVal<std::unique_ptr<FileBackend>> NCCHArchive::OpenFile(const Path& path,
                                                               const Mode& mode) const {

--- a/src/core/file_sys/archive_ncch.h
+++ b/src/core/file_sys/archive_ncch.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <array>
 #include <memory>
 #include <string>
 #include "core/file_sys/archive_backend.h"
@@ -20,6 +21,24 @@ enum class MediaType : u32;
 } // namespace Service
 
 namespace FileSys {
+
+enum class NCCHFilePathType : u32 {
+    RomFS = 0,
+    Code = 1,
+    ExeFS = 2,
+};
+
+enum class NCCHFileOpenType : u32 {
+    NCCHData = 0,
+    SaveData = 1,
+};
+
+/// Helper function to generate a Path for NCCH archives
+Path MakeNCCHArchivePath(u64 tid, Service::FS::MediaType media_type);
+
+/// Helper function to generate a Path for NCCH files
+Path MakeNCCHFilePath(NCCHFileOpenType open_type, u32 content_index, NCCHFilePathType filepath_type,
+                      std::array<char, 8>& exefs_filepath);
 
 /// Archive backend for NCCH Archives (RomFS, ExeFS)
 class NCCHArchive : public ArchiveBackend {

--- a/src/core/hle/service/http_c.cpp
+++ b/src/core/hle/service/http_c.cpp
@@ -286,7 +286,7 @@ void HTTP_C::AddRequestHeader(Kernel::HLERequestContext& ctx) {
               context_handle);
 }
 
-void HTTP_C::DecryptDefaultClientCert() {
+void HTTP_C::DecryptClCertA() {
     static constexpr u32 iv_length = 16;
 
     FileSys::Path archive_path =
@@ -428,7 +428,7 @@ HTTP_C::HTTP_C() : ServiceFramework("http:C", 32) {
     };
     RegisterHandlers(functions);
 
-    DecryptDefaultClientCert();
+    DecryptClCertA();
 }
 
 void InstallInterfaces(SM::ServiceManager& service_manager) {

--- a/src/core/hle/service/http_c.cpp
+++ b/src/core/hle/service/http_c.cpp
@@ -326,7 +326,7 @@ void HTTP_C::DecryptDefaultClientCert() {
         return;
     }
     if (cert_file.Length() <= iv_length) {
-        LOG_ERROR(Service_HTTP, "ctr-common-1-cert.bin size is to small. Size: {}",
+        LOG_ERROR(Service_HTTP, "ctr-common-1-cert.bin size is too small. Size: {}",
                   cert_file.Length());
         return;
     }
@@ -348,7 +348,7 @@ void HTTP_C::DecryptDefaultClientCert() {
         return;
     }
     if (key_file.Length() <= iv_length) {
-        LOG_ERROR(Service_HTTP, "ctr-common-1-key.bin size is to small. Size: {}",
+        LOG_ERROR(Service_HTTP, "ctr-common-1-key.bin size is too small. Size: {}",
                   key_file.Length());
         return;
     }

--- a/src/core/hle/service/http_c.cpp
+++ b/src/core/hle/service/http_c.cpp
@@ -323,7 +323,15 @@ void HTTP_C::DecryptDefaultClientCert() {
 
     const RomFS::RomFSFile cert_file =
         RomFS::GetFile(romfs_buffer.data(), {u"ctr-common-1-cert.bin"});
-    ASSERT_MSG(cert_file.Length() > iv_length, "ctr-common-1-cert.bin missing");
+    if (cert_file.Length() == 0) {
+        LOG_ERROR(Service_HTTP, "ctr-common-1-cert.bin missing");
+        return;
+    }
+    if (cert_file.Length() <= iv_length) {
+        LOG_ERROR(Service_HTTP, "ctr-common-1-cert.bin size is to small. Size: {}",
+                  cert_file.Length());
+        return;
+    }
 
     std::vector<u8> cert_data;
     cert_data.resize(cert_file.Length() - iv_length);
@@ -338,7 +346,15 @@ void HTTP_C::DecryptDefaultClientCert() {
 
     const RomFS::RomFSFile key_file =
         RomFS::GetFile(romfs_buffer.data(), {u"ctr-common-1-key.bin"});
-    ASSERT_MSG(key_file.Length() > iv_length, "ctr-common-1-key.bin missing");
+    if (key_file.Length() == 0) {
+        LOG_ERROR(Service_HTTP, "ctr-common-1-key.bin missing");
+        return;
+    }
+    if (key_file.Length() <= iv_length) {
+        LOG_ERROR(Service_HTTP, "ctr-common-1-key.bin size is to small. Size: {}",
+                  key_file.Length());
+        return;
+    }
 
     std::vector<u8> key_data;
     key_data.resize(key_file.Length() - iv_length);

--- a/src/core/hle/service/http_c.h
+++ b/src/core/hle/service/http_c.h
@@ -197,6 +197,8 @@ private:
      */
     void AddRequestHeader(Kernel::HLERequestContext& ctx);
 
+    void DecryptDefaultClientCert();
+
     Kernel::SharedPtr<Kernel::SharedMemory> shared_memory = nullptr;
 
     /// The next handle number to use when a new HTTP context is created.
@@ -210,6 +212,8 @@ private:
 
     /// Global list of  ClientCert contexts currently opened.
     std::unordered_map<ClientCertContext::Handle, ClientCertContext> client_certs;
+
+    ClientCertContext default_client_cert_context;
 };
 
 void InstallInterfaces(SM::ServiceManager& service_manager);

--- a/src/core/hle/service/http_c.h
+++ b/src/core/hle/service/http_c.h
@@ -197,7 +197,7 @@ private:
      */
     void AddRequestHeader(Kernel::HLERequestContext& ctx);
 
-    void DecryptDefaultClientCert();
+    void DecryptClCertA();
 
     Kernel::SharedPtr<Kernel::SharedMemory> shared_memory = nullptr;
 

--- a/src/core/hle/service/http_c.h
+++ b/src/core/hle/service/http_c.h
@@ -213,7 +213,11 @@ private:
     /// Global list of  ClientCert contexts currently opened.
     std::unordered_map<ClientCertContext::Handle, ClientCertContext> client_certs;
 
-    ClientCertContext default_client_cert_context;
+    struct {
+        std::vector<u8> certificate;
+        std::vector<u8> private_key;
+        bool init = false;
+    } ClCertA;
 };
 
 void InstallInterfaces(SM::ServiceManager& service_manager);

--- a/src/core/hw/aes/key.h
+++ b/src/core/hw/aes/key.h
@@ -12,13 +12,17 @@ namespace HW {
 namespace AES {
 
 enum KeySlotID : size_t {
+
+    // Used to decrypt the SSL client cert/private-key stored in ClCertA.
+    SSLKey = 0x0D,
+
     // AES keyslots used to decrypt NCCH
     NCCHSecure1 = 0x2C,
     NCCHSecure2 = 0x25,
     NCCHSecure3 = 0x18,
     NCCHSecure4 = 0x1B,
 
-    // AES keyslot used to generate the UDS data frame CCMP key.
+    // AES Keyslot used to generate the UDS data frame CCMP key.
     UDSDataKey = 0x2D,
 
     // AES keyslot used for APT:Wrap/Unwrap functions


### PR DESCRIPTION
This will decrypt the ClCartA romfs to provide the default Client Cert and Private Key for the http_c module. This happens in the ctor of HTTP_C to only decrypt once and then provide it every time OpenDefaultClientCertContext is called.

For now the certs aren't used since OpenDefaultClientCertContext isn't implemented yet. This will happen in a follow up PR. 

For citra to make use of that and to allow to connect to some Nintendo URLs those client certs are necessary. They needed to get dumped from title id 0004001b00010002 and the normalkey in keyslot 0x0D (The SSLkey) must be provided in the aes_keys.txt: `slot0x0DKeyN=FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF `

(replacing the FFFFs with the actually key)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4045)
<!-- Reviewable:end -->
