### PR TITLE
audio: implement DSP LLE

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -38,11 +38,14 @@
     path = externals/discord-rpc
     url = https://github.com/discordapp/discord-rpc.git
 [submodule "externals/libzmq"]
-	path = externals/libzmq
-	url = https://github.com/zeromq/libzmq
+    path = externals/libzmq
+    url = https://github.com/zeromq/libzmq
 [submodule "externals/cppzmq"]
-	path = externals/cppzmq
-	url = https://github.com/zeromq/cppzmq
+    path = externals/cppzmq
+    url = https://github.com/zeromq/cppzmq
 [submodule "cpp-jwt"]
-	path = externals/cpp-jwt
-	url = https://github.com/arun11299/cpp-jwt.git
+    path = externals/cpp-jwt
+    url = https://github.com/arun11299/cpp-jwt.git
+[submodule "teakra"]
+    path = externals/teakra
+    url = https://github.com/wwylele/teakra.git

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -51,6 +51,9 @@ add_subdirectory(soundtouch)
 # The SoundTouch target doesn't export the necessary include paths as properties by default
 target_include_directories(SoundTouch INTERFACE ./soundtouch/include)
 
+# Teakra
+add_subdirectory(teakra)
+
 # Xbyak
 if (ARCHITECTURE_x86_64)
     # Defined before "dynarmic" above

--- a/src/audio_core/CMakeLists.txt
+++ b/src/audio_core/CMakeLists.txt
@@ -14,6 +14,8 @@ add_library(audio_core STATIC
     hle/shared_memory.h
     hle/source.cpp
     hle/source.h
+    lle/lle.cpp
+    lle/lle.h
     interpolate.cpp
     interpolate.h
     null_sink.h
@@ -30,7 +32,7 @@ add_library(audio_core STATIC
 create_target_directory_groups(audio_core)
 
 target_link_libraries(audio_core PUBLIC common core)
-target_link_libraries(audio_core PRIVATE SoundTouch)
+target_link_libraries(audio_core PRIVATE SoundTouch teakra)
 
 if(SDL2_FOUND)
     target_link_libraries(audio_core PRIVATE SDL2)
@@ -41,4 +43,3 @@ if(ENABLE_CUBEB)
     target_link_libraries(audio_core PRIVATE cubeb)
     add_definitions(-DHAVE_CUBEB=1)
 endif()
-

--- a/src/audio_core/dsp_interface.cpp
+++ b/src/audio_core/dsp_interface.cpp
@@ -44,6 +44,13 @@ void DspInterface::OutputFrame(StereoFrame16& frame) {
     fifo.Push(frame.data(), frame.size());
 }
 
+void DspInterface::OutputSample(std::array<s16, 2> sample) {
+    if (!sink)
+        return;
+
+    fifo.Push(&sample, 1);
+}
+
 void DspInterface::OutputCallback(s16* buffer, std::size_t num_frames) {
     std::size_t frames_written;
     if (perform_time_stretching) {

--- a/src/audio_core/dsp_interface.h
+++ b/src/audio_core/dsp_interface.h
@@ -88,6 +88,9 @@ public:
     /// Sets the dsp class that we trigger interrupts for
     virtual void SetServiceToInterrupt(std::weak_ptr<Service::DSP::DSP_DSP> dsp) = 0;
 
+    /// Loads the DSP program
+    virtual void LoadComponent(const std::vector<u8>& buffer) = 0;
+
     /// Select the sink to use based on sink id.
     void SetSink(const std::string& sink_id, const std::string& audio_device);
     /// Get the current sink

--- a/src/audio_core/dsp_interface.h
+++ b/src/audio_core/dsp_interface.h
@@ -32,8 +32,13 @@ public:
     DspInterface& operator=(const DspInterface&) = delete;
     DspInterface& operator=(DspInterface&&) = delete;
 
-    /// Get the state of the DSP
-    virtual DspState GetDspState() const = 0;
+    /**
+     * Reads data from one of three DSP registers
+     * @note this function blocks until the data is available
+     * @param register_number the index of the register to read
+     * @returns the value of the register
+     */
+    virtual u16 RecvData(u32 register_number) = 0;
 
     /**
      * Reads `length` bytes from the DSP pipe identified with `pipe_number`.

--- a/src/audio_core/dsp_interface.h
+++ b/src/audio_core/dsp_interface.h
@@ -103,6 +103,7 @@ public:
 
 protected:
     void OutputFrame(StereoFrame16& frame);
+    void OutputSample(std::array<s16, 2> sample);
 
 private:
     void FlushResidualStretcherAudio();

--- a/src/audio_core/dsp_interface.h
+++ b/src/audio_core/dsp_interface.h
@@ -91,6 +91,9 @@ public:
     /// Loads the DSP program
     virtual void LoadComponent(const std::vector<u8>& buffer) = 0;
 
+    /// Unloads the DSP program
+    virtual void UnloadComponent() = 0;
+
     /// Select the sink to use based on sink id.
     void SetSink(const std::string& sink_id, const std::string& audio_device);
     /// Get the current sink

--- a/src/audio_core/dsp_interface.h
+++ b/src/audio_core/dsp_interface.h
@@ -48,6 +48,12 @@ public:
     virtual bool RecvDataIsReady(u32 register_number) const = 0;
 
     /**
+     * Sets the DSP semaphore register
+     * @param semaphore_value the value set to the semaphore register
+     */
+    virtual void SetSemaphore(u16 semaphore_value) = 0;
+
+    /**
      * Reads `length` bytes from the DSP pipe identified with `pipe_number`.
      * @note Can read up to the maximum value of a u16 in bytes (65,535).
      * @note IF an error is encoutered with either an invalid `pipe_number` or `length` value, an

--- a/src/audio_core/dsp_interface.h
+++ b/src/audio_core/dsp_interface.h
@@ -41,6 +41,13 @@ public:
     virtual u16 RecvData(u32 register_number) = 0;
 
     /**
+     * Checks whether data is ready in one of three DSP registers
+     * @param register_number the index of the register to check
+     * @returns true if data is ready
+     */
+    virtual bool RecvDataIsReady(u32 register_number) const = 0;
+
+    /**
      * Reads `length` bytes from the DSP pipe identified with `pipe_number`.
      * @note Can read up to the maximum value of a u16 in bytes (65,535).
      * @note IF an error is encoutered with either an invalid `pipe_number` or `length` value, an

--- a/src/audio_core/hle/hle.cpp
+++ b/src/audio_core/hle/hle.cpp
@@ -375,6 +375,10 @@ bool DspHle::RecvDataIsReady(u32 register_number) const {
     return impl->RecvDataIsReady(register_number);
 }
 
+void DspHle::SetSemaphore(u16 semaphore_value) {
+    // Do nothing in HLE
+}
+
 std::vector<u8> DspHle::PipeRead(DspPipe pipe_number, u32 length) {
     return impl->PipeRead(pipe_number, length);
 }

--- a/src/audio_core/hle/hle.cpp
+++ b/src/audio_core/hle/hle.cpp
@@ -411,4 +411,8 @@ void DspHle::LoadComponent(const std::vector<u8>& component_data) {
     }
 }
 
+void DspHle::UnloadComponent() {
+    // Do nothing
+}
+
 } // namespace AudioCore

--- a/src/audio_core/hle/hle.cpp
+++ b/src/audio_core/hle/hle.cpp
@@ -11,6 +11,7 @@
 #include "audio_core/sink.h"
 #include "common/assert.h"
 #include "common/common_types.h"
+#include "common/hash.h"
 #include "common/logging/log.h"
 #include "core/core.h"
 #include "core/core_timing.h"
@@ -397,6 +398,17 @@ std::array<u8, Memory::DSP_RAM_SIZE>& DspHle::GetDspMemory() {
 
 void DspHle::SetServiceToInterrupt(std::weak_ptr<DSP_DSP> dsp) {
     impl->SetServiceToInterrupt(std::move(dsp));
+}
+
+void DspHle::LoadComponent(const std::vector<u8>& component_data) {
+    // HLE doesn't need DSP program. Only log some info here
+    LOG_INFO(Service_DSP, "Firmware hash: {:#018x}",
+             Common::ComputeHash64(component_data.data(), component_data.size()));
+    // Some versions of the firmware have the location of DSP structures listed here.
+    if (component_data.size() > 0x37C) {
+        LOG_INFO(Service_DSP, "Structures hash: {:#018x}",
+                 Common::ComputeHash64(component_data.data() + 0x340, 60));
+    }
 }
 
 } // namespace AudioCore

--- a/src/audio_core/hle/hle.cpp
+++ b/src/audio_core/hle/hle.cpp
@@ -30,6 +30,7 @@ public:
     DspState GetDspState() const;
 
     u16 RecvData(u32 register_number);
+    bool RecvDataIsReady(u32 register_number) const;
     std::vector<u8> PipeRead(DspPipe pipe_number, u32 length);
     std::size_t GetPipeReadableSize(DspPipe pipe_number) const;
     void PipeWrite(DspPipe pipe_number, const std::vector<u8>& buffer);
@@ -110,6 +111,11 @@ u16 DspHle::Impl::RecvData(u32 register_number) {
         UNREACHABLE();
         break;
     }
+}
+
+bool DspHle::Impl::RecvDataIsReady(u32 register_number) const {
+    ASSERT_MSG(register_number == 0, "Unknown register_number {}", register_number);
+    return true;
 }
 
 std::vector<u8> DspHle::Impl::PipeRead(DspPipe pipe_number, u32 length) {
@@ -363,6 +369,10 @@ DspHle::~DspHle() = default;
 
 u16 DspHle::RecvData(u32 register_number) {
     return impl->RecvData(register_number);
+}
+
+bool DspHle::RecvDataIsReady(u32 register_number) const {
+    return impl->RecvDataIsReady(register_number);
 }
 
 std::vector<u8> DspHle::PipeRead(DspPipe pipe_number, u32 length) {

--- a/src/audio_core/hle/hle.h
+++ b/src/audio_core/hle/hle.h
@@ -35,6 +35,8 @@ public:
 
     void SetServiceToInterrupt(std::weak_ptr<Service::DSP::DSP_DSP> dsp) override;
 
+    void LoadComponent(const std::vector<u8>& buffer) override;
+
 private:
     struct Impl;
     friend struct Impl;

--- a/src/audio_core/hle/hle.h
+++ b/src/audio_core/hle/hle.h
@@ -24,8 +24,7 @@ public:
     explicit DspHle(Memory::MemorySystem& memory);
     ~DspHle();
 
-    DspState GetDspState() const override;
-
+    u16 RecvData(u32 register_number) override;
     std::vector<u8> PipeRead(DspPipe pipe_number, u32 length) override;
     std::size_t GetPipeReadableSize(DspPipe pipe_number) const override;
     void PipeWrite(DspPipe pipe_number, const std::vector<u8>& buffer) override;

--- a/src/audio_core/hle/hle.h
+++ b/src/audio_core/hle/hle.h
@@ -25,6 +25,7 @@ public:
     ~DspHle();
 
     u16 RecvData(u32 register_number) override;
+    bool RecvDataIsReady(u32 register_number) const override;
     std::vector<u8> PipeRead(DspPipe pipe_number, u32 length) override;
     std::size_t GetPipeReadableSize(DspPipe pipe_number) const override;
     void PipeWrite(DspPipe pipe_number, const std::vector<u8>& buffer) override;

--- a/src/audio_core/hle/hle.h
+++ b/src/audio_core/hle/hle.h
@@ -36,6 +36,7 @@ public:
     void SetServiceToInterrupt(std::weak_ptr<Service::DSP::DSP_DSP> dsp) override;
 
     void LoadComponent(const std::vector<u8>& buffer) override;
+    void UnloadComponent() override;
 
 private:
     struct Impl;

--- a/src/audio_core/hle/hle.h
+++ b/src/audio_core/hle/hle.h
@@ -26,6 +26,7 @@ public:
 
     u16 RecvData(u32 register_number) override;
     bool RecvDataIsReady(u32 register_number) const override;
+    void SetSemaphore(u16 semaphore_value) override;
     std::vector<u8> PipeRead(DspPipe pipe_number, u32 length) override;
     std::size_t GetPipeReadableSize(DspPipe pipe_number) const override;
     void PipeWrite(DspPipe pipe_number, const std::vector<u8>& buffer) override;

--- a/src/audio_core/lle/lle.cpp
+++ b/src/audio_core/lle/lle.cpp
@@ -23,6 +23,10 @@ u16 DspLle::RecvData(u32 register_number) {
     return impl->teakra.RecvData(static_cast<u8>(register_number));
 }
 
+bool DspLle::RecvDataIsReady(u32 register_number) const {
+    return impl->teakra.RecvDataIsReady(register_number);
+}
+
 DspLle::DspLle() : impl(std::make_unique<Impl>()) {}
 DspLle::~DspLle() = default;
 

--- a/src/audio_core/lle/lle.cpp
+++ b/src/audio_core/lle/lle.cpp
@@ -9,7 +9,19 @@ namespace AudioCore {
 
 struct DspLle::Impl final {
     Teakra::Teakra teakra;
+
+    static constexpr unsigned TeakraSlice = 20000;
+    void RunTeakraSlice() {
+        teakra.Run(TeakraSlice);
+    }
 };
+
+u16 DspLle::RecvData(u32 register_number) {
+    while (!impl->teakra.RecvDataIsReady(register_number)) {
+        impl->RunTeakraSlice();
+    }
+    return impl->teakra.RecvData(static_cast<u8>(register_number));
+}
 
 DspLle::DspLle() : impl(std::make_unique<Impl>()) {}
 DspLle::~DspLle() = default;

--- a/src/audio_core/lle/lle.cpp
+++ b/src/audio_core/lle/lle.cpp
@@ -1,0 +1,17 @@
+// Copyright 2018 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "audio_core/lle/lle.h"
+#include "teakra/teakra.h"
+
+namespace AudioCore {
+
+struct DspLle::Impl final {
+    Teakra::Teakra teakra;
+};
+
+DspLle::DspLle() : impl(std::make_unique<Impl>()) {}
+DspLle::~DspLle() = default;
+
+} // namespace AudioCore

--- a/src/audio_core/lle/lle.cpp
+++ b/src/audio_core/lle/lle.cpp
@@ -153,7 +153,12 @@ struct DspLle::Impl final {
         return &memory[DspDataOffset + baddr];
     }
 
-    PipeStatus GetPipeStatus(u8 pipe_index, PipeDirection direction) {
+    const u8* GetDspDataPointer(u32 baddr) const {
+        auto& memory = teakra.GetDspMemory();
+        return &memory[DspDataOffset + baddr];
+    }
+
+    PipeStatus GetPipeStatus(u8 pipe_index, PipeDirection direction) const {
         u8 slot_index = PipeIndexToSlotIndex(pipe_index, direction);
         PipeStatus pipe_status;
         std::memcpy(&pipe_status,
@@ -249,7 +254,7 @@ struct DspLle::Impl final {
         }
         return data;
     }
-    u16 GetPipeReadableSize(u8 pipe_index) {
+    u16 GetPipeReadableSize(u8 pipe_index) const {
         PipeStatus pipe_status = GetPipeStatus(pipe_index, PipeDirection::DSPtoCPU);
         u16 size = pipe_status.write_bptr - pipe_status.read_bptr;
         if (pipe_status.IsWrapped()) {
@@ -307,7 +312,7 @@ struct DspLle::Impl final {
             return;
         }
 
-        // Send finalization signal
+        // Send finalization signal via command/reply register 2
         constexpr u16 FinalizeSignal = 0x8000;
         while (!teakra.SendDataIsEmpty(2))
             RunTeakraSlice();

--- a/src/audio_core/lle/lle.cpp
+++ b/src/audio_core/lle/lle.cpp
@@ -349,6 +349,9 @@ void DspLle::SetServiceToInterrupt(std::weak_ptr<Service::DSP::DSP_DSP> dsp) {
     });
 
     auto ProcessPipeEvent = [this, dsp](bool event_from_data) {
+        if (!impl->loaded)
+            return;
+
         auto& teakra = impl->teakra;
         if (event_from_data) {
             impl->data_signaled = true;

--- a/src/audio_core/lle/lle.cpp
+++ b/src/audio_core/lle/lle.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <array>
+#include <teakra/teakra.h>
 #include "audio_core/lle/lle.h"
 #include "common/assert.h"
 #include "common/bit_field.h"
@@ -10,7 +11,6 @@
 #include "core/core.h"
 #include "core/core_timing.h"
 #include "core/hle/service/dsp/dsp_dsp.h"
-#include "teakra/teakra.h"
 
 namespace AudioCore {
 
@@ -22,11 +22,11 @@ enum class SegmentType : u8 {
 
 class Dsp1 {
 public:
-    Dsp1(const std::vector<u8>& raw);
+    explicit Dsp1(const std::vector<u8>& raw);
 
     struct Header {
         std::array<u8, 0x100> signature;
-        std::array<u8, 4> magic;
+        std::array<u8, 0x4> magic;
         u32_le binary_size;
         u16_le memory_layout;
         INSERT_PADDING_BYTES(3);
@@ -72,7 +72,7 @@ Dsp1::Dsp1(const std::vector<u8>& raw) {
                             raw.begin() + header.segments[i].offset + header.segments[i].size);
         segment.memory_type = header.segments[i].memory_type;
         segment.target = header.segments[i].address;
-        segments.push_back(segment);
+        segments.push_back(std::move(segment));
     }
 }
 
@@ -83,6 +83,26 @@ struct PipeStatus {
     u16_le write_bptr;
     u8 slot_index;
     u8 flags;
+
+    static constexpr u16 WrapBit = 0x8000;
+    static constexpr u16 PtrMask = 0x7FFF;
+
+    bool IsFull() const {
+        return (read_bptr ^ write_bptr) == WrapBit;
+    }
+
+    bool IsEmpty() const {
+        return (read_bptr ^ write_bptr) == 0;
+    }
+
+    /*
+     * IsWrapped: Are read and write pointers not in the same pass.
+     * false:  ----[xxxx]----
+     * true:   xxxx]----[xxxx (data is wrapping around the end)
+     */
+    bool IsWrapped() const {
+        return (read_bptr ^ write_bptr) >= WrapBit;
+    }
 };
 
 static_assert(sizeof(PipeStatus) == 10);
@@ -93,7 +113,7 @@ enum class PipeDirection : u8 {
 };
 
 static u8 PipeIndexToSlotIndex(u8 pipe_index, PipeDirection direction) {
-    return (pipe_index << 1) + (u8)direction;
+    return (pipe_index << 1) + static_cast<u8>(direction);
 }
 
 struct DspLle::Impl final {
@@ -111,7 +131,9 @@ struct DspLle::Impl final {
     Core::TimingEventType* teakra_slice_event;
     bool loaded = false;
 
-    static constexpr unsigned TeakraSlice = 20000;
+    static constexpr u32 DspDataOffset = 0x40000;
+    static constexpr u32 TeakraSlice = 20000;
+
     void RunTeakraSlice() {
         teakra.Run(TeakraSlice);
     }
@@ -128,7 +150,7 @@ struct DspLle::Impl final {
 
     u8* GetDspDataPointer(u32 baddr) {
         auto& memory = teakra.GetDspMemory();
-        return &memory[0x40000 + baddr];
+        return &memory[DspDataOffset + baddr];
     }
 
     PipeStatus GetPipeStatus(u8 pipe_index, PipeDirection direction) {
@@ -156,16 +178,15 @@ struct DspLle::Impl final {
         PipeStatus pipe_status = GetPipeStatus(pipe_index, PipeDirection::CPUtoDSP);
         bool need_update = false;
         const u8* buffer_ptr = data.data();
-        u16 bsize = (u16)data.size();
+        u16 bsize = static_cast<u16>(data.size());
         while (bsize != 0) {
-            u16 x = pipe_status.read_bptr ^ pipe_status.write_bptr;
-            ASSERT_MSG(x != 0x8000, "Pipe is Full");
+            ASSERT_MSG(!pipe_status.IsFull(), "Pipe is Full");
             u16 write_bend;
-            if (x > 0x8000)
-                write_bend = pipe_status.read_bptr & 0x7FFF;
+            if (pipe_status.IsWrapped())
+                write_bend = pipe_status.read_bptr & PipeStatus::PtrMask;
             else
                 write_bend = pipe_status.bsize;
-            u16 write_bbegin = pipe_status.write_bptr & 0x7FFF;
+            u16 write_bbegin = pipe_status.write_bptr & PipeStatus::PtrMask;
             ASSERT_MSG(write_bend > write_bbegin,
                        "Pipe is in inconsistent state: end {:04X} <= begin {:04X}, size {:04X}",
                        write_bend, write_bbegin, pipe_status.bsize);
@@ -175,11 +196,11 @@ struct DspLle::Impl final {
             buffer_ptr += write_bsize;
             pipe_status.write_bptr += write_bsize;
             bsize -= write_bsize;
-            ASSERT_MSG((pipe_status.write_bptr & 0x7FFF) <= pipe_status.bsize,
+            ASSERT_MSG((pipe_status.write_bptr & PipeStatus::PtrMask) <= pipe_status.bsize,
                        "Pipe is in inconsistent state: write > size");
-            if ((pipe_status.write_bptr & 0x7FFF) == pipe_status.bsize) {
-                pipe_status.write_bptr &= 0x8000;
-                pipe_status.write_bptr ^= 0x8000;
+            if ((pipe_status.write_bptr & PipeStatus::PtrMask) == pipe_status.bsize) {
+                pipe_status.write_bptr &= PipeStatus::WrapBit;
+                pipe_status.write_bptr ^= PipeStatus::WrapBit;
             }
             need_update = true;
         }
@@ -197,15 +218,14 @@ struct DspLle::Impl final {
         std::vector<u8> data(bsize);
         u8* buffer_ptr = data.data();
         while (bsize != 0) {
-            u16 x = pipe_status.read_bptr ^ pipe_status.write_bptr;
-            ASSERT_MSG(x != 0, "Pipe is empty");
+            ASSERT_MSG(!pipe_status.IsEmpty(), "Pipe is empty");
             u16 read_bend;
-            if (x >= 0x8000) {
+            if (pipe_status.IsWrapped()) {
                 read_bend = pipe_status.bsize;
             } else {
-                read_bend = pipe_status.write_bptr & 0x7FFF;
+                read_bend = pipe_status.write_bptr & PipeStatus::PtrMask;
             }
-            u16 read_bbegin = pipe_status.read_bptr & 0x7FFF;
+            u16 read_bbegin = pipe_status.read_bptr & PipeStatus::PtrMask;
             ASSERT(read_bend > read_bbegin);
             u16 read_bsize = std::min<u16>(bsize, read_bend - read_bbegin);
             std::memcpy(buffer_ptr, GetDspDataPointer(pipe_status.waddress * 2 + read_bbegin),
@@ -213,11 +233,11 @@ struct DspLle::Impl final {
             buffer_ptr += read_bsize;
             pipe_status.read_bptr += read_bsize;
             bsize -= read_bsize;
-            ASSERT_MSG((pipe_status.read_bptr & 0x7FFF) <= pipe_status.bsize,
+            ASSERT_MSG((pipe_status.read_bptr & PipeStatus::PtrMask) <= pipe_status.bsize,
                        "Pipe is in inconsistent state: read > size");
-            if ((pipe_status.read_bptr & 0x7FFF) == pipe_status.bsize) {
-                pipe_status.read_bptr &= 0x8000;
-                pipe_status.read_bptr ^= 0x8000;
+            if ((pipe_status.read_bptr & PipeStatus::PtrMask) == pipe_status.bsize) {
+                pipe_status.read_bptr &= PipeStatus::WrapBit;
+                pipe_status.read_bptr ^= PipeStatus::WrapBit;
             }
             need_update = true;
         }
@@ -232,10 +252,10 @@ struct DspLle::Impl final {
     u16 GetPipeReadableSize(u8 pipe_index) {
         PipeStatus pipe_status = GetPipeStatus(pipe_index, PipeDirection::DSPtoCPU);
         u16 size = pipe_status.write_bptr - pipe_status.read_bptr;
-        if ((pipe_status.read_bptr ^ pipe_status.write_bptr) >= 0x8000) {
+        if (pipe_status.IsWrapped()) {
             size += pipe_status.bsize;
         }
-        return size & 0x7FFF;
+        return size & PipeStatus::PtrMask;
     }
 
     void LoadComponent(const std::vector<u8>& buffer) {
@@ -249,7 +269,7 @@ struct DspLle::Impl final {
         Dsp1 dsp(buffer);
         auto& dsp_memory = teakra.GetDspMemory();
         u8* program = dsp_memory.data();
-        u8* data = dsp_memory.data() + 0x40000;
+        u8* data = dsp_memory.data() + DspDataOffset;
         for (const auto& segment : dsp.segments) {
             if (segment.memory_type == SegmentType::ProgramA ||
                 segment.memory_type == SegmentType::ProgramB) {
@@ -265,10 +285,11 @@ struct DspLle::Impl final {
 
         // Wait for initialization
         if (dsp.recv_data_on_start) {
-            for (unsigned i = 0; i < 3; ++i) {
-                while (!teakra.RecvDataIsReady(i))
-                    RunTeakraSlice();
-                ASSERT(teakra.RecvData(i) == 1);
+            for (u8 i = 0; i < 3; ++i) {
+                do {
+                    while (!teakra.RecvDataIsReady(i))
+                        RunTeakraSlice();
+                } while (teakra.RecvData(i) != 1);
             }
         }
 
@@ -287,10 +308,11 @@ struct DspLle::Impl final {
         }
 
         // Send finalization signal
+        constexpr u16 FinalizeSignal = 0x8000;
         while (!teakra.SendDataIsEmpty(2))
             RunTeakraSlice();
 
-        teakra.SendData(2, 0x8000);
+        teakra.SendData(2, FinalizeSignal);
 
         // Wait for completion
         while (!teakra.RecvDataIsReady(2))

--- a/src/audio_core/lle/lle.cpp
+++ b/src/audio_core/lle/lle.cpp
@@ -3,16 +3,104 @@
 // Refer to the license.txt file included.
 
 #include "audio_core/lle/lle.h"
+#include "common/assert.h"
+#include "common/swap.h"
 #include "teakra/teakra.h"
 
 namespace AudioCore {
 
+struct PipeStatus {
+    u16_le waddress;
+    u16_le bsize;
+    u16_le read_bptr;
+    u16_le write_bptr;
+    u8 slot_index;
+    u8 flags;
+};
+
+static_assert(sizeof(PipeStatus) == 10);
+
+enum class PipeDirection : u8 {
+    DSPtoCPU = 0,
+    CPUtoDSP = 1,
+};
+
+static u8 PipeIndexToSlotIndex(u8 pipe_index, PipeDirection direction) {
+    return (pipe_index << 1) + (u8)direction;
+}
+
 struct DspLle::Impl final {
     Teakra::Teakra teakra;
+    u16 pipe_base_waddr = 0;
 
     static constexpr unsigned TeakraSlice = 20000;
     void RunTeakraSlice() {
         teakra.Run(TeakraSlice);
+    }
+
+    u8* GetDspDataPointer(u32 baddr) {
+        auto& memory = teakra.GetDspMemory();
+        return &memory[0x40000 + baddr];
+    }
+
+    PipeStatus GetPipeStatus(u8 pipe_index, PipeDirection direction) {
+        u8 slot_index = PipeIndexToSlotIndex(pipe_index, direction);
+        PipeStatus pipe_status;
+        std::memcpy(&pipe_status,
+                    GetDspDataPointer(pipe_base_waddr * 2 + slot_index * sizeof(PipeStatus)),
+                    sizeof(PipeStatus));
+        ASSERT(pipe_status.slot_index == slot_index);
+        return pipe_status;
+    }
+
+    void UpdatePipeStatus(const PipeStatus& pipe_status) {
+        u8 slot_index = pipe_status.slot_index;
+        u8* status_address =
+            GetDspDataPointer(pipe_base_waddr * 2 + slot_index * sizeof(PipeStatus));
+        if (slot_index % 2 == 0) {
+            std::memcpy(status_address + 4, &pipe_status.read_bptr, sizeof(u16));
+        } else {
+            std::memcpy(status_address + 6, &pipe_status.write_bptr, sizeof(u16));
+        }
+    }
+
+    void WritePipe(u8 pipe_index, const std::vector<u8>& data) {
+        PipeStatus pipe_status = GetPipeStatus(pipe_index, PipeDirection::CPUtoDSP);
+        bool need_update = false;
+        const u8* buffer_ptr = data.data();
+        u16 bsize = (u16)data.size();
+        while (bsize != 0) {
+            u16 x = pipe_status.read_bptr ^ pipe_status.write_bptr;
+            ASSERT_MSG(x != 0x8000, "Pipe is Full");
+            u16 write_bend;
+            if (x > 0x8000)
+                write_bend = pipe_status.read_bptr & 0x7FFF;
+            else
+                write_bend = pipe_status.bsize;
+            u16 write_bbegin = pipe_status.write_bptr & 0x7FFF;
+            ASSERT_MSG(write_bend > write_bbegin,
+                       "Pipe is in inconsistent state: end {:04X} <= begin {:04X}, size {:04X}",
+                       write_bend, write_bbegin, pipe_status.bsize);
+            u16 write_bsize = std::min<u16>(bsize, write_bend - write_bbegin);
+            std::memcpy(GetDspDataPointer(pipe_status.waddress * 2 + write_bbegin), buffer_ptr,
+                        write_bsize);
+            buffer_ptr += write_bsize;
+            pipe_status.write_bptr += write_bsize;
+            bsize -= write_bsize;
+            ASSERT_MSG((pipe_status.write_bptr & 0x7FFF) <= pipe_status.bsize,
+                       "Pipe is in inconsistent state: write > size");
+            if ((pipe_status.write_bptr & 0x7FFF) == pipe_status.bsize) {
+                pipe_status.write_bptr &= 0x8000;
+                pipe_status.write_bptr ^= 0x8000;
+            }
+            need_update = true;
+        }
+        if (need_update) {
+            UpdatePipeStatus(pipe_status);
+            while (!teakra.SendDataIsEmpty(2))
+                RunTeakraSlice();
+            teakra.SendData(2, pipe_status.slot_index);
+        }
     }
 };
 
@@ -29,6 +117,10 @@ bool DspLle::RecvDataIsReady(u32 register_number) const {
 
 void DspLle::SetSemaphore(u16 semaphore_value) {
     impl->teakra.SetSemaphore(semaphore_value);
+}
+
+void DspLle::PipeWrite(DspPipe pipe_number, const std::vector<u8>& buffer) {
+    impl->WritePipe(static_cast<u8>(pipe_number), buffer);
 }
 
 DspLle::DspLle() : impl(std::make_unique<Impl>()) {}

--- a/src/audio_core/lle/lle.cpp
+++ b/src/audio_core/lle/lle.cpp
@@ -27,6 +27,10 @@ bool DspLle::RecvDataIsReady(u32 register_number) const {
     return impl->teakra.RecvDataIsReady(register_number);
 }
 
+void DspLle::SetSemaphore(u16 semaphore_value) {
+    impl->teakra.SetSemaphore(semaphore_value);
+}
+
 DspLle::DspLle() : impl(std::make_unique<Impl>()) {}
 DspLle::~DspLle() = default;
 

--- a/src/audio_core/lle/lle.h
+++ b/src/audio_core/lle/lle.h
@@ -10,7 +10,7 @@ namespace AudioCore {
 
 class DspLle final : public DspInterface {
 public:
-    explicit DspLle(Memory::MemorySystem& memory);
+    explicit DspLle(Memory::MemorySystem& memory, bool multithread);
     ~DspLle() override;
 
     u16 RecvData(u32 register_number) override;

--- a/src/audio_core/lle/lle.h
+++ b/src/audio_core/lle/lle.h
@@ -10,7 +10,7 @@ namespace AudioCore {
 
 class DspLle final : public DspInterface {
 public:
-    DspLle();
+    explicit DspLle(Memory::MemorySystem& memory);
     ~DspLle();
 
     u16 RecvData(u32 register_number) override;

--- a/src/audio_core/lle/lle.h
+++ b/src/audio_core/lle/lle.h
@@ -11,7 +11,7 @@ namespace AudioCore {
 class DspLle final : public DspInterface {
 public:
     explicit DspLle(Memory::MemorySystem& memory);
-    ~DspLle();
+    ~DspLle() override;
 
     u16 RecvData(u32 register_number) override;
     bool RecvDataIsReady(u32 register_number) const override;
@@ -29,7 +29,6 @@ public:
 
 private:
     struct Impl;
-    friend struct Impl;
     std::unique_ptr<Impl> impl;
 };
 

--- a/src/audio_core/lle/lle.h
+++ b/src/audio_core/lle/lle.h
@@ -16,6 +16,7 @@ public:
     u16 RecvData(u32 register_number) override;
     bool RecvDataIsReady(u32 register_number) const override;
     void SetSemaphore(u16 semaphore_value) override;
+    void PipeWrite(DspPipe pipe_number, const std::vector<u8>& buffer) override;
 
 private:
     struct Impl;

--- a/src/audio_core/lle/lle.h
+++ b/src/audio_core/lle/lle.h
@@ -20,6 +20,10 @@ public:
     std::size_t GetPipeReadableSize(DspPipe pipe_number) const override;
     void PipeWrite(DspPipe pipe_number, const std::vector<u8>& buffer) override;
 
+    std::array<u8, Memory::DSP_RAM_SIZE>& GetDspMemory() override;
+
+    void SetServiceToInterrupt(std::weak_ptr<Service::DSP::DSP_DSP> dsp) override;
+
 private:
     struct Impl;
     friend struct Impl;

--- a/src/audio_core/lle/lle.h
+++ b/src/audio_core/lle/lle.h
@@ -24,6 +24,8 @@ public:
 
     void SetServiceToInterrupt(std::weak_ptr<Service::DSP::DSP_DSP> dsp) override;
 
+    void LoadComponent(const std::vector<u8>& buffer) override;
+
 private:
     struct Impl;
     friend struct Impl;

--- a/src/audio_core/lle/lle.h
+++ b/src/audio_core/lle/lle.h
@@ -25,6 +25,7 @@ public:
     void SetServiceToInterrupt(std::weak_ptr<Service::DSP::DSP_DSP> dsp) override;
 
     void LoadComponent(const std::vector<u8>& buffer) override;
+    void UnloadComponent() override;
 
 private:
     struct Impl;

--- a/src/audio_core/lle/lle.h
+++ b/src/audio_core/lle/lle.h
@@ -1,0 +1,22 @@
+// Copyright 2018 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "audio_core/dsp_interface.h"
+
+namespace AudioCore {
+
+class DspLle final : public DspInterface {
+public:
+    DspLle();
+    ~DspLle();
+
+private:
+    struct Impl;
+    friend struct Impl;
+    std::unique_ptr<Impl> impl;
+};
+
+} // namespace AudioCore

--- a/src/audio_core/lle/lle.h
+++ b/src/audio_core/lle/lle.h
@@ -15,6 +15,7 @@ public:
 
     u16 RecvData(u32 register_number) override;
     bool RecvDataIsReady(u32 register_number) const override;
+    void SetSemaphore(u16 semaphore_value) override;
 
 private:
     struct Impl;

--- a/src/audio_core/lle/lle.h
+++ b/src/audio_core/lle/lle.h
@@ -13,6 +13,8 @@ public:
     DspLle();
     ~DspLle();
 
+    u16 RecvData(u32 register_number) override;
+
 private:
     struct Impl;
     friend struct Impl;

--- a/src/audio_core/lle/lle.h
+++ b/src/audio_core/lle/lle.h
@@ -16,6 +16,8 @@ public:
     u16 RecvData(u32 register_number) override;
     bool RecvDataIsReady(u32 register_number) const override;
     void SetSemaphore(u16 semaphore_value) override;
+    std::vector<u8> PipeRead(DspPipe pipe_number, u32 length) override;
+    std::size_t GetPipeReadableSize(DspPipe pipe_number) const override;
     void PipeWrite(DspPipe pipe_number, const std::vector<u8>& buffer) override;
 
 private:

--- a/src/audio_core/lle/lle.h
+++ b/src/audio_core/lle/lle.h
@@ -14,6 +14,7 @@ public:
     ~DspLle();
 
     u16 RecvData(u32 register_number) override;
+    bool RecvDataIsReady(u32 register_number) const override;
 
 private:
     struct Impl;

--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -156,6 +156,8 @@ void Config::ReadValues() {
 
     // Audio
     Settings::values.enable_dsp_lle = sdl2_config->GetBoolean("Audio", "enable_dsp_lle", false);
+    Settings::values.enable_dsp_lle_multithread =
+        sdl2_config->GetBoolean("Audio", "enable_dsp_lle_multithread", false);
     Settings::values.sink_id = sdl2_config->GetString("Audio", "output_engine", "auto");
     Settings::values.enable_audio_stretching =
         sdl2_config->GetBoolean("Audio", "enable_audio_stretching", true);

--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -155,6 +155,7 @@ void Config::ReadValues() {
         static_cast<u16>(sdl2_config->GetInteger("Layout", "custom_bottom_bottom", 480));
 
     // Audio
+    Settings::values.enable_dsp_lle = sdl2_config->GetBoolean("Audio", "enable_dsp_lle", false);
     Settings::values.sink_id = sdl2_config->GetString("Audio", "output_engine", "auto");
     Settings::values.enable_audio_stretching =
         sdl2_config->GetBoolean("Audio", "enable_audio_stretching", true);

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -167,7 +167,6 @@ custom_bottom_bottom =
 swap_screen =
 
 [Audio]
-
 # Whether or not to enable DSP LLE
 # 0 (default): No, 1: Yes
 enable_dsp_lle =

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -167,6 +167,11 @@ custom_bottom_bottom =
 swap_screen =
 
 [Audio]
+
+# Whether or not to enable DSP LLE
+# 0 (default): No, 1: Yes
+enable_dsp_lle =
+
 # Which audio output engine to use.
 # auto (default): Auto-select, null: No audio output, sdl2: SDL2 (if available)
 output_engine =

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -171,6 +171,11 @@ swap_screen =
 # 0 (default): No, 1: Yes
 enable_dsp_lle =
 
+# Whether or not to run DSP LLE on a different thread
+# 0 (default): No, 1: Yes
+enable_dsp_lle_thread =
+
+
 # Which audio output engine to use.
 # auto (default): Auto-select, null: No audio output, sdl2: SDL2 (if available)
 output_engine =

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -137,6 +137,8 @@ void Config::ReadValues() {
 
     qt_config->beginGroup("Audio");
     Settings::values.enable_dsp_lle = ReadSetting("enable_dsp_lle", false).toBool();
+    Settings::values.enable_dsp_lle_multithread =
+        ReadSetting("enable_dsp_lle_multithread", false).toBool();
     Settings::values.sink_id = ReadSetting("output_engine", "auto").toString().toStdString();
     Settings::values.enable_audio_stretching =
         ReadSetting("enable_audio_stretching", true).toBool();
@@ -417,6 +419,7 @@ void Config::SaveValues() {
 
     qt_config->beginGroup("Audio");
     WriteSetting("enable_dsp_lle", Settings::values.enable_dsp_lle, false);
+    WriteSetting("enable_dsp_lle_multithread", Settings::values.enable_dsp_lle_multithread, false);
     WriteSetting("output_engine", QString::fromStdString(Settings::values.sink_id), "auto");
     WriteSetting("enable_audio_stretching", Settings::values.enable_audio_stretching, true);
     WriteSetting("output_device", QString::fromStdString(Settings::values.audio_device_id), "auto");

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -136,6 +136,7 @@ void Config::ReadValues() {
     qt_config->endGroup();
 
     qt_config->beginGroup("Audio");
+    Settings::values.enable_dsp_lle = ReadSetting("enable_dsp_lle", false).toBool();
     Settings::values.sink_id = ReadSetting("output_engine", "auto").toString().toStdString();
     Settings::values.enable_audio_stretching =
         ReadSetting("enable_audio_stretching", true).toBool();
@@ -415,6 +416,7 @@ void Config::SaveValues() {
     qt_config->endGroup();
 
     qt_config->beginGroup("Audio");
+    WriteSetting("enable_dsp_lle", Settings::values.enable_dsp_lle, false);
     WriteSetting("output_engine", QString::fromStdString(Settings::values.sink_id), "auto");
     WriteSetting("enable_audio_stretching", Settings::values.enable_audio_stretching, true);
     WriteSetting("output_device", QString::fromStdString(Settings::values.audio_device_id), "auto");

--- a/src/citra_qt/configuration/configure_audio.cpp
+++ b/src/citra_qt/configuration/configure_audio.cpp
@@ -22,6 +22,7 @@ ConfigureAudio::ConfigureAudio(QWidget* parent)
 
     ui->emulation_combo_box->addItem(tr("HLE (fast)"));
     ui->emulation_combo_box->addItem(tr("LLE (accurate)"));
+    ui->emulation_combo_box->addItem(tr("LLE multi-core"));
     ui->emulation_combo_box->setEnabled(!Core::System::GetInstance().IsPoweredOn());
 
     connect(ui->volume_slider, &QSlider::valueChanged, this,
@@ -47,7 +48,17 @@ void ConfigureAudio::setConfiguration() {
     ui->volume_slider->setValue(Settings::values.volume * ui->volume_slider->maximum());
     setVolumeIndicatorText(ui->volume_slider->sliderPosition());
 
-    ui->emulation_combo_box->setCurrentIndex(Settings::values.enable_dsp_lle ? 1 : 0);
+    int selection;
+    if (Settings::values.enable_dsp_lle) {
+        if (Settings::values.enable_dsp_lle_multithread) {
+            selection = 2;
+        } else {
+            selection = 1;
+        }
+    } else {
+        selection = 0;
+    }
+    ui->emulation_combo_box->setCurrentIndex(selection);
 }
 
 void ConfigureAudio::setOutputSinkFromSinkID() {
@@ -92,7 +103,8 @@ void ConfigureAudio::applyConfiguration() {
             .toStdString();
     Settings::values.volume =
         static_cast<float>(ui->volume_slider->sliderPosition()) / ui->volume_slider->maximum();
-    Settings::values.enable_dsp_lle = ui->emulation_combo_box->currentIndex() == 1;
+    Settings::values.enable_dsp_lle = ui->emulation_combo_box->currentIndex() != 0;
+    Settings::values.enable_dsp_lle_multithread = ui->emulation_combo_box->currentIndex() == 2;
 }
 
 void ConfigureAudio::updateAudioDevices(int sink_index) {

--- a/src/citra_qt/configuration/configure_audio.cpp
+++ b/src/citra_qt/configuration/configure_audio.cpp
@@ -6,6 +6,7 @@
 #include "audio_core/sink.h"
 #include "audio_core/sink_details.h"
 #include "citra_qt/configuration/configure_audio.h"
+#include "core/core.h"
 #include "core/settings.h"
 #include "ui_configure_audio.h"
 
@@ -18,6 +19,10 @@ ConfigureAudio::ConfigureAudio(QWidget* parent)
     for (const auto& sink_detail : AudioCore::g_sink_details) {
         ui->output_sink_combo_box->addItem(sink_detail.id);
     }
+
+    ui->emulation_combo_box->addItem(tr("HLE (fast)"));
+    ui->emulation_combo_box->addItem(tr("LLE (accurate)"));
+    ui->emulation_combo_box->setEnabled(!Core::System::GetInstance().IsPoweredOn());
 
     connect(ui->volume_slider, &QSlider::valueChanged, this,
             &ConfigureAudio::setVolumeIndicatorText);
@@ -41,6 +46,8 @@ void ConfigureAudio::setConfiguration() {
     ui->toggle_audio_stretching->setChecked(Settings::values.enable_audio_stretching);
     ui->volume_slider->setValue(Settings::values.volume * ui->volume_slider->maximum());
     setVolumeIndicatorText(ui->volume_slider->sliderPosition());
+
+    ui->emulation_combo_box->setCurrentIndex(Settings::values.enable_dsp_lle ? 1 : 0);
 }
 
 void ConfigureAudio::setOutputSinkFromSinkID() {
@@ -85,6 +92,7 @@ void ConfigureAudio::applyConfiguration() {
             .toStdString();
     Settings::values.volume =
         static_cast<float>(ui->volume_slider->sliderPosition()) / ui->volume_slider->maximum();
+    Settings::values.enable_dsp_lle = ui->emulation_combo_box->currentIndex() == 1;
 }
 
 void ConfigureAudio::updateAudioDevices(int sink_index) {

--- a/src/citra_qt/configuration/configure_audio.ui
+++ b/src/citra_qt/configuration/configure_audio.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>188</width>
+    <width>240</width>
     <height>246</height>
    </rect>
   </property>
@@ -17,6 +17,23 @@
       <string>Audio</string>
      </property>
      <layout class="QVBoxLayout">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_emulation">
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="label_emulation">
+          <property name="text">
+           <string>Emulation:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="emulation_combo_box"/>
+        </item>
+       </layout>
+      </item>
       <item>
        <layout class="QHBoxLayout">
         <item>

--- a/src/citra_qt/configuration/configure_audio.ui
+++ b/src/citra_qt/configuration/configure_audio.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>240</width>
+    <width>188</width>
     <height>246</height>
    </rect>
   </property>

--- a/src/common/thread.h
+++ b/src/common/thread.h
@@ -79,9 +79,14 @@ public:
         }
     }
 
+    std::size_t Generation() const {
+        std::unique_lock<std::mutex> lk(mutex);
+        return generation;
+    }
+
 private:
     std::condition_variable condvar;
-    std::mutex mutex;
+    mutable std::mutex mutex;
     std::size_t count;
     std::size_t waiting = 0;
     std::size_t generation = 0; // Incremented once each time the barrier is used

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -6,6 +6,7 @@
 #include <utility>
 #include "audio_core/dsp_interface.h"
 #include "audio_core/hle/hle.h"
+#include "audio_core/lle/lle.h"
 #include "common/logging/log.h"
 #include "core/arm/arm_interface.h"
 #ifdef ARCHITECTURE_x86_64
@@ -188,7 +189,12 @@ System::ResultStatus System::Init(EmuWindow& emu_window, u32 system_mode) {
         cpu_core = std::make_unique<ARM_DynCom>(*this, USER32MODE);
     }
 
-    dsp_core = std::make_unique<AudioCore::DspHle>(*memory);
+    if (Settings::values.enable_dsp_lle) {
+        dsp_core = std::make_unique<AudioCore::DspLle>();
+    } else {
+        dsp_core = std::make_unique<AudioCore::DspHle>(*memory);
+    }
+
     dsp_core->SetSink(Settings::values.sink_id, Settings::values.audio_device_id);
     dsp_core->EnableStretching(Settings::values.enable_audio_stretching);
 

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -190,7 +190,8 @@ System::ResultStatus System::Init(EmuWindow& emu_window, u32 system_mode) {
     }
 
     if (Settings::values.enable_dsp_lle) {
-        dsp_core = std::make_unique<AudioCore::DspLle>(*memory);
+        dsp_core = std::make_unique<AudioCore::DspLle>(*memory,
+                                                       Settings::values.enable_dsp_lle_multithread);
     } else {
         dsp_core = std::make_unique<AudioCore::DspHle>(*memory);
     }

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -190,7 +190,7 @@ System::ResultStatus System::Init(EmuWindow& emu_window, u32 system_mode) {
     }
 
     if (Settings::values.enable_dsp_lle) {
-        dsp_core = std::make_unique<AudioCore::DspLle>();
+        dsp_core = std::make_unique<AudioCore::DspLle>(*memory);
     } else {
         dsp_core = std::make_unique<AudioCore::DspHle>(*memory);
     }

--- a/src/core/hle/kernel/wait_object.cpp
+++ b/src/core/hle/kernel/wait_object.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
+#include <utility>
 #include "common/assert.h"
 #include "common/logging/log.h"
 #include "core/hle/kernel/errors.h"
@@ -96,7 +97,7 @@ const std::vector<SharedPtr<Thread>>& WaitObject::GetWaitingThreads() const {
 }
 
 void WaitObject::SetHLENotifier(std::function<void()> callback) {
-    hle_notifier = callback;
+    hle_notifier = std::move(callback);
 }
 
 } // namespace Kernel

--- a/src/core/hle/kernel/wait_object.cpp
+++ b/src/core/hle/kernel/wait_object.cpp
@@ -86,10 +86,17 @@ void WaitObject::WakeupAllWaitingThreads() {
 
         thread->ResumeFromWait();
     }
+
+    if (hle_notifier)
+        hle_notifier();
 }
 
 const std::vector<SharedPtr<Thread>>& WaitObject::GetWaitingThreads() const {
     return waiting_threads;
+}
+
+void WaitObject::SetHLENotifier(std::function<void()> callback) {
+    hle_notifier = callback;
 }
 
 } // namespace Kernel

--- a/src/core/hle/kernel/wait_object.h
+++ b/src/core/hle/kernel/wait_object.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <functional>
 #include <vector>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 #include "common/common_types.h"
@@ -52,9 +53,15 @@ public:
     /// Get a const reference to the waiting threads list for debug use
     const std::vector<SharedPtr<Thread>>& GetWaitingThreads() const;
 
+    /// Sets a callback which is called when the object becomes available
+    void SetHLENotifier(std::function<void()> callback);
+
 private:
     /// Threads waiting for this object to become available
     std::vector<SharedPtr<Thread>> waiting_threads;
+
+    /// Function to call when this object becomes available
+    std::function<void()> hle_notifier;
 };
 
 // Specialization of DynamicObjectCast for WaitObjects

--- a/src/core/hle/service/dsp/dsp_dsp.cpp
+++ b/src/core/hle/service/dsp/dsp_dsp.cpp
@@ -184,6 +184,17 @@ void DSP_DSP::LoadComponent(Kernel::HLERequestContext& ctx) {
              size, prog_mask, data_mask);
 }
 
+void DSP_DSP::UnloadComponent(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp(ctx, 0x12, 0, 0);
+
+    system.DSP().UnloadComponent();
+
+    IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
+    rb.Push(RESULT_SUCCESS);
+
+    LOG_INFO(Service_DSP, "(STUBBED)");
+}
+
 void DSP_DSP::FlushDataCache(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x13, 2, 2);
     const VAddr address = rp.Pop<u32>();

--- a/src/core/hle/service/dsp/dsp_dsp.cpp
+++ b/src/core/hle/service/dsp/dsp_dsp.cpp
@@ -268,12 +268,12 @@ void DSP_DSP::GetSemaphoreEventHandle(Kernel::HLERequestContext& ctx) {
 
 void DSP_DSP::SetSemaphoreMask(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x17, 1, 0);
-    const u32 mask = rp.Pop<u32>();
+    preset_semaphore = rp.Pop<u16>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     rb.Push(RESULT_SUCCESS);
 
-    LOG_WARNING(Service_DSP, "(STUBBED) called mask=0x{:08X}", mask);
+    LOG_WARNING(Service_DSP, "(STUBBED) called mask=0x{:04X}", preset_semaphore);
 }
 
 void DSP_DSP::GetHeadphoneStatus(Kernel::HLERequestContext& ctx) {
@@ -380,6 +380,9 @@ DSP_DSP::DSP_DSP(Core::System& system)
 
     semaphore_event =
         system.Kernel().CreateEvent(Kernel::ResetType::OneShot, "DSP_DSP::semaphore_event");
+
+    semaphore_event->SetHLENotifier(
+        [this]() { this->system.DSP().SetSemaphore(preset_semaphore); });
 }
 
 DSP_DSP::~DSP_DSP() {

--- a/src/core/hle/service/dsp/dsp_dsp.cpp
+++ b/src/core/hle/service/dsp/dsp_dsp.cpp
@@ -35,11 +35,9 @@ void DSP_DSP::RecvDataIsReady(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x02, 1, 0);
     const u32 register_number = rp.Pop<u32>();
 
-    ASSERT_MSG(register_number == 0, "Unknown register_number {}", register_number);
-
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
     rb.Push(RESULT_SUCCESS);
-    rb.Push(true); /// 0 = not ready, 1 = ready to read
+    rb.Push(system.DSP().RecvDataIsReady(register_number));
 
     LOG_DEBUG(Service_DSP, "register_number={}", register_number);
 }

--- a/src/core/hle/service/dsp/dsp_dsp.cpp
+++ b/src/core/hle/service/dsp/dsp_dsp.cpp
@@ -4,7 +4,6 @@
 
 #include "audio_core/audio_types.h"
 #include "common/assert.h"
-#include "common/hash.h"
 #include "common/logging/log.h"
 #include "core/core.h"
 #include "core/hle/ipc_helpers.h"
@@ -173,23 +172,16 @@ void DSP_DSP::LoadComponent(Kernel::HLERequestContext& ctx) {
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
     rb.Push(RESULT_SUCCESS);
-    rb.Push(true); /// Pretend that we actually loaded the DSP firmware
+    rb.Push(true);
     rb.PushMappedBuffer(buffer);
-
-    // TODO(bunnei): Implement real DSP firmware loading
 
     std::vector<u8> component_data(size);
     buffer.Read(component_data.data(), 0, size);
 
-    LOG_INFO(Service_DSP, "Firmware hash: {:#018x}",
-             Common::ComputeHash64(component_data.data(), component_data.size()));
-    // Some versions of the firmware have the location of DSP structures listed here.
-    if (size > 0x37C) {
-        LOG_INFO(Service_DSP, "Structures hash: {:#018x}",
-                 Common::ComputeHash64(component_data.data() + 0x340, 60));
-    }
-    LOG_WARNING(Service_DSP, "(STUBBED) called size=0x{:X}, prog_mask=0x{:08X}, data_mask=0x{:08X}",
-                size, prog_mask, data_mask);
+    system.DSP().LoadComponent(component_data);
+
+    LOG_INFO(Service_DSP, "(STUBBED) called size=0x{:X}, prog_mask=0x{:08X}, data_mask=0x{:08X}",
+             size, prog_mask, data_mask);
 }
 
 void DSP_DSP::FlushDataCache(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/dsp/dsp_dsp.cpp
+++ b/src/core/hle/service/dsp/dsp_dsp.cpp
@@ -50,7 +50,7 @@ void DSP_DSP::SetSemaphore(Kernel::HLERequestContext& ctx) {
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     rb.Push(RESULT_SUCCESS);
 
-    LOG_WARNING(Service_DSP, "(STUBBED) called, semaphore_value={:04X}", semaphore_value);
+    LOG_INFO(Service_DSP, "called, semaphore_value={:04X}", semaphore_value);
 }
 
 void DSP_DSP::ConvertProcessAddressFromDspDram(Kernel::HLERequestContext& ctx) {
@@ -180,8 +180,8 @@ void DSP_DSP::LoadComponent(Kernel::HLERequestContext& ctx) {
 
     system.DSP().LoadComponent(component_data);
 
-    LOG_INFO(Service_DSP, "(STUBBED) called size=0x{:X}, prog_mask=0x{:08X}, data_mask=0x{:08X}",
-             size, prog_mask, data_mask);
+    LOG_INFO(Service_DSP, "called size=0x{:X}, prog_mask=0x{:08X}, data_mask=0x{:08X}", size,
+             prog_mask, data_mask);
 }
 
 void DSP_DSP::UnloadComponent(Kernel::HLERequestContext& ctx) {
@@ -357,7 +357,7 @@ DSP_DSP::DSP_DSP(Core::System& system)
         {0x000F0080, &DSP_DSP::GetPipeReadableSize, "GetPipeReadableSize"},
         {0x001000C0, &DSP_DSP::ReadPipeIfPossible, "ReadPipeIfPossible"},
         {0x001100C2, &DSP_DSP::LoadComponent, "LoadComponent"},
-        {0x00120000, nullptr, "UnloadComponent"},
+        {0x00120000, &DSP_DSP::UnloadComponent, "UnloadComponent"},
         {0x00130082, &DSP_DSP::FlushDataCache, "FlushDataCache"},
         {0x00140082, &DSP_DSP::InvalidateDataCache, "InvalidateDCache"},
         {0x00150082, &DSP_DSP::RegisterInterruptEvents, "RegisterInterruptEvents"},

--- a/src/core/hle/service/dsp/dsp_dsp.cpp
+++ b/src/core/hle/service/dsp/dsp_dsp.cpp
@@ -46,6 +46,8 @@ void DSP_DSP::SetSemaphore(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x07, 1, 0);
     const u16 semaphore_value = rp.Pop<u16>();
 
+    system.DSP().SetSemaphore(semaphore_value);
+
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     rb.Push(RESULT_SUCCESS);
 

--- a/src/core/hle/service/dsp/dsp_dsp.cpp
+++ b/src/core/hle/service/dsp/dsp_dsp.cpp
@@ -110,11 +110,11 @@ void DSP_DSP::ReadPipe(Kernel::HLERequestContext& ctx) {
     const u16 size = rp.Pop<u16>();
 
     const DspPipe pipe = static_cast<DspPipe>(channel);
-    const u16 pipe_readable_size = static_cast<u16>(Core::DSP().GetPipeReadableSize(pipe));
+    const u16 pipe_readable_size = static_cast<u16>(system.DSP().GetPipeReadableSize(pipe));
 
     std::vector<u8> pipe_buffer;
     if (pipe_readable_size >= size)
-        pipe_buffer = Core::DSP().PipeRead(pipe, size);
+        pipe_buffer = system.DSP().PipeRead(pipe, size);
     else
         UNREACHABLE(); // No more data is in pipe. Hardware hangs in this case; Should never happen.
 
@@ -132,7 +132,7 @@ void DSP_DSP::GetPipeReadableSize(Kernel::HLERequestContext& ctx) {
     const u32 peer = rp.Pop<u32>();
 
     const DspPipe pipe = static_cast<DspPipe>(channel);
-    const u16 pipe_readable_size = static_cast<u16>(Core::DSP().GetPipeReadableSize(pipe));
+    const u16 pipe_readable_size = static_cast<u16>(system.DSP().GetPipeReadableSize(pipe));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
     rb.Push(RESULT_SUCCESS);
@@ -149,11 +149,11 @@ void DSP_DSP::ReadPipeIfPossible(Kernel::HLERequestContext& ctx) {
     const u16 size = rp.Pop<u16>();
 
     const DspPipe pipe = static_cast<DspPipe>(channel);
-    const u16 pipe_readable_size = static_cast<u16>(Core::DSP().GetPipeReadableSize(pipe));
+    const u16 pipe_readable_size = static_cast<u16>(system.DSP().GetPipeReadableSize(pipe));
 
     std::vector<u8> pipe_buffer;
     if (pipe_readable_size >= size)
-        pipe_buffer = Core::DSP().PipeRead(pipe, size);
+        pipe_buffer = system.DSP().PipeRead(pipe, size);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
     rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/dsp/dsp_dsp.cpp
+++ b/src/core/hle/service/dsp/dsp_dsp.cpp
@@ -94,7 +94,7 @@ void DSP_DSP::WriteProcessPipe(Kernel::HLERequestContext& ctx) {
         break;
     }
 
-    Core::DSP().PipeWrite(pipe, buffer);
+    system.DSP().PipeWrite(pipe, buffer);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/dsp/dsp_dsp.h
+++ b/src/core/hle/service/dsp/dsp_dsp.h
@@ -257,6 +257,7 @@ private:
     Core::System& system;
 
     Kernel::SharedPtr<Kernel::Event> semaphore_event;
+    u16 preset_semaphore = 0;
 
     Kernel::SharedPtr<Kernel::Event> interrupt_zero = nullptr; /// Currently unknown purpose
     Kernel::SharedPtr<Kernel::Event> interrupt_one = nullptr;  /// Currently unknown purpose

--- a/src/core/hle/service/dsp/dsp_dsp.h
+++ b/src/core/hle/service/dsp/dsp_dsp.h
@@ -154,6 +154,15 @@ private:
     void LoadComponent(Kernel::HLERequestContext& ctx);
 
     /**
+     * DSP_DSP::UnloadComponent service function
+     *  Inputs:
+     *      0 : Header Code[0x00120000]
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void UnloadComponent(Kernel::HLERequestContext& ctx);
+
+    /**
      * DSP_DSP::FlushDataCache service function
      *
      * This Function is a no-op, We aren't emulating the CPU cache any time soon.

--- a/src/core/hle/service/dsp/dsp_dsp.h
+++ b/src/core/hle/service/dsp/dsp_dsp.h
@@ -245,6 +245,8 @@ private:
     /// Checks if we are trying to register more than 6 events
     bool HasTooManyEventsRegistered() const;
 
+    Core::System& system;
+
     Kernel::SharedPtr<Kernel::Event> semaphore_event;
 
     Kernel::SharedPtr<Kernel::Event> interrupt_zero = nullptr; /// Currently unknown purpose

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -80,6 +80,7 @@ void LogSettings() {
     LogSetting("Layout_LayoutOption", static_cast<int>(Settings::values.layout_option));
     LogSetting("Layout_SwapScreen", Settings::values.swap_screen);
     LogSetting("Audio_EnableDspLle", Settings::values.enable_dsp_lle);
+    LogSetting("Audio_EnableDspLleMultithread", Settings::values.enable_dsp_lle_multithread);
     LogSetting("Audio_OutputEngine", Settings::values.sink_id);
     LogSetting("Audio_EnableAudioStretching", Settings::values.enable_audio_stretching);
     LogSetting("Audio_OutputDevice", Settings::values.audio_device_id);

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -79,6 +79,7 @@ void LogSettings() {
     LogSetting("Layout_Factor3d", Settings::values.factor_3d);
     LogSetting("Layout_LayoutOption", static_cast<int>(Settings::values.layout_option));
     LogSetting("Layout_SwapScreen", Settings::values.swap_screen);
+    LogSetting("Audio_EnableDspLle", Settings::values.enable_dsp_lle);
     LogSetting("Audio_OutputEngine", Settings::values.sink_id);
     LogSetting("Audio_EnableAudioStretching", Settings::values.enable_audio_stretching);
     LogSetting("Audio_OutputDevice", Settings::values.audio_device_id);

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -148,6 +148,7 @@ struct Values {
 
     // Audio
     bool enable_dsp_lle;
+    bool enable_dsp_lle_multithread;
     std::string sink_id;
     bool enable_audio_stretching;
     std::string audio_device_id;

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -147,6 +147,7 @@ struct Values {
     u8 factor_3d;
 
     // Audio
+    bool enable_dsp_lle;
     std::string sink_id;
     bool enable_audio_stretching;
     std::string audio_device_id;


### PR DESCRIPTION
This adds one of my project as submodule: [teakra](https://github.com/wwylele/teakra), which is a functioning but unoptimized interpreter of the DSP core, with necessary peripherals implemented as well. Comments, reviews and PRs to the teakra repo are welcome.

On the citra side, this is implement as a new `DspInterface` named `DspLle`. Some functions originally implemented in `DSP_DSP` service now are pushed to `DspInterface`, due to the implementation difference between `DspHle` and `DspLle`. Please see each commit for added and moved functions.

The state of this code is that the feature-implementing stage is basically finished, and the optimization stage has just started, hence "WIP". I open this early, instead of when it is fully finished, because I want to gain opinions and ideas in public. This project has been relatively personal and had to gone private since it is found to fix Pokemon X/Y, so I need to make this public in the form of a PR so that we can continue it in the usual way for open source development.

## UI change
![screenshot from 2018-12-07 10-37-45](https://user-images.githubusercontent.com/4592895/49673228-c3cff380-fa3b-11e8-896c-b1e1808d595b.png)


A combobox to switch between DSP HLE and LLE is added to the audio tab. The options are named as "HLE (fast)" and "LLE (accurate)".

## TODO

Teakra side:
 - [x] idle / busy wait detect and skip
 - [x] better timer / audio port implementation than the current naive "countdown" way
 - [ ] code style clean up
 - [ ] documentation
 - [ ] far-future goal: maybe JIT?

Citra side:
 - [x] multithreading
 - [ ] ~~down-clocking (needs support from Teakra)~~ Probably not going to do this. With idle skipping it is effectively down clocked
 - [ ] Fix really bad audio when audio stretching is disabled
   - I likely did something bad here. The output from Teakra is a stream of samples instead of frames, so I made a new interface `OutputSample` in `DspInterface`, which only put one sample at a time. The audio stretcher works fine with this, but it doesn't work without it.
 - [ ] maybe DSP debugger widget?

## What about DSP HLE?
We can use LLE to figure out missing protocol in HLE (pipe3, aac decoding etc.) and stub/fix/implement them. @B3n30 has been making great progress on this.

## To Pokemon fans
Yes with this you can play pokemon XY. However it is really slow right now. Stay tuned and we will have update on performance soon!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4490)
<!-- Reviewable:end -->
