### PR TITLE
citra_qt/configuration: retranslate camera tab

### DIFF
--- a/src/citra_qt/configuration/configure_dialog.cpp
+++ b/src/citra_qt/configuration/configure_dialog.cpp
@@ -38,7 +38,7 @@ void ConfigureDialog::onLanguageChanged(const QString& locale) {
     ui->inputTab->retranslateUi();
     ui->graphicsTab->retranslateUi();
     ui->audioTab->retranslateUi();
-    ui->cameraTab->applyConfiguration();
+    ui->cameraTab->retranslateUi();
     ui->debugTab->retranslateUi();
     ui->webTab->retranslateUi();
 }


### PR DESCRIPTION
It was really a stupid mistake..

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4046)
<!-- Reviewable:end -->
