### PR TITLE
citra_qt, video_core: Screenshot functionality

### DIFF
--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -15,6 +15,7 @@
 #include "input_common/main.h"
 #include "input_common/motion_emu.h"
 #include "network/network.h"
+#include "video_core/video_core.h"
 
 EmuThread::EmuThread(GRenderWindow* render_window) : render_window(render_window) {}
 
@@ -333,6 +334,19 @@ void GRenderWindow::InitRenderTarget() {
     NotifyClientAreaSizeChanged(std::pair<unsigned, unsigned>(child->width(), child->height()));
 
     BackupGeometry();
+}
+
+void GRenderWindow::CaptureScreenshot(u16 res_scale, const QString& screenshot_path) {
+    if (!res_scale)
+        res_scale = VideoCore::GetResolutionScaleFactor();
+    const Layout::FramebufferLayout layout{Layout::FrameLayoutFromResolutionScale(res_scale)};
+    screenshot_image = QImage(QSize(layout.width, layout.height), QImage::Format_RGB32);
+    VideoCore::RequestScreenshot(screenshot_image.bits(),
+                                 [=] {
+                                     screenshot_image.mirrored(false, true).save(screenshot_path);
+                                     LOG_INFO(Frontend, "The screenshot is saved.");
+                                 },
+                                 layout);
 }
 
 void GRenderWindow::OnMinimalClientAreaChangeRequest(

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -8,6 +8,7 @@
 #include <condition_variable>
 #include <mutex>
 #include <QGLWidget>
+#include <QImage>
 #include <QThread>
 #include "common/thread.h"
 #include "core/core.h"
@@ -139,6 +140,8 @@ public:
 
     void InitRenderTarget();
 
+    void CaptureScreenshot(u16 res_scale, const QString& screenshot_path);
+
 public slots:
     void moveContext(); // overridden
 
@@ -164,6 +167,9 @@ private:
     QByteArray geometry;
 
     EmuThread* emu_thread;
+
+    /// Temporary storage of the screenshot taken
+    QImage screenshot_image;
 
 protected:
     void showEvent(QShowEvent* event) override;

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -206,6 +206,8 @@ void Config::ReadValues() {
     UISettings::values.theme = ReadSetting("theme", UISettings::themes[0].second).toString();
     UISettings::values.enable_discord_presence =
         ReadSetting("enable_discord_presence", true).toBool();
+    UISettings::values.screenshot_resolution_factor =
+        static_cast<u16>(ReadSetting("screenshot_resolution_factor", 0).toUInt());
 
     qt_config->beginGroup("Updater");
     UISettings::values.check_for_update_on_start =
@@ -251,6 +253,7 @@ void Config::ReadValues() {
     UISettings::values.symbols_path = ReadSetting("symbolsPath").toString();
     UISettings::values.movie_record_path = ReadSetting("movieRecordPath").toString();
     UISettings::values.movie_playback_path = ReadSetting("moviePlaybackPath").toString();
+    UISettings::values.screenshot_path = ReadSetting("screenshotPath").toString();
     UISettings::values.game_dir_deprecated = ReadSetting("gameListRootDir", ".").toString();
     UISettings::values.game_dir_deprecated_deepscan =
         ReadSetting("gameListDeepScan", false).toBool();
@@ -460,6 +463,8 @@ void Config::SaveValues() {
     qt_config->beginGroup("UI");
     WriteSetting("theme", UISettings::values.theme, UISettings::themes[0].second);
     WriteSetting("enable_discord_presence", UISettings::values.enable_discord_presence, true);
+    WriteSetting("screenshot_resolution_factor", UISettings::values.screenshot_resolution_factor,
+                 0);
 
     qt_config->beginGroup("Updater");
     WriteSetting("check_for_update_on_start", UISettings::values.check_for_update_on_start, true);
@@ -487,6 +492,7 @@ void Config::SaveValues() {
     WriteSetting("symbolsPath", UISettings::values.symbols_path);
     WriteSetting("movieRecordPath", UISettings::values.movie_record_path);
     WriteSetting("moviePlaybackPath", UISettings::values.movie_playback_path);
+    WriteSetting("screenshotPath", UISettings::values.screenshot_path);
     qt_config->beginWriteArray("gamedirs");
     for (int i = 0; i < UISettings::values.game_dirs.size(); ++i) {
         qt_config->setArrayIndex(i);

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -365,6 +365,7 @@ void GMainWindow::InitializeHotkeys() {
                                    Qt::ApplicationShortcut);
     hotkey_registry.RegisterHotkey("Main Window", "Remove Amiibo", QKeySequence(Qt::Key_F3),
                                    Qt::ApplicationShortcut);
+    hotkey_registry.RegisterHotkey("Main Window", "Capture Screenshot", QKeySequence(tr("CTRL+P")));
 
     hotkey_registry.LoadHotkeys();
 
@@ -437,6 +438,12 @@ void GMainWindow::InitializeHotkeys() {
             this, [&] {
                 if (ui.action_Remove_Amiibo->isEnabled()) {
                     OnRemoveAmiibo();
+                }
+            });
+    connect(hotkey_registry.GetHotkey("Main Window", "Capture Screenshot", this),
+            &QShortcut::activated, this, [&] {
+                if (emu_thread->IsRunning()) {
+                    OnCaptureScreenshot();
                 }
             });
 }
@@ -588,6 +595,8 @@ void GMainWindow::ConnectMenuEvents() {
             Core::System::GetInstance().frame_limiter.AdvanceFrame();
         }
     });
+    connect(ui.action_Capture_Screenshot, &QAction::triggered, this,
+            &GMainWindow::OnCaptureScreenshot);
 
     // Help
     connect(ui.action_Open_Citra_Folder, &QAction::triggered, this,
@@ -882,6 +891,7 @@ void GMainWindow::ShutdownGame() {
     ui.action_Enable_Frame_Advancing->setEnabled(false);
     ui.action_Enable_Frame_Advancing->setChecked(false);
     ui.action_Advance_Frame->setEnabled(false);
+    ui.action_Capture_Screenshot->setEnabled(false);
     render_window->hide();
     if (game_list->isEmpty())
         game_list_placeholder->show();
@@ -1169,6 +1179,7 @@ void GMainWindow::OnStartGame() {
     ui.action_Load_Amiibo->setEnabled(true);
     ui.action_Report_Compatibility->setEnabled(true);
     ui.action_Enable_Frame_Advancing->setEnabled(true);
+    ui.action_Capture_Screenshot->setEnabled(true);
 
     discord_rpc->Update();
 }
@@ -1179,6 +1190,7 @@ void GMainWindow::OnPauseGame() {
     ui.action_Start->setEnabled(true);
     ui.action_Pause->setEnabled(false);
     ui.action_Stop->setEnabled(true);
+    ui.action_Capture_Screenshot->setEnabled(false);
 }
 
 void GMainWindow::OnStopGame() {
@@ -1537,6 +1549,18 @@ void GMainWindow::OnStopRecordingPlayback() {
     ui.action_Record_Movie->setEnabled(true);
     ui.action_Play_Movie->setEnabled(true);
     ui.action_Stop_Recording_Playback->setEnabled(false);
+}
+
+void GMainWindow::OnCaptureScreenshot() {
+    OnPauseGame();
+    const QString path =
+        QFileDialog::getSaveFileName(this, tr("Capture Screenshot"),
+                                     UISettings::values.screenshot_path, tr("PNG Image (*.png)"));
+    if (!path.isEmpty()) {
+        UISettings::values.screenshot_path = QFileInfo(path).path();
+        render_window->CaptureScreenshot(UISettings::values.screenshot_resolution_factor, path);
+    }
+    OnStartGame();
 }
 
 void GMainWindow::UpdateStatusBar() {

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -183,6 +183,7 @@ private slots:
     void OnRecordMovie();
     void OnPlayMovie();
     void OnStopRecordingPlayback();
+    void OnCaptureScreenshot();
     void OnCoreError(Core::System::ResultStatus, std::string);
     /// Called whenever a user selects Help->About Citra
     void OnMenuAboutCitra();

--- a/src/citra_qt/main.ui
+++ b/src/citra_qt/main.ui
@@ -131,6 +131,8 @@
     <addaction name="separator"/>
     <addaction name="action_Enable_Frame_Advancing"/>
     <addaction name="action_Advance_Frame"/>
+    <addaction name="separator"/>
+    <addaction name="action_Capture_Screenshot"/>
    </widget>
    <widget class="QMenu" name="menu_Multiplayer">
     <property name="enabled">
@@ -313,6 +315,14 @@
    </property>
    <property name="text">
     <string>Advance Frame</string>
+   </property>
+  </action>
+  <action name="action_Capture_Screenshot">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Capture Screenshot</string>
    </property>
   </action>
   <action name="action_View_Lobby">

--- a/src/citra_qt/main.ui
+++ b/src/citra_qt/main.ui
@@ -121,19 +121,6 @@
     <addaction name="separator"/>
     <addaction name="menu_View_Debugging"/>
    </widget>
-   <widget class="QMenu" name="menu_Movie">
-    <property name="title">
-     <string>Movie</string>
-    </property>
-    <addaction name="action_Record_Movie"/>
-    <addaction name="action_Play_Movie"/>
-    <addaction name="action_Stop_Recording_Playback"/>
-    <addaction name="separator"/>
-    <addaction name="action_Enable_Frame_Advancing"/>
-    <addaction name="action_Advance_Frame"/>
-    <addaction name="separator"/>
-    <addaction name="action_Capture_Screenshot"/>
-   </widget>
    <widget class="QMenu" name="menu_Multiplayer">
     <property name="enabled">
      <bool>true</bool>
@@ -148,6 +135,30 @@
     <addaction name="action_Show_Room"/>
     <addaction name="action_Leave_Room"/>
    </widget>
+   <widget class="QMenu" name="menu_Tools">
+    <property name="title">
+     <string>Tools</string>
+    </property>
+    <widget class="QMenu" name="menu_Movie">
+     <property name="title">
+      <string>Movie</string>
+     </property>
+     <addaction name="action_Record_Movie"/>
+     <addaction name="action_Play_Movie"/>
+     <addaction name="action_Stop_Recording_Playback"/>
+    </widget>
+    <widget class="QMenu" name="menu_Frame_Advance">
+     <property name="title">
+      <string>Frame Advance</string>
+     </property>
+     <addaction name="action_Enable_Frame_Advancing"/>
+     <addaction name="action_Advance_Frame"/>
+    </widget>
+    <addaction name="menu_Movie"/>
+    <addaction name="menu_Frame_Advance"/>
+    <addaction name="separator"/>
+    <addaction name="action_Capture_Screenshot"/>
+   </widget>
    <widget class="QMenu" name="menu_Help">
     <property name="title">
      <string>&amp;Help</string>
@@ -161,8 +172,8 @@
    <addaction name="menu_File"/>
    <addaction name="menu_Emulation"/>
    <addaction name="menu_View"/>
-   <addaction name="menu_Movie"/>
    <addaction name="menu_Multiplayer"/>
+   <addaction name="menu_Tools"/>
    <addaction name="menu_Help"/>
   </widget>
   <action name="action_Load_File">

--- a/src/citra_qt/ui_settings.h
+++ b/src/citra_qt/ui_settings.h
@@ -10,6 +10,7 @@
 #include <QMetaType>
 #include <QString>
 #include <QStringList>
+#include "common/common_types.h"
 
 namespace UISettings {
 
@@ -78,10 +79,13 @@ struct Values {
     GameListText game_list_row_2;
     bool game_list_hide_no_icon;
 
+    u16 screenshot_resolution_factor;
+
     QString roms_path;
     QString symbols_path;
     QString movie_record_path;
     QString movie_playback_path;
+    QString screenshot_path;
     QString game_dir_deprecated;
     bool game_dir_deprecated_deepscan;
     QList<UISettings::GameDir> game_dirs;

--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -191,4 +191,50 @@ FramebufferLayout CustomFrameLayout(unsigned width, unsigned height) {
     res.bottom_screen = bot_screen;
     return res;
 }
+
+FramebufferLayout FrameLayoutFromResolutionScale(u16 res_scale) {
+    FramebufferLayout layout;
+    if (Settings::values.custom_layout == true) {
+        layout = CustomFrameLayout(
+            std::max(Settings::values.custom_top_right, Settings::values.custom_bottom_right),
+            std::max(Settings::values.custom_top_bottom, Settings::values.custom_bottom_bottom));
+    } else {
+        int width, height;
+        switch (Settings::values.layout_option) {
+        case Settings::LayoutOption::SingleScreen:
+            if (Settings::values.swap_screen) {
+                width = Core::kScreenBottomWidth * res_scale;
+                height = Core::kScreenBottomHeight * res_scale;
+            } else {
+                width = Core::kScreenTopWidth * res_scale;
+                height = Core::kScreenTopHeight * res_scale;
+            }
+            layout = SingleFrameLayout(width, height, Settings::values.swap_screen);
+            break;
+        case Settings::LayoutOption::LargeScreen:
+            if (Settings::values.swap_screen) {
+                width = (Core::kScreenBottomWidth + Core::kScreenTopWidth / 4) * res_scale;
+                height = Core::kScreenBottomHeight * res_scale;
+            } else {
+                width = (Core::kScreenTopWidth + Core::kScreenBottomWidth / 4) * res_scale;
+                height = Core::kScreenTopHeight * res_scale;
+            }
+            layout = LargeFrameLayout(width, height, Settings::values.swap_screen);
+            break;
+        case Settings::LayoutOption::SideScreen:
+            width = (Core::kScreenTopWidth + Core::kScreenBottomWidth) * res_scale;
+            height = Core::kScreenTopHeight * res_scale;
+            layout = SideFrameLayout(width, height, Settings::values.swap_screen);
+            break;
+        case Settings::LayoutOption::Default:
+        default:
+            width = Core::kScreenTopWidth * res_scale;
+            height = (Core::kScreenTopHeight + Core::kScreenBottomHeight) * res_scale;
+            layout = DefaultFrameLayout(width, height, Settings::values.swap_screen);
+            break;
+        }
+    }
+    return layout;
+}
+
 } // namespace Layout

--- a/src/core/frontend/framebuffer_layout.h
+++ b/src/core/frontend/framebuffer_layout.h
@@ -72,4 +72,11 @@ FramebufferLayout SideFrameLayout(unsigned width, unsigned height, bool is_swapp
  */
 FramebufferLayout CustomFrameLayout(unsigned width, unsigned height);
 
+/**
+ * Convenience method to get frame layout by resolution scale
+ * Read from the current settings to determine which layout to use.
+ * @param res_scale resolution scale factor
+ */
+FramebufferLayout FrameLayoutFromResolutionScale(u16 res_scale);
+
 } // namespace Layout

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -24,7 +24,6 @@
 #include "common/vector_math.h"
 #include "core/frontend/emu_window.h"
 #include "core/memory.h"
-#include "core/settings.h"
 #include "video_core/pica_state.h"
 #include "video_core/renderer_base.h"
 #include "video_core/renderer_opengl/gl_rasterizer_cache.h"
@@ -76,12 +75,6 @@ static const FormatTuple& GetFormatTuple(PixelFormat pixel_format) {
 template <typename Map, typename Interval>
 constexpr auto RangeFromInterval(Map& map, const Interval& interval) {
     return boost::make_iterator_range(map.equal_range(interval));
-}
-
-static u16 GetResolutionScaleFactor() {
-    return !Settings::values.resolution_factor
-               ? VideoCore::g_renderer->GetRenderWindow().GetFramebufferLayout().GetScalingRatio()
-               : Settings::values.resolution_factor;
 }
 
 template <bool morton_to_gl, PixelFormat format>
@@ -1360,9 +1353,9 @@ SurfaceSurfaceRect_Tuple RasterizerCacheOpenGL::GetFramebufferSurfaces(
     const auto& config = regs.framebuffer.framebuffer;
 
     // update resolution_scale_factor and reset cache if changed
-    static u16 resolution_scale_factor = GetResolutionScaleFactor();
-    if (resolution_scale_factor != GetResolutionScaleFactor()) {
-        resolution_scale_factor = GetResolutionScaleFactor();
+    static u16 resolution_scale_factor = VideoCore::GetResolutionScaleFactor();
+    if (resolution_scale_factor != VideoCore::GetResolutionScaleFactor()) {
+        resolution_scale_factor = VideoCore::GetResolutionScaleFactor();
         FlushAll();
         while (!surface_cache.empty())
             UnregisterSurface(*surface_cache.begin()->second.begin());

--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -13,6 +13,10 @@
 #include "video_core/renderer_opengl/gl_resource_manager.h"
 #include "video_core/renderer_opengl/gl_state.h"
 
+namespace Layout {
+class FramebufferLayout;
+}
+
 namespace OpenGL {
 
 /// Structure used for storing information about the textures for each 3DS screen
@@ -50,7 +54,7 @@ private:
     void InitOpenGLObjects();
     void ConfigureFramebufferTexture(TextureInfo& texture,
                                      const GPU::Regs::FramebufferConfig& framebuffer);
-    void DrawScreens();
+    void DrawScreens(const Layout::FramebufferLayout& layout);
     void DrawSingleScreenRotated(const ScreenInfo& screen_info, float x, float y, float w, float h);
     void UpdateFramerate();
 
@@ -66,6 +70,7 @@ private:
     OGLVertexArray vertex_array;
     OGLBuffer vertex_buffer;
     OGLProgram shader;
+    OGLFramebuffer screenshot_framebuffer;
 
     /// Display information for top and bottom screens respectively
     std::array<ScreenInfo, 3> screen_infos;

--- a/src/video_core/video_core.cpp
+++ b/src/video_core/video_core.cpp
@@ -4,6 +4,7 @@
 
 #include <memory>
 #include "common/logging/log.h"
+#include "core/settings.h"
 #include "video_core/pica.h"
 #include "video_core/renderer_base.h"
 #include "video_core/renderer_opengl/renderer_opengl.h"
@@ -22,6 +23,11 @@ std::atomic<bool> g_hw_shader_enabled;
 std::atomic<bool> g_hw_shader_accurate_gs;
 std::atomic<bool> g_hw_shader_accurate_mul;
 std::atomic<bool> g_renderer_bg_color_update_requested;
+// Screenshot
+std::atomic<bool> g_renderer_screenshot_requested;
+void* g_screenshot_bits;
+std::function<void()> g_screenshot_complete_callback;
+Layout::FramebufferLayout g_screenshot_framebuffer_layout;
 
 /// Initialize the video core
 Core::System::ResultStatus Init(EmuWindow& emu_window) {
@@ -46,6 +52,29 @@ void Shutdown() {
     g_renderer.reset();
 
     LOG_DEBUG(Render, "shutdown OK");
+}
+
+void RequestScreenshot(void* data, std::function<void()> callback,
+                       const Layout::FramebufferLayout& layout) {
+    if (g_renderer_screenshot_requested) {
+        LOG_ERROR(Render, "A screenshot is already requested or in progress, ignoring the request");
+        return;
+    }
+    g_screenshot_bits = data;
+    g_screenshot_complete_callback = std::move(callback);
+    g_screenshot_framebuffer_layout = layout;
+    g_renderer_screenshot_requested = true;
+}
+
+u16 GetResolutionScaleFactor() {
+    if (g_hw_renderer_enabled) {
+        return !Settings::values.resolution_factor
+                   ? g_renderer->GetRenderWindow().GetFramebufferLayout().GetScalingRatio()
+                   : Settings::values.resolution_factor;
+    } else {
+        // Software renderer always render at native resolution
+        return 1;
+    }
 }
 
 } // namespace VideoCore

--- a/src/video_core/video_core.h
+++ b/src/video_core/video_core.h
@@ -7,6 +7,7 @@
 #include <atomic>
 #include <memory>
 #include "core/core.h"
+#include "core/frontend/emu_window.h"
 
 class EmuWindow;
 class RendererBase;
@@ -26,11 +27,22 @@ extern std::atomic<bool> g_hw_shader_enabled;
 extern std::atomic<bool> g_hw_shader_accurate_gs;
 extern std::atomic<bool> g_hw_shader_accurate_mul;
 extern std::atomic<bool> g_renderer_bg_color_update_requested;
+// Screenshot
+extern std::atomic<bool> g_renderer_screenshot_requested;
+extern void* g_screenshot_bits;
+extern std::function<void()> g_screenshot_complete_callback;
+extern Layout::FramebufferLayout g_screenshot_framebuffer_layout;
 
 /// Initialize the video core
 Core::System::ResultStatus Init(EmuWindow& emu_window);
 
 /// Shutdown the video core
 void Shutdown();
+
+/// Request a screenshot of the next frame
+void RequestScreenshot(void* data, std::function<void()> callback,
+                       const Layout::FramebufferLayout& layout);
+
+u16 GetResolutionScaleFactor();
 
 } // namespace VideoCore


### PR DESCRIPTION
Closes #3121

Allows capturing screenshot at the current internal resolution (native for software renderer), but a setting is available to capture it in other resolutions (the internal resolution won't be changed, instead the image captured is upscaled/downscaled). The screenshot is saved to a single PNG in the current layout.

Examples of captured images can be found in the #screenshots-videos channel in Citra discord (they were captured with an older version of the code, but I have confirmed the result is the same). This is [one](https://cdn.discordapp.com/attachments/472575481179537418/484372018179997706/screenshot2.zip) of them.

A menu action is added to the Movie menu (I believe this is the most suitable place) as well as a hotkey. The hotkey is bound to Ctrl+S by default.

I have just started to learn GL stuff, and there may be easier ways to achieve what I'm doing in renderer_opengl.cpp. If that's the case, please point it out. Thanks!

Screenshot:
![image](https://user-images.githubusercontent.com/21307832/44914405-baf7c380-ad62-11e8-9131-4ce9dd458893.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4164)
<!-- Reviewable:end -->
