### PR TITLE
Port yuzu-emu/yuzu#1442: "Avoid unnecessary string temporary creation in PrintMessage()"

### DIFF
--- a/src/common/logging/text_formatter.cpp
+++ b/src/common/logging/text_formatter.cpp
@@ -31,7 +31,7 @@ std::string FormatLogMessage(const Entry& entry) {
 }
 
 void PrintMessage(const Entry& entry) {
-    auto str = FormatLogMessage(entry) + '\n';
+    const auto str = FormatLogMessage(entry).append(1, '\n');
     fputs(str.c_str(), stderr);
 }
 


### PR DESCRIPTION
See yuzu-emu/yuzu#1442 for more details.

`operator+ for std::string creates an entirely new string, which is kind
of unnecessary here if we just want to append a null terminator to the
existing one.
Reduces the total amount of potential allocations that need to be done
in the logging path.`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4316)
<!-- Reviewable:end -->
