### PR TITLE
network/room_member: Silence -Wswitch warning

### DIFF
--- a/src/network/room_member.h
+++ b/src/network/room_member.h
@@ -265,6 +265,8 @@ private:
 
 inline const char* GetStateStr(const RoomMember::State& s) {
     switch (s) {
+    case RoomMember::State::Uninitialized:
+        return "Uninitialized";
     case RoomMember::State::Idle:
         return "Idle";
     case RoomMember::State::Joining:


### PR DESCRIPTION
This causes lots of warnings. Adding the Uninitialized case solves this

Fixes 24 of all 100 -Wswitch warnings :sunglasses:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4898)
<!-- Reviewable:end -->
