### PR TITLE
linux-flatpak: revert use precompiled cache

### DIFF
--- a/.travis/linux-flatpak/docker.sh
+++ b/.travis/linux-flatpak/docker.sh
@@ -31,8 +31,6 @@ mkdir -p "$REPO_DIR"
 sshfs "$FLATPAK_SSH_USER@$FLATPAK_SSH_HOSTNAME:$SSH_DIR" "$REPO_DIR" -C -p "$FLATPAK_SSH_PORT" -o IdentityFile="$SSH_KEY"
 
 # setup ccache location
-wget 'https://liushuyu.b-cdn.net/citra-ccache-flatpak.tar.xz'
-tar xf citra-ccache-flatpak.tar.xz -C /root/.ccache --strip-components=1
 mkdir -p "$STATE_DIR"
 ln -sv /root/.ccache "$STATE_DIR/ccache"
 


### PR DESCRIPTION
I accidentally squashed a commit containing `[erase me]` in #4731 and thus the changes weren't erased. 
This removes those changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4755)
<!-- Reviewable:end -->
