### PR TITLE
Destroy the callback after the stream is destroyed to prevent crashes on close

### DIFF
--- a/src/audio_core/cubeb_sink.cpp
+++ b/src/audio_core/cubeb_sink.cpp
@@ -96,8 +96,6 @@ CubebSink::~CubebSink() {
         return;
     }
 
-    impl->cb = nullptr;
-
     if (cubeb_stream_stop(impl->stream) != CUBEB_OK) {
         LOG_CRITICAL(Audio_Sink, "Error stopping cubeb stream");
     }


### PR DESCRIPTION
`impl->cb` is used in the cubeb stream callback, so setting it to `nullptr` while the stream is still running could cause a race condition. When setting `impl->cb` to `nullptr`, this calls the destructor for the `std::function` object, but the cubeb callback thread is still running and it could be using data inside the `std::function` at this point, causing a crash.

Note: i've managed to replicate this a few times now by having a game running while time stretching is enabled and then force closing citra with the task manager. Since this patch, I haven't been able to replicate the crash.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4723)
<!-- Reviewable:end -->
