### PR TITLE
qt: do not use an invalid update smdh

### DIFF
--- a/src/citra_qt/game_list_worker.cpp
+++ b/src/citra_qt/game_list_worker.cpp
@@ -60,28 +60,24 @@ void GameListWorker::AddFstEntriesToGameList(const std::string& dir_path, unsign
             u64 extdata_id = 0;
             loader->ReadExtdataId(extdata_id);
 
-            std::vector<u8> smdh = [program_id, &loader]() -> std::vector<u8> {
-                std::vector<u8> original_smdh;
-                loader->ReadIcon(original_smdh);
-
-                if (program_id < 0x0004000000000000 || program_id > 0x00040000FFFFFFFF)
-                    return original_smdh;
-
+            std::vector<u8> smdh;
+            // Look for an update icon if available
+            if (!(program_id & ~0x00040000FFFFFFFF)) {
                 std::string update_path = Service::AM::GetTitleContentPath(
-                    Service::FS::MediaType::SDMC, program_id + 0x0000000E00000000);
+                    Service::FS::MediaType::SDMC, program_id | 0x0000000E00000000);
+                if (FileUtil::Exists(update_path)) {
+                    std::unique_ptr<Loader::AppLoader> update_loader =
+                        Loader::GetLoader(update_path);
+                    if (update_loader) {
+                        update_loader->ReadIcon(smdh);
+                    }
+                }
+            }
 
-                if (!FileUtil::Exists(update_path))
-                    return original_smdh;
-
-                std::unique_ptr<Loader::AppLoader> update_loader = Loader::GetLoader(update_path);
-
-                if (!update_loader)
-                    return original_smdh;
-
-                std::vector<u8> update_smdh;
-                update_loader->ReadIcon(update_smdh);
-                return update_smdh;
-            }();
+            if (!Loader::IsValidSMDH(smdh)) {
+                // Read the original smdh if there is no valid update smdh
+                loader->ReadIcon(smdh);
+            }
 
             if (!Loader::IsValidSMDH(smdh) && UISettings::values.game_list_hide_no_icon) {
                 // Skip this invalid entry


### PR DESCRIPTION
If the game has an update but the update does not have a valid SMDH, it will now default to the original application's SMDH. 
This should fix some problems where games do not appear on the list that should.
Possibly related to #4117 or #3658 however those both seem to be present before this filtering was implemented.
**Before (Hide Titles without Icon off):**
![image](https://user-images.githubusercontent.com/28246325/71143747-452a9c00-21e1-11ea-85fd-257b22ab6dc4.png)
**After:**
![image](https://user-images.githubusercontent.com/28246325/71143831-8e7aeb80-21e1-11ea-871b-84aabf9b1286.png)
*graphical glitches unrelated*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5033)
<!-- Reviewable:end -->
