### PR TITLE
Interlaced stereo 3d option

### DIFF
--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -131,10 +131,13 @@ void Config::ReadValues() {
         sdl2_config->GetInteger("Renderer", "render_3d", 0));
     Settings::values.factor_3d =
         static_cast<u8>(sdl2_config->GetInteger("Renderer", "factor_3d", 0));
-    Settings::values.pp_shader_name = sdl2_config->GetString(
-        "Renderer", "pp_shader_name",
-        (Settings::values.render_3d == Settings::StereoRenderOption::Anaglyph) ? "dubois (builtin)"
-                                                                               : "none (builtin)");
+    std::string default_shader = "none (builtin)";
+    if (Settings::values.render_3d == Settings::StereoRenderOption::Anaglyph)
+        default_shader = "dubois (builtin)";
+    else if (Settings::values.render_3d == Settings::StereoRenderOption::Interlaced)
+        default_shader = "horizontal (builtin)";
+    Settings::values.pp_shader_name =
+        sdl2_config->GetString("Renderer", "pp_shader_name", default_shader);
     Settings::values.filter_mode = sdl2_config->GetBoolean("Renderer", "filter_mode", true);
 
     Settings::values.bg_red = static_cast<float>(sdl2_config->GetReal("Renderer", "bg_red", 0.0));

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -137,7 +137,7 @@ bg_blue =
 bg_green =
 
 # Whether and how Stereoscopic 3D should be rendered
-# 0 (default): Off, 1: Side by Side, 2: Anaglyph
+# 0 (default): Off, 1: Side by Side, 2: Anaglyph, 3: Interlaced
 render_3d =
 
 # Change 3D Intensity

--- a/src/citra_qt/configuration/configure_enhancements.cpp
+++ b/src/citra_qt/configuration/configure_enhancements.cpp
@@ -21,8 +21,7 @@ ConfigureEnhancements::ConfigureEnhancements(QWidget* parent)
     connect(ui->render_3d_combobox,
             static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
             [this](int currentIndex) {
-                updateShaders(static_cast<Settings::StereoRenderOption>(currentIndex) ==
-                              Settings::StereoRenderOption::Anaglyph);
+                updateShaders(static_cast<Settings::StereoRenderOption>(currentIndex));
             });
 
     connect(ui->bg_button, &QPushButton::clicked, this, [this] {
@@ -49,7 +48,7 @@ void ConfigureEnhancements::SetConfiguration() {
     ui->resolution_factor_combobox->setCurrentIndex(Settings::values.resolution_factor);
     ui->render_3d_combobox->setCurrentIndex(static_cast<int>(Settings::values.render_3d));
     ui->factor_3d->setValue(Settings::values.factor_3d);
-    updateShaders(Settings::values.render_3d == Settings::StereoRenderOption::Anaglyph);
+    updateShaders(Settings::values.render_3d);
     ui->toggle_linear_filter->setChecked(Settings::values.filter_mode);
     ui->layout_combobox->setCurrentIndex(static_cast<int>(Settings::values.layout_option));
     ui->swap_screen->setChecked(Settings::values.swap_screen);
@@ -64,17 +63,20 @@ void ConfigureEnhancements::SetConfiguration() {
     ui->bg_button->setIcon(color_icon);
 }
 
-void ConfigureEnhancements::updateShaders(bool anaglyph) {
+void ConfigureEnhancements::updateShaders(Settings::StereoRenderOption stereo_option) {
     ui->shader_combobox->clear();
 
-    if (anaglyph)
+    if (stereo_option == Settings::StereoRenderOption::Anaglyph)
         ui->shader_combobox->addItem("dubois (builtin)");
+    else if (stereo_option == Settings::StereoRenderOption::Interlaced)
+        ui->shader_combobox->addItem("horizontal (builtin)");
     else
         ui->shader_combobox->addItem("none (builtin)");
 
     ui->shader_combobox->setCurrentIndex(0);
 
-    for (const auto& shader : OpenGL::GetPostProcessingShaderList(anaglyph)) {
+    for (const auto& shader : OpenGL::GetPostProcessingShaderList(
+             stereo_option == Settings::StereoRenderOption::Anaglyph)) {
         ui->shader_combobox->addItem(QString::fromStdString(shader));
         if (Settings::values.pp_shader_name == shader)
             ui->shader_combobox->setCurrentIndex(ui->shader_combobox->count() - 1);

--- a/src/citra_qt/configuration/configure_enhancements.h
+++ b/src/citra_qt/configuration/configure_enhancements.h
@@ -6,6 +6,10 @@
 
 #include <QWidget>
 
+namespace Settings {
+enum class StereoRenderOption;
+}
+
 namespace Ui {
 class ConfigureEnhancements;
 }
@@ -22,7 +26,7 @@ public:
     void SetConfiguration();
 
 private:
-    void updateShaders(bool anaglyph);
+    void updateShaders(Settings::StereoRenderOption stereo_option);
 
     Ui::ConfigureEnhancements* ui;
     QColor bg_color;

--- a/src/citra_qt/configuration/configure_enhancements.ui
+++ b/src/citra_qt/configuration/configure_enhancements.ui
@@ -152,6 +152,11 @@
             <string>Anaglyph</string>
            </property>
           </item>
+          <item>
+           <property name="text">
+            <string>Interlaced</string>
+           </property>
+          </item>
          </widget>
         </item>
        </layout>

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -32,7 +32,7 @@ enum class MicInputType {
     Static,
 };
 
-enum class StereoRenderOption { Off, SideBySide, Anaglyph };
+enum class StereoRenderOption { Off, SideBySide, Anaglyph, Interlaced };
 
 namespace NativeButton {
 enum Values {

--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -77,9 +77,9 @@ private:
                                      const GPU::Regs::FramebufferConfig& framebuffer);
     void DrawScreens(const Layout::FramebufferLayout& layout);
     void DrawSingleScreenRotated(const ScreenInfo& screen_info, float x, float y, float w, float h);
-    void DrawSingleScreenAnaglyphRotated(const ScreenInfo& screen_info_l,
-                                         const ScreenInfo& screen_info_r, float x, float y, float w,
-                                         float h);
+    void DrawSingleScreenStereoRotated(const ScreenInfo& screen_info_l,
+                                       const ScreenInfo& screen_info_r, float x, float y, float w,
+                                       float h);
     void UpdateFramerate();
 
     // Loads framebuffer from emulated memory into the display information structure


### PR DESCRIPTION
This adds support for interlaced 3d (common in passive 3d supported monitors and tv screens).

Images:

![citra_interlaced_ui](https://user-images.githubusercontent.com/15224722/70966561-492bb200-2059-11ea-87b9-63c9650aef3f.JPG)


![citra_interlaced_game](https://user-images.githubusercontent.com/15224722/70966554-4466fe00-2059-11ea-8309-edad575a85e5.JPG)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5018)
<!-- Reviewable:end -->
