### PR TITLE
[NOT FOR MERGE YET] Ignore format reinterpretation hack

### DIFF
--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -121,6 +121,8 @@ void Config::ReadValues() {
     Settings::values.use_frame_limit = sdl2_config->GetBoolean("Renderer", "use_frame_limit", true);
     Settings::values.frame_limit =
         static_cast<u16>(sdl2_config->GetInteger("Renderer", "frame_limit", 100));
+    Settings::values.use_format_reinterpret_hack =
+        static_cast<u16>(sdl2_config->GetBoolean("Renderer", "use_format_reinterpret_hack", true));
 
     Settings::values.toggle_3d = sdl2_config->GetBoolean("Renderer", "toggle_3d", false);
     Settings::values.factor_3d =

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -127,6 +127,12 @@ use_frame_limit =
 # 1 - 9999: Speed limit as a percentage of target game speed. 100 (default)
 frame_limit =
 
+# Advanced option: Ignores flushing surfaces from cpu memory if the surface was created by the gpu
+# and has a different format. This can speed up many games, potentially break some, but is rightfully
+# just a hack as a placeholder for gpu texture encoding/decoding
+# 0: Off, 1: On (default)
+use_format_reinterpret_hack =
+
 # The clear color for the renderer. What shows up on the sides of the bottom screen.
 # Must be in range of 0.0-1.0. Defaults to 0.0 for all.
 bg_red =

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -107,6 +107,8 @@ void Config::ReadValues() {
     Settings::values.use_vsync = ReadSetting("use_vsync", false).toBool();
     Settings::values.use_frame_limit = ReadSetting("use_frame_limit", true).toBool();
     Settings::values.frame_limit = ReadSetting("frame_limit", 100).toInt();
+    Settings::values.use_format_reinterpret_hack =
+        ReadSetting("use_format_reinterpret_hack", true).toBool();
 
     Settings::values.bg_red = ReadSetting("bg_red", 0.0).toFloat();
     Settings::values.bg_green = ReadSetting("bg_green", 0.0).toFloat();
@@ -349,6 +351,7 @@ void Config::SaveValues() {
     WriteSetting("use_vsync", Settings::values.use_vsync, false);
     WriteSetting("use_frame_limit", Settings::values.use_frame_limit, true);
     WriteSetting("frame_limit", Settings::values.frame_limit, 100);
+    WriteSetting("use_format_reinterpret_hack", Settings::values.use_format_reinterpret_hack, true);
 
     // Cast to double because Qt's written float values are not human-readable
     WriteSetting("bg_red", (double)Settings::values.bg_red, 0.0);

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -25,6 +25,7 @@ void Apply() {
     VideoCore::g_hw_shader_enabled = values.use_hw_shader;
     VideoCore::g_hw_shader_accurate_gs = values.shaders_accurate_gs;
     VideoCore::g_hw_shader_accurate_mul = values.shaders_accurate_mul;
+    VideoCore::g_use_format_reinterpret_hack = values.use_format_reinterpret_hack;
 
     if (VideoCore::g_emu_window) {
         auto layout = VideoCore::g_emu_window->GetFramebufferLayout();
@@ -60,6 +61,7 @@ void LogSettings() {
     LogSetting("Renderer_UseVsync", Settings::values.use_vsync);
     LogSetting("Renderer_UseFrameLimit", Settings::values.use_frame_limit);
     LogSetting("Renderer_FrameLimit", Settings::values.frame_limit);
+    LogSetting("Renderer_FormatReinterpretHack", Settings::values.use_format_reinterpret_hack);
     LogSetting("Layout_Toggle3d", Settings::values.toggle_3d);
     LogSetting("Layout_Factor3d", Settings::values.factor_3d);
     LogSetting("Layout_LayoutOption", static_cast<int>(Settings::values.layout_option));

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -117,6 +117,7 @@ struct Values {
     bool use_shader_jit;
     u16 resolution_factor;
     bool use_vsync;
+    bool use_format_reinterpret_hack;
     bool use_frame_limit;
     u16 frame_limit;
 

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -1516,9 +1516,15 @@ void RasterizerCacheOpenGL::ValidateSurface(const Surface& surface, PAddr addr, 
         return;
     }
 
+    auto validate_regions = surface->invalid_regions & validate_interval;
+    auto notify_validated = [&](SurfaceInterval interval) {
+        surface->invalid_regions.erase(interval);
+        validate_regions.erase(interval);
+    };
+
     while (true) {
-        const auto it = surface->invalid_regions.find(validate_interval);
-        if (it == surface->invalid_regions.end())
+        const auto it = validate_regions.begin();
+        if (it == validate_regions.end())
             break;
 
         const auto interval = *it & validate_interval;
@@ -1530,7 +1536,7 @@ void RasterizerCacheOpenGL::ValidateSurface(const Surface& surface, PAddr addr, 
         if (copy_surface != nullptr) {
             SurfaceInterval copy_interval = params.GetCopyableInterval(copy_surface);
             CopySurface(copy_surface, surface, copy_interval);
-            surface->invalid_regions.erase(copy_interval);
+            notify_validated(copy_interval);
             continue;
         }
 
@@ -1550,9 +1556,28 @@ void RasterizerCacheOpenGL::ValidateSurface(const Surface& surface, PAddr addr, 
                 ConvertD24S8toABGR(reinterpret_surface->texture.handle, src_rect,
                                    surface->texture.handle, dest_rect);
 
-                surface->invalid_regions.erase(convert_interval);
+                notify_validated(convert_interval);
                 continue;
             }
+        }
+
+        // By this point, we've checked to see if there was a valid surface that we could have
+        // copied from, so now we want to check if the surface was created on the gpu only. If it
+        // was, and since we already checked if there was a matching surface with the same format,
+        // this means its requesting a different texture format and we will skip it. If any part
+        // that we will validate is from the CPU, then we flush it all.
+
+        // As this is a HACK, remove this when we get proper hw texture en/decoding support
+        if (VideoCore::g_use_format_reinterpret_hack) {
+            bool retry = false;
+            for (const auto& pair : RangeFromInterval(dirty_regions, interval)) {
+                // Don't actually validate the region, and instead just skip it for now
+                validate_regions.erase(pair.first & interval);
+                retry = true;
+            }
+
+            if (retry)
+                continue;
         }
 
         // Load data from 3DS memory
@@ -1560,7 +1585,7 @@ void RasterizerCacheOpenGL::ValidateSurface(const Surface& surface, PAddr addr, 
         surface->LoadGLBuffer(params.addr, params.end);
         surface->UploadGLTexture(surface->GetSubRect(params), read_framebuffer.handle,
                                  draw_framebuffer.handle);
-        surface->invalid_regions.erase(params.GetInterval());
+        notify_validated(params.GetInterval());
     }
 }
 

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -21,7 +21,9 @@
 #include "common/math_util.h"
 #include "common/microprofile.h"
 #include "common/scope_exit.h"
+#include "common/telemetry.h"
 #include "common/vector_math.h"
+#include "core/core.h"
 #include "core/frontend/emu_window.h"
 #include "core/memory.h"
 #include "core/settings.h"
@@ -1641,6 +1643,8 @@ void RasterizerCacheOpenGL::ValidateSurface(const Surface& surface, PAddr addr, 
                   "Validating surface with pixel format {} and found surfaces created on the gpu "
                   "that have the following pixel formats: {}",
                   PixelFormatAsString(surface->pixel_format), s);
+        Core::Telemetry().AddField(Telemetry::FieldType::Session, "VideoCore_FormatReinterpret",
+                                   true);
     }
 }
 

--- a/src/video_core/video_core.cpp
+++ b/src/video_core/video_core.cpp
@@ -23,6 +23,7 @@ std::atomic<bool> g_hw_shader_enabled;
 std::atomic<bool> g_hw_shader_accurate_gs;
 std::atomic<bool> g_hw_shader_accurate_mul;
 std::atomic<bool> g_renderer_bg_color_update_requested;
+std::atomic<bool> g_use_format_reinterpret_hack;
 
 /// Initialize the video core
 bool Init(EmuWindow* emu_window) {

--- a/src/video_core/video_core.h
+++ b/src/video_core/video_core.h
@@ -26,6 +26,7 @@ extern std::atomic<bool> g_hw_shader_enabled;
 extern std::atomic<bool> g_hw_shader_accurate_gs;
 extern std::atomic<bool> g_hw_shader_accurate_mul;
 extern std::atomic<bool> g_renderer_bg_color_update_requested;
+extern std::atomic<bool> g_use_format_reinterpret_hack;
 
 /// Start the video core
 void Start();


### PR DESCRIPTION
# Overview

When the texture cache rework pr #3281 was originally created, there was an additional commit that I added to discuss if we wanted to include it. This commit avoids costly reuploads from CPU memory to the GPU by ignoring validation whenever that surface was created on the GPU only (more on what this means later) I removed it at that time because it had one known regression, and also because I didn't want to stall getting the PR merged with debate over it. I'm bringing this back up for discussion now that its not attached to a massive PR

# Testing this change

The following log filter should be enough to get some log spam in games that hit this edge case 

`*:Info Debug.GPU:Debug`

If you find games that start spamming lines about "Validating surface with pixel format" please post a few of those logs on this PR along with what game was printing those logs and where. Additionally, please mention how much of a performance impact this has on those games when upscaled to 4x resolution (percentage difference with frame limiter off should be sufficient) If you find a game thats broken with just this one PR, please make a post about where it breaks as well.

# Why shouldn't we merge it yet?

### Known Issues
This PR is known to break Paper mario: https://github.com/citra-emu/citra/pull/3281#issuecomment-351174076 This is because paper mario clears the depth/stencil buffer by drawing a quad with depth+stencil write enabled and funcs set to AlwaysTrue. This means that the reinterpret hack will ignore syncing the upload of the depth/stencil buffer from CPU (as the d/s surface was created on the GPU) and when we draw with the unsynced GPU surface, things get a little weird. (Read the full explanation below for more details on why this is broken with this change)

### Unknown Issues
Also, since its a hack, it might break other games that do stupid things. (who knows?)

### Why did you submit it if you know it has issues?

The reason I want to submit this as a PR is because it provides a very significant speed boost to many games, while also not being a large amount of work to do compared to GL texture decoding/encoding. Its pretty clear that we don't have anyone actively working on improving the video core at the moment (only wwylele was working on it, and he's busy with DSP) and I think this can be considered as an acceptable hold over until someone gets around to working on the GPU emulation again.

### What would need addressed to get merged?

I'm submitting this with a second commit that will log cases where the hack takes effect. I plan to use this info to find the games that benefit from the hack, and determine if these are games that hw en/decoding will be able to speed up easily (ie: games that do not reinterpret d/s framebuffers as rgba textures) 

**After we gather some data about what games benefit, what games break, and how hard is it to fix this with gl texture decoding/encoding then I think its fine to merge (only if others think its fine as well of course)**

I currently don't have any plans for hardcoding paper mario detection or anything like that. I personally think we can list it as a known workaround on the wiki to turn this feature off in the ini. But I don't mind adding it to the settings, i'd just like to at least discuss what should be done. When compared to the other GPU options citra has, this one has less known issues compared to Accurate Multiplication or even Hardware Shaders, which is why i didn't feel like adding it to the settings. 

# Why does this happen?

Games have a tendency to abuse the ability to access cached surfaces with different formats than what it was originally uploaded as. In cases where the cached surfaces weren't already synced with the CPU (in the code these are called invalid regions on the cached surface, which are set by the CPU writing to RasterizerCachedMemory pages) we attempt to copy from an existing valid surface when surface is being loaded, before falling back to doing a full surface upload from CPU -> GPU memory. The entire point of the surface cache is to avoid copying data between CPU <-> GPU while still keeping them in sync as much as needed.

# How does this work?

When validating a surface (aka when either emulated CPU / GPU is getting a surface and that surface has regions that were modified on the CPU, but not updated on the GPU surface yet) it does one more additional check to try and prevent a upload. This additional check will look through all of the surfaces that were created only on the gpu (ie: through a texture copy, or when expanding an existing surface that was also GPU only, etc) and aren't currently synced with cpu memory (called `dirty_regions` in the code) and if they overlap entirely, it will not validate that surface, and also return without uploading CPU memory to the GPU. In maybe a little bit simpler terms, we don't sync the memory from the CPU -> GPU in the case where we'd be writing to something that was only created by the GPU and was never read by the CPU.

As a reminder, if there was already a compatible surface with the latest data from the CPU that we could have copied from already, we would have. This is only in the cases where the game is using memory locations that were created by the GPU (and so they weren't necessary to download to cpu memory until the game reads from it), and haven't been read back from by the CPU (else they would've been removed from `dirty_regions`), and are now simply just not synced with the CPU (not like they were synced before anyway). Like I previously mentioned, this is technically a case where we *should* reload the data from CPU -> GPU, but graphically, it doesn't seem to have any impact on games except for paper mario for the reasons mentioned before. But instead of loading, we instead keep those regions marked as invalid, and they'll only be marked valid if the game actually performs a memory read on the surface (which forces a flush from GPU -> CPU)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4089)
<!-- Reviewable:end -->
