### PR TITLE
OSX: Set MACOSX_DEPLOYMENT_TARGET to 10.13

### DIFF
--- a/.travis/macos/build.sh
+++ b/.travis/macos/build.sh
@@ -2,7 +2,7 @@
 
 set -o pipefail
 
-export MACOSX_DEPLOYMENT_TARGET=10.12
+export MACOSX_DEPLOYMENT_TARGET=10.13
 export Qt5_DIR=$(brew --prefix)/opt/qt5
 export PATH="/usr/local/opt/ccache/libexec:$PATH"
 


### PR DESCRIPTION
OSX doesn't ship updates for the stdlibc++ for older OSX versions. So as we start to use features in new libs those builds won't work anymore on older systems. Our CI runs on osx 10.13 with XCode 10 so any system that doesn't have the recent updates won't work with citra.

The first time we introduced such issue was with #4194. The usage of alignas there isn't supported by systems below 10.13. 

For now the easiest fix is to don't support those old systems. Systems not supported anymore are:
- iMac manufactured late 2009 or later
- MacBook manufactured late 2009 or later
- MacBook Pro manufactured mid 2010 or later
- MacBook Air manufactured late 2010 or later
- Mac Mini manufactured mid 2010 or later
- Mac Pro manufactured mid 2010 or later

Other solutions to that issue:
2. Don't use such features. That would mean we should switch our CI to build on such old system (e.g. for Travis this would be XCode 9.2)
3. Build an updated (static?) stdlibc++ together with Citra and build Citra with that lib (and also ship it with that lib).
4. Guide users on those old platforms how to build their own libc++: https://libcxx.llvm.org/docs/BuildingLibcxx.html#build-instructions and https://libcxx.llvm.org/docs/UsingLibcxx.html#alternate-libcxx and then they "just" have to build Citra with that lib.

Every solution expect 2. would allow us to use newer features (like alignas/optional/variant/any/...)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4269)
<!-- Reviewable:end -->
