### PR TITLE
Fix appveyor mingw (partially)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,14 +26,12 @@ install:
   - git submodule update --init --recursive
   - ps: |
         if ($env:BUILD_TYPE -eq 'mingw') {
-          $dependencies = "mingw64/mingw-w64-x86_64-qt5 mingw64/mingw-w64-x86_64-ffmpeg"
+          $dependencies = "mingw64/mingw-w64-x86_64-cmake mingw64/mingw-w64-x86_64-qt5 mingw64/mingw-w64-x86_64-ffmpeg"
           # redirect err to null to prevent warnings from becoming errors
           # workaround to prevent pacman from failing due to cyclical dependencies
           C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S mingw64/mingw-w64-x86_64-freetype mingw64/mingw-w64-x86_64-fontconfig" 2> $null
           C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-SDL2-2.0.5-2-any.pkg.tar.xz" 2> $null
           C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S $dependencies" 2> $null
-          # freeze the cmake to a stable version, on version < 3.9.6 cmake may generate a Makefile links against gcc_eh instead of gcc_s_eh
-          C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-cmake-3.11.1-2-any.pkg.tar.xz" 2> $null
         }
 
 before_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,11 +27,10 @@ install:
   - ps: |
         if ($env:BUILD_TYPE -eq 'mingw') {
           $dependencies = "mingw64/mingw-w64-x86_64-cmake mingw64/mingw-w64-x86_64-qt5 mingw64/mingw-w64-x86_64-ffmpeg"
-          # redirect err to null to prevent warnings from becoming errors
-          # workaround to prevent pacman from failing due to cyclical dependencies
-          C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S mingw64/mingw-w64-x86_64-freetype mingw64/mingw-w64-x86_64-fontconfig" 2> $null
-          C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-SDL2-2.0.5-2-any.pkg.tar.xz" 2> $null
-          C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S $dependencies" 2> $null
+          C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-SDL2-2.0.5-2-any.pkg.tar.xz"
+          C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S $dependencies"
+          # (HACK) ignore errors
+          0
         }
 
 before_build:


### PR DESCRIPTION
The following is just a copy of commit messages.

### Unfreeze CMake version

The original purpose of freezing CMake is to use a **higher** version than supplied in order to fix a certain issue. Now that a very long time has passed and mingw's CMake has been updated, there's really no reason to still freeze it any more. What's more, trying to use a certain version is unreliable by pacman's design and will probably cause issues for using older versions of dependencies. The current (and previous) mingw errors may come from this...

### Added a HACK to ignore errors

Cyclical dependencies will result in errors. Redirecting err to null doesn't help. I removed the redirection so that errors and warnings would show up (they might be useful for us). 

As FFmpeg is added, even more cyclical dependencies are present now. I do not want to figure out what to install first to fix such things, so I just decided to ignore all of them with a `0` at the end.

---

But.. this doesn't really fix the build because Appveyor updated itself to g++ 9 and caused #4766 error

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4886)
<!-- Reviewable:end -->
