### PR TITLE
Meta: Add gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+dist/languages/* linguist-vendored
+dist/qt_themes/* linguist-vendored
+externals/* linguist-vendored
+*.h linguist-language=cpp


### PR DESCRIPTION
Github Linguist will read this file when calculating language stats for
the repository. We can use this to exclude any vendored dependencies in
externals and dist

This should keep github from thinking the project is 50% C code (thanks to the shared_font.h)

see https://github.com/github/linguist#overrides for more information

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4258)
<!-- Reviewable:end -->
