### PR TITLE
frontend: qt: fix a freeze issue

### DIFF
--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -24,8 +24,6 @@ void EmuThread::run() {
 
     MicroProfileOnThreadCreate("EmuThread");
 
-    stop_run = false;
-
     // Holds whether the cpu was running during the last iteration,
     // so that the DebugModeLeft signal can be emitted before the
     // next execution step.


### PR DESCRIPTION
This PR will (hopefully) fix the case where Citra could end up locking up.

To reproduce the hang, you need a pretty specific setup.

In my case, the conditions are:

1. Using Plasma KDE 5 as the Desktop Environment
2. Using the default settings where the single click is the selection (instead of double-click)
3. Click pretty fast on any entry in the game list multiple times

If the conditions above are met, Citra will freeze 100% of the time.

The fix introduces a `QMutex` which will do a lock acquire each time `BootGame` is called to mitigate the issue. In my case, this can resolve the issue

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4684)
<!-- Reviewable:end -->
