### PR TITLE
Port yuzu-emu/yuzu#1441: "logging: Add DebuggerBackend for logging to Visual Studio"

### DIFF
--- a/src/citra/citra.cpp
+++ b/src/citra/citra.cpp
@@ -126,6 +126,9 @@ static void InitializeLogging() {
     const std::string& log_dir = FileUtil::GetUserPath(FileUtil::UserPath::LogDir);
     FileUtil::CreateFullPath(log_dir);
     Log::AddBackend(std::make_unique<Log::FileBackend>(log_dir + LOG_FILE));
+#ifdef _WIN32
+    Log::AddBackend(std::make_unique<Log::DebuggerBackend>());
+#endif
 }
 
 /// Application entry point

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -116,6 +116,9 @@ static void InitializeLogging() {
     const std::string& log_dir = FileUtil::GetUserPath(FileUtil::UserPath::LogDir);
     FileUtil::CreateFullPath(log_dir);
     Log::AddBackend(std::make_unique<Log::FileBackend>(log_dir + LOG_FILE));
+#ifdef _WIN32
+    Log::AddBackend(std::make_unique<Log::DebuggerBackend>());
+#endif
 }
 
 GMainWindow::GMainWindow() : config(new Config()), emu_thread(nullptr) {

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -11,7 +11,8 @@
 #include <thread>
 #include <vector>
 #ifdef _WIN32
-#include <share.h> // For _SH_DENYWR
+#include <share.h>   // For _SH_DENYWR
+#include <windows.h> // For OutputDebugStringW
 #else
 #define _SH_DENYWR 0
 #endif
@@ -133,10 +134,16 @@ void FileBackend::Write(const Entry& entry) {
     if (!file.IsOpen() || bytes_written > MAX_BYTES_WRITTEN) {
         return;
     }
-    bytes_written += file.WriteString(FormatLogMessage(entry) + '\n');
+    bytes_written += file.WriteString(FormatLogMessage(entry).append(1, '\n'));
     if (entry.log_level >= Level::Error) {
         file.Flush();
     }
+}
+
+void DebuggerBackend::Write(const Entry& entry) {
+#ifdef _WIN32
+    ::OutputDebugStringW(Common::UTF8ToUTF16W(FormatLogMessage(entry).append(1, '\n')).c_str());
+#endif
 }
 
 /// Macro listing all log classes. Code should define CLS and SUB as desired before invoking this.

--- a/src/common/logging/backend.h
+++ b/src/common/logging/backend.h
@@ -105,6 +105,20 @@ private:
     std::size_t bytes_written;
 };
 
+/**
+ * Backend that writes to Visual Studio's output window
+ */
+class DebuggerBackend : public Backend {
+public:
+    static const char* Name() {
+        return "debugger";
+    }
+    const char* GetName() const override {
+        return Name();
+    }
+    void Write(const Entry& entry) override;
+};
+
 void AddBackend(std::unique_ptr<Backend> backend);
 
 void RemoveBackend(std::string_view backend_name);


### PR DESCRIPTION
See yuzu-emu/yuzu#1441 for more details.

**Original description:**
This shows the log in the Output window in Visual Studio, or whatever other debugger you use on Windows, like it does in Dolphin.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4418)
<!-- Reviewable:end -->
