### PR TITLE
Handle touch input

### DIFF
--- a/src/citra/emu_window/emu_window_sdl2.cpp
+++ b/src/citra/emu_window/emu_window_sdl2.cpp
@@ -58,12 +58,12 @@ void EmuWindow_SDL2::OnFingerDown(SDL_FingerID finger, float x, float y) {
     // 3DS does
 
     const auto [px, py] = TouchToPixelPos(x, y);
-    TouchPressed((unsigned)std::max(px, 0), (unsigned)std::max(py, 0));
+    TouchPressed(static_cast<unsigned>(std::max(px, 0)), static_cast<unsigned>(std::max(py, 0)));
 }
 
 void EmuWindow_SDL2::OnFingerMotion(SDL_FingerID finger, float x, float y) {
     const auto [px, py] = TouchToPixelPos(x, y);
-    TouchMoved((unsigned)std::max(px, 0), (unsigned)std::max(py, 0));
+    TouchMoved(static_cast<unsigned>(std::max(px, 0)), static_cast<unsigned>(std::max(py, 0)));
 }
 
 void EmuWindow_SDL2::OnFingerUp(SDL_FingerID finger) {

--- a/src/citra/emu_window/emu_window_sdl2.cpp
+++ b/src/citra/emu_window/emu_window_sdl2.cpp
@@ -52,7 +52,7 @@ std::pair<int, int> EmuWindow_SDL2::TouchToPixelPos(float touch_x, float touch_y
     return {static_cast<int>(touch_x + 0.5), static_cast<int>(touch_y + 0.5)};
 }
 
-void EmuWindow_SDL2::OnFingerDown(SDL_FingerID finger, float x, float y) {
+void EmuWindow_SDL2::OnFingerDown(float x, float y) {
     // To do: keep track of multitouch using the fingerID and a dictionary of some kind
     // This isn't critical because the best we can do when we have that is to average them, like the
     // 3DS does
@@ -61,12 +61,12 @@ void EmuWindow_SDL2::OnFingerDown(SDL_FingerID finger, float x, float y) {
     TouchPressed(static_cast<unsigned>(std::max(px, 0)), static_cast<unsigned>(std::max(py, 0)));
 }
 
-void EmuWindow_SDL2::OnFingerMotion(SDL_FingerID finger, float x, float y) {
+void EmuWindow_SDL2::OnFingerMotion(float x, float y) {
     const auto [px, py] = TouchToPixelPos(x, y);
     TouchMoved(static_cast<unsigned>(std::max(px, 0)), static_cast<unsigned>(std::max(py, 0)));
 }
 
-void EmuWindow_SDL2::OnFingerUp(SDL_FingerID finger) {
+void EmuWindow_SDL2::OnFingerUp() {
     TouchReleased();
 }
 
@@ -220,13 +220,13 @@ void EmuWindow_SDL2::PollEvents() {
             }
             break;
         case SDL_FINGERDOWN:
-            OnFingerDown(event.tfinger.fingerId, event.tfinger.x, event.tfinger.y);
+            OnFingerDown(event.tfinger.x, event.tfinger.y);
             break;
         case SDL_FINGERMOTION:
-            OnFingerMotion(event.tfinger.fingerId, event.tfinger.x, event.tfinger.y);
+            OnFingerMotion(event.tfinger.x, event.tfinger.y);
             break;
         case SDL_FINGERUP:
-            OnFingerUp(event.tfinger.fingerId);
+            OnFingerUp();
             break;
         case SDL_QUIT:
             is_open = false;

--- a/src/citra/emu_window/emu_window_sdl2.cpp
+++ b/src/citra/emu_window/emu_window_sdl2.cpp
@@ -214,9 +214,10 @@ void EmuWindow_SDL2::PollEvents() {
         case SDL_MOUSEBUTTONDOWN:
         case SDL_MOUSEBUTTONUP:
             // ignore if it came from touch
-            if (event.button.which != SDL_TOUCH_MOUSEID)
+            if (event.button.which != SDL_TOUCH_MOUSEID) {
                 OnMouseButton(event.button.button, event.button.state, event.button.x,
                               event.button.y);
+            }
             break;
         case SDL_FINGERDOWN:
             OnFingerDown(event.tfinger.fingerId, event.tfinger.x, event.tfinger.y);

--- a/src/citra/emu_window/emu_window_sdl2.cpp
+++ b/src/citra/emu_window/emu_window_sdl2.cpp
@@ -53,7 +53,7 @@ std::pair<unsigned, unsigned> EmuWindow_SDL2::TouchToPixelPos(float touch_x, flo
 }
 
 void EmuWindow_SDL2::OnFingerDown(float x, float y) {
-    // To do: keep track of multitouch using the fingerID and a dictionary of some kind
+    // TODO(NeatNit): keep track of multitouch using the fingerID and a dictionary of some kind
     // This isn't critical because the best we can do when we have that is to average them, like the
     // 3DS does
 

--- a/src/citra/emu_window/emu_window_sdl2.cpp
+++ b/src/citra/emu_window/emu_window_sdl2.cpp
@@ -41,15 +41,15 @@ void EmuWindow_SDL2::OnMouseButton(u32 button, u8 state, s32 x, s32 y) {
     }
 }
 
-void EmuWindow_SDL2::TouchToPixelPos(float touch_x, float touch_y, int* pixel_x, int* pixel_y) {
+std::pair<int, int> EmuWindow_SDL2::TouchToPixelPos(float touch_x, float touch_y) {
     int w, h;
     SDL_GetWindowSize(render_window, &w, &h);
 
     touch_x *= w;
     touch_y *= h;
 
-    *pixel_x = (int)(touch_x + 0.5);
-    *pixel_y = (int)(touch_y + 0.5);
+    // add 0.5 to have .99992 round up instead of down. These will always be near-integers.
+    return {static_cast<int>(touch_x + 0.5), static_cast<int>(touch_y + 0.5)};
 }
 
 void EmuWindow_SDL2::OnFingerDown(SDL_FingerID finger, float x, float y) {
@@ -57,16 +57,12 @@ void EmuWindow_SDL2::OnFingerDown(SDL_FingerID finger, float x, float y) {
     // This isn't critical because the best we can do when we have that is to average them, like the
     // 3DS does
 
-    int px, py;
-    TouchToPixelPos(x, y, &px, &py);
-
+    const auto [px, py] = TouchToPixelPos(x, y);
     TouchPressed((unsigned)std::max(px, 0), (unsigned)std::max(py, 0));
 }
 
 void EmuWindow_SDL2::OnFingerMotion(SDL_FingerID finger, float x, float y) {
-    int px, py;
-    TouchToPixelPos(x, y, &px, &py);
-
+    const auto [px, py] = TouchToPixelPos(x, y);
     TouchMoved((unsigned)std::max(px, 0), (unsigned)std::max(py, 0));
 }
 

--- a/src/citra/emu_window/emu_window_sdl2.cpp
+++ b/src/citra/emu_window/emu_window_sdl2.cpp
@@ -41,15 +41,15 @@ void EmuWindow_SDL2::OnMouseButton(u32 button, u8 state, s32 x, s32 y) {
     }
 }
 
-std::pair<int, int> EmuWindow_SDL2::TouchToPixelPos(float touch_x, float touch_y) const {
+std::pair<unsigned, unsigned> EmuWindow_SDL2::TouchToPixelPos(float touch_x, float touch_y) const {
     int w, h;
     SDL_GetWindowSize(render_window, &w, &h);
 
     touch_x *= w;
     touch_y *= h;
 
-    // add 0.5 to have .99992 round up instead of down. These will always be near-integers.
-    return {static_cast<int>(touch_x + 0.5), static_cast<int>(touch_y + 0.5)};
+    return {static_cast<unsigned>(std::max(std::round(touch_x), 0.0f)),
+            static_cast<unsigned>(std::max(std::round(touch_y), 0.0f))};
 }
 
 void EmuWindow_SDL2::OnFingerDown(float x, float y) {
@@ -58,12 +58,12 @@ void EmuWindow_SDL2::OnFingerDown(float x, float y) {
     // 3DS does
 
     const auto [px, py] = TouchToPixelPos(x, y);
-    TouchPressed(static_cast<unsigned>(std::max(px, 0)), static_cast<unsigned>(std::max(py, 0)));
+    TouchPressed(px, py);
 }
 
 void EmuWindow_SDL2::OnFingerMotion(float x, float y) {
     const auto [px, py] = TouchToPixelPos(x, y);
-    TouchMoved(static_cast<unsigned>(std::max(px, 0)), static_cast<unsigned>(std::max(py, 0)));
+    TouchMoved(px, py);
 }
 
 void EmuWindow_SDL2::OnFingerUp() {

--- a/src/citra/emu_window/emu_window_sdl2.cpp
+++ b/src/citra/emu_window/emu_window_sdl2.cpp
@@ -41,7 +41,7 @@ void EmuWindow_SDL2::OnMouseButton(u32 button, u8 state, s32 x, s32 y) {
     }
 }
 
-std::pair<int, int> EmuWindow_SDL2::TouchToPixelPos(float touch_x, float touch_y) {
+std::pair<int, int> EmuWindow_SDL2::TouchToPixelPos(float touch_x, float touch_y) const {
     int w, h;
     SDL_GetWindowSize(render_window, &w, &h);
 

--- a/src/citra/emu_window/emu_window_sdl2.h
+++ b/src/citra/emu_window/emu_window_sdl2.h
@@ -6,7 +6,7 @@
 
 #include <memory>
 #include <utility>
-#include <SDL_touch.h> // should it include all of <SDL>?
+#include <SDL_touch.h>
 #include "core/frontend/emu_window.h"
 
 struct SDL_Window;

--- a/src/citra/emu_window/emu_window_sdl2.h
+++ b/src/citra/emu_window/emu_window_sdl2.h
@@ -45,13 +45,13 @@ private:
     std::pair<int, int> TouchToPixelPos(float touch_x, float touch_y) const;
 
     /// Called by PollEvents when a finger starts touching the touchscreen
-    void OnFingerDown(SDL_FingerID finger, float x, float y);
+    void OnFingerDown(float x, float y);
 
     /// Called by PollEvents when a finger moves while touching the touchscreen
-    void OnFingerMotion(SDL_FingerID finger, float x, float y);
+    void OnFingerMotion(float x, float y);
 
     /// Called by PollEvents when a finger stops touching the touchscreen
-    void OnFingerUp(SDL_FingerID finger);
+    void OnFingerUp();
 
     /// Called by PollEvents when any event that may cause the window to be resized occurs
     void OnResize();

--- a/src/citra/emu_window/emu_window_sdl2.h
+++ b/src/citra/emu_window/emu_window_sdl2.h
@@ -42,7 +42,7 @@ private:
     void OnMouseButton(u32 button, u8 state, s32 x, s32 y);
 
     /// Translates pixel position (0..1) to pixel positions
-    void TouchToPixelPos(float touch_x, float touch_y, int* pixel_x, int* pixel_y);
+    std::pair<int, int> TouchToPixelPos(float touch_x, float touch_y);
 
     /// Called by PollEvents when a finger starts touching the touchscreen
     void OnFingerDown(SDL_FingerID finger, float x, float y);

--- a/src/citra/emu_window/emu_window_sdl2.h
+++ b/src/citra/emu_window/emu_window_sdl2.h
@@ -6,7 +6,6 @@
 
 #include <memory>
 #include <utility>
-#include <SDL_touch.h>
 #include "core/frontend/emu_window.h"
 
 struct SDL_Window;

--- a/src/citra/emu_window/emu_window_sdl2.h
+++ b/src/citra/emu_window/emu_window_sdl2.h
@@ -42,7 +42,7 @@ private:
     void OnMouseButton(u32 button, u8 state, s32 x, s32 y);
 
     /// Translates pixel position (0..1) to pixel positions
-    std::pair<int, int> TouchToPixelPos(float touch_x, float touch_y) const;
+    std::pair<unsigned, unsigned> TouchToPixelPos(float touch_x, float touch_y) const;
 
     /// Called by PollEvents when a finger starts touching the touchscreen
     void OnFingerDown(float x, float y);

--- a/src/citra/emu_window/emu_window_sdl2.h
+++ b/src/citra/emu_window/emu_window_sdl2.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <utility>
+#include <SDL_touch.h> // should it include all of <SDL>?
 #include "core/frontend/emu_window.h"
 
 struct SDL_Window;
@@ -39,6 +40,18 @@ private:
 
     /// Called by PollEvents when a mouse button is pressed or released
     void OnMouseButton(u32 button, u8 state, s32 x, s32 y);
+
+    /// Translates pixel position (0..1) to pixel positions
+    void TouchToPixelPos(float touch_x, float touch_y, int* pixel_x, int* pixel_y);
+
+    /// Called by PollEvents when a finger starts touching the touchscreen
+    void OnFingerDown(SDL_FingerID finger, float x, float y);
+
+    /// Called by PollEvents when a finger moves while touching the touchscreen
+    void OnFingerMotion(SDL_FingerID finger, float x, float y);
+
+    /// Called by PollEvents when a finger stops touching the touchscreen
+    void OnFingerUp(SDL_FingerID finger);
 
     /// Called by PollEvents when any event that may cause the window to be resized occurs
     void OnResize();

--- a/src/citra/emu_window/emu_window_sdl2.h
+++ b/src/citra/emu_window/emu_window_sdl2.h
@@ -42,7 +42,7 @@ private:
     void OnMouseButton(u32 button, u8 state, s32 x, s32 y);
 
     /// Translates pixel position (0..1) to pixel positions
-    std::pair<int, int> TouchToPixelPos(float touch_x, float touch_y);
+    std::pair<int, int> TouchToPixelPos(float touch_x, float touch_y) const;
 
     /// Called by PollEvents when a finger starts touching the touchscreen
     void OnFingerDown(SDL_FingerID finger, float x, float y);

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -212,7 +212,7 @@ void GRenderWindow::keyReleaseEvent(QKeyEvent* event) {
 
 void GRenderWindow::mousePressEvent(QMouseEvent* event) {
     if (event->source() == Qt::MouseEventSynthesizedBySystem)
-        return; // touch input is handled in touchBeginEvent
+        return; // touch input is handled in TouchBeginEvent
 
     auto pos = event->pos();
     if (event->button() == Qt::LeftButton) {
@@ -226,7 +226,7 @@ void GRenderWindow::mousePressEvent(QMouseEvent* event) {
 
 void GRenderWindow::mouseMoveEvent(QMouseEvent* event) {
     if (event->source() == Qt::MouseEventSynthesizedBySystem)
-        return; // touch input is handled in touchUpdateEvent
+        return; // touch input is handled in TouchUpdateEvent
 
     auto pos = event->pos();
     qreal pixelRatio = windowPixelRatio();
@@ -237,7 +237,7 @@ void GRenderWindow::mouseMoveEvent(QMouseEvent* event) {
 
 void GRenderWindow::mouseReleaseEvent(QMouseEvent* event) {
     if (event->source() == Qt::MouseEventSynthesizedBySystem)
-        return; // touch input is handled in touchEndEvent
+        return; // touch input is handled in TouchEndEvent
 
     if (event->button() == Qt::LeftButton)
         this->TouchReleased();
@@ -245,7 +245,7 @@ void GRenderWindow::mouseReleaseEvent(QMouseEvent* event) {
         InputCommon::GetMotionEmu()->EndTilt();
 }
 
-void GRenderWindow::touchBeginEvent(QTouchEvent* event) {
+void GRenderWindow::TouchBeginEvent(QTouchEvent* event) {
     auto points = event->touchPoints();
     auto tp = points.first(); // there should only be 1 point in TouchBegin
     auto pos = tp.pos();
@@ -256,7 +256,7 @@ void GRenderWindow::touchBeginEvent(QTouchEvent* event) {
                        static_cast<unsigned>(pos.y() * pixelRatio));
 }
 
-void GRenderWindow::touchUpdateEvent(QTouchEvent* event) {
+void GRenderWindow::TouchUpdateEvent(QTouchEvent* event) {
     qreal x = 0.0;
     qreal y = 0.0;
     int active_points = 0;
@@ -280,20 +280,20 @@ void GRenderWindow::touchUpdateEvent(QTouchEvent* event) {
                      std::max(static_cast<unsigned>(y * pixelRatio), 0u));
 }
 
-void GRenderWindow::touchEndEvent(QTouchEvent* event) {
+void GRenderWindow::TouchEndEvent(QTouchEvent* event) {
     // Copied from mouseReleaseEvent:
     this->TouchReleased();
 }
 
 bool GRenderWindow::event(QEvent* event) {
     if (event->type() == QEvent::TouchBegin) {
-        touchBeginEvent(static_cast<QTouchEvent*>(event));
+        TouchBeginEvent(static_cast<QTouchEvent*>(event));
         return true;
     } else if (event->type() == QEvent::TouchUpdate) {
-        touchUpdateEvent(static_cast<QTouchEvent*>(event));
+        TouchUpdateEvent(static_cast<QTouchEvent*>(event));
         return true;
     } else if (event->type() == QEvent::TouchEnd || event->type() == QEvent::TouchCancel) {
-        touchEndEvent(static_cast<QTouchEvent*>(event));
+        TouchEndEvent(static_cast<QTouchEvent*>(event));
         return true;
     }
 

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -250,17 +250,13 @@ std::pair<unsigned, unsigned> GRenderWindow::ScaleTouch(QPointF pos) {
 }
 
 void GRenderWindow::TouchBeginEvent(const QTouchEvent* event) {
-    auto pos = event->touchPoints().first().pos(); // there should only be 1 point in TouchBegin
-
-    const auto [x, y] = ScaleTouch(pos);
-
+    const auto [x, y] = ScaleTouch(event->touchPoints().first().pos());
     this->TouchPressed(x, y);
 }
 
 void GRenderWindow::TouchUpdateEvent(const QTouchEvent* event) {
     QPointF pos;
     int active_points = 0;
-    const auto points = event->touchPoints();
 
     // average all active touch points
     for (const auto tp : event->touchPoints()) {

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -280,8 +280,7 @@ void GRenderWindow::TouchUpdateEvent(const QTouchEvent* event) {
                      std::max(static_cast<unsigned>(y * pixelRatio), 0u));
 }
 
-void GRenderWindow::TouchEndEvent(const QTouchEvent* event) {
-    // Copied from mouseReleaseEvent:
+void GRenderWindow::TouchEndEvent() {
     this->TouchReleased();
 }
 
@@ -293,7 +292,7 @@ bool GRenderWindow::event(QEvent* event) {
         TouchUpdateEvent(static_cast<QTouchEvent*>(event));
         return true;
     } else if (event->type() == QEvent::TouchEnd || event->type() == QEvent::TouchCancel) {
-        TouchEndEvent(static_cast<QTouchEvent*>(event));
+        TouchEndEvent();
         return true;
     }
 

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -216,7 +216,7 @@ void GRenderWindow::mousePressEvent(QMouseEvent* event) {
 
     auto pos = event->pos();
     if (event->button() == Qt::LeftButton) {
-        auto [x, y] = ScaleTouch(QPointF(pos));
+        auto [x, y] = ScaleTouch(pos);
         this->TouchPressed(x, y);
     } else if (event->button() == Qt::RightButton) {
         InputCommon::GetMotionEmu()->BeginTilt(pos.x(), pos.y());
@@ -228,7 +228,7 @@ void GRenderWindow::mouseMoveEvent(QMouseEvent* event) {
         return; // touch input is handled in TouchUpdateEvent
 
     auto pos = event->pos();
-    auto [x, y] = ScaleTouch(QPointF(pos));
+    auto [x, y] = ScaleTouch(pos);
     this->TouchMoved(x, y);
     InputCommon::GetMotionEmu()->Tilt(pos.x(), pos.y());
 }

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -216,7 +216,7 @@ void GRenderWindow::mousePressEvent(QMouseEvent* event) {
 
     auto pos = event->pos();
     if (event->button() == Qt::LeftButton) {
-        auto [x, y] = ScaleTouch(pos);
+        const auto [x, y] = ScaleTouch(pos);
         this->TouchPressed(x, y);
     } else if (event->button() == Qt::RightButton) {
         InputCommon::GetMotionEmu()->BeginTilt(pos.x(), pos.y());
@@ -228,7 +228,7 @@ void GRenderWindow::mouseMoveEvent(QMouseEvent* event) {
         return; // touch input is handled in TouchUpdateEvent
 
     auto pos = event->pos();
-    auto [x, y] = ScaleTouch(pos);
+    const auto [x, y] = ScaleTouch(pos);
     this->TouchMoved(x, y);
     InputCommon::GetMotionEmu()->Tilt(pos.x(), pos.y());
 }
@@ -252,7 +252,7 @@ std::pair<unsigned, unsigned> GRenderWindow::ScaleTouch(QPointF pos) {
 void GRenderWindow::TouchBeginEvent(const QTouchEvent* event) {
     auto pos = event->touchPoints().first().pos(); // there should only be 1 point in TouchBegin
 
-    auto [x, y] = ScaleTouch(pos);
+    const auto [x, y] = ScaleTouch(pos);
 
     this->TouchPressed(x, y);
 }
@@ -272,7 +272,7 @@ void GRenderWindow::TouchUpdateEvent(const QTouchEvent* event) {
 
     pos /= active_points;
 
-    auto [x, y] = ScaleTouch(pos);
+    const auto [x, y] = ScaleTouch(pos);
     this->TouchMoved(x, y);
 }
 

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -245,7 +245,7 @@ void GRenderWindow::mouseReleaseEvent(QMouseEvent* event) {
         InputCommon::GetMotionEmu()->EndTilt();
 }
 
-void GRenderWindow::TouchBeginEvent(QTouchEvent* const event) {
+void GRenderWindow::TouchBeginEvent(const QTouchEvent* event) {
     auto points = event->touchPoints();
     auto tp = points.first(); // there should only be 1 point in TouchBegin
     auto pos = tp.pos();
@@ -256,7 +256,7 @@ void GRenderWindow::TouchBeginEvent(QTouchEvent* const event) {
                        static_cast<unsigned>(pos.y() * pixelRatio));
 }
 
-void GRenderWindow::TouchUpdateEvent(QTouchEvent* const event) {
+void GRenderWindow::TouchUpdateEvent(const QTouchEvent* event) {
     qreal x = 0.0;
     qreal y = 0.0;
     int active_points = 0;
@@ -280,7 +280,7 @@ void GRenderWindow::TouchUpdateEvent(QTouchEvent* const event) {
                      std::max(static_cast<unsigned>(y * pixelRatio), 0u));
 }
 
-void GRenderWindow::TouchEndEvent(QTouchEvent* const event) {
+void GRenderWindow::TouchEndEvent(const QTouchEvent* event) {
     // Copied from mouseReleaseEvent:
     this->TouchReleased();
 }

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -257,23 +257,22 @@ void GRenderWindow::touchBeginEvent(QTouchEvent* event) {
 }
 
 void GRenderWindow::touchUpdateEvent(QTouchEvent* event) {
-    qreal x = 0.0, y = 0.0;
-    int activePoints = 0;
-    auto points = event->touchPoints();
+    qreal x = 0.0;
+    qreal y = 0.0;
+    int active_points = 0;
+    const auto points = event->touchPoints();
 
-    for (int i = 0; i < points.count(); i++) {
-        auto tp = points[i];
-
+    for (const auto tp : event->touchPoints()) {
         if (tp.state() & (Qt::TouchPointPressed | Qt::TouchPointMoved | Qt::TouchPointStationary)) {
-            activePoints++;
+            active_points++;
 
             x += tp.pos().x();
             y += tp.pos().y();
         }
     }
 
-    x /= activePoints;
-    y /= activePoints;
+    x /= active_points;
+    y /= active_points;
 
     // Copied from mouseMoveEvent:
     qreal pixelRatio = windowPixelRatio();

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -250,6 +250,7 @@ void GRenderWindow::mouseReleaseEvent(QMouseEvent* event) {
 }
 
 void GRenderWindow::TouchBeginEvent(const QTouchEvent* event) {
+    // TouchBegin always has exactly one touch point, so take the .first()
     const auto [x, y] = ScaleTouch(event->touchPoints().first().pos());
     this->TouchPressed(x, y);
 }

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -245,7 +245,7 @@ void GRenderWindow::mouseReleaseEvent(QMouseEvent* event) {
         InputCommon::GetMotionEmu()->EndTilt();
 }
 
-void GRenderWindow::TouchBeginEvent(QTouchEvent* event) {
+void GRenderWindow::TouchBeginEvent(QTouchEvent* const event) {
     auto points = event->touchPoints();
     auto tp = points.first(); // there should only be 1 point in TouchBegin
     auto pos = tp.pos();
@@ -256,7 +256,7 @@ void GRenderWindow::TouchBeginEvent(QTouchEvent* event) {
                        static_cast<unsigned>(pos.y() * pixelRatio));
 }
 
-void GRenderWindow::TouchUpdateEvent(QTouchEvent* event) {
+void GRenderWindow::TouchUpdateEvent(QTouchEvent* const event) {
     qreal x = 0.0;
     qreal y = 0.0;
     int active_points = 0;
@@ -280,7 +280,7 @@ void GRenderWindow::TouchUpdateEvent(QTouchEvent* event) {
                      std::max(static_cast<unsigned>(y * pixelRatio), 0u));
 }
 
-void GRenderWindow::TouchEndEvent(QTouchEvent* event) {
+void GRenderWindow::TouchEndEvent(QTouchEvent* const event) {
     // Copied from mouseReleaseEvent:
     this->TouchReleased();
 }

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -192,9 +192,15 @@ QByteArray GRenderWindow::saveGeometry() {
         return geometry;
 }
 
-qreal GRenderWindow::windowPixelRatio() {
+qreal GRenderWindow::windowPixelRatio() const {
     // windowHandle() might not be accessible until the window is displayed to screen.
     return windowHandle() ? windowHandle()->screen()->devicePixelRatio() : 1.0f;
+}
+
+std::pair<unsigned, unsigned> GRenderWindow::ScaleTouch(const QPointF pos) const {
+    const qreal pixel_ratio = windowPixelRatio();
+    return {static_cast<unsigned>(std::max(std::round(pos.x() * pixel_ratio), qreal{0.0})),
+            static_cast<unsigned>(std::max(std::round(pos.y() * pixel_ratio), qreal{0.0}))};
 }
 
 void GRenderWindow::closeEvent(QCloseEvent* event) {
@@ -241,12 +247,6 @@ void GRenderWindow::mouseReleaseEvent(QMouseEvent* event) {
         this->TouchReleased();
     else if (event->button() == Qt::RightButton)
         InputCommon::GetMotionEmu()->EndTilt();
-}
-
-std::pair<unsigned, unsigned> GRenderWindow::ScaleTouch(QPointF pos) {
-    qreal pixel_ratio = windowPixelRatio();
-    return {static_cast<unsigned>(std::max(std::round(pos.x() * pixel_ratio), qreal{0.0})),
-            static_cast<unsigned>(std::max(std::round(pos.y() * pixel_ratio), qreal{0.0}))};
 }
 
 void GRenderWindow::TouchBeginEvent(const QTouchEvent* event) {

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -153,7 +153,7 @@ signals:
 private:
     void TouchBeginEvent(const QTouchEvent* event);
     void TouchUpdateEvent(const QTouchEvent* event);
-    void TouchEndEvent(const QTouchEvent* event);
+    void TouchEndEvent();
 
     void OnMinimalClientAreaChangeRequest(
         const std::pair<unsigned, unsigned>& minimal_size) override;

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -9,13 +9,13 @@
 #include <mutex>
 #include <QGLWidget>
 #include <QThread>
-#include <QTouchEvent>
 #include "common/thread.h"
 #include "core/core.h"
 #include "core/frontend/emu_window.h"
 
 class QKeyEvent;
 class QScreen;
+class QTouchEvent;
 
 class GGLWidgetInternal;
 class GMainWindow;

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -151,9 +151,9 @@ signals:
     void Closed();
 
 private:
-    void TouchBeginEvent(QTouchEvent* event);
-    void TouchUpdateEvent(QTouchEvent* event);
-    void TouchEndEvent(QTouchEvent* event);
+    void TouchBeginEvent(const QTouchEvent* event);
+    void TouchUpdateEvent(const QTouchEvent* event);
+    void TouchEndEvent(const QTouchEvent* event);
 
     void OnMinimalClientAreaChangeRequest(
         const std::pair<unsigned, unsigned>& minimal_size) override;

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -131,10 +131,6 @@ public:
     void mouseMoveEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* event) override;
 
-    void TouchBeginEvent(QTouchEvent* event);
-    void TouchUpdateEvent(QTouchEvent* event);
-    void TouchEndEvent(QTouchEvent* event);
-
     bool event(QEvent* event) override;
 
     void focusOutEvent(QFocusEvent* event) override;
@@ -155,6 +151,10 @@ signals:
     void Closed();
 
 private:
+    void TouchBeginEvent(QTouchEvent* event);
+    void TouchUpdateEvent(QTouchEvent* event);
+    void TouchEndEvent(QTouchEvent* event);
+
     void OnMinimalClientAreaChangeRequest(
         const std::pair<unsigned, unsigned>& minimal_size) override;
 

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -131,9 +131,9 @@ public:
     void mouseMoveEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* event) override;
 
-    void touchBeginEvent(QTouchEvent* event);
-    void touchUpdateEvent(QTouchEvent* event);
-    void touchEndEvent(QTouchEvent* event);
+    void TouchBeginEvent(QTouchEvent* event);
+    void TouchUpdateEvent(QTouchEvent* event);
+    void TouchEndEvent(QTouchEvent* event);
 
     bool event(QEvent* event) override;
 

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -9,6 +9,7 @@
 #include <mutex>
 #include <QGLWidget>
 #include <QThread>
+#include <QTouchEvent>
 #include "common/thread.h"
 #include "core/core.h"
 #include "core/frontend/emu_window.h"
@@ -129,6 +130,12 @@ public:
     void mousePressEvent(QMouseEvent* event) override;
     void mouseMoveEvent(QMouseEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* event) override;
+
+    void touchBeginEvent(QTouchEvent* event);
+    void touchUpdateEvent(QTouchEvent* event);
+    void touchEndEvent(QTouchEvent* event);
+
+    bool event(QEvent* event) override;
 
     void focusOutEvent(QFocusEvent* event) override;
 

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -120,7 +120,7 @@ public:
     void restoreGeometry(const QByteArray& geometry); // overridden
     QByteArray saveGeometry();                        // overridden
 
-    qreal windowPixelRatio();
+    qreal windowPixelRatio() const;
 
     void closeEvent(QCloseEvent* event) override;
 
@@ -151,7 +151,7 @@ signals:
     void Closed();
 
 private:
-    std::pair<unsigned, unsigned> ScaleTouch(QPointF pos);
+    std::pair<unsigned, unsigned> ScaleTouch(const QPointF pos) const;
     void TouchBeginEvent(const QTouchEvent* event);
     void TouchUpdateEvent(const QTouchEvent* event);
     void TouchEndEvent();

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -151,6 +151,7 @@ signals:
     void Closed();
 
 private:
+    std::pair<unsigned, unsigned> ScaleTouch(QPointF pos);
     void TouchBeginEvent(const QTouchEvent* event);
     void TouchUpdateEvent(const QTouchEvent* event);
     void TouchEndEvent();


### PR DESCRIPTION
Fixes #1437.

In both SDL and Qt, this will fix how Citra behaves when it's interacted with using a touchscreen.

In Qt only, using multiple fingers (multi-touch) will make the average position of them be sent to the emulation, making it behave exactly like a real 3DS. In SDL, this is trickier to implement, so what happens instead is that the last finger to move is detected. This doesn't really matter, because users shouldn't be using multi-touch in the first place.

In the process, it improves some mouse input code (DRY), and fixes a minor bug where dragging the mouse from the touchscreen to the left of the emulator window or above it would make the touch be registered at the right or bottom of the touchscreen.

I've tested on a Windows 10 laptop with a built-in touchscreen.

This is my first time using C++ so I'm all ears for what can be done better!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4310)
<!-- Reviewable:end -->
