### PR TITLE
citra_qt: when opening a cia file directly, make Citra ask to install it

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -801,6 +801,18 @@ bool GMainWindow::LoadROM(const QString& filename) {
 }
 
 void GMainWindow::BootGame(const QString& filename) {
+    if (filename.endsWith(".cia")) {
+        const auto answer = QMessageBox::question(
+            this, tr("CIA must be installed before usage"),
+            tr("Before using this CIA, you must install it. Do you want to install it now?"),
+            QMessageBox::Yes | QMessageBox::No);
+
+        if (answer == QMessageBox::Yes)
+            InstallCIA(QStringList(filename));
+
+        return;
+    }
+
     LOG_INFO(Frontend, "Citra starting...");
     StoreRecentFile(filename); // Put the filename on top of the list
 
@@ -1075,6 +1087,10 @@ void GMainWindow::OnMenuInstallCIA() {
     if (filepaths.isEmpty())
         return;
 
+    InstallCIA(filepaths);
+}
+
+void GMainWindow::InstallCIA(QStringList filepaths) {
     ui.action_Install_CIA->setEnabled(false);
     game_list->setDirectoryWatcherEnabled(false);
     progress_bar->show();

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -199,6 +199,7 @@ private:
     void LoadTranslation();
     void SetupUIStrings();
     void RetranslateStatusBar();
+    void InstallCIA(QStringList filepaths);
 
     Ui::MainWindow ui;
 


### PR DESCRIPTION
When dragging a CIA onto Citra, or just opening it by double-clicking in the Windows explorer, Citra tells you that the ROM format is unsupported.

This is
- a) 100% wrong
- b) a hassle for even the people who know that CIA is supported and just want to install it

With this PR, this popup appears when trying to boot a CIA file and asks the user if they want to install the CIA:
![unbenannt](https://user-images.githubusercontent.com/20753089/52302566-e3c55a00-298d-11e9-881e-561a8422d780.PNG)

~~**PS**: I only made this PR cause I really got annoyed by this when frequently installing CIAs for my FileOpen delay tests.~~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4627)
<!-- Reviewable:end -->
