### PR TITLE
Port yuzu-emu/yuzu#3123: "common/logging: Silence no return value warnings"

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -253,8 +253,10 @@ const char* GetLogClassName(Class log_class) {
 #undef CLS
 #undef SUB
     case Class::Count:
-        UNREACHABLE();
+        break;
     }
+    UNREACHABLE();
+    return "Invalid";
 }
 
 const char* GetLevelName(Level log_level) {
@@ -269,9 +271,11 @@ const char* GetLevelName(Level log_level) {
         LVL(Error);
         LVL(Critical);
     case Level::Count:
-        UNREACHABLE();
+        break;
     }
 #undef LVL
+    UNREACHABLE();
+    return "Invalid";
 }
 
 void SetGlobalFilter(const Filter& filter) {


### PR DESCRIPTION
See yuzu-emu/yuzu#3123 for more details.

**Original description**:
Silence no return value warnings with asserts enabled and disabled on common logging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5006)
<!-- Reviewable:end -->
