### PR TITLE
Log disk shader cache setting

### DIFF
--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -90,6 +90,7 @@ void LogSettings() {
     LogSetting("Layout_UprightScreen", Settings::values.upright_screen);
     LogSetting("Utility_DumpTextures", Settings::values.dump_textures);
     LogSetting("Utility_CustomTextures", Settings::values.custom_textures);
+    LogSetting("Utility_UseDiskShaderCache", Settings::values.use_disk_shader_cache);
     LogSetting("Audio_EnableDspLle", Settings::values.enable_dsp_lle);
     LogSetting("Audio_EnableDspLleMultithread", Settings::values.enable_dsp_lle_multithread);
     LogSetting("Audio_OutputEngine", Settings::values.sink_id);


### PR DESCRIPTION
Currently the loading process of the cached shaders has a couple logs for successfully finding shaders, but logging the setting itself would help with miscellaneous and unexpected issues caused by the setting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5073)
<!-- Reviewable:end -->
