### PR TITLE
Memory: eliminate global state

### DIFF
--- a/src/audio_core/hle/hle.h
+++ b/src/audio_core/hle/hle.h
@@ -13,11 +13,15 @@
 #include "core/hle/service/dsp/dsp_dsp.h"
 #include "core/memory.h"
 
+namespace Memory {
+class MemorySystem;
+}
+
 namespace AudioCore {
 
 class DspHle final : public DspInterface {
 public:
-    DspHle();
+    explicit DspHle(Memory::MemorySystem& memory);
     ~DspHle();
 
     DspState GetDspState() const override;

--- a/src/audio_core/hle/source.cpp
+++ b/src/audio_core/hle/source.cpp
@@ -45,6 +45,10 @@ void Source::Reset() {
     state = {};
 }
 
+void Source::SetMemory(Memory::MemorySystem& memory) {
+    memory_system = &memory;
+}
+
 void Source::ParseConfig(SourceConfiguration::Configuration& config,
                          const s16_le (&adpcm_coeffs)[16]) {
     if (!config.dirty_raw) {

--- a/src/audio_core/hle/source.cpp
+++ b/src/audio_core/hle/source.cpp
@@ -290,7 +290,7 @@ bool Source::DequeueBuffer() {
 
     // This physical address masking occurs due to how the DSP DMA hardware is configured by the
     // firmware.
-    const u8* const memory = Memory::GetPhysicalPointer(buf.physical_address & 0xFFFFFFFC);
+    const u8* const memory = memory_system->GetPhysicalPointer(buf.physical_address & 0xFFFFFFFC);
     if (memory) {
         const unsigned num_channels = buf.mono_or_stereo == MonoOrStereo::Stereo ? 2 : 1;
         switch (buf.format) {

--- a/src/audio_core/hle/source.h
+++ b/src/audio_core/hle/source.h
@@ -14,6 +14,10 @@
 #include "audio_core/interpolate.h"
 #include "common/common_types.h"
 
+namespace Memory {
+class MemorySystem;
+}
+
 namespace AudioCore {
 namespace HLE {
 
@@ -34,6 +38,9 @@ public:
 
     /// Resets internal state.
     void Reset();
+
+    /// Sets the memory system to read data from
+    void SetMemory(Memory::MemorySystem& memory);
 
     /**
      * This is called once every audio frame. This performs per-source processing every frame.
@@ -56,6 +63,7 @@ public:
 
 private:
     const std::size_t source_id;
+    Memory::MemorySystem* memory_system;
     StereoFrame16 current_frame;
 
     using Format = SourceConfiguration::Configuration::Format;

--- a/src/citra_qt/debugger/graphics/graphics_cmdlists.cpp
+++ b/src/citra_qt/debugger/graphics/graphics_cmdlists.cpp
@@ -17,6 +17,7 @@
 #include "citra_qt/util/spinbox.h"
 #include "citra_qt/util/util.h"
 #include "common/vector_math.h"
+#include "core/core.h"
 #include "core/memory.h"
 #include "video_core/debug_utils/debug_utils.h"
 #include "video_core/pica_state.h"
@@ -166,7 +167,8 @@ void GPUCommandListWidget::SetCommandInfo(const QModelIndex& index) {
         const auto format = texture.format;
 
         const auto info = Pica::Texture::TextureInfo::FromPicaRegister(config, format);
-        const u8* src = Memory::GetPhysicalPointer(config.GetPhysicalAddress());
+        const u8* src =
+            Core::System::GetInstance().Memory().GetPhysicalPointer(config.GetPhysicalAddress());
         new_info_widget = new TextureInfoWidget(src, info);
     }
     if (command_info_widget) {

--- a/src/citra_qt/debugger/graphics/graphics_surface.cpp
+++ b/src/citra_qt/debugger/graphics/graphics_surface.cpp
@@ -14,6 +14,7 @@
 #include "citra_qt/debugger/graphics/graphics_surface.h"
 #include "citra_qt/util/spinbox.h"
 #include "common/color.h"
+#include "core/core.h"
 #include "core/hw/gpu.h"
 #include "core/memory.h"
 #include "video_core/pica_state.h"
@@ -283,7 +284,7 @@ void GraphicsSurfaceWidget::Pick(int x, int y) {
         return;
     }
 
-    u8* buffer = Memory::GetPhysicalPointer(surface_address);
+    u8* buffer = Core::System::GetInstance().Memory().GetPhysicalPointer(surface_address);
     if (buffer == nullptr) {
         surface_info_label->setText(tr("(unable to access pixel data)"));
         surface_info_label->setAlignment(Qt::AlignCenter);
@@ -549,7 +550,7 @@ void GraphicsSurfaceWidget::OnUpdate() {
     // TODO: Implement a good way to visualize alpha components!
 
     QImage decoded_image(surface_width, surface_height, QImage::Format_ARGB32);
-    u8* buffer = Memory::GetPhysicalPointer(surface_address);
+    u8* buffer = Core::System::GetInstance().Memory().GetPhysicalPointer(surface_address);
 
     if (buffer == nullptr) {
         surface_picture_label->hide();
@@ -679,7 +680,7 @@ void GraphicsSurfaceWidget::SaveSurface() {
         if (pixmap)
             pixmap->save(&file, "PNG");
     } else if (selectedFilter == bin_filter) {
-        const u8* buffer = Memory::GetPhysicalPointer(surface_address);
+        const u8* buffer = Core::System::GetInstance().Memory().GetPhysicalPointer(surface_address);
         ASSERT_MSG(buffer != nullptr, "Memory not accessible");
 
         QFile file(filename);

--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -72,33 +72,34 @@ private:
 class DynarmicUserCallbacks final : public Dynarmic::A32::UserCallbacks {
 public:
     explicit DynarmicUserCallbacks(ARM_Dynarmic& parent)
-        : parent(parent), timing(parent.system.CoreTiming()), svc_context(parent.system) {}
+        : parent(parent), timing(parent.system.CoreTiming()), svc_context(parent.system),
+          memory(parent.system.Memory()) {}
     ~DynarmicUserCallbacks() = default;
 
     std::uint8_t MemoryRead8(VAddr vaddr) override {
-        return Memory::Read8(vaddr);
+        return memory.Read8(vaddr);
     }
     std::uint16_t MemoryRead16(VAddr vaddr) override {
-        return Memory::Read16(vaddr);
+        return memory.Read16(vaddr);
     }
     std::uint32_t MemoryRead32(VAddr vaddr) override {
-        return Memory::Read32(vaddr);
+        return memory.Read32(vaddr);
     }
     std::uint64_t MemoryRead64(VAddr vaddr) override {
-        return Memory::Read64(vaddr);
+        return memory.Read64(vaddr);
     }
 
     void MemoryWrite8(VAddr vaddr, std::uint8_t value) override {
-        Memory::Write8(vaddr, value);
+        memory.Write8(vaddr, value);
     }
     void MemoryWrite16(VAddr vaddr, std::uint16_t value) override {
-        Memory::Write16(vaddr, value);
+        memory.Write16(vaddr, value);
     }
     void MemoryWrite32(VAddr vaddr, std::uint32_t value) override {
-        Memory::Write32(vaddr, value);
+        memory.Write32(vaddr, value);
     }
     void MemoryWrite64(VAddr vaddr, std::uint64_t value) override {
-        Memory::Write64(vaddr, value);
+        memory.Write64(vaddr, value);
     }
 
     void InterpreterFallback(VAddr pc, std::size_t num_instructions) override {
@@ -159,6 +160,7 @@ public:
     ARM_Dynarmic& parent;
     Core::Timing& timing;
     Kernel::SVCContext svc_context;
+    Memory::MemorySystem& memory;
 };
 
 ARM_Dynarmic::ARM_Dynarmic(Core::System& system, PrivilegeMode initial_mode)

--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -172,7 +172,7 @@ ARM_Dynarmic::~ARM_Dynarmic() = default;
 MICROPROFILE_DEFINE(ARM_Jit, "ARM JIT", "ARM JIT", MP_RGB(255, 64, 64));
 
 void ARM_Dynarmic::Run() {
-    ASSERT(Memory::GetCurrentPageTable() == current_page_table);
+    ASSERT(system.Memory().GetCurrentPageTable() == current_page_table);
     MICROPROFILE_SCOPE(ARM_Jit);
 
     jit->Run();
@@ -279,7 +279,7 @@ void ARM_Dynarmic::InvalidateCacheRange(u32 start_address, std::size_t length) {
 }
 
 void ARM_Dynarmic::PageTableChanged() {
-    current_page_table = Memory::GetCurrentPageTable();
+    current_page_table = system.Memory().GetCurrentPageTable();
 
     auto iter = jits.find(current_page_table);
     if (iter != jits.end()) {

--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -137,7 +137,7 @@ public:
                 parent.jit->HaltExecution();
                 parent.SetPC(pc);
                 Kernel::Thread* thread =
-                    Core::System::GetInstance().Kernel().GetThreadManager().GetCurrentThread();
+                    parent.system.Kernel().GetThreadManager().GetCurrentThread();
                 parent.SaveContext(thread->context);
                 GDBStub::Break();
                 GDBStub::SendTrap(thread, 5);
@@ -165,7 +165,7 @@ public:
 
 ARM_Dynarmic::ARM_Dynarmic(Core::System& system, PrivilegeMode initial_mode)
     : system(system), cb(std::make_unique<DynarmicUserCallbacks>(*this)) {
-    interpreter_state = std::make_shared<ARMul_State>(initial_mode);
+    interpreter_state = std::make_shared<ARMul_State>(system, initial_mode);
     PageTableChanged();
 }
 

--- a/src/core/arm/dyncom/arm_dyncom.cpp
+++ b/src/core/arm/dyncom/arm_dyncom.cpp
@@ -68,14 +68,14 @@ private:
     u32 fpexc;
 };
 
-ARM_DynCom::ARM_DynCom(PrivilegeMode initial_mode) {
-    state = std::make_unique<ARMul_State>(initial_mode);
+ARM_DynCom::ARM_DynCom(Core::System& system, PrivilegeMode initial_mode) : system(system) {
+    state = std::make_unique<ARMul_State>(system, initial_mode);
 }
 
 ARM_DynCom::~ARM_DynCom() {}
 
 void ARM_DynCom::Run() {
-    ExecuteInstructions(std::max<s64>(Core::System::GetInstance().CoreTiming().GetDowncount(), 0));
+    ExecuteInstructions(std::max<s64>(system.CoreTiming().GetDowncount(), 0));
 }
 
 void ARM_DynCom::Step() {
@@ -146,7 +146,7 @@ void ARM_DynCom::SetCP15Register(CP15Register reg, u32 value) {
 void ARM_DynCom::ExecuteInstructions(u64 num_instructions) {
     state->NumInstrsToExecute = num_instructions;
     unsigned ticks_executed = InterpreterMainLoop(state.get());
-    Core::System::GetInstance().CoreTiming().AddTicks(ticks_executed);
+    system.CoreTiming().AddTicks(ticks_executed);
     state->ServeBreak();
 }
 

--- a/src/core/arm/dyncom/arm_dyncom.h
+++ b/src/core/arm/dyncom/arm_dyncom.h
@@ -10,9 +10,13 @@
 #include "core/arm/skyeye_common/arm_regformat.h"
 #include "core/arm/skyeye_common/armstate.h"
 
+namespace Core {
+struct System;
+}
+
 class ARM_DynCom final : public ARM_Interface {
 public:
-    explicit ARM_DynCom(PrivilegeMode initial_mode);
+    explicit ARM_DynCom(Core::System& system, PrivilegeMode initial_mode);
     ~ARM_DynCom();
 
     void Run() override;
@@ -44,5 +48,6 @@ public:
 private:
     void ExecuteInstructions(u64 num_instructions);
 
+    Core::System& system;
     std::unique_ptr<ARMul_State> state;
 };

--- a/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
+++ b/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
@@ -811,7 +811,7 @@ MICROPROFILE_DEFINE(DynCom_Decode, "DynCom", "Decode", MP_RGB(255, 64, 64));
 static unsigned int InterpreterTranslateInstruction(const ARMul_State* cpu, const u32 phys_addr,
                                                     ARM_INST_PTR& inst_base) {
     u32 inst_size = 4;
-    u32 inst = Memory::Read32(phys_addr & 0xFFFFFFFC);
+    u32 inst = Core::System::GetInstance().Memory().Read32(phys_addr & 0xFFFFFFFC);
 
     // If we are in Thumb mode, we'll translate one Thumb instruction to the corresponding ARM
     // instruction

--- a/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
+++ b/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
@@ -811,7 +811,7 @@ MICROPROFILE_DEFINE(DynCom_Decode, "DynCom", "Decode", MP_RGB(255, 64, 64));
 static unsigned int InterpreterTranslateInstruction(const ARMul_State* cpu, const u32 phys_addr,
                                                     ARM_INST_PTR& inst_base) {
     u32 inst_size = 4;
-    u32 inst = Core::System::GetInstance().Memory().Read32(phys_addr & 0xFFFFFFFC);
+    u32 inst = cpu->system.Memory().Read32(phys_addr & 0xFFFFFFFC);
 
     // If we are in Thumb mode, we'll translate one Thumb instruction to the corresponding ARM
     // instruction
@@ -3860,11 +3860,11 @@ SUB_INST : {
 SWI_INST : {
     if (inst_base->cond == ConditionCode::AL || CondPassed(cpu, inst_base->cond)) {
         swi_inst* const inst_cream = (swi_inst*)inst_base->component;
-        Core::System::GetInstance().CoreTiming().AddTicks(num_instrs);
+        cpu->system.CoreTiming().AddTicks(num_instrs);
         cpu->NumInstrsToExecute =
             num_instrs >= cpu->NumInstrsToExecute ? 0 : cpu->NumInstrsToExecute - num_instrs;
         num_instrs = 0;
-        Kernel::SVCContext{Core::System::GetInstance()}.CallSVC(inst_cream->num & 0xFFFF);
+        Kernel::SVCContext{cpu->system}.CallSVC(inst_cream->num & 0xFFFF);
         // The kernel would call ERET to get here, which clears exclusive memory state.
         cpu->UnsetExclusiveMemoryAddress();
     }

--- a/src/core/arm/skyeye_common/armstate.cpp
+++ b/src/core/arm/skyeye_common/armstate.cpp
@@ -191,13 +191,13 @@ static void CheckMemoryBreakpoint(u32 address, GDBStub::BreakpointType type) {
 u8 ARMul_State::ReadMemory8(u32 address) const {
     CheckMemoryBreakpoint(address, GDBStub::BreakpointType::Read);
 
-    return Memory::Read8(address);
+    return Core::System::GetInstance().Memory().Read8(address);
 }
 
 u16 ARMul_State::ReadMemory16(u32 address) const {
     CheckMemoryBreakpoint(address, GDBStub::BreakpointType::Read);
 
-    u16 data = Memory::Read16(address);
+    u16 data = Core::System::GetInstance().Memory().Read16(address);
 
     if (InBigEndianMode())
         data = Common::swap16(data);
@@ -208,7 +208,7 @@ u16 ARMul_State::ReadMemory16(u32 address) const {
 u32 ARMul_State::ReadMemory32(u32 address) const {
     CheckMemoryBreakpoint(address, GDBStub::BreakpointType::Read);
 
-    u32 data = Memory::Read32(address);
+    u32 data = Core::System::GetInstance().Memory().Read32(address);
 
     if (InBigEndianMode())
         data = Common::swap32(data);
@@ -219,7 +219,7 @@ u32 ARMul_State::ReadMemory32(u32 address) const {
 u64 ARMul_State::ReadMemory64(u32 address) const {
     CheckMemoryBreakpoint(address, GDBStub::BreakpointType::Read);
 
-    u64 data = Memory::Read64(address);
+    u64 data = Core::System::GetInstance().Memory().Read64(address);
 
     if (InBigEndianMode())
         data = Common::swap64(data);
@@ -230,7 +230,7 @@ u64 ARMul_State::ReadMemory64(u32 address) const {
 void ARMul_State::WriteMemory8(u32 address, u8 data) {
     CheckMemoryBreakpoint(address, GDBStub::BreakpointType::Write);
 
-    Memory::Write8(address, data);
+    Core::System::GetInstance().Memory().Write8(address, data);
 }
 
 void ARMul_State::WriteMemory16(u32 address, u16 data) {
@@ -239,7 +239,7 @@ void ARMul_State::WriteMemory16(u32 address, u16 data) {
     if (InBigEndianMode())
         data = Common::swap16(data);
 
-    Memory::Write16(address, data);
+    Core::System::GetInstance().Memory().Write16(address, data);
 }
 
 void ARMul_State::WriteMemory32(u32 address, u32 data) {
@@ -248,7 +248,7 @@ void ARMul_State::WriteMemory32(u32 address, u32 data) {
     if (InBigEndianMode())
         data = Common::swap32(data);
 
-    Memory::Write32(address, data);
+    Core::System::GetInstance().Memory().Write32(address, data);
 }
 
 void ARMul_State::WriteMemory64(u32 address, u64 data) {
@@ -257,7 +257,7 @@ void ARMul_State::WriteMemory64(u32 address, u64 data) {
     if (InBigEndianMode())
         data = Common::swap64(data);
 
-    Memory::Write64(address, data);
+    Core::System::GetInstance().Memory().Write64(address, data);
 }
 
 // Reads from the CP15 registers. Used with implementation of the MRC instruction.

--- a/src/core/arm/skyeye_common/armstate.h
+++ b/src/core/arm/skyeye_common/armstate.h
@@ -23,6 +23,10 @@
 #include "core/arm/skyeye_common/arm_regformat.h"
 #include "core/gdbstub/gdbstub.h"
 
+namespace Core {
+class System;
+}
+
 // Signal levels
 enum { LOW = 0, HIGH = 1, LOWHIGH = 1, HIGHLOW = 2 };
 
@@ -139,7 +143,7 @@ enum {
 
 struct ARMul_State final {
 public:
-    explicit ARMul_State(PrivilegeMode initial_mode);
+    explicit ARMul_State(Core::System& system, PrivilegeMode initial_mode);
 
     void ChangePrivilegeMode(u32 new_mode);
     void Reset();
@@ -196,6 +200,8 @@ public:
     }
 
     void ServeBreak();
+
+    Core::System& system;
 
     std::array<u32, 16> Reg{}; // The current register file
     std::array<u32, 2> Reg_usr{};

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -182,11 +182,11 @@ System::ResultStatus System::Init(EmuWindow& emu_window, u32 system_mode) {
 #ifdef ARCHITECTURE_x86_64
         cpu_core = std::make_unique<ARM_Dynarmic>(*this, USER32MODE);
 #else
-        cpu_core = std::make_unique<ARM_DynCom>(USER32MODE);
+        cpu_core = std::make_unique<ARM_DynCom>(*this, USER32MODE);
         LOG_WARNING(Core, "CPU JIT requested, but Dynarmic not available");
 #endif
     } else {
-        cpu_core = std::make_unique<ARM_DynCom>(USER32MODE);
+        cpu_core = std::make_unique<ARM_DynCom>(*this, USER32MODE);
     }
 
     dsp_core = std::make_unique<AudioCore::DspHle>(*memory);

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -206,7 +206,7 @@ System::ResultStatus System::Init(EmuWindow& emu_window, u32 system_mode) {
     Service::Init(*this);
     GDBStub::Init();
 
-    ResultStatus result = VideoCore::Init(emu_window);
+    ResultStatus result = VideoCore::Init(emu_window, *memory);
     if (result != ResultStatus::Success) {
         return result;
     }

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -172,6 +172,8 @@ void System::Reschedule() {
 System::ResultStatus System::Init(EmuWindow& emu_window, u32 system_mode) {
     LOG_DEBUG(HW_Memory, "initialized OK");
 
+    memory = std::make_unique<Memory::MemorySystem>();
+
     timing = std::make_unique<Timing>();
 
     kernel = std::make_unique<Kernel::KernelSystem>(system_mode);
@@ -248,6 +250,14 @@ Timing& System::CoreTiming() {
 
 const Timing& System::CoreTiming() const {
     return *timing;
+}
+
+Memory::MemorySystem& System::Memory() {
+    return *memory;
+}
+
+const Memory::MemorySystem& System::Memory() const {
+    return *memory;
 }
 
 Cheats::CheatEngine& System::CheatEngine() {

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -189,7 +189,7 @@ System::ResultStatus System::Init(EmuWindow& emu_window, u32 system_mode) {
         cpu_core = std::make_unique<ARM_DynCom>(USER32MODE);
     }
 
-    dsp_core = std::make_unique<AudioCore::DspHle>();
+    dsp_core = std::make_unique<AudioCore::DspHle>(*memory);
     dsp_core->SetSink(Settings::values.sink_id, Settings::values.audio_device_id);
     dsp_core->EnableStretching(Settings::values.enable_audio_stretching);
 
@@ -202,7 +202,7 @@ System::ResultStatus System::Init(EmuWindow& emu_window, u32 system_mode) {
     service_manager = std::make_shared<Service::SM::ServiceManager>(*this);
     archive_manager = std::make_unique<Service::FS::ArchiveManager>(*this);
 
-    HW::Init();
+    HW::Init(*memory);
     Service::Init(*this);
     GDBStub::Init();
 

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -176,7 +176,7 @@ System::ResultStatus System::Init(EmuWindow& emu_window, u32 system_mode) {
 
     timing = std::make_unique<Timing>();
 
-    kernel = std::make_unique<Kernel::KernelSystem>(system_mode);
+    kernel = std::make_unique<Kernel::KernelSystem>(*memory, system_mode);
 
     if (Settings::values.use_cpu_jit) {
 #ifdef ARCHITECTURE_x86_64

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -143,7 +143,7 @@ System::ResultStatus System::Load(EmuWindow& emu_window, const std::string& file
             return ResultStatus::ErrorLoader;
         }
     }
-    Memory::SetCurrentPageTable(&kernel->GetCurrentProcess()->vm_manager.page_table);
+    memory->SetCurrentPageTable(&kernel->GetCurrentProcess()->vm_manager.page_table);
     cheat_engine = std::make_unique<Cheats::CheatEngine>(*this);
     status = ResultStatus::Success;
     m_emu_window = &emu_window;

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -246,9 +246,6 @@ private:
     /// AppLoader used to load the current executing application
     std::unique_ptr<Loader::AppLoader> app_loader;
 
-    /// Memory system
-    std::unique_ptr<Memory::MemorySystem> memory;
-
     /// ARM11 CPU core
     std::unique_ptr<ARM_Interface> cpu_core;
 
@@ -281,6 +278,8 @@ public: // HACK: this is temporary exposed for tests,
         // due to WIP kernel refactor causing desync state in memory
     std::unique_ptr<Kernel::KernelSystem> kernel;
     std::unique_ptr<Timing> timing;
+    /// Memory system
+    std::unique_ptr<Memory::MemorySystem> memory;
 
 private:
     static System s_instance;

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -16,6 +16,10 @@
 class EmuWindow;
 class ARM_Interface;
 
+namespace Memory {
+class MemorySystem;
+}
+
 namespace AudioCore {
 class DspInterface;
 }
@@ -188,6 +192,12 @@ public:
     /// Gets a const reference to the timing system
     const Timing& CoreTiming() const;
 
+    /// Gets a reference to the memory system
+    Memory::MemorySystem& Memory();
+
+    /// Gets a const reference to the memory system
+    const Memory::MemorySystem& Memory() const;
+
     /// Gets a reference to the cheat engine
     Cheats::CheatEngine& CheatEngine();
 
@@ -235,6 +245,9 @@ private:
 
     /// AppLoader used to load the current executing application
     std::unique_ptr<Loader::AppLoader> app_loader;
+
+    /// Memory system
+    std::unique_ptr<Memory::MemorySystem> memory;
 
     /// ARM11 CPU core
     std::unique_ptr<ARM_Interface> cpu_core;

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -278,6 +278,7 @@ public: // HACK: this is temporary exposed for tests,
         // due to WIP kernel refactor causing desync state in memory
     std::unique_ptr<Kernel::KernelSystem> kernel;
     std::unique_ptr<Timing> timing;
+
     /// Memory system
     std::unique_ptr<Memory::MemorySystem> memory;
 

--- a/src/core/gdbstub/gdbstub.cpp
+++ b/src/core/gdbstub/gdbstub.cpp
@@ -831,8 +831,8 @@ static void ReadMemory() {
         SendReply("E01");
     }
 
-    if (!Memory::IsValidVirtualAddress(*Core::System::GetInstance().Kernel().GetCurrentProcess(),
-                                       addr)) {
+    if (!Core::System::GetInstance().Memory().IsValidVirtualAddress(
+            *Core::System::GetInstance().Kernel().GetCurrentProcess(), addr)) {
         return SendReply("E00");
     }
 
@@ -855,8 +855,8 @@ static void WriteMemory() {
     auto len_pos = std::find(start_offset, command_buffer + command_length, ':');
     u32 len = HexToInt(start_offset, static_cast<u32>(len_pos - start_offset));
 
-    if (!Memory::IsValidVirtualAddress(*Core::System::GetInstance().Kernel().GetCurrentProcess(),
-                                       addr)) {
+    if (!Core::System::GetInstance().Memory().IsValidVirtualAddress(
+            *Core::System::GetInstance().Kernel().GetCurrentProcess(), addr)) {
         return SendReply("E00");
     }
 

--- a/src/core/gdbstub/gdbstub.cpp
+++ b/src/core/gdbstub/gdbstub.cpp
@@ -832,8 +832,8 @@ static void ReadMemory() {
         SendReply("E01");
     }
 
-    if (!Core::System::GetInstance().Memory().IsValidVirtualAddress(
-            *Core::System::GetInstance().Kernel().GetCurrentProcess(), addr)) {
+    if (!Memory::IsValidVirtualAddress(*Core::System::GetInstance().Kernel().GetCurrentProcess(),
+                                       addr)) {
         return SendReply("E00");
     }
 
@@ -856,8 +856,8 @@ static void WriteMemory() {
     auto len_pos = std::find(start_offset, command_buffer + command_length, ':');
     u32 len = HexToInt(start_offset, static_cast<u32>(len_pos - start_offset));
 
-    if (!Core::System::GetInstance().Memory().IsValidVirtualAddress(
-            *Core::System::GetInstance().Kernel().GetCurrentProcess(), addr)) {
+    if (!Memory::IsValidVirtualAddress(*Core::System::GetInstance().Kernel().GetCurrentProcess(),
+                                       addr)) {
         return SendReply("E00");
     }
 

--- a/src/core/hle/kernel/address_arbiter.h
+++ b/src/core/hle/kernel/address_arbiter.h
@@ -52,6 +52,8 @@ private:
     explicit AddressArbiter(KernelSystem& kernel);
     ~AddressArbiter() override;
 
+    KernelSystem& kernel;
+
     /// Puts the thread to wait on the specified arbitration address under this address arbiter.
     void WaitThread(SharedPtr<Thread> thread, VAddr wait_address);
 

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -20,7 +20,7 @@ KernelSystem::KernelSystem(Memory::MemorySystem& memory, u32 system_mode) : memo
     MemoryInit(system_mode);
 
     resource_limits = std::make_unique<ResourceLimitList>(*this);
-    thread_manager = std::make_unique<ThreadManager>();
+    thread_manager = std::make_unique<ThreadManager>(*this);
     timer_manager = std::make_unique<TimerManager>();
 }
 

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -16,7 +16,7 @@
 namespace Kernel {
 
 /// Initialize the kernel
-KernelSystem::KernelSystem(u32 system_mode) {
+KernelSystem::KernelSystem(Memory::MemorySystem& memory, u32 system_mode) : memory(memory) {
     MemoryInit(system_mode);
 
     resource_limits = std::make_unique<ResourceLimitList>(*this);

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -23,6 +23,10 @@ namespace SharedPage {
 class Handler;
 }
 
+namespace Memory {
+class MemorySystem;
+}
+
 namespace Kernel {
 
 class AddressArbiter;
@@ -73,7 +77,7 @@ using SharedPtr = boost::intrusive_ptr<T>;
 
 class KernelSystem {
 public:
-    explicit KernelSystem(u32 system_mode);
+    explicit KernelSystem(Memory::MemorySystem& memory, u32 system_mode);
     ~KernelSystem();
 
     /**
@@ -219,6 +223,8 @@ public:
 
     /// Map of named ports managed by the kernel, which can be retrieved using the ConnectToPort
     std::unordered_map<std::string, SharedPtr<ClientPort>> named_ports;
+
+    Memory::MemorySystem& memory;
 
 private:
     void MemoryInit(u32 mem_type);

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -46,6 +46,7 @@ class SharedMemory;
 class ThreadManager;
 class TimerManager;
 class VMManager;
+struct AddressMapping;
 
 enum class ResetType {
     OneShot,
@@ -215,6 +216,8 @@ public:
     const SharedPage::Handler& GetSharedPageHandler() const;
 
     MemoryRegionInfo* GetMemoryRegion(MemoryRegion region);
+
+    void HandleSpecialMapping(VMManager& address_space, const AddressMapping& mapping);
 
     std::array<MemoryRegionInfo, 3> memory_regions;
 

--- a/src/core/hle/kernel/memory.cpp
+++ b/src/core/hle/kernel/memory.cpp
@@ -83,7 +83,7 @@ MemoryRegionInfo* KernelSystem::GetMemoryRegion(MemoryRegion region) {
     }
 }
 
-void HandleSpecialMapping(VMManager& address_space, const AddressMapping& mapping) {
+void KernelSystem::HandleSpecialMapping(VMManager& address_space, const AddressMapping& mapping) {
     using namespace Memory;
 
     struct MemoryArea {
@@ -128,7 +128,7 @@ void HandleSpecialMapping(VMManager& address_space, const AddressMapping& mappin
         return;
     }
 
-    u8* target_pointer = Memory::GetPhysicalPointer(area->paddr_base + offset_into_region);
+    u8* target_pointer = memory.GetPhysicalPointer(area->paddr_base + offset_into_region);
 
     // TODO(yuriks): This flag seems to have some other effect, but it's unknown what
     MemoryState memory_state = mapping.unk_flag ? MemoryState::Static : MemoryState::IO;

--- a/src/core/hle/kernel/memory.h
+++ b/src/core/hle/kernel/memory.h
@@ -62,6 +62,4 @@ struct MemoryRegionInfo {
     void Free(u32 offset, u32 size);
 };
 
-void HandleSpecialMapping(VMManager& address_space, const AddressMapping& mapping);
-
 } // namespace Kernel

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -136,7 +136,7 @@ void Process::Run(s32 main_thread_priority, u32 stack_size) {
     // Map special address mappings
     kernel.MapSharedPages(vm_manager);
     for (const auto& mapping : address_mappings) {
-        HandleSpecialMapping(vm_manager, mapping);
+        kernel.HandleSpecialMapping(vm_manager, mapping);
     }
 
     status = ProcessStatus::Running;

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -218,7 +218,7 @@ ResultCode Process::HeapFree(VAddr target, u32 size) {
     // Free heaps block by block
     CASCADE_RESULT(auto backing_blocks, vm_manager.GetBackingBlocksForRange(target, size));
     for (const auto [backing_memory, block_size] : backing_blocks) {
-        memory_region->Free(Memory::GetFCRAMOffset(backing_memory), block_size);
+        memory_region->Free(kernel.memory.GetFCRAMOffset(backing_memory), block_size);
     }
 
     ResultCode result = vm_manager.UnmapRange(target, size);

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -120,8 +120,8 @@ void Process::Run(s32 main_thread_priority, u32 stack_size) {
     auto MapSegment = [&](CodeSet::Segment& segment, VMAPermission permissions,
                           MemoryState memory_state) {
         HeapAllocate(segment.addr, segment.size, permissions, memory_state, true);
-        Memory::WriteBlock(*this, segment.addr, codeset->memory->data() + segment.offset,
-                           segment.size);
+        kernel.memory.WriteBlock(*this, segment.addr, codeset->memory->data() + segment.offset,
+                                 segment.size);
     };
 
     // Map CodeSet segments

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -188,10 +188,11 @@ ResultVal<VAddr> Process::HeapAllocate(VAddr target, u32 size, VMAPermission per
         u32 interval_size = interval.upper() - interval.lower();
         LOG_DEBUG(Kernel, "Allocated FCRAM region lower={:08X}, upper={:08X}", interval.lower(),
                   interval.upper());
-        std::fill(Memory::fcram.begin() + interval.lower(),
-                  Memory::fcram.begin() + interval.upper(), 0);
-        auto vma = vm_manager.MapBackingMemory(
-            interval_target, Memory::fcram.data() + interval.lower(), interval_size, memory_state);
+        std::fill(kernel.memory.fcram.begin() + interval.lower(),
+                  kernel.memory.fcram.begin() + interval.upper(), 0);
+        auto vma = vm_manager.MapBackingMemory(interval_target,
+                                               kernel.memory.fcram.data() + interval.lower(),
+                                               interval_size, memory_state);
         ASSERT(vma.Succeeded());
         vm_manager.Reprotect(vma.Unwrap(), perms);
         interval_target += interval_size;
@@ -262,7 +263,7 @@ ResultVal<VAddr> Process::LinearAllocate(VAddr target, u32 size, VMAPermission p
         }
     }
 
-    u8* backing_memory = Memory::fcram.data() + physical_offset;
+    u8* backing_memory = kernel.memory.fcram.data() + physical_offset;
 
     std::fill(backing_memory, backing_memory + size, 0);
     auto vma = vm_manager.MapBackingMemory(target, backing_memory, size, MemoryState::Continuous);

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -188,10 +188,10 @@ ResultVal<VAddr> Process::HeapAllocate(VAddr target, u32 size, VMAPermission per
         u32 interval_size = interval.upper() - interval.lower();
         LOG_DEBUG(Kernel, "Allocated FCRAM region lower={:08X}, upper={:08X}", interval.lower(),
                   interval.upper());
-        std::fill(kernel.memory.fcram.begin() + interval.lower(),
-                  kernel.memory.fcram.begin() + interval.upper(), 0);
+        std::fill(kernel.memory.GetFCRAMPointer(interval.lower()),
+                  kernel.memory.GetFCRAMPointer(interval.upper()), 0);
         auto vma = vm_manager.MapBackingMemory(interval_target,
-                                               kernel.memory.fcram.data() + interval.lower(),
+                                               kernel.memory.GetFCRAMPointer(interval.lower()),
                                                interval_size, memory_state);
         ASSERT(vma.Succeeded());
         vm_manager.Reprotect(vma.Unwrap(), perms);
@@ -263,7 +263,7 @@ ResultVal<VAddr> Process::LinearAllocate(VAddr target, u32 size, VMAPermission p
         }
     }
 
-    u8* backing_memory = kernel.memory.fcram.data() + physical_offset;
+    u8* backing_memory = kernel.memory.GetFCRAMPointer(physical_offset);
 
     std::fill(backing_memory, backing_memory + size, 0);
     auto vma = vm_manager.MapBackingMemory(target, backing_memory, size, MemoryState::Continuous);

--- a/src/core/hle/kernel/shared_memory.cpp
+++ b/src/core/hle/kernel/shared_memory.cpp
@@ -43,8 +43,8 @@ ResultVal<SharedPtr<SharedMemory>> KernelSystem::CreateSharedMemory(
 
         ASSERT_MSG(offset, "Not enough space in region to allocate shared memory!");
 
-        std::fill(Memory::fcram.data() + *offset, Memory::fcram.data() + *offset + size, 0);
-        shared_memory->backing_blocks = {{Memory::fcram.data() + *offset, size}};
+        std::fill(memory.fcram.data() + *offset, memory.fcram.data() + *offset + size, 0);
+        shared_memory->backing_blocks = {{memory.fcram.data() + *offset, size}};
         shared_memory->holding_memory += MemoryRegionInfo::Interval(*offset, *offset + size);
         shared_memory->linear_heap_phys_offset = *offset;
 
@@ -86,8 +86,8 @@ SharedPtr<SharedMemory> KernelSystem::CreateSharedMemoryForApplet(
     shared_memory->other_permissions = other_permissions;
     for (const auto& interval : backing_blocks) {
         shared_memory->backing_blocks.push_back(
-            {Memory::fcram.data() + interval.lower(), interval.upper() - interval.lower()});
-        std::fill(Memory::fcram.data() + interval.lower(), Memory::fcram.data() + interval.upper(),
+            {memory.fcram.data() + interval.lower(), interval.upper() - interval.lower()});
+        std::fill(memory.fcram.data() + interval.lower(), memory.fcram.data() + interval.upper(),
                   0);
     }
     shared_memory->base_address = Memory::HEAP_VADDR + offset;

--- a/src/core/hle/kernel/shared_memory.cpp
+++ b/src/core/hle/kernel/shared_memory.cpp
@@ -87,8 +87,8 @@ SharedPtr<SharedMemory> KernelSystem::CreateSharedMemoryForApplet(
     for (const auto& interval : backing_blocks) {
         shared_memory->backing_blocks.push_back(
             {memory.GetFCRAMPointer(interval.lower()), interval.upper() - interval.lower()});
-        std::fill(memory.GetFCRAMPointer(interval.lower()), memory.GetFCRAMPointer(interval.upper()),
-                  0);
+        std::fill(memory.GetFCRAMPointer(interval.lower()),
+                  memory.GetFCRAMPointer(interval.upper()), 0);
     }
     shared_memory->base_address = Memory::HEAP_VADDR + offset;
 

--- a/src/core/hle/kernel/shared_memory.cpp
+++ b/src/core/hle/kernel/shared_memory.cpp
@@ -43,8 +43,8 @@ ResultVal<SharedPtr<SharedMemory>> KernelSystem::CreateSharedMemory(
 
         ASSERT_MSG(offset, "Not enough space in region to allocate shared memory!");
 
-        std::fill(memory.fcram.data() + *offset, memory.fcram.data() + *offset + size, 0);
-        shared_memory->backing_blocks = {{memory.fcram.data() + *offset, size}};
+        std::fill(memory.GetFCRAMPointer(*offset), memory.GetFCRAMPointer(*offset + size), 0);
+        shared_memory->backing_blocks = {{memory.GetFCRAMPointer(*offset), size}};
         shared_memory->holding_memory += MemoryRegionInfo::Interval(*offset, *offset + size);
         shared_memory->linear_heap_phys_offset = *offset;
 
@@ -86,8 +86,8 @@ SharedPtr<SharedMemory> KernelSystem::CreateSharedMemoryForApplet(
     shared_memory->other_permissions = other_permissions;
     for (const auto& interval : backing_blocks) {
         shared_memory->backing_blocks.push_back(
-            {memory.fcram.data() + interval.lower(), interval.upper() - interval.lower()});
-        std::fill(memory.fcram.data() + interval.lower(), memory.fcram.data() + interval.upper(),
+            {memory.GetFCRAMPointer(interval.lower()), interval.upper() - interval.lower()});
+        std::fill(memory.GetFCRAMPointer(interval.lower()), memory.GetFCRAMPointer(interval.upper()),
                   0);
     }
     shared_memory->base_address = Memory::HEAP_VADDR + offset;

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -352,7 +352,7 @@ ResultCode SVC::ConnectToPort(Handle* out_handle, VAddr port_name_address) {
 
     static constexpr std::size_t PortNameMaxLength = 11;
     // Read 1 char beyond the max allowed port name to detect names that are too long.
-    std::string port_name = Memory::ReadCString(port_name_address, PortNameMaxLength + 1);
+    std::string port_name = memory.ReadCString(port_name_address, PortNameMaxLength + 1);
     if (port_name.size() > PortNameMaxLength)
         return ERR_PORT_NAME_TOO_LONG;
 
@@ -467,7 +467,7 @@ ResultCode SVC::WaitSynchronizationN(s32* out, VAddr handles_address, s32 handle
     std::vector<ObjectPtr> objects(handle_count);
 
     for (int i = 0; i < handle_count; ++i) {
-        Handle handle = Memory::Read32(handles_address + i * sizeof(Handle));
+        Handle handle = memory.Read32(handles_address + i * sizeof(Handle));
         auto object = kernel.GetCurrentProcess()->handle_table.Get<WaitObject>(handle);
         if (object == nullptr)
             return ERR_INVALID_HANDLE;
@@ -636,7 +636,7 @@ ResultCode SVC::ReplyAndReceive(s32* index, VAddr handles_address, s32 handle_co
     SharedPtr<Process> current_process = kernel.GetCurrentProcess();
 
     for (int i = 0; i < handle_count; ++i) {
-        Handle handle = Memory::Read32(handles_address + i * sizeof(Handle));
+        Handle handle = memory.Read32(handles_address + i * sizeof(Handle));
         auto object = current_process->handle_table.Get<WaitObject>(handle);
         if (object == nullptr)
             return ERR_INVALID_HANDLE;
@@ -646,7 +646,7 @@ ResultCode SVC::ReplyAndReceive(s32* index, VAddr handles_address, s32 handle_co
     // We are also sending a command reply.
     // Do not send a reply if the command id in the command buffer is 0xFFFF.
     Thread* thread = kernel.GetThreadManager().GetCurrentThread();
-    u32 cmd_buff_header = Memory::Read32(thread->GetCommandBufferAddress());
+    u32 cmd_buff_header = memory.Read32(thread->GetCommandBufferAddress());
     IPC::Header header{cmd_buff_header};
     if (reply_target != 0 && header.command_id != 0xFFFF) {
         auto session = current_process->handle_table.Get<ServerSession>(reply_target);
@@ -832,9 +832,9 @@ ResultCode SVC::GetResourceLimitCurrentValues(VAddr values, Handle resource_limi
         return ERR_INVALID_HANDLE;
 
     for (unsigned int i = 0; i < name_count; ++i) {
-        u32 name = Memory::Read32(names + i * sizeof(u32));
+        u32 name = memory.Read32(names + i * sizeof(u32));
         s64 value = resource_limit->GetCurrentResourceValue(name);
-        Memory::Write64(values + i * sizeof(u64), value);
+        memory.Write64(values + i * sizeof(u64), value);
     }
 
     return RESULT_SUCCESS;
@@ -852,9 +852,9 @@ ResultCode SVC::GetResourceLimitLimitValues(VAddr values, Handle resource_limit_
         return ERR_INVALID_HANDLE;
 
     for (unsigned int i = 0; i < name_count; ++i) {
-        u32 name = Memory::Read32(names + i * sizeof(u32));
+        u32 name = memory.Read32(names + i * sizeof(u32));
         s64 value = resource_limit->GetMaxResourceValue(name);
-        Memory::Write64(values + i * sizeof(u64), value);
+        memory.Write64(values + i * sizeof(u64), value);
     }
 
     return RESULT_SUCCESS;

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -347,7 +347,7 @@ ResultCode SVC::UnmapMemoryBlock(Handle handle, u32 addr) {
 
 /// Connect to an OS service given the port name, returns the handle to the port to out
 ResultCode SVC::ConnectToPort(Handle* out_handle, VAddr port_name_address) {
-    if (!memory.IsValidVirtualAddress(*kernel.GetCurrentProcess(), port_name_address))
+    if (!Memory::IsValidVirtualAddress(*kernel.GetCurrentProcess(), port_name_address))
         return ERR_NOT_FOUND;
 
     static constexpr std::size_t PortNameMaxLength = 11;
@@ -452,7 +452,7 @@ ResultCode SVC::WaitSynchronizationN(s32* out, VAddr handles_address, s32 handle
                                      bool wait_all, s64 nano_seconds) {
     Thread* thread = kernel.GetThreadManager().GetCurrentThread();
 
-    if (!memory.IsValidVirtualAddress(*kernel.GetCurrentProcess(), handles_address))
+    if (!Memory::IsValidVirtualAddress(*kernel.GetCurrentProcess(), handles_address))
         return ERR_INVALID_POINTER;
 
     // NOTE: on real hardware, there is no nullptr check for 'out' (tested with firmware 4.4). If
@@ -623,7 +623,7 @@ static ResultCode ReceiveIPCRequest(SharedPtr<ServerSession> server_session,
 /// In a single operation, sends a IPC reply and waits for a new request.
 ResultCode SVC::ReplyAndReceive(s32* index, VAddr handles_address, s32 handle_count,
                                 Handle reply_target) {
-    if (!memory.IsValidVirtualAddress(*kernel.GetCurrentProcess(), handles_address))
+    if (!Memory::IsValidVirtualAddress(*kernel.GetCurrentProcess(), handles_address))
         return ERR_INVALID_POINTER;
 
     // Check if 'handle_count' is invalid

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -802,7 +802,7 @@ void SVC::OutputDebugString(VAddr address, s32 len) {
     }
 
     std::string string(len, ' ');
-    Memory::ReadBlock(*kernel.GetCurrentProcess(), address, string.data(), len);
+    memory.ReadBlock(*kernel.GetCurrentProcess(), address, string.data(), len);
     LOG_DEBUG(Debug_Emulated, "{}", string);
 }
 

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -105,6 +105,7 @@ public:
 private:
     Core::System& system;
     Kernel::KernelSystem& kernel;
+    Memory::MemorySystem& memory;
 
     friend class SVCWrapper<SVC>;
 
@@ -346,7 +347,7 @@ ResultCode SVC::UnmapMemoryBlock(Handle handle, u32 addr) {
 
 /// Connect to an OS service given the port name, returns the handle to the port to out
 ResultCode SVC::ConnectToPort(Handle* out_handle, VAddr port_name_address) {
-    if (!Memory::IsValidVirtualAddress(*kernel.GetCurrentProcess(), port_name_address))
+    if (!memory.IsValidVirtualAddress(*kernel.GetCurrentProcess(), port_name_address))
         return ERR_NOT_FOUND;
 
     static constexpr std::size_t PortNameMaxLength = 11;
@@ -451,7 +452,7 @@ ResultCode SVC::WaitSynchronizationN(s32* out, VAddr handles_address, s32 handle
                                      bool wait_all, s64 nano_seconds) {
     Thread* thread = kernel.GetThreadManager().GetCurrentThread();
 
-    if (!Memory::IsValidVirtualAddress(*kernel.GetCurrentProcess(), handles_address))
+    if (!memory.IsValidVirtualAddress(*kernel.GetCurrentProcess(), handles_address))
         return ERR_INVALID_POINTER;
 
     // NOTE: on real hardware, there is no nullptr check for 'out' (tested with firmware 4.4). If
@@ -622,7 +623,7 @@ static ResultCode ReceiveIPCRequest(SharedPtr<ServerSession> server_session,
 /// In a single operation, sends a IPC reply and waits for a new request.
 ResultCode SVC::ReplyAndReceive(s32* index, VAddr handles_address, s32 handle_count,
                                 Handle reply_target) {
-    if (!Memory::IsValidVirtualAddress(*kernel.GetCurrentProcess(), handles_address))
+    if (!memory.IsValidVirtualAddress(*kernel.GetCurrentProcess(), handles_address))
         return ERR_INVALID_POINTER;
 
     // Check if 'handle_count' is invalid
@@ -1584,7 +1585,7 @@ void SVC::CallSVC(u32 immediate) {
     }
 }
 
-SVC::SVC(Core::System& system) : system(system), kernel(system.Kernel()) {}
+SVC::SVC(Core::System& system) : system(system), kernel(system.Kernel()), memory(system.Memory()) {}
 
 u32 SVC::GetReg(std::size_t n) {
     return system.CPU().GetReg(static_cast<int>(n));

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -364,7 +364,7 @@ ResultVal<SharedPtr<Thread>> KernelSystem::CreateThread(std::string name, VAddr 
     thread->tls_address = Memory::TLS_AREA_VADDR + available_page * Memory::PAGE_SIZE +
                           available_slot * Memory::TLS_ENTRY_SIZE;
 
-    Memory::ZeroBlock(owner_process, thread->tls_address, Memory::TLS_ENTRY_SIZE);
+    memory.ZeroBlock(owner_process, thread->tls_address, Memory::TLS_ENTRY_SIZE);
 
     // TODO(peachum): move to ScheduleThread() when scheduler is added so selected core is used
     // to initialize the context

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -303,7 +303,7 @@ ResultVal<SharedPtr<Thread>> KernelSystem::CreateThread(std::string name, VAddr 
 
     // TODO(yuriks): Other checks, returning 0xD9001BEA
 
-    if (!memory.IsValidVirtualAddress(owner_process, entry_point)) {
+    if (!Memory::IsValidVirtualAddress(owner_process, entry_point)) {
         LOG_ERROR(Kernel_SVC, "(name={}): invalid entry {:08x}", name, entry_point);
         // TODO: Verify error
         return ResultCode(ErrorDescription::InvalidAddress, ErrorModule::Kernel,

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -303,7 +303,7 @@ ResultVal<SharedPtr<Thread>> KernelSystem::CreateThread(std::string name, VAddr 
 
     // TODO(yuriks): Other checks, returning 0xD9001BEA
 
-    if (!Memory::IsValidVirtualAddress(owner_process, entry_point)) {
+    if (!memory.IsValidVirtualAddress(owner_process, entry_point)) {
         LOG_ERROR(Kernel_SVC, "(name={}): invalid entry {:08x}", name, entry_point);
         // TODO: Verify error
         return ResultCode(ErrorDescription::InvalidAddress, ErrorModule::Kernel,

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -355,7 +355,7 @@ ResultVal<SharedPtr<Thread>> KernelSystem::CreateThread(std::string name, VAddr 
 
         // Map the page to the current process' address space.
         vm_manager.MapBackingMemory(Memory::TLS_AREA_VADDR + available_page * Memory::PAGE_SIZE,
-                                    Memory::fcram.data() + *offset, Memory::PAGE_SIZE,
+                                    memory.fcram.data() + *offset, Memory::PAGE_SIZE,
                                     MemoryState::Locked);
     }
 

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -355,7 +355,7 @@ ResultVal<SharedPtr<Thread>> KernelSystem::CreateThread(std::string name, VAddr 
 
         // Map the page to the current process' address space.
         vm_manager.MapBackingMemory(Memory::TLS_AREA_VADDR + available_page * Memory::PAGE_SIZE,
-                                    memory.fcram.data() + *offset, Memory::PAGE_SIZE,
+                                    memory.GetFCRAMPointer(*offset), Memory::PAGE_SIZE,
                                     MemoryState::Locked);
     }
 

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -57,7 +57,7 @@ enum class ThreadWakeupReason {
 
 class ThreadManager {
 public:
-    ThreadManager();
+    explicit ThreadManager(Kernel::KernelSystem& kernel);
     ~ThreadManager();
 
     /**
@@ -120,6 +120,8 @@ private:
      * @param cycles_late The number of CPU cycles that have passed since the desired wakeup time
      */
     void ThreadWakeupCallback(u64 thread_id, s64 cycles_late);
+
+    Kernel::KernelSystem& kernel;
 
     u32 next_thread_id = 1;
     SharedPtr<Thread> current_thread;

--- a/src/core/hle/service/cam/cam.cpp
+++ b/src/core/hle/service/cam/cam.cpp
@@ -113,7 +113,7 @@ void Module::CompletionEventCallBack(u64 port_id, s64) {
             if (copy_length <= 0) {
                 break;
             }
-            Memory::WriteBlock(*port.dest_process, dest_ptr, src_ptr, copy_length);
+            system.Memory().WriteBlock(*port.dest_process, dest_ptr, src_ptr, copy_length);
             dest_ptr += copy_length;
             dest_size_left -= copy_length;
             src_ptr += original_width;
@@ -125,8 +125,8 @@ void Module::CompletionEventCallBack(u64 port_id, s64) {
             LOG_ERROR(Service_CAM, "The destination size ({}) doesn't match the source ({})!",
                       port.dest_size, buffer_size);
         }
-        Memory::WriteBlock(*port.dest_process, port.dest, buffer.data(),
-                           std::min<std::size_t>(port.dest_size, buffer_size));
+        system.Memory().WriteBlock(*port.dest_process, port.dest, buffer.data(),
+                                   std::min<std::size_t>(port.dest_size, buffer_size));
     }
 
     port.is_receiving = false;

--- a/src/core/hle/service/gsp/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp/gsp_gpu.cpp
@@ -491,6 +491,7 @@ static void ExecuteCommand(const Command& command, u32 thread_id) {
     // GX request DMA - typically used for copying memory from GSP heap to VRAM
     case CommandId::REQUEST_DMA: {
         MICROPROFILE_SCOPE(GPU_GSP_DMA);
+        Memory::MemorySystem& memory = Core::System::GetInstance().Memory();
 
         // TODO: Consider attempting rasterizer-accelerated surface blit if that usage is ever
         // possible/likely
@@ -502,9 +503,9 @@ static void ExecuteCommand(const Command& command, u32 thread_id) {
 
         // TODO(Subv): These memory accesses should not go through the application's memory mapping.
         // They should go through the GSP module's memory mapping.
-        Memory::CopyBlock(*Core::System::GetInstance().Kernel().GetCurrentProcess(),
-                          command.dma_request.dest_address, command.dma_request.source_address,
-                          command.dma_request.size);
+        memory.CopyBlock(*Core::System::GetInstance().Kernel().GetCurrentProcess(),
+                         command.dma_request.dest_address, command.dma_request.source_address,
+                         command.dma_request.size);
         SignalInterrupt(InterruptId::DMA);
         break;
     }

--- a/src/core/hle/service/ldr_ro/cro_helper.cpp
+++ b/src/core/hle/service/ldr_ro/cro_helper.cpp
@@ -55,7 +55,7 @@ VAddr CROHelper::SegmentTagToAddress(SegmentTag segment_tag) const {
         return 0;
 
     SegmentEntry entry;
-    GetEntry(segment_tag.segment_index, entry);
+    GetEntry(memory, segment_tag.segment_index, entry);
 
     if (segment_tag.offset_into_segment >= entry.size)
         return 0;
@@ -121,7 +121,7 @@ ResultCode CROHelper::ApplyRelocationBatch(VAddr batch, u32 symbol_address, bool
     VAddr relocation_address = batch;
     while (true) {
         RelocationEntry relocation;
-        Memory::ReadBlock(process, relocation_address, &relocation, sizeof(RelocationEntry));
+        memory.ReadBlock(process, relocation_address, &relocation, sizeof(RelocationEntry));
 
         VAddr relocation_target = SegmentTagToAddress(relocation.target_position);
         if (relocation_target == 0) {
@@ -142,9 +142,9 @@ ResultCode CROHelper::ApplyRelocationBatch(VAddr batch, u32 symbol_address, bool
     }
 
     RelocationEntry relocation;
-    Memory::ReadBlock(process, batch, &relocation, sizeof(RelocationEntry));
+    memory.ReadBlock(process, batch, &relocation, sizeof(RelocationEntry));
     relocation.is_batch_resolved = reset ? 0 : 1;
-    Memory::WriteBlock(process, batch, &relocation, sizeof(RelocationEntry));
+    memory.WriteBlock(process, batch, &relocation, sizeof(RelocationEntry));
     return RESULT_SUCCESS;
 }
 
@@ -154,13 +154,13 @@ VAddr CROHelper::FindExportNamedSymbol(const std::string& name) const {
 
     std::size_t len = name.size();
     ExportTreeEntry entry;
-    GetEntry(0, entry);
+    GetEntry(memory, 0, entry);
     ExportTreeEntry::Child next;
     next.raw = entry.left.raw;
     u32 found_id;
 
     while (true) {
-        GetEntry(next.next_index, entry);
+        GetEntry(memory, next.next_index, entry);
 
         if (next.is_end) {
             found_id = entry.export_table_index;
@@ -186,7 +186,7 @@ VAddr CROHelper::FindExportNamedSymbol(const std::string& name) const {
 
     u32 export_strings_size = GetField(ExportStringsSize);
     ExportNamedSymbolEntry symbol_entry;
-    GetEntry(found_id, symbol_entry);
+    GetEntry(memory, found_id, symbol_entry);
 
     if (memory.ReadCString(symbol_entry.name_offset, export_strings_size) != name)
         return 0;
@@ -279,7 +279,7 @@ ResultVal<VAddr> CROHelper::RebaseSegmentTable(u32 cro_size, VAddr data_segment_
     u32 segment_num = GetField(SegmentNum);
     for (u32 i = 0; i < segment_num; ++i) {
         SegmentEntry segment;
-        GetEntry(i, segment);
+        GetEntry(memory, i, segment);
         if (segment.type == SegmentType::Data) {
             if (segment.size != 0) {
                 if (segment.size > data_segment_size)
@@ -298,7 +298,7 @@ ResultVal<VAddr> CROHelper::RebaseSegmentTable(u32 cro_size, VAddr data_segment_
             if (segment.offset > module_address + cro_size)
                 return CROFormatError(0x19);
         }
-        SetEntry(i, segment);
+        SetEntry(memory, i, segment);
     }
     return MakeResult<u32>(prev_data_segment + module_address);
 }
@@ -310,7 +310,7 @@ ResultCode CROHelper::RebaseExportNamedSymbolTable() {
     u32 export_named_symbol_num = GetField(ExportNamedSymbolNum);
     for (u32 i = 0; i < export_named_symbol_num; ++i) {
         ExportNamedSymbolEntry entry;
-        GetEntry(i, entry);
+        GetEntry(memory, i, entry);
 
         if (entry.name_offset != 0) {
             entry.name_offset += module_address;
@@ -320,7 +320,7 @@ ResultCode CROHelper::RebaseExportNamedSymbolTable() {
             }
         }
 
-        SetEntry(i, entry);
+        SetEntry(memory, i, entry);
     }
     return RESULT_SUCCESS;
 }
@@ -329,7 +329,7 @@ ResultCode CROHelper::VerifyExportTreeTable() const {
     u32 tree_num = GetField(ExportTreeNum);
     for (u32 i = 0; i < tree_num; ++i) {
         ExportTreeEntry entry;
-        GetEntry(i, entry);
+        GetEntry(memory, i, entry);
 
         if (entry.left.next_index >= tree_num || entry.right.next_index >= tree_num) {
             return CROFormatError(0x11);
@@ -353,7 +353,7 @@ ResultCode CROHelper::RebaseImportModuleTable() {
     u32 module_num = GetField(ImportModuleNum);
     for (u32 i = 0; i < module_num; ++i) {
         ImportModuleEntry entry;
-        GetEntry(i, entry);
+        GetEntry(memory, i, entry);
 
         if (entry.name_offset != 0) {
             entry.name_offset += module_address;
@@ -379,7 +379,7 @@ ResultCode CROHelper::RebaseImportModuleTable() {
             }
         }
 
-        SetEntry(i, entry);
+        SetEntry(memory, i, entry);
     }
     return RESULT_SUCCESS;
 }
@@ -395,7 +395,7 @@ ResultCode CROHelper::RebaseImportNamedSymbolTable() {
     u32 num = GetField(ImportNamedSymbolNum);
     for (u32 i = 0; i < num; ++i) {
         ImportNamedSymbolEntry entry;
-        GetEntry(i, entry);
+        GetEntry(memory, i, entry);
 
         if (entry.name_offset != 0) {
             entry.name_offset += module_address;
@@ -413,7 +413,7 @@ ResultCode CROHelper::RebaseImportNamedSymbolTable() {
             }
         }
 
-        SetEntry(i, entry);
+        SetEntry(memory, i, entry);
     }
     return RESULT_SUCCESS;
 }
@@ -427,7 +427,7 @@ ResultCode CROHelper::RebaseImportIndexedSymbolTable() {
     u32 num = GetField(ImportIndexedSymbolNum);
     for (u32 i = 0; i < num; ++i) {
         ImportIndexedSymbolEntry entry;
-        GetEntry(i, entry);
+        GetEntry(memory, i, entry);
 
         if (entry.relocation_batch_offset != 0) {
             entry.relocation_batch_offset += module_address;
@@ -437,7 +437,7 @@ ResultCode CROHelper::RebaseImportIndexedSymbolTable() {
             }
         }
 
-        SetEntry(i, entry);
+        SetEntry(memory, i, entry);
     }
     return RESULT_SUCCESS;
 }
@@ -451,7 +451,7 @@ ResultCode CROHelper::RebaseImportAnonymousSymbolTable() {
     u32 num = GetField(ImportAnonymousSymbolNum);
     for (u32 i = 0; i < num; ++i) {
         ImportAnonymousSymbolEntry entry;
-        GetEntry(i, entry);
+        GetEntry(memory, i, entry);
 
         if (entry.relocation_batch_offset != 0) {
             entry.relocation_batch_offset += module_address;
@@ -461,7 +461,7 @@ ResultCode CROHelper::RebaseImportAnonymousSymbolTable() {
             }
         }
 
-        SetEntry(i, entry);
+        SetEntry(memory, i, entry);
     }
     return RESULT_SUCCESS;
 }
@@ -476,14 +476,14 @@ ResultCode CROHelper::ResetExternalRelocations() {
     ExternalRelocationEntry relocation;
 
     // Verifies that the last relocation is the end of a batch
-    GetEntry(external_relocation_num - 1, relocation);
+    GetEntry(memory, external_relocation_num - 1, relocation);
     if (!relocation.is_batch_end) {
         return CROFormatError(0x12);
     }
 
     bool batch_begin = true;
     for (u32 i = 0; i < external_relocation_num; ++i) {
-        GetEntry(i, relocation);
+        GetEntry(memory, i, relocation);
         VAddr relocation_target = SegmentTagToAddress(relocation.target_position);
 
         if (relocation_target == 0) {
@@ -500,7 +500,7 @@ ResultCode CROHelper::ResetExternalRelocations() {
         if (batch_begin) {
             // resets to unresolved state
             relocation.is_batch_resolved = 0;
-            SetEntry(i, relocation);
+            SetEntry(memory, i, relocation);
         }
 
         // if current is an end, then the next is a beginning
@@ -516,7 +516,7 @@ ResultCode CROHelper::ClearExternalRelocations() {
 
     bool batch_begin = true;
     for (u32 i = 0; i < external_relocation_num; ++i) {
-        GetEntry(i, relocation);
+        GetEntry(memory, i, relocation);
         VAddr relocation_target = SegmentTagToAddress(relocation.target_position);
 
         if (relocation_target == 0) {
@@ -532,7 +532,7 @@ ResultCode CROHelper::ClearExternalRelocations() {
         if (batch_begin) {
             // resets to unresolved state
             relocation.is_batch_resolved = 0;
-            SetEntry(i, relocation);
+            SetEntry(memory, i, relocation);
         }
 
         // if current is an end, then the next is a beginning
@@ -554,7 +554,7 @@ ResultCode CROHelper::ApplyStaticAnonymousSymbolToCRS(VAddr crs_address) {
              offset_export_num);
     for (u32 i = 0; i < offset_export_num; ++i) {
         StaticAnonymousSymbolEntry entry;
-        GetEntry(i, entry);
+        GetEntry(memory, i, entry);
         u32 batch_address = entry.relocation_batch_offset + module_address;
 
         if (batch_address < static_relocation_table_offset ||
@@ -579,7 +579,7 @@ ResultCode CROHelper::ApplyInternalRelocations(u32 old_data_segment_address) {
     u32 internal_relocation_num = GetField(InternalRelocationNum);
     for (u32 i = 0; i < internal_relocation_num; ++i) {
         InternalRelocationEntry relocation;
-        GetEntry(i, relocation);
+        GetEntry(memory, i, relocation);
         VAddr target_addressB = SegmentTagToAddress(relocation.target_position);
         if (target_addressB == 0) {
             return CROFormatError(0x15);
@@ -587,7 +587,7 @@ ResultCode CROHelper::ApplyInternalRelocations(u32 old_data_segment_address) {
 
         VAddr target_address;
         SegmentEntry target_segment;
-        GetEntry(relocation.target_position.segment_index, target_segment);
+        GetEntry(memory, relocation.target_position.segment_index, target_segment);
 
         if (target_segment.type == SegmentType::Data) {
             // If the relocation is to the .data segment, we need to relocate it in the old buffer
@@ -602,7 +602,7 @@ ResultCode CROHelper::ApplyInternalRelocations(u32 old_data_segment_address) {
         }
 
         SegmentEntry symbol_segment;
-        GetEntry(relocation.symbol_segment, symbol_segment);
+        GetEntry(memory, relocation.symbol_segment, symbol_segment);
         LOG_TRACE(Service_LDR, "Internally relocates 0x{:08X} with 0x{:08X}", target_address,
                   symbol_segment.offset);
         ResultCode result = ApplyRelocation(target_address, relocation.type, relocation.addend,
@@ -619,7 +619,7 @@ ResultCode CROHelper::ClearInternalRelocations() {
     u32 internal_relocation_num = GetField(InternalRelocationNum);
     for (u32 i = 0; i < internal_relocation_num; ++i) {
         InternalRelocationEntry relocation;
-        GetEntry(i, relocation);
+        GetEntry(memory, i, relocation);
         VAddr target_address = SegmentTagToAddress(relocation.target_position);
 
         if (target_address == 0) {
@@ -639,13 +639,13 @@ void CROHelper::UnrebaseImportAnonymousSymbolTable() {
     u32 num = GetField(ImportAnonymousSymbolNum);
     for (u32 i = 0; i < num; ++i) {
         ImportAnonymousSymbolEntry entry;
-        GetEntry(i, entry);
+        GetEntry(memory, i, entry);
 
         if (entry.relocation_batch_offset != 0) {
             entry.relocation_batch_offset -= module_address;
         }
 
-        SetEntry(i, entry);
+        SetEntry(memory, i, entry);
     }
 }
 
@@ -653,13 +653,13 @@ void CROHelper::UnrebaseImportIndexedSymbolTable() {
     u32 num = GetField(ImportIndexedSymbolNum);
     for (u32 i = 0; i < num; ++i) {
         ImportIndexedSymbolEntry entry;
-        GetEntry(i, entry);
+        GetEntry(memory, i, entry);
 
         if (entry.relocation_batch_offset != 0) {
             entry.relocation_batch_offset -= module_address;
         }
 
-        SetEntry(i, entry);
+        SetEntry(memory, i, entry);
     }
 }
 
@@ -667,7 +667,7 @@ void CROHelper::UnrebaseImportNamedSymbolTable() {
     u32 num = GetField(ImportNamedSymbolNum);
     for (u32 i = 0; i < num; ++i) {
         ImportNamedSymbolEntry entry;
-        GetEntry(i, entry);
+        GetEntry(memory, i, entry);
 
         if (entry.name_offset != 0) {
             entry.name_offset -= module_address;
@@ -677,7 +677,7 @@ void CROHelper::UnrebaseImportNamedSymbolTable() {
             entry.relocation_batch_offset -= module_address;
         }
 
-        SetEntry(i, entry);
+        SetEntry(memory, i, entry);
     }
 }
 
@@ -685,7 +685,7 @@ void CROHelper::UnrebaseImportModuleTable() {
     u32 module_num = GetField(ImportModuleNum);
     for (u32 i = 0; i < module_num; ++i) {
         ImportModuleEntry entry;
-        GetEntry(i, entry);
+        GetEntry(memory, i, entry);
 
         if (entry.name_offset != 0) {
             entry.name_offset -= module_address;
@@ -699,7 +699,7 @@ void CROHelper::UnrebaseImportModuleTable() {
             entry.import_anonymous_symbol_table_offset -= module_address;
         }
 
-        SetEntry(i, entry);
+        SetEntry(memory, i, entry);
     }
 }
 
@@ -707,13 +707,13 @@ void CROHelper::UnrebaseExportNamedSymbolTable() {
     u32 export_named_symbol_num = GetField(ExportNamedSymbolNum);
     for (u32 i = 0; i < export_named_symbol_num; ++i) {
         ExportNamedSymbolEntry entry;
-        GetEntry(i, entry);
+        GetEntry(memory, i, entry);
 
         if (entry.name_offset != 0) {
             entry.name_offset -= module_address;
         }
 
-        SetEntry(i, entry);
+        SetEntry(memory, i, entry);
     }
 }
 
@@ -721,7 +721,7 @@ void CROHelper::UnrebaseSegmentTable() {
     u32 segment_num = GetField(SegmentNum);
     for (u32 i = 0; i < segment_num; ++i) {
         SegmentEntry segment;
-        GetEntry(i, segment);
+        GetEntry(memory, i, segment);
 
         if (segment.type == SegmentType::BSS) {
             segment.offset = 0;
@@ -729,7 +729,7 @@ void CROHelper::UnrebaseSegmentTable() {
             segment.offset -= module_address;
         }
 
-        SetEntry(i, segment);
+        SetEntry(memory, i, segment);
     }
 }
 
@@ -751,11 +751,11 @@ ResultCode CROHelper::ApplyImportNamedSymbol(VAddr crs_address) {
     u32 symbol_import_num = GetField(ImportNamedSymbolNum);
     for (u32 i = 0; i < symbol_import_num; ++i) {
         ImportNamedSymbolEntry entry;
-        GetEntry(i, entry);
+        GetEntry(memory, i, entry);
         VAddr relocation_addr = entry.relocation_batch_offset;
         ExternalRelocationEntry relocation_entry;
-        Memory::ReadBlock(process, relocation_addr, &relocation_entry,
-                          sizeof(ExternalRelocationEntry));
+        memory.ReadBlock(process, relocation_addr, &relocation_entry,
+                         sizeof(ExternalRelocationEntry));
 
         if (!relocation_entry.is_batch_resolved) {
             ResultCode result = ForEachAutoLinkCRO(
@@ -794,11 +794,11 @@ ResultCode CROHelper::ResetImportNamedSymbol() {
     u32 symbol_import_num = GetField(ImportNamedSymbolNum);
     for (u32 i = 0; i < symbol_import_num; ++i) {
         ImportNamedSymbolEntry entry;
-        GetEntry(i, entry);
+        GetEntry(memory, i, entry);
         VAddr relocation_addr = entry.relocation_batch_offset;
         ExternalRelocationEntry relocation_entry;
-        Memory::ReadBlock(process, relocation_addr, &relocation_entry,
-                          sizeof(ExternalRelocationEntry));
+        memory.ReadBlock(process, relocation_addr, &relocation_entry,
+                         sizeof(ExternalRelocationEntry));
 
         ResultCode result = ApplyRelocationBatch(relocation_addr, unresolved_symbol, true);
         if (result.IsError()) {
@@ -815,11 +815,11 @@ ResultCode CROHelper::ResetImportIndexedSymbol() {
     u32 import_num = GetField(ImportIndexedSymbolNum);
     for (u32 i = 0; i < import_num; ++i) {
         ImportIndexedSymbolEntry entry;
-        GetEntry(i, entry);
+        GetEntry(memory, i, entry);
         VAddr relocation_addr = entry.relocation_batch_offset;
         ExternalRelocationEntry relocation_entry;
-        Memory::ReadBlock(process, relocation_addr, &relocation_entry,
-                          sizeof(ExternalRelocationEntry));
+        memory.ReadBlock(process, relocation_addr, &relocation_entry,
+                         sizeof(ExternalRelocationEntry));
 
         ResultCode result = ApplyRelocationBatch(relocation_addr, unresolved_symbol, true);
         if (result.IsError()) {
@@ -836,11 +836,11 @@ ResultCode CROHelper::ResetImportAnonymousSymbol() {
     u32 import_num = GetField(ImportAnonymousSymbolNum);
     for (u32 i = 0; i < import_num; ++i) {
         ImportAnonymousSymbolEntry entry;
-        GetEntry(i, entry);
+        GetEntry(memory, i, entry);
         VAddr relocation_addr = entry.relocation_batch_offset;
         ExternalRelocationEntry relocation_entry;
-        Memory::ReadBlock(process, relocation_addr, &relocation_entry,
-                          sizeof(ExternalRelocationEntry));
+        memory.ReadBlock(process, relocation_addr, &relocation_entry,
+                         sizeof(ExternalRelocationEntry));
 
         ResultCode result = ApplyRelocationBatch(relocation_addr, unresolved_symbol, true);
         if (result.IsError()) {
@@ -857,7 +857,7 @@ ResultCode CROHelper::ApplyModuleImport(VAddr crs_address) {
     u32 import_module_num = GetField(ImportModuleNum);
     for (u32 i = 0; i < import_module_num; ++i) {
         ImportModuleEntry entry;
-        GetEntry(i, entry);
+        GetEntry(memory, i, entry);
         std::string want_cro_name = memory.ReadCString(entry.name_offset, import_strings_size);
 
         ResultCode result = ForEachAutoLinkCRO(
@@ -867,9 +867,9 @@ ResultCode CROHelper::ApplyModuleImport(VAddr crs_address) {
                              ModuleName(), entry.import_indexed_symbol_num, source.ModuleName());
                     for (u32 j = 0; j < entry.import_indexed_symbol_num; ++j) {
                         ImportIndexedSymbolEntry im;
-                        entry.GetImportIndexedSymbolEntry(process, j, im);
+                        entry.GetImportIndexedSymbolEntry(process, memory, j, im);
                         ExportIndexedSymbolEntry ex;
-                        source.GetEntry(im.index, ex);
+                        source.GetEntry(memory, im.index, ex);
                         u32 symbol_address = source.SegmentTagToAddress(ex.symbol_position);
                         LOG_TRACE(Service_LDR, "    Imports 0x{:08X}", symbol_address);
                         ResultCode result =
@@ -884,7 +884,7 @@ ResultCode CROHelper::ApplyModuleImport(VAddr crs_address) {
                              ModuleName(), entry.import_anonymous_symbol_num, source.ModuleName());
                     for (u32 j = 0; j < entry.import_anonymous_symbol_num; ++j) {
                         ImportAnonymousSymbolEntry im;
-                        entry.GetImportAnonymousSymbolEntry(process, j, im);
+                        entry.GetImportAnonymousSymbolEntry(process, memory, j, im);
                         u32 symbol_address = source.SegmentTagToAddress(im.symbol_position);
                         LOG_TRACE(Service_LDR, "    Imports 0x{:08X}", symbol_address);
                         ResultCode result =
@@ -913,11 +913,11 @@ ResultCode CROHelper::ApplyExportNamedSymbol(CROHelper target) {
     u32 target_symbol_import_num = target.GetField(ImportNamedSymbolNum);
     for (u32 i = 0; i < target_symbol_import_num; ++i) {
         ImportNamedSymbolEntry entry;
-        target.GetEntry(i, entry);
+        target.GetEntry(memory, i, entry);
         VAddr relocation_addr = entry.relocation_batch_offset;
         ExternalRelocationEntry relocation_entry;
-        Memory::ReadBlock(process, relocation_addr, &relocation_entry,
-                          sizeof(ExternalRelocationEntry));
+        memory.ReadBlock(process, relocation_addr, &relocation_entry,
+                         sizeof(ExternalRelocationEntry));
 
         if (!relocation_entry.is_batch_resolved) {
             std::string symbol_name =
@@ -944,11 +944,11 @@ ResultCode CROHelper::ResetExportNamedSymbol(CROHelper target) {
     u32 target_symbol_import_num = target.GetField(ImportNamedSymbolNum);
     for (u32 i = 0; i < target_symbol_import_num; ++i) {
         ImportNamedSymbolEntry entry;
-        target.GetEntry(i, entry);
+        target.GetEntry(memory, i, entry);
         VAddr relocation_addr = entry.relocation_batch_offset;
         ExternalRelocationEntry relocation_entry;
-        Memory::ReadBlock(process, relocation_addr, &relocation_entry,
-                          sizeof(ExternalRelocationEntry));
+        memory.ReadBlock(process, relocation_addr, &relocation_entry,
+                         sizeof(ExternalRelocationEntry));
 
         if (relocation_entry.is_batch_resolved) {
             std::string symbol_name =
@@ -974,7 +974,7 @@ ResultCode CROHelper::ApplyModuleExport(CROHelper target) {
     u32 target_import_module_num = target.GetField(ImportModuleNum);
     for (u32 i = 0; i < target_import_module_num; ++i) {
         ImportModuleEntry entry;
-        target.GetEntry(i, entry);
+        target.GetEntry(memory, i, entry);
 
         if (memory.ReadCString(entry.name_offset, target_import_string_size) != module_name)
             continue;
@@ -983,9 +983,9 @@ ResultCode CROHelper::ApplyModuleExport(CROHelper target) {
                  entry.import_indexed_symbol_num, target.ModuleName());
         for (u32 j = 0; j < entry.import_indexed_symbol_num; ++j) {
             ImportIndexedSymbolEntry im;
-            entry.GetImportIndexedSymbolEntry(process, j, im);
+            entry.GetImportIndexedSymbolEntry(process, memory, j, im);
             ExportIndexedSymbolEntry ex;
-            GetEntry(im.index, ex);
+            GetEntry(memory, im.index, ex);
             u32 symbol_address = SegmentTagToAddress(ex.symbol_position);
             LOG_TRACE(Service_LDR, "    exports symbol 0x{:08X}", symbol_address);
             ResultCode result =
@@ -1000,7 +1000,7 @@ ResultCode CROHelper::ApplyModuleExport(CROHelper target) {
                  entry.import_anonymous_symbol_num, target.ModuleName());
         for (u32 j = 0; j < entry.import_anonymous_symbol_num; ++j) {
             ImportAnonymousSymbolEntry im;
-            entry.GetImportAnonymousSymbolEntry(process, j, im);
+            entry.GetImportAnonymousSymbolEntry(process, memory, j, im);
             u32 symbol_address = SegmentTagToAddress(im.symbol_position);
             LOG_TRACE(Service_LDR, "    exports symbol 0x{:08X}", symbol_address);
             ResultCode result =
@@ -1023,7 +1023,7 @@ ResultCode CROHelper::ResetModuleExport(CROHelper target) {
     u32 target_import_module_num = target.GetField(ImportModuleNum);
     for (u32 i = 0; i < target_import_module_num; ++i) {
         ImportModuleEntry entry;
-        target.GetEntry(i, entry);
+        target.GetEntry(memory, i, entry);
 
         if (memory.ReadCString(entry.name_offset, target_import_string_size) != module_name)
             continue;
@@ -1032,7 +1032,7 @@ ResultCode CROHelper::ResetModuleExport(CROHelper target) {
                   target.ModuleName());
         for (u32 j = 0; j < entry.import_indexed_symbol_num; ++j) {
             ImportIndexedSymbolEntry im;
-            entry.GetImportIndexedSymbolEntry(process, j, im);
+            entry.GetImportIndexedSymbolEntry(process, memory, j, im);
             ResultCode result =
                 target.ApplyRelocationBatch(im.relocation_batch_offset, unresolved_symbol, true);
             if (result.IsError()) {
@@ -1045,7 +1045,7 @@ ResultCode CROHelper::ResetModuleExport(CROHelper target) {
                   target.ModuleName());
         for (u32 j = 0; j < entry.import_anonymous_symbol_num; ++j) {
             ImportAnonymousSymbolEntry im;
-            entry.GetImportAnonymousSymbolEntry(process, j, im);
+            entry.GetImportAnonymousSymbolEntry(process, memory, j, im);
             ResultCode result =
                 target.ApplyRelocationBatch(im.relocation_batch_offset, unresolved_symbol, true);
             if (result.IsError()) {
@@ -1063,11 +1063,11 @@ ResultCode CROHelper::ApplyExitRelocations(VAddr crs_address) {
     u32 symbol_import_num = GetField(ImportNamedSymbolNum);
     for (u32 i = 0; i < symbol_import_num; ++i) {
         ImportNamedSymbolEntry entry;
-        GetEntry(i, entry);
+        GetEntry(memory, i, entry);
         VAddr relocation_addr = entry.relocation_batch_offset;
         ExternalRelocationEntry relocation_entry;
-        Memory::ReadBlock(process, relocation_addr, &relocation_entry,
-                          sizeof(ExternalRelocationEntry));
+        memory.ReadBlock(process, relocation_addr, &relocation_entry,
+                         sizeof(ExternalRelocationEntry));
 
         if (memory.ReadCString(entry.name_offset, import_strings_size) == "__aeabi_atexit") {
             ResultCode result = ForEachAutoLinkCRO(
@@ -1266,11 +1266,11 @@ ResultCode CROHelper::Link(VAddr crs_address, bool link_on_load_bug_fix) {
             // so we do the same
             if (GetField(SegmentNum) >= 2) { // means we have .data segment
                 SegmentEntry entry;
-                GetEntry(2, entry);
+                GetEntry(memory, 2, entry);
                 ASSERT(entry.type == SegmentType::Data);
                 data_segment_address = entry.offset;
                 entry.offset = GetField(DataOffset);
-                SetEntry(2, entry);
+                SetEntry(memory, 2, entry);
             }
         }
         SCOPE_EXIT({
@@ -1278,9 +1278,9 @@ ResultCode CROHelper::Link(VAddr crs_address, bool link_on_load_bug_fix) {
             if (link_on_load_bug_fix) {
                 if (GetField(SegmentNum) >= 2) {
                     SegmentEntry entry;
-                    GetEntry(2, entry);
+                    GetEntry(memory, 2, entry);
                     entry.offset = data_segment_address;
-                    SetEntry(2, entry);
+                    SetEntry(memory, 2, entry);
                 }
             }
         });
@@ -1516,7 +1516,7 @@ std::tuple<VAddr, u32> CROHelper::GetExecutablePages() const {
     u32 segment_num = GetField(SegmentNum);
     for (u32 i = 0; i < segment_num; ++i) {
         SegmentEntry entry;
-        GetEntry(i, entry);
+        GetEntry(memory, i, entry);
         if (entry.type == SegmentType::Code && entry.size != 0) {
             VAddr begin = Common::AlignDown(entry.offset, Memory::PAGE_SIZE);
             VAddr end = Common::AlignUp(entry.offset + entry.size, Memory::PAGE_SIZE);

--- a/src/core/hle/service/ldr_ro/cro_helper.cpp
+++ b/src/core/hle/service/ldr_ro/cro_helper.cpp
@@ -1420,9 +1420,10 @@ void CROHelper::Register(VAddr crs_address, bool auto_link) {
 
 void CROHelper::Unregister(VAddr crs_address) {
     CROHelper crs(crs_address, process, memory);
-    CROHelper next_head(crs.NextModule(), process, memory),
-        previous_head(crs.PreviousModule(), process, memory);
-    CROHelper next(NextModule(), process, memory), previous(PreviousModule(), process, memory);
+    CROHelper next_head(crs.NextModule(), process, memory);
+    CROHelper previous_head(crs.PreviousModule(), process, memory);
+    CROHelper next(NextModule(), process, memory);
+    CROHelper previous(PreviousModule(), process, memory);
 
     if (module_address == next_head.module_address ||
         module_address == previous_head.module_address) {

--- a/src/core/hle/service/ldr_ro/cro_helper.h
+++ b/src/core/hle/service/ldr_ro/cro_helper.h
@@ -44,7 +44,7 @@ public:
         : module_address(cro_address), process(process), memory(memory) {}
 
     std::string ModuleName() const {
-        return Memory::ReadCString(GetField(ModuleNameOffset), GetField(ModuleNameSize));
+        return memory.ReadCString(GetField(ModuleNameOffset), GetField(ModuleNameSize));
     }
 
     u32 GetFileSize() const {
@@ -408,11 +408,11 @@ private:
     }
 
     u32 GetField(HeaderField field) const {
-        return Memory::Read32(Field(field));
+        return memory.Read32(Field(field));
     }
 
     void SetField(HeaderField field, u32 value) {
-        Memory::Write32(Field(field), value);
+        memory.Write32(Field(field), value);
     }
 
     /**

--- a/src/core/hle/service/ldr_ro/cro_helper.h
+++ b/src/core/hle/service/ldr_ro/cro_helper.h
@@ -318,20 +318,20 @@ private:
 
         static constexpr HeaderField TABLE_OFFSET_FIELD = ImportModuleTableOffset;
 
-        void GetImportIndexedSymbolEntry(Kernel::Process& process, u32 index,
-                                         ImportIndexedSymbolEntry& entry) {
-            Memory::ReadBlock(process,
-                              import_indexed_symbol_table_offset +
-                                  index * sizeof(ImportIndexedSymbolEntry),
-                              &entry, sizeof(ImportIndexedSymbolEntry));
+        void GetImportIndexedSymbolEntry(Kernel::Process& process, Memory::MemorySystem& memory,
+                                         u32 index, ImportIndexedSymbolEntry& entry) {
+            memory.ReadBlock(process,
+                             import_indexed_symbol_table_offset +
+                                 index * sizeof(ImportIndexedSymbolEntry),
+                             &entry, sizeof(ImportIndexedSymbolEntry));
         }
 
-        void GetImportAnonymousSymbolEntry(Kernel::Process& process, u32 index,
-                                           ImportAnonymousSymbolEntry& entry) {
-            Memory::ReadBlock(process,
-                              import_anonymous_symbol_table_offset +
-                                  index * sizeof(ImportAnonymousSymbolEntry),
-                              &entry, sizeof(ImportAnonymousSymbolEntry));
+        void GetImportAnonymousSymbolEntry(Kernel::Process& process, Memory::MemorySystem& memory,
+                                           u32 index, ImportAnonymousSymbolEntry& entry) {
+            memory.ReadBlock(process,
+                             import_anonymous_symbol_table_offset +
+                                 index * sizeof(ImportAnonymousSymbolEntry),
+                             &entry, sizeof(ImportAnonymousSymbolEntry));
         }
     };
     ASSERT_CRO_STRUCT(ImportModuleEntry, 20);
@@ -423,10 +423,10 @@ private:
      *       indicating which table the entry is in.
      */
     template <typename T>
-    void GetEntry(std::size_t index, T& data) const {
-        Memory::ReadBlock(process,
-                          GetField(T::TABLE_OFFSET_FIELD) + static_cast<u32>(index * sizeof(T)),
-                          &data, sizeof(T));
+    void GetEntry(Memory::MemorySystem& memory, std::size_t index, T& data) const {
+        memory.ReadBlock(process,
+                         GetField(T::TABLE_OFFSET_FIELD) + static_cast<u32>(index * sizeof(T)),
+                         &data, sizeof(T));
     }
 
     /**
@@ -437,10 +437,10 @@ private:
      *       indicating which table the entry is in.
      */
     template <typename T>
-    void SetEntry(std::size_t index, const T& data) {
-        Memory::WriteBlock(process,
-                           GetField(T::TABLE_OFFSET_FIELD) + static_cast<u32>(index * sizeof(T)),
-                           &data, sizeof(T));
+    void SetEntry(Memory::MemorySystem& memory, std::size_t index, const T& data) {
+        memory.WriteBlock(process,
+                          GetField(T::TABLE_OFFSET_FIELD) + static_cast<u32>(index * sizeof(T)),
+                          &data, sizeof(T));
     }
 
     /**

--- a/src/core/hle/service/ldr_ro/ldr_ro.cpp
+++ b/src/core/hle/service/ldr_ro/ldr_ro.cpp
@@ -115,7 +115,7 @@ void RO::Initialize(Kernel::HLERequestContext& ctx) {
         return;
     }
 
-    CROHelper crs(crs_address, *process);
+    CROHelper crs(crs_address, *process, system.Memory());
     crs.InitCRS();
 
     result = crs.Rebase(0, crs_size, 0, 0, 0, 0, true);
@@ -249,7 +249,7 @@ void RO::LoadCRO(Kernel::HLERequestContext& ctx, bool link_on_load_bug_fix) {
         return;
     }
 
-    CROHelper cro(cro_address, *process);
+    CROHelper cro(cro_address, *process, system.Memory());
 
     result = cro.VerifyHash(cro_size, crr_address);
     if (result.IsError()) {
@@ -331,7 +331,7 @@ void RO::UnloadCRO(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_LDR, "called, cro_address=0x{:08X}, zero={}, cro_buffer_ptr=0x{:08X}",
               cro_address, zero, cro_buffer_ptr);
 
-    CROHelper cro(cro_address, *process);
+    CROHelper cro(cro_address, *process, system.Memory());
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
 
@@ -398,7 +398,7 @@ void RO::LinkCRO(Kernel::HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_LDR, "called, cro_address=0x{:08X}", cro_address);
 
-    CROHelper cro(cro_address, *process);
+    CROHelper cro(cro_address, *process, system.Memory());
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
 
@@ -438,7 +438,7 @@ void RO::UnlinkCRO(Kernel::HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_LDR, "called, cro_address=0x{:08X}", cro_address);
 
-    CROHelper cro(cro_address, *process);
+    CROHelper cro(cro_address, *process, system.Memory());
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
 
@@ -487,7 +487,7 @@ void RO::Shutdown(Kernel::HLERequestContext& ctx) {
         return;
     }
 
-    CROHelper crs(slot->loaded_crs, *process);
+    CROHelper crs(slot->loaded_crs, *process, system.Memory());
     crs.Unrebase(true);
 
     ResultCode result = RESULT_SUCCESS;
@@ -502,7 +502,7 @@ void RO::Shutdown(Kernel::HLERequestContext& ctx) {
     rb.Push(result);
 }
 
-RO::RO() : ServiceFramework("ldr:ro", 2) {
+RO::RO(Core::System& system) : ServiceFramework("ldr:ro", 2), system(system) {
     static const FunctionInfo functions[] = {
         {0x000100C2, &RO::Initialize, "Initialize"},
         {0x00020082, &RO::LoadCRR, "LoadCRR"},
@@ -519,7 +519,7 @@ RO::RO() : ServiceFramework("ldr:ro", 2) {
 
 void InstallInterfaces(Core::System& system) {
     auto& service_manager = system.ServiceManager();
-    std::make_shared<RO>()->InstallAsService(service_manager);
+    std::make_shared<RO>(system)->InstallAsService(service_manager);
 }
 
 } // namespace Service::LDR

--- a/src/core/hle/service/ldr_ro/ldr_ro.h
+++ b/src/core/hle/service/ldr_ro/ldr_ro.h
@@ -18,7 +18,7 @@ struct ClientSlot : public Kernel::SessionRequestHandler::SessionDataBase {
 
 class RO final : public ServiceFramework<RO, ClientSlot> {
 public:
-    RO();
+    explicit RO(Core::System& system);
 
 private:
     /**
@@ -149,6 +149,8 @@ private:
      *      1 : Result of function, 0 on success, otherwise error code
      */
     void Shutdown(Kernel::HLERequestContext& self);
+
+    Core::System& system;
 };
 
 void InstallInterfaces(Core::System& system);

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -180,7 +180,8 @@ void ServiceFrameworkBase::HandleSyncRequest(SharedPtr<ServerSession> server_ses
     Kernel::KernelSystem& kernel = Core::System::GetInstance().Kernel();
     auto thread = kernel.GetThreadManager().GetCurrentThread();
     // TODO(wwylele): avoid GetPointer
-    u32* cmd_buf = reinterpret_cast<u32*>(Memory::GetPointer(thread->GetCommandBufferAddress()));
+    u32* cmd_buf = reinterpret_cast<u32*>(
+        Core::System::GetInstance().Memory().GetPointer(thread->GetCommandBufferAddress()));
 
     u32 header_code = cmd_buf[0];
     auto itr = handlers.find(header_code);

--- a/src/core/hw/gpu.cpp
+++ b/src/core/hw/gpu.cpp
@@ -79,12 +79,12 @@ static void MemoryFill(const Regs::MemoryFillConfig& config) {
     const PAddr end_addr = config.GetEndAddress();
 
     // TODO: do hwtest with these cases
-    if (!Memory::IsValidPhysicalAddress(start_addr)) {
+    if (!g_memory->IsValidPhysicalAddress(start_addr)) {
         LOG_CRITICAL(HW_GPU, "invalid start address {:#010X}", start_addr);
         return;
     }
 
-    if (!Memory::IsValidPhysicalAddress(end_addr)) {
+    if (!g_memory->IsValidPhysicalAddress(end_addr)) {
         LOG_CRITICAL(HW_GPU, "invalid end address {:#010X}", end_addr);
         return;
     }
@@ -95,8 +95,8 @@ static void MemoryFill(const Regs::MemoryFillConfig& config) {
         return;
     }
 
-    u8* start = Memory::GetPhysicalPointer(start_addr);
-    u8* end = Memory::GetPhysicalPointer(end_addr);
+    u8* start = g_memory->GetPhysicalPointer(start_addr);
+    u8* end = g_memory->GetPhysicalPointer(end_addr);
 
     if (VideoCore::g_renderer->Rasterizer()->AccelerateFill(config))
         return;
@@ -132,12 +132,12 @@ static void DisplayTransfer(const Regs::DisplayTransferConfig& config) {
     const PAddr dst_addr = config.GetPhysicalOutputAddress();
 
     // TODO: do hwtest with these cases
-    if (!Memory::IsValidPhysicalAddress(src_addr)) {
+    if (!g_memory->IsValidPhysicalAddress(src_addr)) {
         LOG_CRITICAL(HW_GPU, "invalid input address {:#010X}", src_addr);
         return;
     }
 
-    if (!Memory::IsValidPhysicalAddress(dst_addr)) {
+    if (!g_memory->IsValidPhysicalAddress(dst_addr)) {
         LOG_CRITICAL(HW_GPU, "invalid output address {:#010X}", dst_addr);
         return;
     }
@@ -165,8 +165,8 @@ static void DisplayTransfer(const Regs::DisplayTransferConfig& config) {
     if (VideoCore::g_renderer->Rasterizer()->AccelerateDisplayTransfer(config))
         return;
 
-    u8* src_pointer = Memory::GetPhysicalPointer(src_addr);
-    u8* dst_pointer = Memory::GetPhysicalPointer(dst_addr);
+    u8* src_pointer = g_memory->GetPhysicalPointer(src_addr);
+    u8* dst_pointer = g_memory->GetPhysicalPointer(dst_addr);
 
     if (config.scaling > config.ScaleXY) {
         LOG_CRITICAL(HW_GPU, "Unimplemented display transfer scaling mode {}",
@@ -308,12 +308,12 @@ static void TextureCopy(const Regs::DisplayTransferConfig& config) {
     const PAddr dst_addr = config.GetPhysicalOutputAddress();
 
     // TODO: do hwtest with invalid addresses
-    if (!Memory::IsValidPhysicalAddress(src_addr)) {
+    if (!g_memory->IsValidPhysicalAddress(src_addr)) {
         LOG_CRITICAL(HW_GPU, "invalid input address {:#010X}", src_addr);
         return;
     }
 
-    if (!Memory::IsValidPhysicalAddress(dst_addr)) {
+    if (!g_memory->IsValidPhysicalAddress(dst_addr)) {
         LOG_CRITICAL(HW_GPU, "invalid output address {:#010X}", dst_addr);
         return;
     }
@@ -321,8 +321,8 @@ static void TextureCopy(const Regs::DisplayTransferConfig& config) {
     if (VideoCore::g_renderer->Rasterizer()->AccelerateTextureCopy(config))
         return;
 
-    u8* src_pointer = Memory::GetPhysicalPointer(src_addr);
-    u8* dst_pointer = Memory::GetPhysicalPointer(dst_addr);
+    u8* src_pointer = g_memory->GetPhysicalPointer(src_addr);
+    u8* dst_pointer = g_memory->GetPhysicalPointer(dst_addr);
 
     u32 remaining_size = Common::AlignDown(config.texture_copy.size, 16);
 
@@ -471,7 +471,7 @@ inline void Write(u32 addr, const T data) {
         if (config.trigger & 1) {
             MICROPROFILE_SCOPE(GPU_CmdlistProcessing);
 
-            u32* buffer = (u32*)Memory::GetPhysicalPointer(config.GetPhysicalAddress());
+            u32* buffer = (u32*)g_memory->GetPhysicalPointer(config.GetPhysicalAddress());
 
             if (Pica::g_debug_context && Pica::g_debug_context->recorder) {
                 Pica::g_debug_context->recorder->MemoryAccessed((u8*)buffer, config.size,

--- a/src/core/hw/gpu.cpp
+++ b/src/core/hw/gpu.cpp
@@ -27,6 +27,7 @@
 namespace GPU {
 
 Regs g_regs;
+Memory::MemorySystem* g_memory;
 
 /// 268MHz CPU clocks / 60Hz frames per second
 const u64 frame_ticks = static_cast<u64>(BASE_CLOCK_RATE_ARM11 / SCREEN_REFRESH_RATE);
@@ -526,7 +527,8 @@ static void VBlankCallback(u64 userdata, s64 cycles_late) {
 }
 
 /// Initialize hardware
-void Init() {
+void Init(Memory::MemorySystem& memory) {
+    g_memory = &memory;
     memset(&g_regs, 0, sizeof(g_regs));
 
     auto& framebuffer_top = g_regs.framebuffer_config[0];

--- a/src/core/hw/gpu.h
+++ b/src/core/hw/gpu.h
@@ -11,6 +11,10 @@
 #include "common/common_funcs.h"
 #include "common/common_types.h"
 
+namespace Memory {
+class MemorySystem;
+}
+
 namespace GPU {
 
 constexpr float SCREEN_REFRESH_RATE = 60;
@@ -326,7 +330,7 @@ template <typename T>
 void Write(u32 addr, const T data);
 
 /// Initialize hardware
-void Init();
+void Init(Memory::MemorySystem& memory);
 
 /// Shutdown hardware
 void Shutdown();

--- a/src/core/hw/hw.cpp
+++ b/src/core/hw/hw.cpp
@@ -86,9 +86,9 @@ template void Write<u8>(u32 addr, const u8 data);
 void Update() {}
 
 /// Initialize hardware
-void Init() {
+void Init(Memory::MemorySystem& memory) {
     AES::InitKeys();
-    GPU::Init();
+    GPU::Init(memory);
     LCD::Init();
     LOG_DEBUG(HW, "initialized OK");
 }

--- a/src/core/hw/hw.h
+++ b/src/core/hw/hw.h
@@ -6,6 +6,10 @@
 
 #include "common/common_types.h"
 
+namespace Memory {
+class MemorySystem;
+}
+
 namespace HW {
 
 /// Beginnings of IO register regions, in the user VA space.
@@ -42,7 +46,7 @@ void Write(u32 addr, const T data);
 void Update();
 
 /// Initialize hardware
-void Init();
+void Init(Memory::MemorySystem& memory);
 
 /// Shutdown hardware
 void Shutdown();

--- a/src/core/hw/y2r.cpp
+++ b/src/core/hw/y2r.cpp
@@ -10,6 +10,7 @@
 #include "common/color.h"
 #include "common/common_types.h"
 #include "common/vector_math.h"
+#include "core/core.h"
 #include "core/hle/service/y2r_u.h"
 #include "core/hw/y2r.h"
 #include "core/memory.h"
@@ -80,7 +81,7 @@ static void ConvertYUVToRGB(InputFormat input_format, const u8* input_Y, const u
 /// formats to 8-bit.
 template <std::size_t N>
 static void ReceiveData(u8* output, ConversionBuffer& buf, std::size_t amount_of_data) {
-    const u8* input = Memory::GetPointer(buf.address);
+    const u8* input = Core::System::GetInstance().Memory().GetPointer(buf.address);
 
     std::size_t output_unit = buf.transfer_unit / N;
     ASSERT(amount_of_data % output_unit == 0);
@@ -104,7 +105,7 @@ static void ReceiveData(u8* output, ConversionBuffer& buf, std::size_t amount_of
 static void SendData(const u32* input, ConversionBuffer& buf, int amount_of_data,
                      OutputFormat output_format, u8 alpha) {
 
-    u8* output = Memory::GetPointer(buf.address);
+    u8* output = Core::System::GetInstance().Memory().GetPointer(buf.address);
 
     while (amount_of_data > 0) {
         u8* unit_end = output + buf.transfer_unit;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -21,12 +21,6 @@
 
 namespace Memory {
 
-static std::array<u8, Memory::VRAM_SIZE> vram;
-static std::array<u8, Memory::N3DS_EXTRA_RAM_SIZE> n3ds_extra_ram;
-std::array<u8, Memory::FCRAM_N3DS_SIZE> fcram;
-
-static PageTable* current_page_table = nullptr;
-
 void MemorySystem::SetCurrentPageTable(PageTable* page_table) {
     current_page_table = page_table;
     if (Core::System::GetInstance().IsPoweredOn()) {
@@ -78,13 +72,7 @@ void UnmapRegion(PageTable& page_table, VAddr base, u32 size) {
     MapPages(page_table, base / PAGE_SIZE, size / PAGE_SIZE, nullptr, PageType::Unmapped);
 }
 
-/**
- * Gets the pointer for virtual memory where the page is marked as RasterizerCachedMemory.
- * This is used to access the memory where the page pointer is nullptr due to rasterizer cache.
- * Since the cache only happens on linear heap or VRAM, we know the exact physical address and
- * pointer of such virtual address
- */
-static u8* GetPointerForRasterizerCache(VAddr addr) {
+u8* MemorySystem::GetPointerForRasterizerCache(VAddr addr) {
     if (addr >= LINEAR_HEAP_VADDR && addr < LINEAR_HEAP_VADDR_END) {
         return fcram.data() + (addr - LINEAR_HEAP_VADDR);
     }

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -206,7 +206,7 @@ bool IsValidVirtualAddress(const Kernel::Process& process, const VAddr vaddr) {
     return false;
 }
 
-bool IsValidPhysicalAddress(const PAddr paddr) {
+bool MemorySystem::IsValidPhysicalAddress(const PAddr paddr) {
     return GetPhysicalPointer(paddr) != nullptr;
 }
 
@@ -238,7 +238,7 @@ std::string ReadCString(VAddr vaddr, std::size_t max_length) {
     return string;
 }
 
-u8* GetPhysicalPointer(PAddr address) {
+u8* MemorySystem::GetPhysicalPointer(PAddr address) {
     struct MemoryArea {
         PAddr paddr_base;
         u32 size;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -210,7 +210,7 @@ bool MemorySystem::IsValidPhysicalAddress(const PAddr paddr) {
     return GetPhysicalPointer(paddr) != nullptr;
 }
 
-u8* GetPointer(const VAddr vaddr) {
+u8* MemorySystem::GetPointer(const VAddr vaddr) {
     u8* page_pointer = current_page_table->pointers[vaddr >> PAGE_BITS];
     if (page_pointer) {
         return page_pointer + (vaddr & PAGE_MASK);

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -433,8 +433,8 @@ u64 MemorySystem::Read64(const VAddr addr) {
     return Read<u64_le>(addr);
 }
 
-void ReadBlock(const Kernel::Process& process, const VAddr src_addr, void* dest_buffer,
-               const std::size_t size) {
+void MemorySystem::ReadBlock(const Kernel::Process& process, const VAddr src_addr,
+                             void* dest_buffer, const std::size_t size) {
     auto& page_table = process.vm_manager.page_table;
 
     std::size_t remaining_size = size;
@@ -499,8 +499,8 @@ void MemorySystem::Write64(const VAddr addr, const u64 data) {
     Write<u64_le>(addr, data);
 }
 
-void WriteBlock(const Kernel::Process& process, const VAddr dest_addr, const void* src_buffer,
-                const std::size_t size) {
+void MemorySystem::WriteBlock(const Kernel::Process& process, const VAddr dest_addr,
+                              const void* src_buffer, const std::size_t size) {
     auto& page_table = process.vm_manager.page_table;
     std::size_t remaining_size = size;
     std::size_t page_index = dest_addr >> PAGE_BITS;
@@ -547,7 +547,8 @@ void WriteBlock(const Kernel::Process& process, const VAddr dest_addr, const voi
     }
 }
 
-void ZeroBlock(const Kernel::Process& process, const VAddr dest_addr, const std::size_t size) {
+void MemorySystem::ZeroBlock(const Kernel::Process& process, const VAddr dest_addr,
+                             const std::size_t size) {
     auto& page_table = process.vm_manager.page_table;
     std::size_t remaining_size = size;
     std::size_t page_index = dest_addr >> PAGE_BITS;
@@ -595,8 +596,8 @@ void ZeroBlock(const Kernel::Process& process, const VAddr dest_addr, const std:
     }
 }
 
-void CopyBlock(const Kernel::Process& process, VAddr dest_addr, VAddr src_addr,
-               const std::size_t size) {
+void MemorySystem::CopyBlock(const Kernel::Process& process, VAddr dest_addr, VAddr src_addr,
+                             const std::size_t size) {
     auto& page_table = process.vm_manager.page_table;
     std::size_t remaining_size = size;
     std::size_t page_index = src_addr >> PAGE_BITS;
@@ -647,8 +648,9 @@ void CopyBlock(const Kernel::Process& process, VAddr dest_addr, VAddr src_addr,
     }
 }
 
-void CopyBlock(const Kernel::Process& src_process, const Kernel::Process& dest_process,
-               VAddr src_addr, VAddr dest_addr, std::size_t size) {
+void MemorySystem::CopyBlock(const Kernel::Process& src_process,
+                             const Kernel::Process& dest_process, VAddr src_addr, VAddr dest_addr,
+                             std::size_t size) {
     auto& page_table = src_process.vm_manager.page_table;
     std::size_t remaining_size = size;
     std::size_t page_index = src_addr >> PAGE_BITS;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -27,14 +27,14 @@ std::array<u8, Memory::FCRAM_N3DS_SIZE> fcram;
 
 static PageTable* current_page_table = nullptr;
 
-void SetCurrentPageTable(PageTable* page_table) {
+void MemorySystem::SetCurrentPageTable(PageTable* page_table) {
     current_page_table = page_table;
     if (Core::System::GetInstance().IsPoweredOn()) {
         Core::CPU().PageTableChanged();
     }
 }
 
-PageTable* GetCurrentPageTable() {
+PageTable* MemorySystem::GetCurrentPageTable() {
     return current_page_table;
 }
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -114,7 +114,7 @@ template <typename T>
 T ReadMMIO(MMIORegionPointer mmio_handler, VAddr addr);
 
 template <typename T>
-T Read(const VAddr vaddr) {
+T MemorySystem::Read(const VAddr vaddr) {
     const u8* page_pointer = current_page_table->pointers[vaddr >> PAGE_BITS];
     if (page_pointer) {
         // NOTE: Avoid adding any extra logic to this fast-path block
@@ -152,7 +152,7 @@ template <typename T>
 void WriteMMIO(MMIORegionPointer mmio_handler, VAddr addr, const T data);
 
 template <typename T>
-void Write(const VAddr vaddr, const T data) {
+void MemorySystem::Write(const VAddr vaddr, const T data) {
     u8* page_pointer = current_page_table->pointers[vaddr >> PAGE_BITS];
     if (page_pointer) {
         // NOTE: Avoid adding any extra logic to this fast-path block
@@ -224,7 +224,7 @@ u8* MemorySystem::GetPointer(const VAddr vaddr) {
     return nullptr;
 }
 
-std::string ReadCString(VAddr vaddr, std::size_t max_length) {
+std::string MemorySystem::ReadCString(VAddr vaddr, std::size_t max_length) {
     std::string string;
     string.reserve(max_length);
     for (std::size_t i = 0; i < max_length; ++i) {
@@ -417,19 +417,19 @@ void RasterizerFlushVirtualRegion(VAddr start, u32 size, FlushMode mode) {
     CheckRegion(VRAM_VADDR, VRAM_VADDR_END, VRAM_PADDR);
 }
 
-u8 Read8(const VAddr addr) {
+u8 MemorySystem::Read8(const VAddr addr) {
     return Read<u8>(addr);
 }
 
-u16 Read16(const VAddr addr) {
+u16 MemorySystem::Read16(const VAddr addr) {
     return Read<u16_le>(addr);
 }
 
-u32 Read32(const VAddr addr) {
+u32 MemorySystem::Read32(const VAddr addr) {
     return Read<u32_le>(addr);
 }
 
-u64 Read64(const VAddr addr) {
+u64 MemorySystem::Read64(const VAddr addr) {
     return Read<u64_le>(addr);
 }
 
@@ -483,19 +483,19 @@ void ReadBlock(const Kernel::Process& process, const VAddr src_addr, void* dest_
     }
 }
 
-void Write8(const VAddr addr, const u8 data) {
+void MemorySystem::Write8(const VAddr addr, const u8 data) {
     Write<u8>(addr, data);
 }
 
-void Write16(const VAddr addr, const u16 data) {
+void MemorySystem::Write16(const VAddr addr, const u16 data) {
     Write<u16_le>(addr, data);
 }
 
-void Write32(const VAddr addr, const u32 data) {
+void MemorySystem::Write32(const VAddr addr, const u32 data) {
     Write<u32_le>(addr, data);
 }
 
-void Write64(const VAddr addr, const u64 data) {
+void MemorySystem::Write64(const VAddr addr, const u64 data) {
     Write<u64_le>(addr, data);
 }
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -739,7 +739,7 @@ void WriteMMIO<u64>(MMIORegionPointer mmio_handler, VAddr addr, const u64 data) 
     mmio_handler->Write64(addr, data);
 }
 
-u32 GetFCRAMOffset(u8* pointer) {
+u32 MemorySystem::GetFCRAMOffset(u8* pointer) {
     ASSERT(pointer >= fcram.data() && pointer < fcram.data() + fcram.size());
     return pointer - fcram.data();
 }

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -305,7 +305,7 @@ static std::vector<VAddr> PhysicalToVirtualAddressForRasterizer(PAddr addr) {
     return {};
 }
 
-void RasterizerMarkRegionCached(PAddr start, u32 size, bool cached) {
+void MemorySystem::RasterizerMarkRegionCached(PAddr start, u32 size, bool cached) {
     if (start == 0) {
         return;
     }

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -185,7 +185,7 @@ void Write(const VAddr vaddr, const T data) {
     }
 }
 
-bool IsValidVirtualAddress(const Kernel::Process& process, const VAddr vaddr) {
+bool MemorySystem::IsValidVirtualAddress(const Kernel::Process& process, const VAddr vaddr) {
     auto& page_table = process.vm_manager.page_table;
 
     const u8* page_pointer = page_table.pointers[vaddr >> PAGE_BITS];

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -28,7 +28,7 @@ void MemorySystem::SetCurrentPageTable(PageTable* page_table) {
     }
 }
 
-PageTable* MemorySystem::GetCurrentPageTable() {
+PageTable* MemorySystem::GetCurrentPageTable() const {
     return current_page_table;
 }
 
@@ -173,7 +173,7 @@ void MemorySystem::Write(const VAddr vaddr, const T data) {
     }
 }
 
-bool MemorySystem::IsValidVirtualAddress(const Kernel::Process& process, const VAddr vaddr) {
+bool IsValidVirtualAddress(const Kernel::Process& process, const VAddr vaddr) {
     auto& page_table = process.vm_manager.page_table;
 
     const u8* page_pointer = page_table.pointers[vaddr >> PAGE_BITS];

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -29,7 +29,8 @@ public:
         std::fill(n3ds_extra_ram.get(), n3ds_extra_ram.get() + Memory::N3DS_EXTRA_RAM_SIZE, 0);
     }
 
-    // Visual Studio would try to allocate these on compile time if they are std::array, which would exceed the memory limit.
+    // Visual Studio would try to allocate these on compile time if they are std::array, which would
+    // exceed the memory limit.
     std::unique_ptr<u8[]> fcram = std::make_unique<u8[]>(Memory::FCRAM_N3DS_SIZE);
     std::unique_ptr<u8[]> vram = std::make_unique<u8[]>(Memory::VRAM_SIZE);
     std::unique_ptr<u8[]> n3ds_extra_ram = std::make_unique<u8[]>(Memory::N3DS_EXTRA_RAM_SIZE);
@@ -223,7 +224,8 @@ u8* MemorySystem::GetPointer(const VAddr vaddr) {
         return page_pointer + (vaddr & PAGE_MASK);
     }
 
-    if (impl->current_page_table->attributes[vaddr >> PAGE_BITS] == PageType::RasterizerCachedMemory) {
+    if (impl->current_page_table->attributes[vaddr >> PAGE_BITS] ==
+        PageType::RasterizerCachedMemory) {
         return GetPointerForRasterizerCache(vaddr);
     }
 

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -254,4 +254,8 @@ void RasterizerFlushVirtualRegion(VAddr start, u32 size, FlushMode mode);
 /// Gets offset in FCRAM from a pointer inside FCRAM range
 u32 GetFCRAMOffset(u8* pointer);
 
+class MemorySystem {
+
+};
+
 } // namespace Memory

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -212,7 +212,7 @@ class MemorySystem {
 public:
     /// Currently active page table
     void SetCurrentPageTable(PageTable* page_table);
-    PageTable* GetCurrentPageTable();
+    PageTable* GetCurrentPageTable() const;
 
     u8 Read8(VAddr addr);
     u16 Read16(VAddr addr);
@@ -235,9 +235,6 @@ public:
                    VAddr src_addr, VAddr dest_addr, std::size_t size);
 
     std::string ReadCString(VAddr vaddr, std::size_t max_length);
-
-    /// Determines if the given VAddr is valid for the specified process.
-    bool IsValidVirtualAddress(const Kernel::Process& process, VAddr vaddr);
 
     /**
      * Gets a pointer to the memory region beginning at the specified physical address.
@@ -278,5 +275,8 @@ private:
 
     PageTable* current_page_table = nullptr;
 };
+
+/// Determines if the given VAddr is valid for the specified process.
+bool IsValidVirtualAddress(const Kernel::Process& process, VAddr vaddr);
 
 } // namespace Memory

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -180,14 +180,6 @@ enum : VAddr {
 
 extern std::array<u8, Memory::FCRAM_N3DS_SIZE> fcram;
 
-void ReadBlock(const Kernel::Process& process, VAddr src_addr, void* dest_buffer, std::size_t size);
-void WriteBlock(const Kernel::Process& process, VAddr dest_addr, const void* src_buffer,
-                std::size_t size);
-void ZeroBlock(const Kernel::Process& process, VAddr dest_addr, const std::size_t size);
-void CopyBlock(const Kernel::Process& process, VAddr dest_addr, VAddr src_addr, std::size_t size);
-void CopyBlock(const Kernel::Process& src_process, const Kernel::Process& dest_process,
-               VAddr src_addr, VAddr dest_addr, std::size_t size);
-
 /**
  * Mark each page touching the region as cached.
  */
@@ -238,6 +230,16 @@ public:
     void Write16(VAddr addr, u16 data);
     void Write32(VAddr addr, u32 data);
     void Write64(VAddr addr, u64 data);
+
+    void ReadBlock(const Kernel::Process& process, VAddr src_addr, void* dest_buffer,
+                   std::size_t size);
+    void WriteBlock(const Kernel::Process& process, VAddr dest_addr, const void* src_buffer,
+                    std::size_t size);
+    void ZeroBlock(const Kernel::Process& process, VAddr dest_addr, const std::size_t size);
+    void CopyBlock(const Kernel::Process& process, VAddr dest_addr, VAddr src_addr,
+                   std::size_t size);
+    void CopyBlock(const Kernel::Process& src_process, const Kernel::Process& dest_process,
+                   VAddr src_addr, VAddr dest_addr, std::size_t size);
 
     std::string ReadCString(VAddr vaddr, std::size_t max_length);
 

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -178,8 +178,6 @@ enum : VAddr {
     NEW_LINEAR_HEAP_VADDR_END = NEW_LINEAR_HEAP_VADDR + NEW_LINEAR_HEAP_SIZE,
 };
 
-extern std::array<u8, Memory::FCRAM_N3DS_SIZE> fcram;
-
 /**
  * Flushes any externally cached rasterizer resources touching the given region.
  */
@@ -258,12 +256,27 @@ public:
      */
     void RasterizerMarkRegionCached(PAddr start, u32 size, bool cached);
 
+    std::array<u8, Memory::FCRAM_N3DS_SIZE> fcram{};
+
 private:
     template <typename T>
     T Read(const VAddr vaddr);
 
     template <typename T>
     void Write(const VAddr vaddr, const T data);
+
+    /**
+     * Gets the pointer for virtual memory where the page is marked as RasterizerCachedMemory.
+     * This is used to access the memory where the page pointer is nullptr due to rasterizer cache.
+     * Since the cache only happens on linear heap or VRAM, we know the exact physical address and
+     * pointer of such virtual address
+     */
+    u8* GetPointerForRasterizerCache(VAddr addr);
+
+    std::array<u8, Memory::VRAM_SIZE> vram{};
+    std::array<u8, Memory::N3DS_EXTRA_RAM_SIZE> n3ds_extra_ram{};
+
+    PageTable* current_page_table = nullptr;
 };
 
 } // namespace Memory

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -183,8 +183,6 @@ extern std::array<u8, Memory::FCRAM_N3DS_SIZE> fcram;
 /// Determines if the given VAddr is valid for the specified process.
 bool IsValidVirtualAddress(const Kernel::Process& process, VAddr vaddr);
 
-bool IsValidPhysicalAddress(PAddr paddr);
-
 u8 Read8(VAddr addr);
 u16 Read16(VAddr addr);
 u32 Read32(VAddr addr);
@@ -206,11 +204,6 @@ void CopyBlock(const Kernel::Process& src_process, const Kernel::Process& dest_p
 u8* GetPointer(VAddr vaddr);
 
 std::string ReadCString(VAddr vaddr, std::size_t max_length);
-
-/**
- * Gets a pointer to the memory region beginning at the specified physical address.
- */
-u8* GetPhysicalPointer(PAddr address);
 
 /**
  * Mark each page touching the region as cached.
@@ -252,6 +245,13 @@ public:
     /// Currently active page table
     void SetCurrentPageTable(PageTable* page_table);
     PageTable* GetCurrentPageTable();
+
+    /**
+     * Gets a pointer to the memory region beginning at the specified physical address.
+     */
+    u8* GetPhysicalPointer(PAddr address);
+
+    bool IsValidPhysicalAddress(PAddr paddr);
 
     /// Gets offset in FCRAM from a pointer inside FCRAM range
     u32 GetFCRAMOffset(u8* pointer);

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -180,9 +180,6 @@ enum : VAddr {
 
 extern std::array<u8, Memory::FCRAM_N3DS_SIZE> fcram;
 
-/// Determines if the given VAddr is valid for the specified process.
-bool IsValidVirtualAddress(const Kernel::Process& process, VAddr vaddr);
-
 u8 Read8(VAddr addr);
 u16 Read16(VAddr addr);
 u32 Read32(VAddr addr);
@@ -245,6 +242,9 @@ public:
     /// Currently active page table
     void SetCurrentPageTable(PageTable* page_table);
     PageTable* GetCurrentPageTable();
+
+    /// Determines if the given VAddr is valid for the specified process.
+    bool IsValidVirtualAddress(const Kernel::Process& process, VAddr vaddr);
 
     /**
      * Gets a pointer to the memory region beginning at the specified physical address.

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -180,10 +180,6 @@ enum : VAddr {
 
 extern std::array<u8, Memory::FCRAM_N3DS_SIZE> fcram;
 
-/// Currently active page table
-void SetCurrentPageTable(PageTable* page_table);
-PageTable* GetCurrentPageTable();
-
 /// Determines if the given VAddr is valid for the specified process.
 bool IsValidVirtualAddress(const Kernel::Process& process, VAddr vaddr);
 
@@ -253,6 +249,10 @@ void RasterizerFlushVirtualRegion(VAddr start, u32 size, FlushMode mode);
 
 class MemorySystem {
 public:
+    /// Currently active page table
+    void SetCurrentPageTable(PageTable* page_table);
+    PageTable* GetCurrentPageTable();
+
     /// Gets offset in FCRAM from a pointer inside FCRAM range
     u32 GetFCRAMOffset(u8* pointer);
 };

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -198,8 +198,6 @@ void CopyBlock(const Kernel::Process& process, VAddr dest_addr, VAddr src_addr, 
 void CopyBlock(const Kernel::Process& src_process, const Kernel::Process& dest_process,
                VAddr src_addr, VAddr dest_addr, std::size_t size);
 
-u8* GetPointer(VAddr vaddr);
-
 std::string ReadCString(VAddr vaddr, std::size_t max_length);
 
 /**
@@ -250,6 +248,8 @@ public:
      * Gets a pointer to the memory region beginning at the specified physical address.
      */
     u8* GetPhysicalPointer(PAddr address);
+
+    u8* GetPointer(VAddr vaddr);
 
     bool IsValidPhysicalAddress(PAddr paddr);
 

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -180,16 +180,6 @@ enum : VAddr {
 
 extern std::array<u8, Memory::FCRAM_N3DS_SIZE> fcram;
 
-u8 Read8(VAddr addr);
-u16 Read16(VAddr addr);
-u32 Read32(VAddr addr);
-u64 Read64(VAddr addr);
-
-void Write8(VAddr addr, u8 data);
-void Write16(VAddr addr, u16 data);
-void Write32(VAddr addr, u32 data);
-void Write64(VAddr addr, u64 data);
-
 void ReadBlock(const Kernel::Process& process, VAddr src_addr, void* dest_buffer, std::size_t size);
 void WriteBlock(const Kernel::Process& process, VAddr dest_addr, const void* src_buffer,
                 std::size_t size);
@@ -197,8 +187,6 @@ void ZeroBlock(const Kernel::Process& process, VAddr dest_addr, const std::size_
 void CopyBlock(const Kernel::Process& process, VAddr dest_addr, VAddr src_addr, std::size_t size);
 void CopyBlock(const Kernel::Process& src_process, const Kernel::Process& dest_process,
                VAddr src_addr, VAddr dest_addr, std::size_t size);
-
-std::string ReadCString(VAddr vaddr, std::size_t max_length);
 
 /**
  * Mark each page touching the region as cached.
@@ -241,6 +229,18 @@ public:
     void SetCurrentPageTable(PageTable* page_table);
     PageTable* GetCurrentPageTable();
 
+    u8 Read8(VAddr addr);
+    u16 Read16(VAddr addr);
+    u32 Read32(VAddr addr);
+    u64 Read64(VAddr addr);
+
+    void Write8(VAddr addr, u8 data);
+    void Write16(VAddr addr, u16 data);
+    void Write32(VAddr addr, u32 data);
+    void Write64(VAddr addr, u64 data);
+
+    std::string ReadCString(VAddr vaddr, std::size_t max_length);
+
     /// Determines if the given VAddr is valid for the specified process.
     bool IsValidVirtualAddress(const Kernel::Process& process, VAddr vaddr);
 
@@ -255,6 +255,13 @@ public:
 
     /// Gets offset in FCRAM from a pointer inside FCRAM range
     u32 GetFCRAMOffset(u8* pointer);
+
+private:
+    template <typename T>
+    T Read(const VAddr vaddr);
+
+    template <typename T>
+    void Write(const VAddr vaddr, const T data);
 };
 
 } // namespace Memory

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -251,11 +251,10 @@ enum class FlushMode {
  */
 void RasterizerFlushVirtualRegion(VAddr start, u32 size, FlushMode mode);
 
-/// Gets offset in FCRAM from a pointer inside FCRAM range
-u32 GetFCRAMOffset(u8* pointer);
-
 class MemorySystem {
-
+public:
+    /// Gets offset in FCRAM from a pointer inside FCRAM range
+    u32 GetFCRAMOffset(u8* pointer);
 };
 
 } // namespace Memory

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -181,11 +181,6 @@ enum : VAddr {
 extern std::array<u8, Memory::FCRAM_N3DS_SIZE> fcram;
 
 /**
- * Mark each page touching the region as cached.
- */
-void RasterizerMarkRegionCached(PAddr start, u32 size, bool cached);
-
-/**
  * Flushes any externally cached rasterizer resources touching the given region.
  */
 void RasterizerFlushRegion(PAddr start, u32 size);
@@ -257,6 +252,11 @@ public:
 
     /// Gets offset in FCRAM from a pointer inside FCRAM range
     u32 GetFCRAMOffset(u8* pointer);
+
+    /**
+     * Mark each page touching the region as cached.
+     */
+    void RasterizerMarkRegionCached(PAddr start, u32 size, bool cached);
 
 private:
     template <typename T>

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <cstddef>
+#include <memory>
 #include <string>
 #include <vector>
 #include "common/common_types.h"
@@ -210,6 +211,9 @@ void RasterizerFlushVirtualRegion(VAddr start, u32 size, FlushMode mode);
 
 class MemorySystem {
 public:
+    MemorySystem();
+    ~MemorySystem();
+
     /// Currently active page table
     void SetCurrentPageTable(PageTable* page_table);
     PageTable* GetCurrentPageTable() const;
@@ -248,12 +252,13 @@ public:
     /// Gets offset in FCRAM from a pointer inside FCRAM range
     u32 GetFCRAMOffset(u8* pointer);
 
+    /// Gets pointer in FCRAM with given offset
+    u8* GetFCRAMPointer(u32 offset);
+
     /**
      * Mark each page touching the region as cached.
      */
     void RasterizerMarkRegionCached(PAddr start, u32 size, bool cached);
-
-    std::array<u8, Memory::FCRAM_N3DS_SIZE> fcram{};
 
 private:
     template <typename T>
@@ -270,10 +275,9 @@ private:
      */
     u8* GetPointerForRasterizerCache(VAddr addr);
 
-    std::array<u8, Memory::VRAM_SIZE> vram{};
-    std::array<u8, Memory::N3DS_EXTRA_RAM_SIZE> n3ds_extra_ram{};
+    class Impl;
 
-    PageTable* current_page_table = nullptr;
+    std::unique_ptr<Impl> impl;
 };
 
 /// Determines if the given VAddr is valid for the specified process.

--- a/src/core/rpc/rpc_server.cpp
+++ b/src/core/rpc/rpc_server.cpp
@@ -30,8 +30,9 @@ void RPCServer::HandleReadMemory(Packet& packet, u32 address, u32 data_size) {
     }
 
     // Note: Memory read occurs asynchronously from the state of the emulator
-    Memory::ReadBlock(*Core::System::GetInstance().Kernel().GetCurrentProcess(), address,
-                      packet.GetPacketData().data(), data_size);
+    Core::System::GetInstance().Memory().ReadBlock(
+        *Core::System::GetInstance().Kernel().GetCurrentProcess(), address,
+        packet.GetPacketData().data(), data_size);
     packet.SetPacketDataSize(data_size);
     packet.SendReply();
 }
@@ -42,8 +43,8 @@ void RPCServer::HandleWriteMemory(Packet& packet, u32 address, const u8* data, u
         (address >= Memory::HEAP_VADDR && address <= Memory::HEAP_VADDR_END) ||
         (address >= Memory::N3DS_EXTRA_RAM_VADDR && address <= Memory::N3DS_EXTRA_RAM_VADDR_END)) {
         // Note: Memory write occurs asynchronously from the state of the emulator
-        Memory::WriteBlock(*Core::System::GetInstance().Kernel().GetCurrentProcess(), address, data,
-                           data_size);
+        Core::System::GetInstance().Memory().WriteBlock(
+            *Core::System::GetInstance().Kernel().GetCurrentProcess(), address, data, data_size);
         // If the memory happens to be executable code, make sure the changes become visible
         Core::CPU().InvalidateCacheRange(address, data_size);
     }

--- a/src/tests/core/arm/arm_test_common.cpp
+++ b/src/tests/core/arm/arm_test_common.cpp
@@ -20,7 +20,8 @@ TestEnvironment::TestEnvironment(bool mutable_memory_)
     //       so we need to create the kernel object there.
     //       Change this when all global states are eliminated.
     Core::System::GetInstance().timing = std::make_unique<Core::Timing>();
-    Memory::MemorySystem memory;
+    Core::System::GetInstance().memory = std::make_unique<Memory::MemorySystem>();
+    Memory::MemorySystem& memory = *Core::System::GetInstance().memory;
     Core::System::GetInstance().kernel = std::make_unique<Kernel::KernelSystem>(memory, 0);
     kernel = Core::System::GetInstance().kernel.get();
 

--- a/src/tests/core/arm/arm_test_common.cpp
+++ b/src/tests/core/arm/arm_test_common.cpp
@@ -33,7 +33,7 @@ TestEnvironment::TestEnvironment(bool mutable_memory_)
     Memory::MapIoRegion(*page_table, 0x00000000, 0x80000000, test_memory);
     Memory::MapIoRegion(*page_table, 0x80000000, 0x80000000, test_memory);
 
-    Memory::SetCurrentPageTable(page_table);
+    memory.SetCurrentPageTable(page_table);
 }
 
 TestEnvironment::~TestEnvironment() {

--- a/src/tests/core/arm/arm_test_common.cpp
+++ b/src/tests/core/arm/arm_test_common.cpp
@@ -20,7 +20,8 @@ TestEnvironment::TestEnvironment(bool mutable_memory_)
     //       so we need to create the kernel object there.
     //       Change this when all global states are eliminated.
     Core::System::GetInstance().timing = std::make_unique<Core::Timing>();
-    Core::System::GetInstance().kernel = std::make_unique<Kernel::KernelSystem>(0);
+    Memory::MemorySystem memory;
+    Core::System::GetInstance().kernel = std::make_unique<Kernel::KernelSystem>(memory, 0);
     kernel = Core::System::GetInstance().kernel.get();
 
     kernel->SetCurrentProcess(kernel->CreateProcess(kernel->CreateCodeSet("", 0)));

--- a/src/tests/core/arm/dyncom/arm_dyncom_vfp_tests.cpp
+++ b/src/tests/core/arm/dyncom/arm_dyncom_vfp_tests.cpp
@@ -3,8 +3,8 @@
 // Refer to the license.txt file included.
 
 #include <catch2/catch.hpp>
-
 #include "core/arm/dyncom/arm_dyncom.h"
+#include "core/core.h"
 #include "core/core_timing.h"
 #include "tests/core/arm/arm_test_common.h"
 
@@ -23,7 +23,7 @@ TEST_CASE("ARM_DynCom (vfp): vadd", "[arm_dyncom]") {
     test_env.SetMemory32(0, 0xEE321A03); // vadd.f32 s2, s4, s6
     test_env.SetMemory32(4, 0xEAFFFFFE); // b +#0
 
-    ARM_DynCom dyncom(USER32MODE);
+    ARM_DynCom dyncom(Core::System::GetInstance(), USER32MODE);
 
     std::vector<VfpTestCase> test_cases{{
 #include "vfp_vadd_f32.inc"

--- a/src/tests/core/hle/kernel/hle_ipc.cpp
+++ b/src/tests/core/hle/kernel/hle_ipc.cpp
@@ -23,8 +23,8 @@ static SharedPtr<Object> MakeObject(Kernel::KernelSystem& kernel) {
 TEST_CASE("HLERequestContext::PopulateFromIncomingCommandBuffer", "[core][kernel]") {
     // HACK: see comments of member timing
     Core::System::GetInstance().timing = std::make_unique<Core::Timing>();
-    Memory::MemorySystem memory;
-    Kernel::KernelSystem kernel(memory, 0);
+    auto memory = std::make_unique<Memory::MemorySystem>();
+    Kernel::KernelSystem kernel(*memory, 0);
     auto session = std::get<SharedPtr<ServerSession>>(kernel.CreateSessionPair());
     HLERequestContext context(std::move(session));
 
@@ -236,8 +236,8 @@ TEST_CASE("HLERequestContext::PopulateFromIncomingCommandBuffer", "[core][kernel
 TEST_CASE("HLERequestContext::WriteToOutgoingCommandBuffer", "[core][kernel]") {
     // HACK: see comments of member timing
     Core::System::GetInstance().timing = std::make_unique<Core::Timing>();
-    Memory::MemorySystem memory;
-    Kernel::KernelSystem kernel(memory, 0);
+    auto memory = std::make_unique<Memory::MemorySystem>();
+    Kernel::KernelSystem kernel(*memory, 0);
     auto session = std::get<SharedPtr<ServerSession>>(kernel.CreateSessionPair());
     HLERequestContext context(std::move(session));
 

--- a/src/tests/core/hle/kernel/hle_ipc.cpp
+++ b/src/tests/core/hle/kernel/hle_ipc.cpp
@@ -23,7 +23,8 @@ static SharedPtr<Object> MakeObject(Kernel::KernelSystem& kernel) {
 TEST_CASE("HLERequestContext::PopulateFromIncomingCommandBuffer", "[core][kernel]") {
     // HACK: see comments of member timing
     Core::System::GetInstance().timing = std::make_unique<Core::Timing>();
-    Kernel::KernelSystem kernel(0);
+    Memory::MemorySystem memory;
+    Kernel::KernelSystem kernel(memory, 0);
     auto session = std::get<SharedPtr<ServerSession>>(kernel.CreateSessionPair());
     HLERequestContext context(std::move(session));
 
@@ -235,7 +236,8 @@ TEST_CASE("HLERequestContext::PopulateFromIncomingCommandBuffer", "[core][kernel
 TEST_CASE("HLERequestContext::WriteToOutgoingCommandBuffer", "[core][kernel]") {
     // HACK: see comments of member timing
     Core::System::GetInstance().timing = std::make_unique<Core::Timing>();
-    Kernel::KernelSystem kernel(0);
+    Memory::MemorySystem memory;
+    Kernel::KernelSystem kernel(memory, 0);
     auto session = std::get<SharedPtr<ServerSession>>(kernel.CreateSessionPair());
     HLERequestContext context(std::move(session));
 

--- a/src/tests/core/memory/memory.cpp
+++ b/src/tests/core/memory/memory.cpp
@@ -13,7 +13,8 @@
 TEST_CASE("Memory::IsValidVirtualAddress", "[core][memory]") {
     // HACK: see comments of member timing
     Core::System::GetInstance().timing = std::make_unique<Core::Timing>();
-    Kernel::KernelSystem kernel(0);
+    Memory::MemorySystem memory;
+    Kernel::KernelSystem kernel(memory, 0);
     SECTION("these regions should not be mapped on an empty process") {
         auto process = kernel.CreateProcess(kernel.CreateCodeSet("", 0));
         CHECK(Memory::IsValidVirtualAddress(*process, Memory::PROCESS_IMAGE_VADDR) == false);

--- a/src/tests/core/memory/memory.cpp
+++ b/src/tests/core/memory/memory.cpp
@@ -10,27 +10,27 @@
 #include "core/hle/kernel/shared_page.h"
 #include "core/memory.h"
 
-TEST_CASE("MemorySystem::IsValidVirtualAddress", "[core][memory]") {
+TEST_CASE("Memory::IsValidVirtualAddress", "[core][memory]") {
     // HACK: see comments of member timing
     Core::System::GetInstance().timing = std::make_unique<Core::Timing>();
     Memory::MemorySystem memory;
     Kernel::KernelSystem kernel(memory, 0);
     SECTION("these regions should not be mapped on an empty process") {
         auto process = kernel.CreateProcess(kernel.CreateCodeSet("", 0));
-        CHECK(memory.IsValidVirtualAddress(*process, Memory::PROCESS_IMAGE_VADDR) == false);
-        CHECK(memory.IsValidVirtualAddress(*process, Memory::HEAP_VADDR) == false);
-        CHECK(memory.IsValidVirtualAddress(*process, Memory::LINEAR_HEAP_VADDR) == false);
-        CHECK(memory.IsValidVirtualAddress(*process, Memory::VRAM_VADDR) == false);
-        CHECK(memory.IsValidVirtualAddress(*process, Memory::CONFIG_MEMORY_VADDR) == false);
-        CHECK(memory.IsValidVirtualAddress(*process, Memory::SHARED_PAGE_VADDR) == false);
-        CHECK(memory.IsValidVirtualAddress(*process, Memory::TLS_AREA_VADDR) == false);
+        CHECK(Memory::IsValidVirtualAddress(*process, Memory::PROCESS_IMAGE_VADDR) == false);
+        CHECK(Memory::IsValidVirtualAddress(*process, Memory::HEAP_VADDR) == false);
+        CHECK(Memory::IsValidVirtualAddress(*process, Memory::LINEAR_HEAP_VADDR) == false);
+        CHECK(Memory::IsValidVirtualAddress(*process, Memory::VRAM_VADDR) == false);
+        CHECK(Memory::IsValidVirtualAddress(*process, Memory::CONFIG_MEMORY_VADDR) == false);
+        CHECK(Memory::IsValidVirtualAddress(*process, Memory::SHARED_PAGE_VADDR) == false);
+        CHECK(Memory::IsValidVirtualAddress(*process, Memory::TLS_AREA_VADDR) == false);
     }
 
     SECTION("CONFIG_MEMORY_VADDR and SHARED_PAGE_VADDR should be valid after mapping them") {
         auto process = kernel.CreateProcess(kernel.CreateCodeSet("", 0));
         kernel.MapSharedPages(process->vm_manager);
-        CHECK(memory.IsValidVirtualAddress(*process, Memory::CONFIG_MEMORY_VADDR) == true);
-        CHECK(memory.IsValidVirtualAddress(*process, Memory::SHARED_PAGE_VADDR) == true);
+        CHECK(Memory::IsValidVirtualAddress(*process, Memory::CONFIG_MEMORY_VADDR) == true);
+        CHECK(Memory::IsValidVirtualAddress(*process, Memory::SHARED_PAGE_VADDR) == true);
     }
 
     SECTION("special regions should be valid after mapping them") {
@@ -38,13 +38,13 @@ TEST_CASE("MemorySystem::IsValidVirtualAddress", "[core][memory]") {
         SECTION("VRAM") {
             kernel.HandleSpecialMapping(process->vm_manager,
                                         {Memory::VRAM_VADDR, Memory::VRAM_SIZE, false, false});
-            CHECK(memory.IsValidVirtualAddress(*process, Memory::VRAM_VADDR) == true);
+            CHECK(Memory::IsValidVirtualAddress(*process, Memory::VRAM_VADDR) == true);
         }
 
         SECTION("IO (Not yet implemented)") {
             kernel.HandleSpecialMapping(
                 process->vm_manager, {Memory::IO_AREA_VADDR, Memory::IO_AREA_SIZE, false, false});
-            CHECK_FALSE(memory.IsValidVirtualAddress(*process, Memory::IO_AREA_VADDR) == true);
+            CHECK_FALSE(Memory::IsValidVirtualAddress(*process, Memory::IO_AREA_VADDR) == true);
         }
     }
 
@@ -52,6 +52,6 @@ TEST_CASE("MemorySystem::IsValidVirtualAddress", "[core][memory]") {
         auto process = kernel.CreateProcess(kernel.CreateCodeSet("", 0));
         kernel.MapSharedPages(process->vm_manager);
         process->vm_manager.UnmapRange(Memory::CONFIG_MEMORY_VADDR, Memory::CONFIG_MEMORY_SIZE);
-        CHECK(memory.IsValidVirtualAddress(*process, Memory::CONFIG_MEMORY_VADDR) == false);
+        CHECK(Memory::IsValidVirtualAddress(*process, Memory::CONFIG_MEMORY_VADDR) == false);
     }
 }

--- a/src/tests/core/memory/memory.cpp
+++ b/src/tests/core/memory/memory.cpp
@@ -36,13 +36,13 @@ TEST_CASE("Memory::IsValidVirtualAddress", "[core][memory]") {
     SECTION("special regions should be valid after mapping them") {
         auto process = kernel.CreateProcess(kernel.CreateCodeSet("", 0));
         SECTION("VRAM") {
-            Kernel::HandleSpecialMapping(process->vm_manager,
-                                         {Memory::VRAM_VADDR, Memory::VRAM_SIZE, false, false});
+            kernel.HandleSpecialMapping(process->vm_manager,
+                                        {Memory::VRAM_VADDR, Memory::VRAM_SIZE, false, false});
             CHECK(Memory::IsValidVirtualAddress(*process, Memory::VRAM_VADDR) == true);
         }
 
         SECTION("IO (Not yet implemented)") {
-            Kernel::HandleSpecialMapping(
+            kernel.HandleSpecialMapping(
                 process->vm_manager, {Memory::IO_AREA_VADDR, Memory::IO_AREA_SIZE, false, false});
             CHECK_FALSE(Memory::IsValidVirtualAddress(*process, Memory::IO_AREA_VADDR) == true);
         }

--- a/src/tests/core/memory/memory.cpp
+++ b/src/tests/core/memory/memory.cpp
@@ -10,27 +10,27 @@
 #include "core/hle/kernel/shared_page.h"
 #include "core/memory.h"
 
-TEST_CASE("Memory::IsValidVirtualAddress", "[core][memory]") {
+TEST_CASE("MemorySystem::IsValidVirtualAddress", "[core][memory]") {
     // HACK: see comments of member timing
     Core::System::GetInstance().timing = std::make_unique<Core::Timing>();
     Memory::MemorySystem memory;
     Kernel::KernelSystem kernel(memory, 0);
     SECTION("these regions should not be mapped on an empty process") {
         auto process = kernel.CreateProcess(kernel.CreateCodeSet("", 0));
-        CHECK(Memory::IsValidVirtualAddress(*process, Memory::PROCESS_IMAGE_VADDR) == false);
-        CHECK(Memory::IsValidVirtualAddress(*process, Memory::HEAP_VADDR) == false);
-        CHECK(Memory::IsValidVirtualAddress(*process, Memory::LINEAR_HEAP_VADDR) == false);
-        CHECK(Memory::IsValidVirtualAddress(*process, Memory::VRAM_VADDR) == false);
-        CHECK(Memory::IsValidVirtualAddress(*process, Memory::CONFIG_MEMORY_VADDR) == false);
-        CHECK(Memory::IsValidVirtualAddress(*process, Memory::SHARED_PAGE_VADDR) == false);
-        CHECK(Memory::IsValidVirtualAddress(*process, Memory::TLS_AREA_VADDR) == false);
+        CHECK(memory.IsValidVirtualAddress(*process, Memory::PROCESS_IMAGE_VADDR) == false);
+        CHECK(memory.IsValidVirtualAddress(*process, Memory::HEAP_VADDR) == false);
+        CHECK(memory.IsValidVirtualAddress(*process, Memory::LINEAR_HEAP_VADDR) == false);
+        CHECK(memory.IsValidVirtualAddress(*process, Memory::VRAM_VADDR) == false);
+        CHECK(memory.IsValidVirtualAddress(*process, Memory::CONFIG_MEMORY_VADDR) == false);
+        CHECK(memory.IsValidVirtualAddress(*process, Memory::SHARED_PAGE_VADDR) == false);
+        CHECK(memory.IsValidVirtualAddress(*process, Memory::TLS_AREA_VADDR) == false);
     }
 
     SECTION("CONFIG_MEMORY_VADDR and SHARED_PAGE_VADDR should be valid after mapping them") {
         auto process = kernel.CreateProcess(kernel.CreateCodeSet("", 0));
         kernel.MapSharedPages(process->vm_manager);
-        CHECK(Memory::IsValidVirtualAddress(*process, Memory::CONFIG_MEMORY_VADDR) == true);
-        CHECK(Memory::IsValidVirtualAddress(*process, Memory::SHARED_PAGE_VADDR) == true);
+        CHECK(memory.IsValidVirtualAddress(*process, Memory::CONFIG_MEMORY_VADDR) == true);
+        CHECK(memory.IsValidVirtualAddress(*process, Memory::SHARED_PAGE_VADDR) == true);
     }
 
     SECTION("special regions should be valid after mapping them") {
@@ -38,13 +38,13 @@ TEST_CASE("Memory::IsValidVirtualAddress", "[core][memory]") {
         SECTION("VRAM") {
             kernel.HandleSpecialMapping(process->vm_manager,
                                         {Memory::VRAM_VADDR, Memory::VRAM_SIZE, false, false});
-            CHECK(Memory::IsValidVirtualAddress(*process, Memory::VRAM_VADDR) == true);
+            CHECK(memory.IsValidVirtualAddress(*process, Memory::VRAM_VADDR) == true);
         }
 
         SECTION("IO (Not yet implemented)") {
             kernel.HandleSpecialMapping(
                 process->vm_manager, {Memory::IO_AREA_VADDR, Memory::IO_AREA_SIZE, false, false});
-            CHECK_FALSE(Memory::IsValidVirtualAddress(*process, Memory::IO_AREA_VADDR) == true);
+            CHECK_FALSE(memory.IsValidVirtualAddress(*process, Memory::IO_AREA_VADDR) == true);
         }
     }
 
@@ -52,6 +52,6 @@ TEST_CASE("Memory::IsValidVirtualAddress", "[core][memory]") {
         auto process = kernel.CreateProcess(kernel.CreateCodeSet("", 0));
         kernel.MapSharedPages(process->vm_manager);
         process->vm_manager.UnmapRange(Memory::CONFIG_MEMORY_VADDR, Memory::CONFIG_MEMORY_SIZE);
-        CHECK(Memory::IsValidVirtualAddress(*process, Memory::CONFIG_MEMORY_VADDR) == false);
+        CHECK(memory.IsValidVirtualAddress(*process, Memory::CONFIG_MEMORY_VADDR) == false);
     }
 }

--- a/src/tests/core/memory/memory.cpp
+++ b/src/tests/core/memory/memory.cpp
@@ -13,8 +13,8 @@
 TEST_CASE("Memory::IsValidVirtualAddress", "[core][memory]") {
     // HACK: see comments of member timing
     Core::System::GetInstance().timing = std::make_unique<Core::Timing>();
-    Memory::MemorySystem memory;
-    Kernel::KernelSystem kernel(memory, 0);
+    Core::System::GetInstance().memory = std::make_unique<Memory::MemorySystem>();
+    Kernel::KernelSystem kernel(*Core::System::GetInstance().memory, 0);
     SECTION("these regions should not be mapped on an empty process") {
         auto process = kernel.CreateProcess(kernel.CreateCodeSet("", 0));
         CHECK(Memory::IsValidVirtualAddress(*process, Memory::PROCESS_IMAGE_VADDR) == false);

--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -269,7 +269,7 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
     case PICA_REG_INDEX_WORKAROUND(pipeline.command_buffer.trigger[1], 0x23d): {
         unsigned index =
             static_cast<unsigned>(id - PICA_REG_INDEX(pipeline.command_buffer.trigger[0]));
-        u32* head_ptr = (u32*)Memory::GetPhysicalPointer(
+        u32* head_ptr = (u32*)VideoCore::g_memory->GetPhysicalPointer(
             regs.pipeline.command_buffer.GetPhysicalAddress(index));
         g_state.cmd_list.head_ptr = g_state.cmd_list.current_ptr = head_ptr;
         g_state.cmd_list.length = regs.pipeline.command_buffer.GetSize(index) / sizeof(u32);
@@ -328,7 +328,8 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
 
         // Load vertices
         const auto& index_info = regs.pipeline.index_array;
-        const u8* index_address_8 = Memory::GetPhysicalPointer(base_address + index_info.offset);
+        const u8* index_address_8 =
+            VideoCore::g_memory->GetPhysicalPointer(base_address + index_info.offset);
         const u16* index_address_16 = reinterpret_cast<const u16*>(index_address_8);
         bool index_u16 = index_info.format != 0;
 
@@ -338,7 +339,8 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
                 if (!texture.enabled)
                     continue;
 
-                u8* texture_data = Memory::GetPhysicalPointer(texture.config.GetPhysicalAddress());
+                u8* texture_data =
+                    VideoCore::g_memory->GetPhysicalPointer(texture.config.GetPhysicalAddress());
                 g_debug_context->recorder->MemoryAccessed(
                     texture_data,
                     Pica::TexturingRegs::NibblesPerPixel(texture.format) * texture.config.width /
@@ -424,8 +426,8 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
         }
 
         for (auto& range : memory_accesses.ranges) {
-            g_debug_context->recorder->MemoryAccessed(Memory::GetPhysicalPointer(range.first),
-                                                      range.second, range.first);
+            g_debug_context->recorder->MemoryAccessed(
+                VideoCore::g_memory->GetPhysicalPointer(range.first), range.second, range.first);
         }
 
         VideoCore::g_renderer->Rasterizer()->DrawTriangles();

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -24,6 +24,7 @@
 #include "video_core/renderer_opengl/gl_shader_gen.h"
 #include "video_core/renderer_opengl/pica_to_gl.h"
 #include "video_core/renderer_opengl/renderer_opengl.h"
+#include "video_core/video_core.h"
 
 namespace OpenGL {
 
@@ -259,7 +260,7 @@ RasterizerOpenGL::VertexArrayInfo RasterizerOpenGL::AnalyzeVertexArray(bool is_i
     if (is_indexed) {
         const auto& index_info = regs.pipeline.index_array;
         PAddr address = vertex_attributes.GetPhysicalBaseAddress() + index_info.offset;
-        const u8* index_address_8 = Memory::GetPhysicalPointer(address);
+        const u8* index_address_8 = VideoCore::g_memory->GetPhysicalPointer(address);
         const u16* index_address_16 = reinterpret_cast<const u16*>(index_address_8);
         bool index_u16 = index_info.format != 0;
 
@@ -340,7 +341,7 @@ void RasterizerOpenGL::SetupVertexArray(u8* array_ptr, GLintptr buffer_offset,
         u32 data_size = loader.byte_count * vertex_num;
 
         res_cache.FlushRegion(data_addr, data_size, nullptr);
-        std::memcpy(array_ptr, Memory::GetPhysicalPointer(data_addr), data_size);
+        std::memcpy(array_ptr, VideoCore::g_memory->GetPhysicalPointer(data_addr), data_size);
 
         array_ptr += data_size;
         buffer_offset += data_size;
@@ -471,9 +472,9 @@ bool RasterizerOpenGL::AccelerateDrawBatchInternal(bool is_indexed, bool use_gs)
             return false;
         }
 
-        const u8* index_data =
-            Memory::GetPhysicalPointer(regs.pipeline.vertex_attributes.GetPhysicalBaseAddress() +
-                                       regs.pipeline.index_array.offset);
+        const u8* index_data = VideoCore::g_memory->GetPhysicalPointer(
+            regs.pipeline.vertex_attributes.GetPhysicalBaseAddress() +
+            regs.pipeline.index_array.offset);
         std::tie(buffer_ptr, buffer_offset, std::ignore) = index_buffer.Map(index_buffer_size, 4);
         std::memcpy(buffer_ptr, index_data, index_buffer_size);
         index_buffer.Unmap(index_buffer_size);

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -134,7 +134,7 @@ static void MortonCopy(u32 stride, u32 height, u8* gl_buffer, PAddr base, PAddr 
         }
     };
 
-    u8* tile_buffer = Memory::GetPhysicalPointer(start);
+    u8* tile_buffer = VideoCore::g_memory->GetPhysicalPointer(start);
 
     if (start < aligned_start && !morton_to_gl) {
         std::array<u8, tile_size> tmp_buf;
@@ -625,7 +625,7 @@ MICROPROFILE_DEFINE(OpenGL_SurfaceLoad, "OpenGL", "Surface Load", MP_RGB(128, 19
 void CachedSurface::LoadGLBuffer(PAddr load_start, PAddr load_end) {
     ASSERT(type != SurfaceType::Fill);
 
-    const u8* const texture_src_data = Memory::GetPhysicalPointer(addr);
+    const u8* const texture_src_data = VideoCore::g_memory->GetPhysicalPointer(addr);
     if (texture_src_data == nullptr)
         return;
 
@@ -680,7 +680,7 @@ void CachedSurface::LoadGLBuffer(PAddr load_start, PAddr load_end) {
 
 MICROPROFILE_DEFINE(OpenGL_SurfaceFlush, "OpenGL", "Surface Flush", MP_RGB(128, 192, 64));
 void CachedSurface::FlushGLBuffer(PAddr flush_start, PAddr flush_end) {
-    u8* const dst_buffer = Memory::GetPhysicalPointer(addr);
+    u8* const dst_buffer = VideoCore::g_memory->GetPhysicalPointer(addr);
     if (dst_buffer == nullptr)
         return;
 

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -1718,9 +1718,11 @@ void RasterizerCacheOpenGL::UpdatePagesCachedCount(PAddr addr, u32 size, int del
         const u32 interval_size = interval_end_addr - interval_start_addr;
 
         if (delta > 0 && count == delta)
-            Memory::RasterizerMarkRegionCached(interval_start_addr, interval_size, true);
+            VideoCore::g_memory->RasterizerMarkRegionCached(interval_start_addr, interval_size,
+                                                            true);
         else if (delta < 0 && count == -delta)
-            Memory::RasterizerMarkRegionCached(interval_start_addr, interval_size, false);
+            VideoCore::g_memory->RasterizerMarkRegionCached(interval_start_addr, interval_size,
+                                                            false);
         else
             ASSERT(count >= 0);
     }

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -228,7 +228,7 @@ void RendererOpenGL::LoadFBToScreenInfo(const GPU::Regs::FramebufferConfig& fram
 
         Memory::RasterizerFlushRegion(framebuffer_addr, framebuffer.stride * framebuffer.height);
 
-        const u8* framebuffer_data = Memory::GetPhysicalPointer(framebuffer_addr);
+        const u8* framebuffer_data = VideoCore::g_memory->GetPhysicalPointer(framebuffer_addr);
 
         state.texture_units[0].texture_2d = screen_info.texture.resource.handle;
         state.Apply();

--- a/src/video_core/swrasterizer/framebuffer.cpp
+++ b/src/video_core/swrasterizer/framebuffer.cpp
@@ -14,6 +14,7 @@
 #include "video_core/regs_framebuffer.h"
 #include "video_core/swrasterizer/framebuffer.h"
 #include "video_core/utils.h"
+#include "video_core/video_core.h"
 
 namespace Pica {
 namespace Rasterizer {
@@ -31,7 +32,7 @@ void DrawPixel(int x, int y, const Math::Vec4<u8>& color) {
         GPU::Regs::BytesPerPixel(GPU::Regs::PixelFormat(framebuffer.color_format.Value()));
     u32 dst_offset = VideoCore::GetMortonOffset(x, y, bytes_per_pixel) +
                      coarse_y * framebuffer.width * bytes_per_pixel;
-    u8* dst_pixel = Memory::GetPhysicalPointer(addr) + dst_offset;
+    u8* dst_pixel = VideoCore::g_memory->GetPhysicalPointer(addr) + dst_offset;
 
     switch (framebuffer.color_format) {
     case FramebufferRegs::ColorFormat::RGBA8:
@@ -72,7 +73,7 @@ const Math::Vec4<u8> GetPixel(int x, int y) {
         GPU::Regs::BytesPerPixel(GPU::Regs::PixelFormat(framebuffer.color_format.Value()));
     u32 src_offset = VideoCore::GetMortonOffset(x, y, bytes_per_pixel) +
                      coarse_y * framebuffer.width * bytes_per_pixel;
-    u8* src_pixel = Memory::GetPhysicalPointer(addr) + src_offset;
+    u8* src_pixel = VideoCore::g_memory->GetPhysicalPointer(addr) + src_offset;
 
     switch (framebuffer.color_format) {
     case FramebufferRegs::ColorFormat::RGBA8:
@@ -102,7 +103,7 @@ const Math::Vec4<u8> GetPixel(int x, int y) {
 u32 GetDepth(int x, int y) {
     const auto& framebuffer = g_state.regs.framebuffer.framebuffer;
     const PAddr addr = framebuffer.GetDepthBufferPhysicalAddress();
-    u8* depth_buffer = Memory::GetPhysicalPointer(addr);
+    u8* depth_buffer = VideoCore::g_memory->GetPhysicalPointer(addr);
 
     y = framebuffer.height - y;
 
@@ -131,7 +132,7 @@ u32 GetDepth(int x, int y) {
 u8 GetStencil(int x, int y) {
     const auto& framebuffer = g_state.regs.framebuffer.framebuffer;
     const PAddr addr = framebuffer.GetDepthBufferPhysicalAddress();
-    u8* depth_buffer = Memory::GetPhysicalPointer(addr);
+    u8* depth_buffer = VideoCore::g_memory->GetPhysicalPointer(addr);
 
     y = framebuffer.height - y;
 
@@ -158,7 +159,7 @@ u8 GetStencil(int x, int y) {
 void SetDepth(int x, int y, u32 value) {
     const auto& framebuffer = g_state.regs.framebuffer.framebuffer;
     const PAddr addr = framebuffer.GetDepthBufferPhysicalAddress();
-    u8* depth_buffer = Memory::GetPhysicalPointer(addr);
+    u8* depth_buffer = VideoCore::g_memory->GetPhysicalPointer(addr);
 
     y = framebuffer.height - y;
 
@@ -193,7 +194,7 @@ void SetDepth(int x, int y, u32 value) {
 void SetStencil(int x, int y, u8 value) {
     const auto& framebuffer = g_state.regs.framebuffer.framebuffer;
     const PAddr addr = framebuffer.GetDepthBufferPhysicalAddress();
-    u8* depth_buffer = Memory::GetPhysicalPointer(addr);
+    u8* depth_buffer = VideoCore::g_memory->GetPhysicalPointer(addr);
 
     y = framebuffer.height - y;
 
@@ -384,7 +385,7 @@ void DrawShadowMapPixel(int x, int y, u32 depth, u8 stencil) {
     u32 bytes_per_pixel = 4;
     u32 dst_offset = VideoCore::GetMortonOffset(x, y, bytes_per_pixel) +
                      coarse_y * framebuffer.width * bytes_per_pixel;
-    u8* dst_pixel = Memory::GetPhysicalPointer(addr) + dst_offset;
+    u8* dst_pixel = VideoCore::g_memory->GetPhysicalPointer(addr) + dst_offset;
 
     auto ref = DecodeD24S8Shadow(dst_pixel);
     u32 ref_z = ref.x;

--- a/src/video_core/swrasterizer/rasterizer.cpp
+++ b/src/video_core/swrasterizer/rasterizer.cpp
@@ -30,6 +30,7 @@
 #include "video_core/swrasterizer/texturing.h"
 #include "video_core/texture/texture_decode.h"
 #include "video_core/utils.h"
+#include "video_core/video_core.h"
 
 namespace Pica {
 namespace Rasterizer {
@@ -402,7 +403,8 @@ static void ProcessTriangleInternal(const Vertex& v0, const Vertex& v1, const Ve
                     t = texture.config.height - 1 -
                         GetWrappedTexCoord(texture.config.wrap_t, t, texture.config.height);
 
-                    const u8* texture_data = Memory::GetPhysicalPointer(texture_address);
+                    const u8* texture_data =
+                        VideoCore::g_memory->GetPhysicalPointer(texture_address);
                     auto info =
                         Texture::TextureInfo::FromPicaRegister(texture.config, texture.format);
 

--- a/src/video_core/vertex_loader.cpp
+++ b/src/video_core/vertex_loader.cpp
@@ -13,6 +13,7 @@
 #include "video_core/regs_pipeline.h"
 #include "video_core/shader/shader.h"
 #include "video_core/vertex_loader.h"
+#include "video_core/video_core.h"
 
 namespace Pica {
 
@@ -95,32 +96,32 @@ void VertexLoader::LoadVertex(u32 base_address, int index, int vertex,
 
             switch (vertex_attribute_formats[i]) {
             case PipelineRegs::VertexAttributeFormat::BYTE: {
-                const s8* srcdata =
-                    reinterpret_cast<const s8*>(Memory::GetPhysicalPointer(source_addr));
+                const s8* srcdata = reinterpret_cast<const s8*>(
+                    VideoCore::g_memory->GetPhysicalPointer(source_addr));
                 for (unsigned int comp = 0; comp < vertex_attribute_elements[i]; ++comp) {
                     input.attr[i][comp] = float24::FromFloat32(srcdata[comp]);
                 }
                 break;
             }
             case PipelineRegs::VertexAttributeFormat::UBYTE: {
-                const u8* srcdata =
-                    reinterpret_cast<const u8*>(Memory::GetPhysicalPointer(source_addr));
+                const u8* srcdata = reinterpret_cast<const u8*>(
+                    VideoCore::g_memory->GetPhysicalPointer(source_addr));
                 for (unsigned int comp = 0; comp < vertex_attribute_elements[i]; ++comp) {
                     input.attr[i][comp] = float24::FromFloat32(srcdata[comp]);
                 }
                 break;
             }
             case PipelineRegs::VertexAttributeFormat::SHORT: {
-                const s16* srcdata =
-                    reinterpret_cast<const s16*>(Memory::GetPhysicalPointer(source_addr));
+                const s16* srcdata = reinterpret_cast<const s16*>(
+                    VideoCore::g_memory->GetPhysicalPointer(source_addr));
                 for (unsigned int comp = 0; comp < vertex_attribute_elements[i]; ++comp) {
                     input.attr[i][comp] = float24::FromFloat32(srcdata[comp]);
                 }
                 break;
             }
             case PipelineRegs::VertexAttributeFormat::FLOAT: {
-                const float* srcdata =
-                    reinterpret_cast<const float*>(Memory::GetPhysicalPointer(source_addr));
+                const float* srcdata = reinterpret_cast<const float*>(
+                    VideoCore::g_memory->GetPhysicalPointer(source_addr));
                 for (unsigned int comp = 0; comp < vertex_attribute_elements[i]; ++comp) {
                     input.attr[i][comp] = float24::FromFloat32(srcdata[comp]);
                 }

--- a/src/video_core/video_core.cpp
+++ b/src/video_core/video_core.cpp
@@ -29,8 +29,11 @@ void* g_screenshot_bits;
 std::function<void()> g_screenshot_complete_callback;
 Layout::FramebufferLayout g_screenshot_framebuffer_layout;
 
+Memory::MemorySystem* g_memory;
+
 /// Initialize the video core
-Core::System::ResultStatus Init(EmuWindow& emu_window) {
+Core::System::ResultStatus Init(EmuWindow& emu_window, Memory::MemorySystem& memory) {
+    g_memory = &memory;
     Pica::Init();
 
     g_renderer = std::make_unique<OpenGL::RendererOpenGL>(emu_window);

--- a/src/video_core/video_core.h
+++ b/src/video_core/video_core.h
@@ -12,7 +12,7 @@
 class EmuWindow;
 class RendererBase;
 
-namespace Memory{
+namespace Memory {
 class MemorySystem;
 }
 

--- a/src/video_core/video_core.h
+++ b/src/video_core/video_core.h
@@ -12,6 +12,10 @@
 class EmuWindow;
 class RendererBase;
 
+namespace Memory{
+class MemorySystem;
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Video Core namespace
 
@@ -33,8 +37,10 @@ extern void* g_screenshot_bits;
 extern std::function<void()> g_screenshot_complete_callback;
 extern Layout::FramebufferLayout g_screenshot_framebuffer_layout;
 
+extern Memory::MemorySystem* g_memory;
+
 /// Initialize the video core
-Core::System::ResultStatus Init(EmuWindow& emu_window);
+Core::System::ResultStatus Init(EmuWindow& emu_window, Memory::MemorySystem& memory);
 
 /// Shutdown the video core
 void Shutdown();


### PR DESCRIPTION
This PR concentrates on the memory module itself. Some workaround/hack has to be applied temporarily to those module that I haven't been visited yet, such as video_core, where I have to make a global reference there for now. These global references, `Core::System::GetInstance` and `public` hacks for test will be gradually removed in the following PRs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4480)
<!-- Reviewable:end -->
