### PR TITLE
fix soc service - RecvFrom - SendTo

### DIFF
--- a/src/core/hle/service/soc_u.cpp
+++ b/src/core/hle/service/soc_u.cpp
@@ -587,6 +587,8 @@ void SOC_U::RecvFrom(Kernel::HLERequestContext& ctx) {
     if (ret >= 0 && src_addr_len > 0) {
         ctr_src_addr = CTRSockAddr::FromPlatform(src_addr);
         std::memcpy(addr_buff.data(), &ctr_src_addr, sizeof(ctr_src_addr));
+    }else {
+        addr_buff.resize(0);
     }
 
     s32 total_received = ret;

--- a/src/core/hle/service/soc_u.cpp
+++ b/src/core/hle/service/soc_u.cpp
@@ -544,11 +544,10 @@ void SOC_U::SendTo(Kernel::HLERequestContext& ctx) {
     auto input_buff = rp.PopStaticBuffer();
     auto dest_addr_buff = rp.PopStaticBuffer();
 
-    CTRSockAddr ctr_dest_addr;
-    std::memcpy(&ctr_dest_addr, dest_addr_buff.data(), sizeof(ctr_dest_addr));
-
     s32 ret = -1;
     if (addr_len > 0) {
+        CTRSockAddr ctr_dest_addr;
+        std::memcpy(&ctr_dest_addr, dest_addr_buff.data(), sizeof(ctr_dest_addr));
         sockaddr dest_addr = CTRSockAddr::ToPlatform(ctr_dest_addr);
         ret = ::sendto(socket_handle, reinterpret_cast<const char*>(input_buff.data()), len, flags,
                        &dest_addr, sizeof(dest_addr));

--- a/src/core/hle/service/soc_u.cpp
+++ b/src/core/hle/service/soc_u.cpp
@@ -587,7 +587,7 @@ void SOC_U::RecvFrom(Kernel::HLERequestContext& ctx) {
     if (ret >= 0 && src_addr_len > 0) {
         ctr_src_addr = CTRSockAddr::FromPlatform(src_addr);
         std::memcpy(addr_buff.data(), &ctr_src_addr, sizeof(ctr_src_addr));
-    }else {
+    } else {
         addr_buff.resize(0);
     }
 

--- a/src/core/hle/service/soc_u.cpp
+++ b/src/core/hle/service/soc_u.cpp
@@ -580,13 +580,19 @@ void SOC_U::RecvFrom(Kernel::HLERequestContext& ctx) {
     std::vector<u8> addr_buff(sizeof(ctr_src_addr));
     sockaddr src_addr;
     socklen_t src_addr_len = sizeof(src_addr);
-    s32 ret = ::recvfrom(socket_handle, reinterpret_cast<char*>(output_buff.data()), len, flags,
-                         &src_addr, &src_addr_len);
 
-    if (ret >= 0 && src_addr_len > 0) {
-        ctr_src_addr = CTRSockAddr::FromPlatform(src_addr);
-        std::memcpy(addr_buff.data(), &ctr_src_addr, sizeof(ctr_src_addr));
+    s32 ret = -1;
+    if (addr_len > 0) {
+        // Only get src adr if input adr available
+        ret = ::recvfrom(socket_handle, reinterpret_cast<char*>(output_buff.data()), len, flags,
+                         &src_addr, &src_addr_len);
+        if (ret >= 0 && src_addr_len > 0) {
+            ctr_src_addr = CTRSockAddr::FromPlatform(src_addr);
+            std::memcpy(addr_buff.data(), &ctr_src_addr, sizeof(ctr_src_addr));
+        }
     } else {
+        ret = ::recvfrom(socket_handle, reinterpret_cast<char*>(output_buff.data()), len, flags,
+                         NULL, 0);
         addr_buff.resize(0);
     }
 


### PR DESCRIPTION
RecvFrom currently crash immediately when App call `recv` method ( buffsize < 0x2000 )
Because of `HLERequestContext::WriteToOutgoingCommandBuffer` -> `StaticBuffer` failed on
`ASSERT_MSG(target_descriptor.size >= data.size(), "Static buffer data is too big");`
so i resize `addr_buff` to 0 when recvfrom return error

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4113)
<!-- Reviewable:end -->
