### PR TITLE
 Port yuzu-emu/yuzu#1871: "yuzu/wait_tree: Pass QString by value and std::move in the initializer list for WaitTreeText"

### DIFF
--- a/src/citra_qt/debugger/wait_tree.cpp
+++ b/src/citra_qt/debugger/wait_tree.cpp
@@ -61,7 +61,8 @@ std::vector<std::unique_ptr<WaitTreeThread>> WaitTreeItem::MakeThreadItemList() 
     return item_list;
 }
 
-WaitTreeText::WaitTreeText(const QString& t) : text(t) {}
+WaitTreeText::WaitTreeText(QString t) : text(std::move(t)) {}
+WaitTreeText::~WaitTreeText() = default;
 
 QString WaitTreeText::GetText() const {
     return text;

--- a/src/citra_qt/debugger/wait_tree.h
+++ b/src/citra_qt/debugger/wait_tree.h
@@ -50,7 +50,9 @@ private:
 class WaitTreeText : public WaitTreeItem {
     Q_OBJECT
 public:
-    explicit WaitTreeText(const QString& text);
+    explicit WaitTreeText(QString text);
+    ~WaitTreeText() override;
+
     QString GetText() const override;
 
 private:


### PR DESCRIPTION
See yuzu-emu/yuzu#1871 for more details.

**Original description:**
Just a trivial modernization that potentially avoids copying strings in certain scenarios.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4511)
<!-- Reviewable:end -->
