### PR TITLE
Allow displaying the long_title of the game

### DIFF
--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -306,17 +306,19 @@ void Config::ReadValues() {
     }
     UISettings::values.game_list_icon_size = UISettings::GameListIconSize{icon_size};
 
-    int row_1 = ReadSetting("row1", 2).toInt();
-    if (row_1 < 0 || row_1 >= UISettings::GAME_LIST_TEXT_LENGTH) {
-        row_1 = 2;
+    UISettings::GameListText row_1 = UISettings::GameListText{
+        ReadSetting("row1", static_cast<int>(UISettings::GameListText::TitleName)).toInt()};
+    if (row_1 <= UISettings::GameListText::NoText || row_1 >= UISettings::GameListText::ListEnd) {
+        row_1 = UISettings::GameListText::TitleName;
     }
-    UISettings::values.game_list_row_1 = UISettings::GameListText{row_1};
+    UISettings::values.game_list_row_1 = row_1;
 
-    int row_2 = ReadSetting("row2", 0).toInt();
-    if (row_2 < -1 || row_2 >= UISettings::GAME_LIST_TEXT_LENGTH) {
-        row_2 = 0;
+    UISettings::GameListText row_2 = UISettings::GameListText{
+        ReadSetting("row2", static_cast<int>(UISettings::GameListText::FileName)).toInt()};
+    if (row_2 < UISettings::GameListText::NoText || row_2 >= UISettings::GameListText::ListEnd) {
+        row_2 = UISettings::GameListText::FileName;
     }
-    UISettings::values.game_list_row_2 = UISettings::GameListText{row_2};
+    UISettings::values.game_list_row_2 = row_2;
 
     UISettings::values.game_list_hide_no_icon = ReadSetting("hideNoIcon", false).toBool();
     UISettings::values.game_list_single_line_mode = ReadSetting("singleLineMode", false).toBool();

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -307,13 +307,13 @@ void Config::ReadValues() {
     UISettings::values.game_list_icon_size = UISettings::GameListIconSize{icon_size};
 
     int row_1 = ReadSetting("row1", 2).toInt();
-    if (row_1 < 0 || row_1 > 3) {
+    if (row_1 < 0 || row_1 >= UISettings::GAME_LIST_TEXT_LENGTH) {
         row_1 = 2;
     }
     UISettings::values.game_list_row_1 = UISettings::GameListText{row_1};
 
     int row_2 = ReadSetting("row2", 0).toInt();
-    if (row_2 < -1 || row_2 > 3) {
+    if (row_2 < -1 || row_2 >= UISettings::GAME_LIST_TEXT_LENGTH) {
         row_2 = 0;
     }
     UISettings::values.game_list_row_2 = UISettings::GameListText{row_2};

--- a/src/citra_qt/configuration/configure_ui.ui
+++ b/src/citra_qt/configuration/configure_ui.ui
@@ -126,7 +126,12 @@
             </item>
             <item>
              <property name="text">
-              <string>Title Name</string>
+              <string>Title Name (short)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Title Name (long)</string>
              </property>
             </item>
             <item>
@@ -166,7 +171,12 @@
             </item>
             <item>
              <property name="text">
-              <string>Title Name</string>
+              <string>Title Name (short)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Title Name (long)</string>
              </property>
             </item>
             <item>

--- a/src/citra_qt/configuration/configure_ui.ui
+++ b/src/citra_qt/configuration/configure_ui.ui
@@ -131,12 +131,12 @@
             </item>
             <item>
              <property name="text">
-              <string>Title Name (long)</string>
+              <string>Title ID</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>Title ID</string>
+              <string>Title Name (long)</string>
              </property>
             </item>
            </widget>
@@ -176,12 +176,12 @@
             </item>
             <item>
              <property name="text">
-              <string>Title Name (long)</string>
+              <string>Title ID</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>Title ID</string>
+              <string>Title Name (long)</string>
              </property>
             </item>
            </widget>

--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -215,7 +215,7 @@ void GameList::onTextChanged(const QString& newText) {
                     child->data(GameListItemPath::FullPathRole).toString().toLower();
                 QString file_name = file_path.mid(file_path.lastIndexOf("/") + 1);
                 const QString file_title =
-                    child->data(GameListItemPath::TitleRole).toString().toLower();
+                    child->data(GameListItemPath::LongTitleRole).toString().toLower();
                 const QString file_programmid =
                     child->data(GameListItemPath::ProgramIdRole).toString().toLower();
 

--- a/src/citra_qt/game_list_p.h
+++ b/src/citra_qt/game_list_p.h
@@ -71,6 +71,17 @@ static QString GetQStringShortTitleFromSMDH(const Loader::SMDH& smdh,
 }
 
 /**
+ * Gets the long game title from SMDH data.
+ * @param smdh SMDH data
+ * @param language title language
+ * @return QString long title
+ */
+static QString GetQStringLongTitleFromSMDH(const Loader::SMDH& smdh,
+                                            Loader::SMDH::TitleLanguage language) {
+    return QString::fromUtf16(smdh.GetLongTitle(language).data());
+}
+
+/**
  * Gets the game region from SMDH data.
  * @param smdh SMDH data
  * @return QString region
@@ -139,6 +150,7 @@ public:
     static const int FullPathRole = SortRole + 1;
     static const int ProgramIdRole = SortRole + 2;
     static const int ExtdataIdRole = SortRole + 3;
+    static const int LongTitleRole = SortRole + 4;
 
     GameListItemPath() = default;
     GameListItemPath(const QString& game_path, const std::vector<u8>& smdh_data, u64 program_id,
@@ -173,6 +185,10 @@ public:
         // Get title from SMDH
         setData(GetQStringShortTitleFromSMDH(smdh, Loader::SMDH::TitleLanguage::English),
                 TitleRole);
+
+        // Get long title from SMDH
+        setData(GetQStringLongTitleFromSMDH(smdh, Loader::SMDH::TitleLanguage::English),
+                LongTitleRole);
     }
 
     int type() const override {
@@ -189,11 +205,12 @@ public:
                 {UISettings::GameListText::FileName, QString::fromStdString(filename + extension)},
                 {UISettings::GameListText::FullPath, data(FullPathRole).toString()},
                 {UISettings::GameListText::TitleName, data(TitleRole).toString()},
+                {UISettings::GameListText::LongTitleName, data(LongTitleRole).toString()},
                 {UISettings::GameListText::TitleID,
                  QString::fromStdString(fmt::format("{:016X}", data(ProgramIdRole).toULongLong()))},
             };
 
-            const QString& row1 = display_texts.at(UISettings::values.game_list_row_1);
+            const QString& row1 = display_texts.at(UISettings::values.game_list_row_1).simplified();
 
             QString row2;
             auto row_2_id = UISettings::values.game_list_row_2;

--- a/src/citra_qt/game_list_p.h
+++ b/src/citra_qt/game_list_p.h
@@ -77,7 +77,7 @@ static QString GetQStringShortTitleFromSMDH(const Loader::SMDH& smdh,
  * @return QString long title
  */
 static QString GetQStringLongTitleFromSMDH(const Loader::SMDH& smdh,
-                                            Loader::SMDH::TitleLanguage language) {
+                                           Loader::SMDH::TitleLanguage language) {
     return QString::fromUtf16(smdh.GetLongTitle(language).data());
 }
 

--- a/src/citra_qt/game_list_p.h
+++ b/src/citra_qt/game_list_p.h
@@ -220,7 +220,7 @@ public:
                                ? QStringLiteral("     ")
                                : QStringLiteral("\n     ");
                 }
-                row2 += display_texts.at(row_2_id);
+                row2 += display_texts.at(row_2_id).simplified();
             }
             return QString(row1 + row2);
         } else {

--- a/src/citra_qt/uisettings.h
+++ b/src/citra_qt/uisettings.h
@@ -50,6 +50,7 @@ enum class GameListText {
     FileName,    ///< Display the file name of the entry
     FullPath,    ///< Display the full path of the entry
     TitleName,   ///< Display the name of the title
+    LongTitleName,   ///< Display the long name of the title
     TitleID,     ///< Display the title ID
 };
 

--- a/src/citra_qt/uisettings.h
+++ b/src/citra_qt/uisettings.h
@@ -50,9 +50,11 @@ enum class GameListText {
     FileName,    ///< Display the file name of the entry
     FullPath,    ///< Display the full path of the entry
     TitleName,   ///< Display the name of the title
-    LongTitleName,   ///< Display the long name of the title
     TitleID,     ///< Display the title ID
+    LongTitleName, ///< Display the long name of the title
 };
+// The length of the GameListText, excluding NoText
+constexpr int GAME_LIST_TEXT_LENGTH = 5;
 
 struct Values {
     QByteArray geometry;

--- a/src/citra_qt/uisettings.h
+++ b/src/citra_qt/uisettings.h
@@ -52,9 +52,8 @@ enum class GameListText {
     TitleName,     ///< Display the name of the title
     TitleID,       ///< Display the title ID
     LongTitleName, ///< Display the long name of the title
+    ListEnd,       ///< Keep this at the end of the enum.
 };
-// The length of the GameListText, excluding NoText
-constexpr int GAME_LIST_TEXT_LENGTH = 5;
 
 struct Values {
     QByteArray geometry;

--- a/src/citra_qt/uisettings.h
+++ b/src/citra_qt/uisettings.h
@@ -46,11 +46,11 @@ enum class GameListIconSize {
 };
 
 enum class GameListText {
-    NoText = -1, ///< No text
-    FileName,    ///< Display the file name of the entry
-    FullPath,    ///< Display the full path of the entry
-    TitleName,   ///< Display the name of the title
-    TitleID,     ///< Display the title ID
+    NoText = -1,   ///< No text
+    FileName,      ///< Display the file name of the entry
+    FullPath,      ///< Display the full path of the entry
+    TitleName,     ///< Display the name of the title
+    TitleID,       ///< Display the title ID
     LongTitleName, ///< Display the long name of the title
 };
 // The length of the GameListText, excluding NoText

--- a/src/core/loader/smdh.cpp
+++ b/src/core/loader/smdh.cpp
@@ -48,6 +48,10 @@ std::array<u16, 0x40> SMDH::GetShortTitle(Loader::SMDH::TitleLanguage language) 
     return titles[static_cast<int>(language)].short_title;
 }
 
+std::array<u16, 0x80> SMDH::GetLongTitle(Loader::SMDH::TitleLanguage language) const {
+    return titles[static_cast<int>(language)].long_title;
+}
+
 std::vector<SMDH::GameRegion> SMDH::GetRegions() const {
     constexpr u32 REGION_COUNT = 7;
     std::vector<GameRegion> result;

--- a/src/core/loader/smdh.h
+++ b/src/core/loader/smdh.h
@@ -86,6 +86,13 @@ struct SMDH {
      */
     std::array<u16, 0x40> GetShortTitle(Loader::SMDH::TitleLanguage language) const;
 
+    /**
+     * Gets the long game title from SMDH
+     * @param language title language
+     * @return UTF-16 array of the long title
+     */
+    std::array<u16, 0x80> GetLongTitle(Loader::SMDH::TitleLanguage language) const;
+
     std::vector<GameRegion> GetRegions() const;
 };
 static_assert(sizeof(SMDH) == 0x36C0, "SMDH structure size is wrong");


### PR DESCRIPTION
I noticed that sometimes, the game name is shortened even though there was enough space for it. Investigating the code, I discovered Citra uses the short_title provided by the game, and it would be possible to use the long_title without much trouble.

Adds the option to display the full title of the game to the configurations. 
Changes the search to use the long_title instead of the short_title.
As some long titles contain newlines, strips them before displaying.

![game list display](https://user-images.githubusercontent.com/29167336/64374914-338b0300-cffb-11e9-9234-7220a91d533b.png)
![long_title vs short_title](https://user-images.githubusercontent.com/29167336/64374929-37b72080-cffb-11e9-9aea-360af31e2764.png)

Fixes part of the motivation for #4593 
> many games don't show the full name, or sometimes it just shows the initials of the game so it's better to show the file name

I'm still trying to figure out the quirks of how the sorting of the titles is done, so it's not a full fix yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4917)
<!-- Reviewable:end -->
