### PR TITLE
Use the correct register length for index_array

### DIFF
--- a/src/video_core/regs_pipeline.h
+++ b/src/video_core/regs_pipeline.h
@@ -138,7 +138,8 @@ struct PipelineRegs {
         };
 
         union {
-            BitField<0, 31, u32> offset; // relative to base attribute address
+            BitField<0, 28, u32> offset; // relative to base attribute address
+            BitField<28, 3, u32> unused;
             BitField<31, 1, IndexFormat> format;
         };
     } index_array;


### PR DESCRIPTION
The index_array can't possible be 31 bits long as that would index
out of bounds memory. According to 3dbrew, this should be 28

Fixes https://github.com/citra-emu/citra/issues/3984 and maybe a few other crashes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5023)
<!-- Reviewable:end -->
