### PR TITLE
Port yuzu-emu/yuzu#2017: "Frontend: Migrate to QOpenGLWindow and support shared contexts"

### DIFF
--- a/src/citra/emu_window/emu_window_sdl2.cpp
+++ b/src/citra/emu_window/emu_window_sdl2.cpp
@@ -20,6 +20,38 @@
 #include "input_common/sdl/sdl.h"
 #include "network/network.h"
 
+class SDLGLContext : public GraphicsContext {
+public:
+    explicit SDLGLContext() {
+        // create a hidden window to make the shared context against
+        window = SDL_CreateWindow("", SDL_WINDOWPOS_UNDEFINED, // x position
+                                  SDL_WINDOWPOS_UNDEFINED,     // y position
+                                  Core::kScreenTopWidth,
+                                  Core::kScreenTopHeight + Core::kScreenBottomHeight,
+                                  SDL_WINDOW_OPENGL | SDL_WINDOW_HIDDEN);
+        context = SDL_GL_CreateContext(window);
+    }
+
+    ~SDLGLContext() {
+        SDL_GL_DeleteContext(context);
+        SDL_DestroyWindow(window);
+    }
+
+    void MakeCurrent() override {
+        SDL_GL_MakeCurrent(window, context);
+    }
+
+    void DoneCurrent() override {
+        SDL_GL_MakeCurrent(window, nullptr);
+    }
+
+    void SwapBuffers() override {}
+
+private:
+    SDL_Window* window;
+    SDL_GLContext context;
+};
+
 void EmuWindow_SDL2::OnMouseMotion(s32 x, s32 y) {
     TouchMoved((unsigned)std::max(x, 0), (unsigned)std::max(y, 0));
     InputCommon::GetMotionEmu()->Tilt(x, y);
@@ -134,6 +166,7 @@ EmuWindow_SDL2::EmuWindow_SDL2(bool fullscreen) {
     SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8);
     SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 8);
     SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 0);
+    SDL_GL_SetAttribute(SDL_GL_SHARE_WITH_CURRENT_CONTEXT, 1);
 
     std::string window_title = fmt::format("Citra {} | {}-{}", Common::g_build_fullname,
                                            Common::g_scm_branch, Common::g_scm_desc);
@@ -152,7 +185,6 @@ EmuWindow_SDL2::EmuWindow_SDL2(bool fullscreen) {
     if (fullscreen) {
         Fullscreen();
     }
-
     gl_context = SDL_GL_CreateContext(render_window);
 
     if (gl_context == nullptr) {
@@ -256,4 +288,8 @@ void EmuWindow_SDL2::OnMinimalClientAreaChangeRequest(
     const std::pair<unsigned, unsigned>& minimal_size) {
 
     SDL_SetWindowMinimumSize(render_window, minimal_size.first, minimal_size.second);
+}
+
+std::unique_ptr<GraphicsContext> EmuWindow_SDL2::CreateSharedContext() const {
+    return std::make_unique<SDLGLContext>();
 }

--- a/src/citra/emu_window/emu_window_sdl2.cpp
+++ b/src/citra/emu_window/emu_window_sdl2.cpp
@@ -20,7 +20,7 @@
 #include "input_common/sdl/sdl.h"
 #include "network/network.h"
 
-class SDLGLContext : public GraphicsContext {
+class SDLGLContext : public Frontend::GraphicsContext {
 public:
     explicit SDLGLContext() {
         // create a hidden window to make the shared context against
@@ -290,6 +290,6 @@ void EmuWindow_SDL2::OnMinimalClientAreaChangeRequest(
     SDL_SetWindowMinimumSize(render_window, minimal_size.first, minimal_size.second);
 }
 
-std::unique_ptr<GraphicsContext> EmuWindow_SDL2::CreateSharedContext() const {
+std::unique_ptr<Frontend::GraphicsContext> EmuWindow_SDL2::CreateSharedContext() const {
     return std::make_unique<SDLGLContext>();
 }

--- a/src/citra/emu_window/emu_window_sdl2.h
+++ b/src/citra/emu_window/emu_window_sdl2.h
@@ -27,7 +27,7 @@ public:
     /// Releases the GL context from the caller thread
     void DoneCurrent() override;
 
-    std::unique_ptr<GraphicsContext> CreateSharedContext() const override;
+    std::unique_ptr<Frontend::GraphicsContext> CreateSharedContext() const override;
 
     /// Whether the window is still open, and a close request hasn't yet been sent
     bool IsOpen() const;

--- a/src/citra/emu_window/emu_window_sdl2.h
+++ b/src/citra/emu_window/emu_window_sdl2.h
@@ -27,6 +27,8 @@ public:
     /// Releases the GL context from the caller thread
     void DoneCurrent() override;
 
+    std::unique_ptr<GraphicsContext> CreateSharedContext() const override;
+
     /// Whether the window is still open, and a close request hasn't yet been sent
     bool IsOpen() const;
 

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -335,21 +335,16 @@ std::unique_ptr<GraphicsContext> GRenderWindow::CreateSharedContext() const {
 }
 
 void GRenderWindow::InitRenderTarget() {
-    if (shared_context) {
-        shared_context.reset();
-    }
+    shared_context.reset();
+    context.reset();
 
-    if (context) {
-        context.reset();
-    }
+    delete child;
+    child = nullptr;
 
-    if (child) {
-        delete child;
-    }
+    delete container;
+    container = nullptr;
 
-    if (layout()) {
-        delete layout();
-    }
+    delete layout();
 
     // TODO: One of these flags might be interesting: WA_OpaquePaintEvent, WA_NoBackground,
     // WA_DontShowOnScreen, WA_DeleteOnClose
@@ -368,7 +363,7 @@ void GRenderWindow::InitRenderTarget() {
     fmt.setSwapInterval(Settings::values.vsync_enabled);
 
     child = new GGLWidgetInternal(this, shared_context.get());
-    QWidget* container = QWidget::createWindowContainer(child, this);
+    container = QWidget::createWindowContainer(child, this);
     QBoxLayout* layout = new QHBoxLayout(this);
 
     resize(Core::kScreenTopWidth, Core::kScreenTopHeight + Core::kScreenBottomHeight);

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -1,7 +1,15 @@
+// Copyright 2014 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
 #include <QApplication>
 #include <QHBoxLayout>
 #include <QKeyEvent>
+#include <QOffscreenSurface>
+#include <QOpenGLWindow>
+#include <QPainter>
 #include <QScreen>
+#include <QSurfaceFormat>
 #include <QWindow>
 #include <fmt/format.h>
 
@@ -74,13 +82,36 @@ void EmuThread::run() {
     render_window->moveContext();
 }
 
+class GGLContext : public GraphicsContext {
+public:
+    explicit GGLContext(QOpenGLContext* shared_context) : surface() {
+        context = std::make_unique<QOpenGLContext>(shared_context);
+        surface.setFormat(shared_context->format());
+        surface.create();
+    }
+
+    void MakeCurrent() override {
+        context->makeCurrent(&surface);
+    }
+
+    void DoneCurrent() override {
+        context->doneCurrent();
+    }
+
+    void SwapBuffers() override {}
+
+private:
+    std::unique_ptr<QOpenGLContext> context;
+    QOffscreenSurface surface;
+};
+
 // This class overrides paintEvent and resizeEvent to prevent the GUI thread from stealing GL
 // context.
 // The corresponding functionality is handled in EmuThread instead
-class GGLWidgetInternal : public QGLWidget {
+class GGLWidgetInternal : public QOpenGLWindow {
 public:
-    GGLWidgetInternal(QGLFormat fmt, GRenderWindow* parent)
-        : QGLWidget(fmt, parent), parent(parent) {}
+    GGLWidgetInternal(GRenderWindow* parent, QOpenGLContext* shared_context)
+        : QOpenGLWindow(shared_context), parent(parent) {}
 
     void paintEvent(QPaintEvent* ev) override {
         if (do_painting) {
@@ -106,7 +137,7 @@ private:
 };
 
 GRenderWindow::GRenderWindow(QWidget* parent, EmuThread* emu_thread)
-    : QWidget(parent), child(nullptr), emu_thread(emu_thread) {
+    : QWidget(parent), child(nullptr), context(nullptr), emu_thread(emu_thread) {
 
     setWindowTitle(QStringLiteral("Citra %1 | %2-%3")
                        .arg(Common::g_build_name, Common::g_scm_branch, Common::g_scm_desc));
@@ -127,27 +158,27 @@ void GRenderWindow::moveContext() {
     auto thread = (QThread::currentThread() == qApp->thread() && emu_thread != nullptr)
                       ? emu_thread
                       : qApp->thread();
-    child->context()->moveToThread(thread);
+    context->moveToThread(thread);
 }
 
 void GRenderWindow::SwapBuffers() {
-    // In our multi-threaded QGLWidget use case we shouldn't need to call `makeCurrent`,
+    // In our multi-threaded QWidget use case we shouldn't need to call `makeCurrent`,
     // since we never call `doneCurrent` in this thread.
     // However:
     // - The Qt debug runtime prints a bogus warning on the console if `makeCurrent` wasn't called
     // since the last time `swapBuffers` was executed;
     // - On macOS, if `makeCurrent` isn't called explicitely, resizing the buffer breaks.
-    child->makeCurrent();
+    context->makeCurrent(child);
 
-    child->swapBuffers();
+    context->swapBuffers(child);
 }
 
 void GRenderWindow::MakeCurrent() {
-    child->makeCurrent();
+    context->makeCurrent(child);
 }
 
 void GRenderWindow::DoneCurrent() {
-    child->doneCurrent();
+    context->doneCurrent();
 }
 
 void GRenderWindow::PollEvents() {}
@@ -167,7 +198,7 @@ void GRenderWindow::OnFramebufferSizeChanged() {
 }
 
 void GRenderWindow::BackupGeometry() {
-    geometry = ((QGLWidget*)this)->saveGeometry();
+    geometry = ((QWidget*)this)->saveGeometry();
 }
 
 void GRenderWindow::RestoreGeometry() {
@@ -185,7 +216,7 @@ QByteArray GRenderWindow::saveGeometry() {
     // If we are a top-level widget, store the current geometry
     // otherwise, store the last backup
     if (parent() == nullptr)
-        return ((QGLWidget*)this)->saveGeometry();
+        return ((QWidget*)this)->saveGeometry();
     else
         return geometry;
 }
@@ -299,7 +330,19 @@ void GRenderWindow::OnClientAreaResized(unsigned width, unsigned height) {
     NotifyClientAreaSizeChanged(std::make_pair(width, height));
 }
 
+std::unique_ptr<GraphicsContext> GRenderWindow::CreateSharedContext() const {
+    return std::make_unique<GGLContext>(shared_context.get());
+}
+
 void GRenderWindow::InitRenderTarget() {
+    if (shared_context) {
+        shared_context.reset();
+    }
+
+    if (context) {
+        context.reset();
+    }
+
     if (child) {
         delete child;
     }
@@ -310,19 +353,28 @@ void GRenderWindow::InitRenderTarget() {
 
     // TODO: One of these flags might be interesting: WA_OpaquePaintEvent, WA_NoBackground,
     // WA_DontShowOnScreen, WA_DeleteOnClose
-    QGLFormat fmt;
+    QSurfaceFormat fmt;
     fmt.setVersion(3, 3);
-    fmt.setProfile(QGLFormat::CoreProfile);
+    fmt.setProfile(QSurfaceFormat::CoreProfile);
+    // TODO: expose a setting for buffer value (ie default/single/double/triple)
+    fmt.setSwapBehavior(QSurfaceFormat::DefaultSwapBehavior);
+    shared_context = std::make_unique<QOpenGLContext>();
+    shared_context->setFormat(fmt);
+    shared_context->create();
+    context = std::make_unique<QOpenGLContext>();
+    context->setShareContext(shared_context.get());
+    context->setFormat(fmt);
+    context->create();
     fmt.setSwapInterval(Settings::values.vsync_enabled);
 
-    // Requests a forward-compatible context, which is required to get a 3.2+ context on OS X
-    fmt.setOption(QGL::NoDeprecatedFunctions);
-
-    child = new GGLWidgetInternal(fmt, this);
+    child = new GGLWidgetInternal(this, shared_context.get());
+    QWidget* container = QWidget::createWindowContainer(child, this);
     QBoxLayout* layout = new QHBoxLayout(this);
 
     resize(Core::kScreenTopWidth, Core::kScreenTopHeight + Core::kScreenBottomHeight);
-    layout->addWidget(child);
+    child->resize(Core::kScreenTopWidth, Core::kScreenTopHeight + Core::kScreenBottomHeight);
+    container->resize(Core::kScreenTopWidth, Core::kScreenTopHeight + Core::kScreenBottomHeight);
+    layout->addWidget(container);
     layout->setMargin(0);
     setLayout(layout);
 
@@ -332,6 +384,8 @@ void GRenderWindow::InitRenderTarget() {
     NotifyClientAreaSizeChanged(std::pair<unsigned, unsigned>(child->width(), child->height()));
 
     BackupGeometry();
+    // show causes the window to actually be created and the gl context as well
+    show();
 }
 
 void GRenderWindow::CaptureScreenshot(u16 res_scale, const QString& screenshot_path) {

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -179,7 +179,7 @@ private:
 };
 
 GRenderWindow::GRenderWindow(QWidget* parent, EmuThread* emu_thread)
-    : QWidget(parent), child(nullptr), context(nullptr), emu_thread(emu_thread) {
+    : QWidget(parent), emu_thread(emu_thread) {
 
     setWindowTitle(QStringLiteral("Citra %1 | %2-%3")
                        .arg(Common::g_build_name, Common::g_scm_branch, Common::g_scm_desc));

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -386,6 +386,8 @@ void GRenderWindow::InitRenderTarget() {
     BackupGeometry();
     // show causes the window to actually be created and the gl context as well
     show();
+    // but we don't want the widget to be shown yet, so immediately hide it
+    hide();
 }
 
 void GRenderWindow::CaptureScreenshot(u16 res_scale, const QString& screenshot_path) {

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -84,8 +84,8 @@ void EmuThread::run() {
 
 class GGLContext : public GraphicsContext {
 public:
-    explicit GGLContext(QOpenGLContext* shared_context) : surface() {
-        context = std::make_unique<QOpenGLContext>(shared_context);
+    explicit GGLContext(QOpenGLContext* shared_context)
+        : context{std::make_unique<QOpenGLContext>(shared_context)} {
         surface.setFormat(shared_context->format());
         surface.create();
     }

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -82,7 +82,7 @@ void EmuThread::run() {
     render_window->moveContext();
 }
 
-class GGLContext : public GraphicsContext {
+class GGLContext : public Frontend::GraphicsContext {
 public:
     explicit GGLContext(QOpenGLContext* shared_context)
         : context{std::make_unique<QOpenGLContext>(shared_context)} {
@@ -343,7 +343,7 @@ void GRenderWindow::OnClientAreaResized(unsigned width, unsigned height) {
     NotifyClientAreaSizeChanged(std::make_pair(width, height));
 }
 
-std::unique_ptr<GraphicsContext> GRenderWindow::CreateSharedContext() const {
+std::unique_ptr<Frontend::GraphicsContext> GRenderWindow::CreateSharedContext() const {
     return std::make_unique<GGLContext>(shared_context.get());
 }
 

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -364,14 +364,23 @@ void GRenderWindow::InitRenderTarget() {
 
     child = new GGLWidgetInternal(this, shared_context.get());
     container = QWidget::createWindowContainer(child, this);
+
     QBoxLayout* layout = new QHBoxLayout(this);
+    layout->addWidget(container);
+    layout->setMargin(0);
+    setLayout(layout);
+
+    // Reset minimum size to avoid unwanted resizes when this function is called for a second time.
+    setMinimumSize(1, 1);
+
+    // Show causes the window to actually be created and the OpenGL context as well, but we don't
+    // want the widget to be shown yet, so immediately hide it.
+    show();
+    hide();
 
     resize(Core::kScreenTopWidth, Core::kScreenTopHeight + Core::kScreenBottomHeight);
     child->resize(Core::kScreenTopWidth, Core::kScreenTopHeight + Core::kScreenBottomHeight);
     container->resize(Core::kScreenTopWidth, Core::kScreenTopHeight + Core::kScreenBottomHeight);
-    layout->addWidget(container);
-    layout->setMargin(0);
-    setLayout(layout);
 
     OnMinimalClientAreaChangeRequest(GetActiveConfig().min_client_area_size);
 
@@ -379,10 +388,6 @@ void GRenderWindow::InitRenderTarget() {
     NotifyClientAreaSizeChanged(std::pair<unsigned, unsigned>(child->width(), child->height()));
 
     BackupGeometry();
-    // show causes the window to actually be created and the gl context as well
-    show();
-    // but we don't want the widget to be shown yet, so immediately hide it
-    hide();
 }
 
 void GRenderWindow::CaptureScreenshot(u16 res_scale, const QString& screenshot_path) {

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -124,9 +124,51 @@ public:
         parent->OnFramebufferSizeChanged();
     }
 
+    void keyPressEvent(QKeyEvent* event) override {
+        InputCommon::GetKeyboard()->PressKey(event->key());
+    }
+
+    void keyReleaseEvent(QKeyEvent* event) override {
+        InputCommon::GetKeyboard()->ReleaseKey(event->key());
+    }
+
+    void mousePressEvent(QMouseEvent* event) override {
+        if (event->source() == Qt::MouseEventSynthesizedBySystem)
+            return; // touch input is handled in TouchBeginEvent
+
+        const auto pos{event->pos()};
+        if (event->button() == Qt::LeftButton) {
+            const auto [x, y] = parent->ScaleTouch(pos);
+            parent->TouchPressed(x, y);
+        } else if (event->button() == Qt::RightButton) {
+            InputCommon::GetMotionEmu()->BeginTilt(pos.x(), pos.y());
+        }
+    }
+
+    void mouseMoveEvent(QMouseEvent* event) override {
+        if (event->source() == Qt::MouseEventSynthesizedBySystem)
+            return; // touch input is handled in TouchUpdateEvent
+
+        const auto pos{event->pos()};
+        const auto [x, y] = parent->ScaleTouch(pos);
+        parent->TouchMoved(x, y);
+        InputCommon::GetMotionEmu()->Tilt(pos.x(), pos.y());
+    }
+
+    void mouseReleaseEvent(QMouseEvent* event) override {
+        if (event->source() == Qt::MouseEventSynthesizedBySystem)
+            return; // touch input is handled in TouchEndEvent
+
+        if (event->button() == Qt::LeftButton)
+            parent->TouchReleased();
+        else if (event->button() == Qt::RightButton)
+            InputCommon::GetMotionEmu()->EndTilt();
+    }
+
     void DisablePainting() {
         do_painting = false;
     }
+
     void EnablePainting() {
         do_painting = true;
     }
@@ -191,10 +233,22 @@ void GRenderWindow::PollEvents() {}
 void GRenderWindow::OnFramebufferSizeChanged() {
     // Screen changes potentially incur a change in screen DPI, hence we should update the
     // framebuffer size
-    qreal pixelRatio = windowPixelRatio();
+    qreal pixelRatio = GetWindowPixelRatio();
     unsigned width = child->QPaintDevice::width() * pixelRatio;
     unsigned height = child->QPaintDevice::height() * pixelRatio;
     UpdateCurrentFramebufferLayout(width, height);
+}
+
+void GRenderWindow::ForwardKeyPressEvent(QKeyEvent* event) {
+    if (child) {
+        child->keyPressEvent(event);
+    }
+}
+
+void GRenderWindow::ForwardKeyReleaseEvent(QKeyEvent* event) {
+    if (child) {
+        child->keyReleaseEvent(event);
+    }
 }
 
 void GRenderWindow::BackupGeometry() {
@@ -221,13 +275,13 @@ QByteArray GRenderWindow::saveGeometry() {
         return geometry;
 }
 
-qreal GRenderWindow::windowPixelRatio() const {
+qreal GRenderWindow::GetWindowPixelRatio() const {
     // windowHandle() might not be accessible until the window is displayed to screen.
     return windowHandle() ? windowHandle()->screen()->devicePixelRatio() : 1.0f;
 }
 
 std::pair<unsigned, unsigned> GRenderWindow::ScaleTouch(const QPointF pos) const {
-    const qreal pixel_ratio = windowPixelRatio();
+    const qreal pixel_ratio = GetWindowPixelRatio();
     return {static_cast<unsigned>(std::max(std::round(pos.x() * pixel_ratio), qreal{0.0})),
             static_cast<unsigned>(std::max(std::round(pos.y() * pixel_ratio), qreal{0.0}))};
 }
@@ -235,47 +289,6 @@ std::pair<unsigned, unsigned> GRenderWindow::ScaleTouch(const QPointF pos) const
 void GRenderWindow::closeEvent(QCloseEvent* event) {
     emit Closed();
     QWidget::closeEvent(event);
-}
-
-void GRenderWindow::keyPressEvent(QKeyEvent* event) {
-    InputCommon::GetKeyboard()->PressKey(event->key());
-}
-
-void GRenderWindow::keyReleaseEvent(QKeyEvent* event) {
-    InputCommon::GetKeyboard()->ReleaseKey(event->key());
-}
-
-void GRenderWindow::mousePressEvent(QMouseEvent* event) {
-    if (event->source() == Qt::MouseEventSynthesizedBySystem)
-        return; // touch input is handled in TouchBeginEvent
-
-    auto pos = event->pos();
-    if (event->button() == Qt::LeftButton) {
-        const auto [x, y] = ScaleTouch(pos);
-        this->TouchPressed(x, y);
-    } else if (event->button() == Qt::RightButton) {
-        InputCommon::GetMotionEmu()->BeginTilt(pos.x(), pos.y());
-    }
-}
-
-void GRenderWindow::mouseMoveEvent(QMouseEvent* event) {
-    if (event->source() == Qt::MouseEventSynthesizedBySystem)
-        return; // touch input is handled in TouchUpdateEvent
-
-    auto pos = event->pos();
-    const auto [x, y] = ScaleTouch(pos);
-    this->TouchMoved(x, y);
-    InputCommon::GetMotionEmu()->Tilt(pos.x(), pos.y());
-}
-
-void GRenderWindow::mouseReleaseEvent(QMouseEvent* event) {
-    if (event->source() == Qt::MouseEventSynthesizedBySystem)
-        return; // touch input is handled in TouchEndEvent
-
-    if (event->button() == Qt::LeftButton)
-        this->TouchReleased();
-    else if (event->button() == Qt::RightButton)
-        InputCommon::GetMotionEmu()->EndTilt();
 }
 
 void GRenderWindow::TouchBeginEvent(const QTouchEvent* event) {

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -10,7 +10,6 @@
 #include <QImage>
 #include <QThread>
 #include <QWidget>
-#include "common/thread.h"
 #include "core/core.h"
 #include "core/frontend/emu_window.h"
 

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -165,7 +165,8 @@ private:
     void OnMinimalClientAreaChangeRequest(
         const std::pair<unsigned, unsigned>& minimal_size) override;
 
-    GGLWidgetInternal* child;
+    QWidget* container = nullptr;
+    GGLWidgetInternal* child = nullptr;
 
     QByteArray geometry;
 

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -7,9 +7,9 @@
 #include <atomic>
 #include <condition_variable>
 #include <mutex>
-#include <QGLWidget>
 #include <QImage>
 #include <QThread>
+#include <QWidget>
 #include "common/thread.h"
 #include "core/core.h"
 #include "core/frontend/emu_window.h"
@@ -21,6 +21,8 @@ class QTouchEvent;
 class GGLWidgetInternal;
 class GMainWindow;
 class GRenderWindow;
+class QSurface;
+class QOpenGLContext;
 
 class EmuThread : public QThread {
     Q_OBJECT
@@ -115,6 +117,7 @@ public:
     void MakeCurrent() override;
     void DoneCurrent() override;
     void PollEvents() override;
+    std::unique_ptr<GraphicsContext> CreateSharedContext() const override;
 
     void BackupGeometry();
     void RestoreGeometry();
@@ -167,6 +170,11 @@ private:
     QByteArray geometry;
 
     EmuThread* emu_thread;
+    // Context that backs the GGLWidgetInternal (and will be used by core to render)
+    std::unique_ptr<QOpenGLContext> context;
+    // Context that will be shared between all newly created contexts. This should never be made
+    // current
+    std::unique_ptr<QOpenGLContext> shared_context;
 
     /// Temporary storage of the screenshot taken
     QImage screenshot_image;

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -116,7 +116,7 @@ public:
     void MakeCurrent() override;
     void DoneCurrent() override;
     void PollEvents() override;
-    std::unique_ptr<GraphicsContext> CreateSharedContext() const override;
+    std::unique_ptr<Frontend::GraphicsContext> CreateSharedContext() const override;
 
     void ForwardKeyPressEvent(QKeyEvent* event);
     void ForwardKeyReleaseEvent(QKeyEvent* event);

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -119,24 +119,19 @@ public:
     void PollEvents() override;
     std::unique_ptr<GraphicsContext> CreateSharedContext() const override;
 
+    void ForwardKeyPressEvent(QKeyEvent* event);
+    void ForwardKeyReleaseEvent(QKeyEvent* event);
+
     void BackupGeometry();
     void RestoreGeometry();
     void restoreGeometry(const QByteArray& geometry); // overridden
     QByteArray saveGeometry();                        // overridden
 
-    qreal windowPixelRatio() const;
+    qreal GetWindowPixelRatio() const;
+    std::pair<unsigned, unsigned> ScaleTouch(const QPointF pos) const;
 
     void closeEvent(QCloseEvent* event) override;
-
-    void keyPressEvent(QKeyEvent* event) override;
-    void keyReleaseEvent(QKeyEvent* event) override;
-
-    void mousePressEvent(QMouseEvent* event) override;
-    void mouseMoveEvent(QMouseEvent* event) override;
-    void mouseReleaseEvent(QMouseEvent* event) override;
-
     bool event(QEvent* event) override;
-
     void focusOutEvent(QFocusEvent* event) override;
 
     void OnClientAreaResized(unsigned width, unsigned height);
@@ -157,7 +152,6 @@ signals:
     void Closed();
 
 private:
-    std::pair<unsigned, unsigned> ScaleTouch(const QPointF pos) const;
     void TouchBeginEvent(const QTouchEvent* event);
     void TouchUpdateEvent(const QTouchEvent* event);
     void TouchEndEvent();

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -1742,6 +1742,18 @@ void GMainWindow::dragMoveEvent(QDragMoveEvent* event) {
     event->acceptProposedAction();
 }
 
+void GMainWindow::keyPressEvent(QKeyEvent* event) {
+    if (render_window) {
+        render_window->ForwardKeyPressEvent(event);
+    }
+}
+
+void GMainWindow::keyReleaseEvent(QKeyEvent* event) {
+    if (render_window) {
+        render_window->ForwardKeyReleaseEvent(event);
+    }
+}
+
 bool GMainWindow::ConfirmChangeGame() {
     if (emu_thread == nullptr)
         return true;

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -1887,6 +1887,8 @@ int main(int argc, char* argv[]) {
     QCoreApplication::setOrganizationName("Citra team");
     QCoreApplication::setApplicationName("Citra");
 
+    // Enables the core to make the qt created contexts current on std::threads
+    QCoreApplication::setAttribute(Qt::AA_DontCheckOpenGLContextThreadAffinity);
     QApplication app(argc, argv);
 
     // Qt changes the locale and causes issues in float conversion using std::to_string() when

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -259,6 +259,10 @@ protected:
     void dropEvent(QDropEvent* event) override;
     void dragEnterEvent(QDragEnterEvent* event) override;
     void dragMoveEvent(QDragMoveEvent* event) override;
+
+    // Overrides used to forward signals to the render window when the focus moves out.
+    void keyPressEvent(QKeyEvent* event) override;
+    void keyReleaseEvent(QKeyEvent* event) override;
 };
 
 Q_DECLARE_METATYPE(std::size_t);

--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -10,6 +10,8 @@
 
 namespace Frontend {
 
+GraphicsContext::~GraphicsContext() = default;
+
 class EmuWindow::TouchState : public Input::Factory<Input::TouchDevice>,
                               public std::enable_shared_from_this<TouchState> {
 public:

--- a/src/core/frontend/emu_window.h
+++ b/src/core/frontend/emu_window.h
@@ -19,6 +19,8 @@ namespace Frontend {
  */
 class GraphicsContext {
 public:
+    virtual ~GraphicsContext();
+
     /// Makes the graphics context current for the caller thread
     virtual void MakeCurrent() = 0;
 

--- a/src/core/frontend/emu_window.h
+++ b/src/core/frontend/emu_window.h
@@ -13,6 +13,23 @@
 namespace Frontend {
 
 /**
+ * Represents a graphics context that can be used for background computation or drawing. If the
+ * graphics backend doesn't require the context, then the implementation of these methods can be
+ * stubs
+ */
+class GraphicsContext {
+public:
+    /// Makes the graphics context current for the caller thread
+    virtual void MakeCurrent() = 0;
+
+    /// Releases (dunno if this is the "right" word) the context from the caller thread
+    virtual void DoneCurrent() = 0;
+
+    /// Swap buffers to display the next frame
+    virtual void SwapBuffers() = 0;
+};
+
+/**
  * Abstraction class used to provide an interface between emulation code and the frontend
  * (e.g. SDL, QGLWidget, GLFW, etc...).
  *
@@ -30,7 +47,7 @@ namespace Frontend {
  * - DO NOT TREAT THIS CLASS AS A GUI TOOLKIT ABSTRACTION LAYER. That's not what it is. Please
  *   re-read the upper points again and think about it if you don't see this.
  */
-class EmuWindow {
+class EmuWindow : public GraphicsContext {
 public:
     /// Data structure to store emuwindow configuration
     struct WindowConfig {
@@ -40,17 +57,21 @@ public:
         std::pair<unsigned, unsigned> min_client_area_size;
     };
 
-    /// Swap buffers to display the next frame
-    virtual void SwapBuffers() = 0;
-
     /// Polls window events
     virtual void PollEvents() = 0;
 
-    /// Makes the graphics context current for the caller thread
-    virtual void MakeCurrent() = 0;
-
-    /// Releases (dunno if this is the "right" word) the GLFW context from the caller thread
-    virtual void DoneCurrent() = 0;
+    /**
+     * Returns a GraphicsContext that the frontend provides that is shared with the emu window. This
+     * context can be used from other threads for background graphics computation. If the frontend
+     * is using a graphics backend that doesn't need anything specific to run on a different thread,
+     * then it can use a stubbed implemenation for GraphicsContext.
+     *
+     * If the return value is null, then the core should assume that the frontend cannot provide a
+     * Shared Context
+     */
+    virtual std::unique_ptr<GraphicsContext> CreateSharedContext() const {
+        return nullptr;
+    }
 
     /**
      * Signal that a touch pressed event has occurred (e.g. mouse click pressed)


### PR DESCRIPTION
See yuzu-emu/yuzu#2017 for more details.

**Original description**:
Since QT5, QGLWidget has been deprecated and superseded with QOpenGLWidget and other classes. I replace usages of QGLWidget with the comparable QOpenGLWindow, which gives us the bonus ability to easily create shared contexts.

To support shared contexts, frontends can now implement the GraphicsContext class and the core can attempt to get a shared context from the frontend by calling GetSharedContext. If the rendering backend doesn't need shared contexts, then it just doesn't request a shared context from the frontend. If the backend does request a shared context, it should be ready to handle the case where the frontend returns nullptr (ie: because its not supported on this platform or frontend)

In this PR, I added shared context support to the QT and SDL frontends, but I haven't had a chance to extensively test shared contexts yet. We've had several suggested features that could benefit from shared context support, so I wanted to put it out there that the code is ready, but I also understand if others think we should wait until we have code that actually uses shared contexts.

Looking for feedback about the changes I made to EmuWindow to add a new function to get a shared context. I couldn't think of a better way to enable the video core to get a shared context where needed while still letting the frontend actually create that context.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4737)
<!-- Reviewable:end -->
