### PR TITLE
Port yuzu-emu/yuzu#2492: "yuzu/debugger: Specify string conversions explicitly"

### DIFF
--- a/src/citra_qt/debugger/graphics/graphics.cpp
+++ b/src/citra_qt/debugger/graphics/graphics.cpp
@@ -34,8 +34,8 @@ QVariant GPUCommandStreamItemModel::data(const QModelIndex& index, int role) con
             {Service::GSP::CommandId::CACHE_FLUSH, "CACHE_FLUSH"},
         };
         const u32* command_data = reinterpret_cast<const u32*>(&command);
-        QString str = QString("%1 %2 %3 %4 %5 %6 %7 %8 %9")
-                          .arg(command_names[command.id])
+        QString str = QStringLiteral("%1 %2 %3 %4 %5 %6 %7 %8 %9")
+                          .arg(QString::fromUtf8(command_names[command.id]))
                           .arg(command_data[0], 8, 16, QLatin1Char('0'))
                           .arg(command_data[1], 8, 16, QLatin1Char('0'))
                           .arg(command_data[2], 8, 16, QLatin1Char('0'))
@@ -65,7 +65,7 @@ void GPUCommandStreamItemModel::OnGXCommandFinishedInternal(int total_command_co
 
 GPUCommandStreamWidget::GPUCommandStreamWidget(QWidget* parent)
     : QDockWidget(tr("Graphics Debugger"), parent) {
-    setObjectName("GraphicsDebugger");
+    setObjectName(QStringLiteral("GraphicsDebugger"));
 
     GPUCommandStreamItemModel* command_model = new GPUCommandStreamItemModel(this);
     g_debugger.RegisterObserver(command_model);

--- a/src/citra_qt/debugger/graphics/graphics_breakpoints.cpp
+++ b/src/citra_qt/debugger/graphics/graphics_breakpoints.cpp
@@ -141,7 +141,7 @@ GraphicsBreakPointsWidget::GraphicsBreakPointsWidget(
     std::shared_ptr<Pica::DebugContext> debug_context, QWidget* parent)
     : QDockWidget(tr("Pica Breakpoints"), parent), Pica::DebugContext::BreakPointObserver(
                                                        debug_context) {
-    setObjectName("PicaBreakPointsWidget");
+    setObjectName(QStringLiteral("PicaBreakPointsWidget"));
 
     status_text = new QLabel(tr("Emulation running"));
     resume_button = new QPushButton(tr("Resume"));

--- a/src/citra_qt/debugger/graphics/graphics_cmdlists.cpp
+++ b/src/citra_qt/debugger/graphics/graphics_cmdlists.cpp
@@ -76,11 +76,11 @@ QVariant GPUCommandListModel::data(const QModelIndex& index, int role) const {
         case 0:
             return QString::fromLatin1(Pica::Regs::GetRegisterName(write.cmd_id));
         case 1:
-            return QString("%1").arg(write.cmd_id, 3, 16, QLatin1Char('0'));
+            return QStringLiteral("%1").arg(write.cmd_id, 3, 16, QLatin1Char('0'));
         case 2:
-            return QString("%1").arg(write.mask, 4, 2, QLatin1Char('0'));
+            return QStringLiteral("%1").arg(write.mask, 4, 2, QLatin1Char('0'));
         case 3:
-            return QString("%1").arg(write.value, 8, 16, QLatin1Char('0'));
+            return QStringLiteral("%1").arg(write.value, 8, 16, QLatin1Char('0'));
         }
     } else if (role == CommandIdRole) {
         return QVariant::fromValue<int>(write.cmd_id);
@@ -184,7 +184,7 @@ void GPUCommandListWidget::SetCommandInfo(const QModelIndex& index) {
 
 GPUCommandListWidget::GPUCommandListWidget(QWidget* parent)
     : QDockWidget(tr("Pica Command List"), parent) {
-    setObjectName("Pica Command List");
+    setObjectName(QStringLiteral("Pica Command List"));
     GPUCommandListModel* model = new GPUCommandListModel(this);
 
     QWidget* main_widget = new QWidget;
@@ -246,9 +246,9 @@ void GPUCommandListWidget::CopyAllToClipboard() {
         for (int col = 0; col < model->columnCount({}); ++col) {
             QModelIndex index = model->index(row, col);
             text += model->data(index).value<QString>();
-            text += '\t';
+            text += QLatin1Char('\t');
         }
-        text += '\n';
+        text += QLatin1Char('\n');
     }
 
     clipboard->setText(text);

--- a/src/citra_qt/debugger/graphics/graphics_surface.cpp
+++ b/src/citra_qt/debugger/graphics/graphics_surface.cpp
@@ -51,7 +51,7 @@ GraphicsSurfaceWidget::GraphicsSurfaceWidget(std::shared_ptr<Pica::DebugContext>
                                              QWidget* parent)
     : BreakPointObserverDock(debug_context, tr("Pica Surface Viewer"), parent),
       surface_source(Source::ColorBuffer) {
-    setObjectName("PicaSurface");
+    setObjectName(QStringLiteral("PicaSurface"));
 
     surface_source_list = new QComboBox;
     surface_source_list->addItem(tr("Color Buffer"));
@@ -66,7 +66,7 @@ GraphicsSurfaceWidget::GraphicsSurfaceWidget(std::shared_ptr<Pica::DebugContext>
     surface_address_control = new CSpinBox;
     surface_address_control->SetBase(16);
     surface_address_control->SetRange(0, 0xFFFFFFFF);
-    surface_address_control->SetPrefix("0x");
+    surface_address_control->SetPrefix(QStringLiteral("0x"));
 
     unsigned max_dimension = 16384; // TODO: Find actual maximum
 
@@ -121,7 +121,7 @@ GraphicsSurfaceWidget::GraphicsSurfaceWidget(std::shared_ptr<Pica::DebugContext>
     scroll_area->setWidgetResizable(false);
     scroll_area->setWidget(surface_picture_label);
 
-    save_surface = new QPushButton(QIcon::fromTheme("document-save"), tr("Save"));
+    save_surface = new QPushButton(QIcon::fromTheme(QStringLiteral("document-save")), tr("Save"));
 
     // Connections
     connect(this, &GraphicsSurfaceWidget::Update, this, &GraphicsSurfaceWidget::OnUpdate);
@@ -313,7 +313,7 @@ void GraphicsSurfaceWidget::Pick(int x, int y) {
         switch (format) {
         case Format::RGBA8: {
             auto value = Color::DecodeRGBA8(pixel) / 255.0f;
-            return QString("Red: %1, Green: %2, Blue: %3, Alpha: %4")
+            return QStringLiteral("Red: %1, Green: %2, Blue: %3, Alpha: %4")
                 .arg(QString::number(value.r(), 'f', 2))
                 .arg(QString::number(value.g(), 'f', 2))
                 .arg(QString::number(value.b(), 'f', 2))
@@ -321,14 +321,14 @@ void GraphicsSurfaceWidget::Pick(int x, int y) {
         }
         case Format::RGB8: {
             auto value = Color::DecodeRGB8(pixel) / 255.0f;
-            return QString("Red: %1, Green: %2, Blue: %3")
+            return QStringLiteral("Red: %1, Green: %2, Blue: %3")
                 .arg(QString::number(value.r(), 'f', 2))
                 .arg(QString::number(value.g(), 'f', 2))
                 .arg(QString::number(value.b(), 'f', 2));
         }
         case Format::RGB5A1: {
             auto value = Color::DecodeRGB5A1(pixel) / 255.0f;
-            return QString("Red: %1, Green: %2, Blue: %3, Alpha: %4")
+            return QStringLiteral("Red: %1, Green: %2, Blue: %3, Alpha: %4")
                 .arg(QString::number(value.r(), 'f', 2))
                 .arg(QString::number(value.g(), 'f', 2))
                 .arg(QString::number(value.b(), 'f', 2))
@@ -336,69 +336,72 @@ void GraphicsSurfaceWidget::Pick(int x, int y) {
         }
         case Format::RGB565: {
             auto value = Color::DecodeRGB565(pixel) / 255.0f;
-            return QString("Red: %1, Green: %2, Blue: %3")
+            return QStringLiteral("Red: %1, Green: %2, Blue: %3")
                 .arg(QString::number(value.r(), 'f', 2))
                 .arg(QString::number(value.g(), 'f', 2))
                 .arg(QString::number(value.b(), 'f', 2));
         }
         case Format::RGBA4: {
             auto value = Color::DecodeRGBA4(pixel) / 255.0f;
-            return QString("Red: %1, Green: %2, Blue: %3, Alpha: %4")
+            return QStringLiteral("Red: %1, Green: %2, Blue: %3, Alpha: %4")
                 .arg(QString::number(value.r(), 'f', 2))
                 .arg(QString::number(value.g(), 'f', 2))
                 .arg(QString::number(value.b(), 'f', 2))
                 .arg(QString::number(value.a(), 'f', 2));
         }
         case Format::IA8:
-            return QString("Index: %1, Alpha: %2").arg(pixel[0]).arg(pixel[1]);
+            return QStringLiteral("Index: %1, Alpha: %2").arg(pixel[0]).arg(pixel[1]);
         case Format::RG8: {
             auto value = Color::DecodeRG8(pixel) / 255.0f;
-            return QString("Red: %1, Green: %2")
+            return QStringLiteral("Red: %1, Green: %2")
                 .arg(QString::number(value.r(), 'f', 2))
                 .arg(QString::number(value.g(), 'f', 2));
         }
         case Format::I8:
-            return QString("Index: %1").arg(*pixel);
+            return QStringLiteral("Index: %1").arg(*pixel);
         case Format::A8:
-            return QString("Alpha: %1").arg(QString::number(*pixel / 255.0f, 'f', 2));
+            return QStringLiteral("Alpha: %1").arg(QString::number(*pixel / 255.0f, 'f', 2));
         case Format::IA4:
-            return QString("Index: %1, Alpha: %2").arg(*pixel & 0xF).arg((*pixel & 0xF0) >> 4);
+            return QStringLiteral("Index: %1, Alpha: %2")
+                .arg(*pixel & 0xF)
+                .arg((*pixel & 0xF0) >> 4);
         case Format::I4: {
             u8 i = (*pixel >> ((offset % 2) ? 4 : 0)) & 0xF;
-            return QString("Index: %1").arg(i);
+            return QStringLiteral("Index: %1").arg(i);
         }
         case Format::A4: {
             u8 a = (*pixel >> ((offset % 2) ? 4 : 0)) & 0xF;
-            return QString("Alpha: %1").arg(QString::number(a / 15.0f, 'f', 2));
+            return QStringLiteral("Alpha: %1").arg(QString::number(a / 15.0f, 'f', 2));
         }
         case Format::ETC1:
         case Format::ETC1A4:
             // TODO: Display block information or channel values?
-            return QString("Compressed data");
+            return QStringLiteral("Compressed data");
         case Format::D16: {
             auto value = Color::DecodeD16(pixel);
-            return QString("Depth: %1").arg(QString::number(value / (float)0xFFFF, 'f', 4));
+            return QStringLiteral("Depth: %1").arg(QString::number(value / (float)0xFFFF, 'f', 4));
         }
         case Format::D24: {
             auto value = Color::DecodeD24(pixel);
-            return QString("Depth: %1").arg(QString::number(value / (float)0xFFFFFF, 'f', 4));
+            return QStringLiteral("Depth: %1")
+                .arg(QString::number(value / (float)0xFFFFFF, 'f', 4));
         }
         case Format::D24X8:
         case Format::X24S8: {
             auto values = Color::DecodeD24S8(pixel);
-            return QString("Depth: %1, Stencil: %2")
+            return QStringLiteral("Depth: %1, Stencil: %2")
                 .arg(QString::number(values[0] / (float)0xFFFFFF, 'f', 4))
                 .arg(values[1]);
         }
         case Format::Unknown:
-            return QString("Unknown format");
+            return QStringLiteral("Unknown format");
         default:
-            return QString("Unhandled format");
+            return QStringLiteral("Unhandled format");
         }
-        return QString("");
+        return QString{};
     };
 
-    QString nibbles = "";
+    QString nibbles;
     for (unsigned i = 0; i < nibbles_per_pixel; i++) {
         unsigned nibble_index = i;
         if (nibble_mode) {
@@ -410,7 +413,7 @@ void GraphicsSurfaceWidget::Pick(int x, int y) {
     }
 
     surface_info_label->setText(
-        QString("Raw: 0x%3\n(%4)").arg(nibbles).arg(GetText(surface_format, pixel)));
+        QStringLiteral("Raw: 0x%3\n(%4)").arg(nibbles).arg(GetText(surface_format, pixel)));
     surface_info_label->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
 }
 

--- a/src/citra_qt/debugger/graphics/graphics_tracing.cpp
+++ b/src/citra_qt/debugger/graphics/graphics_tracing.cpp
@@ -24,11 +24,11 @@ GraphicsTracingWidget::GraphicsTracingWidget(std::shared_ptr<Pica::DebugContext>
                                              QWidget* parent)
     : BreakPointObserverDock(debug_context, tr("CiTrace Recorder"), parent) {
 
-    setObjectName("CiTracing");
+    setObjectName(QStringLiteral("CiTracing"));
 
     QPushButton* start_recording = new QPushButton(tr("Start Recording"));
     QPushButton* stop_recording =
-        new QPushButton(QIcon::fromTheme("document-save"), tr("Stop and Save"));
+        new QPushButton(QIcon::fromTheme(QStringLiteral("document-save")), tr("Stop and Save"));
     QPushButton* abort_recording = new QPushButton(tr("Abort Recording"));
 
     connect(this, &GraphicsTracingWidget::SetStartTracingButtonEnabled, start_recording,
@@ -109,8 +109,8 @@ void GraphicsTracingWidget::StopRecording() {
     if (!context)
         return;
 
-    QString filename = QFileDialog::getSaveFileName(this, tr("Save CiTrace"), "citrace.ctf",
-                                                    tr("CiTrace File (*.ctf)"));
+    QString filename = QFileDialog::getSaveFileName(
+        this, tr("Save CiTrace"), QStringLiteral("citrace.ctf"), tr("CiTrace File (*.ctf)"));
 
     if (filename.isEmpty()) {
         // If the user canceled the dialog, keep recording

--- a/src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp
+++ b/src/citra_qt/debugger/graphics/graphics_vertex_shader.cpp
@@ -86,10 +86,11 @@ QVariant GraphicsVertexShaderModel::data(const QModelIndex& index, int role) con
             if (par->info.HasLabel(index.row()))
                 return QString::fromStdString(par->info.GetLabel(index.row()));
 
-            return QString("%1").arg(4 * index.row(), 4, 16, QLatin1Char('0'));
+            return QStringLiteral("%1").arg(4 * index.row(), 4, 16, QLatin1Char('0'));
 
         case 1:
-            return QString("%1").arg(par->info.code[index.row()].hex, 8, 16, QLatin1Char('0'));
+            return QStringLiteral("%1").arg(par->info.code[index.row()].hex, 8, 16,
+                                            QLatin1Char('0'));
 
         case 2: {
             std::ostringstream output;
@@ -341,8 +342,9 @@ QVariant GraphicsVertexShaderModel::data(const QModelIndex& index, int role) con
 }
 
 void GraphicsVertexShaderWidget::DumpShader() {
-    QString filename = QFileDialog::getSaveFileName(
-        this, tr("Save Shader Dump"), "shader_dump.shbin", tr("Shader Binary (*.shbin)"));
+    QString filename = QFileDialog::getSaveFileName(this, tr("Save Shader Dump"),
+                                                    QStringLiteral("shader_dump.shbin"),
+                                                    tr("Shader Binary (*.shbin)"));
 
     if (filename.isEmpty()) {
         // If the user canceled the dialog, don't dump anything.
@@ -358,8 +360,8 @@ void GraphicsVertexShaderWidget::DumpShader() {
 
 GraphicsVertexShaderWidget::GraphicsVertexShaderWidget(
     std::shared_ptr<Pica::DebugContext> debug_context, QWidget* parent)
-    : BreakPointObserverDock(debug_context, "Pica Vertex Shader", parent) {
-    setObjectName("PicaVertexShader");
+    : BreakPointObserverDock(debug_context, tr("Pica Vertex Shader"), parent) {
+    setObjectName(QStringLiteral("PicaVertexShader"));
 
     // Clear input vertex data so that it contains valid float values in case a debug shader
     // execution happens before the first Vertex Loaded breakpoint.
@@ -387,7 +389,8 @@ GraphicsVertexShaderWidget::GraphicsVertexShaderWidget(
     binary_list->setRootIsDecorated(false);
     binary_list->setAlternatingRowColors(true);
 
-    auto dump_shader = new QPushButton(QIcon::fromTheme("document-save"), tr("Dump"));
+    auto dump_shader =
+        new QPushButton(QIcon::fromTheme(QStringLiteral("document-save")), tr("Dump"));
 
     instruction_description = new QLabel;
 
@@ -487,14 +490,14 @@ void GraphicsVertexShaderWidget::Reload(bool replace_vertex_data, void* vertex_d
             for (unsigned attr = 0; attr < 16; ++attr) {
                 for (unsigned comp = 0; comp < 4; ++comp) {
                     input_data[4 * attr + comp]->setText(
-                        QString("%1").arg(input_vertex.attr[attr][comp].ToFloat32()));
+                        QStringLiteral("%1").arg(input_vertex.attr[attr][comp].ToFloat32()));
                 }
             }
             breakpoint_warning->hide();
         } else {
             for (unsigned attr = 0; attr < 16; ++attr) {
                 for (unsigned comp = 0; comp < 4; ++comp) {
-                    input_data[4 * attr + comp]->setText(QString("???"));
+                    input_data[4 * attr + comp]->setText(QStringLiteral("???"));
                 }
             }
             breakpoint_warning->show();
@@ -524,7 +527,7 @@ void GraphicsVertexShaderWidget::Reload(bool replace_vertex_data, void* vertex_d
     // Reload widget state
     for (int attr = 0; attr < num_attributes; ++attr) {
         unsigned source_attr = shader_config.GetRegisterForAttribute(attr);
-        input_data_mapping[attr]->setText(QString("-> v%1").arg(source_attr));
+        input_data_mapping[attr]->setText(QStringLiteral("-> v%1").arg(source_attr));
         input_data_container[attr]->setVisible(true);
     }
     // Only show input attributes which are used as input to the shader
@@ -552,6 +555,8 @@ void GraphicsVertexShaderWidget::OnInputAttributeChanged(int index) {
 
 void GraphicsVertexShaderWidget::OnCycleIndexChanged(int index) {
     QString text;
+    const QString true_string = QStringLiteral("true");
+    const QString false_string = QStringLiteral("false");
 
     auto& record = debug_data.records[index];
     if (record.mask & Pica::Shader::DebugDataRecord::SRC1)
@@ -591,15 +596,15 @@ void GraphicsVertexShaderWidget::OnCycleIndexChanged(int index) {
                     .arg(record.address_registers[1]);
     if (record.mask & Pica::Shader::DebugDataRecord::CMP_RESULT)
         text += tr("Compare Result: %1, %2\n")
-                    .arg(record.conditional_code[0] ? "true" : "false")
-                    .arg(record.conditional_code[1] ? "true" : "false");
+                    .arg(record.conditional_code[0] ? true_string : false_string)
+                    .arg(record.conditional_code[1] ? true_string : false_string);
 
     if (record.mask & Pica::Shader::DebugDataRecord::COND_BOOL_IN)
-        text += tr("Static Condition: %1\n").arg(record.cond_bool ? "true" : "false");
+        text += tr("Static Condition: %1\n").arg(record.cond_bool ? true_string : false_string);
     if (record.mask & Pica::Shader::DebugDataRecord::COND_CMP_IN)
         text += tr("Dynamic Conditions: %1, %2\n")
-                    .arg(record.cond_cmp[0] ? "true" : "false")
-                    .arg(record.cond_cmp[1] ? "true" : "false");
+                    .arg(record.cond_cmp[0] ? true_string : false_string)
+                    .arg(record.cond_cmp[1] ? true_string : false_string);
     if (record.mask & Pica::Shader::DebugDataRecord::LOOP_INT_IN)
         text += tr("Loop Parameters: %1 (repeats), %2 (initializer), %3 (increment), %4\n")
                     .arg(record.loop_int.x)

--- a/src/citra_qt/debugger/lle_service_modules.cpp
+++ b/src/citra_qt/debugger/lle_service_modules.cpp
@@ -11,7 +11,7 @@
 
 LLEServiceModulesWidget::LLEServiceModulesWidget(QWidget* parent)
     : QDockWidget(tr("Toggle LLE Service Modules"), parent) {
-    setObjectName("LLEServiceModulesWidget");
+    setObjectName(QStringLiteral("LLEServiceModulesWidget"));
     QScrollArea* scroll_area = new QScrollArea;
     QLayout* scroll_layout = new QVBoxLayout;
     for (const auto& service_module : Settings::values.lle_modules) {

--- a/src/citra_qt/debugger/profiler.cpp
+++ b/src/citra_qt/debugger/profiler.cpp
@@ -46,7 +46,7 @@ private:
 #endif
 
 MicroProfileDialog::MicroProfileDialog(QWidget* parent) : QWidget(parent, Qt::Dialog) {
-    setObjectName("MicroProfile");
+    setObjectName(QStringLiteral("MicroProfile"));
     setWindowTitle(tr("MicroProfile"));
     resize(1000, 600);
     // Remove the "?" button from the titlebar and enable the maximize button
@@ -191,7 +191,7 @@ void MicroProfileDrawText(int x, int y, u32 hex_color, const char* text, u32 tex
     for (u32 i = 0; i < text_length; ++i) {
         // Position the text baseline 1 pixel above the bottom of the text cell, this gives nice
         // vertical alignment of text for a wide range of tested fonts.
-        mp_painter->drawText(x, y + MICROPROFILE_TEXT_HEIGHT - 2, QChar(text[i]));
+        mp_painter->drawText(x, y + MICROPROFILE_TEXT_HEIGHT - 2, QString{QLatin1Char{text[i]}});
         x += MICROPROFILE_TEXT_WIDTH + 1;
     }
 }

--- a/src/citra_qt/debugger/registers.cpp
+++ b/src/citra_qt/debugger/registers.cpp
@@ -16,15 +16,15 @@ RegistersWidget::RegistersWidget(QWidget* parent) : QDockWidget(parent) {
     tree->addTopLevelItem(vfp_registers = new QTreeWidgetItem(QStringList(tr("VFP Registers"))));
     tree->addTopLevelItem(vfp_system_registers =
                               new QTreeWidgetItem(QStringList(tr("VFP System Registers"))));
-    tree->addTopLevelItem(cpsr = new QTreeWidgetItem(QStringList("CPSR")));
+    tree->addTopLevelItem(cpsr = new QTreeWidgetItem(QStringList(QStringLiteral("CPSR"))));
 
     for (int i = 0; i < 16; ++i) {
-        QTreeWidgetItem* child = new QTreeWidgetItem(QStringList(QString("R[%1]").arg(i)));
+        QTreeWidgetItem* child = new QTreeWidgetItem(QStringList(QStringLiteral("R[%1]").arg(i)));
         core_registers->addChild(child);
     }
 
     for (int i = 0; i < 32; ++i) {
-        QTreeWidgetItem* child = new QTreeWidgetItem(QStringList(QString("S[%1]").arg(i)));
+        QTreeWidgetItem* child = new QTreeWidgetItem(QStringList(QStringLiteral("S[%1]").arg(i)));
         vfp_registers->addChild(child);
     }
 
@@ -63,11 +63,11 @@ void RegistersWidget::OnDebugModeEntered() {
 
     for (int i = 0; i < core_registers->childCount(); ++i)
         core_registers->child(i)->setText(
-            1, QString("0x%1").arg(Core::CPU().GetReg(i), 8, 16, QLatin1Char('0')));
+            1, QStringLiteral("0x%1").arg(Core::CPU().GetReg(i), 8, 16, QLatin1Char('0')));
 
     for (int i = 0; i < vfp_registers->childCount(); ++i)
         vfp_registers->child(i)->setText(
-            1, QString("0x%1").arg(Core::CPU().GetVFPReg(i), 8, 16, QLatin1Char('0')));
+            1, QStringLiteral("0x%1").arg(Core::CPU().GetVFPReg(i), 8, 16, QLatin1Char('0')));
 
     UpdateCPSRValues();
     UpdateVFPSystemRegisterValues();
@@ -82,61 +82,61 @@ void RegistersWidget::OnEmulationStarting(EmuThread* emu_thread) {
 void RegistersWidget::OnEmulationStopping() {
     // Reset widget text
     for (int i = 0; i < core_registers->childCount(); ++i)
-        core_registers->child(i)->setText(1, QString(""));
+        core_registers->child(i)->setText(1, QString{});
 
     for (int i = 0; i < vfp_registers->childCount(); ++i)
-        vfp_registers->child(i)->setText(1, QString(""));
+        vfp_registers->child(i)->setText(1, QString{});
 
     for (int i = 0; i < cpsr->childCount(); ++i)
-        cpsr->child(i)->setText(1, QString(""));
+        cpsr->child(i)->setText(1, QString{});
 
-    cpsr->setText(1, QString(""));
+    cpsr->setText(1, QString{});
 
     // FPSCR
     for (int i = 0; i < vfp_system_registers->child(0)->childCount(); ++i)
-        vfp_system_registers->child(0)->child(i)->setText(1, QString(""));
+        vfp_system_registers->child(0)->child(i)->setText(1, QString{});
 
     // FPEXC
     for (int i = 0; i < vfp_system_registers->child(1)->childCount(); ++i)
-        vfp_system_registers->child(1)->child(i)->setText(1, QString(""));
+        vfp_system_registers->child(1)->child(i)->setText(1, QString{});
 
-    vfp_system_registers->child(0)->setText(1, QString(""));
-    vfp_system_registers->child(1)->setText(1, QString(""));
-    vfp_system_registers->child(2)->setText(1, QString(""));
-    vfp_system_registers->child(3)->setText(1, QString(""));
+    vfp_system_registers->child(0)->setText(1, QString{});
+    vfp_system_registers->child(1)->setText(1, QString{});
+    vfp_system_registers->child(2)->setText(1, QString{});
+    vfp_system_registers->child(3)->setText(1, QString{});
 
     setEnabled(false);
 }
 
 void RegistersWidget::CreateCPSRChildren() {
-    cpsr->addChild(new QTreeWidgetItem(QStringList("M")));
-    cpsr->addChild(new QTreeWidgetItem(QStringList("T")));
-    cpsr->addChild(new QTreeWidgetItem(QStringList("F")));
-    cpsr->addChild(new QTreeWidgetItem(QStringList("I")));
-    cpsr->addChild(new QTreeWidgetItem(QStringList("A")));
-    cpsr->addChild(new QTreeWidgetItem(QStringList("E")));
-    cpsr->addChild(new QTreeWidgetItem(QStringList("IT")));
-    cpsr->addChild(new QTreeWidgetItem(QStringList("GE")));
-    cpsr->addChild(new QTreeWidgetItem(QStringList("DNM")));
-    cpsr->addChild(new QTreeWidgetItem(QStringList("J")));
-    cpsr->addChild(new QTreeWidgetItem(QStringList("Q")));
-    cpsr->addChild(new QTreeWidgetItem(QStringList("V")));
-    cpsr->addChild(new QTreeWidgetItem(QStringList("C")));
-    cpsr->addChild(new QTreeWidgetItem(QStringList("Z")));
-    cpsr->addChild(new QTreeWidgetItem(QStringList("N")));
+    cpsr->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("M"))));
+    cpsr->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("T"))));
+    cpsr->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("F"))));
+    cpsr->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("I"))));
+    cpsr->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("A"))));
+    cpsr->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("E"))));
+    cpsr->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("IT"))));
+    cpsr->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("GE"))));
+    cpsr->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("DNM"))));
+    cpsr->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("J"))));
+    cpsr->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("Q"))));
+    cpsr->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("V"))));
+    cpsr->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("C"))));
+    cpsr->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("Z"))));
+    cpsr->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("N"))));
 }
 
 void RegistersWidget::UpdateCPSRValues() {
     const u32 cpsr_val = Core::CPU().GetCPSR();
 
-    cpsr->setText(1, QString("0x%1").arg(cpsr_val, 8, 16, QLatin1Char('0')));
+    cpsr->setText(1, QStringLiteral("0x%1").arg(cpsr_val, 8, 16, QLatin1Char('0')));
     cpsr->child(0)->setText(
-        1, QString("b%1").arg(cpsr_val & 0x1F, 5, 2, QLatin1Char('0'))); // M - Mode
-    cpsr->child(1)->setText(1, QString::number((cpsr_val >> 5) & 1));    // T - State
-    cpsr->child(2)->setText(1, QString::number((cpsr_val >> 6) & 1));    // F - FIQ disable
-    cpsr->child(3)->setText(1, QString::number((cpsr_val >> 7) & 1));    // I - IRQ disable
-    cpsr->child(4)->setText(1, QString::number((cpsr_val >> 8) & 1));    // A - Imprecise abort
-    cpsr->child(5)->setText(1, QString::number((cpsr_val >> 9) & 1));    // E - Data endianness
+        1, QStringLiteral("b%1").arg(cpsr_val & 0x1F, 5, 2, QLatin1Char('0'))); // M - Mode
+    cpsr->child(1)->setText(1, QString::number((cpsr_val >> 5) & 1));           // T - State
+    cpsr->child(2)->setText(1, QString::number((cpsr_val >> 6) & 1));           // F - FIQ disable
+    cpsr->child(3)->setText(1, QString::number((cpsr_val >> 7) & 1));           // I - IRQ disable
+    cpsr->child(4)->setText(1, QString::number((cpsr_val >> 8) & 1)); // A - Imprecise abort
+    cpsr->child(5)->setText(1, QString::number((cpsr_val >> 9) & 1)); // E - Data endianness
     cpsr->child(6)->setText(1,
                             QString::number((cpsr_val >> 10) & 0x3F)); // IT - If-Then state (DNM)
     cpsr->child(7)->setText(1,
@@ -151,43 +151,43 @@ void RegistersWidget::UpdateCPSRValues() {
 }
 
 void RegistersWidget::CreateVFPSystemRegisterChildren() {
-    QTreeWidgetItem* const fpscr = new QTreeWidgetItem(QStringList("FPSCR"));
-    fpscr->addChild(new QTreeWidgetItem(QStringList("IOC")));
-    fpscr->addChild(new QTreeWidgetItem(QStringList("DZC")));
-    fpscr->addChild(new QTreeWidgetItem(QStringList("OFC")));
-    fpscr->addChild(new QTreeWidgetItem(QStringList("UFC")));
-    fpscr->addChild(new QTreeWidgetItem(QStringList("IXC")));
-    fpscr->addChild(new QTreeWidgetItem(QStringList("IDC")));
-    fpscr->addChild(new QTreeWidgetItem(QStringList("IOE")));
-    fpscr->addChild(new QTreeWidgetItem(QStringList("DZE")));
-    fpscr->addChild(new QTreeWidgetItem(QStringList("OFE")));
-    fpscr->addChild(new QTreeWidgetItem(QStringList("UFE")));
-    fpscr->addChild(new QTreeWidgetItem(QStringList("IXE")));
-    fpscr->addChild(new QTreeWidgetItem(QStringList("IDE")));
+    QTreeWidgetItem* const fpscr = new QTreeWidgetItem(QStringList(QStringLiteral("FPSCR")));
+    fpscr->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("IOC"))));
+    fpscr->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("DZC"))));
+    fpscr->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("OFC"))));
+    fpscr->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("UFC"))));
+    fpscr->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("IXC"))));
+    fpscr->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("IDC"))));
+    fpscr->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("IOE"))));
+    fpscr->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("DZE"))));
+    fpscr->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("OFE"))));
+    fpscr->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("UFE"))));
+    fpscr->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("IXE"))));
+    fpscr->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("IDE"))));
     fpscr->addChild(new QTreeWidgetItem(QStringList(tr("Vector Length"))));
     fpscr->addChild(new QTreeWidgetItem(QStringList(tr("Vector Stride"))));
     fpscr->addChild(new QTreeWidgetItem(QStringList(tr("Rounding Mode"))));
-    fpscr->addChild(new QTreeWidgetItem(QStringList("FZ")));
-    fpscr->addChild(new QTreeWidgetItem(QStringList("DN")));
-    fpscr->addChild(new QTreeWidgetItem(QStringList("V")));
-    fpscr->addChild(new QTreeWidgetItem(QStringList("C")));
-    fpscr->addChild(new QTreeWidgetItem(QStringList("Z")));
-    fpscr->addChild(new QTreeWidgetItem(QStringList("N")));
+    fpscr->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("FZ"))));
+    fpscr->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("DN"))));
+    fpscr->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("V"))));
+    fpscr->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("C"))));
+    fpscr->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("Z"))));
+    fpscr->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("N"))));
 
-    QTreeWidgetItem* const fpexc = new QTreeWidgetItem(QStringList("FPEXC"));
-    fpexc->addChild(new QTreeWidgetItem(QStringList("IOC")));
-    fpexc->addChild(new QTreeWidgetItem(QStringList("OFC")));
-    fpexc->addChild(new QTreeWidgetItem(QStringList("UFC")));
-    fpexc->addChild(new QTreeWidgetItem(QStringList("INV")));
+    QTreeWidgetItem* const fpexc = new QTreeWidgetItem(QStringList(QStringLiteral("FPEXC")));
+    fpexc->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("IOC"))));
+    fpexc->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("OFC"))));
+    fpexc->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("UFC"))));
+    fpexc->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("INV"))));
     fpexc->addChild(new QTreeWidgetItem(QStringList(tr("Vector Iteration Count"))));
-    fpexc->addChild(new QTreeWidgetItem(QStringList("FP2V")));
-    fpexc->addChild(new QTreeWidgetItem(QStringList("EN")));
-    fpexc->addChild(new QTreeWidgetItem(QStringList("EX")));
+    fpexc->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("FP2V"))));
+    fpexc->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("EN"))));
+    fpexc->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("EX"))));
 
     vfp_system_registers->addChild(fpscr);
     vfp_system_registers->addChild(fpexc);
-    vfp_system_registers->addChild(new QTreeWidgetItem(QStringList("FPINST")));
-    vfp_system_registers->addChild(new QTreeWidgetItem(QStringList("FPINST2")));
+    vfp_system_registers->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("FPINST"))));
+    vfp_system_registers->addChild(new QTreeWidgetItem(QStringList(QStringLiteral("FPINST2"))));
 }
 
 void RegistersWidget::UpdateVFPSystemRegisterValues() {
@@ -197,7 +197,7 @@ void RegistersWidget::UpdateVFPSystemRegisterValues() {
     const u32 fpinst2_val = Core::CPU().GetVFPSystemReg(VFP_FPINST2);
 
     QTreeWidgetItem* const fpscr = vfp_system_registers->child(0);
-    fpscr->setText(1, QString("0x%1").arg(fpscr_val, 8, 16, QLatin1Char('0')));
+    fpscr->setText(1, QStringLiteral("0x%1").arg(fpscr_val, 8, 16, QLatin1Char('0')));
     fpscr->child(0)->setText(1, QString::number(fpscr_val & 1));
     fpscr->child(1)->setText(1, QString::number((fpscr_val >> 1) & 1));
     fpscr->child(2)->setText(1, QString::number((fpscr_val >> 2) & 1));
@@ -210,9 +210,12 @@ void RegistersWidget::UpdateVFPSystemRegisterValues() {
     fpscr->child(9)->setText(1, QString::number((fpscr_val >> 11) & 1));
     fpscr->child(10)->setText(1, QString::number((fpscr_val >> 12) & 1));
     fpscr->child(11)->setText(1, QString::number((fpscr_val >> 15) & 1));
-    fpscr->child(12)->setText(1, QString("b%1").arg((fpscr_val >> 16) & 7, 3, 2, QLatin1Char('0')));
-    fpscr->child(13)->setText(1, QString("b%1").arg((fpscr_val >> 20) & 3, 2, 2, QLatin1Char('0')));
-    fpscr->child(14)->setText(1, QString("b%1").arg((fpscr_val >> 22) & 3, 2, 2, QLatin1Char('0')));
+    fpscr->child(12)->setText(
+        1, QStringLiteral("b%1").arg((fpscr_val >> 16) & 7, 3, 2, QLatin1Char('0')));
+    fpscr->child(13)->setText(
+        1, QStringLiteral("b%1").arg((fpscr_val >> 20) & 3, 2, 2, QLatin1Char('0')));
+    fpscr->child(14)->setText(
+        1, QStringLiteral("b%1").arg((fpscr_val >> 22) & 3, 2, 2, QLatin1Char('0')));
     fpscr->child(15)->setText(1, QString::number((fpscr_val >> 24) & 1));
     fpscr->child(16)->setText(1, QString::number((fpscr_val >> 25) & 1));
     fpscr->child(17)->setText(1, QString::number((fpscr_val >> 28) & 1));
@@ -221,18 +224,19 @@ void RegistersWidget::UpdateVFPSystemRegisterValues() {
     fpscr->child(20)->setText(1, QString::number((fpscr_val >> 31) & 1));
 
     QTreeWidgetItem* const fpexc = vfp_system_registers->child(1);
-    fpexc->setText(1, QString("0x%1").arg(fpexc_val, 8, 16, QLatin1Char('0')));
+    fpexc->setText(1, QStringLiteral("0x%1").arg(fpexc_val, 8, 16, QLatin1Char('0')));
     fpexc->child(0)->setText(1, QString::number(fpexc_val & 1));
     fpexc->child(1)->setText(1, QString::number((fpexc_val >> 2) & 1));
     fpexc->child(2)->setText(1, QString::number((fpexc_val >> 3) & 1));
     fpexc->child(3)->setText(1, QString::number((fpexc_val >> 7) & 1));
-    fpexc->child(4)->setText(1, QString("b%1").arg((fpexc_val >> 8) & 7, 3, 2, QLatin1Char('0')));
+    fpexc->child(4)->setText(
+        1, QStringLiteral("b%1").arg((fpexc_val >> 8) & 7, 3, 2, QLatin1Char('0')));
     fpexc->child(5)->setText(1, QString::number((fpexc_val >> 28) & 1));
     fpexc->child(6)->setText(1, QString::number((fpexc_val >> 30) & 1));
     fpexc->child(7)->setText(1, QString::number((fpexc_val >> 31) & 1));
 
     vfp_system_registers->child(2)->setText(
-        1, QString("0x%1").arg(fpinst_val, 8, 16, QLatin1Char('0')));
+        1, QStringLiteral("0x%1").arg(fpinst_val, 8, 16, QLatin1Char('0')));
     vfp_system_registers->child(3)->setText(
-        1, QString("0x%1").arg(fpinst2_val, 8, 16, QLatin1Char('0')));
+        1, QStringLiteral("0x%1").arg(fpinst2_val, 8, 16, QLatin1Char('0')));
 }

--- a/src/citra_qt/debugger/wait_tree.cpp
+++ b/src/citra_qt/debugger/wait_tree.cpp
@@ -401,7 +401,7 @@ void WaitTreeModel::InitItems() {
 }
 
 WaitTreeWidget::WaitTreeWidget(QWidget* parent) : QDockWidget(tr("Wait Tree"), parent) {
-    setObjectName("WaitTreeWidget");
+    setObjectName(QStringLiteral("WaitTreeWidget"));
     view = new QTreeView(this);
     view->setHeaderHidden(true);
     setWidget(view);


### PR DESCRIPTION
See yuzu-emu/yuzu#2492 for more details.

**Original description**:
Another set of changes that brings us slightly closer to disabling implicit string conversions in Qt code. This makes all of the string conversions explicit in the debugger, which is relatively lower traffic in terms of changes compared to the rest of the UI code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4856)
<!-- Reviewable:end -->
