### PR TITLE
Memory: don't lock hle mutex in memory read/write

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -176,9 +176,6 @@ T MemorySystem::Read(const VAddr vaddr) {
         return value;
     }
 
-    // The memory access might do an MMIO or cached access, so we have to lock the HLE kernel state
-    std::lock_guard<std::recursive_mutex> lock(HLE::g_hle_lock);
-
     PageType type = impl->current_page_table->attributes[vaddr >> PAGE_BITS];
     switch (type) {
     case PageType::Unmapped:
@@ -212,9 +209,6 @@ void MemorySystem::Write(const VAddr vaddr, const T data) {
         std::memcpy(&page_pointer[vaddr & PAGE_MASK], &data, sizeof(T));
         return;
     }
-
-    // The memory access might do an MMIO or cached access, so we have to lock the HLE kernel state
-    std::lock_guard<std::recursive_mutex> lock(HLE::g_hle_lock);
 
     PageType type = impl->current_page_table->attributes[vaddr >> PAGE_BITS];
     switch (type) {


### PR DESCRIPTION
The comment already invalidates itself: neither MMIO nor rasterizer cache belongs to HLE kernel state. This mutex has a too large scope if MMIO or cache is included, which is prone to dead lock when multiple thread acquires these resource at the same time. If necessary, each MMIO component or rasterizer should have their own lock.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4630)
<!-- Reviewable:end -->
