### PR TITLE
citra_qt: silent sign comparison warning

### DIFF
--- a/src/citra_qt/cheats.cpp
+++ b/src/citra_qt/cheats.cpp
@@ -148,7 +148,7 @@ void CheatDialog::OnRowSelected(int row, int column) {
         ui->tableCheats->setCurrentCell(last_row, last_col);
         return;
     }
-    if (row < cheats.size()) {
+    if (static_cast<std::size_t>(row) < cheats.size()) {
         if (newly_created) {
             // Remove the newly created dummy item
             newly_created = false;

--- a/src/citra_qt/multiplayer/chat_room.cpp
+++ b/src/citra_qt/multiplayer/chat_room.cpp
@@ -406,8 +406,9 @@ void ChatRoom::SetPlayerList(const Network::RoomMember::MemberList& member_list)
 }
 
 void ChatRoom::OnChatTextChanged() {
-    if (ui->chat_message->text().length() > Network::MaxMessageSize)
-        ui->chat_message->setText(ui->chat_message->text().left(Network::MaxMessageSize));
+    if (ui->chat_message->text().length() > static_cast<int>(Network::MaxMessageSize))
+        ui->chat_message->setText(
+            ui->chat_message->text().left(static_cast<int>(Network::MaxMessageSize)));
 }
 
 void ChatRoom::PopupContextMenu(const QPoint& menu_location) {


### PR DESCRIPTION
🖕Qt

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4836)
<!-- Reviewable:end -->
