### PR TITLE
Fixed distance attenuation to use a 0-255 LUT index

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -843,9 +843,9 @@ static void WriteLighting(std::string& out, const PicaFSConfig& config) {
         // If enabled, compute distance attenuation value
         std::string dist_atten = "1.0";
         if (light_config.dist_atten_enable) {
-            std::string index = "clamp(" + light_src + ".dist_atten_scale * length(-view - " +
+            std::string index = "clamp(" + light_src + ".dist_atten_scale * 0.5 * length(-view - " +
                                 light_src + ".position) + " + light_src +
-                                ".dist_atten_bias, 0.0, 1.0)";
+                                ".dist_atten_bias, 0.0, 256.0)/256";
             auto sampler = LightingRegs::DistanceAttenuationSampler(light_config.num);
             dist_atten = "LookupLightingLUTUnsigned(" +
                          std::to_string(static_cast<unsigned>(sampler)) + "," + index + ")";

--- a/src/video_core/swrasterizer/lighting.cpp
+++ b/src/video_core/swrasterizer/lighting.cpp
@@ -92,15 +92,16 @@ std::tuple<Common::Vec4<u8>, Common::Vec4<u8>> ComputeFragmentsColors(
         if (!lighting.IsDistAttenDisabled(num)) {
             auto distance = (-view - position).Length();
             float scale = Pica::float20::FromRaw(light_config.dist_atten_scale).ToFloat32();
+            scale *= 0.5; // Fudge factor
             float bias = Pica::float20::FromRaw(light_config.dist_atten_bias).ToFloat32();
             std::size_t lut =
                 static_cast<std::size_t>(LightingRegs::LightingSampler::DistanceAttenuation) + num;
 
-            float sample_loc = std::clamp(scale * distance + bias, 0.0f, 1.0f);
+            float sample_loc = scale * distance + bias;
 
             u8 lutindex =
-                static_cast<u8>(std::clamp(std::floor(sample_loc * 256.0f), 0.0f, 255.0f));
-            float delta = sample_loc * 256 - lutindex;
+                static_cast<u8>(std::clamp(std::floor(sample_loc), 0.0f, 255.0f));
+            float delta = sample_loc - lutindex;
             dist_atten = LookupLightingLut(lighting_state, lut, lutindex, delta);
         }
 

--- a/src/video_core/swrasterizer/texturing.cpp
+++ b/src/video_core/swrasterizer/texturing.cpp
@@ -14,6 +14,9 @@ namespace Pica::Rasterizer {
 using TevStageConfig = TexturingRegs::TevStageConfig;
 
 int GetWrappedTexCoord(TexturingRegs::TextureConfig::WrapMode mode, int val, unsigned size) {
+    if (size == 0) {
+        return 0;
+    }
     switch (mode) {
     case TexturingRegs::TextureConfig::ClampToEdge2:
         // For negative coordinate, ClampToEdge2 behaves the same as Repeat

--- a/src/video_core/texture/texture_decode.cpp
+++ b/src/video_core/texture/texture_decode.cpp
@@ -58,6 +58,10 @@ size_t CalculateTileSize(TextureFormat format) {
 
 Common::Vec4<u8> LookupTexture(const u8* source, unsigned int x, unsigned int y,
                                const TextureInfo& info, bool disable_alpha) {
+    if (source == nullptr) {
+        return {0, 0, 0, 0};
+    }
+
     // Coordinate in tiles
     const unsigned int coarse_x = x / 8;
     const unsigned int coarse_y = y / 8;


### PR DESCRIPTION
This fixes #4499 by changing how LUT indices are generated for the distance attenuation feature. I don't know for certain if this is correct (in fact I'd be amazed if I didn't miss some nuances) but it seems to broadly make sense. This change also fixes the crash in the software renderer on pokemon X/Y.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4854)
<!-- Reviewable:end -->
