### PR TITLE
Port yuzu-emu/yuzu#2356: "kernel/{server_port, server_session}: Return pairs instead of tuples from pair creation functions"

### DIFF
--- a/src/core/hle/kernel/client_port.cpp
+++ b/src/core/hle/kernel/client_port.cpp
@@ -26,18 +26,17 @@ ResultVal<std::shared_ptr<ClientSession>> ClientPort::Connect() {
     active_sessions++;
 
     // Create a new session pair, let the created sessions inherit the parent port's HLE handler.
-    auto sessions = kernel.CreateSessionPair(server_port->GetName(), SharedFrom(this));
+    auto [server, client] = kernel.CreateSessionPair(server_port->GetName(), SharedFrom(this));
 
     if (server_port->hle_handler)
-        server_port->hle_handler->ClientConnected(
-            std::get<std::shared_ptr<ServerSession>>(sessions));
+        server_port->hle_handler->ClientConnected(server);
     else
-        server_port->pending_sessions.push_back(std::get<std::shared_ptr<ServerSession>>(sessions));
+        server_port->pending_sessions.push_back(server);
 
     // Wake the threads waiting on the ServerPort
     server_port->WakeupAllWaitingThreads();
 
-    return MakeResult(std::get<std::shared_ptr<ClientSession>>(sessions));
+    return MakeResult(client);
 }
 
 void ClientPort::ConnectionClosed() {

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -83,7 +83,8 @@ public:
                           std::function<void()> prepare_reschedule_callback, u32 system_mode);
     ~KernelSystem();
 
-    using PortPair = std::tuple<std::shared_ptr<ServerPort>, std::shared_ptr<ClientPort>>;
+    using PortPair = std::pair<std::shared_ptr<ServerPort>, std::shared_ptr<ClientPort>>;
+    using SessionPair = std::pair<std::shared_ptr<ServerSession>, std::shared_ptr<ClientSession>>;
 
     /**
      * Creates an address arbiter.
@@ -160,8 +161,8 @@ public:
      * @param client_port Optional The ClientPort that spawned this session.
      * @return The created session tuple
      */
-    std::tuple<std::shared_ptr<ServerSession>, std::shared_ptr<ClientSession>> CreateSessionPair(
-        const std::string& name = "Unknown", std::shared_ptr<ClientPort> client_port = nullptr);
+    SessionPair CreateSessionPair(const std::string& name = "Unknown",
+                                  std::shared_ptr<ClientPort> client_port = nullptr);
 
     ResourceLimitList& ResourceLimit();
     const ResourceLimitList& ResourceLimit() const;

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -83,6 +83,8 @@ public:
                           std::function<void()> prepare_reschedule_callback, u32 system_mode);
     ~KernelSystem();
 
+    using PortPair = std::tuple<std::shared_ptr<ServerPort>, std::shared_ptr<ClientPort>>;
+
     /**
      * Creates an address arbiter.
      *
@@ -150,8 +152,7 @@ public:
      * @param name Optional name of the ports
      * @return The created port tuple
      */
-    std::tuple<std::shared_ptr<ServerPort>, std::shared_ptr<ClientPort>> CreatePortPair(
-        u32 max_sessions, std::string name = "UnknownPort");
+    PortPair CreatePortPair(u32 max_sessions, std::string name = "UnknownPort");
 
     /**
      * Creates a pair of ServerSession and an associated ClientSession.

--- a/src/core/hle/kernel/server_port.cpp
+++ b/src/core/hle/kernel/server_port.cpp
@@ -35,9 +35,7 @@ void ServerPort::Acquire(Thread* thread) {
     ASSERT_MSG(!ShouldWait(thread), "object unavailable!");
 }
 
-std::tuple<std::shared_ptr<ServerPort>, std::shared_ptr<ClientPort>> KernelSystem::CreatePortPair(
-    u32 max_sessions, std::string name) {
-
+KernelSystem::PortPair KernelSystem::CreatePortPair(u32 max_sessions, std::string name) {
     auto server_port{std::make_shared<ServerPort>(*this)};
     auto client_port{std::make_shared<ClientPort>(*this)};
 
@@ -47,7 +45,7 @@ std::tuple<std::shared_ptr<ServerPort>, std::shared_ptr<ClientPort>> KernelSyste
     client_port->max_sessions = max_sessions;
     client_port->active_sessions = 0;
 
-    return std::make_tuple(std::move(server_port), std::move(client_port));
+    return std::make_pair(std::move(server_port), std::move(client_port));
 }
 
 } // namespace Kernel

--- a/src/core/hle/kernel/server_session.cpp
+++ b/src/core/hle/kernel/server_session.cpp
@@ -120,8 +120,8 @@ ResultCode ServerSession::HandleSyncRequest(std::shared_ptr<Thread> thread) {
     return RESULT_SUCCESS;
 }
 
-std::tuple<std::shared_ptr<ServerSession>, std::shared_ptr<ClientSession>>
-KernelSystem::CreateSessionPair(const std::string& name, std::shared_ptr<ClientPort> port) {
+KernelSystem::SessionPair KernelSystem::CreateSessionPair(const std::string& name,
+                                                          std::shared_ptr<ClientPort> port) {
     auto server_session = ServerSession::Create(*this, name + "_Server").Unwrap();
     auto client_session{std::make_shared<ClientSession>(*this)};
     client_session->name = name + "_Client";
@@ -134,7 +134,7 @@ KernelSystem::CreateSessionPair(const std::string& name, std::shared_ptr<ClientP
     client_session->parent = parent;
     server_session->parent = parent;
 
-    return std::make_tuple(std::move(server_session), std::move(client_session));
+    return std::make_pair(std::move(server_session), std::move(client_session));
 }
 
 } // namespace Kernel

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1315,14 +1315,12 @@ ResultCode SVC::CreateSessionToPort(Handle* out_client_session, Handle client_po
 }
 
 ResultCode SVC::CreateSession(Handle* server_session, Handle* client_session) {
-    auto sessions = kernel.CreateSessionPair();
+    auto [server, client] = kernel.CreateSessionPair();
 
     std::shared_ptr<Process> current_process = kernel.GetCurrentProcess();
 
-    auto& server = std::get<std::shared_ptr<ServerSession>>(sessions);
     CASCADE_RESULT(*server_session, current_process->handle_table.Create(std::move(server)));
 
-    auto& client = std::get<std::shared_ptr<ClientSession>>(sessions);
     CASCADE_RESULT(*client_session, current_process->handle_table.Create(std::move(client)));
 
     LOG_TRACE(Kernel_SVC, "called");

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1292,13 +1292,11 @@ ResultCode SVC::CreatePort(Handle* server_port, Handle* client_port, VAddr name_
 
     std::shared_ptr<Process> current_process = kernel.GetCurrentProcess();
 
-    auto ports = kernel.CreatePortPair(max_sessions);
-    CASCADE_RESULT(*client_port, current_process->handle_table.Create(
-                                     std::move(std::get<std::shared_ptr<ClientPort>>(ports))));
+    auto [server, client] = kernel.CreatePortPair(max_sessions);
+    CASCADE_RESULT(*client_port, current_process->handle_table.Create(std::move(client)));
     // Note: The 3DS kernel also leaks the client port handle if the server port handle fails to be
     // created.
-    CASCADE_RESULT(*server_port, current_process->handle_table.Create(
-                                     std::move(std::get<std::shared_ptr<ServerPort>>(ports))));
+    CASCADE_RESULT(*server_port, current_process->handle_table.Create(std::move(server)));
 
     LOG_TRACE(Kernel_SVC, "called max_sessions={}", max_sessions);
     return RESULT_SUCCESS;

--- a/src/core/hle/service/fs/file.cpp
+++ b/src/core/hle/service/fs/file.cpp
@@ -197,8 +197,7 @@ void File::OpenLinkFile(Kernel::HLERequestContext& ctx) {
     using Kernel::ServerSession;
     IPC::RequestParser rp(ctx, 0x080C, 0, 0);
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    auto sessions = system.Kernel().CreateSessionPair(GetName());
-    auto server = std::get<std::shared_ptr<ServerSession>>(sessions);
+    auto [server, client] = system.Kernel().CreateSessionPair(GetName());
     ClientConnected(server);
 
     FileSessionSlot* slot = GetSessionData(server);
@@ -210,7 +209,7 @@ void File::OpenLinkFile(Kernel::HLERequestContext& ctx) {
     slot->subfile = false;
 
     rb.Push(RESULT_SUCCESS);
-    rb.PushMoveObjects(std::get<std::shared_ptr<ClientSession>>(sessions));
+    rb.PushMoveObjects(client);
 }
 
 void File::OpenSubFile(Kernel::HLERequestContext& ctx) {
@@ -244,8 +243,7 @@ void File::OpenSubFile(Kernel::HLERequestContext& ctx) {
 
     using Kernel::ClientSession;
     using Kernel::ServerSession;
-    auto sessions = system.Kernel().CreateSessionPair(GetName());
-    auto server = std::get<std::shared_ptr<ServerSession>>(sessions);
+    auto [server, client] = system.Kernel().CreateSessionPair(GetName());
     ClientConnected(server);
 
     FileSessionSlot* slot = GetSessionData(server);
@@ -255,12 +253,11 @@ void File::OpenSubFile(Kernel::HLERequestContext& ctx) {
     slot->subfile = true;
 
     rb.Push(RESULT_SUCCESS);
-    rb.PushMoveObjects(std::get<std::shared_ptr<ClientSession>>(sessions));
+    rb.PushMoveObjects(client);
 }
 
 std::shared_ptr<Kernel::ClientSession> File::Connect() {
-    auto sessions = system.Kernel().CreateSessionPair(GetName());
-    auto server = std::get<std::shared_ptr<Kernel::ServerSession>>(sessions);
+    auto [server, client] = system.Kernel().CreateSessionPair(GetName());
     ClientConnected(server);
 
     FileSessionSlot* slot = GetSessionData(server);
@@ -269,7 +266,7 @@ std::shared_ptr<Kernel::ClientSession> File::Connect() {
     slot->size = backend->GetSize();
     slot->subfile = false;
 
-    return std::get<std::shared_ptr<Kernel::ClientSession>>(sessions);
+    return client;
 }
 
 std::size_t File::GetSessionFileOffset(std::shared_ptr<Kernel::ServerSession> session) {

--- a/src/core/hle/service/fs/fs_user.cpp
+++ b/src/core/hle/service/fs/fs_user.cpp
@@ -306,9 +306,9 @@ void FS_USER::OpenDirectory(Kernel::HLERequestContext& ctx) {
     rb.Push(dir_res.Code());
     if (dir_res.Succeeded()) {
         std::shared_ptr<Directory> directory = *dir_res;
-        auto sessions = system.Kernel().CreateSessionPair(directory->GetName());
-        directory->ClientConnected(std::get<std::shared_ptr<ServerSession>>(sessions));
-        rb.PushMoveObjects(std::get<std::shared_ptr<ClientSession>>(sessions));
+        auto [server, client] = system.Kernel().CreateSessionPair(directory->GetName());
+        directory->ClientConnected(server);
+        rb.PushMoveObjects(client);
     } else {
         LOG_ERROR(Service_FS, "failed to get a handle for directory type={} size={} data={}",
                   static_cast<u32>(dirname_type), dirname_size, dir_path.DebugStr());

--- a/src/tests/core/hle/kernel/hle_ipc.cpp
+++ b/src/tests/core/hle/kernel/hle_ipc.cpp
@@ -24,8 +24,8 @@ TEST_CASE("HLERequestContext::PopulateFromIncomingCommandBuffer", "[core][kernel
     Core::Timing timing;
     Memory::MemorySystem memory;
     Kernel::KernelSystem kernel(memory, timing, [] {}, 0);
-    auto session = std::get<std::shared_ptr<ServerSession>>(kernel.CreateSessionPair());
-    HLERequestContext context(kernel, std::move(session), nullptr);
+    auto [server, client] = kernel.CreateSessionPair();
+    HLERequestContext context(kernel, std::move(server), nullptr);
 
     auto process = kernel.CreateProcess(kernel.CreateCodeSet("", 0));
 
@@ -236,8 +236,8 @@ TEST_CASE("HLERequestContext::WriteToOutgoingCommandBuffer", "[core][kernel]") {
     Core::Timing timing;
     Memory::MemorySystem memory;
     Kernel::KernelSystem kernel(memory, timing, [] {}, 0);
-    auto session = std::get<std::shared_ptr<ServerSession>>(kernel.CreateSessionPair());
-    HLERequestContext context(kernel, std::move(session), nullptr);
+    auto [server, client] = kernel.CreateSessionPair();
+    HLERequestContext context(kernel, std::move(server), nullptr);
 
     auto process = kernel.CreateProcess(kernel.CreateCodeSet("", 0));
     auto* input = context.CommandBuffer();


### PR DESCRIPTION
See yuzu-emu/yuzu#2356 for more details.

**Original description**:
Keeps the returned type consistent with the function name (and potentially considerably less template work depending on tuple implementations). While we're at it, we can also simplify handling of session pairs with the use of structured bindings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4736)
<!-- Reviewable:end -->
