### PR TITLE
Fixed behaviour of some buttons by connecting functors to correct signals

### DIFF
--- a/src/citra_qt/cheats.cpp
+++ b/src/citra_qt/cheats.cpp
@@ -30,16 +30,16 @@ CheatDialog::CheatDialog(QWidget* parent)
         "{:016X}", Core::System::GetInstance().Kernel().GetCurrentProcess()->codeset->program_id);
     ui->labelTitle->setText(tr("Title ID: %1").arg(QString::fromStdString(game_id)));
 
-    connect(ui->buttonClose, &QPushButton::released, this, &CheatDialog::OnCancel);
-    connect(ui->buttonAddCheat, &QPushButton::released, this, &CheatDialog::OnAddCheat);
+    connect(ui->buttonClose, &QPushButton::clicked, this, &CheatDialog::OnCancel);
+    connect(ui->buttonAddCheat, &QPushButton::clicked, this, &CheatDialog::OnAddCheat);
     connect(ui->tableCheats, &QTableWidget::cellClicked, this, &CheatDialog::OnRowSelected);
     connect(ui->lineName, &QLineEdit::textEdited, this, &CheatDialog::OnTextEdited);
     connect(ui->textNotes, &QPlainTextEdit::textChanged, this, &CheatDialog::OnTextEdited);
     connect(ui->textCode, &QPlainTextEdit::textChanged, this, &CheatDialog::OnTextEdited);
 
-    connect(ui->buttonSave, &QPushButton::released,
+    connect(ui->buttonSave, &QPushButton::clicked,
             [this] { SaveCheat(ui->tableCheats->currentRow()); });
-    connect(ui->buttonDelete, &QPushButton::released, this, &CheatDialog::OnDeleteCheat);
+    connect(ui->buttonDelete, &QPushButton::clicked, this, &CheatDialog::OnDeleteCheat);
 
     LoadCheats();
 }

--- a/src/citra_qt/configuration/configure_debug.cpp
+++ b/src/citra_qt/configuration/configure_debug.cpp
@@ -19,7 +19,7 @@ ConfigureDebug::ConfigureDebug(QWidget* parent) : QWidget(parent), ui(new Ui::Co
     ui->setupUi(this);
     SetConfiguration();
 
-    connect(ui->open_log_button, &QPushButton::pressed, []() {
+    connect(ui->open_log_button, &QPushButton::clicked, []() {
         QString path = QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::LogDir));
         QDesktopServices::openUrl(QUrl::fromLocalFile(path));
     });

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -136,7 +136,7 @@ ConfigureInput::ConfigureInput(QWidget* parent)
         if (!button_map[button_id])
             continue;
         button_map[button_id]->setContextMenuPolicy(Qt::CustomContextMenu);
-        connect(button_map[button_id], &QPushButton::released, [=]() {
+        connect(button_map[button_id], &QPushButton::clicked, [=]() {
             HandleClick(button_map[button_id],
                         [=](const Common::ParamPackage& params) {
                             buttons_param[button_id] = params;
@@ -173,7 +173,7 @@ ConfigureInput::ConfigureInput(QWidget* parent)
                 continue;
             analog_map_buttons[analog_id][sub_button_id]->setContextMenuPolicy(
                 Qt::CustomContextMenu);
-            connect(analog_map_buttons[analog_id][sub_button_id], &QPushButton::released, [=]() {
+            connect(analog_map_buttons[analog_id][sub_button_id], &QPushButton::clicked, [=]() {
                 HandleClick(analog_map_buttons[analog_id][sub_button_id],
                             [=](const Common::ParamPackage& params) {
                                 SetAnalogButton(params, analogs_param[analog_id],
@@ -206,7 +206,7 @@ ConfigureInput::ConfigureInput(QWidget* parent)
                             menu_location));
                     });
         }
-        connect(analog_map_stick[analog_id], &QPushButton::released, [=]() {
+        connect(analog_map_stick[analog_id], &QPushButton::clicked, [=]() {
             QMessageBox::information(this, tr("Information"),
                                      tr("After pressing OK, first move your joystick horizontally, "
                                         "and then vertically."));
@@ -220,18 +220,19 @@ ConfigureInput::ConfigureInput(QWidget* parent)
         });
     }
 
-    connect(ui->buttonMotionTouch, &QPushButton::released, [this] {
+    connect(ui->buttonMotionTouch, &QPushButton::clicked, [this] {
         QDialog* motion_touch_dialog = new ConfigureMotionTouch(this);
         return motion_touch_dialog->exec();
     });
 
     ui->buttonDelete->setEnabled(ui->profile->count() > 1);
 
-    connect(ui->buttonClearAll, &QPushButton::released, [this] { ClearAll(); });
-    connect(ui->buttonRestoreDefaults, &QPushButton::released, [this]() { RestoreDefaults(); });
-    connect(ui->buttonNew, &QPushButton::released, [this] { NewProfile(); });
-    connect(ui->buttonDelete, &QPushButton::released, [this] { DeleteProfile(); });
-    connect(ui->buttonRename, &QPushButton::released, [this] { RenameProfile(); });
+    connect(ui->buttonClearAll, &QPushButton::clicked, this, &ConfigureInput::ClearAll);
+    connect(ui->buttonRestoreDefaults, &QPushButton::clicked, this,
+            &ConfigureInput::RestoreDefaults);
+    connect(ui->buttonNew, &QPushButton::clicked, this, &ConfigureInput::NewProfile);
+    connect(ui->buttonDelete, &QPushButton::clicked, this, &ConfigureInput::DeleteProfile);
+    connect(ui->buttonRename, &QPushButton::clicked, this, &ConfigureInput::RenameProfile);
 
     connect(ui->profile, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
             [this](int i) {

--- a/src/citra_qt/multiplayer/chat_room.cpp
+++ b/src/citra_qt/multiplayer/chat_room.cpp
@@ -189,9 +189,9 @@ ChatRoom::ChatRoom(QWidget* parent) : QWidget(parent), ui(std::make_unique<Ui::C
     // Connect all the widgets to the appropriate events
     connect(ui->player_view, &QTreeView::customContextMenuRequested, this,
             &ChatRoom::PopupContextMenu);
-    connect(ui->chat_message, &QLineEdit::returnPressed, ui->send_message, &QPushButton::pressed);
-    connect(ui->chat_message, &QLineEdit::textChanged, this, &::ChatRoom::OnChatTextChanged);
-    connect(ui->send_message, &QPushButton::pressed, this, &ChatRoom::OnSendChat);
+    connect(ui->chat_message, &QLineEdit::returnPressed, this, &ChatRoom::OnSendChat);
+    connect(ui->chat_message, &QLineEdit::textChanged, this, &ChatRoom::OnChatTextChanged);
+    connect(ui->send_message, &QPushButton::clicked, this, &ChatRoom::OnSendChat);
 }
 
 ChatRoom::~ChatRoom() = default;

--- a/src/citra_qt/multiplayer/client_room.cpp
+++ b/src/citra_qt/multiplayer/client_room.cpp
@@ -40,7 +40,7 @@ ClientRoomWindow::ClientRoomWindow(QWidget* parent)
         // TODO (jroweboy) network was not initialized?
     }
 
-    connect(ui->disconnect, &QPushButton::pressed, [this] { Disconnect(); });
+    connect(ui->disconnect, &QPushButton::clicked, this, &ClientRoomWindow::Disconnect);
     ui->disconnect->setDefault(false);
     ui->disconnect->setAutoDefault(false);
     connect(ui->moderation, &QPushButton::clicked, [this] {

--- a/src/citra_qt/multiplayer/direct_connect.cpp
+++ b/src/citra_qt/multiplayer/direct_connect.cpp
@@ -45,7 +45,7 @@ DirectConnectWindow::DirectConnectWindow(QWidget* parent)
 
     // TODO(jroweboy): Show or hide the connection options based on the current value of the combo
     // box. Add this back in when the traversal server support is added.
-    connect(ui->connect, &QPushButton::pressed, this, &DirectConnectWindow::Connect);
+    connect(ui->connect, &QPushButton::clicked, this, &DirectConnectWindow::Connect);
 }
 
 DirectConnectWindow::~DirectConnectWindow() = default;

--- a/src/citra_qt/multiplayer/host_room.cpp
+++ b/src/citra_qt/multiplayer/host_room.cpp
@@ -49,7 +49,7 @@ HostRoomWindow::HostRoomWindow(QWidget* parent, QStandardItemModel* list,
     ui->game_list->setModel(proxy);
 
     // Connect all the widgets to the appropriate events
-    connect(ui->host, &QPushButton::pressed, this, &HostRoomWindow::Host);
+    connect(ui->host, &QPushButton::clicked, this, &HostRoomWindow::Host);
 
     // Restore the settings:
     ui->username->setText(UISettings::values.room_nickname);

--- a/src/citra_qt/multiplayer/lobby.cpp
+++ b/src/citra_qt/multiplayer/lobby.cpp
@@ -63,7 +63,7 @@ Lobby::Lobby(QWidget* parent, QStandardItemModel* list,
     }
 
     // UI Buttons
-    connect(ui->refresh_list, &QPushButton::pressed, this, &Lobby::RefreshLobby);
+    connect(ui->refresh_list, &QPushButton::clicked, this, &Lobby::RefreshLobby);
     connect(ui->games_owned, &QCheckBox::toggled, proxy, &LobbyFilterProxyModel::SetFilterOwned);
     connect(ui->hide_full, &QCheckBox::toggled, proxy, &LobbyFilterProxyModel::SetFilterFull);
     connect(ui->search, &QLineEdit::textChanged, proxy, &LobbyFilterProxyModel::SetFilterSearch);


### PR DESCRIPTION
This PR fixes a few UI buttons reacting to incorrect signals. Previously, a few buttons did not follow the standard UI behaviour and instead of reacting to button **click** (press & release), they executed their actions on **press**. This led to a bit inconsistent experience.

Affected dialogs:
- Cheats
- Configure/Debug
- Configure/Input
- Chat Room
- Direct Connect
- Host
- Lobby List

While this may look like a mass Find & Replace, each case has been analyzed separately and tested for regressions.

# Reproduction Steps

To observe the changes easiest, do the following:
1. Navigate to `Emulation -> Configure -> Controls -> Input`
2. Press the mouse button when hovered over `New`. Do **NOT** release it.
3. Move the mouse cursor outside the button, **without** releasing left mouse button.

# Observed behaviour

"New Profile" dialog opens, as if the button was clicked.

# Expected behaviour

Nothing happens, as user intended to back out of the decision to open the dialog.


This particular example concerns code using a `released()` signal - for code previously using a `pressed()` signal, steps are equivalent, just with functors being executed as soon as the button is pressed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4849)
<!-- Reviewable:end -->
