### PR TITLE
travis: Add missing flags for flatpak build

### DIFF
--- a/.travis/linux-flatpak/generate-data.sh
+++ b/.travis/linux-flatpak/generate-data.sh
@@ -103,7 +103,9 @@ cat > /tmp/org.citra.$REPO_NAME.json <<EOF
                 "-DCMAKE_BUILD_TYPE=Release",
                 "-DENABLE_QT_TRANSLATION=ON",
                 "-DCITRA_ENABLE_COMPATIBILITY_REPORTING=ON",
-                "-DENABLE_COMPATIBILITY_LIST_DOWNLOAD=ON"
+                "-DENABLE_COMPATIBILITY_LIST_DOWNLOAD=ON",
+                "-DUSE_DISCORD_PRESENCE=ON",
+                "-DENABLE_SCRIPTING=ON"
             ],
             "cleanup": [
               "/bin/citra",


### PR DESCRIPTION
So that the flatpak build has discord rpc and scripting support as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4474)
<!-- Reviewable:end -->
