### PR TITLE
Port yuzu-emu/yuzu#2499: "yuzu/configuration: Specify string conversions explicitly"

### DIFF
--- a/src/citra_qt/configuration/configure_audio.cpp
+++ b/src/citra_qt/configuration/configure_audio.cpp
@@ -19,9 +19,9 @@ ConfigureAudio::ConfigureAudio(QWidget* parent)
     ui->setupUi(this);
 
     ui->output_sink_combo_box->clear();
-    ui->output_sink_combo_box->addItem("auto");
+    ui->output_sink_combo_box->addItem(QString::fromUtf8(AudioCore::auto_device_name));
     for (const char* id : AudioCore::GetSinkIDs()) {
-        ui->output_sink_combo_box->addItem(id);
+        ui->output_sink_combo_box->addItem(QString::fromUtf8(id));
     }
 
     ui->emulation_combo_box->addItem(tr("HLE (fast)"));
@@ -131,7 +131,7 @@ void ConfigureAudio::ApplyConfiguration() {
 
 void ConfigureAudio::UpdateAudioOutputDevices(int sink_index) {
     ui->audio_device_combo_box->clear();
-    ui->audio_device_combo_box->addItem(AudioCore::auto_device_name);
+    ui->audio_device_combo_box->addItem(QString::fromUtf8(AudioCore::auto_device_name));
 
     const std::string sink_id = ui->output_sink_combo_box->itemText(sink_index).toStdString();
     for (const auto& device : AudioCore::GetDeviceListForSink(sink_id)) {

--- a/src/citra_qt/configuration/configure_camera.cpp
+++ b/src/citra_qt/configuration/configure_camera.cpp
@@ -84,7 +84,7 @@ void ConfigureCamera::ConnectEvents() {
         ui->camera_file->setDisabled(state == Qt::Checked);
         ui->toolButton->setDisabled(state == Qt::Checked);
         if (state == Qt::Checked) {
-            ui->camera_file->setText("");
+            ui->camera_file->setText(QString{});
         }
     });
     connect(ui->camera_file, &QLineEdit::textChanged, this, [=] { StopPreviewing(); });
@@ -120,7 +120,7 @@ void ConfigureCamera::UpdateImageSourceUI() {
         ui->prompt_before_load->setChecked(false);
         ui->camera_file_label->setHidden(true);
         ui->camera_file->setHidden(true);
-        ui->camera_file->setText("");
+        ui->camera_file->setText(QString{});
         ui->toolButton->setHidden(true);
         break;
     case 1: /* still image */
@@ -132,7 +132,7 @@ void ConfigureCamera::UpdateImageSourceUI() {
             ui->prompt_before_load->setChecked(true);
             ui->camera_file->setDisabled(true);
             ui->toolButton->setDisabled(true);
-            ui->camera_file->setText("");
+            ui->camera_file->setText(QString{});
         } else {
             ui->camera_file->setDisabled(false);
             ui->toolButton->setDisabled(false);
@@ -250,7 +250,7 @@ void ConfigureCamera::SetConfiguration() {
         ui->camera_file->setDisabled(camera_config[index].empty());
         ui->toolButton->setDisabled(camera_config[index].empty());
         if (camera_config[index].empty()) {
-            ui->camera_file->setText("");
+            ui->camera_file->setText(QString{});
         }
     }
     if (camera_name[index] == "qt") {
@@ -270,10 +270,10 @@ void ConfigureCamera::OnToolButtonClicked() {
     QList<QByteArray> types = QImageReader::supportedImageFormats();
     QList<QString> temp_filters;
     for (const QByteArray& type : types) {
-        temp_filters << QString("*." + QString(type));
+        temp_filters << QString("*." + QString::fromUtf8(type));
     }
-    QString filter = tr("Supported image files (%1)").arg(temp_filters.join(" "));
-    QString path = QFileDialog::getOpenFileName(this, tr("Open File"), ".", filter);
+    QString filter = tr("Supported image files (%1)").arg(temp_filters.join(QStringLiteral(" ")));
+    QString path = QFileDialog::getOpenFileName(this, tr("Open File"), QStringLiteral("."), filter);
     if (!path.isEmpty()) {
         ui->camera_file->setText(path);
     }

--- a/src/citra_qt/configuration/configure_dialog.cpp
+++ b/src/citra_qt/configuration/configure_dialog.cpp
@@ -72,11 +72,10 @@ void ConfigureDialog::PopulateSelectionList() {
     ui->selectorList->clear();
 
     const std::array<std::pair<QString, QStringList>, 4> items{
-        {{tr("General"),
-          {QT_TR_NOOP("General"), QT_TR_NOOP("Web"), QT_TR_NOOP("Debug"), QT_TR_NOOP("UI")}},
-         {tr("System"), {QT_TR_NOOP("System"), QT_TR_NOOP("Audio"), QT_TR_NOOP("Camera")}},
-         {tr("Graphics"), {QT_TR_NOOP("Graphics")}},
-         {tr("Controls"), {QT_TR_NOOP("Input"), QT_TR_NOOP("Hotkeys")}}}};
+        {{tr("General"), {tr("General"), tr("Web"), tr("Debug"), tr("UI")}},
+         {tr("System"), {tr("System"), tr("Audio"), tr("Camera")}},
+         {tr("Graphics"), {tr("Graphics")}},
+         {tr("Controls"), {tr("Input"), tr("Hotkeys")}}}};
 
     for (const auto& entry : items) {
         auto* const item = new QListWidgetItem(entry.first);
@@ -121,11 +120,11 @@ void ConfigureDialog::UpdateVisibleTabs() {
         return;
 
     const std::map<QString, QWidget*> widgets = {
-        {"General", ui->generalTab},   {"System", ui->systemTab},
-        {"Input", ui->inputTab},       {"Hotkeys", ui->hotkeysTab},
-        {"Graphics", ui->graphicsTab}, {"Audio", ui->audioTab},
-        {"Camera", ui->cameraTab},     {"Debug", ui->debugTab},
-        {"Web", ui->webTab},           {"UI", ui->uiTab}};
+        {QStringLiteral("General"), ui->generalTab},   {QStringLiteral("System"), ui->systemTab},
+        {QStringLiteral("Input"), ui->inputTab},       {QStringLiteral("Hotkeys"), ui->hotkeysTab},
+        {QStringLiteral("Graphics"), ui->graphicsTab}, {QStringLiteral("Audio"), ui->audioTab},
+        {QStringLiteral("Camera"), ui->cameraTab},     {QStringLiteral("Debug"), ui->debugTab},
+        {QStringLiteral("Web"), ui->webTab},           {QStringLiteral("UI"), ui->uiTab}};
 
     ui->tabWidget->clear();
 

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -32,7 +32,7 @@ static QString GetKeyName(int key_code) {
     case Qt::Key_Alt:
         return QObject::tr("Alt");
     case Qt::Key_Meta:
-        return "";
+        return QString{};
     default:
         return QKeySequence(key_code).toString();
     }
@@ -52,46 +52,70 @@ static void SetAnalogButton(const Common::ParamPackage& input_param,
 static QString ButtonToText(const Common::ParamPackage& param) {
     if (!param.Has("engine")) {
         return QObject::tr("[not set]");
-    } else if (param.Get("engine", "") == "keyboard") {
-        return GetKeyName(param.Get("code", 0));
-    } else if (param.Get("engine", "") == "sdl") {
-        if (param.Has("hat")) {
-            return QString(QObject::tr("Hat %1 %2"))
-                .arg(param.Get("hat", "").c_str(), param.Get("direction", "").c_str());
-        }
-        if (param.Has("axis")) {
-            return QString(QObject::tr("Axis %1%2"))
-                .arg(param.Get("axis", "").c_str(), param.Get("direction", "").c_str());
-        }
-        if (param.Has("button")) {
-            return QString(QObject::tr("Button %1")).arg(param.Get("button", "").c_str());
-        }
-        return QString();
-    } else {
-        return QObject::tr("[unknown]");
     }
-};
+
+    if (param.Get("engine", "") == "keyboard") {
+        return GetKeyName(param.Get("code", 0));
+    }
+
+    if (param.Get("engine", "") == "sdl") {
+        if (param.Has("hat")) {
+            const QString hat_str = QString::fromStdString(param.Get("hat", ""));
+            const QString direction_str = QString::fromStdString(param.Get("direction", ""));
+
+            return QObject::tr("Hat %1 %2").arg(hat_str, direction_str);
+        }
+
+        if (param.Has("axis")) {
+            const QString axis_str = QString::fromStdString(param.Get("axis", ""));
+            const QString direction_str = QString::fromStdString(param.Get("direction", ""));
+
+            return QObject::tr("Axis %1%2").arg(axis_str, direction_str);
+        }
+
+        if (param.Has("button")) {
+            const QString button_str = QString::fromStdString(param.Get("button", ""));
+
+            return QObject::tr("Button %1").arg(button_str);
+        }
+
+        return {};
+    }
+
+    return QObject::tr("[unknown]");
+}
 
 static QString AnalogToText(const Common::ParamPackage& param, const std::string& dir) {
     if (!param.Has("engine")) {
         return QObject::tr("[not set]");
-    } else if (param.Get("engine", "") == "analog_from_button") {
+    }
+
+    if (param.Get("engine", "") == "analog_from_button") {
         return ButtonToText(Common::ParamPackage{param.Get(dir, "")});
-    } else if (param.Get("engine", "") == "sdl") {
+    }
+
+    if (param.Get("engine", "") == "sdl") {
         if (dir == "modifier") {
-            return QString(QObject::tr("[unused]"));
+            return QObject::tr("[unused]");
         }
 
         if (dir == "left" || dir == "right") {
-            return QString(QObject::tr("Axis %1")).arg(param.Get("axis_x", "").c_str());
-        } else if (dir == "up" || dir == "down") {
-            return QString(QObject::tr("Axis %1")).arg(param.Get("axis_y", "").c_str());
+            const QString axis_x_str = QString::fromStdString(param.Get("axis_x", ""));
+
+            return QObject::tr("Axis %1").arg(axis_x_str);
         }
-        return QString();
-    } else {
-        return QObject::tr("[unknown]");
+
+        if (dir == "up" || dir == "down") {
+            const QString axis_y_str = QString::fromStdString(param.Get("axis_y", ""));
+
+            return QObject::tr("Axis %1").arg(axis_y_str);
+        }
+
+        return {};
     }
-};
+
+    return QObject::tr("[unknown]");
+}
 
 ConfigureInput::ConfigureInput(QWidget* parent)
     : QWidget(parent), ui(std::make_unique<Ui::ConfigureInput>()),

--- a/src/citra_qt/configuration/configure_motion_touch.cpp
+++ b/src/citra_qt/configuration/configure_motion_touch.cpp
@@ -81,10 +81,10 @@ ConfigureMotionTouch::ConfigureMotionTouch(QWidget* parent)
     : QDialog(parent), ui(std::make_unique<Ui::ConfigureMotionTouch>()) {
     ui->setupUi(this);
     for (auto [provider, name] : MotionProviders) {
-        ui->motion_provider->addItem(tr(name), provider);
+        ui->motion_provider->addItem(tr(name), QString::fromUtf8(provider));
     }
     for (auto [provider, name] : TouchProviders) {
-        ui->touch_provider->addItem(tr(name), provider);
+        ui->touch_provider->addItem(tr(name), QString::fromUtf8(provider));
     }
 
     ui->udp_learn_more->setOpenExternalLinks(true);
@@ -140,7 +140,7 @@ void ConfigureMotionTouch::UpdateUiDisplay() {
         ui->touch_calibration->setVisible(true);
         ui->touch_calibration_config->setVisible(true);
         ui->touch_calibration_label->setVisible(true);
-        ui->touch_calibration->setText(QString("(%1, %2) - (%3, %4)")
+        ui->touch_calibration->setText(QStringLiteral("(%1, %2) - (%3, %4)")
                                            .arg(QString::number(min_x), QString::number(min_y),
                                                 QString::number(max_x), QString::number(max_y)));
     } else {

--- a/src/citra_qt/configuration/configure_system.cpp
+++ b/src/citra_qt/configuration/configure_system.cpp
@@ -389,7 +389,7 @@ void ConfigureSystem::UpdateBirthdayComboBox(int birthmonth_index) {
 void ConfigureSystem::ConfigureTime() {
     ui->edit_init_time->setCalendarPopup(true);
     QDateTime dt;
-    dt.fromString("2000-01-01 00:00:01", "yyyy-MM-dd hh:mm:ss");
+    dt.fromString(QStringLiteral("2000-01-01 00:00:01"), QStringLiteral("yyyy-MM-dd hh:mm:ss"));
     ui->edit_init_time->setMinimumDateTime(dt);
 
     SetConfiguration();

--- a/src/citra_qt/configuration/configure_ui.cpp
+++ b/src/citra_qt/configuration/configure_ui.cpp
@@ -9,13 +9,13 @@
 
 ConfigureUi::ConfigureUi(QWidget* parent) : QWidget(parent), ui(new Ui::ConfigureUi) {
     ui->setupUi(this);
-    ui->language_combobox->addItem(tr("<System>"), QString(""));
-    ui->language_combobox->addItem(tr("English"), QString("en"));
-    QDirIterator it(":/languages", QDirIterator::NoIteratorFlags);
+    ui->language_combobox->addItem(tr("<System>"), QString{});
+    ui->language_combobox->addItem(tr("English"), QStringLiteral("en"));
+    QDirIterator it(QStringLiteral(":/languages"), QDirIterator::NoIteratorFlags);
     while (it.hasNext()) {
         QString locale = it.next();
-        locale.truncate(locale.lastIndexOf('.'));
-        locale.remove(0, locale.lastIndexOf('/') + 1);
+        locale.truncate(locale.lastIndexOf(QLatin1Char{'.'}));
+        locale.remove(0, locale.lastIndexOf(QLatin1Char{'/'}) + 1);
         QString lang = QLocale::languageToString(QLocale(locale).language());
         ui->language_combobox->addItem(lang, locale);
     }
@@ -28,7 +28,8 @@ ConfigureUi::ConfigureUi(QWidget* parent) : QWidget(parent), ui(new Ui::Configur
             &ConfigureUi::OnLanguageChanged);
 
     for (const auto& theme : UISettings::themes) {
-        ui->theme_combobox->addItem(theme.first, theme.second);
+        ui->theme_combobox->addItem(QString::fromUtf8(theme.first),
+                                    QString::fromUtf8(theme.second));
     }
 
     SetConfiguration();

--- a/src/citra_qt/configuration/configure_web.cpp
+++ b/src/citra_qt/configuration/configure_web.cpp
@@ -80,12 +80,16 @@ void ConfigureWeb::RefreshTelemetryID() {
 void ConfigureWeb::OnLoginChanged() {
     if (ui->edit_username->text().isEmpty() && ui->edit_token->text().isEmpty()) {
         user_verified = true;
-        ui->label_username_verified->setPixmap(QIcon::fromTheme("checked").pixmap(16));
-        ui->label_token_verified->setPixmap(QIcon::fromTheme("checked").pixmap(16));
+
+        const QPixmap pixmap = QIcon::fromTheme(QStringLiteral("checked")).pixmap(16);
+        ui->label_username_verified->setPixmap(pixmap);
+        ui->label_token_verified->setPixmap(pixmap);
     } else {
         user_verified = false;
-        ui->label_username_verified->setPixmap(QIcon::fromTheme("failed").pixmap(16));
-        ui->label_token_verified->setPixmap(QIcon::fromTheme("failed").pixmap(16));
+
+        const QPixmap pixmap = QIcon::fromTheme(QStringLiteral("failed")).pixmap(16);
+        ui->label_username_verified->setPixmap(pixmap);
+        ui->label_token_verified->setPixmap(pixmap);
     }
 }
 
@@ -103,11 +107,14 @@ void ConfigureWeb::OnLoginVerified() {
     ui->button_verify_login->setText(tr("Verify"));
     if (verify_watcher.result()) {
         user_verified = true;
-        ui->label_username_verified->setPixmap(QIcon::fromTheme("checked").pixmap(16));
-        ui->label_token_verified->setPixmap(QIcon::fromTheme("checked").pixmap(16));
+
+        const QPixmap pixmap = QIcon::fromTheme(QStringLiteral("checked")).pixmap(16);
+        ui->label_username_verified->setPixmap(pixmap);
+        ui->label_token_verified->setPixmap(pixmap);
     } else {
-        ui->label_username_verified->setPixmap(QIcon::fromTheme("failed").pixmap(16));
-        ui->label_token_verified->setPixmap(QIcon::fromTheme("failed").pixmap(16));
+        const QPixmap pixmap = QIcon::fromTheme(QStringLiteral("failed")).pixmap(16);
+        ui->label_username_verified->setPixmap(pixmap);
+        ui->label_token_verified->setPixmap(pixmap);
         QMessageBox::critical(
             this, tr("Verification failed"),
             tr("Verification failed. Check that you have entered your username and token "


### PR DESCRIPTION
See yuzu-emu/yuzu#2499 for more details.

**Original description**:
Like the previous changes in the same vein, this moves the UI code a step closer to disabling implicit string conversions. This makes the configuration window compatible with disabled implicit QString conversions. After this, all that's left is to deal with some of the top-level source files in the project directory and the conversions can be disabled.

This also uncovered some strings that weren't marked as translatable but should have been. These are also corrected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4860)
<!-- Reviewable:end -->
