### PR TITLE
Frametime logging for tracking performance over time

### DIFF
--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -234,6 +234,8 @@ void Config::ReadValues() {
     Settings::values.log_filter = sdl2_config->GetString("Miscellaneous", "log_filter", "*:Info");
 
     // Debugging
+    Settings::values.record_frame_times =
+        sdl2_config->GetBoolean("Debugging", "record_frame_times", false);
     Settings::values.use_gdbstub = sdl2_config->GetBoolean("Debugging", "use_gdbstub", false);
     Settings::values.gdbstub_port =
         static_cast<u16>(sdl2_config->GetInteger("Debugging", "gdbstub_port", 24689));

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -261,7 +261,7 @@ camera_inner_flip =
 log_filter = *:Info
 
 [Debugging]
-# Record frame time data, can be found in the log directory
+# Record frame time data, can be found in the log directory. Boolean value
 record_frame_times =
 # Port for listening to GDB connections.
 use_gdbstub=false

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -261,6 +261,8 @@ camera_inner_flip =
 log_filter = *:Info
 
 [Debugging]
+# Record frame time data, can be found in the log directory
+record_frame_times =
 # Port for listening to GDB connections.
 use_gdbstub=false
 gdbstub_port=24689

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -255,7 +255,8 @@ void Config::ReadValues() {
     qt_config->endGroup();
 
     qt_config->beginGroup("Debugging");
-    Settings::values.record_frame_times = ReadSetting("record_frame_times", false).toBool();
+    // Intentionally not using the QT default setting as this is intended to be changed in the ini
+    Settings::values.record_frame_times = qt_config->value("record_frame_times", false).toBool();
     Settings::values.use_gdbstub = ReadSetting("use_gdbstub", false).toBool();
     Settings::values.gdbstub_port = ReadSetting("gdbstub_port", 24689).toInt();
 
@@ -545,7 +546,8 @@ void Config::SaveValues() {
     qt_config->endGroup();
 
     qt_config->beginGroup("Debugging");
-    WriteSetting("record_frame_times", Settings::values.record_frame_times, false);
+    // Intentionally not using the QT default setting as this is intended to be changed in the ini
+    qt_config->setValue("record_frame_times", Settings::values.record_frame_times);
     WriteSetting("use_gdbstub", Settings::values.use_gdbstub, false);
     WriteSetting("gdbstub_port", Settings::values.gdbstub_port, 24689);
 

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -255,6 +255,7 @@ void Config::ReadValues() {
     qt_config->endGroup();
 
     qt_config->beginGroup("Debugging");
+    Settings::values.record_frame_times = ReadSetting("record_frame_times", false).toBool();
     Settings::values.use_gdbstub = ReadSetting("use_gdbstub", false).toBool();
     Settings::values.gdbstub_port = ReadSetting("gdbstub_port", 24689).toInt();
 
@@ -544,6 +545,7 @@ void Config::SaveValues() {
     qt_config->endGroup();
 
     qt_config->beginGroup("Debugging");
+    WriteSetting("record_frame_times", Settings::values.record_frame_times, false);
     WriteSetting("use_gdbstub", Settings::values.use_gdbstub, false);
     WriteSetting("gdbstub_port", Settings::values.gdbstub_port, 24689);
 

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -183,8 +183,8 @@ System::ResultStatus System::Init(Frontend::EmuWindow& emu_window, u32 system_mo
 
     timing = std::make_unique<Timing>();
 
-    kernel = std::make_unique<Kernel::KernelSystem>(
-        *memory, *timing, [this] { PrepareReschedule(); }, system_mode);
+    kernel = std::make_unique<Kernel::KernelSystem>(*memory, *timing,
+                                                    [this] { PrepareReschedule(); }, system_mode);
 
     if (Settings::values.use_cpu_jit) {
 #ifdef ARCHITECTURE_x86_64
@@ -321,6 +321,7 @@ void System::Shutdown() {
     VideoCore::Shutdown();
     HW::Shutdown();
     telemetry_session.reset();
+    perf_stats.reset();
     rpc_server.reset();
     cheat_engine.reset();
     service_manager.reset();

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -216,7 +216,7 @@ public:
     /// Gets a const reference to the video dumper backend
     const VideoDumper::Backend& VideoDumper() const;
 
-    PerfStats perf_stats;
+    std::unique_ptr<PerfStats> perf_stats = std::make_unique<PerfStats>(0);
     FrameLimiter frame_limiter;
 
     void SetStatus(ResultStatus new_status, const char* details = nullptr) {

--- a/src/core/hle/service/gsp/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp/gsp_gpu.cpp
@@ -307,7 +307,7 @@ ResultCode SetBufferSwap(u32 screen_id, const FrameBufferInfo& info) {
 
     if (screen_id == 0) {
         MicroProfileFlip();
-        Core::System::GetInstance().perf_stats.EndGameFrame();
+        Core::System::GetInstance().perf_stats->EndGameFrame();
     }
 
     return RESULT_SUCCESS;

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -228,7 +228,7 @@ void Module::UpdateGyroscopeCallback(u64 userdata, s64 cycles_late) {
 
     Common::Vec3<float> gyro;
     std::tie(std::ignore, gyro) = motion_device->GetStatus();
-    double stretch = system.perf_stats.GetLastFrameTimeScale();
+    double stretch = system.perf_stats->GetLastFrameTimeScale();
     gyro *= gyroscope_coef * static_cast<float>(stretch);
     gyroscope_entry.x = static_cast<s16>(gyro.x);
     gyroscope_entry.y = static_cast<s16>(gyro.y);

--- a/src/core/perf_stats.cpp
+++ b/src/core/perf_stats.cpp
@@ -9,6 +9,7 @@
 #include <numeric>
 #include <thread>
 #include <fmt/format.h>
+#include <fmt/time.h>
 #include "common/file_util.h"
 #include "core/hw/gpu.h"
 #include "core/perf_stats.h"
@@ -31,11 +32,15 @@ PerfStats::~PerfStats() {
     if (!Settings::values.record_frame_times || title_id == 0) {
         return;
     }
+
+    std::time_t t = std::time(nullptr);
     std::ostringstream stream;
     std::copy(perf_history.begin() + IgnoreFrames, perf_history.begin() + current_index,
               std::ostream_iterator<double>(stream, "\n"));
     std::string path = FileUtil::GetUserPath(FileUtil::UserPath::LogDir);
-    std::string filename = fmt::format("{}/{:X}.csv", path, title_id);
+    // %F Date format expanded is "%Y-%m-%d"
+    std::string filename =
+        fmt::format("{}/{:%F-%H-%M}_{:016X}.csv", path, *std::localtime(&t), title_id);
     FileUtil::IOFile file(filename, "w");
     file.WriteString(stream.str());
 }

--- a/src/core/perf_stats.h
+++ b/src/core/perf_stats.h
@@ -59,7 +59,7 @@ private:
     /// Title ID for the game that is running. 0 if there is no game running yet
     u64 title_id{0};
     /// Current index for writing to the perf_history array
-    size_t current_index{0};
+    std::size_t current_index{0};
     /// Stores an hour of historical frametime data useful for processing and tracking performance
     /// regressions with code changes.
     std::array<double, 216000> perf_history = {};

--- a/src/core/perf_stats.h
+++ b/src/core/perf_stats.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <mutex>
@@ -18,6 +19,10 @@ namespace Core {
  */
 class PerfStats {
 public:
+    explicit PerfStats(u64 title_id);
+
+    ~PerfStats();
+
     using Clock = std::chrono::high_resolution_clock;
 
     struct Results {
@@ -38,13 +43,26 @@ public:
     Results GetAndResetStats(std::chrono::microseconds current_system_time_us);
 
     /**
+     * Returns the Arthimetic Mean of all frametime values stored in the performance history.
+     */
+    double GetMeanFrametime();
+
+    /**
      * Gets the ratio between walltime and the emulated time of the previous system frame. This is
      * useful for scaling inputs or outputs moving between the two time domains.
      */
     double GetLastFrameTimeScale();
 
 private:
-    std::mutex object_mutex;
+    std::mutex object_mutex{};
+
+    /// Title ID for the game that is running. 0 if there is no game running yet
+    u64 title_id{0};
+    /// Current index for writing to the perf_history array
+    size_t current_index{0};
+    /// Stores an hour of historical frametime data useful for processing and tracking performance
+    /// regressions with code changes.
+    std::array<double, 216000> perf_history = {};
 
     /// Point when the cumulative counters were reset
     Clock::time_point reset_point = Clock::now();

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -187,6 +187,7 @@ struct Values {
     std::array<int, Service::CAM::NumCameras> camera_flip;
 
     // Debugging
+    bool record_frame_times;
     bool use_gdbstub;
     u16 gdbstub_port;
     std::string log_filter;

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -99,7 +99,7 @@ TelemetrySession::~TelemetrySession() {
                                 std::chrono::system_clock::now().time_since_epoch())
                                 .count()};
     AddField(Telemetry::FieldType::Session, "Shutdown_Time", shutdown_time);
-    AddField(Telemetry::FieldType::Session, "Mean_Frametime_MS",
+    AddField(Telemetry::FieldType::Performance, "Mean_Frametime_MS",
              Core::System::GetInstance().perf_stats->GetMeanFrametime());
 
 #ifdef ENABLE_WEB_SERVICE

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -99,6 +99,8 @@ TelemetrySession::~TelemetrySession() {
                                 std::chrono::system_clock::now().time_since_epoch())
                                 .count()};
     AddField(Telemetry::FieldType::Session, "Shutdown_Time", shutdown_time);
+    AddField(Telemetry::FieldType::Session, "Mean_Frametime_MS",
+             Core::System::GetInstance().perf_stats->GetMeanFrametime());
 
 #ifdef ENABLE_WEB_SERVICE
     auto backend = std::make_unique<WebService::TelemetryJson>(Settings::values.web_api_url,

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -239,7 +239,7 @@ void RendererOpenGL::SwapBuffers() {
     DrawScreens(render_window.GetFramebufferLayout());
     m_current_frame++;
 
-    Core::System::GetInstance().perf_stats.EndSystemFrame();
+    Core::System::GetInstance().perf_stats->EndSystemFrame();
 
     // Swap buffers
     render_window.PollEvents();
@@ -247,7 +247,7 @@ void RendererOpenGL::SwapBuffers() {
 
     Core::System::GetInstance().frame_limiter.DoFrameLimiting(
         Core::System::GetInstance().CoreTiming().GetGlobalTimeUs());
-    Core::System::GetInstance().perf_stats.BeginSystemFrame();
+    Core::System::GetInstance().perf_stats->BeginSystemFrame();
 
     prev_state.Apply();
     RefreshRasterizerSetting();


### PR DESCRIPTION
Supersedes - https://github.com/citra-emu/citra/pull/4636

After addressing many of the concerns in #4636, and running into places where this would be really handy, I want to re-open frametime logging for review. 

## Motivation

When discussing changes to citra that affect performance, we don't have any framework in place for logging performance changes between builds. This has caused, at worst, several "I recall" situations where people try to remember what impact a change had on performance, and at best, other situations where people pull up speed% numbers that they tried their best to sample at the right time in between tests. This change should give better insight into real performance differences between builds allowing us to make more informed decisions when changing the code base.

## Differences from the previous PR

* No longer an option in QT frontend by design. This is strictly an INI option in order to reduce the number of options in the menu, while still letting a small subset of power users that care and devs looking for performance regressions, to enable it and compare across builds.
* Dumping is limited to 216000 frames, roughly an hour of gameplay at 60FPS. This is probably a decent enough tradeoff in terms of time captured, and memory usage.
* Adds a second use case for frametime logging: submitting the mean frametime results to telemetry. Currently, telemetry is not useful for performance tracking because we don't store any performance metrics in the database, and this will enable us to start using telemetry for generalized performance regression tracking.
* Various small changes to make the code simpler (imo)

## Responses to other review comments that are not already addressed

> The feature is also very underdocumented: how would I know the output will land in the log

As its now just an INI feature only, I expect the only people that will use it will have a way to find out (either by checking the code, or by asking the dev who asked them to enable this feature). If it proves to be a real problem that people enable it and can't find the log, we can consider options for documenting it.

> Profiling will be done differently, using more powerful tools. Apparently microprofile is also still part of Citra, so I assume this functionality exists already (to some extend).

I very much agree that microprofile is the preferred tool for the job, but sadly it doesn't support dumping frametime data for reasons I'll explain now. A bit of a tangent, but our microprofile is a very old version now, and since then there are two significant forks of the project with different goals. In order to dump frametime data to csv, we would need to be using the microprofile webserver version instead of the window UI version that we currently use. And changing over to use the webserver microprofile would imply more than just a simple change, as it would impact the workflow of other devs that use microprofile, which means bikeshedding over it. Those two forks I mentioned above (as I understand it please correct me if i'm wrong) were because the main branch moved over entirely to the new webserver interface, while the fork wanted to keep using the builtin UI. As such, committing to one or the other is a more complicated update than just slapping an array in the existing class and writing data out to disk.

> Why would anyone use this feature? Fancy graphs for... what?

Mentioned above, this will be used primarily by telemetry for checking mean frametime for speed regression in prs, and secondarily by devs when testing for speed regressions manually for their own changes.

> Why can't it be solved using the existing tools like microprofile?

See my microprofile section above on why, after having researched using microprofile for this, I decided to stick with in housing this change.

> Why does it have to be solved in Citra, not a third-party solution which most people will have to use anyway?

3rd party tools can't fetch frametime unless we add some hook like we do for microprofile.

> If the feature is only going to be used in very specific instances (YouTubers gathering hard performance data), shouldn't this be a debug only feature? Or is this something that needs to be mainlined in Citra instead of pointing the user in the right direction with 3rd party tools specifically created for these tasks?

As mentioned above, we can't simply expect a 3rd party tool to read our frametime data without hooks like we do for microprofile. And resolving outstanding concerns with microprofile is likely going to be more trouble than its worth, depending on how much bikeshedding that will involve :)

> Feature creep is more of a dev issue rather than a user issue that might hinder the development from making essential process.

I intended this to be as un-invasive as possible, and making the feature as self contained as I could. The change only touches one very small part of the existing code path to keep a total number of system_frames that have elapsed since game launch, and adds a destructor to perf stats to write them to disk.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4882)
<!-- Reviewable:end -->
