### PR TITLE
video_core: improve efficiency of CachedSurface::IsSurfaceFullyInvalid

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -344,7 +344,8 @@ struct CachedSurface : SurfaceParams, std::enable_shared_from_this<CachedSurface
     }
 
     bool IsSurfaceFullyInvalid() const {
-        return (invalid_regions & GetInterval()) == SurfaceRegions(GetInterval());
+        auto interval = GetInterval();
+        return *invalid_regions.equal_range(interval).first == interval;
     }
 
     bool registered = false;


### PR DESCRIPTION
The current method constructs two additional boost interval_sets which is somewhat expensive. This accomplishes the same thing (checking that `interval` is fully contained in `invalid_regions`) with a smaller impact. Speed difference ranges from none to 2x in certain areas of pilotwings.
Frame time data from the games tested can be found here:
https://docs.google.com/spreadsheets/d/1lMMQN_52nURA5OsU1JMNER5Y_FnQrEhHRNBoAJ-x-EQ/edit?usp=sharing

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4633)
<!-- Reviewable:end -->
