### PR TITLE
Citra_qt: Display all valid regions in game_list

### DIFF
--- a/src/citra_qt/game_list_p.h
+++ b/src/citra_qt/game_list_p.h
@@ -77,13 +77,13 @@ static QString GetQStringShortTitleFromSMDH(const Loader::SMDH& smdh,
 static QString GetRegionFromSMDH(const Loader::SMDH& smdh) {
     using GameRegion = Loader::SMDH::GameRegion;
     static const std::map<GameRegion, QString> regions_map = {
-        {GameRegion::Japan, QObject::tr("Japan")},
-        {GameRegion::NorthAmerica, QObject::tr("North America")},
-        {GameRegion::Europe, QObject::tr("Europe")},
-        {GameRegion::Australia, QObject::tr("Australia")},
-        {GameRegion::China, QObject::tr("China")},
-        {GameRegion::Korea, QObject::tr("Korea")},
-        {GameRegion::Taiwan, QObject::tr("Taiwan")}};
+        {GameRegion::Japan, QT_TR_NOOP("Japan")},
+        {GameRegion::NorthAmerica, QT_TR_NOOP("North America")},
+        {GameRegion::Europe, QT_TR_NOOP("Europe")},
+        {GameRegion::Australia, QT_TR_NOOP("Australia")},
+        {GameRegion::China, QT_TR_NOOP("China")},
+        {GameRegion::Korea, QT_TR_NOOP("Korea")},
+        {GameRegion::Taiwan, QT_TR_NOOP("Taiwan")}};
 
     std::vector<GameRegion> regions = smdh.GetRegions();
 

--- a/src/citra_qt/game_list_p.h
+++ b/src/citra_qt/game_list_p.h
@@ -75,30 +75,32 @@ static QString GetQStringShortTitleFromSMDH(const Loader::SMDH& smdh,
  * @return QString region
  */
 static QString GetRegionFromSMDH(const Loader::SMDH& smdh) {
-    const Loader::SMDH::GameRegion region = smdh.GetRegion();
+    using GameRegion = Loader::SMDH::GameRegion;
+    static const std::map<GameRegion, QString> regions_map = {
+        {GameRegion::Japan, QObject::tr("Japan")},
+        {GameRegion::NorthAmerica, QObject::tr("North America")},
+        {GameRegion::Europe, QObject::tr("Europe")},
+        {GameRegion::Australia,QObject::tr("Australia")},
+        {GameRegion::China, QObject::tr("China")},
+        {GameRegion::Korea, QObject::tr("Korea")},
+        {GameRegion::Taiwan, QObject::tr("Taiwan")}
+    };
 
-    switch (region) {
-    case Loader::SMDH::GameRegion::Invalid:
+    std::vector<GameRegion> regions = smdh.GetRegions();
+
+    if (regions.empty()) {
         return QObject::tr("Invalid region");
-    case Loader::SMDH::GameRegion::Japan:
-        return QObject::tr("Japan");
-    case Loader::SMDH::GameRegion::NorthAmerica:
-        return QObject::tr("North America");
-    case Loader::SMDH::GameRegion::Europe:
-        return QObject::tr("Europe");
-    case Loader::SMDH::GameRegion::Australia:
-        return QObject::tr("Australia");
-    case Loader::SMDH::GameRegion::China:
-        return QObject::tr("China");
-    case Loader::SMDH::GameRegion::Korea:
-        return QObject::tr("Korea");
-    case Loader::SMDH::GameRegion::Taiwan:
-        return QObject::tr("Taiwan");
-    case Loader::SMDH::GameRegion::RegionFree:
-        return QObject::tr("Region free");
-    default:
-        return QObject::tr("Invalid Region");
     }
+
+    if (std::find(regions.begin(), regions.end(), GameRegion::RegionFree) != regions.end()) {
+        return QObject::tr("Region free");
+    }
+
+    QString result = regions_map.at(regions.front());
+    for (auto region = ++regions.begin(); region != regions.end(); ++region) {
+        result += "\n" + regions_map.at(*region);
+    }
+    return result;
 }
 
 class GameListItem : public QStandardItem {

--- a/src/citra_qt/game_list_p.h
+++ b/src/citra_qt/game_list_p.h
@@ -80,11 +80,10 @@ static QString GetRegionFromSMDH(const Loader::SMDH& smdh) {
         {GameRegion::Japan, QObject::tr("Japan")},
         {GameRegion::NorthAmerica, QObject::tr("North America")},
         {GameRegion::Europe, QObject::tr("Europe")},
-        {GameRegion::Australia,QObject::tr("Australia")},
+        {GameRegion::Australia, QObject::tr("Australia")},
         {GameRegion::China, QObject::tr("China")},
         {GameRegion::Korea, QObject::tr("Korea")},
-        {GameRegion::Taiwan, QObject::tr("Taiwan")}
-    };
+        {GameRegion::Taiwan, QObject::tr("Taiwan")}};
 
     std::vector<GameRegion> regions = smdh.GetRegions();
 

--- a/src/citra_qt/game_list_p.h
+++ b/src/citra_qt/game_list_p.h
@@ -76,7 +76,7 @@ static QString GetQStringShortTitleFromSMDH(const Loader::SMDH& smdh,
  */
 static QString GetRegionFromSMDH(const Loader::SMDH& smdh) {
     using GameRegion = Loader::SMDH::GameRegion;
-    static const std::map<GameRegion, QString> regions_map = {
+    static const std::map<GameRegion, const char*> regions_map = {
         {GameRegion::Japan, QT_TR_NOOP("Japan")},
         {GameRegion::NorthAmerica, QT_TR_NOOP("North America")},
         {GameRegion::Europe, QT_TR_NOOP("Europe")},
@@ -95,9 +95,9 @@ static QString GetRegionFromSMDH(const Loader::SMDH& smdh) {
         return QObject::tr("Region free");
     }
 
-    QString result = regions_map.at(regions.front());
+    QString result = QObject::tr(regions_map.at(regions.front()));
     for (auto region = ++regions.begin(); region != regions.end(); ++region) {
-        result += "\n" + regions_map.at(*region);
+        result += QStringLiteral("\n") + QObject::tr(regions_map.at(*region));
     }
     return result;
 }

--- a/src/core/loader/smdh.cpp
+++ b/src/core/loader/smdh.cpp
@@ -48,26 +48,20 @@ std::array<u16, 0x40> SMDH::GetShortTitle(Loader::SMDH::TitleLanguage language) 
     return titles[static_cast<int>(language)].short_title;
 }
 
-SMDH::GameRegion SMDH::GetRegion() const {
+std::vector<SMDH::GameRegion> SMDH::GetRegions() const {
     if (region_lockout == 0x7fffffff) {
-        return GameRegion::RegionFree;
+        return std::vector<GameRegion>{GameRegion::RegionFree};
     }
 
-    constexpr u32 taiwan_and_china =
-        (1 << static_cast<u32>(GameRegion::Taiwan)) | (1 << static_cast<u32>(GameRegion::China));
-    if (region_lockout == taiwan_and_china) {
-        return GameRegion::Taiwan;
-    } // hack to fix TWN games that support CHN consoles
-
     constexpr u32 REGION_COUNT = 7;
-    u32 region = 0;
-    for (; region < REGION_COUNT; ++region) {
+    std::vector<GameRegion> result;
+    for (u32 region = 0; region < REGION_COUNT; ++region) {
         if (region_lockout & (1 << region)) {
-            return static_cast<GameRegion>(region);
+            result.push_back(static_cast<GameRegion>(region));
         }
     }
 
-    return GameRegion::Invalid;
+    return result;
 }
 
 } // namespace Loader

--- a/src/core/loader/smdh.h
+++ b/src/core/loader/smdh.h
@@ -63,7 +63,6 @@ struct SMDH {
     };
 
     enum class GameRegion {
-        Invalid = -1,
         Japan = 0,
         NorthAmerica = 1,
         Europe = 2,
@@ -88,7 +87,7 @@ struct SMDH {
      */
     std::array<u16, 0x40> GetShortTitle(Loader::SMDH::TitleLanguage language) const;
 
-    GameRegion GetRegion() const;
+    std::vector<GameRegion> GetRegions() const;
 };
 static_assert(sizeof(SMDH) == 0x36C0, "SMDH structure size is wrong");
 


### PR DESCRIPTION
This supersedes #4846.

![Bildschirmfoto 2019-08-11 um 13 56 27](https://user-images.githubusercontent.com/26032316/62833484-e0ae6d80-bc3f-11e9-9708-913387d57cfa.png)

The perfect solution would be to display images of flags. But this can come in a later PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4878)
<!-- Reviewable:end -->
