### PR TITLE
gl_rasterizer: change shadow_texture_bias from shader config to shader uniform

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -203,6 +203,7 @@ void RasterizerOpenGL::SyncEntireState() {
     SyncProcTexNoise();
     SyncProcTexBias();
     SyncShadowBias();
+    SyncShadowTextureBias();
 }
 
 /**
@@ -901,6 +902,11 @@ void RasterizerOpenGL::NotifyPicaRegisterChanged(u32 id) {
         break;
     case PICA_REG_INDEX(framebuffer.output_merger.blend_const):
         SyncBlendColor();
+        break;
+
+    // Shadow texture
+    case PICA_REG_INDEX(texturing.shadow):
+        SyncShadowTextureBias();
         break;
 
     // Fog state
@@ -1902,6 +1908,14 @@ void RasterizerOpenGL::SyncShadowBias() {
         linear != uniform_block_data.data.shadow_bias_linear) {
         uniform_block_data.data.shadow_bias_constant = constant;
         uniform_block_data.data.shadow_bias_linear = linear;
+        uniform_block_data.dirty = true;
+    }
+}
+
+void RasterizerOpenGL::SyncShadowTextureBias() {
+    GLint bias = Pica::g_state.regs.texturing.shadow.bias << 1;
+    if (bias != uniform_block_data.data.shadow_texture_bias) {
+        uniform_block_data.data.shadow_texture_bias = bias;
         uniform_block_data.dirty = true;
     }
 }

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -214,6 +214,9 @@ private:
     /// Syncs the shadow rendering bias to match the PICA register
     void SyncShadowBias();
 
+    /// Syncs the shadow texture bias to match the PICA register
+    void SyncShadowTextureBias();
+
     /// Syncs and uploads the lighting, fog and proctex LUTs
     void SyncAndUploadLUTs();
 

--- a/src/video_core/renderer_opengl/gl_shader_gen.h
+++ b/src/video_core/renderer_opengl/gl_shader_gen.h
@@ -118,7 +118,6 @@ struct PicaFSConfigState {
 
     bool shadow_rendering;
     bool shadow_texture_orthographic;
-    u32 shadow_texture_bias;
 };
 
 /**

--- a/src/video_core/renderer_opengl/gl_shader_manager.h
+++ b/src/video_core/renderer_opengl/gl_shader_manager.h
@@ -49,6 +49,7 @@ struct UniformData {
     GLint proctex_lut_offset;
     GLint proctex_diff_lut_offset;
     GLfloat proctex_bias;
+    GLint shadow_texture_bias;
     alignas(16) GLivec4 lighting_lut_offset[Pica::LightingRegs::NumLightingSampler / 4];
     alignas(16) GLvec3 fog_color;
     alignas(8) GLvec2 proctex_noise_f;


### PR DESCRIPTION
Games can frequently change this register. Using it as shader config var would generates a lot of shaders, causing slowdown on shader compilation and lookup.

Fixes #4293. Huge thanks to @tywald for tracing down the issue :heart:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4619)
<!-- Reviewable:end -->
