### PR TITLE
[EXPERIMENT] gl_rasterizer: decrease vertex buffer size

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -276,7 +276,7 @@ private:
     std::unique_ptr<ShaderProgramManager> shader_program_manager;
 
     // They shall be big enough for about one frame.
-    static constexpr std::size_t VERTEX_BUFFER_SIZE = 32 * 1024 * 1024;
+    static constexpr std::size_t VERTEX_BUFFER_SIZE = 16 * 1024 * 1024;
     static constexpr std::size_t INDEX_BUFFER_SIZE = 1 * 1024 * 1024;
     static constexpr std::size_t UNIFORM_BUFFER_SIZE = 2 * 1024 * 1024;
     static constexpr std::size_t TEXTURE_BUFFER_SIZE = 1 * 1024 * 1024;


### PR DESCRIPTION
We recently had increased reports about flickering issue in pokemon games on Nvidia graphics. This issue has been known since day 1 of hardware shader + vertex buffer streaming. The root cause has never been found. However, it was found that whether it flickers or not depends on vertex buffer size, or video memory usage in general. Originally we adjusted this size in the hardware shader PR to reduce the flickering. Recently, we merged some seemingly unrelated PR to video core (like screenshot, video capture etc.), which might affect this due to more video memory usage. I want people to test if reducing the size helps anything.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4703)
<!-- Reviewable:end -->
