### PR TITLE
citra_qt/configure_motion_touch: fix slot name

### DIFF
--- a/src/citra_qt/configuration/configure_motion_touch.ui
+++ b/src/citra_qt/configuration/configure_motion_touch.ui
@@ -278,7 +278,7 @@
    <sender>buttonBox</sender>
    <signal>accepted()</signal>
    <receiver>ConfigureMotionTouch</receiver>
-   <slot>applyConfiguration()</slot>
+   <slot>ApplyConfiguration()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>220</x>


### PR DESCRIPTION
Fixes #4840, hopefully

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4841)
<!-- Reviewable:end -->
