### PR TITLE
UDS: implement deprecated functions

### DIFF
--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -1219,7 +1219,7 @@ void NWM_UDS::ConnectToNetworkDeprecated(Kernel::HLERequestContext& ctx) {
 
     std::vector<u8> passphrase = rp.PopStaticBuffer();
 
-    ConnectToNetwork(ctx, 0x11, network_info_buffer.data(), network_info_buffer.size(),
+    ConnectToNetwork(ctx, 0x09, network_info_buffer.data(), network_info_buffer.size(),
                      connection_type, std::move(passphrase));
 
     LOG_DEBUG(Service_NWM, "called");

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -1249,8 +1249,8 @@ void NWM_UDS::SetApplicationData(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS);
 }
 
-void NWM_UDS::DecryptBeaconData(Kernel::HLERequestContext& ctx) {
-    IPC::RequestParser rp(ctx, 0x1F, 0, 6);
+void NWM_UDS::DecryptBeaconData(Kernel::HLERequestContext& ctx, u16 command_id) {
+    IPC::RequestParser rp(ctx, command_id, 0, 6);
 
     const std::vector<u8> network_struct_buffer = rp.PopStaticBuffer();
     ASSERT(network_struct_buffer.size() == sizeof(NetworkInfo));
@@ -1315,6 +1315,11 @@ void NWM_UDS::DecryptBeaconData(Kernel::HLERequestContext& ctx) {
     rb.PushStaticBuffer(output_buffer, 0);
 }
 
+template <u16 command_id>
+void NWM_UDS::DecryptBeaconData(Kernel::HLERequestContext& ctx) {
+    DecryptBeaconData(ctx, command_id);
+}
+
 // Sends a 802.11 beacon frame with information about the current network.
 void NWM_UDS::BeaconBroadcastCallback(u64 userdata, s64 cycles_late) {
     // Don't do anything if we're not actually hosting a network
@@ -1352,7 +1357,7 @@ NWM_UDS::NWM_UDS(Core::System& system) : ServiceFramework("nwm::UDS"), system(sy
         {0x000A0000, &NWM_UDS::DisconnectNetwork, "DisconnectNetwork"},
         {0x000B0000, &NWM_UDS::GetConnectionStatus, "GetConnectionStatus"},
         {0x000D0040, &NWM_UDS::GetNodeInformation, "GetNodeInformation"},
-        {0x000E0006, nullptr, "DecryptBeaconData (deprecated)"},
+        {0x000E0006, &NWM_UDS::DecryptBeaconData<0x0E>, "DecryptBeaconData (deprecated)"},
         {0x000F0404, &NWM_UDS::RecvBeaconBroadcastData, "RecvBeaconBroadcastData"},
         {0x00100042, &NWM_UDS::SetApplicationData, "SetApplicationData"},
         {0x00110040, nullptr, "GetApplicationData"},
@@ -1365,7 +1370,7 @@ NWM_UDS::NWM_UDS(Core::System& system) : ServiceFramework("nwm::UDS"), system(sy
         {0x001B0302, &NWM_UDS::InitializeWithVersion, "InitializeWithVersion"},
         {0x001D0044, &NWM_UDS::BeginHostingNetwork, "BeginHostingNetwork"},
         {0x001E0084, &NWM_UDS::ConnectToNetwork, "ConnectToNetwork"},
-        {0x001F0006, &NWM_UDS::DecryptBeaconData, "DecryptBeaconData"},
+        {0x001F0006, &NWM_UDS::DecryptBeaconData<0x1F>, "DecryptBeaconData"},
         {0x00200040, nullptr, "Flush"},
         {0x00210080, nullptr, "SetProbeResponseParam"},
         {0x00220402, nullptr, "ScanOnConnection"},

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -1207,6 +1207,24 @@ void NWM_UDS::ConnectToNetwork(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_NWM, "called");
 }
 
+void NWM_UDS::ConnectToNetworkDeprecated(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp(ctx, 0x09, 0x11, 2);
+
+    // Similar to BeginHostingNetworkDeprecated, we only read the first 0x3C bytes into the network
+    // info
+    const auto network_info_buffer = rp.PopRaw<std::array<u8, 0x3C>>();
+
+    u8 connection_type = rp.Pop<u8>();
+    u32 passphrase_size = rp.Pop<u32>();
+
+    std::vector<u8> passphrase = rp.PopStaticBuffer();
+
+    ConnectToNetwork(ctx, network_info_buffer.data(), network_info_buffer.size(), connection_type,
+                     std::move(passphrase));
+
+    LOG_DEBUG(Service_NWM, "called");
+}
+
 void NWM_UDS::SetApplicationData(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x10, 1, 2);
 
@@ -1330,7 +1348,7 @@ NWM_UDS::NWM_UDS(Core::System& system) : ServiceFramework("nwm::UDS"), system(sy
         {0x00060000, nullptr, "EjectSpectator"},
         {0x00070080, &NWM_UDS::UpdateNetworkAttribute, "UpdateNetworkAttribute"},
         {0x00080000, &NWM_UDS::DestroyNetwork, "DestroyNetwork"},
-        {0x00090442, nullptr, "ConnectNetwork (deprecated)"},
+        {0x00090442, &NWM_UDS::ConnectToNetworkDeprecated, "ConnectToNetwork (deprecated)"},
         {0x000A0000, &NWM_UDS::DisconnectNetwork, "DisconnectNetwork"},
         {0x000B0000, &NWM_UDS::GetConnectionStatus, "GetConnectionStatus"},
         {0x000D0040, &NWM_UDS::GetNodeInformation, "GetNodeInformation"},

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -1165,9 +1165,9 @@ void NWM_UDS::GetChannel(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_NWM, "called");
 }
 
-void NWM_UDS::ConnectToNetwork(Kernel::HLERequestContext& ctx, const u8* network_info_buffer,
-                               std::size_t network_info_size, u8 connection_type,
-                               std::vector<u8> passphrase) {
+void NWM_UDS::ConnectToNetwork(Kernel::HLERequestContext& ctx, u16 command_id,
+                               const u8* network_info_buffer, std::size_t network_info_size,
+                               u8 connection_type, std::vector<u8> passphrase) {
     network_info = {};
     std::memcpy(&network_info, network_info_buffer, network_info_size);
 
@@ -1181,10 +1181,10 @@ void NWM_UDS::ConnectToNetwork(Kernel::HLERequestContext& ctx, const u8* network
     connection_event = ctx.SleepClientThread(
         system.Kernel().GetThreadManager().GetCurrentThread(), "uds::ConnectToNetwork",
         UDSConnectionTimeout,
-        [](Kernel::SharedPtr<Kernel::Thread> thread, Kernel::HLERequestContext& ctx,
-           Kernel::ThreadWakeupReason reason) {
+        [command_id](Kernel::SharedPtr<Kernel::Thread> thread, Kernel::HLERequestContext& ctx,
+                     Kernel::ThreadWakeupReason reason) {
             // TODO(B3N30): Add error handling for host full and timeout
-            IPC::RequestBuilder rb(ctx, 0x1E, 1, 0);
+            IPC::RequestBuilder rb(ctx, command_id, 1, 0);
             rb.Push(RESULT_SUCCESS);
             LOG_DEBUG(Service_NWM, "connection sequence finished");
         });
@@ -1201,8 +1201,8 @@ void NWM_UDS::ConnectToNetwork(Kernel::HLERequestContext& ctx) {
 
     std::vector<u8> passphrase = rp.PopStaticBuffer();
 
-    ConnectToNetwork(ctx, network_info_buffer.data(), network_info_buffer.size(), connection_type,
-                     std::move(passphrase));
+    ConnectToNetwork(ctx, 0x1E, network_info_buffer.data(), network_info_buffer.size(),
+                     connection_type, std::move(passphrase));
 
     LOG_DEBUG(Service_NWM, "called");
 }
@@ -1219,8 +1219,8 @@ void NWM_UDS::ConnectToNetworkDeprecated(Kernel::HLERequestContext& ctx) {
 
     std::vector<u8> passphrase = rp.PopStaticBuffer();
 
-    ConnectToNetwork(ctx, network_info_buffer.data(), network_info_buffer.size(), connection_type,
-                     std::move(passphrase));
+    ConnectToNetwork(ctx, 0x11, network_info_buffer.data(), network_info_buffer.size(),
+                     connection_type, std::move(passphrase));
 
     LOG_DEBUG(Service_NWM, "called");
 }

--- a/src/core/hle/service/nwm/nwm_uds.h
+++ b/src/core/hle/service/nwm/nwm_uds.h
@@ -423,9 +423,9 @@ private:
     ResultCode BeginHostingNetwork(const u8* network_info_buffer, std::size_t network_info_size,
                                    std::vector<u8> passphrase);
 
-    void ConnectToNetwork(Kernel::HLERequestContext& ctx, const u8* network_info_buffer,
-                          std::size_t network_info_size, u8 connection_type,
-                          std::vector<u8> passphrase);
+    void ConnectToNetwork(Kernel::HLERequestContext& ctx, u16 command_id,
+                          const u8* network_info_buffer, std::size_t network_info_size,
+                          u8 connection_type, std::vector<u8> passphrase);
 
     void BeaconBroadcastCallback(u64 userdata, s64 cycles_late);
 

--- a/src/core/hle/service/nwm/nwm_uds.h
+++ b/src/core/hle/service/nwm/nwm_uds.h
@@ -388,6 +388,9 @@ private:
         u32 sharedmem_size, const NodeInfo& node, u16 version,
         Kernel::SharedPtr<Kernel::SharedMemory> sharedmem);
 
+    ResultCode BeginHostingNetwork(const u8* network_info_buffer, std::size_t network_info_size,
+                                   std::vector<u8> passphrase);
+
     void BeaconBroadcastCallback(u64 userdata, s64 cycles_late);
 
     /**

--- a/src/core/hle/service/nwm/nwm_uds.h
+++ b/src/core/hle/service/nwm/nwm_uds.h
@@ -411,6 +411,9 @@ private:
      *      1 : Result of function, 0 on success, otherwise error code
      *      2, 3: output buffer return descriptor & ptr
      */
+    void DecryptBeaconData(Kernel::HLERequestContext& ctx, u16 command_id);
+
+    template <u16 command_id>
     void DecryptBeaconData(Kernel::HLERequestContext& ctx);
 
     ResultVal<Kernel::SharedPtr<Kernel::Event>> Initialize(

--- a/src/core/hle/service/nwm/nwm_uds.h
+++ b/src/core/hle/service/nwm/nwm_uds.h
@@ -379,6 +379,22 @@ private:
     void ConnectToNetwork(Kernel::HLERequestContext& ctx);
 
     /**
+     * NWM_UDS::ConnectToNetwork Deprecatedservice function.
+     * This connects to the specified network
+     *  Inputs:
+     *      0 : Command header
+     *      1 - 15 : the NetworkInfo structure, excluding application data
+     *      16 : Connection type: 0x1 = Client, 0x2 = Spectator.
+     *      17 : Passphrase buffer size
+     *      18 : (PassphraseSize<<12) | 2
+     *      19 : Input passphrase buffer ptr
+     *  Outputs:
+     *      0 : Return header
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void ConnectToNetworkDeprecated(Kernel::HLERequestContext& ctx);
+
+    /**
      * NWM_UDS::DecryptBeaconData service function.
      * Decrypts the encrypted data tags contained in the 802.11 beacons.
      *  Inputs:

--- a/src/core/hle/service/nwm/nwm_uds.h
+++ b/src/core/hle/service/nwm/nwm_uds.h
@@ -321,6 +321,21 @@ private:
     void InitializeWithVersion(Kernel::HLERequestContext& ctx);
 
     /**
+     * NWM_UDS::InitializeDeprecated service function
+     *  Inputs:
+     *      1 : Shared memory size
+     *   2-11 : Input NodeInfo Structure
+     *     13 : Value 0
+     *     14 : Shared memory handle
+     *  Outputs:
+     *      0 : Return header
+     *      1 : Result of function, 0 on success, otherwise error code
+     *      2 : Value 0
+     *      3 : Output event handle
+     */
+    void InitializeDeprecated(Kernel::HLERequestContext& ctx);
+
+    /**
      * NWM_UDS::BeginHostingNetwork service function.
      * Creates a network and starts broadcasting its presence.
      *  Inputs:

--- a/src/core/hle/service/nwm/nwm_uds.h
+++ b/src/core/hle/service/nwm/nwm_uds.h
@@ -404,6 +404,10 @@ private:
     ResultCode BeginHostingNetwork(const u8* network_info_buffer, std::size_t network_info_size,
                                    std::vector<u8> passphrase);
 
+    void ConnectToNetwork(Kernel::HLERequestContext& ctx, const u8* network_info_buffer,
+                          std::size_t network_info_size, u8 connection_type,
+                          std::vector<u8> passphrase);
+
     void BeaconBroadcastCallback(u64 userdata, s64 cycles_late);
 
     /**

--- a/src/core/hle/service/nwm/nwm_uds.h
+++ b/src/core/hle/service/nwm/nwm_uds.h
@@ -349,6 +349,19 @@ private:
     void BeginHostingNetwork(Kernel::HLERequestContext& ctx);
 
     /**
+     * NWM_UDS::BeginHostingNetworkDeprecated service function.
+     * Creates a network and starts broadcasting its presence.
+     *  Inputs:
+     *      1 - 15 : the NetworkInfo structure, excluding application data
+     *      16 : passphrase size
+     *      18 : VAddr of the passphrase.
+     *  Outputs:
+     *      0 : Return header
+     *      1 : Result of function, 0 on success, otherwise error code
+     */
+    void BeginHostingNetworkDeprecated(Kernel::HLERequestContext& ctx);
+
+    /**
      * NWM_UDS::ConnectToNetwork service function.
      * This connects to the specified network
      *  Inputs:

--- a/src/core/hle/service/nwm/nwm_uds.h
+++ b/src/core/hle/service/nwm/nwm_uds.h
@@ -369,6 +369,10 @@ private:
      */
     void DecryptBeaconData(Kernel::HLERequestContext& ctx);
 
+    ResultVal<Kernel::SharedPtr<Kernel::Event>> Initialize(
+        u32 sharedmem_size, const NodeInfo& node, u16 version,
+        Kernel::SharedPtr<Kernel::SharedMemory> sharedmem);
+
     void BeaconBroadcastCallback(u64 userdata, s64 cycles_late);
 
     /**


### PR DESCRIPTION
TODO:
 - [x] Initialize
 - [x] CreateNetwork
 - [x] ConnectNetwork
 - [x] DecryptBeaconData

This is reverse-engineered by comparing the two versions of functions (deprecated vs. current). So far it turned out that NWM module parses IPC different params and then forward them to the same base functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4690)
<!-- Reviewable:end -->
