### PR TITLE
Port yuzu-emu/yuzu#1639: "qt: Add help option to open yuzu folder"

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -569,6 +569,8 @@ void GMainWindow::ConnectMenuEvents() {
     });
 
     // Help
+    connect(ui.action_Open_Citra_Folder, &QAction::triggered, this,
+            &GMainWindow::OnOpenCitraFolder);
     connect(ui.action_FAQ, &QAction::triggered,
             []() { QDesktopServices::openUrl(QUrl("https://citra-emu.org/wiki/faq/")); });
     connect(ui.action_About, &QAction::triggered, this, &GMainWindow::OnMenuAboutCitra);
@@ -1328,6 +1330,11 @@ void GMainWindow::OnRemoveAmiibo() {
         nfc->RemoveAmiibo();
         ui.action_Remove_Amiibo->setEnabled(false);
     }
+}
+
+void GMainWindow::OnOpenCitraFolder() {
+    QDesktopServices::openUrl(QUrl::fromLocalFile(
+        QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::UserDir))));
 }
 
 void GMainWindow::OnToggleFilterBar() {

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -168,6 +168,7 @@ private slots:
     void OnConfigure();
     void OnLoadAmiibo();
     void OnRemoveAmiibo();
+    void OnOpenCitraFolder();
     void OnToggleFilterBar();
     void OnDisplayTitleBars(bool);
     void ToggleFullscreen();

--- a/src/citra_qt/main.ui
+++ b/src/citra_qt/main.ui
@@ -71,6 +71,8 @@
     <addaction name="separator"/>
     <addaction name="menu_Amiibo"/>
     <addaction name="separator"/>
+    <addaction name="action_Open_Citra_Folder"/>
+    <addaction name="separator"/>
     <addaction name="action_Exit"/>
    </widget>
    <widget class="QMenu" name="menu_Emulation">
@@ -147,8 +149,6 @@
     <property name="title">
      <string>&amp;Help</string>
     </property>
-    <addaction name="action_Open_Citra_Folder"/>
-    <addaction name="separator"/>
     <addaction name="action_Check_For_Updates"/>
     <addaction name="action_Open_Maintenance_Tool"/>
     <addaction name="separator"/>

--- a/src/citra_qt/main.ui
+++ b/src/citra_qt/main.ui
@@ -147,6 +147,8 @@
     <property name="title">
      <string>&amp;Help</string>
     </property>
+    <addaction name="action_Open_Citra_Folder"/>
+    <addaction name="separator"/>
     <addaction name="action_Check_For_Updates"/>
     <addaction name="action_Open_Maintenance_Tool"/>
     <addaction name="separator"/>
@@ -438,6 +440,11 @@
    </property>
    <property name="text">
     <string>Remove</string>
+   </property>
+  </action>
+  <action name="action_Open_Citra_Folder">
+   <property name="text">
+    <string>Open Citra Folder</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
See yuzu-emu/yuzu#1639 for more details.

**Original description:**
Opens a windows explorer/file manager window at the user's yuzu folder (%APPDATA%/yuzu on windows).

Meant to make following guide or making configuration changes easier.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4419)
<!-- Reviewable:end -->
