### PR TITLE
Add missing vsync telemetry field

### DIFF
--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -192,6 +192,7 @@ void TelemetrySession::AddInitialInfo(Loader::AppLoader& app_loader) {
              Settings::values.shaders_accurate_mul);
     AddField(Telemetry::FieldType::UserConfig, "Renderer_UseShaderJit",
              Settings::values.use_shader_jit);
+    AddField(Telemetry::FieldType::UserConfig, "Renderer_UseVsync", Settings::values.use_vsync_new);
     AddField(Telemetry::FieldType::UserConfig, "Renderer_FilterMode", Settings::values.filter_mode);
     AddField(Telemetry::FieldType::UserConfig, "Renderer_Render3d",
              static_cast<int>(Settings::values.render_3d));


### PR DESCRIPTION
Was removed as part of #4940 but readded again. Brings it back with the same name as before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5028)
<!-- Reviewable:end -->
