### PR TITLE
applets/swkbd: Add callback support

### DIFF
--- a/src/citra_qt/applets/mii_selector.cpp
+++ b/src/citra_qt/applets/mii_selector.cpp
@@ -14,20 +14,6 @@
 #include "core/file_sys/file_backend.h"
 #include "core/hle/service/ptm/ptm.h"
 
-/**
- * Converts a UTF-16 text in a container to a UTF-8 std::string.
- */
-template <typename T>
-std::string TextFromBuffer(const T& text) {
-    const auto text_end = std::find(text.begin(), text.end(), u'\0');
-    const std::size_t text_size = std::distance(text.begin(), text_end);
-    std::u16string buffer(text_size, 0);
-    std::transform(text.begin(), text_end, buffer.begin(), [](u16_le character) {
-        return static_cast<char16_t>(static_cast<u16>(character));
-    });
-    return Common::UTF16ToUTF8(buffer);
-}
-
 QtMiiSelectorDialog::QtMiiSelectorDialog(QWidget* parent, QtMiiSelector* mii_selector_)
     : QDialog(parent), mii_selector(mii_selector_) {
     using namespace Frontend;
@@ -71,7 +57,7 @@ QtMiiSelectorDialog::QtMiiSelectorDialog(QWidget* parent, QtMiiSelector* mii_sel
                 file->Read(saved_miis_offset, sizeof(mii), mii_raw.data());
                 std::memcpy(&mii, mii_raw.data(), sizeof(mii));
                 if (mii.mii_id != 0) {
-                    std::string name = TextFromBuffer(mii.mii_name);
+                    std::string name = Common::UTF16BufferToUTF8(mii.mii_name);
                     miis.push_back(mii);
                     combobox->addItem(QString::fromStdString(name));
                 }

--- a/src/citra_qt/applets/swkbd.cpp
+++ b/src/citra_qt/applets/swkbd.cpp
@@ -109,12 +109,18 @@ void QtKeyboardDialog::HandleValidationError(Frontend::ValidationError error) {
 
 QtKeyboard::QtKeyboard(QWidget& parent_) : parent(parent_) {}
 
-void QtKeyboard::Setup(const Frontend::KeyboardConfig& config) {
-    SoftwareKeyboard::Setup(config);
+void QtKeyboard::Execute(const Frontend::KeyboardConfig& config) {
+    SoftwareKeyboard::Execute(config);
     if (this->config.button_config != Frontend::ButtonConfig::None) {
         ok_id = static_cast<u8>(this->config.button_config);
     }
     QMetaObject::invokeMethod(this, "OpenInputDialog", Qt::BlockingQueuedConnection);
+}
+
+void QtKeyboard::ShowError(const std::string& error) {
+    QString message = QString::fromStdString(error);
+    QMetaObject::invokeMethod(this, "ShowErrorDialog", Qt::BlockingQueuedConnection,
+                              Q_ARG(QString, message));
 }
 
 void QtKeyboard::OpenInputDialog() {
@@ -126,4 +132,8 @@ void QtKeyboard::OpenInputDialog() {
     LOG_INFO(Frontend, "SWKBD input dialog finished, text={}, button={}", dialog.text.toStdString(),
              dialog.button);
     Finalize(dialog.text.toStdString(), dialog.button);
+}
+
+void QtKeyboard::ShowErrorDialog(QString message) {
+    QMessageBox::critical(&parent, tr("Software Keyboard"), message);
 }

--- a/src/citra_qt/applets/swkbd.h
+++ b/src/citra_qt/applets/swkbd.h
@@ -48,10 +48,12 @@ class QtKeyboard final : public QObject, public Frontend::SoftwareKeyboard {
 
 public:
     explicit QtKeyboard(QWidget& parent);
-    void Setup(const Frontend::KeyboardConfig& config) override;
+    void Execute(const Frontend::KeyboardConfig& config) override;
+    void ShowError(const std::string& error) override;
 
 private:
     Q_INVOKABLE void OpenInputDialog();
+    Q_INVOKABLE void ShowErrorDialog(QString message);
 
     /// Index of the buttons
     u8 ok_id;

--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -4,10 +4,12 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
 #include <string>
 #include <vector>
 #include "common/common_types.h"
+#include "common/swap.h"
 
 namespace Common {
 
@@ -56,6 +58,20 @@ bool ComparePartialString(InIt begin, InIt end, const char* other) {
     }
     // Only return true if both strings finished at the same point
     return (begin == end) == (*other == '\0');
+}
+
+/**
+ * Converts a UTF-16 text in a container to a UTF-8 std::string.
+ */
+template <typename T>
+std::string UTF16BufferToUTF8(const T& text) {
+    const auto text_end = std::find(text.begin(), text.end(), u'\0');
+    const std::size_t text_size = std::distance(text.begin(), text_end);
+    std::u16string buffer(text_size, 0);
+    std::transform(text.begin(), text_end, buffer.begin(), [](u16_le character) {
+        return static_cast<char16_t>(static_cast<u16>(character));
+    });
+    return UTF16ToUTF8(buffer);
 }
 
 /**

--- a/src/core/frontend/applets/swkbd.cpp
+++ b/src/core/frontend/applets/swkbd.cpp
@@ -132,7 +132,7 @@ ValidationError SoftwareKeyboard::Finalize(const std::string& text, u8 button) {
     return ValidationError::None;
 }
 
-bool SoftwareKeyboard::DataReady() {
+bool SoftwareKeyboard::DataReady() const {
     return data_ready;
 }
 

--- a/src/core/frontend/applets/swkbd.cpp
+++ b/src/core/frontend/applets/swkbd.cpp
@@ -39,10 +39,6 @@ ValidationError SoftwareKeyboard::ValidateFilters(const std::string& input) cons
         // TODO: check the profanity filter
         LOG_INFO(Frontend, "App requested swkbd profanity filter, but its not implemented.");
     }
-    if (config.filters.enable_callback) {
-        // TODO: check the callback
-        LOG_INFO(Frontend, "App requested a swkbd callback, but its not implemented.");
-    }
     return ValidationError::None;
 }
 
@@ -132,11 +128,21 @@ ValidationError SoftwareKeyboard::Finalize(const std::string& text, u8 button) {
         return error;
     }
     data = {text, button};
+    data_ready = true;
     return ValidationError::None;
 }
 
-void DefaultKeyboard::Setup(const Frontend::KeyboardConfig& config) {
-    SoftwareKeyboard::Setup(config);
+bool SoftwareKeyboard::DataReady() {
+    return data_ready;
+}
+
+const KeyboardData& SoftwareKeyboard::ReceiveData() {
+    data_ready = false;
+    return data;
+}
+
+void DefaultKeyboard::Execute(const Frontend::KeyboardConfig& config) {
+    SoftwareKeyboard::Execute(config);
 
     auto cfg = Service::CFG::GetModule(Core::System::GetInstance());
     ASSERT_MSG(cfg, "CFG Module missing!");
@@ -155,6 +161,10 @@ void DefaultKeyboard::Setup(const Frontend::KeyboardConfig& config) {
     default:
         UNREACHABLE();
     }
+}
+
+void DefaultKeyboard::ShowError(const std::string& error) {
+    LOG_ERROR(Applet_SWKBD, "Default keyboard text is unaccepted! error: {}", error);
 }
 
 } // namespace Frontend

--- a/src/core/frontend/applets/swkbd.h
+++ b/src/core/frontend/applets/swkbd.h
@@ -93,7 +93,7 @@ public:
     /**
      * Whether the result data is ready to be received.
      */
-    bool DataReady();
+    bool DataReady() const;
 
     /**
      * Receives the current result data stored in the applet, and clears the ready state.

--- a/src/core/frontend/applets/swkbd.h
+++ b/src/core/frontend/applets/swkbd.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -82,13 +83,27 @@ enum class ValidationError {
 
 class SoftwareKeyboard {
 public:
-    virtual void Setup(const KeyboardConfig& config) {
-        this->config = KeyboardConfig(config);
+    /**
+     * Executes the software keyboard, configured with the given parameters.
+     */
+    virtual void Execute(const KeyboardConfig& config) {
+        this->config = config;
     }
 
-    const KeyboardData& ReceiveData() const {
-        return data;
-    }
+    /**
+     * Whether the result data is ready to be received.
+     */
+    bool DataReady();
+
+    /**
+     * Receives the current result data stored in the applet, and clears the ready state.
+     */
+    const KeyboardData& ReceiveData();
+
+    /**
+     * Shows an error text returned by the callback.
+     */
+    virtual void ShowError(const std::string& error) = 0;
 
     /**
      * Validates if the provided string breaks any of the filter rules. This is meant to be called
@@ -118,11 +133,14 @@ public:
 protected:
     KeyboardConfig config;
     KeyboardData data;
+
+    std::atomic_bool data_ready = false;
 };
 
 class DefaultKeyboard final : public SoftwareKeyboard {
 public:
-    void Setup(const KeyboardConfig& config) override;
+    void Execute(const KeyboardConfig& config) override;
+    void ShowError(const std::string& error) override;
 };
 
 } // namespace Frontend

--- a/src/core/hle/applets/mii_selector.cpp
+++ b/src/core/hle/applets/mii_selector.cpp
@@ -19,20 +19,6 @@
 
 namespace HLE::Applets {
 
-/**
- * Converts a UTF-16 text in a container to a UTF-8 std::string.
- */
-template <typename T>
-std::string TextFromBuffer(const T& text) {
-    const auto text_end = std::find(text.begin(), text.end(), u'\0');
-    const std::size_t text_size = std::distance(text.begin(), text_end);
-    std::u16string buffer(text_size, 0);
-    std::transform(text.begin(), text_end, buffer.begin(), [](u16_le character) {
-        return static_cast<char16_t>(static_cast<u16>(character));
-    });
-    return Common::UTF16ToUTF8(buffer);
-}
-
 ResultCode MiiSelector::ReceiveParameter(const Service::APT::MessageParameter& parameter) {
     if (parameter.signal != Service::APT::SignalType::Request) {
         LOG_ERROR(Service_APT, "unsupported signal {}", static_cast<u32>(parameter.signal));
@@ -156,7 +142,7 @@ MiiResult MiiSelector::GetStandardMiiResult() {
 Frontend::MiiSelectorConfig MiiSelector::ToFrontendConfig(const MiiConfig& config) const {
     Frontend::MiiSelectorConfig frontend_config;
     frontend_config.enable_cancel_button = config.enable_cancel_button == 1;
-    frontend_config.title = TextFromBuffer(config.title);
+    frontend_config.title = Common::UTF16BufferToUTF8(config.title);
     frontend_config.initially_selected_mii_index = config.initially_selected_mii_index;
     return frontend_config;
 }

--- a/src/core/hle/applets/swkbd.h
+++ b/src/core/hle/applets/swkbd.h
@@ -161,7 +161,7 @@ struct SoftwareKeyboardConfig {
     u32_le text_offset; ///< Offset in the SharedMemory where the output text starts
     u16_le text_length; ///< Length in characters of the output text
 
-    s32_le callback_result;
+    enum_le<SoftwareKeyboardCallbackResult> callback_result;
     std::array<u16_le, MAX_CALLBACK_MSG_LEN + 1> callback_msg;
     bool skip_at_check;
     INSERT_PADDING_BYTES(0xAB);


### PR DESCRIPTION
Implements callbacks in the HLE swkbd applet by sending the config (containing text offset and length) as a parameter of signal type `Message`. The application should then send the callback result parameter, also using signal type `Message`.

If the result is `Close`, an error dialog will be shown and then the applet will exit with code `BannedInput`. If the result is `Continue`, an error dialog will be shown and the user will be asked for input again.

Slight cleanups are also done to the code like replacing pointers with references.

Fix #4568

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4700)
<!-- Reviewable:end -->
