### PR TITLE
citra_qt/main.ui: remove unused actions "Load Symbol Map..." and "Select Game Directory..."

### DIFF
--- a/src/citra_qt/main.ui
+++ b/src/citra_qt/main.ui
@@ -187,11 +187,6 @@
     <string>Install CIA...</string>
    </property>
   </action>
-  <action name="action_Load_Symbol_Map">
-   <property name="text">
-    <string>Load Symbol Map...</string>
-   </property>
-  </action>
   <action name="action_Exit">
    <property name="text">
     <string>E&amp;xit</string>
@@ -271,14 +266,6 @@
    </property>
    <property name="text">
     <string>Show Status Bar</string>
-   </property>
-  </action>
-  <action name="action_Select_Game_List_Root">
-   <property name="text">
-    <string>Select Game Directory...</string>
-   </property>
-   <property name="toolTip">
-    <string>Selects a folder to display in the game list</string>
    </property>
   </action>
   <action name="action_Create_Pica_Surface_Viewer">


### PR DESCRIPTION
Self-explanatory. No UI changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4953)
<!-- Reviewable:end -->
