### PR TITLE
ISSUE_TEMPLATE: also ask for a log file

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -18,6 +18,7 @@ When submitting an issue, please check the following:
 - You have provided sufficient detail for the issue to be reproduced.
 - You have provided system specs (if relevant).
 - Please also provide:
+  - For any issues, a log file
   - For crashes, a backtrace.
   - For graphical issues, comparison screenshots with real hardware.
   - For emulation inaccuracies, a test-case (if able).


### PR DESCRIPTION
Exactly like we do for yuzu too, we should also mention for Citra that we need a log.