### PR TITLE
dsp_interface: fix sound being played while volume is 0

### DIFF
--- a/src/audio_core/dsp_interface.cpp
+++ b/src/audio_core/dsp_interface.cpp
@@ -77,7 +77,8 @@ void DspInterface::OutputCallback(s16* buffer, std::size_t num_frames) {
     // Implementation of the hardware volume slider with a dynamic range of 60 dB
     const float linear_volume = std::clamp(Settings::values.volume, 0.0f, 1.0f);
     if (linear_volume != 1.0) {
-        const float volume_scale_factor = std::exp(6.90775f * linear_volume) * 0.001f;
+        const float volume_scale_factor =
+            linear_volume == 0 ? 0 : std::exp(6.90775f * linear_volume) * 0.001f;
         for (std::size_t i = 0; i < num_frames; i++) {
             buffer[i * 2 + 0] = static_cast<s16>(buffer[i * 2 + 0] * volume_scale_factor);
             buffer[i * 2 + 1] = static_cast<s16>(buffer[i * 2 + 1] * volume_scale_factor);


### PR DESCRIPTION
According to documentation, if the argument of std::exp is zero, one is returned.
However we want the return value to be also zero in this case, so no audio is played.