### PR TITLE
 GSP_GPU: move used_thread_ids into the class 

### DIFF
--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -72,7 +72,7 @@ public:
 
 protected:
     /// Creates the storage for the session data of the service.
-    virtual std::unique_ptr<SessionDataBase> MakeSessionData() const = 0;
+    virtual std::unique_ptr<SessionDataBase> MakeSessionData() = 0;
 
     /// Returns the session data associated with the server session.
     template <typename T>

--- a/src/core/hle/service/gsp/gsp.cpp
+++ b/src/core/hle/service/gsp/gsp.cpp
@@ -12,12 +12,6 @@ namespace Service::GSP {
 
 static std::weak_ptr<GSP_GPU> gsp_gpu;
 
-FrameBufferUpdate* GetFrameBufferInfo(u32 thread_id, u32 screen_index) {
-    auto gpu = gsp_gpu.lock();
-    ASSERT(gpu != nullptr);
-    return gpu->GetFrameBufferInfo(thread_id, screen_index);
-}
-
 void SignalInterrupt(InterruptId interrupt_id) {
     auto gpu = gsp_gpu.lock();
     ASSERT(gpu != nullptr);

--- a/src/core/hle/service/gsp/gsp.h
+++ b/src/core/hle/service/gsp/gsp.h
@@ -17,15 +17,6 @@ class System;
 
 namespace Service::GSP {
 /**
- * Retrieves the framebuffer info stored in the GSP shared memory for the
- * specified screen index and thread id.
- * @param thread_id GSP thread id of the process that accesses the structure that we are requesting.
- * @param screen_index Index of the screen we are requesting (Top = 0, Bottom = 1).
- * @returns FramebufferUpdate Information about the specified framebuffer.
- */
-FrameBufferUpdate* GetFrameBufferInfo(u32 thread_id, u32 screen_index);
-
-/**
  * Signals that the specified interrupt type has occurred to userland code
  * @param interrupt_id ID of interrupt that is being signalled
  */

--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -156,7 +156,7 @@ protected:
         RegisterHandlersBase(functions, n);
     }
 
-    std::unique_ptr<SessionDataBase> MakeSessionData() const override {
+    std::unique_ptr<SessionDataBase> MakeSessionData() override {
         return std::make_unique<SessionData>();
     }
 


### PR DESCRIPTION
...and remove an unused function while we are on it.

With the change, `GSP::SessionData` essentially depends on a `GSP_GPU` to construct, and therefore a pointer needs to be passed in to the constructor, and the `MakeSessionData` function is override. The default constructor is still provided to make the default implementation compilable, but it is marked unreachable at runtime. The `const` specifier is also removed from `MakeSessionData` because, as seen in GSP_GPU, constructing a session can surely alter the state of the service.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4801)
<!-- Reviewable:end -->
