### PR TITLE
audio_core: Simplify sink interface

### DIFF
--- a/src/audio_core/cubeb_sink.cpp
+++ b/src/audio_core/cubeb_sink.cpp
@@ -13,13 +13,11 @@ namespace AudioCore {
 
 struct CubebSink::Impl {
     unsigned int sample_rate = 0;
-    std::vector<std::string> device_list;
 
     cubeb* ctx = nullptr;
     cubeb_stream* stream = nullptr;
 
-    std::mutex queue_mutex;
-    std::vector<s16> queue;
+    std::function<void(s16*, std::size_t)> cb;
 
     static long DataCallback(cubeb_stream* stream, void* user_data, const void* input_buffer,
                              void* output_buffer, long num_frames);
@@ -95,45 +93,19 @@ unsigned int CubebSink::GetNativeSampleRate() const {
     return impl->sample_rate;
 }
 
-void CubebSink::EnqueueSamples(const s16* samples, std::size_t sample_count) {
-    if (!impl->ctx)
-        return;
-
-    std::lock_guard lock{impl->queue_mutex};
-
-    impl->queue.reserve(impl->queue.size() + sample_count * 2);
-    std::copy(samples, samples + sample_count * 2, std::back_inserter(impl->queue));
-}
-
-size_t CubebSink::SamplesInQueue() const {
-    if (!impl->ctx)
-        return 0;
-
-    std::lock_guard lock{impl->queue_mutex};
-    return impl->queue.size() / 2;
+void CubebSink::SetCallback(std::function<void(s16*, std::size_t)> cb) {
+    impl->cb = cb;
 }
 
 long CubebSink::Impl::DataCallback(cubeb_stream* stream, void* user_data, const void* input_buffer,
                                    void* output_buffer, long num_frames) {
     Impl* impl = static_cast<Impl*>(user_data);
-    u8* buffer = reinterpret_cast<u8*>(output_buffer);
+    s16* buffer = reinterpret_cast<s16*>(output_buffer);
 
-    if (!impl)
+    if (!impl || !impl->cb)
         return 0;
 
-    std::lock_guard lock{impl->queue_mutex};
-
-    std::size_t frames_to_write =
-        std::min(impl->queue.size() / 2, static_cast<std::size_t>(num_frames));
-
-    memcpy(buffer, impl->queue.data(), frames_to_write * sizeof(s16) * 2);
-    impl->queue.erase(impl->queue.begin(), impl->queue.begin() + frames_to_write * 2);
-
-    if (frames_to_write < num_frames) {
-        // Fill the rest of the frames with silence
-        memset(buffer + frames_to_write * sizeof(s16) * 2, 0,
-               (num_frames - frames_to_write) * sizeof(s16) * 2);
-    }
+    impl->cb(buffer, num_frames);
 
     return num_frames;
 }

--- a/src/audio_core/cubeb_sink.h
+++ b/src/audio_core/cubeb_sink.h
@@ -17,9 +17,7 @@ public:
 
     unsigned int GetNativeSampleRate() const override;
 
-    void EnqueueSamples(const s16* samples, std::size_t sample_count) override;
-
-    std::size_t SamplesInQueue() const override;
+    void SetCallback(std::function<void(s16*, std::size_t)> cb) override;
 
 private:
     struct Impl;

--- a/src/audio_core/dsp_interface.cpp
+++ b/src/audio_core/dsp_interface.cpp
@@ -15,7 +15,6 @@ DspInterface::DspInterface() = default;
 DspInterface::~DspInterface() = default;
 
 void DspInterface::SetSink(const std::string& sink_id, const std::string& audio_device) {
-    sink.reset();
     const SinkDetails& sink_details = GetSinkDetails(sink_id);
     sink = sink_details.factory(audio_device);
     sink->SetCallback(

--- a/src/audio_core/dsp_interface.cpp
+++ b/src/audio_core/dsp_interface.cpp
@@ -15,6 +15,7 @@ DspInterface::DspInterface() = default;
 DspInterface::~DspInterface() = default;
 
 void DspInterface::SetSink(const std::string& sink_id, const std::string& audio_device) {
+    sink.reset();
     const SinkDetails& sink_details = GetSinkDetails(sink_id);
     sink = sink_details.factory(audio_device);
     sink->SetCallback(
@@ -32,7 +33,7 @@ void DspInterface::EnableStretching(bool enable) {
         return;
 
     if (!enable) {
-        FlushResidualStretcherAudio();
+        flushing_time_stretcher = true;
     }
     perform_time_stretching = enable;
 }
@@ -51,17 +52,27 @@ void DspInterface::OutputFrame(StereoFrame16& frame) {
     fifo.Push(frame.data(), frame.size());
 }
 
-void DspInterface::FlushResidualStretcherAudio() {}
-
-void DspInterface::OutputCallback(s16* buffer, size_t num_frames) {
-    const size_t frames_written = fifo.Pop(buffer, num_frames);
+void DspInterface::OutputCallback(s16* buffer, std::size_t num_frames) {
+    std::size_t frames_written;
+    if (perform_time_stretching) {
+        const std::vector<s16> in{fifo.Pop()};
+        const std::size_t num_in{in.size() / 2};
+        frames_written = time_stretcher.Process(in.data(), num_in, buffer, num_frames);
+    } else if (flushing_time_stretcher) {
+        time_stretcher.Flush();
+        frames_written = time_stretcher.Process(nullptr, 0, buffer, num_frames);
+        frames_written += fifo.Pop(buffer, num_frames - frames_written);
+        flushing_time_stretcher = false;
+    } else {
+        frames_written = fifo.Pop(buffer, num_frames);
+    }
 
     if (frames_written > 0) {
         std::memcpy(&last_frame[0], buffer + 2 * (frames_written - 1), 2 * sizeof(s16));
     }
 
     // Hold last emitted frame; this prevents popping.
-    for (size_t i = frames_written; i < num_frames; i++) {
+    for (std::size_t i = frames_written; i < num_frames; i++) {
         std::memcpy(buffer + 2 * i, &last_frame[0], 2 * sizeof(s16));
     }
 }

--- a/src/audio_core/dsp_interface.h
+++ b/src/audio_core/dsp_interface.h
@@ -85,7 +85,8 @@ private:
     void OutputCallback(s16* buffer, std::size_t num_frames);
 
     std::unique_ptr<Sink> sink;
-    bool perform_time_stretching = false;
+    std::atomic<bool> perform_time_stretching = false;
+    std::atomic<bool> flushing_time_stretcher = false;
     Common::RingBuffer<s16, 0x2000, 2> fifo;
     std::array<s16, 2> last_frame{};
     TimeStretcher time_stretcher;

--- a/src/audio_core/dsp_interface.h
+++ b/src/audio_core/dsp_interface.h
@@ -9,6 +9,7 @@
 #include "audio_core/audio_types.h"
 #include "audio_core/time_stretch.h"
 #include "common/common_types.h"
+#include "common/ring_buffer.h"
 #include "core/memory.h"
 
 namespace Service {
@@ -81,9 +82,12 @@ protected:
 
 private:
     void FlushResidualStretcherAudio();
+    void OutputCallback(s16* buffer, std::size_t num_frames);
 
     std::unique_ptr<Sink> sink;
     bool perform_time_stretching = false;
+    Common::RingBuffer<s16, 0x2000, 2> fifo;
+    std::array<s16, 2> last_frame{};
     TimeStretcher time_stretcher;
 };
 

--- a/src/audio_core/null_sink.h
+++ b/src/audio_core/null_sink.h
@@ -19,11 +19,7 @@ public:
         return native_sample_rate;
     }
 
-    void EnqueueSamples(const s16*, std::size_t) override {}
-
-    std::size_t SamplesInQueue() const override {
-        return 0;
-    }
+    void SetCallback(std::function<void(s16*, std::size_t)>) override {}
 };
 
 } // namespace AudioCore

--- a/src/audio_core/sdl2_sink.h
+++ b/src/audio_core/sdl2_sink.h
@@ -17,9 +17,7 @@ public:
 
     unsigned int GetNativeSampleRate() const override;
 
-    void EnqueueSamples(const s16* samples, std::size_t sample_count) override;
-
-    std::size_t SamplesInQueue() const override;
+    void SetCallback(std::function<void(s16*, std::size_t)> cb) override;
 
 private:
     struct Impl;

--- a/src/audio_core/sink.h
+++ b/src/audio_core/sink.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <vector>
+#include <functional>
 #include "common/common_types.h"
 
 namespace AudioCore {
@@ -20,19 +20,16 @@ class Sink {
 public:
     virtual ~Sink() = default;
 
-    /// The native rate of this sink. The sink expects to be fed samples that respect this. (Units:
-    /// samples/sec)
+    /// The native rate of this sink. The sink expects to be fed samples that respect this.
+    /// (Units: samples/sec)
     virtual unsigned int GetNativeSampleRate() const = 0;
 
     /**
-     * Feed stereo samples to sink.
+     * Set callback for samples
      * @param samples Samples in interleaved stereo PCM16 format.
      * @param sample_count Number of samples.
      */
-    virtual void EnqueueSamples(const s16* samples, std::size_t sample_count) = 0;
-
-    /// Samples enqueued that have not been played yet.
-    virtual std::size_t SamplesInQueue() const = 0;
+    virtual void SetCallback(std::function<void(s16*, std::size_t)> cb) = 0;
 };
 
 } // namespace AudioCore

--- a/src/audio_core/time_stretch.h
+++ b/src/audio_core/time_stretch.h
@@ -4,57 +4,39 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include <memory>
-#include <vector>
 #include "common/common_types.h"
+
+namespace soundtouch {
+class SoundTouch;
+}
 
 namespace AudioCore {
 
-class TimeStretcher final {
+class TimeStretcher {
 public:
     TimeStretcher();
     ~TimeStretcher();
 
-    /**
-     * Set sample rate for the samples that Process returns.
-     * @param sample_rate The sample rate.
-     */
     void SetOutputSampleRate(unsigned int sample_rate);
 
-    /**
-     * Add samples to be processed.
-     * @param sample_buffer Buffer of samples in interleaved stereo PCM16 format.
-     * @param num_samples Number of samples.
-     */
-    void AddSamples(const s16* sample_buffer, std::size_t num_samples);
+    /// @param in       Input sample buffer
+    /// @param num_in   Number of input frames in `in`
+    /// @param out      Output sample buffer
+    /// @param num_out  Desired number of output frames in `out`
+    /// @returns Actual number of frames written to `out`
+    std::size_t Process(const s16* in, std::size_t num_in, s16* out, std::size_t num_out);
 
-    /// Flush audio remaining in internal buffers.
+    void Clear();
+
     void Flush();
 
-    /// Resets internal state and clears buffers.
-    void Reset();
-
-    /**
-     * Does audio stretching and produces the time-stretched samples.
-     * Timer calculations use sample_delay to determine how much of a margin we have.
-     * @param sample_delay How many samples are buffered downstream of this module and haven't been
-     * played yet.
-     * @return Samples to play in interleaved stereo PCM16 format.
-     */
-    std::vector<s16> Process(std::size_t sample_delay);
-
 private:
-    struct Impl;
-    std::unique_ptr<Impl> impl;
-
-    /// INTERNAL: ratio = wallclock time / emulated time
-    double CalculateCurrentRatio();
-    /// INTERNAL: If we have too many or too few samples downstream, nudge ratio in the appropriate
-    /// direction.
-    double CorrectForUnderAndOverflow(double ratio, std::size_t sample_delay) const;
-    /// INTERNAL: Gets the time-stretched samples from SoundTouch.
-    std::vector<s16> GetSamples();
+    unsigned int sample_rate;
+    std::unique_ptr<soundtouch::SoundTouch> sound_touch;
+    double stretch_ratio = 1.0;
 };
 
 } // namespace AudioCore

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -72,6 +72,7 @@ add_library(common STATIC
     param_package.cpp
     param_package.h
     quaternion.h
+    ring_buffer.h
     scm_rev.cpp
     scm_rev.h
     scope_exit.h

--- a/src/common/ring_buffer.h
+++ b/src/common/ring_buffer.h
@@ -56,7 +56,7 @@ public:
     }
 
     std::size_t Push(const std::vector<T>& input) {
-        return Push(input.data(), input.size());
+        return Push(input.data(), input.size() / granularity);
     }
 
     /// Pops slots from the ring buffer

--- a/src/common/ring_buffer.h
+++ b/src/common/ring_buffer.h
@@ -1,0 +1,111 @@
+// Copyright 2018 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <cstring>
+#include <type_traits>
+#include <vector>
+#include "common/common_types.h"
+
+namespace Common {
+
+/// SPSC ring buffer
+/// @tparam T            Element type
+/// @tparam capacity     Number of slots in ring buffer
+/// @tparam granularity  Slot size in terms of number of elements
+template <typename T, std::size_t capacity, std::size_t granularity = 1>
+class RingBuffer {
+    /// A "slot" is made of `granularity` elements of `T`.
+    static constexpr std::size_t slot_size = granularity * sizeof(T);
+    // T must be safely memcpy-able and have a trivial default constructor.
+    static_assert(std::is_trivial_v<T>);
+    // Ensure capacity is sensible.
+    static_assert(capacity < std::numeric_limits<std::size_t>::max() / 2 / granularity);
+    static_assert((capacity & (capacity - 1)) == 0, "capacity must be a power of two");
+    // Ensure lock-free.
+    static_assert(std::atomic<std::size_t>::is_always_lock_free);
+
+public:
+    /// Pushes slots into the ring buffer
+    /// @param new_slots   Pointer to the slots to push
+    /// @param slot_count  Number of slots to push
+    /// @returns The number of slots actually pushed
+    std::size_t Push(const void* new_slots, std::size_t slot_count) {
+        const std::size_t write_index = m_write_index.load();
+        const std::size_t slots_free = capacity + m_read_index.load() - write_index;
+        const std::size_t push_count = std::min(slot_count, slots_free);
+
+        const std::size_t pos = write_index % capacity;
+        const std::size_t first_copy = std::min(capacity - pos, push_count);
+        const std::size_t second_copy = push_count - first_copy;
+
+        const char* in = static_cast<const char*>(new_slots);
+        std::memcpy(m_data.data() + pos * granularity, in, first_copy * slot_size);
+        in += first_copy * slot_size;
+        std::memcpy(m_data.data(), in, second_copy * slot_size);
+
+        m_write_index.store(write_index + push_count);
+
+        return push_count;
+    }
+
+    std::size_t Push(const std::vector<T>& input) {
+        return Push(input.data(), input.size());
+    }
+
+    /// Pops slots from the ring buffer
+    /// @param output     Where to store the popped slots
+    /// @param max_slots  Maximum number of slots to pop
+    /// @returns The number of slots actually popped
+    std::size_t Pop(void* output, std::size_t max_slots = ~std::size_t(0)) {
+        const std::size_t read_index = m_read_index.load();
+        const std::size_t slots_filled = m_write_index.load() - read_index;
+        const std::size_t pop_count = std::min(slots_filled, max_slots);
+
+        const std::size_t pos = read_index % capacity;
+        const std::size_t first_copy = std::min(capacity - pos, pop_count);
+        const std::size_t second_copy = pop_count - first_copy;
+
+        char* out = static_cast<char*>(output);
+        std::memcpy(out, m_data.data() + pos * granularity, first_copy * slot_size);
+        out += first_copy * slot_size;
+        std::memcpy(out, m_data.data(), second_copy * slot_size);
+
+        m_read_index.store(read_index + pop_count);
+
+        return pop_count;
+    }
+
+    std::vector<T> Pop(std::size_t max_slots = ~std::size_t(0)) {
+        std::vector<T> out(std::min(max_slots, capacity) * granularity);
+        const std::size_t count = Pop(out.data(), out.size() / granularity);
+        out.resize(count * granularity);
+        return out;
+    }
+
+    /// @returns Number of slots used
+    std::size_t Size() const {
+        return m_write_index.load() - m_read_index.load();
+    }
+
+    /// @returns Maximum size of ring buffer
+    constexpr std::size_t Capacity() const {
+        return capacity;
+    }
+
+private:
+    // It is important to align the below variables for performance reasons:
+    // Having them on the same cache-line would result in false-sharing between them.
+    alignas(128) std::atomic<std::size_t> m_read_index{0};
+    alignas(128) std::atomic<std::size_t> m_write_index{0};
+
+    std::array<T, granularity * capacity> m_data;
+};
+
+} // namespace Common


### PR DESCRIPTION
We simplify the sink interface so it's just a callback now. We also do now do all audio processing in one place instead of duplicating code between the sinks.

Changes made:

* Added a proper lock-free audio FIFO.
* Simplify audio-stretching related code.
* Audio-stretching now occurs on the audio thread and not the emulation thread.
* Reduced popping upon underflow.
* Perform volume adjustment on audio thread.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4194)
<!-- Reviewable:end -->
