### PR TITLE
Launch directly in Mac without terminal

### DIFF
--- a/.travis/macos/upload.sh
+++ b/.travis/macos/upload.sh
@@ -20,18 +20,6 @@ $(brew --prefix)/opt/qt5/bin/macdeployqt "${REV_NAME}/citra-qt.app" -executable=
 # move libs into folder for deployment
 macpack "${REV_NAME}/citra" -d "libs"
 
-# Make the citra-qt.app application launch a debugging terminal.
-# Store away the actual binary
-mv ${REV_NAME}/citra-qt.app/Contents/MacOS/citra-qt ${REV_NAME}/citra-qt.app/Contents/MacOS/citra-qt-bin
-
-cat > ${REV_NAME}/citra-qt.app/Contents/MacOS/citra-qt <<EOL
-#!/usr/bin/env bash
-cd "\`dirname "\$0"\`"
-chmod +x citra-qt-bin
-open citra-qt-bin --args "\$@"
-EOL
-# Content that will serve as the launching script for citra (within the .app folder)
-
 # Make the launching script executable
 chmod +x ${REV_NAME}/citra-qt.app/Contents/MacOS/citra-qt
 


### PR DESCRIPTION
This is no longer needed for logging because logs are written to disk.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4748)
<!-- Reviewable:end -->
