### PR TITLE
Port yuzu-emu/yuzu#2526: "core/telemetry_session: Remove usages of the global system accessor"

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -94,7 +94,6 @@ System::ResultStatus System::SingleStep() {
 
 System::ResultStatus System::Load(Frontend::EmuWindow& emu_window, const std::string& filepath) {
     app_loader = Loader::GetLoader(filepath);
-
     if (!app_loader) {
         LOG_CRITICAL(Core, "Failed to obtain loader for {}!", filepath);
         return ResultStatus::ErrorGetLoader;
@@ -125,6 +124,7 @@ System::ResultStatus System::Load(Frontend::EmuWindow& emu_window, const std::st
         return init_result;
     }
 
+    telemetry_session->AddInitialInfo(*app_loader);
     std::shared_ptr<Kernel::Process> process;
     const Loader::ResultStatus load_result{app_loader->Load(process)};
     kernel->SetCurrentProcess(process);

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -108,12 +108,11 @@ TelemetrySession::~TelemetrySession() {
     auto backend = std::make_unique<Telemetry::NullVisitor>();
 #endif
 
-    // Complete the session, submitting to web service if necessary
+    // Complete the session, submitting to the web service backend if necessary
     field_collection.Accept(*backend);
     if (Settings::values.enable_telemetry) {
         backend->Complete();
     }
-    backend = nullptr;
 }
 
 void TelemetrySession::AddInitialInfo(Loader::AppLoader& app_loader) {

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -91,7 +91,32 @@ bool VerifyLogin(const std::string& username, const std::string& token) {
 #endif
 }
 
-TelemetrySession::TelemetrySession() {
+TelemetrySession::TelemetrySession() = default;
+
+TelemetrySession::~TelemetrySession() {
+    // Log one-time session end information
+    const s64 shutdown_time{std::chrono::duration_cast<std::chrono::milliseconds>(
+                                std::chrono::system_clock::now().time_since_epoch())
+                                .count()};
+    AddField(Telemetry::FieldType::Session, "Shutdown_Time", shutdown_time);
+
+#ifdef ENABLE_WEB_SERVICE
+    auto backend = std::make_unique<WebService::TelemetryJson>(Settings::values.web_api_url,
+                                                               Settings::values.citra_username,
+                                                               Settings::values.citra_token);
+#else
+    auto backend = std::make_unique<Telemetry::NullVisitor>();
+#endif
+
+    // Complete the session, submitting to web service if necessary
+    field_collection.Accept(*backend);
+    if (Settings::values.enable_telemetry) {
+        backend->Complete();
+    }
+    backend = nullptr;
+}
+
+void TelemetrySession::AddInitialInfo(Loader::AppLoader& app_loader) {
     // Log one-time top-level information
     AddField(Telemetry::FieldType::None, "TelemetryId", GetTelemetryId());
 
@@ -101,7 +126,7 @@ TelemetrySession::TelemetrySession() {
                             .count()};
     AddField(Telemetry::FieldType::Session, "Init_Time", init_time);
     std::string program_name;
-    const Loader::ResultStatus res{System::GetInstance().GetAppLoader().ReadTitle(program_name)};
+    const Loader::ResultStatus res{app_loader.ReadTitle(program_name)};
     if (res == Loader::ResultStatus::Success) {
         AddField(Telemetry::FieldType::Session, "ProgramName", program_name);
     }
@@ -176,28 +201,6 @@ TelemetrySession::TelemetrySession() {
              Settings::values.factor_3d.load());
     AddField(Telemetry::FieldType::UserConfig, "System_IsNew3ds", Settings::values.is_new_3ds);
     AddField(Telemetry::FieldType::UserConfig, "System_RegionValue", Settings::values.region_value);
-}
-
-TelemetrySession::~TelemetrySession() {
-    // Log one-time session end information
-    const s64 shutdown_time{std::chrono::duration_cast<std::chrono::milliseconds>(
-                                std::chrono::system_clock::now().time_since_epoch())
-                                .count()};
-    AddField(Telemetry::FieldType::Session, "Shutdown_Time", shutdown_time);
-
-#ifdef ENABLE_WEB_SERVICE
-    auto backend = std::make_unique<WebService::TelemetryJson>(Settings::values.web_api_url,
-                                                               Settings::values.citra_username,
-                                                               Settings::values.citra_token);
-#else
-    auto backend = std::make_unique<Telemetry::NullVisitor>();
-#endif
-
-    // Complete the session, submitting to web service if necessary
-    field_collection.Accept(*backend);
-    if (Settings::values.enable_telemetry)
-        backend->Complete();
-    backend = nullptr;
 }
 
 bool TelemetrySession::SubmitTestcase() {

--- a/src/core/telemetry_session.h
+++ b/src/core/telemetry_session.h
@@ -8,6 +8,10 @@
 #include <string>
 #include "common/telemetry.h"
 
+namespace Loader {
+class AppLoader;
+}
+
 namespace Core {
 
 /**
@@ -17,7 +21,7 @@ namespace Core {
  */
 class TelemetrySession {
 public:
-    TelemetrySession();
+    explicit TelemetrySession();
     ~TelemetrySession();
 
     TelemetrySession(const TelemetrySession&) = delete;
@@ -25,6 +29,22 @@ public:
 
     TelemetrySession(TelemetrySession&&) = delete;
     TelemetrySession& operator=(TelemetrySession&&) = delete;
+
+    /**
+     * Adds the initial telemetry info necessary when starting up a title.
+     *
+     * This includes information such as:
+     *   - Telemetry ID
+     *   - Initialization time
+     *   - Title ID
+     *   - Title name
+     *   - Title file format
+     *   - Miscellaneous settings values.
+     *
+     * @param app_loader The application loader to use to retrieve
+     *                   title-specific information.
+     */
+    void AddInitialInfo(Loader::AppLoader& app_loader);
 
     /**
      * Wrapper around the Telemetry::FieldCollection::AddField method.

--- a/src/core/telemetry_session.h
+++ b/src/core/telemetry_session.h
@@ -15,10 +15,16 @@ namespace Core {
  * session, logging any one-time fields. Interfaces with the telemetry backend used for submitting
  * data to the web service. Submits session data on close.
  */
-class TelemetrySession : NonCopyable {
+class TelemetrySession {
 public:
     TelemetrySession();
     ~TelemetrySession();
+
+    TelemetrySession(const TelemetrySession&) = delete;
+    TelemetrySession& operator=(const TelemetrySession&) = delete;
+
+    TelemetrySession(TelemetrySession&&) = delete;
+    TelemetrySession& operator=(TelemetrySession&&) = delete;
 
     /**
      * Wrapper around the Telemetry::FieldCollection::AddField method.


### PR DESCRIPTION
See yuzu-emu/yuzu#2526 for more details.

**Original description**:
A case where the use of global variables in the past is coming up to bite us, previously the initial telemetry data would always be bogus for the bits that relied on the app loader. At initialization time, the app loader will never have any useful information in it, because a game isn't considered to be loading them. Only at load time is that a thing.

Coincidentally, Init() is called in Load(), which prevents any issues from occurring, but if they were ever separated in the future, this would cause issues (and even crash the emulator). By making the dependency part of the interface, we strongly enforce it on the caller, making them call the necessary functions when the objects are known to exist.

While we're at it, we can also get rid of a related, but unnecessary loader function that's a holdover from Citra.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4793)
<!-- Reviewable:end -->
