### PR TITLE
dedicated_room: fix crash (count != 0) when closing the room

### DIFF
--- a/src/dedicated_room/citra-room.cpp
+++ b/src/dedicated_room/citra-room.cpp
@@ -329,17 +329,7 @@ int main(int argc, char** argv) {
             std::string in;
             std::cin >> in;
             if (in.size() > 0) {
-                if (announce) {
-                    announce_session->Stop();
-                }
-                announce_session.reset();
-                // Save the ban list
-                if (!ban_list_file.empty()) {
-                    SaveBanList(room->GetBanList(), ban_list_file);
-                }
-                room->Destroy();
-                Network::Shutdown();
-                return 0;
+                break;
             }
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }


### PR DESCRIPTION
Instead of adding a `detached_tasks.WaitForAllTasks();` to the `if (in.size() > 0)`, this PR changes the `if (in.size() > 0)` body to a `break;` because when the `while (room->GetState() == Network::Room::State::Open)` ends, all the current code in the `if (in.size() > 0)` and the `detached_tasks.WaitForAllTasks();` runs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/4998)
<!-- Reviewable:end -->
