### PR TITLE
Automatic Controller Binding

### DIFF
--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -269,6 +269,7 @@ ConfigureInput::ConfigureInput(QWidget* parent)
 
     ui->buttonDelete->setEnabled(ui->profile->count() > 1);
 
+    connect(ui->buttonAutoMap, &QPushButton::clicked, this, &ConfigureInput::AutoMap);
     connect(ui->buttonClearAll, &QPushButton::clicked, this, &ConfigureInput::ClearAll);
     connect(ui->buttonRestoreDefaults, &QPushButton::clicked, this,
             &ConfigureInput::RestoreDefaults);
@@ -425,6 +426,43 @@ void ConfigureInput::UpdateButtonLabels() {
     }
 
     EmitInputKeysChanged();
+}
+
+void ConfigureInput::MapFromButton(const Common::ParamPackage& params) {
+    Common::ParamPackage aux_param;
+    for (int button_id = 0; button_id < Settings::NativeButton::NumButtons; button_id++) {
+        aux_param = InputCommon::GetSDLControllerButtonBindByGUID(params.Get("guid", "0"),
+                                                                  params.Get("port", 0), button_id);
+        if (aux_param.Has("engine")) {
+            buttons_param[button_id] = aux_param;
+        }
+    }
+    for (int analog_id = 0; analog_id < Settings::NativeAnalog::NumAnalogs; analog_id++) {
+        aux_param = InputCommon::GetSDLControllerAnalogBindByGUID(params.Get("guid", "0"),
+                                                                  params.Get("port", 0), analog_id);
+        if (aux_param.Has("engine")) {
+            analogs_param[analog_id] = aux_param;
+        }
+    }
+}
+
+void ConfigureInput::AutoMap() {
+    if (QMessageBox::information(this, tr("Information"),
+                                 tr("After pressing OK, press any button on your joystick"),
+                                 QMessageBox::Ok | QMessageBox::Cancel) == QMessageBox::Ok) {
+        input_setter = [=](const Common::ParamPackage& params) {
+            MapFromButton(params);
+            ApplyConfiguration();
+            Settings::SaveProfile(ui->profile->currentIndex());
+        };
+        device_pollers = InputCommon::Polling::GetPollers(InputCommon::Polling::DeviceType::Button);
+        want_keyboard_keys = false;
+        for (auto& poller : device_pollers) {
+            poller->Start();
+        }
+        timeout_timer->start(5000); // Cancel after 5 seconds
+        poll_timer->start(200);     // Check for new inputs every 200ms
+    }
 }
 
 void ConfigureInput::HandleClick(QPushButton* button,

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -449,20 +449,21 @@ void ConfigureInput::MapFromButton(const Common::ParamPackage& params) {
 void ConfigureInput::AutoMap() {
     if (QMessageBox::information(this, tr("Information"),
                                  tr("After pressing OK, press any button on your joystick"),
-                                 QMessageBox::Ok | QMessageBox::Cancel) == QMessageBox::Ok) {
-        input_setter = [=](const Common::ParamPackage& params) {
-            MapFromButton(params);
-            ApplyConfiguration();
-            Settings::SaveProfile(ui->profile->currentIndex());
-        };
-        device_pollers = InputCommon::Polling::GetPollers(InputCommon::Polling::DeviceType::Button);
-        want_keyboard_keys = false;
-        for (auto& poller : device_pollers) {
-            poller->Start();
-        }
-        timeout_timer->start(5000); // Cancel after 5 seconds
-        poll_timer->start(200);     // Check for new inputs every 200ms
+                                 QMessageBox::Ok | QMessageBox::Cancel) == QMessageBox::Cancel) {
+        return;
     }
+    input_setter = [=](const Common::ParamPackage& params) {
+        MapFromButton(params);
+        ApplyConfiguration();
+        Settings::SaveProfile(ui->profile->currentIndex());
+    };
+    device_pollers = InputCommon::Polling::GetPollers(InputCommon::Polling::DeviceType::Button);
+    want_keyboard_keys = false;
+    for (auto& poller : device_pollers) {
+        poller->Start();
+    }
+    timeout_timer->start(5000); // Cancel after 5 seconds
+    poll_timer->start(200);     // Check for new inputs every 200ms
 }
 
 void ConfigureInput::HandleClick(QPushButton* button,

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -430,11 +430,13 @@ void ConfigureInput::UpdateButtonLabels() {
 
 void ConfigureInput::MapFromButton(const Common::ParamPackage& params) {
     Common::ParamPackage aux_param;
+    bool mapped = false;
     for (int button_id = 0; button_id < Settings::NativeButton::NumButtons; button_id++) {
         aux_param = InputCommon::GetSDLControllerButtonBindByGUID(params.Get("guid", "0"),
                                                                   params.Get("port", 0), button_id);
         if (aux_param.Has("engine")) {
             buttons_param[button_id] = aux_param;
+            mapped = true;
         }
     }
     for (int analog_id = 0; analog_id < Settings::NativeAnalog::NumAnalogs; analog_id++) {
@@ -442,7 +444,13 @@ void ConfigureInput::MapFromButton(const Common::ParamPackage& params) {
                                                                   params.Get("port", 0), analog_id);
         if (aux_param.Has("engine")) {
             analogs_param[analog_id] = aux_param;
+            mapped = true;
         }
+    }
+    if (!mapped) {
+        QMessageBox::warning(
+            this, tr("Warning"),
+            tr("Auto mapping failed. Your controller may not have a corresponding mapping"));
     }
 }
 

--- a/src/citra_qt/configuration/configure_input.h
+++ b/src/citra_qt/configuration/configure_input.h
@@ -98,6 +98,9 @@ private:
     /// Generates list of all used keys
     QList<QKeySequence> GetUsedKeyboardKeys();
 
+    void MapFromButton(const Common::ParamPackage& params);
+    void AutoMap();
+
     /// Restore all buttons to their default values.
     void RestoreDefaults();
     /// Clear all input configuration

--- a/src/citra_qt/configuration/configure_input.ui
+++ b/src/citra_qt/configuration/configure_input.ui
@@ -727,17 +727,32 @@
         </widget>
        </item>
        <item>
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+        <widget class="QPushButton" name="buttonAutoMap">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
-         <property name="sizeHint" stdset="0">
+         <property name="sizeIncrement">
           <size>
-           <width>40</width>
-           <height>20</height>
+           <width>0</width>
+           <height>0</height>
           </size>
          </property>
-        </spacer>
+         <property name="baseSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="layoutDirection">
+          <enum>Qt::LeftToRight</enum>
+         </property>
+         <property name="text">
+          <string>Auto Map</string>
+         </property>
+        </widget>
        </item>
        <item>
         <widget class="QPushButton" name="buttonClearAll">

--- a/src/input_common/main.cpp
+++ b/src/input_common/main.cpp
@@ -10,6 +10,7 @@
 #include "input_common/main.h"
 #include "input_common/motion_emu.h"
 #include "input_common/sdl/sdl.h"
+#include "input_common/sdl/sdl_impl.h"
 #include "input_common/touch_from_button.h"
 #include "input_common/udp/udp.h"
 
@@ -74,6 +75,18 @@ std::string GenerateAnalogParamFromKeys(int key_up, int key_down, int key_left, 
         {"modifier_scale", std::to_string(modifier_scale)},
     };
     return circle_pad_param.Serialize();
+}
+
+Common::ParamPackage GetSDLControllerButtonBindByGUID(const std::string& guid, int port,
+                                                      int button) {
+    return dynamic_cast<SDL::SDLState*>(sdl.get())->GetSDLControllerButtonBindByGUID(
+        guid, port, static_cast<Settings::NativeButton::Values>(button));
+}
+
+Common::ParamPackage GetSDLControllerAnalogBindByGUID(const std::string& guid, int port,
+                                                      int analog) {
+    return dynamic_cast<SDL::SDLState*>(sdl.get())->GetSDLControllerAnalogBindByGUID(
+        guid, port, static_cast<Settings::NativeAnalog::Values>(analog));
 }
 
 void ReloadInputDevices() {

--- a/src/input_common/main.h
+++ b/src/input_common/main.h
@@ -37,6 +37,11 @@ std::string GenerateKeyboardParam(int key_code);
 std::string GenerateAnalogParamFromKeys(int key_up, int key_down, int key_left, int key_right,
                                         int key_modifier, float modifier_scale);
 
+Common::ParamPackage GetSDLControllerButtonBindByGUID(const std::string& guid, int port,
+                                                      int button);
+Common::ParamPackage GetSDLControllerAnalogBindByGUID(const std::string& guid, int port,
+                                                      int analog);
+
 /// Reloads the input devices
 void ReloadInputDevices();
 

--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -48,7 +48,7 @@ static int SDLEventWatcher(void* userdata, SDL_Event* event) {
     return 0;
 }
 
-static const std::array<SDL_GameControllerButton, Settings::NativeButton::NumButtons>
+constexpr std::array<SDL_GameControllerButton, Settings::NativeButton::NumButtons>
     xinput_to_3ds_mapping = {{
         SDL_CONTROLLER_BUTTON_B,
         SDL_CONTROLLER_BUTTON_A,
@@ -145,7 +145,7 @@ public:
             std::unique_ptr<SDL_Joystick, decltype(&SDL_JoystickClose)>(joystick, deleter);
     }
 
-    SDL_GameController* GetGameController() {
+    SDL_GameController* GetGameController() const {
         return SDL_GameControllerFromInstanceID(SDL_JoystickInstanceID(sdl_joystick.get()));
     }
 
@@ -280,7 +280,7 @@ Common::ParamPackage SDLState::GetSDLControllerButtonBindByGUID(
     SDL_GameController* controller = GetSDLGameControllerByGUID(guid, port)->GetSDLGameController();
     SDL_GameControllerButtonBind button_bind;
 
-    if (controller == NULL) {
+    if (!controller) {
         LOG_WARNING(Input, "failed to open controller {}", guid);
         return {{}};
     }
@@ -329,7 +329,6 @@ Common::ParamPackage SDLState::GetSDLControllerButtonBindByGUID(
     default:
         LOG_WARNING(Input, "unknown SDL bind type {}", button_bind.bindType);
         return {{}};
-        break;
     }
 
     return params;
@@ -344,7 +343,7 @@ Common::ParamPackage SDLState::GetSDLControllerAnalogBindByGUID(
     SDL_GameControllerButtonBind button_bind_x;
     SDL_GameControllerButtonBind button_bind_y;
 
-    if (controller == NULL) {
+    if (!controller) {
         LOG_WARNING(Input, "failed to open controller {}", guid);
         return {{}};
     }
@@ -352,11 +351,9 @@ Common::ParamPackage SDLState::GetSDLControllerAnalogBindByGUID(
     if (analog == Settings::NativeAnalog::Values::CirclePad) {
         button_bind_x = SDL_GameControllerGetBindForAxis(controller, SDL_CONTROLLER_AXIS_LEFTX);
         button_bind_y = SDL_GameControllerGetBindForAxis(controller, SDL_CONTROLLER_AXIS_LEFTY);
-
     } else if (analog == Settings::NativeAnalog::Values::CStick) {
         button_bind_x = SDL_GameControllerGetBindForAxis(controller, SDL_CONTROLLER_AXIS_RIGHTX);
         button_bind_y = SDL_GameControllerGetBindForAxis(controller, SDL_CONTROLLER_AXIS_RIGHTY);
-
     } else {
         LOG_WARNING(Input, "analog value out of range {}", analog);
         return {{}};

--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -350,7 +350,6 @@ Common::ParamPackage SDLState::GetSDLControllerButtonBindByGUID(
     } else {
         button_bind = SDL_GameControllerGetBindForButton(controller, mapped_button);
     }
-    extended_bind = (controller)->bindings[mapped_button];
 
     switch (button_bind.bindType) {
     case SDL_CONTROLLER_BINDTYPE_BUTTON:
@@ -377,6 +376,9 @@ Common::ParamPackage SDLState::GetSDLControllerButtonBindByGUID(
         break;
     case SDL_CONTROLLER_BINDTYPE_AXIS:
         params.Set("axis", button_bind.value.axis);
+
+#if SDL_VERSION_ATLEAST(2, 0, 6)
+        extended_bind = (controller)->bindings[mapped_button];
         if (extended_bind.input.axis.axis_max < extended_bind.input.axis.axis_min) {
             params.Set("direction", "-");
         } else {
@@ -387,6 +389,9 @@ Common::ParamPackage SDLState::GetSDLControllerButtonBindByGUID(
             (extended_bind.input.axis.axis_min +
              (extended_bind.input.axis.axis_max - extended_bind.input.axis.axis_min) / 2.0f) /
                 SDL_JOYSTICK_AXIS_MAX);
+#else
+        params.Set("direction", "+"); // lacks extended_bind, so just a guess
+#endif
         break;
     case SDL_CONTROLLER_BINDTYPE_NONE:
         LOG_WARNING(Input, "Button not bound: {}", Settings::NativeButton::mapping[button]);

--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -436,7 +436,8 @@ Common::ParamPackage SDLState::GetSDLControllerAnalogBindByGUID(
 void SDLState::InitJoystick(int joystick_index) {
     SDL_Joystick* sdl_joystick = SDL_JoystickOpen(joystick_index);
     if (!sdl_joystick) {
-        LOG_ERROR(Input, "failed to open joystick {}", joystick_index);
+        LOG_ERROR(Input, "failed to open joystick {}, with error: ", joystick_index,
+                  SDL_GetError());
         return;
     }
     const std::string guid = GetGUID(sdl_joystick);

--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -388,6 +388,9 @@ Common::ParamPackage SDLState::GetSDLControllerButtonBindByGUID(
              (extended_bind.input.axis.axis_max - extended_bind.input.axis.axis_min) / 2.0f) /
                 SDL_JOYSTICK_AXIS_MAX);
         break;
+    case SDL_CONTROLLER_BINDTYPE_NONE:
+        LOG_WARNING(Input, "Button not bound: {}", Settings::NativeButton::mapping[button]);
+        return {{}};
     default:
         LOG_WARNING(Input, "unknown SDL bind type {}", button_bind.bindType);
         return {{}};
@@ -421,12 +424,12 @@ Common::ParamPackage SDLState::GetSDLControllerAnalogBindByGUID(
         return {{}};
     }
 
-    if (button_bind_x.bindType == SDL_CONTROLLER_BINDTYPE_AXIS &&
-        button_bind_y.bindType == SDL_CONTROLLER_BINDTYPE_AXIS) {
-        params.Set("axis_x", button_bind_x.value.axis);
-        params.Set("axis_y", button_bind_y.value.axis);
+    if (button_bind_x.bindType != SDL_CONTROLLER_BINDTYPE_AXIS ||
+        button_bind_y.bindType != SDL_CONTROLLER_BINDTYPE_AXIS) {
+        return {{}};
     }
-
+    params.Set("axis_x", button_bind_x.value.axis);
+    params.Set("axis_y", button_bind_y.value.axis);
     return params;
 }
 

--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -293,6 +293,7 @@ Common::ParamPackage SDLState::GetSDLControllerAnalogBindByGUID(
     SDL_GameControllerButtonBind button_bind_y;
 
     if (controller == NULL) {
+        LOG_WARNING(Input, "failed to open controller {}", guid);
         return {{}};
     }
 
@@ -589,9 +590,9 @@ SDLState::SDLState() {
     RegisterFactory<AnalogDevice>("sdl", std::make_shared<SDLAnalogFactory>(*this));
 
     // If the frontend is going to manage the event loop, then we dont start one here
-    start_thread = !SDL_WasInit(SDL_INIT_JOYSTICK);
-    if (start_thread && SDL_Init(SDL_INIT_JOYSTICK) < 0) {
-        LOG_CRITICAL(Input, "SDL_Init(SDL_INIT_JOYSTICK) failed with: {}", SDL_GetError());
+    start_thread = !SDL_WasInit(SDL_INIT_GAMECONTROLLER);
+    if (start_thread && SDL_Init(SDL_INIT_GAMECONTROLLER) < 0) {
+        LOG_CRITICAL(Input, "SDL_Init(SDL_INIT_GAMECONTROLLER) failed with: {}", SDL_GetError());
         return;
     }
     if (SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1") == SDL_FALSE) {
@@ -635,7 +636,7 @@ SDLState::~SDLState() {
     initialized = false;
     if (start_thread) {
         poll_thread.join();
-        SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
+        SDL_QuitSubSystem(SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER);
     }
 }
 

--- a/src/input_common/sdl/sdl_impl.h
+++ b/src/input_common/sdl/sdl_impl.h
@@ -14,10 +14,12 @@
 union SDL_Event;
 using SDL_Joystick = struct _SDL_Joystick;
 using SDL_JoystickID = s32;
+using SDL_GameController = struct _SDL_GameController;
 
 namespace InputCommon::SDL {
 
 class SDLJoystick;
+class SDLGameController;
 class SDLButtonFactory;
 class SDLAnalogFactory;
 
@@ -35,6 +37,9 @@ public:
     std::shared_ptr<SDLJoystick> GetSDLJoystickBySDLID(SDL_JoystickID sdl_id);
     std::shared_ptr<SDLJoystick> GetSDLJoystickByGUID(const std::string& guid, int port);
 
+    std::shared_ptr<SDLGameController> GetSDLGameControllerByGUID(const std::string& guid,
+                                                                  int port);
+
     Common::ParamPackage GetSDLControllerButtonBindByGUID(const std::string& guid, int port,
                                                           Settings::NativeButton::Values button);
     Common::ParamPackage GetSDLControllerAnalogBindByGUID(const std::string& guid, int port,
@@ -51,12 +56,20 @@ private:
     void InitJoystick(int joystick_index);
     void CloseJoystick(SDL_Joystick* sdl_joystick);
 
+    void InitGameController(int joystick_index);
+    void CloseGameController(SDL_GameController* sdl_controller);
+
     /// Needs to be called before SDL_QuitSubSystem.
     void CloseJoysticks();
+    void CloseGameControllers();
 
     /// Map of GUID of a list of corresponding virtual Joysticks
     std::unordered_map<std::string, std::vector<std::shared_ptr<SDLJoystick>>> joystick_map;
     std::mutex joystick_map_mutex;
+
+    /// Map of GUID of a list of corresponding virtual Controllers
+    std::unordered_map<std::string, std::vector<std::shared_ptr<SDLGameController>>> controller_map;
+    std::mutex controller_map_mutex;
 
     std::shared_ptr<SDLButtonFactory> button_factory;
     std::shared_ptr<SDLAnalogFactory> analog_factory;

--- a/src/input_common/sdl/sdl_impl.h
+++ b/src/input_common/sdl/sdl_impl.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <thread>
 #include "common/threadsafe_queue.h"
+#include "core/settings.h"
 #include "input_common/sdl/sdl.h"
 
 union SDL_Event;
@@ -33,6 +34,9 @@ public:
 
     std::shared_ptr<SDLJoystick> GetSDLJoystickBySDLID(SDL_JoystickID sdl_id);
     std::shared_ptr<SDLJoystick> GetSDLJoystickByGUID(const std::string& guid, int port);
+
+    Common::ParamPackage GetSDLControllerButtonBindByGUID(const std::string& guid, int port, Settings::NativeButton::Values button);
+    Common::ParamPackage GetSDLControllerAnalogBindByGUID(const std::string& guid, int port, Settings::NativeAnalog::Values analog);
 
     /// Get all DevicePoller that use the SDL backend for a specific device type
     Pollers GetPollers(Polling::DeviceType type) override;

--- a/src/input_common/sdl/sdl_impl.h
+++ b/src/input_common/sdl/sdl_impl.h
@@ -35,8 +35,10 @@ public:
     std::shared_ptr<SDLJoystick> GetSDLJoystickBySDLID(SDL_JoystickID sdl_id);
     std::shared_ptr<SDLJoystick> GetSDLJoystickByGUID(const std::string& guid, int port);
 
-    Common::ParamPackage GetSDLControllerButtonBindByGUID(const std::string& guid, int port, Settings::NativeButton::Values button);
-    Common::ParamPackage GetSDLControllerAnalogBindByGUID(const std::string& guid, int port, Settings::NativeAnalog::Values analog);
+    Common::ParamPackage GetSDLControllerButtonBindByGUID(const std::string& guid, int port,
+                                                          Settings::NativeButton::Values button);
+    Common::ParamPackage GetSDLControllerAnalogBindByGUID(const std::string& guid, int port,
+                                                          Settings::NativeAnalog::Values analog);
 
     /// Get all DevicePoller that use the SDL backend for a specific device type
     Pollers GetPollers(Polling::DeviceType type) override;


### PR DESCRIPTION
If the joystick has a controller mapping in the SDL database, use it as a reference to automatically map the buttons.
Currently maps on the current profile, and doesn't do anything to buttons that don't have a binding.

![Auto Map Dialog](https://user-images.githubusercontent.com/29167336/75000810-3610d600-543e-11ea-8414-27a3325f0d9b.PNG)

To do:
- [x] Get additional information from the SDL_ExtendedGameControllerBind.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5100)
<!-- Reviewable:end -->
