### PR TITLE
Port yuzu-emu/yuzu#1571: "graphic_breakpoints: Correct translation of strings in BreakpointModel's data() function"

### DIFF
--- a/src/citra_qt/debugger/graphics/graphics_breakpoints.cpp
+++ b/src/citra_qt/debugger/graphics/graphics_breakpoints.cpp
@@ -30,23 +30,8 @@ QVariant BreakPointModel::data(const QModelIndex& index, int role) const {
     switch (role) {
     case Qt::DisplayRole: {
         if (index.column() == 0) {
-            static const std::map<Pica::DebugContext::Event, QString> map = {
-                {Pica::DebugContext::Event::PicaCommandLoaded, tr("Pica command loaded")},
-                {Pica::DebugContext::Event::PicaCommandProcessed, tr("Pica command processed")},
-                {Pica::DebugContext::Event::IncomingPrimitiveBatch, tr("Incoming primitive batch")},
-                {Pica::DebugContext::Event::FinishedPrimitiveBatch, tr("Finished primitive batch")},
-                {Pica::DebugContext::Event::VertexShaderInvocation, tr("Vertex shader invocation")},
-                {Pica::DebugContext::Event::IncomingDisplayTransfer,
-                 tr("Incoming display transfer")},
-                {Pica::DebugContext::Event::GSPCommandProcessed, tr("GSP command processed")},
-                {Pica::DebugContext::Event::BufferSwapped, tr("Buffers swapped")},
-            };
-
-            DEBUG_ASSERT(map.size() ==
-                         static_cast<std::size_t>(Pica::DebugContext::Event::NumEvents));
-            return (map.find(event) != map.end()) ? map.at(event) : QString();
+            return DebugContextEventToString(event);
         }
-
         break;
     }
 
@@ -126,6 +111,30 @@ void BreakPointModel::OnResumed() {
     emit dataChanged(createIndex(static_cast<int>(active_breakpoint), 0),
                      createIndex(static_cast<int>(active_breakpoint), 0));
     active_breakpoint = context->active_breakpoint;
+}
+
+QString BreakPointModel::DebugContextEventToString(Pica::DebugContext::Event event) {
+    switch (event) {
+    case Pica::DebugContext::Event::PicaCommandLoaded:
+        return tr("Pica command loaded");
+    case Pica::DebugContext::Event::PicaCommandProcessed:
+        return tr("Pica command processed");
+    case Pica::DebugContext::Event::IncomingPrimitiveBatch:
+        return tr("Incoming primitive batch");
+    case Pica::DebugContext::Event::FinishedPrimitiveBatch:
+        return tr("Finished primitive batch");
+    case Pica::DebugContext::Event::VertexShaderInvocation:
+        return tr("Vertex shader invocation");
+    case Pica::DebugContext::Event::IncomingDisplayTransfer:
+        return tr("Incoming display transfer");
+    case Pica::DebugContext::Event::GSPCommandProcessed:
+        return tr("GSP command processed");
+    case Pica::DebugContext::Event::BufferSwapped:
+        return tr("Buffers swapped");
+    case Pica::DebugContext::Event::NumEvents:
+        break;
+    }
+    return tr("Unknown debug context event");
 }
 
 GraphicsBreakPointsWidget::GraphicsBreakPointsWidget(

--- a/src/citra_qt/debugger/graphics/graphics_breakpoints_p.h
+++ b/src/citra_qt/debugger/graphics/graphics_breakpoints_p.h
@@ -29,6 +29,8 @@ public:
     void OnResumed();
 
 private:
+    static QString DebugContextEventToString(Pica::DebugContext::Event event);
+
     std::weak_ptr<Pica::DebugContext> context_weak;
     bool at_breakpoint;
     Pica::DebugContext::Event active_breakpoint;


### PR DESCRIPTION
See yuzu-emu/yuzu#1571.

**Original description:**
tr() will not function properly on static/global data like this, as the
object is only ever constructed once, so the strings won't translate if
the language is changed without restarting the program, which is
undesirable. Instead we can just turn the map into a plain old function
that maps the values to their equivalent strings. This is also lessens
the memory allocated, since it's only allocating memory for the strings
themselves, and not an encompassing map as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4376)
<!-- Reviewable:end -->
