### PR TITLE
service/soc_u: Implement getaddrinfo and getnameinfo

### DIFF
--- a/src/core/hle/service/soc_u.h
+++ b/src/core/hle/service/soc_u.h
@@ -44,8 +44,11 @@ private:
     void ShutdownSockets(Kernel::HLERequestContext& ctx);
     void GetSockOpt(Kernel::HLERequestContext& ctx);
     void SetSockOpt(Kernel::HLERequestContext& ctx);
-    void GetAddrInfo(Kernel::HLERequestContext& ctx);
-    void GetNameInfo(Kernel::HLERequestContext& ctx);
+
+    // Some platforms seem to have GetAddrInfo and GetNameInfo defined as macros,
+    // so we have to use a different name here.
+    void GetAddrInfoImpl(Kernel::HLERequestContext& ctx);
+    void GetNameInfoImpl(Kernel::HLERequestContext& ctx);
 
     /// Close all open sockets
     void CleanupSockets();

--- a/src/core/hle/service/soc_u.h
+++ b/src/core/hle/service/soc_u.h
@@ -44,6 +44,8 @@ private:
     void ShutdownSockets(Kernel::HLERequestContext& ctx);
     void GetSockOpt(Kernel::HLERequestContext& ctx);
     void SetSockOpt(Kernel::HLERequestContext& ctx);
+    void GetAddrInfo(Kernel::HLERequestContext& ctx);
+    void GetNameInfo(Kernel::HLERequestContext& ctx);
 
     /// Close all open sockets
     void CleanupSockets();


### PR DESCRIPTION
Implements two additional functions in soc:U, getaddrinfo and getnameinfo, using the corresponding host socket functions.

I only tested this with a few (self-written) homebrews and things seem to work fine so far... more testing and reviews would be appreciated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4632)
<!-- Reviewable:end -->
