### PR TITLE
core_timing: Silence sign comparison warnings

### DIFF
--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -56,11 +56,11 @@ inline s64 usToCycles(int us) {
 }
 
 inline s64 usToCycles(s64 us) {
-    if (us / 1000000 > MAX_VALUE_TO_MULTIPLY) {
+    if (us / 1000000 > static_cast<s64>(MAX_VALUE_TO_MULTIPLY)) {
         LOG_ERROR(Core_Timing, "Integer overflow, use max value");
         return std::numeric_limits<s64>::max();
     }
-    if (us > MAX_VALUE_TO_MULTIPLY) {
+    if (us > static_cast<s64>(MAX_VALUE_TO_MULTIPLY)) {
         LOG_DEBUG(Core_Timing, "Time very big, do rounding");
         return BASE_CLOCK_RATE_ARM11 * (us / 1000000);
     }
@@ -88,11 +88,11 @@ inline s64 nsToCycles(int ns) {
 }
 
 inline s64 nsToCycles(s64 ns) {
-    if (ns / 1000000000 > MAX_VALUE_TO_MULTIPLY) {
+    if (ns / 1000000000 > static_cast<s64>(MAX_VALUE_TO_MULTIPLY)) {
         LOG_ERROR(Core_Timing, "Integer overflow, use max value");
         return std::numeric_limits<s64>::max();
     }
-    if (ns > MAX_VALUE_TO_MULTIPLY) {
+    if (ns > static_cast<s64>(MAX_VALUE_TO_MULTIPLY)) {
         LOG_DEBUG(Core_Timing, "Time very big, do rounding");
         return BASE_CLOCK_RATE_ARM11 * (ns / 1000000000);
     }


### PR DESCRIPTION
This is causing a lot of warnings all over the place.

Fixes 986 of the 1,053 -Wsign-compare warnings 😎

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4897)
<!-- Reviewable:end -->
