### PR TITLE
Guard unistd.h with MacOS only macro

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -15,7 +15,9 @@
 #include <QtGui>
 #include <QtWidgets>
 #include <fmt/format.h>
-#include <unistd.h>
+#ifdef __APPLE__
+#include <unistd.h> // for chdir
+#endif
 #include "citra_qt/aboutdialog.h"
 #include "citra_qt/applets/mii_selector.h"
 #include "citra_qt/applets/swkbd.h"


### PR DESCRIPTION
Fix compile error on Windows caused by #4877 
Weird, I thought I saw this guard during the code review...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4884)
<!-- Reviewable:end -->
