### PR TITLE
Fix GLES version header on picky drivers

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_util.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_util.cpp
@@ -14,8 +14,7 @@
 namespace OpenGL {
 
 GLuint LoadShader(const char* source, GLenum type) {
-    const std::string version = GLES ? R"(
-#version 310 es
+    const std::string version = GLES ? R"(#version 310 es
 
 #define CITRA_GLES
 


### PR DESCRIPTION
Some GLES drivers complain about the GLES version string not being on the first line. With how it was defined, technically it's not wrong as the first line is an empty newline. This puts the version declaration on the first line.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4698)
<!-- Reviewable:end -->
