### PR TITLE
Revert "Set Discord Rich Presence "OFF" by default"

### DIFF
--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -208,7 +208,7 @@ void Config::ReadValues() {
     qt_config->beginGroup("UI");
     UISettings::values.theme = ReadSetting("theme", UISettings::themes[0].second).toString();
     UISettings::values.enable_discord_presence =
-        ReadSetting("enable_discord_presence", false).toBool();
+        ReadSetting("enable_discord_presence", true).toBool();
 
     qt_config->beginGroup("Updater");
     UISettings::values.check_for_update_on_start =
@@ -442,7 +442,7 @@ void Config::SaveValues() {
 
     qt_config->beginGroup("UI");
     WriteSetting("theme", UISettings::values.theme, UISettings::themes[0].second);
-    WriteSetting("enable_discord_presence", UISettings::values.enable_discord_presence, false);
+    WriteSetting("enable_discord_presence", UISettings::values.enable_discord_presence, true);
 
     qt_config->beginGroup("Updater");
     WriteSetting("check_for_update_on_start", UISettings::values.check_for_update_on_start, true);


### PR DESCRIPTION
Reverts citra-emu/citra#4109

@B3n30 requesting permission to revert this.

Discussion: on the matter  https://i.imgur.com/K8MGdDD.png and https://i.imgur.com/mH4Ctir.png

(also good job creating the branch on this repo instead of my fork, github...)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4110)
<!-- Reviewable:end -->
