### PR TITLE
Port yuzu-emu/yuzu#1490: "citra_qt/main: Simplify OnMenuLoadFile()"

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -989,20 +989,20 @@ void GMainWindow::OnGameListShowList(bool show) {
 };
 
 void GMainWindow::OnMenuLoadFile() {
-    QString extensions;
-    for (const auto& piece : game_list->supported_file_extensions)
-        extensions += "*." + piece + " ";
+    const QString extensions =
+        QString("*.").append(GameList::supported_file_extensions.join(" *."));
+    const QString file_filter = tr("3DS Executable (%1);;All Files (*.*)",
+                                   "%1 is an identifier for the 3DS executable file extensions.")
+                                    .arg(extensions);
+    const QString filename = QFileDialog::getOpenFileName(
+        this, tr("Load File"), UISettings::values.roms_path, file_filter);
 
-    QString file_filter = tr("3DS Executable") + " (" + extensions + ")";
-    file_filter += ";;" + tr("All Files (*.*)");
-
-    QString filename = QFileDialog::getOpenFileName(this, tr("Load File"),
-                                                    UISettings::values.roms_path, file_filter);
-    if (!filename.isEmpty()) {
-        UISettings::values.roms_path = QFileInfo(filename).path();
-
-        BootGame(filename);
+    if (filename.isEmpty()) {
+        return;
     }
+
+    UISettings::values.roms_path = QFileInfo(filename).path();
+    BootGame(filename);
 }
 
 void GMainWindow::OnMenuInstallCIA() {


### PR DESCRIPTION
See yuzu-emu/yuzu#1490 for more details.

```
We can utilize QStringList's join() function to perform all of the
appending in a single function call.

While we're at it, make the extension list a single translatable string
and add a disambiguation comment to explain to translators what %1
actually is.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4338)
<!-- Reviewable:end -->
