### PR TITLE
Port yuzu-emu/yuzu#2388: "kernel: Make handle type declarations constexpr"

### DIFF
--- a/src/core/hle/kernel/address_arbiter.h
+++ b/src/core/hle/kernel/address_arbiter.h
@@ -42,7 +42,7 @@ public:
         return name;
     }
 
-    static const HandleType HANDLE_TYPE = HandleType::AddressArbiter;
+    static constexpr HandleType HANDLE_TYPE = HandleType::AddressArbiter;
     HandleType GetHandleType() const override {
         return HANDLE_TYPE;
     }

--- a/src/core/hle/kernel/client_port.h
+++ b/src/core/hle/kernel/client_port.h
@@ -28,7 +28,7 @@ public:
         return name;
     }
 
-    static const HandleType HANDLE_TYPE = HandleType::ClientPort;
+    static constexpr HandleType HANDLE_TYPE = HandleType::ClientPort;
     HandleType GetHandleType() const override {
         return HANDLE_TYPE;
     }

--- a/src/core/hle/kernel/client_session.h
+++ b/src/core/hle/kernel/client_session.h
@@ -30,7 +30,7 @@ public:
         return name;
     }
 
-    static const HandleType HANDLE_TYPE = HandleType::ClientSession;
+    static constexpr HandleType HANDLE_TYPE = HandleType::ClientSession;
     HandleType GetHandleType() const override {
         return HANDLE_TYPE;
     }

--- a/src/core/hle/kernel/event.h
+++ b/src/core/hle/kernel/event.h
@@ -25,7 +25,7 @@ public:
         this->name = name;
     }
 
-    static const HandleType HANDLE_TYPE = HandleType::Event;
+    static constexpr HandleType HANDLE_TYPE = HandleType::Event;
     HandleType GetHandleType() const override {
         return HANDLE_TYPE;
     }

--- a/src/core/hle/kernel/mutex.h
+++ b/src/core/hle/kernel/mutex.h
@@ -27,7 +27,7 @@ public:
         return name;
     }
 
-    static const HandleType HANDLE_TYPE = HandleType::Mutex;
+    static constexpr HandleType HANDLE_TYPE = HandleType::Mutex;
     HandleType GetHandleType() const override {
         return HANDLE_TYPE;
     }

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -68,7 +68,7 @@ public:
         return name;
     }
 
-    static const HandleType HANDLE_TYPE = HandleType::CodeSet;
+    static constexpr HandleType HANDLE_TYPE = HandleType::CodeSet;
     HandleType GetHandleType() const override {
         return HANDLE_TYPE;
     }
@@ -120,7 +120,7 @@ public:
         return codeset->name;
     }
 
-    static const HandleType HANDLE_TYPE = HandleType::Process;
+    static constexpr HandleType HANDLE_TYPE = HandleType::Process;
     HandleType GetHandleType() const override {
         return HANDLE_TYPE;
     }

--- a/src/core/hle/kernel/resource_limit.h
+++ b/src/core/hle/kernel/resource_limit.h
@@ -49,7 +49,7 @@ public:
         return name;
     }
 
-    static const HandleType HANDLE_TYPE = HandleType::ResourceLimit;
+    static constexpr HandleType HANDLE_TYPE = HandleType::ResourceLimit;
     HandleType GetHandleType() const override {
         return HANDLE_TYPE;
     }

--- a/src/core/hle/kernel/semaphore.h
+++ b/src/core/hle/kernel/semaphore.h
@@ -25,7 +25,7 @@ public:
         return name;
     }
 
-    static const HandleType HANDLE_TYPE = HandleType::Semaphore;
+    static constexpr HandleType HANDLE_TYPE = HandleType::Semaphore;
     HandleType GetHandleType() const override {
         return HANDLE_TYPE;
     }

--- a/src/core/hle/kernel/server_port.h
+++ b/src/core/hle/kernel/server_port.h
@@ -30,7 +30,7 @@ public:
         return name;
     }
 
-    static const HandleType HANDLE_TYPE = HandleType::ServerPort;
+    static constexpr HandleType HANDLE_TYPE = HandleType::ServerPort;
     HandleType GetHandleType() const override {
         return HANDLE_TYPE;
     }

--- a/src/core/hle/kernel/server_session.h
+++ b/src/core/hle/kernel/server_session.h
@@ -47,7 +47,7 @@ public:
         return "ServerSession";
     }
 
-    static const HandleType HANDLE_TYPE = HandleType::ServerSession;
+    static constexpr HandleType HANDLE_TYPE = HandleType::ServerSession;
     HandleType GetHandleType() const override {
         return HANDLE_TYPE;
     }

--- a/src/core/hle/kernel/shared_memory.h
+++ b/src/core/hle/kernel/shared_memory.h
@@ -28,7 +28,7 @@ public:
         this->name = std::move(name);
     }
 
-    static const HandleType HANDLE_TYPE = HandleType::SharedMemory;
+    static constexpr HandleType HANDLE_TYPE = HandleType::SharedMemory;
     HandleType GetHandleType() const override {
         return HANDLE_TYPE;
     }

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -160,7 +160,7 @@ public:
         return "Thread";
     }
 
-    static const HandleType HANDLE_TYPE = HandleType::Thread;
+    static constexpr HandleType HANDLE_TYPE = HandleType::Thread;
     HandleType GetHandleType() const override {
         return HANDLE_TYPE;
     }

--- a/src/core/hle/kernel/timer.h
+++ b/src/core/hle/kernel/timer.h
@@ -47,7 +47,7 @@ public:
         return name;
     }
 
-    static const HandleType HANDLE_TYPE = HandleType::Timer;
+    static constexpr HandleType HANDLE_TYPE = HandleType::Timer;
     HandleType GetHandleType() const override {
         return HANDLE_TYPE;
     }


### PR DESCRIPTION
See yuzu-emu/yuzu#2388 for more details.

**Original description**:
Some objects declare their handle type as const, while others declare it as constexpr. This makes the const ones constexpr for consistency, and prevents unexpected compilation errors if these happen to be attempted to be used within a constexpr context.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4735)
<!-- Reviewable:end -->
