### PR TITLE
Fixing some compiler warnings in core/arm/

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic.h
+++ b/src/core/arm/dynarmic/arm_dynarmic.h
@@ -17,7 +17,7 @@ class MemorySystem;
 } // namespace Memory
 
 namespace Core {
-struct System;
+class System;
 }
 
 class DynarmicUserCallbacks;

--- a/src/core/arm/dyncom/arm_dyncom.h
+++ b/src/core/arm/dyncom/arm_dyncom.h
@@ -11,7 +11,7 @@
 #include "core/arm/skyeye_common/armstate.h"
 
 namespace Core {
-struct System;
+class System;
 }
 
 namespace Memory {


### PR DESCRIPTION
Fixing a couple of compiler warnings on clang complaining about some forward declarations that didn't match the signature of the `System` class.

if this is not useful please feel free to close!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4851)
<!-- Reviewable:end -->
