### PR TITLE
Port yuzu-emu/yuzu#3339: "GUI: fix minor issues with dark themes + rename and reorder themes"

### DIFF
--- a/dist/qt_themes/qdarkstyle/style.qss
+++ b/dist/qt_themes/qdarkstyle/style.qss
@@ -2,7 +2,8 @@ QToolTip {
     border: 1px solid #76797C;
     background-color: #5A7566;
     color: white;
-    padding: 0px;                /*remove padding, for fix combobox tooltip.*/
+    /*remove padding, for fix combobox tooltip.*/
+    padding: 0;
     opacity: 200;
 }
 
@@ -13,7 +14,7 @@ QWidget {
     selection-color: #eff0f1;
     background-clip: border;
     border-image: none;
-    border: 0px transparent black;
+    border: 0;
     outline: 0;
 }
 
@@ -27,10 +28,10 @@ QWidget:item:selected {
 }
 
 QCheckBox {
-    spacing: 5px;
+    spacing: 6px;
     outline: none;
     color: #eff0f1;
-    margin-bottom: 2px;
+    margin: 0 2px 1px 0;
 }
 
 QCheckBox:disabled {
@@ -163,7 +164,7 @@ QMenuBar::item:selected {
 }
 
 QMenuBar::item:pressed {
-    border: 1px solid #76797C;
+    border: 1px solid #18465d;
     background-color: #3daee9;
     color: #eff0f1;
     margin-bottom: -1px;
@@ -171,9 +172,9 @@ QMenuBar::item:pressed {
 }
 
 QMenu {
-    border: 1px solid #76797C;
+    border: 1px solid #434242;
+    padding: 2px;
     color: #eff0f1;
-    margin: 2px;
 }
 
 QMenu::icon {
@@ -190,11 +191,21 @@ QMenu::item:selected {
     color: #eff0f1;
 }
 
-QMenu::separator {
-    height: 2px;
-    background: #76797C;
-    margin-left: 10px;
-    margin-right: 5px;
+QMenu::item:disabled {
+    color: #54575B;
+}
+
+QMenu::item:disabled:hover,
+QMenu::item:disabled:selected {
+    background-color: #393e43;
+    color: #666;
+}
+
+QMenu::separator,
+QMenuBar::separator {
+    height: 1px;
+    background-color: #54575B;
+    margin: 2px 4px 2px 40px;
 }
 
 QMenu::indicator {
@@ -203,10 +214,7 @@ QMenu::indicator {
     height: 18px;
 }
 
-
-/* non-exclusive indicator = check box style indicator
-   (see QActionGroup::setExclusive) */
-
+/* non-exclusive indicator = check box style indicator (see QActionGroup::setExclusive) */
 QMenu::indicator:non-exclusive:unchecked {
     image: url(:/qss_icons/rc/checkbox_unchecked.png);
 }
@@ -223,9 +231,7 @@ QMenu::indicator:non-exclusive:checked:selected {
     image: url(:/qss_icons/rc/checkbox_checked_disabled.png);
 }
 
-
 /* exclusive indicator = radio button style indicator (see QActionGroup::setExclusive) */
-
 QMenu::indicator:exclusive:unchecked {
     image: url(:/qss_icons/rc/radio_unchecked.png);
 }
@@ -243,12 +249,12 @@ QMenu::indicator:exclusive:checked:selected {
 }
 
 QMenu::right-arrow {
-    margin: 5px;
+    margin-right: 10px;
     image: url(:/qss_icons/rc/right_arrow.png)
 }
 
 QWidget:disabled {
-    color: #454545;
+    color: #4f515b;
     background-color: #31363b;
 }
 
@@ -259,23 +265,30 @@ QAbstractItemView {
     border-radius: 2px;
 }
 
-QWidget:focus,
-QMenuBar:focus {
+QAbstractItemView:disabled,
+QAbstractItemView:read-only {
+    alternate-background-color: #232629;
+}
+
+QWidget:focus {
     border: 1px solid #3daee9;
 }
 
 QTabWidget:focus,
 QCheckBox:focus,
 QRadioButton:focus,
-QSlider:focus {
+QSlider:focus,
+QTreeView:focus,
+QMenu:focus,
+QMenuBar:focus,
+QTabBar:focus {
     border: none;
 }
 
 QLineEdit {
     background-color: #232629;
     padding: 5px;
-    border-style: solid;
-    border: 1px solid #76797C;
+    border: 1px solid #54575B;
     border-radius: 2px;
     color: #eff0f1;
 }
@@ -285,9 +298,10 @@ QAbstractItemView QLineEdit {
 }
 
 QGroupBox {
-    border: 1px solid #76797C;
+    border: 1px solid #54575B;
     border-radius: 2px;
-    margin-top: 20px;
+    margin-top: 12px;
+    padding-top: 2px;
 }
 
 QGroupBox::title {
@@ -295,12 +309,12 @@ QGroupBox::title {
     subcontrol-position: top center;
     padding-left: 10px;
     padding-right: 10px;
-    padding-top: 10px;
+    padding-top: 2px;
 }
 
 QAbstractScrollArea {
     border-radius: 2px;
-    border: 1px solid #76797C;
+    border: 1px solid #54575B;
     background-color: transparent;
 }
 
@@ -319,7 +333,7 @@ QScrollBar::handle:horizontal {
 }
 
 QScrollBar::add-line:horizontal {
-    margin: 0px 3px 0px 3px;
+    margin: 0 3px;
     border-image: url(:/qss_icons/rc/right_arrow_disabled.png);
     width: 10px;
     height: 10px;
@@ -328,7 +342,7 @@ QScrollBar::add-line:horizontal {
 }
 
 QScrollBar::sub-line:horizontal {
-    margin: 0px 3px 0px 3px;
+    margin: 0 3px;
     border-image: url(:/qss_icons/rc/left_arrow_disabled.png);
     height: 10px;
     width: 10px;
@@ -379,7 +393,7 @@ QScrollBar::handle:vertical {
 }
 
 QScrollBar::sub-line:vertical {
-    margin: 3px 0px 3px 0px;
+    margin: 3px 0;
     border-image: url(:/qss_icons/rc/up_arrow_disabled.png);
     height: 10px;
     width: 10px;
@@ -388,7 +402,7 @@ QScrollBar::sub-line:vertical {
 }
 
 QScrollBar::add-line:vertical {
-    margin: 3px 0px 3px 0px;
+    margin: 3px 0;
     border-image: url(:/qss_icons/rc/down_arrow_disabled.png);
     height: 10px;
     width: 10px;
@@ -427,15 +441,14 @@ QScrollBar::sub-page:vertical {
 QTextEdit {
     background-color: #232629;
     color: #eff0f1;
-    border: 1px solid #76797C;
+    border: 1px solid #54575B;
 }
 
 QPlainTextEdit {
     background-color: #232629;
-    ;
     color: #eff0f1;
     border-radius: 2px;
-    border: 1px solid #76797C;
+    border: 1px solid #54575B;
 }
 
 QHeaderView::section {
@@ -465,15 +478,6 @@ QMainWindow::separator:hover {
     padding-left: 4px;
     border: 1px solid #76797C;
     spacing: 2px;
-}
-
-QMenu::separator {
-    height: 1px;
-    background-color: #76797C;
-    color: white;
-    padding-left: 4px;
-    margin-left: 10px;
-    margin-right: 5px;
 }
 
 QFrame {
@@ -518,25 +522,19 @@ QToolButton#qt_toolbar_ext_button {
 
 QPushButton {
     color: #eff0f1;
-    background-color: #31363b;
     border-width: 1px;
-    border-color: #76797C;
+    border-color: #54575B;
     border-style: solid;
-    padding: 5px;
+    padding: 6px 4px;
     border-radius: 2px;
     outline: none;
+    min-width: 100px;
+    background-color: #232629;
 }
 
 QPushButton:disabled {
     background-color: #31363b;
-    border-width: 1px;
     border-color: #454545;
-    border-style: solid;
-    padding-top: 5px;
-    padding-bottom: 5px;
-    padding-left: 10px;
-    padding-right: 10px;
-    border-radius: 2px;
     color: #454545;
 }
 
@@ -553,11 +551,11 @@ QPushButton:pressed {
 
 QComboBox {
     selection-background-color: #3daee9;
-    border-style: solid;
-    border: 1px solid #76797C;
+    border: 1px solid #54575B;
     border-radius: 2px;
-    padding: 5px;
+    padding: 4px 6px;
     min-width: 75px;
+    background-color: #232629;
 }
 
 QPushButton:checked {
@@ -571,8 +569,7 @@ QAbstractSpinBox:hover,
 QLineEdit:hover,
 QTextEdit:hover,
 QPlainTextEdit:hover,
-QAbstractView:hover,
-QTreeView:hover {
+QAbstractView:hover {
     border: 1px solid #3daee9;
     color: #eff0f1;
 }
@@ -591,6 +588,7 @@ QComboBox QAbstractItemView {
 QComboBox::drop-down {
     subcontrol-origin: padding;
     subcontrol-position: top right;
+    left: -6px;
     width: 15px;
     border-left-width: 0px;
     border-left-color: darkgray;
@@ -610,8 +608,8 @@ QComboBox::down-arrow:focus {
 }
 
 QAbstractSpinBox {
-    padding: 5px;
-    border: 1px solid #76797C;
+    padding: 4px 6px;
+    border: 1px solid #54575B;
     background-color: #232629;
     color: #eff0f1;
     border-radius: 2px;
@@ -622,12 +620,14 @@ QAbstractSpinBox:up-button {
     background-color: transparent;
     subcontrol-origin: border;
     subcontrol-position: center right;
+    left: -6px;
 }
 
 QAbstractSpinBox:down-button {
     background-color: transparent;
     subcontrol-origin: border;
     subcontrol-position: center left;
+    right: -6px;
 }
 
 QAbstractSpinBox::up-arrow,
@@ -654,31 +654,32 @@ QAbstractSpinBox::down-arrow:hover {
     image: url(:/qss_icons/rc/down_arrow.png);
 }
 
-QLabel {
-    border: 0px solid black;
+QLabel,
+QTabWidget {
+    border: 0;
 }
 
 QTabWidget {
-    border: 0px transparent black;
+    padding-top: 1px;
 }
 
 QTabWidget::pane {
     border: 1px solid #76797C;
     padding: 5px;
-    margin: 0px;
+    position: absolute;
+    top: -1px;
+    border-top-right-radius: 2px;
+    border-bottom-right-radius: 2px;
+    border-bottom-left-radius: 2px;
 }
 
 QTabWidget::tab-bar {
-    /* left: 5px; move to the right by 5px */
+    overflow: visible;
 }
 
 QTabBar {
     qproperty-drawBase: 0;
     border-radius: 3px;
-}
-
-QTabBar:focus {
-    border: 0px transparent black;
 }
 
 QTabBar::close-button {
@@ -696,36 +697,33 @@ QTabBar::close-button:pressed {
     background: transparent;
 }
 
-
 /* TOP TABS */
-
 QTabBar::tab:top {
     color: #eff0f1;
-    border: 1px solid #76797C;
-    border-bottom: 2px transparent;
-    background-color: #31363b;
-    padding: 4px 16px 2px;
-    min-width: 38px;
+    border: 1px solid #54575B;
+    background-color: #2a2f33;
+    padding: 4px 16px 5px;
+    min-width: 36px;
     border-top-left-radius: 2px;
     border-top-right-radius: 2px;
 }
 
 QTabBar::tab:top:selected {
-    color: #eff0f1;
-    background-color: #54575B;
-    border: 1px solid #76797C;
-    border-bottom: 2px solid #3daee9;
-    border-top-left-radius: 2px;
-    border-top-right-radius: 2px;
+    border-color: #76797C;
+    background-color: #31363b;
+    border-bottom-color: #31363b;
+}
+
+QTabBar::tab:top:!selected {
+    margin-top: 1px;
+    border-bottom-color: #76797C;
 }
 
 QTabBar::tab:top:!selected:hover {
     background-color: #3daee9;
 }
 
-
 /* BOTTOM TABS */
-
 QTabBar::tab:bottom {
     color: #eff0f1;
     border: 1px solid #76797C;
@@ -750,9 +748,7 @@ QTabBar::tab:bottom:!selected:hover {
     background-color: #3daee9;
 }
 
-
 /* LEFT TABS */
-
 QTabBar::tab:left {
     color: #eff0f1;
     border: 1px solid #76797C;
@@ -777,9 +773,7 @@ QTabBar::tab:left:!selected:hover {
     background-color: #3daee9;
 }
 
-
 /* RIGHT TABS */
-
 QTabBar::tab:right {
     color: #eff0f1;
     border: 1px solid #76797C;
@@ -847,7 +841,7 @@ QDockWidget::float-button:pressed {
 
 QTreeView,
 QListView {
-    border: 1px solid #76797C;
+    border: 1px solid #54575B;
     background-color: #232629;
 }
 
@@ -978,8 +972,8 @@ QSlider::handle:vertical {
 }
 
 QToolButton {
-    background-color: transparent;
-    border: 1px transparent #76797C;
+    background-color: #232629;
+    border: 1px solid #54575B;
     border-radius: 2px;
     margin: 3px;
     padding: 5px;
@@ -988,7 +982,6 @@ QToolButton {
 QToolButton[popupMode="1"] {
     /* only for MenuButtonPopup */
     padding-right: 20px;
-    /* make way for the popup button */
     border: 1px #76797C;
     border-radius: 5px;
 }
@@ -996,7 +989,6 @@ QToolButton[popupMode="1"] {
 QToolButton[popupMode="2"] {
     /* only for InstantPopup */
     padding-right: 10px;
-    /* make way for the popup button */
     border: 1px #76797C;
 }
 
@@ -1015,19 +1007,14 @@ QToolButton::menu-button:pressed {
     padding: 5px;
 }
 
-
 /* the subcontrol below is used only in the InstantPopup or DelayedPopup mode */
-
 QToolButton::menu-indicator {
     image: url(:/qss_icons/rc/down_arrow.png);
     top: -7px;
     left: -2px;
-    /* shift it a bit */
 }
 
-
 /* the subcontrols below are used only in the MenuButtonPopup mode */
-
 QToolButton::menu-button {
     border: 1px transparent #76797C;
     border-top-right-radius: 6px;
@@ -1052,14 +1039,22 @@ QPushButton::menu-indicator {
 }
 
 QTableView {
-    border: 1px solid #76797C;
+    border: 1px solid #54575B;
     gridline-color: #31363b;
     background-color: #232629;
 }
 
+QTreeView:disabled {
+    background-color: #1f2225;
+}
+
 QTableView,
 QHeaderView {
-    border-radius: 0px;
+    border-radius: 0;
+}
+
+QListView:focus {
+    border-color: #54575B;
 }
 
 QTableView::item:pressed,
@@ -1088,7 +1083,7 @@ QHeaderView::section {
     background-color: #232629;
     color: #eff0f1;
     padding: 0 5px;
-    border: 1px solid #403F3F;
+    border: 1px solid #434242;
     border-bottom: 0;
     border-radius: 0px;
     text-align: center;
@@ -1118,9 +1113,7 @@ QHeaderView::section:checked {
     background-color: #334e5e;
 }
 
-
-/* style the sort indicator */
-
+/* sort indicator */
 QHeaderView::down-arrow {
     image: url(:/qss_icons/rc/down_arrow.png);
 }
@@ -1150,14 +1143,13 @@ QToolBox::tab {
 }
 
 QToolBox::tab:selected {
-    /* italicize selected tabs */
     font: italic;
     background-color: #31363b;
     border-color: #3daee9;
 }
 
 QStatusBar::item {
-    border: 0px transparent dark;
+    border: 0;
 }
 
 QFrame[height="3"],
@@ -1194,7 +1186,6 @@ QProgressBar::chunk {
 
 QDateEdit {
     selection-background-color: #3daee9;
-    border-style: solid;
     border: 1px solid #3375A3;
     border-radius: 2px;
     padding: 1px;
@@ -1218,7 +1209,7 @@ QDateEdit::drop-down {
     subcontrol-origin: padding;
     subcontrol-position: top right;
     width: 15px;
-    border-left-width: 0px;
+    border-left-width: 0;
     border-left-color: darkgray;
     border-left-style: solid;
     border-top-right-radius: 3px;
@@ -1233,4 +1224,15 @@ QDateEdit::down-arrow:on,
 QDateEdit::down-arrow:hover,
 QDateEdit::down-arrow:focus {
     image: url(:/qss_icons/rc/down_arrow.png);
+}
+
+QComboBox:disabled,
+QPushButton:disabled,
+QAbstractSpinBox:disabled,
+QDateEdit:disabled,
+QLineEdit:disabled,
+QTextEdit:disabled,
+QToolButton:disabled,
+QPlainTextEdit:disabled {
+    background-color: #2b2e31;
 }

--- a/dist/qt_themes/qdarkstyle/style.qss
+++ b/dist/qt_themes/qdarkstyle/style.qss
@@ -181,7 +181,7 @@ QMenu::icon {
 }
 
 QMenu::item {
-    padding: 5px 30px 5px 30px;
+    padding: 5px 16px 5px 40px;
     border: 1px solid transparent;
     /* reserve space for selection border */
 }
@@ -192,12 +192,13 @@ QMenu::item:selected {
 
 QMenu::separator {
     height: 2px;
-    background: lightblue;
+    background: #76797C;
     margin-left: 10px;
     margin-right: 5px;
 }
 
 QMenu::indicator {
+	margin: 0 -26px 0 8px;
     width: 18px;
     height: 18px;
 }
@@ -252,7 +253,7 @@ QWidget:disabled {
 }
 
 QAbstractItemView {
-    alternate-background-color: #31363b;
+    alternate-background-color: #2c2f32;
     color: #eff0f1;
     border: 1px solid #3A3939;
     border-radius: 2px;
@@ -577,8 +578,6 @@ QTreeView:hover {
 }
 
 QComboBox:on {
-    padding-top: 3px;
-    padding-left: 4px;
     selection-background-color: #4a4a4a;
 }
 
@@ -703,10 +702,10 @@ QTabBar::close-button:pressed {
 QTabBar::tab:top {
     color: #eff0f1;
     border: 1px solid #76797C;
-    border-bottom: 1px transparent black;
+    border-bottom: 2px transparent;
     background-color: #31363b;
-    padding: 5px;
-    min-width: 50px;
+    padding: 4px 16px 2px;
+    min-width: 38px;
     border-top-left-radius: 2px;
     border-top-right-radius: 2px;
 }
@@ -1078,7 +1077,7 @@ QListView::item:selected:active {
 }
 
 QHeaderView {
-    background-color: #31363b;
+    background-color: #403F3F;
     border: 1px transparent;
     border-radius: 0px;
     margin: 0px;
@@ -1086,30 +1085,32 @@ QHeaderView {
 }
 
 QHeaderView::section {
-    background-color: #31363b;
+    background-color: #232629;
     color: #eff0f1;
-    padding: 5px;
-    border: 1px solid #76797C;
+    padding: 0 5px;
+    border: 1px solid #403F3F;
+	border-bottom: 0;
     border-radius: 0px;
     text-align: center;
 }
 
 QHeaderView::section::vertical::first,
 QHeaderView::section::vertical::only-one {
-    border-top: 1px solid #76797C;
+    border-top: 1px solid #31363b;
 }
 
 QHeaderView::section::vertical {
     border-top: transparent;
 }
 
+QHeaderView::section::horizontal,
 QHeaderView::section::horizontal::first,
 QHeaderView::section::horizontal::only-one {
-    border-left: 1px solid #76797C;
+    border-left: transparent;
 }
 
-QHeaderView::section::horizontal {
-    border-left: transparent;
+QHeaderView::section::horizontal::last {
+	border-right: transparent;
 }
 
 QHeaderView::section:checked {

--- a/dist/qt_themes/qdarkstyle/style.qss
+++ b/dist/qt_themes/qdarkstyle/style.qss
@@ -198,7 +198,7 @@ QMenu::separator {
 }
 
 QMenu::indicator {
-	margin: 0 -26px 0 8px;
+    margin: 0 -26px 0 8px;
     width: 18px;
     height: 18px;
 }
@@ -1089,7 +1089,7 @@ QHeaderView::section {
     color: #eff0f1;
     padding: 0 5px;
     border: 1px solid #403F3F;
-	border-bottom: 0;
+    border-bottom: 0;
     border-radius: 0px;
     text-align: center;
 }
@@ -1110,7 +1110,7 @@ QHeaderView::section::horizontal::only-one {
 }
 
 QHeaderView::section::horizontal::last {
-	border-right: transparent;
+    border-right: transparent;
 }
 
 QHeaderView::section:checked {

--- a/src/citra_qt/uisettings.cpp
+++ b/src/citra_qt/uisettings.cpp
@@ -7,10 +7,10 @@
 namespace UISettings {
 
 const Themes themes{{
-    {"Default", "default"},
+    {"Light", "default"},
+    {"Light Colorful", "colorful"},
     {"Dark", "qdarkstyle"},
-    {"Colorful", "colorful"},
-    {"Colorful Dark", "colorful_dark"},
+    {"Dark Colorful", "colorful_dark"},
 }};
 
 Values values = {};


### PR DESCRIPTION
See yuzu-emu/yuzu#3339 for more details.

**Original description**:
This PR fixes few minor UI issues with dark themes also trying to mimic more "Default" ("Light") mode styling and component sizes to avoid resize on theme change. The following changes has been made:

- mimic "Default" theme list headers styling - use list background color, border omission, no extra padding - **_Screenshot 1_**
- decrease contrast of even rows on the lists to mimic "Default"  theme styling and differentiate those rows more from Status Bar or Filter Bar - **_Screenshot 1_**
- update tabs minimal size and padding to roughly match "Default" theme styling - **_Screenshot 2_**
- fix Main Menu and Context Menu (ex. game row) checkbox position and items padding - **_Screenshot 3_**
- fix ComboBox currently selected value being repositioned on options list open (only "Dark" themes seems affected) - **_Preview 1_**

I have also changed the themes names and reordered them to make it even more obvious for user how the theme will be looking like. It's completely optional change, even rather proposition, which I can ditch if you don't like it. 

Currently themes list looks like:
- Default
- Dark
- Colorful
- Colorful Dark

Proposed names and order (also visible in _Preview 1_):
- Light
- Light Colorful
- Dark
- Dark Colorful

I'm open to any suggestions and I would like to try to fix some more themes issues if you have experienced any.


#### Screenshot 1
<img width="692" alt="y1" src="https://user-images.githubusercontent.com/719641/72930780-f8486100-3d5c-11ea-90f0-2dc604bacbfe.png">

#### Screenshot 2 
<img width="847" alt="y2" src="https://user-images.githubusercontent.com/719641/72930817-131ad580-3d5d-11ea-89d7-23cd58c84da9.png">

#### Screenshot 3 
<img width="692" alt="y3" src="https://user-images.githubusercontent.com/719641/72930829-1a41e380-3d5d-11ea-9f73-30868a1786f6.png">

#### Preview 1
![yuzucb](https://user-images.githubusercontent.com/719641/72932097-5e35e800-3d5f-11ea-9eaf-df6f5a40f48c.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5077)
<!-- Reviewable:end -->
