### PR TITLE
NCCH_Container: Add file_path log to Load()

### DIFF
--- a/src/core/file_sys/ncch_container.cpp
+++ b/src/core/file_sys/ncch_container.cpp
@@ -122,6 +122,7 @@ Loader::ResultStatus NCCHContainer::OpenFile(const std::string& filepath, u32 nc
 }
 
 Loader::ResultStatus NCCHContainer::Load() {
+    LOG_INFO(Service_FS, "Loading NCCH from file {}", filepath);
     if (is_loaded)
         return Loader::ResultStatus::Success;
 


### PR DESCRIPTION
We currently receive a lot of reports from users with the log just showing
`[   0.806359] Service.FS <Error> core/file_sys/ncch_container.cpp:Load:175: Secure1 KeyX missing
[   0.806604] Service.FS <Error> core/file_sys/ncch_container.cpp:Load:189: Secure2 KeyX missing
[   0.806612] Service.FS <Error> core/file_sys/ncch_container.cpp:Load:275: Failed to decrypt
[   0.806636] Service.FS <Error> core/file_sys/ncch_container.cpp:Load:175: Secure1 KeyX missing
[   0.806643] Service.FS <Error> core/file_sys/ncch_container.cpp:Load:189: Secure2 KeyX missing
[   0.806652] Service.FS <Error> core/file_sys/ncch_container.cpp:Load:275: Failed to decrypt
[   0.808210] Service.FS <Error> core/file_sys/ncch_container.cpp:Load:175: Secure1 KeyX missing`

To help debug this I added a line that logs the filepath when a ncch_container gets loaded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4165)
<!-- Reviewable:end -->
