### PR TITLE
Add FPS to SDL title bar

### DIFF
--- a/src/citra/citra.cpp
+++ b/src/citra/citra.cpp
@@ -346,8 +346,6 @@ int main(int argc, char** argv) {
 
     Core::System& system{Core::System::GetInstance()};
 
-    SCOPE_EXIT({ system.Shutdown(); });
-
     const Core::System::ResultStatus load_result{system.Load(*emu_window, filepath)};
 
     switch (load_result) {
@@ -417,6 +415,8 @@ int main(int argc, char** argv) {
     if (system.VideoDumper().IsDumping()) {
         system.VideoDumper().StopDumping();
     }
+
+    system.Shutdown();
 
     detached_tasks.WaitForAllTasks();
     return 0;

--- a/src/citra/emu_window/emu_window_sdl2.cpp
+++ b/src/citra/emu_window/emu_window_sdl2.cpp
@@ -13,6 +13,7 @@
 #include "common/logging/log.h"
 #include "common/scm_rev.h"
 #include "core/3ds.h"
+#include "core/core.h"
 #include "core/settings.h"
 #include "input_common/keyboard.h"
 #include "input_common/main.h"
@@ -241,6 +242,16 @@ void EmuWindow_SDL2::PollEvents() {
         default:
             break;
         }
+    }
+
+    const u32 current_time = SDL_GetTicks();
+    if (current_time > last_time + 2000) {
+        const auto results = Core::System::GetInstance().GetAndResetPerfStats();
+        const auto title = fmt::format(
+            "Citra {} | {}-{} | FPS: {:.0f} ({:.0%})", Common::g_build_fullname,
+            Common::g_scm_branch, Common::g_scm_desc, results.game_fps, results.emulation_speed);
+        SDL_SetWindowTitle(render_window, title.c_str());
+        last_time = current_time;
     }
 }
 

--- a/src/citra/emu_window/emu_window_sdl2.h
+++ b/src/citra/emu_window/emu_window_sdl2.h
@@ -70,4 +70,7 @@ private:
     using SDL_GLContext = void*;
     /// The OpenGL context associated with the window
     SDL_GLContext gl_context;
+
+    /// Keeps track of how often to update the title bar during gameplay
+    u32 last_time = 0;
 };


### PR DESCRIPTION
Also fix a small issue with incorrect shutdown ordering in SDL.
Previously the system would still be running so the telemetry task
didn't launch and detached_tasks would assert(count == 0)

I'm adding this so that we can visually have people test to see if theres a performance difference between SDL and Qt. We techincally could have them turn on frametime logging, but thats still *slightly* unreliable since we learned about how SwapBuffers() isn't included in frametime calculations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4950)
<!-- Reviewable:end -->
