### PR TITLE
gl_rasiterzer/proctex: revert back to round() for Nearest sampling

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -1158,8 +1158,7 @@ float ProcTexNoiseCoef(vec2 x) {
     case ProcTexFilter::NearestMipmapLinear:
     case ProcTexFilter::NearestMipmapNearest:
         out += "lut_coord += lut_offset;\n";
-        // Note: float->int conversion here is indeed floor, not round
-        out += "return texelFetch(texture_buffer_lut_rgba, int(lut_coord) + "
+        out += "return texelFetch(texture_buffer_lut_rgba, int(round(lut_coord)) + "
                "proctex_lut_offset);\n";
         break;
     }


### PR DESCRIPTION
This change to floor() was made in 2927c88 (#3916) (from https://github.com/citra-emu/citra/pull/3916/files#diff-21b620fbb9c59667998f26b07834ff81L1183 to https://github.com/citra-emu/citra/pull/3916/files#diff-21b620fbb9c59667998f26b07834ff81R1160) , which was a result of doing some hwtest. It turned out that it was buggy edge cases in PICA, and for most cases round() still applies. Revert back to round to make it work for most common cases.

Fixes #4150. @suppaflie could you test to see if this also fixes #4103 ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4174)
<!-- Reviewable:end -->
