### PR TITLE
Add shortcuts and status bar widgets to toggle and set 3D factor

### DIFF
--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -54,14 +54,16 @@ const std::array<std::array<int, 5>, Settings::NativeAnalog::NumAnalogs> Config:
 // QKeySequnce(...).toString() is NOT ALLOWED HERE.
 // This must be in alphabetical order according to action name as it must have the same order as
 // UISetting::values.shortcuts, which is alphabetically ordered.
-const std::array<UISettings::Shortcut, 19> Config::default_hotkeys{
+const std::array<UISettings::Shortcut, 22> Config::default_hotkeys{
     {{"Advance Frame", "Main Window", {"\\", Qt::ApplicationShortcut}},
      {"Capture Screenshot", "Main Window", {"Ctrl+P", Qt::ApplicationShortcut}},
      {"Continue/Pause Emulation", "Main Window", {"F4", Qt::WindowShortcut}},
+     {"Decrease 3D Factor", "Main Window", {"Ctrl+-", Qt::ApplicationShortcut}},
      {"Decrease Speed Limit", "Main Window", {"-", Qt::ApplicationShortcut}},
      {"Exit Citra", "Main Window", {"Ctrl+Q", Qt::WindowShortcut}},
      {"Exit Fullscreen", "Main Window", {"Esc", Qt::WindowShortcut}},
      {"Fullscreen", "Main Window", {"F11", Qt::WindowShortcut}},
+     {"Increase 3D Factor", "Main Window", {"Ctrl++", Qt::ApplicationShortcut}},
      {"Increase Speed Limit", "Main Window", {"+", Qt::ApplicationShortcut}},
      {"Load Amiibo", "Main Window", {"F2", Qt::ApplicationShortcut}},
      {"Load File", "Main Window", {"Ctrl+O", Qt::WindowShortcut}},
@@ -69,6 +71,7 @@ const std::array<UISettings::Shortcut, 19> Config::default_hotkeys{
      {"Restart Emulation", "Main Window", {"F6", Qt::WindowShortcut}},
      {"Stop Emulation", "Main Window", {"F5", Qt::WindowShortcut}},
      {"Swap Screens", "Main Window", {"F9", Qt::WindowShortcut}},
+     {"Toggle 3D", "Main Window", {"Ctrl+3", Qt::ApplicationShortcut}},
      {"Toggle Filter Bar", "Main Window", {"Ctrl+F", Qt::WindowShortcut}},
      {"Toggle Frame Advancing", "Main Window", {"Ctrl+A", Qt::ApplicationShortcut}},
      {"Toggle Screen Layout", "Main Window", {"F10", Qt::WindowShortcut}},

--- a/src/citra_qt/configuration/config.h
+++ b/src/citra_qt/configuration/config.h
@@ -32,7 +32,7 @@ private:
     void WriteSetting(const QString& name, const QVariant& value);
     void WriteSetting(const QString& name, const QVariant& value, const QVariant& default_value);
 
-    static const std::array<UISettings::Shortcut, 19> default_hotkeys;
+    static const std::array<UISettings::Shortcut, 22> default_hotkeys;
 
     std::unique_ptr<QSettings> qt_config;
     std::string qt_config_loc;

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -658,7 +658,7 @@ void GMainWindow::ConnectMenuEvents() {
 
 void GMainWindow::ConnectStatusBarEvents() {
     connect(status_3d_label, &ClickableLabel::clicked, this, &GMainWindow::Toggle3D);
-    connect(factor_3d_spinbox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+    connect(factor_3d_spinbox, qOverload<int>(&QSpinBox::valueChanged),
         this, [&](int value) {
                 Settings::values.factor_3d = value;
                 UpdateStatusBar();

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -659,7 +659,7 @@ void GMainWindow::ConnectMenuEvents() {
 void GMainWindow::ConnectStatusBarEvents() {
     connect(status_3d_label, &ClickableLabel::clicked, this, &GMainWindow::Toggle3D);
     connect(factor_3d_spinbox, qOverload<int>(&QSpinBox::valueChanged),
-        this, [&](int value) {
+        this, [this](int value) {
                 Settings::values.factor_3d = value;
                 UpdateStatusBar();
             });

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -467,7 +467,7 @@ void GMainWindow::InitializeHotkeys() {
     // variable hold a garbage value after this function exits
     static constexpr u16 FACTOR_3D_STEP = 5;
     connect(hotkey_registry.GetHotkey("Main Window", "Decrease 3D Factor", this),
-            &QShortcut::activated, this, [&] {
+            &QShortcut::activated, this, [this] {
                 if (Settings::values.factor_3d > 0) {
                     if (Settings::values.factor_3d % FACTOR_3D_STEP != 0) {
                         Settings::values.factor_3d -= Settings::values.factor_3d % FACTOR_3D_STEP;
@@ -479,7 +479,7 @@ void GMainWindow::InitializeHotkeys() {
             });
 
     connect(hotkey_registry.GetHotkey("Main Window", "Increase 3D Factor", this),
-            &QShortcut::activated, this, [&] {
+            &QShortcut::activated, this, [this] {
                 if (Settings::values.factor_3d < 100) {
                     if (Settings::values.factor_3d % FACTOR_3D_STEP != 0) {
                         Settings::values.factor_3d +=

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -382,20 +382,6 @@ void GMainWindow::InitializeHotkeys() {
     ui.action_Show_Status_Bar->setShortcutContext(
         hotkey_registry.GetShortcutContext("Main Window", "Toggle Status Bar"));
 
-    ui.action_Toggle_3D->setShortcut(hotkey_registry.GetKeySequence("Main Window", "Toggle 3D"));
-    ui.action_Toggle_3D->setShortcutContext(
-        hotkey_registry.GetShortcutContext("Main Window", "Toggle 3D"));
-
-    ui.action_Increase_3D->setShortcut(
-        hotkey_registry.GetKeySequence("Main Window", "Increase 3D Factor"));
-    ui.action_Increase_3D->setShortcutContext(
-        hotkey_registry.GetShortcutContext("Main Window", "Increase 3D Factor"));
-
-    ui.action_Decrease_3D->setShortcut(
-        hotkey_registry.GetKeySequence("Main Window", "Decrease 3D Factor"));
-    ui.action_Decrease_3D->setShortcutContext(
-        hotkey_registry.GetShortcutContext("Main Window", "Decrease 3D Factor"));
-
     connect(hotkey_registry.GetHotkey("Main Window", "Load File", this), &QShortcut::activated,
             this, &GMainWindow::OnMenuLoadFile);
 
@@ -476,7 +462,7 @@ void GMainWindow::InitializeHotkeys() {
             });
 
     connect(hotkey_registry.GetHotkey("Main Window", "Toggle 3D", this), &QShortcut::activated,
-            ui.action_Toggle_3D, &QAction::trigger);
+            this, &GMainWindow::Toggle3D);
 
     // We use "static" here in order to avoid capturing by lambda due to a MSVC bug, which makes the
     // variable hold a garbage value after this function exits
@@ -671,10 +657,9 @@ void GMainWindow::ConnectMenuEvents() {
 }
 
 void GMainWindow::ConnectStatusBarEvents() {
-    connect(ui.action_Toggle_3D, &QAction::triggered, this, &GMainWindow::Toggle3D);
-    connect(status_3d_label, &ClickableLabel::clicked, ui.action_Toggle_3D, &QAction::trigger);
+    connect(status_3d_label, &ClickableLabel::clicked, this, &GMainWindow::Toggle3D);
     connect(factor_3d_spinbox, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
-            this, [&](int value) {
+        this, [&](int value) {
                 Settings::values.factor_3d = value;
                 UpdateStatusBar();
             });
@@ -1752,7 +1737,7 @@ void GMainWindow::OnMenuAboutCitra() {
 }
 
 void GMainWindow::Toggle3D() {
-    Settings::values.toggle_3d = !ui.action_Toggle_3D->isChecked();
+    Settings::values.toggle_3d = !Settings::values.toggle_3d;
     UpdateStatusBar();
 }
 

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -658,9 +658,8 @@ void GMainWindow::ConnectMenuEvents() {
 
 void GMainWindow::ConnectStatusBarEvents() {
     connect(status_3d_label, &ClickableLabel::clicked, this, &GMainWindow::Toggle3D);
-    connect(factor_3d_slider, qOverload<int>(&QSlider::valueChanged), this, [this](int value) {
-        Settings::values.factor_3d = value;
-    });
+    connect(factor_3d_slider, qOverload<int>(&QSlider::valueChanged), this,
+            [this](int value) { Settings::values.factor_3d = value; });
 }
 
 void GMainWindow::OnDisplayTitleBars(bool show) {

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -241,7 +241,7 @@ void GMainWindow::InitializeWidgets() {
         tr("Indicates whether 3D is currently on or off. Click to toggle."));
 
     factor_3d_spinbox = new QSpinBox(this);
-    factor_3d_spinbox->setToolTip(("Current 3D factor while 3D is enabled."));
+    factor_3d_spinbox->setToolTip(tr("Current 3D factor while 3D is enabled."));
     factor_3d_spinbox->setSingleStep(5);
     factor_3d_spinbox->setRange(0, 100);
     factor_3d_spinbox->setVisible(false);

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -250,6 +250,7 @@ void GMainWindow::InitializeWidgets() {
                         emu_frametime_label}) {
         label->setVisible(false);
         label->setFrameStyle(QFrame::NoFrame);
+        label->setSizePolicy(QSizePolicy::Policy::MinimumExpanding, QSizePolicy::Policy::Minimum);
         label->setContentsMargins(4, 0, 4, 0);
         statusBar()->addPermanentWidget(label, 0);
     }

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -240,12 +240,11 @@ void GMainWindow::InitializeWidgets() {
     status_3d_label->setToolTip(
         tr("Indicates whether 3D is currently on or off. Click to toggle."));
 
-    factor_3d_spinbox = new QSpinBox(this);
-    factor_3d_spinbox->setToolTip(tr("Current 3D factor while 3D is enabled."));
-    factor_3d_spinbox->setSingleStep(5);
-    factor_3d_spinbox->setRange(0, 100);
-    factor_3d_spinbox->setVisible(false);
-    statusBar()->addPermanentWidget(factor_3d_spinbox, 0);
+    factor_3d_slider = new QSlider(Qt::Orientation::Horizontal, this);
+    factor_3d_slider->setToolTip(tr("Current 3D factor while 3D is enabled."));
+    factor_3d_slider->setRange(0, 100);
+    factor_3d_slider->setVisible(false);
+    statusBar()->addPermanentWidget(factor_3d_slider, 0);
 
     for (auto& label : {static_cast<QLabel*>(status_3d_label), emu_speed_label, game_fps_label,
                         emu_frametime_label}) {
@@ -658,9 +657,8 @@ void GMainWindow::ConnectMenuEvents() {
 
 void GMainWindow::ConnectStatusBarEvents() {
     connect(status_3d_label, &ClickableLabel::clicked, this, &GMainWindow::Toggle3D);
-    connect(factor_3d_spinbox, qOverload<int>(&QSpinBox::valueChanged), this, [this](int value) {
+    connect(factor_3d_slider, qOverload<int>(&QSlider::valueChanged), this, [this](int value) {
         Settings::values.factor_3d = value;
-        UpdateStatusBar();
     });
 }
 
@@ -972,7 +970,7 @@ void GMainWindow::ShutdownGame() {
     game_fps_label->setVisible(false);
     emu_frametime_label->setVisible(false);
     status_3d_label->setVisible(false);
-    factor_3d_spinbox->setVisible(false);
+    factor_3d_slider->setVisible(false);
 
     emulation_running = false;
 
@@ -1668,13 +1666,13 @@ void GMainWindow::UpdateStatusBar() {
     emu_frametime_label->setText(tr("Frame: %1 ms").arg(results.frametime * 1000.0, 0, 'f', 2));
     status_3d_label->setText(
         tr("3D status: %1").arg(Settings::values.toggle_3d ? tr("ON") : tr("OFF")));
-    factor_3d_spinbox->setValue(Settings::values.factor_3d);
+    factor_3d_slider->setValue(Settings::values.factor_3d);
 
     emu_speed_label->setVisible(true);
     game_fps_label->setVisible(true);
     emu_frametime_label->setVisible(true);
     status_3d_label->setVisible(true);
-    factor_3d_spinbox->setVisible(Settings::values.toggle_3d);
+    factor_3d_slider->setVisible(Settings::values.toggle_3d);
 }
 
 void GMainWindow::OnCoreError(Core::System::ResultStatus result, std::string details) {

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -658,11 +658,10 @@ void GMainWindow::ConnectMenuEvents() {
 
 void GMainWindow::ConnectStatusBarEvents() {
     connect(status_3d_label, &ClickableLabel::clicked, this, &GMainWindow::Toggle3D);
-    connect(factor_3d_spinbox, qOverload<int>(&QSpinBox::valueChanged),
-        this, [this](int value) {
-                Settings::values.factor_3d = value;
-                UpdateStatusBar();
-            });
+    connect(factor_3d_spinbox, qOverload<int>(&QSpinBox::valueChanged), this, [this](int value) {
+        Settings::values.factor_3d = value;
+        UpdateStatusBar();
+    });
 }
 
 void GMainWindow::OnDisplayTitleBars(bool show) {

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -37,7 +37,7 @@ class ProfilerWidget;
 template <typename>
 class QFutureWatcher;
 class QProgressBar;
-class QSpinBox;
+class QSlider;
 class RegistersWidget;
 class Updater;
 class WaitTreeWidget;
@@ -217,7 +217,7 @@ private:
     QLabel* game_fps_label = nullptr;
     QLabel* emu_frametime_label = nullptr;
     ClickableLabel* status_3d_label = nullptr;
-    QSpinBox* factor_3d_spinbox = nullptr;
+    QSlider* factor_3d_slider = nullptr;
     QTimer status_bar_update_timer;
 
     MultiplayerState* multiplayer_state = nullptr;

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -37,6 +37,7 @@ class ProfilerWidget;
 template <typename>
 class QFutureWatcher;
 class QProgressBar;
+class QSpinBox;
 class RegistersWidget;
 class Updater;
 class WaitTreeWidget;
@@ -103,6 +104,7 @@ private:
 
     void ConnectWidgetEvents();
     void ConnectMenuEvents();
+    void ConnectStatusBarEvents();
 
     bool LoadROM(const QString& filename);
     void BootGame(const QString& filename);
@@ -185,6 +187,7 @@ private slots:
     void OnStopRecordingPlayback();
     void OnCaptureScreenshot();
     void OnCoreError(Core::System::ResultStatus, std::string);
+    void Toggle3D();
     /// Called whenever a user selects Help->About Citra
     void OnMenuAboutCitra();
     void OnUpdateFound(bool found, bool error);
@@ -213,6 +216,8 @@ private:
     QLabel* emu_speed_label = nullptr;
     QLabel* game_fps_label = nullptr;
     QLabel* emu_frametime_label = nullptr;
+    ClickableLabel* status_3d_label = nullptr;
+    QSpinBox* factor_3d_spinbox = nullptr;
     QTimer status_bar_update_timer;
 
     MultiplayerState* multiplayer_state = nullptr;

--- a/src/citra_qt/main.ui
+++ b/src/citra_qt/main.ui
@@ -474,24 +474,6 @@
     <string>Open Citra Folder</string>
    </property>
   </action>
-  <action name="action_Toggle_3D">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Toggle 3D</string>
-   </property>
-  </action>
-  <action name="action_Increase_3D">
-   <property name="text">
-    <string>Increase 3D</string>
-   </property>
-  </action>
-  <action name="action_Decrease_3D">
-   <property name="text">
-    <string>Decrease 3D</string>
-   </property>
-  </action>
  </widget>
  <resources/>
  <connections/>

--- a/src/citra_qt/main.ui
+++ b/src/citra_qt/main.ui
@@ -474,6 +474,24 @@
     <string>Open Citra Folder</string>
    </property>
   </action>
+  <action name="action_Toggle_3D">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Toggle 3D</string>
+   </property>
+  </action>
+  <action name="action_Increase_3D">
+   <property name="text">
+    <string>Increase 3D</string>
+   </property>
+  </action>
+  <action name="action_Decrease_3D">
+   <property name="text">
+    <string>Decrease 3D</string>
+   </property>
+  </action>
  </widget>
  <resources/>
  <connections/>


### PR DESCRIPTION
Resolves #4621 

Summary of changes
- Add shortcut to toggle 3D (Ctrl+3 keybind by default)
- Add shortcut to decrease 3D factor by 5 (Ctrl+- keybind by default)
- Add shortcut to increase 3D factor by 5 (Ctrl++ keybind by default)
- Add 3D status label to the status bar. Clicking the label toggles the 3D as well.
- Add 3D factor QSpinBox next to the status label. SingleStep set to 5.

One thing that I couldn't for the love of god figure out is how to make the QSpinBox narrower, because it's wider than it needs to be imo. Calling `setMaximumWidth()` nor `setFocusedWidth()` seemed to help. Any suggestions there?

Let me know if there's anything not up to par with the coding style or if I perhaps forgot something.

# Screenshots:
## 3D off
![image](https://user-images.githubusercontent.com/732314/58748345-9e1a2900-8477-11e9-90cc-e2ee7f34fc89.png)
## 3D on
![image](https://user-images.githubusercontent.com/732314/58748348-a7a39100-8477-11e9-90eb-e9ee010b7218.png)


Now that I think about it, maybe we should move these widgets either to the right, or set the other labels to fixed size? Since the speed, framerate and frametime changing all the time causes all the widgets to the left of them to also move due to anchoring.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4787)
<!-- Reviewable:end -->
