### PR TITLE
Port yuzu-emu/yuzu#1412: "kernel/object: Remove unnecessary std::move from DynamicObjectCast()"

### DIFF
--- a/src/core/hle/kernel/object.h
+++ b/src/core/hle/kernel/object.h
@@ -6,7 +6,6 @@
 
 #include <atomic>
 #include <string>
-#include <utility>
 
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 
@@ -99,7 +98,7 @@ using SharedPtr = boost::intrusive_ptr<T>;
 template <typename T>
 inline SharedPtr<T> DynamicObjectCast(SharedPtr<Object> object) {
     if (object != nullptr && object->GetHandleType() == T::HANDLE_TYPE) {
-        return boost::static_pointer_cast<T>(std::move(object));
+        return boost::static_pointer_cast<T>(object);
     }
     return nullptr;
 }

--- a/src/core/hle/kernel/wait_object.h
+++ b/src/core/hle/kernel/wait_object.h
@@ -59,7 +59,7 @@ private:
 template <>
 inline SharedPtr<WaitObject> DynamicObjectCast<WaitObject>(SharedPtr<Object> object) {
     if (object != nullptr && object->IsWaitable()) {
-        return boost::static_pointer_cast<WaitObject>(std::move(object));
+        return boost::static_pointer_cast<WaitObject>(object);
     }
     return nullptr;
 }


### PR DESCRIPTION
See yuzu-emu/yuzu#1412 for more details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4280)
<!-- Reviewable:end -->
