### PR TITLE
HLE Audio: Increase frame position by input buffer sample rate

### DIFF
--- a/src/audio_core/hle/source.cpp
+++ b/src/audio_core/hle/source.cpp
@@ -267,7 +267,9 @@ void Source::GenerateFrame() {
             break;
         }
     }
-    state.next_sample_number += static_cast<u32>(frame_position);
+    // TODO(jroweboy): Keep track of frame_position independently so that it doesn't lose precision
+    // over time
+    state.next_sample_number += static_cast<u32>(frame_position * state.rate_multiplier);
 
     state.filters.ProcessFrame(current_frame);
 }

--- a/src/audio_core/interpolate.cpp
+++ b/src/audio_core/interpolate.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 Citra Emulator Project
+﻿// Copyright 2016 Citra Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/audio_core/interpolate.cpp
+++ b/src/audio_core/interpolate.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright 2016 Citra Emulator Project
+// Copyright 2016 Citra Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 


### PR DESCRIPTION
Currently the frame position moves ahead by the number of samples
output, but thats a fixed number based on the 3ds native sample rate.
Instead, based on a homebrew by cyuubi and looking at the lle audio,
this sample position should be moved forward by the number of samples
from the input buffer that was read, based on the buffer's sample rate.

This might fix the following issues related to audio playback/sync in citra 

- https://github.com/citra-emu/citra/issues/4649 
- https://github.com/citra-emu/citra/issues/5045 
- less likely, but it might fix games with issues in HLE but not LLE (won't affect games that don't work in LLE)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5049)
<!-- Reviewable:end -->
