### PR TITLE
Give frontend access to the hle service interfaces

### DIFF
--- a/src/core/hle/kernel/client_port.h
+++ b/src/core/hle/kernel/client_port.h
@@ -7,11 +7,11 @@
 #include <string>
 #include "common/common_types.h"
 #include "core/hle/kernel/object.h"
+#include "core/hle/kernel/server_port.h"
 #include "core/hle/result.h"
 
 namespace Kernel {
 
-class ServerPort;
 class ClientSession;
 
 class ClientPort final : public Object {
@@ -27,6 +27,10 @@ public:
     static const HandleType HANDLE_TYPE = HandleType::ClientPort;
     HandleType GetHandleType() const override {
         return HANDLE_TYPE;
+    }
+
+    SharedPtr<ServerPort> GetServerPort() const {
+        return server_port;
     }
 
     /**

--- a/src/core/hle/kernel/server_port.h
+++ b/src/core/hle/kernel/server_port.h
@@ -10,6 +10,7 @@
 #include "common/common_types.h"
 #include "core/hle/kernel/object.h"
 #include "core/hle/kernel/wait_object.h"
+#include "core/hle/result.h"
 
 namespace Kernel {
 

--- a/src/core/hle/service/sm/sm.cpp
+++ b/src/core/hle/service/sm/sm.cpp
@@ -4,9 +4,7 @@
 
 #include <tuple>
 #include "common/assert.h"
-#include "core/hle/kernel/client_port.h"
 #include "core/hle/kernel/client_session.h"
-#include "core/hle/kernel/server_port.h"
 #include "core/hle/result.h"
 #include "core/hle/service/sm/sm.h"
 #include "core/hle/service/sm/srv.h"

--- a/src/core/hle/service/sm/sm.h
+++ b/src/core/hle/service/sm/sm.h
@@ -6,16 +6,16 @@
 
 #include <memory>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
-
+#include "core/hle/kernel/client_port.h"
 #include "core/hle/kernel/object.h"
+#include "core/hle/kernel/server_port.h"
 #include "core/hle/result.h"
 #include "core/hle/service/service.h"
 
 namespace Kernel {
-class ClientPort;
 class ClientSession;
-class ServerPort;
 class SessionRequestHandler;
 } // namespace Kernel
 
@@ -45,6 +45,22 @@ public:
                                                                      unsigned int max_sessions);
     ResultVal<Kernel::SharedPtr<Kernel::ClientPort>> GetServicePort(const std::string& name);
     ResultVal<Kernel::SharedPtr<Kernel::ClientSession>> ConnectToService(const std::string& name);
+
+    template <typename T>
+    std::shared_ptr<T> GetService(const std::string& service_name) {
+        static_assert(std::is_base_of_v<Kernel::SessionRequestHandler, T>,
+                      "Not a base of ServiceFrameworkBase");
+        auto service = registered_services.find(service_name);
+        if (service == registered_services.end()) {
+            LOG_DEBUG(Service, "Can't find service: {}", service_name);
+            return nullptr;
+        }
+        auto port = service->second->GetServerPort();
+        if (port == nullptr) {
+            return nullptr;
+        }
+        return std::dynamic_pointer_cast<T>(port->hle_handler);
+    }
 
 private:
     std::weak_ptr<SRV> srv_interface;

--- a/src/core/hle/service/sm/sm.h
+++ b/src/core/hle/service/sm/sm.h
@@ -47,7 +47,7 @@ public:
     ResultVal<Kernel::SharedPtr<Kernel::ClientSession>> ConnectToService(const std::string& name);
 
     template <typename T>
-    std::shared_ptr<T> GetService(const std::string& service_name) {
+    std::shared_ptr<T> GetService(const std::string& service_name) const {
         static_assert(std::is_base_of_v<Kernel::SessionRequestHandler, T>,
                       "Not a base of ServiceFrameworkBase");
         auto service = registered_services.find(service_name);
@@ -59,7 +59,7 @@ public:
         if (port == nullptr) {
             return nullptr;
         }
-        return std::dynamic_pointer_cast<T>(port->hle_handler);
+        return std::static_pointer_cast<T>(port->hle_handler);
     }
 
 private:


### PR DESCRIPTION
This allows frontends to access hle service interfaces e.g to change their state. ATM NFC is waiting for that change, but there might be other parts, too.

the usage (e.g. for NFC) would be: 
```
auto sm = system.ServiceManager(); 
if (sm != nullptr) { 
    std::shared_ptr<Service::NFC::Module::Interface> nfc = sm->GetService("NFC");
    if(nfc != nullptr) { 
        ...
    }
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4296)
<!-- Reviewable:end -->
