### PR TITLE
Port yuzu-emu/yuzu#2521: "yuzu/configuration: Make function naming consistent"

### DIFF
--- a/src/citra_qt/configuration/configure_audio.cpp
+++ b/src/citra_qt/configuration/configure_audio.cpp
@@ -30,7 +30,7 @@ ConfigureAudio::ConfigureAudio(QWidget* parent)
     ui->emulation_combo_box->setEnabled(!Core::System::GetInstance().IsPoweredOn());
 
     connect(ui->volume_slider, &QSlider::valueChanged, this,
-            &ConfigureAudio::setVolumeIndicatorText);
+            &ConfigureAudio::SetVolumeIndicatorText);
 
     ui->input_device_combo_box->clear();
     ui->input_device_combo_box->addItem(tr("Default"));
@@ -40,26 +40,26 @@ ConfigureAudio::ConfigureAudio(QWidget* parent)
     }
 #endif
     connect(ui->input_type_combo_box, qOverload<int>(&QComboBox::currentIndexChanged), this,
-            &ConfigureAudio::updateAudioInputDevices);
+            &ConfigureAudio::UpdateAudioInputDevices);
 
-    this->setConfiguration();
+    SetConfiguration();
     connect(ui->output_sink_combo_box, qOverload<int>(&QComboBox::currentIndexChanged), this,
-            &ConfigureAudio::updateAudioOutputDevices);
+            &ConfigureAudio::UpdateAudioOutputDevices);
 }
 
 ConfigureAudio::~ConfigureAudio() {}
 
-void ConfigureAudio::setConfiguration() {
-    setOutputSinkFromSinkID();
+void ConfigureAudio::SetConfiguration() {
+    SetOutputSinkFromSinkID();
 
     // The device list cannot be pre-populated (nor listed) until the output sink is known.
-    updateAudioOutputDevices(ui->output_sink_combo_box->currentIndex());
+    UpdateAudioOutputDevices(ui->output_sink_combo_box->currentIndex());
 
-    setAudioDeviceFromDeviceID();
+    SetAudioDeviceFromDeviceID();
 
     ui->toggle_audio_stretching->setChecked(Settings::values.enable_audio_stretching);
     ui->volume_slider->setValue(Settings::values.volume * ui->volume_slider->maximum());
-    setVolumeIndicatorText(ui->volume_slider->sliderPosition());
+    SetVolumeIndicatorText(ui->volume_slider->sliderPosition());
 
     int selection;
     if (Settings::values.enable_dsp_lle) {
@@ -77,10 +77,10 @@ void ConfigureAudio::setConfiguration() {
     ui->input_type_combo_box->setCurrentIndex(index);
     ui->input_device_combo_box->setCurrentText(
         QString::fromStdString(Settings::values.mic_input_device));
-    updateAudioInputDevices(index);
+    UpdateAudioInputDevices(index);
 }
 
-void ConfigureAudio::setOutputSinkFromSinkID() {
+void ConfigureAudio::SetOutputSinkFromSinkID() {
     int new_sink_index = 0;
 
     const QString sink_id = QString::fromStdString(Settings::values.sink_id);
@@ -94,7 +94,7 @@ void ConfigureAudio::setOutputSinkFromSinkID() {
     ui->output_sink_combo_box->setCurrentIndex(new_sink_index);
 }
 
-void ConfigureAudio::setAudioDeviceFromDeviceID() {
+void ConfigureAudio::SetAudioDeviceFromDeviceID() {
     int new_device_index = -1;
 
     const QString device_id = QString::fromStdString(Settings::values.audio_device_id);
@@ -108,11 +108,11 @@ void ConfigureAudio::setAudioDeviceFromDeviceID() {
     ui->audio_device_combo_box->setCurrentIndex(new_device_index);
 }
 
-void ConfigureAudio::setVolumeIndicatorText(int percentage) {
+void ConfigureAudio::SetVolumeIndicatorText(int percentage) {
     ui->volume_indicator->setText(tr("%1%", "Volume percentage (e.g. 50%)").arg(percentage));
 }
 
-void ConfigureAudio::applyConfiguration() {
+void ConfigureAudio::ApplyConfiguration() {
     Settings::values.sink_id =
         ui->output_sink_combo_box->itemText(ui->output_sink_combo_box->currentIndex())
             .toStdString();
@@ -129,7 +129,7 @@ void ConfigureAudio::applyConfiguration() {
     Settings::values.mic_input_device = ui->input_device_combo_box->currentText().toStdString();
 }
 
-void ConfigureAudio::updateAudioOutputDevices(int sink_index) {
+void ConfigureAudio::UpdateAudioOutputDevices(int sink_index) {
     ui->audio_device_combo_box->clear();
     ui->audio_device_combo_box->addItem(AudioCore::auto_device_name);
 
@@ -139,8 +139,8 @@ void ConfigureAudio::updateAudioOutputDevices(int sink_index) {
     }
 }
 
-void ConfigureAudio::updateAudioInputDevices(int index) {}
+void ConfigureAudio::UpdateAudioInputDevices(int index) {}
 
-void ConfigureAudio::retranslateUi() {
+void ConfigureAudio::RetranslateUI() {
     ui->retranslateUi(this);
 }

--- a/src/citra_qt/configuration/configure_audio.h
+++ b/src/citra_qt/configuration/configure_audio.h
@@ -18,17 +18,17 @@ public:
     explicit ConfigureAudio(QWidget* parent = nullptr);
     ~ConfigureAudio() override;
 
-    void applyConfiguration();
-    void retranslateUi();
-    void setConfiguration();
+    void ApplyConfiguration();
+    void RetranslateUI();
+    void SetConfiguration();
 
 private:
-    void updateAudioOutputDevices(int sink_index);
-    void updateAudioInputDevices(int index);
+    void UpdateAudioOutputDevices(int sink_index);
+    void UpdateAudioInputDevices(int index);
 
-    void setOutputSinkFromSinkID();
-    void setAudioDeviceFromDeviceID();
-    void setVolumeIndicatorText(int percentage);
+    void SetOutputSinkFromSinkID();
+    void SetAudioDeviceFromDeviceID();
+    void SetVolumeIndicatorText(int percentage);
 
     std::unique_ptr<Ui::ConfigureAudio> ui;
 };

--- a/src/citra_qt/configuration/configure_camera.cpp
+++ b/src/citra_qt/configuration/configure_camera.cpp
@@ -32,27 +32,27 @@ ConfigureCamera::ConfigureCamera(QWidget* parent)
     for (const QCameraInfo& cameraInfo : cameras) {
         ui->system_camera->addItem(cameraInfo.deviceName());
     }
-    updateCameraMode();
-    setConfiguration();
-    connectEvents();
+    UpdateCameraMode();
+    SetConfiguration();
+    ConnectEvents();
     ui->preview_box->setHidden(true);
 }
 
 ConfigureCamera::~ConfigureCamera() {
-    stopPreviewing();
+    StopPreviewing();
 }
 
-void ConfigureCamera::connectEvents() {
+void ConfigureCamera::ConnectEvents() {
     connect(ui->image_source,
             static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, [this] {
-                stopPreviewing();
-                updateImageSourceUI();
+                StopPreviewing();
+                UpdateImageSourceUI();
             });
     connect(ui->camera_selection,
             static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, [this] {
-                stopPreviewing();
-                if (getCameraSelection() != current_selected) {
-                    recordConfig();
+                StopPreviewing();
+                if (GetCameraSelection() != current_selected) {
+                    RecordConfig();
                 }
                 if (ui->camera_selection->currentIndex() == 1) {
                     ui->camera_mode->setCurrentIndex(1); // Double
@@ -60,26 +60,26 @@ void ConfigureCamera::connectEvents() {
                         ui->camera_mode->setCurrentIndex(0); // Single
                     }
                 }
-                updateCameraMode();
-                setConfiguration();
+                UpdateCameraMode();
+                SetConfiguration();
             });
     connect(ui->camera_mode, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
             this, [this] {
-                stopPreviewing();
+                StopPreviewing();
                 ui->camera_position_label->setVisible(ui->camera_mode->currentIndex() == 1);
                 ui->camera_position->setVisible(ui->camera_mode->currentIndex() == 1);
-                current_selected = getCameraSelection();
+                current_selected = GetCameraSelection();
             });
     connect(ui->camera_position,
             static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, [this] {
-                stopPreviewing();
-                if (getCameraSelection() != current_selected) {
-                    recordConfig();
+                StopPreviewing();
+                if (GetCameraSelection() != current_selected) {
+                    RecordConfig();
                 }
-                setConfiguration();
+                SetConfiguration();
             });
-    connect(ui->toolButton, &QToolButton::clicked, this, &ConfigureCamera::onToolButtonClicked);
-    connect(ui->preview_button, &QPushButton::clicked, this, [=] { startPreviewing(); });
+    connect(ui->toolButton, &QToolButton::clicked, this, &ConfigureCamera::OnToolButtonClicked);
+    connect(ui->preview_button, &QPushButton::clicked, this, [=] { StartPreviewing(); });
     connect(ui->prompt_before_load, &QCheckBox::stateChanged, this, [this](int state) {
         ui->camera_file->setDisabled(state == Qt::Checked);
         ui->toolButton->setDisabled(state == Qt::Checked);
@@ -87,16 +87,16 @@ void ConfigureCamera::connectEvents() {
             ui->camera_file->setText("");
         }
     });
-    connect(ui->camera_file, &QLineEdit::textChanged, this, [=] { stopPreviewing(); });
+    connect(ui->camera_file, &QLineEdit::textChanged, this, [=] { StopPreviewing(); });
     connect(ui->system_camera,
             static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
-            [=] { stopPreviewing(); });
+            [=] { StopPreviewing(); });
     connect(ui->camera_flip, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
-            this, [=] { stopPreviewing(); });
+            this, [=] { StopPreviewing(); });
 }
 
-void ConfigureCamera::updateCameraMode() {
-    CameraPosition pos = getCameraSelection();
+void ConfigureCamera::UpdateCameraMode() {
+    CameraPosition pos = GetCameraSelection();
     // Set the visibility of the camera mode selection widgets
     if (pos == CameraPosition::RearBoth) {
         ui->camera_position->setHidden(true);
@@ -111,7 +111,7 @@ void ConfigureCamera::updateCameraMode() {
     }
 }
 
-void ConfigureCamera::updateImageSourceUI() {
+void ConfigureCamera::UpdateImageSourceUI() {
     int image_source = ui->image_source->currentIndex();
     switch (image_source) {
     case 0: /* blank */
@@ -128,7 +128,7 @@ void ConfigureCamera::updateImageSourceUI() {
         ui->camera_file_label->setHidden(false);
         ui->camera_file->setHidden(false);
         ui->toolButton->setHidden(false);
-        if (camera_config[getSelectedCameraIndex()].empty()) {
+        if (camera_config[GetSelectedCameraIndex()].empty()) {
             ui->prompt_before_load->setChecked(true);
             ui->camera_file->setDisabled(true);
             ui->toolButton->setDisabled(true);
@@ -147,7 +147,7 @@ void ConfigureCamera::updateImageSourceUI() {
     ui->camera_flip->setHidden(image_source == 0);
 }
 
-void ConfigureCamera::recordConfig() {
+void ConfigureCamera::RecordConfig() {
     std::string implementation = Implementations[ui->image_source->currentIndex()];
     int image_source = ui->image_source->currentIndex();
     std::string config;
@@ -170,14 +170,14 @@ void ConfigureCamera::recordConfig() {
         camera_config[index] = config;
         camera_flip[index] = ui->camera_flip->currentIndex();
     }
-    current_selected = getCameraSelection();
+    current_selected = GetCameraSelection();
 }
 
-void ConfigureCamera::startPreviewing() {
-    current_selected = getCameraSelection();
-    recordConfig();
-    int camera_selection = getSelectedCameraIndex();
-    stopPreviewing();
+void ConfigureCamera::StartPreviewing() {
+    current_selected = GetCameraSelection();
+    RecordConfig();
+    int camera_selection = GetSelectedCameraIndex();
+    StopPreviewing();
     // Init preview box
     ui->preview_box->setHidden(false);
     ui->preview_button->setHidden(true);
@@ -190,7 +190,7 @@ void ConfigureCamera::startPreviewing() {
         camera_name[camera_selection], camera_config[camera_selection], preview_width,
         preview_height, static_cast<Service::CAM::Flip>(camera_flip[camera_selection]));
     if (!previewing_camera) {
-        stopPreviewing();
+        StopPreviewing();
         return;
     }
     previewing_camera->SetResolution(
@@ -204,7 +204,7 @@ void ConfigureCamera::startPreviewing() {
     timer_id = startTimer(1000 / 30);
 }
 
-void ConfigureCamera::stopPreviewing() {
+void ConfigureCamera::StopPreviewing() {
     ui->preview_box->setHidden(true);
     ui->preview_button->setHidden(false);
 
@@ -231,7 +231,7 @@ void ConfigureCamera::timerEvent(QTimerEvent* event) {
     int width = ui->preview_box->size().width();
     int height = width * 0.75;
     if (width != preview_width || height != preview_height) {
-        stopPreviewing();
+        StopPreviewing();
         return;
     }
     QImage image(width, height, QImage::Format::Format_RGB16);
@@ -239,8 +239,8 @@ void ConfigureCamera::timerEvent(QTimerEvent* event) {
     ui->preview_box->setPixmap(QPixmap::fromImage(image));
 }
 
-void ConfigureCamera::setConfiguration() {
-    int index = getSelectedCameraIndex();
+void ConfigureCamera::SetConfiguration() {
+    int index = GetSelectedCameraIndex();
     for (int i = 0; i < Implementations.size(); i++) {
         if (Implementations[i] == camera_name[index]) {
             ui->image_source->setCurrentIndex(i);
@@ -262,11 +262,11 @@ void ConfigureCamera::setConfiguration() {
         ui->camera_file->setText(QString::fromStdString(camera_config[index]));
     }
     ui->camera_flip->setCurrentIndex(camera_flip[index]);
-    updateImageSourceUI();
+    UpdateImageSourceUI();
 }
 
-void ConfigureCamera::onToolButtonClicked() {
-    stopPreviewing();
+void ConfigureCamera::OnToolButtonClicked() {
+    StopPreviewing();
     QList<QByteArray> types = QImageReader::supportedImageFormats();
     QList<QString> temp_filters;
     for (const QByteArray& type : types) {
@@ -279,15 +279,15 @@ void ConfigureCamera::onToolButtonClicked() {
     }
 }
 
-void ConfigureCamera::applyConfiguration() {
-    recordConfig();
-    stopPreviewing();
+void ConfigureCamera::ApplyConfiguration() {
+    RecordConfig();
+    StopPreviewing();
     Settings::values.camera_name = camera_name;
     Settings::values.camera_config = camera_config;
     Settings::values.camera_flip = camera_flip;
 }
 
-ConfigureCamera::CameraPosition ConfigureCamera::getCameraSelection() {
+ConfigureCamera::CameraPosition ConfigureCamera::GetCameraSelection() {
     switch (ui->camera_selection->currentIndex()) {
     case 0: // Front
         return CameraPosition::Front;
@@ -306,8 +306,8 @@ ConfigureCamera::CameraPosition ConfigureCamera::getCameraSelection() {
     }
 }
 
-int ConfigureCamera::getSelectedCameraIndex() {
-    CameraPosition pos = getCameraSelection();
+int ConfigureCamera::GetSelectedCameraIndex() {
+    CameraPosition pos = GetCameraSelection();
     int camera_selection = static_cast<int>(pos);
     if (pos == CameraPosition::RearBoth) { // Single Mode
         camera_selection = 0;              // Either camera is the same, so we return RearRight
@@ -315,6 +315,6 @@ int ConfigureCamera::getSelectedCameraIndex() {
     return camera_selection;
 }
 
-void ConfigureCamera::retranslateUi() {
+void ConfigureCamera::RetranslateUI() {
     ui->retranslateUi(this);
 }

--- a/src/citra_qt/configuration/configure_camera.h
+++ b/src/citra_qt/configuration/configure_camera.h
@@ -18,30 +18,30 @@ public:
     explicit ConfigureCamera(QWidget* parent = nullptr);
     ~ConfigureCamera() override;
 
-    void applyConfiguration();
-    void retranslateUi();
+    void ApplyConfiguration();
+    void RetranslateUI();
 
     void timerEvent(QTimerEvent*) override;
 
 public slots:
-    /// recordConfig() and updateUiDisplay()
-    void setConfiguration();
-    void onToolButtonClicked();
+    /// RecordConfig() and UpdateUiDisplay()
+    void SetConfiguration();
+    void OnToolButtonClicked();
 
 private:
     enum class CameraPosition { RearRight, Front, RearLeft, RearBoth, Null };
     static const std::array<std::string, 3> Implementations;
     /// Record the current configuration
-    void recordConfig();
+    void RecordConfig();
     /// Updates camera mode
-    void updateCameraMode();
+    void UpdateCameraMode();
     /// Updates image source
-    void updateImageSourceUI();
-    void startPreviewing();
-    void stopPreviewing();
-    void connectEvents();
-    CameraPosition getCameraSelection();
-    int getSelectedCameraIndex();
+    void UpdateImageSourceUI();
+    void StartPreviewing();
+    void StopPreviewing();
+    void ConnectEvents();
+    CameraPosition GetCameraSelection();
+    int GetSelectedCameraIndex();
 
 private:
     std::unique_ptr<Ui::ConfigureCamera> ui;

--- a/src/citra_qt/configuration/configure_debug.cpp
+++ b/src/citra_qt/configuration/configure_debug.cpp
@@ -17,7 +17,8 @@
 
 ConfigureDebug::ConfigureDebug(QWidget* parent) : QWidget(parent), ui(new Ui::ConfigureDebug) {
     ui->setupUi(this);
-    this->setConfiguration();
+    SetConfiguration();
+
     connect(ui->open_log_button, &QPushButton::pressed, []() {
         QString path = QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::LogDir));
         QDesktopServices::openUrl(QUrl::fromLocalFile(path));
@@ -27,7 +28,7 @@ ConfigureDebug::ConfigureDebug(QWidget* parent) : QWidget(parent), ui(new Ui::Co
 
 ConfigureDebug::~ConfigureDebug() = default;
 
-void ConfigureDebug::setConfiguration() {
+void ConfigureDebug::SetConfiguration() {
     ui->toggle_gdbstub->setChecked(Settings::values.use_gdbstub);
     ui->gdbport_spinbox->setEnabled(Settings::values.use_gdbstub);
     ui->gdbport_spinbox->setValue(Settings::values.gdbstub_port);
@@ -37,7 +38,7 @@ void ConfigureDebug::setConfiguration() {
     ui->toggle_cpu_jit->setChecked(Settings::values.use_cpu_jit);
 }
 
-void ConfigureDebug::applyConfiguration() {
+void ConfigureDebug::ApplyConfiguration() {
     Settings::values.use_gdbstub = ui->toggle_gdbstub->isChecked();
     Settings::values.gdbstub_port = ui->gdbport_spinbox->value();
     UISettings::values.show_console = ui->toggle_console->isChecked();
@@ -49,6 +50,6 @@ void ConfigureDebug::applyConfiguration() {
     Settings::values.use_cpu_jit = ui->toggle_cpu_jit->isChecked();
 }
 
-void ConfigureDebug::retranslateUi() {
+void ConfigureDebug::RetranslateUI() {
     ui->retranslateUi(this);
 }

--- a/src/citra_qt/configuration/configure_debug.h
+++ b/src/citra_qt/configuration/configure_debug.h
@@ -18,9 +18,9 @@ public:
     explicit ConfigureDebug(QWidget* parent = nullptr);
     ~ConfigureDebug() override;
 
-    void applyConfiguration();
-    void retranslateUi();
-    void setConfiguration();
+    void ApplyConfiguration();
+    void RetranslateUI();
+    void SetConfiguration();
 
     std::unique_ptr<Ui::ConfigureDebug> ui;
 };

--- a/src/citra_qt/configuration/configure_dialog.cpp
+++ b/src/citra_qt/configuration/configure_dialog.cpp
@@ -16,11 +16,11 @@ ConfigureDialog::ConfigureDialog(QWidget* parent, HotkeyRegistry& registry, bool
     ui->hotkeysTab->Populate(registry);
     ui->webTab->SetWebServiceConfigEnabled(enable_web_config);
 
-    this->PopulateSelectionList();
+    PopulateSelectionList();
 
     setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
-    connect(ui->uiTab, &ConfigureUi::languageChanged, this, &ConfigureDialog::onLanguageChanged);
+    connect(ui->uiTab, &ConfigureUi::LanguageChanged, this, &ConfigureDialog::OnLanguageChanged);
     connect(ui->selectorList, &QListWidget::itemSelectionChanged, this,
             &ConfigureDialog::UpdateVisibleTabs);
 
@@ -40,30 +40,30 @@ ConfigureDialog::ConfigureDialog(QWidget* parent, HotkeyRegistry& registry, bool
 
 ConfigureDialog::~ConfigureDialog() = default;
 
-void ConfigureDialog::setConfiguration() {
-    ui->generalTab->setConfiguration();
-    ui->systemTab->setConfiguration();
-    ui->inputTab->loadConfiguration();
-    ui->graphicsTab->setConfiguration();
-    ui->audioTab->setConfiguration();
-    ui->cameraTab->setConfiguration();
-    ui->debugTab->setConfiguration();
-    ui->webTab->setConfiguration();
-    ui->uiTab->setConfiguration();
+void ConfigureDialog::SetConfiguration() {
+    ui->generalTab->SetConfiguration();
+    ui->systemTab->SetConfiguration();
+    ui->inputTab->LoadConfiguration();
+    ui->graphicsTab->SetConfiguration();
+    ui->audioTab->SetConfiguration();
+    ui->cameraTab->SetConfiguration();
+    ui->debugTab->SetConfiguration();
+    ui->webTab->SetConfiguration();
+    ui->uiTab->SetConfiguration();
 }
 
-void ConfigureDialog::applyConfiguration() {
-    ui->generalTab->applyConfiguration();
-    ui->systemTab->applyConfiguration();
-    ui->inputTab->applyConfiguration();
+void ConfigureDialog::ApplyConfiguration() {
+    ui->generalTab->ApplyConfiguration();
+    ui->systemTab->ApplyConfiguration();
+    ui->inputTab->ApplyConfiguration();
     ui->inputTab->ApplyProfile();
-    ui->hotkeysTab->applyConfiguration(registry);
-    ui->graphicsTab->applyConfiguration();
-    ui->audioTab->applyConfiguration();
-    ui->cameraTab->applyConfiguration();
-    ui->debugTab->applyConfiguration();
-    ui->webTab->applyConfiguration();
-    ui->uiTab->applyConfiguration();
+    ui->hotkeysTab->ApplyConfiguration(registry);
+    ui->graphicsTab->ApplyConfiguration();
+    ui->audioTab->ApplyConfiguration();
+    ui->cameraTab->ApplyConfiguration();
+    ui->debugTab->ApplyConfiguration();
+    ui->webTab->ApplyConfiguration();
+    ui->uiTab->ApplyConfiguration();
     Settings::Apply();
     Settings::LogSettings();
 }
@@ -86,15 +86,15 @@ void ConfigureDialog::PopulateSelectionList() {
     }
 }
 
-void ConfigureDialog::onLanguageChanged(const QString& locale) {
-    emit languageChanged(locale);
+void ConfigureDialog::OnLanguageChanged(const QString& locale) {
+    emit LanguageChanged(locale);
     // first apply the configuration, and then restore the display
-    applyConfiguration();
-    retranslateUi();
-    setConfiguration();
+    ApplyConfiguration();
+    RetranslateUI();
+    SetConfiguration();
 }
 
-void ConfigureDialog::retranslateUi() {
+void ConfigureDialog::RetranslateUI() {
     int old_row = ui->selectorList->currentRow();
     int old_index = ui->tabWidget->currentIndex();
     ui->retranslateUi(this);
@@ -103,16 +103,16 @@ void ConfigureDialog::retranslateUi() {
     ui->selectorList->setCurrentRow(old_row);
     ui->tabWidget->setCurrentIndex(old_index);
 
-    ui->generalTab->retranslateUi();
-    ui->systemTab->retranslateUi();
-    ui->inputTab->retranslateUi();
-    ui->hotkeysTab->retranslateUi();
-    ui->graphicsTab->retranslateUi();
-    ui->audioTab->retranslateUi();
-    ui->cameraTab->retranslateUi();
-    ui->debugTab->retranslateUi();
-    ui->webTab->retranslateUi();
-    ui->uiTab->retranslateUi();
+    ui->generalTab->RetranslateUI();
+    ui->systemTab->RetranslateUI();
+    ui->inputTab->RetranslateUI();
+    ui->hotkeysTab->RetranslateUI();
+    ui->graphicsTab->RetranslateUI();
+    ui->audioTab->RetranslateUI();
+    ui->cameraTab->RetranslateUI();
+    ui->debugTab->RetranslateUI();
+    ui->webTab->RetranslateUI();
+    ui->uiTab->RetranslateUI();
 }
 
 void ConfigureDialog::UpdateVisibleTabs() {

--- a/src/citra_qt/configuration/configure_dialog.h
+++ b/src/citra_qt/configuration/configure_dialog.h
@@ -21,17 +21,17 @@ public:
                              bool enable_web_config = true);
     ~ConfigureDialog() override;
 
-    void applyConfiguration();
+    void ApplyConfiguration();
 
 private slots:
-    void onLanguageChanged(const QString& locale);
+    void OnLanguageChanged(const QString& locale);
 
 signals:
-    void languageChanged(const QString& locale);
+    void LanguageChanged(const QString& locale);
 
 private:
-    void setConfiguration();
-    void retranslateUi();
+    void SetConfiguration();
+    void RetranslateUI();
     void UpdateVisibleTabs();
     void PopulateSelectionList();
 

--- a/src/citra_qt/configuration/configure_general.cpp
+++ b/src/citra_qt/configuration/configure_general.cpp
@@ -13,7 +13,7 @@ ConfigureGeneral::ConfigureGeneral(QWidget* parent)
     : QWidget(parent), ui(new Ui::ConfigureGeneral) {
 
     ui->setupUi(this);
-    this->setConfiguration();
+    SetConfiguration();
 
     ui->updateBox->setVisible(UISettings::values.updater_found);
     connect(ui->button_reset_defaults, &QPushButton::clicked, this,
@@ -22,7 +22,7 @@ ConfigureGeneral::ConfigureGeneral(QWidget* parent)
 
 ConfigureGeneral::~ConfigureGeneral() = default;
 
-void ConfigureGeneral::setConfiguration() {
+void ConfigureGeneral::SetConfiguration() {
     ui->toggle_check_exit->setChecked(UISettings::values.confirm_before_closing);
 
     ui->toggle_update_check->setChecked(UISettings::values.check_for_update_on_start);
@@ -45,7 +45,7 @@ void ConfigureGeneral::ResetDefaults() {
     std::exit(0);
 }
 
-void ConfigureGeneral::applyConfiguration() {
+void ConfigureGeneral::ApplyConfiguration() {
     UISettings::values.confirm_before_closing = ui->toggle_check_exit->isChecked();
 
     UISettings::values.check_for_update_on_start = ui->toggle_update_check->isChecked();
@@ -54,6 +54,6 @@ void ConfigureGeneral::applyConfiguration() {
     Settings::values.region_value = ui->region_combobox->currentIndex() - 1;
 }
 
-void ConfigureGeneral::retranslateUi() {
+void ConfigureGeneral::RetranslateUI() {
     ui->retranslateUi(this);
 }

--- a/src/citra_qt/configuration/configure_general.h
+++ b/src/citra_qt/configuration/configure_general.h
@@ -21,9 +21,9 @@ public:
     ~ConfigureGeneral() override;
 
     void ResetDefaults();
-    void applyConfiguration();
-    void retranslateUi();
-    void setConfiguration();
+    void ApplyConfiguration();
+    void RetranslateUI();
+    void SetConfiguration();
 
 private:
     std::unique_ptr<Ui::ConfigureGeneral> ui;

--- a/src/citra_qt/configuration/configure_graphics.cpp
+++ b/src/citra_qt/configuration/configure_graphics.cpp
@@ -14,7 +14,7 @@
 ConfigureGraphics::ConfigureGraphics(QWidget* parent)
     : QWidget(parent), ui(new Ui::ConfigureGraphics) {
     ui->setupUi(this);
-    setConfiguration();
+    SetConfiguration();
 
     connect(ui->toggle_frame_limit, &QCheckBox::toggled, ui->frame_limit, &QSpinBox::setEnabled);
 
@@ -53,7 +53,7 @@ ConfigureGraphics::ConfigureGraphics(QWidget* parent)
 
 ConfigureGraphics::~ConfigureGraphics() = default;
 
-void ConfigureGraphics::setConfiguration() {
+void ConfigureGraphics::SetConfiguration() {
     ui->toggle_hw_renderer->setChecked(Settings::values.use_hw_renderer);
     ui->toggle_hw_shader->setChecked(Settings::values.use_hw_shader);
     ui->toggle_accurate_gs->setChecked(Settings::values.shaders_accurate_gs);
@@ -75,7 +75,7 @@ void ConfigureGraphics::setConfiguration() {
     ui->bg_button->setIcon(color_icon);
 }
 
-void ConfigureGraphics::applyConfiguration() {
+void ConfigureGraphics::ApplyConfiguration() {
     Settings::values.use_hw_renderer = ui->toggle_hw_renderer->isChecked();
     Settings::values.use_hw_shader = ui->toggle_hw_shader->isChecked();
     Settings::values.shaders_accurate_gs = ui->toggle_accurate_gs->isChecked();
@@ -95,6 +95,6 @@ void ConfigureGraphics::applyConfiguration() {
     Settings::values.bg_blue = static_cast<float>(bg_color.blueF());
 }
 
-void ConfigureGraphics::retranslateUi() {
+void ConfigureGraphics::RetranslateUI() {
     ui->retranslateUi(this);
 }

--- a/src/citra_qt/configuration/configure_graphics.h
+++ b/src/citra_qt/configuration/configure_graphics.h
@@ -18,9 +18,9 @@ public:
     explicit ConfigureGraphics(QWidget* parent = nullptr);
     ~ConfigureGraphics() override;
 
-    void applyConfiguration();
-    void retranslateUi();
-    void setConfiguration();
+    void ApplyConfiguration();
+    void RetranslateUI();
+    void SetConfiguration();
 
     std::unique_ptr<Ui::ConfigureGraphics> ui;
     QColor bg_color;

--- a/src/citra_qt/configuration/configure_hotkeys.cpp
+++ b/src/citra_qt/configuration/configure_hotkeys.cpp
@@ -99,7 +99,7 @@ bool ConfigureHotkeys::IsUsedKey(QKeySequence key_sequence) const {
     return input_keys_list.contains(key_sequence) || GetUsedKeyList().contains(key_sequence);
 }
 
-void ConfigureHotkeys::applyConfiguration(HotkeyRegistry& registry) {
+void ConfigureHotkeys::ApplyConfiguration(HotkeyRegistry& registry) {
     for (int key_id = 0; key_id < model->rowCount(); key_id++) {
         QStandardItem* parent = model->item(key_id, 0);
         for (int key_column_id = 0; key_column_id < parent->rowCount(); key_column_id++) {
@@ -120,6 +120,6 @@ void ConfigureHotkeys::applyConfiguration(HotkeyRegistry& registry) {
     registry.SaveHotkeys();
 }
 
-void ConfigureHotkeys::retranslateUi() {
+void ConfigureHotkeys::RetranslateUI() {
     ui->retranslateUi(this);
 }

--- a/src/citra_qt/configuration/configure_hotkeys.h
+++ b/src/citra_qt/configuration/configure_hotkeys.h
@@ -21,8 +21,8 @@ public:
     explicit ConfigureHotkeys(QWidget* parent = nullptr);
     ~ConfigureHotkeys();
 
-    void applyConfiguration(HotkeyRegistry& registry);
-    void retranslateUi();
+    void ApplyConfiguration(HotkeyRegistry& registry);
+    void RetranslateUI();
 
     void EmitHotkeysChanged();
 

--- a/src/citra_qt/configuration/configure_input.h
+++ b/src/citra_qt/configuration/configure_input.h
@@ -34,11 +34,11 @@ public:
     ~ConfigureInput() override;
 
     /// Save all button configurations to settings file
-    void applyConfiguration();
-    void retranslateUi();
+    void ApplyConfiguration();
+    void RetranslateUI();
 
     /// Load configuration settings.
-    void loadConfiguration();
+    void LoadConfiguration();
     void EmitInputKeysChanged();
 
     /// Save the current input profile index
@@ -94,15 +94,15 @@ private:
     QList<QKeySequence> GetUsedKeyboardKeys();
 
     /// Restore all buttons to their default values.
-    void restoreDefaults();
+    void RestoreDefaults();
     /// Clear all input configuration
     void ClearAll();
 
     /// Update UI to reflect current configuration.
-    void updateButtonLabels();
+    void UpdateButtonLabels();
 
     /// Called when the button was pressed.
-    void handleClick(QPushButton* button,
+    void HandleClick(QPushButton* button,
                      std::function<void(const Common::ParamPackage&)> new_input_setter,
                      InputCommon::Polling::DeviceType type);
 
@@ -110,7 +110,7 @@ private:
     int previous_key_code;
 
     /// Finish polling and configure input using the input_setter
-    void setPollingResult(const Common::ParamPackage& params, bool abort);
+    void SetPollingResult(const Common::ParamPackage& params, bool abort);
 
     /// Handle key press events.
     void keyPressEvent(QKeyEvent* event) override;

--- a/src/citra_qt/configuration/configure_motion_touch.cpp
+++ b/src/citra_qt/configuration/configure_motion_touch.cpp
@@ -94,14 +94,14 @@ ConfigureMotionTouch::ConfigureMotionTouch(QWidget* parent)
            "using-a-controller-or-android-phone-for-motion-or-touch-input'><span "
            "style=\"text-decoration: underline; color:#039be5;\">Learn More</span></a>"));
 
-    setConfiguration();
-    updateUiDisplay();
-    connectEvents();
+    SetConfiguration();
+    UpdateUiDisplay();
+    ConnectEvents();
 }
 
 ConfigureMotionTouch::~ConfigureMotionTouch() = default;
 
-void ConfigureMotionTouch::setConfiguration() {
+void ConfigureMotionTouch::SetConfiguration() {
     Common::ParamPackage motion_param(Settings::values.current_input_profile.motion_device);
     Common::ParamPackage touch_param(Settings::values.current_input_profile.touch_device);
     std::string motion_engine = motion_param.Get("engine", "motion_emu");
@@ -124,7 +124,7 @@ void ConfigureMotionTouch::setConfiguration() {
     ui->udp_pad_index->setCurrentIndex(Settings::values.current_input_profile.udp_pad_index);
 }
 
-void ConfigureMotionTouch::updateUiDisplay() {
+void ConfigureMotionTouch::UpdateUiDisplay() {
     std::string motion_engine = ui->motion_provider->currentData().toString().toStdString();
     std::string touch_engine = ui->touch_provider->currentData().toString().toStdString();
 
@@ -156,13 +156,13 @@ void ConfigureMotionTouch::updateUiDisplay() {
     }
 }
 
-void ConfigureMotionTouch::connectEvents() {
+void ConfigureMotionTouch::ConnectEvents() {
     connect(ui->motion_provider,
             static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
-            [this](int index) { updateUiDisplay(); });
+            [this](int index) { UpdateUiDisplay(); });
     connect(ui->touch_provider,
             static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
-            [this](int index) { updateUiDisplay(); });
+            [this](int index) { UpdateUiDisplay(); });
     connect(ui->udp_test, &QPushButton::clicked, this, &ConfigureMotionTouch::OnCemuhookUDPTest);
     connect(ui->touch_calibration_config, &QPushButton::clicked, this,
             &ConfigureMotionTouch::OnConfigureTouchCalibration);
@@ -204,7 +204,7 @@ void ConfigureMotionTouch::OnConfigureTouchCalibration() {
         LOG_INFO(Frontend,
                  "UDP touchpad calibration config success: min_x={}, min_y={}, max_x={}, max_y={}",
                  min_x, min_y, max_x, max_y);
-        updateUiDisplay();
+        UpdateUiDisplay();
     } else {
         LOG_ERROR(Frontend, "UDP touchpad calibration config failed");
     }
@@ -244,7 +244,7 @@ bool ConfigureMotionTouch::CanCloseDialog() {
     return true;
 }
 
-void ConfigureMotionTouch::applyConfiguration() {
+void ConfigureMotionTouch::ApplyConfiguration() {
     if (!CanCloseDialog())
         return;
 

--- a/src/citra_qt/configuration/configure_motion_touch.h
+++ b/src/citra_qt/configuration/configure_motion_touch.h
@@ -49,7 +49,7 @@ public:
     ~ConfigureMotionTouch() override;
 
 public slots:
-    void applyConfiguration();
+    void ApplyConfiguration();
 
 private slots:
     void OnCemuhookUDPTest();
@@ -58,9 +58,9 @@ private slots:
 private:
     void closeEvent(QCloseEvent* event) override;
     Q_INVOKABLE void ShowUDPTestResult(bool result);
-    void setConfiguration();
-    void updateUiDisplay();
-    void connectEvents();
+    void SetConfiguration();
+    void UpdateUiDisplay();
+    void ConnectEvents();
     bool CanCloseDialog();
 
     std::unique_ptr<Ui::ConfigureMotionTouch> ui;

--- a/src/citra_qt/configuration/configure_system.cpp
+++ b/src/citra_qt/configuration/configure_system.cpp
@@ -237,7 +237,7 @@ ConfigureSystem::ConfigureSystem(QWidget* parent) : QWidget(parent), ui(new Ui::
 
 ConfigureSystem::~ConfigureSystem() = default;
 
-void ConfigureSystem::setConfiguration() {
+void ConfigureSystem::SetConfiguration() {
     enabled = !Core::System::GetInstance().IsPoweredOn();
 
     ui->combo_init_clock->setCurrentIndex(static_cast<u8>(Settings::values.init_clock));
@@ -297,9 +297,10 @@ void ConfigureSystem::ReadSystemSettings() {
     ui->spinBox_play_coins->setValue(play_coin);
 }
 
-void ConfigureSystem::applyConfiguration() {
-    if (!enabled)
+void ConfigureSystem::ApplyConfiguration() {
+    if (!enabled) {
         return;
+    }
 
     bool modified = false;
 
@@ -349,8 +350,9 @@ void ConfigureSystem::applyConfiguration() {
     }
 
     // update the config savegame if any item is modified.
-    if (modified)
+    if (modified) {
         cfg->UpdateConfigNANDSavegame();
+    }
 
     Settings::values.init_clock =
         static_cast<Settings::InitClock>(ui->combo_init_clock->currentIndex());
@@ -389,7 +391,7 @@ void ConfigureSystem::ConfigureTime() {
     dt.fromString("2000-01-01 00:00:01", "yyyy-MM-dd hh:mm:ss");
     ui->edit_init_time->setMinimumDateTime(dt);
 
-    this->setConfiguration();
+    SetConfiguration();
 
     UpdateInitTime(ui->combo_init_clock->currentIndex());
 }
@@ -409,8 +411,10 @@ void ConfigureSystem::RefreshConsoleID() {
                               "if you use an outdated config savegame. Continue?");
     reply = QMessageBox::critical(this, tr("Warning"), warning_text,
                                   QMessageBox::No | QMessageBox::Yes);
-    if (reply == QMessageBox::No)
+    if (reply == QMessageBox::No) {
         return;
+    }
+
     u32 random_number;
     u64 console_id;
     cfg->GenerateConsoleUniqueId(random_number, console_id);
@@ -420,6 +424,6 @@ void ConfigureSystem::RefreshConsoleID() {
         tr("Console ID: 0x%1").arg(QString::number(console_id, 16).toUpper()));
 }
 
-void ConfigureSystem::retranslateUi() {
+void ConfigureSystem::RetranslateUI() {
     ui->retranslateUi(this);
 }

--- a/src/citra_qt/configuration/configure_system.h
+++ b/src/citra_qt/configuration/configure_system.h
@@ -25,9 +25,9 @@ public:
     explicit ConfigureSystem(QWidget* parent = nullptr);
     ~ConfigureSystem() override;
 
-    void applyConfiguration();
-    void setConfiguration();
-    void retranslateUi();
+    void ApplyConfiguration();
+    void SetConfiguration();
+    void RetranslateUI();
 
 private:
     void ReadSystemSettings();

--- a/src/citra_qt/configuration/configure_ui.cpp
+++ b/src/citra_qt/configuration/configure_ui.cpp
@@ -25,18 +25,18 @@ ConfigureUi::ConfigureUi(QWidget* parent) : QWidget(parent), ui(new Ui::Configur
     // retranslating when passing back.
     connect(ui->language_combobox,
             static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
-            &ConfigureUi::onLanguageChanged);
+            &ConfigureUi::OnLanguageChanged);
 
     for (const auto& theme : UISettings::themes) {
         ui->theme_combobox->addItem(theme.first, theme.second);
     }
 
-    this->setConfiguration();
+    SetConfiguration();
 }
 
 ConfigureUi::~ConfigureUi() = default;
 
-void ConfigureUi::setConfiguration() {
+void ConfigureUi::SetConfiguration() {
     ui->theme_combobox->setCurrentIndex(ui->theme_combobox->findData(UISettings::values.theme));
     ui->language_combobox->setCurrentIndex(
         ui->language_combobox->findData(UISettings::values.language));
@@ -48,7 +48,7 @@ void ConfigureUi::setConfiguration() {
     ui->toggle_hide_no_icon->setChecked(UISettings::values.game_list_hide_no_icon);
 }
 
-void ConfigureUi::applyConfiguration() {
+void ConfigureUi::ApplyConfiguration() {
     UISettings::values.theme =
         ui->theme_combobox->itemData(ui->theme_combobox->currentIndex()).toString();
     UISettings::values.game_list_icon_size =
@@ -60,13 +60,13 @@ void ConfigureUi::applyConfiguration() {
     UISettings::values.game_list_hide_no_icon = ui->toggle_hide_no_icon->isChecked();
 }
 
-void ConfigureUi::onLanguageChanged(int index) {
+void ConfigureUi::OnLanguageChanged(int index) {
     if (index == -1)
         return;
 
-    emit languageChanged(ui->language_combobox->itemData(index).toString());
+    emit LanguageChanged(ui->language_combobox->itemData(index).toString());
 }
 
-void ConfigureUi::retranslateUi() {
+void ConfigureUi::RetranslateUI() {
     ui->retranslateUi(this);
 }

--- a/src/citra_qt/configuration/configure_ui.h
+++ b/src/citra_qt/configuration/configure_ui.h
@@ -18,15 +18,15 @@ public:
     explicit ConfigureUi(QWidget* parent = nullptr);
     ~ConfigureUi() override;
 
-    void applyConfiguration();
-    void retranslateUi();
-    void setConfiguration();
+    void ApplyConfiguration();
+    void RetranslateUI();
+    void SetConfiguration();
 
 private slots:
-    void onLanguageChanged(int index);
+    void OnLanguageChanged(int index);
 
 signals:
-    void languageChanged(const QString& locale);
+    void LanguageChanged(const QString& locale);
 
 private:
     std::unique_ptr<Ui::ConfigureUi> ui;

--- a/src/citra_qt/configuration/configure_web.cpp
+++ b/src/citra_qt/configuration/configure_web.cpp
@@ -22,12 +22,12 @@ ConfigureWeb::ConfigureWeb(QWidget* parent)
 #ifndef USE_DISCORD_PRESENCE
     ui->discord_group->setVisible(false);
 #endif
-    this->setConfiguration();
+    SetConfiguration();
 }
 
 ConfigureWeb::~ConfigureWeb() = default;
 
-void ConfigureWeb::setConfiguration() {
+void ConfigureWeb::SetConfiguration() {
     ui->web_credentials_disclaimer->setWordWrap(true);
     ui->telemetry_learn_more->setOpenExternalLinks(true);
     ui->telemetry_learn_more->setText(tr("<a "
@@ -58,7 +58,7 @@ void ConfigureWeb::setConfiguration() {
     ui->toggle_discordrpc->setChecked(UISettings::values.enable_discord_presence);
 }
 
-void ConfigureWeb::applyConfiguration() {
+void ConfigureWeb::ApplyConfiguration() {
     Settings::values.enable_telemetry = ui->toggle_telemetry->isChecked();
     UISettings::values.enable_discord_presence = ui->toggle_discordrpc->isChecked();
     if (user_verified) {
@@ -115,7 +115,7 @@ void ConfigureWeb::OnLoginVerified() {
     }
 }
 
-void ConfigureWeb::retranslateUi() {
+void ConfigureWeb::RetranslateUI() {
     ui->retranslateUi(this);
 }
 

--- a/src/citra_qt/configuration/configure_web.h
+++ b/src/citra_qt/configuration/configure_web.h
@@ -19,9 +19,9 @@ public:
     explicit ConfigureWeb(QWidget* parent = nullptr);
     ~ConfigureWeb() override;
 
-    void applyConfiguration();
-    void retranslateUi();
-    void setConfiguration();
+    void ApplyConfiguration();
+    void RetranslateUI();
+    void SetConfiguration();
     void SetWebServiceConfigEnabled(bool enabled);
 
 private:

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -1339,7 +1339,7 @@ void GMainWindow::OnCheats() {
 void GMainWindow::OnConfigure() {
     ConfigureDialog configureDialog(this, hotkey_registry,
                                     !multiplayer_state->IsHostingPublicRoom());
-    connect(&configureDialog, &ConfigureDialog::languageChanged, this,
+    connect(&configureDialog, &ConfigureDialog::LanguageChanged, this,
             &GMainWindow::OnLanguageChanged);
     auto old_theme = UISettings::values.theme;
     const int old_input_profile_index = Settings::values.current_input_profile_index;
@@ -1347,7 +1347,7 @@ void GMainWindow::OnConfigure() {
     const bool old_discord_presence = UISettings::values.enable_discord_presence;
     auto result = configureDialog.exec();
     if (result == QDialog::Accepted) {
-        configureDialog.applyConfiguration();
+        configureDialog.ApplyConfiguration();
         InitializeHotkeys();
         if (UISettings::values.theme != old_theme)
             UpdateUITheme();


### PR DESCRIPTION
See yuzu-emu/yuzu#2521 for more details.

**Original description**:
Makes the naming of functions match our project style (CamelCase), unless a Qt function is being overridden. Figured I'd get this out of the way before performing future work on making the configuration dialog itself more friendly when it comes to future handling translations (handling LanguageChanged events, which only one dialog tab handles properly right now; the game list tab)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4823)
<!-- Reviewable:end -->
