### PR TITLE
videocore/renderer_opengl/gl_rasterizer_cache: Move bits per pixel table out of function

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -138,31 +138,33 @@ struct SurfaceParams {
         Invalid = 5
     };
 
-    static constexpr unsigned int GetFormatBpp(PixelFormat format) {
-        constexpr std::array<unsigned int, 18> bpp_table = {
-            32, // RGBA8
-            24, // RGB8
-            16, // RGB5A1
-            16, // RGB565
-            16, // RGBA4
-            16, // IA8
-            16, // RG8
-            8,  // I8
-            8,  // A8
-            8,  // IA4
-            4,  // I4
-            4,  // A4
-            4,  // ETC1
-            8,  // ETC1A4
-            16, // D16
-            0,
-            24, // D24
-            32, // D24S8
-        };
+    static constexpr std::array<unsigned int, 18> BPP_TABLE = {
+        32, // RGBA8
+        24, // RGB8
+        16, // RGB5A1
+        16, // RGB565
+        16, // RGBA4
+        16, // IA8
+        16, // RG8
+        8,  // I8
+        8,  // A8
+        8,  // IA4
+        4,  // I4
+        4,  // A4
+        4,  // ETC1
+        8,  // ETC1A4
+        16, // D16
+        0,
+        24, // D24
+        32, // D24S8
+    };
 
-        assert(static_cast<std::size_t>(format) < bpp_table.size());
-        return bpp_table[static_cast<std::size_t>(format)];
+    static constexpr unsigned int GetFormatBpp(PixelFormat format) {
+        const auto format_idx = static_cast<std::size_t>(format);
+        DEBUG_ASSERT_MSG(format_idx < bpp_table.size(), "Invalid pixel format {}", format_idx);
+        return BPP_TABLE[format_idx];
     }
+
     unsigned int GetFormatBpp() const {
         return GetFormatBpp(pixel_format);
     }

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -161,7 +161,7 @@ struct SurfaceParams {
 
     static constexpr unsigned int GetFormatBpp(PixelFormat format) {
         const auto format_idx = static_cast<std::size_t>(format);
-        DEBUG_ASSERT_MSG(format_idx < bpp_table.size(), "Invalid pixel format {}", format_idx);
+        DEBUG_ASSERT_MSG(format_idx < BPP_TABLE.size(), "Invalid pixel format {}", format_idx);
         return BPP_TABLE[format_idx];
     }
 

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -101,6 +101,29 @@ enum class ScaleMatch {
 };
 
 struct SurfaceParams {
+private:
+    static constexpr std::array<unsigned int, 18> BPP_TABLE = {
+        32, // RGBA8
+        24, // RGB8
+        16, // RGB5A1
+        16, // RGB565
+        16, // RGBA4
+        16, // IA8
+        16, // RG8
+        8,  // I8
+        8,  // A8
+        8,  // IA4
+        4,  // I4
+        4,  // A4
+        4,  // ETC1
+        8,  // ETC1A4
+        16, // D16
+        0,
+        24, // D24
+        32, // D24S8
+    };
+
+public:
     enum class PixelFormat {
         // First 5 formats are shared between textures and color buffers
         RGBA8 = 0,
@@ -136,27 +159,6 @@ struct SurfaceParams {
         DepthStencil = 3,
         Fill = 4,
         Invalid = 5
-    };
-
-    static constexpr std::array<unsigned int, 18> BPP_TABLE = {
-        32, // RGBA8
-        24, // RGB8
-        16, // RGB5A1
-        16, // RGB565
-        16, // RGBA4
-        16, // IA8
-        16, // RG8
-        8,  // I8
-        8,  // A8
-        8,  // IA4
-        4,  // I4
-        4,  // A4
-        4,  // ETC1
-        8,  // ETC1A4
-        16, // D16
-        0,
-        24, // D24
-        32, // D24S8
     };
 
     static constexpr unsigned int GetFormatBpp(PixelFormat format) {


### PR DESCRIPTION
GCC and MSVC copy the table at runtime with the old implementation, which is wasteful and prevents inlining. Unfortunately, static constexpr variables are not legal in constexpr functions, so the table has to be external.
Also replaced non-standard assert with DEBUG_ASSERT_MSG.
[Relevant compiler output](https://godbolt.org/z/-whv8_)
Ideas for how to do this without exposing the table are welcome.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5101)
<!-- Reviewable:end -->
