### PR TITLE
citra_qt: set object name for LLEServiceModulesWidget

### DIFF
--- a/src/citra_qt/debugger/lle_service_modules.cpp
+++ b/src/citra_qt/debugger/lle_service_modules.cpp
@@ -11,6 +11,7 @@
 
 LLEServiceModulesWidget::LLEServiceModulesWidget(QWidget* parent)
     : QDockWidget(tr("Toggle LLE Service Modules"), parent) {
+    setObjectName("LLEServiceModulesWidget");
     QScrollArea* scroll_area = new QScrollArea;
     QLayout* scroll_layout = new QVBoxLayout;
     for (const auto& service_module : Settings::values.lle_modules) {


### PR DESCRIPTION
Gets rid of a qt error similar to `QMainWindow::saveState(): 'objectName' not set for QDockWidget 0x55c3d1c98b00 'Toggle LLE Service Modules;` that occurs when Citra is closed.

introduced by #3967

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4099)
<!-- Reviewable:end -->
