### PR TITLE
Cleanup System::GetInstance reference - Part 1

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic.h
+++ b/src/core/arm/dynarmic/arm_dynarmic.h
@@ -13,6 +13,7 @@
 
 namespace Memory {
 struct PageTable;
+class MemorySystem;
 } // namespace Memory
 
 namespace Core {
@@ -23,7 +24,7 @@ class DynarmicUserCallbacks;
 
 class ARM_Dynarmic final : public ARM_Interface {
 public:
-    ARM_Dynarmic(Core::System& system, PrivilegeMode initial_mode);
+    ARM_Dynarmic(Core::System* system, Memory::MemorySystem& memory, PrivilegeMode initial_mode);
     ~ARM_Dynarmic();
 
     void Run() override;
@@ -55,6 +56,7 @@ public:
 private:
     friend class DynarmicUserCallbacks;
     Core::System& system;
+    Memory::MemorySystem& memory;
     std::unique_ptr<DynarmicUserCallbacks> cb;
     std::unique_ptr<Dynarmic::A32::Jit> MakeJit();
 

--- a/src/core/arm/dyncom/arm_dyncom.h
+++ b/src/core/arm/dyncom/arm_dyncom.h
@@ -14,9 +14,14 @@ namespace Core {
 struct System;
 }
 
+namespace Memory {
+class MemorySystem;
+}
+
 class ARM_DynCom final : public ARM_Interface {
 public:
-    explicit ARM_DynCom(Core::System& system, PrivilegeMode initial_mode);
+    explicit ARM_DynCom(Core::System* system, Memory::MemorySystem& memory,
+                        PrivilegeMode initial_mode);
     ~ARM_DynCom();
 
     void Run() override;
@@ -48,6 +53,6 @@ public:
 private:
     void ExecuteInstructions(u64 num_instructions);
 
-    Core::System& system;
+    Core::System* system;
     std::unique_ptr<ARMul_State> state;
 };

--- a/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
+++ b/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
@@ -811,7 +811,7 @@ MICROPROFILE_DEFINE(DynCom_Decode, "DynCom", "Decode", MP_RGB(255, 64, 64));
 static unsigned int InterpreterTranslateInstruction(const ARMul_State* cpu, const u32 phys_addr,
                                                     ARM_INST_PTR& inst_base) {
     u32 inst_size = 4;
-    u32 inst = cpu->system.Memory().Read32(phys_addr & 0xFFFFFFFC);
+    u32 inst = cpu->memory.Read32(phys_addr & 0xFFFFFFFC);
 
     // If we are in Thumb mode, we'll translate one Thumb instruction to the corresponding ARM
     // instruction
@@ -3859,12 +3859,13 @@ SUB_INST : {
 }
 SWI_INST : {
     if (inst_base->cond == ConditionCode::AL || CondPassed(cpu, inst_base->cond)) {
+        DEBUG_ASSERT(cpu->system != nullptr);
         swi_inst* const inst_cream = (swi_inst*)inst_base->component;
-        cpu->system.CoreTiming().AddTicks(num_instrs);
+        cpu->system->CoreTiming().AddTicks(num_instrs);
         cpu->NumInstrsToExecute =
             num_instrs >= cpu->NumInstrsToExecute ? 0 : cpu->NumInstrsToExecute - num_instrs;
         num_instrs = 0;
-        Kernel::SVCContext{cpu->system}.CallSVC(inst_cream->num & 0xFFFF);
+        Kernel::SVCContext{*cpu->system}.CallSVC(inst_cream->num & 0xFFFF);
         // The kernel would call ERET to get here, which clears exclusive memory state.
         cpu->UnsetExclusiveMemoryAddress();
     }

--- a/src/core/arm/skyeye_common/armstate.h
+++ b/src/core/arm/skyeye_common/armstate.h
@@ -27,6 +27,10 @@ namespace Core {
 class System;
 }
 
+namespace Memory {
+class MemorySystem;
+}
+
 // Signal levels
 enum { LOW = 0, HIGH = 1, LOWHIGH = 1, HIGHLOW = 2 };
 
@@ -143,7 +147,8 @@ enum {
 
 struct ARMul_State final {
 public:
-    explicit ARMul_State(Core::System& system, PrivilegeMode initial_mode);
+    explicit ARMul_State(Core::System* system, Memory::MemorySystem& memory,
+                         PrivilegeMode initial_mode);
 
     void ChangePrivilegeMode(u32 new_mode);
     void Reset();
@@ -201,7 +206,8 @@ public:
 
     void ServeBreak();
 
-    Core::System& system;
+    Core::System* system;
+    Memory::MemorySystem& memory;
 
     std::array<u32, 16> Reg{}; // The current register file
     std::array<u32, 2> Reg_usr{};

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -179,13 +179,13 @@ System::ResultStatus System::Init(EmuWindow& emu_window, u32 system_mode) {
 
     if (Settings::values.use_cpu_jit) {
 #ifdef ARCHITECTURE_x86_64
-        cpu_core = std::make_unique<ARM_Dynarmic>(*this, USER32MODE);
+        cpu_core = std::make_unique<ARM_Dynarmic>(this, *memory, USER32MODE);
 #else
-        cpu_core = std::make_unique<ARM_DynCom>(*this, USER32MODE);
+        cpu_core = std::make_unique<ARM_DynCom>(this, *memory, USER32MODE);
         LOG_WARNING(Core, "CPU JIT requested, but Dynarmic not available");
 #endif
     } else {
-        cpu_core = std::make_unique<ARM_DynCom>(*this, USER32MODE);
+        cpu_core = std::make_unique<ARM_DynCom>(this, *memory, USER32MODE);
     }
 
     kernel->GetThreadManager().SetCPU(*cpu_core);

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -187,6 +187,8 @@ System::ResultStatus System::Init(EmuWindow& emu_window, u32 system_mode) {
         cpu_core = std::make_unique<ARM_DynCom>(*this, USER32MODE);
     }
 
+    kernel->GetThreadManager().SetCPU(*cpu_core);
+
     if (Settings::values.enable_dsp_lle) {
         dsp_core = std::make_unique<AudioCore::DspLle>(*memory,
                                                        Settings::values.enable_dsp_lle_multithread);

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -189,6 +189,7 @@ System::ResultStatus System::Init(EmuWindow& emu_window, u32 system_mode) {
     }
 
     kernel->GetThreadManager().SetCPU(*cpu_core);
+    memory->SetCPU(*cpu_core);
 
     if (Settings::values.enable_dsp_lle) {
         dsp_core = std::make_unique<AudioCore::DspLle>(*memory,

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -174,7 +174,7 @@ System::ResultStatus System::Init(EmuWindow& emu_window, u32 system_mode) {
 
     timing = std::make_unique<Timing>();
 
-    kernel = std::make_unique<Kernel::KernelSystem>(*memory, system_mode);
+    kernel = std::make_unique<Kernel::KernelSystem>(*memory, *timing, system_mode);
 
     if (Settings::values.use_cpu_jit) {
 #ifdef ARCHITECTURE_x86_64

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -174,7 +174,8 @@ System::ResultStatus System::Init(EmuWindow& emu_window, u32 system_mode) {
 
     timing = std::make_unique<Timing>();
 
-    kernel = std::make_unique<Kernel::KernelSystem>(*memory, *timing, system_mode);
+    kernel = std::make_unique<Kernel::KernelSystem>(*memory, *timing,
+                                                    [this] { PrepareReschedule(); }, system_mode);
 
     if (Settings::values.use_cpu_jit) {
 #ifdef ARCHITECTURE_x86_64

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -270,8 +270,6 @@ private:
 
     std::unique_ptr<Service::FS::ArchiveManager> archive_manager;
 
-public: // HACK: this is temporary exposed for tests,
-        // due to WIP kernel refactor causing desync state in memory
     std::unique_ptr<Memory::MemorySystem> memory;
     std::unique_ptr<Kernel::KernelSystem> kernel;
     std::unique_ptr<Timing> timing;

--- a/src/core/hle/kernel/ipc.cpp
+++ b/src/core/hle/kernel/ipc.cpp
@@ -16,11 +16,11 @@
 
 namespace Kernel {
 
-ResultCode TranslateCommandBuffer(SharedPtr<Thread> src_thread, SharedPtr<Thread> dst_thread,
-                                  VAddr src_address, VAddr dst_address,
+ResultCode TranslateCommandBuffer(Memory::MemorySystem& memory, SharedPtr<Thread> src_thread,
+                                  SharedPtr<Thread> dst_thread, VAddr src_address,
+                                  VAddr dst_address,
                                   std::vector<MappedBufferContext>& mapped_buffer_context,
                                   bool reply) {
-    Memory::MemorySystem& memory = Core::System::GetInstance().Memory();
     auto& src_process = src_thread->owner_process;
     auto& dst_process = dst_thread->owner_process;
 

--- a/src/core/hle/kernel/ipc.h
+++ b/src/core/hle/kernel/ipc.h
@@ -10,6 +10,10 @@
 #include "core/hle/ipc.h"
 #include "core/hle/kernel/thread.h"
 
+namespace Memory {
+class MemorySystem;
+}
+
 namespace Kernel {
 
 struct MappedBufferContext {
@@ -23,8 +27,9 @@ struct MappedBufferContext {
 };
 
 /// Performs IPC command buffer translation from one process to another.
-ResultCode TranslateCommandBuffer(SharedPtr<Thread> src_thread, SharedPtr<Thread> dst_thread,
-                                  VAddr src_address, VAddr dst_address,
+ResultCode TranslateCommandBuffer(Memory::MemorySystem& memory, SharedPtr<Thread> src_thread,
+                                  SharedPtr<Thread> dst_thread, VAddr src_address,
+                                  VAddr dst_address,
                                   std::vector<MappedBufferContext>& mapped_buffer_context,
                                   bool reply);
 } // namespace Kernel

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -16,12 +16,13 @@
 namespace Kernel {
 
 /// Initialize the kernel
-KernelSystem::KernelSystem(Memory::MemorySystem& memory, u32 system_mode) : memory(memory) {
+KernelSystem::KernelSystem(Memory::MemorySystem& memory, Core::Timing& timing, u32 system_mode)
+    : memory(memory), timing(timing) {
     MemoryInit(system_mode);
 
     resource_limits = std::make_unique<ResourceLimitList>(*this);
     thread_manager = std::make_unique<ThreadManager>(*this);
-    timer_manager = std::make_unique<TimerManager>();
+    timer_manager = std::make_unique<TimerManager>(timing);
 }
 
 /// Shutdown the kernel

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -16,8 +16,10 @@
 namespace Kernel {
 
 /// Initialize the kernel
-KernelSystem::KernelSystem(Memory::MemorySystem& memory, Core::Timing& timing, u32 system_mode)
-    : memory(memory), timing(timing) {
+KernelSystem::KernelSystem(Memory::MemorySystem& memory, Core::Timing& timing,
+                           std::function<void()> prepare_reschedule_callback, u32 system_mode)
+    : memory(memory), timing(timing),
+      prepare_reschedule_callback(std::move(prepare_reschedule_callback)) {
     MemoryInit(system_mode);
 
     resource_limits = std::make_unique<ResourceLimitList>(*this);

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <atomic>
+#include <functional>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -82,7 +83,8 @@ using SharedPtr = boost::intrusive_ptr<T>;
 
 class KernelSystem {
 public:
-    explicit KernelSystem(Memory::MemorySystem& memory, Core::Timing& timing, u32 system_mode);
+    explicit KernelSystem(Memory::MemorySystem& memory, Core::Timing& timing,
+                          std::function<void()> prepare_reschedule_callback, u32 system_mode);
     ~KernelSystem();
 
     /**
@@ -228,6 +230,10 @@ public:
     /// Adds a port to the named port table
     void AddNamedPort(std::string name, SharedPtr<ClientPort> port);
 
+    void PrepareReschedule() {
+        prepare_reschedule_callback();
+    }
+
     /// Map of named ports managed by the kernel, which can be retrieved using the ConnectToPort
     std::unordered_map<std::string, SharedPtr<ClientPort>> named_ports;
 
@@ -237,6 +243,8 @@ public:
 
 private:
     void MemoryInit(u32 mem_type);
+
+    std::function<void()> prepare_reschedule_callback;
 
     std::unique_ptr<ResourceLimitList> resource_limits;
     std::atomic<u32> next_object_id{0};

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -27,6 +27,10 @@ namespace Memory {
 class MemorySystem;
 }
 
+namespace Core {
+class Timing;
+}
+
 namespace Kernel {
 
 class AddressArbiter;
@@ -78,7 +82,7 @@ using SharedPtr = boost::intrusive_ptr<T>;
 
 class KernelSystem {
 public:
-    explicit KernelSystem(Memory::MemorySystem& memory, u32 system_mode);
+    explicit KernelSystem(Memory::MemorySystem& memory, Core::Timing& timing, u32 system_mode);
     ~KernelSystem();
 
     /**
@@ -228,6 +232,8 @@ public:
     std::unordered_map<std::string, SharedPtr<ClientPort>> named_ports;
 
     Memory::MemorySystem& memory;
+
+    Core::Timing& timing;
 
 private:
     void MemoryInit(u32 mem_type);

--- a/src/core/hle/kernel/memory.cpp
+++ b/src/core/hle/kernel/memory.cpp
@@ -66,7 +66,7 @@ void KernelSystem::MemoryInit(u32 mem_type) {
     config_mem.sys_mem_alloc = memory_regions[1].size;
     config_mem.base_mem_alloc = memory_regions[2].size;
 
-    shared_page_handler = std::make_unique<SharedPage::Handler>();
+    shared_page_handler = std::make_unique<SharedPage::Handler>(timing);
 }
 
 MemoryRegionInfo* KernelSystem::GetMemoryRegion(MemoryRegion region) {

--- a/src/core/hle/kernel/mutex.cpp
+++ b/src/core/hle/kernel/mutex.cpp
@@ -24,7 +24,7 @@ void ReleaseThreadMutexes(Thread* thread) {
     thread->held_mutexes.clear();
 }
 
-Mutex::Mutex(KernelSystem& kernel) : WaitObject(kernel) {}
+Mutex::Mutex(KernelSystem& kernel) : WaitObject(kernel), kernel(kernel) {}
 Mutex::~Mutex() {}
 
 SharedPtr<Mutex> KernelSystem::CreateMutex(bool initial_locked, std::string name) {
@@ -54,7 +54,7 @@ void Mutex::Acquire(Thread* thread) {
         thread->held_mutexes.insert(this);
         holding_thread = thread;
         thread->UpdatePriority();
-        Core::System::GetInstance().PrepareReschedule();
+        kernel.PrepareReschedule();
     }
 
     lock_count++;
@@ -87,7 +87,7 @@ ResultCode Mutex::Release(Thread* thread) {
         holding_thread->UpdatePriority();
         holding_thread = nullptr;
         WakeupAllWaitingThreads();
-        Core::System::GetInstance().PrepareReschedule();
+        kernel.PrepareReschedule();
     }
 
     return RESULT_SUCCESS;

--- a/src/core/hle/kernel/mutex.h
+++ b/src/core/hle/kernel/mutex.h
@@ -57,6 +57,7 @@ private:
     ~Mutex() override;
 
     friend class KernelSystem;
+    KernelSystem& kernel;
 };
 
 /**

--- a/src/core/hle/kernel/shared_page.h
+++ b/src/core/hle/kernel/shared_page.h
@@ -23,7 +23,8 @@
 
 namespace Core {
 struct TimingEventType;
-}
+class Timing;
+} // namespace Core
 
 namespace SharedPage {
 
@@ -83,7 +84,7 @@ static_assert(sizeof(SharedPageDef) == Memory::SHARED_PAGE_SIZE,
 
 class Handler {
 public:
-    Handler();
+    Handler(Core::Timing& timing);
 
     void SetMacAddress(const MacAddress&);
 
@@ -98,6 +99,7 @@ public:
 private:
     u64 GetSystemTime() const;
     void UpdateTimeCallback(u64 userdata, int cycles_late);
+    Core::Timing& timing;
     Core::TimingEventType* update_time_event;
     std::chrono::seconds init_time;
 

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -224,7 +224,7 @@ void Thread::ResumeFromWait() {
 
     thread_manager.ready_queue.push_back(current_priority, this);
     status = ThreadStatus::Ready;
-    Core::System::GetInstance().PrepareReschedule();
+    thread_manager.kernel.PrepareReschedule();
 }
 
 void ThreadManager::DebugThreadQueue() {

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -101,6 +101,14 @@ public:
      */
     const std::vector<SharedPtr<Thread>>& GetThreadList();
 
+    void SetCPU(ARM_Interface& cpu) {
+        this->cpu = &cpu;
+    }
+
+    std::unique_ptr<ARM_Interface::ThreadContext> NewContext() {
+        return cpu->NewContext();
+    }
+
 private:
     /**
      * Switches the CPU's active thread context to that of the specified thread
@@ -122,6 +130,7 @@ private:
     void ThreadWakeupCallback(u64 thread_id, s64 cycles_late);
 
     Kernel::KernelSystem& kernel;
+    ARM_Interface* cpu;
 
     u32 next_thread_id = 1;
     SharedPtr<Thread> current_thread;

--- a/src/core/hle/kernel/timer.h
+++ b/src/core/hle/kernel/timer.h
@@ -9,15 +9,21 @@
 #include "core/hle/kernel/object.h"
 #include "core/hle/kernel/wait_object.h"
 
+namespace Core {
+class Timing;
+}
+
 namespace Kernel {
 
 class TimerManager {
 public:
-    TimerManager();
+    TimerManager(Core::Timing& timing);
 
 private:
     /// The timer callback event, called when a timer is fired
     void TimerCallback(u64 callback_id, s64 cycles_late);
+
+    Core::Timing& timing;
 
     /// The event type of the generic timer callback event
     Core::TimingEventType* timer_callback_event_type = nullptr;
@@ -93,6 +99,7 @@ private:
     /// ID used as userdata to reference this object when inserting into the CoreTiming queue.
     u64 callback_id;
 
+    KernelSystem& kernel;
     TimerManager& timer_manager;
 
     friend class KernelSystem;

--- a/src/core/hle/service/ldr_ro/cro_helper.h
+++ b/src/core/hle/service/ldr_ro/cro_helper.h
@@ -15,6 +15,8 @@ namespace Kernel {
 class Process;
 }
 
+class ARM_Interface;
+
 namespace Service::LDR {
 
 // GCC versions < 5.0 do not implement std::is_trivially_copyable.
@@ -40,8 +42,9 @@ static constexpr u32 CRO_HASH_SIZE = 0x80;
 class CROHelper final {
 public:
     // TODO (wwylele): pass in the process handle for memory access
-    explicit CROHelper(VAddr cro_address, Kernel::Process& process, Memory::MemorySystem& memory)
-        : module_address(cro_address), process(process), memory(memory) {}
+    explicit CROHelper(VAddr cro_address, Kernel::Process& process, Memory::MemorySystem& memory,
+                       ARM_Interface& cpu)
+        : module_address(cro_address), process(process), memory(memory), cpu(cpu) {}
 
     std::string ModuleName() const {
         return memory.ReadCString(GetField(ModuleNameOffset), GetField(ModuleNameSize));
@@ -151,6 +154,7 @@ private:
     const VAddr module_address; ///< the virtual address of this module
     Kernel::Process& process;   ///< the owner process of this module
     Memory::MemorySystem& memory;
+    ARM_Interface& cpu;
 
     /**
      * Each item in this enum represents a u32 field in the header begin from address+0x80,
@@ -480,10 +484,11 @@ private:
      */
     template <typename FunctionObject>
     static ResultCode ForEachAutoLinkCRO(Kernel::Process& process, Memory::MemorySystem& memory,
-                                         VAddr crs_address, FunctionObject func) {
+                                         ARM_Interface& cpu, VAddr crs_address,
+                                         FunctionObject func) {
         VAddr current = crs_address;
         while (current != 0) {
-            CROHelper cro(current, process, memory);
+            CROHelper cro(current, process, memory, cpu);
             CASCADE_RESULT(bool next, func(cro));
             if (!next)
                 break;

--- a/src/core/hle/service/ldr_ro/ldr_ro.cpp
+++ b/src/core/hle/service/ldr_ro/ldr_ro.cpp
@@ -115,7 +115,7 @@ void RO::Initialize(Kernel::HLERequestContext& ctx) {
         return;
     }
 
-    CROHelper crs(crs_address, *process, system.Memory());
+    CROHelper crs(crs_address, *process, system.Memory(), system.CPU());
     crs.InitCRS();
 
     result = crs.Rebase(0, crs_size, 0, 0, 0, 0, true);
@@ -249,7 +249,7 @@ void RO::LoadCRO(Kernel::HLERequestContext& ctx, bool link_on_load_bug_fix) {
         return;
     }
 
-    CROHelper cro(cro_address, *process, system.Memory());
+    CROHelper cro(cro_address, *process, system.Memory(), system.CPU());
 
     result = cro.VerifyHash(cro_size, crr_address);
     if (result.IsError()) {
@@ -313,7 +313,7 @@ void RO::LoadCRO(Kernel::HLERequestContext& ctx, bool link_on_load_bug_fix) {
         }
     }
 
-    Core::CPU().InvalidateCacheRange(cro_address, cro_size);
+    system.CPU().InvalidateCacheRange(cro_address, cro_size);
 
     LOG_INFO(Service_LDR, "CRO \"{}\" loaded at 0x{:08X}, fixed_end=0x{:08X}", cro.ModuleName(),
              cro_address, cro_address + fix_size);
@@ -331,7 +331,7 @@ void RO::UnloadCRO(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_LDR, "called, cro_address=0x{:08X}, zero={}, cro_buffer_ptr=0x{:08X}",
               cro_address, zero, cro_buffer_ptr);
 
-    CROHelper cro(cro_address, *process, system.Memory());
+    CROHelper cro(cro_address, *process, system.Memory(), system.CPU());
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
 
@@ -386,7 +386,7 @@ void RO::UnloadCRO(Kernel::HLERequestContext& ctx) {
         LOG_ERROR(Service_LDR, "Error unmapping CRO {:08X}", result.raw);
     }
 
-    Core::CPU().InvalidateCacheRange(cro_address, fixed_size);
+    system.CPU().InvalidateCacheRange(cro_address, fixed_size);
 
     rb.Push(result);
 }
@@ -398,7 +398,7 @@ void RO::LinkCRO(Kernel::HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_LDR, "called, cro_address=0x{:08X}", cro_address);
 
-    CROHelper cro(cro_address, *process, system.Memory());
+    CROHelper cro(cro_address, *process, system.Memory(), system.CPU());
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
 
@@ -438,7 +438,7 @@ void RO::UnlinkCRO(Kernel::HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_LDR, "called, cro_address=0x{:08X}", cro_address);
 
-    CROHelper cro(cro_address, *process, system.Memory());
+    CROHelper cro(cro_address, *process, system.Memory(), system.CPU());
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
 
@@ -487,7 +487,7 @@ void RO::Shutdown(Kernel::HLERequestContext& ctx) {
         return;
     }
 
-    CROHelper crs(slot->loaded_crs, *process, system.Memory());
+    CROHelper crs(slot->loaded_crs, *process, system.Memory(), system.CPU());
     crs.Unrebase(true);
 
     ResultCode result = RESULT_SUCCESS;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -65,15 +65,21 @@ public:
     PageTable* current_page_table = nullptr;
     RasterizerCacheMarker cache_marker;
     std::vector<PageTable*> page_table_list;
+
+    ARM_Interface* cpu = nullptr;
 };
 
 MemorySystem::MemorySystem() : impl(std::make_unique<Impl>()) {}
 MemorySystem::~MemorySystem() = default;
 
+void MemorySystem::SetCPU(ARM_Interface& cpu) {
+    impl->cpu = &cpu;
+}
+
 void MemorySystem::SetCurrentPageTable(PageTable* page_table) {
     impl->current_page_table = page_table;
-    if (Core::System::GetInstance().IsPoweredOn()) {
-        Core::CPU().PageTableChanged();
+    if (impl->cpu != nullptr) {
+        impl->cpu->PageTableChanged();
     }
 }
 

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -12,6 +12,8 @@
 #include "common/common_types.h"
 #include "core/mmio.h"
 
+class ARM_Interface;
+
 namespace Kernel {
 class Process;
 }
@@ -213,6 +215,9 @@ class MemorySystem {
 public:
     MemorySystem();
     ~MemorySystem();
+
+    /// Sets CPU to notify page table change
+    void SetCPU(ARM_Interface& cpu);
 
     /**
      * Maps an allocated buffer onto a region of the emulated process address space.

--- a/src/tests/audio_core/decoder_tests.cpp
+++ b/src/tests/audio_core/decoder_tests.cpp
@@ -20,17 +20,13 @@
 #include "audio_fixures.h"
 
 TEST_CASE("DSP HLE Audio Decoder", "[audio_core]") {
-    // HACK: see comments of member timing
-    Core::System::GetInstance().timing = std::make_unique<Core::Timing>();
-    Core::System::GetInstance().memory = std::make_unique<Memory::MemorySystem>();
-    Kernel::KernelSystem kernel(*Core::System::GetInstance().memory, 0);
+    Memory::MemorySystem memory;
     SECTION("decoder should produce correct samples") {
-        auto process = kernel.CreateProcess(kernel.CreateCodeSet("", 0));
         auto decoder =
 #ifdef HAVE_MF
-            std::make_unique<AudioCore::HLE::WMFDecoder>(*Core::System::GetInstance().memory);
+            std::make_unique<AudioCore::HLE::WMFDecoder>(memory);
 #elif HAVE_FFMPEG
-            std::make_unique<AudioCore::HLE::FFMPEGDecoder>(*Core::System::GetInstance().memory);
+            std::make_unique<AudioCore::HLE::FFMPEGDecoder>(memory);
 #endif
         AudioCore::HLE::BinaryRequest request;
 
@@ -40,7 +36,7 @@ TEST_CASE("DSP HLE Audio Decoder", "[audio_core]") {
         std::optional<AudioCore::HLE::BinaryResponse> response = decoder->ProcessRequest(request);
 
         request.cmd = AudioCore::HLE::DecoderCommand::Decode;
-        u8* fcram = Core::System::GetInstance().memory->GetFCRAMPointer(0);
+        u8* fcram = memory.GetFCRAMPointer(0);
 
         memcpy(fcram, fixure_buffer, fixure_buffer_size);
         request.src_addr = Memory::FCRAM_PADDR;

--- a/src/tests/core/arm/arm_test_common.cpp
+++ b/src/tests/core/arm/arm_test_common.cpp
@@ -21,8 +21,8 @@ TestEnvironment::TestEnvironment(bool mutable_memory_)
     Core::System::GetInstance().timing = std::make_unique<Core::Timing>();
     Core::System::GetInstance().memory = std::make_unique<Memory::MemorySystem>();
     Memory::MemorySystem& memory = *Core::System::GetInstance().memory;
-    Core::System::GetInstance().kernel =
-        std::make_unique<Kernel::KernelSystem>(memory, *Core::System::GetInstance().timing, 0);
+    Core::System::GetInstance().kernel = std::make_unique<Kernel::KernelSystem>(
+        memory, *Core::System::GetInstance().timing, [] {}, 0);
     kernel = Core::System::GetInstance().kernel.get();
 
     kernel->SetCurrentProcess(kernel->CreateProcess(kernel->CreateCodeSet("", 0)));

--- a/src/tests/core/arm/arm_test_common.cpp
+++ b/src/tests/core/arm/arm_test_common.cpp
@@ -21,7 +21,8 @@ TestEnvironment::TestEnvironment(bool mutable_memory_)
     Core::System::GetInstance().timing = std::make_unique<Core::Timing>();
     Core::System::GetInstance().memory = std::make_unique<Memory::MemorySystem>();
     Memory::MemorySystem& memory = *Core::System::GetInstance().memory;
-    Core::System::GetInstance().kernel = std::make_unique<Kernel::KernelSystem>(memory, 0);
+    Core::System::GetInstance().kernel =
+        std::make_unique<Kernel::KernelSystem>(memory, *Core::System::GetInstance().timing, 0);
     kernel = Core::System::GetInstance().kernel.get();
 
     kernel->SetCurrentProcess(kernel->CreateProcess(kernel->CreateCodeSet("", 0)));

--- a/src/tests/core/arm/arm_test_common.cpp
+++ b/src/tests/core/arm/arm_test_common.cpp
@@ -15,15 +15,9 @@ static Memory::PageTable* page_table = nullptr;
 TestEnvironment::TestEnvironment(bool mutable_memory_)
     : mutable_memory(mutable_memory_), test_memory(std::make_shared<TestMemory>(this)) {
 
-    // HACK: some memory functions are currently referring kernel from the global instance,
-    //       so we need to create the kernel object there.
-    //       Change this when all global states are eliminated.
-    Core::System::GetInstance().timing = std::make_unique<Core::Timing>();
-    Core::System::GetInstance().memory = std::make_unique<Memory::MemorySystem>();
-    Memory::MemorySystem& memory = *Core::System::GetInstance().memory;
-    Core::System::GetInstance().kernel = std::make_unique<Kernel::KernelSystem>(
-        memory, *Core::System::GetInstance().timing, [] {}, 0);
-    kernel = Core::System::GetInstance().kernel.get();
+    timing = std::make_unique<Core::Timing>();
+    memory = std::make_unique<Memory::MemorySystem>();
+    kernel = std::make_unique<Kernel::KernelSystem>(*memory, *timing, [] {}, 0);
 
     kernel->SetCurrentProcess(kernel->CreateProcess(kernel->CreateCodeSet("", 0)));
     page_table = &kernel->GetCurrentProcess()->vm_manager.page_table;
@@ -31,17 +25,15 @@ TestEnvironment::TestEnvironment(bool mutable_memory_)
     page_table->pointers.fill(nullptr);
     page_table->attributes.fill(Memory::PageType::Unmapped);
 
-    memory.MapIoRegion(*page_table, 0x00000000, 0x80000000, test_memory);
-    memory.MapIoRegion(*page_table, 0x80000000, 0x80000000, test_memory);
+    memory->MapIoRegion(*page_table, 0x00000000, 0x80000000, test_memory);
+    memory->MapIoRegion(*page_table, 0x80000000, 0x80000000, test_memory);
 
-    memory.SetCurrentPageTable(page_table);
+    memory->SetCurrentPageTable(page_table);
 }
 
 TestEnvironment::~TestEnvironment() {
-    Memory::MemorySystem& memory = *Core::System::GetInstance().memory;
-    memory.UnmapRegion(*page_table, 0x80000000, 0x80000000);
-    memory.UnmapRegion(*page_table, 0x00000000, 0x80000000);
-    Core::System::GetInstance().kernel.reset();
+    memory->UnmapRegion(*page_table, 0x80000000, 0x80000000);
+    memory->UnmapRegion(*page_table, 0x00000000, 0x80000000);
 }
 
 void TestEnvironment::SetMemory64(VAddr vaddr, u64 value) {

--- a/src/tests/core/arm/arm_test_common.h
+++ b/src/tests/core/arm/arm_test_common.h
@@ -49,6 +49,10 @@ public:
     /// Empties the internal write-record store.
     void ClearWriteRecords();
 
+    Memory::MemorySystem& GetMemory() {
+        return *memory;
+    }
+
 private:
     friend struct TestMemory;
     struct TestMemory final : Memory::MMIORegion {
@@ -80,7 +84,9 @@ private:
     std::shared_ptr<TestMemory> test_memory;
     std::vector<WriteRecord> write_records;
 
-    Kernel::KernelSystem* kernel;
+    std::unique_ptr<Core::Timing> timing;
+    std::unique_ptr<Memory::MemorySystem> memory;
+    std::unique_ptr<Kernel::KernelSystem> kernel;
 };
 
 } // namespace ArmTests

--- a/src/tests/core/arm/dyncom/arm_dyncom_vfp_tests.cpp
+++ b/src/tests/core/arm/dyncom/arm_dyncom_vfp_tests.cpp
@@ -23,7 +23,7 @@ TEST_CASE("ARM_DynCom (vfp): vadd", "[arm_dyncom]") {
     test_env.SetMemory32(0, 0xEE321A03); // vadd.f32 s2, s4, s6
     test_env.SetMemory32(4, 0xEAFFFFFE); // b +#0
 
-    ARM_DynCom dyncom(Core::System::GetInstance(), USER32MODE);
+    ARM_DynCom dyncom(nullptr, test_env.GetMemory(), USER32MODE);
 
     std::vector<VfpTestCase> test_cases{{
 #include "vfp_vadd_f32.inc"

--- a/src/tests/core/hle/kernel/hle_ipc.cpp
+++ b/src/tests/core/hle/kernel/hle_ipc.cpp
@@ -24,7 +24,7 @@ TEST_CASE("HLERequestContext::PopulateFromIncomingCommandBuffer", "[core][kernel
     // HACK: see comments of member timing
     Core::System::GetInstance().timing = std::make_unique<Core::Timing>();
     auto memory = std::make_unique<Memory::MemorySystem>();
-    Kernel::KernelSystem kernel(*memory, *Core::System::GetInstance().timing, 0);
+    Kernel::KernelSystem kernel(*memory, *Core::System::GetInstance().timing, [] {}, 0);
     auto session = std::get<SharedPtr<ServerSession>>(kernel.CreateSessionPair());
     HLERequestContext context(std::move(session));
 
@@ -237,7 +237,7 @@ TEST_CASE("HLERequestContext::WriteToOutgoingCommandBuffer", "[core][kernel]") {
     // HACK: see comments of member timing
     Core::System::GetInstance().timing = std::make_unique<Core::Timing>();
     auto memory = std::make_unique<Memory::MemorySystem>();
-    Kernel::KernelSystem kernel(*memory, *Core::System::GetInstance().timing, 0);
+    Kernel::KernelSystem kernel(*memory, *Core::System::GetInstance().timing, [] {}, 0);
     auto session = std::get<SharedPtr<ServerSession>>(kernel.CreateSessionPair());
     HLERequestContext context(std::move(session));
 

--- a/src/tests/core/hle/kernel/hle_ipc.cpp
+++ b/src/tests/core/hle/kernel/hle_ipc.cpp
@@ -24,7 +24,7 @@ TEST_CASE("HLERequestContext::PopulateFromIncomingCommandBuffer", "[core][kernel
     // HACK: see comments of member timing
     Core::System::GetInstance().timing = std::make_unique<Core::Timing>();
     auto memory = std::make_unique<Memory::MemorySystem>();
-    Kernel::KernelSystem kernel(*memory, 0);
+    Kernel::KernelSystem kernel(*memory, *Core::System::GetInstance().timing, 0);
     auto session = std::get<SharedPtr<ServerSession>>(kernel.CreateSessionPair());
     HLERequestContext context(std::move(session));
 
@@ -237,7 +237,7 @@ TEST_CASE("HLERequestContext::WriteToOutgoingCommandBuffer", "[core][kernel]") {
     // HACK: see comments of member timing
     Core::System::GetInstance().timing = std::make_unique<Core::Timing>();
     auto memory = std::make_unique<Memory::MemorySystem>();
-    Kernel::KernelSystem kernel(*memory, 0);
+    Kernel::KernelSystem kernel(*memory, *Core::System::GetInstance().timing, 0);
     auto session = std::get<SharedPtr<ServerSession>>(kernel.CreateSessionPair());
     HLERequestContext context(std::move(session));
 

--- a/src/tests/core/hle/kernel/hle_ipc.cpp
+++ b/src/tests/core/hle/kernel/hle_ipc.cpp
@@ -21,10 +21,9 @@ static SharedPtr<Object> MakeObject(Kernel::KernelSystem& kernel) {
 }
 
 TEST_CASE("HLERequestContext::PopulateFromIncomingCommandBuffer", "[core][kernel]") {
-    // HACK: see comments of member timing
-    Core::System::GetInstance().timing = std::make_unique<Core::Timing>();
-    auto memory = std::make_unique<Memory::MemorySystem>();
-    Kernel::KernelSystem kernel(*memory, *Core::System::GetInstance().timing, [] {}, 0);
+    Core::Timing timing;
+    Memory::MemorySystem memory;
+    Kernel::KernelSystem kernel(memory, timing, [] {}, 0);
     auto session = std::get<SharedPtr<ServerSession>>(kernel.CreateSessionPair());
     HLERequestContext context(std::move(session));
 
@@ -234,10 +233,9 @@ TEST_CASE("HLERequestContext::PopulateFromIncomingCommandBuffer", "[core][kernel
 }
 
 TEST_CASE("HLERequestContext::WriteToOutgoingCommandBuffer", "[core][kernel]") {
-    // HACK: see comments of member timing
-    Core::System::GetInstance().timing = std::make_unique<Core::Timing>();
-    auto memory = std::make_unique<Memory::MemorySystem>();
-    Kernel::KernelSystem kernel(*memory, *Core::System::GetInstance().timing, [] {}, 0);
+    Core::Timing timing;
+    Memory::MemorySystem memory;
+    Kernel::KernelSystem kernel(memory, timing, [] {}, 0);
     auto session = std::get<SharedPtr<ServerSession>>(kernel.CreateSessionPair());
     HLERequestContext context(std::move(session));
 

--- a/src/tests/core/memory/memory.cpp
+++ b/src/tests/core/memory/memory.cpp
@@ -14,7 +14,8 @@ TEST_CASE("Memory::IsValidVirtualAddress", "[core][memory]") {
     // HACK: see comments of member timing
     Core::System::GetInstance().timing = std::make_unique<Core::Timing>();
     Core::System::GetInstance().memory = std::make_unique<Memory::MemorySystem>();
-    Kernel::KernelSystem kernel(*Core::System::GetInstance().memory, 0);
+    Kernel::KernelSystem kernel(*Core::System::GetInstance().memory,
+                                *Core::System::GetInstance().timing, 0);
     SECTION("these regions should not be mapped on an empty process") {
         auto process = kernel.CreateProcess(kernel.CreateCodeSet("", 0));
         CHECK(Memory::IsValidVirtualAddress(*process, Memory::PROCESS_IMAGE_VADDR) == false);

--- a/src/tests/core/memory/memory.cpp
+++ b/src/tests/core/memory/memory.cpp
@@ -11,11 +11,9 @@
 #include "core/memory.h"
 
 TEST_CASE("Memory::IsValidVirtualAddress", "[core][memory]") {
-    // HACK: see comments of member timing
-    Core::System::GetInstance().timing = std::make_unique<Core::Timing>();
-    Core::System::GetInstance().memory = std::make_unique<Memory::MemorySystem>();
-    Kernel::KernelSystem kernel(*Core::System::GetInstance().memory,
-                                *Core::System::GetInstance().timing, [] {}, 0);
+    Core::Timing timing;
+    Memory::MemorySystem memory;
+    Kernel::KernelSystem kernel(memory, timing, [] {}, 0);
     SECTION("these regions should not be mapped on an empty process") {
         auto process = kernel.CreateProcess(kernel.CreateCodeSet("", 0));
         CHECK(Memory::IsValidVirtualAddress(*process, Memory::PROCESS_IMAGE_VADDR) == false);

--- a/src/tests/core/memory/memory.cpp
+++ b/src/tests/core/memory/memory.cpp
@@ -15,7 +15,7 @@ TEST_CASE("Memory::IsValidVirtualAddress", "[core][memory]") {
     Core::System::GetInstance().timing = std::make_unique<Core::Timing>();
     Core::System::GetInstance().memory = std::make_unique<Memory::MemorySystem>();
     Kernel::KernelSystem kernel(*Core::System::GetInstance().memory,
-                                *Core::System::GetInstance().timing, 0);
+                                *Core::System::GetInstance().timing, [] {}, 0);
     SECTION("these regions should not be mapped on an empty process") {
         auto process = kernel.CreateProcess(kernel.CreateCodeSet("", 0));
         CHECK(Memory::IsValidVirtualAddress(*process, Memory::PROCESS_IMAGE_VADDR) == false);


### PR DESCRIPTION
After this, the temporary `private -> public` hack in `System` for unit tests is removed. core/hle/kernel is mostly global-state-reference-free except for HLE IPC (will be in the next PR).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4616)
<!-- Reviewable:end -->
