### PR TITLE
Fixup! Prevent issue deleting PerfStats

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -155,6 +155,10 @@ System::ResultStatus System::Load(Frontend::EmuWindow& emu_window, const std::st
     status = ResultStatus::Success;
     m_emu_window = &emu_window;
     m_filepath = filepath;
+
+    // Reset counters and set time origin to current frame
+    GetAndResetPerfStats();
+    perf_stats->BeginSystemFrame();
     return status;
 }
 
@@ -235,10 +239,6 @@ System::ResultStatus System::Init(Frontend::EmuWindow& emu_window, u32 system_mo
 
     LOG_DEBUG(Core, "Initialized OK");
 
-    // Reset counters and set time origin to current frame
-    GetAndResetPerfStats();
-    perf_stats->BeginSystemFrame();
-
     return ResultStatus::Success;
 }
 
@@ -315,6 +315,8 @@ void System::Shutdown() {
                                 perf_results.game_fps);
     telemetry_session->AddField(Telemetry::FieldType::Performance, "Shutdown_Frametime",
                                 perf_results.frametime * 1000.0);
+    telemetry_session->AddField(Telemetry::FieldType::Performance, "Mean_Frametime_MS",
+                                perf_stats->GetMeanFrametime());
 
     // Shutdown emulation session
     GDBStub::Shutdown();

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -216,7 +216,7 @@ public:
     /// Gets a const reference to the video dumper backend
     const VideoDumper::Backend& VideoDumper() const;
 
-    std::unique_ptr<PerfStats> perf_stats = std::make_unique<PerfStats>(0);
+    std::unique_ptr<PerfStats> perf_stats;
     FrameLimiter frame_limiter;
 
     void SetStatus(ResultStatus new_status, const char* details = nullptr) {

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -99,8 +99,6 @@ TelemetrySession::~TelemetrySession() {
                                 std::chrono::system_clock::now().time_since_epoch())
                                 .count()};
     AddField(Telemetry::FieldType::Session, "Shutdown_Time", shutdown_time);
-    AddField(Telemetry::FieldType::Performance, "Mean_Frametime_MS",
-             Core::System::GetInstance().perf_stats->GetMeanFrametime());
 
 #ifdef ENABLE_WEB_SERVICE
     auto backend = std::make_unique<WebService::TelemetryJson>(Settings::values.web_api_url,


### PR DESCRIPTION
Fixes an error where it causes citra to crash on second game launch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4891)
<!-- Reviewable:end -->
