### PR TITLE
Joystick: Allow for background events; Add deadzone to SDLAnalog

### DIFF
--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -438,7 +438,7 @@ public:
         const int port = params.Get("port", 0);
         const int axis_x = params.Get("axis_x", 0);
         const int axis_y = params.Get("axis_y", 1);
-        float deadzone = std::clamp(params.Get("deadzone", 0.0f), 0.0f, .099f);
+        float deadzone = std::clamp(params.Get("deadzone", 0.0f), 0.0f, .99f);
 
         auto joystick = state.GetSDLJoystickByGUID(guid, port);
 

--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -324,17 +324,26 @@ private:
 
 class SDLAnalog final : public Input::AnalogDevice {
 public:
-    SDLAnalog(std::shared_ptr<SDLJoystick> joystick_, int axis_x_, int axis_y_)
-        : joystick(std::move(joystick_)), axis_x(axis_x_), axis_y(axis_y_) {}
+    SDLAnalog(std::shared_ptr<SDLJoystick> joystick_, int axis_x_, int axis_y_, float deadzone_)
+        : joystick(std::move(joystick_)), axis_x(axis_x_), axis_y(axis_y_), deadzone(deadzone_) {}
 
     std::tuple<float, float> GetStatus() const override {
-        return joystick->GetAnalog(axis_x, axis_y);
+        float x;
+        float y;
+        std::tie(x, y) = joystick->GetAnalog(axis_x, axis_y);
+        const float r = std::sqrt((x * x) + (y * y));
+        if (r > deadzone) {
+            return std::make_tuple(x / r * (r - deadzone) / (1 - deadzone),
+                                   y / r * (r - deadzone) / (1 - deadzone));
+        }
+        return std::make_tuple<float, float>(0.0f, 0.0f);
     }
 
 private:
     std::shared_ptr<SDLJoystick> joystick;
-    int axis_x;
-    int axis_y;
+    const int axis_x;
+    const int axis_y;
+    const float deadzone;
 };
 
 /// A button device factory that creates button devices from SDL joystick
@@ -429,13 +438,14 @@ public:
         const int port = params.Get("port", 0);
         const int axis_x = params.Get("axis_x", 0);
         const int axis_y = params.Get("axis_y", 1);
+        float deadzone = std::clamp(params.Get("deadzone", 0.0f), 0.0f, .099f);
 
         auto joystick = state.GetSDLJoystickByGUID(guid, port);
 
         // This is necessary so accessing GetAxis with axis_x and axis_y won't crash
         joystick->SetAxis(axis_x, 0);
         joystick->SetAxis(axis_y, 0);
-        return std::make_unique<SDLAnalog>(joystick, axis_x, axis_y);
+        return std::make_unique<SDLAnalog>(joystick, axis_x, axis_y, deadzone);
     }
 
 private:
@@ -452,6 +462,9 @@ SDLState::SDLState() {
     if (start_thread && SDL_Init(SDL_INIT_JOYSTICK) < 0) {
         LOG_CRITICAL(Input, "SDL_Init(SDL_INIT_JOYSTICK) failed with: {}", SDL_GetError());
         return;
+    }
+    if (SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1") == SDL_FALSE) {
+        LOG_ERROR(Input, "Failed to set Hint for background events", SDL_GetError());
     }
 
     SDL_AddEventWatch(&SDLEventWatcher, this);

--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -328,9 +328,7 @@ public:
         : joystick(std::move(joystick_)), axis_x(axis_x_), axis_y(axis_y_), deadzone(deadzone_) {}
 
     std::tuple<float, float> GetStatus() const override {
-        float x;
-        float y;
-        std::tie(x, y) = joystick->GetAnalog(axis_x, axis_y);
+        const auto [x, y] = joystick->GetAnalog(axis_x, axis_y);
         const float r = std::sqrt((x * x) + (y * y));
         if (r > deadzone) {
             return std::make_tuple(x / r * (r - deadzone) / (1 - deadzone),


### PR DESCRIPTION
This adds two features to the joystick code:

1. Events from joysticks will now get registered even if citra isn't in focus
2. Analog axis can have a deadzone. There is no gui for setting it yet. Adding a deadzone can be done via the config inis, e.g.:
`circle_pad="port:0,guid:050000005769696d6f74652028303000,axis_x:0,axis_y:1,engine:sdl,deadzone:0.5"`

the deadzone needs to be: `0.0 <= deadzone < 1.0`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4193)
<!-- Reviewable:end -->
