### PR TITLE
Service::SM: Wait till client is registered

### DIFF
--- a/src/core/hle/service/sm/srv.cpp
+++ b/src/core/hle/service/sm/srv.cpp
@@ -101,8 +101,7 @@ void SRV::GetServiceHandle(Kernel::HLERequestContext& ctx) {
     // TODO(yuriks): Permission checks go here
 
     auto get_handle = [name, this](Kernel::SharedPtr<Kernel::Thread> thread,
-                                                         Kernel::HLERequestContext& ctx,
-                                                         ThreadWakeupReason reason) {
+                                   Kernel::HLERequestContext& ctx, ThreadWakeupReason reason) {
         LOG_ERROR(Service_SRV, "called service={} wakeup", name);
         auto client_port = service_manager->GetServicePort(name);
 

--- a/src/core/hle/service/sm/srv.h
+++ b/src/core/hle/service/sm/srv.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <unordered_map>
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/service/service.h"
 
@@ -32,6 +33,8 @@ private:
 
     std::shared_ptr<ServiceManager> service_manager;
     Kernel::SharedPtr<Kernel::Semaphore> notification_semaphore;
+    std::unordered_map<std::string, Kernel::SharedPtr<Kernel::Event>>
+        get_service_handle_delayed_map;
 };
 
 } // namespace SM


### PR DESCRIPTION
This wasn't necessary for HLE services but the run multiple LLE services it is.
There is no timeout for the wait, similar to a real 3ds

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4069)
<!-- Reviewable:end -->
