### PR TITLE
Reenable AAC FFMPEG decoding

### DIFF
--- a/src/audio_core/hle/ffmpeg_decoder.cpp
+++ b/src/audio_core/hle/ffmpeg_decoder.cpp
@@ -13,7 +13,7 @@ public:
     ~Impl();
     std::optional<BinaryResponse> ProcessRequest(const BinaryRequest& request);
     bool IsValid() const {
-        return initalized;
+        return have_ffmpeg_dl;
     }
 
 private:


### PR DESCRIPTION
Simple cut/paste issue where initialized is only set to true when the
emulation attempts to init the Binary Pipe, but we used it to test if
the FFMPEG decoder was valid and disabled it if it wasn't. Just return
the value of have_ffmpeg_dl instead so when dynamic loading is added
it'll still work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5027)
<!-- Reviewable:end -->
