### PR TITLE
renderer_opengl: Fix string comparison

### DIFF
--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -551,7 +551,7 @@ Core::System::ResultStatus RendererOpenGL::Init() {
     Core::Telemetry().AddField(Telemetry::FieldType::UserSystem, "GPU_Model", gpu_model);
     Core::Telemetry().AddField(Telemetry::FieldType::UserSystem, "GPU_OpenGL_Version", gl_version);
 
-    if (gpu_vendor == "GDI Generic") {
+    if (!strcmp(gpu_vendor, "GDI Generic")) {
         return Core::System::ResultStatus::ErrorVideoCore_ErrorGenericDrivers;
     }
 


### PR DESCRIPTION
This PR fixes a bad string comparison (comparing pointer values instead of string content) in the opengl renderer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4484)
<!-- Reviewable:end -->
