### PR TITLE
Runtime Load MediaFoundation dlls on Windows

### DIFF
--- a/src/audio_core/CMakeLists.txt
+++ b/src/audio_core/CMakeLists.txt
@@ -45,7 +45,9 @@ if(ENABLE_MF)
         hle/wmf_decoder_utils.cpp
         hle/wmf_decoder_utils.h
     )
-    target_link_libraries(audio_core PRIVATE mf.lib mfplat.lib mfuuid.lib)
+    # We dynamically load the required symbols from mf.dll and mfplat.dll but mfuuid is not a dll
+    # just a static library of GUIDS so include that one directly.
+    target_link_libraries(audio_core PRIVATE mfuuid.lib)
     target_compile_definitions(audio_core PUBLIC HAVE_MF)
 elseif(ENABLE_FFMPEG_AUDIO_DECODER)
     target_sources(audio_core PRIVATE

--- a/src/audio_core/hle/decoder.h
+++ b/src/audio_core/hle/decoder.h
@@ -56,6 +56,9 @@ class DecoderBase {
 public:
     virtual ~DecoderBase();
     virtual std::optional<BinaryResponse> ProcessRequest(const BinaryRequest& request) = 0;
+    /// Return true if this Decoder can be loaded. Return false if the system cannot create the
+    /// decoder
+    virtual bool IsValid() const = 0;
 };
 
 class NullDecoder final : public DecoderBase {
@@ -63,6 +66,9 @@ public:
     NullDecoder();
     ~NullDecoder() override;
     std::optional<BinaryResponse> ProcessRequest(const BinaryRequest& request) override;
+    bool IsValid() const override {
+        return true;
+    }
 };
 
 } // namespace AudioCore::HLE

--- a/src/audio_core/hle/ffmpeg_decoder.cpp
+++ b/src/audio_core/hle/ffmpeg_decoder.cpp
@@ -12,6 +12,9 @@ public:
     explicit Impl(Memory::MemorySystem& memory);
     ~Impl();
     std::optional<BinaryResponse> ProcessRequest(const BinaryRequest& request);
+    bool IsValid() const {
+        return initalized;
+    }
 
 private:
     std::optional<BinaryResponse> Initalize(const BinaryRequest& request);
@@ -259,6 +262,10 @@ FFMPEGDecoder::~FFMPEGDecoder() = default;
 
 std::optional<BinaryResponse> FFMPEGDecoder::ProcessRequest(const BinaryRequest& request) {
     return impl->ProcessRequest(request);
+}
+
+bool FFMPEGDecoder::IsValid() const {
+    return impl->IsValid();
 }
 
 } // namespace AudioCore::HLE

--- a/src/audio_core/hle/ffmpeg_decoder.h
+++ b/src/audio_core/hle/ffmpeg_decoder.h
@@ -13,6 +13,7 @@ public:
     explicit FFMPEGDecoder(Memory::MemorySystem& memory);
     ~FFMPEGDecoder() override;
     std::optional<BinaryResponse> ProcessRequest(const BinaryRequest& request) override;
+    bool IsValid() const override;
 
 private:
     class Impl;

--- a/src/audio_core/hle/wmf_decoder.h
+++ b/src/audio_core/hle/wmf_decoder.h
@@ -13,6 +13,7 @@ public:
     explicit WMFDecoder(Memory::MemorySystem& memory);
     ~WMFDecoder() override;
     std::optional<BinaryResponse> ProcessRequest(const BinaryRequest& request) override;
+    bool IsValid() const override;
 
 private:
     class Impl;


### PR DESCRIPTION
This should resolve issues people have with mf.dll missing errors by changing mf.dll from loadtime loading to runtime loading. If the user doesn't have Media Foundation it will try FFMpeg (if the compilation option for that was turned on) and lastly it'll fall back to the null decoder option if all else fails. I haven't throughly tested the MF -> FFMPEG fallback but it should be *good enough* i hope.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5020)
<!-- Reviewable:end -->
