### PR TITLE
videocore/renderer_opengl/gl_rasterizer_cache: implement LRU cached surface culling

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "boost"]
     path = externals/boost
-    url = https://github.com/citra-emu/ext-boost.git
+    url = https://github.com/BreadFish64/ext-boost.git
 [submodule "nihstro"]
     path = externals/nihstro
     url = https://github.com/neobrain/nihstro.git

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -1222,10 +1222,15 @@ Surface FindMatch(const SurfaceCache& surface_cache, const SurfaceParams& params
             });
         }
     }
+    if (match_surface)
+        match_surface->LRUBump();
     return match_surface;
 }
 
 RasterizerCacheOpenGL::RasterizerCacheOpenGL() {
+    // 1GB / max size of surface with mips
+    lru_max_size = (1024 * 1024 * 1024) / (1024 * 1024 * 4 / 3);
+
     read_framebuffer.Create();
     draw_framebuffer.Create();
 
@@ -2045,6 +2050,11 @@ void RasterizerCacheOpenGL::RegisterSurface(const Surface& surface) {
     }
     surface->registered = true;
     surface_cache.add({surface->GetInterval(), SurfaceSet{surface}});
+
+    if (lru.size() == lru_max_size)
+        UnregisterSurface(lru.back()->shared_from_this());
+    surface->AddToLRU(lru);
+
     UpdatePagesCachedCount(surface->addr, surface->size, 1);
 }
 
@@ -2053,6 +2063,7 @@ void RasterizerCacheOpenGL::UnregisterSurface(const Surface& surface) {
         return;
     }
     surface->registered = false;
+    surface->RemoveFromLRU();
     UpdatePagesCachedCount(surface->addr, surface->size, -1);
     surface_cache.subtract({surface->GetInterval(), SurfaceSet{surface}});
 }

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -2051,8 +2051,10 @@ void RasterizerCacheOpenGL::RegisterSurface(const Surface& surface) {
     surface->registered = true;
     surface_cache.add({surface->GetInterval(), SurfaceSet{surface}});
 
-    if (lru.size() == lru_max_size)
+    if (lru.size() == lru_max_size) {
+        LOG_DEBUG(Render_OpenGL, "Surface evicted from cache");
         UnregisterSurface(lru.back()->shared_from_this());
+    }
     surface->AddToLRU(lru);
 
     UpdatePagesCachedCount(surface->addr, surface->size, 1);

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -20,6 +20,7 @@
 #endif
 #include <unordered_map>
 #include <boost/functional/hash.hpp>
+#include <boost/pool/pool_alloc.hpp>
 #include <glad/glad.h>
 #include "common/assert.h"
 #include "common/common_funcs.h"
@@ -83,6 +84,11 @@ using SurfaceSet = std::set<Surface>;
 using SurfaceRegions = boost::icl::interval_set<PAddr>;
 using SurfaceMap = boost::icl::interval_map<PAddr, Surface>;
 using SurfaceCache = boost::icl::interval_map<PAddr, SurfaceSet>;
+
+using LRUSurfaceLookup =
+    std::list<CachedSurface*,
+              boost::fast_pool_allocator<CachedSurface*, boost::default_user_allocator_new_delete,
+                                         boost::details::pool::null_mutex>>;
 
 using SurfaceInterval = SurfaceCache::interval_type;
 static_assert(std::is_same<SurfaceRegions::interval_type, SurfaceCache::interval_type>() &&
@@ -341,6 +347,10 @@ private:
 };
 
 struct CachedSurface : SurfaceParams, std::enable_shared_from_this<CachedSurface> {
+    ~CachedSurface() {
+        RemoveFromLRU();
+    }
+
     bool CanFill(const SurfaceParams& dest_surface, SurfaceInterval fill_interval) const;
     bool CanCopy(const SurfaceParams& dest_surface, SurfaceInterval copy_interval) const;
 
@@ -420,7 +430,29 @@ struct CachedSurface : SurfaceParams, std::enable_shared_from_this<CachedSurface
         watchers.clear();
     }
 
+    void AddToLRU(LRUSurfaceLookup& new_lru) {
+        lru = &new_lru;
+        lru->emplace_front(this);
+        lru_pos = lru->begin();
+    }
+
+    void LRUBump() {
+        lru->erase(lru_pos);
+        lru->emplace_front(this);
+        lru_pos = lru->begin();
+    }
+
+    void RemoveFromLRU() {
+        if (!lru)
+            return;
+        lru->erase(lru_pos);
+        lru_pos = {};
+        lru = nullptr;
+    }
+
 private:
+    LRUSurfaceLookup* lru;
+    LRUSurfaceLookup::iterator lru_pos;
     std::list<std::weak_ptr<SurfaceWatcher>> watchers;
 };
 
@@ -505,6 +537,8 @@ private:
     void UpdatePagesCachedCount(PAddr addr, u32 size, int delta);
 
     SurfaceCache surface_cache;
+    std::size_t lru_max_size;
+    LRUSurfaceLookup lru;
     PageMap cached_pages;
     SurfaceMap dirty_regions;
     SurfaceSet remove_surfaces;

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -9,18 +9,18 @@
 #include <memory>
 #include <set>
 #include <tuple>
+#include <unordered_map>
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-local-typedefs"
 #endif
+#include <boost/functional/hash.hpp>
 #include <boost/icl/interval_map.hpp>
 #include <boost/icl/interval_set.hpp>
+#include <boost/pool/pool_alloc.hpp>
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif
-#include <unordered_map>
-#include <boost/functional/hash.hpp>
-#include <boost/pool/pool_alloc.hpp>
 #include <glad/glad.h>
 #include "common/assert.h"
 #include "common/common_funcs.h"


### PR DESCRIPTION
This should fix some of the problems with games slowing down over time because we never clear the cache.

TODO:
- [ ] base max cache size based on available VRAM

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5107)
<!-- Reviewable:end -->
