### PR TITLE
ipc_debugger: Fixing NULL ptr call on multiple clear

### DIFF
--- a/src/citra_qt/debugger/ipc/recorder.cpp
+++ b/src/citra_qt/debugger/ipc/recorder.cpp
@@ -114,7 +114,7 @@ void IPCRecorderWidget::SetEnabled(bool enabled) {
 }
 
 void IPCRecorderWidget::Clear() {
-    id_offset = records.size() + 1;
+    id_offset += records.size();
 
     records.clear();
     ui->main->invisibleRootItem()->takeChildren();


### PR DESCRIPTION
Fixes a segfault when using the IPC Debugger by calling a NULL pointer.

The IPC Debugger logs all IPC calls from tracing to element X. When clearing, we save the number of element X so that we know not to repeat already cleared IPC calls and show them accordingly. This was done by using the length of the treeBox. Unfortunately, after clearing once the list, the treeBox size cannot be up to date anymore, as past elements have been cleared, and as such some calculations were off leading to non-existing objects being processed.
This was replaced by using the offset calculated by the clear function added on top of the records list size.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5105)
<!-- Reviewable:end -->
