### PR TITLE
applets/swkbd: Remove text memory clearing

### DIFF
--- a/src/core/hle/applets/swkbd.cpp
+++ b/src/core/hle/applets/swkbd.cpp
@@ -99,9 +99,6 @@ ResultCode SoftwareKeyboard::StartImpl(Service::APT::AppletStartupParameter cons
     memcpy(&config, parameter.buffer.data(), parameter.buffer.size());
     text_memory = std::static_pointer_cast<Kernel::SharedMemory, Kernel::Object>(parameter.object);
 
-    // TODO(Subv): Verify if this is the correct behavior
-    memset(text_memory->GetPointer(), 0, text_memory->GetSize());
-
     DrawScreenKeyboard();
 
     using namespace Frontend;
@@ -121,7 +118,8 @@ void SoftwareKeyboard::Update() {
     using namespace Frontend;
     const KeyboardData& data = frontend_applet->ReceiveData();
     std::u16string text = Common::UTF8ToUTF16(data.text);
-    memcpy(text_memory->GetPointer(), text.c_str(), text.length() * sizeof(char16_t));
+    // Include a null terminator
+    memcpy(text_memory->GetPointer(), text.c_str(), (text.length() + 1) * sizeof(char16_t));
     switch (config.num_buttons_m1) {
     case SoftwareKeyboardButtonConfig::SingleButton:
         config.return_code = SoftwareKeyboardResult::D0Click;


### PR DESCRIPTION
The text shared memory wasn't supposed to be cleared according to my comparison with the LLE swkbd. This can cause issues in certain games such as Harvest Moon.

A null terminator is added to the text copied to mark the end of the string.

Fixes #4178.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5016)
<!-- Reviewable:end -->
