### PR TITLE
DSP: Add address mask for physical pointers to audio data buffers

### DIFF
--- a/src/audio_core/hle/source.cpp
+++ b/src/audio_core/hle/source.cpp
@@ -284,7 +284,7 @@ bool Source::DequeueBuffer() {
         state.adpcm_state.yn2 = buf.adpcm_yn[1];
     }
 
-    const u8* const memory = Memory::GetPhysicalPointer(buf.physical_address);
+    const u8* const memory = Memory::GetPhysicalPointer(buf.physical_address & 0xFFFFFFFC);
     if (memory) {
         const unsigned num_channels = buf.mono_or_stereo == MonoOrStereo::Stereo ? 2 : 1;
         switch (buf.format) {

--- a/src/audio_core/hle/source.cpp
+++ b/src/audio_core/hle/source.cpp
@@ -284,6 +284,8 @@ bool Source::DequeueBuffer() {
         state.adpcm_state.yn2 = buf.adpcm_yn[1];
     }
 
+    // This physical address masking occurs due to how the DSP DMA hardware is configured by the
+    // firmware.
     const u8* const memory = Memory::GetPhysicalPointer(buf.physical_address & 0xFFFFFFFC);
     if (memory) {
         const unsigned num_channels = buf.mono_or_stereo == MonoOrStereo::Stereo ? 2 : 1;


### PR DESCRIPTION
Fixes #3313 and #3393, and probably also #3378 and #3392.

The physical audio buffer addresses that Luigi's Mansion Dark Moon gives to the DSP have the least-significant bit set for no obvious reason. Citra took it at its word, resulting in garbled audio. Masking the addresses with `0xFFFFFFFE` is enough to fix the issue, but hardware testing (thanks to @Dragios and @jroweboy) indicated that `0xFFFFFFFC` is actually the correct mask for all audio formats (mono and stereo PCM8, mono and stereo PCM16, and ADPCM). This fixes the audio on Dark Moon, The Amazing Spiderman, Metroid Prime Federation Force, and probably also some other games that haven't been re-tested yet (see the issues I linked above).

A few extra notes:

- Luigi's Mansion Dark Moon, Metroid Prime Federation Force, The Amazing Spiderman and Disney Princess - My Fairytale Adventure all use the Wwise audio engine, so it's a good guess that this fix also affects any other games using that engine. Monster 4x4 3D was too obscure for me to determine just by Internet sleuthing if it uses Wwise or not.
- Setting the bottom bit of the address didn't seem to cause any noticeable difference during the hardware tests.
- I also hardware-tested whether the most significant address bit is masked out or not, and it seems to not be (unlike on several other Nintendo consoles). I didn't check any other high address bits, but it's a pretty safe assumption that those are also not masked out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4483)
<!-- Reviewable:end -->
