### PR TITLE
citra_qt: show demos on game list

### DIFF
--- a/src/citra_qt/game_list_worker.cpp
+++ b/src/citra_qt/game_list_worker.cpp
@@ -117,15 +117,22 @@ void GameListWorker::run() {
     stop_processing = false;
     for (UISettings::GameDir& game_dir : game_dirs) {
         if (game_dir.path == "INSTALLED") {
-            QString path =
+            QString games_path =
                 QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir)) +
                 "Nintendo "
                 "3DS/00000000000000000000000000000000/"
                 "00000000000000000000000000000000/title/00040000";
-            watch_list.append(path);
+            QString demos_path =
+                QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir)) +
+                "Nintendo "
+                "3DS/00000000000000000000000000000000/00000000000000000000000000000000/title/"
+                "00040002";
+            watch_list.append(games_path);
+            watch_list.append(demos_path);
             GameListDir* game_list_dir = new GameListDir(game_dir, GameListItemType::InstalledDir);
             emit DirEntryReady({game_list_dir});
-            AddFstEntriesToGameList(path.toStdString(), 2, game_list_dir);
+            AddFstEntriesToGameList(games_path.toStdString(), 2, game_list_dir);
+            AddFstEntriesToGameList(demos_path.toStdString(), 2, game_list_dir);
         } else if (game_dir.path == "SYSTEM") {
             QString path =
                 QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::NANDDir)) +


### PR DESCRIPTION
Previously, the game list wouldn't show demos if they were installed. This fixes that, and shows them under the "Installed Titles" category.

Please let me know if I did anything wrong.

![nedjs8b](https://user-images.githubusercontent.com/11739422/52512934-90454d00-2bd5-11e9-8b0a-2f3406329b41.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4631)
<!-- Reviewable:end -->
