### PR TITLE
Change the coding style of GameListIconSize bounds check to use the enum

### DIFF
--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -300,11 +300,13 @@ void Config::ReadValues() {
     qt_config->endGroup();
 
     qt_config->beginGroup("GameList");
-    int icon_size = ReadSetting("iconSize", 2).toInt();
-    if (icon_size < 0 || icon_size > 2) {
-        icon_size = 2;
+    UISettings::GameListIconSize icon_size = UISettings::GameListIconSize{
+        ReadSetting("iconSize", static_cast<int>(UISettings::GameListIconSize::LargeIcon)).toInt()};
+    if (icon_size < UISettings::GameListIconSize::NoIcon ||
+        icon_size > UISettings::GameListIconSize::LargeIcon) {
+        icon_size = UISettings::GameListIconSize::LargeIcon;
     }
-    UISettings::values.game_list_icon_size = UISettings::GameListIconSize{icon_size};
+    UISettings::values.game_list_icon_size = icon_size;
 
     int row_1 = ReadSetting("row1", 2).toInt();
     if (row_1 < 0 || row_1 > 3) {

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -300,7 +300,7 @@ void Config::ReadValues() {
     qt_config->endGroup();
 
     qt_config->beginGroup("GameList");
-    UISettings::GameListIconSize icon_size = UISettings::GameListIconSize{
+    auto icon_size = UISettings::GameListIconSize{
         ReadSetting("iconSize", static_cast<int>(UISettings::GameListIconSize::LargeIcon)).toInt()};
     if (icon_size < UISettings::GameListIconSize::NoIcon ||
         icon_size > UISettings::GameListIconSize::LargeIcon) {


### PR DESCRIPTION
Changes the code to use the defined enums instead of magic numbers.
Shouldn't change functionality or UI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4925)
<!-- Reviewable:end -->
