### PR TITLE
Port "file_util: Avoid sign-conversions in WriteArray() and ReadArray()" from yuzu

### DIFF
--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -8,6 +8,7 @@
 #include <cstdio>
 #include <fstream>
 #include <functional>
+#include <limits>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -183,7 +184,7 @@ public:
 
         if (!IsOpen()) {
             m_good = false;
-            return -1;
+            return std::numeric_limits<size_t>::max();
         }
 
         size_t items_read = std::fread(data, sizeof(T), length, m_file);
@@ -204,7 +205,7 @@ public:
 
         if (!IsOpen()) {
             m_good = false;
-            return -1;
+            return std::numeric_limits<size_t>::max();
         }
 
         size_t items_written = std::fwrite(data, sizeof(T), length, m_file);


### PR DESCRIPTION
*This PR is generated by portbot.*

Please refer to yuzu-emu/yuzu#967 for details.

**Caution! This PR had cherry-pick conflicts while being generated.**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4061)
<!-- Reviewable:end -->
