### PR TITLE
citra_qt: Use QFileInfo instead of QDir for checking existence

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -1001,9 +1001,7 @@ void GMainWindow::OnGameListOpenFolder(u64 data_id, GameListOpenTarget target) {
     }
 
     QString qpath = QString::fromStdString(path);
-
-    QDir dir(qpath);
-    if (!dir.exists()) {
+    if (!QFileInfo::exists(qpath)) {
         QMessageBox::critical(
             this, tr("Error Opening %1 Folder").arg(QString::fromStdString(open_target)),
             tr("Folder does not exist!"));


### PR DESCRIPTION
There's no need of constructing a `QDir` here, solely for checking the existence of the folder.

Actually this minor PR is an attempt to fix the issue #4471, considering the only differences between "Open XX Location" (for games) and "Open Directory Location" is (a) the former one has all paths ending in '/'  while the latter doesn't (at least not necessarily) (b) the former one constructs a `QDir` to judge whether the directory exists (which I think has a chance to be restricted due to RO permissions?) while the latter one uses `QFileInfo` only.

And, it won't hurt to simplify the code and unify the two functions a bit anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4861)
<!-- Reviewable:end -->
