### PR TITLE
scripting/citra: Removed unused import binascii

### DIFF
--- a/dist/scripting/citra.py
+++ b/dist/scripting/citra.py
@@ -1,7 +1,6 @@
 import zmq
 import struct
 import random
-import binascii
 import enum
 
 CURRENT_REQUEST_VERSION = 1


### PR DESCRIPTION
Removed unused import `binascii`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4368)
<!-- Reviewable:end -->
