### PR TITLE
Port yuzu-emu/yuzu#1314: "audio_core/time_stretch: Silence truncation warnings in Process()"

### DIFF
--- a/src/audio_core/time_stretch.cpp
+++ b/src/audio_core/time_stretch.cpp
@@ -62,8 +62,8 @@ std::size_t TimeStretcher::Process(const s16* in, std::size_t num_in, s16* out,
     LOG_DEBUG(Audio, "{:5}/{:5} ratio:{:0.6f} backlog:{:0.6f}", num_in, num_out, stretch_ratio,
               backlog_fullness);
 
-    sound_touch->putSamples(in, num_in);
-    return sound_touch->receiveSamples(out, num_out);
+    sound_touch->putSamples(in, static_cast<u32>(num_in));
+    return sound_touch->receiveSamples(out, static_cast<u32>(num_out));
 }
 
 void TimeStretcher::Clear() {


### PR DESCRIPTION
See yuzu-emu/yuzu#1314: for more details.

Original description: `The SoundTouch API only accepts uint amount of samples.`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4247)
<!-- Reviewable:end -->
