### PR TITLE
rpc: send ending packet in Server instead of UDPServer

### DIFF
--- a/src/core/rpc/server.cpp
+++ b/src/core/rpc/server.cpp
@@ -25,6 +25,7 @@ void Server::Start() {
 
 void Server::Stop() {
     udp_server.reset();
+    NewRequestCallback(nullptr); // Notify the RPC server to end
 }
 
 void Server::NewRequestCallback(std::unique_ptr<RPC::Packet> new_request) {

--- a/src/core/rpc/udp_server.cpp
+++ b/src/core/rpc/udp_server.cpp
@@ -20,10 +20,7 @@ public:
           new_request_callback(std::move(new_request_callback)) {
 
         StartReceive();
-        worker_thread = std::thread([this] {
-            io_context.run();
-            this->new_request_callback(nullptr);
-        });
+        worker_thread = std::thread([this] { io_context.run(); });
     }
 
     ~Impl() {


### PR DESCRIPTION
udp_server might not be created due to error (occupied port etc.), in which case its destructor and thread-ending call chain will not be excuted in Server::Stop. However, the ending packet still need to be send no matter udp is on or not, so move it to Server::Stop

Fixes #4662

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4669)
<!-- Reviewable:end -->
