### PR TITLE
Inform the user about common configuration mistakes

### DIFF
--- a/src/citra_qt/configuration/configure_general.cpp
+++ b/src/citra_qt/configuration/configure_general.cpp
@@ -20,6 +20,11 @@ ConfigureGeneral::ConfigureGeneral(QWidget* parent)
     ui->updateBox->setVisible(UISettings::values.updater_found);
     connect(ui->button_reset_defaults, &QPushButton::clicked, this,
             &ConfigureGeneral::ResetDefaults);
+
+    ui->label_is_n3ds_true->setVisible(Settings::values.is_new_3ds);
+    ui->label_GDB_debug->setVisible(Settings::values.use_gdbstub);
+    bool messages_to_show = Settings::values.use_gdbstub || Settings::values.is_new_3ds;
+    ui->info_messages_group->setVisible(messages_to_show);
 }
 
 ConfigureGeneral::~ConfigureGeneral() = default;

--- a/src/citra_qt/configuration/configure_general.ui
+++ b/src/citra_qt/configuration/configure_general.ui
@@ -138,6 +138,29 @@
        </layout>
       </widget>
      </item>
+     <item>
+      <widget class="QGroupBox" name="info_messages_group">
+       <property name="title">
+        <string>Informational Messages</string>
+       </property>
+       <layout class="QVBoxLayout">
+        <item>
+         <widget class="QLabel" name="label_is_n3ds_true">
+          <property name="text">
+           <string>The flag System_IsNew3ds is set to true. This may cause problems. Reset settings to fix this.</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="label_GDB_debug">
+          <property name="text">
+           <string>GDB Stub debugging is on. This may cause problems with starting games.</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
      <item alignment="Qt::AlignRight">
       <widget class="QPushButton" name="button_reset_defaults">
        <property name="text">


### PR DESCRIPTION
Looking at some logs from the discord support channel, some users somehow turn on some settings they shouldn't even be messing with, like debug settings or the is_new_3ds flag (just how?).
This is a small suggestion to have a message in the configurations window that notifies the user of such configurations.

![info_messages_ui_example](https://user-images.githubusercontent.com/29167336/64499375-1e2e0700-d28f-11e9-93fd-f5af115e6ac7.PNG)

(This was hastily put together by me, so I expect many changes to be necessary before it's ready to go into Citra)

Please comment if you have more suggestions for configurations to be checked, and better messages for explanation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4926)
<!-- Reviewable:end -->
