### PR TITLE
yuzu/game_list&multiplayer: Specify string conversions explicitly

### DIFF
--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -27,7 +27,6 @@
 #include "citra_qt/game_list_worker.h"
 #include "citra_qt/main.h"
 #include "citra_qt/uisettings.h"
-#include "common/common_paths.h"
 #include "common/logging/log.h"
 #include "core/file_sys/archive_extsavedata.h"
 #include "core/file_sys/archive_source_sd_savedata.h"
@@ -54,7 +53,7 @@ bool GameListSearchField::KeyReleaseEater::eventFilter(QObject* obj, QEvent* eve
                 return QObject::eventFilter(obj, event);
             } else {
                 gamelist->search_field->edit_filter->clear();
-                edit_filter_text = "";
+                edit_filter_text.clear();
             }
             break;
         }
@@ -67,9 +66,9 @@ bool GameListSearchField::KeyReleaseEater::eventFilter(QObject* obj, QEvent* eve
                 QString file_path = gamelist->getLastFilterResultItem();
 
                 // To avoid loading error dialog loops while confirming them using enter
-                // Also users usually want to run a diffrent game after closing one
-                gamelist->search_field->edit_filter->setText("");
-                edit_filter_text = "";
+                // Also users usually want to run a different game after closing one
+                gamelist->search_field->edit_filter->clear();
+                edit_filter_text.clear();
                 emit gamelist->GameChosen(file_path);
             } else {
                 return QObject::eventFilter(obj, event);
@@ -96,7 +95,7 @@ void GameListSearchField::setFilterResult(int visible, int total) {
         result_text = tr("results");
     }
     label_filter_result->setText(
-        QString("%1 %2 %3 %4").arg(visible).arg(result_of_text).arg(total).arg(result_text));
+        QStringLiteral("%1 %2 %3 %4").arg(visible).arg(result_of_text).arg(total).arg(result_text));
 }
 
 QString GameList::getLastFilterResultItem() const {
@@ -119,7 +118,7 @@ QString GameList::getLastFilterResultItem() const {
 }
 
 void GameListSearchField::clear() {
-    edit_filter->setText("");
+    edit_filter->clear();
 }
 
 void GameListSearchField::setFocus() {
@@ -129,25 +128,26 @@ void GameListSearchField::setFocus() {
 }
 
 GameListSearchField::GameListSearchField(GameList* parent) : QWidget{parent} {
-    KeyReleaseEater* keyReleaseEater = new KeyReleaseEater(parent);
+    auto* const key_release_eater = new KeyReleaseEater(parent);
     layout_filter = new QHBoxLayout;
     layout_filter->setMargin(8);
     label_filter = new QLabel;
     label_filter->setText(tr("Filter:"));
     edit_filter = new QLineEdit;
-    edit_filter->setText("");
+    edit_filter->clear();
     edit_filter->setPlaceholderText(tr("Enter pattern to filter"));
-    edit_filter->installEventFilter(keyReleaseEater);
+    edit_filter->installEventFilter(key_release_eater);
     edit_filter->setClearButtonEnabled(true);
     connect(edit_filter, &QLineEdit::textChanged, parent, &GameList::onTextChanged);
     label_filter_result = new QLabel;
     button_filter_close = new QToolButton(this);
-    button_filter_close->setText("X");
+    button_filter_close->setText(QStringLiteral("X"));
     button_filter_close->setCursor(Qt::ArrowCursor);
-    button_filter_close->setStyleSheet("QToolButton{ border: none; padding: 0px; color: "
-                                       "#000000; font-weight: bold; background: #F0F0F0; }"
-                                       "QToolButton:hover{ border: none; padding: 0px; color: "
-                                       "#EEEEEE; font-weight: bold; background: #E81123}");
+    button_filter_close->setStyleSheet(
+        QStringLiteral("QToolButton{ border: none; padding: 0px; color: "
+                       "#000000; font-weight: bold; background: #F0F0F0; }"
+                       "QToolButton:hover{ border: none; padding: 0px; color: "
+                       "#EEEEEE; font-weight: bold; background: #E81123}"));
     connect(button_filter_close, &QToolButton::clicked, parent, &GameList::onFilterCloseClicked);
     layout_filter->setSpacing(10);
     layout_filter->addWidget(label_filter);
@@ -167,7 +167,7 @@ GameListSearchField::GameListSearchField(GameList* parent) : QWidget{parent} {
  */
 static bool ContainsAllWords(const QString& haystack, const QString& userinput) {
     const QStringList userinput_split =
-        userinput.split(' ', QString::SplitBehavior::SkipEmptyParts);
+        userinput.split(QLatin1Char{' '}, QString::SplitBehavior::SkipEmptyParts);
 
     return std::all_of(userinput_split.begin(), userinput_split.end(),
                        [&haystack](const QString& s) { return haystack.contains(s); });
@@ -183,16 +183,16 @@ void GameList::onItemExpanded(const QModelIndex& item) {
 }
 
 // Event in order to filter the gamelist after editing the searchfield
-void GameList::onTextChanged(const QString& newText) {
-    const int folderCount = tree_view->model()->rowCount();
-    QString edit_filter_text = newText.toLower();
+void GameList::onTextChanged(const QString& new_text) {
+    const int folder_count = tree_view->model()->rowCount();
+    QString edit_filter_text = new_text.toLower();
     QStandardItem* folder;
     int children_total = 0;
 
     // If the searchfield is empty every item is visible
     // Otherwise the filter gets applied
     if (edit_filter_text.isEmpty()) {
-        for (int i = 0; i < folderCount; ++i) {
+        for (int i = 0; i < folder_count; ++i) {
             folder = item_model->item(i, 0);
             const QModelIndex folder_index = folder->index();
             const int children_count = folder->rowCount();
@@ -204,7 +204,7 @@ void GameList::onTextChanged(const QString& newText) {
         search_field->setFilterResult(children_total, children_total);
     } else {
         int result_count = 0;
-        for (int i = 0; i < folderCount; ++i) {
+        for (int i = 0; i < folder_count; ++i) {
             folder = item_model->item(i, 0);
             const QModelIndex folder_index = folder->index();
             const int children_count = folder->rowCount();
@@ -213,10 +213,9 @@ void GameList::onTextChanged(const QString& newText) {
                 const QStandardItem* child = folder->child(j, 0);
                 const QString file_path =
                     child->data(GameListItemPath::FullPathRole).toString().toLower();
-                QString file_name = file_path.mid(file_path.lastIndexOf("/") + 1);
                 const QString file_title =
                     child->data(GameListItemPath::LongTitleRole).toString().toLower();
-                const QString file_programmid =
+                const QString file_program_id =
                     child->data(GameListItemPath::ProgramIdRole).toString().toLower();
 
                 // Only items which filename in combination with its title contains all words
@@ -224,8 +223,11 @@ void GameList::onTextChanged(const QString& newText) {
                 // The search is case insensitive because of toLower()
                 // I decided not to use Qt::CaseInsensitive in containsAllWords to prevent
                 // multiple conversions of edit_filter_text for each game in the gamelist
-                if (ContainsAllWords(file_name.append(' ').append(file_title), edit_filter_text) ||
-                    (file_programmid.count() == 16 && edit_filter_text.contains(file_programmid))) {
+                const QString file_name =
+                    file_path.mid(file_path.lastIndexOf(QLatin1Char{'/'}) + 1) + QLatin1Char{' '} +
+                    file_title;
+                if (ContainsAllWords(file_name, edit_filter_text) ||
+                    (file_program_id.count() == 16 && edit_filter_text.contains(file_program_id))) {
                     tree_view->setRowHidden(j, folder_index, false);
                     ++result_count;
                 } else {
@@ -243,20 +245,23 @@ void GameList::onUpdateThemedIcons() {
 
         switch (child->data(GameListItem::TypeRole).value<GameListItemType>()) {
         case GameListItemType::InstalledDir:
-            child->setData(QIcon::fromTheme("sd_card").pixmap(48), Qt::DecorationRole);
+            child->setData(QIcon::fromTheme(QStringLiteral("sd_card")).pixmap(48),
+                           Qt::DecorationRole);
             break;
         case GameListItemType::SystemDir:
-            child->setData(QIcon::fromTheme("chip").pixmap(48), Qt::DecorationRole);
+            child->setData(QIcon::fromTheme(QStringLiteral("chip")).pixmap(48), Qt::DecorationRole);
             break;
         case GameListItemType::CustomDir: {
             const UISettings::GameDir* game_dir =
                 child->data(GameListDir::GameDirRole).value<UISettings::GameDir*>();
-            const QString icon_name = QFileInfo::exists(game_dir->path) ? "folder" : "bad_folder";
+            const QString icon_name = QFileInfo::exists(game_dir->path)
+                                          ? QStringLiteral("folder")
+                                          : QStringLiteral("bad_folder");
             child->setData(QIcon::fromTheme(icon_name).pixmap(48), Qt::DecorationRole);
             break;
         }
         case GameListItemType::AddDir:
-            child->setData(QIcon::fromTheme("plus").pixmap(48), Qt::DecorationRole);
+            child->setData(QIcon::fromTheme(QStringLiteral("plus")).pixmap(48), Qt::DecorationRole);
             break;
         }
     }
@@ -286,7 +291,7 @@ GameList::GameList(GMainWindow* parent) : QWidget{parent} {
     tree_view->setSortingEnabled(true);
     tree_view->setEditTriggers(QHeaderView::NoEditTriggers);
     tree_view->setContextMenuPolicy(Qt::CustomContextMenu);
-    tree_view->setStyleSheet("QTreeView{ border: none; }");
+    tree_view->setStyleSheet(QStringLiteral("QTreeView{ border: none; }"));
 
     item_model->insertColumns(0, COLUMN_COUNT);
     item_model->setHeaderData(COLUMN_NAME, Qt::Horizontal, tr("Name"));
@@ -561,7 +566,7 @@ void GameList::AddPermDirPopup(QMenu& context_menu, QModelIndex selected) {
 }
 
 void GameList::LoadCompatibilityList() {
-    QFile compat_list{":compatibility_list/compatibility_list.json"};
+    QFile compat_list{QStringLiteral(":compatibility_list/compatibility_list.json")};
 
     if (!compat_list.open(QFile::ReadOnly | QFile::Text)) {
         LOG_ERROR(Frontend, "Unable to open game compatibility list");
@@ -579,25 +584,27 @@ void GameList::LoadCompatibilityList() {
         return;
     }
 
-    const QString string_content = content;
-    QJsonDocument json = QJsonDocument::fromJson(string_content.toUtf8());
-    QJsonArray arr = json.array();
+    const QJsonDocument json = QJsonDocument::fromJson(content);
+    const QJsonArray arr = json.array();
 
-    for (const QJsonValueRef value : arr) {
-        QJsonObject game = value.toObject();
+    for (const QJsonValue value : arr) {
+        const QJsonObject game = value.toObject();
+        const QString compatibility_key = QStringLiteral("compatibility");
 
-        if (game.contains("compatibility") && game["compatibility"].isDouble()) {
-            int compatibility = game["compatibility"].toInt();
-            QString directory = game["directory"].toString();
-            QJsonArray ids = game["releases"].toArray();
+        if (!game.contains(compatibility_key) || !game[compatibility_key].isDouble()) {
+            continue;
+        }
 
-            for (const QJsonValueRef id_ref : ids) {
-                QJsonObject id_object = id_ref.toObject();
-                QString id = id_object["id"].toString();
-                compatibility_list.emplace(
-                    id.toUpper().toStdString(),
-                    std::make_pair(QString::number(compatibility), directory));
-            }
+        const int compatibility = game[compatibility_key].toInt();
+        const QString directory = game[QStringLiteral("directory")].toString();
+        const QJsonArray ids = game[QStringLiteral("releases")].toArray();
+
+        for (const QJsonValue id_ref : ids) {
+            const QJsonObject id_object = id_ref.toObject();
+            const QString id = id_object[QStringLiteral("id")].toString();
+
+            compatibility_list.emplace(id.toUpper().toStdString(),
+                                       std::make_pair(QString::number(compatibility), directory));
         }
     }
 }
@@ -645,8 +652,9 @@ void GameList::LoadInterfaceLayout() {
     item_model->sort(header->sortIndicatorSection(), header->sortIndicatorOrder());
 }
 
-const QStringList GameList::supported_file_extensions = {"3ds", "3dsx", "elf", "axf",
-                                                         "cci", "cxi",  "app"};
+const QStringList GameList::supported_file_extensions = {
+    QStringLiteral("3ds"), QStringLiteral("3dsx"), QStringLiteral("elf"), QStringLiteral("axf"),
+    QStringLiteral("cci"), QStringLiteral("cxi"),  QStringLiteral("app")};
 
 void GameList::RefreshGameDirectory() {
     if (!UISettings::values.game_dirs.isEmpty() && current_worker != nullptr) {
@@ -670,7 +678,7 @@ QString GameList::FindGameByProgramID(QStandardItem* current_item, u64 program_i
                 return path;
         }
     }
-    return "";
+    return QString();
 }
 
 GameListPlaceholder::GameListPlaceholder(GMainWindow* parent) : QWidget{parent} {
@@ -681,7 +689,7 @@ GameListPlaceholder::GameListPlaceholder(GMainWindow* parent) : QWidget{parent} 
     image = new QLabel;
     text = new QLabel;
     layout->setAlignment(Qt::AlignCenter);
-    image->setPixmap(QIcon::fromTheme("plus_folder").pixmap(200));
+    image->setPixmap(QIcon::fromTheme(QStringLiteral("plus_folder")).pixmap(200));
 
     text->setText(tr("Double-click to add a new folder to the game list"));
     QFont font = text->font();
@@ -698,7 +706,7 @@ GameListPlaceholder::GameListPlaceholder(GMainWindow* parent) : QWidget{parent} 
 GameListPlaceholder::~GameListPlaceholder() = default;
 
 void GameListPlaceholder::onUpdateThemedIcons() {
-    image->setPixmap(QIcon::fromTheme("plus_folder").pixmap(200));
+    image->setPixmap(QIcon::fromTheme(QStringLiteral("plus_folder")).pixmap(200));
 }
 
 void GameListPlaceholder::mouseDoubleClickEvent(QMouseEvent* event) {

--- a/src/citra_qt/game_list.h
+++ b/src/citra_qt/game_list.h
@@ -81,7 +81,7 @@ signals:
 
 private slots:
     void onItemExpanded(const QModelIndex& item);
-    void onTextChanged(const QString& newText);
+    void onTextChanged(const QString& new_text);
     void onFilterCloseClicked();
     void onUpdateThemedIcons();
 

--- a/src/citra_qt/game_list_p.h
+++ b/src/citra_qt/game_list_p.h
@@ -244,13 +244,13 @@ public:
         };
         // clang-format off
         static const std::map<QString, CompatStatus> status_data = {
-        {"0",  {"#5c93ed", QT_TR_NOOP("Perfect"),    QT_TR_NOOP("Game functions flawless with no audio or graphical glitches, all tested functionality works as intended without\nany workarounds needed.")}},
-        {"1",  {"#47d35c", QT_TR_NOOP("Great"),      QT_TR_NOOP("Game functions with minor graphical or audio glitches and is playable from start to finish. May require some\nworkarounds.")}},
-        {"2",  {"#94b242", QT_TR_NOOP("Okay"),       QT_TR_NOOP("Game functions with major graphical or audio glitches, but game is playable from start to finish with\nworkarounds.")}},
-        {"3",  {"#f2d624", QT_TR_NOOP("Bad"),        QT_TR_NOOP("Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches\neven with workarounds.")}},
-        {"4",  {"#ff0000", QT_TR_NOOP("Intro/Menu"), QT_TR_NOOP("Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start\nScreen.")}},
-        {"5",  {"#828282", QT_TR_NOOP("Won't Boot"), QT_TR_NOOP("The game crashes when attempting to startup.")}},
-        {"99", {"#000000", QT_TR_NOOP("Not Tested"), QT_TR_NOOP("The game has not yet been tested.")}}};
+        {QStringLiteral("0"),  {QStringLiteral("#5c93ed"), QT_TR_NOOP("Perfect"),    QT_TR_NOOP("Game functions flawless with no audio or graphical glitches, all tested functionality works as intended without\nany workarounds needed.")}},
+        {QStringLiteral("1"),  {QStringLiteral("#47d35c"), QT_TR_NOOP("Great"),      QT_TR_NOOP("Game functions with minor graphical or audio glitches and is playable from start to finish. May require some\nworkarounds.")}},
+        {QStringLiteral("2"),  {QStringLiteral("#94b242"), QT_TR_NOOP("Okay"),       QT_TR_NOOP("Game functions with major graphical or audio glitches, but game is playable from start to finish with\nworkarounds.")}},
+        {QStringLiteral("3"),  {QStringLiteral("#f2d624"), QT_TR_NOOP("Bad"),        QT_TR_NOOP("Game functions, but with major graphical or audio glitches. Unable to progress in specific areas due to glitches\neven with workarounds.")}},
+        {QStringLiteral("4"),  {QStringLiteral("#ff0000"), QT_TR_NOOP("Intro/Menu"), QT_TR_NOOP("Game is completely unplayable due to major graphical or audio glitches. Unable to progress past the Start\nScreen.")}},
+        {QStringLiteral("5"),  {QStringLiteral("#828282"), QT_TR_NOOP("Won't Boot"), QT_TR_NOOP("The game crashes when attempting to startup.")}},
+        {QStringLiteral("99"), {QStringLiteral("#000000"), QT_TR_NOOP("Not Tested"), QT_TR_NOOP("The game has not yet been tested.")}}};
         // clang-format on
 
         auto iterator = status_data.find(compatibility);

--- a/src/citra_qt/game_list_worker.cpp
+++ b/src/citra_qt/game_list_worker.cpp
@@ -91,7 +91,7 @@ void GameListWorker::AddFstEntriesToGameList(const std::string& dir_path, unsign
             auto it = FindMatchingCompatibilityEntry(compatibility_list, program_id);
 
             // The game list uses this as compatibility number for untested games
-            QString compatibility("99");
+            QString compatibility(QStringLiteral("99"));
             if (it != compatibility_list.end())
                 compatibility = it->second.first;
 
@@ -121,7 +121,7 @@ void GameListWorker::AddFstEntriesToGameList(const std::string& dir_path, unsign
 void GameListWorker::run() {
     stop_processing = false;
     for (UISettings::GameDir& game_dir : game_dirs) {
-        if (game_dir.path == "INSTALLED") {
+        if (game_dir.path == QStringLiteral("INSTALLED")) {
             QString games_path =
                 QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir)) +
                 "Nintendo "
@@ -138,7 +138,7 @@ void GameListWorker::run() {
             emit DirEntryReady({game_list_dir});
             AddFstEntriesToGameList(games_path.toStdString(), 2, game_list_dir);
             AddFstEntriesToGameList(demos_path.toStdString(), 2, game_list_dir);
-        } else if (game_dir.path == "SYSTEM") {
+        } else if (game_dir.path == QStringLiteral("SYSTEM")) {
             QString path =
                 QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::NANDDir)) +
                 "00000000000000000000000000000000/title/00040010";

--- a/src/citra_qt/multiplayer/chat_room.cpp
+++ b/src/citra_qt/multiplayer/chat_room.cpp
@@ -44,10 +44,10 @@ public:
         }
 
         // Handle pings at the beginning and end of message
-        QString fixed_message = QString(" %1 ").arg(message);
-        if (fixed_message.contains(QString(" @%1 ").arg(cur_nickname)) ||
+        QString fixed_message = QStringLiteral(" %1 ").arg(message);
+        if (fixed_message.contains(QStringLiteral(" @%1 ").arg(cur_nickname)) ||
             (!cur_username.isEmpty() &&
-             fixed_message.contains(QString(" @%1 ").arg(cur_username)))) {
+             fixed_message.contains(QStringLiteral(" @%1 ").arg(cur_username)))) {
 
             contains_ping = true;
         } else {
@@ -66,20 +66,20 @@ public:
         if (username.isEmpty() || username == nickname) {
             name = nickname;
         } else {
-            name = QString("%1 (%2)").arg(nickname, username);
+            name = QStringLiteral("%1 (%2)").arg(nickname, username);
         }
 
         QString style, text_color;
         if (ContainsPing()) {
             // Add a background color to these messages
-            style = QString("background-color: %1").arg(ping_color);
+            style = QStringLiteral("background-color: %1").arg(QString::fromStdString(ping_color));
             // Add a font color
-            text_color = "color='#000000'";
+            text_color = QStringLiteral("color='#000000'");
         }
 
-        return QString("[%1] <font color='%2'>&lt;%3&gt;</font> <font style='%4' "
-                       "%5>%6</font>")
-            .arg(timestamp, color, name.toHtmlEscaped(), style, text_color,
+        return QStringLiteral("[%1] <font color='%2'>&lt;%3&gt;</font> <font style='%4' "
+                              "%5>%6</font>")
+            .arg(timestamp, QString::fromStdString(color), name.toHtmlEscaped(), style, text_color,
                  message.toHtmlEscaped());
     }
 
@@ -106,7 +106,8 @@ public:
     }
 
     QString GetSystemChatMessage() const {
-        return QString("[%1] <font color='%2'>* %3</font>").arg(timestamp, system_color, message);
+        return QStringLiteral("[%1] <font color='%2'>* %3</font>")
+            .arg(timestamp, QString::fromStdString(system_color), message);
     }
 
 private:
@@ -146,9 +147,9 @@ public:
         if (username.isEmpty() || username == nickname) {
             name = nickname;
         } else {
-            name = QString("%1 (%2)").arg(nickname, username);
+            name = QStringLiteral("%1 (%2)").arg(nickname, username);
         }
-        return QString("%1\n      %2").arg(name, data(GameNameRole).toString());
+        return QStringLiteral("%1\n      %2").arg(name, data(GameNameRole).toString());
     }
 };
 
@@ -288,8 +289,8 @@ void ChatRoom::OnStatusMessageReceive(const Network::StatusMessageEntry& status_
     if (status_message.username.empty() || status_message.username == status_message.nickname) {
         name = QString::fromStdString(status_message.nickname);
     } else {
-        name = QString("%1 (%2)").arg(QString::fromStdString(status_message.nickname),
-                                      QString::fromStdString(status_message.username));
+        name = QStringLiteral("%1 (%2)").arg(QString::fromStdString(status_message.nickname),
+                                             QString::fromStdString(status_message.username));
     }
     QString message;
     switch (status_message.type) {
@@ -353,7 +354,8 @@ void ChatRoom::UpdateIconDisplay() {
         if (icon_cache.count(avatar_url)) {
             item->setData(icon_cache.at(avatar_url), Qt::DecorationRole);
         } else {
-            item->setData(QIcon::fromTheme("no_avatar").pixmap(48), Qt::DecorationRole);
+            item->setData(QIcon::fromTheme(QStringLiteral("no_avatar")).pixmap(48),
+                          Qt::DecorationRole);
         }
     }
 }
@@ -373,7 +375,7 @@ void ChatRoom::SetPlayerList(const Network::RoomMember::MemberList& member_list)
             const QUrl url(QString::fromStdString(member.avatar_url));
             QFuture<std::string> future = QtConcurrent::run([url] {
                 WebService::Client client(
-                    QString("%1://%2").arg(url.scheme(), url.host()).toStdString(), "", "");
+                    QStringLiteral("%1://%2").arg(url.scheme(), url.host()).toStdString(), "", "");
                 auto result = client.GetImage(url.path().toStdString(), true);
                 if (result.returned_data.empty()) {
                     LOG_ERROR(WebService, "Failed to get avatar");
@@ -426,7 +428,7 @@ void ChatRoom::PopupContextMenu(const QPoint& menu_location) {
         QAction* view_profile_action = context_menu.addAction(tr("View Profile"));
         connect(view_profile_action, &QAction::triggered, [username] {
             QDesktopServices::openUrl(
-                QUrl(QString("https://community.citra-emu.org/u/%1").arg(username)));
+                QUrl(QStringLiteral("https://community.citra-emu.org/u/%1").arg(username)));
         });
     }
 

--- a/src/citra_qt/multiplayer/lobby.cpp
+++ b/src/citra_qt/multiplayer/lobby.cpp
@@ -99,8 +99,9 @@ void Lobby::RetranslateUi() {
 
 QString Lobby::PasswordPrompt() {
     bool ok;
-    const QString text = QInputDialog::getText(this, tr("Password Required to Join"),
-                                               tr("Password:"), QLineEdit::Password, "", &ok);
+    const QString text =
+        QInputDialog::getText(this, tr("Password Required to Join"), tr("Password:"),
+                              QLineEdit::Password, QString(), &ok);
     return ok ? text : QString();
 }
 
@@ -181,7 +182,7 @@ void Lobby::OnJoinRoom(const QModelIndex& source) {
 void Lobby::ResetModel() {
     model->clear();
     model->insertColumns(0, Column::TOTAL);
-    model->setHeaderData(Column::EXPAND, Qt::Horizontal, "", Qt::DisplayRole);
+    model->setHeaderData(Column::EXPAND, Qt::Horizontal, QString(), Qt::DisplayRole);
     model->setHeaderData(Column::ROOM_NAME, Qt::Horizontal, tr("Room Name"), Qt::DisplayRole);
     model->setHeaderData(Column::GAME_NAME, Qt::Horizontal, tr("Preferred Game"), Qt::DisplayRole);
     model->setHeaderData(Column::HOST, Qt::Horizontal, tr("Host"), Qt::DisplayRole);

--- a/src/citra_qt/multiplayer/lobby_p.h
+++ b/src/citra_qt/multiplayer/lobby_p.h
@@ -42,7 +42,7 @@ public:
     QVariant data(int role) const override {
         if (role == Qt::DecorationRole) {
             bool has_password = data(PasswordRole).toBool();
-            return has_password ? QIcon::fromTheme("lock").pixmap(16) : QIcon();
+            return has_password ? QIcon::fromTheme(QStringLiteral("lock")).pixmap(16) : QIcon();
         }
         if (role != Qt::DisplayRole) {
             return LobbyItem::data(role);
@@ -69,7 +69,7 @@ public:
             return LobbyItem::data(role);
         }
         auto description = data(DescriptionRole).toString();
-        description.prepend("Description: ");
+        description.prepend(QStringLiteral("Description: "));
         return description;
     }
 
@@ -157,7 +157,7 @@ public:
         if (username.isEmpty() || username == nickname) {
             return nickname;
         } else {
-            return QString("%1 (%2)").arg(nickname, username);
+            return QStringLiteral("%1 (%2)").arg(nickname, username);
         }
     }
     u64 GetTitleId() const {
@@ -192,8 +192,8 @@ public:
             return LobbyItem::data(role);
         }
         auto members = data(MemberListRole).toList();
-        return QString("%1 / %2").arg(QString::number(members.size()),
-                                      data(MaxPlayerRole).toString());
+        return QStringLiteral("%1 / %2").arg(QString::number(members.size()),
+                                             data(MaxPlayerRole).toString());
     }
 
     bool operator<(const QStandardItem& other) const override {
@@ -225,7 +225,7 @@ public:
         bool first = true;
         for (const auto& member : members) {
             if (!first)
-                out += '\n';
+                out.append(QStringLiteral("\n"));
             const auto& m = member.value<LobbyMember>();
             if (m.GetGameName().isEmpty()) {
                 out += QString(QObject::tr("%1 is not playing a game")).arg(m.GetName());

--- a/src/citra_qt/multiplayer/state.cpp
+++ b/src/citra_qt/multiplayer/state.cpp
@@ -46,7 +46,7 @@ MultiplayerState::MultiplayerState(QWidget* parent, QStandardItemModel* game_lis
     status_icon = new ClickableLabel(this);
     status_text->setToolTip(tr("Current connection status"));
     status_text->setText(tr("Not Connected. Click here to find a room!"));
-    status_icon->setPixmap(QIcon::fromTheme("disconnected").pixmap(16));
+    status_icon->setPixmap(QIcon::fromTheme(QStringLiteral("disconnected")).pixmap(16));
 
     connect(status_text, &ClickableLabel::clicked, this, &MultiplayerState::OnOpenNetworkRoom);
     connect(status_icon, &ClickableLabel::clicked, this, &MultiplayerState::OnOpenNetworkRoom);
@@ -113,12 +113,12 @@ void MultiplayerState::OnNetworkStateChanged(const Network::RoomMember::State& s
         state == Network::RoomMember::State::Moderator) {
 
         OnOpenNetworkRoom();
-        status_icon->setPixmap(QIcon::fromTheme("connected").pixmap(16));
+        status_icon->setPixmap(QIcon::fromTheme(QStringLiteral("connected")).pixmap(16));
         status_text->setText(tr("Connected"));
         leave_room->setEnabled(true);
         show_room->setEnabled(true);
     } else {
-        status_icon->setPixmap(QIcon::fromTheme("disconnected").pixmap(16));
+        status_icon->setPixmap(QIcon::fromTheme(QStringLiteral("disconnected")).pixmap(16));
         status_text->setText(tr("Not Connected"));
         leave_room->setEnabled(false);
         show_room->setEnabled(false);
@@ -183,13 +183,14 @@ void MultiplayerState::OnAnnounceFailed(const Common::WebResult& result) {
 
 void MultiplayerState::UpdateThemedIcons() {
     if (show_notification) {
-        status_icon->setPixmap(QIcon::fromTheme("connected_notification").pixmap(16));
+        status_icon->setPixmap(
+            QIcon::fromTheme(QStringLiteral("connected_notification")).pixmap(16));
     } else if (current_state == Network::RoomMember::State::Joined ||
                current_state == Network::RoomMember::State::Moderator) {
 
-        status_icon->setPixmap(QIcon::fromTheme("connected").pixmap(16));
+        status_icon->setPixmap(QIcon::fromTheme(QStringLiteral("connected")).pixmap(16));
     } else {
-        status_icon->setPixmap(QIcon::fromTheme("disconnected").pixmap(16));
+        status_icon->setPixmap(QIcon::fromTheme(QStringLiteral("disconnected")).pixmap(16));
     }
     if (client_room)
         client_room->UpdateIconDisplay();
@@ -245,13 +246,13 @@ void MultiplayerState::ShowNotification() {
         return; // Do not show notification if the chat window currently has focus
     show_notification = true;
     QApplication::alert(nullptr);
-    status_icon->setPixmap(QIcon::fromTheme("connected_notification").pixmap(16));
+    status_icon->setPixmap(QIcon::fromTheme(QStringLiteral("connected_notification")).pixmap(16));
     status_text->setText(tr("New Messages Received"));
 }
 
 void MultiplayerState::HideNotification() {
     show_notification = false;
-    status_icon->setPixmap(QIcon::fromTheme("connected").pixmap(16));
+    status_icon->setPixmap(QIcon::fromTheme(QStringLiteral("connected")).pixmap(16));
     status_text->setText(tr("Connected"));
 }
 

--- a/src/citra_qt/multiplayer/validation.h
+++ b/src/citra_qt/multiplayer/validation.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <QRegExp>
+#include <QString>
 #include <QValidator>
 
 class Validation {
@@ -29,18 +30,18 @@ public:
 
 private:
     /// room name can be alphanumeric and " " "_" "." and "-" and must have a size of 4-20
-    QRegExp room_name_regex = QRegExp("^[a-zA-Z0-9._- ]{4,20}$");
+    QRegExp room_name_regex = QRegExp(QStringLiteral("^[a-zA-Z0-9._- ]{4,20}$"));
     QRegExpValidator room_name;
 
     /// nickname can be alphanumeric and " " "_" "." and "-" and must have a size of 4-20
-    QRegExp nickname_regex = QRegExp("^[a-zA-Z0-9._- ]{4,20}$");
+    QRegExp nickname_regex = QRegExp(QStringLiteral("^[a-zA-Z0-9._- ]{4,20}$"));
     QRegExpValidator nickname;
 
     /// ipv4 address only
     // TODO remove this when we support hostnames in direct connect
-    QRegExp ip_regex = QRegExp(
+    QRegExp ip_regex = QRegExp(QStringLiteral(
         "(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|"
-        "2[0-4][0-9]|25[0-5])");
+        "2[0-4][0-9]|25[0-5])"));
     QRegExpValidator ip;
 
     /// port must be between 0 and 65535

--- a/src/citra_qt/updater/updater_p.h
+++ b/src/citra_qt/updater/updater_p.h
@@ -59,8 +59,8 @@ private:
 
     bool launch_ui_on_exit = false;
 
-    QStringList run_arguments{"--updater"};
-    QStringList silent_arguments{"--silentUpdate"};
+    QStringList run_arguments{QStringLiteral("--updater")};
+    QStringList silent_arguments{QStringLiteral("--silentUpdate")};
 
     friend class Updater;
 };


### PR DESCRIPTION
Also see https://github.com/yuzu-emu/yuzu/pull/2503.

Makes all top-level source files compilable with implicit Qt string conversions disabled. Now all that's left is to address main.cpp, which I'll do in a follow-up PR, as it's quite a large file, and would like to have those changes reviewed separately. The follow up change will also finally pass compilation flags that disable implicit Qt string conversions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4992)
<!-- Reviewable:end -->
