### PR TITLE
Port yuzu-emu/yuzu#1321: "cubeb_sink: Get rid of variable shadowing within CubebSink's constructor"

### DIFF
--- a/src/audio_core/cubeb_sink.cpp
+++ b/src/audio_core/cubeb_sink.cpp
@@ -53,11 +53,11 @@ CubebSink::CubebSink(std::string target_device_name) : impl(std::make_unique<Imp
         if (cubeb_enumerate_devices(impl->ctx, CUBEB_DEVICE_TYPE_OUTPUT, &collection) != CUBEB_OK) {
             LOG_WARNING(Audio_Sink, "Audio output device enumeration not supported");
         } else {
-            const auto collection_end = collection.device + collection.count;
-            const auto device = std::find_if(collection.device, collection_end,
-                                             [&](const cubeb_device_info& device) {
-                                                 return target_device_name == device.friendly_name;
-                                             });
+            const auto collection_end{collection.device + collection.count};
+            const auto device{
+                std::find_if(collection.device, collection_end, [&](const cubeb_device_info& info) {
+                    return target_device_name == info.friendly_name;
+                })};
             if (device != collection_end) {
                 output_device = device->devid;
             }


### PR DESCRIPTION
See yuzu-emu/yuzu#1321 for more details.

Original description: `The parameter of the lambda was shadowing the variable that was being assigned to.`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4248)
<!-- Reviewable:end -->
