### PR TITLE
Add Frame Time Recording

### DIFF
--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -223,6 +223,8 @@ void Config::ReadValues() {
     Settings::values.log_filter = sdl2_config->GetString("Miscellaneous", "log_filter", "*:Info");
 
     // Debugging
+    Settings::values.record_frame_times =
+        sdl2_config->GetBoolean("Debugging", "record_frame_times", false);
     Settings::values.use_gdbstub = sdl2_config->GetBoolean("Debugging", "use_gdbstub", false);
     Settings::values.gdbstub_port =
         static_cast<u16>(sdl2_config->GetInteger("Debugging", "gdbstub_port", 24689));

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -251,6 +251,8 @@ camera_inner_flip =
 log_filter = *:Info
 
 [Debugging]
+# Record frame time data, can be found in the log directory
+record_frame_times =
 # Port for listening to GDB connections.
 use_gdbstub=false
 gdbstub_port=24689

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -239,6 +239,7 @@ void Config::ReadValues() {
     qt_config->endGroup();
 
     qt_config->beginGroup("Debugging");
+    Settings::values.record_frame_times = ReadSetting("record_frame_times", false).toBool();
     Settings::values.use_gdbstub = ReadSetting("use_gdbstub", false).toBool();
     Settings::values.gdbstub_port = ReadSetting("gdbstub_port", 24689).toInt();
 
@@ -519,6 +520,7 @@ void Config::SaveValues() {
     qt_config->endGroup();
 
     qt_config->beginGroup("Debugging");
+    WriteSetting("record_frame_times", Settings::values.record_frame_times.operator bool(), false);
     WriteSetting("use_gdbstub", Settings::values.use_gdbstub, false);
     WriteSetting("gdbstub_port", Settings::values.gdbstub_port, 24689);
 

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -192,6 +192,8 @@ void GMainWindow::InitializeWidgets() {
 #ifdef CITRA_ENABLE_COMPATIBILITY_REPORTING
     ui.action_Report_Compatibility->setVisible(true);
 #endif
+    ui.action_Record_Frame_Times->setChecked(Settings::values.record_frame_times);
+
     render_window = new GRenderWindow(this, emu_thread.get());
     render_window->hide();
 
@@ -575,11 +577,14 @@ void GMainWindow::ConnectMenuEvents() {
     connect(ui.action_Screen_Layout_Swap_Screens, &QAction::triggered, this,
             &GMainWindow::OnSwapScreens);
 
-    // Movie
+    // Tools
     connect(ui.action_Record_Movie, &QAction::triggered, this, &GMainWindow::OnRecordMovie);
     connect(ui.action_Play_Movie, &QAction::triggered, this, &GMainWindow::OnPlayMovie);
     connect(ui.action_Stop_Recording_Playback, &QAction::triggered, this,
             &GMainWindow::OnStopRecordingPlayback);
+    connect(ui.action_Record_Frame_Times, &QAction::triggered, this, [this] {
+        Settings::values.record_frame_times = ui.action_Record_Frame_Times->isChecked();
+    });
     connect(ui.action_Enable_Frame_Advancing, &QAction::triggered, this, [this] {
         if (emulation_running) {
             Core::System::GetInstance().frame_limiter.SetFrameAdvancing(

--- a/src/citra_qt/main.ui
+++ b/src/citra_qt/main.ui
@@ -156,6 +156,7 @@
     </widget>
     <addaction name="menu_Movie"/>
     <addaction name="menu_Frame_Advance"/>
+    <addaction name="action_Record_Frame_Times"/>
     <addaction name="separator"/>
     <addaction name="action_Capture_Screenshot"/>
    </widget>
@@ -472,6 +473,17 @@
   <action name="action_Open_Citra_Folder">
    <property name="text">
     <string>Open Citra Folder</string>
+   </property>
+  </action>
+  <action name="action_Record_Frame_Times">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Record Frame Times</string>
+   </property>
+   <property name="toolTip">
+    <string>Frame time data can be found in the log folder</string>
    </property>
   </action>
  </widget>

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -36,6 +36,8 @@ namespace Core {
 
 /*static*/ System System::s_instance;
 
+System::System() : perf_stats(*this) {}
+
 System::ResultStatus System::RunLoop(bool tight_loop) {
     status = ResultStatus::Success;
     if (!cpu_core) {
@@ -279,6 +281,7 @@ void System::RegisterSoftwareKeyboard(std::shared_ptr<Frontend::SoftwareKeyboard
 }
 
 void System::Shutdown() {
+    perf_stats.FlushFrameData();
     // Log last frame performance stats
     auto perf_results = GetAndResetPerfStats();
     Telemetry().AddField(Telemetry::FieldType::Performance, "Shutdown_EmulationSpeed",

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -51,6 +51,8 @@ class Timing;
 
 class System {
 public:
+    explicit System();
+
     /**
      * Gets the instance of the System singleton class.
      * @returns Reference to the instance of the System singleton class.

--- a/src/core/perf_stats.cpp
+++ b/src/core/perf_stats.cpp
@@ -6,16 +6,23 @@
 #include <chrono>
 #include <mutex>
 #include <thread>
+#include "common/detached_tasks.h"
+#include "common/file_util.h"
+#include "core/core.h"
 #include "core/hw/gpu.h"
 #include "core/perf_stats.h"
 #include "core/settings.h"
+#include "fmt/time.h"
 
 using namespace std::chrono_literals;
-using DoubleSecs = std::chrono::duration<double, std::chrono::seconds::period>;
 using std::chrono::duration_cast;
 using std::chrono::microseconds;
 
 namespace Core {
+
+PerfStats::PerfStats(System& system) : system{system} {}
+
+PerfStats::~PerfStats() = default;
 
 void PerfStats::BeginSystemFrame() {
     std::lock_guard<std::mutex> lock(object_mutex);
@@ -32,6 +39,12 @@ void PerfStats::EndSystemFrame() {
 
     previous_frame_length = frame_end - previous_frame_end;
     previous_frame_end = frame_end;
+
+    if (Settings::values.record_frame_times) {
+        PerfStats::RecordFrameTime(duration_cast<DoubleSecs>(previous_frame_length));
+    } else if (frame_data) {
+        FlushFrameData();
+    }
 }
 
 void PerfStats::EndGameFrame() {
@@ -71,6 +84,29 @@ double PerfStats::GetLastFrameTimeScale() {
 
     constexpr double FRAME_LENGTH = 1.0 / GPU::SCREEN_REFRESH_RATE;
     return duration_cast<DoubleSecs>(previous_frame_length).count() / FRAME_LENGTH;
+}
+
+void PerfStats::RecordFrameTime(DoubleSecs frame_time) {
+    if (!frame_data)
+        frame_data.emplace();
+    *frame_data << frame_time.count() << '\n';
+}
+
+void PerfStats::FlushFrameData() {
+    if (!frame_data)
+        return;
+
+    std::string game_title;
+    system.GetAppLoader().ReadTitle(game_title);
+
+    Common::DetachedTasks::AddTask([game_title, data = frame_data->str()]() {
+        std::string path = FileUtil::GetUserPath(FileUtil::UserPath::LogDir) + game_title +
+                           fmt::format(" {:%F %H-%M-%S}.csv", fmt::localtime(std::time(nullptr)));
+        // file path is "log/<game title> <date> <time stamp>.csv"
+        FileUtil::WriteStringToFile(true, data, path.data());
+    });
+
+    frame_data.reset();
 }
 
 void FrameLimiter::DoFrameLimiting(microseconds current_system_time_us) {

--- a/src/core/perf_stats.cpp
+++ b/src/core/perf_stats.cpp
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <fstream>
 #include <mutex>
+#include <regex>
 #include <thread>
 #include "common/detached_tasks.h"
 #include "common/file_util.h"
@@ -100,8 +101,10 @@ void PerfStats::FlushFrameData() {
     system.GetAppLoader().ReadTitle(game_title);
 
     Common::DetachedTasks::AddTask([game_title, data = std::move(*frame_data)]() {
+        static const std::regex invalid_chars(R"([\\/:"*?<>|])");
         // file path is "log/<game title> <version>.csv"
-        std::string path = FileUtil::GetUserPath(FileUtil::UserPath::LogDir) + game_title;
+        std::string path = FileUtil::GetUserPath(FileUtil::UserPath::LogDir) +
+                           std::regex_replace(game_title, invalid_chars, "");
         unsigned int i = 1;
         while (FileUtil::Exists(path + ' ' + std::to_string(i) + ".csv"))
             ++i;

--- a/src/core/perf_stats.cpp
+++ b/src/core/perf_stats.cpp
@@ -13,7 +13,6 @@
 #include "core/hw/gpu.h"
 #include "core/perf_stats.h"
 #include "core/settings.h"
-#include "fmt/time.h"
 
 using namespace std::chrono_literals;
 using std::chrono::duration_cast;
@@ -101,9 +100,12 @@ void PerfStats::FlushFrameData() {
     system.GetAppLoader().ReadTitle(game_title);
 
     Common::DetachedTasks::AddTask([game_title, data = std::move(*frame_data)]() {
-        // file path is "log/<game title> <date> <time stamp>.csv"
-        std::string path = FileUtil::GetUserPath(FileUtil::UserPath::LogDir) + game_title +
-                           fmt::format(" {:%F %H-%M-%S}.csv", fmt::localtime(std::time(nullptr)));
+        // file path is "log/<game title> <version>.csv"
+        std::string path = FileUtil::GetUserPath(FileUtil::UserPath::LogDir) + game_title;
+        unsigned int i = 1;
+        while (FileUtil::Exists(path + ' ' + std::to_string(i) + ".csv"))
+            ++i;
+        path += ' ' + std::to_string(i) + ".csv";
 
         std::ofstream file;
         OpenFStream(file, path, std::ofstream::out);

--- a/src/core/perf_stats.h
+++ b/src/core/perf_stats.h
@@ -6,6 +6,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <deque>
 #include <mutex>
 #include <optional>
 #include "common/common_types.h"
@@ -57,7 +58,7 @@ private:
 
     std::mutex object_mutex;
 
-    std::optional<std::vector<double>> frame_data;
+    std::optional<std::deque<double>> frame_data;
 
     /// Point when the cumulative counters were reset
     Clock::time_point reset_point = Clock::now();

--- a/src/core/perf_stats.h
+++ b/src/core/perf_stats.h
@@ -8,7 +8,6 @@
 #include <chrono>
 #include <mutex>
 #include <optional>
-#include <sstream>
 #include "common/common_types.h"
 #include "common/thread.h"
 
@@ -58,7 +57,7 @@ private:
 
     std::mutex object_mutex;
 
-    std::optional<std::ostringstream> frame_data;
+    std::optional<std::vector<double>> frame_data;
 
     /// Point when the cumulative counters were reset
     Clock::time_point reset_point = Clock::now();
@@ -79,7 +78,7 @@ private:
     /// Total visible duration (including frame-limiting, etc.) of the previous system frame
     Clock::duration previous_frame_length = Clock::duration::zero();
 
-    void RecordFrameTime(DoubleSecs frame_time);
+    inline void RecordFrameTime(DoubleSecs frame_time);
 };
 
 class FrameLimiter {

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -176,6 +176,7 @@ struct Values {
     // Debugging
     bool use_gdbstub;
     u16 gdbstub_port;
+    std::atomic_bool record_frame_times;
     std::string log_filter;
     std::unordered_map<std::string, bool> lle_modules;
 


### PR DESCRIPTION
Frame times are recorded until the game stops or the user unchecks this option:
![image](https://user-images.githubusercontent.com/28246325/52542247-7cc7ec80-2d63-11e9-85bd-4de24224320c.png)
Then the data is dumped to a .csv file in the log directory and can be used to make fancy graphs like this:
![image](https://user-images.githubusercontent.com/28246325/52542266-b1d43f00-2d63-11e9-83f4-4aed4a848452.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4636)
<!-- Reviewable:end -->
