### PR TITLE
Remove 'Accurate Geometry Shader' setting

### DIFF
--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -115,8 +115,6 @@ void Config::ReadValues() {
 #else
     Settings::values.use_hw_shader = sdl2_config->GetBoolean("Renderer", "use_hw_shader", true);
 #endif
-    Settings::values.shaders_accurate_gs =
-        sdl2_config->GetBoolean("Renderer", "shaders_accurate_gs", true);
     Settings::values.shaders_accurate_mul =
         sdl2_config->GetBoolean("Renderer", "shaders_accurate_mul", false);
     Settings::values.use_shader_jit = sdl2_config->GetBoolean("Renderer", "use_shader_jit", true);

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -108,10 +108,6 @@ use_hw_shader =
 # 0: Off (Default. Faster, but causes issues in some games) 1: On (Slower, but correct)
 shaders_accurate_mul =
 
-# Whether to fallback to software for geometry shaders
-# 0: Off (Faster, but causes issues in some games) 1: On (Default. Slower, but correct)
-shaders_accurate_gs =
-
 # Whether to use the Just-In-Time (JIT) compiler for shader emulation
 # 0: Interpreter (slow), 1 (default): JIT (fast)
 use_shader_jit =

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -160,7 +160,6 @@ void Config::ReadValues() {
 #else
     Settings::values.use_hw_shader = ReadSetting("use_hw_shader", true).toBool();
 #endif
-    Settings::values.shaders_accurate_gs = ReadSetting("shaders_accurate_gs", true).toBool();
     Settings::values.shaders_accurate_mul = ReadSetting("shaders_accurate_mul", false).toBool();
     Settings::values.use_shader_jit = ReadSetting("use_shader_jit", true).toBool();
     Settings::values.resolution_factor =
@@ -459,7 +458,6 @@ void Config::SaveValues() {
     qt_config->beginGroup("Renderer");
     WriteSetting("use_hw_renderer", Settings::values.use_hw_renderer, true);
     WriteSetting("use_hw_shader", Settings::values.use_hw_shader, true);
-    WriteSetting("shaders_accurate_gs", Settings::values.shaders_accurate_gs, true);
     WriteSetting("shaders_accurate_mul", Settings::values.shaders_accurate_mul, false);
     WriteSetting("use_shader_jit", Settings::values.use_shader_jit, true);
     WriteSetting("resolution_factor", Settings::values.resolution_factor, 1);

--- a/src/citra_qt/configuration/configure_graphics.cpp
+++ b/src/citra_qt/configuration/configure_graphics.cpp
@@ -62,7 +62,6 @@ ConfigureGraphics::~ConfigureGraphics() = default;
 void ConfigureGraphics::SetConfiguration() {
     ui->toggle_hw_renderer->setChecked(Settings::values.use_hw_renderer);
     ui->toggle_hw_shader->setChecked(Settings::values.use_hw_shader);
-    ui->toggle_accurate_gs->setChecked(Settings::values.shaders_accurate_gs);
     ui->toggle_accurate_mul->setChecked(Settings::values.shaders_accurate_mul);
     ui->toggle_shader_jit->setChecked(Settings::values.use_shader_jit);
     ui->resolution_factor_combobox->setCurrentIndex(Settings::values.resolution_factor);
@@ -83,7 +82,6 @@ void ConfigureGraphics::SetConfiguration() {
 void ConfigureGraphics::ApplyConfiguration() {
     Settings::values.use_hw_renderer = ui->toggle_hw_renderer->isChecked();
     Settings::values.use_hw_shader = ui->toggle_hw_shader->isChecked();
-    Settings::values.shaders_accurate_gs = ui->toggle_accurate_gs->isChecked();
     Settings::values.shaders_accurate_mul = ui->toggle_accurate_mul->isChecked();
     Settings::values.use_shader_jit = ui->toggle_shader_jit->isChecked();
     Settings::values.resolution_factor =

--- a/src/citra_qt/configuration/configure_graphics.ui
+++ b/src/citra_qt/configuration/configure_graphics.ui
@@ -150,16 +150,6 @@
               </property>
              </widget>
             </item>
-            <item>
-             <widget class="QCheckBox" name="toggle_accurate_gs">
-              <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Force to fall back to software shader emulation when geometry shaders are used. &lt;/p&gt;&lt;p&gt;Some games require this to be enabled for the hardware shader to render properly.&lt;/p&gt;&lt;p&gt;However this might reduce performance in some games&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-              </property>
-              <property name="text">
-               <string>Accurate Geometry Shader</string>
-              </property>
-             </widget>
-            </item>
            </layout>
           </widget>
          </item>

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -27,7 +27,6 @@ void Apply() {
     VideoCore::g_hw_renderer_enabled = values.use_hw_renderer;
     VideoCore::g_shader_jit_enabled = values.use_shader_jit;
     VideoCore::g_hw_shader_enabled = values.use_hw_shader;
-    VideoCore::g_hw_shader_accurate_gs = values.shaders_accurate_gs;
     VideoCore::g_hw_shader_accurate_mul = values.shaders_accurate_mul;
 
     if (VideoCore::g_renderer) {
@@ -76,7 +75,6 @@ void LogSettings() {
     LogSetting("Renderer_UseGLES", Settings::values.use_gles);
     LogSetting("Renderer_UseHwRenderer", Settings::values.use_hw_renderer);
     LogSetting("Renderer_UseHwShader", Settings::values.use_hw_shader);
-    LogSetting("Renderer_ShadersAccurateGs", Settings::values.shaders_accurate_gs);
     LogSetting("Renderer_ShadersAccurateMul", Settings::values.shaders_accurate_mul);
     LogSetting("Renderer_UseShaderJit", Settings::values.use_shader_jit);
     LogSetting("Renderer_UseResolutionFactor", Settings::values.resolution_factor);

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -141,7 +141,6 @@ struct Values {
     bool use_gles;
     bool use_hw_renderer;
     bool use_hw_shader;
-    bool shaders_accurate_gs;
     bool shaders_accurate_mul;
     bool use_shader_jit;
     u16 resolution_factor;

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -188,8 +188,6 @@ void TelemetrySession::AddInitialInfo(Loader::AppLoader& app_loader) {
              Settings::values.use_hw_renderer);
     AddField(Telemetry::FieldType::UserConfig, "Renderer_UseHwShader",
              Settings::values.use_hw_shader);
-    AddField(Telemetry::FieldType::UserConfig, "Renderer_ShadersAccurateGs",
-             Settings::values.shaders_accurate_gs);
     AddField(Telemetry::FieldType::UserConfig, "Renderer_ShadersAccurateMul",
              Settings::values.shaders_accurate_mul);
     AddField(Telemetry::FieldType::UserConfig, "Renderer_UseShaderJit",

--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -293,9 +293,7 @@ static void WritePicaReg(u32 id, u32 value, u32 mask) {
             // this, so this is left unimplemented for now. Revisit this when an issue is found in
             // games.
         } else {
-            if (VideoCore::g_hw_shader_accurate_gs) {
-                accelerate_draw = false;
-            }
+            accelerate_draw = false;
         }
 
         bool is_indexed = (id == PICA_REG_INDEX(pipeline.trigger_draw_indexed));

--- a/src/video_core/video_core.cpp
+++ b/src/video_core/video_core.cpp
@@ -21,7 +21,6 @@ std::unique_ptr<RendererBase> g_renderer; ///< Renderer plugin
 std::atomic<bool> g_hw_renderer_enabled;
 std::atomic<bool> g_shader_jit_enabled;
 std::atomic<bool> g_hw_shader_enabled;
-std::atomic<bool> g_hw_shader_accurate_gs;
 std::atomic<bool> g_hw_shader_accurate_mul;
 std::atomic<bool> g_renderer_bg_color_update_requested;
 std::atomic<bool> g_renderer_sampler_update_requested;

--- a/src/video_core/video_core.h
+++ b/src/video_core/video_core.h
@@ -31,7 +31,6 @@ extern std::unique_ptr<RendererBase> g_renderer; ///< Renderer plugin
 extern std::atomic<bool> g_hw_renderer_enabled;
 extern std::atomic<bool> g_shader_jit_enabled;
 extern std::atomic<bool> g_hw_shader_enabled;
-extern std::atomic<bool> g_hw_shader_accurate_gs;
 extern std::atomic<bool> g_hw_shader_accurate_mul;
 extern std::atomic<bool> g_renderer_bg_color_update_requested;
 extern std::atomic<bool> g_renderer_sampler_update_requested;


### PR DESCRIPTION
This setting is currently set to be enabled by default and when disabled causes performance loss in games that use GS and can cause graphical glitches. There should be no instance where turning it off is beneficial so let's just remove the option to do so.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4879)
<!-- Reviewable:end -->
