### PR TITLE
Port yuzu-emu/yuzu#2032: "yuzu/configuration/configure_web: Amend verification string"

### DIFF
--- a/src/citra_qt/configuration/configure_web.cpp
+++ b/src/citra_qt/configuration/configure_web.cpp
@@ -91,7 +91,7 @@ void ConfigureWeb::OnLoginChanged() {
 
 void ConfigureWeb::VerifyLogin() {
     ui->button_verify_login->setDisabled(true);
-    ui->button_verify_login->setText(tr("Verifying"));
+    ui->button_verify_login->setText(tr("Verifying..."));
     verify_watcher.setFuture(
         QtConcurrent::run([this, username = ui->edit_username->text().toStdString(),
                            token = ui->edit_token->text().toStdString()]() {

--- a/src/citra_qt/configuration/configure_web.cpp
+++ b/src/citra_qt/configuration/configure_web.cpp
@@ -92,11 +92,10 @@ void ConfigureWeb::OnLoginChanged() {
 void ConfigureWeb::VerifyLogin() {
     ui->button_verify_login->setDisabled(true);
     ui->button_verify_login->setText(tr("Verifying..."));
-    verify_watcher.setFuture(
-        QtConcurrent::run([this, username = ui->edit_username->text().toStdString(),
-                           token = ui->edit_token->text().toStdString()]() {
-            return Core::VerifyLogin(username, token);
-        }));
+    verify_watcher.setFuture(QtConcurrent::run([username = ui->edit_username->text().toStdString(),
+                                                token = ui->edit_token->text().toStdString()] {
+        return Core::VerifyLogin(username, token);
+    }));
 }
 
 void ConfigureWeb::OnLoginVerified() {


### PR DESCRIPTION
See yuzu-emu/yuzu#2032 for more details.

**Original desc:**
It's general practice to use an ellipsis to indicate an ongoing action within a UI. While we're at it, this also removes an unused lambda capture in the same function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4591)
<!-- Reviewable:end -->
