### PR TITLE
Set citra-qt project as default StartUp Project in Visual Studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -383,6 +383,9 @@ add_subdirectory(externals)
 add_subdirectory(src)
 add_subdirectory(dist/installer)
 
+# Set citra-qt project as default StartUp Project in Visual Studio
+set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT citra-qt)
+
 
 # Installation instructions
 # =========================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -383,9 +383,13 @@ add_subdirectory(externals)
 add_subdirectory(src)
 add_subdirectory(dist/installer)
 
-# Set citra-qt project as default StartUp Project in Visual Studio
-set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT citra-qt)
 
+# Set citra-qt project or citra project as default StartUp Project in Visual Studio depending on whether QT is enabled or not
+if(ENABLE_QT)
+    set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT citra-qt)
+else()
+    set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT citra)
+endif()
 
 # Installation instructions
 # =========================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -383,9 +383,6 @@ add_subdirectory(externals)
 add_subdirectory(src)
 add_subdirectory(dist/installer)
 
-# Set citra-qt project as default StartUp Project in Visual Studio
-set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT citra-qt)
-
 
 # Set citra-qt project or citra project as default StartUp Project in Visual Studio depending on whether QT is enabled or not
 if(ENABLE_QT)


### PR DESCRIPTION
Set citra-qt project as default StartUp Project in Visual Studio

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4214)
<!-- Reviewable:end -->
