### PR TITLE
Update minimum window size based on current layout

### DIFF
--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -374,6 +374,7 @@ void GRenderWindow::InitRenderTarget() {
     core_context = CreateSharedContext();
     resize(Core::kScreenTopWidth, Core::kScreenTopHeight + Core::kScreenBottomHeight);
     OnMinimalClientAreaChangeRequest(GetActiveConfig().min_client_area_size);
+    OnFramebufferSizeChanged();
     BackupGeometry();
 }
 

--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -4,6 +4,7 @@
 
 #include <cmath>
 #include <mutex>
+#include "core/3ds.h"
 #include "core/frontend/emu_window.h"
 #include "core/frontend/input.h"
 #include "core/settings.h"
@@ -45,7 +46,7 @@ private:
 
 EmuWindow::EmuWindow() {
     // TODO: Find a better place to set this.
-    config.min_client_area_size = std::make_pair(400u, 480u);
+    config.min_client_area_size = std::make_pair(Core::kScreenTopWidth, Core::kScreenTopHeight + Core::kScreenBottomHeight);
     active_config = config;
     touch_state = std::make_shared<TouchState>();
     Input::RegisterFactory<Input::TouchDevice>("emu_window", touch_state);
@@ -153,27 +154,27 @@ void EmuWindow::UpdateCurrentFramebufferLayout(unsigned width, unsigned height) 
         case Settings::LayoutOption::SingleScreen:
             layout = Layout::SingleFrameLayout(width, height, Settings::values.swap_screen,
                                                Settings::values.upright_screen);
-            min_width = Settings::values.swap_screen ? 320u : 400u;
-            min_height = 240u;
+            min_width = Settings::values.swap_screen ? Core::kScreenBottomWidth : Core::kScreenTopWidth;
+            min_height = Core::kScreenBottomHeight;
             break;
         case Settings::LayoutOption::LargeScreen:
             layout = Layout::LargeFrameLayout(width, height, Settings::values.swap_screen,
                                               Settings::values.upright_screen);
-            min_width = Settings::values.swap_screen ? 420u : 480u;
-            min_height = 240u;
+            min_width = Settings::values.swap_screen ? Core::kScreenTopWidth/4 + Core::kScreenBottomWidth : Core::kScreenTopWidth + Core::kScreenBottomWidth/4;
+            min_height = Core::kScreenBottomHeight;
             break;
         case Settings::LayoutOption::SideScreen:
             layout = Layout::SideFrameLayout(width, height, Settings::values.swap_screen,
                                              Settings::values.upright_screen);
-            min_width = 720u;
-            min_height = 240u;
+            min_width = Core::kScreenTopWidth + Core::kScreenBottomWidth;
+            min_height = Core::kScreenBottomHeight;
             break;
         case Settings::LayoutOption::Default:
         default:
             layout = Layout::DefaultFrameLayout(width, height, Settings::values.swap_screen,
                                                 Settings::values.upright_screen);
-            min_width = 400u;
-            min_height = 480u;
+            min_width = Core::kScreenTopWidth;
+            min_height = Core::kScreenTopHeight + Core::kScreenBottomHeight;
             break;
         }
         if(Settings::values.upright_screen){

--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -46,7 +46,8 @@ private:
 
 EmuWindow::EmuWindow() {
     // TODO: Find a better place to set this.
-    config.min_client_area_size = std::make_pair(Core::kScreenTopWidth, Core::kScreenTopHeight + Core::kScreenBottomHeight);
+    config.min_client_area_size =
+        std::make_pair(Core::kScreenTopWidth, Core::kScreenTopHeight + Core::kScreenBottomHeight);
     active_config = config;
     touch_state = std::make_shared<TouchState>();
     Input::RegisterFactory<Input::TouchDevice>("emu_window", touch_state);
@@ -152,35 +153,41 @@ void EmuWindow::UpdateCurrentFramebufferLayout(unsigned width, unsigned height) 
     } else {
         switch (Settings::values.layout_option) {
         case Settings::LayoutOption::SingleScreen:
-            min_width = Settings::values.swap_screen ? Core::kScreenBottomWidth : Core::kScreenTopWidth;
+            min_width =
+                Settings::values.swap_screen ? Core::kScreenBottomWidth : Core::kScreenTopWidth;
             min_height = Core::kScreenBottomHeight;
-            layout = Layout::SingleFrameLayout(std::max(width, min_width), std::max(height, min_height), Settings::values.swap_screen,
-                                               Settings::values.upright_screen);
+            layout = Layout::SingleFrameLayout(
+                std::max(width, min_width), std::max(height, min_height),
+                Settings::values.swap_screen, Settings::values.upright_screen);
             break;
         case Settings::LayoutOption::LargeScreen:
-            min_width = Settings::values.swap_screen ? Core::kScreenTopWidth/4 + Core::kScreenBottomWidth : Core::kScreenTopWidth + Core::kScreenBottomWidth/4;
+            min_width = Settings::values.swap_screen
+                            ? Core::kScreenTopWidth / 4 + Core::kScreenBottomWidth
+                            : Core::kScreenTopWidth + Core::kScreenBottomWidth / 4;
             min_height = Core::kScreenBottomHeight;
-            layout = Layout::LargeFrameLayout(std::max(width, min_width), std::max(height, min_height), Settings::values.swap_screen,
-                                              Settings::values.upright_screen);
+            layout = Layout::LargeFrameLayout(
+                std::max(width, min_width), std::max(height, min_height),
+                Settings::values.swap_screen, Settings::values.upright_screen);
             break;
         case Settings::LayoutOption::SideScreen:
             min_width = Core::kScreenTopWidth + Core::kScreenBottomWidth;
             min_height = Core::kScreenBottomHeight;
-            layout = Layout::SideFrameLayout(std::max(width, min_width), std::max(height, min_height), Settings::values.swap_screen,
-                                             Settings::values.upright_screen);
+            layout = Layout::SideFrameLayout(
+                std::max(width, min_width), std::max(height, min_height),
+                Settings::values.swap_screen, Settings::values.upright_screen);
             break;
         case Settings::LayoutOption::Default:
         default:
             min_width = Core::kScreenTopWidth;
             min_height = Core::kScreenTopHeight + Core::kScreenBottomHeight;
-            layout = Layout::DefaultFrameLayout(std::max(width, min_width), std::max(height, min_height), Settings::values.swap_screen,
-                                                Settings::values.upright_screen);
+            layout = Layout::DefaultFrameLayout(
+                std::max(width, min_width), std::max(height, min_height),
+                Settings::values.swap_screen, Settings::values.upright_screen);
             break;
         }
-        if(Settings::values.upright_screen){
+        if (Settings::values.upright_screen) {
             UpdateMinimumWindowSize(min_height, min_width);
-        }
-        else{
+        } else {
             UpdateMinimumWindowSize(min_width, min_height);
         }
     }

--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -152,29 +152,29 @@ void EmuWindow::UpdateCurrentFramebufferLayout(unsigned width, unsigned height) 
     } else {
         switch (Settings::values.layout_option) {
         case Settings::LayoutOption::SingleScreen:
-            layout = Layout::SingleFrameLayout(width, height, Settings::values.swap_screen,
-                                               Settings::values.upright_screen);
             min_width = Settings::values.swap_screen ? Core::kScreenBottomWidth : Core::kScreenTopWidth;
             min_height = Core::kScreenBottomHeight;
+            layout = Layout::SingleFrameLayout(std::max(width, min_width), std::max(height, min_height), Settings::values.swap_screen,
+                                               Settings::values.upright_screen);
             break;
         case Settings::LayoutOption::LargeScreen:
-            layout = Layout::LargeFrameLayout(width, height, Settings::values.swap_screen,
-                                              Settings::values.upright_screen);
             min_width = Settings::values.swap_screen ? Core::kScreenTopWidth/4 + Core::kScreenBottomWidth : Core::kScreenTopWidth + Core::kScreenBottomWidth/4;
             min_height = Core::kScreenBottomHeight;
+            layout = Layout::LargeFrameLayout(std::max(width, min_width), std::max(height, min_height), Settings::values.swap_screen,
+                                              Settings::values.upright_screen);
             break;
         case Settings::LayoutOption::SideScreen:
-            layout = Layout::SideFrameLayout(width, height, Settings::values.swap_screen,
-                                             Settings::values.upright_screen);
             min_width = Core::kScreenTopWidth + Core::kScreenBottomWidth;
             min_height = Core::kScreenBottomHeight;
+            layout = Layout::SideFrameLayout(std::max(width, min_width), std::max(height, min_height), Settings::values.swap_screen,
+                                             Settings::values.upright_screen);
             break;
         case Settings::LayoutOption::Default:
         default:
-            layout = Layout::DefaultFrameLayout(width, height, Settings::values.swap_screen,
-                                                Settings::values.upright_screen);
             min_width = Core::kScreenTopWidth;
             min_height = Core::kScreenTopHeight + Core::kScreenBottomHeight;
+            layout = Layout::DefaultFrameLayout(std::max(width, min_width), std::max(height, min_height), Settings::values.swap_screen,
+                                                Settings::values.upright_screen);
             break;
         }
         if(Settings::values.upright_screen){

--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -147,8 +147,8 @@ void EmuWindow::TouchMoved(unsigned framebuffer_x, unsigned framebuffer_y) {
 
 void EmuWindow::UpdateCurrentFramebufferLayout(unsigned width, unsigned height) {
     Layout::FramebufferLayout layout;
-    Settings::LayoutOption layout_option = Settings::values.layout_option;
-    std::pair<unsigned, unsigned> min_size =
+    const auto layout_option = Settings::values.layout_option;
+    const auto min_size =
         Layout::GetMinimumSizeFromLayout(layout_option, Settings::values.upright_screen);
 
     if (Settings::values.custom_layout == true) {
@@ -178,6 +178,13 @@ void EmuWindow::UpdateCurrentFramebufferLayout(unsigned width, unsigned height) 
         UpdateMinimumWindowSize(min_size);
     }
     NotifyFramebufferLayoutChanged(layout);
+}
+
+void EmuWindow::UpdateMinimumWindowSize(std::pair<unsigned, unsigned> min_size) {
+    WindowConfig new_config = config;
+    new_config.min_client_area_size = min_size;
+    SetConfig(new_config);
+    ProcessConfigurationChanges();
 }
 
 } // namespace Frontend

--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -145,6 +145,7 @@ void EmuWindow::TouchMoved(unsigned framebuffer_x, unsigned framebuffer_y) {
 
 void EmuWindow::UpdateCurrentFramebufferLayout(unsigned width, unsigned height) {
     Layout::FramebufferLayout layout;
+    unsigned int min_width, min_height;
     if (Settings::values.custom_layout == true) {
         layout = Layout::CustomFrameLayout(width, height);
     } else {
@@ -152,20 +153,34 @@ void EmuWindow::UpdateCurrentFramebufferLayout(unsigned width, unsigned height) 
         case Settings::LayoutOption::SingleScreen:
             layout = Layout::SingleFrameLayout(width, height, Settings::values.swap_screen,
                                                Settings::values.upright_screen);
+            min_width = Settings::values.swap_screen ? 320u : 400u;
+            min_height = 240u;
             break;
         case Settings::LayoutOption::LargeScreen:
             layout = Layout::LargeFrameLayout(width, height, Settings::values.swap_screen,
                                               Settings::values.upright_screen);
+            min_width = Settings::values.swap_screen ? 420u : 480u;
+            min_height = 240u;
             break;
         case Settings::LayoutOption::SideScreen:
             layout = Layout::SideFrameLayout(width, height, Settings::values.swap_screen,
                                              Settings::values.upright_screen);
+            min_width = 720u;
+            min_height = 240u;
             break;
         case Settings::LayoutOption::Default:
         default:
             layout = Layout::DefaultFrameLayout(width, height, Settings::values.swap_screen,
                                                 Settings::values.upright_screen);
+            min_width = 400u;
+            min_height = 480u;
             break;
+        }
+        if(Settings::values.upright_screen){
+            UpdateMinimumWindowSize(min_height, min_width);
+        }
+        else{
+            UpdateMinimumWindowSize(min_width, min_height);
         }
     }
     NotifyFramebufferLayoutChanged(layout);

--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -147,49 +147,35 @@ void EmuWindow::TouchMoved(unsigned framebuffer_x, unsigned framebuffer_y) {
 
 void EmuWindow::UpdateCurrentFramebufferLayout(unsigned width, unsigned height) {
     Layout::FramebufferLayout layout;
-    unsigned int min_width, min_height;
+    Settings::LayoutOption layout_option = Settings::values.layout_option;
+    std::pair<unsigned, unsigned> min_size =
+        Layout::GetMinimumSizeFromLayout(layout_option, Settings::values.upright_screen);
+
     if (Settings::values.custom_layout == true) {
         layout = Layout::CustomFrameLayout(width, height);
     } else {
-        switch (Settings::values.layout_option) {
+        width = std::max(width, min_size.first);
+        height = std::max(height, min_size.second);
+        switch (layout_option) {
         case Settings::LayoutOption::SingleScreen:
-            min_width =
-                Settings::values.swap_screen ? Core::kScreenBottomWidth : Core::kScreenTopWidth;
-            min_height = Core::kScreenBottomHeight;
-            layout = Layout::SingleFrameLayout(
-                std::max(width, min_width), std::max(height, min_height),
-                Settings::values.swap_screen, Settings::values.upright_screen);
+            layout = Layout::SingleFrameLayout(width, height, Settings::values.swap_screen,
+                                               Settings::values.upright_screen);
             break;
         case Settings::LayoutOption::LargeScreen:
-            min_width = Settings::values.swap_screen
-                            ? Core::kScreenTopWidth / 4 + Core::kScreenBottomWidth
-                            : Core::kScreenTopWidth + Core::kScreenBottomWidth / 4;
-            min_height = Core::kScreenBottomHeight;
-            layout = Layout::LargeFrameLayout(
-                std::max(width, min_width), std::max(height, min_height),
-                Settings::values.swap_screen, Settings::values.upright_screen);
+            layout = Layout::LargeFrameLayout(width, height, Settings::values.swap_screen,
+                                              Settings::values.upright_screen);
             break;
         case Settings::LayoutOption::SideScreen:
-            min_width = Core::kScreenTopWidth + Core::kScreenBottomWidth;
-            min_height = Core::kScreenBottomHeight;
-            layout = Layout::SideFrameLayout(
-                std::max(width, min_width), std::max(height, min_height),
-                Settings::values.swap_screen, Settings::values.upright_screen);
+            layout = Layout::SideFrameLayout(width, height, Settings::values.swap_screen,
+                                             Settings::values.upright_screen);
             break;
         case Settings::LayoutOption::Default:
         default:
-            min_width = Core::kScreenTopWidth;
-            min_height = Core::kScreenTopHeight + Core::kScreenBottomHeight;
-            layout = Layout::DefaultFrameLayout(
-                std::max(width, min_width), std::max(height, min_height),
-                Settings::values.swap_screen, Settings::values.upright_screen);
+            layout = Layout::DefaultFrameLayout(width, height, Settings::values.swap_screen,
+                                                Settings::values.upright_screen);
             break;
         }
-        if (Settings::values.upright_screen) {
-            UpdateMinimumWindowSize(min_height, min_width);
-        } else {
-            UpdateMinimumWindowSize(min_width, min_height);
-        }
+        UpdateMinimumWindowSize(min_size);
     }
     NotifyFramebufferLayoutChanged(layout);
 }

--- a/src/core/frontend/emu_window.h
+++ b/src/core/frontend/emu_window.h
@@ -216,7 +216,7 @@ private:
      */
     std::tuple<unsigned, unsigned> ClipToTouchScreen(unsigned new_x, unsigned new_y) const;
 
-    void UpdateMinimumWindowSize(unsigned int min_width, unsigned int min_height){
+    void UpdateMinimumWindowSize(unsigned int min_width, unsigned int min_height) {
         WindowConfig new_config = config;
         new_config.min_client_area_size = std::make_pair(min_width, min_height);
         SetConfig(new_config);

--- a/src/core/frontend/emu_window.h
+++ b/src/core/frontend/emu_window.h
@@ -216,9 +216,9 @@ private:
      */
     std::tuple<unsigned, unsigned> ClipToTouchScreen(unsigned new_x, unsigned new_y) const;
 
-    void UpdateMinimumWindowSize(unsigned int min_width, unsigned int min_height) {
+    void UpdateMinimumWindowSize(std::pair<unsigned, unsigned> min_size) {
         WindowConfig new_config = config;
-        new_config.min_client_area_size = std::make_pair(min_width, min_height);
+        new_config.min_client_area_size = min_size;
         SetConfig(new_config);
         ProcessConfigurationChanges();
     }

--- a/src/core/frontend/emu_window.h
+++ b/src/core/frontend/emu_window.h
@@ -215,6 +215,13 @@ private:
      * Clip the provided coordinates to be inside the touchscreen area.
      */
     std::tuple<unsigned, unsigned> ClipToTouchScreen(unsigned new_x, unsigned new_y) const;
+
+    void UpdateMinimumWindowSize(unsigned int min_width, unsigned int min_height){
+        WindowConfig new_config = config;
+        new_config.min_client_area_size = std::make_pair(min_width, min_height);
+        SetConfig(new_config);
+        ProcessConfigurationChanges();
+    }
 };
 
 } // namespace Frontend

--- a/src/core/frontend/emu_window.h
+++ b/src/core/frontend/emu_window.h
@@ -216,12 +216,7 @@ private:
      */
     std::tuple<unsigned, unsigned> ClipToTouchScreen(unsigned new_x, unsigned new_y) const;
 
-    void UpdateMinimumWindowSize(std::pair<unsigned, unsigned> min_size) {
-        WindowConfig new_config = config;
-        new_config.min_client_area_size = min_size;
-        SetConfig(new_config);
-        ProcessConfigurationChanges();
-    }
+    void UpdateMinimumWindowSize(std::pair<unsigned, unsigned> min_size);
 };
 
 } // namespace Frontend

--- a/src/core/frontend/emu_window.h
+++ b/src/core/frontend/emu_window.h
@@ -180,7 +180,7 @@ protected:
 
         if (config.min_client_area_size != active_config.min_client_area_size) {
             OnMinimalClientAreaChangeRequest(config.min_client_area_size);
-            config.min_client_area_size = active_config.min_client_area_size;
+            active_config.min_client_area_size = config.min_client_area_size;
         }
     }
 

--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -363,4 +363,36 @@ FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale) {
     return layout;
 }
 
+std::pair<unsigned, unsigned> GetMinimumSizeFromLayout(Settings::LayoutOption layout,
+                                                       bool upright_screen) {
+    unsigned min_width, min_height;
+
+    switch (layout) {
+    case Settings::LayoutOption::SingleScreen:
+        min_width = Settings::values.swap_screen ? Core::kScreenBottomWidth : Core::kScreenTopWidth;
+        min_height = Core::kScreenBottomHeight;
+        break;
+    case Settings::LayoutOption::LargeScreen:
+        min_width = Settings::values.swap_screen
+                        ? Core::kScreenTopWidth / 4 + Core::kScreenBottomWidth
+                        : Core::kScreenTopWidth + Core::kScreenBottomWidth / 4;
+        min_height = Core::kScreenBottomHeight;
+        break;
+    case Settings::LayoutOption::SideScreen:
+        min_width = Core::kScreenTopWidth + Core::kScreenBottomWidth;
+        min_height = Core::kScreenBottomHeight;
+        break;
+    case Settings::LayoutOption::Default:
+    default:
+        min_width = Core::kScreenTopWidth;
+        min_height = Core::kScreenTopHeight + Core::kScreenBottomHeight;
+        break;
+    }
+    if (upright_screen) {
+        return std::make_pair(min_height, min_width);
+    } else {
+        return std::make_pair(min_width, min_height);
+    }
+}
+
 } // namespace Layout

--- a/src/core/frontend/framebuffer_layout.h
+++ b/src/core/frontend/framebuffer_layout.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "common/math_util.h"
+#include "core/settings.h"
 
 namespace Layout {
 
@@ -79,5 +80,8 @@ FramebufferLayout CustomFrameLayout(u32 width, u32 height);
  * @param res_scale resolution scale factor
  */
 FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale);
+
+std::pair<unsigned, unsigned> GetMinimumSizeFromLayout(Settings::LayoutOption layout,
+                                                       bool upright_screen);
 
 } // namespace Layout


### PR DESCRIPTION
Currently the minimum window size is always based on the default layout, but users might want to resize the window differently depending on the current layout. 
This change also prevents sub 1x window sizes for the different layouts.
(For the large layout, the minimum size is calculated based on the top screen)

closes #2675

As discussed on discord, it might be better to wait to merge this until after the incoming changes to layout.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5069)
<!-- Reviewable:end -->
