### PR TITLE
fix c++ standard flag for msvc

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -52,7 +52,7 @@ workflows:
                 sudo apt remove cmake -y
                 sudo apt purge --auto-remove cmake -y
                 sudo apt install ninja-build -y
-                version=3.8
+                version=3.10
                 build=2
                 mkdir ~/temp
                 cd ~/temp
@@ -97,7 +97,7 @@ workflows:
                 sudo apt remove cmake -y
                 sudo apt purge --auto-remove cmake -y
                 sudo apt install ninja-build -y
-                version=3.8
+                version=3.10
                 build=2
                 mkdir ~/temp
                 cd ~/temp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,7 +38,6 @@ if (MSVC)
         /Zo
         /permissive-
         /EHsc
-        /std:c++latest
         /volatile:iso
         /Zc:externConstexpr
         /Zc:inline


### PR DESCRIPTION
~~C++17 is already specified through cmake~~
apparently this doesn't work before CMake 10, but the below warning is still fixed by specifying /std:c++17
fixes MSVC spamming the following:
> \source\repos\citra\out\build\x64-Debug\cl : Command line warning D9025: overriding '/std:c++latest' with '/std:c++17'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5047)
<!-- Reviewable:end -->
