### PR TITLE
ac: Improve stub for GetWifiStatus

### DIFF
--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -15,6 +15,7 @@
 #include "core/hle/service/ac/ac_i.h"
 #include "core/hle/service/ac/ac_u.h"
 #include "core/memory.h"
+#include "core/settings.h"
 
 namespace Service::AC {
 void Module::Interface::CreateDefaultConfig(Kernel::HLERequestContext& ctx) {
@@ -90,12 +91,10 @@ void Module::Interface::GetCloseResult(Kernel::HLERequestContext& ctx) {
 void Module::Interface::GetWifiStatus(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0xD, 0, 0);
 
-    // TODO(purpasmart96): This function is only a stub,
-    // it returns a valid result without implementing full functionality.
-
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
     rb.Push(RESULT_SUCCESS);
-    rb.Push<u32>(0); // Connection type set to none
+    // Connection type set to Old3DS/New3DS Internet
+    rb.Push<u32>(Settings::values.is_new_3ds ? 2 : 1);
 
     LOG_WARNING(Service_AC, "(STUBBED) called");
 }


### PR DESCRIPTION
For an emulator it doesn't make much sense not to tell the applications we're connected to the internet.

Also removes the TODO message as we don't do this for any other stubs and it's not really necessary.

Gets #4186 booting further.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4540)
<!-- Reviewable:end -->
