### PR TITLE
Port yuzu-emu/yuzu#1126 from yuzu: "Don't allocate std::string instances for program lifetime in GetTelemetryId() and RegenerateTelemetryId()"

### DIFF
--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -45,7 +45,7 @@ static u64 GenerateTelemetryId() {
 
 u64 GetTelemetryId() {
     u64 telemetry_id{};
-    static const std::string& filename{FileUtil::GetUserPath(D_CONFIG_IDX) + "telemetry_id"};
+    const std::string filename{FileUtil::GetUserPath(D_CONFIG_IDX) + "telemetry_id"};
 
     if (FileUtil::Exists(filename)) {
         FileUtil::IOFile file(filename, "rb");
@@ -69,7 +69,7 @@ u64 GetTelemetryId() {
 
 u64 RegenerateTelemetryId() {
     const u64 new_telemetry_id{GenerateTelemetryId()};
-    static const std::string& filename{FileUtil::GetUserPath(D_CONFIG_IDX) + "telemetry_id"};
+    const std::string filename{FileUtil::GetUserPath(D_CONFIG_IDX) + "telemetry_id"};
 
     FileUtil::IOFile file(filename, "wb");
     if (!file.IsOpen()) {


### PR DESCRIPTION
See yuzu-emu/yuzu#1126 for more details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4162)
<!-- Reviewable:end -->
