### PR TITLE
Check input profile name for duplicates in New/Rename

### DIFF
--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -437,9 +437,8 @@ void ConfigureInput::NewProfile() {
     if (name.isEmpty()) {
         return;
     }
-    if (ui->profile->findText(name, Qt::MatchFixedString | Qt::MatchCaseSensitive) != -1) {
-        QMessageBox::warning(this, tr("Duplicate profile name"),
-                             tr("Profile name already exists. Please choose a different name."));
+    if (IsProfileNameDuplicate(name)) {
+        WarnProposedProfileNameIsDuplicate();
         return;
     }
 
@@ -471,12 +470,23 @@ void ConfigureInput::RenameProfile() {
     if (new_name.isEmpty()) {
         return;
     }
-    if (ui->profile->findText(new_name, Qt::MatchFixedString | Qt::MatchCaseSensitive) != -1) {
-        QMessageBox::warning(this, tr("Duplicate profile name"),
-                                 tr("Profile name already exists. Please choose a different name."));
+    if (IsProfileNameDuplicate(new_name)) {
+        WarnProposedProfileNameIsDuplicate();
         return;
     }
 
     ui->profile->setItemText(ui->profile->currentIndex(), new_name);
     Settings::RenameCurrentProfile(new_name.toStdString());
+}
+
+bool ConfigureInput::IsProfileNameDuplicate(const QString& name) {
+    if (ui->profile->findText(name, Qt::MatchFixedString | Qt::MatchCaseSensitive) != -1) {
+        return true;
+    }
+    return false;
+}
+
+void ConfigureInput::WarnProposedProfileNameIsDuplicate() {
+    QMessageBox::warning(this, tr("Duplicate profile name"),
+                         tr("Profile name already exists. Please choose a different name."));
 }

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -437,6 +437,12 @@ void ConfigureInput::NewProfile() {
     if (name.isEmpty()) {
         return;
     }
+    if (ui->profile->findText(name, Qt::MatchFixedString | Qt::MatchCaseSensitive) != -1) {
+        QMessageBox::warning(this, tr("Duplicate profile name"),
+                             tr("Profile name already exists. Please choose a different name."));
+        return;
+    }
+
     applyConfiguration();
     Settings::SaveProfile(ui->profile->currentIndex());
     Settings::CreateProfile(name.toStdString());
@@ -465,6 +471,12 @@ void ConfigureInput::RenameProfile() {
     if (new_name.isEmpty()) {
         return;
     }
+    if (ui->profile->findText(new_name, Qt::MatchFixedString | Qt::MatchCaseSensitive) != -1) {
+        QMessageBox::warning(this, tr("Duplicate profile name"),
+                                 tr("Profile name already exists. Please choose a different name."));
+        return;
+    }
+
     ui->profile->setItemText(ui->profile->currentIndex(), new_name);
     Settings::RenameCurrentProfile(new_name.toStdString());
 }

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -480,10 +480,7 @@ void ConfigureInput::RenameProfile() {
 }
 
 bool ConfigureInput::IsProfileNameDuplicate(const QString& name) {
-    if (ui->profile->findText(name, Qt::MatchFixedString | Qt::MatchCaseSensitive) != -1) {
-        return true;
-    }
-    return false;
+    return ui->profile->findText(name, Qt::MatchFixedString | Qt::MatchCaseSensitive) != -1;
 }
 
 void ConfigureInput::WarnProposedProfileNameIsDuplicate() {

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -479,7 +479,7 @@ void ConfigureInput::RenameProfile() {
     Settings::RenameCurrentProfile(new_name.toStdString());
 }
 
-bool ConfigureInput::IsProfileNameDuplicate(const QString& name) {
+bool ConfigureInput::IsProfileNameDuplicate(const QString& name) const {
     return ui->profile->findText(name, Qt::MatchFixedString | Qt::MatchCaseSensitive) != -1;
 }
 

--- a/src/citra_qt/configuration/configure_input.h
+++ b/src/citra_qt/configuration/configure_input.h
@@ -120,6 +120,6 @@ private:
     void DeleteProfile();
     void RenameProfile();
 
-    bool IsProfileNameDuplicate(const QString& name);
+    bool IsProfileNameDuplicate(const QString& name) const;
     void WarnProposedProfileNameIsDuplicate();
 };

--- a/src/citra_qt/configuration/configure_input.h
+++ b/src/citra_qt/configuration/configure_input.h
@@ -119,4 +119,7 @@ private:
     void NewProfile();
     void DeleteProfile();
     void RenameProfile();
+
+    bool IsProfileNameDuplicate(const QString& name);
+    void WarnProposedProfileNameIsDuplicate();
 };


### PR DESCRIPTION
Closes #4611

Perhaps I could shove the condition into a separate function instead of copypasting it? I would certainly do that in C#, but I'm not particularly familiar with C++ codebases and coding styles, so let me know.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4779)
<!-- Reviewable:end -->
