### PR TITLE
Port yuzu-emu/yuzu#2550: "yuzu/CMakeLists: Pass compilation flags that make it more difficult to cause bugs in Qt code"

### DIFF
--- a/src/citra_qt/CMakeLists.txt
+++ b/src/citra_qt/CMakeLists.txt
@@ -231,6 +231,9 @@ target_compile_definitions(citra-qt PRIVATE
 
     # Disable implicit type narrowing in signal/slot connect() calls.
     -DQT_NO_NARROWING_CONVERSIONS_IN_CONNECT
+
+    # Disable unsafe overloads of QProcess' start() function.
+    -DQT_NO_PROCESS_COMBINED_ARGUMENT_START
 )
 
 if (CITRA_ENABLE_COMPATIBILITY_REPORTING)

--- a/src/citra_qt/CMakeLists.txt
+++ b/src/citra_qt/CMakeLists.txt
@@ -234,6 +234,9 @@ target_compile_definitions(citra-qt PRIVATE
 
     # Disable unsafe overloads of QProcess' start() function.
     -DQT_NO_PROCESS_COMBINED_ARGUMENT_START
+
+    # Disable implicit QString->QUrl conversions to enforce use of proper resolving functions.
+    -DQT_NO_URL_CAST_FROM_STRING
 )
 
 if (CITRA_ENABLE_COMPATIBILITY_REPORTING)

--- a/src/citra_qt/CMakeLists.txt
+++ b/src/citra_qt/CMakeLists.txt
@@ -228,6 +228,9 @@ target_compile_definitions(citra-qt PRIVATE
     # Use QStringBuilder for string concatenation to reduce
     # the overall number of temporary strings created.
     -DQT_USE_QSTRINGBUILDER
+
+    # Disable implicit type narrowing in signal/slot connect() calls.
+    -DQT_NO_NARROWING_CONVERSIONS_IN_CONNECT
 )
 
 if (CITRA_ENABLE_COMPATIBILITY_REPORTING)

--- a/src/citra_qt/configuration/configure_graphics.cpp
+++ b/src/citra_qt/configuration/configure_graphics.cpp
@@ -21,11 +21,10 @@ ConfigureGraphics::ConfigureGraphics(QWidget* parent)
     ui->layoutBox->setEnabled(!Settings::values.custom_layout);
 
     ui->hw_renderer_group->setEnabled(ui->toggle_hw_renderer->isChecked());
-    connect(ui->toggle_hw_renderer, &QCheckBox::stateChanged, ui->hw_renderer_group,
+    connect(ui->toggle_hw_renderer, &QCheckBox::toggled, ui->hw_renderer_group,
             &QWidget::setEnabled);
     ui->hw_shader_group->setEnabled(ui->toggle_hw_shader->isChecked());
-    connect(ui->toggle_hw_shader, &QCheckBox::stateChanged, ui->hw_shader_group,
-            &QWidget::setEnabled);
+    connect(ui->toggle_hw_shader, &QCheckBox::toggled, ui->hw_shader_group, &QWidget::setEnabled);
 #ifdef __APPLE__
     connect(ui->toggle_hw_shader, &QCheckBox::stateChanged, this, [this](int state) {
         if (state == Qt::Checked) {

--- a/src/citra_qt/multiplayer/chat_room.cpp
+++ b/src/citra_qt/multiplayer/chat_room.cpp
@@ -425,7 +425,7 @@ void ChatRoom::PopupContextMenu(const QPoint& menu_location) {
         QAction* view_profile_action = context_menu.addAction(tr("View Profile"));
         connect(view_profile_action, &QAction::triggered, [username] {
             QDesktopServices::openUrl(
-                QString("https://community.citra-emu.org/u/%1").arg(username));
+                QUrl(QString("https://community.citra-emu.org/u/%1").arg(username)));
         });
     }
 

--- a/src/citra_qt/multiplayer/lobby.cpp
+++ b/src/citra_qt/multiplayer/lobby.cpp
@@ -64,9 +64,8 @@ Lobby::Lobby(QWidget* parent, QStandardItemModel* list,
 
     // UI Buttons
     connect(ui->refresh_list, &QPushButton::pressed, this, &Lobby::RefreshLobby);
-    connect(ui->games_owned, &QCheckBox::stateChanged, proxy,
-            &LobbyFilterProxyModel::SetFilterOwned);
-    connect(ui->hide_full, &QCheckBox::stateChanged, proxy, &LobbyFilterProxyModel::SetFilterFull);
+    connect(ui->games_owned, &QCheckBox::toggled, proxy, &LobbyFilterProxyModel::SetFilterOwned);
+    connect(ui->hide_full, &QCheckBox::toggled, proxy, &LobbyFilterProxyModel::SetFilterFull);
     connect(ui->search, &QLineEdit::textChanged, proxy, &LobbyFilterProxyModel::SetFilterSearch);
     connect(ui->room_list, &QTreeView::doubleClicked, this, &Lobby::OnJoinRoom);
     connect(ui->room_list, &QTreeView::clicked, this, &Lobby::OnExpandRoom);


### PR DESCRIPTION
See yuzu-emu/yuzu#2550 for more details.

**Original description**:
Passes three defines that Qt doesn't enable by default that make it harder to introduce bugs in Qt frontend code. Mainly makes it so written code is required to be more explicit in expressing its intent. e.g. if narrowing is desirable, it should be explicitly handled so it's made evident the writer intended that behavior to happen, etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4807)
<!-- Reviewable:end -->
