### PR TITLE
Kernel/SharedMemory: make owner_process a raw pointer

### DIFF
--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -407,6 +407,12 @@ Kernel::Process::Process(KernelSystem& kernel)
     kernel.memory.RegisterPageTable(&vm_manager.page_table);
 }
 Kernel::Process::~Process() {
+    // Release all objects this process owns first so that their potential destructor can do clean
+    // up with this process before further destruction.
+    // TODO(wwylele): explicitly destroy or invalidate objects this process owns (threads, shared
+    // memory etc.) even if they are still referenced by other processes.
+    handle_table.Clear();
+
     kernel.memory.UnregisterPageTable(&vm_manager.page_table);
 }
 

--- a/src/core/hle/kernel/shared_memory.h
+++ b/src/core/hle/kernel/shared_memory.h
@@ -94,7 +94,7 @@ private:
     /// Permission restrictions applied to other processes mapping the block.
     MemoryPermission other_permissions{};
     /// Process that created this shared memory block.
-    SharedPtr<Process> owner_process;
+    Process* owner_process;
     /// Address of shared memory block in the owner process if specified.
     VAddr base_address = 0;
     /// Name of shared memory object.


### PR DESCRIPTION
To break a circular reference formed by process->handle_table->shared_memory->process. Since SharedMemory uses its owner process in the destructor, which is not kept alive by SharedMemory any more, we need to make sure that the lifetime of process is longer than the shared memory. To partially resolve this, Process now explicitly releases shared memory first in its destructor. This is with the assumtion that there is no inter-process reference to shared memory on exit, which is not true when we introduce more multi-process emulation. A TODO is left there for this, as more RE needs to be done on how 3DS handles this situation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4608)
<!-- Reviewable:end -->
