### PR TITLE
Threaded CPU vertex shader processing

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -83,6 +83,7 @@ add_library(common STATIC
     telemetry.h
     thread.cpp
     thread.h
+    thread_pool.h
     thread_queue_list.h
     threadsafe_queue.h
     timer.cpp

--- a/src/common/thread_pool.h
+++ b/src/common/thread_pool.h
@@ -1,0 +1,110 @@
+// Copyright 2018 Citra Emulator Project / PPSSPP Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <atomic>
+#include <functional>
+#include <future>
+#include <mutex>
+#include <thread>
+#include <vector>
+#include "common/assert.h"
+#include "common/threadsafe_queue.h"
+
+namespace Common {
+
+class ThreadPool : NonCopyable {
+private:
+    explicit ThreadPool(std::size_t num_threads) : num_threads(num_threads), workers(num_threads) {
+        ASSERT(num_threads);
+    }
+
+public:
+    static ThreadPool& GetPool() {
+        static ThreadPool thread_pool(std::thread::hardware_concurrency());
+        return thread_pool;
+    }
+
+    void SetSpinlocking(bool enable) {
+        for (auto& worker : workers) {
+            worker.spinlock_enabled = enable;
+            if (enable) {
+                std::unique_lock<std::mutex> lock(worker.mutex);
+                lock.unlock();
+                worker.cv.notify_one();
+            }
+        }
+    }
+
+    template <typename F, typename... Args>
+    auto Push(F&& f, Args&&... args) {
+        auto ret = workers[next_worker].Push(std::forward<F>(f), std::forward<Args>(args)...);
+        next_worker = (next_worker + 1) % num_threads;
+        return ret;
+    }
+
+    std::size_t TotalThreads() const {
+        return num_threads;
+    }
+
+private:
+    class Worker {
+    public:
+        Worker() : exit_loop(false), spinlock_enabled(false), thread([this] { Loop(); }) {}
+
+        ~Worker() {
+            exit_loop = true;
+            std::unique_lock<std::mutex> lock(mutex);
+            lock.unlock();
+            cv.notify_one();
+            thread.join();
+        }
+
+        template <typename F, typename... Args>
+        std::future<void> Push(F&& f, Args&&... args) {
+            auto task = std::make_shared<std::packaged_task<decltype(f(args...))()>>(
+                std::bind(std::forward<F>(f), std::forward<Args>(args)...));
+
+            queue.Push([task] { (*task)(); });
+
+            if (!spinlock_enabled.load(std::memory_order_relaxed)) {
+                std::unique_lock<std::mutex> lock(mutex);
+                lock.unlock();
+                cv.notify_one();
+            }
+
+            return task->get_future();
+        }
+
+        std::atomic<bool> spinlock_enabled;
+        std::mutex mutex;
+        std::condition_variable cv;
+
+    private:
+        void Loop() {
+            while (true) {
+                std::function<void()> task;
+                while (queue.Pop(task))
+                    task();
+                if (spinlock_enabled)
+                    continue;
+
+                std::unique_lock<std::mutex> lock(mutex);
+                if (!queue.Empty())
+                    continue;
+                if (exit_loop)
+                    break;
+                cv.wait(lock);
+            }
+        }
+
+        bool exit_loop;
+        SPSCQueue<std::function<void()>> queue;
+        std::thread thread;
+    };
+
+    const std::size_t num_threads;
+    std::size_t next_worker = 0;
+    std::vector<Worker> workers;
+};
+} // namespace Common

--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -4,11 +4,13 @@
 
 #include <array>
 #include <cstddef>
+#include <future>
 #include <memory>
 #include <utility>
 #include "common/assert.h"
 #include "common/logging/log.h"
 #include "common/microprofile.h"
+#include "common/thread_pool.h"
 #include "common/vector_math.h"
 #include "core/hle/service/gsp/gsp.h"
 #include "core/hw/gpu.h"
@@ -320,17 +322,50 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
         }
 
         // Processes information about internal vertex attributes to figure out how a vertex is
-        // loaded.
-        // Later, these can be compiled and cached.
+        // loaded. Later, these can be compiled and cached.
         const u32 base_address = regs.pipeline.vertex_attributes.GetPhysicalBaseAddress();
         VertexLoader loader(regs.pipeline);
         Shader::OutputVertex::ValidateSemantics(regs.rasterizer);
+
+        // Multithreaded vertex cache. Each thread will lock the vertex that its processing and add
+        // the data to that batch
+        struct CachedVertex {
+            explicit CachedVertex() : batch(0), lock ATOMIC_FLAG_INIT {}
+            CachedVertex(const CachedVertex& other) : CachedVertex() {}
+            union {
+                Shader::AttributeBuffer output_attr; // GS used
+                Shader::OutputVertex output_vertex;  // No GS
+            };
+            std::atomic<u32> batch;
+            std::atomic_flag lock;
+        };
+        static std::vector<CachedVertex> vs_output(0x10000);
+
+        if (!is_indexed && vs_output.size() < regs.pipeline.num_vertices) {
+            vs_output.resize(regs.pipeline.num_vertices);
+        }
+
+        // used to invalidate data from the previous batch without clearing it
+        static u32 batch_id = std::numeric_limits<u32>::max();
+        ++batch_id;
+        // reset cache when id overflows for safety
+        if (batch_id == 0) {
+            ++batch_id;
+            for (auto& entry : vs_output)
+                entry.batch = 0;
+        }
 
         // Load vertices
         const auto& index_info = regs.pipeline.index_array;
         const u8* index_address_8 = Memory::GetPhysicalPointer(base_address + index_info.offset);
         const u16* index_address_16 = reinterpret_cast<const u16*>(index_address_8);
         bool index_u16 = index_info.format != 0;
+
+        auto VertexIndex = [&](unsigned int index) {
+            // Indexed rendering doesn't use the start offset
+            return is_indexed ? (index_u16 ? index_address_16[index] : index_address_8[index])
+                              : (index + regs.pipeline.vertex_offset);
+        };
 
         if (g_debug_context && g_debug_context->recorder) {
             for (int i = 0; i < 3; ++i) {
@@ -349,79 +384,126 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
 
         DebugUtils::MemoryAccessTracker memory_accesses;
 
-        // Simple circular-replacement vertex cache
-        // The size has been tuned for optimal balance between hit-rate and the cost of lookup
-        const std::size_t VERTEX_CACHE_SIZE = 32;
-        std::array<bool, VERTEX_CACHE_SIZE> vertex_cache_valid{};
-        std::array<u16, VERTEX_CACHE_SIZE> vertex_cache_ids;
-        std::array<Shader::AttributeBuffer, VERTEX_CACHE_SIZE> vertex_cache;
-        Shader::AttributeBuffer vs_output;
-
-        unsigned int vertex_cache_pos = 0;
-
         auto* shader_engine = Shader::GetEngine();
         Shader::UnitState shader_unit;
 
         shader_engine->SetupBatch(g_state.vs, regs.vs.main_offset);
+
+        const bool use_gs = regs.pipeline.use_gs == PipelineRegs::UseGS::Yes;
+
+        auto VSUnitLoop = [&](u32 thread_id, auto num_threads) {
+            constexpr bool single_thread =
+                std::is_same<std::integral_constant<u32, 1>, decltype(num_threads)>();
+            Shader::UnitState shader_unit;
+
+            for (unsigned int index = thread_id; index < regs.pipeline.num_vertices;
+                 index += num_threads) {
+                unsigned int vertex = VertexIndex(index);
+                auto& cached_vertex = vs_output[is_indexed ? vertex : index];
+
+                if (is_indexed) {
+
+                    if (g_debug_context && Pica::g_debug_context->recorder) {
+                        int size = index_u16 ? 2 : 1;
+                        memory_accesses.AddAccess(base_address + index_info.offset + size * index,
+                                                  size);
+                    }
+                    if (!single_thread) {
+                        // Try locking this vertex
+                        if (cached_vertex.lock.test_and_set(std::memory_order_acquire)) {
+                            // Another thread is processing this vertex
+                            continue;
+                        } else if (cached_vertex.batch.load(std::memory_order_acquire) ==
+                                   batch_id) {
+                            // Vertex is not being processed and is from the correct batch so unlock
+                            cached_vertex.lock.clear(std::memory_order_release);
+                            continue;
+                        }
+                    } else if (cached_vertex.batch.load(std::memory_order_relaxed) == batch_id) {
+                        continue;
+                    }
+                }
+                Shader::AttributeBuffer attribute_buffer;
+                Shader::AttributeBuffer& output_attr =
+                    use_gs ? cached_vertex.output_attr : attribute_buffer;
+
+                // Initialize data for the current vertex
+                loader.LoadVertex(base_address, index, vertex, attribute_buffer, memory_accesses);
+
+                // Send to vertex shader
+                if (g_debug_context)
+                    g_debug_context->OnEvent(DebugContext::Event::VertexShaderInvocation,
+                                             &attribute_buffer);
+                shader_unit.LoadInput(regs.vs, attribute_buffer);
+                shader_engine->Run(g_state.vs, shader_unit);
+                shader_unit.WriteOutput(regs.vs, output_attr);
+                if (!use_gs) {
+                    cached_vertex.output_vertex =
+                        Shader::OutputVertex::FromAttributeBuffer(regs.rasterizer, output_attr);
+                }
+                if (!single_thread) {
+                    cached_vertex.batch.store(batch_id, std::memory_order_release);
+
+                    if (is_indexed) {
+                        cached_vertex.lock.clear(std::memory_order_release);
+                    }
+                } else if (is_indexed) {
+                    cached_vertex.batch.store(batch_id, std::memory_order_relaxed);
+                }
+            }
+        };
+
+        auto& thread_pool = Common::ThreadPool::GetPool();
+        std::vector<std::future<void>> futures;
+
+        constexpr unsigned int MIN_VERTICES_PER_THREAD = 10;
+        u32 vs_threads = regs.pipeline.num_vertices / MIN_VERTICES_PER_THREAD;
+        vs_threads = std::min(vs_threads, std::thread::hardware_concurrency() - 1);
+
+        if (!vs_threads) {
+            VSUnitLoop(0, std::integral_constant<u32, 1>{});
+        } else {
+            for (unsigned int thread_id = 0; thread_id < vs_threads; ++thread_id) {
+                futures.emplace_back(thread_pool.Push(VSUnitLoop, thread_id, vs_threads));
+            }
+        }
 
         g_state.geometry_pipeline.Reconfigure();
         g_state.geometry_pipeline.Setup(shader_engine);
         if (g_state.geometry_pipeline.NeedIndexInput())
             ASSERT(is_indexed);
 
-        for (unsigned int index = 0; index < regs.pipeline.num_vertices; ++index) {
-            // Indexed rendering doesn't use the start offset
-            unsigned int vertex =
-                is_indexed ? (index_u16 ? index_address_16[index] : index_address_8[index])
-                           : (index + regs.pipeline.vertex_offset);
+        const auto AddTriangle =
+            [rasterizer = VideoCore::g_renderer->Rasterizer()](auto& v0, auto& v1, auto& v2) {
+                rasterizer->AddTriangle(v0, v1, v2);
+            };
 
-            bool vertex_cache_hit = false;
+        for (u32 index = 0; index < regs.pipeline.num_vertices; ++index) {
+            u32 vertex = VertexIndex(index);
+            auto& cached_vertex = vs_output[is_indexed ? vertex : index];
 
-            if (is_indexed) {
-                if (g_state.geometry_pipeline.NeedIndexInput()) {
-                    g_state.geometry_pipeline.SubmitIndex(vertex);
-                    continue;
-                }
+            if (use_gs && is_indexed && g_state.geometry_pipeline.NeedIndexInput()) {
+                g_state.geometry_pipeline.SubmitIndex(vertex);
+                continue;
+            }
 
-                if (g_debug_context && Pica::g_debug_context->recorder) {
-                    int size = index_u16 ? 2 : 1;
-                    memory_accesses.AddAccess(base_address + index_info.offset + size * index,
-                                              size);
-                }
-
-                for (unsigned int i = 0; i < VERTEX_CACHE_SIZE; ++i) {
-                    if (vertex_cache_valid[i] && vertex == vertex_cache_ids[i]) {
-                        vs_output = vertex_cache[i];
-                        vertex_cache_hit = true;
-                        break;
-                    }
+            // Synchronize threads
+            if (vs_threads) {
+                while (cached_vertex.batch.load(std::memory_order_acquire) != batch_id) {
+                    std::this_thread::yield();
                 }
             }
 
-            if (!vertex_cache_hit) {
-                // Initialize data for the current vertex
-                Shader::AttributeBuffer input;
-                loader.LoadVertex(base_address, index, vertex, input, memory_accesses);
-
-                // Send to vertex shader
-                if (g_debug_context)
-                    g_debug_context->OnEvent(DebugContext::Event::VertexShaderInvocation,
-                                             (void*)&input);
-                shader_unit.LoadInput(regs.vs, input);
-                shader_engine->Run(g_state.vs, shader_unit);
-                shader_unit.WriteOutput(regs.vs, vs_output);
-
-                if (is_indexed) {
-                    vertex_cache[vertex_cache_pos] = vs_output;
-                    vertex_cache_valid[vertex_cache_pos] = true;
-                    vertex_cache_ids[vertex_cache_pos] = vertex;
-                    vertex_cache_pos = (vertex_cache_pos + 1) % VERTEX_CACHE_SIZE;
-                }
+            if (use_gs) {
+                // Send to geometry pipeline
+                g_state.geometry_pipeline.SubmitVertex(cached_vertex.output_attr);
+            } else {
+                primitive_assembler.SubmitVertex(cached_vertex.output_vertex, AddTriangle);
             }
-
-            // Send to geometry pipeline
-            g_state.geometry_pipeline.SubmitVertex(vs_output);
         }
+
+        for (auto& future : futures)
+            future.get();
 
         for (auto& range : memory_accesses.ranges) {
             g_debug_context->recorder->MemoryAccessed(Memory::GetPhysicalPointer(range.first),
@@ -649,7 +731,7 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
     if (g_debug_context)
         g_debug_context->OnEvent(DebugContext::Event::PicaCommandProcessed,
                                  reinterpret_cast<void*>(&id));
-}
+} // namespace CommandProcessor
 
 void ProcessCommandList(const u32* list, u32 size) {
     g_state.cmd_list.head_ptr = g_state.cmd_list.current_ptr = list;

--- a/src/video_core/debug_utils/debug_utils.h
+++ b/src/video_core/debug_utils/debug_utils.h
@@ -232,12 +232,16 @@ class MemoryAccessTracker {
 public:
     /// Record a particular memory access in the list
     void AddAccess(u32 paddr, u32 size) {
+        std::lock_guard<std::mutex> lock(access_guard);
+
         // Create new range or extend existing one
         ranges[paddr] = std::max(ranges[paddr], size);
 
         // Simplify ranges...
         SimplifyRanges();
     }
+
+    std::mutex access_guard;
 
     /// Map of accessed ranges (mapping start address to range size)
     std::map<u32, u32> ranges;

--- a/src/video_core/primitive_assembly.cpp
+++ b/src/video_core/primitive_assembly.cpp
@@ -15,7 +15,7 @@ PrimitiveAssembler<VertexType>::PrimitiveAssembler(PipelineRegs::TriangleTopolog
 
 template <typename VertexType>
 void PrimitiveAssembler<VertexType>::SubmitVertex(const VertexType& vtx,
-                                                  TriangleHandler triangle_handler) {
+                                                  const TriangleHandler& triangle_handler) {
     switch (topology) {
     case PipelineRegs::TriangleTopology::List:
     case PipelineRegs::TriangleTopology::Shader:

--- a/src/video_core/primitive_assembly.h
+++ b/src/video_core/primitive_assembly.h
@@ -27,7 +27,7 @@ struct PrimitiveAssembler {
      * NOTE: We could specify the triangle handler in the constructor, but this way we can
      * keep event and handler code next to each other.
      */
-    void SubmitVertex(const VertexType& vtx, TriangleHandler triangle_handler);
+    void SubmitVertex(const VertexType& vtx, const TriangleHandler& triangle_handler);
 
     /**
      * Invert the vertex order of the next triangle. Called by geometry shader emitter.


### PR DESCRIPTION
Picking up where https://github.com/citra-emu/citra/pull/2970 left off.

In #2970, it introduced threaded vertex shaders, but was attempting to mimic exactly the way that the 3ds runs vertex shaders, which ended up making it way more complicated, and reduced almost any speed benefits we got from threading. This PR will instead use as many threads as appropriate for the hardware, making a substantial speed boost for people that still need to use CPU shader jit. Currently AMD users and Mac users have issues with GLSL shaders, and citra emulation only uses a single core, those users should experience a fair speed boost depending on how powerful their CPU is.

These two tests were taken at 4x resolution with GLSL shaders off and Shader JIT on.

![Before](https://user-images.githubusercontent.com/952515/46168050-99500600-c254-11e8-8a0d-a03dccfd04b6.png)

![After](https://user-images.githubusercontent.com/952515/46168049-98b76f80-c254-11e8-93e8-c42a4528f445.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4270)
<!-- Reviewable:end -->
