### PR TITLE
 cfg, ptm: access FS via backend directly 

### DIFF
--- a/src/citra_qt/configuration/configure_system.cpp
+++ b/src/citra_qt/configuration/configure_system.cpp
@@ -7,7 +7,6 @@
 #include "citra_qt/ui_settings.h"
 #include "core/core.h"
 #include "core/hle/service/cfg/cfg.h"
-#include "core/hle/service/fs/archive.h"
 #include "core/hle/service/ptm/ptm.h"
 #include "core/settings.h"
 #include "ui_configure_system.h"
@@ -252,11 +251,8 @@ void ConfigureSystem::setConfiguration() {
         ui->group_system_settings->setEnabled(false);
     } else {
         // This tab is enabled only when game is not running (i.e. all service are not initialized).
-        // Temporarily register archive types and load the config savegame file to memory.
-        Service::FS::RegisterArchiveTypes();
         cfg = std::make_shared<Service::CFG::Module>();
         ReadSystemSettings();
-        Service::FS::UnregisterArchiveTypes();
 
         ui->label_disable_info->hide();
     }
@@ -348,10 +344,7 @@ void ConfigureSystem::applyConfiguration() {
     // apply play coin
     u16 new_play_coin = static_cast<u16>(ui->spinBox_play_coins->value());
     if (play_coin != new_play_coin) {
-        // archive types must be registered to set play coins
-        Service::FS::RegisterArchiveTypes();
         Service::PTM::Module::SetPlayCoins(new_play_coin);
-        Service::FS::UnregisterArchiveTypes();
     }
 
     // update the config savegame if any item is modified.

--- a/src/core/file_sys/archive_extsavedata.cpp
+++ b/src/core/file_sys/archive_extsavedata.cpp
@@ -194,15 +194,6 @@ ArchiveFactory_ExtSaveData::ArchiveFactory_ExtSaveData(const std::string& mount_
     LOG_DEBUG(Service_FS, "Directory {} set as base for ExtSaveData.", mount_point);
 }
 
-bool ArchiveFactory_ExtSaveData::Initialize() {
-    if (!FileUtil::CreateFullPath(mount_point)) {
-        LOG_ERROR(Service_FS, "Unable to create ExtSaveData base path.");
-        return false;
-    }
-
-    return true;
-}
-
 Path ArchiveFactory_ExtSaveData::GetCorrectedPath(const Path& path) {
     if (!shared)
         return path;

--- a/src/core/file_sys/archive_extsavedata.h
+++ b/src/core/file_sys/archive_extsavedata.h
@@ -20,12 +20,6 @@ class ArchiveFactory_ExtSaveData final : public ArchiveFactory {
 public:
     ArchiveFactory_ExtSaveData(const std::string& mount_point, bool shared);
 
-    /**
-     * Initialize the archive.
-     * @return true if it initialized successfully
-     */
-    bool Initialize();
-
     std::string GetName() const override {
         return "ExtSaveData";
     }

--- a/src/core/hle/service/cfg/cfg.h
+++ b/src/core/hle/service/cfg/cfg.h
@@ -8,7 +8,11 @@
 #include <memory>
 #include <string>
 #include "common/common_types.h"
-#include "core/hle/service/fs/archive.h"
+#include "core/hle/service/service.h"
+
+namespace FileSys {
+class ArchiveBackend;
+}
 
 namespace Service::CFG {
 
@@ -399,7 +403,7 @@ public:
 private:
     static constexpr u32 CONFIG_SAVEFILE_SIZE = 0x8000;
     std::array<u8, CONFIG_SAVEFILE_SIZE> cfg_config_file_buffer;
-    Service::FS::ArchiveHandle cfg_system_save_data_archive;
+    std::unique_ptr<FileSys::ArchiveBackend> cfg_system_save_data_archive;
     u32 preferred_region_code = 0;
 };
 

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -646,19 +646,11 @@ void RegisterArchiveTypes() {
 
     auto extsavedata_factory =
         std::make_unique<FileSys::ArchiveFactory_ExtSaveData>(sdmc_directory, false);
-    if (extsavedata_factory->Initialize())
-        RegisterArchiveType(std::move(extsavedata_factory), ArchiveIdCode::ExtSaveData);
-    else
-        LOG_ERROR(Service_FS, "Can't instantiate ExtSaveData archive with path {}",
-                  extsavedata_factory->GetMountPoint());
+    RegisterArchiveType(std::move(extsavedata_factory), ArchiveIdCode::ExtSaveData);
 
     auto sharedextsavedata_factory =
         std::make_unique<FileSys::ArchiveFactory_ExtSaveData>(nand_directory, true);
-    if (sharedextsavedata_factory->Initialize())
-        RegisterArchiveType(std::move(sharedextsavedata_factory), ArchiveIdCode::SharedExtSaveData);
-    else
-        LOG_ERROR(Service_FS, "Can't instantiate SharedExtSaveData archive with path {}",
-                  sharedextsavedata_factory->GetMountPoint());
+    RegisterArchiveType(std::move(sharedextsavedata_factory), ArchiveIdCode::SharedExtSaveData);
 
     // Create the NCCH archive, basically a small variation of the RomFS archive
     auto savedatacheck_factory = std::make_unique<FileSys::ArchiveFactory_NCCH>();


### PR DESCRIPTION
Similar to #4277
I put these two together because they can decouple the FS dependency in Qt configuration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4278)
<!-- Reviewable:end -->
