### PR TITLE
Remove unused boost header

### DIFF
--- a/src/core/hle/kernel/wait_object.h
+++ b/src/core/hle/kernel/wait_object.h
@@ -7,7 +7,6 @@
 #include <functional>
 #include <memory>
 #include <vector>
-#include <boost/smart_ptr/intrusive_ptr.hpp>
 #include "common/common_types.h"
 #include "core/hle/kernel/object.h"
 


### PR DESCRIPTION
`intrusive_ptr` isn't used in the code anymore, so this shouldn't be needed anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4933)
<!-- Reviewable:end -->
