### PR TITLE
filesys/ncch: prevent buffer overflow on calculating SHA256

### DIFF
--- a/src/core/file_sys/ncch_container.cpp
+++ b/src/core/file_sys/ncch_container.cpp
@@ -179,7 +179,9 @@ Loader::ResultStatus NCCHContainer::Load() {
                         std::memcpy(input.data(), key_y_primary.data(), key_y_primary.size());
                         std::memcpy(input.data() + key_y_primary.size(), seed.data(), seed.size());
                         CryptoPP::SHA256 sha;
-                        sha.CalculateDigest(key_y_secondary.data(), input.data(), input.size());
+                        std::array<u8, CryptoPP::SHA256::DIGESTSIZE> hash;
+                        sha.CalculateDigest(hash.data(), input.data(), input.size());
+                        std::memcpy(key_y_secondary.data(), hash.data(), key_y_secondary.size());
                     }
                 }
 


### PR DESCRIPTION
I start to like sanitizer now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4425)
<!-- Reviewable:end -->
