### PR TITLE
Fix moderation by room host in dedicated rooms

### DIFF
--- a/src/dedicated_room/citra-room.cpp
+++ b/src/dedicated_room/citra-room.cpp
@@ -302,6 +302,7 @@ int main(int argc, char** argv) {
             std::cout << "Hosting a public room\n\n";
             Settings::values.web_api_url = web_api_url;
             Settings::values.citra_username = UsernameFromDisplayToken(token);
+            username = Settings::values.citra_username;
             Settings::values.citra_token = TokenFromDisplayToken(token);
         } else {
             std::cout << "Hosting a public room\n\n";


### PR DESCRIPTION
Username passed to `room->Create` was always empty if using the new token format.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5002)
<!-- Reviewable:end -->
