### PR TITLE
Port yuzu-emu/yuzu#1309: "service: Use nested namespace specifiers where applicable"

### DIFF
--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -15,8 +15,7 @@
 #include "core/hle/service/ac/ac_u.h"
 #include "core/memory.h"
 
-namespace Service {
-namespace AC {
+namespace Service::AC {
 void Module::Interface::CreateDefaultConfig(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x1, 0, 0);
 
@@ -178,5 +177,4 @@ void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<AC_U>(ac)->InstallAsService(service_manager);
 }
 
-} // namespace AC
-} // namespace Service
+} // namespace Service::AC

--- a/src/core/hle/service/ac/ac.h
+++ b/src/core/hle/service/ac/ac.h
@@ -13,8 +13,7 @@ namespace Kernel {
 class Event;
 }
 
-namespace Service {
-namespace AC {
+namespace Service::AC {
 class Module final {
 public:
     class Interface : public ServiceFramework<Interface> {
@@ -155,5 +154,4 @@ protected:
 
 void InstallInterfaces(SM::ServiceManager& service_manager);
 
-} // namespace AC
-} // namespace Service
+} // namespace Service::AC

--- a/src/core/hle/service/ac/ac_i.cpp
+++ b/src/core/hle/service/ac/ac_i.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/ac/ac_i.h"
 
-namespace Service {
-namespace AC {
+namespace Service::AC {
 
 AC_I::AC_I(std::shared_ptr<Module> ac) : Module::Interface(std::move(ac), "ac:i", 10) {
     static const FunctionInfo functions[] = {
@@ -33,5 +32,4 @@ AC_I::AC_I(std::shared_ptr<Module> ac) : Module::Interface(std::move(ac), "ac:i"
     RegisterHandlers(functions);
 }
 
-} // namespace AC
-} // namespace Service
+} // namespace Service::AC

--- a/src/core/hle/service/ac/ac_i.h
+++ b/src/core/hle/service/ac/ac_i.h
@@ -7,13 +7,11 @@
 #include <memory>
 #include "core/hle/service/ac/ac.h"
 
-namespace Service {
-namespace AC {
+namespace Service::AC {
 
 class AC_I final : public Module::Interface {
 public:
     explicit AC_I(std::shared_ptr<Module> ac);
 };
 
-} // namespace AC
-} // namespace Service
+} // namespace Service::AC

--- a/src/core/hle/service/ac/ac_u.cpp
+++ b/src/core/hle/service/ac/ac_u.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/ac/ac_u.h"
 
-namespace Service {
-namespace AC {
+namespace Service::AC {
 
 AC_U::AC_U(std::shared_ptr<Module> ac) : Module::Interface(std::move(ac), "ac:u", 10) {
     static const FunctionInfo functions[] = {
@@ -33,5 +32,4 @@ AC_U::AC_U(std::shared_ptr<Module> ac) : Module::Interface(std::move(ac), "ac:u"
     RegisterHandlers(functions);
 }
 
-} // namespace AC
-} // namespace Service
+} // namespace Service::AC

--- a/src/core/hle/service/ac/ac_u.h
+++ b/src/core/hle/service/ac/ac_u.h
@@ -7,13 +7,11 @@
 #include <memory>
 #include "core/hle/service/ac/ac.h"
 
-namespace Service {
-namespace AC {
+namespace Service::AC {
 
 class AC_U final : public Module::Interface {
 public:
     explicit AC_U(std::shared_ptr<Module> ac);
 };
 
-} // namespace AC
-} // namespace Service
+} // namespace Service::AC

--- a/src/core/hle/service/act/act.cpp
+++ b/src/core/hle/service/act/act.cpp
@@ -6,8 +6,7 @@
 #include "core/hle/service/act/act_a.h"
 #include "core/hle/service/act/act_u.h"
 
-namespace Service {
-namespace ACT {
+namespace Service::ACT {
 
 Module::Interface::Interface(std::shared_ptr<Module> act, const char* name)
     : ServiceFramework(name, 1 /* Placeholder */), act(std::move(act)) {}
@@ -20,5 +19,4 @@ void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<ACT_U>(act)->InstallAsService(service_manager);
 }
 
-} // namespace ACT
-} // namespace Service
+} // namespace Service::ACT

--- a/src/core/hle/service/act/act.h
+++ b/src/core/hle/service/act/act.h
@@ -6,8 +6,7 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace ACT {
+namespace Service::ACT {
 
 /// Initializes all ACT services
 class Module final {
@@ -24,5 +23,4 @@ public:
 
 void InstallInterfaces(SM::ServiceManager& service_manager);
 
-} // namespace ACT
-} // namespace Service
+} // namespace Service::ACT

--- a/src/core/hle/service/act/act_a.cpp
+++ b/src/core/hle/service/act/act_a.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/act/act_a.h"
 
-namespace Service {
-namespace ACT {
+namespace Service::ACT {
 
 ACT_A::ACT_A(std::shared_ptr<Module> act) : Module::Interface(std::move(act), "act:a") {
     const FunctionInfo functions[] = {
@@ -24,5 +23,4 @@ ACT_A::ACT_A(std::shared_ptr<Module> act) : Module::Interface(std::move(act), "a
     RegisterHandlers(functions);
 }
 
-} // namespace ACT
-} // namespace Service
+} // namespace Service::ACT

--- a/src/core/hle/service/act/act_a.h
+++ b/src/core/hle/service/act/act_a.h
@@ -6,13 +6,11 @@
 
 #include "core/hle/service/act/act.h"
 
-namespace Service {
-namespace ACT {
+namespace Service::ACT {
 
 class ACT_A final : public Module::Interface {
 public:
     explicit ACT_A(std::shared_ptr<Module> act);
 };
 
-} // namespace ACT
-} // namespace Service
+} // namespace Service::ACT

--- a/src/core/hle/service/act/act_u.cpp
+++ b/src/core/hle/service/act/act_u.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/act/act_u.h"
 
-namespace Service {
-namespace ACT {
+namespace Service::ACT {
 
 ACT_U::ACT_U(std::shared_ptr<Module> act) : Module::Interface(std::move(act), "act:u") {
     static const FunctionInfo functions[] = {
@@ -20,5 +19,4 @@ ACT_U::ACT_U(std::shared_ptr<Module> act) : Module::Interface(std::move(act), "a
     RegisterHandlers(functions);
 }
 
-} // namespace ACT
-} // namespace Service
+} // namespace Service::ACT

--- a/src/core/hle/service/act/act_u.h
+++ b/src/core/hle/service/act/act_u.h
@@ -6,13 +6,11 @@
 
 #include "core/hle/service/act/act.h"
 
-namespace Service {
-namespace ACT {
+namespace Service::ACT {
 
 class ACT_U final : public Module::Interface {
 public:
     explicit ACT_U(std::shared_ptr<Module> act);
 };
 
-} // namespace ACT
-} // namespace Service
+} // namespace Service::ACT

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -30,8 +30,7 @@
 #include "core/loader/loader.h"
 #include "core/loader/smdh.h"
 
-namespace Service {
-namespace AM {
+namespace Service::AM {
 
 constexpr u16 PLATFORM_CTR = 0x0004;
 constexpr u16 CATEGORY_SYSTEM = 0x0010;
@@ -1326,6 +1325,4 @@ void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<AM_U>(am)->InstallAsService(service_manager);
 }
 
-} // namespace AM
-
-} // namespace Service
+} // namespace Service::AM

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -14,14 +14,11 @@
 #include "core/hle/result.h"
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace FS {
+namespace Service::FS {
 enum class MediaType : u32;
 }
-} // namespace Service
 
-namespace Service {
-namespace AM {
+namespace Service::AM {
 
 namespace ErrCodes {
 enum {
@@ -526,5 +523,4 @@ private:
 
 void InstallInterfaces(SM::ServiceManager& service_manager);
 
-} // namespace AM
-} // namespace Service
+} // namespace Service::AM

--- a/src/core/hle/service/am/am_app.cpp
+++ b/src/core/hle/service/am/am_app.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/am/am_app.h"
 
-namespace Service {
-namespace AM {
+namespace Service::AM {
 
 AM_APP::AM_APP(std::shared_ptr<Module> am) : Module::Interface(std::move(am), "am:app", 5) {
     static const FunctionInfo functions[] = {
@@ -26,5 +25,4 @@ AM_APP::AM_APP(std::shared_ptr<Module> am) : Module::Interface(std::move(am), "a
     RegisterHandlers(functions);
 }
 
-} // namespace AM
-} // namespace Service
+} // namespace Service::AM

--- a/src/core/hle/service/am/am_app.h
+++ b/src/core/hle/service/am/am_app.h
@@ -6,13 +6,11 @@
 
 #include "core/hle/service/am/am.h"
 
-namespace Service {
-namespace AM {
+namespace Service::AM {
 
 class AM_APP final : public Module::Interface {
 public:
     explicit AM_APP(std::shared_ptr<Module> am);
 };
 
-} // namespace AM
-} // namespace Service
+} // namespace Service::AM

--- a/src/core/hle/service/am/am_net.cpp
+++ b/src/core/hle/service/am/am_net.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/am/am_net.h"
 
-namespace Service {
-namespace AM {
+namespace Service::AM {
 
 AM_NET::AM_NET(std::shared_ptr<Module> am) : Module::Interface(std::move(am), "am:net", 5) {
     static const FunctionInfo functions[] = {
@@ -123,5 +122,4 @@ AM_NET::AM_NET(std::shared_ptr<Module> am) : Module::Interface(std::move(am), "a
     RegisterHandlers(functions);
 }
 
-} // namespace AM
-} // namespace Service
+} // namespace Service::AM

--- a/src/core/hle/service/am/am_net.h
+++ b/src/core/hle/service/am/am_net.h
@@ -6,13 +6,11 @@
 
 #include "core/hle/service/am/am.h"
 
-namespace Service {
-namespace AM {
+namespace Service::AM {
 
 class AM_NET final : public Module::Interface {
 public:
     explicit AM_NET(std::shared_ptr<Module> am);
 };
 
-} // namespace AM
-} // namespace Service
+} // namespace Service::AM

--- a/src/core/hle/service/am/am_sys.cpp
+++ b/src/core/hle/service/am/am_sys.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/am/am_sys.h"
 
-namespace Service {
-namespace AM {
+namespace Service::AM {
 
 AM_SYS::AM_SYS(std::shared_ptr<Module> am) : Module::Interface(std::move(am), "am:sys", 5) {
     static const FunctionInfo functions[] = {
@@ -71,5 +70,4 @@ AM_SYS::AM_SYS(std::shared_ptr<Module> am) : Module::Interface(std::move(am), "a
     RegisterHandlers(functions);
 }
 
-} // namespace AM
-} // namespace Service
+} // namespace Service::AM

--- a/src/core/hle/service/am/am_sys.h
+++ b/src/core/hle/service/am/am_sys.h
@@ -6,13 +6,11 @@
 
 #include "core/hle/service/am/am.h"
 
-namespace Service {
-namespace AM {
+namespace Service::AM {
 
 class AM_SYS final : public Module::Interface {
 public:
     explicit AM_SYS(std::shared_ptr<Module> am);
 };
 
-} // namespace AM
-} // namespace Service
+} // namespace Service::AM

--- a/src/core/hle/service/am/am_u.cpp
+++ b/src/core/hle/service/am/am_u.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/am/am_u.h"
 
-namespace Service {
-namespace AM {
+namespace Service::AM {
 
 AM_U::AM_U(std::shared_ptr<Module> am) : Module::Interface(std::move(am), "am:u", 5) {
     static const FunctionInfo functions[] = {
@@ -83,5 +82,4 @@ AM_U::AM_U(std::shared_ptr<Module> am) : Module::Interface(std::move(am), "am:u"
     RegisterHandlers(functions);
 }
 
-} // namespace AM
-} // namespace Service
+} // namespace Service::AM

--- a/src/core/hle/service/am/am_u.h
+++ b/src/core/hle/service/am/am_u.h
@@ -6,13 +6,11 @@
 
 #include "core/hle/service/am/am.h"
 
-namespace Service {
-namespace AM {
+namespace Service::AM {
 
 class AM_U final : public Module::Interface {
 public:
     explicit AM_U(std::shared_ptr<Module> am);
 };
 
-} // namespace AM
-} // namespace Service
+} // namespace Service::AM

--- a/src/core/hle/service/apt/applet_manager.cpp
+++ b/src/core/hle/service/apt/applet_manager.cpp
@@ -9,8 +9,7 @@
 #include "core/hle/service/cfg/cfg.h"
 #include "core/hle/service/ns/ns.h"
 
-namespace Service {
-namespace APT {
+namespace Service::APT {
 
 enum class AppletPos { Application = 0, Library = 1, System = 2, SysLibrary = 3, Resident = 4 };
 
@@ -486,5 +485,4 @@ AppletManager::~AppletManager() {
     HLE::Applets::Shutdown();
 }
 
-} // namespace APT
-} // namespace Service
+} // namespace Service::APT

--- a/src/core/hle/service/apt/applet_manager.h
+++ b/src/core/hle/service/apt/applet_manager.h
@@ -11,8 +11,7 @@
 #include "core/hle/result.h"
 #include "core/hle/service/fs/archive.h"
 
-namespace Service {
-namespace APT {
+namespace Service::APT {
 
 /// Signals used by APT functions
 enum class SignalType : u32 {
@@ -185,5 +184,4 @@ private:
     SignalType library_applet_closing_command;
 };
 
-} // namespace APT
-} // namespace Service
+} // namespace Service::APT

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -24,8 +24,7 @@
 #include "core/hw/aes/ccm.h"
 #include "core/hw/aes/key.h"
 
-namespace Service {
-namespace APT {
+namespace Service::APT {
 
 void Module::Interface::Initialize(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x2, 2, 0); // 0x20080
@@ -871,5 +870,4 @@ void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<APT_A>(apt)->InstallAsService(service_manager);
 }
 
-} // namespace APT
-} // namespace Service
+} // namespace Service::APT

--- a/src/core/hle/service/apt/apt.h
+++ b/src/core/hle/service/apt/apt.h
@@ -16,8 +16,7 @@ class Mutex;
 class SharedMemory;
 } // namespace Kernel
 
-namespace Service {
-namespace APT {
+namespace Service::APT {
 
 class AppletManager;
 
@@ -605,5 +604,4 @@ private:
 
 void InstallInterfaces(SM::ServiceManager& service_manager);
 
-} // namespace APT
-} // namespace Service
+} // namespace Service::APT

--- a/src/core/hle/service/apt/apt_a.cpp
+++ b/src/core/hle/service/apt/apt_a.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/apt/apt_a.h"
 
-namespace Service {
-namespace APT {
+namespace Service::APT {
 
 APT_A::APT_A(std::shared_ptr<Module> apt)
     : Module::Interface(std::move(apt), "APT:A", MaxAPTSessions) {
@@ -105,5 +104,4 @@ APT_A::APT_A(std::shared_ptr<Module> apt)
     RegisterHandlers(functions);
 }
 
-} // namespace APT
-} // namespace Service
+} // namespace Service::APT

--- a/src/core/hle/service/apt/apt_a.h
+++ b/src/core/hle/service/apt/apt_a.h
@@ -6,13 +6,11 @@
 
 #include "core/hle/service/apt/apt.h"
 
-namespace Service {
-namespace APT {
+namespace Service::APT {
 
 class APT_A final : public Module::Interface {
 public:
     explicit APT_A(std::shared_ptr<Module> apt);
 };
 
-} // namespace APT
-} // namespace Service
+} // namespace Service::APT

--- a/src/core/hle/service/apt/apt_s.cpp
+++ b/src/core/hle/service/apt/apt_s.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/apt/apt_s.h"
 
-namespace Service {
-namespace APT {
+namespace Service::APT {
 
 APT_S::APT_S(std::shared_ptr<Module> apt)
     : Module::Interface(std::move(apt), "APT:S", MaxAPTSessions) {
@@ -105,5 +104,4 @@ APT_S::APT_S(std::shared_ptr<Module> apt)
     RegisterHandlers(functions);
 }
 
-} // namespace APT
-} // namespace Service
+} // namespace Service::APT

--- a/src/core/hle/service/apt/apt_s.h
+++ b/src/core/hle/service/apt/apt_s.h
@@ -6,8 +6,7 @@
 
 #include "core/hle/service/apt/apt.h"
 
-namespace Service {
-namespace APT {
+namespace Service::APT {
 
 // Application and title launching service. These services handle signaling for home/power button as
 // well. Only one session for either APT service can be open at a time, normally processes close the
@@ -21,5 +20,4 @@ public:
     explicit APT_S(std::shared_ptr<Module> apt);
 };
 
-} // namespace APT
-} // namespace Service
+} // namespace Service::APT

--- a/src/core/hle/service/apt/apt_u.cpp
+++ b/src/core/hle/service/apt/apt_u.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/apt/apt_u.h"
 
-namespace Service {
-namespace APT {
+namespace Service::APT {
 
 APT_U::APT_U(std::shared_ptr<Module> apt)
     : Module::Interface(std::move(apt), "APT:U", MaxAPTSessions) {
@@ -102,5 +101,4 @@ APT_U::APT_U(std::shared_ptr<Module> apt)
     RegisterHandlers(functions);
 }
 
-} // namespace APT
-} // namespace Service
+} // namespace Service::APT

--- a/src/core/hle/service/apt/apt_u.h
+++ b/src/core/hle/service/apt/apt_u.h
@@ -6,8 +6,7 @@
 
 #include "core/hle/service/apt/apt.h"
 
-namespace Service {
-namespace APT {
+namespace Service::APT {
 
 // Application and title launching service. These services handle signaling for home/power button as
 // well. Only one session for either APT service can be open at a time, normally processes close the
@@ -21,5 +20,4 @@ public:
     explicit APT_U(std::shared_ptr<Module> apt);
 };
 
-} // namespace APT
-} // namespace Service
+} // namespace Service::APT

--- a/src/core/hle/service/apt/bcfnt/bcfnt.cpp
+++ b/src/core/hle/service/apt/bcfnt/bcfnt.cpp
@@ -5,9 +5,7 @@
 #include "core/hle/service/apt/bcfnt/bcfnt.h"
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace APT {
-namespace BCFNT {
+namespace Service::APT::BCFNT {
 
 void RelocateSharedFont(Kernel::SharedPtr<Kernel::SharedMemory> shared_font, VAddr new_address) {
     static const u32 SharedFontStartOffset = 0x80;
@@ -105,6 +103,4 @@ void RelocateSharedFont(Kernel::SharedPtr<Kernel::SharedMemory> shared_font, VAd
     }
 }
 
-} // namespace BCFNT
-} // namespace APT
-} // namespace Service
+} // namespace Service::APT::BCFNT

--- a/src/core/hle/service/apt/bcfnt/bcfnt.h
+++ b/src/core/hle/service/apt/bcfnt/bcfnt.h
@@ -8,9 +8,7 @@
 #include "core/hle/kernel/shared_memory.h"
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace APT {
-namespace BCFNT { ///< BCFNT Shared Font file structures
+namespace Service::APT::BCFNT { ///< BCFNT Shared Font file structures
 
 struct CFNT {
     u8 magic[4];
@@ -87,6 +85,4 @@ struct CWDH {
  */
 void RelocateSharedFont(Kernel::SharedPtr<Kernel::SharedMemory> shared_font, VAddr new_address);
 
-} // namespace BCFNT
-} // namespace APT
-} // namespace Service
+} // namespace Service::APT::BCFNT

--- a/src/core/hle/service/apt/errors.h
+++ b/src/core/hle/service/apt/errors.h
@@ -4,13 +4,9 @@
 
 #pragma once
 
-namespace Service {
-namespace APT {
-namespace ErrCodes {
+namespace Service::APT::ErrCodes {
 enum {
     ParameterPresent = 2,
     InvalidAppletSlot = 4,
 };
-} // namespace ErrCodes
-} // namespace APT
-} // namespace Service
+} // namespace Service::APT::ErrCodes

--- a/src/core/hle/service/boss/boss.cpp
+++ b/src/core/hle/service/boss/boss.cpp
@@ -9,8 +9,7 @@
 #include "core/hle/service/boss/boss_p.h"
 #include "core/hle/service/boss/boss_u.h"
 
-namespace Service {
-namespace BOSS {
+namespace Service::BOSS {
 
 void Module::Interface::InitializeSession(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x01, 2, 2);
@@ -915,5 +914,4 @@ void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<BOSS_U>(boss)->InstallAsService(service_manager);
 }
 
-} // namespace BOSS
-} // namespace Service
+} // namespace Service::BOSS

--- a/src/core/hle/service/boss/boss.h
+++ b/src/core/hle/service/boss/boss.h
@@ -7,8 +7,7 @@
 #include "core/hle/kernel/event.h"
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace BOSS {
+namespace Service::BOSS {
 
 class Module final {
 public:
@@ -963,5 +962,4 @@ private:
 
 void InstallInterfaces(SM::ServiceManager& service_manager);
 
-} // namespace BOSS
-} // namespace Service
+} // namespace Service::BOSS

--- a/src/core/hle/service/boss/boss_p.cpp
+++ b/src/core/hle/service/boss/boss_p.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/boss/boss_p.h"
 
-namespace Service {
-namespace BOSS {
+namespace Service::BOSS {
 
 BOSS_P::BOSS_P(std::shared_ptr<Module> boss)
     : Module::Interface(std::move(boss), "boss:P", DefaultMaxSessions) {
@@ -84,5 +83,4 @@ BOSS_P::BOSS_P(std::shared_ptr<Module> boss)
     RegisterHandlers(functions);
 }
 
-} // namespace BOSS
-} // namespace Service
+} // namespace Service::BOSS

--- a/src/core/hle/service/boss/boss_p.h
+++ b/src/core/hle/service/boss/boss_p.h
@@ -6,13 +6,11 @@
 
 #include "core/hle/service/boss/boss.h"
 
-namespace Service {
-namespace BOSS {
+namespace Service::BOSS {
 
 class BOSS_P final : public Module::Interface {
 public:
     explicit BOSS_P(std::shared_ptr<Module> boss);
 };
 
-} // namespace BOSS
-} // namespace Service
+} // namespace Service::BOSS

--- a/src/core/hle/service/boss/boss_u.cpp
+++ b/src/core/hle/service/boss/boss_u.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/boss/boss_u.h"
 
-namespace Service {
-namespace BOSS {
+namespace Service::BOSS {
 
 BOSS_U::BOSS_U(std::shared_ptr<Module> boss)
     : Module::Interface(std::move(boss), "boss:U", DefaultMaxSessions) {
@@ -72,5 +71,4 @@ BOSS_U::BOSS_U(std::shared_ptr<Module> boss)
     RegisterHandlers(functions);
 }
 
-} // namespace BOSS
-} // namespace Service
+} // namespace Service::BOSS

--- a/src/core/hle/service/boss/boss_u.h
+++ b/src/core/hle/service/boss/boss_u.h
@@ -6,13 +6,11 @@
 
 #include "core/hle/service/boss/boss.h"
 
-namespace Service {
-namespace BOSS {
+namespace Service::BOSS {
 
 class BOSS_U final : public Module::Interface {
 public:
     explicit BOSS_U(std::shared_ptr<Module> boss);
 };
 
-} // namespace BOSS
-} // namespace Service
+} // namespace Service::BOSS

--- a/src/core/hle/service/cam/cam.cpp
+++ b/src/core/hle/service/cam/cam.cpp
@@ -19,8 +19,7 @@
 #include "core/memory.h"
 #include "core/settings.h"
 
-namespace Service {
-namespace CAM {
+namespace Service::CAM {
 
 static std::weak_ptr<Module> current_cam;
 
@@ -1065,6 +1064,4 @@ void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<CAM_Q>()->InstallAsService(service_manager);
 }
 
-} // namespace CAM
-
-} // namespace Service
+} // namespace Service::CAM

--- a/src/core/hle/service/cam/cam.h
+++ b/src/core/hle/service/cam/cam.h
@@ -25,8 +25,7 @@ namespace Kernel {
 class Process;
 }
 
-namespace Service {
-namespace CAM {
+namespace Service::CAM {
 
 enum CameraIndex {
     OuterRightCamera = 0,
@@ -785,5 +784,4 @@ void ReloadCameraDevices();
 
 void InstallInterfaces(SM::ServiceManager& service_manager);
 
-} // namespace CAM
-} // namespace Service
+} // namespace Service::CAM

--- a/src/core/hle/service/cam/cam_c.cpp
+++ b/src/core/hle/service/cam/cam_c.cpp
@@ -5,8 +5,7 @@
 #include "core/hle/service/cam/cam.h"
 #include "core/hle/service/cam/cam_c.h"
 
-namespace Service {
-namespace CAM {
+namespace Service::CAM {
 
 CAM_C::CAM_C(std::shared_ptr<Module> cam) : Module::Interface(std::move(cam), "cam:c", 1) {
     static const FunctionInfo functions[] = {
@@ -79,5 +78,4 @@ CAM_C::CAM_C(std::shared_ptr<Module> cam) : Module::Interface(std::move(cam), "c
     RegisterHandlers(functions);
 }
 
-} // namespace CAM
-} // namespace Service
+} // namespace Service::CAM

--- a/src/core/hle/service/cam/cam_c.h
+++ b/src/core/hle/service/cam/cam_c.h
@@ -6,13 +6,11 @@
 
 #include "core/hle/service/cam/cam.h"
 
-namespace Service {
-namespace CAM {
+namespace Service::CAM {
 
 class CAM_C final : public Module::Interface {
 public:
     explicit CAM_C(std::shared_ptr<Module> cam);
 };
 
-} // namespace CAM
-} // namespace Service
+} // namespace Service::CAM

--- a/src/core/hle/service/cam/cam_q.cpp
+++ b/src/core/hle/service/cam/cam_q.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/cam/cam_q.h"
 
-namespace Service {
-namespace CAM {
+namespace Service::CAM {
 
 CAM_Q::CAM_Q() : ServiceFramework("cam:q", 1 /*TODO: find the true value*/) {
     // Empty arrays are illegal -- commented out until an entry is added.
@@ -13,5 +12,4 @@ CAM_Q::CAM_Q() : ServiceFramework("cam:q", 1 /*TODO: find the true value*/) {
     // RegisterHandlers(functions);
 }
 
-} // namespace CAM
-} // namespace Service
+} // namespace Service::CAM

--- a/src/core/hle/service/cam/cam_q.h
+++ b/src/core/hle/service/cam/cam_q.h
@@ -6,13 +6,11 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace CAM {
+namespace Service::CAM {
 
 class CAM_Q : public ServiceFramework<CAM_Q> {
 public:
     CAM_Q();
 };
 
-} // namespace CAM
-} // namespace Service
+} // namespace Service::CAM

--- a/src/core/hle/service/cam/cam_s.cpp
+++ b/src/core/hle/service/cam/cam_s.cpp
@@ -5,8 +5,7 @@
 #include "core/hle/service/cam/cam.h"
 #include "core/hle/service/cam/cam_s.h"
 
-namespace Service {
-namespace CAM {
+namespace Service::CAM {
 
 CAM_S::CAM_S(std::shared_ptr<Module> cam) : Module::Interface(std::move(cam), "cam:s", 1) {
     static const FunctionInfo functions[] = {
@@ -79,5 +78,4 @@ CAM_S::CAM_S(std::shared_ptr<Module> cam) : Module::Interface(std::move(cam), "c
     RegisterHandlers(functions);
 }
 
-} // namespace CAM
-} // namespace Service
+} // namespace Service::CAM

--- a/src/core/hle/service/cam/cam_s.h
+++ b/src/core/hle/service/cam/cam_s.h
@@ -6,13 +6,11 @@
 
 #include "core/hle/service/cam/cam.h"
 
-namespace Service {
-namespace CAM {
+namespace Service::CAM {
 
 class CAM_S final : public Module::Interface {
 public:
     explicit CAM_S(std::shared_ptr<Module> cam);
 };
 
-} // namespace CAM
-} // namespace Service
+} // namespace Service::CAM

--- a/src/core/hle/service/cam/cam_u.cpp
+++ b/src/core/hle/service/cam/cam_u.cpp
@@ -5,8 +5,7 @@
 #include "core/hle/service/cam/cam.h"
 #include "core/hle/service/cam/cam_u.h"
 
-namespace Service {
-namespace CAM {
+namespace Service::CAM {
 
 CAM_U::CAM_U(std::shared_ptr<Module> cam) : Module::Interface(std::move(cam), "cam:u", 1) {
     static const FunctionInfo functions[] = {
@@ -79,5 +78,4 @@ CAM_U::CAM_U(std::shared_ptr<Module> cam) : Module::Interface(std::move(cam), "c
     RegisterHandlers(functions);
 }
 
-} // namespace CAM
-} // namespace Service
+} // namespace Service::CAM

--- a/src/core/hle/service/cam/cam_u.h
+++ b/src/core/hle/service/cam/cam_u.h
@@ -6,13 +6,11 @@
 
 #include "core/hle/service/cam/cam.h"
 
-namespace Service {
-namespace CAM {
+namespace Service::CAM {
 
 class CAM_U final : public Module::Interface {
 public:
     explicit CAM_U(std::shared_ptr<Module> cam);
 };
 
-} // namespace CAM
-} // namespace Service
+} // namespace Service::CAM

--- a/src/core/hle/service/cecd/cecd.cpp
+++ b/src/core/hle/service/cecd/cecd.cpp
@@ -10,8 +10,7 @@
 #include "core/hle/service/cecd/cecd_s.h"
 #include "core/hle/service/cecd/cecd_u.h"
 
-namespace Service {
-namespace CECD {
+namespace Service::CECD {
 
 void Module::Interface::GetCecStateAbbreviated(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x0E, 0, 0);
@@ -59,5 +58,4 @@ void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<CECD_U>(cecd)->InstallAsService(service_manager);
 }
 
-} // namespace CECD
-} // namespace Service
+} // namespace Service::CECD

--- a/src/core/hle/service/cecd/cecd.h
+++ b/src/core/hle/service/cecd/cecd.h
@@ -7,8 +7,7 @@
 #include "core/hle/kernel/event.h"
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace CECD {
+namespace Service::CECD {
 
 enum class CecStateAbbreviated : u32 {
     CEC_STATE_ABBREV_IDLE = 1,      ///< Corresponds to CEC_STATE_IDLE
@@ -73,5 +72,4 @@ private:
 /// Initialize CECD service(s)
 void InstallInterfaces(SM::ServiceManager& service_manager);
 
-} // namespace CECD
-} // namespace Service
+} // namespace Service::CECD

--- a/src/core/hle/service/cecd/cecd_ndm.cpp
+++ b/src/core/hle/service/cecd/cecd_ndm.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/cecd/cecd_ndm.h"
 
-namespace Service {
-namespace CECD {
+namespace Service::CECD {
 
 CECD_NDM::CECD_NDM(std::shared_ptr<Module> cecd)
     : Module::Interface(std::move(cecd), "cecd:ndm", DefaultMaxSessions) {
@@ -21,5 +20,4 @@ CECD_NDM::CECD_NDM(std::shared_ptr<Module> cecd)
     RegisterHandlers(functions);
 }
 
-} // namespace CECD
-} // namespace Service
+} // namespace Service::CECD

--- a/src/core/hle/service/cecd/cecd_ndm.h
+++ b/src/core/hle/service/cecd/cecd_ndm.h
@@ -6,13 +6,11 @@
 
 #include "core/hle/service/cecd/cecd.h"
 
-namespace Service {
-namespace CECD {
+namespace Service::CECD {
 
 class CECD_NDM final : public Module::Interface {
 public:
     explicit CECD_NDM(std::shared_ptr<Module> cecd);
 };
 
-} // namespace CECD
-} // namespace Service
+} // namespace Service::CECD

--- a/src/core/hle/service/cecd/cecd_s.cpp
+++ b/src/core/hle/service/cecd/cecd_s.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/cecd/cecd_s.h"
 
-namespace Service {
-namespace CECD {
+namespace Service::CECD {
 
 CECD_S::CECD_S(std::shared_ptr<Module> cecd)
     : Module::Interface(std::move(cecd), "cecd:s", DefaultMaxSessions) {
@@ -34,5 +33,4 @@ CECD_S::CECD_S(std::shared_ptr<Module> cecd)
     RegisterHandlers(functions);
 }
 
-} // namespace CECD
-} // namespace Service
+} // namespace Service::CECD

--- a/src/core/hle/service/cecd/cecd_s.h
+++ b/src/core/hle/service/cecd/cecd_s.h
@@ -6,13 +6,11 @@
 
 #include "core/hle/service/cecd/cecd.h"
 
-namespace Service {
-namespace CECD {
+namespace Service::CECD {
 
 class CECD_S final : public Module::Interface {
 public:
     explicit CECD_S(std::shared_ptr<Module> cecd);
 };
 
-} // namespace CECD
-} // namespace Service
+} // namespace Service::CECD

--- a/src/core/hle/service/cecd/cecd_u.cpp
+++ b/src/core/hle/service/cecd/cecd_u.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/cecd/cecd_u.h"
 
-namespace Service {
-namespace CECD {
+namespace Service::CECD {
 
 CECD_U::CECD_U(std::shared_ptr<Module> cecd)
     : Module::Interface(std::move(cecd), "cecd:u", DefaultMaxSessions) {
@@ -34,5 +33,4 @@ CECD_U::CECD_U(std::shared_ptr<Module> cecd)
     RegisterHandlers(functions);
 }
 
-} // namespace CECD
-} // namespace Service
+} // namespace Service::CECD

--- a/src/core/hle/service/cecd/cecd_u.h
+++ b/src/core/hle/service/cecd/cecd_u.h
@@ -6,13 +6,11 @@
 
 #include "core/hle/service/cecd/cecd.h"
 
-namespace Service {
-namespace CECD {
+namespace Service::CECD {
 
 class CECD_U final : public Module::Interface {
 public:
     explicit CECD_U(std::shared_ptr<Module> cecd);
 };
 
-} // namespace CECD
-} // namespace Service
+} // namespace Service::CECD

--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -21,8 +21,7 @@
 #include "core/hle/service/cfg/cfg_u.h"
 #include "core/settings.h"
 
-namespace Service {
-namespace CFG {
+namespace Service::CFG {
 
 /// The maximum number of block entries that can exist in the config file
 static const u32 CONFIG_FILE_MAX_BLOCK_ENTRIES = 1479;
@@ -721,5 +720,4 @@ void InstallInterfaces(SM::ServiceManager& service_manager) {
     current_cfg = cfg;
 }
 
-} // namespace CFG
-} // namespace Service
+} // namespace Service::CFG

--- a/src/core/hle/service/cfg/cfg.h
+++ b/src/core/hle/service/cfg/cfg.h
@@ -10,8 +10,7 @@
 #include "common/common_types.h"
 #include "core/hle/service/fs/archive.h"
 
-namespace Service {
-namespace CFG {
+namespace Service::CFG {
 
 enum SystemModel {
     NINTENDO_3DS = 0,
@@ -407,5 +406,4 @@ private:
 void InstallInterfaces(SM::ServiceManager& service_manager);
 std::shared_ptr<Module> GetCurrentModule();
 
-} // namespace CFG
-} // namespace Service
+} // namespace Service::CFG

--- a/src/core/hle/service/cfg/cfg_i.cpp
+++ b/src/core/hle/service/cfg/cfg_i.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/cfg/cfg_i.h"
 
-namespace Service {
-namespace CFG {
+namespace Service::CFG {
 
 CFG_I::CFG_I(std::shared_ptr<Module> cfg) : Module::Interface(std::move(cfg), "cfg:i", 23) {
     static const FunctionInfo functions[] = {
@@ -60,5 +59,4 @@ CFG_I::CFG_I(std::shared_ptr<Module> cfg) : Module::Interface(std::move(cfg), "c
     RegisterHandlers(functions);
 }
 
-} // namespace CFG
-} // namespace Service
+} // namespace Service::CFG

--- a/src/core/hle/service/cfg/cfg_i.h
+++ b/src/core/hle/service/cfg/cfg_i.h
@@ -6,13 +6,11 @@
 
 #include "core/hle/service/cfg/cfg.h"
 
-namespace Service {
-namespace CFG {
+namespace Service::CFG {
 
 class CFG_I final : public Module::Interface {
 public:
     explicit CFG_I(std::shared_ptr<Module> cfg);
 };
 
-} // namespace CFG
-} // namespace Service
+} // namespace Service::CFG

--- a/src/core/hle/service/cfg/cfg_nor.cpp
+++ b/src/core/hle/service/cfg/cfg_nor.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/cfg/cfg_nor.h"
 
-namespace Service {
-namespace CFG {
+namespace Service::CFG {
 
 CFG_NOR::CFG_NOR() : ServiceFramework("cfg:nor", 23) {
     static const FunctionInfo functions[] = {
@@ -17,5 +16,4 @@ CFG_NOR::CFG_NOR() : ServiceFramework("cfg:nor", 23) {
     RegisterHandlers(functions);
 }
 
-} // namespace CFG
-} // namespace Service
+} // namespace Service::CFG

--- a/src/core/hle/service/cfg/cfg_nor.h
+++ b/src/core/hle/service/cfg/cfg_nor.h
@@ -6,13 +6,11 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace CFG {
+namespace Service::CFG {
 
 class CFG_NOR final : public ServiceFramework<CFG_NOR> {
 public:
     CFG_NOR();
 };
 
-} // namespace CFG
-} // namespace Service
+} // namespace Service::CFG

--- a/src/core/hle/service/cfg/cfg_s.cpp
+++ b/src/core/hle/service/cfg/cfg_s.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/cfg/cfg_s.h"
 
-namespace Service {
-namespace CFG {
+namespace Service::CFG {
 
 CFG_S::CFG_S(std::shared_ptr<Module> cfg) : Module::Interface(std::move(cfg), "cfg:s", 23) {
     static const FunctionInfo functions[] = {
@@ -36,5 +35,4 @@ CFG_S::CFG_S(std::shared_ptr<Module> cfg) : Module::Interface(std::move(cfg), "c
     RegisterHandlers(functions);
 }
 
-} // namespace CFG
-} // namespace Service
+} // namespace Service::CFG

--- a/src/core/hle/service/cfg/cfg_s.h
+++ b/src/core/hle/service/cfg/cfg_s.h
@@ -6,13 +6,11 @@
 
 #include "core/hle/service/cfg/cfg.h"
 
-namespace Service {
-namespace CFG {
+namespace Service::CFG {
 
 class CFG_S final : public Module::Interface {
 public:
     explicit CFG_S(std::shared_ptr<Module> cfg);
 };
 
-} // namespace CFG
-} // namespace Service
+} // namespace Service::CFG

--- a/src/core/hle/service/cfg/cfg_u.cpp
+++ b/src/core/hle/service/cfg/cfg_u.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/cfg/cfg_u.h"
 
-namespace Service {
-namespace CFG {
+namespace Service::CFG {
 
 CFG_U::CFG_U(std::shared_ptr<Module> cfg) : Module::Interface(std::move(cfg), "cfg:u", 23) {
     static const FunctionInfo functions[] = {
@@ -25,5 +24,4 @@ CFG_U::CFG_U(std::shared_ptr<Module> cfg) : Module::Interface(std::move(cfg), "c
     RegisterHandlers(functions);
 }
 
-} // namespace CFG
-} // namespace Service
+} // namespace Service::CFG

--- a/src/core/hle/service/cfg/cfg_u.h
+++ b/src/core/hle/service/cfg/cfg_u.h
@@ -6,13 +6,11 @@
 
 #include "core/hle/service/cfg/cfg.h"
 
-namespace Service {
-namespace CFG {
+namespace Service::CFG {
 
 class CFG_U final : public Module::Interface {
 public:
     explicit CFG_U(std::shared_ptr<Module> cfg);
 };
 
-} // namespace CFG
-} // namespace Service
+} // namespace Service::CFG

--- a/src/core/hle/service/csnd/csnd_snd.cpp
+++ b/src/core/hle/service/csnd/csnd_snd.cpp
@@ -7,8 +7,7 @@
 #include "core/hle/result.h"
 #include "core/hle/service/csnd/csnd_snd.h"
 
-namespace Service {
-namespace CSND {
+namespace Service::CSND {
 
 void CSND_SND::Initialize(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x01, 5, 0);
@@ -198,5 +197,4 @@ void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<CSND_SND>()->InstallAsService(service_manager);
 }
 
-} // namespace CSND
-} // namespace Service
+} // namespace Service::CSND

--- a/src/core/hle/service/csnd/csnd_snd.h
+++ b/src/core/hle/service/csnd/csnd_snd.h
@@ -8,8 +8,7 @@
 #include "core/hle/kernel/shared_memory.h"
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace CSND {
+namespace Service::CSND {
 
 class CSND_SND final : public ServiceFramework<CSND_SND> {
 public:
@@ -181,5 +180,4 @@ private:
 /// Initializes the CSND_SND Service
 void InstallInterfaces(SM::ServiceManager& service_manager);
 
-} // namespace CSND
-} // namespace Service
+} // namespace Service::CSND

--- a/src/core/hle/service/dlp/dlp.cpp
+++ b/src/core/hle/service/dlp/dlp.cpp
@@ -7,8 +7,7 @@
 #include "core/hle/service/dlp/dlp_fkcl.h"
 #include "core/hle/service/dlp/dlp_srvr.h"
 
-namespace Service {
-namespace DLP {
+namespace Service::DLP {
 
 void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<DLP_CLNT>()->InstallAsService(service_manager);
@@ -16,5 +15,4 @@ void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<DLP_SRVR>()->InstallAsService(service_manager);
 }
 
-} // namespace DLP
-} // namespace Service
+} // namespace Service::DLP

--- a/src/core/hle/service/dlp/dlp.h
+++ b/src/core/hle/service/dlp/dlp.h
@@ -6,11 +6,9 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace DLP {
+namespace Service::DLP {
 
 /// Initializes the DLP services.
 void InstallInterfaces(SM::ServiceManager& service_manager);
 
-} // namespace DLP
-} // namespace Service
+} // namespace Service::DLP

--- a/src/core/hle/service/dlp/dlp_clnt.cpp
+++ b/src/core/hle/service/dlp/dlp_clnt.cpp
@@ -5,8 +5,7 @@
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/service/dlp/dlp_clnt.h"
 
-namespace Service {
-namespace DLP {
+namespace Service::DLP {
 
 DLP_CLNT::DLP_CLNT() : ServiceFramework("dlp:CLNT", 1) {
     static const FunctionInfo functions[] = {
@@ -37,5 +36,4 @@ DLP_CLNT::DLP_CLNT() : ServiceFramework("dlp:CLNT", 1) {
     RegisterHandlers(functions);
 }
 
-} // namespace DLP
-} // namespace Service
+} // namespace Service::DLP

--- a/src/core/hle/service/dlp/dlp_clnt.h
+++ b/src/core/hle/service/dlp/dlp_clnt.h
@@ -6,8 +6,7 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace DLP {
+namespace Service::DLP {
 
 class DLP_CLNT final : public ServiceFramework<DLP_CLNT> {
 public:
@@ -15,5 +14,4 @@ public:
     ~DLP_CLNT() = default;
 };
 
-} // namespace DLP
-} // namespace Service
+} // namespace Service::DLP

--- a/src/core/hle/service/dlp/dlp_fkcl.cpp
+++ b/src/core/hle/service/dlp/dlp_fkcl.cpp
@@ -5,8 +5,7 @@
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/service/dlp/dlp_fkcl.h"
 
-namespace Service {
-namespace DLP {
+namespace Service::DLP {
 
 DLP_FKCL::DLP_FKCL() : ServiceFramework("dlp:FKCL", 1) {
     static const FunctionInfo functions[] = {
@@ -34,5 +33,4 @@ DLP_FKCL::DLP_FKCL() : ServiceFramework("dlp:FKCL", 1) {
     RegisterHandlers(functions);
 }
 
-} // namespace DLP
-} // namespace Service
+} // namespace Service::DLP

--- a/src/core/hle/service/dlp/dlp_fkcl.h
+++ b/src/core/hle/service/dlp/dlp_fkcl.h
@@ -6,8 +6,7 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace DLP {
+namespace Service::DLP {
 
 class DLP_FKCL final : public ServiceFramework<DLP_FKCL> {
 public:
@@ -15,5 +14,4 @@ public:
     ~DLP_FKCL() = default;
 };
 
-} // namespace DLP
-} // namespace Service
+} // namespace Service::DLP

--- a/src/core/hle/service/dlp/dlp_srvr.cpp
+++ b/src/core/hle/service/dlp/dlp_srvr.cpp
@@ -8,8 +8,7 @@
 #include "core/hle/result.h"
 #include "core/hle/service/dlp/dlp_srvr.h"
 
-namespace Service {
-namespace DLP {
+namespace Service::DLP {
 
 void DLP_SRVR::IsChild(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x0E, 1, 0);
@@ -47,5 +46,4 @@ DLP_SRVR::DLP_SRVR() : ServiceFramework("dlp:SRVR", 1) {
     RegisterHandlers(functions);
 }
 
-} // namespace DLP
-} // namespace Service
+} // namespace Service::DLP

--- a/src/core/hle/service/dlp/dlp_srvr.h
+++ b/src/core/hle/service/dlp/dlp_srvr.h
@@ -6,8 +6,7 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace DLP {
+namespace Service::DLP {
 
 class DLP_SRVR final : public ServiceFramework<DLP_SRVR> {
 public:
@@ -18,5 +17,4 @@ private:
     void IsChild(Kernel::HLERequestContext& ctx);
 };
 
-} // namespace DLP
-} // namespace Service
+} // namespace Service::DLP

--- a/src/core/hle/service/dsp/dsp_dsp.cpp
+++ b/src/core/hle/service/dsp/dsp_dsp.cpp
@@ -18,8 +18,7 @@ namespace AudioCore {
 enum class DspPipe;
 }
 
-namespace Service {
-namespace DSP {
+namespace Service::DSP {
 
 void DSP_DSP::RecvData(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x01, 1, 0);
@@ -406,5 +405,4 @@ void InstallInterfaces(SM::ServiceManager& service_manager) {
     Core::DSP().SetServiceToInterrupt(std::move(dsp));
 }
 
-} // namespace DSP
-} // namespace Service
+} // namespace Service::DSP

--- a/src/core/hle/service/dsp/dsp_dsp.h
+++ b/src/core/hle/service/dsp/dsp_dsp.h
@@ -9,8 +9,7 @@
 #include "core/hle/result.h"
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace DSP {
+namespace Service::DSP {
 
 class DSP_DSP final : public ServiceFramework<DSP_DSP> {
 public:
@@ -253,5 +252,4 @@ private:
 
 void InstallInterfaces(SM::ServiceManager& service_manager);
 
-} // namespace DSP
-} // namespace Service
+} // namespace Service::DSP

--- a/src/core/hle/service/err_f.cpp
+++ b/src/core/hle/service/err_f.cpp
@@ -15,8 +15,7 @@
 #include "core/hle/result.h"
 #include "core/hle/service/err_f.h"
 
-namespace Service {
-namespace ERR {
+namespace Service::ERR {
 
 enum class FatalErrType : u32 {
     Generic = 0,
@@ -248,5 +247,4 @@ void InstallInterfaces() {
     errf->InstallAsNamedPort();
 }
 
-} // namespace ERR
-} // namespace Service
+} // namespace Service::ERR

--- a/src/core/hle/service/err_f.h
+++ b/src/core/hle/service/err_f.h
@@ -10,8 +10,7 @@ namespace Kernel {
 class HLERequestContext;
 }
 
-namespace Service {
-namespace ERR {
+namespace Service::ERR {
 
 /// Interface to "err:f" service
 class ERR_F final : public ServiceFramework<ERR_F> {
@@ -33,5 +32,4 @@ private:
 
 void InstallInterfaces();
 
-} // namespace ERR
-} // namespace Service
+} // namespace Service::ERR

--- a/src/core/hle/service/frd/frd.cpp
+++ b/src/core/hle/service/frd/frd.cpp
@@ -13,8 +13,7 @@
 #include "core/hle/service/frd/frd_a.h"
 #include "core/hle/service/frd/frd_u.h"
 
-namespace Service {
-namespace FRD {
+namespace Service::FRD {
 
 Module::Interface::Interface(std::shared_ptr<Module> frd, const char* name, u32 max_session)
     : ServiceFramework(name, max_session), frd(std::move(frd)) {}
@@ -156,6 +155,4 @@ void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<FRD_A>(frd)->InstallAsService(service_manager);
 }
 
-} // namespace FRD
-
-} // namespace Service
+} // namespace Service::FRD

--- a/src/core/hle/service/frd/frd.h
+++ b/src/core/hle/service/frd/frd.h
@@ -8,9 +8,7 @@
 #include "common/common_types.h"
 #include "core/hle/service/service.h"
 
-namespace Service {
-
-namespace FRD {
+namespace Service::FRD {
 
 struct FriendKey {
     u32 friend_id;
@@ -139,5 +137,4 @@ private:
 
 void InstallInterfaces(SM::ServiceManager& service_manager);
 
-} // namespace FRD
-} // namespace Service
+} // namespace Service::FRD

--- a/src/core/hle/service/frd/frd_a.cpp
+++ b/src/core/hle/service/frd/frd_a.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/frd/frd_a.h"
 
-namespace Service {
-namespace FRD {
+namespace Service::FRD {
 
 FRD_A::FRD_A(std::shared_ptr<Module> frd) : Module::Interface(std::move(frd), "frd:a", 8) {
     static const FunctionInfo functions[] = {
@@ -66,5 +65,4 @@ FRD_A::FRD_A(std::shared_ptr<Module> frd) : Module::Interface(std::move(frd), "f
     RegisterHandlers(functions);
 }
 
-} // namespace FRD
-} // namespace Service
+} // namespace Service::FRD

--- a/src/core/hle/service/frd/frd_a.h
+++ b/src/core/hle/service/frd/frd_a.h
@@ -6,13 +6,11 @@
 
 #include "core/hle/service/frd/frd.h"
 
-namespace Service {
-namespace FRD {
+namespace Service::FRD {
 
 class FRD_A final : public Module::Interface {
 public:
     explicit FRD_A(std::shared_ptr<Module> frd);
 };
 
-} // namespace FRD
-} // namespace Service
+} // namespace Service::FRD

--- a/src/core/hle/service/frd/frd_u.cpp
+++ b/src/core/hle/service/frd/frd_u.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/frd/frd_u.h"
 
-namespace Service {
-namespace FRD {
+namespace Service::FRD {
 
 FRD_U::FRD_U(std::shared_ptr<Module> frd) : Module::Interface(std::move(frd), "frd:u", 8) {
     static const FunctionInfo functions[] = {
@@ -66,5 +65,4 @@ FRD_U::FRD_U(std::shared_ptr<Module> frd) : Module::Interface(std::move(frd), "f
     RegisterHandlers(functions);
 }
 
-} // namespace FRD
-} // namespace Service
+} // namespace Service::FRD

--- a/src/core/hle/service/frd/frd_u.h
+++ b/src/core/hle/service/frd/frd_u.h
@@ -6,13 +6,11 @@
 
 #include "core/hle/service/frd/frd.h"
 
-namespace Service {
-namespace FRD {
+namespace Service::FRD {
 
 class FRD_U final : public Module::Interface {
 public:
     explicit FRD_U(std::shared_ptr<Module> frd);
 };
 
-} // namespace FRD
-} // namespace Service
+} // namespace Service::FRD

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -40,8 +40,7 @@
 #include "core/hle/service/service.h"
 #include "core/memory.h"
 
-namespace Service {
-namespace FS {
+namespace Service::FS {
 
 // Command to access directory
 enum class DirectoryCommand : u32 {
@@ -701,5 +700,4 @@ void ArchiveShutdown() {
     UnregisterArchiveTypes();
 }
 
-} // namespace FS
-} // namespace Service
+} // namespace Service::FS

--- a/src/core/hle/service/fs/archive.h
+++ b/src/core/hle/service/fs/archive.h
@@ -28,8 +28,7 @@ namespace Loader {
 class AppLoader;
 }
 
-namespace Service {
-namespace FS {
+namespace Service::FS {
 
 /// Supported archive types
 enum class ArchiveIdCode : u32 {
@@ -296,5 +295,4 @@ void RegisterArchiveTypes();
 /// Unregister all archive types
 void UnregisterArchiveTypes();
 
-} // namespace FS
-} // namespace Service
+} // namespace Service::FS

--- a/src/core/hle/service/fs/fs_user.cpp
+++ b/src/core/hle/service/fs/fs_user.cpp
@@ -30,8 +30,7 @@ using Kernel::ClientSession;
 using Kernel::ServerSession;
 using Kernel::SharedPtr;
 
-namespace Service {
-namespace FS {
+namespace Service::FS {
 
 void FS_USER::Initialize(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x0801, 0, 2);
@@ -857,5 +856,4 @@ FS_USER::FS_USER() : ServiceFramework("fs:USER", 30) {
 void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<FS_USER>()->InstallAsService(service_manager);
 }
-} // namespace FS
-} // namespace Service
+} // namespace Service::FS

--- a/src/core/hle/service/fs/fs_user.h
+++ b/src/core/hle/service/fs/fs_user.h
@@ -7,8 +7,7 @@
 #include "common/common_types.h"
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace FS {
+namespace Service::FS {
 
 class FS_USER final : public ServiceFramework<FS_USER> {
 public:
@@ -520,5 +519,4 @@ private:
 
 void InstallInterfaces(SM::ServiceManager& service_manager);
 
-} // namespace FS
-} // namespace Service
+} // namespace Service::FS

--- a/src/core/hle/service/gsp/gsp.cpp
+++ b/src/core/hle/service/gsp/gsp.cpp
@@ -7,8 +7,7 @@
 #include "core/hle/kernel/shared_memory.h"
 #include "core/hle/service/gsp/gsp.h"
 
-namespace Service {
-namespace GSP {
+namespace Service::GSP {
 
 static std::weak_ptr<GSP_GPU> gsp_gpu;
 
@@ -32,5 +31,4 @@ void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<GSP_LCD>()->InstallAsService(service_manager);
 }
 
-} // namespace GSP
-} // namespace Service
+} // namespace Service::GSP

--- a/src/core/hle/service/gsp/gsp.h
+++ b/src/core/hle/service/gsp/gsp.h
@@ -11,8 +11,7 @@
 #include "core/hle/service/gsp/gsp_gpu.h"
 #include "core/hle/service/gsp/gsp_lcd.h"
 
-namespace Service {
-namespace GSP {
+namespace Service::GSP {
 /**
  * Retrieves the framebuffer info stored in the GSP shared memory for the
  * specified screen index and thread id.
@@ -29,5 +28,4 @@ FrameBufferUpdate* GetFrameBufferInfo(u32 thread_id, u32 screen_index);
 void SignalInterrupt(InterruptId interrupt_id);
 
 void InstallInterfaces(SM::ServiceManager& service_manager);
-} // namespace GSP
-} // namespace Service
+} // namespace Service::GSP

--- a/src/core/hle/service/gsp/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp/gsp_gpu.cpp
@@ -23,8 +23,7 @@
 // Main graphics debugger object - TODO: Here is probably not the best place for this
 GraphicsDebugger g_debugger;
 
-namespace Service {
-namespace GSP {
+namespace Service::GSP {
 
 // Beginning address of HW regs
 const u32 REGS_BEGIN = 0x1EB00000;
@@ -807,5 +806,4 @@ SessionData::~SessionData() {
     used_thread_ids[thread_id] = false;
 }
 
-} // namespace GSP
-} // namespace Service
+} // namespace Service::GSP

--- a/src/core/hle/service/gsp/gsp_gpu.h
+++ b/src/core/hle/service/gsp/gsp_gpu.h
@@ -17,8 +17,7 @@ namespace Kernel {
 class SharedMemory;
 } // namespace Kernel
 
-namespace Service {
-namespace GSP {
+namespace Service::GSP {
 
 /// GSP interrupt ID
 enum class InterruptId : u8 {
@@ -411,5 +410,4 @@ private:
 
 ResultCode SetBufferSwap(u32 screen_id, const FrameBufferInfo& info);
 
-} // namespace GSP
-} // namespace Service
+} // namespace Service::GSP

--- a/src/core/hle/service/gsp/gsp_lcd.cpp
+++ b/src/core/hle/service/gsp/gsp_lcd.cpp
@@ -5,8 +5,7 @@
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/service/gsp/gsp_lcd.h"
 
-namespace Service {
-namespace GSP {
+namespace Service::GSP {
 
 GSP_LCD::GSP_LCD() : ServiceFramework("gsp::Lcd") {
     static const FunctionInfo functions[] = {
@@ -23,5 +22,4 @@ GSP_LCD::GSP_LCD() : ServiceFramework("gsp::Lcd") {
     RegisterHandlers(functions);
 };
 
-} // namespace GSP
-} // namespace Service
+} // namespace Service::GSP

--- a/src/core/hle/service/gsp/gsp_lcd.h
+++ b/src/core/hle/service/gsp/gsp_lcd.h
@@ -6,8 +6,7 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace GSP {
+namespace Service::GSP {
 
 class GSP_LCD final : public ServiceFramework<GSP_LCD> {
 public:
@@ -15,5 +14,4 @@ public:
     ~GSP_LCD() = default;
 };
 
-} // namespace GSP
-} // namespace Service
+} // namespace Service::GSP

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -19,8 +19,7 @@
 #include "core/movie.h"
 #include "video_core/video_core.h"
 
-namespace Service {
-namespace HID {
+namespace Service::HID {
 
 static std::weak_ptr<Module> current_module;
 
@@ -401,6 +400,4 @@ void InstallInterfaces(SM::ServiceManager& service_manager) {
     current_module = hid;
 }
 
-} // namespace HID
-
-} // namespace Service
+} // namespace Service::HID

--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -27,9 +27,7 @@ namespace CoreTiming {
 struct EventType;
 };
 
-namespace Service {
-
-namespace HID {
+namespace Service::HID {
 
 /**
  * Structure of a Pad controller state.
@@ -335,5 +333,4 @@ void InstallInterfaces(SM::ServiceManager& service_manager);
 
 /// Reload input devices. Used when input configuration changed
 void ReloadInputDevices();
-} // namespace HID
-} // namespace Service
+} // namespace Service::HID

--- a/src/core/hle/service/hid/hid_spvr.cpp
+++ b/src/core/hle/service/hid/hid_spvr.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/hid/hid_spvr.h"
 
-namespace Service {
-namespace HID {
+namespace Service::HID {
 
 Spvr::Spvr(std::shared_ptr<Module> hid) : Module::Interface(std::move(hid), "hid:SPVR", 6) {
     static const FunctionInfo functions[] = {
@@ -26,5 +25,4 @@ Spvr::Spvr(std::shared_ptr<Module> hid) : Module::Interface(std::move(hid), "hid
     RegisterHandlers(functions);
 }
 
-} // namespace HID
-} // namespace Service
+} // namespace Service::HID

--- a/src/core/hle/service/hid/hid_spvr.h
+++ b/src/core/hle/service/hid/hid_spvr.h
@@ -6,13 +6,11 @@
 
 #include "core/hle/service/hid/hid.h"
 
-namespace Service {
-namespace HID {
+namespace Service::HID {
 
 class Spvr final : public Module::Interface {
 public:
     explicit Spvr(std::shared_ptr<Module> hid);
 };
 
-} // namespace HID
-} // namespace Service
+} // namespace Service::HID

--- a/src/core/hle/service/hid/hid_user.cpp
+++ b/src/core/hle/service/hid/hid_user.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/hid/hid_user.h"
 
-namespace Service {
-namespace HID {
+namespace Service::HID {
 
 User::User(std::shared_ptr<Module> hid) : Module::Interface(std::move(hid), "hid:USER", 6) {
     static const FunctionInfo functions[] = {
@@ -26,5 +25,4 @@ User::User(std::shared_ptr<Module> hid) : Module::Interface(std::move(hid), "hid
     RegisterHandlers(functions);
 }
 
-} // namespace HID
-} // namespace Service
+} // namespace Service::HID

--- a/src/core/hle/service/hid/hid_user.h
+++ b/src/core/hle/service/hid/hid_user.h
@@ -9,13 +9,11 @@
 // This service is used for interfacing to physical user controls.
 // Uses include game pad controls, touchscreen, accelerometers, gyroscopes, and debug pad.
 
-namespace Service {
-namespace HID {
+namespace Service::HID {
 
 class User final : public Module::Interface {
 public:
     explicit User(std::shared_ptr<Module> hid);
 };
 
-} // namespace HID
-} // namespace Service
+} // namespace Service::HID

--- a/src/core/hle/service/http_c.cpp
+++ b/src/core/hle/service/http_c.cpp
@@ -13,8 +13,7 @@
 #include "core/hle/service/http_c.h"
 #include "core/hw/aes/key.h"
 
-namespace Service {
-namespace HTTP {
+namespace Service::HTTP {
 
 namespace ErrCodes {
 enum {
@@ -434,5 +433,4 @@ HTTP_C::HTTP_C() : ServiceFramework("http:C", 32) {
 void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<HTTP_C>()->InstallAsService(service_manager);
 }
-} // namespace HTTP
-} // namespace Service
+} // namespace Service::HTTP

--- a/src/core/hle/service/http_c.h
+++ b/src/core/hle/service/http_c.h
@@ -12,8 +12,7 @@
 #include "core/hle/kernel/shared_memory.h"
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace HTTP {
+namespace Service::HTTP {
 
 enum class RequestMethod : u8 {
     None = 0x0,
@@ -222,5 +221,4 @@ private:
 
 void InstallInterfaces(SM::ServiceManager& service_manager);
 
-} // namespace HTTP
-} // namespace Service
+} // namespace Service::HTTP

--- a/src/core/hle/service/ir/extra_hid.cpp
+++ b/src/core/hle/service/ir/extra_hid.cpp
@@ -9,8 +9,7 @@
 #include "core/movie.h"
 #include "core/settings.h"
 
-namespace Service {
-namespace IR {
+namespace Service::IR {
 
 enum class RequestID : u8 {
     /**
@@ -270,5 +269,4 @@ void ExtraHID::LoadInputDevices() {
         Settings::values.analogs[Settings::NativeAnalog::CStick]);
 }
 
-} // namespace IR
-} // namespace Service
+} // namespace Service::IR

--- a/src/core/hle/service/ir/extra_hid.h
+++ b/src/core/hle/service/ir/extra_hid.h
@@ -15,8 +15,7 @@ namespace CoreTiming {
 struct EventType;
 } // namespace CoreTiming
 
-namespace Service {
-namespace IR {
+namespace Service::IR {
 
 struct ExtraHIDResponse {
     union {
@@ -66,5 +65,4 @@ private:
     std::atomic<bool> is_device_reload_pending;
 };
 
-} // namespace IR
-} // namespace Service
+} // namespace Service::IR

--- a/src/core/hle/service/ir/ir.cpp
+++ b/src/core/hle/service/ir/ir.cpp
@@ -9,8 +9,7 @@
 #include "core/hle/service/ir/ir_user.h"
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace IR {
+namespace Service::IR {
 
 static std::weak_ptr<IR_RST> current_ir_rst;
 static std::weak_ptr<IR_USER> current_ir_user;
@@ -35,6 +34,4 @@ void InstallInterfaces(SM::ServiceManager& service_manager) {
     current_ir_rst = ir_rst;
 }
 
-} // namespace IR
-
-} // namespace Service
+} // namespace Service::IR

--- a/src/core/hle/service/ir/ir.h
+++ b/src/core/hle/service/ir/ir.h
@@ -8,13 +8,11 @@ namespace SM {
 class ServiceManager;
 }
 
-namespace Service {
-namespace IR {
+namespace Service::IR {
 
 /// Reload input devices. Used when input configuration changed
 void ReloadInputDevices();
 
 void InstallInterfaces(SM::ServiceManager& service_manager);
 
-} // namespace IR
-} // namespace Service
+} // namespace Service::IR

--- a/src/core/hle/service/ir/ir_rst.cpp
+++ b/src/core/hle/service/ir/ir_rst.cpp
@@ -11,8 +11,7 @@
 #include "core/movie.h"
 #include "core/settings.h"
 
-namespace Service {
-namespace IR {
+namespace Service::IR {
 
 struct PadDataEntry {
     PadState current_state;
@@ -174,5 +173,4 @@ void IR_RST::ReloadInputDevices() {
     is_device_reload_pending.store(true);
 }
 
-} // namespace IR
-} // namespace Service
+} // namespace Service::IR

--- a/src/core/hle/service/ir/ir_rst.h
+++ b/src/core/hle/service/ir/ir_rst.h
@@ -22,8 +22,7 @@ namespace CoreTiming {
 struct EventType;
 };
 
-namespace Service {
-namespace IR {
+namespace Service::IR {
 
 union PadState {
     u32_le hex{};
@@ -90,5 +89,4 @@ private:
     int update_period{0};
 };
 
-} // namespace IR
-} // namespace Service
+} // namespace Service::IR

--- a/src/core/hle/service/ir/ir_u.cpp
+++ b/src/core/hle/service/ir/ir_u.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/ir/ir_u.h"
 
-namespace Service {
-namespace IR {
+namespace Service::IR {
 
 IR_U::IR_U() : ServiceFramework("ir:u", 1) {
     static const FunctionInfo functions[] = {
@@ -31,5 +30,4 @@ IR_U::IR_U() : ServiceFramework("ir:u", 1) {
     RegisterHandlers(functions);
 }
 
-} // namespace IR
-} // namespace Service
+} // namespace Service::IR

--- a/src/core/hle/service/ir/ir_u.h
+++ b/src/core/hle/service/ir/ir_u.h
@@ -6,8 +6,7 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace IR {
+namespace Service::IR {
 
 /// Interface to "ir:u" service
 class IR_U final : public ServiceFramework<IR_U> {
@@ -15,5 +14,4 @@ public:
     IR_U();
 };
 
-} // namespace IR
-} // namespace Service
+} // namespace Service::IR

--- a/src/core/hle/service/ir/ir_user.cpp
+++ b/src/core/hle/service/ir/ir_user.cpp
@@ -12,8 +12,7 @@
 #include "core/hle/service/ir/extra_hid.h"
 #include "core/hle/service/ir/ir_user.h"
 
-namespace Service {
-namespace IR {
+namespace Service::IR {
 
 // This is a header that will present in the ir:USER shared memory if it is initialized with
 // InitializeIrNopShared service function. Otherwise the shared memory doesn't have this header if
@@ -439,5 +438,4 @@ void IRDevice::Send(const std::vector<u8>& data) {
     send_func(data);
 }
 
-} // namespace IR
-} // namespace Service
+} // namespace Service::IR

--- a/src/core/hle/service/ir/ir_user.h
+++ b/src/core/hle/service/ir/ir_user.h
@@ -18,8 +18,7 @@ namespace CoreTiming {
 struct EventType;
 };
 
-namespace Service {
-namespace IR {
+namespace Service::IR {
 
 class BufferManager;
 class ExtraHID;
@@ -174,5 +173,4 @@ private:
     std::unique_ptr<ExtraHID> extra_hid;
 };
 
-} // namespace IR
-} // namespace Service
+} // namespace Service::IR

--- a/src/core/hle/service/ldr_ro/cro_helper.cpp
+++ b/src/core/hle/service/ldr_ro/cro_helper.cpp
@@ -9,8 +9,7 @@
 #include "core/core.h"
 #include "core/hle/service/ldr_ro/cro_helper.h"
 
-namespace Service {
-namespace LDR {
+namespace Service::LDR {
 
 static const ResultCode ERROR_BUFFER_TOO_SMALL = // 0xE0E12C1F
     ResultCode(static_cast<ErrorDescription>(31), ErrorModule::RO, ErrorSummary::InvalidArgument,
@@ -1514,5 +1513,4 @@ std::tuple<VAddr, u32> CROHelper::GetExecutablePages() const {
     return std::make_tuple(0, 0);
 }
 
-} // namespace LDR
-} // namespace Service
+} // namespace Service::LDR

--- a/src/core/hle/service/ldr_ro/cro_helper.h
+++ b/src/core/hle/service/ldr_ro/cro_helper.h
@@ -11,8 +11,7 @@
 #include "core/hle/result.h"
 #include "core/memory.h"
 
-namespace Service {
-namespace LDR {
+namespace Service::LDR {
 
 // GCC versions < 5.0 do not implement std::is_trivially_copyable.
 // Excluding MSVC because it has weird behaviour for std::is_trivially_copyable.
@@ -711,5 +710,4 @@ private:
     ResultCode ApplyExitRelocations(VAddr crs_address);
 };
 
-} // namespace LDR
-} // namespace Service
+} // namespace Service::LDR

--- a/src/core/hle/service/ldr_ro/ldr_ro.cpp
+++ b/src/core/hle/service/ldr_ro/ldr_ro.cpp
@@ -12,8 +12,7 @@
 #include "core/hle/service/ldr_ro/cro_helper.h"
 #include "core/hle/service/ldr_ro/ldr_ro.h"
 
-namespace Service {
-namespace LDR {
+namespace Service::LDR {
 
 static const ResultCode ERROR_ALREADY_INITIALIZED = // 0xD9612FF9
     ResultCode(ErrorDescription::AlreadyInitialized, ErrorModule::RO, ErrorSummary::Internal,
@@ -591,5 +590,4 @@ void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<RO>()->InstallAsService(service_manager);
 }
 
-} // namespace LDR
-} // namespace Service
+} // namespace Service::LDR

--- a/src/core/hle/service/ldr_ro/ldr_ro.h
+++ b/src/core/hle/service/ldr_ro/ldr_ro.h
@@ -7,8 +7,7 @@
 #include "core/hle/service/ldr_ro/memory_synchronizer.h"
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace LDR {
+namespace Service::LDR {
 
 struct ClientSlot : public Kernel::SessionRequestHandler::SessionDataBase {
     MemorySynchronizer memory_synchronizer;
@@ -152,5 +151,4 @@ private:
 
 void InstallInterfaces(SM::ServiceManager& service_manager);
 
-} // namespace LDR
-} // namespace Service
+} // namespace Service::LDR

--- a/src/core/hle/service/ldr_ro/memory_synchronizer.cpp
+++ b/src/core/hle/service/ldr_ro/memory_synchronizer.cpp
@@ -7,8 +7,7 @@
 #include "core/hle/kernel/process.h"
 #include "core/hle/service/ldr_ro/memory_synchronizer.h"
 
-namespace Service {
-namespace LDR {
+namespace Service::LDR {
 
 auto MemorySynchronizer::FindMemoryBlock(VAddr mapping, VAddr original) {
     auto block = std::find_if(memory_blocks.begin(), memory_blocks.end(),
@@ -39,5 +38,4 @@ void MemorySynchronizer::SynchronizeOriginalMemory(Kernel::Process& process) {
     }
 }
 
-} // namespace LDR
-} // namespace Service
+} // namespace Service::LDR

--- a/src/core/hle/service/ldr_ro/memory_synchronizer.h
+++ b/src/core/hle/service/ldr_ro/memory_synchronizer.h
@@ -11,8 +11,7 @@ namespace Kernel {
 class Process;
 }
 
-namespace Service {
-namespace LDR {
+namespace Service::LDR {
 
 /**
  * This is a work-around before we implement memory aliasing.
@@ -42,5 +41,4 @@ private:
     auto FindMemoryBlock(VAddr mapping, VAddr original);
 };
 
-} // namespace LDR
-} // namespace Service
+} // namespace Service::LDR

--- a/src/core/hle/service/mic_u.cpp
+++ b/src/core/hle/service/mic_u.cpp
@@ -11,8 +11,7 @@
 #include "core/hle/kernel/shared_memory.h"
 #include "core/hle/service/mic_u.h"
 
-namespace Service {
-namespace MIC {
+namespace Service::MIC {
 
 enum class Encoding : u8 {
     PCM8 = 0,
@@ -295,5 +294,4 @@ void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<MIC_U>()->InstallAsService(service_manager);
 }
 
-} // namespace MIC
-} // namespace Service
+} // namespace Service::MIC

--- a/src/core/hle/service/mic_u.h
+++ b/src/core/hle/service/mic_u.h
@@ -8,8 +8,7 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace MIC {
+namespace Service::MIC {
 
 class MIC_U final : public ServiceFramework<MIC_U> {
 public:
@@ -189,5 +188,4 @@ private:
 
 void InstallInterfaces(SM::ServiceManager& service_manager);
 
-} // namespace MIC
-} // namespace Service
+} // namespace Service::MIC

--- a/src/core/hle/service/mvd/mvd.cpp
+++ b/src/core/hle/service/mvd/mvd.cpp
@@ -5,12 +5,10 @@
 #include "core/hle/service/mvd/mvd.h"
 #include "core/hle/service/mvd/mvd_std.h"
 
-namespace Service {
-namespace MVD {
+namespace Service::MVD {
 
 void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<MVD_STD>()->InstallAsService(service_manager);
 }
 
-} // namespace MVD
-} // namespace Service
+} // namespace Service::MVD

--- a/src/core/hle/service/mvd/mvd.h
+++ b/src/core/hle/service/mvd/mvd.h
@@ -6,11 +6,9 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace MVD {
+namespace Service::MVD {
 
 /// Initializes all MVD services.
 void InstallInterfaces(SM::ServiceManager& service_manager);
 
-} // namespace MVD
-} // namespace Service
+} // namespace Service::MVD

--- a/src/core/hle/service/mvd/mvd_std.cpp
+++ b/src/core/hle/service/mvd/mvd_std.cpp
@@ -5,8 +5,7 @@
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/service/mvd/mvd_std.h"
 
-namespace Service {
-namespace MVD {
+namespace Service::MVD {
 
 MVD_STD::MVD_STD() : ServiceFramework("mvd:std", 1) {
     static const FunctionInfo functions[] = {
@@ -29,5 +28,4 @@ MVD_STD::MVD_STD() : ServiceFramework("mvd:std", 1) {
     RegisterHandlers(functions);
 };
 
-} // namespace MVD
-} // namespace Service
+} // namespace Service::MVD

--- a/src/core/hle/service/mvd/mvd_std.h
+++ b/src/core/hle/service/mvd/mvd_std.h
@@ -6,8 +6,7 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace MVD {
+namespace Service::MVD {
 
 class MVD_STD final : public ServiceFramework<MVD_STD> {
 public:
@@ -15,5 +14,4 @@ public:
     ~MVD_STD() = default;
 };
 
-} // namespace MVD
-} // namespace Service
+} // namespace Service::MVD

--- a/src/core/hle/service/ndm/ndm_u.cpp
+++ b/src/core/hle/service/ndm/ndm_u.cpp
@@ -5,8 +5,7 @@
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/service/ndm/ndm_u.h"
 
-namespace Service {
-namespace NDM {
+namespace Service::NDM {
 
 void NDM_U::EnterExclusiveState(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x01, 1, 2);
@@ -241,5 +240,4 @@ void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<NDM_U>()->InstallAsService(service_manager);
 }
 
-} // namespace NDM
-} // namespace Service
+} // namespace Service::NDM

--- a/src/core/hle/service/ndm/ndm_u.h
+++ b/src/core/hle/service/ndm/ndm_u.h
@@ -7,8 +7,7 @@
 #include <array>
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace NDM {
+namespace Service::NDM {
 
 class NDM_U final : public ServiceFramework<NDM_U> {
 public:
@@ -271,5 +270,4 @@ private:
 
 void InstallInterfaces(SM::ServiceManager& service_manager);
 
-} // namespace NDM
-} // namespace Service
+} // namespace Service::NDM

--- a/src/core/hle/service/news/news.cpp
+++ b/src/core/hle/service/news/news.cpp
@@ -7,14 +7,11 @@
 #include "core/hle/service/news/news_u.h"
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace NEWS {
+namespace Service::NEWS {
 
 void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<NEWS_S>()->InstallAsService(service_manager);
     std::make_shared<NEWS_U>()->InstallAsService(service_manager);
 }
 
-} // namespace NEWS
-
-} // namespace Service
+} // namespace Service::NEWS

--- a/src/core/hle/service/news/news.h
+++ b/src/core/hle/service/news/news.h
@@ -4,10 +4,8 @@
 
 #pragma once
 
-namespace Service {
-namespace NEWS {
+namespace Service::NEWS {
 
 void InstallInterfaces(SM::ServiceManager& service_manager);
 
-} // namespace NEWS
-} // namespace Service
+} // namespace Service::NEWS

--- a/src/core/hle/service/news/news_s.cpp
+++ b/src/core/hle/service/news/news_s.cpp
@@ -5,8 +5,7 @@
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/service/news/news_s.h"
 
-namespace Service {
-namespace NEWS {
+namespace Service::NEWS {
 
 void NEWS_S::GetTotalNotifications(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x5, 0, 0);
@@ -38,5 +37,4 @@ NEWS_S::NEWS_S() : ServiceFramework("news:s", 2) {
     RegisterHandlers(functions);
 }
 
-} // namespace NEWS
-} // namespace Service
+} // namespace Service::NEWS

--- a/src/core/hle/service/news/news_s.h
+++ b/src/core/hle/service/news/news_s.h
@@ -7,8 +7,7 @@
 #include <memory>
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace NEWS {
+namespace Service::NEWS {
 
 class NEWS_S final : public ServiceFramework<NEWS_S> {
 public:
@@ -27,5 +26,4 @@ private:
     void GetTotalNotifications(Kernel::HLERequestContext& ctx);
 };
 
-} // namespace NEWS
-} // namespace Service
+} // namespace Service::NEWS

--- a/src/core/hle/service/news/news_u.cpp
+++ b/src/core/hle/service/news/news_u.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/news/news_u.h"
 
-namespace Service {
-namespace NEWS {
+namespace Service::NEWS {
 
 NEWS_U::NEWS_U() : ServiceFramework("news:u", 1) {
     const FunctionInfo functions[] = {
@@ -14,5 +13,4 @@ NEWS_U::NEWS_U() : ServiceFramework("news:u", 1) {
     RegisterHandlers(functions);
 }
 
-} // namespace NEWS
-} // namespace Service
+} // namespace Service::NEWS

--- a/src/core/hle/service/news/news_u.h
+++ b/src/core/hle/service/news/news_u.h
@@ -7,13 +7,11 @@
 #include <memory>
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace NEWS {
+namespace Service::NEWS {
 
 class NEWS_U final : public ServiceFramework<NEWS_U> {
 public:
     NEWS_U();
 };
 
-} // namespace NEWS
-} // namespace Service
+} // namespace Service::NEWS

--- a/src/core/hle/service/nfc/nfc.cpp
+++ b/src/core/hle/service/nfc/nfc.cpp
@@ -8,8 +8,7 @@
 #include "core/hle/service/nfc/nfc_m.h"
 #include "core/hle/service/nfc/nfc_u.h"
 
-namespace Service {
-namespace NFC {
+namespace Service::NFC {
 
 void Module::Interface::Initialize(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x01, 1, 0);
@@ -155,5 +154,4 @@ void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<NFC_U>(nfc)->InstallAsService(service_manager);
 }
 
-} // namespace NFC
-} // namespace Service
+} // namespace Service::NFC

--- a/src/core/hle/service/nfc/nfc.h
+++ b/src/core/hle/service/nfc/nfc.h
@@ -13,8 +13,7 @@ namespace Kernel {
 class Event;
 } // namespace Kernel
 
-namespace Service {
-namespace NFC {
+namespace Service::NFC {
 
 namespace ErrCodes {
 enum {
@@ -177,5 +176,4 @@ private:
 
 void InstallInterfaces(SM::ServiceManager& service_manager);
 
-} // namespace NFC
-} // namespace Service
+} // namespace Service::NFC

--- a/src/core/hle/service/nfc/nfc_m.cpp
+++ b/src/core/hle/service/nfc/nfc_m.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/nfc/nfc_m.h"
 
-namespace Service {
-namespace NFC {
+namespace Service::NFC {
 
 NFC_M::NFC_M(std::shared_ptr<Module> nfc) : Module::Interface(std::move(nfc), "nfc:m", 1) {
     static const FunctionInfo functions[] = {
@@ -41,5 +40,4 @@ NFC_M::NFC_M(std::shared_ptr<Module> nfc) : Module::Interface(std::move(nfc), "n
     RegisterHandlers(functions);
 }
 
-} // namespace NFC
-} // namespace Service
+} // namespace Service::NFC

--- a/src/core/hle/service/nfc/nfc_m.h
+++ b/src/core/hle/service/nfc/nfc_m.h
@@ -6,13 +6,11 @@
 
 #include "core/hle/service/nfc/nfc.h"
 
-namespace Service {
-namespace NFC {
+namespace Service::NFC {
 
 class NFC_M final : public Module::Interface {
 public:
     explicit NFC_M(std::shared_ptr<Module> nfc);
 };
 
-} // namespace NFC
-} // namespace Service
+} // namespace Service::NFC

--- a/src/core/hle/service/nfc/nfc_u.cpp
+++ b/src/core/hle/service/nfc/nfc_u.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/nfc/nfc_u.h"
 
-namespace Service {
-namespace NFC {
+namespace Service::NFC {
 
 NFC_U::NFC_U(std::shared_ptr<Module> nfc) : Module::Interface(std::move(nfc), "nfc:u", 1) {
     static const FunctionInfo functions[] = {
@@ -38,5 +37,4 @@ NFC_U::NFC_U(std::shared_ptr<Module> nfc) : Module::Interface(std::move(nfc), "n
     RegisterHandlers(functions);
 }
 
-} // namespace NFC
-} // namespace Service
+} // namespace Service::NFC

--- a/src/core/hle/service/nfc/nfc_u.h
+++ b/src/core/hle/service/nfc/nfc_u.h
@@ -6,13 +6,11 @@
 
 #include "core/hle/service/nfc/nfc.h"
 
-namespace Service {
-namespace NFC {
+namespace Service::NFC {
 
 class NFC_U final : public Module::Interface {
 public:
     explicit NFC_U(std::shared_ptr<Module> nfc);
 };
 
-} // namespace NFC
-} // namespace Service
+} // namespace Service::NFC

--- a/src/core/hle/service/nim/nim.cpp
+++ b/src/core/hle/service/nim/nim.cpp
@@ -7,8 +7,7 @@
 #include "core/hle/service/nim/nim_s.h"
 #include "core/hle/service/nim/nim_u.h"
 
-namespace Service {
-namespace NIM {
+namespace Service::NIM {
 
 void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<NIM_AOC>()->InstallAsService(service_manager);
@@ -16,6 +15,4 @@ void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<NIM_U>()->InstallAsService(service_manager);
 }
 
-} // namespace NIM
-
-} // namespace Service
+} // namespace Service::NIM

--- a/src/core/hle/service/nim/nim.h
+++ b/src/core/hle/service/nim/nim.h
@@ -6,10 +6,8 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace NIM {
+namespace Service::NIM {
 
 void InstallInterfaces(SM::ServiceManager& service_manager);
 
-} // namespace NIM
-} // namespace Service
+} // namespace Service::NIM

--- a/src/core/hle/service/nim/nim_aoc.cpp
+++ b/src/core/hle/service/nim/nim_aoc.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/nim/nim_aoc.h"
 
-namespace Service {
-namespace NIM {
+namespace Service::NIM {
 
 NIM_AOC::NIM_AOC() : ServiceFramework("nim:aoc", 2) {
     const FunctionInfo functions[] = {
@@ -23,5 +22,4 @@ NIM_AOC::NIM_AOC() : ServiceFramework("nim:aoc", 2) {
 
 NIM_AOC::~NIM_AOC() = default;
 
-} // namespace NIM
-} // namespace Service
+} // namespace Service::NIM

--- a/src/core/hle/service/nim/nim_aoc.h
+++ b/src/core/hle/service/nim/nim_aoc.h
@@ -6,8 +6,7 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace NIM {
+namespace Service::NIM {
 
 class NIM_AOC final : public ServiceFramework<NIM_AOC> {
 public:
@@ -15,5 +14,4 @@ public:
     ~NIM_AOC();
 };
 
-} // namespace NIM
-} // namespace Service
+} // namespace Service::NIM

--- a/src/core/hle/service/nim/nim_s.cpp
+++ b/src/core/hle/service/nim/nim_s.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/nim/nim_s.h"
 
-namespace Service {
-namespace NIM {
+namespace Service::NIM {
 
 NIM_S::NIM_S() : ServiceFramework("nim:s", 1) {
     const FunctionInfo functions[] = {
@@ -20,5 +19,4 @@ NIM_S::NIM_S() : ServiceFramework("nim:s", 1) {
 
 NIM_S::~NIM_S() = default;
 
-} // namespace NIM
-} // namespace Service
+} // namespace Service::NIM

--- a/src/core/hle/service/nim/nim_s.h
+++ b/src/core/hle/service/nim/nim_s.h
@@ -6,8 +6,7 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace NIM {
+namespace Service::NIM {
 
 class NIM_S final : public ServiceFramework<NIM_S> {
 public:
@@ -15,5 +14,4 @@ public:
     ~NIM_S();
 };
 
-} // namespace NIM
-} // namespace Service
+} // namespace Service::NIM

--- a/src/core/hle/service/nim/nim_u.cpp
+++ b/src/core/hle/service/nim/nim_u.cpp
@@ -6,8 +6,7 @@
 #include "core/hle/kernel/event.h"
 #include "core/hle/service/nim/nim_u.h"
 
-namespace Service {
-namespace NIM {
+namespace Service::NIM {
 
 NIM_U::NIM_U() : ServiceFramework("nim:u", 2) {
     const FunctionInfo functions[] = {
@@ -44,5 +43,4 @@ void NIM_U::CheckSysUpdateAvailable(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service_NIM, "(STUBBED) called");
 }
 
-} // namespace NIM
-} // namespace Service
+} // namespace Service::NIM

--- a/src/core/hle/service/nim/nim_u.h
+++ b/src/core/hle/service/nim/nim_u.h
@@ -6,8 +6,7 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace NIM {
+namespace Service::NIM {
 
 class NIM_U final : public ServiceFramework<NIM_U> {
 public:
@@ -39,5 +38,4 @@ private:
     Kernel::SharedPtr<Kernel::Event> nim_system_update_event;
 };
 
-} // namespace NIM
-} // namespace Service
+} // namespace Service::NIM

--- a/src/core/hle/service/ns/ns.cpp
+++ b/src/core/hle/service/ns/ns.cpp
@@ -8,8 +8,7 @@
 #include "core/hle/service/ns/ns_s.h"
 #include "core/loader/loader.h"
 
-namespace Service {
-namespace NS {
+namespace Service::NS {
 
 Kernel::SharedPtr<Kernel::Process> LaunchTitle(FS::MediaType media_type, u64 title_id) {
     std::string path = AM::GetTitleContentPath(media_type, title_id);
@@ -35,5 +34,4 @@ void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<NS_S>()->InstallAsService(service_manager);
 }
 
-} // namespace NS
-} // namespace Service
+} // namespace Service::NS

--- a/src/core/hle/service/ns/ns.h
+++ b/src/core/hle/service/ns/ns.h
@@ -8,8 +8,7 @@
 #include "core/hle/service/fs/archive.h"
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace NS {
+namespace Service::NS {
 
 /// Loads and launches the title identified by title_id in the specified media type.
 Kernel::SharedPtr<Kernel::Process> LaunchTitle(FS::MediaType media_type, u64 title_id);
@@ -17,5 +16,4 @@ Kernel::SharedPtr<Kernel::Process> LaunchTitle(FS::MediaType media_type, u64 tit
 /// Registers all NS services with the specified service manager.
 void InstallInterfaces(SM::ServiceManager& service_manager);
 
-} // namespace NS
-} // namespace Service
+} // namespace Service::NS

--- a/src/core/hle/service/ns/ns_s.cpp
+++ b/src/core/hle/service/ns/ns_s.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/ns/ns_s.h"
 
-namespace Service {
-namespace NS {
+namespace Service::NS {
 
 NS_S::NS_S() : ServiceFramework("ns:s", 2) {
     static const FunctionInfo functions[] = {
@@ -30,5 +29,4 @@ NS_S::NS_S() : ServiceFramework("ns:s", 2) {
 
 NS_S::~NS_S() = default;
 
-} // namespace NS
-} // namespace Service
+} // namespace Service::NS

--- a/src/core/hle/service/ns/ns_s.h
+++ b/src/core/hle/service/ns/ns_s.h
@@ -7,8 +7,7 @@
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace NS {
+namespace Service::NS {
 
 /// Interface to "ns:s" service
 class NS_S final : public ServiceFramework<NS_S> {
@@ -17,5 +16,4 @@ public:
     ~NS_S();
 };
 
-} // namespace NS
-} // namespace Service
+} // namespace Service::NS

--- a/src/core/hle/service/nwm/nwm.cpp
+++ b/src/core/hle/service/nwm/nwm.cpp
@@ -11,8 +11,7 @@
 #include "core/hle/service/nwm/nwm_tst.h"
 #include "core/hle/service/nwm/nwm_uds.h"
 
-namespace Service {
-namespace NWM {
+namespace Service::NWM {
 
 void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<NWM_CEC>()->InstallAsService(service_manager);
@@ -24,5 +23,4 @@ void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<NWM_UDS>()->InstallAsService(service_manager);
 }
 
-} // namespace NWM
-} // namespace Service
+} // namespace Service::NWM

--- a/src/core/hle/service/nwm/nwm.h
+++ b/src/core/hle/service/nwm/nwm.h
@@ -6,11 +6,9 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace NWM {
+namespace Service::NWM {
 
 /// Initialize all NWM services
 void InstallInterfaces(SM::ServiceManager& service_manager);
 
-} // namespace NWM
-} // namespace Service
+} // namespace Service::NWM

--- a/src/core/hle/service/nwm/nwm_cec.cpp
+++ b/src/core/hle/service/nwm/nwm_cec.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/nwm/nwm_cec.h"
 
-namespace Service {
-namespace NWM {
+namespace Service::NWM {
 
 NWM_CEC::NWM_CEC() : ServiceFramework("nwm::CEC") {
     static const FunctionInfo functions[] = {
@@ -14,5 +13,4 @@ NWM_CEC::NWM_CEC() : ServiceFramework("nwm::CEC") {
     RegisterHandlers(functions);
 }
 
-} // namespace NWM
-} // namespace Service
+} // namespace Service::NWM

--- a/src/core/hle/service/nwm/nwm_cec.h
+++ b/src/core/hle/service/nwm/nwm_cec.h
@@ -6,13 +6,11 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace NWM {
+namespace Service::NWM {
 
 class NWM_CEC final : public ServiceFramework<NWM_CEC> {
 public:
     NWM_CEC();
 };
 
-} // namespace NWM
-} // namespace Service
+} // namespace Service::NWM

--- a/src/core/hle/service/nwm/nwm_ext.cpp
+++ b/src/core/hle/service/nwm/nwm_ext.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/nwm/nwm_ext.h"
 
-namespace Service {
-namespace NWM {
+namespace Service::NWM {
 
 NWM_EXT::NWM_EXT() : ServiceFramework("nwm::EXT") {
     static const FunctionInfo functions[] = {
@@ -14,5 +13,4 @@ NWM_EXT::NWM_EXT() : ServiceFramework("nwm::EXT") {
     RegisterHandlers(functions);
 }
 
-} // namespace NWM
-} // namespace Service
+} // namespace Service::NWM

--- a/src/core/hle/service/nwm/nwm_ext.h
+++ b/src/core/hle/service/nwm/nwm_ext.h
@@ -6,13 +6,11 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace NWM {
+namespace Service::NWM {
 
 class NWM_EXT final : public ServiceFramework<NWM_EXT> {
 public:
     NWM_EXT();
 };
 
-} // namespace NWM
-} // namespace Service
+} // namespace Service::NWM

--- a/src/core/hle/service/nwm/nwm_inf.cpp
+++ b/src/core/hle/service/nwm/nwm_inf.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/nwm/nwm_inf.h"
 
-namespace Service {
-namespace NWM {
+namespace Service::NWM {
 
 NWM_INF::NWM_INF() : ServiceFramework("nwm::INF") {
     static const FunctionInfo functions[] = {
@@ -16,5 +15,4 @@ NWM_INF::NWM_INF() : ServiceFramework("nwm::INF") {
     RegisterHandlers(functions);
 }
 
-} // namespace NWM
-} // namespace Service
+} // namespace Service::NWM

--- a/src/core/hle/service/nwm/nwm_inf.h
+++ b/src/core/hle/service/nwm/nwm_inf.h
@@ -6,13 +6,11 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace NWM {
+namespace Service::NWM {
 
 class NWM_INF final : public ServiceFramework<NWM_INF> {
 public:
     NWM_INF();
 };
 
-} // namespace NWM
-} // namespace Service
+} // namespace Service::NWM

--- a/src/core/hle/service/nwm/nwm_sap.cpp
+++ b/src/core/hle/service/nwm/nwm_sap.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/nwm/nwm_sap.h"
 
-namespace Service {
-namespace NWM {
+namespace Service::NWM {
 
 NWM_SAP::NWM_SAP() : ServiceFramework("nwm::SAP") {
     /*
@@ -15,5 +14,4 @@ NWM_SAP::NWM_SAP() : ServiceFramework("nwm::SAP") {
     */
 }
 
-} // namespace NWM
-} // namespace Service
+} // namespace Service::NWM

--- a/src/core/hle/service/nwm/nwm_sap.h
+++ b/src/core/hle/service/nwm/nwm_sap.h
@@ -6,13 +6,11 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace NWM {
+namespace Service::NWM {
 
 class NWM_SAP final : public ServiceFramework<NWM_SAP> {
 public:
     NWM_SAP();
 };
 
-} // namespace NWM
-} // namespace Service
+} // namespace Service::NWM

--- a/src/core/hle/service/nwm/nwm_soc.cpp
+++ b/src/core/hle/service/nwm/nwm_soc.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/nwm/nwm_soc.h"
 
-namespace Service {
-namespace NWM {
+namespace Service::NWM {
 
 NWM_SOC::NWM_SOC() : ServiceFramework("nwm::SOC") {
     /*
@@ -15,5 +14,4 @@ NWM_SOC::NWM_SOC() : ServiceFramework("nwm::SOC") {
     */
 }
 
-} // namespace NWM
-} // namespace Service
+} // namespace Service::NWM

--- a/src/core/hle/service/nwm/nwm_soc.h
+++ b/src/core/hle/service/nwm/nwm_soc.h
@@ -6,13 +6,11 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace NWM {
+namespace Service::NWM {
 
 class NWM_SOC final : public ServiceFramework<NWM_SOC> {
 public:
     NWM_SOC();
 };
 
-} // namespace NWM
-} // namespace Service
+} // namespace Service::NWM

--- a/src/core/hle/service/nwm/nwm_tst.cpp
+++ b/src/core/hle/service/nwm/nwm_tst.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/nwm/nwm_tst.h"
 
-namespace Service {
-namespace NWM {
+namespace Service::NWM {
 
 NWM_TST::NWM_TST() : ServiceFramework("nwm::TST") {
     /*
@@ -15,5 +14,4 @@ NWM_TST::NWM_TST() : ServiceFramework("nwm::TST") {
     */
 }
 
-} // namespace NWM
-} // namespace Service
+} // namespace Service::NWM

--- a/src/core/hle/service/nwm/nwm_tst.h
+++ b/src/core/hle/service/nwm/nwm_tst.h
@@ -6,13 +6,11 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace NWM {
+namespace Service::NWM {
 
 class NWM_TST final : public ServiceFramework<NWM_TST> {
 public:
     NWM_TST();
 };
 
-} // namespace NWM
-} // namespace Service
+} // namespace Service::NWM

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -28,8 +28,7 @@
 #include "core/memory.h"
 #include "network/network.h"
 
-namespace Service {
-namespace NWM {
+namespace Service::NWM {
 
 namespace ErrCodes {
 enum {
@@ -1359,5 +1358,4 @@ NWM_UDS::~NWM_UDS() {
     CoreTiming::UnscheduleEvent(beacon_broadcast_event, 0);
 }
 
-} // namespace NWM
-} // namespace Service
+} // namespace Service::NWM

--- a/src/core/hle/service/nwm/nwm_uds.h
+++ b/src/core/hle/service/nwm/nwm_uds.h
@@ -13,8 +13,7 @@
 
 // Local-WLAN service
 
-namespace Service {
-namespace NWM {
+namespace Service::NWM {
 
 const std::size_t ApplicationDataSize = 0xC8;
 const u8 DefaultNetworkChannel = 11;
@@ -343,5 +342,4 @@ private:
     void DecryptBeaconData(Kernel::HLERequestContext& ctx);
 };
 
-} // namespace NWM
-} // namespace Service
+} // namespace Service::NWM

--- a/src/core/hle/service/nwm/uds_beacon.cpp
+++ b/src/core/hle/service/nwm/uds_beacon.cpp
@@ -13,8 +13,7 @@
 #include "core/hle/service/nwm/nwm_uds.h"
 #include "core/hle/service/nwm/uds_beacon.h"
 
-namespace Service {
-namespace NWM {
+namespace Service::NWM {
 
 // 802.11 broadcast MAC address
 constexpr MacAddress BroadcastMac = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
@@ -328,5 +327,4 @@ std::vector<u8> GenerateBeaconFrame(const NetworkInfo& network_info, const NodeL
     return buffer;
 }
 
-} // namespace NWM
-} // namespace Service
+} // namespace Service::NWM

--- a/src/core/hle/service/nwm/uds_beacon.h
+++ b/src/core/hle/service/nwm/uds_beacon.h
@@ -11,8 +11,7 @@
 #include "common/swap.h"
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace NWM {
+namespace Service::NWM {
 
 using MacAddress = std::array<u8, 6>;
 constexpr std::array<u8, 3> NintendoOUI = {0x00, 0x1F, 0x32};
@@ -136,5 +135,4 @@ void DecryptBeacon(const NetworkInfo& network_info, std::vector<u8>& buffer);
  */
 std::vector<u8> GenerateBeaconFrame(const NetworkInfo& network_info, const NodeList& nodes);
 
-} // namespace NWM
-} // namespace Service
+} // namespace Service::NWM

--- a/src/core/hle/service/nwm/uds_connection.cpp
+++ b/src/core/hle/service/nwm/uds_connection.cpp
@@ -6,8 +6,7 @@
 #include "core/hle/service/nwm/uds_connection.h"
 #include "fmt/format.h"
 
-namespace Service {
-namespace NWM {
+namespace Service::NWM {
 
 // Note: These values were taken from a packet capture of an o3DS XL
 // broadcasting a Super Smash Bros. 4 lobby.
@@ -84,5 +83,4 @@ std::tuple<AssocStatus, u16> GetAssociationResult(const std::vector<u8>& body) {
                            frame.assoc_id & AssociationIdMask);
 }
 
-} // namespace NWM
-} // namespace Service
+} // namespace Service::NWM

--- a/src/core/hle/service/nwm/uds_connection.h
+++ b/src/core/hle/service/nwm/uds_connection.h
@@ -10,8 +10,7 @@
 #include "common/swap.h"
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace NWM {
+namespace Service::NWM {
 
 /// Sequence number of the 802.11 authentication frames.
 enum class AuthenticationSeq : u16 { SEQ1 = 1, SEQ2 = 2 };
@@ -52,5 +51,4 @@ std::vector<u8> GenerateAssocResponseFrame(AssocStatus status, u16 association_i
 /// frame.
 std::tuple<AssocStatus, u16> GetAssociationResult(const std::vector<u8>& body);
 
-} // namespace NWM
-} // namespace Service
+} // namespace Service::NWM

--- a/src/core/hle/service/nwm/uds_data.cpp
+++ b/src/core/hle/service/nwm/uds_data.cpp
@@ -15,8 +15,7 @@
 #include "core/hle/service/nwm/uds_data.h"
 #include "core/hw/aes/key.h"
 
-namespace Service {
-namespace NWM {
+namespace Service::NWM {
 
 using MacAddress = std::array<u8, 6>;
 
@@ -383,5 +382,4 @@ EAPoLLogoffPacket ParseEAPoLLogoffFrame(const std::vector<u8>& frame) {
     return eapol_logoff;
 }
 
-} // namespace NWM
-} // namespace Service
+} // namespace Service::NWM

--- a/src/core/hle/service/nwm/uds_data.h
+++ b/src/core/hle/service/nwm/uds_data.h
@@ -11,8 +11,7 @@
 #include "core/hle/service/nwm/uds_beacon.h"
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace NWM {
+namespace Service::NWM {
 
 enum class SAP : u8 { SNAPExtensionUsed = 0xAA };
 
@@ -169,5 +168,4 @@ std::vector<u8> GenerateEAPoLLogoffFrame(const MacAddress& mac_address, u16 netw
  */
 EAPoLLogoffPacket ParseEAPoLLogoffFrame(const std::vector<u8>& frame);
 
-} // namespace NWM
-} // namespace Service
+} // namespace Service::NWM

--- a/src/core/hle/service/pm/pm.cpp
+++ b/src/core/hle/service/pm/pm.cpp
@@ -6,13 +6,11 @@
 #include "core/hle/service/pm/pm_app.h"
 #include "core/hle/service/pm/pm_dbg.h"
 
-namespace Service {
-namespace PM {
+namespace Service::PM {
 
 void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<PM_APP>()->InstallAsService(service_manager);
     std::make_shared<PM_DBG>()->InstallAsService(service_manager);
 }
 
-} // namespace PM
-} // namespace Service
+} // namespace Service::PM

--- a/src/core/hle/service/pm/pm.h
+++ b/src/core/hle/service/pm/pm.h
@@ -6,11 +6,9 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace PM {
+namespace Service::PM {
 
 /// Initializes the PM services.
 void InstallInterfaces(SM::ServiceManager& service_manager);
 
-} // namespace PM
-} // namespace Service
+} // namespace Service::PM

--- a/src/core/hle/service/pm/pm_app.cpp
+++ b/src/core/hle/service/pm/pm_app.cpp
@@ -5,8 +5,7 @@
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/service/pm/pm_app.h"
 
-namespace Service {
-namespace PM {
+namespace Service::PM {
 
 PM_APP::PM_APP() : ServiceFramework("pm:app", 3) {
     static const FunctionInfo functions[] = {
@@ -30,5 +29,4 @@ PM_APP::PM_APP() : ServiceFramework("pm:app", 3) {
     RegisterHandlers(functions);
 }
 
-} // namespace PM
-} // namespace Service
+} // namespace Service::PM

--- a/src/core/hle/service/pm/pm_app.h
+++ b/src/core/hle/service/pm/pm_app.h
@@ -6,8 +6,7 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace PM {
+namespace Service::PM {
 
 class PM_APP final : public ServiceFramework<PM_APP> {
 public:
@@ -15,5 +14,4 @@ public:
     ~PM_APP() = default;
 };
 
-} // namespace PM
-} // namespace Service
+} // namespace Service::PM

--- a/src/core/hle/service/pm/pm_dbg.cpp
+++ b/src/core/hle/service/pm/pm_dbg.cpp
@@ -5,8 +5,7 @@
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/service/pm/pm_dbg.h"
 
-namespace Service {
-namespace PM {
+namespace Service::PM {
 
 PM_DBG::PM_DBG() : ServiceFramework("pm:dbg", 3) {
     static const FunctionInfo functions[] = {
@@ -20,5 +19,4 @@ PM_DBG::PM_DBG() : ServiceFramework("pm:dbg", 3) {
     RegisterHandlers(functions);
 }
 
-} // namespace PM
-} // namespace Service
+} // namespace Service::PM

--- a/src/core/hle/service/pm/pm_dbg.h
+++ b/src/core/hle/service/pm/pm_dbg.h
@@ -6,8 +6,7 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace PM {
+namespace Service::PM {
 
 class PM_DBG final : public ServiceFramework<PM_DBG> {
 public:
@@ -15,5 +14,4 @@ public:
     ~PM_DBG() = default;
 };
 
-} // namespace PM
-} // namespace Service
+} // namespace Service::PM

--- a/src/core/hle/service/ps/ps_ps.cpp
+++ b/src/core/hle/service/ps/ps_ps.cpp
@@ -5,8 +5,7 @@
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/service/ps/ps_ps.h"
 
-namespace Service {
-namespace PS {
+namespace Service::PS {
 
 PS_PS::PS_PS() : ServiceFramework("ps:ps", DefaultMaxSessions) {
     static const FunctionInfo functions[] = {
@@ -37,5 +36,4 @@ void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<PS_PS>()->InstallAsService(service_manager);
 }
 
-} // namespace PS
-} // namespace Service
+} // namespace Service::PS

--- a/src/core/hle/service/ps/ps_ps.h
+++ b/src/core/hle/service/ps/ps_ps.h
@@ -6,8 +6,7 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace PS {
+namespace Service::PS {
 
 class PS_PS final : public ServiceFramework<PS_PS> {
 public:
@@ -227,5 +226,4 @@ private:
 /// Initializes the PS_PS Service
 void InstallInterfaces(SM::ServiceManager& service_manager);
 
-} // namespace PS
-} // namespace Service
+} // namespace Service::PS

--- a/src/core/hle/service/ptm/ptm.cpp
+++ b/src/core/hle/service/ptm/ptm.cpp
@@ -15,8 +15,7 @@
 #include "core/hle/service/ptm/ptm_u.h"
 #include "core/settings.h"
 
-namespace Service {
-namespace PTM {
+namespace Service::PTM {
 
 /// Values for the default gamecoin.dat file
 static const GameCoin default_game_coin = {0x4F00, 42, 0, 0, 0, 2014, 12, 29};
@@ -181,5 +180,4 @@ void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<PTM_U>(ptm)->InstallAsService(service_manager);
 }
 
-} // namespace PTM
-} // namespace Service
+} // namespace Service::PTM

--- a/src/core/hle/service/ptm/ptm.h
+++ b/src/core/hle/service/ptm/ptm.h
@@ -9,8 +9,7 @@
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace PTM {
+namespace Service::PTM {
 
 /// Charge levels used by PTM functions
 enum class ChargeLevels : u32 {
@@ -141,5 +140,4 @@ private:
 
 void InstallInterfaces(SM::ServiceManager& service_manager);
 
-} // namespace PTM
-} // namespace Service
+} // namespace Service::PTM

--- a/src/core/hle/service/ptm/ptm_gets.cpp
+++ b/src/core/hle/service/ptm/ptm_gets.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/ptm/ptm_gets.h"
 
-namespace Service {
-namespace PTM {
+namespace Service::PTM {
 
 PTM_Gets::PTM_Gets(std::shared_ptr<Module> ptm)
     : Module::Interface(std::move(ptm), "ptm:gets", 26) {
@@ -32,5 +31,4 @@ PTM_Gets::PTM_Gets(std::shared_ptr<Module> ptm)
     RegisterHandlers(functions);
 }
 
-} // namespace PTM
-} // namespace Service
+} // namespace Service::PTM

--- a/src/core/hle/service/ptm/ptm_gets.h
+++ b/src/core/hle/service/ptm/ptm_gets.h
@@ -7,13 +7,11 @@
 #include <memory>
 #include "core/hle/service/ptm/ptm.h"
 
-namespace Service {
-namespace PTM {
+namespace Service::PTM {
 
 class PTM_Gets final : public Module::Interface {
 public:
     explicit PTM_Gets(std::shared_ptr<Module> ptm);
 };
 
-} // namespace PTM
-} // namespace Service
+} // namespace Service::PTM

--- a/src/core/hle/service/ptm/ptm_play.cpp
+++ b/src/core/hle/service/ptm/ptm_play.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/ptm/ptm_play.h"
 
-namespace Service {
-namespace PTM {
+namespace Service::PTM {
 
 PTM_Play::PTM_Play(std::shared_ptr<Module> ptm)
     : Module::Interface(std::move(ptm), "ptm:play", 26) {
@@ -35,5 +34,4 @@ PTM_Play::PTM_Play(std::shared_ptr<Module> ptm)
     RegisterHandlers(functions);
 }
 
-} // namespace PTM
-} // namespace Service
+} // namespace Service::PTM

--- a/src/core/hle/service/ptm/ptm_play.h
+++ b/src/core/hle/service/ptm/ptm_play.h
@@ -7,13 +7,11 @@
 #include <memory>
 #include "core/hle/service/ptm/ptm.h"
 
-namespace Service {
-namespace PTM {
+namespace Service::PTM {
 
 class PTM_Play final : public Module::Interface {
 public:
     explicit PTM_Play(std::shared_ptr<Module> ptm);
 };
 
-} // namespace PTM
-} // namespace Service
+} // namespace Service::PTM

--- a/src/core/hle/service/ptm/ptm_sets.cpp
+++ b/src/core/hle/service/ptm/ptm_sets.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/ptm/ptm_sets.h"
 
-namespace Service {
-namespace PTM {
+namespace Service::PTM {
 
 PTM_Sets::PTM_Sets(std::shared_ptr<Module> ptm) : Module::Interface(std::move(ptm), "ptm:sets", 1) {
     static const FunctionInfo functions[] = {
@@ -15,5 +14,4 @@ PTM_Sets::PTM_Sets(std::shared_ptr<Module> ptm) : Module::Interface(std::move(pt
     RegisterHandlers(functions);
 }
 
-} // namespace PTM
-} // namespace Service
+} // namespace Service::PTM

--- a/src/core/hle/service/ptm/ptm_sets.h
+++ b/src/core/hle/service/ptm/ptm_sets.h
@@ -7,13 +7,11 @@
 #include <memory>
 #include "core/hle/service/ptm/ptm.h"
 
-namespace Service {
-namespace PTM {
+namespace Service::PTM {
 
 class PTM_Sets final : public Module::Interface {
 public:
     explicit PTM_Sets(std::shared_ptr<Module> ptm);
 };
 
-} // namespace PTM
-} // namespace Service
+} // namespace Service::PTM

--- a/src/core/hle/service/ptm/ptm_sysm.cpp
+++ b/src/core/hle/service/ptm/ptm_sysm.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/ptm/ptm_sysm.h"
 
-namespace Service {
-namespace PTM {
+namespace Service::PTM {
 
 PTM_S_Common::PTM_S_Common(std::shared_ptr<Module> ptm, const char* name)
     : Module::Interface(std::move(ptm), name, 26) {
@@ -66,5 +65,4 @@ PTM_S::PTM_S(std::shared_ptr<Module> ptm) : PTM_S_Common(std::move(ptm), "ptm:s"
 
 PTM_Sysm::PTM_Sysm(std::shared_ptr<Module> ptm) : PTM_S_Common(std::move(ptm), "ptm:sysm") {}
 
-} // namespace PTM
-} // namespace Service
+} // namespace Service::PTM

--- a/src/core/hle/service/ptm/ptm_sysm.h
+++ b/src/core/hle/service/ptm/ptm_sysm.h
@@ -7,8 +7,7 @@
 #include <memory>
 #include "core/hle/service/ptm/ptm.h"
 
-namespace Service {
-namespace PTM {
+namespace Service::PTM {
 
 class PTM_S_Common : public Module::Interface {
 public:
@@ -25,5 +24,4 @@ public:
     explicit PTM_Sysm(std::shared_ptr<Module> ptm);
 };
 
-} // namespace PTM
-} // namespace Service
+} // namespace Service::PTM

--- a/src/core/hle/service/ptm/ptm_u.cpp
+++ b/src/core/hle/service/ptm/ptm_u.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/ptm/ptm_u.h"
 
-namespace Service {
-namespace PTM {
+namespace Service::PTM {
 
 PTM_U::PTM_U(std::shared_ptr<Module> ptm) : Module::Interface(std::move(ptm), "ptm:u", 26) {
     static const FunctionInfo functions[] = {
@@ -28,5 +27,4 @@ PTM_U::PTM_U(std::shared_ptr<Module> ptm) : Module::Interface(std::move(ptm), "p
     RegisterHandlers(functions);
 }
 
-} // namespace PTM
-} // namespace Service
+} // namespace Service::PTM

--- a/src/core/hle/service/ptm/ptm_u.h
+++ b/src/core/hle/service/ptm/ptm_u.h
@@ -7,13 +7,11 @@
 #include <memory>
 #include "core/hle/service/ptm/ptm.h"
 
-namespace Service {
-namespace PTM {
+namespace Service::PTM {
 
 class PTM_U final : public Module::Interface {
 public:
     explicit PTM_U(std::shared_ptr<Module> ptm);
 };
 
-} // namespace PTM
-} // namespace Service
+} // namespace Service::PTM

--- a/src/core/hle/service/pxi/dev.cpp
+++ b/src/core/hle/service/pxi/dev.cpp
@@ -4,8 +4,7 @@
 
 #include "core/hle/service/pxi/dev.h"
 
-namespace Service {
-namespace PXI {
+namespace Service::PXI {
 
 DEV::DEV() : ServiceFramework("pxi:dev", 1) {
     // clang-format off
@@ -32,5 +31,4 @@ DEV::DEV() : ServiceFramework("pxi:dev", 1) {
 
 DEV::~DEV() = default;
 
-} // namespace PXI
-} // namespace Service
+} // namespace Service::PXI

--- a/src/core/hle/service/pxi/dev.h
+++ b/src/core/hle/service/pxi/dev.h
@@ -7,8 +7,7 @@
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace PXI {
+namespace Service::PXI {
 
 /// Interface to "pxi:dev" service
 class DEV final : public ServiceFramework<DEV> {
@@ -17,5 +16,4 @@ public:
     ~DEV();
 };
 
-} // namespace PXI
-} // namespace Service
+} // namespace Service::PXI

--- a/src/core/hle/service/pxi/pxi.cpp
+++ b/src/core/hle/service/pxi/pxi.cpp
@@ -5,12 +5,10 @@
 #include "core/hle/service/pxi/dev.h"
 #include "core/hle/service/pxi/pxi.h"
 
-namespace Service {
-namespace PXI {
+namespace Service::PXI {
 
 void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<DEV>()->InstallAsService(service_manager);
 }
 
-} // namespace PXI
-} // namespace Service
+} // namespace Service::PXI

--- a/src/core/hle/service/pxi/pxi.h
+++ b/src/core/hle/service/pxi/pxi.h
@@ -6,11 +6,9 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace PXI {
+namespace Service::PXI {
 
 /// Registers all PXI services with the specified service manager.
 void InstallInterfaces(SM::ServiceManager& service_manager);
 
-} // namespace PXI
-} // namespace Service
+} // namespace Service::PXI

--- a/src/core/hle/service/qtm/qtm.cpp
+++ b/src/core/hle/service/qtm/qtm.cpp
@@ -8,8 +8,7 @@
 #include "core/hle/service/qtm/qtm_sp.h"
 #include "core/hle/service/qtm/qtm_u.h"
 
-namespace Service {
-namespace QTM {
+namespace Service::QTM {
 
 void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<QTM_C>()->InstallAsService(service_manager);
@@ -18,5 +17,4 @@ void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<QTM_U>()->InstallAsService(service_manager);
 }
 
-} // namespace QTM
-} // namespace Service
+} // namespace Service::QTM

--- a/src/core/hle/service/qtm/qtm.h
+++ b/src/core/hle/service/qtm/qtm.h
@@ -6,11 +6,9 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace QTM {
+namespace Service::QTM {
 
 /// Initializes all QTM services.
 void InstallInterfaces(SM::ServiceManager& service_manager);
 
-} // namespace QTM
-} // namespace Service
+} // namespace Service::QTM

--- a/src/core/hle/service/qtm/qtm_c.cpp
+++ b/src/core/hle/service/qtm/qtm_c.cpp
@@ -5,8 +5,7 @@
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/service/qtm/qtm_c.h"
 
-namespace Service {
-namespace QTM {
+namespace Service::QTM {
 
 QTM_C::QTM_C() : ServiceFramework("qtm:c", 2) {
     static const FunctionInfo functions[] = {
@@ -20,5 +19,4 @@ QTM_C::QTM_C() : ServiceFramework("qtm:c", 2) {
     RegisterHandlers(functions);
 };
 
-} // namespace QTM
-} // namespace Service
+} // namespace Service::QTM

--- a/src/core/hle/service/qtm/qtm_c.h
+++ b/src/core/hle/service/qtm/qtm_c.h
@@ -6,8 +6,7 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace QTM {
+namespace Service::QTM {
 
 class QTM_C final : public ServiceFramework<QTM_C> {
 public:
@@ -15,5 +14,4 @@ public:
     ~QTM_C() = default;
 };
 
-} // namespace QTM
-} // namespace Service
+} // namespace Service::QTM

--- a/src/core/hle/service/qtm/qtm_s.cpp
+++ b/src/core/hle/service/qtm/qtm_s.cpp
@@ -5,8 +5,7 @@
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/service/qtm/qtm_s.h"
 
-namespace Service {
-namespace QTM {
+namespace Service::QTM {
 
 QTM_S::QTM_S() : ServiceFramework("qtm:s", 2) {
     static const FunctionInfo functions[] = {
@@ -20,5 +19,4 @@ QTM_S::QTM_S() : ServiceFramework("qtm:s", 2) {
     RegisterHandlers(functions);
 }
 
-} // namespace QTM
-} // namespace Service
+} // namespace Service::QTM

--- a/src/core/hle/service/qtm/qtm_s.h
+++ b/src/core/hle/service/qtm/qtm_s.h
@@ -6,8 +6,7 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace QTM {
+namespace Service::QTM {
 
 class QTM_S final : public ServiceFramework<QTM_S> {
 public:
@@ -15,5 +14,4 @@ public:
     ~QTM_S() = default;
 };
 
-} // namespace QTM
-} // namespace Service
+} // namespace Service::QTM

--- a/src/core/hle/service/qtm/qtm_sp.cpp
+++ b/src/core/hle/service/qtm/qtm_sp.cpp
@@ -5,8 +5,7 @@
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/service/qtm/qtm_sp.h"
 
-namespace Service {
-namespace QTM {
+namespace Service::QTM {
 
 QTM_SP::QTM_SP() : ServiceFramework("qtm:sp", 2) {
     static const FunctionInfo functions[] = {
@@ -20,5 +19,4 @@ QTM_SP::QTM_SP() : ServiceFramework("qtm:sp", 2) {
     RegisterHandlers(functions);
 }
 
-} // namespace QTM
-} // namespace Service
+} // namespace Service::QTM

--- a/src/core/hle/service/qtm/qtm_sp.h
+++ b/src/core/hle/service/qtm/qtm_sp.h
@@ -6,8 +6,7 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace QTM {
+namespace Service::QTM {
 
 class QTM_SP final : public ServiceFramework<QTM_SP> {
 public:
@@ -15,5 +14,4 @@ public:
     ~QTM_SP() = default;
 };
 
-} // namespace QTM
-} // namespace Service
+} // namespace Service::QTM

--- a/src/core/hle/service/qtm/qtm_u.cpp
+++ b/src/core/hle/service/qtm/qtm_u.cpp
@@ -5,8 +5,7 @@
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/service/qtm/qtm_u.h"
 
-namespace Service {
-namespace QTM {
+namespace Service::QTM {
 
 QTM_U::QTM_U() : ServiceFramework("qtm:u", 2) {
     static const FunctionInfo functions[] = {
@@ -20,5 +19,4 @@ QTM_U::QTM_U() : ServiceFramework("qtm:u", 2) {
     RegisterHandlers(functions);
 }
 
-} // namespace QTM
-} // namespace Service
+} // namespace Service::QTM

--- a/src/core/hle/service/qtm/qtm_u.h
+++ b/src/core/hle/service/qtm/qtm_u.h
@@ -6,8 +6,7 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace QTM {
+namespace Service::QTM {
 
 class QTM_U final : public ServiceFramework<QTM_U> {
 public:
@@ -15,5 +14,4 @@ public:
     ~QTM_U() = default;
 };
 
-} // namespace QTM
-} // namespace Service
+} // namespace Service::QTM

--- a/src/core/hle/service/sm/sm.cpp
+++ b/src/core/hle/service/sm/sm.cpp
@@ -11,8 +11,7 @@
 #include "core/hle/service/sm/sm.h"
 #include "core/hle/service/sm/srv.h"
 
-namespace Service {
-namespace SM {
+namespace Service::SM {
 
 static ResultCode ValidateServiceName(const std::string& name) {
     if (name.size() <= 0 || name.size() > 8) {
@@ -67,5 +66,4 @@ ResultVal<Kernel::SharedPtr<Kernel::ClientSession>> ServiceManager::ConnectToSer
     return client_port->Connect();
 }
 
-} // namespace SM
-} // namespace Service
+} // namespace Service::SM

--- a/src/core/hle/service/sm/sm.h
+++ b/src/core/hle/service/sm/sm.h
@@ -19,8 +19,7 @@ class ServerPort;
 class SessionRequestHandler;
 } // namespace Kernel
 
-namespace Service {
-namespace SM {
+namespace Service::SM {
 
 class SRV;
 
@@ -54,5 +53,4 @@ private:
     std::unordered_map<std::string, Kernel::SharedPtr<Kernel::ClientPort>> registered_services;
 };
 
-} // namespace SM
-} // namespace Service
+} // namespace Service::SM

--- a/src/core/hle/service/sm/srv.cpp
+++ b/src/core/hle/service/sm/srv.cpp
@@ -19,8 +19,7 @@
 #include "core/hle/service/sm/sm.h"
 #include "core/hle/service/sm/srv.h"
 
-namespace Service {
-namespace SM {
+namespace Service::SM {
 
 constexpr int MAX_PENDING_NOTIFICATIONS = 16;
 
@@ -266,5 +265,4 @@ SRV::SRV(std::shared_ptr<ServiceManager> service_manager)
 
 SRV::~SRV() = default;
 
-} // namespace SM
-} // namespace Service
+} // namespace Service::SM

--- a/src/core/hle/service/sm/srv.h
+++ b/src/core/hle/service/sm/srv.h
@@ -13,8 +13,7 @@ class HLERequestContext;
 class Semaphore;
 } // namespace Kernel
 
-namespace Service {
-namespace SM {
+namespace Service::SM {
 
 /// Interface to "srv:" service
 class SRV final : public ServiceFramework<SRV> {
@@ -37,5 +36,4 @@ private:
         get_service_handle_delayed_map;
 };
 
-} // namespace SM
-} // namespace Service
+} // namespace Service::SM

--- a/src/core/hle/service/soc_u.cpp
+++ b/src/core/hle/service/soc_u.cpp
@@ -50,8 +50,7 @@
 #define closesocket(x) close(x)
 #endif
 
-namespace Service {
-namespace SOC {
+namespace Service::SOC {
 
 const s32 SOCKET_ERROR_VALUE = -1;
 
@@ -914,5 +913,4 @@ void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<SOC_U>()->InstallAsService(service_manager);
 }
 
-} // namespace SOC
-} // namespace Service
+} // namespace Service::SOC

--- a/src/core/hle/service/soc_u.h
+++ b/src/core/hle/service/soc_u.h
@@ -7,8 +7,7 @@
 #include <unordered_map>
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace SOC {
+namespace Service::SOC {
 
 /// Holds information about a particular socket
 struct SocketHolder {
@@ -51,5 +50,4 @@ private:
 
 void InstallInterfaces(SM::ServiceManager& service_manager);
 
-} // namespace SOC
-} // namespace Service
+} // namespace Service::SOC

--- a/src/core/hle/service/ssl_c.cpp
+++ b/src/core/hle/service/ssl_c.cpp
@@ -7,8 +7,7 @@
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/service/ssl_c.h"
 
-namespace Service {
-namespace SSL {
+namespace Service::SSL {
 
 void SSL_C::Initialize(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x01, 0, 2);
@@ -91,5 +90,4 @@ void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<SSL_C>()->InstallAsService(service_manager);
 }
 
-} // namespace SSL
-} // namespace Service
+} // namespace Service::SSL

--- a/src/core/hle/service/ssl_c.h
+++ b/src/core/hle/service/ssl_c.h
@@ -7,8 +7,7 @@
 #include <random>
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace SSL {
+namespace Service::SSL {
 
 class SSL_C final : public ServiceFramework<SSL_C> {
 public:
@@ -24,5 +23,4 @@ private:
 
 void InstallInterfaces(SM::ServiceManager& service_manager);
 
-} // namespace SSL
-} // namespace Service
+} // namespace Service::SSL

--- a/src/core/hle/service/y2r_u.cpp
+++ b/src/core/hle/service/y2r_u.cpp
@@ -11,8 +11,7 @@
 #include "core/hle/service/y2r_u.h"
 #include "core/hw/y2r.h"
 
-namespace Service {
-namespace Y2R {
+namespace Service::Y2R {
 
 static const CoefficientSet standard_coefficients[4] = {
     {{0x100, 0x166, 0xB6, 0x58, 0x1C5, -0x166F, 0x10EE, -0x1C5B}}, // ITU_Rec601
@@ -691,5 +690,4 @@ void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<Y2R_U>()->InstallAsService(service_manager);
 }
 
-} // namespace Y2R
-} // namespace Service
+} // namespace Service::Y2R

--- a/src/core/hle/service/y2r_u.h
+++ b/src/core/hle/service/y2r_u.h
@@ -16,8 +16,7 @@ namespace Kernel {
 class Event;
 }
 
-namespace Service {
-namespace Y2R {
+namespace Service::Y2R {
 
 enum class InputFormat : u8 {
     /// 8-bit input, with YUV components in separate planes and 4:2:2 subsampling.
@@ -301,5 +300,4 @@ private:
 
 void InstallInterfaces(SM::ServiceManager& service_manager);
 
-} // namespace Y2R
-} // namespace Service
+} // namespace Service::Y2R


### PR DESCRIPTION
See yuzu-emu/yuzu#1309 for more details.

Originial description: `There were a few places where nested namespace specifiers weren't being
used where they could be within the service code. This amends that to
make the namespacing a tiny bit more compact.`

Have fun reviewing this :P

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4251)
<!-- Reviewable:end -->
