### PR TITLE
fs_user: Add a delay for each file open

### DIFF
--- a/src/core/file_sys/archive_backend.h
+++ b/src/core/file_sys/archive_backend.h
@@ -12,6 +12,7 @@
 #include "common/common_types.h"
 #include "common/swap.h"
 #include "core/hle/result.h"
+#include "delay_generator.h"
 
 namespace FileSys {
 
@@ -153,6 +154,27 @@ public:
      * @return The number of free bytes in the archive
      */
     virtual u64 GetFreeBytes() const = 0;
+
+    u64 GetReadDelayNs(std::size_t length) {
+        if (delay_generator != nullptr) {
+            return delay_generator->GetReadDelayNs(length);
+        }
+        LOG_ERROR(Service_FS, "Delay generator was not initalized. Using default");
+        delay_generator = std::make_unique<DefaultDelayGenerator>();
+        return delay_generator->GetReadDelayNs(length);
+    }
+
+    u64 GetOpenDelayNs() {
+        if (delay_generator != nullptr) {
+            return delay_generator->GetOpenDelayNs();
+        }
+        LOG_ERROR(Service_FS, "Delay generator was not initalized. Using default");
+        delay_generator = std::make_unique<DefaultDelayGenerator>();
+        return delay_generator->GetOpenDelayNs();
+    }
+
+protected:
+    std::unique_ptr<DelayGenerator> delay_generator;
 };
 
 class ArchiveFactory : NonCopyable {

--- a/src/core/file_sys/archive_backend.h
+++ b/src/core/file_sys/archive_backend.h
@@ -11,8 +11,8 @@
 #include "common/bit_field.h"
 #include "common/common_types.h"
 #include "common/swap.h"
+#include "core/file_sys/delay_generator.h"
 #include "core/hle/result.h"
-#include "delay_generator.h"
 
 namespace FileSys {
 
@@ -154,15 +154,6 @@ public:
      * @return The number of free bytes in the archive
      */
     virtual u64 GetFreeBytes() const = 0;
-
-    u64 GetReadDelayNs(std::size_t length) {
-        if (delay_generator != nullptr) {
-            return delay_generator->GetReadDelayNs(length);
-        }
-        LOG_ERROR(Service_FS, "Delay generator was not initalized. Using default");
-        delay_generator = std::make_unique<DefaultDelayGenerator>();
-        return delay_generator->GetReadDelayNs(length);
-    }
 
     u64 GetOpenDelayNs() {
         if (delay_generator != nullptr) {

--- a/src/core/file_sys/archive_extsavedata.cpp
+++ b/src/core/file_sys/archive_extsavedata.cpp
@@ -71,10 +71,10 @@ public:
     }
 
     u64 GetOpenDelayNs() override {
-        // This is the delay measured for a savedata open,
-        // not for extsaveData
-        // For now we will take that
-        static constexpr u64 IPCDelayNanoseconds(269082);
+        // This is the delay measured on N3DS with
+        // https://gist.github.com/FearlessTobi/929b68489f4abb2c6cf81d56970a20b4
+        // from the results the average of each length was taken.
+        static constexpr u64 IPCDelayNanoseconds(3085068);
         return IPCDelayNanoseconds;
     }
 };

--- a/src/core/file_sys/archive_sdmc.cpp
+++ b/src/core/file_sys/archive_sdmc.cpp
@@ -29,6 +29,14 @@ public:
         u64 IPCDelayNanoseconds = std::max<u64>(static_cast<u64>(length) * slope + offset, minimum);
         return IPCDelayNanoseconds;
     }
+
+    u64 GetOpenDelayNs() override {
+        // This is the delay measured on O3DS and O2DS with
+        // https://gist.github.com/FearlessTobi/c37e143c314789251f98f2c45cd706d2
+        // from the results the average of each length was taken.
+        static constexpr u64 IPCDelayNanoseconds(269082);
+        return IPCDelayNanoseconds;
+    }
 };
 
 ResultVal<std::unique_ptr<FileBackend>> SDMCArchive::OpenFile(const Path& path,
@@ -378,7 +386,8 @@ bool ArchiveFactory_SDMC::Initialize() {
 
 ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_SDMC::Open(const Path& path,
                                                                      u64 program_id) {
-    auto archive = std::make_unique<SDMCArchive>(sdmc_directory);
+    std::unique_ptr<DelayGenerator> delay_generator = std::make_unique<SDMCDelayGenerator>();
+    auto archive = std::make_unique<SDMCArchive>(sdmc_directory, std::move(delay_generator));
     return MakeResult<std::unique_ptr<ArchiveBackend>>(std::move(archive));
 }
 

--- a/src/core/file_sys/archive_sdmc.h
+++ b/src/core/file_sys/archive_sdmc.h
@@ -17,7 +17,11 @@ namespace FileSys {
 /// Archive backend for SDMC archive
 class SDMCArchive : public ArchiveBackend {
 public:
-    explicit SDMCArchive(const std::string& mount_point_) : mount_point(mount_point_) {}
+    explicit SDMCArchive(const std::string& mount_point_,
+                         std::unique_ptr<DelayGenerator> delay_generator_)
+        : mount_point(mount_point_) {
+        delay_generator = std::move(delay_generator_);
+    }
 
     std::string GetName() const override {
         return "SDMCArchive: " + mount_point;

--- a/src/core/file_sys/archive_sdmcwriteonly.cpp
+++ b/src/core/file_sys/archive_sdmcwriteonly.cpp
@@ -15,6 +15,28 @@
 
 namespace FileSys {
 
+class SDMCWriteOnlyDelayGenerator : public DelayGenerator {
+public:
+    u64 GetReadDelayNs(std::size_t length) override {
+        // This is the delay measured on O3DS and O2DS with
+        // https://gist.github.com/B3n30/ac40eac20603f519ff106107f4ac9182
+        // from the results the average of each length was taken.
+        static constexpr u64 slope(183);
+        static constexpr u64 offset(524879);
+        static constexpr u64 minimum(631826);
+        u64 IPCDelayNanoseconds = std::max<u64>(static_cast<u64>(length) * slope + offset, minimum);
+        return IPCDelayNanoseconds;
+    }
+
+    u64 GetOpenDelayNs() override {
+        // This is the delay measured on O3DS and O2DS with
+        // https://gist.github.com/FearlessTobi/c37e143c314789251f98f2c45cd706d2
+        // from the results the average of each length was taken.
+        static constexpr u64 IPCDelayNanoseconds(269082);
+        return IPCDelayNanoseconds;
+    }
+};
+
 ResultVal<std::unique_ptr<FileBackend>> SDMCWriteOnlyArchive::OpenFile(const Path& path,
                                                                        const Mode& mode) const {
     if (mode.read_flag) {
@@ -51,7 +73,10 @@ bool ArchiveFactory_SDMCWriteOnly::Initialize() {
 
 ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_SDMCWriteOnly::Open(const Path& path,
                                                                               u64 program_id) {
-    auto archive = std::make_unique<SDMCWriteOnlyArchive>(sdmc_directory);
+    std::unique_ptr<DelayGenerator> delay_generator =
+        std::make_unique<SDMCWriteOnlyDelayGenerator>();
+    auto archive =
+        std::make_unique<SDMCWriteOnlyArchive>(sdmc_directory, std::move(delay_generator));
     return MakeResult<std::unique_ptr<ArchiveBackend>>(std::move(archive));
 }
 

--- a/src/core/file_sys/archive_sdmcwriteonly.h
+++ b/src/core/file_sys/archive_sdmcwriteonly.h
@@ -19,7 +19,9 @@ namespace FileSys {
  */
 class SDMCWriteOnlyArchive : public SDMCArchive {
 public:
-    explicit SDMCWriteOnlyArchive(const std::string& mount_point) : SDMCArchive(mount_point) {}
+    explicit SDMCWriteOnlyArchive(const std::string& mount_point,
+                                  std::unique_ptr<DelayGenerator> delay_generator_)
+        : SDMCArchive(mount_point, std::move(delay_generator_)) {}
 
     std::string GetName() const override {
         return "SDMCWriteOnlyArchive: " + mount_point;

--- a/src/core/file_sys/delay_generator.cpp
+++ b/src/core/file_sys/delay_generator.cpp
@@ -19,4 +19,11 @@ u64 DefaultDelayGenerator::GetReadDelayNs(std::size_t length) {
     return IPCDelayNanoseconds;
 }
 
+u64 DefaultDelayGenerator::GetOpenDelayNs() {
+    // This is the delay measured for a romfs open.
+    // For now we will take that as a default
+    static constexpr u64 IPCDelayNanoseconds(9438006);
+    return IPCDelayNanoseconds;
+}
+
 } // namespace FileSys

--- a/src/core/file_sys/delay_generator.h
+++ b/src/core/file_sys/delay_generator.h
@@ -13,6 +13,7 @@ class DelayGenerator {
 public:
     virtual ~DelayGenerator();
     virtual u64 GetReadDelayNs(std::size_t length) = 0;
+    virtual u64 GetOpenDelayNs() = 0;
 
     // TODO (B3N30): Add getter for all other file/directory io operations
 };
@@ -20,6 +21,7 @@ public:
 class DefaultDelayGenerator : public DelayGenerator {
 public:
     u64 GetReadDelayNs(std::size_t length) override;
+    u64 GetOpenDelayNs() override;
 };
 
 } // namespace FileSys

--- a/src/core/file_sys/file_backend.h
+++ b/src/core/file_sys/file_backend.h
@@ -55,6 +55,15 @@ public:
         return delay_generator->GetReadDelayNs(length);
     }
 
+    u64 GetOpenDelayNs() {
+        if (delay_generator != nullptr) {
+            return delay_generator->GetOpenDelayNs();
+        }
+        LOG_ERROR(Service_FS, "Delay generator was not initalized. Using default");
+        delay_generator = std::make_unique<DefaultDelayGenerator>();
+        return delay_generator->GetOpenDelayNs();
+    }
+
     /**
      * Get the size of the file in bytes
      * @return Size of the file in bytes

--- a/src/core/file_sys/ivfc_archive.cpp
+++ b/src/core/file_sys/ivfc_archive.cpp
@@ -14,7 +14,11 @@
 
 namespace FileSys {
 
-IVFCArchive::IVFCArchive(std::shared_ptr<RomFSReader> file) : romfs_file(std::move(file)) {}
+IVFCArchive::IVFCArchive(std::shared_ptr<RomFSReader> file,
+                         std::unique_ptr<DelayGenerator> delay_generator_)
+    : romfs_file(std::move(file)) {
+    delay_generator = std::move(delay_generator_);
+}
 
 std::string IVFCArchive::GetName() const {
     return "IVFC";

--- a/src/core/file_sys/ivfc_archive.h
+++ b/src/core/file_sys/ivfc_archive.h
@@ -31,6 +31,13 @@ class IVFCDelayGenerator : public DelayGenerator {
         u64 IPCDelayNanoseconds = std::max<u64>(static_cast<u64>(length) * slope + offset, minimum);
         return IPCDelayNanoseconds;
     }
+
+    u64 GetOpenDelayNs() override {
+        // This is the delay measured for a romfs open.
+        // For now we will take that as a default
+        static constexpr u64 IPCDelayNanoseconds(9438006);
+        return IPCDelayNanoseconds;
+    }
 };
 
 class RomFSDelayGenerator : public DelayGenerator {
@@ -43,6 +50,14 @@ public:
         static constexpr u64 offset(582778);
         static constexpr u64 minimum(663124);
         u64 IPCDelayNanoseconds = std::max<u64>(static_cast<u64>(length) * slope + offset, minimum);
+        return IPCDelayNanoseconds;
+    }
+
+    u64 GetOpenDelayNs() override {
+        // This is the delay measured on O3DS and O2DS with
+        // https://gist.github.com/FearlessTobi/eb1d70619c65c7e6f02141d71e79a36e
+        // from the results the average of each length was taken.
+        static constexpr u64 IPCDelayNanoseconds(9438006);
         return IPCDelayNanoseconds;
     }
 };
@@ -59,6 +74,14 @@ public:
         u64 IPCDelayNanoseconds = std::max<u64>(static_cast<u64>(length) * slope + offset, minimum);
         return IPCDelayNanoseconds;
     }
+
+    u64 GetOpenDelayNs() override {
+        // This is the delay measured on O3DS and O2DS with
+        // https://gist.github.com/FearlessTobi/eb1d70619c65c7e6f02141d71e79a36e
+        // from the results the average of each length was taken.
+        static constexpr u64 IPCDelayNanoseconds(9438006);
+        return IPCDelayNanoseconds;
+    }
 };
 
 /**
@@ -68,7 +91,8 @@ public:
  */
 class IVFCArchive : public ArchiveBackend {
 public:
-    IVFCArchive(std::shared_ptr<RomFSReader> file);
+    IVFCArchive(std::shared_ptr<RomFSReader> file,
+                std::unique_ptr<DelayGenerator> delay_generator_);
 
     std::string GetName() const override;
 

--- a/src/core/file_sys/savedata_archive.cpp
+++ b/src/core/file_sys/savedata_archive.cpp
@@ -25,6 +25,14 @@ public:
         u64 IPCDelayNanoseconds = std::max<u64>(static_cast<u64>(length) * slope + offset, minimum);
         return IPCDelayNanoseconds;
     }
+
+    u64 GetOpenDelayNs() override {
+        // This is the delay measured on O3DS and O2DS with
+        // https://gist.github.com/FearlessTobi/c37e143c314789251f98f2c45cd706d2
+        // from the results the average of each length was taken.
+        static constexpr u64 IPCDelayNanoseconds(269082);
+        return IPCDelayNanoseconds;
+    }
 };
 
 ResultVal<std::unique_ptr<FileBackend>> SaveDataArchive::OpenFile(const Path& path,

--- a/src/core/hle/service/fs/archive.h
+++ b/src/core/hle/service/fs/archive.h
@@ -234,6 +234,8 @@ public:
     /// Registers a new NCCH file with the SelfNCCH archive factory
     void RegisterSelfNCCH(Loader::AppLoader& app_loader);
 
+    ArchiveBackend* GetArchive(ArchiveHandle handle);
+
 private:
     Core::System& system;
 
@@ -247,8 +249,6 @@ private:
 
     /// Register all archive types
     void RegisterArchiveTypes();
-
-    ArchiveBackend* GetArchive(ArchiveHandle handle);
 
     /**
      * Map of registered archives, identified by id code. Once an archive is registered here, it is

--- a/src/core/hle/service/fs/archive.h
+++ b/src/core/hle/service/fs/archive.h
@@ -77,11 +77,10 @@ public:
      * @param archive_handle Handle to an open Archive object
      * @param path Path to the File inside of the Archive
      * @param mode Mode under which to open the File
-     * @return The opened File object
+     * @return Tuple of the opened File object and the open delay
      */
-    ResultVal<std::shared_ptr<File>> OpenFileFromArchive(ArchiveHandle archive_handle,
-                                                         const FileSys::Path& path,
-                                                         const FileSys::Mode mode);
+    std::tuple<ResultVal<std::shared_ptr<File>>, std::chrono::nanoseconds> OpenFileFromArchive(
+        ArchiveHandle archive_handle, const FileSys::Path& path, const FileSys::Mode mode);
 
     /**
      * Delete a File from an Archive
@@ -234,8 +233,6 @@ public:
     /// Registers a new NCCH file with the SelfNCCH archive factory
     void RegisterSelfNCCH(Loader::AppLoader& app_loader);
 
-    ArchiveBackend* GetArchive(ArchiveHandle handle);
-
 private:
     Core::System& system;
 
@@ -249,6 +246,8 @@ private:
 
     /// Register all archive types
     void RegisterArchiveTypes();
+
+    ArchiveBackend* GetArchive(ArchiveHandle handle);
 
     /**
      * Map of registered archives, identified by id code. Once an archive is registered here, it is

--- a/src/core/hle/service/fs/file.cpp
+++ b/src/core/hle/service/fs/file.cpp
@@ -71,12 +71,12 @@ void File::Read(Kernel::HLERequestContext& ctx) {
     rb.PushMappedBuffer(buffer);
 
     std::chrono::nanoseconds read_timeout_ns{backend->GetReadDelayNs(length)};
-    ctx.SleepClientThread(system.Kernel().GetThreadManager().GetCurrentThread(), "file::read",
-                          read_timeout_ns,
-                          [](Kernel::SharedPtr<Kernel::Thread> thread,
-                             Kernel::HLERequestContext& ctx, Kernel::ThreadWakeupReason reason) {
-                              // Nothing to do here
-                          });
+    ctx.SleepClientThread(
+        system.Kernel().GetThreadManager().GetCurrentThread(), "file::read", read_timeout_ns,
+        [](Kernel::SharedPtr<Kernel::Thread> /*thread*/, Kernel::HLERequestContext& /*ctx*/,
+           Kernel::ThreadWakeupReason /*reason*/) {
+            // Nothing to do here
+        });
 }
 
 void File::Write(Kernel::HLERequestContext& ctx) {


### PR DESCRIPTION
File IOs on a 3DS take much longer then our currently emulated 39000 ns for each SVC call. Without the additional delay added by that PR the thread opening a file is executed much faster then it should, leading e.g. to deadlocks.

The time it took for the opening of files were tested with homebrews (links to their source code can be found in the code). The delay values were taken from the averages of all FileOpen operations for the specified archive type.
For now RomFS, ExeFS, and reading savefiles were tested. For all other values for now the RomFS/ExeFS delay was assumed until they get measured to. Adding that delay instead of the 39000 ns seems to be at least a bit more precise.

The final goal is still to measure all delays for File IOs (Read, FileCreate, FileDelete, DirCreate, DirDelete, etc... ) and to add them to Citra.

For this PR, I made ArchiveBackend also able to hold the delay generator. I saw no other possibility than this if I wanted to add accurate delays for when file opening fails.

This fixes https://github.com/citra-emu/citra/issues/2446.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4396)
<!-- Reviewable:end -->
