### PR TITLE
citra-qt: disable directory watcher during CIA installation

### DIFF
--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -257,7 +257,8 @@ void GameList::onFilterCloseClicked() {
 
 GameList::GameList(GMainWindow* parent) : QWidget{parent} {
     watcher = new QFileSystemWatcher(this);
-    connect(watcher, &QFileSystemWatcher::directoryChanged, this, &GameList::RefreshGameDirectory);
+    connect(watcher, &QFileSystemWatcher::directoryChanged, this, &GameList::RefreshGameDirectory,
+            Qt::UniqueConnection);
 
     this->main_window = parent;
     layout = new QVBoxLayout;
@@ -313,6 +314,15 @@ void GameList::setFilterFocus() {
 
 void GameList::setFilterVisible(bool visibility) {
     search_field->setVisible(visibility);
+}
+
+void GameList::setDirectoryWatcherEnabled(bool enabled) {
+    if (enabled)
+        connect(watcher, &QFileSystemWatcher::directoryChanged, this,
+                &GameList::RefreshGameDirectory, Qt::UniqueConnection);
+    else
+        disconnect(watcher, &QFileSystemWatcher::directoryChanged, this,
+                   &GameList::RefreshGameDirectory);
 }
 
 void GameList::clearFilter() {

--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -317,12 +317,13 @@ void GameList::setFilterVisible(bool visibility) {
 }
 
 void GameList::setDirectoryWatcherEnabled(bool enabled) {
-    if (enabled)
+    if (enabled) {
         connect(watcher, &QFileSystemWatcher::directoryChanged, this,
                 &GameList::RefreshGameDirectory, Qt::UniqueConnection);
-    else
+    } else {
         disconnect(watcher, &QFileSystemWatcher::directoryChanged, this,
                    &GameList::RefreshGameDirectory);
+    }
 }
 
 void GameList::clearFilter() {

--- a/src/citra_qt/game_list.h
+++ b/src/citra_qt/game_list.h
@@ -49,6 +49,7 @@ public:
     void clearFilter();
     void setFilterFocus();
     void setFilterVisible(bool visibility);
+    void setDirectoryWatcherEnabled(bool enabled);
     bool isEmpty();
 
     void LoadCompatibilityList();

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -1000,6 +1000,7 @@ void GMainWindow::OnMenuInstallCIA() {
         return;
 
     ui.action_Install_CIA->setEnabled(false);
+    game_list->setDirectoryWatcherEnabled(false);
     progress_bar->show();
     progress_bar->setMaximum(INT_MAX);
 
@@ -1053,7 +1054,9 @@ void GMainWindow::OnCIAInstallReport(Service::AM::InstallStatus status, QString 
 void GMainWindow::OnCIAInstallFinished() {
     progress_bar->hide();
     progress_bar->setValue(0);
+    game_list->setDirectoryWatcherEnabled(true);
     ui.action_Install_CIA->setEnabled(true);
+    game_list->PopulateAsync(UISettings::values.game_dirs);
 }
 
 void GMainWindow::OnMenuRecentFile() {


### PR DESCRIPTION
fixes several errors while installing multiple CIAs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4284)
<!-- Reviewable:end -->
