### PR TITLE
travis: use OSXCross

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,19 @@ matrix:
       after_success: "./.travis/macos/upload.sh"
       cache: ccache
     - os: linux
+      env: NAME="OSXCross build"
+      sudo: required
+      dist: trusty
+      services: docker
+      addons:
+        apt:
+          packages:
+            - p7zip-full
+      install: "./.travis/linux-osxcross/deps.sh"
+      script: "./.travis/linux-osxcross/build.sh"
+      after_success: "./.travis/linux-osxcross/upload.sh"
+      cache: ccache
+    - os: linux
       env: NAME="linux build (frozen versions of dependencies)"
       sudo: required
       dist: trusty

--- a/.travis/linux-osxcross/build.sh
+++ b/.travis/linux-osxcross/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -ex
+mkdir -p "$HOME/.ccache"
+docker run --env-file .travis/common/travis-ci.env -v $(pwd):/citra -v "$HOME/.ccache":/root/.ccache liushuyu/osxcross:qt5 /bin/bash -ex /citra/.travis/linux-osxcross/docker.sh

--- a/.travis/linux-osxcross/deps.sh
+++ b/.travis/linux-osxcross/deps.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -ex
+
+docker pull liushuyu/osxcross:qt5

--- a/.travis/linux-osxcross/docker.sh
+++ b/.travis/linux-osxcross/docker.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -ex
+
+cd /citra
+
+export MACOSX_DEPLOYMENT_TARGET=10.13
+mkdir build && cd build
+x86_64-apple-darwin18-cmake .. -DCMAKE_OSX_ARCHITECTURES="x86_64;x86_64h" -DCMAKE_BUILD_TYPE=Release -DENABLE_QT_TRANSLATION=ON -DCITRA_ENABLE_COMPATIBILITY_REPORTING=${ENABLE_COMPATIBILITY_REPORTING:-"OFF"} -DENABLE_COMPATIBILITY_LIST_DOWNLOAD=ON -DUSE_DISCORD_PRESENCE=ON -DUSE_CCACHE=ON -DENABLE_FFMPEG=ON
+make -j4
+
+echo "Tests skipped"
+# ctest -VV -C Release
+ccache -s
+
+# prepare the package
+function patch_ffmpeg_path() {
+  LIBS=$(x86_64-apple-darwin18-otool -L "$1" | perl -ne '/(\@loader_path\/libav.*dylib)/ && print "$1\n"' | sort -u)
+  for i in ${LIBS}; do
+    x86_64-apple-darwin18-install_name_tool -change "$i" "${i/@loader_path/@rpath}" "$1"
+  done
+}
+
+echo 'Preparing binaries...'
+cd ..
+mkdir package
+
+cp build/bin/citra 'package'
+cp -r build/bin/citra-qt.app 'package'
+cp build/bin/citra-room 'package'
+
+export MP_DIR='/opt/osxcross/macports/pkgs/opt/local/'
+echo "Deploying dependencies..."
+patch_ffmpeg_path 'package/citra'
+patch_ffmpeg_path 'package/citra-qt.app/Contents/MacOS/citra-qt'
+macdeployqt "package/citra-qt.app" -executable=package/citra -executable=package/citra-room
+# ffmpeg binaries from Zeranoe contains "@loader_path" which make macdeployqt think the binary
+# has no dependencies
+cp -rv "${MP_DIR}"/lib/{libswresample.3,libswscale.5}.dylib 'package/citra-qt.app/Contents/Frameworks/'

--- a/.travis/linux-osxcross/upload.sh
+++ b/.travis/linux-osxcross/upload.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -ex
+
+. .travis/common/pre-upload.sh
+
+REV_NAME="citra-osx-${GITDATE}-${GITREV}"
+ARCHIVE_NAME="${REV_NAME}.tar.gz"
+COMPRESSION_FLAGS="-czvf"
+
+mkdir "$REV_NAME"
+
+# get around the permission issues
+cp -r package/* "$REV_NAME"
+
+# Make the citra-qt.app application launch a debugging terminal.
+# Store away the actual binary
+mv ${REV_NAME}/citra-qt.app/Contents/MacOS/citra-qt ${REV_NAME}/citra-qt.app/Contents/MacOS/citra-qt-bin
+
+cat > ${REV_NAME}/citra-qt.app/Contents/MacOS/citra-qt <<EOL
+#!/usr/bin/env bash
+cd "\`dirname "\$0"\`"
+chmod +x citra-qt-bin
+open citra-qt-bin --args "\$@"
+EOL
+# Content that will serve as the launching script for citra (within the .app folder)
+
+# Make the launching script executable
+chmod +x ${REV_NAME}/citra-qt.app/Contents/MacOS/citra-qt
+
+
+. .travis/common/post-upload.sh


### PR DESCRIPTION
Use OSXCross to compile macOS binary in a Linux container.

Currently blocked by citra-emu/build-environments#12 .

This PR should still pass Travis CI though. And do not merge if commit 033e165 is not removed.

More information on how it works: https://github.com/citra-emu/build-environments/pull/12#issue-237043543

TL;DR version:

Item | Status
-------|---------
Basic Build | :heavy_check_mark:
Full Build (same w/ `macos` native) | :heavy_check_mark:
FAT Binary | :heavy_check_mark: (`x86_64` and `x86_64h`)
Bundle Deploy | :white_check_mark: (`macdeploy` finish w/ false-positive error message)
Binary works on a Mac(R) | :heavy_check_mark:
`dmg` Creation | Not Included in this PR

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4492)
<!-- Reviewable:end -->
