### PR TITLE
Port yuzu-emu/yuzu#1440: "ui_settings: Place definition of the theme array within the cpp file"

### DIFF
--- a/src/citra_qt/configuration/configure_general.cpp
+++ b/src/citra_qt/configuration/configure_general.cpp
@@ -31,7 +31,7 @@ ConfigureGeneral::ConfigureGeneral(QWidget* parent)
             static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
             &ConfigureGeneral::onLanguageChanged);
 
-    for (auto theme : UISettings::themes) {
+    for (const auto& theme : UISettings::themes) {
         ui->theme_combobox->addItem(theme.first, theme.second);
     }
 

--- a/src/citra_qt/ui_settings.cpp
+++ b/src/citra_qt/ui_settings.cpp
@@ -6,5 +6,13 @@
 
 namespace UISettings {
 
+const Themes themes{{
+    {"Default", "default"},
+    {"Dark", "qdarkstyle"},
+    {"Colorful", "colorful"},
+    {"Colorful Dark", "colorful_dark"},
+}};
+
 Values values = {};
-}
+
+} // namespace UISettings

--- a/src/citra_qt/ui_settings.h
+++ b/src/citra_qt/ui_settings.h
@@ -16,11 +16,8 @@ namespace UISettings {
 using ContextualShortcut = std::pair<QString, int>;
 using Shortcut = std::pair<QString, ContextualShortcut>;
 
-static const std::array<std::pair<QString, QString>, 4> themes = {
-    {std::make_pair(QString("Default"), QString("default")),
-     std::make_pair(QString("Dark"), QString("qdarkstyle")),
-     std::make_pair(QString("Colorful"), QString("colorful")),
-     std::make_pair(QString("Colorful Dark"), QString("colorful_dark"))}};
+using Themes = std::array<std::pair<const char*, const char*>, 4>;
+extern const Themes themes;
 
 struct GameDir {
     QString path;


### PR DESCRIPTION
See yuzu-emu/yuzu#1440 for more details.

Original description: 
`Placing the array wholesale into the header places a copy of the whole
array into every translation unit that uses the data, which is wasteful.
Particularly given that this array is referenced from three different
translation units.
This also changes the array to contain pairs of const char*, rather than
QString instances. This way, the string data is able to be fixed into
the read-only segment of the program, as well as eliminate static
constructors/heap allocation immediately on program start.`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4314)
<!-- Reviewable:end -->
