### PR TITLE
Port yuzu-emu/yuzu#1346: "svc_wrap: Convert the PARAM macro into a function"

### DIFF
--- a/src/core/hle/function_wrappers.h
+++ b/src/core/hle/function_wrappers.h
@@ -14,7 +14,9 @@
 
 namespace HLE {
 
-#define PARAM(n) Core::CPU().GetReg(n)
+static inline u32 Param(int n) {
+    return Core::CPU().GetReg(n);
+}
 
 /**
  * HLE a function return from the current ARM11 userland process
@@ -39,13 +41,13 @@ static inline void FuncReturn64(u64 res) {
 
 template <ResultCode func(u32, u32, u32, u32)>
 void Wrap() {
-    FuncReturn(func(PARAM(0), PARAM(1), PARAM(2), PARAM(3)).raw);
+    FuncReturn(func(Param(0), Param(1), Param(2), Param(3)).raw);
 }
 
 template <ResultCode func(u32*, u32, u32, u32, u32, u32)>
 void Wrap() {
     u32 param_1 = 0;
-    u32 retval = func(&param_1, PARAM(0), PARAM(1), PARAM(2), PARAM(3), PARAM(4)).raw;
+    u32 retval = func(&param_1, Param(0), Param(1), Param(2), Param(3), Param(4)).raw;
     Core::CPU().SetReg(1, param_1);
     FuncReturn(retval);
 }
@@ -53,7 +55,7 @@ void Wrap() {
 template <ResultCode func(u32*, u32, u32, u32, u32, s32)>
 void Wrap() {
     u32 param_1 = 0;
-    u32 retval = func(&param_1, PARAM(0), PARAM(1), PARAM(2), PARAM(3), PARAM(4)).raw;
+    u32 retval = func(&param_1, Param(0), Param(1), Param(2), Param(3), Param(4)).raw;
     Core::CPU().SetReg(1, param_1);
     FuncReturn(retval);
 }
@@ -62,7 +64,7 @@ template <ResultCode func(s32*, VAddr, s32, bool, s64)>
 void Wrap() {
     s32 param_1 = 0;
     s32 retval =
-        func(&param_1, PARAM(1), (s32)PARAM(2), (PARAM(3) != 0), (((s64)PARAM(4) << 32) | PARAM(0)))
+        func(&param_1, Param(1), (s32)Param(2), (Param(3) != 0), (((s64)Param(4) << 32) | Param(0)))
             .raw;
 
     Core::CPU().SetReg(1, (u32)param_1);
@@ -72,7 +74,7 @@ void Wrap() {
 template <ResultCode func(s32*, VAddr, s32, u32)>
 void Wrap() {
     s32 param_1 = 0;
-    u32 retval = func(&param_1, PARAM(1), (s32)PARAM(2), PARAM(3)).raw;
+    u32 retval = func(&param_1, Param(1), (s32)Param(2), Param(3)).raw;
 
     Core::CPU().SetReg(1, (u32)param_1);
     FuncReturn(retval);
@@ -81,7 +83,7 @@ void Wrap() {
 template <ResultCode func(u32, u32, u32, u32, s64)>
 void Wrap() {
     FuncReturn(
-        func(PARAM(0), PARAM(1), PARAM(2), PARAM(3), (((s64)PARAM(5) << 32) | PARAM(4))).raw);
+        func(Param(0), Param(1), Param(2), Param(3), (((s64)Param(5) << 32) | Param(4))).raw);
 }
 
 template <ResultCode func(u32*)>
@@ -94,7 +96,7 @@ void Wrap() {
 
 template <ResultCode func(u32, s64)>
 void Wrap() {
-    s32 retval = func(PARAM(0), (((s64)PARAM(3) << 32) | PARAM(2))).raw;
+    s32 retval = func(Param(0), (((s64)Param(3) << 32) | Param(2))).raw;
 
     FuncReturn(retval);
 }
@@ -103,7 +105,7 @@ template <ResultCode func(Kernel::MemoryInfo*, Kernel::PageInfo*, u32)>
 void Wrap() {
     Kernel::MemoryInfo memory_info = {};
     Kernel::PageInfo page_info = {};
-    u32 retval = func(&memory_info, &page_info, PARAM(2)).raw;
+    u32 retval = func(&memory_info, &page_info, Param(2)).raw;
     Core::CPU().SetReg(1, memory_info.base_address);
     Core::CPU().SetReg(2, memory_info.size);
     Core::CPU().SetReg(3, memory_info.permission);
@@ -116,7 +118,7 @@ template <ResultCode func(Kernel::MemoryInfo*, Kernel::PageInfo*, Kernel::Handle
 void Wrap() {
     Kernel::MemoryInfo memory_info = {};
     Kernel::PageInfo page_info = {};
-    u32 retval = func(&memory_info, &page_info, PARAM(2), PARAM(3)).raw;
+    u32 retval = func(&memory_info, &page_info, Param(2), Param(3)).raw;
     Core::CPU().SetReg(1, memory_info.base_address);
     Core::CPU().SetReg(2, memory_info.size);
     Core::CPU().SetReg(3, memory_info.permission);
@@ -128,33 +130,33 @@ void Wrap() {
 template <ResultCode func(s32*, u32)>
 void Wrap() {
     s32 param_1 = 0;
-    u32 retval = func(&param_1, PARAM(1)).raw;
+    u32 retval = func(&param_1, Param(1)).raw;
     Core::CPU().SetReg(1, param_1);
     FuncReturn(retval);
 }
 
 template <ResultCode func(u32, s32)>
 void Wrap() {
-    FuncReturn(func(PARAM(0), (s32)PARAM(1)).raw);
+    FuncReturn(func(Param(0), (s32)Param(1)).raw);
 }
 
 template <ResultCode func(u32*, u32)>
 void Wrap() {
     u32 param_1 = 0;
-    u32 retval = func(&param_1, PARAM(1)).raw;
+    u32 retval = func(&param_1, Param(1)).raw;
     Core::CPU().SetReg(1, param_1);
     FuncReturn(retval);
 }
 
 template <ResultCode func(u32)>
 void Wrap() {
-    FuncReturn(func(PARAM(0)).raw);
+    FuncReturn(func(Param(0)).raw);
 }
 
 template <ResultCode func(u32*, s32, s32)>
 void Wrap() {
     u32 param_1 = 0;
-    u32 retval = func(&param_1, PARAM(1), PARAM(2)).raw;
+    u32 retval = func(&param_1, Param(1), Param(2)).raw;
     Core::CPU().SetReg(1, param_1);
     FuncReturn(retval);
 }
@@ -162,7 +164,7 @@ void Wrap() {
 template <ResultCode func(s32*, u32, s32)>
 void Wrap() {
     s32 param_1 = 0;
-    u32 retval = func(&param_1, PARAM(1), PARAM(2)).raw;
+    u32 retval = func(&param_1, Param(1), Param(2)).raw;
     Core::CPU().SetReg(1, param_1);
     FuncReturn(retval);
 }
@@ -170,7 +172,7 @@ void Wrap() {
 template <ResultCode func(s64*, u32, s32)>
 void Wrap() {
     s64 param_1 = 0;
-    u32 retval = func(&param_1, PARAM(1), PARAM(2)).raw;
+    u32 retval = func(&param_1, Param(1), Param(2)).raw;
     Core::CPU().SetReg(1, (u32)param_1);
     Core::CPU().SetReg(2, (u32)(param_1 >> 32));
     FuncReturn(retval);
@@ -180,22 +182,22 @@ template <ResultCode func(u32*, u32, u32, u32, u32)>
 void Wrap() {
     u32 param_1 = 0;
     // The last parameter is passed in R0 instead of R4
-    u32 retval = func(&param_1, PARAM(1), PARAM(2), PARAM(3), PARAM(0)).raw;
+    u32 retval = func(&param_1, Param(1), Param(2), Param(3), Param(0)).raw;
     Core::CPU().SetReg(1, param_1);
     FuncReturn(retval);
 }
 
 template <ResultCode func(u32, s64, s64)>
 void Wrap() {
-    s64 param1 = ((u64)PARAM(3) << 32) | PARAM(2);
-    s64 param2 = ((u64)PARAM(4) << 32) | PARAM(1);
-    FuncReturn(func(PARAM(0), param1, param2).raw);
+    s64 param1 = ((u64)Param(3) << 32) | Param(2);
+    s64 param2 = ((u64)Param(4) << 32) | Param(1);
+    FuncReturn(func(Param(0), param1, param2).raw);
 }
 
 template <ResultCode func(s64*, Kernel::Handle, u32)>
 void Wrap() {
     s64 param_1 = 0;
-    u32 retval = func(&param_1, PARAM(1), PARAM(2)).raw;
+    u32 retval = func(&param_1, Param(1), Param(2)).raw;
     Core::CPU().SetReg(1, (u32)param_1);
     Core::CPU().SetReg(2, (u32)(param_1 >> 32));
     FuncReturn(retval);
@@ -203,14 +205,14 @@ void Wrap() {
 
 template <ResultCode func(Kernel::Handle, u32)>
 void Wrap() {
-    FuncReturn(func(PARAM(0), PARAM(1)).raw);
+    FuncReturn(func(Param(0), Param(1)).raw);
 }
 
 template <ResultCode func(Kernel::Handle*, Kernel::Handle*, VAddr, u32)>
 void Wrap() {
     Kernel::Handle param_1 = 0;
     Kernel::Handle param_2 = 0;
-    u32 retval = func(&param_1, &param_2, PARAM(2), PARAM(3)).raw;
+    u32 retval = func(&param_1, &param_2, Param(2), Param(3)).raw;
     Core::CPU().SetReg(1, param_1);
     Core::CPU().SetReg(2, param_2);
     FuncReturn(retval);
@@ -247,20 +249,17 @@ void Wrap() {
 
 template <void func(s64)>
 void Wrap() {
-    func(((s64)PARAM(1) << 32) | PARAM(0));
+    func(((s64)Param(1) << 32) | Param(0));
 }
 
 template <void func(VAddr, int len)>
 void Wrap() {
-    func(PARAM(0), PARAM(1));
+    func(Param(0), Param(1));
 }
 
 template <void func(u8)>
 void Wrap() {
-    func((u8)PARAM(0));
+    func((u8)Param(0));
 }
-
-#undef PARAM
-#undef FuncReturn
 
 } // namespace HLE


### PR DESCRIPTION
See yuzu-emu/yuzu#1346 for more details.

Original description: `This can just be a regular function, getting rid of the need to also
explicitly undef the define at the end of the file. Given FuncReturn()
was already converted into a function, it's #undef can also be removed.`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4246)
<!-- Reviewable:end -->
