### PR TITLE
Kernel/CodeSet: change struct to class

### DIFF
--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -50,7 +50,8 @@ enum class ProcessStatus { Created, Running, Exited };
 class ResourceLimit;
 struct MemoryRegionInfo;
 
-struct CodeSet final : public Object {
+class CodeSet final : public Object {
+public:
     struct Segment {
         std::size_t offset = 0;
         VAddr addr = 0;


### PR DESCRIPTION
Fix a warning where class definition and forward declaration mismatch. CodeSet is a kernel object and have ctor/dtor/private members like others, so in convention it should be a class

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4386)
<!-- Reviewable:end -->
