### PR TITLE
kernel/svc: Do nothing if svcOutputDebugString's length is <= 0

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -662,6 +662,10 @@ static void Break(u8 break_reason) {
 
 /// Used to output a message on a debug hardware unit - does nothing on a retail unit
 static void OutputDebugString(VAddr address, int len) {
+    if (len <= 0) {
+        return;
+    }
+
     std::string string(len, ' ');
     Memory::ReadBlock(address, string.data(), len);
     LOG_DEBUG(Debug_Emulated, "{}", string);


### PR DESCRIPTION
While likely very uncommon, this sanitizes the input and does nothing in the event of the length being equal to or less than zero, avoiding constructing a `std::string` when there's no need to. It also avoids an
out-of-memory scenario, as a negative value would wrap around to its equivalent unsigned representation in `std::string`'s constructor.

e.g. If someone was silly and a length of `-1` was specified, this would make a string with a length of 0xFFFFFFFFFFFFFFFF on a 64-bit platform when converted to a `std::size_t`, which will obviously eventually fail due to the allocation being way too large.