### PR TITLE
Remove unused stuff

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -1650,7 +1650,7 @@ void GMainWindow::OnCoreError(Core::System::ResultStatus result, std::string det
     message_box.setWindowTitle(title);
     message_box.setText(message);
     message_box.setIcon(QMessageBox::Icon::Critical);
-    QPushButton* continue_button = message_box.addButton(tr("Continue"), QMessageBox::RejectRole);
+    message_box.addButton(tr("Continue"), QMessageBox::RejectRole);
     QPushButton* abort_button = message_box.addButton(tr("Abort"), QMessageBox::AcceptRole);
     if (result != Core::System::ResultStatus::ShutdownRequested)
         message_box.exec();

--- a/src/core/file_sys/archive_ncch.cpp
+++ b/src/core/file_sys/archive_ncch.cpp
@@ -240,8 +240,6 @@ NCCHFile::NCCHFile(std::vector<u8> buffer, std::unique_ptr<DelayGenerator> delay
 ResultVal<std::size_t> NCCHFile::Read(const u64 offset, const std::size_t length,
                                       u8* buffer) const {
     LOG_TRACE(Service_FS, "called offset={}, length={}", offset, length);
-    std::size_t length_left = static_cast<std::size_t>(data_size - offset);
-    std::size_t read_length = static_cast<std::size_t>(std::min(length, length_left));
 
     std::size_t available_size = static_cast<std::size_t>(file_buffer.size() - offset);
     std::size_t copy_size = std::min(length, available_size);

--- a/src/core/file_sys/archive_ncch.h
+++ b/src/core/file_sys/archive_ncch.h
@@ -82,8 +82,6 @@ public:
 
 private:
     std::vector<u8> file_buffer;
-    u64 data_offset;
-    u64 data_size;
 };
 
 /// File system interface to the NCCH archive

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -576,9 +576,6 @@ void Module::Interface::FindDLCContentInfos(Kernel::HLERequestContext& ctx) {
         std::size_t write_offset = 0;
         // Get info for each content index requested
         for (std::size_t i = 0; i < content_count; i++) {
-            std::shared_ptr<FileUtil::IOFile> romfs_file;
-            u64 romfs_offset = 0;
-
             if (content_requested[i] >= tmd.GetContentCount()) {
                 LOG_ERROR(Service_AM,
                           "Attempted to get info for non-existent content index {:04x}.",
@@ -644,9 +641,6 @@ void Module::Interface::ListDLCContentInfos(Kernel::HLERequestContext& ctx) {
             std::min(start_index + content_count, static_cast<u32>(tmd.GetContentCount()));
         std::size_t write_offset = 0;
         for (u32 i = start_index; i < end_index; i++) {
-            std::shared_ptr<FileUtil::IOFile> romfs_file;
-            u64 romfs_offset = 0;
-
             ContentInfo content_info = {};
             content_info.index = static_cast<u16>(i);
             content_info.type = tmd.GetContentTypeByIndex(i);

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -358,7 +358,6 @@ static std::string SampleTexture(const PicaFSConfig& config, unsigned texture_un
 /// Writes the specified TEV stage source component(s)
 static void AppendSource(std::string& out, const PicaFSConfig& config,
                          TevStageConfig::Source source, const std::string& index_name) {
-    const auto& state = config.state;
     using Source = TevStageConfig::Source;
     switch (source) {
     case Source::PrimaryColor:


### PR DESCRIPTION
Some unused variables are still kept in services, as they are parameters passed from the command buffer and might be used in the future

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4832)
<!-- Reviewable:end -->
