### PR TITLE
Filter non-executable files out of the game list.

### DIFF
--- a/src/citra_qt/game_list_worker.cpp
+++ b/src/citra_qt/game_list_worker.cpp
@@ -49,6 +49,11 @@ void GameListWorker::AddFstEntriesToGameList(const std::string& dir_path, unsign
             if (!loader)
                 return true;
 
+            bool executable = false;
+            loader->IsExecutable(executable);
+            if (!executable)
+                return true;
+
             u64 program_id = 0;
             loader->ReadProgramId(program_id);
 

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -113,6 +113,16 @@ public:
     }
 
     /**
+     * Get whether this application is executable.
+     * @param out_executable Reference to store the executable flag into.
+     * @return ResultStatus result of function
+     */
+    virtual ResultStatus IsExecutable(bool& out_executable) {
+        out_executable = true;
+        return ResultStatus::Success;
+    }
+
+    /**
      * Get the code (typically .code section) of the application
      * @param buffer Reference to buffer to store data
      * @return ResultStatus result of function

--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -198,6 +198,15 @@ ResultStatus AppLoader_NCCH::Load(std::shared_ptr<Kernel::Process>& process) {
     return ResultStatus::Success;
 }
 
+ResultStatus AppLoader_NCCH::IsExecutable(bool& out_executable) {
+    Loader::ResultStatus result = overlay_ncch->Load();
+    if (result != Loader::ResultStatus::Success)
+        return result;
+
+    out_executable = overlay_ncch->ncch_header.is_executable != 0;
+    return ResultStatus::Success;
+}
+
 ResultStatus AppLoader_NCCH::ReadCode(std::vector<u8>& buffer) {
     return overlay_ncch->LoadSectionExeFS(".code", buffer);
 }

--- a/src/core/loader/ncch.h
+++ b/src/core/loader/ncch.h
@@ -41,6 +41,8 @@ public:
      */
     std::pair<std::optional<u32>, ResultStatus> LoadKernelSystemMode() override;
 
+    ResultStatus IsExecutable(bool& out_executable) override;
+
     ResultStatus ReadCode(std::vector<u8>& buffer) override;
 
     ResultStatus ReadIcon(std::vector<u8>& buffer) override;


### PR DESCRIPTION
Currently, installing game CIAs will add a bunch of unusable entries for extra NCCH files like manual data. This change checks the executable bit in the NCCH header and filters non-executable entries out of the game list.

Before:
![before](https://user-images.githubusercontent.com/1269164/64472395-a1761e00-d112-11e9-9d9a-09f91271cd48.png)

After:
![after](https://user-images.githubusercontent.com/1269164/64472396-a509a500-d112-11e9-9e32-675c4b29461e.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4922)
<!-- Reviewable:end -->
