### PR TITLE
citra_qt: fix translation for opengl version error

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -667,12 +667,12 @@ bool GMainWindow::LoadROM(const QString& filename) {
     render_window->InitRenderTarget();
     render_window->MakeCurrent();
 
-    const char* below_gl33_title = "OpenGL 3.3 Unsupported";
-    const char* below_gl33_message = "Your GPU may not support OpenGL 3.3, or you do not "
-                                     "have the latest graphics driver.";
+    const QString below_gl33_title = tr("OpenGL 3.3 Unsupported");
+    const QString below_gl33_message = tr("Your GPU may not support OpenGL 3.3, or you do not "
+                                          "have the latest graphics driver.");
 
     if (!gladLoadGL()) {
-        QMessageBox::critical(this, tr(below_gl33_title), tr(below_gl33_message));
+        QMessageBox::critical(this, below_gl33_title, below_gl33_message);
         return false;
     }
 
@@ -743,7 +743,7 @@ bool GMainWindow::LoadROM(const QString& filename) {
             break;
 
         case Core::System::ResultStatus::ErrorVideoCore_ErrorBelowGL33:
-            QMessageBox::critical(this, tr(below_gl33_title), tr(below_gl33_message));
+            QMessageBox::critical(this, below_gl33_title, below_gl33_message);
             break;
 
         default:


### PR DESCRIPTION
Variable in tr() won't trigger linguist to generate translation entry. Instead it needs a string literal

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4364)
<!-- Reviewable:end -->
