### PR TITLE
Port minor changes for BitField from yuzu

### DIFF
--- a/src/common/bit_field.h
+++ b/src/common/bit_field.h
@@ -125,7 +125,7 @@ private:
     using StorageTypeWithEndian = typename AddEndian<StorageType, EndianTag>::type;
 
 public:
-    BitField& operator=(const BitField&) = default;
+    constexpr BitField& operator=(const BitField&) = default;
 
     /// Constants to allow limited introspection of fields if needed
     static constexpr std::size_t position = Position;
@@ -166,15 +166,15 @@ public:
     // so that we can use this within unions
     constexpr BitField() = default;
 
-    FORCE_INLINE operator T() const {
+    constexpr FORCE_INLINE operator T() const {
         return Value();
     }
 
-    FORCE_INLINE void Assign(const T& value) {
+    constexpr FORCE_INLINE void Assign(const T& value) {
         storage = (static_cast<StorageType>(storage) & ~mask) | FormatValue(value);
     }
 
-    FORCE_INLINE T Value() const {
+    constexpr T Value() const {
         return ExtractValue(storage);
     }
 

--- a/src/common/bit_field.h
+++ b/src/common/bit_field.h
@@ -166,11 +166,11 @@ public:
     // so that we can use this within unions
     constexpr BitField() = default;
 
-    constexpr FORCE_INLINE operator T() const {
+    constexpr operator T() const {
         return Value();
     }
 
-    constexpr FORCE_INLINE void Assign(const T& value) {
+    constexpr void Assign(const T& value) {
         storage = (static_cast<StorageType>(storage) & ~mask) | FormatValue(value);
     }
 
@@ -191,12 +191,9 @@ private:
     static_assert(position < 8 * sizeof(T), "Invalid position");
     static_assert(bits <= 8 * sizeof(T), "Invalid number of bits");
     static_assert(bits > 0, "Invalid number of bits");
-    static_assert(std::is_pod<T>::value, "Invalid base type");
+    static_assert(std::is_trivially_copyable_v<T>, "T must be trivially copyable in a BitField");
 };
 #pragma pack()
-
-static_assert(std::is_trivially_copyable<BitField<0, 1, unsigned>>::value,
-              "BitField must be trivially copyable");
 
 template <std::size_t Position, std::size_t Bits, typename T>
 using BitFieldBE = BitField<Position, Bits, T, BETag>;


### PR DESCRIPTION
This ports https://github.com/yuzu-emu/yuzu/commit/0315fe8c3dc8cb267284b061a20b85c09cd5d98b#diff-08ca154e611eee771a3dc2d7e929d0a9 and https://github.com/yuzu-emu/yuzu/commit/e59126809c9c092d0913e6c1446f6d0ecf20bca2#diff-08ca154e611eee771a3dc2d7e929d0a9.

I only saw them now cause bunnei put them in two mega PRs which hid the changes from me.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4629)
<!-- Reviewable:end -->
