### PR TITLE
CoreTiming: wrap into class

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -71,7 +71,8 @@ private:
 
 class DynarmicUserCallbacks final : public Dynarmic::A32::UserCallbacks {
 public:
-    explicit DynarmicUserCallbacks(ARM_Dynarmic& parent) : parent(parent) {}
+    explicit DynarmicUserCallbacks(ARM_Dynarmic& parent)
+        : parent(parent), timing(parent.system.CoreTiming()) {}
     ~DynarmicUserCallbacks() = default;
 
     std::uint8_t MemoryRead8(VAddr vaddr) override {
@@ -148,18 +149,19 @@ public:
     }
 
     void AddTicks(std::uint64_t ticks) override {
-        CoreTiming::AddTicks(ticks);
+        timing.AddTicks(ticks);
     }
     std::uint64_t GetTicksRemaining() override {
-        s64 ticks = CoreTiming::GetDowncount();
+        s64 ticks = timing.GetDowncount();
         return static_cast<u64>(ticks <= 0 ? 0 : ticks);
     }
 
     ARM_Dynarmic& parent;
+    Core::Timing& timing;
 };
 
-ARM_Dynarmic::ARM_Dynarmic(PrivilegeMode initial_mode)
-    : cb(std::make_unique<DynarmicUserCallbacks>(*this)) {
+ARM_Dynarmic::ARM_Dynarmic(Core::System& system, PrivilegeMode initial_mode)
+    : system(system), cb(std::make_unique<DynarmicUserCallbacks>(*this)) {
     interpreter_state = std::make_shared<ARMul_State>(initial_mode);
     PageTableChanged();
 }

--- a/src/core/arm/dynarmic/arm_dynarmic.h
+++ b/src/core/arm/dynarmic/arm_dynarmic.h
@@ -15,11 +15,15 @@ namespace Memory {
 struct PageTable;
 } // namespace Memory
 
+namespace Core {
+struct System;
+}
+
 class DynarmicUserCallbacks;
 
 class ARM_Dynarmic final : public ARM_Interface {
 public:
-    explicit ARM_Dynarmic(PrivilegeMode initial_mode);
+    ARM_Dynarmic(Core::System& system, PrivilegeMode initial_mode);
     ~ARM_Dynarmic();
 
     void Run() override;
@@ -50,6 +54,7 @@ public:
 
 private:
     friend class DynarmicUserCallbacks;
+    Core::System& system;
     std::unique_ptr<DynarmicUserCallbacks> cb;
     std::unique_ptr<Dynarmic::A32::Jit> MakeJit();
 

--- a/src/core/arm/dyncom/arm_dyncom.cpp
+++ b/src/core/arm/dyncom/arm_dyncom.cpp
@@ -75,7 +75,7 @@ ARM_DynCom::ARM_DynCom(PrivilegeMode initial_mode) {
 ARM_DynCom::~ARM_DynCom() {}
 
 void ARM_DynCom::Run() {
-    ExecuteInstructions(std::max<s64>(CoreTiming::GetDowncount(), 0));
+    ExecuteInstructions(std::max<s64>(Core::System::GetInstance().CoreTiming().GetDowncount(), 0));
 }
 
 void ARM_DynCom::Step() {
@@ -146,7 +146,7 @@ void ARM_DynCom::SetCP15Register(CP15Register reg, u32 value) {
 void ARM_DynCom::ExecuteInstructions(u64 num_instructions) {
     state->NumInstrsToExecute = num_instructions;
     unsigned ticks_executed = InterpreterMainLoop(state.get());
-    CoreTiming::AddTicks(ticks_executed);
+    Core::System::GetInstance().CoreTiming().AddTicks(ticks_executed);
     state->ServeBreak();
 }
 

--- a/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
+++ b/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
@@ -18,6 +18,7 @@
 #include "core/arm/skyeye_common/armstate.h"
 #include "core/arm/skyeye_common/armsupp.h"
 #include "core/arm/skyeye_common/vfp/vfp.h"
+#include "core/core.h"
 #include "core/core_timing.h"
 #include "core/gdbstub/gdbstub.h"
 #include "core/hle/kernel/svc.h"
@@ -3859,7 +3860,7 @@ SUB_INST : {
 SWI_INST : {
     if (inst_base->cond == ConditionCode::AL || CondPassed(cpu, inst_base->cond)) {
         swi_inst* const inst_cream = (swi_inst*)inst_base->component;
-        CoreTiming::AddTicks(num_instrs);
+        Core::System::GetInstance().CoreTiming().AddTicks(num_instrs);
         cpu->NumInstrsToExecute =
             num_instrs >= cpu->NumInstrsToExecute ? 0 : cpu->NumInstrsToExecute - num_instrs;
         num_instrs = 0;

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -41,6 +41,8 @@ class KernelSystem;
 
 namespace Core {
 
+class Timing;
+
 class System {
 public:
     /**
@@ -176,6 +178,12 @@ public:
     /// Gets a const reference to the kernel
     const Kernel::KernelSystem& Kernel() const;
 
+    /// Gets a reference to the timing system
+    Timing& CoreTiming();
+
+    /// Gets a const reference to the timing system
+    const Timing& CoreTiming() const;
+
     PerfStats perf_stats;
     FrameLimiter frame_limiter;
 
@@ -246,6 +254,7 @@ private:
 public: // HACK: this is temporary exposed for tests,
         // due to WIP kernel refactor causing desync state in memory
     std::unique_ptr<Kernel::KernelSystem> kernel;
+    std::unique_ptr<Timing> timing;
 
 private:
     static System s_instance;

--- a/src/core/core_timing.cpp
+++ b/src/core/core_timing.cpp
@@ -2,75 +2,25 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include "core/core_timing.h"
-
 #include <algorithm>
 #include <cinttypes>
-#include <mutex>
-#include <string>
 #include <tuple>
-#include <unordered_map>
-#include <vector>
 #include "common/assert.h"
 #include "common/logging/log.h"
-#include "common/thread.h"
-#include "common/threadsafe_queue.h"
+#include "core/core_timing.h"
 
-namespace CoreTiming {
-
-static s64 global_timer;
-static s64 slice_length;
-static s64 downcount;
-
-struct EventType {
-    TimedCallback callback;
-    const std::string* name;
-};
-
-struct Event {
-    s64 time;
-    u64 fifo_order;
-    u64 userdata;
-    const EventType* type;
-};
+namespace Core {
 
 // Sort by time, unless the times are the same, in which case sort by the order added to the queue
-static bool operator>(const Event& left, const Event& right) {
-    return std::tie(left.time, left.fifo_order) > std::tie(right.time, right.fifo_order);
+bool Timing::Event::operator>(const Event& right) const {
+    return std::tie(time, fifo_order) > std::tie(right.time, right.fifo_order);
 }
 
-static bool operator<(const Event& left, const Event& right) {
-    return std::tie(left.time, left.fifo_order) < std::tie(right.time, right.fifo_order);
+bool Timing::Event::operator<(const Event& right) const {
+    return std::tie(time, fifo_order) < std::tie(right.time, right.fifo_order);
 }
 
-// unordered_map stores each element separately as a linked list node so pointers to elements
-// remain stable regardless of rehashes/resizing.
-static std::unordered_map<std::string, EventType> event_types;
-
-// The queue is a min-heap using std::make_heap/push_heap/pop_heap.
-// We don't use std::priority_queue because we need to be able to serialize, unserialize and
-// erase arbitrary events (RemoveEvent()) regardless of the queue order. These aren't accomodated
-// by the standard adaptor class.
-static std::vector<Event> event_queue;
-static u64 event_fifo_id;
-// the queue for storing the events from other threads threadsafe until they will be added
-// to the event_queue by the emu thread
-static Common::MPSCQueue<Event, false> ts_queue;
-
-static constexpr int MAX_SLICE_LENGTH = 20000;
-
-static s64 idled_cycles;
-
-// Are we in a function that has been called from Advance()
-// If events are sheduled from a function that gets called from Advance(),
-// don't change slice_length and downcount.
-static bool is_global_timer_sane;
-
-static EventType* ev_lost = nullptr;
-
-static void EmptyTimedCallback(u64 userdata, s64 cyclesLate) {}
-
-EventType* RegisterEvent(const std::string& name, TimedCallback callback) {
+TimingEventType* Timing::RegisterEvent(const std::string& name, TimedCallback callback) {
     // check for existing type with same name.
     // we want event type names to remain unique so that we can use them for serialization.
     ASSERT_MSG(event_types.find(name) == event_types.end(),
@@ -78,42 +28,17 @@ EventType* RegisterEvent(const std::string& name, TimedCallback callback) {
                "during Init to avoid breaking save states.",
                name);
 
-    auto info = event_types.emplace(name, EventType{callback, nullptr});
-    EventType* event_type = &info.first->second;
+    auto info = event_types.emplace(name, TimingEventType{callback, nullptr});
+    TimingEventType* event_type = &info.first->second;
     event_type->name = &info.first->first;
     return event_type;
 }
 
-void UnregisterAllEvents() {
-    ASSERT_MSG(event_queue.empty(), "Cannot unregister events with events pending");
-    event_types.clear();
-}
-
-void Init() {
-    downcount = MAX_SLICE_LENGTH;
-    slice_length = MAX_SLICE_LENGTH;
-    global_timer = 0;
-    idled_cycles = 0;
-
-    // The time between CoreTiming being intialized and the first call to Advance() is considered
-    // the slice boundary between slice -1 and slice 0. Dispatcher loops must call Advance() before
-    // executing the first cycle of each slice to prepare the slice length and downcount for
-    // that slice.
-    is_global_timer_sane = true;
-
-    event_fifo_id = 0;
-    ev_lost = RegisterEvent("_lost_event", &EmptyTimedCallback);
-}
-
-void Shutdown() {
+Timing::~Timing() {
     MoveEvents();
-    ClearPendingEvents();
-    UnregisterAllEvents();
 }
 
-// This should only be called from the CPU thread. If you are calling
-// it from any other thread, you are doing something evil
-u64 GetTicks() {
+u64 Timing::GetTicks() const {
     u64 ticks = static_cast<u64>(global_timer);
     if (!is_global_timer_sane) {
         ticks += slice_length - downcount;
@@ -121,19 +46,16 @@ u64 GetTicks() {
     return ticks;
 }
 
-void AddTicks(u64 ticks) {
+void Timing::AddTicks(u64 ticks) {
     downcount -= ticks;
 }
 
-u64 GetIdleTicks() {
+u64 Timing::GetIdleTicks() const {
     return static_cast<u64>(idled_cycles);
 }
 
-void ClearPendingEvents() {
-    event_queue.clear();
-}
-
-void ScheduleEvent(s64 cycles_into_future, const EventType* event_type, u64 userdata) {
+void Timing::ScheduleEvent(s64 cycles_into_future, const TimingEventType* event_type,
+                           u64 userdata) {
     ASSERT(event_type != nullptr);
     s64 timeout = GetTicks() + cycles_into_future;
 
@@ -145,11 +67,12 @@ void ScheduleEvent(s64 cycles_into_future, const EventType* event_type, u64 user
     std::push_heap(event_queue.begin(), event_queue.end(), std::greater<>());
 }
 
-void ScheduleEventThreadsafe(s64 cycles_into_future, const EventType* event_type, u64 userdata) {
+void Timing::ScheduleEventThreadsafe(s64 cycles_into_future, const TimingEventType* event_type,
+                                     u64 userdata) {
     ts_queue.Push(Event{global_timer + cycles_into_future, 0, userdata, event_type});
 }
 
-void UnscheduleEvent(const EventType* event_type, u64 userdata) {
+void Timing::UnscheduleEvent(const TimingEventType* event_type, u64 userdata) {
     auto itr = std::remove_if(event_queue.begin(), event_queue.end(), [&](const Event& e) {
         return e.type == event_type && e.userdata == userdata;
     });
@@ -161,7 +84,7 @@ void UnscheduleEvent(const EventType* event_type, u64 userdata) {
     }
 }
 
-void RemoveEvent(const EventType* event_type) {
+void Timing::RemoveEvent(const TimingEventType* event_type) {
     auto itr = std::remove_if(event_queue.begin(), event_queue.end(),
                               [&](const Event& e) { return e.type == event_type; });
 
@@ -172,12 +95,12 @@ void RemoveEvent(const EventType* event_type) {
     }
 }
 
-void RemoveNormalAndThreadsafeEvent(const EventType* event_type) {
+void Timing::RemoveNormalAndThreadsafeEvent(const TimingEventType* event_type) {
     MoveEvents();
     RemoveEvent(event_type);
 }
 
-void ForceExceptionCheck(s64 cycles) {
+void Timing::ForceExceptionCheck(s64 cycles) {
     cycles = std::max<s64>(0, cycles);
     if (downcount > cycles) {
         slice_length -= downcount - cycles;
@@ -185,7 +108,7 @@ void ForceExceptionCheck(s64 cycles) {
     }
 }
 
-void MoveEvents() {
+void Timing::MoveEvents() {
     for (Event ev; ts_queue.Pop(ev);) {
         ev.fifo_order = event_fifo_id++;
         event_queue.emplace_back(std::move(ev));
@@ -193,7 +116,7 @@ void MoveEvents() {
     }
 }
 
-void Advance() {
+void Timing::Advance() {
     MoveEvents();
 
     s64 cycles_executed = slice_length - downcount;
@@ -220,17 +143,17 @@ void Advance() {
     downcount = slice_length;
 }
 
-void Idle() {
+void Timing::Idle() {
     idled_cycles += downcount;
     downcount = 0;
 }
 
-std::chrono::microseconds GetGlobalTimeUs() {
+std::chrono::microseconds Timing::GetGlobalTimeUs() const {
     return std::chrono::microseconds{GetTicks() * 1000000 / BASE_CLOCK_RATE_ARM11};
 }
 
-s64 GetDowncount() {
+s64 Timing::GetDowncount() const {
     return downcount;
 }
 
-} // namespace CoreTiming
+} // namespace Core

--- a/src/core/hle/kernel/shared_page.cpp
+++ b/src/core/hle/kernel/shared_page.cpp
@@ -4,6 +4,7 @@
 
 #include <chrono>
 #include <cstring>
+#include "core/core.h"
 #include "core/core_timing.h"
 #include "core/hle/kernel/shared_page.h"
 #include "core/hle/service/ptm/ptm.h"
@@ -53,9 +54,9 @@ Handler::Handler() {
     init_time = GetInitTime();
 
     using namespace std::placeholders;
-    update_time_event = CoreTiming::RegisterEvent(
+    update_time_event = Core::System::GetInstance().CoreTiming().RegisterEvent(
         "SharedPage::UpdateTimeCallback", std::bind(&Handler::UpdateTimeCallback, this, _1, _2));
-    CoreTiming::ScheduleEvent(0, update_time_event);
+    Core::System::GetInstance().CoreTiming().ScheduleEvent(0, update_time_event);
 
     float slidestate =
         Settings::values.toggle_3d ? (float_le)Settings::values.factor_3d / 100 : 0.0f;
@@ -65,8 +66,8 @@ Handler::Handler() {
 /// Gets system time in 3DS format. The epoch is Jan 1900, and the unit is millisecond.
 u64 Handler::GetSystemTime() const {
     std::chrono::milliseconds now =
-        init_time +
-        std::chrono::duration_cast<std::chrono::milliseconds>(CoreTiming::GetGlobalTimeUs());
+        init_time + std::chrono::duration_cast<std::chrono::milliseconds>(
+                        Core::System::GetInstance().CoreTiming().GetGlobalTimeUs());
 
     // 3DS system does't allow user to set a time before Jan 1 2000,
     // so we use it as an auxiliary epoch to calculate the console time.
@@ -97,14 +98,15 @@ void Handler::UpdateTimeCallback(u64 userdata, int cycles_late) {
         shared_page.date_time_counter % 2 ? shared_page.date_time_0 : shared_page.date_time_1;
 
     date_time.date_time = GetSystemTime();
-    date_time.update_tick = CoreTiming::GetTicks();
+    date_time.update_tick = Core::System::GetInstance().CoreTiming().GetTicks();
     date_time.tick_to_second_coefficient = BASE_CLOCK_RATE_ARM11;
     date_time.tick_offset = 0;
 
     ++shared_page.date_time_counter;
 
     // system time is updated hourly
-    CoreTiming::ScheduleEvent(msToCycles(60 * 60 * 1000) - cycles_late, update_time_event);
+    Core::System::GetInstance().CoreTiming().ScheduleEvent(msToCycles(60 * 60 * 1000) - cycles_late,
+                                                           update_time_event);
 }
 
 void Handler::SetMacAddress(const MacAddress& addr) {

--- a/src/core/hle/kernel/shared_page.h
+++ b/src/core/hle/kernel/shared_page.h
@@ -21,8 +21,8 @@
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-namespace CoreTiming {
-struct EventType;
+namespace Core {
+struct TimingEventType;
 }
 
 namespace SharedPage {
@@ -96,7 +96,7 @@ public:
 private:
     u64 GetSystemTime() const;
     void UpdateTimeCallback(u64 userdata, int cycles_late);
-    CoreTiming::EventType* update_time_event;
+    Core::TimingEventType* update_time_event;
     std::chrono::seconds init_time;
 
     SharedPageDef shared_page;

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1111,9 +1111,10 @@ static void SleepThread(s64 nanoseconds) {
 
 /// This returns the total CPU ticks elapsed since the CPU was powered-on
 static s64 GetSystemTick() {
-    s64 result = CoreTiming::GetTicks();
+    s64 result = Core::System::GetInstance().CoreTiming().GetTicks();
     // Advance time to defeat dumb games (like Cubic Ninja) that busy-wait for the frame to end.
-    CoreTiming::AddTicks(150); // Measured time between two calls on a 9.2 o3DS with Ninjhax 1.1b
+    // Measured time between two calls on a 9.2 o3DS with Ninjhax 1.1b
+    Core::System::GetInstance().CoreTiming().AddTicks(150);
     return result;
 }
 

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -48,7 +48,8 @@ Thread* ThreadManager::GetCurrentThread() const {
 
 void Thread::Stop() {
     // Cancel any outstanding wakeup events for this thread
-    CoreTiming::UnscheduleEvent(thread_manager.ThreadWakeupEventType, thread_id);
+    Core::System::GetInstance().CoreTiming().UnscheduleEvent(thread_manager.ThreadWakeupEventType,
+                                                             thread_id);
     thread_manager.wakeup_callback_table.erase(thread_id);
 
     // Clean up thread from ready queue
@@ -80,9 +81,11 @@ void Thread::Stop() {
 void ThreadManager::SwitchContext(Thread* new_thread) {
     Thread* previous_thread = GetCurrentThread();
 
+    Core::Timing& timing = Core::System::GetInstance().CoreTiming();
+
     // Save context for previous thread
     if (previous_thread) {
-        previous_thread->last_running_ticks = CoreTiming::GetTicks();
+        previous_thread->last_running_ticks = timing.GetTicks();
         Core::CPU().SaveContext(previous_thread->context);
 
         if (previous_thread->status == ThreadStatus::Running) {
@@ -99,7 +102,7 @@ void ThreadManager::SwitchContext(Thread* new_thread) {
                    "Thread must be ready to become running.");
 
         // Cancel any outstanding wakeup events for this thread
-        CoreTiming::UnscheduleEvent(ThreadWakeupEventType, new_thread->thread_id);
+        timing.UnscheduleEvent(ThreadWakeupEventType, new_thread->thread_id);
 
         auto previous_process = Core::System::GetInstance().Kernel().GetCurrentProcess();
 
@@ -182,8 +185,8 @@ void Thread::WakeAfterDelay(s64 nanoseconds) {
     if (nanoseconds == -1)
         return;
 
-    CoreTiming::ScheduleEvent(nsToCycles(nanoseconds), thread_manager.ThreadWakeupEventType,
-                              thread_id);
+    Core::System::GetInstance().CoreTiming().ScheduleEvent(
+        nsToCycles(nanoseconds), thread_manager.ThreadWakeupEventType, thread_id);
 }
 
 void Thread::ResumeFromWait() {
@@ -316,7 +319,7 @@ ResultVal<SharedPtr<Thread>> KernelSystem::CreateThread(std::string name, VAddr 
     thread->entry_point = entry_point;
     thread->stack_top = stack_top;
     thread->nominal_priority = thread->current_priority = priority;
-    thread->last_running_ticks = CoreTiming::GetTicks();
+    thread->last_running_ticks = Core::System::GetInstance().CoreTiming().GetTicks();
     thread->processor_id = processor_id;
     thread->wait_objects.clear();
     thread->wait_address = 0;
@@ -462,10 +465,9 @@ VAddr Thread::GetCommandBufferAddress() const {
 }
 
 ThreadManager::ThreadManager() {
-    ThreadWakeupEventType =
-        CoreTiming::RegisterEvent("ThreadWakeupCallback", [this](u64 thread_id, s64 cycle_late) {
-            ThreadWakeupCallback(thread_id, cycle_late);
-        });
+    ThreadWakeupEventType = Core::System::GetInstance().CoreTiming().RegisterEvent(
+        "ThreadWakeupCallback",
+        [this](u64 thread_id, s64 cycle_late) { ThreadWakeupCallback(thread_id, cycle_late); });
 }
 
 ThreadManager::~ThreadManager() {

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -127,7 +127,7 @@ private:
     std::unordered_map<u64, Thread*> wakeup_callback_table;
 
     /// Event type for the thread wake up event
-    CoreTiming::EventType* ThreadWakeupEventType = nullptr;
+    Core::TimingEventType* ThreadWakeupEventType = nullptr;
 
     // Lists all threadsthat aren't deleted.
     std::vector<SharedPtr<Thread>> thread_list;

--- a/src/core/hle/kernel/timer.h
+++ b/src/core/hle/kernel/timer.h
@@ -20,7 +20,7 @@ private:
     void TimerCallback(u64 callback_id, s64 cycles_late);
 
     /// The event type of the generic timer callback event
-    CoreTiming::EventType* timer_callback_event_type = nullptr;
+    Core::TimingEventType* timer_callback_event_type = nullptr;
 
     u64 next_timer_callback_id = 0;
     std::unordered_map<u64, Timer*> timer_callback_table;

--- a/src/core/hle/service/cam/cam.h
+++ b/src/core/hle/service/cam/cam.h
@@ -21,8 +21,8 @@ namespace Camera {
 class CameraInterface;
 }
 
-namespace CoreTiming {
-struct EventType;
+namespace Core {
+struct TimingEventType;
 }
 
 namespace Kernel {
@@ -779,9 +779,10 @@ private:
 
     void LoadCameraImplementation(CameraConfig& camera, int camera_id);
 
+    Core::System& system;
     std::array<CameraConfig, NumCameras> cameras;
     std::array<PortConfig, 2> ports;
-    CoreTiming::EventType* completion_event_callback;
+    Core::TimingEventType* completion_event_callback;
     std::atomic<bool> is_camera_reload_pending{false};
 };
 

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -128,7 +128,7 @@ void Module::UpdatePadCallback(u64 userdata, s64 cycles_late) {
     // If we just updated index 0, provide a new timestamp
     if (mem->pad.index == 0) {
         mem->pad.index_reset_ticks_previous = mem->pad.index_reset_ticks;
-        mem->pad.index_reset_ticks = (s64)CoreTiming::GetTicks();
+        mem->pad.index_reset_ticks = (s64)system.CoreTiming().GetTicks();
     }
 
     mem->touch.index = next_touch_index;
@@ -152,7 +152,7 @@ void Module::UpdatePadCallback(u64 userdata, s64 cycles_late) {
     // If we just updated index 0, provide a new timestamp
     if (mem->touch.index == 0) {
         mem->touch.index_reset_ticks_previous = mem->touch.index_reset_ticks;
-        mem->touch.index_reset_ticks = (s64)CoreTiming::GetTicks();
+        mem->touch.index_reset_ticks = (s64)system.CoreTiming().GetTicks();
     }
 
     // Signal both handles when there's an update to Pad or touch
@@ -160,7 +160,7 @@ void Module::UpdatePadCallback(u64 userdata, s64 cycles_late) {
     event_pad_or_touch_2->Signal();
 
     // Reschedule recurrent event
-    CoreTiming::ScheduleEvent(pad_update_ticks - cycles_late, pad_update_event);
+    system.CoreTiming().ScheduleEvent(pad_update_ticks - cycles_late, pad_update_event);
 }
 
 void Module::UpdateAccelerometerCallback(u64 userdata, s64 cycles_late) {
@@ -198,13 +198,14 @@ void Module::UpdateAccelerometerCallback(u64 userdata, s64 cycles_late) {
     // If we just updated index 0, provide a new timestamp
     if (mem->accelerometer.index == 0) {
         mem->accelerometer.index_reset_ticks_previous = mem->accelerometer.index_reset_ticks;
-        mem->accelerometer.index_reset_ticks = (s64)CoreTiming::GetTicks();
+        mem->accelerometer.index_reset_ticks = (s64)system.CoreTiming().GetTicks();
     }
 
     event_accelerometer->Signal();
 
     // Reschedule recurrent event
-    CoreTiming::ScheduleEvent(accelerometer_update_ticks - cycles_late, accelerometer_update_event);
+    system.CoreTiming().ScheduleEvent(accelerometer_update_ticks - cycles_late,
+                                      accelerometer_update_event);
 }
 
 void Module::UpdateGyroscopeCallback(u64 userdata, s64 cycles_late) {
@@ -233,13 +234,13 @@ void Module::UpdateGyroscopeCallback(u64 userdata, s64 cycles_late) {
     // If we just updated index 0, provide a new timestamp
     if (mem->gyroscope.index == 0) {
         mem->gyroscope.index_reset_ticks_previous = mem->gyroscope.index_reset_ticks;
-        mem->gyroscope.index_reset_ticks = (s64)CoreTiming::GetTicks();
+        mem->gyroscope.index_reset_ticks = (s64)system.CoreTiming().GetTicks();
     }
 
     event_gyroscope->Signal();
 
     // Reschedule recurrent event
-    CoreTiming::ScheduleEvent(gyroscope_update_ticks - cycles_late, gyroscope_update_event);
+    system.CoreTiming().ScheduleEvent(gyroscope_update_ticks - cycles_late, gyroscope_update_event);
 }
 
 void Module::Interface::GetIPCHandles(Kernel::HLERequestContext& ctx) {
@@ -257,7 +258,8 @@ void Module::Interface::EnableAccelerometer(Kernel::HLERequestContext& ctx) {
 
     // Schedules the accelerometer update event if the accelerometer was just enabled
     if (hid->enable_accelerometer_count == 1) {
-        CoreTiming::ScheduleEvent(accelerometer_update_ticks, hid->accelerometer_update_event);
+        hid->system.CoreTiming().ScheduleEvent(accelerometer_update_ticks,
+                                               hid->accelerometer_update_event);
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
@@ -273,7 +275,7 @@ void Module::Interface::DisableAccelerometer(Kernel::HLERequestContext& ctx) {
 
     // Unschedules the accelerometer update event if the accelerometer was just disabled
     if (hid->enable_accelerometer_count == 0) {
-        CoreTiming::UnscheduleEvent(hid->accelerometer_update_event, 0);
+        hid->system.CoreTiming().UnscheduleEvent(hid->accelerometer_update_event, 0);
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
@@ -289,7 +291,7 @@ void Module::Interface::EnableGyroscopeLow(Kernel::HLERequestContext& ctx) {
 
     // Schedules the gyroscope update event if the gyroscope was just enabled
     if (hid->enable_gyroscope_count == 1) {
-        CoreTiming::ScheduleEvent(gyroscope_update_ticks, hid->gyroscope_update_event);
+        hid->system.CoreTiming().ScheduleEvent(gyroscope_update_ticks, hid->gyroscope_update_event);
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
@@ -305,7 +307,7 @@ void Module::Interface::DisableGyroscopeLow(Kernel::HLERequestContext& ctx) {
 
     // Unschedules the gyroscope update event if the gyroscope was just disabled
     if (hid->enable_gyroscope_count == 0) {
-        CoreTiming::UnscheduleEvent(hid->gyroscope_update_event, 0);
+        hid->system.CoreTiming().UnscheduleEvent(hid->gyroscope_update_event, 0);
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
@@ -371,19 +373,21 @@ Module::Module(Core::System& system) : system(system) {
     event_debug_pad = system.Kernel().CreateEvent(ResetType::OneShot, "HID:EventDebugPad");
 
     // Register update callbacks
+    Core::Timing& timing = system.CoreTiming();
     pad_update_event =
-        CoreTiming::RegisterEvent("HID::UpdatePadCallback", [this](u64 userdata, s64 cycles_late) {
+        timing.RegisterEvent("HID::UpdatePadCallback", [this](u64 userdata, s64 cycles_late) {
             UpdatePadCallback(userdata, cycles_late);
         });
-    accelerometer_update_event = CoreTiming::RegisterEvent(
+    accelerometer_update_event = timing.RegisterEvent(
         "HID::UpdateAccelerometerCallback", [this](u64 userdata, s64 cycles_late) {
             UpdateAccelerometerCallback(userdata, cycles_late);
         });
-    gyroscope_update_event = CoreTiming::RegisterEvent(
-        "HID::UpdateGyroscopeCallback",
-        [this](u64 userdata, s64 cycles_late) { UpdateGyroscopeCallback(userdata, cycles_late); });
+    gyroscope_update_event =
+        timing.RegisterEvent("HID::UpdateGyroscopeCallback", [this](u64 userdata, s64 cycles_late) {
+            UpdateGyroscopeCallback(userdata, cycles_late);
+        });
 
-    CoreTiming::ScheduleEvent(pad_update_ticks, pad_update_event);
+    timing.ScheduleEvent(pad_update_ticks, pad_update_event);
 }
 
 void Module::ReloadInputDevices() {

--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -27,8 +27,8 @@ class Event;
 class SharedMemory;
 } // namespace Kernel
 
-namespace CoreTiming {
-struct EventType;
+namespace Core {
+struct TimingEventType;
 };
 
 namespace Service::HID {
@@ -325,9 +325,9 @@ private:
     int enable_accelerometer_count = 0; // positive means enabled
     int enable_gyroscope_count = 0;     // positive means enabled
 
-    CoreTiming::EventType* pad_update_event;
-    CoreTiming::EventType* accelerometer_update_event;
-    CoreTiming::EventType* gyroscope_update_event;
+    Core::TimingEventType* pad_update_event;
+    Core::TimingEventType* accelerometer_update_event;
+    Core::TimingEventType* gyroscope_update_event;
 
     std::atomic<bool> is_device_reload_pending{true};
     std::array<std::unique_ptr<Input::ButtonDevice>, Settings::NativeButton::NUM_BUTTONS_HID>

--- a/src/core/hle/service/ir/extra_hid.h
+++ b/src/core/hle/service/ir/extra_hid.h
@@ -11,9 +11,9 @@
 #include "core/frontend/input.h"
 #include "core/hle/service/ir/ir_user.h"
 
-namespace CoreTiming {
-struct EventType;
-} // namespace CoreTiming
+namespace Core {
+struct TimingEventType;
+} // namespace Core
 
 namespace Service::IR {
 
@@ -57,7 +57,7 @@ private:
     void LoadInputDevices();
 
     u8 hid_period;
-    CoreTiming::EventType* hid_polling_callback_id;
+    Core::TimingEventType* hid_polling_callback_id;
     std::array<u8, 0x40> calibration_data;
     std::unique_ptr<Input::ButtonDevice> zl;
     std::unique_ptr<Input::ButtonDevice> zr;

--- a/src/core/hle/service/ir/ir_rst.cpp
+++ b/src/core/hle/service/ir/ir_rst.cpp
@@ -100,13 +100,13 @@ void IR_RST::UpdateCallback(u64 userdata, s64 cycles_late) {
     // If we just updated index 0, provide a new timestamp
     if (mem->index == 0) {
         mem->index_reset_ticks_previous = mem->index_reset_ticks;
-        mem->index_reset_ticks = CoreTiming::GetTicks();
+        mem->index_reset_ticks = system.CoreTiming().GetTicks();
     }
 
     update_event->Signal();
 
     // Reschedule recurrent event
-    CoreTiming::ScheduleEvent(msToCycles(update_period) - cycles_late, update_callback_id);
+    system.CoreTiming().ScheduleEvent(msToCycles(update_period) - cycles_late, update_callback_id);
 }
 
 void IR_RST::GetHandles(Kernel::HLERequestContext& ctx) {
@@ -126,7 +126,7 @@ void IR_RST::Initialize(Kernel::HLERequestContext& ctx) {
 
     next_pad_index = 0;
     is_device_reload_pending.store(true);
-    CoreTiming::ScheduleEvent(msToCycles(update_period), update_callback_id);
+    system.CoreTiming().ScheduleEvent(msToCycles(update_period), update_callback_id);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     rb.Push(RESULT_SUCCESS);
@@ -137,7 +137,7 @@ void IR_RST::Initialize(Kernel::HLERequestContext& ctx) {
 void IR_RST::Shutdown(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x03, 0, 0);
 
-    CoreTiming::UnscheduleEvent(update_callback_id, 0);
+    system.CoreTiming().UnscheduleEvent(update_callback_id, 0);
     UnloadInputDevices();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
@@ -145,7 +145,7 @@ void IR_RST::Shutdown(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_IR, "called");
 }
 
-IR_RST::IR_RST(Core::System& system) : ServiceFramework("ir:rst", 1) {
+IR_RST::IR_RST(Core::System& system) : ServiceFramework("ir:rst", 1), system(system) {
     using namespace Kernel;
     // Note: these two kernel objects are even available before Initialize service function is
     // called.
@@ -154,10 +154,9 @@ IR_RST::IR_RST(Core::System& system) : ServiceFramework("ir:rst", 1) {
                                                        MemoryRegion::BASE, "IRRST:SharedMemory");
     update_event = system.Kernel().CreateEvent(ResetType::OneShot, "IRRST:UpdateEvent");
 
-    update_callback_id =
-        CoreTiming::RegisterEvent("IRRST:UpdateCallBack", [this](u64 userdata, s64 cycles_late) {
-            UpdateCallback(userdata, cycles_late);
-        });
+    update_callback_id = system.CoreTiming().RegisterEvent(
+        "IRRST:UpdateCallBack",
+        [this](u64 userdata, s64 cycles_late) { UpdateCallback(userdata, cycles_late); });
 
     static const FunctionInfo functions[] = {
         {0x00010000, &IR_RST::GetHandles, "GetHandles"},

--- a/src/core/hle/service/ir/ir_rst.h
+++ b/src/core/hle/service/ir/ir_rst.h
@@ -18,8 +18,8 @@ class Event;
 class SharedMemory;
 } // namespace Kernel
 
-namespace CoreTiming {
-struct EventType;
+namespace Core {
+struct TimingEventType;
 };
 
 namespace Service::IR {
@@ -77,10 +77,11 @@ private:
     void UnloadInputDevices();
     void UpdateCallback(u64 userdata, s64 cycles_late);
 
+    Core::System& system;
     Kernel::SharedPtr<Kernel::Event> update_event;
     Kernel::SharedPtr<Kernel::SharedMemory> shared_memory;
     u32 next_pad_index{0};
-    CoreTiming::EventType* update_callback_id;
+    Core::TimingEventType* update_callback_id;
     std::unique_ptr<Input::ButtonDevice> zl_button;
     std::unique_ptr<Input::ButtonDevice> zr_button;
     std::unique_ptr<Input::AnalogDevice> c_stick;

--- a/src/core/hle/service/ir/ir_user.h
+++ b/src/core/hle/service/ir/ir_user.h
@@ -14,10 +14,6 @@ class Event;
 class SharedMemory;
 } // namespace Kernel
 
-namespace CoreTiming {
-struct EventType;
-};
-
 namespace Service::IR {
 
 class BufferManager;

--- a/src/core/hle/service/nwm/nwm_uds.h
+++ b/src/core/hle/service/nwm/nwm_uds.h
@@ -352,6 +352,8 @@ private:
      *      2, 3: output buffer return descriptor & ptr
      */
     void DecryptBeaconData(Kernel::HLERequestContext& ctx);
+
+    void BeaconBroadcastCallback(u64 userdata, s64 cycles_late);
 };
 
 } // namespace Service::NWM

--- a/src/core/hw/gpu.cpp
+++ b/src/core/hw/gpu.cpp
@@ -31,7 +31,7 @@ Regs g_regs;
 /// 268MHz CPU clocks / 60Hz frames per second
 const u64 frame_ticks = static_cast<u64>(BASE_CLOCK_RATE_ARM11 / SCREEN_REFRESH_RATE);
 /// Event id for CoreTiming
-static CoreTiming::EventType* vblank_event;
+static Core::TimingEventType* vblank_event;
 
 template <typename T>
 inline void Read(T& var, const u32 raw_addr) {
@@ -522,7 +522,7 @@ static void VBlankCallback(u64 userdata, s64 cycles_late) {
     Service::GSP::SignalInterrupt(Service::GSP::InterruptId::PDC1);
 
     // Reschedule recurrent event
-    CoreTiming::ScheduleEvent(frame_ticks - cycles_late, vblank_event);
+    Core::System::GetInstance().CoreTiming().ScheduleEvent(frame_ticks - cycles_late, vblank_event);
 }
 
 /// Initialize hardware
@@ -555,8 +555,9 @@ void Init() {
     framebuffer_sub.color_format.Assign(Regs::PixelFormat::RGB8);
     framebuffer_sub.active_fb = 0;
 
-    vblank_event = CoreTiming::RegisterEvent("GPU::VBlankCallback", VBlankCallback);
-    CoreTiming::ScheduleEvent(frame_ticks, vblank_event);
+    Core::Timing& timing = Core::System::GetInstance().CoreTiming();
+    vblank_event = timing.RegisterEvent("GPU::VBlankCallback", VBlankCallback);
+    timing.ScheduleEvent(frame_ticks, vblank_event);
 
     LOG_DEBUG(HW_GPU, "initialized OK");
 }

--- a/src/tests/core/arm/arm_test_common.cpp
+++ b/src/tests/core/arm/arm_test_common.cpp
@@ -16,10 +16,10 @@ static Memory::PageTable* page_table = nullptr;
 TestEnvironment::TestEnvironment(bool mutable_memory_)
     : mutable_memory(mutable_memory_), test_memory(std::make_shared<TestMemory>(this)) {
 
-    CoreTiming::Init();
     // HACK: some memory functions are currently referring kernel from the global instance,
     //       so we need to create the kernel object there.
     //       Change this when all global states are eliminated.
+    Core::System::GetInstance().timing = std::make_unique<Core::Timing>();
     Core::System::GetInstance().kernel = std::make_unique<Kernel::KernelSystem>(0);
     kernel = Core::System::GetInstance().kernel.get();
 
@@ -38,8 +38,6 @@ TestEnvironment::TestEnvironment(bool mutable_memory_)
 TestEnvironment::~TestEnvironment() {
     Memory::UnmapRegion(*page_table, 0x80000000, 0x80000000);
     Memory::UnmapRegion(*page_table, 0x00000000, 0x80000000);
-
-    CoreTiming::Shutdown();
 }
 
 void TestEnvironment::SetMemory64(VAddr vaddr, u64 value) {

--- a/src/tests/core/hle/kernel/hle_ipc.cpp
+++ b/src/tests/core/hle/kernel/hle_ipc.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <catch2/catch.hpp>
+#include "core/core.h"
 #include "core/core_timing.h"
 #include "core/hle/ipc.h"
 #include "core/hle/kernel/client_port.h"
@@ -20,7 +21,8 @@ static SharedPtr<Object> MakeObject(Kernel::KernelSystem& kernel) {
 }
 
 TEST_CASE("HLERequestContext::PopulateFromIncomingCommandBuffer", "[core][kernel]") {
-    CoreTiming::Init();
+    // HACK: see comments of member timing
+    Core::System::GetInstance().timing = std::make_unique<Core::Timing>();
     Kernel::KernelSystem kernel(0);
     auto session = std::get<SharedPtr<ServerSession>>(kernel.CreateSessionPair());
     HLERequestContext context(std::move(session));
@@ -227,12 +229,11 @@ TEST_CASE("HLERequestContext::PopulateFromIncomingCommandBuffer", "[core][kernel
         REQUIRE(process->vm_manager.UnmapRange(target_address_mapped, buffer_mapped->size()) ==
                 RESULT_SUCCESS);
     }
-
-    CoreTiming::Shutdown();
 }
 
 TEST_CASE("HLERequestContext::WriteToOutgoingCommandBuffer", "[core][kernel]") {
-    CoreTiming::Init();
+    // HACK: see comments of member timing
+    Core::System::GetInstance().timing = std::make_unique<Core::Timing>();
     Kernel::KernelSystem kernel(0);
     auto session = std::get<SharedPtr<ServerSession>>(kernel.CreateSessionPair());
     HLERequestContext context(std::move(session));
@@ -369,8 +370,6 @@ TEST_CASE("HLERequestContext::WriteToOutgoingCommandBuffer", "[core][kernel]") {
         REQUIRE(process->vm_manager.UnmapRange(target_address, output_buffer->size()) ==
                 RESULT_SUCCESS);
     }
-
-    CoreTiming::Shutdown();
 }
 
 } // namespace Kernel

--- a/src/tests/core/memory/memory.cpp
+++ b/src/tests/core/memory/memory.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <catch2/catch.hpp>
+#include "core/core.h"
 #include "core/core_timing.h"
 #include "core/hle/kernel/memory.h"
 #include "core/hle/kernel/process.h"
@@ -10,7 +11,8 @@
 #include "core/memory.h"
 
 TEST_CASE("Memory::IsValidVirtualAddress", "[core][memory]") {
-    CoreTiming::Init();
+    // HACK: see comments of member timing
+    Core::System::GetInstance().timing = std::make_unique<Core::Timing>();
     Kernel::KernelSystem kernel(0);
     SECTION("these regions should not be mapped on an empty process") {
         auto process = kernel.CreateProcess(kernel.CreateCodeSet("", 0));
@@ -51,6 +53,4 @@ TEST_CASE("Memory::IsValidVirtualAddress", "[core][memory]") {
         process->vm_manager.UnmapRange(Memory::CONFIG_MEMORY_VADDR, Memory::CONFIG_MEMORY_SIZE);
         CHECK(Memory::IsValidVirtualAddress(*process, Memory::CONFIG_MEMORY_VADDR) == false);
     }
-
-    CoreTiming::Shutdown();
 }

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -146,7 +146,8 @@ void RendererOpenGL::SwapBuffers() {
     render_window.PollEvents();
     render_window.SwapBuffers();
 
-    Core::System::GetInstance().frame_limiter.DoFrameLimiting(CoreTiming::GetGlobalTimeUs());
+    Core::System::GetInstance().frame_limiter.DoFrameLimiting(
+        Core::System::GetInstance().CoreTiming().GetGlobalTimeUs());
     Core::System::GetInstance().perf_stats.BeginSystemFrame();
 
     prev_state.Apply();


### PR DESCRIPTION
All function previously under the name space `CoreTiming::` are now in the class `Core::Timing::`. Specifically, `CoreTiming::Event` now becomes `Core::TimingEvent`. This was chosen to keep the event time in the same namespace while keeping the name style. It didn't become a nested class `Core::Timing::Event` because some usage of forward declaration of this type in many places. I don't like this very much, so better naming idea is welcome.

`Core::System::GetInstance()...` is added to where the system/timing instance can't be easily referenced yet. They will be changed in future PRs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4400)
<!-- Reviewable:end -->
