### PR TITLE
ConfigureInput::GetUsedKeyboardKeys(): Change index of home button to use NativeButton instead of magic number.

### DIFF
--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -287,16 +287,16 @@ void ConfigureInput::OnHotkeysChanged(QList<QKeySequence> new_key_list) {
 QList<QKeySequence> ConfigureInput::GetUsedKeyboardKeys() {
     QList<QKeySequence> list;
     for (int button = 0; button < Settings::NativeButton::NumButtons; button++) {
-        auto button_param = buttons_param[button];
+        // TODO(adityaruplaha): Add home button to list when we finally emulate it
+        if (button == Settings::NativeButton::Home) {
+            continue;
+        }
 
+        auto button_param = buttons_param[button];
         if (button_param.Get("engine", "") == "keyboard") {
             list << QKeySequence(button_param.Get("code", 0));
         }
     }
-
-    // TODO(adityaruplaha): Add home button to list when we finally emulate it
-    // Button ID of home button is 14: Referred from citra_qt/configuration/config.cpp
-    list.removeOne(list.indexOf(QKeySequence(buttons_param[14].Get("code", 0))));
     return list;
 }
 


### PR DESCRIPTION
Fixes a bug where users can't bind anything to the B key.
Arises because this was not changed in #4537.

Tested with no issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4722)
<!-- Reviewable:end -->
