### PR TITLE
multiplayer: minor UI fixes

### DIFF
--- a/src/citra_qt/multiplayer/chat_room.cpp
+++ b/src/citra_qt/multiplayer/chat_room.cpp
@@ -42,8 +42,12 @@ public:
             cur_nickname = QString::fromStdString(room->GetNickname());
             cur_username = QString::fromStdString(room->GetUsername());
         }
-        if (message.contains(QString("@").append(cur_nickname)) ||
-            (!cur_username.isEmpty() && message.contains(QString("@").append(cur_username)))) {
+
+        // Handle pings at the beginning and end of message
+        QString fixed_message = QString(" %1 ").arg(message);
+        if (fixed_message.contains(QString(" @%1 ").arg(cur_nickname)) ||
+            (!cur_username.isEmpty() &&
+             fixed_message.contains(QString(" @%1 ").arg(cur_username)))) {
 
             contains_ping = true;
         } else {
@@ -65,15 +69,18 @@ public:
             name = QString("%1 (%2)").arg(nickname, username);
         }
 
-        QString style;
+        QString style, text_color;
         if (ContainsPing()) {
             // Add a background color to these messages
             style = QString("background-color: %1").arg(ping_color);
+            // Add a font color
+            text_color = "color='#000000'";
         }
 
         return QString("[%1] <font color='%2'>&lt;%3&gt;</font> <font style='%4' "
-                       "color='#000000'>%5</font>")
-            .arg(timestamp, color, name.toHtmlEscaped(), style, message.toHtmlEscaped());
+                       "%5>%6</font>")
+            .arg(timestamp, color, name.toHtmlEscaped(), style, text_color,
+                 message.toHtmlEscaped());
     }
 
 private:

--- a/src/citra_qt/multiplayer/chat_room.cpp
+++ b/src/citra_qt/multiplayer/chat_room.cpp
@@ -352,6 +352,8 @@ void ChatRoom::UpdateIconDisplay() {
             item->data(PlayerListItem::AvatarUrlRole).toString().toStdString();
         if (icon_cache.count(avatar_url)) {
             item->setData(icon_cache.at(avatar_url), Qt::DecorationRole);
+        } else {
+            item->setData(QIcon::fromTheme("no_avatar").pixmap(48), Qt::DecorationRole);
         }
     }
 }
@@ -365,45 +367,41 @@ void ChatRoom::SetPlayerList(const Network::RoomMember::MemberList& member_list)
         QStandardItem* name_item = new PlayerListItem(member.nickname, member.username,
                                                       member.avatar_url, member.game_info.name);
 
-        if (!icon_cache.count(member.avatar_url)) {
-            // Emplace a default question mark icon as avatar
-            icon_cache.emplace(member.avatar_url, QIcon::fromTheme("no_avatar").pixmap(48));
-            if (!member.avatar_url.empty()) {
 #ifdef ENABLE_WEB_SERVICE
-                // Start a request to get the member's avatar
-                const QUrl url(QString::fromStdString(member.avatar_url));
-                QFuture<std::string> future = QtConcurrent::run([url] {
-                    WebService::Client client(
-                        QString("%1://%2").arg(url.scheme(), url.host()).toStdString(), "", "");
-                    auto result = client.GetImage(url.path().toStdString(), true);
-                    if (result.returned_data.empty()) {
-                        LOG_ERROR(WebService, "Failed to get avatar");
-                    }
-                    return result.returned_data;
-                });
-                auto* future_watcher = new QFutureWatcher<std::string>(this);
-                connect(future_watcher, &QFutureWatcher<std::string>::finished, this,
-                        [this, future_watcher, avatar_url = member.avatar_url] {
-                            const std::string result = future_watcher->result();
-                            if (result.empty())
-                                return;
-                            QPixmap pixmap;
-                            if (!pixmap.loadFromData(reinterpret_cast<const u8*>(result.data()),
-                                                     result.size()))
-                                return;
-                            icon_cache[avatar_url] = pixmap.scaled(48, 48, Qt::IgnoreAspectRatio,
-                                                                   Qt::SmoothTransformation);
-                            // Update all the displayed icons with the new icon_cache
-                            UpdateIconDisplay();
-                        });
-                future_watcher->setFuture(future);
-#endif
-            }
+        if (!icon_cache.count(member.avatar_url) && !member.avatar_url.empty()) {
+            // Start a request to get the member's avatar
+            const QUrl url(QString::fromStdString(member.avatar_url));
+            QFuture<std::string> future = QtConcurrent::run([url] {
+                WebService::Client client(
+                    QString("%1://%2").arg(url.scheme(), url.host()).toStdString(), "", "");
+                auto result = client.GetImage(url.path().toStdString(), true);
+                if (result.returned_data.empty()) {
+                    LOG_ERROR(WebService, "Failed to get avatar");
+                }
+                return result.returned_data;
+            });
+            auto* future_watcher = new QFutureWatcher<std::string>(this);
+            connect(future_watcher, &QFutureWatcher<std::string>::finished, this,
+                    [this, future_watcher, avatar_url = member.avatar_url] {
+                        const std::string result = future_watcher->result();
+                        if (result.empty())
+                            return;
+                        QPixmap pixmap;
+                        if (!pixmap.loadFromData(reinterpret_cast<const u8*>(result.data()),
+                                                 result.size()))
+                            return;
+                        icon_cache[avatar_url] =
+                            pixmap.scaled(48, 48, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+                        // Update all the displayed icons with the new icon_cache
+                        UpdateIconDisplay();
+                    });
+            future_watcher->setFuture(future);
         }
-        name_item->setData(icon_cache.at(member.avatar_url), Qt::DecorationRole);
+#endif
 
         player_list->invisibleRootItem()->appendRow(name_item);
     }
+    UpdateIconDisplay();
     // TODO(B3N30): Restore row selection
 }
 

--- a/src/citra_qt/multiplayer/chat_room.h
+++ b/src/citra_qt/multiplayer/chat_room.h
@@ -37,6 +37,7 @@ public:
     ~ChatRoom();
 
     void SetModPerms(bool is_mod);
+    void UpdateIconDisplay();
 
 public slots:
     void OnRoomUpdate(const Network::RoomInformation& info);
@@ -58,7 +59,6 @@ private:
     void AppendChatMessage(const QString&);
     bool ValidateMessage(const std::string&);
     void SendModerationRequest(Network::RoomMessageTypes type, const std::string& nickname);
-    void UpdateIconDisplay();
 
     bool has_mod_perms = false;
     QStandardItemModel* player_list;

--- a/src/citra_qt/multiplayer/client_room.cpp
+++ b/src/citra_qt/multiplayer/client_room.cpp
@@ -109,3 +109,7 @@ void ClientRoomWindow::UpdateView() {
     // TODO(B3N30): can't get RoomMember*, show error and close window
     close();
 }
+
+void ClientRoomWindow::UpdateIconDisplay() {
+    ui->chat->UpdateIconDisplay();
+}

--- a/src/citra_qt/multiplayer/client_room.h
+++ b/src/citra_qt/multiplayer/client_room.h
@@ -18,6 +18,7 @@ public:
     ~ClientRoomWindow();
 
     void RetranslateUi();
+    void UpdateIconDisplay();
 
 public slots:
     void OnRoomUpdate(const Network::RoomInformation&);

--- a/src/citra_qt/multiplayer/state.cpp
+++ b/src/citra_qt/multiplayer/state.cpp
@@ -194,6 +194,7 @@ void MultiplayerState::UpdateThemedIcons() {
     } else {
         status_icon->setPixmap(QIcon::fromTheme("disconnected").pixmap(16));
     }
+    client_room->UpdateIconDisplay();
 }
 
 static void BringWidgetToFront(QWidget* widget) {


### PR DESCRIPTION
Just three minor fixes:
1. Font color is black in dark theme. It is now only black for pings.
2. If a user is called `abc`, you can ping them by `@abc_`. Now a ping only takes effect when there are spaces around it.
3. Fixes #4541

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4569)
<!-- Reviewable:end -->
