### PR TITLE
Port yuzu-emu/yuzu#1376: "Logging: Change the TimeStretch::Process log from debug to trace level."

### DIFF
--- a/src/audio_core/time_stretch.cpp
+++ b/src/audio_core/time_stretch.cpp
@@ -59,7 +59,7 @@ std::size_t TimeStretcher::Process(const s16* in, std::size_t num_in, s16* out,
     stretch_ratio = std::max(stretch_ratio, 0.05);
     sound_touch->setTempo(stretch_ratio);
 
-    LOG_DEBUG(Audio, "{:5}/{:5} ratio:{:0.6f} backlog:{:0.6f}", num_in, num_out, stretch_ratio,
+    LOG_TRACE(Audio, "{:5}/{:5} ratio:{:0.6f} backlog:{:0.6f}", num_in, num_out, stretch_ratio,
               backlog_fullness);
 
     sound_touch->putSamples(in, static_cast<u32>(num_in));


### PR DESCRIPTION
See yuzu-emu/yuzu#1376 for more details.

`This function is called too many times and makes the debug logging basically unusable due to the spam.`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4317)
<!-- Reviewable:end -->
