### PR TITLE
citra_qt: Use QPixmap/QIcon for background color selection button

### DIFF
--- a/src/citra_qt/configuration/configure_graphics.cpp
+++ b/src/citra_qt/configuration/configure_graphics.cpp
@@ -47,8 +47,10 @@ ConfigureGraphics::ConfigureGraphics(QWidget* parent)
         if (!new_bg_color.isValid())
             return;
         bg_color = new_bg_color;
-        ui->bg_button->setStyleSheet(
-            QString("QPushButton { background-color: %1 }").arg(bg_color.name()));
+        QPixmap pixmap(ui->bg_button->size());
+        pixmap.fill(bg_color);
+        const QIcon color_icon(pixmap);
+        ui->bg_button->setIcon(color_icon);
     });
 }
 
@@ -70,8 +72,10 @@ void ConfigureGraphics::setConfiguration() {
     ui->swap_screen->setChecked(Settings::values.swap_screen);
     bg_color = QColor::fromRgbF(Settings::values.bg_red, Settings::values.bg_green,
                                 Settings::values.bg_blue);
-    ui->bg_button->setStyleSheet(
-        QString("QPushButton { background-color: %1 }").arg(bg_color.name()));
+    QPixmap pixmap(ui->bg_button->size());
+    pixmap.fill(bg_color);
+    const QIcon color_icon(pixmap);
+    ui->bg_button->setIcon(color_icon);
 }
 
 void ConfigureGraphics::applyConfiguration() {


### PR DESCRIPTION
Currently, to indicate the current background color on the background color selection button, a stylesheet is used. This apparently doesn't work with GTK buttons, and while changing the border parameters does seem to fix it, it completely breaks the button's style across every OS.

In addition, on platforms that do support a background color, it can be confusing whether a color was selected. Under KDE, the whole button is highlighted blue after selecting a color, hiding the selected color.

Using an icon to indicate the background color addresses both of these issues.