### PR TITLE
ipc_helpers: silent signed comparison warning

### DIFF
--- a/src/core/hle/ipc_helpers.h
+++ b/src/core/hle/ipc_helpers.h
@@ -19,7 +19,7 @@ class RequestHelperBase {
 protected:
     Kernel::HLERequestContext* context;
     u32* cmdbuf;
-    ptrdiff_t index = 1;
+    std::size_t index = 1;
     Header header;
 
 public:


### PR DESCRIPTION
index is only used as positive index in arrays. The warning is in DEBUG_ASSERT_MSG(index == TotalSize() ...)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4839)
<!-- Reviewable:end -->
