### PR TITLE
cmake: Output binaries to bin on every platform

### DIFF
--- a/.travis/linux/upload.sh
+++ b/.travis/linux/upload.sh
@@ -8,9 +8,9 @@ COMPRESSION_FLAGS="-cJvf"
 
 mkdir "$REV_NAME"
 
-cp build/src/citra/citra "$REV_NAME"
-cp build/src/dedicated_room/citra-room "$REV_NAME"
-cp build/src/citra_qt/citra-qt "$REV_NAME"
+cp build/bin/citra "$REV_NAME"
+cp build/bin/citra-room "$REV_NAME"
+cp build/bin/citra-qt "$REV_NAME"
 
 # We need icons on Linux for .desktop entries
 mkdir "$REV_NAME/dist"

--- a/.travis/macos/upload.sh
+++ b/.travis/macos/upload.sh
@@ -8,9 +8,9 @@ COMPRESSION_FLAGS="-czvf"
 
 mkdir "$REV_NAME"
 
-cp build/src/citra/citra "$REV_NAME"
-cp -r build/src/citra_qt/citra-qt.app "$REV_NAME"
-cp build/src/dedicated_room/citra-room "$REV_NAME"
+cp build/bin/citra "$REV_NAME"
+cp -r build/bin/citra-qt.app "$REV_NAME"
+cp build/bin/citra-room "$REV_NAME"
 
 # move qt libs into app bundle for deployment
 $(brew --prefix)/opt/qt5/bin/macdeployqt "${REV_NAME}/citra-qt.app"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,10 @@ message(STATUS "Target architecture: ${ARCHITECTURE}")
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# set up output paths for executable binaries
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+
 if (NOT MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-attributes")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
@@ -126,8 +130,6 @@ else()
     # Avoid windows.h from including some usually unused libs like winsocks.h, since this might cause some redefinition errors.
     add_definitions(/DWIN32_LEAN_AND_MEAN)
 
-    # set up output paths for executable binaries (.exe-files, and .dll-files on DLL-capable platforms)
-    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
     set(CMAKE_CONFIGURATION_TYPES Debug Release CACHE STRING "" FORCE)
 
     # Tweak optimization settings


### PR DESCRIPTION
Much cleaner than having executables in ``$BUILD_DIR/src/foo/foo``.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4263)
<!-- Reviewable:end -->
