### PR TITLE
Kernel/SharedMemory: set and reset source memory state

### DIFF
--- a/src/core/hle/applets/swkbd.cpp
+++ b/src/core/hle/applets/swkbd.cpp
@@ -136,6 +136,7 @@ void SoftwareKeyboard::Finalize() {
     SendParameter(message);
 
     is_running = false;
+    text_memory = nullptr;
 }
 
 Frontend::KeyboardConfig SoftwareKeyboard::ToFrontendConfig(

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -170,12 +170,12 @@ public:
      * linear heap.
      * @param name Optional object name, used for debugging purposes.
      */
-    SharedPtr<SharedMemory> CreateSharedMemory(Process* owner_process, u32 size,
-                                               MemoryPermission permissions,
-                                               MemoryPermission other_permissions,
-                                               VAddr address = 0,
-                                               MemoryRegion region = MemoryRegion::BASE,
-                                               std::string name = "Unknown");
+    ResultVal<SharedPtr<SharedMemory>> CreateSharedMemory(Process* owner_process, u32 size,
+                                                          MemoryPermission permissions,
+                                                          MemoryPermission other_permissions,
+                                                          VAddr address = 0,
+                                                          MemoryRegion region = MemoryRegion::BASE,
+                                                          std::string name = "Unknown");
 
     /**
      * Creates a shared memory object from a block of memory managed by an HLE applet.

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1250,9 +1250,10 @@ ResultCode SVC::CreateMemoryBlock(Handle* out_handle, u32 addr, u32 size, u32 my
     if (addr == 0 && current_process->flags.shared_device_mem)
         region = current_process->flags.memory_region;
 
-    shared_memory = kernel.CreateSharedMemory(
-        current_process.get(), size, static_cast<MemoryPermission>(my_permission),
-        static_cast<MemoryPermission>(other_permission), addr, region);
+    CASCADE_RESULT(shared_memory,
+                   kernel.CreateSharedMemory(
+                       current_process.get(), size, static_cast<MemoryPermission>(my_permission),
+                       static_cast<MemoryPermission>(other_permission), addr, region));
     CASCADE_RESULT(*out_handle, current_process->handle_table.Create(std::move(shared_memory)));
 
     LOG_WARNING(Kernel_SVC, "called addr=0x{:08X}", addr);

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -861,10 +861,11 @@ Module::Module(Core::System& system) : system(system) {
     applet_manager = std::make_shared<AppletManager>(system);
 
     using Kernel::MemoryPermission;
-    shared_font_mem =
-        system.Kernel().CreateSharedMemory(nullptr, 0x332000, // 3272 KB
-                                           MemoryPermission::ReadWrite, MemoryPermission::Read, 0,
-                                           Kernel::MemoryRegion::SYSTEM, "APT:SharedFont");
+    shared_font_mem = system.Kernel()
+                          .CreateSharedMemory(nullptr, 0x332000, // 3272 KB
+                                              MemoryPermission::ReadWrite, MemoryPermission::Read,
+                                              0, Kernel::MemoryRegion::SYSTEM, "APT:SharedFont")
+                          .Unwrap();
 
     lock = system.Kernel().CreateMutex(false, "APT_U:Lock");
 }

--- a/src/core/hle/service/csnd/csnd_snd.cpp
+++ b/src/core/hle/service/csnd/csnd_snd.cpp
@@ -20,9 +20,11 @@ void CSND_SND::Initialize(Kernel::HLERequestContext& ctx) {
 
     using Kernel::MemoryPermission;
     mutex = system.Kernel().CreateMutex(false, "CSND:mutex");
-    shared_memory = system.Kernel().CreateSharedMemory(
-        nullptr, size, MemoryPermission::ReadWrite, MemoryPermission::ReadWrite, 0,
-        Kernel::MemoryRegion::BASE, "CSND:SharedMemory");
+    shared_memory = system.Kernel()
+                        .CreateSharedMemory(nullptr, size, MemoryPermission::ReadWrite,
+                                            MemoryPermission::ReadWrite, 0,
+                                            Kernel::MemoryRegion::BASE, "CSND:SharedMemory")
+                        .Unwrap();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 3);
     rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/gsp/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp/gsp_gpu.cpp
@@ -787,9 +787,11 @@ GSP_GPU::GSP_GPU(Core::System& system) : ServiceFramework("gsp::Gpu", 2), system
     RegisterHandlers(functions);
 
     using Kernel::MemoryPermission;
-    shared_memory = system.Kernel().CreateSharedMemory(
-        nullptr, 0x1000, MemoryPermission::ReadWrite, MemoryPermission::ReadWrite, 0,
-        Kernel::MemoryRegion::BASE, "GSP:SharedMemory");
+    shared_memory = system.Kernel()
+                        .CreateSharedMemory(nullptr, 0x1000, MemoryPermission::ReadWrite,
+                                            MemoryPermission::ReadWrite, 0,
+                                            Kernel::MemoryRegion::BASE, "GSP:SharedMemory")
+                        .Unwrap();
 
     first_initialization = true;
 };

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -361,9 +361,11 @@ std::shared_ptr<Module> Module::Interface::GetModule() const {
 Module::Module(Core::System& system) : system(system) {
     using namespace Kernel;
 
-    shared_mem = system.Kernel().CreateSharedMemory(nullptr, 0x1000, MemoryPermission::ReadWrite,
-                                                    MemoryPermission::Read, 0, MemoryRegion::BASE,
-                                                    "HID:SharedMemory");
+    shared_mem =
+        system.Kernel()
+            .CreateSharedMemory(nullptr, 0x1000, MemoryPermission::ReadWrite,
+                                MemoryPermission::Read, 0, MemoryRegion::BASE, "HID:SharedMemory")
+            .Unwrap();
 
     // Create event handles
     event_pad_or_touch_1 = system.Kernel().CreateEvent(ResetType::OneShot, "HID:EventPadOrTouch1");

--- a/src/core/hle/service/http_c.cpp
+++ b/src/core/hle/service/http_c.cpp
@@ -443,6 +443,17 @@ void HTTP_C::CloseClientCertContext(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_HTTP, "called, cert_handle={}", cert_handle);
 }
 
+void HTTP_C::Finalize(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp(ctx, 0x39, 0, 0);
+
+    shared_memory = nullptr;
+
+    IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
+    rb.Push(RESULT_SUCCESS);
+
+    LOG_WARNING(Service_HTTP, "(STUBBED) called");
+}
+
 void HTTP_C::DecryptClCertA() {
     static constexpr u32 iv_length = 16;
 
@@ -575,7 +586,7 @@ HTTP_C::HTTP_C() : ServiceFramework("http:C", 32) {
         {0x00360000, nullptr, "ClearDNSCache"},
         {0x00370080, nullptr, "SetKeepAlive"},
         {0x003800C0, nullptr, "SetPostDataTypeSize"},
-        {0x00390000, nullptr, "Finalize"},
+        {0x00390000, &HTTP_C::Finalize, "Finalize"},
     };
     RegisterHandlers(functions);
 

--- a/src/core/hle/service/http_c.h
+++ b/src/core/hle/service/http_c.h
@@ -240,6 +240,13 @@ private:
      */
     void CloseClientCertContext(Kernel::HLERequestContext& ctx);
 
+    /**
+     * HTTP_C::Finalize service function
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void Finalize(Kernel::HLERequestContext& ctx);
+
     void DecryptClCertA();
 
     Kernel::SharedPtr<Kernel::SharedMemory> shared_memory = nullptr;

--- a/src/core/hle/service/ir/ir_rst.cpp
+++ b/src/core/hle/service/ir/ir_rst.cpp
@@ -149,9 +149,11 @@ IR_RST::IR_RST(Core::System& system) : ServiceFramework("ir:rst", 1), system(sys
     using namespace Kernel;
     // Note: these two kernel objects are even available before Initialize service function is
     // called.
-    shared_memory = system.Kernel().CreateSharedMemory(nullptr, 0x1000, MemoryPermission::ReadWrite,
-                                                       MemoryPermission::Read, 0,
-                                                       MemoryRegion::BASE, "IRRST:SharedMemory");
+    shared_memory =
+        system.Kernel()
+            .CreateSharedMemory(nullptr, 0x1000, MemoryPermission::ReadWrite,
+                                MemoryPermission::Read, 0, MemoryRegion::BASE, "IRRST:SharedMemory")
+            .Unwrap();
     update_event = system.Kernel().CreateEvent(ResetType::OneShot, "IRRST:UpdateEvent");
 
     update_callback_id = system.CoreTiming().RegisterEvent(

--- a/src/core/hle/service/mic_u.cpp
+++ b/src/core/hle/service/mic_u.cpp
@@ -52,6 +52,7 @@ struct MIC_U::Impl {
     void UnmapSharedMem(Kernel::HLERequestContext& ctx) {
         IPC::RequestParser rp{ctx, 0x02, 0, 0};
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
+        shared_memory = nullptr;
         rb.Push(RESULT_SUCCESS);
         LOG_WARNING(Service_MIC, "called");
     }


### PR DESCRIPTION
Implemented according to hardware test. Similar to the `svcControlMemory(MAP)` operation, the source memory is locked to the `Locked` memory state until the SharedMemory object is destructed (`svcCloseHandle` is used in the hwtest)