### PR TITLE
citra: default_ini bg color default value fix

### DIFF
--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -111,7 +111,7 @@ use_frame_limit =
 frame_limit =
 
 # The clear color for the renderer. What shows up on the sides of the bottom screen.
-# Must be in range of 0.0-1.0. Defaults to 1.0 for all.
+# Must be in range of 0.0-1.0. Defaults to 0.0 for all.
 bg_red =
 bg_blue =
 bg_green =


### PR DESCRIPTION
I discovered this while making changing background color.. Just a minor nit.

Do not look at the branch name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4051)
<!-- Reviewable:end -->
