### PR TITLE
Port yuzu-emu/yuzu#1543: "CMakeLists: Use target_compile_definitions instead of add_definitions to define CITRA_ENABLE_COMPATIBILITY_REPORTING"

### DIFF
--- a/src/citra_qt/CMakeLists.txt
+++ b/src/citra_qt/CMakeLists.txt
@@ -209,7 +209,7 @@ target_link_libraries(citra-qt PRIVATE Boost::boost glad nihstro-headers Qt5::Op
 target_link_libraries(citra-qt PRIVATE ${PLATFORM_LIBRARIES} Threads::Threads)
 
 if (CITRA_ENABLE_COMPATIBILITY_REPORTING)
-    add_definitions(-DCITRA_ENABLE_COMPATIBILITY_REPORTING)
+    target_compile_definitions(citra-qt PRIVATE -DCITRA_ENABLE_COMPATIBILITY_REPORTING)
 endif()
 
 if (USE_DISCORD_PRESENCE)


### PR DESCRIPTION
See yuzu-emu/yuzu#1543.

`Keeps the definition constrained to the citra_qt target and prevents
polluting anything else in the same directory (should that ever happen).
It also keeps it consistent with how the USE_DISCORD_PRESENCE definition
is introduced below it.`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4360)
<!-- Reviewable:end -->
