### PR TITLE
Memory: IO area is at most 4MB

### DIFF
--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -75,7 +75,7 @@ struct PageTable {
 enum : PAddr {
     /// IO register area
     IO_AREA_PADDR = 0x10100000,
-    IO_AREA_SIZE = 0x01000000, ///< IO area size (16MB)
+    IO_AREA_SIZE = 0x00400000, ///< IO area size (4MB)
     IO_AREA_PADDR_END = IO_AREA_PADDR + IO_AREA_SIZE,
 
     /// MPCore internal memory region


### PR DESCRIPTION
The virtual address range of IO region is 0x1EC00000 to 0x1F000000. It can't go beyond because 0x1F000000 is the start of VRAM. 3dbrew doesn't document any more IO region after the GPU IO region, which starts at VAddr=0x1EF00000, PAddr=0x10400000, whose length is no more that 0x2000 bytes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4429)
<!-- Reviewable:end -->
