### PR TITLE
video_core: remove MSVC hack comment on TevStageConfigRaw

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_gen.h
+++ b/src/video_core/renderer_opengl/gl_shader_gen.h
@@ -27,11 +27,7 @@ enum Attributes {
     ATTRIBUTE_VIEW,
 };
 
-// NOTE: MSVC15 (Update 2) doesn't think `delete`'d constructors and operators are TC.
-//       This makes BitField not TC when used in a union or struct so we have to resort
-//       to this ugly hack.
-//       Once that bug is fixed we can use Pica::Regs::TevStageConfig here.
-//       Doesn't include const_color because we don't sync it, see comment in BuildFromRegs()
+// Doesn't include const_color because we don't sync it, see comment in BuildFromRegs()
 struct TevStageConfigRaw {
     u32 sources_raw;
     u32 modifiers_raw;


### PR DESCRIPTION
This comment is no longer applicable. TexStageConfigRaw remains unchanged to avoid hashing const_color.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5004)
<!-- Reviewable:end -->
