### PR TITLE
citra_qt: add Clear Recent Files menu action

### DIFF
--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -205,6 +205,8 @@ private:
     std::unique_ptr<EmuThread> emu_thread;
     // The title of the game currently running
     QString game_title;
+    // The path to the game currently running
+    QString game_path;
 
     // Debugger panes
     ProfilerWidget* profilerWidget;


### PR DESCRIPTION
I had to edit a bit of the Restart action so that it does not go wrong because recent files are cleared.

Screenshot:
![image](https://user-images.githubusercontent.com/21307832/43692424-5794f734-995a-11e8-9b15-e0036301dfc1.png)

Fix #4055

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4056)
<!-- Reviewable:end -->
