### PR TITLE
(QLabel)_is_already_in_use-Correct_Auto_Default

### DIFF
--- a/src/citra_qt/configuration/configure_audio.ui
+++ b/src/citra_qt/configuration/configure_audio.ui
@@ -20,7 +20,7 @@
       <item>
        <layout class="QHBoxLayout">
         <item>
-         <widget class="QLabel" name="label">
+         <widget class="QLabel" name="label1">
           <property name="text">
            <string>Output Engine:</string>
           </property>
@@ -44,7 +44,7 @@
       <item>
        <layout class="QHBoxLayout">
         <item>
-         <widget class="QLabel" name="label">
+         <widget class="QLabel" name="label2">
           <property name="text">
            <string>Audio Device:</string>
           </property>


### PR DESCRIPTION
As titled - (QLabel)_is_already_in_use

configure_audio.ui : warning : The name 'label' (QLabel) is already in use, defaulting to 'label1'. [C:\projects\citra\msvc_build\src\citra_qt\citra-qt_autogen.vcxproj]
configure_audio.ui : warning : The name 'label' (QLabel) is already in use, defaulting to 'label2'. [C:\projects\citra\msvc_build\src\citra_qt\citra-qt_autogen.vcxproj]

label used twice, corrects auto default message in compiling

Not much but it's a start