### PR TITLE
movie: Add clock init time to CTM header

### DIFF
--- a/src/citra/citra.cpp
+++ b/src/citra/citra.cpp
@@ -271,6 +271,13 @@ int main(int argc, char** argv) {
         return -1;
     }
 
+    if (!movie_record.empty()) {
+        Core::Movie::GetInstance().PrepareForRecording();
+    }
+    if (!movie_play.empty()) {
+        Core::Movie::GetInstance().PrepareForPlayback(movie_play);
+    }
+
     // Apply the command line arguments
     Settings::values.gdbstub_port = gdb_port;
     Settings::values.use_gdbstub = use_gdbstub;
@@ -332,7 +339,7 @@ int main(int argc, char** argv) {
     }
 
     if (!movie_play.empty()) {
-        Core::Movie::GetInstance().StartPlayback(movie_play);
+        Core::Movie::GetInstance().StartPlayback(movie_play, [] {});
     }
     if (!movie_record.empty()) {
         Core::Movie::GetInstance().StartRecording(movie_record);

--- a/src/citra/citra.cpp
+++ b/src/citra/citra.cpp
@@ -339,7 +339,7 @@ int main(int argc, char** argv) {
     }
 
     if (!movie_play.empty()) {
-        Core::Movie::GetInstance().StartPlayback(movie_play, [] {});
+        Core::Movie::GetInstance().StartPlayback(movie_play);
     }
     if (!movie_record.empty()) {
         Core::Movie::GetInstance().StartRecording(movie_record);

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -746,6 +746,10 @@ void GMainWindow::BootGame(const QString& filename) {
     LOG_INFO(Frontend, "Citra starting...");
     StoreRecentFile(filename); // Put the filename on top of the list
 
+    if (movie_record_on_start) {
+        Core::Movie::GetInstance().PrepareForRecording();
+    }
+
     if (!LoadROM(filename))
         return;
 
@@ -1261,6 +1265,15 @@ void GMainWindow::OnCreateGraphicsSurfaceViewer() {
 }
 
 void GMainWindow::OnRecordMovie() {
+    if (emulation_running) {
+        QMessageBox::StandardButton answer = QMessageBox::warning(
+            this, tr("Record Movie"),
+            tr("To keep consistency with the RNG, it is recommended to record the movie from game "
+               "start.<br>Are you sure you still want to record movies now?"),
+            QMessageBox::Yes | QMessageBox::No);
+        if (answer == QMessageBox::No)
+            return;
+    }
     const QString path =
         QFileDialog::getSaveFileName(this, tr("Record Movie"), UISettings::values.movie_record_path,
                                      tr("Citra TAS Movie (*.ctm)"));
@@ -1322,6 +1335,16 @@ bool GMainWindow::ValidateMovie(const QString& path, u64 program_id) {
 }
 
 void GMainWindow::OnPlayMovie() {
+    if (emulation_running) {
+        QMessageBox::StandardButton answer = QMessageBox::warning(
+            this, tr("Play Movie"),
+            tr("To keep consistency with the RNG, it is recommended to play the movie from game "
+               "start.<br>Are you sure you still want to play movies now?"),
+            QMessageBox::Yes | QMessageBox::No);
+        if (answer == QMessageBox::No)
+            return;
+    }
+
     const QString path =
         QFileDialog::getOpenFileName(this, tr("Play Movie"), UISettings::values.movie_playback_path,
                                      tr("Citra TAS Movie (*.ctm)"));
@@ -1353,6 +1376,7 @@ void GMainWindow::OnPlayMovie() {
         }
         if (!ValidateMovie(path, program_id))
             return;
+        Core::Movie::GetInstance().PrepareForPlayback(path.toStdString());
         BootGame(game_path);
     }
     Core::Movie::GetInstance().StartPlayback(path.toStdString(), [this] {

--- a/src/core/hle/shared_page.cpp
+++ b/src/core/hle/shared_page.cpp
@@ -7,6 +7,7 @@
 #include "core/core_timing.h"
 #include "core/hle/service/ptm/ptm.h"
 #include "core/hle/shared_page.h"
+#include "core/movie.h"
 #include "core/settings.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -14,6 +15,12 @@
 namespace SharedPage {
 
 static std::chrono::seconds GetInitTime() {
+    u64 override_init_time = Core::Movie::GetInstance().GetOverrideInitTime();
+    if (override_init_time) {
+        // Override the clock init time with the one in the movie
+        return std::chrono::seconds(override_init_time);
+    }
+
     switch (Settings::values.init_clock) {
     case Settings::InitClock::SystemTime: {
         auto now = std::chrono::system_clock::now();

--- a/src/core/movie.h
+++ b/src/core/movie.h
@@ -42,7 +42,7 @@ public:
     }
 
     void StartPlayback(const std::string& movie_file,
-                       std::function<void()> completion_callback = {});
+                       std::function<void()> completion_callback = [] {});
     void StartRecording(const std::string& movie_file);
 
     /// Prepare to override the clock before playing back movies

--- a/src/core/movie.h
+++ b/src/core/movie.h
@@ -44,7 +44,17 @@ public:
     void StartPlayback(const std::string& movie_file,
                        std::function<void()> completion_callback = {});
     void StartRecording(const std::string& movie_file);
+
+    /// Prepare to override the clock before playing back movies
+    void PrepareForPlayback(const std::string& movie_file);
+
+    /// Prepare to override the clock before recording movies
+    void PrepareForRecording();
+
     ValidationResult ValidateMovie(const std::string& movie_file, u64 program_id = 0) const;
+
+    /// Get the init time that would override the one in the settings
+    u64 GetOverrideInitTime() const;
     u64 GetMovieProgramID(const std::string& movie_file) const;
 
     void Shutdown();
@@ -119,6 +129,7 @@ private:
     PlayMode play_mode;
     std::string record_movie_file;
     std::vector<u8> recorded_input;
+    u64 init_time;
     std::function<void()> playback_completion_callback;
     std::size_t current_byte = 0;
 };


### PR DESCRIPTION
This adds a clock init time field to the CTM header. The clock settings would be overridden when playing a movie. And when recording a movie, if the clock is set to System Time, it would be set to fixed init time at the current moment as well. In this way this keeps consistency with the RNG even if the user does just no setting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4267)
<!-- Reviewable:end -->
