### PR TITLE
citra_qt: fix the stuck in fullscreen mode and hotkey bugs

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -353,18 +353,6 @@ void GMainWindow::InitializeRecentFileMenuActions() {
 void GMainWindow::InitializeHotkeys() {
     hotkey_registry.LoadHotkeys();
 
-    ui.action_Load_File->setShortcut(hotkey_registry.GetKeySequence("Main Window", "Load File"));
-    ui.action_Load_File->setShortcutContext(
-        hotkey_registry.GetShortcutContext("Main Window", "Load File"));
-
-    ui.action_Exit->setShortcut(hotkey_registry.GetKeySequence("Main Window", "Exit Citra"));
-    ui.action_Exit->setShortcutContext(
-        hotkey_registry.GetShortcutContext("Main Window", "Exit Citra"));
-
-    ui.action_Stop->setShortcut(hotkey_registry.GetKeySequence("Main Window", "Stop Emulation"));
-    ui.action_Stop->setShortcutContext(
-        hotkey_registry.GetShortcutContext("Main Window", "Stop Emulation"));
-
     ui.action_Show_Filter_Bar->setShortcut(
         hotkey_registry.GetKeySequence("Main Window", "Toggle Filter Bar"));
     ui.action_Show_Filter_Bar->setShortcutContext(
@@ -376,7 +364,13 @@ void GMainWindow::InitializeHotkeys() {
         hotkey_registry.GetShortcutContext("Main Window", "Toggle Status Bar"));
 
     connect(hotkey_registry.GetHotkey("Main Window", "Load File", this), &QShortcut::activated,
-            this, &GMainWindow::OnMenuLoadFile);
+            ui.action_Load_File, &QAction::trigger);
+
+    connect(hotkey_registry.GetHotkey("Main Window", "Stop Emulation", this), &QShortcut::activated,
+            ui.action_Stop, &QAction::trigger);
+
+    connect(hotkey_registry.GetHotkey("Main Window", "Exit Citra", this), &QShortcut::activated,
+            ui.action_Exit, &QAction::trigger);
 
     connect(hotkey_registry.GetHotkey("Main Window", "Continue/Pause Emulation", this),
             &QShortcut::activated, this, [&] {
@@ -891,6 +885,14 @@ void GMainWindow::BootGame(const QString& filename) {
 }
 
 void GMainWindow::ShutdownGame() {
+    if (!emulation_running) {
+        return;
+    }
+
+    if (ui.action_Fullscreen->isChecked()) {
+        HideFullscreen();
+    }
+
     if (Core::System::GetInstance().VideoDumper().IsDumping()) {
         game_shutdown_delayed = true;
         OnStopVideoDumping();


### PR DESCRIPTION
The stuck in fullscreen mode bug happens if the emulated program exits, is fixed by adding [this](https://github.com/citra-emu/citra/compare/master...vvanelslande:hotkey-and-fullscreen-fixes?expand=1#diff-5e8bf22f5c3b3579c402308dd96b7563R888-R894), steps to reproduce:
- Start [FBI](https://github.com/Steveice10/FBI)
- Press START

The fixed hotkeys (I changed them to use [connect](https://doc.qt.io/qt-5/qobject.html#connect) instead of [setShortcut](https://doc.qt.io/qt-5/qaction.html#shortcut-prop) + [setShortcutContext](https://doc.qt.io/qt-5/qaction.html#shortcutContext-prop)) are:
- Load File (was not working in windowed mode), fixed by removing the [setShortcut](https://doc.qt.io/qt-5/qaction.html#shortcut-prop) + [setShortcutContext](https://doc.qt.io/qt-5/qaction.html#shortcutContext-prop) calls (there was already a [connect](https://doc.qt.io/qt-5/qobject.html#connect) call)
- Stop Emulation (was not working in fullscreen mode), fixed with the [connect](https://doc.qt.io/qt-5/qobject.html#connect) change and [this](https://github.com/citra-emu/citra/compare/master...vvanelslande:hotkey-and-fullscreen-fixes?expand=1#diff-5e8bf22f5c3b3579c402308dd96b7563R888-R894) change
- Exit Citra (was not working in fullscreen mode), fixed with the [connect](https://doc.qt.io/qt-5/qobject.html#connect) change

Fixes #4876

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4906)
<!-- Reviewable:end -->
