### PR TITLE
[WIP] Video_Core::OpenGL: Format Conversion

### DIFF
--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -23,6 +23,8 @@ add_library(video_core STATIC
     regs_texturing.h
     renderer_base.cpp
     renderer_base.h
+    renderer_opengl/gl_format_converter.cpp
+    renderer_opengl/gl_format_converter.h
     renderer_opengl/gl_rasterizer.cpp
     renderer_opengl/gl_rasterizer.h
     renderer_opengl/gl_rasterizer_cache.cpp

--- a/src/video_core/renderer_opengl/gl_format_converter.cpp
+++ b/src/video_core/renderer_opengl/gl_format_converter.cpp
@@ -1,0 +1,169 @@
+#include <map>
+#include <vector>
+#include "common/assert.h"
+#include "common/scope_exit.h"
+#include "video_core/renderer_opengl/gl_format_converter.h"
+#include "video_core/renderer_opengl/gl_state.h"
+#include "video_core/renderer_opengl/gl_vars.h"
+
+namespace OpenGL {
+
+class FormatConverterBase {
+public:
+    virtual ~FormatConverterBase() = default;
+    virtual void Convert(GLuint src_tex, const Common::Rectangle<u32>& src_rect,
+                         GLuint read_fb_handle, GLuint dst_tex,
+                         const Common::Rectangle<u32>& dst_rect, GLuint draw_fb_handle) = 0;
+};
+
+class ConverterD24S8toABGR final : public FormatConverterBase {
+public:
+    ConverterD24S8toABGR() {
+        attributeless_vao.Create();
+        d24s8_abgr_buffer.Create();
+        d24s8_abgr_buffer_size = 0;
+
+        std::string vs_source = R"(
+const vec2 vertices[4] = vec2[4](vec2(-1.0, -1.0), vec2(1.0, -1.0), vec2(-1.0, 1.0), vec2(1.0, 1.0));
+void main() {
+    gl_Position = vec4(vertices[gl_VertexID], 0.0, 1.0);
+}
+)";
+
+        std::string fs_source = GLES ? fragment_shader_precision_OES : "";
+        fs_source += R"(
+uniform samplerBuffer tbo;
+uniform vec2 tbo_size;
+uniform vec4 viewport;
+
+out vec4 color;
+
+void main() {
+    vec2 tbo_coord = (gl_FragCoord.xy - viewport.xy) * tbo_size / viewport.zw;
+    int tbo_offset = int(tbo_coord.y) * int(tbo_size.x) + int(tbo_coord.x);
+    color = texelFetch(tbo, tbo_offset).rabg;
+}
+)";
+        d24s8_abgr_shader.Create(vs_source.c_str(), fs_source.c_str());
+
+        OpenGLState state = OpenGLState::GetCurState();
+        GLuint old_program = state.draw.shader_program;
+        state.draw.shader_program = d24s8_abgr_shader.handle;
+        state.Apply();
+
+        GLint tbo_u_id = glGetUniformLocation(d24s8_abgr_shader.handle, "tbo");
+        ASSERT(tbo_u_id != -1);
+        glUniform1i(tbo_u_id, 0);
+
+        state.draw.shader_program = old_program;
+        state.Apply();
+
+        d24s8_abgr_tbo_size_u_id = glGetUniformLocation(d24s8_abgr_shader.handle, "tbo_size");
+        ASSERT(d24s8_abgr_tbo_size_u_id != -1);
+        d24s8_abgr_viewport_u_id = glGetUniformLocation(d24s8_abgr_shader.handle, "viewport");
+        ASSERT(d24s8_abgr_viewport_u_id != -1);
+    }
+
+    ~ConverterD24S8toABGR(){};
+
+    void Convert(GLuint src_tex, const Common::Rectangle<u32>& src_rect, GLuint read_fb_handle,
+                 GLuint dst_tex, const Common::Rectangle<u32>& dst_rect,
+                 GLuint draw_fb_handle) override {
+        OpenGLState prev_state = OpenGLState::GetCurState();
+        SCOPE_EXIT({ prev_state.Apply(); });
+
+        OpenGLState state;
+        state.draw.read_framebuffer = read_fb_handle;
+        state.draw.draw_framebuffer = draw_fb_handle;
+        state.Apply();
+
+        glBindBuffer(GL_PIXEL_PACK_BUFFER, d24s8_abgr_buffer.handle);
+
+        GLsizeiptr target_pbo_size = src_rect.GetWidth() * src_rect.GetHeight() * 4;
+        if (target_pbo_size > d24s8_abgr_buffer_size) {
+            d24s8_abgr_buffer_size = target_pbo_size * 2;
+            glBufferData(GL_PIXEL_PACK_BUFFER, d24s8_abgr_buffer_size, nullptr, GL_STREAM_COPY);
+        }
+
+        glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, 0, 0);
+        glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D,
+                               src_tex, 0);
+        glReadPixels(static_cast<GLint>(src_rect.left), static_cast<GLint>(src_rect.bottom),
+                     static_cast<GLsizei>(src_rect.GetWidth()),
+                     static_cast<GLsizei>(src_rect.GetHeight()), GL_DEPTH_STENCIL,
+                     GL_UNSIGNED_INT_24_8, 0);
+
+        glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+
+        // PBO now contains src_tex in RABG format
+        state.draw.shader_program = d24s8_abgr_shader.handle;
+        state.draw.vertex_array = attributeless_vao.handle;
+        state.viewport.x = static_cast<GLint>(dst_rect.left);
+        state.viewport.y = static_cast<GLint>(dst_rect.bottom);
+        state.viewport.width = static_cast<GLsizei>(dst_rect.GetWidth());
+        state.viewport.height = static_cast<GLsizei>(dst_rect.GetHeight());
+        state.Apply();
+
+        OGLTexture tbo;
+        tbo.Create();
+        glActiveTexture(GL_TEXTURE0);
+        glBindTexture(GL_TEXTURE_BUFFER, tbo.handle);
+        glTexBuffer(GL_TEXTURE_BUFFER, GL_RGBA8, d24s8_abgr_buffer.handle);
+
+        glUniform2f(d24s8_abgr_tbo_size_u_id, static_cast<GLfloat>(src_rect.GetWidth()),
+                    static_cast<GLfloat>(src_rect.GetHeight()));
+        glUniform4f(d24s8_abgr_viewport_u_id, static_cast<GLfloat>(state.viewport.x),
+                    static_cast<GLfloat>(state.viewport.y),
+                    static_cast<GLfloat>(state.viewport.width),
+                    static_cast<GLfloat>(state.viewport.height));
+
+        glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, dst_tex,
+                               0);
+        glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, 0,
+                               0);
+        glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+
+        glBindTexture(GL_TEXTURE_BUFFER, 0);
+    }
+
+private:
+    OGLVertexArray attributeless_vao;
+    OGLBuffer d24s8_abgr_buffer;
+    GLsizeiptr d24s8_abgr_buffer_size;
+    OGLProgram d24s8_abgr_shader;
+    GLint d24s8_abgr_tbo_size_u_id;
+    GLint d24s8_abgr_viewport_u_id;
+};
+
+FormatConverterOpenGL::FormatConverterOpenGL() {
+    converters[std::make_pair(PixelFormat::D24S8, PixelFormat::RGBA8)] =
+        std::make_shared<ConverterD24S8toABGR>();
+}
+
+FormatConverterOpenGL::~FormatConverterOpenGL() = default;
+
+std::vector<PixelFormat> FormatConverterOpenGL::GetPossibleConversions(
+    PixelFormat dst_format) const {
+    static const std::map<PixelFormat, std::vector<PixelFormat>> possible_conversions{
+        {PixelFormat::RGBA8, {PixelFormat::D24S8}}};
+    auto itr = possible_conversions.find(dst_format);
+    if (itr != possible_conversions.end()) {
+        return itr->second;
+    }
+    return std::vector<PixelFormat>();
+}
+
+bool FormatConverterOpenGL::Convert(PixelFormat src_format, GLuint src_tex,
+                                    const Common::Rectangle<u32>& src_rect, GLuint read_fb_handle,
+                                    PixelFormat dst_format, GLuint dst_tex,
+                                    const Common::Rectangle<u32>& dst_rect, GLuint draw_fb_handle) {
+    auto converter = converters.find(std::make_pair(src_format, dst_format));
+    if (converter != converters.end()) {
+        converter->second->Convert(src_tex, src_rect, read_fb_handle, dst_tex, dst_rect,
+                                   draw_fb_handle);
+        return true;
+    }
+    return false;
+}
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_format_converter.h
+++ b/src/video_core/renderer_opengl/gl_format_converter.h
@@ -1,0 +1,59 @@
+// Copyright 2019 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+#include <glad/glad.h>
+#include "common/common_types.h"
+#include "common/math_util.h"
+#include "video_core/renderer_opengl/gl_resource_manager.h"
+
+namespace OpenGL {
+
+enum class PixelFormat {
+    // First 5 formats are shared between textures and color buffers
+    RGBA8 = 0,
+    RGB8 = 1,
+    RGB5A1 = 2,
+    RGB565 = 3,
+    RGBA4 = 4,
+
+    // Texture-only formats
+    IA8 = 5,
+    RG8 = 6,
+    I8 = 7,
+    A8 = 8,
+    IA4 = 9,
+    I4 = 10,
+    A4 = 11,
+    ETC1 = 12,
+    ETC1A4 = 13,
+
+    // Depth buffer-only formats
+    D16 = 14,
+    // gap
+    D24 = 16,
+    D24S8 = 17,
+
+    Invalid = 255,
+};
+
+class FormatConverterBase;
+
+class FormatConverterOpenGL : NonCopyable {
+public:
+    FormatConverterOpenGL();
+    ~FormatConverterOpenGL();
+
+    std::vector<PixelFormat> GetPossibleConversions(PixelFormat dst_format) const;
+
+    bool Convert(PixelFormat src_format, GLuint src_tex, const Common::Rectangle<u32>& src_rect,
+                 GLuint read_fb_handle, PixelFormat dst_format, GLuint dst_tex,
+                 const Common::Rectangle<u32>& dst_rect, GLuint draw_fb_handle);
+
+private:
+    using FromToFormatPair = std::pair<PixelFormat, PixelFormat>;
+    std::map<FromToFormatPair, std::shared_ptr<FormatConverterBase>> converters;
+};
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_format_converter.h
+++ b/src/video_core/renderer_opengl/gl_format_converter.h
@@ -1,8 +1,10 @@
-// Copyright 2019 Citra Emulator Project
+﻿// Copyright 2019 Citra Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
 #pragma once
+
+#include <array>
 #include <glad/glad.h>
 #include "common/common_types.h"
 #include "common/math_util.h"
@@ -40,6 +42,12 @@ enum class PixelFormat {
 
 class FormatConverterBase;
 
+enum class AvailableConverters : std::size_t {
+    ReadPixel_D24S8_ABGR8,
+    Count,
+    Unavailable,
+};
+
 class FormatConverterOpenGL : NonCopyable {
 public:
     FormatConverterOpenGL();
@@ -52,8 +60,9 @@ public:
                  const Common::Rectangle<u32>& dst_rect, GLuint draw_fb_handle);
 
 private:
-    using FromToFormatPair = std::pair<PixelFormat, PixelFormat>;
-    std::map<FromToFormatPair, std::shared_ptr<FormatConverterBase>> converters;
+    std::array<std::unique_ptr<FormatConverterBase>,
+               static_cast<std::size_t>(AvailableConverters::Count)>
+        converters{};
 };
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -29,7 +29,6 @@
 
 namespace OpenGL {
 
-using PixelFormat = SurfaceParams::PixelFormat;
 using SurfaceType = SurfaceParams::SurfaceType;
 
 MICROPROFILE_DEFINE(OpenGL_VAO, "OpenGL", "Vertex Array Setup", MP_RGB(255, 128, 0));

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -1238,6 +1238,8 @@ static const char* PixelFormatAsString(PixelFormat format) {
         return "RGBA4";
     case PixelFormat::IA8:
         return "IA8";
+    case PixelFormat::RG8:
+        return "RG8";
     case PixelFormat::I8:
         return "I8";
     case PixelFormat::A8:
@@ -1862,11 +1864,22 @@ void RasterizerCacheOpenGL::ValidateSurface(const Surface& surface, PAddr addr, 
         }
 
         // Could not find a matching converter, check if we need to implement a converter
-        static const std::array<PixelFormat, 17> all_formats{
-            PixelFormat::RGBA8, PixelFormat::RGB8,   PixelFormat::RGB5A1, PixelFormat::RGB565,
-            PixelFormat::RGBA4, PixelFormat::IA8,    PixelFormat::RG8,    PixelFormat::I8,
-            PixelFormat::A8,    PixelFormat::IA4,    PixelFormat::I4,     PixelFormat::A4,
-            PixelFormat::ETC1,  PixelFormat::ETC1A4, PixelFormat::D16,    PixelFormat::D24,
+        // Skip I4, A4, and ETC1 because GetFormatBpp < 8 which will result in a crash
+        static const std::array<PixelFormat, 14> all_formats{
+            PixelFormat::RGBA8,
+            PixelFormat::RGB8,
+            PixelFormat::RGB5A1,
+            PixelFormat::RGB565,
+            PixelFormat::RGBA4,
+            PixelFormat::IA8,
+            PixelFormat::RG8,
+            PixelFormat::I8,
+            PixelFormat::A8,
+            PixelFormat::IA4,
+            /*PixelFormat::I4,*/ /*PixelFormat::A4,*/
+            /*PixelFormat::ETC1,*/ PixelFormat::ETC1A4,
+            PixelFormat::D16,
+            PixelFormat::D24,
             PixelFormat::D24S8};
         for (PixelFormat format : all_formats) {
             params.pixel_format = format;

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -1,4 +1,4 @@
-// Copyright 2015 Citra Emulator Project
+﻿// Copyright 2015 Citra Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -1822,9 +1822,9 @@ void RasterizerCacheOpenGL::ValidateSurface(const Surface& surface, PAddr addr, 
             break;
 
         const auto interval = *it & validate_interval;
+
         // Look for a valid surface to copy from
         SurfaceParams params = surface->FromInterval(interval);
-
         Surface copy_surface =
             FindMatch<MatchFlags::Copy>(surface_cache, params, ScaleMatch::Ignore, interval);
         if (copy_surface != nullptr) {
@@ -1876,17 +1876,20 @@ void RasterizerCacheOpenGL::ValidateSurface(const Surface& surface, PAddr addr, 
             PixelFormat::I8,
             PixelFormat::A8,
             PixelFormat::IA4,
-            /*PixelFormat::I4,*/ /*PixelFormat::A4,*/
-            /*PixelFormat::ETC1,*/ PixelFormat::ETC1A4,
+            // PixelFormat::I4,
+            // PixelFormat::A4,
+            // PixelFormat::ETC1,
+            PixelFormat::ETC1A4,
             PixelFormat::D16,
             PixelFormat::D24,
-            PixelFormat::D24S8};
+            PixelFormat::D24S8,
+        };
         for (PixelFormat format : all_formats) {
             params.pixel_format = format;
             Surface test_surface =
                 FindMatch<MatchFlags::Copy>(surface_cache, params, ScaleMatch::Ignore, interval);
             if (test_surface != nullptr) {
-                LOG_ERROR(Render_OpenGL, "Missing converter: {} -> {}", PixelFormatAsString(format),
+                LOG_DEBUG(Render_OpenGL, "Missing converter: {} -> {}", PixelFormatAsString(format),
                           PixelFormatAsString(surface->pixel_format));
             }
         }

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -1224,6 +1224,45 @@ Surface FindMatch(const SurfaceCache& surface_cache, const SurfaceParams& params
     return match_surface;
 }
 
+static const char* PixelFormatAsString(PixelFormat format) {
+    switch (format) {
+    case PixelFormat::RGBA8:
+        return "RGBA8";
+    case PixelFormat::RGB8:
+        return "RGB8";
+    case PixelFormat::RGB5A1:
+        return "RGB5A1";
+    case PixelFormat::RGB565:
+        return "RGB565";
+    case PixelFormat::RGBA4:
+        return "RGBA4";
+    case PixelFormat::IA8:
+        return "IA8";
+    case PixelFormat::I8:
+        return "I8";
+    case PixelFormat::A8:
+        return "A8";
+    case PixelFormat::IA4:
+        return "IA4";
+    case PixelFormat::I4:
+        return "I4";
+    case PixelFormat::A4:
+        return "A4";
+    case PixelFormat::ETC1:
+        return "ETC1";
+    case PixelFormat::ETC1A4:
+        return "ETC1A4";
+    case PixelFormat::D16:
+        return "D16";
+    case PixelFormat::D24:
+        return "D24";
+    case PixelFormat::D24S8:
+        return "D24S8";
+    default:
+        return "Not a real pixel format";
+    }
+}
+
 RasterizerCacheOpenGL::RasterizerCacheOpenGL() {
     read_framebuffer.Create();
     draw_framebuffer.Create();
@@ -1820,6 +1859,23 @@ void RasterizerCacheOpenGL::ValidateSurface(const Surface& surface, PAddr addr, 
         }
         if (retry) {
             continue;
+        }
+
+        // Could not find a matching converter, check if we need to implement a converter
+        static const std::array all_formats{
+            PixelFormat::RGBA8, PixelFormat::RGB8,   PixelFormat::RGB5A1, PixelFormat::RGB565,
+            PixelFormat::RGBA4, PixelFormat::IA8,    PixelFormat::RG8,    PixelFormat::I8,
+            PixelFormat::A8,    PixelFormat::IA4,    PixelFormat::I4,     PixelFormat::A4,
+            PixelFormat::ETC1,  PixelFormat::ETC1A4, PixelFormat::D16,    PixelFormat::D24,
+            PixelFormat::D24S8};
+        for (PixelFormat format : all_formats) {
+            params.pixel_format = format;
+            Surface test_surface =
+                FindMatch<MatchFlags::Copy>(surface_cache, params, ScaleMatch::Ignore, interval);
+            if (test_surface != nullptr) {
+                LOG_ERROR(Render_OpenGL, "Missing converter: {} -> {}", PixelFormatAsString(format),
+                          PixelFormatAsString(surface->pixel_format));
+            }
         }
 
         // Load data from 3DS memory

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -1862,7 +1862,7 @@ void RasterizerCacheOpenGL::ValidateSurface(const Surface& surface, PAddr addr, 
         }
 
         // Could not find a matching converter, check if we need to implement a converter
-        static const std::array all_formats{
+        static const std::array<PixelFormat, 17> all_formats{
             PixelFormat::RGBA8, PixelFormat::RGB8,   PixelFormat::RGB5A1, PixelFormat::RGB565,
             PixelFormat::RGBA4, PixelFormat::IA8,    PixelFormat::RG8,    PixelFormat::I8,
             PixelFormat::A8,    PixelFormat::IA4,    PixelFormat::I4,     PixelFormat::A4,

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -29,6 +29,7 @@
 #include "core/hw/gpu.h"
 #include "video_core/regs_framebuffer.h"
 #include "video_core/regs_texturing.h"
+#include "video_core/renderer_opengl/gl_format_converter.h"
 #include "video_core/renderer_opengl/gl_resource_manager.h"
 #include "video_core/texture/texture_decode.h"
 
@@ -101,34 +102,6 @@ enum class ScaleMatch {
 };
 
 struct SurfaceParams {
-    enum class PixelFormat {
-        // First 5 formats are shared between textures and color buffers
-        RGBA8 = 0,
-        RGB8 = 1,
-        RGB5A1 = 2,
-        RGB565 = 3,
-        RGBA4 = 4,
-
-        // Texture-only formats
-        IA8 = 5,
-        RG8 = 6,
-        I8 = 7,
-        A8 = 8,
-        IA4 = 9,
-        I4 = 10,
-        A4 = 11,
-        ETC1 = 12,
-        ETC1A4 = 13,
-
-        // Depth buffer-only formats
-        D16 = 14,
-        // gap
-        D24 = 16,
-        D24S8 = 17,
-
-        Invalid = 255,
-    };
-
     enum class SurfaceType {
         Color = 0,
         Texture = 1,
@@ -440,9 +413,6 @@ public:
     bool BlitSurfaces(const Surface& src_surface, const Common::Rectangle<u32>& src_rect,
                       const Surface& dst_surface, const Common::Rectangle<u32>& dst_rect);
 
-    void ConvertD24S8toABGR(GLuint src_tex, const Common::Rectangle<u32>& src_rect, GLuint dst_tex,
-                            const Common::Rectangle<u32>& dst_rect);
-
     /// Copy one surface's region to another
     void CopySurface(const Surface& src_surface, const Surface& dst_surface,
                      SurfaceInterval copy_interval);
@@ -507,13 +477,7 @@ private:
 
     OGLFramebuffer read_framebuffer;
     OGLFramebuffer draw_framebuffer;
-
-    OGLVertexArray attributeless_vao;
-    OGLBuffer d24s8_abgr_buffer;
-    GLsizeiptr d24s8_abgr_buffer_size;
-    OGLProgram d24s8_abgr_shader;
-    GLint d24s8_abgr_tbo_size_u_id;
-    GLint d24s8_abgr_viewport_u_id;
+    FormatConverterOpenGL format_converter;
 
     std::unordered_map<TextureCubeConfig, CachedTextureCube> texture_cube_cache;
 };


### PR DESCRIPTION
This is a kind of follow up of #4089.

Sometimes the rasterizer cache won't find a match because the requested surface has just another PixelFormat. In that case we reload the texture from CPU in the other format. For better performance we can just convert the Texture on GPU. We already do that for RGBA8 -> D24S8 conversion. 

The first step was to move the current implementation and log which converters should get implemented.

From the previous PR the following Converters should probably get implemented:

- [x] RGBA8 -> D24S8
- [ ] D16 -> D24S8
- [ ] D24S8 -> D16
- [ ] RGBA8 -> D24S8
- [ ] RGB565 -> RGBA8
- [ ] RGB5A1 -> RGBA8
- [ ] RGB8 -> RGBA8
- [ ] RGBA4 -> RGB5A1

The format conversion from dolphin https://github.com/dolphin-emu/dolphin/blob/c829351c90f8f9833a0a311c7982603c0c1339c9/Source/Core/VideoCommon/FramebufferShaderGen.cpp#L434 could help here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4902)
<!-- Reviewable:end -->
