### PR TITLE
remove GetCurrentModule() functions in HLE Services

### DIFF
--- a/src/citra_qt/configuration/configure_system.cpp
+++ b/src/citra_qt/configuration/configure_system.cpp
@@ -246,12 +246,7 @@ void ConfigureSystem::setConfiguration() {
     ui->edit_init_time->setDateTime(date_time);
 
     if (!enabled) {
-
-        auto cfg_interface = Core::System::GetInstance()
-                                 .ServiceManager()
-                                 .GetService<Service::CFG::Module::Interface>("cfg:u");
-        ASSERT_MSG(cfg_interface, "cfg:u not started!");
-        cfg = cfg_interface->GetModule();
+        cfg = Service::CFG::GetModule(Core::System::GetInstance());
         ASSERT_MSG(cfg, "CFG Module missing!");
         ReadSystemSettings();
         ui->group_system_settings->setEnabled(false);

--- a/src/citra_qt/configuration/configure_system.cpp
+++ b/src/citra_qt/configuration/configure_system.cpp
@@ -246,7 +246,13 @@ void ConfigureSystem::setConfiguration() {
     ui->edit_init_time->setDateTime(date_time);
 
     if (!enabled) {
-        cfg = Service::CFG::GetCurrentModule();
+
+        auto cfg_interface = Core::System::GetInstance()
+                                 .ServiceManager()
+                                 .GetService<Service::CFG::Module::Interface>("cfg:u");
+        ASSERT_MSG(cfg_interface, "cfg:u not started!");
+        cfg = cfg_interface->GetModule();
+        ASSERT_MSG(cfg, "CFG Module missing!");
         ReadSystemSettings();
         ui->group_system_settings->setEnabled(false);
     } else {

--- a/src/core/frontend/applets/swkbd.cpp
+++ b/src/core/frontend/applets/swkbd.cpp
@@ -135,7 +135,14 @@ ValidationError SoftwareKeyboard::Finalize(const std::string& text, u8 button) {
 
 void DefaultKeyboard::Setup(const Frontend::KeyboardConfig* config) {
     SoftwareKeyboard::Setup(config);
-    std::string username = Common::UTF16ToUTF8(Service::CFG::GetCurrentModule()->GetUsername());
+
+    auto cfg =
+        Core::System::GetInstance().ServiceManager().GetService<Service::CFG::Module::Interface>(
+            "cfg:u");
+    ASSERT_MSG(cfg, "cfg:u not started!");
+    auto cfg_module = cfg->GetModule();
+    ASSERT_MSG(cfg_module, "CFG Module missing!");
+    std::string username = Common::UTF16ToUTF8(cfg_module->GetUsername());
     switch (this->config.button_config) {
     case ButtonConfig::None:
     case ButtonConfig::Single:

--- a/src/core/frontend/applets/swkbd.cpp
+++ b/src/core/frontend/applets/swkbd.cpp
@@ -136,13 +136,9 @@ ValidationError SoftwareKeyboard::Finalize(const std::string& text, u8 button) {
 void DefaultKeyboard::Setup(const Frontend::KeyboardConfig* config) {
     SoftwareKeyboard::Setup(config);
 
-    auto cfg =
-        Core::System::GetInstance().ServiceManager().GetService<Service::CFG::Module::Interface>(
-            "cfg:u");
-    ASSERT_MSG(cfg, "cfg:u not started!");
-    auto cfg_module = cfg->GetModule();
-    ASSERT_MSG(cfg_module, "CFG Module missing!");
-    std::string username = Common::UTF16ToUTF8(cfg_module->GetUsername());
+    auto cfg = Service::CFG::GetModule(Core::System::GetInstance());
+    ASSERT_MSG(cfg, "CFG Module missing!");
+    std::string username = Common::UTF16ToUTF8(cfg->GetUsername());
     switch (this->config.button_config) {
     case ButtonConfig::None:
     case ButtonConfig::Single:

--- a/src/core/hle/service/apt/applet_manager.cpp
+++ b/src/core/hle/service/apt/applet_manager.cpp
@@ -465,11 +465,9 @@ ResultVal<AppletManager::AppletInfo> AppletManager::GetAppletInfo(AppletId app_i
                           ErrorLevel::Status);
     }
 
-    auto cfg = system.ServiceManager().GetService<Service::CFG::Module::Interface>("cfg:u");
-    ASSERT_MSG(cfg, "cfg:u not started!");
-    auto cfg_module = cfg->GetModule();
-    ASSERT_MSG(cfg_module, "CFG Module missing!");
-    u32 region_value = cfg_module->GetRegionValue();
+    auto cfg = Service::CFG::GetModule(system);
+    ASSERT_MSG(cfg, "CFG Module missing!");
+    u32 region_value = cfg->GetRegionValue();
     return MakeResult<AppletInfo>({GetTitleIdForApplet(app_id, region_value),
                                    Service::FS::MediaType::NAND, slot->registered, slot->loaded,
                                    slot->attributes.raw});
@@ -554,11 +552,9 @@ void AppletManager::EnsureHomeMenuLoaded() {
         return;
     }
 
-    auto cfg = system.ServiceManager().GetService<Service::CFG::Module::Interface>("cfg:u");
-    ASSERT_MSG(cfg, "cfg:u not started!");
-    auto cfg_module = cfg->GetModule();
-    ASSERT_MSG(cfg_module, "CFG Module missing!");
-    u32 region_value = cfg_module->GetRegionValue();
+    auto cfg = Service::CFG::GetModule(system);
+    ASSERT_MSG(cfg, "CFG Module missing!");
+    u32 region_value = cfg->GetRegionValue();
     u64 menu_title_id = GetTitleIdForApplet(AppletId::HomeMenu, region_value);
     auto process = NS::LaunchTitle(FS::MediaType::NAND, menu_title_id);
     if (!process) {

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -5,6 +5,7 @@
 #include "common/common_paths.h"
 #include "common/file_util.h"
 #include "common/logging/log.h"
+#include "common/string_util.h"
 #include "core/core.h"
 #include "core/file_sys/archive_ncch.h"
 #include "core/file_sys/file_backend.h"
@@ -103,7 +104,14 @@ static u32 DecompressLZ11(const u8* in, u8* out) {
 
 bool Module::LoadSharedFont() {
     u8 font_region_code;
-    switch (CFG::GetCurrentModule()->GetRegionValue()) {
+    auto cfg =
+        Core::System::GetInstance().ServiceManager().GetService<Service::CFG::Module::Interface>(
+            "cfg:u");
+    ASSERT_MSG(cfg, "cfg:u not started!");
+    auto cfg_module = cfg->GetModule();
+    ASSERT_MSG(cfg_module, "CFG Module missing!");
+    std::string username = Common::UTF16ToUTF8(cfg_module->GetUsername());
+    switch (cfg_module->GetRegionValue()) {
     case 4: // CHN
         font_region_code = 2;
         break;

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -103,13 +103,9 @@ static u32 DecompressLZ11(const u8* in, u8* out) {
 
 bool Module::LoadSharedFont() {
     u8 font_region_code;
-    auto cfg =
-        Core::System::GetInstance().ServiceManager().GetService<Service::CFG::Module::Interface>(
-            "cfg:u");
-    ASSERT_MSG(cfg, "cfg:u not started!");
-    auto cfg_module = cfg->GetModule();
-    ASSERT_MSG(cfg_module, "CFG Module missing!");
-    switch (cfg_module->GetRegionValue()) {
+    auto cfg = Service::CFG::GetModule(Core::System::GetInstance());
+    ASSERT_MSG(cfg, "CFG Module missing!");
+    switch (cfg->GetRegionValue()) {
     case 4: // CHN
         font_region_code = 2;
         break;

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -5,7 +5,6 @@
 #include "common/common_paths.h"
 #include "common/file_util.h"
 #include "common/logging/log.h"
-#include "common/string_util.h"
 #include "core/core.h"
 #include "core/file_sys/archive_ncch.h"
 #include "core/file_sys/file_backend.h"
@@ -110,7 +109,6 @@ bool Module::LoadSharedFont() {
     ASSERT_MSG(cfg, "cfg:u not started!");
     auto cfg_module = cfg->GetModule();
     ASSERT_MSG(cfg_module, "CFG Module missing!");
-    std::string username = Common::UTF16ToUTF8(cfg_module->GetUsername());
     switch (cfg_module->GetRegionValue()) {
     case 4: // CHN
         font_region_code = 2;

--- a/src/core/hle/service/cam/cam.cpp
+++ b/src/core/hle/service/cam/cam.cpp
@@ -1052,6 +1052,13 @@ void Module::LoadCameraImplementation(CameraConfig& camera, int camera_id) {
     camera.impl->SetResolution(camera.contexts[0].resolution);
 }
 
+std::shared_ptr<Module> GetModule(Core::System& system) {
+    auto cam = system.ServiceManager().GetService<Service::CAM::Module::Interface>("cam:u");
+    if (!cam)
+        return nullptr;
+    return cam->GetModule();
+}
+
 void InstallInterfaces(Core::System& system) {
     auto& service_manager = system.ServiceManager();
     auto cam = std::make_shared<Module>();

--- a/src/core/hle/service/cam/cam.cpp
+++ b/src/core/hle/service/cam/cam.cpp
@@ -22,8 +22,6 @@
 
 namespace Service::CAM {
 
-static std::weak_ptr<Module> current_cam;
-
 // built-in resolution parameters
 constexpr std::array<Resolution, 8> PRESET_RESOLUTION{{
     {640, 480, 0, 0, 639, 479},  // VGA
@@ -199,6 +197,10 @@ Module::Interface::Interface(std::shared_ptr<Module> cam, const char* name, u32 
     : ServiceFramework(name, max_session), cam(std::move(cam)) {}
 
 Module::Interface::~Interface() = default;
+
+std::shared_ptr<Module> Module::Interface::GetModule() const {
+    return cam;
+}
 
 void Module::Interface::StartCapture(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x01, 1, 0);
@@ -1050,15 +1052,9 @@ void Module::LoadCameraImplementation(CameraConfig& camera, int camera_id) {
     camera.impl->SetResolution(camera.contexts[0].resolution);
 }
 
-void ReloadCameraDevices() {
-    if (auto cam = current_cam.lock())
-        cam->ReloadCameraDevices();
-}
-
 void InstallInterfaces(Core::System& system) {
     auto& service_manager = system.ServiceManager();
     auto cam = std::make_shared<Module>();
-    current_cam = cam;
 
     std::make_shared<CAM_U>(cam)->InstallAsService(service_manager);
     std::make_shared<CAM_S>(cam)->InstallAsService(service_manager);

--- a/src/core/hle/service/cam/cam.h
+++ b/src/core/hle/service/cam/cam.h
@@ -250,6 +250,8 @@ public:
         Interface(std::shared_ptr<Module> cam, const char* name, u32 max_session);
         ~Interface();
 
+        std::shared_ptr<Module> GetModule() const;
+
     protected:
         /**
          * Starts capturing at the selected port.
@@ -782,9 +784,6 @@ private:
     CoreTiming::EventType* completion_event_callback;
     std::atomic<bool> is_camera_reload_pending{false};
 };
-
-/// Reload camera devices. Used when input configuration changed
-void ReloadCameraDevices();
 
 void InstallInterfaces(Core::System& system);
 

--- a/src/core/hle/service/cam/cam.h
+++ b/src/core/hle/service/cam/cam.h
@@ -785,6 +785,8 @@ private:
     std::atomic<bool> is_camera_reload_pending{false};
 };
 
+std::shared_ptr<Module> GetModule(Core::System& system);
+
 void InstallInterfaces(Core::System& system);
 
 } // namespace Service::CAM

--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -114,14 +114,6 @@ static const std::vector<u8> cfg_system_savedata_id = {
     0x00, 0x00, 0x00, 0x00, 0x17, 0x00, 0x01, 0x00,
 };
 
-static std::weak_ptr<Module> current_cfg;
-
-std::shared_ptr<Module> GetCurrentModule() {
-    auto cfg = current_cfg.lock();
-    ASSERT_MSG(cfg, "No CFG module running!");
-    return cfg;
-}
-
 Module::Interface::Interface(std::shared_ptr<Module> cfg, const char* name, u32 max_session)
     : ServiceFramework(name, max_session), cfg(std::move(cfg)) {}
 
@@ -143,6 +135,10 @@ void Module::Interface::GetCountryCodeString(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS);
     // the real CFG service copies only three bytes (including the null-terminator) here
     rb.Push<u32>(country_codes[country_code_id]);
+}
+
+std::shared_ptr<Module> Module::Interface::GetModule() const {
+    return cfg;
 }
 
 void Module::Interface::GetCountryCodeID(Kernel::HLERequestContext& ctx) {
@@ -729,7 +725,6 @@ void InstallInterfaces(Core::System& system) {
     std::make_shared<CFG_S>(cfg)->InstallAsService(service_manager);
     std::make_shared<CFG_U>(cfg)->InstallAsService(service_manager);
     std::make_shared<CFG_NOR>()->InstallAsService(service_manager);
-    current_cfg = cfg;
 }
 
 } // namespace Service::CFG

--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -137,7 +137,7 @@ void Module::Interface::GetCountryCodeString(Kernel::HLERequestContext& ctx) {
     rb.Push<u32>(country_codes[country_code_id]);
 }
 
-std::shared_ptr<Module> Module::Interface::GetModule() const {
+std::shared_ptr<Module> Module::Interface::Interface::GetModule() const {
     return cfg;
 }
 
@@ -716,6 +716,13 @@ u64 Module::GetConsoleUniqueId() {
     u64_le console_id_le;
     GetConfigInfoBlock(ConsoleUniqueID2BlockID, sizeof(console_id_le), 0xE, &console_id_le);
     return console_id_le;
+}
+
+std::shared_ptr<Module> GetModule(Core::System& system) {
+    auto cfg = system.ServiceManager().GetService<Service::CFG::Module::Interface>("cfg:u");
+    if (!cfg)
+        return nullptr;
+    return cfg->GetModule();
 }
 
 void InstallInterfaces(Core::System& system) {

--- a/src/core/hle/service/cfg/cfg.h
+++ b/src/core/hle/service/cfg/cfg.h
@@ -97,6 +97,8 @@ public:
         Interface(std::shared_ptr<Module> cfg, const char* name, u32 max_session);
         ~Interface();
 
+        std::shared_ptr<Module> GetModule() const;
+
         /**
          * CFG::GetCountryCodeString service function
          *  Inputs:
@@ -116,8 +118,6 @@ public:
          *      2 : Country Code ID
          */
         void GetCountryCodeID(Kernel::HLERequestContext& ctx);
-
-        u32 GetRegionValue();
 
         /**
          * CFG::SecureInfoGetRegion service function
@@ -412,6 +412,5 @@ private:
 };
 
 void InstallInterfaces(Core::System& system);
-std::shared_ptr<Module> GetCurrentModule();
 
 } // namespace Service::CFG

--- a/src/core/hle/service/cfg/cfg.h
+++ b/src/core/hle/service/cfg/cfg.h
@@ -411,6 +411,8 @@ private:
     u32 preferred_region_code = 0;
 };
 
+std::shared_ptr<Module> GetModule(Core::System& system);
+
 void InstallInterfaces(Core::System& system);
 
 } // namespace Service::CFG

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -390,6 +390,13 @@ void Module::ReloadInputDevices() {
     is_device_reload_pending.store(true);
 }
 
+std::shared_ptr<Module> GetModule(Core::System& system) {
+    auto hid = system.ServiceManager().GetService<Service::HID::Module::Interface>("hid:USER");
+    if (!hid)
+        return nullptr;
+    return hid->GetModule();
+}
+
 void InstallInterfaces(Core::System& system) {
     auto& service_manager = system.ServiceManager();
     auto hid = std::make_shared<Module>(system);

--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -208,6 +208,8 @@ public:
     public:
         Interface(std::shared_ptr<Module> hid, const char* name, u32 max_session);
 
+        std::shared_ptr<Module> GetModule() const;
+
     protected:
         /**
          * HID::GetIPCHandles service function
@@ -336,7 +338,4 @@ private:
 };
 
 void InstallInterfaces(Core::System& system);
-
-/// Reload input devices. Used when input configuration changed
-void ReloadInputDevices();
 } // namespace Service::HID

--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -337,5 +337,7 @@ private:
     std::unique_ptr<Input::TouchDevice> touch_device;
 };
 
+std::shared_ptr<Module> GetModule(Core::System& system);
+
 void InstallInterfaces(Core::System& system);
 } // namespace Service::HID

--- a/src/core/hle/service/ir/ir.cpp
+++ b/src/core/hle/service/ir/ir.cpp
@@ -12,28 +12,15 @@
 
 namespace Service::IR {
 
-static std::weak_ptr<IR_RST> current_ir_rst;
-static std::weak_ptr<IR_USER> current_ir_user;
-
-void ReloadInputDevices() {
-    if (auto ir_user = current_ir_user.lock())
-        ir_user->ReloadInputDevices();
-
-    if (auto ir_rst = current_ir_rst.lock())
-        ir_rst->ReloadInputDevices();
-}
-
 void InstallInterfaces(Core::System& system) {
     auto& service_manager = system.ServiceManager();
     std::make_shared<IR_U>()->InstallAsService(service_manager);
 
     auto ir_user = std::make_shared<IR_USER>();
     ir_user->InstallAsService(service_manager);
-    current_ir_user = ir_user;
 
     auto ir_rst = std::make_shared<IR_RST>();
     ir_rst->InstallAsService(service_manager);
-    current_ir_rst = ir_rst;
 }
 
 } // namespace Service::IR

--- a/src/core/hle/service/ir/ir.h
+++ b/src/core/hle/service/ir/ir.h
@@ -14,9 +14,6 @@ class ServiceManager;
 
 namespace Service::IR {
 
-/// Reload input devices. Used when input configuration changed
-void ReloadInputDevices();
-
 void InstallInterfaces(Core::System& system);
 
 } // namespace Service::IR

--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -144,13 +144,9 @@ void AppLoader_NCCH::ParseRegionLockoutInfo() {
             }
             region_lockout >>= 1;
         }
-        auto cfg = Core::System::GetInstance()
-                       .ServiceManager()
-                       .GetService<Service::CFG::Module::Interface>("cfg:u");
-        ASSERT_MSG(cfg, "cfg:u not started!");
-        auto cfg_module = cfg->GetModule();
-        ASSERT_MSG(cfg_module, "CFG Module missing!");
-        cfg_module->SetPreferredRegionCodes(regions);
+        auto cfg = Service::CFG::GetModule(Core::System::GetInstance());
+        ASSERT_MSG(cfg, "CFG Module missing!");
+        cfg->SetPreferredRegionCodes(regions);
     }
 }
 

--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -144,7 +144,13 @@ void AppLoader_NCCH::ParseRegionLockoutInfo() {
             }
             region_lockout >>= 1;
         }
-        Service::CFG::GetCurrentModule()->SetPreferredRegionCodes(regions);
+        auto cfg = Core::System::GetInstance()
+                       .ServiceManager()
+                       .GetService<Service::CFG::Module::Interface>("cfg:u");
+        ASSERT_MSG(cfg, "cfg:u not started!");
+        auto cfg_module = cfg->GetModule();
+        ASSERT_MSG(cfg_module, "CFG Module missing!");
+        cfg_module->SetPreferredRegionCodes(regions);
     }
 }
 

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -38,30 +38,22 @@ void Apply() {
         Core::DSP().SetSink(values.sink_id, values.audio_device_id);
         Core::DSP().EnableStretching(values.enable_audio_stretching);
 
-        auto& sm = system.ServiceManager();
-
-        auto hid = sm.GetService<Service::HID::Module::Interface>("hid:USER");
+        auto hid = Service::HID::GetModule(system);
         if (hid) {
-            auto hid_module = hid->GetModule();
-            if (hid_module) {
-                hid_module->ReloadInputDevices();
-            }
+            hid->ReloadInputDevices();
         }
 
+        auto sm = system.ServiceManager();
         auto ir_user = sm.GetService<Service::IR::IR_USER>("ir:USER");
         if (ir_user)
             ir_user->ReloadInputDevices();
-
         auto ir_rst = sm.GetService<Service::IR::IR_RST>("ir:rst");
         if (ir_rst)
             ir_rst->ReloadInputDevices();
 
-        auto cam = sm.GetService<Service::CAM::Module::Interface>("cam:u");
+        auto cam = Service::CAM::GetModule(system);
         if (cam) {
-            auto cam_module = cam->GetModule();
-            if (cam_module) {
-                cam_module->ReloadCameraDevices();
-            }
+            cam->ReloadCameraDevices();
         }
     }
 }

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -6,7 +6,8 @@
 #include "core/core.h"
 #include "core/gdbstub/gdbstub.h"
 #include "core/hle/service/hid/hid.h"
-#include "core/hle/service/ir/ir.h"
+#include "core/hle/service/ir/ir_rst.h"
+#include "core/hle/service/ir/ir_user.h"
 #include "core/settings.h"
 #include "video_core/renderer_base.h"
 #include "video_core/video_core.h"
@@ -32,14 +33,37 @@ void Apply() {
 
     VideoCore::g_renderer_bg_color_update_requested = true;
 
-    if (Core::System::GetInstance().IsPoweredOn()) {
+    auto& system = Core::System::GetInstance();
+    if (system.IsPoweredOn()) {
         Core::DSP().SetSink(values.sink_id, values.audio_device_id);
         Core::DSP().EnableStretching(values.enable_audio_stretching);
-    }
 
-    Service::HID::ReloadInputDevices();
-    Service::IR::ReloadInputDevices();
-    Service::CAM::ReloadCameraDevices();
+        auto& sm = system.ServiceManager();
+
+        auto hid = sm.GetService<Service::HID::Module::Interface>("hid:USER");
+        if (hid) {
+            auto hid_module = hid->GetModule();
+            if (hid_module) {
+                hid_module->ReloadInputDevices();
+            }
+        }
+
+        auto ir_user = sm.GetService<Service::IR::IR_USER>("ir:USER");
+        if (ir_user)
+            ir_user->ReloadInputDevices();
+
+        auto ir_rst = sm.GetService<Service::IR::IR_RST>("ir:rst");
+        if (ir_rst)
+            ir_rst->ReloadInputDevices();
+
+        auto cam = sm.GetService<Service::CAM::Module::Interface>("cam:u");
+        if (cam) {
+            auto cam_module = cam->GetModule();
+            if (cam_module) {
+                cam_module->ReloadCameraDevices();
+            }
+        }
+    }
 }
 
 template <typename T>


### PR DESCRIPTION
This removes some global weak_ptr<Module> in CFG, CAM, HID, and IR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4328)
<!-- Reviewable:end -->
