### PR TITLE
Port yuzu-emu/yuzu#2376: "yuzu/configure_hotkey: Minor changes"

### DIFF
--- a/src/citra_qt/configuration/configure_dialog.cpp
+++ b/src/citra_qt/configuration/configure_dialog.cpp
@@ -11,7 +11,7 @@
 #include "ui_configure.h"
 
 ConfigureDialog::ConfigureDialog(QWidget* parent, HotkeyRegistry& registry, bool enable_web_config)
-    : QDialog(parent), registry(registry), ui(new Ui::ConfigureDialog) {
+    : QDialog(parent), ui(new Ui::ConfigureDialog), registry(registry) {
     ui->setupUi(this);
     ui->hotkeysTab->Populate(registry);
     ui->webTab->SetWebServiceConfigEnabled(enable_web_config);

--- a/src/citra_qt/configuration/configure_hotkeys.cpp
+++ b/src/citra_qt/configuration/configure_hotkeys.cpp
@@ -78,10 +78,10 @@ void ConfigureHotkeys::Configure(QModelIndex index) {
     auto* const model = ui->hotkey_list->model();
     const auto previous_key = model->data(index);
 
-    auto* const hotkey_dialog = new SequenceDialog;
+    SequenceDialog hotkey_dialog;
 
-    const int return_code = hotkey_dialog->exec();
-    const auto key_sequence = hotkey_dialog->GetSequence();
+    const int return_code = hotkey_dialog.exec();
+    const auto key_sequence = hotkey_dialog.GetSequence();
     if (return_code == QDialog::Rejected || key_sequence.isEmpty()) {
         return;
     }

--- a/src/citra_qt/configuration/configure_hotkeys.cpp
+++ b/src/citra_qt/configuration/configure_hotkeys.cpp
@@ -78,7 +78,7 @@ void ConfigureHotkeys::Configure(QModelIndex index) {
     auto* const model = ui->hotkey_list->model();
     const auto previous_key = model->data(index);
 
-    SequenceDialog hotkey_dialog;
+    SequenceDialog hotkey_dialog{this};
 
     const int return_code = hotkey_dialog.exec();
     const auto key_sequence = hotkey_dialog.GetSequence();

--- a/src/citra_qt/configuration/configure_hotkeys.cpp
+++ b/src/citra_qt/configuration/configure_hotkeys.cpp
@@ -75,16 +75,16 @@ void ConfigureHotkeys::Configure(QModelIndex index) {
     }
 
     index = index.sibling(index.row(), 1);
-    auto* model = ui->hotkey_list->model();
-    auto previous_key = model->data(index);
+    auto* const model = ui->hotkey_list->model();
+    const auto previous_key = model->data(index);
 
-    auto* hotkey_dialog = new SequenceDialog;
-    int return_code = hotkey_dialog->exec();
+    auto* const hotkey_dialog = new SequenceDialog;
 
-    auto key_sequence = hotkey_dialog->GetSequence();
-
-    if (return_code == QDialog::Rejected || key_sequence.isEmpty())
+    const int return_code = hotkey_dialog->exec();
+    const auto key_sequence = hotkey_dialog->GetSequence();
+    if (return_code == QDialog::Rejected || key_sequence.isEmpty()) {
         return;
+    }
 
     if (IsUsedKey(key_sequence) && key_sequence != QKeySequence(previous_key.toString())) {
         QMessageBox::critical(this, tr("Error in inputted key"),

--- a/src/citra_qt/configuration/configure_hotkeys.cpp
+++ b/src/citra_qt/configuration/configure_hotkeys.cpp
@@ -35,7 +35,7 @@ void ConfigureHotkeys::EmitHotkeysChanged() {
     emit HotkeysChanged(GetUsedKeyList());
 }
 
-QList<QKeySequence> ConfigureHotkeys::GetUsedKeyList() {
+QList<QKeySequence> ConfigureHotkeys::GetUsedKeyList() const {
     QList<QKeySequence> list;
     for (int r = 0; r < model->rowCount(); r++) {
         QStandardItem* parent = model->item(r, 0);
@@ -94,7 +94,7 @@ void ConfigureHotkeys::Configure(QModelIndex index) {
     }
 }
 
-bool ConfigureHotkeys::IsUsedKey(QKeySequence key_sequence) {
+bool ConfigureHotkeys::IsUsedKey(QKeySequence key_sequence) const {
     return input_keys_list.contains(key_sequence) || GetUsedKeyList().contains(key_sequence);
 }
 

--- a/src/citra_qt/configuration/configure_hotkeys.cpp
+++ b/src/citra_qt/configuration/configure_hotkeys.cpp
@@ -70,8 +70,9 @@ void ConfigureHotkeys::OnInputKeysChanged(QList<QKeySequence> new_key_list) {
 }
 
 void ConfigureHotkeys::Configure(QModelIndex index) {
-    if (index.parent() == QModelIndex())
+    if (!index.parent().isValid()) {
         return;
+    }
 
     index = index.sibling(index.row(), 1);
     auto* model = ui->hotkey_list->model();

--- a/src/citra_qt/configuration/configure_hotkeys.h
+++ b/src/citra_qt/configuration/configure_hotkeys.h
@@ -6,7 +6,6 @@
 
 #include <memory>
 #include <QWidget>
-#include "core/settings.h"
 
 namespace Ui {
 class ConfigureHotkeys;

--- a/src/citra_qt/configuration/configure_hotkeys.h
+++ b/src/citra_qt/configuration/configure_hotkeys.h
@@ -42,8 +42,8 @@ signals:
 
 private:
     void Configure(QModelIndex index);
-    bool IsUsedKey(QKeySequence key_sequence);
-    QList<QKeySequence> GetUsedKeyList();
+    bool IsUsedKey(QKeySequence key_sequence) const;
+    QList<QKeySequence> GetUsedKeyList() const;
 
     std::unique_ptr<Ui::ConfigureHotkeys> ui;
 


### PR DESCRIPTION
See yuzu-emu/yuzu#2376 for more details.

**Original description**:
Minor clean-up related changes to the hotkey configuration dialog. This also notably prevents the logging window from stealing the initial focus of the hotkey dialog window.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4744)
<!-- Reviewable:end -->
