### PR TITLE
Port yuzu-emu/yuzu#2580: "kernel/vm_manager: Remove redundant Reset call in destructor "

### DIFF
--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -40,9 +40,7 @@ VMManager::VMManager(Memory::MemorySystem& memory) : memory(memory) {
     Reset();
 }
 
-VMManager::~VMManager() {
-    Reset();
-}
+VMManager::~VMManager() = default;
 
 void VMManager::Reset() {
     vma_map.clear();


### PR DESCRIPTION
See yuzu-emu/yuzu#2580 for more details.

**Original description**:
This is performing more work than would otherwise be necessary during VMManager's destruction. All we actually want to occur in this scenario is for any allocated memory to be freed, which will happen automatically as the VMManager instance goes out of scope. Anything else being done is unnecessary work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4803)
<!-- Reviewable:end -->
