### PR TITLE
Port yuzu-emu/yuzu#1874: "hle/service, hle/sm: Minor cleanup"

### DIFF
--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -143,9 +143,7 @@ void ServiceFrameworkBase::InstallAsService(SM::ServiceManager& service_manager)
 
 void ServiceFrameworkBase::InstallAsNamedPort(Kernel::KernelSystem& kernel) {
     ASSERT(port == nullptr);
-    SharedPtr<ServerPort> server_port;
-    SharedPtr<ClientPort> client_port;
-    std::tie(server_port, client_port) = kernel.CreatePortPair(max_sessions, service_name);
+    auto [server_port, client_port] = kernel.CreatePortPair(max_sessions, service_name);
     server_port->SetHleHandler(shared_from_this());
     kernel.AddNamedPort(service_name, std::move(client_port));
 }

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -54,11 +54,6 @@
 #include "core/hle/service/ssl_c.h"
 #include "core/hle/service/y2r_u.h"
 
-using Kernel::ClientPort;
-using Kernel::ServerPort;
-using Kernel::ServerSession;
-using Kernel::SharedPtr;
-
 namespace Service {
 
 const std::array<ServiceModuleInfo, 40> service_module_map{
@@ -174,7 +169,8 @@ void ServiceFrameworkBase::ReportUnimplementedFunction(u32* cmd_buf, const Funct
     cmd_buf[1] = 0;
 }
 
-void ServiceFrameworkBase::HandleSyncRequest(SharedPtr<ServerSession> server_session) {
+void ServiceFrameworkBase::HandleSyncRequest(
+    Kernel::SharedPtr<Kernel::ServerSession> server_session) {
     Kernel::KernelSystem& kernel = Core::System::GetInstance().Kernel();
     auto thread = kernel.GetThreadManager().GetCurrentThread();
     // TODO(wwylele): avoid GetPointer
@@ -222,7 +218,7 @@ static bool AttemptLLE(const ServiceModuleInfo& service_module) {
                   service_module.name);
         return false;
     }
-    SharedPtr<Kernel::Process> process;
+    Kernel::SharedPtr<Kernel::Process> process;
     loader->Load(process);
     LOG_DEBUG(Service, "Service module \"{}\" has been successfully loaded.", service_module.name);
     return true;

--- a/src/core/hle/service/sm/sm.cpp
+++ b/src/core/hle/service/sm/sm.cpp
@@ -43,7 +43,7 @@ ResultVal<Kernel::SharedPtr<Kernel::ServerPort>> ServiceManager::RegisterService
     auto [server_port, client_port] = system.Kernel().CreatePortPair(max_sessions, name);
 
     registered_services.emplace(std::move(name), std::move(client_port));
-    return MakeResult<Kernel::SharedPtr<Kernel::ServerPort>>(std::move(server_port));
+    return MakeResult(std::move(server_port));
 }
 
 ResultVal<Kernel::SharedPtr<Kernel::ClientPort>> ServiceManager::GetServicePort(
@@ -55,7 +55,7 @@ ResultVal<Kernel::SharedPtr<Kernel::ClientPort>> ServiceManager::GetServicePort(
         return ERR_SERVICE_NOT_REGISTERED;
     }
 
-    return MakeResult<Kernel::SharedPtr<Kernel::ClientPort>>(it->second);
+    return MakeResult(it->second);
 }
 
 ResultVal<Kernel::SharedPtr<Kernel::ClientSession>> ServiceManager::ConnectToService(

--- a/src/core/hle/service/sm/sm.cpp
+++ b/src/core/hle/service/sm/sm.cpp
@@ -40,9 +40,7 @@ ResultVal<Kernel::SharedPtr<Kernel::ServerPort>> ServiceManager::RegisterService
     if (registered_services.find(name) != registered_services.end())
         return ERR_ALREADY_REGISTERED;
 
-    Kernel::SharedPtr<Kernel::ServerPort> server_port;
-    Kernel::SharedPtr<Kernel::ClientPort> client_port;
-    std::tie(server_port, client_port) = system.Kernel().CreatePortPair(max_sessions, name);
+    auto [server_port, client_port] = system.Kernel().CreatePortPair(max_sessions, name);
 
     registered_services.emplace(std::move(name), std::move(client_port));
     return MakeResult<Kernel::SharedPtr<Kernel::ServerPort>>(std::move(server_port));


### PR DESCRIPTION
See yuzu-emu/yuzu#1874 for more details.

**Original description:**
Tidies up the pre-C++17 code to use structured bindings where applicable and cleans up a few other minor things along the way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4494)
<!-- Reviewable:end -->
