### PR TITLE
citra_qt: Add Game List configuration

### DIFF
--- a/src/citra_qt/CMakeLists.txt
+++ b/src/citra_qt/CMakeLists.txt
@@ -43,6 +43,8 @@ add_executable(citra-qt
     configuration/configure_motion_touch.h
     configuration/configure_system.cpp
     configuration/configure_system.h
+    configuration/configure_ui.cpp
+    configuration/configure_ui.h
     configuration/configure_web.cpp
     configuration/configure_web.h
     debugger/console.h
@@ -119,6 +121,7 @@ set(UIS
     configuration/configure_input.ui
     configuration/configure_motion_touch.ui
     configuration/configure_system.ui
+    configuration/configure_ui.ui
     configuration/configure_web.ui
     debugger/registers.ui
     multiplayer/direct_connect.ui

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -219,6 +219,31 @@ void Config::ReadValues() {
         ReadSetting("microProfileDialogVisible", false).toBool();
     qt_config->endGroup();
 
+    qt_config->beginGroup("GameList");
+    UISettings::values.game_list_icon_size = ReadSetting("iconSize", 2).toInt();
+    if (UISettings::values.game_list_icon_size < 0 || UISettings::values.game_list_icon_size > 2) {
+        LOG_ERROR(Config, "Invalid value for game_list_icon_size: {}",
+                  UISettings::values.game_list_icon_size);
+        UISettings::values.game_list_icon_size = 2;
+    }
+
+    UISettings::values.game_list_row_1 = ReadSetting("row1", 2).toInt();
+    if (UISettings::values.game_list_row_1 < 0 || UISettings::values.game_list_row_1 > 3) {
+        LOG_ERROR(Config, "Invalid value for game_list_row_1: {}",
+                  UISettings::values.game_list_row_1);
+        UISettings::values.game_list_row_1 = 2;
+    }
+
+    UISettings::values.game_list_row_2 = ReadSetting("row2", 0).toInt();
+    if (UISettings::values.game_list_row_2 < -1 || UISettings::values.game_list_row_2 > 3) {
+        LOG_ERROR(Config, "Invalid value for game_list_row_2: {}",
+                  UISettings::values.game_list_row_2);
+        UISettings::values.game_list_row_2 = 0;
+    }
+
+    UISettings::values.game_list_hide_no_icon = ReadSetting("hideNoIcon", false).toBool();
+    qt_config->endGroup();
+
     qt_config->beginGroup("Paths");
     UISettings::values.roms_path = ReadSetting("romsPath").toString();
     UISettings::values.symbols_path = ReadSetting("symbolsPath").toString();
@@ -446,6 +471,13 @@ void Config::SaveValues() {
     WriteSetting("gameListHeaderState", UISettings::values.gamelist_header_state);
     WriteSetting("microProfileDialogGeometry", UISettings::values.microprofile_geometry);
     WriteSetting("microProfileDialogVisible", UISettings::values.microprofile_visible, false);
+    qt_config->endGroup();
+
+    qt_config->beginGroup("GameList");
+    WriteSetting("iconSize", UISettings::values.game_list_icon_size, 2);
+    WriteSetting("row1", UISettings::values.game_list_row_1, 2);
+    WriteSetting("row2", UISettings::values.game_list_row_2, 0);
+    WriteSetting("hideNoIcon", UISettings::values.game_list_hide_no_icon, false);
     qt_config->endGroup();
 
     qt_config->beginGroup("Paths");

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -220,26 +220,23 @@ void Config::ReadValues() {
     qt_config->endGroup();
 
     qt_config->beginGroup("GameList");
-    UISettings::values.game_list_icon_size = ReadSetting("iconSize", 2).toInt();
-    if (UISettings::values.game_list_icon_size < 0 || UISettings::values.game_list_icon_size > 2) {
-        LOG_ERROR(Config, "Invalid value for game_list_icon_size: {}",
-                  UISettings::values.game_list_icon_size);
-        UISettings::values.game_list_icon_size = 2;
+    int icon_size = ReadSetting("iconSize", 2).toInt();
+    if (icon_size < 0 || icon_size > 2) {
+        icon_size = 2;
     }
+    UISettings::values.game_list_icon_size = UISettings::GameListIconSize{icon_size};
 
-    UISettings::values.game_list_row_1 = ReadSetting("row1", 2).toInt();
-    if (UISettings::values.game_list_row_1 < 0 || UISettings::values.game_list_row_1 > 3) {
-        LOG_ERROR(Config, "Invalid value for game_list_row_1: {}",
-                  UISettings::values.game_list_row_1);
-        UISettings::values.game_list_row_1 = 2;
+    int row_1 = ReadSetting("row1", 2).toInt();
+    if (row_1 < 0 || row_1 > 3) {
+        row_1 = 2;
     }
+    UISettings::values.game_list_row_1 = UISettings::GameListText{row_1};
 
-    UISettings::values.game_list_row_2 = ReadSetting("row2", 0).toInt();
-    if (UISettings::values.game_list_row_2 < -1 || UISettings::values.game_list_row_2 > 3) {
-        LOG_ERROR(Config, "Invalid value for game_list_row_2: {}",
-                  UISettings::values.game_list_row_2);
-        UISettings::values.game_list_row_2 = 0;
+    int row_2 = ReadSetting("row2", 0).toInt();
+    if (row_2 < -1 || row_2 > 3) {
+        row_2 = 0;
     }
+    UISettings::values.game_list_row_2 = UISettings::GameListText{row_2};
 
     UISettings::values.game_list_hide_no_icon = ReadSetting("hideNoIcon", false).toBool();
     qt_config->endGroup();
@@ -474,9 +471,9 @@ void Config::SaveValues() {
     qt_config->endGroup();
 
     qt_config->beginGroup("GameList");
-    WriteSetting("iconSize", UISettings::values.game_list_icon_size, 2);
-    WriteSetting("row1", UISettings::values.game_list_row_1, 2);
-    WriteSetting("row2", UISettings::values.game_list_row_2, 0);
+    WriteSetting("iconSize", static_cast<int>(UISettings::values.game_list_icon_size), 2);
+    WriteSetting("row1", static_cast<int>(UISettings::values.game_list_row_1), 2);
+    WriteSetting("row2", static_cast<int>(UISettings::values.game_list_row_2), 0);
     WriteSetting("hideNoIcon", UISettings::values.game_list_hide_no_icon, false);
     qt_config->endGroup();
 

--- a/src/citra_qt/configuration/configure.ui
+++ b/src/citra_qt/configuration/configure.ui
@@ -63,6 +63,11 @@
          <string>Web</string>
         </attribute>
        </widget>
+       <widget class="ConfigureUi" name="uiTab">
+        <attribute name="title">
+         <string>UI</string>
+        </attribute>
+       </widget>
       </widget>
      </item>
     </layout>
@@ -123,6 +128,12 @@
    <class>ConfigureWeb</class>
    <extends>QWidget</extends>
    <header>configuration/configure_web.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ConfigureUi</class>
+   <extends>QWidget</extends>
+   <header>configuration/configure_ui.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/citra_qt/configuration/configure_dialog.cpp
+++ b/src/citra_qt/configuration/configure_dialog.cpp
@@ -16,8 +16,7 @@ ConfigureDialog::ConfigureDialog(QWidget* parent, const HotkeyRegistry& registry
     ui->generalTab->PopulateHotkeyList(registry);
     this->setConfiguration();
     this->PopulateSelectionList();
-    connect(ui->generalTab, &ConfigureGeneral::languageChanged, this,
-            &ConfigureDialog::onLanguageChanged);
+    connect(ui->uiTab, &ConfigureUi::languageChanged, this, &ConfigureDialog::onLanguageChanged);
     connect(ui->selectorList, &QListWidget::itemSelectionChanged, this,
             &ConfigureDialog::UpdateVisibleTabs);
 
@@ -39,6 +38,7 @@ void ConfigureDialog::applyConfiguration() {
     ui->cameraTab->applyConfiguration();
     ui->debugTab->applyConfiguration();
     ui->webTab->applyConfiguration();
+    ui->uiTab->applyConfiguration();
     Settings::Apply();
     Settings::LogSettings();
 }
@@ -46,7 +46,7 @@ void ConfigureDialog::applyConfiguration() {
 void ConfigureDialog::PopulateSelectionList() {
 
     const std::array<std::pair<QString, QStringList>, 4> items{
-        {{tr("General"), {tr("General"), tr("Web"), tr("Debug")}},
+        {{tr("General"), {tr("General"), tr("Web"), tr("Debug"), tr("UI")}},
          {tr("System"), {tr("System"), tr("Audio"), tr("Camera")}},
          {tr("Graphics"), {tr("Graphics")}},
          {tr("Controls"), {tr("Input")}}}};
@@ -70,6 +70,7 @@ void ConfigureDialog::onLanguageChanged(const QString& locale) {
     ui->cameraTab->retranslateUi();
     ui->debugTab->retranslateUi();
     ui->webTab->retranslateUi();
+    ui->uiTab->retranslateUi();
 }
 
 void ConfigureDialog::UpdateVisibleTabs() {
@@ -77,11 +78,15 @@ void ConfigureDialog::UpdateVisibleTabs() {
     if (items.isEmpty())
         return;
 
-    const QHash<QString, QWidget*> widgets = {
-        {tr("General"), ui->generalTab}, {tr("System"), ui->systemTab},
-        {tr("Input"), ui->inputTab},     {tr("Graphics"), ui->graphicsTab},
-        {tr("Audio"), ui->audioTab},     {tr("Camera"), ui->cameraTab},
-        {tr("Debug"), ui->debugTab},     {tr("Web"), ui->webTab}};
+    const QHash<QString, QWidget*> widgets = {{tr("General"), ui->generalTab},
+                                              {tr("System"), ui->systemTab},
+                                              {tr("Input"), ui->inputTab},
+                                              {tr("Graphics"), ui->graphicsTab},
+                                              {tr("Audio"), ui->audioTab},
+                                              {tr("Camera"), ui->cameraTab},
+                                              {tr("Debug"), ui->debugTab},
+                                              {tr("Web"), ui->webTab},
+                                              {tr("UI"), ui->uiTab}};
 
     ui->tabWidget->clear();
 

--- a/src/citra_qt/configuration/configure_general.cpp
+++ b/src/citra_qt/configuration/configure_general.cpp
@@ -2,7 +2,6 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <QDirIterator>
 #include "citra_qt/configuration/configure_general.h"
 #include "citra_qt/ui_settings.h"
 #include "core/core.h"
@@ -13,28 +12,6 @@ ConfigureGeneral::ConfigureGeneral(QWidget* parent)
     : QWidget(parent), ui(new Ui::ConfigureGeneral) {
 
     ui->setupUi(this);
-    ui->language_combobox->addItem(tr("<System>"), QString(""));
-    ui->language_combobox->addItem(tr("English"), QString("en"));
-    QDirIterator it(":/languages", QDirIterator::NoIteratorFlags);
-    while (it.hasNext()) {
-        QString locale = it.next();
-        locale.truncate(locale.lastIndexOf('.'));
-        locale.remove(0, locale.lastIndexOf('/') + 1);
-        QString lang = QLocale::languageToString(QLocale(locale).language());
-        ui->language_combobox->addItem(lang, locale);
-    }
-
-    // Unlike other configuration changes, interface language changes need to be reflected on the
-    // interface immediately. This is done by passing a signal to the main window, and then
-    // retranslating when passing back.
-    connect(ui->language_combobox,
-            static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
-            &ConfigureGeneral::onLanguageChanged);
-
-    for (const auto& theme : UISettings::themes) {
-        ui->theme_combobox->addItem(theme.first, theme.second);
-    }
-
     this->setConfiguration();
 
     ui->updateBox->setVisible(UISettings::values.updater_found);
@@ -50,10 +27,6 @@ void ConfigureGeneral::setConfiguration() {
 
     // The first item is "auto-select" with actual value -1, so plus one here will do the trick
     ui->region_combobox->setCurrentIndex(Settings::values.region_value + 1);
-
-    ui->theme_combobox->setCurrentIndex(ui->theme_combobox->findData(UISettings::values.theme));
-    ui->language_combobox->setCurrentIndex(
-        ui->language_combobox->findData(UISettings::values.language));
 }
 
 void ConfigureGeneral::PopulateHotkeyList(const HotkeyRegistry& registry) {
@@ -62,20 +35,11 @@ void ConfigureGeneral::PopulateHotkeyList(const HotkeyRegistry& registry) {
 
 void ConfigureGeneral::applyConfiguration() {
     UISettings::values.confirm_before_closing = ui->toggle_check_exit->isChecked();
-    UISettings::values.theme =
-        ui->theme_combobox->itemData(ui->theme_combobox->currentIndex()).toString();
 
     UISettings::values.check_for_update_on_start = ui->toggle_update_check->isChecked();
     UISettings::values.update_on_close = ui->toggle_auto_update->isChecked();
 
     Settings::values.region_value = ui->region_combobox->currentIndex() - 1;
-}
-
-void ConfigureGeneral::onLanguageChanged(int index) {
-    if (index == -1)
-        return;
-
-    emit languageChanged(ui->language_combobox->itemData(index).toString());
 }
 
 void ConfigureGeneral::retranslateUi() {

--- a/src/citra_qt/configuration/configure_general.h
+++ b/src/citra_qt/configuration/configure_general.h
@@ -24,12 +24,6 @@ public:
     void applyConfiguration();
     void retranslateUi();
 
-private slots:
-    void onLanguageChanged(int index);
-
-signals:
-    void languageChanged(const QString& locale);
-
 private:
     void setConfiguration();
 

--- a/src/citra_qt/configuration/configure_general.ui
+++ b/src/citra_qt/configuration/configure_general.ui
@@ -31,20 +31,6 @@
             </property>
            </widget>
           </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_2">
-            <item>
-             <widget class="QLabel" name="language_label">
-              <property name="text">
-               <string>Interface language</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QComboBox" name="language_combobox"/>
-            </item>
-           </layout>
-          </item>
          </layout>
         </item>
        </layout>
@@ -137,33 +123,6 @@
                </property>
               </item>
              </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
-      <widget class="QGroupBox" name="theme_group_box">
-       <property name="title">
-        <string>Theme</string>
-       </property>
-       <layout class="QHBoxLayout" name="theme_qhbox_layout">
-        <item>
-         <layout class="QVBoxLayout" name="theme_qvbox_layout">
-          <item>
-           <layout class="QHBoxLayout" name="theme_qhbox_layout_2">
-            <item>
-             <widget class="QLabel" name="theme_label">
-              <property name="text">
-               <string>Theme:</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QComboBox" name="theme_combobox"/>
             </item>
            </layout>
           </item>

--- a/src/citra_qt/configuration/configure_ui.cpp
+++ b/src/citra_qt/configuration/configure_ui.cpp
@@ -40,18 +40,23 @@ void ConfigureUi::setConfiguration() {
     ui->theme_combobox->setCurrentIndex(ui->theme_combobox->findData(UISettings::values.theme));
     ui->language_combobox->setCurrentIndex(
         ui->language_combobox->findData(UISettings::values.language));
-    ui->icon_size_combobox->setCurrentIndex(UISettings::values.game_list_icon_size);
-    ui->row_1_text_combobox->setCurrentIndex(UISettings::values.game_list_row_1);
-    ui->row_2_text_combobox->setCurrentIndex(UISettings::values.game_list_row_2 + 1);
+    ui->icon_size_combobox->setCurrentIndex(
+        static_cast<int>(UISettings::values.game_list_icon_size));
+    ui->row_1_text_combobox->setCurrentIndex(static_cast<int>(UISettings::values.game_list_row_1));
+    ui->row_2_text_combobox->setCurrentIndex(static_cast<int>(UISettings::values.game_list_row_2) +
+                                             1);
     ui->toggle_hide_no_icon->setChecked(UISettings::values.game_list_hide_no_icon);
 }
 
 void ConfigureUi::applyConfiguration() {
     UISettings::values.theme =
         ui->theme_combobox->itemData(ui->theme_combobox->currentIndex()).toString();
-    UISettings::values.game_list_icon_size = ui->icon_size_combobox->currentIndex();
-    UISettings::values.game_list_row_1 = ui->row_1_text_combobox->currentIndex();
-    UISettings::values.game_list_row_2 = ui->row_2_text_combobox->currentIndex() - 1;
+    UISettings::values.game_list_icon_size =
+        static_cast<UISettings::GameListIconSize>(ui->icon_size_combobox->currentIndex());
+    UISettings::values.game_list_row_1 =
+        static_cast<UISettings::GameListText>(ui->row_1_text_combobox->currentIndex());
+    UISettings::values.game_list_row_2 =
+        static_cast<UISettings::GameListText>(ui->row_2_text_combobox->currentIndex() - 1);
     UISettings::values.game_list_hide_no_icon = ui->toggle_hide_no_icon->isChecked();
 }
 

--- a/src/citra_qt/configuration/configure_ui.cpp
+++ b/src/citra_qt/configuration/configure_ui.cpp
@@ -1,0 +1,67 @@
+// Copyright 2018 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <QDirIterator>
+#include "citra_qt/configuration/configure_ui.h"
+#include "citra_qt/ui_settings.h"
+#include "ui_configure_ui.h"
+
+ConfigureUi::ConfigureUi(QWidget* parent) : QWidget(parent), ui(new Ui::ConfigureUi) {
+    ui->setupUi(this);
+    ui->language_combobox->addItem(tr("<System>"), QString(""));
+    ui->language_combobox->addItem(tr("English"), QString("en"));
+    QDirIterator it(":/languages", QDirIterator::NoIteratorFlags);
+    while (it.hasNext()) {
+        QString locale = it.next();
+        locale.truncate(locale.lastIndexOf('.'));
+        locale.remove(0, locale.lastIndexOf('/') + 1);
+        QString lang = QLocale::languageToString(QLocale(locale).language());
+        ui->language_combobox->addItem(lang, locale);
+    }
+
+    // Unlike other configuration changes, interface language changes need to be reflected on the
+    // interface immediately. This is done by passing a signal to the main window, and then
+    // retranslating when passing back.
+    connect(ui->language_combobox,
+            static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+            &ConfigureUi::onLanguageChanged);
+
+    for (const auto& theme : UISettings::themes) {
+        ui->theme_combobox->addItem(theme.first, theme.second);
+    }
+
+    this->setConfiguration();
+}
+
+ConfigureUi::~ConfigureUi() = default;
+
+void ConfigureUi::setConfiguration() {
+    ui->theme_combobox->setCurrentIndex(ui->theme_combobox->findData(UISettings::values.theme));
+    ui->language_combobox->setCurrentIndex(
+        ui->language_combobox->findData(UISettings::values.language));
+    ui->icon_size_combobox->setCurrentIndex(UISettings::values.game_list_icon_size);
+    ui->row_1_text_combobox->setCurrentIndex(UISettings::values.game_list_row_1);
+    ui->row_2_text_combobox->setCurrentIndex(UISettings::values.game_list_row_2 + 1);
+    ui->toggle_hide_no_icon->setChecked(UISettings::values.game_list_hide_no_icon);
+}
+
+void ConfigureUi::applyConfiguration() {
+    UISettings::values.theme =
+        ui->theme_combobox->itemData(ui->theme_combobox->currentIndex()).toString();
+    UISettings::values.game_list_icon_size = ui->icon_size_combobox->currentIndex();
+    UISettings::values.game_list_row_1 = ui->row_1_text_combobox->currentIndex();
+    UISettings::values.game_list_row_2 = ui->row_2_text_combobox->currentIndex() - 1;
+    UISettings::values.game_list_hide_no_icon = ui->toggle_hide_no_icon->isChecked();
+}
+
+void ConfigureUi::onLanguageChanged(int index) {
+    if (index == -1)
+        return;
+
+    emit languageChanged(ui->language_combobox->itemData(index).toString());
+}
+
+void ConfigureUi::retranslateUi() {
+    ui->retranslateUi(this);
+}

--- a/src/citra_qt/configuration/configure_ui.h
+++ b/src/citra_qt/configuration/configure_ui.h
@@ -1,0 +1,34 @@
+// Copyright 2018 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include <QWidget>
+
+namespace Ui {
+class ConfigureUi;
+}
+
+class ConfigureUi : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ConfigureUi(QWidget* parent = nullptr);
+    ~ConfigureUi();
+
+    void applyConfiguration();
+    void retranslateUi();
+
+private slots:
+    void onLanguageChanged(int index);
+
+signals:
+    void languageChanged(const QString& locale);
+
+private:
+    void setConfiguration();
+
+    std::unique_ptr<Ui::ConfigureUi> ui;
+};

--- a/src/citra_qt/configuration/configure_ui.ui
+++ b/src/citra_qt/configuration/configure_ui.ui
@@ -1,0 +1,194 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConfigureUi</class>
+ <widget class="QWidget" name="ConfigureUi">
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>290</width>
+    <height>280</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="general_groupBox">
+     <property name="title">
+      <string>General</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <item>
+           <widget class="QLabel" name="language_label">
+            <property name="text">
+             <string>Interface language:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="language_combobox"/>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_3">
+          <item>
+           <widget class="QLabel" name="theme_label">
+            <property name="text">
+             <string>Theme:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="theme_combobox"/>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="game_list_groupBox">
+     <property name="title">
+      <string>Game List</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_4">
+      <item>
+       <layout class="QVBoxLayout" name="verticalLayout_3">
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_5">
+          <item>
+           <widget class="QLabel" name="icon_size_label">
+            <property name="text">
+             <string>Icon Size:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="icon_size_combobox">
+            <item>
+             <property name="text">
+              <string>None</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Small (24x24)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Large (48x48)</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_6">
+          <item>
+           <widget class="QLabel" name="row_1_text_label">
+            <property name="text">
+             <string>Row 1 Text:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="row_1_text_combobox">
+            <item>
+             <property name="text">
+              <string>File Name</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Full Path</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Title Name</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Title ID</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_7">
+          <item>
+           <widget class="QLabel" name="row_2_text_label">
+            <property name="text">
+             <string>Row 2 Text:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="row_2_text_combobox">
+            <item>
+             <property name="text">
+              <string>None</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>File Name</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Full Path</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Title Name</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Title ID</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="toggle_hide_no_icon">
+          <property name="text">
+           <string>Hide Titles without Icon</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer>
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -723,6 +723,11 @@ void GameListWorker::AddFstEntriesToGameList(const std::string& dir_path, unsign
                 return update_smdh;
             }();
 
+            if (!Loader::IsValidSMDH(smdh) && UISettings::values.game_list_hide_no_icon) {
+                // Skip this invalid entry
+                return true;
+            }
+
             auto it = FindMatchingCompatibilityEntry(compatibility_list, program_id);
 
             // The game list uses this as compatibility number for untested games

--- a/src/citra_qt/game_list.h
+++ b/src/citra_qt/game_list.h
@@ -62,6 +62,8 @@ public:
 
     QString FindGameByProgramID(u64 program_id);
 
+    void RefreshGameDirectory();
+
     static const QStringList supported_file_extensions;
 
 signals:
@@ -86,8 +88,6 @@ private:
     void AddEntry(const QList<QStandardItem*>& entry_items, GameListDir* parent);
     void ValidateEntry(const QModelIndex& item);
     void DonePopulating(QStringList watch_list);
-
-    void RefreshGameDirectory();
 
     void PopupContextMenu(const QPoint& menu_location);
     void AddGamePopup(QMenu& context_menu, const QString& path, u64 program_id, u64 extdata_id);

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -1257,6 +1257,7 @@ void GMainWindow::OnConfigure() {
             SetDiscordEnabled(UISettings::values.enable_discord_presence);
         emit UpdateThemedIcons();
         SyncMenuUISettings();
+        game_list->RefreshGameDirectory();
         config->Save();
     }
 }

--- a/src/citra_qt/ui_settings.h
+++ b/src/citra_qt/ui_settings.h
@@ -58,6 +58,12 @@ struct Values {
     // Discord RPC
     bool enable_discord_presence;
 
+    // Game List
+    int game_list_icon_size;
+    int game_list_row_1;
+    int game_list_row_2;
+    bool game_list_hide_no_icon;
+
     QString roms_path;
     QString symbols_path;
     QString movie_record_path;

--- a/src/citra_qt/ui_settings.h
+++ b/src/citra_qt/ui_settings.h
@@ -31,6 +31,20 @@ struct GameDir {
     };
 };
 
+enum class GameListIconSize {
+    NoIcon,    ///< Do not display icons
+    SmallIcon, ///< Display a small (24x24) icon
+    LargeIcon, ///< Display a large (48x48) icon
+};
+
+enum class GameListText {
+    NoText = -1, ///< No text
+    FileName,    ///< Display the file name of the entry
+    FullPath,    ///< Display the full path of the entry
+    TitleName,   ///< Display the name of the title
+    TitleID,     ///< Display the title ID
+};
+
 struct Values {
     QByteArray geometry;
     QByteArray state;
@@ -59,9 +73,9 @@ struct Values {
     bool enable_discord_presence;
 
     // Game List
-    int game_list_icon_size;
-    int game_list_row_1;
-    int game_list_row_2;
+    GameListIconSize game_list_icon_size;
+    GameListText game_list_row_1;
+    GameListText game_list_row_2;
     bool game_list_hide_no_icon;
 
     QString roms_path;


### PR DESCRIPTION
This adds a Game List configuration group box which is similar to yuzu's, with features including icon size setting, row 1/2 text, and ability to hide invalid titles (those without a valid SMDH). I also added a UI tab and moved the language and theme settings there.

Screenshot:
![image](https://user-images.githubusercontent.com/21307832/45923984-d5b6f580-bf26-11e8-97e0-28f9e566c052.png)
(Icon size set to Small, row 1 set to Title Name and row 2 set to Title ID)

![image](https://user-images.githubusercontent.com/21307832/45927255-0288fe00-bf63-11e8-821c-08f4cf4f0051.png)
(The new UI tab)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4259)
<!-- Reviewable:end -->
