### PR TITLE
Add a cancel option to analog stick configuration

### DIFF
--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -231,16 +231,19 @@ ConfigureInput::ConfigureInput(QWidget* parent)
                     });
         }
         connect(analog_map_stick[analog_id], &QPushButton::clicked, [=]() {
-            QMessageBox::information(this, tr("Information"),
-                                     tr("After pressing OK, first move your joystick horizontally, "
-                                        "and then vertically."));
-            HandleClick(analog_map_stick[analog_id],
-                        [=](const Common::ParamPackage& params) {
-                            analogs_param[analog_id] = params;
-                            ApplyConfiguration();
-                            Settings::SaveProfile(ui->profile->currentIndex());
-                        },
-                        InputCommon::Polling::DeviceType::Analog);
+            if (QMessageBox::information(
+                    this, tr("Information"),
+                    tr("After pressing OK, first move your joystick horizontally, "
+                       "and then vertically."),
+                    QMessageBox::Ok | QMessageBox::Cancel) == QMessageBox::Ok) {
+                HandleClick(analog_map_stick[analog_id],
+                            [=](const Common::ParamPackage& params) {
+                                analogs_param[analog_id] = params;
+                                ApplyConfiguration();
+                                Settings::SaveProfile(ui->profile->currentIndex());
+                            },
+                            InputCommon::Polling::DeviceType::Analog);
+            }
         });
     }
 


### PR DESCRIPTION
When a user clicks the "Set Analog Stick" button, Citra will pop up an information window with instructions for setting it up. 
The message reads "After pressing OK, first move your joystick horizontally, and then vertically."

There's a small incongruence between what the message says and the actual behavior, as Citra will try to accept an input even if the user closes the information window by pressing 'Esc' or by clicking the 'x' (not sure how to properly call it).

This PR proposes the addition of a 'Cancel' button and a check for the button clicked by the user. 
According to the Qt documentation, this will also assign 'Cancel' as the Escape Button, triggering it when the user presses 'Esc'.

![popup comparison](https://user-images.githubusercontent.com/29167336/64070751-530ede00-cc3f-11e9-9433-b0625e1a4e7c.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4911)
<!-- Reviewable:end -->
