### PR TITLE
Port yuzu-emu/yuzu#1946: "renderer_opengl: Correct forward declaration of FramebufferLayout"

### DIFF
--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -14,7 +14,7 @@
 #include "video_core/renderer_opengl/gl_state.h"
 
 namespace Layout {
-class FramebufferLayout;
+struct FramebufferLayout;
 }
 
 namespace OpenGL {


### PR DESCRIPTION
See yuzu-emu/yuzu#1946 for more details.

**Original description:**
This is actually a struct, not a class, which can lead to compilation warnings.