### PR TITLE
Port citra-emu/citra#2818: "externals: update fmt to 6.0.0"

### DIFF
--- a/src/core/perf_stats.cpp
+++ b/src/core/perf_stats.cpp
@@ -8,8 +8,8 @@
 #include <mutex>
 #include <numeric>
 #include <thread>
+#include <fmt/chrono.h>
 #include <fmt/format.h>
-#include <fmt/time.h>
 #include "common/file_util.h"
 #include "core/hw/gpu.h"
 #include "core/perf_stats.h"


### PR DESCRIPTION
See citra-emu/citra#2818 for more details.

Should fix https://github.com/citra-emu/citra/issues/4766.

**Original description**:
This is required for yuzu to build on Linux.
Credit to @Cleverking2003

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4915)
<!-- Reviewable:end -->
