### PR TITLE
 kernel: Eliminate global state in process and handle_table

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -126,7 +126,9 @@ System::ResultStatus System::Load(EmuWindow& emu_window, const std::string& file
         return init_result;
     }
 
-    const Loader::ResultStatus load_result{app_loader->Load(Kernel::g_current_process)};
+    Kernel::SharedPtr<Kernel::Process> process;
+    const Loader::ResultStatus load_result{app_loader->Load(process)};
+    kernel->SetCurrentProcess(process);
     if (Loader::ResultStatus::Success != load_result) {
         LOG_CRITICAL(Core, "Failed to load ROM (Error {})!", static_cast<u32>(load_result));
         System::Shutdown();
@@ -140,7 +142,7 @@ System::ResultStatus System::Load(EmuWindow& emu_window, const std::string& file
             return ResultStatus::ErrorLoader;
         }
     }
-    Memory::SetCurrentPageTable(&Kernel::g_current_process->vm_manager.page_table);
+    Memory::SetCurrentPageTable(&kernel->GetCurrentProcess()->vm_manager.page_table);
     status = ResultStatus::Success;
     m_emu_window = &emu_window;
     m_filepath = filepath;

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -251,8 +251,11 @@ private:
 
     std::unique_ptr<Service::FS::ArchiveManager> archive_manager;
 
+public: // HACK: this is temporary exposed for tests,
+        // due to WIP kernel refactor causing desync state in memory
     std::unique_ptr<Kernel::KernelSystem> kernel;
 
+private:
     static System s_instance;
 
     ResultStatus status = ResultStatus::Success;

--- a/src/core/file_sys/archive_savedata.cpp
+++ b/src/core/file_sys/archive_savedata.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <utility>
+#include "core/core.h"
 #include "core/file_sys/archive_savedata.h"
 #include "core/hle/kernel/process.h"
 
@@ -16,16 +17,19 @@ ArchiveFactory_SaveData::ArchiveFactory_SaveData(
     : sd_savedata_source(std::move(sd_savedata)) {}
 
 ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_SaveData::Open(const Path& path) {
-    return sd_savedata_source->Open(Kernel::g_current_process->codeset->program_id);
+    return sd_savedata_source->Open(
+        Core::System::GetInstance().Kernel().GetCurrentProcess()->codeset->program_id);
 }
 
 ResultCode ArchiveFactory_SaveData::Format(const Path& path,
                                            const FileSys::ArchiveFormatInfo& format_info) {
-    return sd_savedata_source->Format(Kernel::g_current_process->codeset->program_id, format_info);
+    return sd_savedata_source->Format(
+        Core::System::GetInstance().Kernel().GetCurrentProcess()->codeset->program_id, format_info);
 }
 
 ResultVal<ArchiveFormatInfo> ArchiveFactory_SaveData::GetFormatInfo(const Path& path) const {
-    return sd_savedata_source->GetFormatInfo(Kernel::g_current_process->codeset->program_id);
+    return sd_savedata_source->GetFormatInfo(
+        Core::System::GetInstance().Kernel().GetCurrentProcess()->codeset->program_id);
 }
 
 } // namespace FileSys

--- a/src/core/file_sys/archive_selfncch.cpp
+++ b/src/core/file_sys/archive_selfncch.cpp
@@ -7,6 +7,7 @@
 #include "common/common_types.h"
 #include "common/logging/log.h"
 #include "common/swap.h"
+#include "core/core.h"
 #include "core/file_sys/archive_selfncch.h"
 #include "core/file_sys/errors.h"
 #include "core/file_sys/ivfc_archive.h"
@@ -279,7 +280,7 @@ void ArchiveFactory_SelfNCCH::Register(Loader::AppLoader& app_loader) {
 
 ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_SelfNCCH::Open(const Path& path) {
     auto archive = std::make_unique<SelfNCCHArchive>(
-        ncch_data[Kernel::g_current_process->codeset->program_id]);
+        ncch_data[Core::System::GetInstance().Kernel().GetCurrentProcess()->codeset->program_id]);
     return MakeResult<std::unique_ptr<ArchiveBackend>>(std::move(archive));
 }
 

--- a/src/core/hle/kernel/handle_table.cpp
+++ b/src/core/hle/kernel/handle_table.cpp
@@ -5,7 +5,6 @@
 #include <utility>
 #include "common/assert.h"
 #include "common/logging/log.h"
-#include "core/core.h" // TODO: for current_process. Remove this later
 #include "core/hle/kernel/errors.h"
 #include "core/hle/kernel/handle_table.h"
 #include "core/hle/kernel/process.h"
@@ -13,9 +12,7 @@
 
 namespace Kernel {
 
-HandleTable g_handle_table;
-
-HandleTable::HandleTable() {
+HandleTable::HandleTable(KernelSystem& kernel) : kernel(kernel) {
     next_generation = 1;
     Clear();
 }
@@ -77,9 +74,7 @@ SharedPtr<Object> HandleTable::GetGeneric(Handle handle) const {
     if (handle == CurrentThread) {
         return GetCurrentThread();
     } else if (handle == CurrentProcess) {
-        // TODO: should this return HandleTable's parent process, or kernel's current process?
-        // Should change this either way
-        return Core::System::GetInstance().Kernel().GetCurrentProcess();
+        return kernel.GetCurrentProcess();
     }
 
     if (!IsValid(handle)) {

--- a/src/core/hle/kernel/handle_table.cpp
+++ b/src/core/hle/kernel/handle_table.cpp
@@ -5,6 +5,7 @@
 #include <utility>
 #include "common/assert.h"
 #include "common/logging/log.h"
+#include "core/core.h" // TODO: for current_process. Remove this later
 #include "core/hle/kernel/errors.h"
 #include "core/hle/kernel/handle_table.h"
 #include "core/hle/kernel/process.h"
@@ -76,7 +77,9 @@ SharedPtr<Object> HandleTable::GetGeneric(Handle handle) const {
     if (handle == CurrentThread) {
         return GetCurrentThread();
     } else if (handle == CurrentProcess) {
-        return g_current_process;
+        // TODO: should this return HandleTable's parent process, or kernel's current process?
+        // Should change this either way
+        return Core::System::GetInstance().Kernel().GetCurrentProcess();
     }
 
     if (!IsValid(handle)) {

--- a/src/core/hle/kernel/handle_table.h
+++ b/src/core/hle/kernel/handle_table.h
@@ -42,7 +42,7 @@ enum KernelHandle : Handle {
  */
 class HandleTable final : NonCopyable {
 public:
-    HandleTable();
+    explicit HandleTable(KernelSystem& kernel);
 
     /**
      * Allocates a handle for the given object.
@@ -119,8 +119,8 @@ private:
 
     /// Head of the free slots linked list.
     u16 next_free_slot;
-};
 
-extern HandleTable g_handle_table;
+    KernelSystem& kernel;
+};
 
 } // namespace Kernel

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -226,11 +226,9 @@ public:
     MappedBuffer& GetMappedBuffer(u32 id_from_cmdbuf);
 
     /// Populates this context with data from the requesting process/thread.
-    ResultCode PopulateFromIncomingCommandBuffer(const u32_le* src_cmdbuf, Process& src_process,
-                                                 HandleTable& src_table);
+    ResultCode PopulateFromIncomingCommandBuffer(const u32_le* src_cmdbuf, Process& src_process);
     /// Writes data from this context back to the requesting process/thread.
-    ResultCode WriteToOutgoingCommandBuffer(u32_le* dst_cmdbuf, Process& dst_process,
-                                            HandleTable& dst_table) const;
+    ResultCode WriteToOutgoingCommandBuffer(u32_le* dst_cmdbuf, Process& dst_process) const;
 
 private:
     std::array<u32, IPC::COMMAND_BUFFER_LENGTH> cmd_buf;

--- a/src/core/hle/kernel/ipc.cpp
+++ b/src/core/hle/kernel/ipc.cpp
@@ -60,9 +60,9 @@ ResultCode TranslateCommandBuffer(SharedPtr<Thread> src_thread, SharedPtr<Thread
                 } else if (handle == CurrentProcess) {
                     object = src_process;
                 } else if (handle != 0) {
-                    object = g_handle_table.GetGeneric(handle);
+                    object = src_process->handle_table.GetGeneric(handle);
                     if (descriptor == IPC::DescriptorType::MoveHandle) {
-                        g_handle_table.Close(handle);
+                        src_process->handle_table.Close(handle);
                     }
                 }
 
@@ -73,7 +73,7 @@ ResultCode TranslateCommandBuffer(SharedPtr<Thread> src_thread, SharedPtr<Thread
                     continue;
                 }
 
-                auto result = g_handle_table.Create(std::move(object));
+                auto result = dst_process->handle_table.Create(std::move(object));
                 cmd_buf[i++] = result.ValueOr(0);
             }
             break;

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -27,8 +27,6 @@ KernelSystem::KernelSystem(u32 system_mode) {
 
 /// Shutdown the kernel
 KernelSystem::~KernelSystem() {
-    g_handle_table.Clear(); // Free all kernel objects
-
     Kernel::ThreadingShutdown();
 
     Kernel::TimersShutdown();

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -30,7 +30,6 @@ KernelSystem::~KernelSystem() {
     g_handle_table.Clear(); // Free all kernel objects
 
     Kernel::ThreadingShutdown();
-    g_current_process = nullptr;
 
     Kernel::TimersShutdown();
     Kernel::MemoryShutdown();
@@ -46,6 +45,14 @@ const ResourceLimitList& KernelSystem::ResourceLimit() const {
 
 u32 KernelSystem::GenerateObjectID() {
     return next_object_id++;
+}
+
+SharedPtr<Process> KernelSystem::GetCurrentProcess() const {
+    return current_process;
+}
+
+void KernelSystem::SetCurrentProcess(SharedPtr<Process> process) {
+    current_process = std::move(process);
 }
 
 } // namespace Kernel

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -23,9 +23,6 @@ KernelSystem::KernelSystem(u32 system_mode) {
     resource_limits = std::make_unique<ResourceLimitList>(*this);
     Kernel::ThreadingInit();
     Kernel::TimersInit();
-    // TODO(Subv): Start the process ids from 10 for now, as lower PIDs are
-    // reserved for low-level services
-    Process::next_process_id = 10;
 }
 
 /// Shutdown the kernel

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -7,6 +7,7 @@
 #include <atomic>
 #include <memory>
 #include <string>
+#include <vector>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include "common/common_types.h"
 #include "core/hle/result.h"
@@ -180,6 +181,9 @@ public:
 
     u32 GenerateObjectID();
 
+    /// Retrieves a process from the current list of processes.
+    SharedPtr<Process> GetProcessById(u32 process_id) const;
+
 private:
     std::unique_ptr<ResourceLimitList> resource_limits;
     std::atomic<u32> next_object_id{0};
@@ -187,6 +191,9 @@ private:
     // TODO(Subv): Start the process ids from 10 for now, as lower PIDs are
     // reserved for low-level services
     u32 next_process_id = 10;
+
+    // Lists all processes that exist in the current session.
+    std::vector<SharedPtr<Process>> process_list;
 };
 
 } // namespace Kernel

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -102,7 +102,7 @@ public:
      */
     ResultVal<SharedPtr<Thread>> CreateThread(std::string name, VAddr entry_point, u32 priority,
                                               u32 arg, s32 processor_id, VAddr stack_top,
-                                              SharedPtr<Process> owner_process);
+                                              Process* owner_process);
 
     /**
      * Creates a semaphore.
@@ -156,7 +156,7 @@ public:
      * linear heap.
      * @param name Optional object name, used for debugging purposes.
      */
-    SharedPtr<SharedMemory> CreateSharedMemory(SharedPtr<Process> owner_process, u32 size,
+    SharedPtr<SharedMemory> CreateSharedMemory(Process* owner_process, u32 size,
                                                MemoryPermission permissions,
                                                MemoryPermission other_permissions,
                                                VAddr address = 0,

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -183,6 +183,10 @@ public:
 private:
     std::unique_ptr<ResourceLimitList> resource_limits;
     std::atomic<u32> next_object_id{0};
+
+    // TODO(Subv): Start the process ids from 10 for now, as lower PIDs are
+    // reserved for low-level services
+    u32 next_process_id = 10;
 };
 
 } // namespace Kernel

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -184,6 +184,9 @@ public:
     /// Retrieves a process from the current list of processes.
     SharedPtr<Process> GetProcessById(u32 process_id) const;
 
+    SharedPtr<Process> GetCurrentProcess() const;
+    void SetCurrentProcess(SharedPtr<Process> process);
+
 private:
     std::unique_ptr<ResourceLimitList> resource_limits;
     std::atomic<u32> next_object_id{0};
@@ -194,6 +197,8 @@ private:
 
     // Lists all processes that exist in the current session.
     std::vector<SharedPtr<Process>> process_list;
+
+    SharedPtr<Process> current_process;
 };
 
 } // namespace Kernel

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -102,7 +102,7 @@ public:
      */
     ResultVal<SharedPtr<Thread>> CreateThread(std::string name, VAddr entry_point, u32 priority,
                                               u32 arg, s32 processor_id, VAddr stack_top,
-                                              Process* owner_process);
+                                              Process& owner_process);
 
     /**
      * Creates a semaphore.

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -300,7 +300,8 @@ ResultCode Process::LinearFree(VAddr target, u32 size) {
     return RESULT_SUCCESS;
 }
 
-Kernel::Process::Process(KernelSystem& kernel) : Object(kernel), kernel(kernel) {}
+Kernel::Process::Process(KernelSystem& kernel)
+    : Object(kernel), handle_table(kernel), kernel(kernel) {}
 Kernel::Process::~Process() {}
 
 SharedPtr<Process> KernelSystem::GetProcessById(u32 process_id) const {

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -17,9 +17,6 @@
 
 namespace Kernel {
 
-// Lists all processes that exist in the current session.
-static std::vector<SharedPtr<Process>> process_list;
-
 SharedPtr<CodeSet> KernelSystem::CreateCodeSet(std::string name, u64 program_id) {
     SharedPtr<CodeSet> codeset(new CodeSet(*this));
 
@@ -306,11 +303,7 @@ ResultCode Process::LinearFree(VAddr target, u32 size) {
 Kernel::Process::Process(KernelSystem& kernel) : Object(kernel), kernel(kernel) {}
 Kernel::Process::~Process() {}
 
-void ClearProcessList() {
-    process_list.clear();
-}
-
-SharedPtr<Process> GetProcessById(u32 process_id) {
+SharedPtr<Process> KernelSystem::GetProcessById(u32 process_id) const {
     auto itr = std::find_if(
         process_list.begin(), process_list.end(),
         [&](const SharedPtr<Process>& process) { return process->process_id == process_id; });

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -313,6 +313,4 @@ SharedPtr<Process> KernelSystem::GetProcessById(u32 process_id) const {
 
     return *itr;
 }
-
-SharedPtr<Process> g_current_process;
 } // namespace Kernel

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -32,8 +32,6 @@ SharedPtr<CodeSet> KernelSystem::CreateCodeSet(std::string name, u64 program_id)
 CodeSet::CodeSet(KernelSystem& kernel) : Object(kernel) {}
 CodeSet::~CodeSet() {}
 
-u32 Process::next_process_id;
-
 SharedPtr<Process> KernelSystem::CreateProcess(SharedPtr<CodeSet> code_set) {
     SharedPtr<Process> process(new Process(*this));
 
@@ -41,6 +39,7 @@ SharedPtr<Process> KernelSystem::CreateProcess(SharedPtr<CodeSet> code_set) {
     process->flags.raw = 0;
     process->flags.memory_region.Assign(MemoryRegion::APPLICATION);
     process->status = ProcessStatus::Created;
+    process->process_id = ++next_process_id;
 
     process_list.push_back(process);
     return process;

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -198,10 +198,5 @@ private:
     KernelSystem& kernel;
 };
 
-void ClearProcessList();
-
-/// Retrieves a process from the current list of processes.
-SharedPtr<Process> GetProcessById(u32 process_id);
-
 extern SharedPtr<Process> g_current_process;
 } // namespace Kernel

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -13,6 +13,7 @@
 #include <boost/container/static_vector.hpp>
 #include "common/bit_field.h"
 #include "common/common_types.h"
+#include "core/hle/kernel/handle_table.h"
 #include "core/hle/kernel/object.h"
 #include "core/hle/kernel/vm_manager.h"
 
@@ -122,6 +123,8 @@ public:
     HandleType GetHandleType() const override {
         return HANDLE_TYPE;
     }
+
+    HandleTable handle_table;
 
     SharedPtr<CodeSet> codeset;
     /// Resource limit descriptor for this process

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -197,6 +197,4 @@ private:
     friend class KernelSystem;
     KernelSystem& kernel;
 };
-
-extern SharedPtr<Process> g_current_process;
 } // namespace Kernel

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -123,8 +123,6 @@ public:
         return HANDLE_TYPE;
     }
 
-    static u32 next_process_id;
-
     SharedPtr<CodeSet> codeset;
     /// Resource limit descriptor for this process
     SharedPtr<ResourceLimit> resource_limit;
@@ -145,7 +143,7 @@ public:
     ProcessStatus status;
 
     /// The id of this process
-    u32 process_id = next_process_id++;
+    u32 process_id;
 
     /**
      * Parses a list of kernel capability descriptors (as found in the ExHeader) and applies them

--- a/src/core/hle/kernel/shared_memory.cpp
+++ b/src/core/hle/kernel/shared_memory.cpp
@@ -52,8 +52,8 @@ SharedPtr<SharedMemory> KernelSystem::CreateSharedMemory(SharedPtr<Process> owne
         }
 
         // Refresh the address mappings for the current process.
-        if (Kernel::g_current_process != nullptr) {
-            Kernel::g_current_process->vm_manager.RefreshMemoryBlockMappings(linheap_memory.get());
+        if (current_process != nullptr) {
+            current_process->vm_manager.RefreshMemoryBlockMappings(linheap_memory.get());
         }
     } else {
         auto& vm_manager = shared_memory->owner_process->vm_manager;

--- a/src/core/hle/kernel/shared_memory.cpp
+++ b/src/core/hle/kernel/shared_memory.cpp
@@ -14,7 +14,7 @@ namespace Kernel {
 SharedMemory::SharedMemory(KernelSystem& kernel) : Object(kernel) {}
 SharedMemory::~SharedMemory() {}
 
-SharedPtr<SharedMemory> KernelSystem::CreateSharedMemory(SharedPtr<Process> owner_process, u32 size,
+SharedPtr<SharedMemory> KernelSystem::CreateSharedMemory(Process* owner_process, u32 size,
                                                          MemoryPermission permissions,
                                                          MemoryPermission other_permissions,
                                                          VAddr address, MemoryRegion region,

--- a/src/core/hle/kernel/shared_memory.h
+++ b/src/core/hle/kernel/shared_memory.h
@@ -58,7 +58,7 @@ public:
     u8* GetPointer(u32 offset = 0);
 
     /// Process that created this shared memory block.
-    SharedPtr<Process> owner_process;
+    Process* owner_process;
     /// Address of shared memory block in the owner process if specified.
     VAddr base_address;
     /// Physical address of the shared memory block in the linear heap if no address was specified

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -182,7 +182,9 @@ static ResultCode MapMemoryBlock(Handle handle, u32 addr, u32 permissions, u32 o
               "otherpermission={}",
               handle, addr, permissions, other_permissions);
 
-    SharedPtr<SharedMemory> shared_memory = g_handle_table.Get<SharedMemory>(handle);
+    SharedPtr<SharedMemory> shared_memory =
+        Core::System::GetInstance().Kernel().GetCurrentProcess()->handle_table.Get<SharedMemory>(
+            handle);
     if (shared_memory == nullptr)
         return ERR_INVALID_HANDLE;
 
@@ -211,12 +213,12 @@ static ResultCode UnmapMemoryBlock(Handle handle, u32 addr) {
 
     // TODO(Subv): Return E0A01BF5 if the address is not in the application's heap
 
-    SharedPtr<SharedMemory> shared_memory = g_handle_table.Get<SharedMemory>(handle);
+    SharedPtr<Process> current_process = Core::System::GetInstance().Kernel().GetCurrentProcess();
+    SharedPtr<SharedMemory> shared_memory = current_process->handle_table.Get<SharedMemory>(handle);
     if (shared_memory == nullptr)
         return ERR_INVALID_HANDLE;
 
-    return shared_memory->Unmap(Core::System::GetInstance().Kernel().GetCurrentProcess().get(),
-                                addr);
+    return shared_memory->Unmap(current_process.get(), addr);
 }
 
 /// Connect to an OS service given the port name, returns the handle to the port to out
@@ -244,13 +246,17 @@ static ResultCode ConnectToPort(Handle* out_handle, VAddr port_name_address) {
     CASCADE_RESULT(client_session, client_port->Connect());
 
     // Return the client session
-    CASCADE_RESULT(*out_handle, g_handle_table.Create(client_session));
+    CASCADE_RESULT(*out_handle,
+                   Core::System::GetInstance().Kernel().GetCurrentProcess()->handle_table.Create(
+                       client_session));
     return RESULT_SUCCESS;
 }
 
 /// Makes a blocking IPC call to an OS service.
 static ResultCode SendSyncRequest(Handle handle) {
-    SharedPtr<ClientSession> session = g_handle_table.Get<ClientSession>(handle);
+    SharedPtr<ClientSession> session =
+        Core::System::GetInstance().Kernel().GetCurrentProcess()->handle_table.Get<ClientSession>(
+            handle);
     if (session == nullptr) {
         return ERR_INVALID_HANDLE;
     }
@@ -265,12 +271,14 @@ static ResultCode SendSyncRequest(Handle handle) {
 /// Close a handle
 static ResultCode CloseHandle(Handle handle) {
     LOG_TRACE(Kernel_SVC, "Closing handle 0x{:08X}", handle);
-    return g_handle_table.Close(handle);
+    return Core::System::GetInstance().Kernel().GetCurrentProcess()->handle_table.Close(handle);
 }
 
 /// Wait for a handle to synchronize, timeout after the specified nanoseconds
 static ResultCode WaitSynchronization1(Handle handle, s64 nano_seconds) {
-    auto object = g_handle_table.Get<WaitObject>(handle);
+    auto object =
+        Core::System::GetInstance().Kernel().GetCurrentProcess()->handle_table.Get<WaitObject>(
+            handle);
     Thread* thread = GetCurrentThread();
 
     if (object == nullptr)
@@ -341,7 +349,9 @@ static ResultCode WaitSynchronizationN(s32* out, VAddr handles_address, s32 hand
 
     for (int i = 0; i < handle_count; ++i) {
         Handle handle = Memory::Read32(handles_address + i * sizeof(Handle));
-        auto object = g_handle_table.Get<WaitObject>(handle);
+        auto object =
+            Core::System::GetInstance().Kernel().GetCurrentProcess()->handle_table.Get<WaitObject>(
+                handle);
         if (object == nullptr)
             return ERR_INVALID_HANDLE;
         objects[i] = object;
@@ -505,9 +515,11 @@ static ResultCode ReplyAndReceive(s32* index, VAddr handles_address, s32 handle_
     using ObjectPtr = SharedPtr<WaitObject>;
     std::vector<ObjectPtr> objects(handle_count);
 
+    SharedPtr<Process> current_process = Core::System::GetInstance().Kernel().GetCurrentProcess();
+
     for (int i = 0; i < handle_count; ++i) {
         Handle handle = Memory::Read32(handles_address + i * sizeof(Handle));
-        auto object = g_handle_table.Get<WaitObject>(handle);
+        auto object = current_process->handle_table.Get<WaitObject>(handle);
         if (object == nullptr)
             return ERR_INVALID_HANDLE;
         objects[i] = object;
@@ -518,7 +530,7 @@ static ResultCode ReplyAndReceive(s32* index, VAddr handles_address, s32 handle_
     u32* cmd_buff = GetCommandBuffer();
     IPC::Header header{cmd_buff[0]};
     if (reply_target != 0 && header.command_id != 0xFFFF) {
-        auto session = g_handle_table.Get<ServerSession>(reply_target);
+        auto session = current_process->handle_table.Get<ServerSession>(reply_target);
         if (session == nullptr)
             return ERR_INVALID_HANDLE;
 
@@ -618,8 +630,10 @@ static ResultCode ReplyAndReceive(s32* index, VAddr handles_address, s32 handle_
 
 /// Create an address arbiter (to allocate access to shared resources)
 static ResultCode CreateAddressArbiter(Handle* out_handle) {
-    SharedPtr<AddressArbiter> arbiter = Core::System::GetInstance().Kernel().CreateAddressArbiter();
-    CASCADE_RESULT(*out_handle, g_handle_table.Create(std::move(arbiter)));
+    KernelSystem& kernel = Core::System::GetInstance().Kernel();
+    SharedPtr<AddressArbiter> arbiter = kernel.CreateAddressArbiter();
+    CASCADE_RESULT(*out_handle,
+                   kernel.GetCurrentProcess()->handle_table.Create(std::move(arbiter)));
     LOG_TRACE(Kernel_SVC, "returned handle=0x{:08X}", *out_handle);
     return RESULT_SUCCESS;
 }
@@ -630,7 +644,9 @@ static ResultCode ArbitrateAddress(Handle handle, u32 address, u32 type, u32 val
     LOG_TRACE(Kernel_SVC, "called handle=0x{:08X}, address=0x{:08X}, type=0x{:08X}, value=0x{:08X}",
               handle, address, type, value);
 
-    SharedPtr<AddressArbiter> arbiter = g_handle_table.Get<AddressArbiter>(handle);
+    SharedPtr<AddressArbiter> arbiter =
+        Core::System::GetInstance().Kernel().GetCurrentProcess()->handle_table.Get<AddressArbiter>(
+            handle);
     if (arbiter == nullptr)
         return ERR_INVALID_HANDLE;
 
@@ -678,11 +694,12 @@ static void OutputDebugString(VAddr address, int len) {
 static ResultCode GetResourceLimit(Handle* resource_limit, Handle process_handle) {
     LOG_TRACE(Kernel_SVC, "called process=0x{:08X}", process_handle);
 
-    SharedPtr<Process> process = g_handle_table.Get<Process>(process_handle);
+    SharedPtr<Process> current_process = Core::System::GetInstance().Kernel().GetCurrentProcess();
+    SharedPtr<Process> process = current_process->handle_table.Get<Process>(process_handle);
     if (process == nullptr)
         return ERR_INVALID_HANDLE;
 
-    CASCADE_RESULT(*resource_limit, g_handle_table.Create(process->resource_limit));
+    CASCADE_RESULT(*resource_limit, current_process->handle_table.Create(process->resource_limit));
 
     return RESULT_SUCCESS;
 }
@@ -694,7 +711,8 @@ static ResultCode GetResourceLimitCurrentValues(VAddr values, Handle resource_li
               resource_limit_handle, names, name_count);
 
     SharedPtr<ResourceLimit> resource_limit =
-        g_handle_table.Get<ResourceLimit>(resource_limit_handle);
+        Core::System::GetInstance().Kernel().GetCurrentProcess()->handle_table.Get<ResourceLimit>(
+            resource_limit_handle);
     if (resource_limit == nullptr)
         return ERR_INVALID_HANDLE;
 
@@ -714,7 +732,8 @@ static ResultCode GetResourceLimitLimitValues(VAddr values, Handle resource_limi
               resource_limit_handle, names, name_count);
 
     SharedPtr<ResourceLimit> resource_limit =
-        g_handle_table.Get<ResourceLimit>(resource_limit_handle);
+        Core::System::GetInstance().Kernel().GetCurrentProcess()->handle_table.Get<ResourceLimit>(
+            resource_limit_handle);
     if (resource_limit == nullptr)
         return ERR_INVALID_HANDLE;
 
@@ -773,7 +792,7 @@ static ResultCode CreateThread(Handle* out_handle, u32 priority, u32 entry_point
     thread->context->SetFpscr(FPSCR_DEFAULT_NAN | FPSCR_FLUSH_TO_ZERO |
                               FPSCR_ROUND_TOZERO); // 0x03C00000
 
-    CASCADE_RESULT(*out_handle, g_handle_table.Create(std::move(thread)));
+    CASCADE_RESULT(*out_handle, current_process->handle_table.Create(std::move(thread)));
 
     Core::System::GetInstance().PrepareReschedule();
 
@@ -795,7 +814,8 @@ static void ExitThread() {
 
 /// Gets the priority for the specified thread
 static ResultCode GetThreadPriority(u32* priority, Handle handle) {
-    const SharedPtr<Thread> thread = g_handle_table.Get<Thread>(handle);
+    const SharedPtr<Thread> thread =
+        Core::System::GetInstance().Kernel().GetCurrentProcess()->handle_table.Get<Thread>(handle);
     if (thread == nullptr)
         return ERR_INVALID_HANDLE;
 
@@ -809,7 +829,8 @@ static ResultCode SetThreadPriority(Handle handle, u32 priority) {
         return ERR_OUT_OF_RANGE;
     }
 
-    SharedPtr<Thread> thread = g_handle_table.Get<Thread>(handle);
+    SharedPtr<Thread> thread =
+        Core::System::GetInstance().Kernel().GetCurrentProcess()->handle_table.Get<Thread>(handle);
     if (thread == nullptr)
         return ERR_INVALID_HANDLE;
 
@@ -834,9 +855,10 @@ static ResultCode SetThreadPriority(Handle handle, u32 priority) {
 
 /// Create a mutex
 static ResultCode CreateMutex(Handle* out_handle, u32 initial_locked) {
-    SharedPtr<Mutex> mutex = Core::System::GetInstance().Kernel().CreateMutex(initial_locked != 0);
+    KernelSystem& kernel = Core::System::GetInstance().Kernel();
+    SharedPtr<Mutex> mutex = kernel.CreateMutex(initial_locked != 0);
     mutex->name = fmt::format("mutex-{:08x}", Core::CPU().GetReg(14));
-    CASCADE_RESULT(*out_handle, g_handle_table.Create(std::move(mutex)));
+    CASCADE_RESULT(*out_handle, kernel.GetCurrentProcess()->handle_table.Create(std::move(mutex)));
 
     LOG_TRACE(Kernel_SVC, "called initial_locked={} : created handle=0x{:08X}",
               initial_locked ? "true" : "false", *out_handle);
@@ -848,7 +870,8 @@ static ResultCode CreateMutex(Handle* out_handle, u32 initial_locked) {
 static ResultCode ReleaseMutex(Handle handle) {
     LOG_TRACE(Kernel_SVC, "called handle=0x{:08X}", handle);
 
-    SharedPtr<Mutex> mutex = g_handle_table.Get<Mutex>(handle);
+    SharedPtr<Mutex> mutex =
+        Core::System::GetInstance().Kernel().GetCurrentProcess()->handle_table.Get<Mutex>(handle);
     if (mutex == nullptr)
         return ERR_INVALID_HANDLE;
 
@@ -859,7 +882,9 @@ static ResultCode ReleaseMutex(Handle handle) {
 static ResultCode GetProcessId(u32* process_id, Handle process_handle) {
     LOG_TRACE(Kernel_SVC, "called process=0x{:08X}", process_handle);
 
-    const SharedPtr<Process> process = g_handle_table.Get<Process>(process_handle);
+    const SharedPtr<Process> process =
+        Core::System::GetInstance().Kernel().GetCurrentProcess()->handle_table.Get<Process>(
+            process_handle);
     if (process == nullptr)
         return ERR_INVALID_HANDLE;
 
@@ -871,7 +896,9 @@ static ResultCode GetProcessId(u32* process_id, Handle process_handle) {
 static ResultCode GetProcessIdOfThread(u32* process_id, Handle thread_handle) {
     LOG_TRACE(Kernel_SVC, "called thread=0x{:08X}", thread_handle);
 
-    const SharedPtr<Thread> thread = g_handle_table.Get<Thread>(thread_handle);
+    const SharedPtr<Thread> thread =
+        Core::System::GetInstance().Kernel().GetCurrentProcess()->handle_table.Get<Thread>(
+            thread_handle);
     if (thread == nullptr)
         return ERR_INVALID_HANDLE;
 
@@ -887,7 +914,8 @@ static ResultCode GetProcessIdOfThread(u32* process_id, Handle thread_handle) {
 static ResultCode GetThreadId(u32* thread_id, Handle handle) {
     LOG_TRACE(Kernel_SVC, "called thread=0x{:08X}", handle);
 
-    const SharedPtr<Thread> thread = g_handle_table.Get<Thread>(handle);
+    const SharedPtr<Thread> thread =
+        Core::System::GetInstance().Kernel().GetCurrentProcess()->handle_table.Get<Thread>(handle);
     if (thread == nullptr)
         return ERR_INVALID_HANDLE;
 
@@ -897,10 +925,12 @@ static ResultCode GetThreadId(u32* thread_id, Handle handle) {
 
 /// Creates a semaphore
 static ResultCode CreateSemaphore(Handle* out_handle, s32 initial_count, s32 max_count) {
+    KernelSystem& kernel = Core::System::GetInstance().Kernel();
     CASCADE_RESULT(SharedPtr<Semaphore> semaphore,
-                   Core::System::GetInstance().Kernel().CreateSemaphore(initial_count, max_count));
+                   kernel.CreateSemaphore(initial_count, max_count));
     semaphore->name = fmt::format("semaphore-{:08x}", Core::CPU().GetReg(14));
-    CASCADE_RESULT(*out_handle, g_handle_table.Create(std::move(semaphore)));
+    CASCADE_RESULT(*out_handle,
+                   kernel.GetCurrentProcess()->handle_table.Create(std::move(semaphore)));
 
     LOG_TRACE(Kernel_SVC, "called initial_count={}, max_count={}, created handle=0x{:08X}",
               initial_count, max_count, *out_handle);
@@ -911,7 +941,9 @@ static ResultCode CreateSemaphore(Handle* out_handle, s32 initial_count, s32 max
 static ResultCode ReleaseSemaphore(s32* count, Handle handle, s32 release_count) {
     LOG_TRACE(Kernel_SVC, "called release_count={}, handle=0x{:08X}", release_count, handle);
 
-    SharedPtr<Semaphore> semaphore = g_handle_table.Get<Semaphore>(handle);
+    SharedPtr<Semaphore> semaphore =
+        Core::System::GetInstance().Kernel().GetCurrentProcess()->handle_table.Get<Semaphore>(
+            handle);
     if (semaphore == nullptr)
         return ERR_INVALID_HANDLE;
 
@@ -923,7 +955,9 @@ static ResultCode ReleaseSemaphore(s32* count, Handle handle, s32 release_count)
 /// Query process memory
 static ResultCode QueryProcessMemory(MemoryInfo* memory_info, PageInfo* page_info,
                                      Handle process_handle, u32 addr) {
-    SharedPtr<Process> process = g_handle_table.Get<Process>(process_handle);
+    SharedPtr<Process> process =
+        Core::System::GetInstance().Kernel().GetCurrentProcess()->handle_table.Get<Process>(
+            process_handle);
     if (process == nullptr)
         return ERR_INVALID_HANDLE;
 
@@ -949,9 +983,10 @@ static ResultCode QueryMemory(MemoryInfo* memory_info, PageInfo* page_info, u32 
 
 /// Create an event
 static ResultCode CreateEvent(Handle* out_handle, u32 reset_type) {
-    SharedPtr<Event> evt = Core::System::GetInstance().Kernel().CreateEvent(
-        static_cast<ResetType>(reset_type), fmt::format("event-{:08x}", Core::CPU().GetReg(14)));
-    CASCADE_RESULT(*out_handle, g_handle_table.Create(std::move(evt)));
+    KernelSystem& kernel = Core::System::GetInstance().Kernel();
+    SharedPtr<Event> evt = kernel.CreateEvent(static_cast<ResetType>(reset_type),
+                                              fmt::format("event-{:08x}", Core::CPU().GetReg(14)));
+    CASCADE_RESULT(*out_handle, kernel.GetCurrentProcess()->handle_table.Create(std::move(evt)));
 
     LOG_TRACE(Kernel_SVC, "called reset_type=0x{:08X} : created handle=0x{:08X}", reset_type,
               *out_handle);
@@ -960,7 +995,9 @@ static ResultCode CreateEvent(Handle* out_handle, u32 reset_type) {
 
 /// Duplicates a kernel handle
 static ResultCode DuplicateHandle(Handle* out, Handle handle) {
-    CASCADE_RESULT(*out, g_handle_table.Duplicate(handle));
+    CASCADE_RESULT(
+        *out,
+        Core::System::GetInstance().Kernel().GetCurrentProcess()->handle_table.Duplicate(handle));
     LOG_TRACE(Kernel_SVC, "duplicated 0x{:08X} to 0x{:08X}", handle, *out);
     return RESULT_SUCCESS;
 }
@@ -969,7 +1006,8 @@ static ResultCode DuplicateHandle(Handle* out, Handle handle) {
 static ResultCode SignalEvent(Handle handle) {
     LOG_TRACE(Kernel_SVC, "called event=0x{:08X}", handle);
 
-    SharedPtr<Event> evt = g_handle_table.Get<Event>(handle);
+    SharedPtr<Event> evt =
+        Core::System::GetInstance().Kernel().GetCurrentProcess()->handle_table.Get<Event>(handle);
     if (evt == nullptr)
         return ERR_INVALID_HANDLE;
 
@@ -982,7 +1020,8 @@ static ResultCode SignalEvent(Handle handle) {
 static ResultCode ClearEvent(Handle handle) {
     LOG_TRACE(Kernel_SVC, "called event=0x{:08X}", handle);
 
-    SharedPtr<Event> evt = g_handle_table.Get<Event>(handle);
+    SharedPtr<Event> evt =
+        Core::System::GetInstance().Kernel().GetCurrentProcess()->handle_table.Get<Event>(handle);
     if (evt == nullptr)
         return ERR_INVALID_HANDLE;
 
@@ -992,9 +1031,10 @@ static ResultCode ClearEvent(Handle handle) {
 
 /// Creates a timer
 static ResultCode CreateTimer(Handle* out_handle, u32 reset_type) {
-    SharedPtr<Timer> timer = Core::System::GetInstance().Kernel().CreateTimer(
+    KernelSystem& kernel = Core::System::GetInstance().Kernel();
+    SharedPtr<Timer> timer = kernel.CreateTimer(
         static_cast<ResetType>(reset_type), fmt ::format("timer-{:08x}", Core::CPU().GetReg(14)));
-    CASCADE_RESULT(*out_handle, g_handle_table.Create(std::move(timer)));
+    CASCADE_RESULT(*out_handle, kernel.GetCurrentProcess()->handle_table.Create(std::move(timer)));
 
     LOG_TRACE(Kernel_SVC, "called reset_type=0x{:08X} : created handle=0x{:08X}", reset_type,
               *out_handle);
@@ -1005,7 +1045,8 @@ static ResultCode CreateTimer(Handle* out_handle, u32 reset_type) {
 static ResultCode ClearTimer(Handle handle) {
     LOG_TRACE(Kernel_SVC, "called timer=0x{:08X}", handle);
 
-    SharedPtr<Timer> timer = g_handle_table.Get<Timer>(handle);
+    SharedPtr<Timer> timer =
+        Core::System::GetInstance().Kernel().GetCurrentProcess()->handle_table.Get<Timer>(handle);
     if (timer == nullptr)
         return ERR_INVALID_HANDLE;
 
@@ -1021,7 +1062,8 @@ static ResultCode SetTimer(Handle handle, s64 initial, s64 interval) {
         return ERR_OUT_OF_RANGE_KERNEL;
     }
 
-    SharedPtr<Timer> timer = g_handle_table.Get<Timer>(handle);
+    SharedPtr<Timer> timer =
+        Core::System::GetInstance().Kernel().GetCurrentProcess()->handle_table.Get<Timer>(handle);
     if (timer == nullptr)
         return ERR_INVALID_HANDLE;
 
@@ -1034,7 +1076,8 @@ static ResultCode SetTimer(Handle handle, s64 initial, s64 interval) {
 static ResultCode CancelTimer(Handle handle) {
     LOG_TRACE(Kernel_SVC, "called timer=0x{:08X}", handle);
 
-    SharedPtr<Timer> timer = g_handle_table.Get<Timer>(handle);
+    SharedPtr<Timer> timer =
+        Core::System::GetInstance().Kernel().GetCurrentProcess()->handle_table.Get<Timer>(handle);
     if (timer == nullptr)
         return ERR_INVALID_HANDLE;
 
@@ -1116,7 +1159,7 @@ static ResultCode CreateMemoryBlock(Handle* out_handle, u32 addr, u32 size, u32 
     shared_memory = Core::System::GetInstance().Kernel().CreateSharedMemory(
         current_process, size, static_cast<MemoryPermission>(my_permission),
         static_cast<MemoryPermission>(other_permission), addr, region);
-    CASCADE_RESULT(*out_handle, g_handle_table.Create(std::move(shared_memory)));
+    CASCADE_RESULT(*out_handle, current_process->handle_table.Create(std::move(shared_memory)));
 
     LOG_WARNING(Kernel_SVC, "called addr=0x{:08X}", addr);
     return RESULT_SUCCESS;
@@ -1127,48 +1170,58 @@ static ResultCode CreatePort(Handle* server_port, Handle* client_port, VAddr nam
     // TODO(Subv): Implement named ports.
     ASSERT_MSG(name_address == 0, "Named ports are currently unimplemented");
 
-    auto ports = Core::System::GetInstance().Kernel().CreatePortPair(max_sessions);
-    CASCADE_RESULT(*client_port,
-                   g_handle_table.Create(std::move(std::get<SharedPtr<ClientPort>>(ports))));
+    KernelSystem& kernel = Core::System::GetInstance().Kernel();
+    SharedPtr<Process> current_process = kernel.GetCurrentProcess();
+
+    auto ports = kernel.CreatePortPair(max_sessions);
+    CASCADE_RESULT(*client_port, current_process->handle_table.Create(
+                                     std::move(std::get<SharedPtr<ClientPort>>(ports))));
     // Note: The 3DS kernel also leaks the client port handle if the server port handle fails to be
     // created.
-    CASCADE_RESULT(*server_port,
-                   g_handle_table.Create(std::move(std::get<SharedPtr<ServerPort>>(ports))));
+    CASCADE_RESULT(*server_port, current_process->handle_table.Create(
+                                     std::move(std::get<SharedPtr<ServerPort>>(ports))));
 
     LOG_TRACE(Kernel_SVC, "called max_sessions={}", max_sessions);
     return RESULT_SUCCESS;
 }
 
 static ResultCode CreateSessionToPort(Handle* out_client_session, Handle client_port_handle) {
-    SharedPtr<ClientPort> client_port = g_handle_table.Get<ClientPort>(client_port_handle);
+    SharedPtr<Process> current_process = Core::System::GetInstance().Kernel().GetCurrentProcess();
+    SharedPtr<ClientPort> client_port =
+        current_process->handle_table.Get<ClientPort>(client_port_handle);
     if (client_port == nullptr)
         return ERR_INVALID_HANDLE;
 
     CASCADE_RESULT(auto session, client_port->Connect());
-    CASCADE_RESULT(*out_client_session, g_handle_table.Create(std::move(session)));
+    CASCADE_RESULT(*out_client_session, current_process->handle_table.Create(std::move(session)));
     return RESULT_SUCCESS;
 }
 
 static ResultCode CreateSession(Handle* server_session, Handle* client_session) {
-    auto sessions = Core::System::GetInstance().Kernel().CreateSessionPair();
+    KernelSystem& kernel = Core::System::GetInstance().Kernel();
+    auto sessions = kernel.CreateSessionPair();
+
+    SharedPtr<Process> current_process = kernel.GetCurrentProcess();
 
     auto& server = std::get<SharedPtr<ServerSession>>(sessions);
-    CASCADE_RESULT(*server_session, g_handle_table.Create(std::move(server)));
+    CASCADE_RESULT(*server_session, current_process->handle_table.Create(std::move(server)));
 
     auto& client = std::get<SharedPtr<ClientSession>>(sessions);
-    CASCADE_RESULT(*client_session, g_handle_table.Create(std::move(client)));
+    CASCADE_RESULT(*client_session, current_process->handle_table.Create(std::move(client)));
 
     LOG_TRACE(Kernel_SVC, "called");
     return RESULT_SUCCESS;
 }
 
 static ResultCode AcceptSession(Handle* out_server_session, Handle server_port_handle) {
-    SharedPtr<ServerPort> server_port = g_handle_table.Get<ServerPort>(server_port_handle);
+    SharedPtr<Process> current_process = Core::System::GetInstance().Kernel().GetCurrentProcess();
+    SharedPtr<ServerPort> server_port =
+        current_process->handle_table.Get<ServerPort>(server_port_handle);
     if (server_port == nullptr)
         return ERR_INVALID_HANDLE;
 
     CASCADE_RESULT(auto session, server_port->Accept());
-    CASCADE_RESULT(*out_server_session, g_handle_table.Create(std::move(session)));
+    CASCADE_RESULT(*out_server_session, current_process->handle_table.Create(std::move(session)));
     return RESULT_SUCCESS;
 }
 
@@ -1218,7 +1271,9 @@ static ResultCode GetSystemInfo(s64* out, u32 type, s32 param) {
 static ResultCode GetProcessInfo(s64* out, Handle process_handle, u32 type) {
     LOG_TRACE(Kernel_SVC, "called process=0x{:08X} type={}", process_handle, type);
 
-    SharedPtr<Process> process = g_handle_table.Get<Process>(process_handle);
+    SharedPtr<Process> process =
+        Core::System::GetInstance().Kernel().GetCurrentProcess()->handle_table.Get<Process>(
+            process_handle);
     if (process == nullptr)
         return ERR_INVALID_HANDLE;
 

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -785,9 +785,9 @@ static ResultCode CreateThread(Handle* out_handle, u32 priority, u32 entry_point
         break;
     }
 
-    CASCADE_RESULT(SharedPtr<Thread> thread,
-                   Core::System::GetInstance().Kernel().CreateThread(
-                       name, entry_point, priority, arg, processor_id, stack_top, current_process));
+    CASCADE_RESULT(SharedPtr<Thread> thread, Core::System::GetInstance().Kernel().CreateThread(
+                                                 name, entry_point, priority, arg, processor_id,
+                                                 stack_top, current_process.get()));
 
     thread->context->SetFpscr(FPSCR_DEFAULT_NAN | FPSCR_FLUSH_TO_ZERO |
                               FPSCR_ROUND_TOZERO); // 0x03C00000
@@ -1157,7 +1157,7 @@ static ResultCode CreateMemoryBlock(Handle* out_handle, u32 addr, u32 size, u32 
         region = current_process->flags.memory_region;
 
     shared_memory = Core::System::GetInstance().Kernel().CreateSharedMemory(
-        current_process, size, static_cast<MemoryPermission>(my_permission),
+        current_process.get(), size, static_cast<MemoryPermission>(my_permission),
         static_cast<MemoryPermission>(other_permission), addr, region);
     CASCADE_RESULT(*out_handle, current_process->handle_table.Create(std::move(shared_memory)));
 

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -787,7 +787,7 @@ static ResultCode CreateThread(Handle* out_handle, u32 priority, u32 entry_point
 
     CASCADE_RESULT(SharedPtr<Thread> thread, Core::System::GetInstance().Kernel().CreateThread(
                                                  name, entry_point, priority, arg, processor_id,
-                                                 stack_top, current_process.get()));
+                                                 stack_top, *current_process));
 
     thread->context->SetFpscr(FPSCR_DEFAULT_NAN | FPSCR_FLUSH_TO_ZERO |
                               FPSCR_ROUND_TOZERO); // 0x03C00000

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -516,7 +516,6 @@ void ThreadingShutdown() {
     }
     thread_list.clear();
     ready_queue.clear();
-    ClearProcessList();
 }
 
 const std::vector<SharedPtr<Thread>>& GetThreadList() {

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -320,8 +320,7 @@ static void ResetThreadContext(const std::unique_ptr<ARM_Interface::ThreadContex
 
 ResultVal<SharedPtr<Thread>> KernelSystem::CreateThread(std::string name, VAddr entry_point,
                                                         u32 priority, u32 arg, s32 processor_id,
-                                                        VAddr stack_top,
-                                                        SharedPtr<Process> owner_process) {
+                                                        VAddr stack_top, Process* owner_process) {
     // Check if priority is in ranged. Lowest priority -> highest priority id.
     if (priority > ThreadPrioLowest) {
         LOG_ERROR(Kernel_SVC, "Invalid thread priority: {}", priority);
@@ -447,7 +446,7 @@ SharedPtr<Thread> SetupMainThread(KernelSystem& kernel, u32 entry_point, u32 pri
     // Initialize new "main" thread
     auto thread_res =
         kernel.CreateThread("main", entry_point, priority, 0, owner_process->ideal_processor,
-                            Memory::HEAP_VADDR_END, owner_process);
+                            Memory::HEAP_VADDR_END, owner_process.get());
 
     SharedPtr<Thread> thread = std::move(thread_res).Unwrap();
 

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -38,7 +38,6 @@ void Thread::Acquire(Thread* thread) {
     ASSERT_MSG(!ShouldWait(thread), "object unavailable!");
 }
 
-static u64 next_callback_id;
 static std::unordered_map<u64, Thread*> wakeup_callback_table;
 
 // Lists all thread ids that aren't deleted/etc.

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -199,9 +199,6 @@ public:
 
     std::string name;
 
-    /// Handle used as userdata to reference this object when inserting into the CoreTiming queue.
-    Handle callback_handle;
-
     using WakeupCallback = void(ThreadWakeupReason reason, SharedPtr<Thread> thread,
                                 SharedPtr<WaitObject> object);
     // Callback that will be invoked when the thread is resumed from a waiting state. If the thread

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -189,7 +189,7 @@ public:
     /// Mutexes that this thread is currently waiting for.
     boost::container::flat_set<SharedPtr<Mutex>> pending_mutexes;
 
-    SharedPtr<Process> owner_process; ///< Process that owns this thread
+    Process* owner_process; ///< Process that owns this thread
 
     /// Objects that the thread is waiting on, in the same order as they were
     // passed to WaitSynchronization1/N.

--- a/src/core/hle/kernel/timer.h
+++ b/src/core/hle/kernel/timer.h
@@ -71,8 +71,8 @@ private:
     bool signaled;    ///< Whether the timer has been signaled or not
     std::string name; ///< Name of timer (optional)
 
-    /// Handle used as userdata to reference this object when inserting into the CoreTiming queue.
-    Handle callback_handle;
+    /// ID used as userdata to reference this object when inserting into the CoreTiming queue.
+    u64 callback_id;
 
     friend class KernelSystem;
 };

--- a/src/core/hle/service/apt/applet_manager.cpp
+++ b/src/core/hle/service/apt/applet_manager.cpp
@@ -258,7 +258,7 @@ ResultVal<AppletManager::InitializeResult> AppletManager::Initialize(AppletId ap
     slot_data->applet_id = static_cast<AppletId>(app_id);
     // Note: In the real console the title id of a given applet slot is set by the APT module when
     // calling StartApplication.
-    slot_data->title_id = Kernel::g_current_process->codeset->program_id;
+    slot_data->title_id = system.Kernel().GetCurrentProcess()->codeset->program_id;
     slot_data->attributes.raw = attributes.raw;
 
     if (slot_data->applet_id == AppletId::Application ||

--- a/src/core/hle/service/cecd/cecd.cpp
+++ b/src/core/hle/service/cecd/cecd.cpp
@@ -97,7 +97,7 @@ void Module::Interface::Open(Kernel::HLERequestContext& ctx) {
 
         if (path_type == CecDataPathType::MboxProgramId) {
             std::vector<u8> program_id(8);
-            u64_le le_program_id = Kernel::g_current_process->codeset->program_id;
+            u64_le le_program_id = cecd->system.Kernel().GetCurrentProcess()->codeset->program_id;
             std::memcpy(program_id.data(), &le_program_id, sizeof(u64));
             session_data->file->Write(0, sizeof(u64), true, program_id.data());
             session_data->file->Close();
@@ -1351,7 +1351,7 @@ Module::SessionData::~SessionData() {
 Module::Interface::Interface(std::shared_ptr<Module> cecd, const char* name, u32 max_session)
     : ServiceFramework(name, max_session), cecd(std::move(cecd)) {}
 
-Module::Module(Core::System& system) {
+Module::Module(Core::System& system) : system(system) {
     using namespace Kernel;
     cecinfo_event = system.Kernel().CreateEvent(Kernel::ResetType::OneShot, "CECD::cecinfo_event");
     change_state_event =

--- a/src/core/hle/service/cecd/cecd.h
+++ b/src/core/hle/service/cecd/cecd.h
@@ -610,6 +610,8 @@ private:
 
     Kernel::SharedPtr<Kernel::Event> cecinfo_event;
     Kernel::SharedPtr<Kernel::Event> change_state_event;
+
+    Core::System& system;
 };
 
 /// Initialize CECD service(s)

--- a/src/core/hle/service/fs/fs_user.cpp
+++ b/src/core/hle/service/fs/fs_user.cpp
@@ -619,7 +619,7 @@ void FS_USER::GetProgramLaunchInfo(Kernel::HLERequestContext& ctx) {
 
     // TODO(Subv): The real FS service manages its own process list and only checks the processes
     // that were registered with the 'fs:REG' service.
-    auto process = Kernel::GetProcessById(process_id);
+    auto process = system.Kernel().GetProcessById(process_id);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(5, 0);
 

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -194,7 +194,7 @@ void ServiceFrameworkBase::HandleSyncRequest(SharedPtr<ServerSession> server_ses
     // TODO(yuriks): The kernel should be the one handling this as part of translation after
     // everything else is migrated
     Kernel::HLERequestContext context(std::move(server_session));
-    context.PopulateFromIncomingCommandBuffer(cmd_buf, *current_process, Kernel::g_handle_table);
+    context.PopulateFromIncomingCommandBuffer(cmd_buf, *current_process);
 
     LOG_TRACE(Service, "{}", MakeFunctionString(info->name, GetServiceName().c_str(), cmd_buf));
     handler_invoker(this, info->handler_callback, context);
@@ -206,7 +206,7 @@ void ServiceFrameworkBase::HandleSyncRequest(SharedPtr<ServerSession> server_ses
     // the thread to sleep then the writing of the command buffer will be deferred to the wakeup
     // callback.
     if (thread->status == Kernel::ThreadStatus::Running) {
-        context.WriteToOutgoingCommandBuffer(cmd_buf, *current_process, Kernel::g_handle_table);
+        context.WriteToOutgoingCommandBuffer(cmd_buf, *current_process);
     }
 }
 

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -188,11 +188,13 @@ void ServiceFrameworkBase::HandleSyncRequest(SharedPtr<ServerSession> server_ses
         return ReportUnimplementedFunction(cmd_buf, info);
     }
 
+    Kernel::SharedPtr<Kernel::Process> current_process =
+        Core::System::GetInstance().Kernel().GetCurrentProcess();
+
     // TODO(yuriks): The kernel should be the one handling this as part of translation after
     // everything else is migrated
     Kernel::HLERequestContext context(std::move(server_session));
-    context.PopulateFromIncomingCommandBuffer(cmd_buf, *Kernel::g_current_process,
-                                              Kernel::g_handle_table);
+    context.PopulateFromIncomingCommandBuffer(cmd_buf, *current_process, Kernel::g_handle_table);
 
     LOG_TRACE(Service, "{}", MakeFunctionString(info->name, GetServiceName().c_str(), cmd_buf));
     handler_invoker(this, info->handler_callback, context);
@@ -204,8 +206,7 @@ void ServiceFrameworkBase::HandleSyncRequest(SharedPtr<ServerSession> server_ses
     // the thread to sleep then the writing of the command buffer will be deferred to the wakeup
     // callback.
     if (thread->status == Kernel::ThreadStatus::Running) {
-        context.WriteToOutgoingCommandBuffer(cmd_buf, *Kernel::g_current_process,
-                                             Kernel::g_handle_table);
+        context.WriteToOutgoingCommandBuffer(cmd_buf, *current_process, Kernel::g_handle_table);
     }
 }
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -111,7 +111,7 @@ static u8* GetPointerFromVMA(const Kernel::Process& process, VAddr vaddr) {
  * using a VMA from the current process.
  */
 static u8* GetPointerFromVMA(VAddr vaddr) {
-    return GetPointerFromVMA(*Kernel::g_current_process, vaddr);
+    return GetPointerFromVMA(*Core::System::GetInstance().Kernel().GetCurrentProcess(), vaddr);
 }
 
 /**
@@ -128,7 +128,8 @@ static MMIORegionPointer GetMMIOHandler(const PageTable& page_table, VAddr vaddr
 }
 
 static MMIORegionPointer GetMMIOHandler(VAddr vaddr) {
-    const PageTable& page_table = Kernel::g_current_process->vm_manager.page_table;
+    const PageTable& page_table =
+        Core::System::GetInstance().Kernel().GetCurrentProcess()->vm_manager.page_table;
     return GetMMIOHandler(page_table, vaddr);
 }
 
@@ -229,7 +230,7 @@ bool IsValidVirtualAddress(const Kernel::Process& process, const VAddr vaddr) {
 }
 
 bool IsValidVirtualAddress(const VAddr vaddr) {
-    return IsValidVirtualAddress(*Kernel::g_current_process, vaddr);
+    return IsValidVirtualAddress(*Core::System::GetInstance().Kernel().GetCurrentProcess(), vaddr);
 }
 
 bool IsValidPhysicalAddress(const PAddr paddr) {
@@ -524,7 +525,8 @@ void ReadBlock(const Kernel::Process& process, const VAddr src_addr, void* dest_
 }
 
 void ReadBlock(const VAddr src_addr, void* dest_buffer, const std::size_t size) {
-    ReadBlock(*Kernel::g_current_process, src_addr, dest_buffer, size);
+    ReadBlock(*Core::System::GetInstance().Kernel().GetCurrentProcess(), src_addr, dest_buffer,
+              size);
 }
 
 void Write8(const VAddr addr, const u8 data) {
@@ -592,7 +594,8 @@ void WriteBlock(const Kernel::Process& process, const VAddr dest_addr, const voi
 }
 
 void WriteBlock(const VAddr dest_addr, const void* src_buffer, const std::size_t size) {
-    WriteBlock(*Kernel::g_current_process, dest_addr, src_buffer, size);
+    WriteBlock(*Core::System::GetInstance().Kernel().GetCurrentProcess(), dest_addr, src_buffer,
+               size);
 }
 
 void ZeroBlock(const Kernel::Process& process, const VAddr dest_addr, const std::size_t size) {
@@ -644,7 +647,7 @@ void ZeroBlock(const Kernel::Process& process, const VAddr dest_addr, const std:
 }
 
 void ZeroBlock(const VAddr dest_addr, const std::size_t size) {
-    ZeroBlock(*Kernel::g_current_process, dest_addr, size);
+    ZeroBlock(*Core::System::GetInstance().Kernel().GetCurrentProcess(), dest_addr, size);
 }
 
 void CopyBlock(const Kernel::Process& process, VAddr dest_addr, VAddr src_addr,
@@ -699,7 +702,7 @@ void CopyBlock(const Kernel::Process& process, VAddr dest_addr, VAddr src_addr,
 }
 
 void CopyBlock(VAddr dest_addr, VAddr src_addr, const std::size_t size) {
-    CopyBlock(*Kernel::g_current_process, dest_addr, src_addr, size);
+    CopyBlock(*Core::System::GetInstance().Kernel().GetCurrentProcess(), dest_addr, src_addr, size);
 }
 
 template <>
@@ -778,7 +781,8 @@ std::optional<VAddr> PhysicalToVirtualAddress(const PAddr addr) {
     } else if (addr >= VRAM_PADDR && addr < VRAM_PADDR_END) {
         return addr - VRAM_PADDR + VRAM_VADDR;
     } else if (addr >= FCRAM_PADDR && addr < FCRAM_PADDR_END) {
-        return addr - FCRAM_PADDR + Kernel::g_current_process->GetLinearHeapAreaAddress();
+        return addr - FCRAM_PADDR +
+               Core::System::GetInstance().Kernel().GetCurrentProcess()->GetLinearHeapAreaAddress();
     } else if (addr >= DSP_RAM_PADDR && addr < DSP_RAM_PADDR_END) {
         return addr - DSP_RAM_PADDR + DSP_RAM_VADDR;
     } else if (addr >= IO_AREA_PADDR && addr < IO_AREA_PADDR_END) {

--- a/src/tests/core/arm/arm_test_common.h
+++ b/src/tests/core/arm/arm_test_common.h
@@ -80,7 +80,7 @@ private:
     std::shared_ptr<TestMemory> test_memory;
     std::vector<WriteRecord> write_records;
 
-    std::unique_ptr<Kernel::KernelSystem> kernel;
+    Kernel::KernelSystem* kernel;
 };
 
 } // namespace ArmTests


### PR DESCRIPTION
Global state elimination for kernel: part 2. 

Functional change: make handle table per-process (as it is in real 3DS), plus a minor fix in `Thread::Stop()`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4358)
<!-- Reviewable:end -->
