### PR TITLE
Revert "travis: Add missing flags for flatpak build"

### DIFF
--- a/.travis/linux-flatpak/generate-data.sh
+++ b/.travis/linux-flatpak/generate-data.sh
@@ -103,9 +103,7 @@ cat > /tmp/org.citra.$REPO_NAME.json <<EOF
                 "-DCMAKE_BUILD_TYPE=Release",
                 "-DENABLE_QT_TRANSLATION=ON",
                 "-DCITRA_ENABLE_COMPATIBILITY_REPORTING=ON",
-                "-DENABLE_COMPATIBILITY_LIST_DOWNLOAD=ON",
-                "-DUSE_DISCORD_PRESENCE=ON",
-                "-DENABLE_SCRIPTING=ON"
+                "-DENABLE_COMPATIBILITY_LIST_DOWNLOAD=ON"
             ],
             "cleanup": [
               "/bin/citra",


### PR DESCRIPTION
Reverts citra-emu/citra#4474

It is believed that these flags were actually dropped intentionally, as scripting (libzmq) won't build properly, and discord-rpc likely won't work inside a sandbox.

Sorry, I did not test it before adding the flags.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4475)
<!-- Reviewable:end -->
