### PR TITLE
Remove GCC version checks

### DIFF
--- a/src/audio_core/hle/shared_memory.h
+++ b/src/audio_core/hle/shared_memory.h
@@ -58,9 +58,7 @@ private:
     }
     u32_le storage;
 };
-#if (__GNUC__ >= 5) || defined(__clang__) || defined(_MSC_VER)
 static_assert(std::is_trivially_copyable<u32_dsp>::value, "u32_dsp isn't trivially copyable");
-#endif
 
 // There are 15 structures in each memory region. A table of them in the order they appear in memory
 // is presented below:
@@ -103,21 +101,12 @@ static_assert(std::is_trivially_copyable<u32_dsp>::value, "u32_dsp isn't trivial
 
 #define INSERT_PADDING_DSPWORDS(num_words) INSERT_PADDING_BYTES(2 * (num_words))
 
-// GCC versions < 5.0 do not implement std::is_trivially_copyable.
-// Excluding MSVC because it has weird behaviour for std::is_trivially_copyable.
-#if (__GNUC__ >= 5) || defined(__clang__)
 #define ASSERT_DSP_STRUCT(name, size)                                                              \
     static_assert(std::is_standard_layout<name>::value,                                            \
                   "DSP structure " #name " doesn't use standard layout");                          \
     static_assert(std::is_trivially_copyable<name>::value,                                         \
                   "DSP structure " #name " isn't trivially copyable");                             \
     static_assert(sizeof(name) == (size), "Unexpected struct size for DSP structure " #name)
-#else
-#define ASSERT_DSP_STRUCT(name, size)                                                              \
-    static_assert(std::is_standard_layout<name>::value,                                            \
-                  "DSP structure " #name " doesn't use standard layout");                          \
-    static_assert(sizeof(name) == (size), "Unexpected struct size for DSP structure " #name)
-#endif
 
 struct SourceConfiguration {
     struct Configuration {

--- a/src/common/bit_field.h
+++ b/src/common/bit_field.h
@@ -195,10 +195,8 @@ private:
 };
 #pragma pack()
 
-#if (__GNUC__ >= 5) || defined(__clang__) || defined(_MSC_VER)
 static_assert(std::is_trivially_copyable<BitField<0, 1, unsigned>>::value,
               "BitField must be trivially copyable");
-#endif
 
 template <std::size_t Position, std::size_t Bits, typename T>
 using BitFieldBE = BitField<Position, Bits, T, BETag>;

--- a/src/common/swap.h
+++ b/src/common/swap.h
@@ -30,8 +30,8 @@
 #include <cstring>
 #include "common/common_types.h"
 
-// GCC 4.6+
-#if __GNUC__ >= 5 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
+// GCC
+#ifdef __GNUC__
 
 #if __BYTE_ORDER__ && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) && !defined(COMMON_LITTLE_ENDIAN)
 #define COMMON_LITTLE_ENDIAN 1
@@ -40,7 +40,7 @@
 #endif
 
 // LLVM/clang
-#elif __clang__
+#elif defined(__clang__)
 
 #if __LITTLE_ENDIAN__ && !defined(COMMON_LITTLE_ENDIAN)
 #define COMMON_LITTLE_ENDIAN 1

--- a/src/core/hle/service/ldr_ro/cro_helper.h
+++ b/src/core/hle/service/ldr_ro/cro_helper.h
@@ -17,21 +17,12 @@ class Process;
 
 namespace Service::LDR {
 
-// GCC versions < 5.0 do not implement std::is_trivially_copyable.
-// Excluding MSVC because it has weird behaviour for std::is_trivially_copyable.
-#if (__GNUC__ >= 5) || defined(__clang__)
 #define ASSERT_CRO_STRUCT(name, size)                                                              \
     static_assert(std::is_standard_layout<name>::value,                                            \
                   "CRO structure " #name " doesn't use standard layout");                          \
     static_assert(std::is_trivially_copyable<name>::value,                                         \
                   "CRO structure " #name " isn't trivially copyable");                             \
     static_assert(sizeof(name) == (size), "Unexpected struct size for CRO structure " #name)
-#else
-#define ASSERT_CRO_STRUCT(name, size)                                                              \
-    static_assert(std::is_standard_layout<name>::value,                                            \
-                  "CRO structure " #name " doesn't use standard layout");                          \
-    static_assert(sizeof(name) == (size), "Unexpected struct size for CRO structure " #name)
-#endif
 
 static constexpr u32 CRO_HEADER_SIZE = 0x138;
 static constexpr u32 CRO_HASH_SIZE = 0x80;


### PR DESCRIPTION
Citra can't be compiled using GCC <7 because of required C++17 support, so these version checks don't need to exist anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4655)
<!-- Reviewable:end -->
