### PR TITLE
configure_general: Add an option to reset defaults

### DIFF
--- a/src/citra_qt/configuration/configure_general.cpp
+++ b/src/citra_qt/configuration/configure_general.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <QMessageBox>
 #include "citra_qt/configuration/configure_general.h"
 #include "citra_qt/ui_settings.h"
 #include "core/core.h"
@@ -15,6 +16,8 @@ ConfigureGeneral::ConfigureGeneral(QWidget* parent)
     this->setConfiguration();
 
     ui->updateBox->setVisible(UISettings::values.updater_found);
+    connect(ui->button_reset_defaults, &QPushButton::clicked, this,
+            &ConfigureGeneral::ResetDefaults);
 }
 
 ConfigureGeneral::~ConfigureGeneral() = default;
@@ -31,6 +34,19 @@ void ConfigureGeneral::setConfiguration() {
 
 void ConfigureGeneral::PopulateHotkeyList(const HotkeyRegistry& registry) {
     ui->hotkeysDialog->Populate(registry);
+}
+
+void ConfigureGeneral::ResetDefaults() {
+    QMessageBox::StandardButton answer = QMessageBox::question(
+        this, tr("Citra"),
+        tr("Are you sure you want to <b>reset your settings</b> and close Citra?"),
+        QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+
+    if (answer == QMessageBox::No)
+        return;
+
+    FileUtil::Delete(FileUtil::GetUserPath(FileUtil::UserPath::ConfigDir) + "qt-config.ini");
+    std::exit(0);
 }
 
 void ConfigureGeneral::applyConfiguration() {

--- a/src/citra_qt/configuration/configure_general.h
+++ b/src/citra_qt/configuration/configure_general.h
@@ -21,6 +21,7 @@ public:
     ~ConfigureGeneral();
 
     void PopulateHotkeyList(const HotkeyRegistry& registry);
+    void ResetDefaults();
     void applyConfiguration();
     void retranslateUi();
 

--- a/src/citra_qt/configuration/configure_general.ui
+++ b/src/citra_qt/configuration/configure_general.ui
@@ -147,6 +147,13 @@
        </layout>
       </widget>
      </item>
+     <item alignment="Qt::AlignRight">
+      <widget class="QPushButton" name="button_reset_defaults">
+       <property name="text">
+        <string>Reset All Settings</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
   </layout>


### PR DESCRIPTION
I think this change is fairly self-explanatory.

When the button is clicked, the settings file gets deleted and Citra gets closed.

Screenshots:
![unbenannt1](https://user-images.githubusercontent.com/20753089/47609067-83428a80-da38-11e8-9eb9-2f74520c63a6.PNG)
![unbenannt2](https://user-images.githubusercontent.com/20753089/47609068-83db2100-da38-11e8-8c2d-dc0e09a5247d.PNG)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4382)
<!-- Reviewable:end -->
