### PR TITLE
Revert "Port yuzu/#1367 from yuzu: "game_list: Handle plurals within setFilterResult() better""

### DIFF
--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -85,7 +85,15 @@ void GameListSearchField::setFilterResult(int visible, int total) {
     this->visible = visible;
     this->total = total;
 
-    label_filter_result->setText(tr("%1 of %n result(s)", "", total).arg(visible));
+    QString result_of_text = tr("of");
+    QString result_text;
+    if (total == 1) {
+        result_text = tr("result");
+    } else {
+        result_text = tr("results");
+    }
+    label_filter_result->setText(
+        QString("%1 %2 %3 %4").arg(visible).arg(result_of_text).arg(total).arg(result_text));
 }
 
 QString GameList::getLastFilterResultItem() {


### PR DESCRIPTION
Reverts citra-emu/citra#4241

> So eh... I looked into the current transifex push failure
> which is related to the plurals
> I think the introduction of plurals broke the current transifex+qt update model a little bit...
> The problem is like this
> To fully support plurals, Qt requires loading the "translation" of the source language (english) as well, which should contains man-made translations, say, "result" and "results" (no, qt doesn't automatically generates them)
> The current model assumes that the english translation is a no-op and the en.qm file doesn't need to be loaded (and shouldn't, as qt has a bug/feature that loading an empty qm file return failure https://bugreports.qt.io/browse/QTBUG-31031 (fixed in alpha version))(edited)
> and transifex probably does not accept a srouce ts file that has unfinished plural translation. Or it might be a bug that it expects two unfinished slots (for "result" and "results"), while lupdate only generates one

> Any objection on I reverting https://github.com/citra-emu/citra/pull/4241 for now, so that we can have some transifex push after a long break, and only adding it back after I investigate the transifex issue?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4301)
<!-- Reviewable:end -->
