### PR TITLE
Fix dialog and message box placement for SBS 3D mode.

### DIFF
--- a/src/citra_qt/CMakeLists.txt
+++ b/src/citra_qt/CMakeLists.txt
@@ -104,6 +104,8 @@ add_executable(citra-qt
     multiplayer/state.cpp
     multiplayer/state.h
     multiplayer/validation.h
+    sbs_3d_ui.cpp
+    sbs_3d_ui.h
     ui_settings.cpp
     ui_settings.h
     updater/updater.cpp

--- a/src/citra_qt/applets/swkbd.cpp
+++ b/src/citra_qt/applets/swkbd.cpp
@@ -9,6 +9,7 @@
 #include <QString>
 #include <QVBoxLayout>
 #include "citra_qt/applets/swkbd.h"
+#include "citra_qt/sbs_3d_ui.h"
 
 QtKeyboardValidator::QtKeyboardValidator(QtKeyboard* keyboard_) : keyboard(keyboard_) {}
 
@@ -104,7 +105,7 @@ void QtKeyboardDialog::HandleValidationError(Frontend::ValidationError error) {
         {ValidationError::BlankInputNotAllowed, tr("Blank input is not allowed")},
         {ValidationError::EmptyInputNotAllowed, tr("Empty input is not allowed")},
     };
-    QMessageBox::critical(this, tr("Validation error"), VALIDATION_ERROR_MESSAGES.at(error));
+    QMessageBox3D::critical(this, tr("Validation error"), VALIDATION_ERROR_MESSAGES.at(error));
 }
 
 QtKeyboard::QtKeyboard(QWidget& parent_) : parent(parent_) {}

--- a/src/citra_qt/camera/qt_camera_base.cpp
+++ b/src/citra_qt/camera/qt_camera_base.cpp
@@ -5,6 +5,7 @@
 #include <QMessageBox>
 #include "citra_qt/camera/camera_util.h"
 #include "citra_qt/camera/qt_camera_base.h"
+#include "citra_qt/sbs_3d_ui.h"
 
 namespace Camera {
 
@@ -48,7 +49,7 @@ std::unique_ptr<CameraInterface> QtCameraFactory::CreatePreview(const std::strin
     if (camera->IsPreviewAvailable()) {
         return camera;
     }
-    QMessageBox::critical(
+    QMessageBox3D::critical(
         nullptr, QObject::tr("Error"),
         (config.empty() ? QObject::tr("Couldn't load the camera")
                         : QObject::tr("Couldn't load %1").arg(QString::fromStdString(config))));

--- a/src/citra_qt/compatdb.cpp
+++ b/src/citra_qt/compatdb.cpp
@@ -7,6 +7,7 @@
 #include <QPushButton>
 #include <QtConcurrent/qtconcurrentrun.h>
 #include "citra_qt/compatdb.h"
+#include "citra_qt/sbs_3d_ui.h"
 #include "common/telemetry.h"
 #include "core/core.h"
 #include "ui_compatdb.h"
@@ -68,8 +69,8 @@ void CompatDB::Submit() {
 
 void CompatDB::OnTestcaseSubmitted() {
     if (!testcase_watcher.result()) {
-        QMessageBox::critical(this, tr("Communication error"),
-                              tr("An error occured while sending the Testcase"));
+        QMessageBox3D::critical(this, tr("Communication error"),
+                                tr("An error occured while sending the Testcase"));
         button(NextButton)->setEnabled(true);
         button(NextButton)->setText(tr("Next"));
         button(QWizard::CancelButton)->setVisible(true);

--- a/src/citra_qt/configuration/configure_graphics.cpp
+++ b/src/citra_qt/configuration/configure_graphics.cpp
@@ -7,6 +7,7 @@
 #include <QMessageBox>
 #endif
 #include "citra_qt/configuration/configure_graphics.h"
+#include "citra_qt/sbs_3d_ui.h"
 #include "core/core.h"
 #include "core/settings.h"
 #include "ui_configure_graphics.h"
@@ -32,7 +33,7 @@ ConfigureGraphics::ConfigureGraphics(QWidget* parent)
 #ifdef __APPLE__
     connect(ui->toggle_hw_shader, &QCheckBox::stateChanged, this, [this](int state) {
         if (state == Qt::Checked) {
-            QMessageBox::warning(
+            QMessageBox3D::warning(
                 this, tr("Hardware Shader Warning"),
                 tr("Hardware Shader support is broken on macOS, and will cause graphical issues "
                    "like showing a black screen.<br><br>The option is only there for "

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -12,6 +12,7 @@
 #include "citra_qt/configuration/config.h"
 #include "citra_qt/configuration/configure_input.h"
 #include "citra_qt/configuration/configure_motion_touch.h"
+#include "citra_qt/sbs_3d_ui.h"
 #include "common/param_package.h"
 
 const std::array<std::string, ConfigureInput::ANALOG_SUB_BUTTONS_NUM>
@@ -207,9 +208,10 @@ ConfigureInput::ConfigureInput(QWidget* parent)
                     });
         }
         connect(analog_map_stick[analog_id], &QPushButton::released, [=]() {
-            QMessageBox::information(this, tr("Information"),
-                                     tr("After pressing OK, first move your joystick horizontally, "
-                                        "and then vertically."));
+            QMessageBox3D::information(
+                this, tr("Information"),
+                tr("After pressing OK, first move your joystick horizontally, "
+                   "and then vertically."));
             handleClick(analog_map_stick[analog_id],
                         [=](const Common::ParamPackage& params) {
                             analogs_param[analog_id] = params;
@@ -410,9 +412,9 @@ void ConfigureInput::NewProfile() {
 }
 
 void ConfigureInput::DeleteProfile() {
-    const auto answer = QMessageBox::question(
+    const auto answer = QMessageBox3D::question(
         this, tr("Delete Profile"), tr("Delete profile %1?").arg(ui->profile->currentText()));
-    if (answer != QMessageBox::Yes) {
+    if (answer != QMessageBox3D::Yes) {
         return;
     }
     const int index = ui->profile->currentIndex();

--- a/src/citra_qt/configuration/configure_motion_touch.cpp
+++ b/src/citra_qt/configuration/configure_motion_touch.cpp
@@ -9,6 +9,7 @@
 #include <QPushButton>
 #include <QVBoxLayout>
 #include "citra_qt/configuration/configure_motion_touch.h"
+#include "citra_qt/sbs_3d_ui.h"
 #include "core/settings.h"
 #include "input_common/main.h"
 #include "ui_configure_motion_touch.h"
@@ -222,13 +223,13 @@ void ConfigureMotionTouch::closeEvent(QCloseEvent* event) {
 void ConfigureMotionTouch::ShowUDPTestResult(bool result) {
     udp_test_in_progress = false;
     if (result) {
-        QMessageBox::information(this, tr("Test Successful"),
-                                 tr("Successfully received data from the server."));
+        QMessageBox3D::information(this, tr("Test Successful"),
+                                   tr("Successfully received data from the server."));
     } else {
-        QMessageBox::warning(this, tr("Test Failed"),
-                             tr("Could not receive valid data from the server.<br>Please verify "
-                                "that the server is set up correctly and "
-                                "the address and port are correct."));
+        QMessageBox3D::warning(this, tr("Test Failed"),
+                               tr("Could not receive valid data from the server.<br>Please verify "
+                                  "that the server is set up correctly and "
+                                  "the address and port are correct."));
     }
     ui->udp_test->setEnabled(true);
     ui->udp_test->setText(tr("Test"));
@@ -236,9 +237,9 @@ void ConfigureMotionTouch::ShowUDPTestResult(bool result) {
 
 bool ConfigureMotionTouch::CanCloseDialog() {
     if (udp_test_in_progress) {
-        QMessageBox::warning(this, tr("Citra"),
-                             tr("UDP Test or calibration configuration is in progress.<br>Please "
-                                "wait for them to finish."));
+        QMessageBox3D::warning(this, tr("Citra"),
+                               tr("UDP Test or calibration configuration is in progress.<br>Please "
+                                  "wait for them to finish."));
         return false;
     }
     return true;

--- a/src/citra_qt/configuration/configure_system.cpp
+++ b/src/citra_qt/configuration/configure_system.cpp
@@ -4,6 +4,7 @@
 
 #include <QMessageBox>
 #include "citra_qt/configuration/configure_system.h"
+#include "citra_qt/sbs_3d_ui.h"
 #include "citra_qt/ui_settings.h"
 #include "core/core.h"
 #include "core/hle/service/cfg/cfg.h"
@@ -402,14 +403,14 @@ void ConfigureSystem::UpdateInitTime(int init_clock) {
 }
 
 void ConfigureSystem::RefreshConsoleID() {
-    QMessageBox::StandardButton reply;
+    QMessageBox3D::StandardButton reply;
     QString warning_text = tr("This will replace your current virtual 3DS with a new one. "
                               "Your current virtual 3DS will not be recoverable. "
                               "This might have unexpected effects in games. This might fail, "
                               "if you use an outdated config savegame. Continue?");
-    reply = QMessageBox::critical(this, tr("Warning"), warning_text,
-                                  QMessageBox::No | QMessageBox::Yes);
-    if (reply == QMessageBox::No)
+    reply = QMessageBox3D::critical(this, tr("Warning"), warning_text,
+                                    QMessageBox3D::No | QMessageBox3D::Yes);
+    if (reply == QMessageBox3D::No)
         return;
     u32 random_number;
     u64 console_id;

--- a/src/citra_qt/configuration/configure_web.cpp
+++ b/src/citra_qt/configuration/configure_web.cpp
@@ -6,6 +6,7 @@
 #include <QMessageBox>
 #include <QtConcurrent/QtConcurrentRun>
 #include "citra_qt/configuration/configure_web.h"
+#include "citra_qt/sbs_3d_ui.h"
 #include "citra_qt/ui_settings.h"
 #include "core/settings.h"
 #include "core/telemetry_session.h"
@@ -65,9 +66,9 @@ void ConfigureWeb::applyConfiguration() {
         Settings::values.citra_username = ui->edit_username->text().toStdString();
         Settings::values.citra_token = ui->edit_token->text().toStdString();
     } else {
-        QMessageBox::warning(this, tr("Username and token not verified"),
-                             tr("Username and token were not verified. The changes to your "
-                                "username and/or token have not been saved."));
+        QMessageBox3D::warning(this, tr("Username and token not verified"),
+                               tr("Username and token were not verified. The changes to your "
+                                  "username and/or token have not been saved."));
     }
 }
 
@@ -108,7 +109,7 @@ void ConfigureWeb::OnLoginVerified() {
     } else {
         ui->label_username_verified->setPixmap(QIcon::fromTheme("failed").pixmap(16));
         ui->label_token_verified->setPixmap(QIcon::fromTheme("failed").pixmap(16));
-        QMessageBox::critical(
+        QMessageBox3D::critical(
             this, tr("Verification failed"),
             tr("Verification failed. Check that you have entered your username and token "
                "correctly, and that your internet connection is working."));

--- a/src/citra_qt/debugger/graphics/graphics_tracing.cpp
+++ b/src/citra_qt/debugger/graphics/graphics_tracing.cpp
@@ -13,6 +13,7 @@
 #include <QPushButton>
 #include <boost/range/algorithm/copy.hpp>
 #include "citra_qt/debugger/graphics/graphics_tracing.h"
+#include "citra_qt/sbs_3d_ui.h"
 #include "common/common_types.h"
 #include "core/hw/gpu.h"
 #include "core/hw/lcd.h"
@@ -159,12 +160,12 @@ void GraphicsTracingWidget::OnEmulationStopping() {
 
     if (context->recorder) {
         auto reply =
-            QMessageBox::question(this, tr("CiTracing still active"),
-                                  tr("A CiTrace is still being recorded. Do you want to save it? "
-                                     "If not, all recorded data will be discarded."),
-                                  QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
+            QMessageBox3D::question(this, tr("CiTracing still active"),
+                                    tr("A CiTrace is still being recorded. Do you want to save it? "
+                                       "If not, all recorded data will be discarded."),
+                                    QMessageBox3D::Yes | QMessageBox3D::No, QMessageBox3D::Yes);
 
-        if (reply == QMessageBox::Yes) {
+        if (reply == QMessageBox3D::Yes) {
             StopRecording();
         } else {
             AbortRecording();

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -41,6 +41,7 @@
 #include "citra_qt/hotkeys.h"
 #include "citra_qt/main.h"
 #include "citra_qt/multiplayer/state.h"
+#include "citra_qt/sbs_3d_ui.h"
 #include "citra_qt/ui_settings.h"
 #include "citra_qt/updater/updater.h"
 #include "citra_qt/util/clickable_label.h"
@@ -100,7 +101,7 @@ void GMainWindow::ShowTelemetryCallout() {
         tr("<a href='https://citra-emu.org/entry/telemetry-and-why-thats-a-good-thing/'>Anonymous "
            "data is collected</a> to help improve Citra. "
            "<br/><br/>Would you like to share your usage data with us?");
-    if (QMessageBox::question(this, tr("Telemetry"), telemetry_message) != QMessageBox::Yes) {
+    if (QMessageBox3D::question(this, tr("Telemetry"), telemetry_message) != QMessageBox3D::Yes) {
         Settings::values.enable_telemetry = false;
         Settings::Apply();
     }
@@ -680,19 +681,19 @@ void GMainWindow::ShowUpdatePrompt() {
     defer_update_prompt = false;
 
     auto result =
-        QMessageBox::question(this, tr("Update Available"),
-                              tr("An update is available. Would you like to install it now?"),
-                              QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
+        QMessageBox3D::question(this, tr("Update Available"),
+                                tr("An update is available. Would you like to install it now?"),
+                                QMessageBox3D::Yes | QMessageBox3D::No, QMessageBox3D::Yes);
 
-    if (result == QMessageBox::Yes) {
+    if (result == QMessageBox3D::Yes) {
         updater->LaunchUIOnExit();
         close();
     }
 }
 
 void GMainWindow::ShowNoUpdatePrompt() {
-    QMessageBox::information(this, tr("No Update Found"), tr("No update is found."),
-                             QMessageBox::Ok, QMessageBox::Ok);
+    QMessageBox3D::information(this, tr("No Update Found"), tr("No update is found."),
+                               QMessageBox3D::Ok, QMessageBox3D::Ok);
 }
 
 void GMainWindow::OnOpenUpdater() {
@@ -712,7 +713,7 @@ bool GMainWindow::LoadROM(const QString& filename) {
                                           "have the latest graphics driver.");
 
     if (!gladLoadGL()) {
-        QMessageBox::critical(this, below_gl33_title, below_gl33_message);
+        QMessageBox3D::critical(this, below_gl33_title, below_gl33_message);
         return false;
     }
 
@@ -724,7 +725,7 @@ bool GMainWindow::LoadROM(const QString& filename) {
         switch (result) {
         case Core::System::ResultStatus::ErrorGetLoader:
             LOG_CRITICAL(Frontend, "Failed to obtain loader for {}!", filename.toStdString());
-            QMessageBox::critical(
+            QMessageBox3D::critical(
                 this, tr("Invalid ROM Format"),
                 tr("Your ROM format is not supported.<br/>Please follow the guides to redump your "
                    "<a href='https://citra-emu.org/wiki/dumping-game-cartridges/'>game "
@@ -735,7 +736,7 @@ bool GMainWindow::LoadROM(const QString& filename) {
 
         case Core::System::ResultStatus::ErrorSystemMode:
             LOG_CRITICAL(Frontend, "Failed to load ROM!");
-            QMessageBox::critical(
+            QMessageBox3D::critical(
                 this, tr("ROM Corrupted"),
                 tr("Your ROM is corrupted. <br/>Please follow the guides to redump your "
                    "<a href='https://citra-emu.org/wiki/dumping-game-cartridges/'>game "
@@ -745,7 +746,7 @@ bool GMainWindow::LoadROM(const QString& filename) {
             break;
 
         case Core::System::ResultStatus::ErrorLoader_ErrorEncrypted: {
-            QMessageBox::critical(
+            QMessageBox3D::critical(
                 this, tr("ROM Encrypted"),
                 tr("Your ROM is encrypted. <br/>Please follow the guides to redump your "
                    "<a href='https://citra-emu.org/wiki/dumping-game-cartridges/'>game "
@@ -755,7 +756,7 @@ bool GMainWindow::LoadROM(const QString& filename) {
             break;
         }
         case Core::System::ResultStatus::ErrorLoader_ErrorInvalidFormat:
-            QMessageBox::critical(
+            QMessageBox3D::critical(
                 this, tr("Invalid ROM Format"),
                 tr("Your ROM format is not supported.<br/>Please follow the guides to redump your "
                    "<a href='https://citra-emu.org/wiki/dumping-game-cartridges/'>game "
@@ -765,7 +766,7 @@ bool GMainWindow::LoadROM(const QString& filename) {
             break;
 
         case Core::System::ResultStatus::ErrorVideoCore:
-            QMessageBox::critical(
+            QMessageBox3D::critical(
                 this, tr("Video Core Error"),
                 tr("An error has occured. Please <a "
                    "href='https://community.citra-emu.org/t/how-to-upload-the-log-file/296'>see "
@@ -775,7 +776,7 @@ bool GMainWindow::LoadROM(const QString& filename) {
             break;
 
         case Core::System::ResultStatus::ErrorVideoCore_ErrorGenericDrivers:
-            QMessageBox::critical(
+            QMessageBox3D::critical(
                 this, tr("Video Core Error"),
                 tr("You are running default Windows drivers "
                    "for your GPU. You need to install the "
@@ -783,11 +784,11 @@ bool GMainWindow::LoadROM(const QString& filename) {
             break;
 
         case Core::System::ResultStatus::ErrorVideoCore_ErrorBelowGL33:
-            QMessageBox::critical(this, below_gl33_title, below_gl33_message);
+            QMessageBox3D::critical(this, below_gl33_title, below_gl33_message);
             break;
 
         default:
-            QMessageBox::critical(
+            QMessageBox3D::critical(
                 this, tr("Error while loading ROM!"),
                 tr("An unknown error occured. Please see the log for more details."));
             break;
@@ -993,7 +994,7 @@ void GMainWindow::OnGameListOpenFolder(u64 data_id, GameListOpenTarget target) {
 
     QDir dir(qpath);
     if (!dir.exists()) {
-        QMessageBox::critical(
+        QMessageBox3D::critical(
             this, tr("Error Opening %1 Folder").arg(QString::fromStdString(open_target)),
             tr("Folder does not exist!"));
         return;
@@ -1031,7 +1032,8 @@ void GMainWindow::OnGameListOpenDirectory(QString directory) {
         path = directory;
     }
     if (!QFileInfo::exists(path)) {
-        QMessageBox::critical(this, tr("Error Opening %1").arg(path), tr("Folder does not exist!"));
+        QMessageBox3D::critical(this, tr("Error Opening %1").arg(path),
+                                tr("Folder does not exist!"));
         return;
     }
     QDesktopServices::openUrl(QUrl::fromLocalFile(path));
@@ -1112,23 +1114,24 @@ void GMainWindow::OnCIAInstallReport(Service::AM::InstallStatus status, QString 
         this->statusBar()->showMessage(tr("%1 has been installed successfully.").arg(filename));
         break;
     case Service::AM::InstallStatus::ErrorFailedToOpenFile:
-        QMessageBox::critical(this, tr("Unable to open File"),
-                              tr("Could not open %1").arg(filename));
+        QMessageBox3D::critical(this, tr("Unable to open File"),
+                                tr("Could not open %1").arg(filename));
         break;
     case Service::AM::InstallStatus::ErrorAborted:
-        QMessageBox::critical(
+        QMessageBox3D::critical(
             this, tr("Installation aborted"),
             tr("The installation of %1 was aborted. Please see the log for more details")
                 .arg(filename));
         break;
     case Service::AM::InstallStatus::ErrorInvalid:
-        QMessageBox::critical(this, tr("Invalid File"), tr("%1 is not a valid CIA").arg(filename));
+        QMessageBox3D::critical(this, tr("Invalid File"),
+                                tr("%1 is not a valid CIA").arg(filename));
         break;
     case Service::AM::InstallStatus::ErrorEncrypted:
-        QMessageBox::critical(this, tr("Encrypted File"),
-                              tr("%1 must be decrypted "
-                                 "before being used with Citra. A real 3DS is required.")
-                                  .arg(filename));
+        QMessageBox3D::critical(this, tr("Encrypted File"),
+                                tr("%1 must be decrypted "
+                                   "before being used with Citra. A real 3DS is required.")
+                                    .arg(filename));
         break;
     }
 }
@@ -1150,8 +1153,8 @@ void GMainWindow::OnMenuRecentFile() {
         BootGame(filename);
     } else {
         // Display an error message and remove the file from the list.
-        QMessageBox::information(this, tr("File not found"),
-                                 tr("File \"%1\" not found").arg(filename));
+        QMessageBox3D::information(this, tr("File not found"),
+                                   tr("File \"%1\" not found").arg(filename));
 
         UISettings::values.recent_files.removeOne(filename);
         UpdateRecentFiles();
@@ -1205,9 +1208,9 @@ void GMainWindow::OnMenuReportCompatibility() {
         CompatDB compatdb{this};
         compatdb.exec();
     } else {
-        QMessageBox::critical(this, tr("Missing Citra Account"),
-                              tr("You must link your Citra account to submit test cases."
-                                 "<br/>Go to Emulation &gt; Configure... &gt; Web to do so."));
+        QMessageBox3D::critical(this, tr("Missing Citra Account"),
+                                tr("You must link your Citra account to submit test cases."
+                                   "<br/>Go to Emulation &gt; Configure... &gt; Web to do so."));
     }
 }
 
@@ -1318,6 +1321,7 @@ void GMainWindow::OnSwapScreens() {
 
 void GMainWindow::OnCheats() {
     CheatDialog cheat_dialog(this);
+    MoveDialogToLeftEye(&cheat_dialog, this);
     cheat_dialog.exec();
 }
 
@@ -1325,6 +1329,7 @@ void GMainWindow::OnConfigure() {
     ConfigureDialog configureDialog(this, hotkey_registry);
     connect(&configureDialog, &ConfigureDialog::languageChanged, this,
             &GMainWindow::OnLanguageChanged);
+    MoveDialogToLeftEye(&configureDialog, this);
     auto old_theme = UISettings::values.theme;
     const int old_input_profile_index = Settings::values.current_input_profile_index;
     const auto old_input_profiles = Settings::values.input_profiles;
@@ -1364,8 +1369,8 @@ void GMainWindow::OnLoadAmiibo() {
 
     QFile nfc_file{filename};
     if (!nfc_file.open(QIODevice::ReadOnly)) {
-        QMessageBox::warning(this, tr("Error opening Amiibo data file"),
-                             tr("Unable to open Amiibo file \"%1\" for reading.").arg(filename));
+        QMessageBox3D::warning(this, tr("Error opening Amiibo data file"),
+                               tr("Unable to open Amiibo file \"%1\" for reading.").arg(filename));
         return;
     }
 
@@ -1373,11 +1378,12 @@ void GMainWindow::OnLoadAmiibo() {
     const u64 read_size =
         nfc_file.read(reinterpret_cast<char*>(&amiibo_data), sizeof(Service::NFC::AmiiboData));
     if (read_size != sizeof(Service::NFC::AmiiboData)) {
-        QMessageBox::warning(this, tr("Error reading Amiibo data file"),
-                             tr("Unable to fully read Amiibo data. Expected to read %1 bytes, but "
-                                "was only able to read %2 bytes.")
-                                 .arg(sizeof(Service::NFC::AmiiboData))
-                                 .arg(read_size));
+        QMessageBox3D::warning(
+            this, tr("Error reading Amiibo data file"),
+            tr("Unable to fully read Amiibo data. Expected to read %1 bytes, but "
+               "was only able to read %2 bytes.")
+                .arg(sizeof(Service::NFC::AmiiboData))
+                .arg(read_size));
         return;
     }
 
@@ -1420,12 +1426,12 @@ void GMainWindow::OnCreateGraphicsSurfaceViewer() {
 
 void GMainWindow::OnRecordMovie() {
     if (emulation_running) {
-        QMessageBox::StandardButton answer = QMessageBox::warning(
+        QMessageBox3D::StandardButton answer = QMessageBox3D::warning(
             this, tr("Record Movie"),
             tr("To keep consistency with the RNG, it is recommended to record the movie from game "
                "start.<br>Are you sure you still want to record movies now?"),
-            QMessageBox::Yes | QMessageBox::No);
-        if (answer == QMessageBox::No)
+            QMessageBox3D::Yes | QMessageBox3D::No);
+        if (answer == QMessageBox3D::No)
             return;
     }
     const QString path =
@@ -1439,8 +1445,8 @@ void GMainWindow::OnRecordMovie() {
     } else {
         movie_record_on_start = true;
         movie_record_path = path;
-        QMessageBox::information(this, tr("Record Movie"),
-                                 tr("Recording will start once you boot a game."));
+        QMessageBox3D::information(this, tr("Record Movie"),
+                                   tr("Recording will start once you boot a game."));
     }
     ui.action_Record_Movie->setEnabled(false);
     ui.action_Play_Movie->setEnabled(false);
@@ -1468,19 +1474,19 @@ bool GMainWindow::ValidateMovie(const QString& path, u64 program_id) {
     int answer;
     switch (result) {
     case Movie::ValidationResult::RevisionDismatch:
-        answer = QMessageBox::question(this, tr("Revision Dismatch"), revision_dismatch_text,
-                                       QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
-        if (answer != QMessageBox::Yes)
+        answer = QMessageBox3D::question(this, tr("Revision Dismatch"), revision_dismatch_text,
+                                         QMessageBox3D::Yes | QMessageBox3D::No, QMessageBox3D::No);
+        if (answer != QMessageBox3D::Yes)
             return false;
         break;
     case Movie::ValidationResult::GameDismatch:
-        answer = QMessageBox::question(this, tr("Game Dismatch"), game_dismatch_text,
-                                       QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
-        if (answer != QMessageBox::Yes)
+        answer = QMessageBox3D::question(this, tr("Game Dismatch"), game_dismatch_text,
+                                         QMessageBox3D::Yes | QMessageBox3D::No, QMessageBox3D::No);
+        if (answer != QMessageBox3D::Yes)
             return false;
         break;
     case Movie::ValidationResult::Invalid:
-        QMessageBox::critical(this, tr("Invalid Movie File"), invalid_movie_text);
+        QMessageBox3D::critical(this, tr("Invalid Movie File"), invalid_movie_text);
         return false;
     default:
         break;
@@ -1490,12 +1496,12 @@ bool GMainWindow::ValidateMovie(const QString& path, u64 program_id) {
 
 void GMainWindow::OnPlayMovie() {
     if (emulation_running) {
-        QMessageBox::StandardButton answer = QMessageBox::warning(
+        QMessageBox3D::StandardButton answer = QMessageBox3D::warning(
             this, tr("Play Movie"),
             tr("To keep consistency with the RNG, it is recommended to play the movie from game "
                "start.<br>Are you sure you still want to play movies now?"),
-            QMessageBox::Yes | QMessageBox::No);
-        if (answer == QMessageBox::No)
+            QMessageBox3D::Yes | QMessageBox3D::No);
+        if (answer == QMessageBox3D::No)
             return;
     }
 
@@ -1517,15 +1523,15 @@ void GMainWindow::OnPlayMovie() {
                "<br/>Please choose a different movie file and try again.");
         u64 program_id = Core::Movie::GetInstance().GetMovieProgramID(path.toStdString());
         if (!program_id) {
-            QMessageBox::critical(this, tr("Invalid Movie File"), invalid_movie_text);
+            QMessageBox3D::critical(this, tr("Invalid Movie File"), invalid_movie_text);
             return;
         }
         QString game_path = game_list->FindGameByProgramID(program_id);
         if (game_path.isEmpty()) {
-            QMessageBox::warning(this, tr("Game Not Found"),
-                                 tr("The movie you are trying to play is from a game that is not "
-                                    "in the game list. If you own the game, please add the game "
-                                    "folder to the game list and try to play the movie again."));
+            QMessageBox3D::warning(this, tr("Game Not Found"),
+                                   tr("The movie you are trying to play is from a game that is not "
+                                      "in the game list. If you own the game, please add the game "
+                                      "folder to the game list and try to play the movie again."));
             return;
         }
         if (!ValidateMovie(path, program_id))
@@ -1543,15 +1549,15 @@ void GMainWindow::OnPlayMovie() {
 
 void GMainWindow::OnStopRecordingPlayback() {
     if (movie_record_on_start) {
-        QMessageBox::information(this, tr("Record Movie"), tr("Movie recording cancelled."));
+        QMessageBox3D::information(this, tr("Record Movie"), tr("Movie recording cancelled."));
         movie_record_on_start = false;
         movie_record_path.clear();
     } else {
         const bool was_recording = Core::Movie::GetInstance().IsRecordingInput();
         Core::Movie::GetInstance().Shutdown();
         if (was_recording) {
-            QMessageBox::information(this, tr("Movie Saved"),
-                                     tr("The movie is successfully saved."));
+            QMessageBox3D::information(this, tr("Movie Saved"),
+                                       tr("The movie is successfully saved."));
         }
     }
     ui.action_Record_Movie->setEnabled(true);
@@ -1623,12 +1629,12 @@ void GMainWindow::OnCoreError(Core::System::ResultStatus result, std::string det
         status_message = "Fatal Error encountered";
     }
 
-    QMessageBox message_box;
+    QMessageBox3D message_box;
     message_box.setWindowTitle(title);
     message_box.setText(message);
-    message_box.setIcon(QMessageBox::Icon::Critical);
-    QPushButton* continue_button = message_box.addButton(tr("Continue"), QMessageBox::RejectRole);
-    QPushButton* abort_button = message_box.addButton(tr("Abort"), QMessageBox::AcceptRole);
+    message_box.setIcon(QMessageBox3D::Icon::Critical);
+    QPushButton* continue_button = message_box.addButton(tr("Continue"), QMessageBox3D::RejectRole);
+    QPushButton* abort_button = message_box.addButton(tr("Abort"), QMessageBox3D::AcceptRole);
     if (result != Core::System::ResultStatus::ShutdownRequested)
         message_box.exec();
 
@@ -1649,6 +1655,7 @@ void GMainWindow::OnCoreError(Core::System::ResultStatus result, std::string det
 
 void GMainWindow::OnMenuAboutCitra() {
     AboutDialog about{this};
+    MoveDialogToLeftEye(&about, this);
     about.exec();
 }
 
@@ -1657,8 +1664,8 @@ bool GMainWindow::ConfirmClose() {
         return true;
 
     QMessageBox::StandardButton answer =
-        QMessageBox::question(this, tr("Citra"), tr("Would you like to exit now?"),
-                              QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+        QMessageBox3D::question(this, tr("Citra"), tr("Would you like to exit now?"),
+                                QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
     return answer != QMessageBox::No;
 }
 
@@ -1723,10 +1730,10 @@ bool GMainWindow::ConfirmChangeGame() {
     if (emu_thread == nullptr)
         return true;
 
-    auto answer = QMessageBox::question(
+    auto answer = QMessageBox3D::question(
         this, tr("Citra"), tr("The game is still running. Would you like to stop emulation?"),
-        QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
-    return answer != QMessageBox::No;
+        QMessageBox3D::Yes | QMessageBox3D::No, QMessageBox3D::No);
+    return answer != QMessageBox3D::No;
 }
 
 void GMainWindow::filterBarSetChecked(bool state) {
@@ -1797,7 +1804,7 @@ void GMainWindow::OnLanguageChanged(const QString& locale) {
 }
 
 void GMainWindow::OnMoviePlaybackCompleted() {
-    QMessageBox::information(this, tr("Playback Completed"), tr("Movie playback completed."));
+    QMessageBox3D::information(this, tr("Playback Completed"), tr("Movie playback completed."));
     ui.action_Record_Movie->setEnabled(true);
     ui.action_Play_Movie->setEnabled(true);
     ui.action_Stop_Recording_Playback->setEnabled(false);

--- a/src/citra_qt/multiplayer/message.cpp
+++ b/src/citra_qt/multiplayer/message.cpp
@@ -6,6 +6,7 @@
 #include <QString>
 
 #include "citra_qt/multiplayer/message.h"
+#include "citra_qt/sbs_3d_ui.h"
 
 namespace NetworkMessage {
 const ConnectionError USERNAME_NOT_VALID(
@@ -48,13 +49,13 @@ const ConnectionError NO_SUCH_USER(QT_TR_NOOP(
     "The user you are trying to kick/ban could not be found.\nThey may have left the room."));
 
 static bool WarnMessage(const std::string& title, const std::string& text) {
-    return QMessageBox::Ok == QMessageBox::warning(nullptr, QObject::tr(title.c_str()),
-                                                   QObject::tr(text.c_str()),
-                                                   QMessageBox::Ok | QMessageBox::Cancel);
+    return QMessageBox3D::Ok == QMessageBox3D::warning(nullptr, QObject::tr(title.c_str()),
+                                                       QObject::tr(text.c_str()),
+                                                       QMessageBox3D::Ok | QMessageBox3D::Cancel);
 }
 
 void ShowError(const ConnectionError& e) {
-    QMessageBox::critical(nullptr, QObject::tr("Error"), QObject::tr(e.GetString().c_str()));
+    QMessageBox3D::critical(nullptr, QObject::tr("Error"), QObject::tr(e.GetString().c_str()));
 }
 
 bool WarnCloseRoom() {

--- a/src/citra_qt/multiplayer/state.cpp
+++ b/src/citra_qt/multiplayer/state.cpp
@@ -200,7 +200,7 @@ void MultiplayerState::UpdateThemedIcons() {
 }
 
 void MultiplayerState::BringWidgetToFront(QWidget* widget) {
-    MoveDialogToLeftEye(widget, qobject_cast<QWidget*>(parent()));
+    MoveDialogToLeftEye(widget, parentWidget());
     widget->show();
     widget->activateWindow();
     widget->raise();

--- a/src/citra_qt/multiplayer/state.cpp
+++ b/src/citra_qt/multiplayer/state.cpp
@@ -14,6 +14,7 @@
 #include "citra_qt/multiplayer/lobby.h"
 #include "citra_qt/multiplayer/message.h"
 #include "citra_qt/multiplayer/state.h"
+#include "citra_qt/sbs_3d_ui.h"
 #include "citra_qt/ui_settings.h"
 #include "citra_qt/util/clickable_label.h"
 #include "common/announce_multiplayer_room.h"
@@ -198,7 +199,8 @@ void MultiplayerState::UpdateThemedIcons() {
         client_room->UpdateIconDisplay();
 }
 
-static void BringWidgetToFront(QWidget* widget) {
+void MultiplayerState::BringWidgetToFront(QWidget* widget) {
+    MoveDialogToLeftEye(widget, qobject_cast<QWidget*>(parent()));
     widget->show();
     widget->activateWindow();
     widget->raise();

--- a/src/citra_qt/multiplayer/state.h
+++ b/src/citra_qt/multiplayer/state.h
@@ -37,6 +37,7 @@ public:
     }
 
     void retranslateUi();
+    void BringWidgetToFront(QWidget* widget);
 
 public slots:
     void OnNetworkStateChanged(const Network::RoomMember::State& state);

--- a/src/citra_qt/sbs_3d_ui.cpp
+++ b/src/citra_qt/sbs_3d_ui.cpp
@@ -1,0 +1,64 @@
+// Copyright 2014 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <algorithm>
+#include <glad/glad.h>
+#define QT_NO_OPENGL
+#include <QMessageBox>
+#include <QtWidgets>
+#include "citra_qt/sbs_3d_ui.h"
+#include "core/settings.h"
+
+void MoveDialogToLeftEye(QWidget* dialog, QWidget* parent) {
+    // move dialog to centre of left eye in SBS 3D mode
+    if (Settings::values.toggle_3d) {
+        dialog->adjustSize();
+        QRect screen_geometry = parent->geometry();
+        screen_geometry.setWidth(screen_geometry.width() / 2);
+        int dialog_width = std::min(dialog->width(), screen_geometry.width());
+        int dialog_height = std::min(dialog->height(), screen_geometry.height());
+        dialog->move(screen_geometry.center().x() - dialog_width / 2,
+                     screen_geometry.center().y() - dialog_height / 2);
+    }
+}
+
+QMessageBox::StandardButton QMessageBox3D::showNewMessageBox(
+    QWidget* parent, QMessageBox::Icon icon, const QString& title, const QString& text,
+    QMessageBox::StandardButtons buttons, QMessageBox::StandardButton defaultButton) {
+    QMessageBox msg_box(icon, title, text, buttons, parent);
+    msg_box.setDefaultButton(defaultButton);
+    MoveDialogToLeftEye(&msg_box, parent);
+    if (msg_box.exec() == -1)
+        return QMessageBox::Cancel;
+    return msg_box.standardButton(msg_box.clickedButton());
+}
+
+QMessageBox::StandardButton QMessageBox3D::information(QWidget* parent, const QString& title,
+                                                       const QString& text, StandardButtons buttons,
+                                                       StandardButton defaultButton) {
+    return showNewMessageBox(parent, Information, title, text, buttons, defaultButton);
+}
+
+QMessageBox::StandardButton QMessageBox3D::question(QWidget* parent, const QString& title,
+                                                    const QString& text, StandardButtons buttons,
+                                                    StandardButton defaultButton) {
+    return showNewMessageBox(parent, Question, title, text, buttons, defaultButton);
+}
+
+QMessageBox::StandardButton QMessageBox3D::warning(QWidget* parent, const QString& title,
+                                                   const QString& text, StandardButtons buttons,
+                                                   StandardButton defaultButton) {
+    return showNewMessageBox(parent, Warning, title, text, buttons, defaultButton);
+}
+
+QMessageBox::StandardButton QMessageBox3D::critical(QWidget* parent, const QString& title,
+                                                    const QString& text, StandardButtons buttons,
+                                                    StandardButton defaultButton) {
+    return showNewMessageBox(parent, Critical, title, text, buttons, defaultButton);
+}
+
+int QMessageBox3D::exec() {
+    MoveDialogToLeftEye(this, static_cast<QWidget*>(parent()));
+    return QMessageBox::exec();
+}

--- a/src/citra_qt/sbs_3d_ui.cpp
+++ b/src/citra_qt/sbs_3d_ui.cpp
@@ -9,8 +9,6 @@
 #include "citra_qt/sbs_3d_ui.h"
 #include "core/settings.h"
 
-#define PARALLAX 8
-
 // move dialog to centre of left eye in SBS 3D mode
 void MoveDialogToLeftEye(QWidget* dialog, QWidget* parent, int offset) {
     if (!Settings::values.toggle_3d) {
@@ -42,12 +40,13 @@ void MoveDialogToRightEye(QWidget* dialog, QWidget* parent, int offset) {
 QMessageBox::StandardButton QMessageBox3D::showNewMessageBox(
     QWidget* parent, QMessageBox::Icon icon, const QString& title, const QString& text,
     QMessageBox::StandardButtons buttons, QMessageBox::StandardButton defaultButton) {
+    constexpr int parallax = 8;
     QMessageBox left_box(icon, title, text, buttons, parent);
     QMessageBox right_box(icon, title, text, buttons, parent);
     left_box.setDefaultButton(defaultButton);
     right_box.setDefaultButton(defaultButton);
-    MoveDialogToLeftEye(&left_box, parent, +PARALLAX);
-    MoveDialogToRightEye(&right_box, parent, -PARALLAX);
+    MoveDialogToLeftEye(&left_box, parent, +parallax);
+    MoveDialogToRightEye(&right_box, parent, -parallax);
     right_box.show();
     if (left_box.exec() == -1)
         return QMessageBox::Cancel;

--- a/src/citra_qt/sbs_3d_ui.cpp
+++ b/src/citra_qt/sbs_3d_ui.cpp
@@ -3,40 +3,40 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
-#include <glad/glad.h>
 #define QT_NO_OPENGL
 #include <QMessageBox>
-#include <QtWidgets>
+#include <QWidget>
 #include "citra_qt/sbs_3d_ui.h"
 #include "core/settings.h"
 
 #define PARALLAX 8
 
+// move dialog to centre of left eye in SBS 3D mode
 void MoveDialogToLeftEye(QWidget* dialog, QWidget* parent, int offset) {
-    // move dialog to centre of left eye in SBS 3D mode
-    if (Settings::values.toggle_3d) {
-        dialog->adjustSize();
-        QRect screen_geometry = parent->geometry();
-        screen_geometry.setWidth(screen_geometry.width() / 2);
-        int dialog_width = std::min(dialog->width(), screen_geometry.width());
-        int dialog_height = std::min(dialog->height(), screen_geometry.height());
-        dialog->move(screen_geometry.center().x() + offset - dialog_width / 2,
-                     screen_geometry.center().y() - dialog_height / 2);
+    if (!Settings::values.toggle_3d) {
+        return;
     }
+    dialog->adjustSize();
+    QRect screen_geometry = parent->geometry();
+    screen_geometry.setWidth(screen_geometry.width() / 2);
+    int dialog_width = std::min(dialog->width(), screen_geometry.width());
+    int dialog_height = std::min(dialog->height(), screen_geometry.height());
+    dialog->move(screen_geometry.center().x() + offset - dialog_width / 2,
+                 screen_geometry.center().y() - dialog_height / 2);
 }
 
+// move dialog to centre of right eye in SBS 3D mode
 void MoveDialogToRightEye(QWidget* dialog, QWidget* parent, int offset) {
-    // move dialog to centre of right eye in SBS 3D mode
-    if (Settings::values.toggle_3d) {
-        dialog->adjustSize();
-        QRect screen_geometry = parent->geometry();
-        screen_geometry.setWidth(screen_geometry.width() / 2);
-        int dialog_width = std::min(dialog->width(), screen_geometry.width());
-        int dialog_height = std::min(dialog->height(), screen_geometry.height());
-        dialog->move(screen_geometry.width() + screen_geometry.center().x() + offset -
-                         dialog_width / 2,
-                     screen_geometry.center().y() - dialog_height / 2);
+    if (!Settings::values.toggle_3d) {
+        return;
     }
+    dialog->adjustSize();
+    QRect screen_geometry = parent->geometry();
+    screen_geometry.setWidth(screen_geometry.width() / 2);
+    int dialog_width = std::min(dialog->width(), screen_geometry.width());
+    int dialog_height = std::min(dialog->height(), screen_geometry.height());
+    dialog->move(screen_geometry.width() + screen_geometry.center().x() + offset - dialog_width / 2,
+                 screen_geometry.center().y() - dialog_height / 2);
 }
 
 QMessageBox::StandardButton QMessageBox3D::showNewMessageBox(
@@ -79,6 +79,6 @@ QMessageBox::StandardButton QMessageBox3D::critical(QWidget* parent, const QStri
 }
 
 int QMessageBox3D::exec() {
-    MoveDialogToLeftEye(this, static_cast<QWidget*>(parent()));
+    MoveDialogToLeftEye(this, parentWidget());
     return QMessageBox::exec();
 }

--- a/src/citra_qt/sbs_3d_ui.h
+++ b/src/citra_qt/sbs_3d_ui.h
@@ -28,5 +28,5 @@ public:
     static QMessageBox3D::StandardButton showNewMessageBox(
         QWidget* parent, QMessageBox::Icon icon, const QString& title, const QString& text,
         QMessageBox::StandardButtons buttons, QMessageBox::StandardButton defaultButton);
-    int exec();
+    int exec() override;
 };

--- a/src/citra_qt/sbs_3d_ui.h
+++ b/src/citra_qt/sbs_3d_ui.h
@@ -7,7 +7,8 @@
 #include <QMessageBox>
 #include <QWidget>
 
-void MoveDialogToLeftEye(QWidget* dialog, QWidget* parent);
+void MoveDialogToLeftEye(QWidget* dialog, QWidget* parent, int offset = 0);
+void MoveDialogToRightEye(QWidget* dialog, QWidget* parent, int offset = 0);
 
 class QMessageBox3D : public QMessageBox {
     Q_OBJECT

--- a/src/citra_qt/sbs_3d_ui.h
+++ b/src/citra_qt/sbs_3d_ui.h
@@ -1,0 +1,31 @@
+// Copyright 2014 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QMessageBox>
+#include <QWidget>
+
+void MoveDialogToLeftEye(QWidget* dialog, QWidget* parent);
+
+class QMessageBox3D : public QMessageBox {
+    Q_OBJECT
+public:
+    static StandardButton information(QWidget* parent, const QString& title, const QString& text,
+                                      StandardButtons buttons = Ok,
+                                      StandardButton defaultButton = NoButton);
+    static StandardButton question(QWidget* parent, const QString& title, const QString& text,
+                                   StandardButtons buttons = StandardButtons(Yes | No),
+                                   StandardButton defaultButton = NoButton);
+    static StandardButton warning(QWidget* parent, const QString& title, const QString& text,
+                                  StandardButtons buttons = Ok,
+                                  StandardButton defaultButton = NoButton);
+    static StandardButton critical(QWidget* parent, const QString& title, const QString& text,
+                                   StandardButtons buttons = Ok,
+                                   StandardButton defaultButton = NoButton);
+    static QMessageBox3D::StandardButton showNewMessageBox(
+        QWidget* parent, QMessageBox::Icon icon, const QString& title, const QString& text,
+        QMessageBox::StandardButtons buttons, QMessageBox::StandardButton defaultButton);
+    int exec();
+};


### PR DESCRIPTION
In 3D SBS mode, dialogs should all appear in the left eye instead of split over both eyes.
A 3D-aware QMessageBox3D class is added which should be used instead of QMessageBox.
I didn't change the file dialogs because they already always appeared in the left eye.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4605)
<!-- Reviewable:end -->
