### PR TITLE
citra_qt: on osx chdir to bundle dir to allow detection of user folder

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -15,6 +15,7 @@
 #include <QtGui>
 #include <QtWidgets>
 #include <fmt/format.h>
+#include <unistd.h>
 #include "citra_qt/aboutdialog.h"
 #include "citra_qt/applets/mii_selector.h"
 #include "citra_qt/applets/swkbd.h"

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -1887,6 +1887,11 @@ int main(int argc, char* argv[]) {
     QCoreApplication::setOrganizationName("Citra team");
     QCoreApplication::setApplicationName("Citra");
 
+#ifdef __APPLE__
+    std::string bin_path = FileUtil::GetBundleDirectory() + DIR_SEP + "..";
+    chdir(bin_path.c_str());
+#endif
+
     QApplication app(argc, argv);
 
     // Qt changes the locale and causes issues in float conversion using std::to_string() when


### PR DESCRIPTION
if you start a bundle(binary) on osx from without the terminal to working directory is /
But since we require to working directory to be the executable path for the location of the user folder in the Qt Frontend we should cd into that working directory

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4877)
<!-- Reviewable:end -->
