### PR TITLE
kernel: handle all page table changes internally when switching processes

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -141,7 +141,6 @@ System::ResultStatus System::Load(Frontend::EmuWindow& emu_window, const std::st
             return ResultStatus::ErrorLoader;
         }
     }
-    memory->SetCurrentPageTable(&kernel->GetCurrentProcess()->vm_manager.page_table);
     cheat_engine = std::make_unique<Cheats::CheatEngine>(*this);
     status = ResultStatus::Success;
     m_emu_window = &emu_window;
@@ -179,16 +178,16 @@ System::ResultStatus System::Init(Frontend::EmuWindow& emu_window, u32 system_mo
 
     if (Settings::values.use_cpu_jit) {
 #ifdef ARCHITECTURE_x86_64
-        cpu_core = std::make_unique<ARM_Dynarmic>(this, *memory, USER32MODE);
+        cpu_core = std::make_shared<ARM_Dynarmic>(this, *memory, USER32MODE);
 #else
-        cpu_core = std::make_unique<ARM_DynCom>(this, *memory, USER32MODE);
+        cpu_core = std::make_shared<ARM_DynCom>(this, *memory, USER32MODE);
         LOG_WARNING(Core, "CPU JIT requested, but Dynarmic not available");
 #endif
     } else {
-        cpu_core = std::make_unique<ARM_DynCom>(this, *memory, USER32MODE);
+        cpu_core = std::make_shared<ARM_DynCom>(this, *memory, USER32MODE);
     }
 
-    kernel->GetThreadManager().SetCPU(*cpu_core);
+    kernel->SetCPU(cpu_core);
 
     if (Settings::values.enable_dsp_lle) {
         dsp_core = std::make_unique<AudioCore::DspLle>(*memory,

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -189,7 +189,6 @@ System::ResultStatus System::Init(Frontend::EmuWindow& emu_window, u32 system_mo
     }
 
     kernel->GetThreadManager().SetCPU(*cpu_core);
-    memory->SetCPU(*cpu_core);
 
     if (Settings::values.enable_dsp_lle) {
         dsp_core = std::make_unique<AudioCore::DspLle>(*memory,

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -255,7 +255,7 @@ private:
     std::unique_ptr<Loader::AppLoader> app_loader;
 
     /// ARM11 CPU core
-    std::unique_ptr<ARM_Interface> cpu_core;
+    std::shared_ptr<ARM_Interface> cpu_core;
 
     /// DSP core
     std::unique_ptr<AudioCore::DspInterface> dsp_core;

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -53,7 +53,9 @@ void KernelSystem::SetCurrentProcess(std::shared_ptr<Process> process) {
 
 void KernelSystem::SetCurrentMemPageTable(Memory::PageTable* page_table) {
     memory.SetCurrentPageTable(page_table);
-    current_cpu->PageTableChanged(); // notify the CPU the page table in memory has changed
+    if (current_cpu != nullptr) {
+        current_cpu->PageTableChanged(); // notify the CPU the page table in memory has changed
+    }
 }
 
 void KernelSystem::SetCPU(std::shared_ptr<ARM_Interface> cpu) {

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -48,10 +48,10 @@ std::shared_ptr<Process> KernelSystem::GetCurrentProcess() const {
 
 void KernelSystem::SetCurrentProcess(std::shared_ptr<Process> process) {
     current_process = process;
-    SetCurrentMemPageTable(&process->vm_manager.page_table);
+    SetCurrentMemoryPageTable(&process->vm_manager.page_table);
 }
 
-void KernelSystem::SetCurrentMemPageTable(Memory::PageTable* page_table) {
+void KernelSystem::SetCurrentMemoryPageTable(Memory::PageTable* page_table) {
     memory.SetCurrentPageTable(page_table);
     if (current_cpu != nullptr) {
         current_cpu->PageTableChanged(); // notify the CPU the page table in memory has changed

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -47,7 +47,18 @@ std::shared_ptr<Process> KernelSystem::GetCurrentProcess() const {
 }
 
 void KernelSystem::SetCurrentProcess(std::shared_ptr<Process> process) {
-    current_process = std::move(process);
+    current_process = process;
+    SetCurrentMemPageTable(&process->vm_manager.page_table);
+}
+
+void KernelSystem::SetCurrentMemPageTable(Memory::PageTable* page_table) {
+    memory.SetCurrentPageTable(page_table);
+    current_cpu->PageTableChanged(); // notify the CPU the page table in memory has changed
+}
+
+void KernelSystem::SetCPU(std::shared_ptr<ARM_Interface> cpu) {
+    current_cpu = cpu;
+    thread_manager->SetCPU(*cpu);
 }
 
 ThreadManager& KernelSystem::GetThreadManager() {

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -207,7 +207,7 @@ public:
     std::shared_ptr<Process> GetCurrentProcess() const;
     void SetCurrentProcess(std::shared_ptr<Process> process);
 
-    void SetCurrentMemPageTable(Memory::PageTable* page_table);
+    void SetCurrentMemoryPageTable(Memory::PageTable* page_table);
 
     void SetCPU(std::shared_ptr<ARM_Interface> cpu);
 

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -14,6 +14,7 @@
 #include "common/common_types.h"
 #include "core/hle/kernel/memory.h"
 #include "core/hle/result.h"
+#include "core/memory.h"
 
 namespace ConfigMem {
 class Handler;
@@ -206,6 +207,10 @@ public:
     std::shared_ptr<Process> GetCurrentProcess() const;
     void SetCurrentProcess(std::shared_ptr<Process> process);
 
+    void SetCurrentMemPageTable(Memory::PageTable* page_table);
+
+    void SetCPU(std::shared_ptr<ARM_Interface> cpu);
+
     ThreadManager& GetThreadManager();
     const ThreadManager& GetThreadManager() const;
 
@@ -232,6 +237,8 @@ public:
 
     /// Map of named ports managed by the kernel, which can be retrieved using the ConnectToPort
     std::unordered_map<std::string, std::shared_ptr<ClientPort>> named_ports;
+
+    std::shared_ptr<ARM_Interface> current_cpu;
 
     Memory::MemorySystem& memory;
 

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -114,6 +114,7 @@ void ThreadManager::SwitchContext(Thread* new_thread) {
             kernel.SetCurrentProcess(SharedFrom(current_thread->owner_process));
             kernel.memory.SetCurrentPageTable(
                 &current_thread->owner_process->vm_manager.page_table);
+            cpu->PageTableChanged(); // notify the CPU the page table in memory has changed
         }
 
         cpu->LoadContext(new_thread->context);

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -112,9 +112,6 @@ void ThreadManager::SwitchContext(Thread* new_thread) {
 
         if (previous_process.get() != current_thread->owner_process) {
             kernel.SetCurrentProcess(SharedFrom(current_thread->owner_process));
-            kernel.memory.SetCurrentPageTable(
-                &current_thread->owner_process->vm_manager.page_table);
-            cpu->PageTableChanged(); // notify the CPU the page table in memory has changed
         }
 
         cpu->LoadContext(new_thread->context);

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -66,22 +66,14 @@ public:
     RasterizerCacheMarker cache_marker;
     std::vector<PageTable*> page_table_list;
 
-    ARM_Interface* cpu = nullptr;
     AudioCore::DspInterface* dsp = nullptr;
 };
 
 MemorySystem::MemorySystem() : impl(std::make_unique<Impl>()) {}
 MemorySystem::~MemorySystem() = default;
 
-void MemorySystem::SetCPU(ARM_Interface& cpu) {
-    impl->cpu = &cpu;
-}
-
 void MemorySystem::SetCurrentPageTable(PageTable* page_table) {
     impl->current_page_table = page_table;
-    if (impl->cpu != nullptr) {
-        impl->cpu->PageTableChanged();
-    }
 }
 
 PageTable* MemorySystem::GetCurrentPageTable() const {

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -220,9 +220,6 @@ public:
     MemorySystem();
     ~MemorySystem();
 
-    /// Sets CPU to notify page table change
-    void SetCPU(ARM_Interface& cpu);
-
     /**
      * Maps an allocated buffer onto a region of the emulated process address space.
      *

--- a/src/tests/core/arm/arm_test_common.cpp
+++ b/src/tests/core/arm/arm_test_common.cpp
@@ -28,7 +28,7 @@ TestEnvironment::TestEnvironment(bool mutable_memory_)
     memory->MapIoRegion(*page_table, 0x00000000, 0x80000000, test_memory);
     memory->MapIoRegion(*page_table, 0x80000000, 0x80000000, test_memory);
 
-    kernel->SetCurrentMemPageTable(page_table);
+    kernel->SetCurrentMemoryPageTable(page_table);
 }
 
 TestEnvironment::~TestEnvironment() {

--- a/src/tests/core/arm/arm_test_common.cpp
+++ b/src/tests/core/arm/arm_test_common.cpp
@@ -28,7 +28,7 @@ TestEnvironment::TestEnvironment(bool mutable_memory_)
     memory->MapIoRegion(*page_table, 0x00000000, 0x80000000, test_memory);
     memory->MapIoRegion(*page_table, 0x80000000, 0x80000000, test_memory);
 
-    memory->SetCurrentPageTable(page_table);
+    kernel->SetCurrentMemPageTable(page_table);
 }
 
 TestEnvironment::~TestEnvironment() {


### PR DESCRIPTION
This removes cpu_core instance from memory.cpp making cpu_core and memory being completely independent components inside the system, having a simpler and more understandable initialization process

The thread which casues page table changes in memory will be responsible of notifying the cpu_core too

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4799)
<!-- Reviewable:end -->
