### PR TITLE
SVC: QueryMemory merges similar VMA

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -964,10 +964,27 @@ static ResultCode QueryProcessMemory(MemoryInfo* memory_info, PageInfo* page_inf
     if (vma == process->vm_manager.vma_map.end())
         return ERR_INVALID_ADDRESS;
 
-    memory_info->base_address = vma->second.base;
-    memory_info->permission = static_cast<u32>(vma->second.permissions);
-    memory_info->size = vma->second.size;
-    memory_info->state = static_cast<u32>(vma->second.meminfo_state);
+    auto permissions = vma->second.permissions;
+    auto state = vma->second.meminfo_state;
+
+    // Query(Process)Memory merges vma with neighbours when they share the same state and
+    // permissions, regardless of their physical mapping.
+
+    auto mismatch = [permissions, state](const std::pair<VAddr, Kernel::VirtualMemoryArea>& v) {
+        return v.second.permissions != permissions || v.second.meminfo_state != state;
+    };
+
+    std::reverse_iterator rvma(vma);
+
+    auto lower = std::find_if(rvma, process->vm_manager.vma_map.crend(), mismatch);
+    --lower;
+    auto upper = std::find_if(vma, process->vm_manager.vma_map.cend(), mismatch);
+    --upper;
+
+    memory_info->base_address = lower->second.base;
+    memory_info->permission = static_cast<u32>(permissions);
+    memory_info->size = upper->second.base + upper->second.size - lower->second.base;
+    memory_info->state = static_cast<u32>(state);
 
     page_info->flags = 0;
     LOG_TRACE(Kernel_SVC, "called process=0x{:08X} addr=0x{:08X}", process_handle, addr);


### PR DESCRIPTION
Hardware test shows that svcQueryMemory reports a merged memory block for the same state & permission, regardless whether the internal mapping is continuous. The test included:
 - consecutive heap pages that are allocated in random order (so their physical memory should be in random order)
 - two consecutive memory alias block mapped from different source.
 - two consecutive shared memory block mapped from different service.
In all this cases QueryMemory reported a merged block.

Our VMManager merges blocks only when the physical mapping is continuous (and has the same state & permission), so we need to merge similar blocks on fly when svcQueryMemory is called.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4427)
<!-- Reviewable:end -->
