### PR TITLE
threadsafe_queue: Add PopWait and use it where possible

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -38,9 +38,7 @@ public:
     const Impl& operator=(Impl const&) = delete;
 
     void PushEntry(Entry e) {
-        std::lock_guard<std::mutex> lock(message_mutex);
         message_queue.Push(std::move(e));
-        message_cv.notify_one();
     }
 
     void AddBackend(std::unique_ptr<Backend> backend) {
@@ -83,14 +81,13 @@ private:
                     backend->Write(e);
                 }
             };
-            while (true) {
-                std::unique_lock<std::mutex> lock(message_mutex);
-                message_cv.wait(lock, [&] { return !running || message_queue.Pop(entry); });
-                if (!running) {
+            while (message_queue.PopWait(entry)) {
+                if (entry.final_entry) {
                     break;
                 }
                 write_logs(entry);
             }
+
             // Drain the logging queue. Only writes out up to MAX_LOGS_TO_WRITE to prevent a case
             // where a system is repeatedly spamming logs even on close.
             constexpr int MAX_LOGS_TO_WRITE = 100;
@@ -102,14 +99,13 @@ private:
     }
 
     ~Impl() {
-        running = false;
-        message_cv.notify_one();
+        Entry entry;
+        entry.final_entry = true;
+        message_queue.Push(entry);
         backend_thread.join();
     }
 
-    std::atomic_bool running{true};
-    std::mutex message_mutex, writing_mutex;
-    std::condition_variable message_cv;
+    std::mutex writing_mutex;
     std::thread backend_thread;
     std::vector<std::unique_ptr<Backend>> backends;
     Common::MPSCQueue<Log::Entry> message_queue;

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -81,7 +81,8 @@ private:
                     backend->Write(e);
                 }
             };
-            while (message_queue.PopWait(entry)) {
+            while (true) {
+                entry = message_queue.PopWait();
                 if (entry.final_entry) {
                     break;
                 }

--- a/src/common/logging/backend.h
+++ b/src/common/logging/backend.h
@@ -28,6 +28,7 @@ struct Entry {
     unsigned int line_num;
     std::string function;
     std::string message;
+    bool final_entry = false;
 
     Entry() = default;
     Entry(Entry&& o) = default;

--- a/src/common/threadsafe_queue.h
+++ b/src/common/threadsafe_queue.h
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <condition_variable>
 #include <cstddef>
 #include <mutex>
 #include "common/common_types.h"
@@ -41,7 +42,7 @@ public:
     template <typename Arg>
     void Push(Arg&& t) {
         // create the element, add it to the queue
-        write_ptr->current = std::forward<Arg>(t);
+        write_ptr->current = std::move(t);
         // set the next pointer to a new element ptr
         // then advance the write pointer
         ElementPtr* new_ptr = new ElementPtr();
@@ -49,6 +50,7 @@ public:
         write_ptr = new_ptr;
         if (NeedSize)
             size++;
+        cv.notify_one();
     }
 
     void Pop() {
@@ -66,15 +68,24 @@ public:
         if (Empty())
             return false;
 
+        ElementPtr* tmpptr = read_ptr;
+
         if (NeedSize)
             size--;
 
-        ElementPtr* tmpptr = read_ptr;
         read_ptr = tmpptr->next.load(std::memory_order_acquire);
         t = std::move(tmpptr->current);
         tmpptr->next.store(nullptr);
         delete tmpptr;
         return true;
+    }
+
+    bool PopWait(T& t) {
+        if (Empty()) {
+            std::unique_lock<std::mutex> lock(cv_mutex);
+            cv.wait(lock, [this]() { return !Empty(); });
+        }
+        return Pop(t);
     }
 
     // not thread-safe
@@ -104,6 +115,8 @@ private:
     ElementPtr* write_ptr;
     ElementPtr* read_ptr;
     std::atomic<u32> size;
+    std::mutex cv_mutex;
+    std::condition_variable cv;
 };
 
 // a simple thread-safe,
@@ -136,6 +149,10 @@ public:
 
     bool Pop(T& t) {
         return spsc_queue.Pop(t);
+    }
+
+    bool PopWait(T& t) {
+        return spsc_queue.PopWait(t);
     }
 
     // not thread-safe

--- a/src/common/threadsafe_queue.h
+++ b/src/common/threadsafe_queue.h
@@ -42,7 +42,7 @@ public:
     template <typename Arg>
     void Push(Arg&& t) {
         // create the element, add it to the queue
-        write_ptr->current = std::move(t);
+        write_ptr->current = std::forward<Arg>(t);
         // set the next pointer to a new element ptr
         // then advance the write pointer
         ElementPtr* new_ptr = new ElementPtr();
@@ -68,11 +68,10 @@ public:
         if (Empty())
             return false;
 
-        ElementPtr* tmpptr = read_ptr;
-
         if (NeedSize)
             size--;
 
+        ElementPtr* tmpptr = read_ptr;
         read_ptr = tmpptr->next.load(std::memory_order_acquire);
         t = std::move(tmpptr->current);
         tmpptr->next.store(nullptr);
@@ -80,12 +79,14 @@ public:
         return true;
     }
 
-    bool PopWait(T& t) {
+    T PopWait() {
         if (Empty()) {
             std::unique_lock<std::mutex> lock(cv_mutex);
             cv.wait(lock, [this]() { return !Empty(); });
         }
-        return Pop(t);
+        T t;
+        Pop(t);
+        return t;
     }
 
     // not thread-safe
@@ -151,8 +152,8 @@ public:
         return spsc_queue.Pop(t);
     }
 
-    bool PopWait(T& t) {
-        return spsc_queue.PopWait(t);
+    T PopWait() {
+        return spsc_queue.PopWait();
     }
 
     // not thread-safe

--- a/src/core/rpc/rpc_server.cpp
+++ b/src/core/rpc/rpc_server.cpp
@@ -106,10 +106,8 @@ void RPCServer::HandleRequestsLoop() {
 
     LOG_INFO(RPC_Server, "Request handler started.");
 
-    while (true) {
-        std::unique_lock<std::mutex> lock(request_queue_mutex);
-        request_queue_cv.wait(lock, [&] { return !running || request_queue.Pop(request_packet); });
-        if (!running) {
+    while (request_queue.PopWait(request_packet)) {
+        if (!request_packet) {
             break;
         }
         HandleSingleRequest(std::move(request_packet));
@@ -117,23 +115,18 @@ void RPCServer::HandleRequestsLoop() {
 }
 
 void RPCServer::QueueRequest(std::unique_ptr<RPC::Packet> request) {
-    std::unique_lock<std::mutex> lock(request_queue_mutex);
     request_queue.Push(std::move(request));
-    request_queue_cv.notify_one();
 }
 
 void RPCServer::Start() {
-    running = true;
     const auto threadFunction = [this]() { HandleRequestsLoop(); };
     request_handler_thread = std::thread(threadFunction);
     server.Start();
 }
 
 void RPCServer::Stop() {
-    running = false;
-    request_queue_cv.notify_one();
-    request_handler_thread.join();
     server.Stop();
+    request_handler_thread.join();
 }
 
 }; // namespace RPC

--- a/src/core/rpc/rpc_server.cpp
+++ b/src/core/rpc/rpc_server.cpp
@@ -106,10 +106,7 @@ void RPCServer::HandleRequestsLoop() {
 
     LOG_INFO(RPC_Server, "Request handler started.");
 
-    while (request_queue.PopWait(request_packet)) {
-        if (!request_packet) {
-            break;
-        }
+    while ((request_packet = request_queue.PopWait())) {
         HandleSingleRequest(std::move(request_packet));
     }
 }

--- a/src/core/rpc/rpc_server.h
+++ b/src/core/rpc/rpc_server.h
@@ -31,10 +31,7 @@ private:
 
     Server server;
     Common::SPSCQueue<std::unique_ptr<Packet>> request_queue;
-    bool running = false;
     std::thread request_handler_thread;
-    std::mutex request_queue_mutex;
-    std::condition_variable request_queue_cv;
 };
 
 } // namespace RPC

--- a/src/core/rpc/server.cpp
+++ b/src/core/rpc/server.cpp
@@ -1,6 +1,5 @@
 #include <functional>
 
-#include "common/threadsafe_queue.h"
 #include "core/core.h"
 #include "core/rpc/rpc_server.h"
 #include "core/rpc/server.h"

--- a/src/core/rpc/server.cpp
+++ b/src/core/rpc/server.cpp
@@ -25,9 +25,13 @@ void Server::Stop() {
 }
 
 void Server::NewRequestCallback(std::unique_ptr<RPC::Packet> new_request) {
-    LOG_INFO(RPC_Server, "Received request version={} id={} type={} size={}",
-             new_request->GetVersion(), new_request->GetId(),
-             static_cast<u32>(new_request->GetPacketType()), new_request->GetPacketDataSize());
+    if (new_request) {
+        LOG_INFO(RPC_Server, "Received request version={} id={} type={} size={}",
+                 new_request->GetVersion(), new_request->GetId(),
+                 static_cast<u32>(new_request->GetPacketType()), new_request->GetPacketDataSize());
+    } else {
+        LOG_INFO(RPC_Server, "Received end packet");
+    }
     rpc_server.QueueRequest(std::move(new_request));
 }
 

--- a/src/core/rpc/zmq_server.cpp
+++ b/src/core/rpc/zmq_server.cpp
@@ -52,7 +52,8 @@ void ZMQServer::WorkerLoop() {
             LOG_WARNING(RPC_Server, "Failed to receive data on ZeroMQ socket");
         }
     }
-
+    std::unique_ptr<Packet> end_packet = nullptr;
+    new_request_callback(std::move(end_packet));
     // Destroying the socket must be done by this thread.
     zmq_socket.reset();
 }


### PR DESCRIPTION
This adds a way to wait until the SPSCQueue / MPSCQueue isn't empty anymore. I didn't add a WaitFor and WaitUntil yet, but this can be easily added if necessary.

For now there is only one instance where this gets used (logging) but scripting (#4016) should also use it. This also assures that Wait isn't ended spuriously.

@jroweboy @EverOddish : What's your opinions on that?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4197)
<!-- Reviewable:end -->
