### PR TITLE
core/file_sys: Add alternative override pathes for ExeFS files

### DIFF
--- a/src/core/file_sys/ncch_container.cpp
+++ b/src/core/file_sys/ncch_container.cpp
@@ -539,9 +539,11 @@ Loader::ResultStatus NCCHContainer::ApplyCodePatch(std::vector<u8>& code) const 
     const auto mods_path =
         fmt::format("{}mods/{:016X}/", FileUtil::GetUserPath(FileUtil::UserPath::LoadDir),
                     GetModId(ncch_header.program_id));
-    const std::array<PatchLocation, 4> patch_paths{{
+    const std::array<PatchLocation, 6> patch_paths{{
         {mods_path + "exefs/code.ips", Patch::ApplyIpsPatch},
         {mods_path + "exefs/code.bps", Patch::ApplyBpsPatch},
+        {mods_path + "code.ips", Patch::ApplyIpsPatch},
+        {mods_path + "code.bps", Patch::ApplyBpsPatch},
         {filepath + ".exefsdir/code.ips", Patch::ApplyIpsPatch},
         {filepath + ".exefsdir/code.bps", Patch::ApplyBpsPatch},
     }};
@@ -583,8 +585,9 @@ Loader::ResultStatus NCCHContainer::LoadOverrideExeFSSection(const char* name,
     const auto mods_path =
         fmt::format("{}mods/{:016X}/", FileUtil::GetUserPath(FileUtil::UserPath::LoadDir),
                     GetModId(ncch_header.program_id));
-    std::array<std::string, 2> override_paths{{
+    std::array<std::string, 3> override_paths{{
         mods_path + "exefs/" + override_name,
+        mods_path + override_name,
         filepath + ".exefsdir/" + override_name,
     }};
 

--- a/src/core/file_sys/ncch_container.cpp
+++ b/src/core/file_sys/ncch_container.cpp
@@ -315,7 +315,7 @@ Loader::ResultStatus NCCHContainer::Load() {
             const auto mods_path =
                 fmt::format("{}mods/{:016X}/", FileUtil::GetUserPath(FileUtil::UserPath::LoadDir),
                             GetModId(ncch_header.program_id));
-            std::array<std::string, 2> exheader_override_paths{{
+            const std::array<std::string, 2> exheader_override_paths{{
                 mods_path + "exheader.bin",
                 filepath + ".exheader",
             }};
@@ -585,7 +585,7 @@ Loader::ResultStatus NCCHContainer::LoadOverrideExeFSSection(const char* name,
     const auto mods_path =
         fmt::format("{}mods/{:016X}/", FileUtil::GetUserPath(FileUtil::UserPath::LoadDir),
                     GetModId(ncch_header.program_id));
-    std::array<std::string, 3> override_paths{{
+    const std::array<std::string, 3> override_paths{{
         mods_path + "exefs/" + override_name,
         mods_path + override_name,
         filepath + ".exefsdir/" + override_name,


### PR DESCRIPTION
You can now directly place ExeFS overrides/patches inside the mod folder (instead of the exefs subfolder). This allows us to have drop-in compatibility with Luma3DS mods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5110)
<!-- Reviewable:end -->
