### PR TITLE
Port yuzu-emu/yuzu#3316: "Add headbar icon on Linux"

### DIFF
--- a/src/citra_qt/main.ui
+++ b/src/citra_qt/main.ui
@@ -15,7 +15,7 @@
   </property>
   <property name="windowIcon">
    <iconset>
-    <normaloff>src/pcafe/res/icon3_64x64.ico</normaloff>src/pcafe/res/icon3_64x64.ico</iconset>
+    <normaloff>../dist/citra.ico</normaloff>../dist/citra.ico</iconset>
   </property>
   <property name="tabShape">
    <enum>QTabWidget::Rounded</enum>


### PR DESCRIPTION
See yuzu-emu/yuzu#3316 for more details.

**Original description**:
Fixes yuzu-emu/yuzu#1898.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5061)
<!-- Reviewable:end -->
