### PR TITLE
Dont load Disk Cache when HWShader is disabled

### DIFF
--- a/src/citra_qt/configuration/configure_enhancements.cpp
+++ b/src/citra_qt/configuration/configure_enhancements.cpp
@@ -42,6 +42,8 @@ ConfigureEnhancements::ConfigureEnhancements(QWidget* parent)
         if (!ui->toggle_preload_textures->isEnabled())
             ui->toggle_preload_textures->setChecked(false);
     });
+
+    ui->toggle_disk_shader_cache->setEnabled(Settings::values.use_hw_shader);
 }
 
 void ConfigureEnhancements::SetConfiguration() {
@@ -52,7 +54,8 @@ void ConfigureEnhancements::SetConfiguration() {
     ui->toggle_linear_filter->setChecked(Settings::values.filter_mode);
     ui->layout_combobox->setCurrentIndex(static_cast<int>(Settings::values.layout_option));
     ui->swap_screen->setChecked(Settings::values.swap_screen);
-    ui->toggle_disk_shader_cache->setChecked(Settings::values.use_disk_shader_cache);
+    ui->toggle_disk_shader_cache->setChecked(Settings::values.use_hw_shader &&
+                                             Settings::values.use_disk_shader_cache);
     ui->upright_screen->setChecked(Settings::values.upright_screen);
     ui->toggle_dump_textures->setChecked(Settings::values.dump_textures);
     ui->toggle_custom_textures->setChecked(Settings::values.custom_textures);
@@ -101,7 +104,8 @@ void ConfigureEnhancements::ApplyConfiguration() {
     Settings::values.layout_option =
         static_cast<Settings::LayoutOption>(ui->layout_combobox->currentIndex());
     Settings::values.swap_screen = ui->swap_screen->isChecked();
-    Settings::values.use_disk_shader_cache = ui->toggle_disk_shader_cache->isChecked();
+    Settings::values.use_disk_shader_cache =
+        Settings::values.use_hw_shader && ui->toggle_disk_shader_cache->isChecked();
     Settings::values.upright_screen = ui->upright_screen->isChecked();
     Settings::values.dump_textures = ui->toggle_dump_textures->isChecked();
     Settings::values.custom_textures = ui->toggle_custom_textures->isChecked();

--- a/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
@@ -106,7 +106,7 @@ ShaderDiskCache::ShaderDiskCache(bool separable) : separable{separable} {}
 
 std::optional<std::vector<ShaderDiskCacheRaw>> ShaderDiskCache::LoadTransferable() {
     const bool has_title_id = GetProgramID() != 0;
-    if (!Settings::values.use_disk_shader_cache || !has_title_id)
+    if (!Settings::values.use_hw_shader || !Settings::values.use_disk_shader_cache || !has_title_id)
         return {};
     tried_to_load = true;
 


### PR DESCRIPTION
Two commits here:

* Check for hw shader when loading the disk cache. This is the actual fix for the issue.
* Prevent people from selecting disk cache when hw shader is disabled. Since its on a different UI tab its a little wonky, but its probably "good enough". This is just to update the config window when disk shader cache is effectively disabled.

As this is affecting Mac users in nightly, I'd like to get this merged quickly. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5072)
<!-- Reviewable:end -->
