### PR TITLE
applet_manager: remove the "we are going to disable loading LLE applets before further fixes are done" comments

### DIFF
--- a/src/core/hle/service/apt/applet_manager.cpp
+++ b/src/core/hle/service/apt/applet_manager.cpp
@@ -324,9 +324,6 @@ ResultCode AppletManager::PrepareToStartLibraryApplet(AppletId applet_id) {
                           ErrorSummary::InvalidState, ErrorLevel::Status);
     }
 
-    // There are some problems with LLE applets. The rasterizer cache gets out of sync
-    // when the applet is closed. To avoid breaking applications because of the issue,
-    // we are going to disable loading LLE applets before further fixes are done.
     auto cfg = Service::CFG::GetModule(system);
     u32 region_value = cfg->GetRegionValue();
     auto process =
@@ -354,9 +351,6 @@ ResultCode AppletManager::PreloadLibraryApplet(AppletId applet_id) {
                           ErrorSummary::InvalidState, ErrorLevel::Status);
     }
 
-    // There are some problems with LLE applets. The rasterizer cache gets out of sync
-    // when the applet is closed. To avoid breaking applications because of the issue,
-    // we are going to disable loading LLE applets before further fixes are done.
     auto cfg = Service::CFG::GetModule(system);
     u32 region_value = cfg->GetRegionValue();
     auto process =


### PR DESCRIPTION
LLE Applets are enabled again in #4500, but @wwylele didn't remove these comments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4907)
<!-- Reviewable:end -->
