### PR TITLE
Port yuzu-emu/yuzu#2404: "CMakeLists: Ensure we specify Unicode as the codepage on Windows"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,9 @@ if (MSVC)
     # Avoid windows.h from including some usually unused libs like winsocks.h, since this might cause some redefinition errors.
     add_definitions(-DWIN32_LEAN_AND_MEAN)
 
+    # Ensure that projects build with Unicode support.
+    add_definitions(-DUNICODE -D_UNICODE)
+
     # /W3                 - Level 3 warnings
     # /MP                 - Multi-threaded compilation
     # /Zi                 - Output debugging information

--- a/src/citra/citra.cpp
+++ b/src/citra/citra.cpp
@@ -11,11 +11,6 @@
 // This needs to be included before getopt.h because the latter #defines symbols used by it
 #include "common/microprofile.h"
 
-#include <getopt.h>
-#ifndef _MSC_VER
-#include <unistd.h>
-#endif
-
 #ifdef _WIN32
 // windows.h needs to be included before shellapi.h
 #include <windows.h>
@@ -44,6 +39,12 @@
 #include "core/movie.h"
 #include "core/settings.h"
 #include "network/network.h"
+
+#undef _UNICODE
+#include <getopt.h>
+#ifndef _MSC_VER
+#include <unistd.h>
+#endif
 
 #ifdef _WIN32
 extern "C" {

--- a/src/dedicated_room/citra-room.cpp
+++ b/src/dedicated_room/citra-room.cpp
@@ -11,13 +11,6 @@
 #include <thread>
 #include <glad/glad.h>
 
-#ifdef _MSC_VER
-#include <getopt.h>
-#else
-#include <getopt.h>
-#include <unistd.h>
-#endif
-
 #ifdef _WIN32
 // windows.h needs to be included before shellapi.h
 #include <windows.h>
@@ -38,6 +31,12 @@
 
 #ifdef ENABLE_WEB_SERVICE
 #include "web_service/verify_user_jwt.h"
+#endif
+
+#undef _UNICODE
+#include <getopt.h>
+#ifndef _MSC_VER
+#include <unistd.h>
 #endif
 
 static void PrintHelp(const char* argv0) {


### PR DESCRIPTION
See yuzu-emu/yuzu#2404.

**Original description**:
Previously we were building with MBCS, which is pretty undesirable. We want the application to be Unicode-aware in general.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4804)
<!-- Reviewable:end -->
