### PR TITLE
core: Remove outdated MSVC workarounds

### DIFF
--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -6,9 +6,7 @@
 
 #include <array>
 #include <atomic>
-#ifndef _MSC_VER
 #include <cstddef>
-#endif
 #include <memory>
 #include "common/bit_field.h"
 #include "common/common_funcs.h"
@@ -177,10 +175,6 @@ struct GyroscopeCalibrateParam {
     } x, y, z;
 };
 
-// TODO: MSVC does not support using offsetof() on non-static data members even though this
-//       is technically allowed since C++11. This macro should be enabled once MSVC adds
-//       support for that.
-#ifndef _MSC_VER
 #define ASSERT_REG_POSITION(field_name, position)                                                  \
     static_assert(offsetof(SharedMem, field_name) == position * 4,                                 \
                   "Field " #field_name " has invalid position")
@@ -189,7 +183,6 @@ ASSERT_REG_POSITION(pad.index_reset_ticks, 0x0);
 ASSERT_REG_POSITION(touch.index_reset_ticks, 0x2A);
 
 #undef ASSERT_REG_POSITION
-#endif // !defined(_MSC_VER)
 
 struct DirectionState {
     bool up;

--- a/src/core/hw/gpu.cpp
+++ b/src/core/hw/gpu.cpp
@@ -402,8 +402,8 @@ inline void Write(u32 addr, const T data) {
     switch (index) {
 
     // Memory fills are triggered once the fill value is written.
-    case GPU_REG_INDEX_WORKAROUND(memory_fill_config[0].trigger, 0x00004 + 0x3):
-    case GPU_REG_INDEX_WORKAROUND(memory_fill_config[1].trigger, 0x00008 + 0x3): {
+    case GPU_REG_INDEX(memory_fill_config[0].trigger):
+    case GPU_REG_INDEX(memory_fill_config[1].trigger): {
         const bool is_second_filler = (index != GPU_REG_INDEX(memory_fill_config[0].trigger));
         auto& config = g_regs.memory_fill_config[is_second_filler];
 


### PR DESCRIPTION
GPU_REG_INDEX_WORKAROUND is no longer necessary
ASSERT_REG_POSITION now works properly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5099)
<!-- Reviewable:end -->
