### PR TITLE
kernel/shared_memory: std::move the string parameter in SetName()

### DIFF
--- a/src/core/hle/kernel/shared_memory.h
+++ b/src/core/hle/kernel/shared_memory.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <string>
+#include <utility>
 #include "common/common_types.h"
 #include "core/hle/kernel/object.h"
 #include "core/hle/kernel/process.h"
@@ -21,7 +22,7 @@ public:
         return name;
     }
     void SetName(std::string name) {
-        this->name = name;
+        this->name = std::move(name);
     }
 
     static const HandleType HANDLE_TYPE = HandleType::SharedMemory;


### PR DESCRIPTION
This avoids a potential reallocation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4465)
<!-- Reviewable:end -->
