### PR TITLE
core, citra_qt: unify status of system archives and shared fonts

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -1407,14 +1407,15 @@ void GMainWindow::UpdateStatusBar() {
 void GMainWindow::OnCoreError(Core::System::ResultStatus result, std::string details) {
     QMessageBox::StandardButton answer;
     QString status_message;
-    const QString common_message =
-        tr("%1 is missing. Please <a "
-           "href='https://citra-emu.org/wiki/"
-           "dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/'>dump your "
-           "system archives</a>.<br/>Continuing emulation may result in crashes and bugs.");
+
     QString title, message;
-    switch (result) {
-    case Core::System::ResultStatus::ErrorSystemFiles: {
+    if (result == Core::System::ResultStatus::ErrorSystemFiles) {
+        const QString common_message =
+            tr("%1 is missing. Please <a "
+               "href='https://citra-emu.org/wiki/"
+               "dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/'>dump your "
+               "system archives</a>.<br/>Continuing emulation may result in crashes and bugs.");
+
         if (!details.empty()) {
             message = common_message.arg(QString::fromStdString(details));
         } else {
@@ -1423,18 +1424,7 @@ void GMainWindow::OnCoreError(Core::System::ResultStatus result, std::string det
 
         title = tr("System Archive Not Found");
         status_message = "System Archive Missing";
-        break;
-    }
-
-    case Core::System::ResultStatus::ErrorSharedFont: {
-        message = tr("Shared fonts not found. ");
-        message.append(common_message);
-        title = tr("Shared Fonts Not Found");
-        status_message = "Shared Font Missing";
-        break;
-    }
-
-    default:
+    } else {
         title = tr("Fatal Error");
         message =
             tr("A fatal error occured. "
@@ -1442,7 +1432,6 @@ void GMainWindow::OnCoreError(Core::System::ResultStatus result, std::string det
                "the log</a> for details."
                "<br/>Continuing emulation may result in crashes and bugs.");
         status_message = "Fatal Error encountered";
-        break;
     }
 
     QMessageBox message_box;

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -50,7 +50,6 @@ public:
         ErrorLoader_ErrorInvalidFormat,     ///< Error loading the specified application due to an
                                             /// invalid format
         ErrorSystemFiles,                   ///< Error in finding system files
-        ErrorSharedFont,                    ///< Error in finding shared font
         ErrorVideoCore,                     ///< Error in the video core
         ErrorVideoCore_ErrorGenericDrivers, ///< Error in the video core due to the user having
                                             /// generic drivers installed

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -204,7 +204,8 @@ void Module::Interface::GetSharedFont(Kernel::HLERequestContext& ctx) {
             rb.Push<u32>(-1); // TODO: Find the right error code
             rb.Push<u32>(0);
             rb.PushCopyObjects<Kernel::Object>(nullptr);
-            Core::System::GetInstance().SetStatus(Core::System::ResultStatus::ErrorSharedFont);
+            Core::System::GetInstance().SetStatus(Core::System::ResultStatus::ErrorSystemFiles,
+                                                  "Shared fonts");
             return;
         }
     }


### PR DESCRIPTION
Shared fonts is no different from any other system archives, and there is not really any point to make a separate status for it. This also fixes the incorrect error message that was introduced when I made the UI text improvements.

The incorrect error message:
![image](https://user-images.githubusercontent.com/21307832/44666027-09971c00-aa4a-11e8-9f1f-02dcf711a4fd.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4143)
<!-- Reviewable:end -->
