### PR TITLE
Port yuzu-emu/yuzu#2116: "threadsafe_queue: Remove NeedSize template parameter"

### DIFF
--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -218,7 +218,7 @@ private:
     u64 event_fifo_id = 0;
     // the queue for storing the events from other threads threadsafe until they will be added
     // to the event_queue by the emu thread
-    Common::MPSCQueue<Event, false> ts_queue;
+    Common::MPSCQueue<Event> ts_queue;
     s64 idled_cycles = 0;
 
     // Are we in a function that has been called from Advance()


### PR DESCRIPTION
See yuzu-emu/yuzu#2116 for more details.

**Original description**:
The necessity of this parameter is dubious at best (even if enabled, it would still include the size data member as part of the class instead of removing it with template shenanigans), and in 2019 probably offers completely negligible savings as opposed to just leaving this enabled. This removes it and simplifies the overall interface.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4645)
<!-- Reviewable:end -->
