### PR TITLE
Service::HTTP_C: Implement Client Cert opening and closing

### DIFF
--- a/src/core/hle/service/http_c.cpp
+++ b/src/core/hle/service/http_c.cpp
@@ -449,6 +449,7 @@ void HTTP_C::CloseClientCertContext(Kernel::HLERequestContext& ctx) {
     }
 
     client_certs.erase(cert_handle);
+    session_data->num_client_certs--;
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/http_c.cpp
+++ b/src/core/hle/service/http_c.cpp
@@ -41,7 +41,7 @@ const ResultCode ERROR_NOT_IMPLEMENTED = // 0xD960A3F4
 const ResultCode ERROR_TOO_MANY_CLIENT_CERTS = // 0xD8A0A0CB
     ResultCode(ErrCodes::TooManyClientCerts, ErrorModule::HTTP, ErrorSummary::InvalidState,
                ErrorLevel::Permanent);
-const ResultCode ERROR_WRONG_CERT_ID = // 0xD8A0A0CB
+const ResultCode ERROR_WRONG_CERT_ID = // 0xD8E0B839
     ResultCode(57, ErrorModule::SSL, ErrorSummary::InvalidArgument, ErrorLevel::Permanent);
 
 void HTTP_C::Initialize(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/http_c.h
+++ b/src/core/hle/service/http_c.h
@@ -43,6 +43,8 @@ enum class RequestState : u8 {
 struct ClientCertContext {
     using Handle = u32;
     Handle handle;
+    u32 session_id;
+    u8 cert_id;
     std::vector<u8> certificate;
     std::vector<u8> private_key;
 };
@@ -54,11 +56,13 @@ struct RootCertChain {
     struct RootCACert {
         using Handle = u32;
         Handle handle;
+        u32 session_id;
         std::vector<u8> certificate;
     };
 
     using Handle = u32;
     Handle handle;
+    u32 session_id;
     std::vector<RootCACert> certificates;
 };
 
@@ -105,6 +109,7 @@ public:
     };
 
     Handle handle;
+    u32 session_id;
     std::string url;
     RequestMethod method;
     RequestState state = RequestState::NotStarted;
@@ -120,6 +125,8 @@ struct SessionData : public Kernel::SessionRequestHandler::SessionDataBase {
     /// The HTTP context that is currently bound to this session, this can be empty if no context
     /// has been bound. Certain commands can only be called on a session with a bound context.
     boost::optional<Context::Handle> current_http_context;
+
+    u32 session_id;
 
     /// Number of HTTP contexts that are currently opened in this session.
     u32 num_http_contexts = 0;
@@ -197,9 +204,45 @@ private:
      */
     void AddRequestHeader(Kernel::HLERequestContext& ctx);
 
+    /**
+     * HTTP_C::OpenClientCertContext service function
+     *  Inputs:
+     *      1 :  Cert size
+     *      2 :  Key size
+     *      3 :  (CertSize<<4) | 10
+     *      4 :  Pointer to input cert
+     *      5 :  (KeySize<<4) | 10
+     *      6 :  Pointer to input key
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void OpenClientCertContext(Kernel::HLERequestContext& ctx);
+
+    /**
+     * HTTP_C::OpenDefaultClientCertContext service function
+     *  Inputs:
+     * 1 : CertID
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     *      2 : Client Cert context handle
+     */
+    void OpenDefaultClientCertContext(Kernel::HLERequestContext& ctx);
+
+    /**
+     * HTTP_C::CloseClientCertContext service function
+     *  Inputs:
+     * 1 : ClientCert Handle
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void CloseClientCertContext(Kernel::HLERequestContext& ctx);
+
     void DecryptClCertA();
 
     Kernel::SharedPtr<Kernel::SharedMemory> shared_memory = nullptr;
+
+    /// The next number to use when a new HTTP session is initalized.
+    u32 session_counter = 0;
 
     /// The next handle number to use when a new HTTP context is created.
     Context::Handle context_counter = 0;


### PR DESCRIPTION
Implements:
- HTTP_C::OpenClientCertContext
- HTTP_C::OpenDefaultClientCertContext
- HTTP_C::CloseClientCertContext

Behavior and error codes from testing with hombrew and dissasembly 

This also adds a session_id to SessionData, Context, RootCertChain, RootCACert, and ClientCert

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4072)
<!-- Reviewable:end -->
