### PR TITLE
Port yuzu-emu/yuzu#2405: "CMakeLists: Define QT_USE_QSTRINGBUILDER for the Qt target"

### DIFF
--- a/src/citra_qt/CMakeLists.txt
+++ b/src/citra_qt/CMakeLists.txt
@@ -224,6 +224,12 @@ target_link_libraries(citra-qt PRIVATE audio_core common core input_common netwo
 target_link_libraries(citra-qt PRIVATE Boost::boost glad nihstro-headers Qt5::OpenGL Qt5::Widgets Qt5::Multimedia)
 target_link_libraries(citra-qt PRIVATE ${PLATFORM_LIBRARIES} Threads::Threads)
 
+target_compile_definitions(citra-qt PRIVATE
+    # Use QStringBuilder for string concatenation to reduce
+    # the overall number of temporary strings created.
+    -DQT_USE_QSTRINGBUILDER
+)
+
 if (CITRA_ENABLE_COMPATIBILITY_REPORTING)
     target_compile_definitions(citra-qt PRIVATE -DCITRA_ENABLE_COMPATIBILITY_REPORTING)
 endif()

--- a/src/citra_qt/game_list_p.h
+++ b/src/citra_qt/game_list_p.h
@@ -192,7 +192,7 @@ public:
             if (row_2_id != UISettings::GameListText::NoText) {
                 row2 = (row1.isEmpty() ? "" : "\n     ") + display_texts.at(row_2_id);
             }
-            return row1 + row2;
+            return QString(row1 + row2);
         } else {
             return GameListItem::data(role);
         }


### PR DESCRIPTION
See yuzu-emu/yuzu#2405 for more details.

**Original description**:
This is a compile definition introduced in Qt 4.8 for reducing the total
potential number of strings created when performing string
concatenation. This allows for less memory churn.

This can be read about here:
https://blog.qt.io/blog/2011/06/13/string-concatenation-with-qstringbuilder/

For a change that isn't source-compatible, we only had one occurrence
that actually need to have its type clarified, which is pretty good, as
far as transitioning goes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4743)
<!-- Reviewable:end -->
