### PR TITLE
[WIP] Remove line that caused GPU to stall

### DIFF
--- a/src/audio_core/dsp_interface.cpp
+++ b/src/audio_core/dsp_interface.cpp
@@ -45,7 +45,7 @@ void DspInterface::OutputFrame(StereoFrame16& frame) {
     fifo.Push(frame.data(), frame.size());
 
     if (Core::System::GetInstance().VideoDumper().IsDumping()) {
-        Core::System::GetInstance().VideoDumper().AddAudioFrame(frame);
+        Core::System::GetInstance().VideoDumper().AddAudioFrame(std::move(frame));
     }
 }
 
@@ -56,7 +56,7 @@ void DspInterface::OutputSample(std::array<s16, 2> sample) {
     fifo.Push(&sample, 1);
 
     if (Core::System::GetInstance().VideoDumper().IsDumping()) {
-        Core::System::GetInstance().VideoDumper().AddAudioSample(sample);
+        Core::System::GetInstance().VideoDumper().AddAudioSample(std::move(sample));
     }
 }
 

--- a/src/core/dumping/backend.h
+++ b/src/core/dumping/backend.h
@@ -30,9 +30,9 @@ public:
     virtual ~Backend();
     virtual bool StartDumping(const std::string& path, const std::string& format,
                               const Layout::FramebufferLayout& layout) = 0;
-    virtual void AddVideoFrame(const VideoFrame& frame) = 0;
-    virtual void AddAudioFrame(const AudioCore::StereoFrame16& frame) = 0;
-    virtual void AddAudioSample(const std::array<s16, 2>& sample) = 0;
+    virtual void AddVideoFrame(VideoFrame&& frame) = 0;
+    virtual void AddAudioFrame(AudioCore::StereoFrame16&& frame) = 0;
+    virtual void AddAudioSample(std::array<s16, 2>&& sample) = 0;
     virtual void StopDumping() = 0;
     virtual bool IsDumping() const = 0;
     virtual Layout::FramebufferLayout GetLayout() const = 0;
@@ -45,9 +45,9 @@ public:
                       const Layout::FramebufferLayout& /*layout*/) override {
         return false;
     }
-    void AddVideoFrame(const VideoFrame& /*frame*/) override {}
-    void AddAudioFrame(const AudioCore::StereoFrame16& /*frame*/) override {}
-    void AddAudioSample(const std::array<s16, 2>& /*sample*/) override {}
+    void AddVideoFrame(VideoFrame&& /*frame*/) override {}
+    void AddAudioFrame(AudioCore::StereoFrame16&& /*frame*/) override {}
+    void AddAudioSample(std::array<s16, 2>&& /*sample*/) override {}
     void StopDumping() override {}
     bool IsDumping() const override {
         return false;

--- a/src/core/dumping/ffmpeg_backend.cpp
+++ b/src/core/dumping/ffmpeg_backend.cpp
@@ -450,13 +450,13 @@ bool FFmpegBackend::StartDumping(const std::string& path, const std::string& for
     return true;
 }
 
-void FFmpegBackend::AddVideoFrame(const VideoFrame& frame) {
+void FFmpegBackend::AddVideoFrame(VideoFrame&& frame) {
     event1.Wait();
     video_frame_buffers[next_buffer] = std::move(frame);
     event2.Set();
 }
 
-void FFmpegBackend::AddAudioFrame(const AudioCore::StereoFrame16& frame) {
+void FFmpegBackend::AddAudioFrame(AudioCore::StereoFrame16&& frame) {
     std::array<std::array<s16, 160>, 2> refactored_frame;
     for (std::size_t i = 0; i < frame.size(); i++) {
         refactored_frame[0][i] = frame[i][0];
@@ -470,7 +470,7 @@ void FFmpegBackend::AddAudioFrame(const AudioCore::StereoFrame16& frame) {
     CheckAudioBuffer();
 }
 
-void FFmpegBackend::AddAudioSample(const std::array<s16, 2>& sample) {
+void FFmpegBackend::AddAudioSample(std::array<s16, 2>&& sample) {
     for (auto i : {0, 1}) {
         audio_buffers[i].push_back(sample[i]);
     }

--- a/src/core/dumping/ffmpeg_backend.h
+++ b/src/core/dumping/ffmpeg_backend.h
@@ -163,9 +163,9 @@ public:
     ~FFmpegBackend() override;
     bool StartDumping(const std::string& path, const std::string& format,
                       const Layout::FramebufferLayout& layout) override;
-    void AddVideoFrame(const VideoFrame& frame) override;
-    void AddAudioFrame(const AudioCore::StereoFrame16& frame) override;
-    void AddAudioSample(const std::array<s16, 2>& sample) override;
+    void AddVideoFrame(VideoFrame&& frame) override;
+    void AddAudioFrame(AudioCore::StereoFrame16&& frame) override;
+    void AddAudioSample(std::array<s16, 2>&& sample) override;
     void StopDumping() override;
     bool IsDumping() const override;
     Layout::FramebufferLayout GetLayout() const override;

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -447,14 +447,15 @@ void RendererOpenGL::RenderVideoDumping() {
         }
 
         const auto& layout = Core::System::GetInstance().VideoDumper().GetLayout();
-        glBindFramebuffer(GL_READ_FRAMEBUFFER, frame_dumping_framebuffer.handle);
         glBindFramebuffer(GL_DRAW_FRAMEBUFFER, frame_dumping_framebuffer.handle);
         DrawScreens(layout);
 
+        // Start the async transfer for the current frame data from GPU -> CPU
         glBindBuffer(GL_PIXEL_PACK_BUFFER, frame_dumping_pbos[current_pbo].handle);
         glReadPixels(0, 0, layout.width, layout.height, GL_BGRA, GL_UNSIGNED_INT_8_8_8_8_REV, 0);
-        glBindBuffer(GL_PIXEL_PACK_BUFFER, frame_dumping_pbos[next_pbo].handle);
 
+        // Finalize the previous frame's data transfer and submit it to the VideoDumper
+        glBindBuffer(GL_PIXEL_PACK_BUFFER, frame_dumping_pbos[next_pbo].handle);
         GLubyte* pixels = static_cast<GLubyte*>(glMapBuffer(GL_PIXEL_PACK_BUFFER, GL_READ_ONLY));
         VideoDumper::VideoFrame frame_data{layout.width, layout.height, pixels};
         Core::System::GetInstance().VideoDumper().AddVideoFrame(frame_data);

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -89,7 +89,7 @@ public:
         glBindFramebuffer(GL_FRAMEBUFFER, frame->present.handle);
         glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER,
                                   frame->color.handle);
-        if (!glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE) {
+        if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
             LOG_CRITICAL(Render_OpenGL, "Failed to recreate present FBO!");
         }
         glBindFramebuffer(GL_DRAW_FRAMEBUFFER, previous_draw_fbo);
@@ -115,7 +115,7 @@ public:
         state.Apply();
         glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER,
                                   frame->color.handle);
-        if (!glCheckFramebufferStatus(GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE) {
+        if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
             LOG_CRITICAL(Render_OpenGL, "Failed to recreate render FBO!");
         }
         prev_state.Apply();
@@ -458,7 +458,7 @@ void RendererOpenGL::RenderVideoDumping() {
         glBindBuffer(GL_PIXEL_PACK_BUFFER, frame_dumping_pbos[next_pbo].handle);
         GLubyte* pixels = static_cast<GLubyte*>(glMapBuffer(GL_PIXEL_PACK_BUFFER, GL_READ_ONLY));
         VideoDumper::VideoFrame frame_data{layout.width, layout.height, pixels};
-        Core::System::GetInstance().VideoDumper().AddVideoFrame(frame_data);
+        Core::System::GetInstance().VideoDumper().AddVideoFrame(std::move(frame_data));
 
         glUnmapBuffer(GL_PIXEL_PACK_BUFFER);
         glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);


### PR DESCRIPTION
For some reason, this line wasn't needed, but also caused the pipeline to stall
when downloading the pixels and mapping the previous frame. I don't really understand
it but it gave a hefty speed increase in video dumping.

EDIT: This breaks video dumping cuz i'm bad at life

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5031)
<!-- Reviewable:end -->
