### PR TITLE
nfc: Add Amiibo support

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -1278,13 +1278,8 @@ void GMainWindow::OnLoadAmiibo() {
         Service::SM::ServiceManager& sm = system.ServiceManager();
         auto nfc = sm.GetService<Service::NFC::Module::Interface>("nfc:u");
         if (nfc != nullptr) {
-            auto nfc_module = nfc->GetModule();
-            if (nfc_module != nullptr) {
-                nfc_module->nfc_filename = filename.toStdString();
-                nfc_module->nfc_tag_state = Service::NFC::TagState::TagInRange;
-                nfc_module->tag_in_range_event->Signal();
-                ui.action_Remove_Amiibo->setEnabled(true);
-            }
+            nfc->LoadAmiibo(filename.toStdString());
+            ui.action_Remove_Amiibo->setEnabled(true);
         }
     }
 }
@@ -1294,13 +1289,8 @@ void GMainWindow::OnRemoveAmiibo() {
     Service::SM::ServiceManager& sm = system.ServiceManager();
     auto nfc = sm.GetService<Service::NFC::Module::Interface>("nfc:u");
     if (nfc != nullptr) {
-        auto nfc_module = nfc->GetModule();
-        if (nfc_module != nullptr) {
-            nfc_module->nfc_filename = "";
-            nfc_module->nfc_tag_state = Service::NFC::TagState::TagOutOfRange;
-            nfc_module->tag_out_of_range_event->Signal();
-            ui.action_Remove_Amiibo->setEnabled(false);
-        }
+        nfc->RemoveAmiibo();
+        ui.action_Remove_Amiibo->setEnabled(false);
     }
 }
 

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -44,6 +44,7 @@
 #include "citra_qt/util/clickable_label.h"
 #include "common/common_paths.h"
 #include "common/detached_tasks.h"
+#include "common/file_util.h"
 #include "common/logging/backend.h"
 #include "common/logging/filter.h"
 #include "common/logging/log.h"
@@ -1278,7 +1279,10 @@ void GMainWindow::OnLoadAmiibo() {
         Service::SM::ServiceManager& sm = system.ServiceManager();
         auto nfc = sm.GetService<Service::NFC::Module::Interface>("nfc:u");
         if (nfc != nullptr) {
-            nfc->LoadAmiibo(filename.toStdString());
+            Service::NFC::AmiiboData amiibo_data{};
+            auto nfc_file = FileUtil::IOFile(filename.toStdString(), "rb");
+            nfc_file.ReadBytes(&amiibo_data, sizeof(Service::NFC::AmiiboData));
+            nfc->LoadAmiibo(amiibo_data);
             ui.action_Remove_Amiibo->setEnabled(true);
         }
     }

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -166,6 +166,7 @@ private slots:
     void OnCIAInstallFinished();
     void OnMenuRecentFile();
     void OnConfigure();
+    void OnLoadAmiibo();
     void OnToggleFilterBar();
     void OnDisplayTitleBars(bool);
     void ToggleFullscreen();

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -167,6 +167,7 @@ private slots:
     void OnMenuRecentFile();
     void OnConfigure();
     void OnLoadAmiibo();
+    void OnRemoveAmiibo();
     void OnToggleFilterBar();
     void OnDisplayTitleBars(bool);
     void ToggleFullscreen();

--- a/src/citra_qt/main.ui
+++ b/src/citra_qt/main.ui
@@ -62,6 +62,8 @@
     <addaction name="separator"/>
     <addaction name="menu_recent_files"/>
     <addaction name="separator"/>
+    <addaction name="action_Load_Amiibo"/>
+    <addaction name="separator"/>
     <addaction name="action_Exit"/>
    </widget>
    <widget class="QMenu" name="menu_Emulation">
@@ -393,6 +395,14 @@
     <string>Restart</string>
    </property>
   </action>
+   <action name="action_Load_Amiibo">
+     <property name="enabled">
+       <bool>false</bool>
+     </property>
+     <property name="text">
+       <string>Load Amiibo...</string>
+     </property>
+   </action>
  </widget>
  <resources/>
  <connections/>

--- a/src/citra_qt/main.ui
+++ b/src/citra_qt/main.ui
@@ -62,7 +62,14 @@
     <addaction name="separator"/>
     <addaction name="menu_recent_files"/>
     <addaction name="separator"/>
+     <widget class="QMenu" name="menu_Amiibo">
+       <property name="title">
+         <string>Amiibo</string>
+       </property>
     <addaction name="action_Load_Amiibo"/>
+    <addaction name="action_Remove_Amiibo"/>
+     </widget>
+     <addaction name="menu_Amiibo"/>
     <addaction name="separator"/>
     <addaction name="action_Exit"/>
    </widget>
@@ -400,7 +407,15 @@
        <bool>false</bool>
      </property>
      <property name="text">
-       <string>Load Amiibo...</string>
+       <string>Load...</string>
+     </property>
+   </action>
+   <action name="action_Remove_Amiibo">
+     <property name="enabled">
+       <bool>false</bool>
+     </property>
+     <property name="text">
+       <string>Remove</string>
      </property>
    </action>
  </widget>

--- a/src/core/hle/service/nfc/nfc.cpp
+++ b/src/core/hle/service/nfc/nfc.cpp
@@ -12,27 +12,48 @@
 namespace Service::NFC {
 
 struct TagInfo {
-    u16 id_offset_size;
+    u16_le id_offset_size;
     u8 unk1;
     u8 unk2;
     std::array<u8, 7> uuid;
-    INSERT_PADDING_BYTES(0x1D + 3);
+    INSERT_PADDING_BYTES(0x20);
 };
 static_assert(sizeof(TagInfo) == 0x2C, "TagInfo is an invalid size");
 
 struct AmiiboConfig {
-    u16 lastwritedate_year;
+    u16_le lastwritedate_year;
     u8 lastwritedate_month;
     u8 lastwritedate_day;
-    u16 write_counter;
+    u16_le write_counter;
     std::array<u8, 3> characterID;
-    u16 amiiboID;
+    u16_le amiiboID;
     u8 type;
     u8 pagex4_byte3;
-    u16 appdata_size;
+    u16_le appdata_size;
     INSERT_PADDING_BYTES(0x30);
 };
 static_assert(sizeof(AmiiboConfig) == 0x40, "AmiiboConfig is an invalid size");
+
+struct IdentificationBlockRaw {
+    u16_le char_id;
+    u8 char_variant;
+    u8 figure_type;
+    u16_be model_number;
+    u8 series;
+    INSERT_PADDING_BYTES(0x2F);
+};
+static_assert(sizeof(IdentificationBlockRaw) == 0x36, "IdentificationBlockRaw is an invalid size");
+
+struct IdentificationBlockReply {
+    u16_le char_id;
+    u8 char_variant;
+    u8 series;
+    u16_le model_number;
+    u8 figure_type;
+    INSERT_PADDING_BYTES(0x2F);
+};
+static_assert(sizeof(IdentificationBlockReply) == 0x36,
+              "IdentificationBlockReply is an invalid size");
 
 void Module::Interface::Initialize(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x01, 1, 0);
@@ -96,7 +117,7 @@ void Module::Interface::GetTagInfo(Kernel::HLERequestContext& ctx) {
     IPC::RequestBuilder rb = rp.MakeBuilder(12, 0);
     rb.Push(RESULT_SUCCESS);
     rb.PushRaw<TagInfo>(tag_info);
-    LOG_CRITICAL(Service_NFC, "called");
+    LOG_WARNING(Service_NFC, "(STUBBED) called");
 }
 
 void Module::Interface::GetAmiiboConfig(Kernel::HLERequestContext& ctx) {
@@ -111,7 +132,7 @@ void Module::Interface::GetAmiiboConfig(Kernel::HLERequestContext& ctx) {
     IPC::RequestBuilder rb = rp.MakeBuilder(17, 0);
     rb.Push(RESULT_SUCCESS);
     rb.PushRaw<AmiiboConfig>(amiibo_config);
-    LOG_CRITICAL(Service_NFC, "called");
+    LOG_WARNING(Service_NFC, "(STUBBED) called");
 }
 
 void Module::Interface::StopTagScanning(Kernel::HLERequestContext& ctx) {
@@ -178,6 +199,38 @@ void Module::Interface::CommunicationGetStatus(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS);
     rb.PushEnum(nfc->nfc_status);
     LOG_DEBUG(Service_NFC, "(STUBBED) called");
+}
+
+void Module::Interface::Unknown0x1A(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp(ctx, 0x1A, 0, 0);
+
+    nfc->nfc_tag_state = TagState::Unknown6;
+
+    IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
+    rb.Push(RESULT_SUCCESS);
+    LOG_DEBUG(Service_NFC, "called");
+}
+
+void Module::Interface::Unknown0x1B(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp(ctx, 0x1B, 0, 0);
+
+    IdentificationBlockRaw identification_block_raw{};
+    auto nfc_file = FileUtil::IOFile(nfc->nfc_filename, "rb");
+    // go to offset of the Amiibo identification block
+    nfc_file.Seek(0x54, SEEK_SET);
+    nfc_file.ReadBytes(&identification_block_raw, 0x7);
+
+    IdentificationBlockReply identification_block_reply{};
+    identification_block_reply.char_id = identification_block_raw.char_id;
+    identification_block_reply.char_variant = identification_block_raw.char_variant;
+    identification_block_reply.series = identification_block_raw.series;
+    identification_block_reply.model_number = identification_block_raw.model_number;
+    identification_block_reply.figure_type = identification_block_raw.figure_type;
+
+    IPC::RequestBuilder rb = rp.MakeBuilder(0x1F, 0);
+    rb.Push(RESULT_SUCCESS);
+    rb.PushRaw<IdentificationBlockReply>(identification_block_reply);
+    LOG_DEBUG(Service_NFC, "called");
 }
 
 Module::Interface::Interface(std::shared_ptr<Module> nfc, const char* name, u32 max_session)

--- a/src/core/hle/service/nfc/nfc.h
+++ b/src/core/hle/service/nfc/nfc.h
@@ -67,7 +67,7 @@ public:
 
         std::shared_ptr<Module> GetModule() const;
 
-        void LoadAmiibo(const std::string& filename);
+        void LoadAmiibo(const AmiiboData& amiibo_data);
 
         void RemoveAmiibo();
 

--- a/src/core/hle/service/nfc/nfc.h
+++ b/src/core/hle/service/nfc/nfc.h
@@ -49,6 +49,8 @@ public:
         Interface(std::shared_ptr<Module> nfc, const char* name, u32 max_session);
         ~Interface();
 
+        std::shared_ptr<Module> GetModule() const;
+
     protected:
         /**
          * NFC::Initialize service function
@@ -167,15 +169,36 @@ public:
          */
         void CommunicationGetStatus(Kernel::HLERequestContext& ctx);
 
+        /**
+         * NFC::GetTagInfo service function
+         *  Inputs:
+         *      0 : Header code [0x00110000]
+         *  Outputs:
+         *      1 : Result of function, 0 on success, otherwise error code
+         *   2-12 : 0x2C-byte struct
+         */
+        void GetTagInfo(Kernel::HLERequestContext& ctx);
+
+        /**
+         * NFC::GetAmiiboConfig service function
+         *  Inputs:
+         *      0 : Header code [0x00180000]
+         *  Outputs:
+         *      1 : Result of function, 0 on success, otherwise error code
+         *   2-17 : 0x40-byte config struct
+         */
+        void GetAmiiboConfig(Kernel::HLERequestContext& ctx);
+
     private:
         std::shared_ptr<Module> nfc;
     };
 
-private:
     Kernel::SharedPtr<Kernel::Event> tag_in_range_event;
     Kernel::SharedPtr<Kernel::Event> tag_out_of_range_event;
     TagState nfc_tag_state = TagState::NotInitialized;
     CommunicationStatus nfc_status = CommunicationStatus::NfcInitialized;
+
+    std::string nfc_filename;
 };
 
 void InstallInterfaces(Core::System& system);

--- a/src/core/hle/service/nfc/nfc.h
+++ b/src/core/hle/service/nfc/nfc.h
@@ -32,6 +32,7 @@ enum class TagState : u8 {
     TagInRange = 3,
     TagOutOfRange = 4,
     TagDataLoaded = 5,
+    Unknown6 = 6,
 };
 
 enum class CommunicationStatus : u8 {
@@ -188,6 +189,25 @@ public:
          *   2-17 : 0x40-byte config struct
          */
         void GetAmiiboConfig(Kernel::HLERequestContext& ctx);
+
+        /**
+         * NFC::Unknown0x1A service function
+         *  Inputs:
+         *      0 : Header code [0x001A0000]
+         *  Outputs:
+         *      1 : Result of function, 0 on success, otherwise error code
+         */
+        void Unknown0x1A(Kernel::HLERequestContext& ctx);
+
+        /**
+         * NFC::Unknown0x1B service function
+         *  Inputs:
+         *      0 : Header code [0x001B0000]
+         *  Outputs:
+         *      1 : Result of function, 0 on success, otherwise error code
+         *   2-31 : 0x36-byte struct
+         */
+        void Unknown0x1B(Kernel::HLERequestContext& ctx);
 
     private:
         std::shared_ptr<Module> nfc;

--- a/src/core/hle/service/nfc/nfc_m.cpp
+++ b/src/core/hle/service/nfc/nfc_m.cpp
@@ -33,6 +33,8 @@ NFC_M::NFC_M(std::shared_ptr<Module> nfc) : Module::Interface(std::move(nfc), "n
         {0x00170000, nullptr, "GetAmiiboSettings"},
         {0x00180000, &NFC_M::GetAmiiboConfig, "GetAmiiboConfig"},
         {0x00190000, nullptr, "GetAppDataInitStruct"},
+        {0x001A0000, &NFC_M::Unknown0x1A, "Unknown0x1A"},
+        {0x001B0000, &NFC_M::Unknown0x1B, "Unknown0x1B"},
         // nfc:m
         {0x04040A40, nullptr, "SetAmiiboSettings"}
         // clang-format on

--- a/src/core/hle/service/nfc/nfc_m.cpp
+++ b/src/core/hle/service/nfc/nfc_m.cpp
@@ -34,7 +34,7 @@ NFC_M::NFC_M(std::shared_ptr<Module> nfc) : Module::Interface(std::move(nfc), "n
         {0x00180000, &NFC_M::GetAmiiboConfig, "GetAmiiboConfig"},
         {0x00190000, nullptr, "GetAppDataInitStruct"},
         {0x001A0000, &NFC_M::Unknown0x1A, "Unknown0x1A"},
-        {0x001B0000, &NFC_M::Unknown0x1B, "Unknown0x1B"},
+        {0x001B0000, &NFC_M::GetIdentificationBlock, "GetIdentificationBlock"},
         // nfc:m
         {0x04040A40, nullptr, "SetAmiiboSettings"}
         // clang-format on

--- a/src/core/hle/service/nfc/nfc_m.cpp
+++ b/src/core/hle/service/nfc/nfc_m.cpp
@@ -24,14 +24,14 @@ NFC_M::NFC_M(std::shared_ptr<Module> nfc) : Module::Interface(std::move(nfc), "n
         {0x000D0000, &NFC_M::GetTagState, "GetTagState"},
         {0x000F0000, &NFC_M::CommunicationGetStatus, "CommunicationGetStatus"},
         {0x00100000, nullptr, "GetTagInfo2"},
-        {0x00110000, nullptr, "GetTagInfo"},
+        {0x00110000, &NFC_M::GetTagInfo, "GetTagInfo"},
         {0x00120000, nullptr, "CommunicationGetResult"},
         {0x00130040, nullptr, "OpenAppData"},
         {0x00140384, nullptr, "InitializeWriteAppData"},
         {0x00150040, nullptr, "ReadAppData"},
         {0x00160242, nullptr, "WriteAppData"},
         {0x00170000, nullptr, "GetAmiiboSettings"},
-        {0x00180000, nullptr, "GetAmiiboConfig"},
+        {0x00180000, &NFC_M::GetAmiiboConfig, "GetAmiiboConfig"},
         {0x00190000, nullptr, "GetAppDataInitStruct"},
         // nfc:m
         {0x04040A40, nullptr, "SetAmiiboSettings"}

--- a/src/core/hle/service/nfc/nfc_u.cpp
+++ b/src/core/hle/service/nfc/nfc_u.cpp
@@ -32,6 +32,8 @@ NFC_U::NFC_U(std::shared_ptr<Module> nfc) : Module::Interface(std::move(nfc), "n
         {0x00170000, nullptr, "GetAmiiboSettings"},
         {0x00180000, &NFC_U::GetAmiiboConfig, "GetAmiiboConfig"},
         {0x00190000, nullptr, "GetAppDataInitStruct"},
+        {0x001A0000, &NFC_U::Unknown0x1A, "Unknown0x1A"},
+        {0x001B0000, &NFC_U::Unknown0x1B, "Unknown0x1B"},
         // clang-format on
     };
     RegisterHandlers(functions);

--- a/src/core/hle/service/nfc/nfc_u.cpp
+++ b/src/core/hle/service/nfc/nfc_u.cpp
@@ -33,7 +33,7 @@ NFC_U::NFC_U(std::shared_ptr<Module> nfc) : Module::Interface(std::move(nfc), "n
         {0x00180000, &NFC_U::GetAmiiboConfig, "GetAmiiboConfig"},
         {0x00190000, nullptr, "GetAppDataInitStruct"},
         {0x001A0000, &NFC_U::Unknown0x1A, "Unknown0x1A"},
-        {0x001B0000, &NFC_U::Unknown0x1B, "Unknown0x1B"},
+        {0x001B0000, &NFC_U::GetIdentificationBlock, "GetIdentificationBlock"},
         // clang-format on
     };
     RegisterHandlers(functions);

--- a/src/core/hle/service/nfc/nfc_u.cpp
+++ b/src/core/hle/service/nfc/nfc_u.cpp
@@ -23,14 +23,14 @@ NFC_U::NFC_U(std::shared_ptr<Module> nfc) : Module::Interface(std::move(nfc), "n
         {0x000D0000, &NFC_U::GetTagState, "GetTagState"},
         {0x000F0000, &NFC_U::CommunicationGetStatus, "CommunicationGetStatus"},
         {0x00100000, nullptr, "GetTagInfo2"},
-        {0x00110000, nullptr, "GetTagInfo"},
+        {0x00110000, &NFC_U::GetTagInfo, "GetTagInfo"},
         {0x00120000, nullptr, "CommunicationGetResult"},
         {0x00130040, nullptr, "OpenAppData"},
         {0x00140384, nullptr, "InitializeWriteAppData"},
         {0x00150040, nullptr, "ReadAppData"},
         {0x00160242, nullptr, "WriteAppData"},
         {0x00170000, nullptr, "GetAmiiboSettings"},
-        {0x00180000, nullptr, "GetAmiiboConfig"},
+        {0x00180000, &NFC_U::GetAmiiboConfig, "GetAmiiboConfig"},
         {0x00190000, nullptr, "GetAppDataInitStruct"},
         // clang-format on
     };


### PR DESCRIPTION
This PR adds the ability to use "virtual Amiibo" files to emulate the scanning of them. 
Currently no keys are needed cause the encrypted sections are not accessed.

UI screenshot:
![unbenannt](https://user-images.githubusercontent.com/20753089/46885382-1932be80-ce58-11e8-8c61-20e2c14df1df.png)

Example:
![grafik](https://user-images.githubusercontent.com/20753089/46885602-c0175a80-ce58-11e8-9e91-8822a9d9d8a9.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4333)
<!-- Reviewable:end -->
