### PR TITLE
web_service: Unify links for web service endpoints

### DIFF
--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -229,13 +229,8 @@ void Config::ReadValues() {
     // Web Service
     Settings::values.enable_telemetry =
         sdl2_config->GetBoolean("WebService", "enable_telemetry", true);
-    Settings::values.telemetry_endpoint_url = sdl2_config->Get(
-        "WebService", "telemetry_endpoint_url", "https://services.citra-emu.org/api/telemetry");
-    Settings::values.verify_endpoint_url = sdl2_config->Get(
-        "WebService", "verify_endpoint_url", "https://services.citra-emu.org/api/profile");
-    Settings::values.announce_multiplayer_room_endpoint_url =
-        sdl2_config->Get("WebService", "announce_multiplayer_room_endpoint_url",
-                         "https://services.citra-emu.org/api/multiplayer/rooms");
+    Settings::values.web_services_endpoint_url =
+        sdl2_config->Get("WebService", "web_services_endpoint_url", "https://api.citra-emu.org");
     Settings::values.citra_username = sdl2_config->Get("WebService", "citra_username", "");
     Settings::values.citra_token = sdl2_config->Get("WebService", "citra_token", "");
 }

--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -229,8 +229,8 @@ void Config::ReadValues() {
     // Web Service
     Settings::values.enable_telemetry =
         sdl2_config->GetBoolean("WebService", "enable_telemetry", true);
-    Settings::values.web_services_endpoint_url =
-        sdl2_config->Get("WebService", "web_services_endpoint_url", "https://api.citra-emu.org");
+    Settings::values.web_api_url =
+        sdl2_config->Get("WebService", "web_api_url", "https://api.citra-emu.org");
     Settings::values.citra_username = sdl2_config->Get("WebService", "citra_username", "");
     Settings::values.citra_token = sdl2_config->Get("WebService", "citra_token", "");
 }

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -245,8 +245,8 @@ gdbstub_port=24689
 # Whether or not to enable telemetry
 # 0: No, 1 (default): Yes
 enable_telemetry =
-# Endpoint URL for web services
-web_services_endpoint_url = https://api.citra-emu.org
+# URL for Web API
+web_api_url = https://api.citra-emu.org
 # Username and token for Citra Web Service
 # See https://services.citra-emu.org/ for more info
 citra_username =

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -245,12 +245,8 @@ gdbstub_port=24689
 # Whether or not to enable telemetry
 # 0: No, 1 (default): Yes
 enable_telemetry =
-# Endpoint URL for submitting telemetry data
-telemetry_endpoint_url = https://services.citra-emu.org/api/telemetry
-# Endpoint URL to verify the username and token
-verify_endpoint_url = https://services.citra-emu.org/api/profile
-# Endpoint URL for announcing public rooms
-announce_multiplayer_room_endpoint_url = https://services.citra-emu.org/api/multiplayer/rooms
+# Endpoint URL for web services
+web_services_endpoint_url = https://api.citra-emu.org
 # Username and token for Citra Web Service
 # See https://services.citra-emu.org/ for more info
 citra_username =

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -191,10 +191,8 @@ void Config::ReadValues() {
 
     qt_config->beginGroup("WebService");
     Settings::values.enable_telemetry = ReadSetting("enable_telemetry", true).toBool();
-    Settings::values.web_services_endpoint_url =
-        ReadSetting("web_services_endpoint_url", "https://api.citra-emu.org")
-            .toString()
-            .toStdString();
+    Settings::values.web_api_url =
+        ReadSetting("web_api_url", "https://api.citra-emu.org").toString().toStdString();
     Settings::values.citra_username = ReadSetting("citra_username").toString().toStdString();
     Settings::values.citra_token = ReadSetting("citra_token").toString().toStdString();
     qt_config->endGroup();
@@ -426,8 +424,7 @@ void Config::SaveValues() {
 
     qt_config->beginGroup("WebService");
     WriteSetting("enable_telemetry", Settings::values.enable_telemetry, true);
-    WriteSetting("web_services_endpoint_url",
-                 QString::fromStdString(Settings::values.web_services_endpoint_url),
+    WriteSetting("web_api_url", QString::fromStdString(Settings::values.web_api_url),
                  "https://api.citra-emu.org");
     WriteSetting("citra_username", QString::fromStdString(Settings::values.citra_username));
     WriteSetting("citra_token", QString::fromStdString(Settings::values.citra_token));

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -191,17 +191,8 @@ void Config::ReadValues() {
 
     qt_config->beginGroup("WebService");
     Settings::values.enable_telemetry = ReadSetting("enable_telemetry", true).toBool();
-    Settings::values.telemetry_endpoint_url =
-        ReadSetting("telemetry_endpoint_url", "https://services.citra-emu.org/api/telemetry")
-            .toString()
-            .toStdString();
-    Settings::values.verify_endpoint_url =
-        ReadSetting("verify_endpoint_url", "https://services.citra-emu.org/api/profile")
-            .toString()
-            .toStdString();
-    Settings::values.announce_multiplayer_room_endpoint_url =
-        ReadSetting("announce_multiplayer_room_endpoint_url",
-                    "https://services.citra-emu.org/api/multiplayer/rooms")
+    Settings::values.web_services_endpoint_url =
+        ReadSetting("web_services_endpoint_url", "https://api.citra-emu.org")
             .toString()
             .toStdString();
     Settings::values.citra_username = ReadSetting("citra_username").toString().toStdString();
@@ -435,16 +426,9 @@ void Config::SaveValues() {
 
     qt_config->beginGroup("WebService");
     WriteSetting("enable_telemetry", Settings::values.enable_telemetry, true);
-    WriteSetting("telemetry_endpoint_url",
-                 QString::fromStdString(Settings::values.telemetry_endpoint_url),
-                 "https://services.citra-emu.org/api/telemetry");
-    WriteSetting("verify_endpoint_url",
-                 QString::fromStdString(Settings::values.verify_endpoint_url),
-                 "https://services.citra-emu.org/api/profile");
-    WriteSetting("announce_multiplayer_room_endpoint_url",
-                 QString::fromStdString(Settings::values.announce_multiplayer_room_endpoint_url),
-                 "https://services.citra-emu.org/"
-                 "api/multiplayer/rooms");
+    WriteSetting("web_services_endpoint_url",
+                 QString::fromStdString(Settings::values.web_services_endpoint_url),
+                 "https://api.citra-emu.org");
     WriteSetting("citra_username", QString::fromStdString(Settings::values.citra_username));
     WriteSetting("citra_token", QString::fromStdString(Settings::values.citra_token));
     qt_config->endGroup();

--- a/src/core/announce_multiplayer_session.cpp
+++ b/src/core/announce_multiplayer_session.cpp
@@ -21,9 +21,9 @@ static constexpr std::chrono::seconds announce_time_interval(15);
 
 AnnounceMultiplayerSession::AnnounceMultiplayerSession() {
 #ifdef ENABLE_WEB_SERVICE
-    backend = std::make_unique<WebService::RoomJson>(
-        Settings::values.web_services_endpoint_url + "/lobby", Settings::values.citra_username,
-        Settings::values.citra_token);
+    backend = std::make_unique<WebService::RoomJson>(Settings::values.web_api_url + "/lobby",
+                                                     Settings::values.citra_username,
+                                                     Settings::values.citra_token);
 #else
     backend = std::make_unique<AnnounceMultiplayerRoom::NullBackend>();
 #endif

--- a/src/core/announce_multiplayer_session.cpp
+++ b/src/core/announce_multiplayer_session.cpp
@@ -22,7 +22,7 @@ static constexpr std::chrono::seconds announce_time_interval(15);
 AnnounceMultiplayerSession::AnnounceMultiplayerSession() {
 #ifdef ENABLE_WEB_SERVICE
     backend = std::make_unique<WebService::RoomJson>(
-        Settings::values.announce_multiplayer_room_endpoint_url, Settings::values.citra_username,
+        Settings::values.web_services_endpoint_url + "/lobby", Settings::values.citra_username,
         Settings::values.citra_token);
 #else
     backend = std::make_unique<AnnounceMultiplayerRoom::NullBackend>();

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -165,7 +165,7 @@ struct Values {
 
     // WebService
     bool enable_telemetry;
-    std::string web_services_endpoint_url;
+    std::string web_api_url;
     std::string citra_username;
     std::string citra_token;
 } extern values;

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -165,9 +165,7 @@ struct Values {
 
     // WebService
     bool enable_telemetry;
-    std::string telemetry_endpoint_url;
-    std::string verify_endpoint_url;
-    std::string announce_multiplayer_room_endpoint_url;
+    std::string web_services_endpoint_url;
     std::string citra_username;
     std::string citra_token;
 } extern values;

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -82,7 +82,8 @@ u64 RegenerateTelemetryId() {
 
 std::future<bool> VerifyLogin(std::string username, std::string token, std::function<void()> func) {
 #ifdef ENABLE_WEB_SERVICE
-    return WebService::VerifyLogin(username, token, Settings::values.verify_endpoint_url, func);
+    return WebService::VerifyLogin(username, token,
+                                   Settings::values.web_services_endpoint_url + "/profile", func);
 #else
     return std::async(std::launch::async, [func{std::move(func)}]() {
         func();
@@ -95,8 +96,8 @@ TelemetrySession::TelemetrySession() {
 #ifdef ENABLE_WEB_SERVICE
     if (Settings::values.enable_telemetry) {
         backend = std::make_unique<WebService::TelemetryJson>(
-            Settings::values.telemetry_endpoint_url, Settings::values.citra_username,
-            Settings::values.citra_token);
+            Settings::values.web_services_endpoint_url + "/telemetry",
+            Settings::values.citra_username, Settings::values.citra_token);
     } else {
         backend = std::make_unique<Telemetry::NullVisitor>();
     }

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -82,8 +82,8 @@ u64 RegenerateTelemetryId() {
 
 std::future<bool> VerifyLogin(std::string username, std::string token, std::function<void()> func) {
 #ifdef ENABLE_WEB_SERVICE
-    return WebService::VerifyLogin(username, token,
-                                   Settings::values.web_services_endpoint_url + "/profile", func);
+    return WebService::VerifyLogin(username, token, Settings::values.web_api_url + "/profile",
+                                   func);
 #else
     return std::async(std::launch::async, [func{std::move(func)}]() {
         func();
@@ -96,8 +96,8 @@ TelemetrySession::TelemetrySession() {
 #ifdef ENABLE_WEB_SERVICE
     if (Settings::values.enable_telemetry) {
         backend = std::make_unique<WebService::TelemetryJson>(
-            Settings::values.web_services_endpoint_url + "/telemetry",
-            Settings::values.citra_username, Settings::values.citra_token);
+            Settings::values.web_api_url + "/telemetry", Settings::values.citra_username,
+            Settings::values.citra_token);
     } else {
         backend = std::make_unique<Telemetry::NullVisitor>();
     }

--- a/src/dedicated_room/citra-room.cpp
+++ b/src/dedicated_room/citra-room.cpp
@@ -166,7 +166,7 @@ int main(int argc, char** argv) {
     }
     if (announce) {
         std::cout << "Hosting a public room\n\n";
-        Settings::values.announce_multiplayer_room_endpoint_url = announce_url;
+        Settings::values.web_services_endpoint_url = announce_url;
         Settings::values.citra_username = username;
         Settings::values.citra_token = token;
     }

--- a/src/dedicated_room/citra-room.cpp
+++ b/src/dedicated_room/citra-room.cpp
@@ -42,7 +42,7 @@ static void PrintHelp(const char* argv0) {
                  "--preferred-game-id The preferred game-id for this room\n"
                  "--username          The username used for announce\n"
                  "--token             The token used for announce\n"
-                 "--endpoint-url      The endpoint url to the announce server\n"
+                 "--web-api-url       Citra Web API url\n"
                  "-h, --help          Display this help and exit\n"
                  "-v, --version       Output version information and exit\n";
 }
@@ -65,7 +65,7 @@ int main(int argc, char** argv) {
     std::string preferred_game;
     std::string username;
     std::string token;
-    std::string endpoint_url;
+    std::string web_api_url;
     u64 preferred_game_id = 0;
     u32 port = Network::DefaultRoomPort;
     u32 max_members = 16;
@@ -79,7 +79,7 @@ int main(int argc, char** argv) {
         {"preferred-game-id", required_argument, 0, 'i'},
         {"username", required_argument, 0, 'u'},
         {"token", required_argument, 0, 't'},
-        {"endpoint-url", required_argument, 0, 'a'},
+        {"web-api-url", required_argument, 0, 'a'},
         {"help", no_argument, 0, 'h'},
         {"version", no_argument, 0, 'v'},
         {0, 0, 0, 0},
@@ -114,7 +114,7 @@ int main(int argc, char** argv) {
                 token.assign(optarg);
                 break;
             case 'a':
-                endpoint_url.assign(optarg);
+                web_api_url.assign(optarg);
                 break;
             case 'h':
                 PrintHelp(argv[0]);
@@ -160,13 +160,13 @@ int main(int argc, char** argv) {
         announce = false;
         std::cout << "token is empty: Hosting a private room\n\n";
     }
-    if (endpoint_url.empty() && announce) {
+    if (web_api_url.empty() && announce) {
         announce = false;
         std::cout << "endpoint url is empty: Hosting a private room\n\n";
     }
     if (announce) {
         std::cout << "Hosting a public room\n\n";
-        Settings::values.web_services_endpoint_url = endpoint_url;
+        Settings::values.web_api_url = web_api_url;
         Settings::values.citra_username = username;
         Settings::values.citra_token = token;
     }

--- a/src/dedicated_room/citra-room.cpp
+++ b/src/dedicated_room/citra-room.cpp
@@ -42,7 +42,7 @@ static void PrintHelp(const char* argv0) {
                  "--preferred-game-id The preferred game-id for this room\n"
                  "--username          The username used for announce\n"
                  "--token             The token used for announce\n"
-                 "--announce-url      The url to the announce server\n"
+                 "--endpoint-url      The endpoint url to the announce server\n"
                  "-h, --help          Display this help and exit\n"
                  "-v, --version       Output version information and exit\n";
 }
@@ -65,7 +65,7 @@ int main(int argc, char** argv) {
     std::string preferred_game;
     std::string username;
     std::string token;
-    std::string announce_url;
+    std::string endpoint_url;
     u64 preferred_game_id = 0;
     u32 port = Network::DefaultRoomPort;
     u32 max_members = 16;
@@ -79,7 +79,7 @@ int main(int argc, char** argv) {
         {"preferred-game-id", required_argument, 0, 'i'},
         {"username", required_argument, 0, 'u'},
         {"token", required_argument, 0, 't'},
-        {"announce-url", required_argument, 0, 'a'},
+        {"endpoint-url", required_argument, 0, 'a'},
         {"help", no_argument, 0, 'h'},
         {"version", no_argument, 0, 'v'},
         {0, 0, 0, 0},
@@ -114,7 +114,7 @@ int main(int argc, char** argv) {
                 token.assign(optarg);
                 break;
             case 'a':
-                announce_url.assign(optarg);
+                endpoint_url.assign(optarg);
                 break;
             case 'h':
                 PrintHelp(argv[0]);
@@ -160,13 +160,13 @@ int main(int argc, char** argv) {
         announce = false;
         std::cout << "token is empty: Hosting a private room\n\n";
     }
-    if (announce_url.empty() && announce) {
+    if (endpoint_url.empty() && announce) {
         announce = false;
-        std::cout << "announce url is empty: Hosting a private room\n\n";
+        std::cout << "endpoint url is empty: Hosting a private room\n\n";
     }
     if (announce) {
         std::cout << "Hosting a public room\n\n";
-        Settings::values.web_services_endpoint_url = announce_url;
+        Settings::values.web_services_endpoint_url = endpoint_url;
         Settings::values.citra_username = username;
         Settings::values.citra_token = token;
     }

--- a/src/web_service/web_backend.cpp
+++ b/src/web_service/web_backend.cpp
@@ -25,8 +25,8 @@ std::string UpdateCoreJWT(bool force_new_token, const std::string& username,
     static std::string jwt;
     if (jwt.empty() || force_new_token) {
         if (!username.empty() && !token.empty()) {
-            std::future<Common::WebResult> future =
-                PostJson("https://api.citra-emu.org/jwt/internal", username, token);
+            std::future<Common::WebResult> future = PostJson(
+                Settings::values.web_services_endpoint_url + "/jwt/internal", username, token);
             jwt = future.get().returned_data;
         }
     }

--- a/src/web_service/web_backend.cpp
+++ b/src/web_service/web_backend.cpp
@@ -25,8 +25,8 @@ std::string UpdateCoreJWT(bool force_new_token, const std::string& username,
     static std::string jwt;
     if (jwt.empty() || force_new_token) {
         if (!username.empty() && !token.empty()) {
-            std::future<Common::WebResult> future = PostJson(
-                Settings::values.web_services_endpoint_url + "/jwt/internal", username, token);
+            std::future<Common::WebResult> future =
+                PostJson(Settings::values.web_api_url + "/jwt/internal", username, token);
             jwt = future.get().returned_data;
         }
     }


### PR DESCRIPTION
This PR aims to unify the links for web service endpoints into one. 
All links for the respective features like telemetry, rooms, etc. are then directly hardcoded in the code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4138)
<!-- Reviewable:end -->
