### PR TITLE
audio_core: use nested namespaces

### DIFF
--- a/src/audio_core/codec.cpp
+++ b/src/audio_core/codec.cpp
@@ -11,8 +11,7 @@
 #include "common/assert.h"
 #include "common/common_types.h"
 
-namespace AudioCore {
-namespace Codec {
+namespace AudioCore::Codec {
 
 StereoBuffer16 DecodeADPCM(const u8* const data, const std::size_t sample_count,
                            const std::array<s16, 16>& adpcm_coeff, ADPCMState& state) {
@@ -123,5 +122,4 @@ StereoBuffer16 DecodePCM16(const unsigned num_channels, const u8* const data,
 
     return ret;
 }
-} // namespace Codec
-} // namespace AudioCore
+} // namespace AudioCore::Codec

--- a/src/audio_core/codec.h
+++ b/src/audio_core/codec.h
@@ -8,8 +8,7 @@
 #include "audio_core/audio_types.h"
 #include "common/common_types.h"
 
-namespace AudioCore {
-namespace Codec {
+namespace AudioCore::Codec {
 
 /// See: Codec::DecodeADPCM
 struct ADPCMState {
@@ -46,5 +45,4 @@ StereoBuffer16 DecodePCM8(const unsigned num_channels, const u8* const data,
  */
 StereoBuffer16 DecodePCM16(const unsigned num_channels, const u8* const data,
                            const std::size_t sample_count);
-} // namespace Codec
-} // namespace AudioCore
+} // namespace AudioCore::Codec

--- a/src/audio_core/dsp_interface.h
+++ b/src/audio_core/dsp_interface.h
@@ -12,11 +12,9 @@
 #include "common/ring_buffer.h"
 #include "core/memory.h"
 
-namespace Service {
-namespace DSP {
+namespace Service::DSP {
 class DSP_DSP;
-} // namespace DSP
-} // namespace Service
+} // namespace Service::DSP
 
 namespace AudioCore {
 

--- a/src/audio_core/hle/common.h
+++ b/src/audio_core/hle/common.h
@@ -7,8 +7,7 @@
 #include <algorithm>
 #include <cstddef>
 
-namespace AudioCore {
-namespace HLE {
+namespace AudioCore::HLE {
 
 constexpr std::size_t num_sources = 24;
 
@@ -22,5 +21,4 @@ void FilterFrame(FrameT& frame, FilterT& filter) {
                    [&filter](const auto& sample) { return filter.ProcessSample(sample); });
 }
 
-} // namespace HLE
-} // namespace AudioCore
+} // namespace AudioCore::HLE

--- a/src/audio_core/hle/filter.cpp
+++ b/src/audio_core/hle/filter.cpp
@@ -10,8 +10,7 @@
 #include "audio_core/hle/shared_memory.h"
 #include "common/common_types.h"
 
-namespace AudioCore {
-namespace HLE {
+namespace AudioCore::HLE {
 
 void SourceFilters::Reset() {
     Enable(false, false);
@@ -113,5 +112,4 @@ std::array<s16, 2> SourceFilters::BiquadFilter::ProcessSample(const std::array<s
     return y0;
 }
 
-} // namespace HLE
-} // namespace AudioCore
+} // namespace AudioCore::HLE

--- a/src/audio_core/hle/filter.h
+++ b/src/audio_core/hle/filter.h
@@ -9,8 +9,7 @@
 #include "audio_core/hle/shared_memory.h"
 #include "common/common_types.h"
 
-namespace AudioCore {
-namespace HLE {
+namespace AudioCore::HLE {
 
 /// Preprocessing filters. There is an independent set of filters for each Source.
 class SourceFilters final {
@@ -113,5 +112,4 @@ private:
     } biquad_filter;
 };
 
-} // namespace HLE
-} // namespace AudioCore
+} // namespace AudioCore::HLE

--- a/src/audio_core/hle/mixers.cpp
+++ b/src/audio_core/hle/mixers.cpp
@@ -8,8 +8,7 @@
 #include "common/assert.h"
 #include "common/logging/log.h"
 
-namespace AudioCore {
-namespace HLE {
+namespace AudioCore::HLE {
 
 void Mixers::Reset() {
     current_frame.fill({});
@@ -203,5 +202,4 @@ DspStatus Mixers::GetCurrentStatus() const {
     return status;
 }
 
-} // namespace HLE
-} // namespace AudioCore
+} // namespace AudioCore::HLE

--- a/src/audio_core/hle/mixers.h
+++ b/src/audio_core/hle/mixers.h
@@ -8,8 +8,7 @@
 #include "audio_core/audio_types.h"
 #include "audio_core/hle/shared_memory.h"
 
-namespace AudioCore {
-namespace HLE {
+namespace AudioCore::HLE {
 
 class Mixers final {
 public:
@@ -57,5 +56,4 @@ private:
     DspStatus GetCurrentStatus() const;
 };
 
-} // namespace HLE
-} // namespace AudioCore
+} // namespace AudioCore::HLE

--- a/src/audio_core/hle/shared_memory.h
+++ b/src/audio_core/hle/shared_memory.h
@@ -15,8 +15,7 @@
 #include "common/common_types.h"
 #include "common/swap.h"
 
-namespace AudioCore {
-namespace HLE {
+namespace AudioCore::HLE {
 
 // The application-accessible region of DSP memory consists of two parts. Both are marked as IO and
 // have Read/Write permissions.
@@ -559,5 +558,4 @@ static_assert(offsetof(SharedMemory, unknown14) % 2 == 0,
 #undef INSERT_PADDING_DSPWORDS
 #undef ASSERT_DSP_STRUCT
 
-} // namespace HLE
-} // namespace AudioCore
+} // namespace AudioCore::HLE

--- a/src/audio_core/hle/source.cpp
+++ b/src/audio_core/hle/source.cpp
@@ -12,8 +12,7 @@
 #include "common/logging/log.h"
 #include "core/memory.h"
 
-namespace AudioCore {
-namespace HLE {
+namespace AudioCore::HLE {
 
 SourceStatus::Status Source::Tick(SourceConfiguration::Configuration& config,
                                   const s16_le (&adpcm_coeffs)[16]) {
@@ -349,5 +348,4 @@ SourceStatus::Status Source::GetCurrentStatus() {
     return ret;
 }
 
-} // namespace HLE
-} // namespace AudioCore
+} // namespace AudioCore::HLE

--- a/src/audio_core/hle/source.h
+++ b/src/audio_core/hle/source.h
@@ -18,8 +18,7 @@ namespace Memory {
 class MemorySystem;
 }
 
-namespace AudioCore {
-namespace HLE {
+namespace AudioCore::HLE {
 
 /**
  * This module performs:
@@ -153,5 +152,4 @@ private:
     SourceStatus::Status GetCurrentStatus();
 };
 
-} // namespace HLE
-} // namespace AudioCore
+} // namespace AudioCore::HLE

--- a/src/audio_core/interpolate.cpp
+++ b/src/audio_core/interpolate.cpp
@@ -6,8 +6,7 @@
 #include "audio_core/interpolate.h"
 #include "common/assert.h"
 
-namespace AudioCore {
-namespace AudioInterp {
+namespace AudioCore::AudioInterp {
 
 // Calculations are done in fixed point with 24 fractional bits.
 // (This is not verified. This was chosen for minimal error.)
@@ -74,5 +73,4 @@ void Linear(State& state, StereoBuffer16& input, float rate, StereoFrame16& outp
                     });
 }
 
-} // namespace AudioInterp
-} // namespace AudioCore
+} // namespace AudioCore::AudioInterp

--- a/src/audio_core/interpolate.h
+++ b/src/audio_core/interpolate.h
@@ -9,8 +9,7 @@
 #include "audio_core/audio_types.h"
 #include "common/common_types.h"
 
-namespace AudioCore {
-namespace AudioInterp {
+namespace AudioCore::AudioInterp {
 
 /// A variable length buffer of signed PCM16 stereo samples.
 using StereoBuffer16 = std::deque<std::array<s16, 2>>;
@@ -47,5 +46,4 @@ void None(State& state, StereoBuffer16& input, float rate, StereoFrame16& output
 void Linear(State& state, StereoBuffer16& input, float rate, StereoFrame16& output,
             std::size_t& outputi);
 
-} // namespace AudioInterp
-} // namespace AudioCore
+} // namespace AudioCore::AudioInterp


### PR DESCRIPTION
Some files already used nested namespaces, however some didn't. No functional changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4652)
<!-- Reviewable:end -->
