### PR TITLE
citra_qt/multiplayer: retranslate multiplayer dialogs

### DIFF
--- a/src/citra_qt/multiplayer/chat_room.cpp
+++ b/src/citra_qt/multiplayer/chat_room.cpp
@@ -110,6 +110,10 @@ ChatRoom::ChatRoom(QWidget* parent) : QWidget(parent), ui(std::make_unique<Ui::C
 
 ChatRoom::~ChatRoom() = default;
 
+void ChatRoom::RetranslateUi() {
+    ui->retranslateUi(this);
+}
+
 void ChatRoom::Clear() {
     ui->chat_history->clear();
     block_list.clear();

--- a/src/citra_qt/multiplayer/chat_room.h
+++ b/src/citra_qt/multiplayer/chat_room.h
@@ -30,6 +30,7 @@ class ChatRoom : public QWidget {
 
 public:
     explicit ChatRoom(QWidget* parent);
+    void RetranslateUi();
     void SetPlayerList(const Network::RoomMember::MemberList& member_list);
     void Clear();
     void AppendStatusMessage(const QString& msg);

--- a/src/citra_qt/multiplayer/client_room.cpp
+++ b/src/citra_qt/multiplayer/client_room.cpp
@@ -45,6 +45,11 @@ ClientRoomWindow::ClientRoomWindow(QWidget* parent)
 
 ClientRoomWindow::~ClientRoomWindow() = default;
 
+void ClientRoomWindow::RetranslateUi() {
+    ui->retranslateUi(this);
+    ui->chat->RetranslateUi();
+}
+
 void ClientRoomWindow::OnRoomUpdate(const Network::RoomInformation& info) {
     UpdateView();
 }

--- a/src/citra_qt/multiplayer/client_room.h
+++ b/src/citra_qt/multiplayer/client_room.h
@@ -17,6 +17,8 @@ public:
     explicit ClientRoomWindow(QWidget* parent);
     ~ClientRoomWindow();
 
+    void RetranslateUi();
+
 public slots:
     void OnRoomUpdate(const Network::RoomInformation&);
     void OnStateChange(const Network::RoomMember::State&);

--- a/src/citra_qt/multiplayer/direct_connect.cpp
+++ b/src/citra_qt/multiplayer/direct_connect.cpp
@@ -49,6 +49,10 @@ DirectConnectWindow::DirectConnectWindow(QWidget* parent)
 
 DirectConnectWindow::~DirectConnectWindow() = default;
 
+void DirectConnectWindow::RetranslateUi() {
+    ui->retranslateUi(this);
+}
+
 void DirectConnectWindow::Connect() {
     if (!ui->nickname->hasAcceptableInput()) {
         NetworkMessage::ShowError(NetworkMessage::USERNAME_NOT_VALID);

--- a/src/citra_qt/multiplayer/direct_connect.h
+++ b/src/citra_qt/multiplayer/direct_connect.h
@@ -20,6 +20,8 @@ public:
     explicit DirectConnectWindow(QWidget* parent = nullptr);
     ~DirectConnectWindow();
 
+    void RetranslateUi();
+
 signals:
     /**
      * Signalled by this widget when it is closing itself and destroying any state such as

--- a/src/citra_qt/multiplayer/host_room.cpp
+++ b/src/citra_qt/multiplayer/host_room.cpp
@@ -73,6 +73,10 @@ HostRoomWindow::HostRoomWindow(QWidget* parent, QStandardItemModel* list,
 
 HostRoomWindow::~HostRoomWindow() = default;
 
+void HostRoomWindow::RetranslateUi() {
+    ui->retranslateUi(this);
+}
+
 void HostRoomWindow::Host() {
     if (!ui->username->hasAcceptableInput()) {
         NetworkMessage::ShowError(NetworkMessage::USERNAME_NOT_VALID);

--- a/src/citra_qt/multiplayer/host_room.h
+++ b/src/citra_qt/multiplayer/host_room.h
@@ -34,6 +34,8 @@ public:
                             std::shared_ptr<Core::AnnounceMultiplayerSession> session);
     ~HostRoomWindow();
 
+    void RetranslateUi();
+
 private slots:
     /**
      * Handler for connection status changes. Launches the chat window if successful or

--- a/src/citra_qt/multiplayer/lobby.cpp
+++ b/src/citra_qt/multiplayer/lobby.cpp
@@ -84,6 +84,10 @@ Lobby::Lobby(QWidget* parent, QStandardItemModel* list,
     RefreshLobby();
 }
 
+void Lobby::RetranslateUi() {
+    ui->retranslateUi(this);
+}
+
 QString Lobby::PasswordPrompt() {
     bool ok;
     const QString text = QInputDialog::getText(this, tr("Password Required to Join"),

--- a/src/citra_qt/multiplayer/lobby.h
+++ b/src/citra_qt/multiplayer/lobby.h
@@ -30,6 +30,8 @@ public:
                    std::shared_ptr<Core::AnnounceMultiplayerSession> session);
     ~Lobby() = default;
 
+    void RetranslateUi();
+
 public slots:
     /**
      * Begin the process to pull the latest room list from web services. After the listing is

--- a/src/citra_qt/multiplayer/state.cpp
+++ b/src/citra_qt/multiplayer/state.cpp
@@ -75,6 +75,15 @@ void MultiplayerState::retranslateUi() {
     } else {
         status_text->setText(tr("Not Connected"));
     }
+
+    if (lobby)
+        lobby->RetranslateUi();
+    if (host_room)
+        host_room->RetranslateUi();
+    if (client_room)
+        client_room->RetranslateUi();
+    if (direct_connect)
+        direct_connect->RetranslateUi();
 }
 
 void MultiplayerState::OnNetworkStateChanged(const Network::RoomMember::State& state) {


### PR DESCRIPTION
These dialogs are only hidden when closed and currently will not be retranslated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4326)
<!-- Reviewable:end -->
