### PR TITLE
network/room_member: in-header function should be inline

### DIFF
--- a/src/network/room_member.h
+++ b/src/network/room_member.h
@@ -263,7 +263,7 @@ private:
     std::unique_ptr<RoomMemberImpl> room_member_impl;
 };
 
-static const char* GetStateStr(const RoomMember::State& s) {
+inline const char* GetStateStr(const RoomMember::State& s) {
     switch (s) {
     case RoomMember::State::Idle:
         return "Idle";
@@ -277,7 +277,7 @@ static const char* GetStateStr(const RoomMember::State& s) {
     return "Unknown";
 }
 
-static const char* GetErrorStr(const RoomMember::Error& e) {
+inline const char* GetErrorStr(const RoomMember::Error& e) {
     switch (e) {
     case RoomMember::Error::LostConnection:
         return "LostConnection";


### PR DESCRIPTION
Otherwise produces multpile definition in translation units and generates unused warnings

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4833)
<!-- Reviewable:end -->
