### PR TITLE
ncch_container: Fix code.bin replacement

### DIFF
--- a/src/core/file_sys/ncch_container.cpp
+++ b/src/core/file_sys/ncch_container.cpp
@@ -559,7 +559,7 @@ Loader::ResultStatus NCCHContainer::LoadOverrideExeFSSection(const char* name,
     if (!strcmp(name, ".code"))
         override_name = "code.bin";
     else if (!strcmp(name, "icon"))
-        override_name = "code.bin";
+        override_name = "icon.bin";
     else if (!strcmp(name, "banner"))
         override_name = "banner.bnr";
     else if (!strcmp(name, "logo"))


### PR DESCRIPTION
Currently, having a replacement code.bin causes Citra to crash as it is
trying to load icon data from code.bin because of a typo. This commit
fixes that typo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4812)
<!-- Reviewable:end -->
