### PR TITLE
 compatdb: Use a seperate endpoint for testcase submission

### DIFF
--- a/src/citra_qt/compatdb.h
+++ b/src/citra_qt/compatdb.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <memory>
+#include <QFutureWatcher>
 #include <QWizard>
 
 namespace Ui {
@@ -19,8 +20,11 @@ public:
     ~CompatDB();
 
 private:
+    QFutureWatcher<bool> testcase_watcher;
+
     std::unique_ptr<Ui::CompatDB> ui;
 
     void Submit();
+    void OnTestcaseSubmitted();
     void EnableNext();
 };

--- a/src/citra_qt/main.ui
+++ b/src/citra_qt/main.ui
@@ -82,6 +82,8 @@
     <addaction name="action_Stop"/>
     <addaction name="action_Restart"/>
     <addaction name="separator"/>
+    <addaction name="action_Report_Compatibility"/>
+    <addaction name="separator"/>
     <addaction name="action_Configure"/>
    </widget>
    <widget class="QMenu" name="menu_View">
@@ -147,8 +149,6 @@
     </property>
     <addaction name="action_Check_For_Updates"/>
     <addaction name="action_Open_Maintenance_Tool"/>
-    <addaction name="separator"/>
-    <addaction name="action_Report_Compatibility"/>
     <addaction name="separator"/>
     <addaction name="action_FAQ"/>
     <addaction name="action_About"/>

--- a/src/common/telemetry.h
+++ b/src/common/telemetry.h
@@ -153,6 +153,7 @@ struct VisitorInterface : NonCopyable {
 
     /// Completion method, called once all fields have been visited
     virtual void Complete() = 0;
+    virtual bool SubmitTestcase() = 0;
 };
 
 /**
@@ -178,6 +179,9 @@ struct NullVisitor : public VisitorInterface {
     void Visit(const Field<std::chrono::microseconds>& /*field*/) override {}
 
     void Complete() override {}
+    bool SubmitTestcase() override {
+        return false;
+    }
 };
 
 } // namespace Telemetry

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -203,4 +203,13 @@ TelemetrySession::~TelemetrySession() {
     backend = nullptr;
 }
 
+bool TelemetrySession::SubmitTestcase() {
+#ifdef ENABLE_WEB_SERVICE
+    field_collection.Accept(*backend);
+    return backend->SubmitTestcase();
+#else
+    return false;
+#endif
+}
+
 } // namespace Core

--- a/src/core/telemetry_session.h
+++ b/src/core/telemetry_session.h
@@ -31,6 +31,12 @@ public:
         field_collection.AddField(type, name, std::move(value));
     }
 
+    /**
+     * Submits a Testcase.
+     * @returns A bool indicating whether the submission succeeded
+     */
+    bool SubmitTestcase();
+
 private:
     Telemetry::FieldCollection field_collection; ///< Tracks all added fields for the session
     std::unique_ptr<Telemetry::VisitorInterface> backend; ///< Backend interface that logs fields

--- a/src/web_service/telemetry_json.h
+++ b/src/web_service/telemetry_json.h
@@ -36,6 +36,7 @@ public:
     void Visit(const Telemetry::Field<std::chrono::microseconds>& field) override;
 
     void Complete() override;
+    bool SubmitTestcase() override;
 
 private:
     struct Impl;


### PR DESCRIPTION
This PR switches the endpoint for testcases to `api.citra-emu.org/gamedb/testcase` instead of sending them as part of Telemetry. It also adds basic error handling to the compatdb wizard and shows the user a popup in case submission failed.

It also moves the `Report compatibility` button to the emulation tab. This was done to get more users to submit testcase cause it's way more likely a user will visit this tab, than the help tab. If you've got any opinions on this change, don't hesitate to voice them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4369)
<!-- Reviewable:end -->
