### PR TITLE
Port yuzu-emu/yuzu#1705: "Include QT imageformat dependencies with releases"

### DIFF
--- a/.travis/linux-mingw/docker.sh
+++ b/.travis/linux-mingw/docker.sh
@@ -35,3 +35,4 @@ done
 
 pip3 install pefile
 python3 .travis/linux-mingw/scan_dll.py package/*.exe "package/"
+python3 .travis/linux-mingw/scan_dll.py package/imageformats/*.dll "package/"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -119,17 +119,6 @@ after_build:
           Copy-Item -path "$CMAKE_SOURCE_DIR/license.txt" -destination $RELEASE_DIST
           Copy-Item -path "$CMAKE_SOURCE_DIR/README.md" -destination $RELEASE_DIST
 
-          # copy all the dll dependencies to the release folder
-          . "./.appveyor/FindDependencies.ps1"
-          $DLLSearchPath = "C:\msys64\mingw64\bin;$env:PATH"
-          $MingwDLLs = RecursivelyGetDeps $DLLSearchPath "$RELEASE_DIST\citra.exe"
-          $MingwDLLs += RecursivelyGetDeps $DLLSearchPath  "$RELEASE_DIST\citra-qt.exe"
-          Write-Host "Detected the following dependencies:"
-          Write-Host $MingwDLLs
-          foreach ($file in $MingwDLLs) {
-            Copy-Item -path "$file" -force -destination "$RELEASE_DIST"
-          }
-
           # copy the qt windows plugin dll to platforms
           Copy-Item -path "C:/msys64/mingw64/share/qt5/plugins/platforms/qwindows.dll" -force -destination "$RELEASE_DIST/platforms"
 
@@ -141,6 +130,18 @@ after_build:
 
           # copy the qt imageformats plugin dlls to imageformats
           Get-ChildItem "C:/msys64/mingw64/share/qt5/plugins/imageformats" -Exclude "*d.dll" | Copy-Item -force -destination "$RELEASE_DIST/imageformats"
+
+          # copy all the dll dependencies to the release folder
+          . "./.appveyor/FindDependencies.ps1"
+          $DLLSearchPath = "C:\msys64\mingw64\bin;$env:PATH"
+          $MingwDLLs = RecursivelyGetDeps $DLLSearchPath "$RELEASE_DIST\citra.exe"
+          $MingwDLLs += RecursivelyGetDeps $DLLSearchPath  "$RELEASE_DIST\citra-qt.exe"
+          $MingwDLLs += RecursivelyGetDeps $DLLSearchPath  "$RELEASE_DIST\imageformats\qjpeg.dll"
+          Write-Host "Detected the following dependencies:"
+          Write-Host $MingwDLLs
+          foreach ($file in $MingwDLLs) {
+            Copy-Item -path "$file" -force -destination "$RELEASE_DIST"
+          }
 
           # process PDBs
           . "./.appveyor/ProcessPdb.ps1"


### PR DESCRIPTION
See yuzu-emu/yuzu#1705 for more details.

**Original description:**
Problem:
Game icons do not show in mingw builds

Cause:
Missing libjpeg dll

Solution:
This PR (hopefully). I don't currently have a Linux environment set up to fully test this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4440)
<!-- Reviewable:end -->
