### PR TITLE
swkbd: Fix digit filter

### DIFF
--- a/src/core/frontend/applets/swkbd.cpp
+++ b/src/core/frontend/applets/swkbd.cpp
@@ -15,9 +15,9 @@ namespace Frontend {
 
 ValidationError SoftwareKeyboard::ValidateFilters(const std::string& input) const {
     if (config.filters.prevent_digit) {
-        if (std::any_of(input.begin(), input.end(),
-                        [](unsigned char c) { return std::isdigit(c); })) {
-            return ValidationError::DigitNotAllowed;
+        if (std::count_if(input.begin(), input.end(),
+                          [](unsigned char c) { return std::isdigit(c); }) > config.max_digits) {
+            return ValidationError::MaxDigitsExceeded;
         }
     }
     if (config.filters.prevent_at) {

--- a/src/core/frontend/applets/swkbd.h
+++ b/src/core/frontend/applets/swkbd.h
@@ -47,8 +47,7 @@ struct KeyboardConfig {
     bool has_custom_button_text; /// If true, use the button_text instead
     std::vector<std::string> button_text; /// Contains the button text that the caller provides
     struct Filters {
-        bool prevent_digit;     /// Disallow the use of more than a certain number of digits
-                                /// TODO: how many is a certain number
+        bool prevent_digit;     /// Limit maximum digit count to max_digits
         bool prevent_at;        /// Disallow the use of the @ sign.
         bool prevent_percent;   /// Disallow the use of the % sign.
         bool prevent_backslash; /// Disallow the use of the \ sign.
@@ -68,7 +67,7 @@ enum class ValidationError {
     // Button Selection
     ButtonOutOfRange,
     // Configured Filters
-    DigitNotAllowed,
+    MaxDigitsExceeded,
     AtSignNotAllowed,
     PercentNotAllowed,
     BackslashNotAllowed,


### PR DESCRIPTION
Fixes #4938.

The DIGIT filter was incorrectly implemented as preventing all digits. It actually limits the maximum digit count to max_digits, according to ctrulib and hardware testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5086)
<!-- Reviewable:end -->
