### PR TITLE
Fix to Windows sleep issues

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -712,6 +712,18 @@ void GMainWindow::OnOpenUpdater() {
     updater->LaunchUI();
 }
 
+void GMainWindow::PreventOSSleep() {
+#ifdef _WIN32
+    SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED | ES_DISPLAY_REQUIRED);
+#endif
+}
+
+void GMainWindow::AllowOSSleep() {
+#ifdef _WIN32
+    SetThreadExecutionState(ES_CONTINUOUS);
+#endif
+}
+
 bool GMainWindow::LoadROM(const QString& filename) {
     // Shutdown previous session if the emu thread is still active...
     if (emu_thread != nullptr)
@@ -902,9 +914,7 @@ void GMainWindow::ShutdownGame() {
         return;
     }
 
-#ifdef _WIN32
-    SetThreadExecutionState(ES_CONTINUOUS);
-#endif
+    AllowOSSleep();
 
     discord_rpc->Pause();
     OnStopRecordingPlayback();
@@ -1223,9 +1233,7 @@ void GMainWindow::OnStartGame() {
         movie_record_path.clear();
     }
 
-#ifdef _WIN32
-    SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED | ES_DISPLAY_REQUIRED);
-#endif
+    PreventOSSleep();
 
     emu_thread->SetRunning(true);
     qRegisterMetaType<Core::System::ResultStatus>("Core::System::ResultStatus");
@@ -1255,9 +1263,7 @@ void GMainWindow::OnPauseGame() {
     ui.action_Stop->setEnabled(true);
     ui.action_Capture_Screenshot->setEnabled(false);
 
-#ifdef _WIN32
-    SetThreadExecutionState(ES_CONTINUOUS);
-#endif
+    AllowOSSleep();
 }
 
 void GMainWindow::OnStopGame() {

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -18,6 +18,9 @@
 #ifdef __APPLE__
 #include <unistd.h> // for chdir
 #endif
+#ifdef _WIN32
+#include <windows.h>
+#endif
 #include "citra_qt/aboutdialog.h"
 #include "citra_qt/applets/mii_selector.h"
 #include "citra_qt/applets/swkbd.h"
@@ -899,6 +902,10 @@ void GMainWindow::ShutdownGame() {
         return;
     }
 
+#ifdef _WIN32
+    SetThreadExecutionState(ES_CONTINUOUS);
+#endif
+
     discord_rpc->Pause();
     OnStopRecordingPlayback();
     emu_thread->RequestStop();
@@ -1216,6 +1223,10 @@ void GMainWindow::OnStartGame() {
         movie_record_path.clear();
     }
 
+#ifdef _WIN32
+    SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED | ES_DISPLAY_REQUIRED);
+#endif
+
     emu_thread->SetRunning(true);
     qRegisterMetaType<Core::System::ResultStatus>("Core::System::ResultStatus");
     qRegisterMetaType<std::string>("std::string");
@@ -1243,6 +1254,10 @@ void GMainWindow::OnPauseGame() {
     ui.action_Pause->setEnabled(false);
     ui.action_Stop->setEnabled(true);
     ui.action_Capture_Screenshot->setEnabled(false);
+
+#ifdef _WIN32
+    SetThreadExecutionState(ES_CONTINUOUS);
+#endif
 }
 
 void GMainWindow::OnStopGame() {

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -104,6 +104,9 @@ private:
     void ConnectWidgetEvents();
     void ConnectMenuEvents();
 
+    void PreventOSSleep();
+    void AllowOSSleep();
+
     bool LoadROM(const QString& filename);
     void BootGame(const QString& filename);
     void ShutdownGame();


### PR DESCRIPTION
Fixes #4870 , uses the provided [SetThreadExecutionState](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setthreadexecutionstate) function to keep display and system awake while a game is being played.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4914)
<!-- Reviewable:end -->
