### PR TITLE
video_core: renderer_opengl: gles color fix

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -176,15 +176,13 @@ static void MortonCopyTile(u32 stride, u8* tile_buffer, u8* gl_buffer) {
                     gl_ptr[0] = tile_ptr[3];
                     std::memcpy(gl_ptr + 1, tile_ptr, 3);
                 } else if (format == PixelFormat::RGBA8 && GLES) {
-                    // because GLES does not have BGR format
+                    // because GLES does not have ABGR format
                     // so we will do byteswapping here
                     gl_ptr[0] = tile_ptr[3];
                     gl_ptr[1] = tile_ptr[2];
                     gl_ptr[2] = tile_ptr[1];
                     gl_ptr[3] = tile_ptr[0];
                 } else if (format == PixelFormat::RGB8 && GLES) {
-                    // the last channel Alpha should keep the same
-                    // position as the original
                     gl_ptr[0] = tile_ptr[2];
                     gl_ptr[1] = tile_ptr[1];
                     gl_ptr[2] = tile_ptr[0];
@@ -763,16 +761,16 @@ void CachedSurface::LoadGLBuffer(PAddr load_start, PAddr load_end) {
             // cannot fully test this
             if (pixel_format == PixelFormat::RGBA8) {
                 for (size_t i = start_offset; i < load_end - addr; i += 4) {
-                    gl_buffer[i] = *(texture_src_data + start_offset + i + 3);
-                    gl_buffer[i + 1] = *(texture_src_data + start_offset + i + 2);
-                    gl_buffer[i + 2] = *(texture_src_data + start_offset + i + 1);
-                    gl_buffer[i + 3] = *(texture_src_data + start_offset + i);
+                    gl_buffer[i] = *(texture_src_data + i + 3);
+                    gl_buffer[i + 1] = *(texture_src_data + i + 2);
+                    gl_buffer[i + 2] = *(texture_src_data + i + 1);
+                    gl_buffer[i + 3] = *(texture_src_data + i);
                 }
             } else if (pixel_format == PixelFormat::RGB8) {
                 for (size_t i = start_offset; i < load_end - addr; i += 3) {
-                    gl_buffer[i] = *(texture_src_data + start_offset + i + 2);
-                    gl_buffer[i + 1] = *(texture_src_data + start_offset + i + 1);
-                    gl_buffer[i + 2] = *(texture_src_data + start_offset + i);
+                    gl_buffer[i] = *(texture_src_data + i + 2);
+                    gl_buffer[i + 1] = *(texture_src_data + i + 1);
+                    gl_buffer[i + 2] = *(texture_src_data + i);
                 }
             }
         } else {

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -188,7 +188,6 @@ static void MortonCopyTile(u32 stride, u8* tile_buffer, u8* gl_buffer) {
                     gl_ptr[0] = tile_ptr[2];
                     gl_ptr[1] = tile_ptr[1];
                     gl_ptr[2] = tile_ptr[0];
-                    gl_ptr[3] = tile_ptr[3];
                 } else {
                     std::memcpy(gl_ptr, tile_ptr, bytes_per_pixel);
                 }
@@ -733,7 +732,6 @@ void RasterizerCacheOpenGL::CopySurface(const Surface& src_surface, const Surfac
 MICROPROFILE_DEFINE(OpenGL_SurfaceLoad, "OpenGL", "Surface Load", MP_RGB(128, 192, 64));
 void CachedSurface::LoadGLBuffer(PAddr load_start, PAddr load_end) {
     ASSERT(type != SurfaceType::Fill);
-    // FIXME(liushuyu): not endianness-aware, assumed little-endian
     bool need_swap =
         GLES && (pixel_format == PixelFormat::RGBA8 || pixel_format == PixelFormat::RGB8);
 
@@ -771,11 +769,10 @@ void CachedSurface::LoadGLBuffer(PAddr load_start, PAddr load_end) {
                     gl_buffer[i + 3] = *(texture_src_data + start_offset + i);
                 }
             } else if (pixel_format == PixelFormat::RGB8) {
-                for (size_t i = start_offset; i < load_end - addr; i += 4) {
+                for (size_t i = start_offset; i < load_end - addr; i += 3) {
                     gl_buffer[i] = *(texture_src_data + start_offset + i + 2);
                     gl_buffer[i + 1] = *(texture_src_data + start_offset + i + 1);
                     gl_buffer[i + 2] = *(texture_src_data + start_offset + i);
-                    gl_buffer[i + 3] = *(texture_src_data + start_offset + i + 3);
                 }
             }
         } else {
@@ -801,7 +798,6 @@ void CachedSurface::LoadGLBuffer(PAddr load_start, PAddr load_end) {
                         Pica::Texture::LookupTexture(texture_src_data, x, height - 1 - y, tex_info);
                     const std::size_t offset = (x + (width * y)) * 4;
                     std::memcpy(&gl_buffer[offset], vec4.AsArray(), 4);
-                    // TODO(liushuyu): byteswap textures
                 }
             }
         } else {

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -730,7 +730,7 @@ void RasterizerCacheOpenGL::CopySurface(const Surface& src_surface, const Surfac
 MICROPROFILE_DEFINE(OpenGL_SurfaceLoad, "OpenGL", "Surface Load", MP_RGB(128, 192, 64));
 void CachedSurface::LoadGLBuffer(PAddr load_start, PAddr load_end) {
     ASSERT(type != SurfaceType::Fill);
-    bool need_swap =
+    const bool need_swap =
         GLES && (pixel_format == PixelFormat::RGBA8 || pixel_format == PixelFormat::RGB8);
 
     const u8* const texture_src_data = VideoCore::g_memory->GetPhysicalPointer(addr);
@@ -760,17 +760,17 @@ void CachedSurface::LoadGLBuffer(PAddr load_start, PAddr load_end) {
             // TODO(liushuyu): check if the byteswap here is 100% correct
             // cannot fully test this
             if (pixel_format == PixelFormat::RGBA8) {
-                for (size_t i = start_offset; i < load_end - addr; i += 4) {
-                    gl_buffer[i] = *(texture_src_data + i + 3);
-                    gl_buffer[i + 1] = *(texture_src_data + i + 2);
-                    gl_buffer[i + 2] = *(texture_src_data + i + 1);
-                    gl_buffer[i + 3] = *(texture_src_data + i);
+                for (std::size_t i = start_offset; i < load_end - addr; i += 4) {
+                    gl_buffer[i] = texture_src_data[i + 3];
+                    gl_buffer[i + 1] = texture_src_data[i + 2];
+                    gl_buffer[i + 2] = texture_src_data[i + 1];
+                    gl_buffer[i + 3] = texture_src_data[i];
                 }
             } else if (pixel_format == PixelFormat::RGB8) {
-                for (size_t i = start_offset; i < load_end - addr; i += 3) {
-                    gl_buffer[i] = *(texture_src_data + i + 2);
-                    gl_buffer[i + 1] = *(texture_src_data + i + 1);
-                    gl_buffer[i + 2] = *(texture_src_data + i);
+                for (std::size_t i = start_offset; i < load_end - addr; i += 3) {
+                    gl_buffer[i] = texture_src_data[i + 2];
+                    gl_buffer[i + 1] = texture_src_data[i + 1];
+                    gl_buffer[i + 2] = texture_src_data[i];
                 }
             }
         } else {


### PR DESCRIPTION
This PR attempt to fix the inverted color when rendered using OpenGL ES renderer. The issue is caused by OpenGL ES lacks `GL_BGR` and `GL_BGRA` formats. This PR fixes this issue by manually doing the byte-swap on the pixels.

Not sure about the performance for now and the PR is highly unoptimized, so comments and suggestions are highly welcomed.

Thanks for @wwylele and @jroweboy for their great help on how to approach the solution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4691)
<!-- Reviewable:end -->
