### PR TITLE
Implement SeedDB & Seed Crypto

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -69,6 +69,8 @@ add_library(core STATIC
     file_sys/romfs_reader.h
     file_sys/savedata_archive.cpp
     file_sys/savedata_archive.h
+    file_sys/seed_db.cpp
+    file_sys/seed_db.h
     file_sys/ticket.cpp
     file_sys/ticket.h
     file_sys/title_metadata.cpp

--- a/src/core/file_sys/seed_db.cpp
+++ b/src/core/file_sys/seed_db.cpp
@@ -1,0 +1,149 @@
+// Copyright 2018 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <fmt/format.h>
+#include "common/file_util.h"
+#include "common/logging/log.h"
+#include "core/file_sys/seed_db.h"
+
+namespace FileSys {
+
+bool SeedDB::Load() {
+    seeds.clear();
+    const std::string path{
+        fmt::format("{}/seeddb.bin", FileUtil::GetUserPath(FileUtil::UserPath::SysDataDir))};
+    if (!FileUtil::Exists(path)) {
+        if (!FileUtil::CreateFullPath(path)) {
+            LOG_ERROR(Service_FS, "Failed to create seed database");
+            return false;
+        }
+        if (!Save()) {
+            LOG_ERROR(Service_FS, "Failed to save seed database");
+            return false;
+        }
+        return true;
+    }
+    FileUtil::IOFile file{path, "rb"};
+    if (!file.IsOpen()) {
+        LOG_ERROR(Service_FS, "Failed to open seed database");
+        return false;
+    }
+    u32 count;
+    if (!file.ReadBytes(&count, sizeof(count))) {
+        LOG_ERROR(Service_FS, "Failed to read seed database count fully");
+        return false;
+    }
+    if (!file.Seek(file.Tell() + SEEDDB_PADDING_BYTES, SEEK_SET)) {
+        LOG_ERROR(Service_FS, "Failed to skip seed database padding");
+        return false;
+    }
+    for (u32 i = 0; i < count; ++i) {
+        Seed seed;
+        if (!file.ReadBytes(&seed.title_id, sizeof(seed.title_id))) {
+            LOG_ERROR(Service_FS, "Failed to read seed {} title ID", i);
+            return false;
+        }
+        if (!file.ReadBytes(seed.data.data(), seed.data.size())) {
+            LOG_ERROR(Service_FS, "Failed to read seed {} data", i);
+            return false;
+        }
+        if (!file.ReadBytes(seed.reserved.data(), seed.reserved.size())) {
+            LOG_ERROR(Service_FS, "Failed to read seed {} reserved data", i);
+            return false;
+        }
+        seeds.push_back(seed);
+    }
+    return true;
+}
+
+bool SeedDB::Save() {
+    const std::string path{
+        fmt::format("{}/seeddb.bin", FileUtil::GetUserPath(FileUtil::UserPath::SysDataDir))};
+    if (!FileUtil::CreateFullPath(path)) {
+        LOG_ERROR(Service_FS, "Failed to create seed database");
+        return false;
+    }
+    FileUtil::IOFile file{path, "wb"};
+    if (!file.IsOpen()) {
+        LOG_ERROR(Service_FS, "Failed to open seed database");
+        return false;
+    }
+    u32 count{static_cast<u32>(seeds.size())};
+    if (file.WriteBytes(&count, sizeof(count)) != sizeof(count)) {
+        LOG_ERROR(Service_FS, "Failed to write seed database count fully");
+        return false;
+    }
+    std::array<u8, SEEDDB_PADDING_BYTES> padding{};
+    if (file.WriteBytes(padding.data(), padding.size()) != padding.size()) {
+        LOG_ERROR(Service_FS, "Failed to write seed database padding fully");
+        return false;
+    }
+    for (std::size_t i = 0; i < count; ++i) {
+        if (file.WriteBytes(&seeds[i].title_id, sizeof(seeds[i].title_id)) !=
+            sizeof(seeds[i].title_id)) {
+            LOG_ERROR(Service_FS, "Failed to write seed {} title ID fully", i);
+            return false;
+        }
+        if (file.WriteBytes(seeds[i].data.data(), seeds[i].data.size()) != seeds[i].data.size()) {
+            LOG_ERROR(Service_FS, "Failed to write seed {} data fully", i);
+            return false;
+        }
+        if (file.WriteBytes(seeds[i].reserved.data(), seeds[i].reserved.size()) !=
+            seeds[i].reserved.size()) {
+            LOG_ERROR(Service_FS, "Failed to write seed {} reserved data fully", i);
+            return false;
+        }
+    }
+    return true;
+}
+
+void SeedDB::Add(const Seed& seed) {
+    seeds.push_back(seed);
+}
+
+std::size_t SeedDB::GetCount() const {
+    return seeds.size();
+}
+
+auto SeedDB::FindSeedByTitleID(u64 title_id) const {
+    return std::find_if(seeds.begin(), seeds.end(),
+                        [title_id](const auto& seed) { return seed.title_id == title_id; });
+}
+
+bool AddSeed(const Seed& seed) {
+    // TODO: does this skip/replace if the SeedDB contains a seed for seed.title_id?
+    SeedDB db;
+    if (!db.Load()) {
+        LOG_ERROR(Service_FS, "Failed to load seed database");
+        return false;
+    }
+    db.Add(seed);
+    if (!db.Save()) {
+        LOG_ERROR(Service_FS, "Failed to save seed database");
+        return false;
+    }
+    return true;
+}
+
+std::optional<Seed::Data> GetSeed(u64 title_id) {
+    SeedDB db;
+    if (!db.Load()) {
+        return std::nullopt;
+    }
+    const auto found_seed_iter{db.FindSeedByTitleID(title_id)};
+    if (found_seed_iter != db.seeds.end()) {
+        return found_seed_iter->data;
+    }
+    return std::nullopt;
+}
+
+u32 GetSeedCount() {
+    SeedDB db;
+    if (!db.Load()) {
+        return 0;
+    }
+    return db.GetCount();
+}
+
+} // namespace FileSys

--- a/src/core/file_sys/seed_db.h
+++ b/src/core/file_sys/seed_db.h
@@ -1,0 +1,38 @@
+// Copyright 2018 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <array>
+#include <optional>
+#include <vector>
+#include "common/common_types.h"
+#include "common/swap.h"
+
+namespace FileSys {
+
+constexpr std::size_t SEEDDB_PADDING_BYTES{12};
+
+struct Seed {
+    using Data = std::array<u8, 16>;
+
+    u64_le title_id;
+    Data data;
+    std::array<u8, 8> reserved;
+};
+
+struct SeedDB {
+    std::vector<Seed> seeds;
+
+    bool Load();
+    bool Save();
+    void Add(const Seed& seed);
+
+    std::size_t GetCount() const;
+    auto FindSeedByTitleID(u64 title_id) const;
+};
+
+bool AddSeed(const Seed& seed);
+std::optional<Seed::Data> GetSeed(u64 title_id);
+u32 GetSeedCount();
+
+} // namespace FileSys

--- a/src/core/hle/service/fs/fs_user.h
+++ b/src/core/hle/service/fs/fs_user.h
@@ -486,6 +486,18 @@ private:
     void GetNumSeeds(Kernel::HLERequestContext& ctx);
 
     /**
+     * FS_User::AddSeed service function.
+     *  Inputs:
+     *      0 : 0x087A0180
+     *    1-2 : u64, Title ID
+     *    3-6 : Seed
+     *  Outputs:
+     *      0 : 0x087A0180
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void AddSeed(Kernel::HLERequestContext& ctx);
+
+    /**
      * FS_User::SetSaveDataSecureValue service function.
      *  Inputs:
      *      0 : 0x08650140

--- a/src/core/hle/service/fs/fs_user.h
+++ b/src/core/hle/service/fs/fs_user.h
@@ -492,7 +492,7 @@ private:
      *    1-2 : u64, Title ID
      *    3-6 : Seed
      *  Outputs:
-     *      0 : 0x087A0180
+     *      0 : 0x087A0040
      *      1 : Result of function, 0 on success, otherwise error code
      */
     void AddSeed(Kernel::HLERequestContext& ctx);


### PR DESCRIPTION
This PR implements SeedDB, Seed Crypto and FS AddSeed & GetNumSeeds functions.

#### Files & Directories Used:
##### User Directory/sysdata/seeddb.bin:
SeedDB.
Format:
- Number of seeds in the SeedDB (u32)
- Padding (12 bytes)
- Seeds (format below)

#### Seed Format
- Title ID (u64)
- Seed data (16 bytes)
- Reserved data (8 bytes)

#### Screenshots
Nightly:
![captura de pantalla de 2018-10-01 10-38-16](https://user-images.githubusercontent.com/22228082/46299357-cbb87680-c566-11e8-95fd-e8ed6769fdbb.png)

This PR:
![captura de pantalla de 2018-10-01 10-47-09](https://user-images.githubusercontent.com/22228082/46299623-5dc07f00-c567-11e8-86e9-237445e6739a.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4283)
<!-- Reviewable:end -->
