### PR TITLE
Set accepted EULA version to max value

### DIFF
--- a/src/core/hle/service/cecd/cecd.cpp
+++ b/src/core/hle/service/cecd/cecd.cpp
@@ -615,9 +615,8 @@ void Module::Interface::ReadData(Kernel::HLERequestContext& ctx) {
     switch (info_type) {
     case CecSystemInfoType::EulaVersion: {
         auto cfg = Service::CFG::GetModule(cecd->system);
-        u32 version = cfg->GetEULAVersion();
-        // only the first two bytes contain the version
-        dest_buffer.Write(&version, 0, 2);
+        Service::CFG::EULAVersion version = cfg->GetEULAVersion();
+        dest_buffer.Write(&version, 0, sizeof(version));
         break;
     }
     case CecSystemInfoType::Eula:

--- a/src/core/hle/service/cecd/cecd.cpp
+++ b/src/core/hle/service/cecd/cecd.cpp
@@ -21,6 +21,7 @@
 #include "core/hle/service/cecd/cecd_ndm.h"
 #include "core/hle/service/cecd/cecd_s.h"
 #include "core/hle/service/cecd/cecd_u.h"
+#include "core/hle/service/cfg/cfg.h"
 #include "fmt/format.h"
 
 namespace Service::CECD {
@@ -612,10 +613,13 @@ void Module::Interface::ReadData(Kernel::HLERequestContext& ctx) {
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 4);
     std::vector<u8> buffer;
     switch (info_type) {
-    case CecSystemInfoType::EulaVersion: // TODO: Read config Eula version
-        buffer = {0xFF, 0xFF};
-        dest_buffer.Write(buffer.data(), 0, buffer.size());
+    case CecSystemInfoType::EulaVersion: {
+        auto cfg = Service::CFG::GetModule(cecd->system);
+        u32 version = cfg->GetEULAVersion();
+        // only the first two bytes contain the version
+        dest_buffer.Write(&version, 0, 2);
         break;
+    }
     case CecSystemInfoType::Eula:
         buffer = {0x01}; // Eula agreed
         dest_buffer.Write(buffer.data(), 0, buffer.size());

--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -565,10 +565,10 @@ ResultCode Module::LoadConfigNANDSaveFile() {
 
 Module::Module() {
     LoadConfigNANDSaveFile();
-    // Check the config savegame EULA Version and update it to 0xFFFF if necessary
+    // Check the config savegame EULA Version and update it to 0x7F7F if necessary
     // so users will never get a promt to accept EULA
     if (GetEULAVersion() != MAX_EULA_VERSION) {
-        LOG_INFO(Service_CFG, "Updating accepted EULA version to {}", MAX_EULA_VERSION);
+        LOG_INFO(Service_CFG, "Updating accepted EULA version to {:X}", MAX_EULA_VERSION);
         SetEULAVersion(Service::CFG::MAX_EULA_VERSION);
         UpdateConfigNANDSavegame();
     }

--- a/src/core/hle/service/cfg/cfg.h
+++ b/src/core/hle/service/cfg/cfg.h
@@ -399,6 +399,18 @@ public:
     u64 GetConsoleUniqueId();
 
     /**
+     * Sets the accepted EULA version in the config savegame.
+     * @param version the version to set
+     */
+    void SetEULAVersion(u32 version);
+
+    /**
+     * Gets the accepted EULA version from config savegame.
+     * @returns the EULA version
+     */
+    u32 GetEULAVersion();
+
+    /**
      * Writes the config savegame memory buffer to the config savegame file in the filesystem
      * @returns ResultCode indicating the result of the operation, 0 on success
      */

--- a/src/core/hle/service/cfg/cfg.h
+++ b/src/core/hle/service/cfg/cfg.h
@@ -47,6 +47,11 @@ enum SystemLanguage {
 
 enum SoundOutputMode { SOUND_MONO = 0, SOUND_STEREO = 1, SOUND_SURROUND = 2 };
 
+struct EULAVersion {
+    u8 minor;
+    u8 major;
+};
+
 /// Block header in the config savedata file
 struct SaveConfigBlockEntry {
     u32 block_id;       ///< The id of the current block
@@ -402,13 +407,13 @@ public:
      * Sets the accepted EULA version in the config savegame.
      * @param version the version to set
      */
-    void SetEULAVersion(u32 version);
+    void SetEULAVersion(const EULAVersion& version);
 
     /**
      * Gets the accepted EULA version from config savegame.
      * @returns the EULA version
      */
-    u32 GetEULAVersion();
+    EULAVersion GetEULAVersion();
 
     /**
      * Writes the config savegame memory buffer to the config savegame file in the filesystem


### PR DESCRIPTION
CFG: write the max value of 0x7F7F to the default cfg savegame and auto update on init
CECD: Actually read the EULA version from CFG instad of magic numbers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4728)
<!-- Reviewable:end -->
