### PR TITLE
citra_qt/RecordDialog: close when OK is clicked

### DIFF
--- a/src/citra_qt/debugger/ipc/record_dialog.cpp
+++ b/src/citra_qt/debugger/ipc/record_dialog.cpp
@@ -52,6 +52,7 @@ RecordDialog::RecordDialog(QWidget* parent, const IPCDebugger::RequestRecord& re
 
     connect(ui->cmdbufSelection, qOverload<int>(&QComboBox::currentIndexChanged), this,
             &RecordDialog::UpdateCmdbufDisplay);
+    connect(ui->okButton, &QPushButton::clicked, this, &QDialog::close);
 }
 
 RecordDialog::~RecordDialog() = default;


### PR DESCRIPTION
The OK button didn't do anything before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4946)
<!-- Reviewable:end -->
