### PR TITLE
gl_rasterizer_cache/MortonCopy: avoid read/write to invalid address

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -147,9 +147,18 @@ static void MortonCopy(u32 stride, u32 height, u8* gl_buffer, PAddr base, PAddr 
     }
 
     const u8* const buffer_end = tile_buffer + aligned_end - aligned_start;
+    PAddr current_paddr = aligned_start;
     while (tile_buffer < buffer_end) {
+        // Pokemon Super Mystery Dungeon will try to use textures that go beyond
+        // the end address of VRAM. Stop reading if reaches invalid address
+        if (!VideoCore::g_memory->IsValidPhysicalAddress(current_paddr) ||
+            !VideoCore::g_memory->IsValidPhysicalAddress(current_paddr + tile_size)) {
+            LOG_ERROR(Render_OpenGL, "Out of bound texture");
+            break;
+        }
         MortonCopyTile<morton_to_gl, format>(stride, tile_buffer, gl_buffer);
         tile_buffer += tile_size;
+        current_paddr += tile_size;
         glbuf_next_tile();
     }
 


### PR DESCRIPTION
This is a workaround to the recurring problem #2110. The game tries to load a texture part of which goes beyond VRAM region. On real hardware this would results in garbage data being read. However this is safe because the game then only use the first valid part of the texture to do following rendering operations.

#2799 "Fixed" the crash on citra by adding boundary check during address conversion for rasterizer cache. However, it leaves the out-of-bound read in texture loading there, and the texture would copy garbage data from host memory.

Recent memory module change in #4480 moves VRAM from global to heap, resulting in runtime adding unmapped/guard pages around the VRAM memory, and now causing the out-of-bound read crash. This PR prevents the out-of-bound read when detecting invalid addresses to fix the crash.

tl;dr: fixes a recent regression in  Pokemon Super Mystery Dungeon

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4496)
<!-- Reviewable:end -->
