### PR TITLE
Use immutable storage when available

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
+#include <cmath>
 #include <cstring>
 #include <iterator>
 #include <memory>
@@ -327,8 +328,14 @@ static void AllocateSurfaceTexture(GLuint texture, const FormatTuple& format_tup
     cur_state.Apply();
     glActiveTexture(GL_TEXTURE0);
 
-    glTexImage2D(GL_TEXTURE_2D, 0, format_tuple.internal_format, width, height, 0,
-                 format_tuple.format, format_tuple.type, nullptr);
+    if (GL_ARB_texture_storage) {
+        // Allocate all possible mipmap levels upfront
+        auto levels = std::log2(std::max(width, height)) + 1;
+        glTexStorage2D(GL_TEXTURE_2D, levels, format_tuple.internal_format, width, height);
+    } else {
+        glTexImage2D(GL_TEXTURE_2D, 0, format_tuple.internal_format, width, height, 0,
+                     format_tuple.format, format_tuple.type, nullptr);
+    }
 
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
@@ -348,17 +355,22 @@ static void AllocateTextureCube(GLuint texture, const FormatTuple& format_tuple,
     cur_state.texture_cube_unit.texture_cube = texture;
     cur_state.Apply();
     glActiveTexture(TextureUnits::TextureCube.Enum());
-
-    for (auto faces : {
-             GL_TEXTURE_CUBE_MAP_POSITIVE_X,
-             GL_TEXTURE_CUBE_MAP_POSITIVE_Y,
-             GL_TEXTURE_CUBE_MAP_POSITIVE_Z,
-             GL_TEXTURE_CUBE_MAP_NEGATIVE_X,
-             GL_TEXTURE_CUBE_MAP_NEGATIVE_Y,
-             GL_TEXTURE_CUBE_MAP_NEGATIVE_Z,
-         }) {
-        glTexImage2D(faces, 0, format_tuple.internal_format, width, width, 0, format_tuple.format,
-                     format_tuple.type, nullptr);
+    if (GL_ARB_texture_storage) {
+        // Allocate all possible mipmap levels in case the game uses them later
+        auto levels = std::log2(width) + 1;
+        glTexStorage2D(GL_TEXTURE_CUBE_MAP, levels, format_tuple.internal_format, width, width);
+    } else {
+        for (auto faces : {
+                 GL_TEXTURE_CUBE_MAP_POSITIVE_X,
+                 GL_TEXTURE_CUBE_MAP_POSITIVE_Y,
+                 GL_TEXTURE_CUBE_MAP_POSITIVE_Z,
+                 GL_TEXTURE_CUBE_MAP_NEGATIVE_X,
+                 GL_TEXTURE_CUBE_MAP_NEGATIVE_Y,
+                 GL_TEXTURE_CUBE_MAP_NEGATIVE_Z,
+             }) {
+            glTexImage2D(faces, 0, format_tuple.internal_format, width, width, 0,
+                         format_tuple.format, format_tuple.type, nullptr);
+        }
     }
 
     // Restore previous texture bindings
@@ -1549,9 +1561,14 @@ Surface RasterizerCacheOpenGL::GetTextureSurface(const Pica::Texture::TextureInf
                 width = surface->width * surface->res_scale;
                 height = surface->height * surface->res_scale;
             }
-            for (u32 level = surface->max_level + 1; level <= max_level; ++level) {
-                glTexImage2D(GL_TEXTURE_2D, level, format_tuple.internal_format, width >> level,
-                             height >> level, 0, format_tuple.format, format_tuple.type, nullptr);
+            // If we are using ARB_texture_storage then we've already allocated all of the mipmap
+            // levels
+            if (!GL_ARB_texture_storage) {
+                for (u32 level = surface->max_level + 1; level <= max_level; ++level) {
+                    glTexImage2D(GL_TEXTURE_2D, level, format_tuple.internal_format, width >> level,
+                                 height >> level, 0, format_tuple.format, format_tuple.type,
+                                 nullptr);
+                }
             }
             if (surface->is_custom) {
                 // TODO: proper mipmap support for custom textures


### PR DESCRIPTION
In preparation for using texture views which require immutable storage, we need to add a separate allocation path for when immutable storage is available.

Immutable storage is basically the "sane" way to allocate textures in modern GL. You need only a single call to preallocate all of the storage that the texture might need and then thats that. No need to later add on mipmap levels like you do with glTexImage. The downside is that it might not be available on all cards that we support with a minimum of GL 3.3, so we have to support the old way as well.

I plan to use texture views for two things coming up soon:
* Faster subrect - useful for games that render into a power of two framebuffer, which we then need to subrect for the final frame. Subrect can be costly since it uses `glBlitFramebuffer` to blit the full size framebuffer to a smaller texture and then tracks both in the cache. With texture views, we can make a new subrect texture that uses the same underlying texture memory for free.
* Faster depth/stencil reinterpret - With texture views + stencil texturing, we can attach the depth/stencil to a single draw pass and render them into a new texture. This should avoid the slow `glReadPixels` that we have to do currently to do for reinterpret, but once again, this is limited in device support.

No guarantees that I'll finish them, but immutable storage is a small patch i'd need for both, so might as well get it merged first and make sure we aren't breaking anything.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5053)
<!-- Reviewable:end -->
