### PR TITLE
Frontend: Only reload icons in chat when the chat room is open

### DIFF
--- a/src/citra_qt/multiplayer/state.cpp
+++ b/src/citra_qt/multiplayer/state.cpp
@@ -194,7 +194,8 @@ void MultiplayerState::UpdateThemedIcons() {
     } else {
         status_icon->setPixmap(QIcon::fromTheme("disconnected").pixmap(16));
     }
-    client_room->UpdateIconDisplay();
+    if (client_room)
+        client_room->UpdateIconDisplay();
 }
 
 static void BringWidgetToFront(QWidget* widget) {


### PR DESCRIPTION
This keeps config from crashing when the chat room is not open.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4576)
<!-- Reviewable:end -->
