### PR TITLE
citra_qt/configuration: fix language configuration issues

### DIFF
--- a/src/citra_qt/configuration/configure_audio.h
+++ b/src/citra_qt/configuration/configure_audio.h
@@ -20,12 +20,12 @@ public:
 
     void applyConfiguration();
     void retranslateUi();
+    void setConfiguration();
 
 public slots:
     void updateAudioDevices(int sink_index);
 
 private:
-    void setConfiguration();
     void setOutputSinkFromSinkID();
     void setAudioDeviceFromDeviceID();
     void setVolumeIndicatorText(int percentage);

--- a/src/citra_qt/configuration/configure_debug.h
+++ b/src/citra_qt/configuration/configure_debug.h
@@ -20,8 +20,6 @@ public:
 
     void applyConfiguration();
     void retranslateUi();
-
-private:
     void setConfiguration();
 
 private:

--- a/src/citra_qt/configuration/configure_dialog.cpp
+++ b/src/citra_qt/configuration/configure_dialog.cpp
@@ -14,7 +14,6 @@ ConfigureDialog::ConfigureDialog(QWidget* parent, const HotkeyRegistry& registry
     : QDialog(parent), ui(new Ui::ConfigureDialog) {
     ui->setupUi(this);
     ui->generalTab->PopulateHotkeyList(registry);
-    this->setConfiguration();
     this->PopulateSelectionList();
     connect(ui->uiTab, &ConfigureUi::languageChanged, this, &ConfigureDialog::onLanguageChanged);
     connect(ui->selectorList, &QListWidget::itemSelectionChanged, this,
@@ -27,7 +26,17 @@ ConfigureDialog::ConfigureDialog(QWidget* parent, const HotkeyRegistry& registry
 
 ConfigureDialog::~ConfigureDialog() = default;
 
-void ConfigureDialog::setConfiguration() {}
+void ConfigureDialog::setConfiguration() {
+    ui->generalTab->setConfiguration();
+    ui->systemTab->setConfiguration();
+    ui->inputTab->loadConfiguration();
+    ui->graphicsTab->setConfiguration();
+    ui->audioTab->setConfiguration();
+    ui->cameraTab->setConfiguration();
+    ui->debugTab->setConfiguration();
+    ui->webTab->setConfiguration();
+    ui->uiTab->setConfiguration();
+}
 
 void ConfigureDialog::applyConfiguration() {
     ui->generalTab->applyConfiguration();
@@ -44,12 +53,14 @@ void ConfigureDialog::applyConfiguration() {
 }
 
 void ConfigureDialog::PopulateSelectionList() {
+    ui->selectorList->clear();
 
     const std::array<std::pair<QString, QStringList>, 4> items{
-        {{tr("General"), {tr("General"), tr("Web"), tr("Debug"), tr("UI")}},
-         {tr("System"), {tr("System"), tr("Audio"), tr("Camera")}},
-         {tr("Graphics"), {tr("Graphics")}},
-         {tr("Controls"), {tr("Input")}}}};
+        {{tr("General"),
+          {QT_TR_NOOP("General"), QT_TR_NOOP("Web"), QT_TR_NOOP("Debug"), QT_TR_NOOP("UI")}},
+         {tr("System"), {QT_TR_NOOP("System"), QT_TR_NOOP("Audio"), QT_TR_NOOP("Camera")}},
+         {tr("Graphics"), {QT_TR_NOOP("Graphics")}},
+         {tr("Controls"), {QT_TR_NOOP("Input")}}}};
 
     for (const auto& entry : items) {
         auto* item = new QListWidgetItem(entry.first);
@@ -61,7 +72,21 @@ void ConfigureDialog::PopulateSelectionList() {
 
 void ConfigureDialog::onLanguageChanged(const QString& locale) {
     emit languageChanged(locale);
+    // first apply the configuration, and then restore the display
+    applyConfiguration();
+    retranslateUi();
+    setConfiguration();
+}
+
+void ConfigureDialog::retranslateUi() {
+    int old_row = ui->selectorList->currentRow();
+    int old_index = ui->tabWidget->currentIndex();
     ui->retranslateUi(this);
+    PopulateSelectionList();
+    // restore selection after repopulating
+    ui->selectorList->setCurrentRow(old_row);
+    ui->tabWidget->setCurrentIndex(old_index);
+
     ui->generalTab->retranslateUi();
     ui->systemTab->retranslateUi();
     ui->inputTab->retranslateUi();
@@ -78,20 +103,15 @@ void ConfigureDialog::UpdateVisibleTabs() {
     if (items.isEmpty())
         return;
 
-    const QHash<QString, QWidget*> widgets = {{tr("General"), ui->generalTab},
-                                              {tr("System"), ui->systemTab},
-                                              {tr("Input"), ui->inputTab},
-                                              {tr("Graphics"), ui->graphicsTab},
-                                              {tr("Audio"), ui->audioTab},
-                                              {tr("Camera"), ui->cameraTab},
-                                              {tr("Debug"), ui->debugTab},
-                                              {tr("Web"), ui->webTab},
-                                              {tr("UI"), ui->uiTab}};
+    const QHash<QString, QWidget*> widgets = {
+        {"General", ui->generalTab},   {"System", ui->systemTab}, {"Input", ui->inputTab},
+        {"Graphics", ui->graphicsTab}, {"Audio", ui->audioTab},   {"Camera", ui->cameraTab},
+        {"Debug", ui->debugTab},       {"Web", ui->webTab},       {"UI", ui->uiTab}};
 
     ui->tabWidget->clear();
 
     QStringList tabs = items[0]->data(Qt::UserRole).toStringList();
 
     for (const auto& tab : tabs)
-        ui->tabWidget->addTab(widgets[tab], tab);
+        ui->tabWidget->addTab(widgets[tab], tr(qPrintable(tab)));
 }

--- a/src/citra_qt/configuration/configure_dialog.h
+++ b/src/citra_qt/configuration/configure_dialog.h
@@ -32,6 +32,7 @@ signals:
 
 private:
     void setConfiguration();
+    void retranslateUi();
 
 private:
     std::unique_ptr<Ui::ConfigureDialog> ui;

--- a/src/citra_qt/configuration/configure_general.h
+++ b/src/citra_qt/configuration/configure_general.h
@@ -24,9 +24,8 @@ public:
     void ResetDefaults();
     void applyConfiguration();
     void retranslateUi();
-
-private:
     void setConfiguration();
 
+private:
     std::unique_ptr<Ui::ConfigureGeneral> ui;
 };

--- a/src/citra_qt/configuration/configure_graphics.h
+++ b/src/citra_qt/configuration/configure_graphics.h
@@ -20,8 +20,6 @@ public:
 
     void applyConfiguration();
     void retranslateUi();
-
-private:
     void setConfiguration();
 
 private:

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -343,5 +343,4 @@ void ConfigureInput::keyPressEvent(QKeyEvent* event) {
 
 void ConfigureInput::retranslateUi() {
     ui->retranslateUi(this);
-    updateButtonLabels();
 }

--- a/src/citra_qt/configuration/configure_input.h
+++ b/src/citra_qt/configuration/configure_input.h
@@ -35,6 +35,9 @@ public:
     void applyConfiguration();
     void retranslateUi();
 
+    /// Load configuration settings.
+    void loadConfiguration();
+
 private:
     std::unique_ptr<Ui::ConfigureInput> ui;
 
@@ -69,8 +72,6 @@ private:
     /// keyboard events are ignored.
     bool want_keyboard_keys = false;
 
-    /// Load configuration settings.
-    void loadConfiguration();
     /// Restore all buttons to their default values.
     void restoreDefaults();
     /// Clear all input configuration

--- a/src/citra_qt/configuration/configure_system.cpp
+++ b/src/citra_qt/configuration/configure_system.cpp
@@ -422,5 +422,4 @@ void ConfigureSystem::RefreshConsoleID() {
 
 void ConfigureSystem::retranslateUi() {
     ui->retranslateUi(this);
-    ReadSystemSettings();
 }

--- a/src/citra_qt/configuration/configure_ui.h
+++ b/src/citra_qt/configuration/configure_ui.h
@@ -20,6 +20,7 @@ public:
 
     void applyConfiguration();
     void retranslateUi();
+    void setConfiguration();
 
 private slots:
     void onLanguageChanged(int index);
@@ -28,7 +29,5 @@ signals:
     void languageChanged(const QString& locale);
 
 private:
-    void setConfiguration();
-
     std::unique_ptr<Ui::ConfigureUi> ui;
 };

--- a/src/citra_qt/configuration/configure_ui.ui
+++ b/src/citra_qt/configuration/configure_ui.ui
@@ -23,6 +23,16 @@
       <item>
        <layout class="QVBoxLayout" name="verticalLayout_2">
         <item>
+         <widget class="QLabel" name="label_change_language_info">
+          <property name="text">
+           <string>Note: Changing language will apply your configuration.</string>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
          <layout class="QHBoxLayout" name="horizontalLayout_2">
           <item>
            <widget class="QLabel" name="language_label">

--- a/src/citra_qt/configuration/configure_web.h
+++ b/src/citra_qt/configuration/configure_web.h
@@ -21,6 +21,7 @@ public:
 
     void applyConfiguration();
     void retranslateUi();
+    void setConfiguration();
 
 public slots:
     void RefreshTelemetryID();
@@ -29,8 +30,6 @@ public slots:
     void OnLoginVerified();
 
 private:
-    void setConfiguration();
-
     bool user_verified = true;
     QFutureWatcher<bool> verify_watcher;
 


### PR DESCRIPTION
Fixes #4372.

Changing languages will now apply the settings - and load them back to the UI afterwards. Also fixed a bug introduced in the tabbed config PR caused by using translated strings in the data.

@FearlessTobi Can you verify that language configuration works properly now?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4398)
<!-- Reviewable:end -->
