### PR TITLE
Silence warnings from unused code and mismatched declaration

### DIFF
--- a/src/core/hle/service/gsp/gsp_gpu.h
+++ b/src/core/hle/service/gsp/gsp_gpu.h
@@ -185,7 +185,8 @@ static_assert(sizeof(CommandBuffer) == 0x200, "CommandBuffer struct has incorrec
 
 class GSP_GPU;
 
-struct SessionData : public Kernel::SessionRequestHandler::SessionDataBase {
+class SessionData : public Kernel::SessionRequestHandler::SessionDataBase {
+public:
     SessionData();
     SessionData(GSP_GPU* gsp);
     ~SessionData();

--- a/src/core/hle/service/ptm/ptm.cpp
+++ b/src/core/hle/service/ptm/ptm.cpp
@@ -188,7 +188,7 @@ static GameCoin ReadGameCoinData() {
         LOG_ERROR(Service_PTM, "Could not open the game coin data file!");
         return default_game_coin;
     }
-    u16 result;
+
     auto gamecoin = std::move(gamecoin_result).Unwrap();
     GameCoin gamecoin_data;
     gamecoin->Read(0, sizeof(GameCoin), reinterpret_cast<u8*>(&gamecoin_data));

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -1759,7 +1759,6 @@ struct Vertex {
            semantic(VSOutputAttributes::POSITION_Y) + ", " +
            semantic(VSOutputAttributes::POSITION_Z) + ", " +
            semantic(VSOutputAttributes::POSITION_W) + ");\n";
-    semantic(VSOutputAttributes::POSITION_W) + ");\n";
     out += "    gl_Position = vtx_pos;\n";
     out += "#if !defined(CITRA_GLES) || defined(GL_EXT_clip_cull_distance)\n";
     out += "    gl_ClipDistance[0] = -vtx_pos.z;\n"; // fixed PICA clipping plane z <= 0


### PR DESCRIPTION
Silences some warnings (C4099, C4101, C4834) related to a mismatched declaration and unused code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4918)
<!-- Reviewable:end -->
