### PR TITLE
Fix getopt return type on systems where char is unsigned by default

### DIFF
--- a/src/citra/citra.cpp
+++ b/src/citra/citra.cpp
@@ -221,9 +221,9 @@ int main(int argc, char** argv) {
     };
 
     while (optind < argc) {
-        char arg = getopt_long(argc, argv, "g:i:m:r:p:fhv", long_options, &option_index);
+        int arg = getopt_long(argc, argv, "g:i:m:r:p:fhv", long_options, &option_index);
         if (arg != -1) {
-            switch (arg) {
+            switch (static_cast<char>(arg)) {
             case 'g':
                 errno = 0;
                 gdb_port = strtoul(optarg, &endarg, 0);

--- a/src/dedicated_room/citra-room.cpp
+++ b/src/dedicated_room/citra-room.cpp
@@ -170,9 +170,9 @@ int main(int argc, char** argv) {
     };
 
     while (optind < argc) {
-        char arg = getopt_long(argc, argv, "n:d:p:m:w:g:u:t:a:i:hv", long_options, &option_index);
+        int arg = getopt_long(argc, argv, "n:d:p:m:w:g:u:t:a:i:hv", long_options, &option_index);
         if (arg != -1) {
-            switch (arg) {
+            switch (static_cast<char>(arg)) {
             case 'n':
                 room_name.assign(optarg);
                 break;


### PR DESCRIPTION
getopt_long returns a signed integer, and the parsing loop expects it to return -1 when an option specified doesn't exist (e.g. a filename).

The char type is not only the wrong return type for getopt_long, it is not guaranteed to be signed on all systems (e.g. ARM).

Obviously that wouldn't work, so this branch addresses the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4697)
<!-- Reviewable:end -->
