### PR TITLE
Fix incorrect display of some Taiwan region games

### DIFF
--- a/src/core/loader/smdh.cpp
+++ b/src/core/loader/smdh.cpp
@@ -54,7 +54,7 @@ SMDH::GameRegion SMDH::GetRegion() const {
     }
 
     constexpr u32 taiwan_and_china =
-        (1 << static_cast<u32>(GameRegion::Taiwan)) & (1 << static_cast<u32>(GameRegion::China));
+        (1 << static_cast<u32>(GameRegion::Taiwan)) | (1 << static_cast<u32>(GameRegion::China));
     if (region_lockout == taiwan_and_china) {
         return GameRegion::Taiwan;
     } // hack to fix TWN games that support CHN consoles

--- a/src/core/loader/smdh.cpp
+++ b/src/core/loader/smdh.cpp
@@ -53,7 +53,8 @@ SMDH::GameRegion SMDH::GetRegion() const {
         return GameRegion::RegionFree;
     }
 
-    constexpr u32 taiwan_and_china = (1 << GameRegion::Taiwan) & (1 << GameRegion::China);
+    constexpr u32 taiwan_and_china =
+        (1 << static_cast<u32>(GameRegion::Taiwan)) & (1 << static_cast<u32>(GameRegion::China));
     if (region_lockout == taiwan_and_china) {
         return GameRegion::Taiwan;
     } // hack to fix TWN games that support CHN consoles

--- a/src/core/loader/smdh.cpp
+++ b/src/core/loader/smdh.cpp
@@ -53,10 +53,11 @@ SMDH::GameRegion SMDH::GetRegion() const {
         return GameRegion::RegionFree;
     }
     
-    if (region_lockout == 0x00000050) {
+    constexpr u32 taiwan_and_china = (1 << GameRegion::Taiwan) & (1 << GameRegion::China);
+    if (region_lockout == taiwan_and_china) {
         return GameRegion::Taiwan;
     } // hack to fix TWN games that support CHN consoles
-
+    
     constexpr u32 REGION_COUNT = 7;
     u32 region = 0;
     for (; region < REGION_COUNT; ++region) {

--- a/src/core/loader/smdh.cpp
+++ b/src/core/loader/smdh.cpp
@@ -52,12 +52,12 @@ SMDH::GameRegion SMDH::GetRegion() const {
     if (region_lockout == 0x7fffffff) {
         return GameRegion::RegionFree;
     }
-    
+
     constexpr u32 taiwan_and_china = (1 << GameRegion::Taiwan) & (1 << GameRegion::China);
     if (region_lockout == taiwan_and_china) {
         return GameRegion::Taiwan;
     } // hack to fix TWN games that support CHN consoles
-    
+
     constexpr u32 REGION_COUNT = 7;
     u32 region = 0;
     for (; region < REGION_COUNT; ++region) {

--- a/src/core/loader/smdh.cpp
+++ b/src/core/loader/smdh.cpp
@@ -52,6 +52,10 @@ SMDH::GameRegion SMDH::GetRegion() const {
     if (region_lockout == 0x7fffffff) {
         return GameRegion::RegionFree;
     }
+    
+    if (region_lockout == 0x00000050) {
+        return GameRegion::Taiwan;
+    } // hack to fix TWN games that support CHN consoles
 
     constexpr u32 REGION_COUNT = 7;
     u32 region = 0;


### PR DESCRIPTION
Adds a simple hack to fix China-compatible Taiwan-region games from displaying incorrectly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4846)
<!-- Reviewable:end -->
