### PR TITLE
svc: Correct vma_map boundary check within QueryProcessMemory

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -923,7 +923,7 @@ static ResultCode QueryProcessMemory(MemoryInfo* memory_info, PageInfo* page_inf
 
     auto vma = process->vm_manager.FindVMA(addr);
 
-    if (vma == g_current_process->vm_manager.vma_map.end())
+    if (vma == process->vm_manager.vma_map.end())
         return ERR_INVALID_ADDRESS;
 
     memory_info->base_address = vma->second.base;


### PR DESCRIPTION
This should be using the process instance retrieved within the function, and not g_current_process, otherwise this is potentially comparing iterators from unrelated vma_map instances (which is undefined behavior).