### PR TITLE
Port "core_timing: Use transparent functors where applicable" from yuzu

### DIFF
--- a/src/core/core_timing.cpp
+++ b/src/core/core_timing.cpp
@@ -142,7 +142,7 @@ void ScheduleEvent(s64 cycles_into_future, const EventType* event_type, u64 user
         ForceExceptionCheck(cycles_into_future);
 
     event_queue.emplace_back(Event{timeout, event_fifo_id++, userdata, event_type});
-    std::push_heap(event_queue.begin(), event_queue.end(), std::greater<Event>());
+    std::push_heap(event_queue.begin(), event_queue.end(), std::greater<>());
 }
 
 void ScheduleEventThreadsafe(s64 cycles_into_future, const EventType* event_type, u64 userdata) {
@@ -157,7 +157,7 @@ void UnscheduleEvent(const EventType* event_type, u64 userdata) {
     // Removing random items breaks the invariant so we have to re-establish it.
     if (itr != event_queue.end()) {
         event_queue.erase(itr, event_queue.end());
-        std::make_heap(event_queue.begin(), event_queue.end(), std::greater<Event>());
+        std::make_heap(event_queue.begin(), event_queue.end(), std::greater<>());
     }
 }
 
@@ -168,7 +168,7 @@ void RemoveEvent(const EventType* event_type) {
     // Removing random items breaks the invariant so we have to re-establish it.
     if (itr != event_queue.end()) {
         event_queue.erase(itr, event_queue.end());
-        std::make_heap(event_queue.begin(), event_queue.end(), std::greater<Event>());
+        std::make_heap(event_queue.begin(), event_queue.end(), std::greater<>());
     }
 }
 
@@ -189,7 +189,7 @@ void MoveEvents() {
     for (Event ev; ts_queue.Pop(ev);) {
         ev.fifo_order = event_fifo_id++;
         event_queue.emplace_back(std::move(ev));
-        std::push_heap(event_queue.begin(), event_queue.end(), std::greater<Event>());
+        std::push_heap(event_queue.begin(), event_queue.end(), std::greater<>());
     }
 }
 
@@ -204,7 +204,7 @@ void Advance() {
 
     while (!event_queue.empty() && event_queue.front().time <= global_timer) {
         Event evt = std::move(event_queue.front());
-        std::pop_heap(event_queue.begin(), event_queue.end(), std::greater<Event>());
+        std::pop_heap(event_queue.begin(), event_queue.end(), std::greater<>());
         event_queue.pop_back();
         evt.type->callback(evt.userdata, global_timer - evt.time);
     }

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -121,14 +121,16 @@ inline u64 cyclesToMs(s64 cycles) {
 
 namespace CoreTiming {
 
+struct EventType;
+
+using TimedCallback = std::function<void(u64 userdata, int cycles_late)>;
+
 /**
  * CoreTiming begins at the boundary of timing slice -1. An initial call to Advance() is
  * required to end slice -1 and start slice 0 before the first cycle of code is executed.
  */
 void Init();
 void Shutdown();
-
-typedef std::function<void(u64 userdata, s64 cycles_late)> TimedCallback;
 
 /**
  * This should only be called from the emu thread, if you are calling it any other thread, you are
@@ -137,8 +139,6 @@ typedef std::function<void(u64 userdata, s64 cycles_late)> TimedCallback;
 u64 GetTicks();
 u64 GetIdleTicks();
 void AddTicks(u64 ticks);
-
-struct EventType;
 
 /**
  * Returns the event_type identifier. if name is not unique, it will assert.


### PR DESCRIPTION
*This PR is generated by portbot.*

Please refer to yuzu-emu/yuzu#932 for details.

**Caution! This PR had cherry-pick conflicts while being generated.**

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4079)
<!-- Reviewable:end -->
