### PR TITLE
Memory: GetPhysicalPointer should accept right open bound address

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -274,7 +274,6 @@ u8* GetPhysicalPointer(PAddr address) {
 
     static constexpr MemoryArea memory_areas[] = {
         {VRAM_PADDR, VRAM_SIZE},
-        {IO_AREA_PADDR, IO_AREA_SIZE},
         {DSP_RAM_PADDR, DSP_RAM_SIZE},
         {FCRAM_PADDR, FCRAM_N3DS_SIZE},
         {N3DS_EXTRA_RAM_PADDR, N3DS_EXTRA_RAM_SIZE},
@@ -282,16 +281,13 @@ u8* GetPhysicalPointer(PAddr address) {
 
     const auto area =
         std::find_if(std::begin(memory_areas), std::end(memory_areas), [&](const auto& area) {
-            return address >= area.paddr_base && address < area.paddr_base + area.size;
+            // Note: the region end check is inclusive because the user can pass in an address that
+            // represents an open right bound
+            return address >= area.paddr_base && address <= area.paddr_base + area.size;
         });
 
     if (area == std::end(memory_areas)) {
         LOG_ERROR(HW_Memory, "unknown GetPhysicalPointer @ 0x{:08X}", address);
-        return nullptr;
-    }
-
-    if (area->paddr_base == IO_AREA_PADDR) {
-        LOG_ERROR(HW_Memory, "MMIO mappings are not supported yet. phys_addr=0x{:08X}", address);
         return nullptr;
     }
 


### PR DESCRIPTION
Also note that the four regions to check (VRAM, DSP, FCRAM, N3DS_EXTRA) are all isolated in the physical address space, so there is no collision on checking the boundary address. The returned pointer of boundary is also safe, as C++ permits one-past-the-end pointer for pointer arithmetic. It is just not dereferencable.

This is used in GPU for memory range check.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4436)
<!-- Reviewable:end -->
