### PR TITLE
Port yuzu-emu/yuzu#2450: "CMakeLists: Explicitly specify -Wall for the non-MSVC case"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,7 +35,10 @@ if (MSVC)
     set(CMAKE_EXE_LINKER_FLAGS_DEBUG   "/DEBUG /MANIFEST:NO" CACHE STRING "" FORCE)
     set(CMAKE_EXE_LINKER_FLAGS_RELEASE "/DEBUG /MANIFEST:NO /INCREMENTAL:NO /OPT:REF,ICF" CACHE STRING "" FORCE)
 else()
-    add_compile_options("-Wno-attributes")
+    add_compile_options(
+        -Wall
+        -Wno-attributes
+    )
 
     if (APPLE AND CMAKE_CXX_COMPILER_ID STREQUAL Clang)
         add_compile_options("-stdlib=libc++")


### PR DESCRIPTION
See yuzu-emu/yuzu#2450 for more details.

**Original description**:
Ensures that -Wall is always active as a compilation flag regardless of build type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4806)
<!-- Reviewable:end -->
