### PR TITLE
audio_core: dsp_hle: use better f32 to s16 algorithm

### DIFF
--- a/src/audio_core/hle/ffmpeg_decoder.cpp
+++ b/src/audio_core/hle/ffmpeg_decoder.cpp
@@ -218,6 +218,7 @@ std::optional<BinaryResponse> FFMPEGDecoder::Impl::Decode(const BinaryRequest& r
                     for (std::size_t channel(0); channel < decoded_frame->channels; channel++) {
                         std::memcpy(&val_float, decoded_frame->data[channel] + current_pos,
                                     sizeof(val_float));
+                        val_float = std::clamp(val_float, -1.0f, 1.0f);
                         s16 val = static_cast<s16>(0x7FFF * val_float);
                         out_streams[channel].push_back(val & 0xFF);
                         out_streams[channel].push_back(val >> 8);

--- a/src/audio_core/hle/wmf_decoder.cpp
+++ b/src/audio_core/hle/wmf_decoder.cpp
@@ -129,7 +129,7 @@ MFOutputState WMFDecoder::Impl::DecodingLoop(ADTSData adts_header,
             f32 val_f32;
             for (std::size_t i = 0; i < output_buffer->size();) {
                 for (std::size_t channel = 0; channel < adts_header.channels; channel++) {
-                    val_f32 = output_buffer->at(i);
+                    val_f32 = std::clamp(output_buffer->at(i), -1.0f, 1.0f);
                     s16 val = static_cast<s16>(0x7FFF * val_f32);
                     out_streams[channel].push_back(val & 0xFF);
                     out_streams[channel].push_back(val >> 8);


### PR DESCRIPTION
This PR uses a better resampling algorithm when converting `f32` to `s16` data type in the audio decoders.

**TL;DR** This will resolve the pops and clicks in the game audio like Fire Emblem, Pokemon X/Y 
 and other games where HLE AAC decoder is used.

The pops and clicks are caused by the signal clipping, by clamping in the calculation, the peaks are smoothed out so the hard clipping will be avoided.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4763)
<!-- Reviewable:end -->
