### PR TITLE
Remove boost headers not currently used

### DIFF
--- a/src/core/hle/kernel/mutex.cpp
+++ b/src/core/hle/kernel/mutex.cpp
@@ -4,7 +4,6 @@
 
 #include <map>
 #include <vector>
-#include <boost/range/algorithm_ext/erase.hpp>
 #include "common/assert.h"
 #include "core/core.h"
 #include "core/hle/kernel/errors.h"

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -8,7 +8,6 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <boost/container/flat_map.hpp>
 #include <boost/container/flat_set.hpp>
 #include "common/common_types.h"
 #include "common/thread_queue_list.h"

--- a/src/video_core/swrasterizer/clipper.cpp
+++ b/src/video_core/swrasterizer/clipper.cpp
@@ -6,7 +6,6 @@
 #include <array>
 #include <cstddef>
 #include <boost/container/static_vector.hpp>
-#include <boost/container/vector.hpp>
 #include "common/bit_field.h"
 #include "common/common_types.h"
 #include "common/logging/log.h"


### PR DESCRIPTION
Other boost headers that may not be needed anymore.
I checked flat_map manually, was added on commit 17b29d8865ea4d96c18f7e1671bd6d0f01eab95f and removed on commit fd95b6ee2606da4cd47c5f2916ad3b4f86c0e0f4 . (~~Is there a better way to refer to them?~~ nvm, github links them properly)
vector seems to be there since before github tracking, so I don't know.
erase doesn't look like it was ever needed (the code uses the flat_set erase public method), was introduced in commit 4e84df8be30c5bac65e4c4e9faf07bf0fc3fb33a

(This can be saved for a rainy day)
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4934)
<!-- Reviewable:end -->
