### PR TITLE
Port yuzu-emu/yuzu#2312: "general: Use deducation guides for std::lock_guard and std::unique_lock"

### DIFF
--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -59,7 +59,7 @@ void EmuThread::run() {
 
             was_active = false;
         } else {
-            std::unique_lock<std::mutex> lock(running_mutex);
+            std::unique_lock lock{running_mutex};
             running_cv.wait(lock, [this] { return IsRunning() || exec_step || stop_run; });
         }
     }

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -49,7 +49,7 @@ public:
      * @note This function is thread-safe
      */
     void SetRunning(bool running) {
-        std::unique_lock<std::mutex> lock(running_mutex);
+        std::unique_lock lock{running_mutex};
         this->running = running;
         lock.unlock();
         running_cv.notify_all();

--- a/src/common/detached_tasks.cpp
+++ b/src/common/detached_tasks.cpp
@@ -16,22 +16,22 @@ DetachedTasks::DetachedTasks() {
 }
 
 void DetachedTasks::WaitForAllTasks() {
-    std::unique_lock<std::mutex> lock(mutex);
+    std::unique_lock lock{mutex};
     cv.wait(lock, [this]() { return count == 0; });
 }
 
 DetachedTasks::~DetachedTasks() {
-    std::unique_lock<std::mutex> lock(mutex);
+    std::unique_lock lock{mutex};
     ASSERT(count == 0);
     instance = nullptr;
 }
 
 void DetachedTasks::AddTask(std::function<void()> task) {
-    std::unique_lock<std::mutex> lock(instance->mutex);
+    std::unique_lock lock{instance->mutex};
     ++instance->count;
     std::thread([task{std::move(task)}]() {
         task();
-        std::unique_lock<std::mutex> lock(instance->mutex);
+        std::unique_lock lock{instance->mutex};
         --instance->count;
         std::notify_all_at_thread_exit(instance->cv, std::move(lock));
     })

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -44,12 +44,12 @@ public:
     }
 
     void AddBackend(std::unique_ptr<Backend> backend) {
-        std::lock_guard<std::mutex> lock(writing_mutex);
+        std::lock_guard lock{writing_mutex};
         backends.push_back(std::move(backend));
     }
 
     void RemoveBackend(std::string_view backend_name) {
-        std::lock_guard<std::mutex> lock(writing_mutex);
+        std::lock_guard lock{writing_mutex};
         const auto it =
             std::remove_if(backends.begin(), backends.end(),
                            [&backend_name](const auto& i) { return backend_name == i->GetName(); });
@@ -78,7 +78,7 @@ private:
         backend_thread = std::thread([&] {
             Entry entry;
             auto write_logs = [&](Entry& e) {
-                std::lock_guard<std::mutex> lock(writing_mutex);
+                std::lock_guard lock{writing_mutex};
                 for (const auto& backend : backends) {
                     backend->Write(e);
                 }

--- a/src/common/thread.h
+++ b/src/common/thread.h
@@ -16,7 +16,7 @@ namespace Common {
 class Event {
 public:
     void Set() {
-        std::lock_guard<std::mutex> lk(mutex);
+        std::lock_guard lk{mutex};
         if (!is_set) {
             is_set = true;
             condvar.notify_one();
@@ -24,14 +24,14 @@ public:
     }
 
     void Wait() {
-        std::unique_lock<std::mutex> lk(mutex);
+        std::unique_lock lk{mutex};
         condvar.wait(lk, [&] { return is_set; });
         is_set = false;
     }
 
     template <class Duration>
     bool WaitFor(const std::chrono::duration<Duration>& time) {
-        std::unique_lock<std::mutex> lk(mutex);
+        std::unique_lock lk(mutex);
         if (!condvar.wait_for(lk, time, [this] { return is_set; }))
             return false;
         is_set = false;
@@ -40,7 +40,7 @@ public:
 
     template <class Clock, class Duration>
     bool WaitUntil(const std::chrono::time_point<Clock, Duration>& time) {
-        std::unique_lock<std::mutex> lk(mutex);
+        std::unique_lock lk{mutex};
         if (!condvar.wait_until(lk, time, [this] { return is_set; }))
             return false;
         is_set = false;
@@ -48,7 +48,7 @@ public:
     }
 
     void Reset() {
-        std::unique_lock<std::mutex> lk(mutex);
+        std::unique_lock lk{mutex};
         // no other action required, since wait loops on the predicate and any lingering signal will
         // get cleared on the first iteration
         is_set = false;
@@ -66,7 +66,7 @@ public:
 
     /// Blocks until all "count" threads have called Sync()
     void Sync() {
-        std::unique_lock<std::mutex> lk(mutex);
+        std::unique_lock lk{mutex};
         const std::size_t current_generation = generation;
 
         if (++waiting == count) {
@@ -80,7 +80,7 @@ public:
     }
 
     std::size_t Generation() const {
-        std::unique_lock<std::mutex> lk(mutex);
+        std::unique_lock lk(mutex);
         return generation;
     }
 

--- a/src/common/threadsafe_queue.h
+++ b/src/common/threadsafe_queue.h
@@ -78,7 +78,7 @@ public:
 
     T PopWait() {
         if (Empty()) {
-            std::unique_lock<std::mutex> lock(cv_mutex);
+            std::unique_lock lock{cv_mutex};
             cv.wait(lock, [this]() { return !Empty(); });
         }
         T t;
@@ -137,7 +137,7 @@ public:
 
     template <typename Arg>
     void Push(Arg&& t) {
-        std::lock_guard<std::mutex> lock(write_lock);
+        std::lock_guard lock{write_lock};
         spsc_queue.Push(t);
     }
 

--- a/src/core/announce_multiplayer_session.cpp
+++ b/src/core/announce_multiplayer_session.cpp
@@ -65,14 +65,14 @@ void AnnounceMultiplayerSession::Stop() {
 
 AnnounceMultiplayerSession::CallbackHandle AnnounceMultiplayerSession::BindErrorCallback(
     std::function<void(const Common::WebResult&)> function) {
-    std::lock_guard<std::mutex> lock(callback_mutex);
+    std::lock_guard lock(callback_mutex);
     auto handle = std::make_shared<std::function<void(const Common::WebResult&)>>(function);
     error_callbacks.insert(handle);
     return handle;
 }
 
 void AnnounceMultiplayerSession::UnbindErrorCallback(CallbackHandle handle) {
-    std::lock_guard<std::mutex> lock(callback_mutex);
+    std::lock_guard lock(callback_mutex);
     error_callbacks.erase(handle);
 }
 
@@ -112,7 +112,7 @@ void AnnounceMultiplayerSession::AnnounceMultiplayerLoop() {
         UpdateBackendData(room);
         Common::WebResult result = backend->Update();
         if (result.result_code != Common::WebResult::Code::Success) {
-            std::lock_guard<std::mutex> lock(callback_mutex);
+            std::lock_guard lock(callback_mutex);
             for (auto callback : error_callbacks) {
                 (*callback)(result);
             }

--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -28,7 +28,7 @@ private:
         explicit Device(std::weak_ptr<TouchState>&& touch_state) : touch_state(touch_state) {}
         std::tuple<float, float, bool> GetStatus() const override {
             if (auto state = touch_state.lock()) {
-                std::lock_guard<std::mutex> guard(state->mutex);
+                std::lock_guard guard{state->mutex};
                 return std::make_tuple(state->touch_x, state->touch_y, state->touch_pressed);
             }
             return std::make_tuple(0.0f, 0.0f, false);
@@ -98,7 +98,7 @@ void EmuWindow::TouchPressed(unsigned framebuffer_x, unsigned framebuffer_y) {
 
     if (Settings::values.toggle_3d && framebuffer_x >= framebuffer_layout.width / 2)
         framebuffer_x -= framebuffer_layout.width / 2;
-    std::lock_guard<std::mutex> guard(touch_state->mutex);
+    std::lock_guard guard(touch_state->mutex);
     if (Settings::values.toggle_3d) {
         touch_state->touch_x =
             static_cast<float>(framebuffer_x - framebuffer_layout.bottom_screen.left / 2) /
@@ -117,7 +117,7 @@ void EmuWindow::TouchPressed(unsigned framebuffer_x, unsigned framebuffer_y) {
 }
 
 void EmuWindow::TouchReleased() {
-    std::lock_guard<std::mutex> guard(touch_state->mutex);
+    std::lock_guard guard{touch_state->mutex};
     touch_state->touch_pressed = false;
     touch_state->touch_x = 0;
     touch_state->touch_y = 0;

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1575,7 +1575,7 @@ void SVC::CallSVC(u32 immediate) {
     MICROPROFILE_SCOPE(Kernel_SVC);
 
     // Lock the global kernel mutex when we enter the kernel HLE.
-    std::lock_guard<std::recursive_mutex> lock(HLE::g_hle_lock);
+    std::lock_guard lock{HLE::g_hle_lock};
 
     DEBUG_ASSERT_MSG(kernel.GetCurrentProcess()->status == ProcessStatus::Running,
                      "Running threads from exiting processes is unimplemented");

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -41,7 +41,7 @@ constexpr u16 BroadcastNetworkNodeId = 0xFFFF;
 constexpr u16 HostDestNodeId = 1;
 
 std::list<Network::WifiPacket> NWM_UDS::GetReceivedBeacons(const MacAddress& sender) {
-    std::lock_guard<std::mutex> lock(beacon_mutex);
+    std::lock_guard lock(beacon_mutex);
     if (sender != Network::BroadcastMac) {
         std::list<Network::WifiPacket> filtered_list;
         const auto beacon = std::find_if(received_beacons.begin(), received_beacons.end(),
@@ -107,7 +107,7 @@ void NWM_UDS::BroadcastNodeMap() {
 }
 
 void NWM_UDS::HandleNodeMapPacket(const Network::WifiPacket& packet) {
-    std::lock_guard<std::mutex> lock(connection_status_mutex);
+    std::lock_guard lock(connection_status_mutex);
     if (connection_status.status == static_cast<u32>(NetworkStatus::ConnectedAsHost)) {
         LOG_DEBUG(Service_NWM, "Ignored NodeMapPacket since connection_status is host");
         return;
@@ -129,7 +129,7 @@ void NWM_UDS::HandleNodeMapPacket(const Network::WifiPacket& packet) {
 }
 
 void NWM_UDS::HandleBeaconFrame(const Network::WifiPacket& packet) {
-    std::lock_guard<std::mutex> lock(beacon_mutex);
+    std::lock_guard lock(beacon_mutex);
     const auto unique_beacon =
         std::find_if(received_beacons.begin(), received_beacons.end(),
                      [&packet](const Network::WifiPacket& new_packet) {
@@ -153,7 +153,7 @@ void NWM_UDS::HandleAssociationResponseFrame(const Network::WifiPacket& packet) 
     ASSERT_MSG(std::get<AssocStatus>(assoc_result) == AssocStatus::Successful,
                "Could not join network");
     {
-        std::lock_guard<std::mutex> lock(connection_status_mutex);
+        std::lock_guard lock(connection_status_mutex);
         if (connection_status.status != static_cast<u32>(NetworkStatus::Connecting)) {
             LOG_DEBUG(Service_NWM,
                       "Ignored AssociationResponseFrame because connection status is {}",
@@ -175,8 +175,8 @@ void NWM_UDS::HandleAssociationResponseFrame(const Network::WifiPacket& packet) 
 }
 
 void NWM_UDS::HandleEAPoLPacket(const Network::WifiPacket& packet) {
-    std::unique_lock<std::recursive_mutex> hle_lock(HLE::g_hle_lock, std::defer_lock);
-    std::unique_lock<std::mutex> lock(connection_status_mutex, std::defer_lock);
+    std::unique_lock hle_lock(HLE::g_hle_lock, std::defer_lock);
+    std::unique_lock lock(connection_status_mutex, std::defer_lock);
     std::lock(hle_lock, lock);
 
     if (GetEAPoLFrameType(packet.data) == EAPoLStartMagic) {
@@ -295,8 +295,8 @@ void NWM_UDS::HandleEAPoLPacket(const Network::WifiPacket& packet) {
 
 void NWM_UDS::HandleSecureDataPacket(const Network::WifiPacket& packet) {
     auto secure_data = ParseSecureDataHeader(packet.data);
-    std::unique_lock<std::recursive_mutex> hle_lock(HLE::g_hle_lock, std::defer_lock);
-    std::unique_lock<std::mutex> lock(connection_status_mutex, std::defer_lock);
+    std::unique_lock hle_lock(HLE::g_hle_lock, std::defer_lock);
+    std::unique_lock lock(connection_status_mutex, std::defer_lock);
     std::lock(hle_lock, lock);
 
     if (connection_status.status != static_cast<u32>(NetworkStatus::ConnectedAsHost) &&
@@ -358,7 +358,7 @@ void NWM_UDS::StartConnectionSequence(const MacAddress& server) {
     using Network::WifiPacket;
     WifiPacket auth_request;
     {
-        std::lock_guard<std::mutex> lock(connection_status_mutex);
+        std::lock_guard lock(connection_status_mutex);
         connection_status.status = static_cast<u32>(NetworkStatus::Connecting);
 
         // TODO(Subv): Handle timeout.
@@ -378,7 +378,7 @@ void NWM_UDS::SendAssociationResponseFrame(const MacAddress& address) {
     WifiPacket assoc_response;
 
     {
-        std::lock_guard<std::mutex> lock(connection_status_mutex);
+        std::lock_guard lock(connection_status_mutex);
         if (connection_status.status != static_cast<u32>(NetworkStatus::ConnectedAsHost)) {
             LOG_ERROR(Service_NWM, "Connection sequence aborted, because connection status is {}",
                       connection_status.status);
@@ -404,7 +404,7 @@ void NWM_UDS::HandleAuthenticationFrame(const Network::WifiPacket& packet) {
         using Network::WifiPacket;
         WifiPacket auth_request;
         {
-            std::lock_guard<std::mutex> lock(connection_status_mutex);
+            std::lock_guard lock(connection_status_mutex);
             if (connection_status.status != static_cast<u32>(NetworkStatus::ConnectedAsHost)) {
                 LOG_ERROR(Service_NWM,
                           "Connection sequence aborted, because connection status is {}",
@@ -438,8 +438,8 @@ void NWM_UDS::HandleAuthenticationFrame(const Network::WifiPacket& packet) {
 
 void NWM_UDS::HandleDeauthenticationFrame(const Network::WifiPacket& packet) {
     LOG_DEBUG(Service_NWM, "called");
-    std::unique_lock<std::recursive_mutex> hle_lock(HLE::g_hle_lock, std::defer_lock);
-    std::unique_lock<std::mutex> lock(connection_status_mutex, std::defer_lock);
+    std::unique_lock hle_lock(HLE::g_hle_lock, std::defer_lock);
+    std::unique_lock lock(connection_status_mutex, std::defer_lock);
     std::lock(hle_lock, lock);
     if (connection_status.status != static_cast<u32>(NetworkStatus::ConnectedAsHost)) {
         LOG_ERROR(Service_NWM, "Got deauthentication frame but we are not the host");
@@ -633,7 +633,7 @@ ResultVal<std::shared_ptr<Kernel::Event>> NWM_UDS::Initialize(
     }
 
     {
-        std::lock_guard<std::mutex> lock(connection_status_mutex);
+        std::lock_guard lock(connection_status_mutex);
 
         // Reset the connection status, it contains all zeros after initialization,
         // except for the actual status value.
@@ -686,7 +686,7 @@ void NWM_UDS::GetConnectionStatus(Kernel::HLERequestContext& ctx) {
 
     rb.Push(RESULT_SUCCESS);
     {
-        std::lock_guard<std::mutex> lock(connection_status_mutex);
+        std::lock_guard lock(connection_status_mutex);
         rb.PushRaw(connection_status);
 
         // Reset the bitmask of changed nodes after each call to this
@@ -711,7 +711,7 @@ void NWM_UDS::GetNodeInformation(Kernel::HLERequestContext& ctx) {
     }
 
     {
-        std::lock_guard<std::mutex> lock(connection_status_mutex);
+        std::lock_guard lock(connection_status_mutex);
         auto itr = std::find_if(node_info.begin(), node_info.end(),
                                 [network_node_id](const NodeInfo& node) {
                                     return node.network_node_id == network_node_id;
@@ -770,7 +770,7 @@ void NWM_UDS::Bind(Kernel::HLERequestContext& ctx) {
     // Create a new event for this bind node.
     auto event = system.Kernel().CreateEvent(Kernel::ResetType::OneShot,
                                              "NWM::BindNodeEvent" + std::to_string(bind_node_id));
-    std::lock_guard<std::mutex> lock(connection_status_mutex);
+    std::lock_guard lock(connection_status_mutex);
 
     ASSERT(channel_data.find(data_channel) == channel_data.end());
     // TODO(B3N30): Support more than one bind node per channel.
@@ -792,7 +792,7 @@ void NWM_UDS::Unbind(Kernel::HLERequestContext& ctx) {
         return;
     }
 
-    std::lock_guard<std::mutex> lock(connection_status_mutex);
+    std::lock_guard lock(connection_status_mutex);
 
     auto itr =
         std::find_if(channel_data.begin(), channel_data.end(), [bind_node_id](const auto& data) {
@@ -819,7 +819,7 @@ ResultCode NWM_UDS::BeginHostingNetwork(const u8* network_info_buffer,
     // TODO(Subv): Store the passphrase and verify it when attempting a connection.
 
     {
-        std::lock_guard<std::mutex> lock(connection_status_mutex);
+        std::lock_guard lock(connection_status_mutex);
         network_info = {};
         std::memcpy(&network_info, network_info_buffer, network_info_size);
 
@@ -933,7 +933,7 @@ void NWM_UDS::DestroyNetwork(Kernel::HLERequestContext& ctx) {
     system.CoreTiming().UnscheduleEvent(beacon_broadcast_event, 0);
 
     // Only a host can destroy
-    std::lock_guard<std::mutex> lock(connection_status_mutex);
+    std::lock_guard lock(connection_status_mutex);
     if (connection_status.status != static_cast<u8>(NetworkStatus::ConnectedAsHost)) {
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
         rb.Push(ResultCode(ErrCodes::WrongStatus, ErrorModule::UDS, ErrorSummary::InvalidState,
@@ -970,7 +970,7 @@ void NWM_UDS::DisconnectNetwork(Kernel::HLERequestContext& ctx) {
     using Network::WifiPacket;
     WifiPacket deauth;
     {
-        std::lock_guard<std::mutex> lock(connection_status_mutex);
+        std::lock_guard lock(connection_status_mutex);
         if (connection_status.status == static_cast<u32>(NetworkStatus::ConnectedAsHost)) {
             // A real 3ds makes strange things here. We do the same
             u16_le tmp_node_id = connection_status.network_node_id;
@@ -1027,7 +1027,7 @@ void NWM_UDS::SendTo(Kernel::HLERequestContext& ctx) {
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
 
-    std::lock_guard<std::mutex> lock(connection_status_mutex);
+    std::lock_guard lock(connection_status_mutex);
     if (connection_status.status != static_cast<u32>(NetworkStatus::ConnectedAsClient) &&
         connection_status.status != static_cast<u32>(NetworkStatus::ConnectedAsHost)) {
         rb.Push(ResultCode(ErrorDescription::NotAuthorized, ErrorModule::UDS,
@@ -1091,7 +1091,7 @@ void NWM_UDS::PullPacket(Kernel::HLERequestContext& ctx) {
     // This size is hard coded into the uds module. We don't know the meaning yet.
     u32 buff_size = std::min<u32>(max_out_buff_size_aligned, 0x172) << 2;
 
-    std::lock_guard<std::mutex> lock(connection_status_mutex);
+    std::lock_guard lock(connection_status_mutex);
     if (connection_status.status != static_cast<u32>(NetworkStatus::ConnectedAsHost) &&
         connection_status.status != static_cast<u32>(NetworkStatus::ConnectedAsClient) &&
         connection_status.status != static_cast<u32>(NetworkStatus::ConnectedAsSpectator)) {
@@ -1154,7 +1154,7 @@ void NWM_UDS::GetChannel(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x1A, 0, 0);
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
 
-    std::lock_guard<std::mutex> lock(connection_status_mutex);
+    std::lock_guard lock(connection_status_mutex);
     bool is_connected = connection_status.status != static_cast<u32>(NetworkStatus::NotConnected);
 
     u8 channel = is_connected ? network_channel : 0;

--- a/src/core/perf_stats.cpp
+++ b/src/core/perf_stats.cpp
@@ -18,13 +18,13 @@ using std::chrono::microseconds;
 namespace Core {
 
 void PerfStats::BeginSystemFrame() {
-    std::lock_guard<std::mutex> lock(object_mutex);
+    std::lock_guard lock{object_mutex};
 
     frame_begin = Clock::now();
 }
 
 void PerfStats::EndSystemFrame() {
-    std::lock_guard<std::mutex> lock(object_mutex);
+    std::lock_guard lock{object_mutex};
 
     auto frame_end = Clock::now();
     accumulated_frametime += frame_end - frame_begin;
@@ -35,13 +35,13 @@ void PerfStats::EndSystemFrame() {
 }
 
 void PerfStats::EndGameFrame() {
-    std::lock_guard<std::mutex> lock(object_mutex);
+    std::lock_guard lock{object_mutex};
 
     game_frames += 1;
 }
 
 PerfStats::Results PerfStats::GetAndResetStats(microseconds current_system_time_us) {
-    std::lock_guard<std::mutex> lock(object_mutex);
+    std::lock_guard lock(object_mutex);
 
     const auto now = Clock::now();
     // Walltime elapsed since stats were reset
@@ -67,7 +67,7 @@ PerfStats::Results PerfStats::GetAndResetStats(microseconds current_system_time_
 }
 
 double PerfStats::GetLastFrameTimeScale() {
-    std::lock_guard<std::mutex> lock(object_mutex);
+    std::lock_guard lock{object_mutex};
 
     constexpr double FRAME_LENGTH = 1.0 / GPU::SCREEN_REFRESH_RATE;
     return duration_cast<DoubleSecs>(previous_frame_length).count() / FRAME_LENGTH;

--- a/src/input_common/keyboard.cpp
+++ b/src/input_common/keyboard.cpp
@@ -36,18 +36,18 @@ struct KeyButtonPair {
 class KeyButtonList {
 public:
     void AddKeyButton(int key_code, KeyButton* key_button) {
-        std::lock_guard<std::mutex> guard(mutex);
+        std::lock_guard guard{mutex};
         list.push_back(KeyButtonPair{key_code, key_button});
     }
 
     void RemoveKeyButton(const KeyButton* key_button) {
-        std::lock_guard<std::mutex> guard(mutex);
+        std::lock_guard guard{mutex};
         list.remove_if(
             [key_button](const KeyButtonPair& pair) { return pair.key_button == key_button; });
     }
 
     void ChangeKeyStatus(int key_code, bool pressed) {
-        std::lock_guard<std::mutex> guard(mutex);
+        std::lock_guard guard{mutex};
         for (const KeyButtonPair& pair : list) {
             if (pair.key_code == key_code)
                 pair.key_button->status.store(pressed);
@@ -55,7 +55,7 @@ public:
     }
 
     void ChangeAllKeyStatus(bool pressed) {
-        std::lock_guard<std::mutex> guard(mutex);
+        std::lock_guard guard{mutex};
         for (const KeyButtonPair& pair : list) {
             pair.key_button->status.store(pressed);
         }

--- a/src/input_common/motion_emu.cpp
+++ b/src/input_common/motion_emu.cpp
@@ -40,7 +40,7 @@ public:
     void Tilt(int x, int y) {
         auto mouse_move = Common::MakeVec(x, y) - mouse_origin;
         if (is_tilting) {
-            std::lock_guard<std::mutex> guard(tilt_mutex);
+            std::lock_guard guard{tilt_mutex};
             if (mouse_move.x == 0 && mouse_move.y == 0) {
                 tilt_angle = 0;
             } else {
@@ -52,13 +52,13 @@ public:
     }
 
     void EndTilt() {
-        std::lock_guard<std::mutex> guard(tilt_mutex);
+        std::lock_guard guard{tilt_mutex};
         tilt_angle = 0;
         is_tilting = false;
     }
 
     std::tuple<Common::Vec3<float>, Common::Vec3<float>> GetStatus() {
-        std::lock_guard<std::mutex> guard(status_mutex);
+        std::lock_guard guard{status_mutex};
         return status;
     }
 
@@ -95,7 +95,7 @@ private:
             old_q = q;
 
             {
-                std::lock_guard<std::mutex> guard(tilt_mutex);
+                std::lock_guard guard{tilt_mutex};
 
                 // Find the quaternion describing current 3DS tilting
                 q = Common::MakeQuaternion(
@@ -117,7 +117,7 @@ private:
 
             // Update the sensor state
             {
-                std::lock_guard<std::mutex> guard(status_mutex);
+                std::lock_guard guard{status_mutex};
                 status = std::make_tuple(gravity, angular_rate);
             }
         }

--- a/src/input_common/udp/client.cpp
+++ b/src/input_common/udp/client.cpp
@@ -165,7 +165,7 @@ void Client::OnPadData(Response::PadData data) {
     Common::Vec3f accel = Common::MakeVec<float>(-data.accel.x, data.accel.y, -data.accel.z);
     Common::Vec3f gyro = Common::MakeVec<float>(-data.gyro.pitch, -data.gyro.yaw, data.gyro.roll);
     {
-        std::lock_guard<std::mutex> guard(status->update_mutex);
+        std::lock_guard guard(status->update_mutex);
 
         status->motion_status = {accel, gyro};
 

--- a/src/input_common/udp/udp.cpp
+++ b/src/input_common/udp/udp.cpp
@@ -15,7 +15,7 @@ class UDPTouchDevice final : public Input::TouchDevice {
 public:
     explicit UDPTouchDevice(std::shared_ptr<DeviceStatus> status_) : status(std::move(status_)) {}
     std::tuple<float, float, bool> GetStatus() const {
-        std::lock_guard<std::mutex> guard(status->update_mutex);
+        std::lock_guard guard(status->update_mutex);
         return status->touch_status;
     }
 
@@ -27,7 +27,7 @@ class UDPMotionDevice final : public Input::MotionDevice {
 public:
     explicit UDPMotionDevice(std::shared_ptr<DeviceStatus> status_) : status(std::move(status_)) {}
     std::tuple<Common::Vec3<float>, Common::Vec3<float>> GetStatus() const {
-        std::lock_guard<std::mutex> guard(status->update_mutex);
+        std::lock_guard guard(status->update_mutex);
         return status->motion_status;
     }
 
@@ -41,7 +41,7 @@ public:
 
     std::unique_ptr<Input::TouchDevice> Create(const Common::ParamPackage& params) override {
         {
-            std::lock_guard<std::mutex> guard(status->update_mutex);
+            std::lock_guard guard(status->update_mutex);
             status->touch_calibration.emplace();
             // These default values work well for DS4 but probably not other touch inputs
             status->touch_calibration->min_x = params.Get("min_x", 100);

--- a/src/network/room_member.cpp
+++ b/src/network/room_member.cpp
@@ -157,7 +157,7 @@ bool RoomMember::RoomMemberImpl::IsConnected() const {
 void RoomMember::RoomMemberImpl::MemberLoop() {
     // Receive packets while the connection is open
     while (IsConnected()) {
-        std::lock_guard<std::mutex> lock(network_mutex);
+        std::lock_guard lock(network_mutex);
         ENetEvent event;
         if (enet_host_service(client, &event, 100) > 0) {
             switch (event.type) {
@@ -245,7 +245,7 @@ void RoomMember::RoomMemberImpl::MemberLoop() {
             }
         }
         {
-            std::lock_guard<std::mutex> lock(send_list_mutex);
+            std::lock_guard lock(send_list_mutex);
             for (const auto& packet : send_list) {
                 ENetPacket* enetPacket = enet_packet_create(packet.GetData(), packet.GetDataSize(),
                                                             ENET_PACKET_FLAG_RELIABLE);
@@ -263,7 +263,7 @@ void RoomMember::RoomMemberImpl::StartLoop() {
 }
 
 void RoomMember::RoomMemberImpl::Send(Packet&& packet) {
-    std::lock_guard<std::mutex> lock(send_list_mutex);
+    std::lock_guard lock(send_list_mutex);
     send_list.push_back(std::move(packet));
 }
 
@@ -318,7 +318,7 @@ void RoomMember::RoomMemberImpl::HandleRoomInformationPacket(const ENetEvent* ev
         packet >> member.avatar_url;
 
         {
-            std::lock_guard<std::mutex> lock(username_mutex);
+            std::lock_guard lock(username_mutex);
             if (member.nickname == nickname) {
                 username = member.username;
             }
@@ -473,7 +473,7 @@ RoomMember::RoomMemberImpl::Callbacks::Get() {
 
 template <typename T>
 void RoomMember::RoomMemberImpl::Invoke(const T& data) {
-    std::lock_guard<std::mutex> lock(callback_mutex);
+    std::lock_guard lock(callback_mutex);
     CallbackSet<T> callback_set = callbacks.Get<T>();
     for (auto const& callback : callback_set)
         (*callback)(data);
@@ -482,7 +482,7 @@ void RoomMember::RoomMemberImpl::Invoke(const T& data) {
 template <typename T>
 RoomMember::CallbackHandle<T> RoomMember::RoomMemberImpl::Bind(
     std::function<void(const T&)> callback) {
-    std::lock_guard<std::mutex> lock(callback_mutex);
+    std::lock_guard lock(callback_mutex);
     CallbackHandle<T> handle;
     handle = std::make_shared<std::function<void(const T&)>>(callback);
     callbacks.Get<T>().insert(handle);
@@ -512,7 +512,7 @@ const std::string& RoomMember::GetNickname() const {
 }
 
 const std::string& RoomMember::GetUsername() const {
-    std::lock_guard<std::mutex> lock(room_member_impl->username_mutex);
+    std::lock_guard lock(room_member_impl->username_mutex);
     return room_member_impl->username;
 }
 
@@ -663,7 +663,7 @@ RoomMember::CallbackHandle<Room::BanList> RoomMember::BindOnBanListReceived(
 
 template <typename T>
 void RoomMember::Unbind(CallbackHandle<T> handle) {
-    std::lock_guard<std::mutex> lock(room_member_impl->callback_mutex);
+    std::lock_guard lock(room_member_impl->callback_mutex);
     room_member_impl->callbacks.Get<T>().erase(handle);
 }
 

--- a/src/video_core/debug_utils/debug_utils.cpp
+++ b/src/video_core/debug_utils/debug_utils.cpp
@@ -43,7 +43,7 @@ namespace Pica {
 
 void DebugContext::DoOnEvent(Event event, void* data) {
     {
-        std::unique_lock<std::mutex> lock(breakpoint_mutex);
+        std::unique_lock lock{breakpoint_mutex};
 
         // Commit the rasterizer's caches so framebuffers, render targets, etc. will show on debug
         // widgets
@@ -66,7 +66,7 @@ void DebugContext::DoOnEvent(Event event, void* data) {
 
 void DebugContext::Resume() {
     {
-        std::lock_guard<std::mutex> lock(breakpoint_mutex);
+        std::lock_guard lock{breakpoint_mutex};
 
         // Tell all observers that we are about to resume
         for (auto& breakpoint_observer : breakpoint_observers) {
@@ -282,14 +282,14 @@ void StartPicaTracing() {
         return;
     }
 
-    std::lock_guard<std::mutex> lock(pica_trace_mutex);
+    std::lock_guard lock(pica_trace_mutex);
     pica_trace = std::make_unique<PicaTrace>();
 
     g_is_pica_tracing = true;
 }
 
 void OnPicaRegWrite(PicaTrace::Write write) {
-    std::lock_guard<std::mutex> lock(pica_trace_mutex);
+    std::lock_guard lock(pica_trace_mutex);
 
     if (!g_is_pica_tracing)
         return;
@@ -307,7 +307,7 @@ std::unique_ptr<PicaTrace> FinishPicaTracing() {
     g_is_pica_tracing = false;
 
     // Wait until running tracing is finished
-    std::lock_guard<std::mutex> lock(pica_trace_mutex);
+    std::lock_guard lock(pica_trace_mutex);
     std::unique_ptr<PicaTrace> ret(std::move(pica_trace));
 
     return ret;

--- a/src/video_core/debug_utils/debug_utils.h
+++ b/src/video_core/debug_utils/debug_utils.h
@@ -63,14 +63,14 @@ public:
         /// Constructs the object such that it observes events of the given DebugContext.
         BreakPointObserver(std::shared_ptr<DebugContext> debug_context)
             : context_weak(debug_context) {
-            std::unique_lock<std::mutex> lock(debug_context->breakpoint_mutex);
+            std::unique_lock lock{debug_context->breakpoint_mutex};
             debug_context->breakpoint_observers.push_back(this);
         }
 
         virtual ~BreakPointObserver() {
             auto context = context_weak.lock();
             if (context) {
-                std::unique_lock<std::mutex> lock(context->breakpoint_mutex);
+                std::unique_lock lock(context->breakpoint_mutex);
                 context->breakpoint_observers.remove(this);
 
                 // If we are the last observer to be destroyed, tell the debugger context that

--- a/src/web_service/web_backend.cpp
+++ b/src/web_service/web_backend.cpp
@@ -26,7 +26,7 @@ constexpr std::size_t TIMEOUT_SECONDS = 30;
 struct Client::Impl {
     Impl(std::string host, std::string username, std::string token)
         : host{std::move(host)}, username{std::move(username)}, token{std::move(token)} {
-        std::lock_guard<std::mutex> lock(jwt_cache.mutex);
+        std::lock_guard lock{jwt_cache.mutex};
         if (this->username == jwt_cache.username && this->token == jwt_cache.token) {
             jwt = jwt_cache.jwt;
         }
@@ -154,7 +154,7 @@ struct Client::Impl {
         if (result.result_code != Common::WebResult::Code::Success) {
             LOG_ERROR(WebService, "UpdateJWT failed");
         } else {
-            std::lock_guard<std::mutex> lock(jwt_cache.mutex);
+            std::lock_guard lock{jwt_cache.mutex};
             jwt_cache.username = username;
             jwt_cache.token = token;
             jwt_cache.jwt = jwt = result.returned_data;


### PR DESCRIPTION
See yuzu-emu/yuzu#2312 for more details.

**Original description**:
Since C++17, the introduction of deduction guides for locking facilities means that we no longer need to hardcode the mutex type into the locks and guards themselves, making it easier to switch mutex types, should it ever be necessary in the future (and also makes for less reading).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4726)
<!-- Reviewable:end -->
