### PR TITLE
gdbstub: only let Execute breakpoints write/restore BKPT opcodes into memory

### DIFF
--- a/src/core/gdbstub/gdbstub.cpp
+++ b/src/core/gdbstub/gdbstub.cpp
@@ -409,10 +409,13 @@ static void RemoveBreakpoint(BreakpointType type, VAddr addr) {
 
     LOG_DEBUG(Debug_GDBStub, "gdb: removed a breakpoint: {:08x} bytes at {:08x} of type {}",
               bp->second.len, bp->second.addr, static_cast<int>(type));
-    Core::System::GetInstance().Memory().WriteBlock(
-        *Core::System::GetInstance().Kernel().GetCurrentProcess(), bp->second.addr,
-        bp->second.inst.data(), bp->second.inst.size());
-    Core::CPU().ClearInstructionCache();
+
+    if (type == BreakpointType::Execute) {
+        Core::System::GetInstance().Memory().WriteBlock(
+            *Core::System::GetInstance().Kernel().GetCurrentProcess(), bp->second.addr,
+            bp->second.inst.data(), bp->second.inst.size());
+        Core::CPU().ClearInstructionCache();
+    }
     p.erase(addr);
 }
 
@@ -921,11 +924,14 @@ static bool CommitBreakpoint(BreakpointType type, VAddr addr, u32 len) {
     Core::System::GetInstance().Memory().ReadBlock(
         *Core::System::GetInstance().Kernel().GetCurrentProcess(), addr, breakpoint.inst.data(),
         breakpoint.inst.size());
+
     static constexpr std::array<u8, 4> btrap{0x70, 0x00, 0x20, 0xe1};
-    Core::System::GetInstance().Memory().WriteBlock(
-        *Core::System::GetInstance().Kernel().GetCurrentProcess(), addr, btrap.data(),
-        btrap.size());
-    Core::CPU().ClearInstructionCache();
+    if (type == BreakpointType::Execute) {
+        Core::System::GetInstance().Memory().WriteBlock(
+            *Core::System::GetInstance().Kernel().GetCurrentProcess(), addr, btrap.data(),
+            btrap.size());
+        Core::CPU().ClearInstructionCache();
+    }
     p.insert({addr, breakpoint});
 
     LOG_DEBUG(Debug_GDBStub, "gdb: added {} breakpoint: {:08x} bytes at {:08x}\n",


### PR DESCRIPTION
Back in August last year, commit bd658a88014152551c2c833205b implemented logic for code breakpoints to be hit via a `bkpt 0` opcode that temporarily overwrites the targeted instruction (by the `CommitBreakpoint` / `RemoveBreakpoint` functions). However, this is also done inadvertently for watchpoints (Read-, Write-, or Access-type breakpoint types), which can corrupt data used by the software (#4502). This PR adds a simple check to both functions.

**Note to users/testers:** Currently, CPU JIT isn't designed around memory watchpoints, so make sure it's off.
Speaking of which, although my MS2017 debugger reveals that watchpoints are being hit internally (i.e. calls [`CheckMemoryBreakpoint(VAddr, type)`](https://github.com/citra-emu/citra/blob/8b047a49ae2dcf972560567b7146554f74ac4ad6/src/core/arm/skyeye_common/armstate.cpp#L184) -> `GDBStub::Break(true)`), the deferred logic I'm seeing (in the interpreter loop?) seems to do nothing: no signal is sent to the GDB client. and the game keeps running.

This other issue is separate from the issue this PR fixes (#4502, even though the OP and I have also mentioned it there) and exists on latest master on my Windows release build. I use the `arm-none-eabi-gdb` client, and recall getting watchpoints to fire on Luma3ds (real 3DS).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4603)
<!-- Reviewable:end -->
