### PR TITLE
Pause when in background

### DIFF
--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -384,6 +384,7 @@ void Config::ReadValues() {
     UISettings::values.first_start = ReadSetting("firstStart", true).toBool();
     UISettings::values.callout_flags = ReadSetting("calloutFlags", 0).toUInt();
     UISettings::values.show_console = ReadSetting("showConsole", false).toBool();
+    UISettings::values.pause_when_on_background = ReadSetting("pauseWhenOnBackground", false).toBool();
 
     qt_config->beginGroup("Multiplayer");
     UISettings::values.nickname = ReadSetting("nickname", "").toString();
@@ -636,6 +637,7 @@ void Config::SaveValues() {
     WriteSetting("firstStart", UISettings::values.first_start, true);
     WriteSetting("calloutFlags", UISettings::values.callout_flags, 0);
     WriteSetting("showConsole", UISettings::values.show_console, false);
+    WriteSetting("pauseWhenOnBackground", UISettings::values.pause_when_on_background, false);
 
     qt_config->beginGroup("Multiplayer");
     WriteSetting("nickname", UISettings::values.nickname, "");

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -384,7 +384,8 @@ void Config::ReadValues() {
     UISettings::values.first_start = ReadSetting("firstStart", true).toBool();
     UISettings::values.callout_flags = ReadSetting("calloutFlags", 0).toUInt();
     UISettings::values.show_console = ReadSetting("showConsole", false).toBool();
-    UISettings::values.pause_when_on_background = ReadSetting("pauseWhenOnBackground", false).toBool();
+    UISettings::values.pause_when_in_background =
+        ReadSetting("pauseWhenInBackground", false).toBool();
 
     qt_config->beginGroup("Multiplayer");
     UISettings::values.nickname = ReadSetting("nickname", "").toString();
@@ -637,7 +638,7 @@ void Config::SaveValues() {
     WriteSetting("firstStart", UISettings::values.first_start, true);
     WriteSetting("calloutFlags", UISettings::values.callout_flags, 0);
     WriteSetting("showConsole", UISettings::values.show_console, false);
-    WriteSetting("pauseWhenOnBackground", UISettings::values.pause_when_on_background, false);
+    WriteSetting("pauseWhenInBackground", UISettings::values.pause_when_in_background, false);
 
     qt_config->beginGroup("Multiplayer");
     WriteSetting("nickname", UISettings::values.nickname, "");

--- a/src/citra_qt/configuration/configure_general.cpp
+++ b/src/citra_qt/configuration/configure_general.cpp
@@ -26,6 +26,7 @@ ConfigureGeneral::~ConfigureGeneral() = default;
 
 void ConfigureGeneral::SetConfiguration() {
     ui->toggle_check_exit->setChecked(UISettings::values.confirm_before_closing);
+    ui->toggle_background_pause->setChecked(UISettings::values.pause_when_on_background);
 
     ui->toggle_update_check->setChecked(UISettings::values.check_for_update_on_start);
     ui->toggle_auto_update->setChecked(UISettings::values.update_on_close);
@@ -53,6 +54,7 @@ void ConfigureGeneral::ResetDefaults() {
 
 void ConfigureGeneral::ApplyConfiguration() {
     UISettings::values.confirm_before_closing = ui->toggle_check_exit->isChecked();
+    UISettings::values.pause_when_on_background = ui->toggle_background_pause->isChecked();
 
     UISettings::values.check_for_update_on_start = ui->toggle_update_check->isChecked();
     UISettings::values.update_on_close = ui->toggle_auto_update->isChecked();

--- a/src/citra_qt/configuration/configure_general.cpp
+++ b/src/citra_qt/configuration/configure_general.cpp
@@ -26,7 +26,7 @@ ConfigureGeneral::~ConfigureGeneral() = default;
 
 void ConfigureGeneral::SetConfiguration() {
     ui->toggle_check_exit->setChecked(UISettings::values.confirm_before_closing);
-    ui->toggle_background_pause->setChecked(UISettings::values.pause_when_on_background);
+    ui->toggle_background_pause->setChecked(UISettings::values.pause_when_in_background);
 
     ui->toggle_update_check->setChecked(UISettings::values.check_for_update_on_start);
     ui->toggle_auto_update->setChecked(UISettings::values.update_on_close);
@@ -54,7 +54,7 @@ void ConfigureGeneral::ResetDefaults() {
 
 void ConfigureGeneral::ApplyConfiguration() {
     UISettings::values.confirm_before_closing = ui->toggle_check_exit->isChecked();
-    UISettings::values.pause_when_on_background = ui->toggle_background_pause->isChecked();
+    UISettings::values.pause_when_in_background = ui->toggle_background_pause->isChecked();
 
     UISettings::values.check_for_update_on_start = ui->toggle_update_check->isChecked();
     UISettings::values.update_on_close = ui->toggle_auto_update->isChecked();

--- a/src/citra_qt/configuration/configure_general.ui
+++ b/src/citra_qt/configuration/configure_general.ui
@@ -29,7 +29,7 @@
           </property>
          </widget>
         </item>
-       <item>
+        <item>
          <widget class="QCheckBox" name="toggle_background_pause">
           <property name="text">
            <string>Pause emulation when in background</string>

--- a/src/citra_qt/configuration/configure_general.ui
+++ b/src/citra_qt/configuration/configure_general.ui
@@ -32,7 +32,7 @@
        <item>
          <widget class="QCheckBox" name="toggle_background_pause">
           <property name="text">
-           <string>Pause emulation when on background</string>
+           <string>Pause emulation when in background</string>
           </property>
          </widget>
         </item>

--- a/src/citra_qt/configuration/configure_general.ui
+++ b/src/citra_qt/configuration/configure_general.ui
@@ -29,6 +29,13 @@
           </property>
          </widget>
         </item>
+       <item>
+         <widget class="QCheckBox" name="toggle_background_pause">
+          <property name="text">
+           <string>Pause emulation when on background</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </widget>
      </item>

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -503,9 +503,11 @@ void GMainWindow::OnLoseFocus(Qt::ApplicationState state) {
     if (ui.action_Pause->isEnabled() &&
         (state == Qt::ApplicationSuspended ||
          state & (Qt::ApplicationHidden | Qt::ApplicationInactive))) {
+        auto_paused = true;
         OnPauseGame();
     }
-    if (ui.action_Start->isEnabled() && state == Qt::ApplicationActive) {
+    if (ui.action_Start->isEnabled() && auto_paused && state == Qt::ApplicationActive) {
+        auto_paused = false;
         OnStartGame();
     }
 }

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -500,15 +500,17 @@ void GMainWindow::RestoreUIState() {
 }
 
 void GMainWindow::OnLoseFocus(Qt::ApplicationState state) {
-    if (ui.action_Pause->isEnabled() &&
-        (state == Qt::ApplicationSuspended ||
-         state & (Qt::ApplicationHidden | Qt::ApplicationInactive))) {
-        auto_paused = true;
-        OnPauseGame();
-    }
-    if (ui.action_Start->isEnabled() && auto_paused && state == Qt::ApplicationActive) {
-        auto_paused = false;
-        OnStartGame();
+    if (UISettings::values.pause_when_on_background) {
+        if (ui.action_Pause->isEnabled() &&
+            (state == Qt::ApplicationSuspended ||
+             state & (Qt::ApplicationHidden | Qt::ApplicationInactive))) {
+            auto_paused = true;
+            OnPauseGame();
+        }
+        if (ui.action_Start->isEnabled() && auto_paused && state == Qt::ApplicationActive) {
+            auto_paused = false;
+            OnStartGame();
+        }
     }
 }
 

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -499,8 +499,8 @@ void GMainWindow::RestoreUIState() {
     statusBar()->setVisible(ui.action_Show_Status_Bar->isChecked());
 }
 
-void GMainWindow::OnLoseFocus(Qt::ApplicationState state) {
-    if (UISettings::values.pause_when_on_background) {
+void GMainWindow::OnAppFocusStateChanged(Qt::ApplicationState state) {
+    if (UISettings::values.pause_when_in_background) {
         if (ui.action_Pause->isEnabled() &&
             (state == Qt::ApplicationSuspended ||
              state & (Qt::ApplicationHidden | Qt::ApplicationInactive))) {
@@ -2030,7 +2030,7 @@ int main(int argc, char* argv[]) {
     main_window.show();
 
     QObject::connect(&app, &QGuiApplication::applicationStateChanged, &main_window,
-                     &GMainWindow::OnLoseFocus);
+                     &GMainWindow::OnAppFocusStateChanged);
 
     int result = app.exec();
     detached_tasks.WaitForAllTasks();

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -499,6 +499,17 @@ void GMainWindow::RestoreUIState() {
     statusBar()->setVisible(ui.action_Show_Status_Bar->isChecked());
 }
 
+void GMainWindow::OnLoseFocus(Qt::ApplicationState state) {
+    if (ui.action_Pause->isEnabled() &&
+        (state == Qt::ApplicationSuspended ||
+         state & (Qt::ApplicationHidden | Qt::ApplicationInactive))) {
+        OnPauseGame();
+    }
+    if (ui.action_Start->isEnabled() && state == Qt::ApplicationActive) {
+        OnStartGame();
+    }
+}
+
 void GMainWindow::ConnectWidgetEvents() {
     connect(game_list, &GameList::GameChosen, this, &GMainWindow::OnGameListLoadFile);
     connect(game_list, &GameList::OpenDirectory, this, &GMainWindow::OnGameListOpenDirectory);
@@ -2013,6 +2024,10 @@ int main(int argc, char* argv[]) {
     Core::System::GetInstance().RegisterSoftwareKeyboard(std::make_shared<QtKeyboard>(main_window));
 
     main_window.show();
+
+    QObject::connect(&app, &QGuiApplication::applicationStateChanged, &main_window,
+                     &GMainWindow::OnLoseFocus);
+
     int result = app.exec();
     detached_tasks.WaitForAllTasks();
     return result;

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -503,12 +503,15 @@ void GMainWindow::OnAppFocusStateChanged(Qt::ApplicationState state) {
     if (!UISettings::values.pause_when_in_background) {
         return;
     }
+    if (state != Qt::ApplicationHidden && state != Qt::ApplicationInactive &&
+        state != Qt::ApplicationActive) {
+        LOG_DEBUG(Frontend, "ApplicationState unusual flag: {} ", state);
+    }
     if (ui.action_Pause->isEnabled() &&
         (state & (Qt::ApplicationHidden | Qt::ApplicationInactive))) {
         auto_paused = true;
         OnPauseGame();
-    }
-    if (ui.action_Start->isEnabled() && auto_paused && state == Qt::ApplicationActive) {
+    } else if (ui.action_Start->isEnabled() && auto_paused && state == Qt::ApplicationActive) {
         auto_paused = false;
         OnStartGame();
     }

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -500,17 +500,17 @@ void GMainWindow::RestoreUIState() {
 }
 
 void GMainWindow::OnAppFocusStateChanged(Qt::ApplicationState state) {
-    if (UISettings::values.pause_when_in_background) {
-        if (ui.action_Pause->isEnabled() &&
-            (state == Qt::ApplicationSuspended ||
-             state & (Qt::ApplicationHidden | Qt::ApplicationInactive))) {
-            auto_paused = true;
-            OnPauseGame();
-        }
-        if (ui.action_Start->isEnabled() && auto_paused && state == Qt::ApplicationActive) {
-            auto_paused = false;
-            OnStartGame();
-        }
+    if (!UISettings::values.pause_when_in_background) {
+        return;
+    }
+    if (ui.action_Pause->isEnabled() &&
+        (state & (Qt::ApplicationHidden | Qt::ApplicationInactive))) {
+        auto_paused = true;
+        OnPauseGame();
+    }
+    if (ui.action_Start->isEnabled() && auto_paused && state == Qt::ApplicationActive) {
+        auto_paused = false;
+        OnStartGame();
     }
 }
 

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -233,6 +233,8 @@ private:
     // The path to the game currently running
     QString game_path;
 
+    bool auto_paused = false;
+
     // Movie
     bool movie_record_on_start = false;
     QString movie_record_path;

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -68,6 +68,8 @@ public:
     GameList* game_list;
     std::unique_ptr<DiscordRPC::DiscordInterface> discord_rpc;
 
+public slots:
+    void OnLoseFocus(Qt::ApplicationState state);
 signals:
 
     /**

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -69,7 +69,7 @@ public:
     std::unique_ptr<DiscordRPC::DiscordInterface> discord_rpc;
 
 public slots:
-    void OnLoseFocus(Qt::ApplicationState state);
+    void OnAppFocusStateChanged(Qt::ApplicationState state);
 signals:
 
     /**

--- a/src/citra_qt/uisettings.h
+++ b/src/citra_qt/uisettings.h
@@ -72,6 +72,7 @@ struct Values {
 
     bool confirm_before_closing;
     bool first_start;
+    bool pause_when_on_background;
 
     bool updater_found;
     bool update_on_close;

--- a/src/citra_qt/uisettings.h
+++ b/src/citra_qt/uisettings.h
@@ -72,7 +72,7 @@ struct Values {
 
     bool confirm_before_closing;
     bool first_start;
-    bool pause_when_on_background;
+    bool pause_when_in_background;
 
     bool updater_found;
     bool update_on_close;


### PR DESCRIPTION
Addresses and should close #4481. 

Creates the option for Citra to pause when it's in the background or minimized.

![Pause when on background](https://user-images.githubusercontent.com/29167336/64902320-accdca00-d67b-11e9-8d41-1b2e47709758.PNG)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4930)
<!-- Reviewable:end -->
