### PR TITLE
Qt Linguistic warnings

### DIFF
--- a/src/citra_qt/game_list_p.h
+++ b/src/citra_qt/game_list_p.h
@@ -89,18 +89,18 @@ static QString GetQStringLongTitleFromSMDH(const Loader::SMDH& smdh,
 static QString GetRegionFromSMDH(const Loader::SMDH& smdh) {
     using GameRegion = Loader::SMDH::GameRegion;
     static const std::map<GameRegion, const char*> regions_map = {
-        {GameRegion::Japan, QT_TR_NOOP("Japan")},
-        {GameRegion::NorthAmerica, QT_TR_NOOP("North America")},
-        {GameRegion::Europe, QT_TR_NOOP("Europe")},
-        {GameRegion::Australia, QT_TR_NOOP("Australia")},
-        {GameRegion::China, QT_TR_NOOP("China")},
-        {GameRegion::Korea, QT_TR_NOOP("Korea")},
-        {GameRegion::Taiwan, QT_TR_NOOP("Taiwan")}};
+        {GameRegion::Japan, QT_TRANSLATE_NOOP("GameRegion", "Japan")},
+        {GameRegion::NorthAmerica, QT_TRANSLATE_NOOP("GameRegion", "North America")},
+        {GameRegion::Europe, QT_TRANSLATE_NOOP("GameRegion", "Europe")},
+        {GameRegion::Australia, QT_TRANSLATE_NOOP("GameRegion", "Australia")},
+        {GameRegion::China, QT_TRANSLATE_NOOP("GameRegion", "China")},
+        {GameRegion::Korea, QT_TRANSLATE_NOOP("GameRegion", "Korea")},
+        {GameRegion::Taiwan, QT_TRANSLATE_NOOP("GameRegion", "Taiwan")}};
 
     std::vector<GameRegion> regions = smdh.GetRegions();
 
     if (regions.empty()) {
-        return QObject::tr("Invalid region");
+        return QCoreApplication::translate("GameRegion", "Invalid region");
     }
 
     const bool region_free =
@@ -108,14 +108,14 @@ static QString GetRegionFromSMDH(const Loader::SMDH& smdh) {
             return std::find(regions.begin(), regions.end(), it.first) != regions.end();
         });
     if (region_free) {
-        return QObject::tr("Region free");
+        return QCoreApplication::translate("GameRegion", "Region free");
     }
 
     const QString separator =
         UISettings::values.game_list_single_line_mode ? QStringLiteral(", ") : QStringLiteral("\n");
-    QString result = QObject::tr(regions_map.at(regions.front()));
+    QString result = QCoreApplication::translate("GameRegion", regions_map.at(regions.front()));
     for (auto region = ++regions.begin(); region != regions.end(); ++region) {
-        result += separator + QObject::tr(regions_map.at(*region));
+        result += separator + QCoreApplication::translate("GameRegion", regions_map.at(*region));
     }
     return result;
 }

--- a/src/citra_qt/multiplayer/chat_room.cpp
+++ b/src/citra_qt/multiplayer/chat_room.cpp
@@ -226,7 +226,7 @@ void ChatRoom::SendModerationRequest(Network::RoomMessageTypes type, const std::
                                    return member.nickname == nickname;
                                });
         if (it == members.end()) {
-            NetworkMessage::ShowError(NetworkMessage::NO_SUCH_USER);
+            NetworkMessage::ErrorManager::ShowError(NetworkMessage::ErrorManager::NO_SUCH_USER);
             return;
         }
         room->SendModerationRequest(type, nickname);

--- a/src/citra_qt/multiplayer/direct_connect.cpp
+++ b/src/citra_qt/multiplayer/direct_connect.cpp
@@ -56,7 +56,7 @@ void DirectConnectWindow::RetranslateUi() {
 
 void DirectConnectWindow::Connect() {
     if (!ui->nickname->hasAcceptableInput()) {
-        NetworkMessage::ShowError(NetworkMessage::USERNAME_NOT_VALID);
+        NetworkMessage::ErrorManager::ShowError(NetworkMessage::ErrorManager::USERNAME_NOT_VALID);
         return;
     }
     if (const auto member = Network::GetRoomMember().lock()) {
@@ -75,11 +75,12 @@ void DirectConnectWindow::Connect() {
         break;
     case ConnectionType::IP:
         if (!ui->ip->hasAcceptableInput()) {
-            NetworkMessage::ShowError(NetworkMessage::IP_ADDRESS_NOT_VALID);
+            NetworkMessage::ErrorManager::ShowError(
+                NetworkMessage::ErrorManager::IP_ADDRESS_NOT_VALID);
             return;
         }
         if (!ui->port->hasAcceptableInput()) {
-            NetworkMessage::ShowError(NetworkMessage::PORT_NOT_VALID);
+            NetworkMessage::ErrorManager::ShowError(NetworkMessage::ErrorManager::PORT_NOT_VALID);
             return;
         }
         break;

--- a/src/citra_qt/multiplayer/host_room.cpp
+++ b/src/citra_qt/multiplayer/host_room.cpp
@@ -104,19 +104,19 @@ std::unique_ptr<Network::VerifyUser::Backend> HostRoomWindow::CreateVerifyBacken
 
 void HostRoomWindow::Host() {
     if (!ui->username->hasAcceptableInput()) {
-        NetworkMessage::ShowError(NetworkMessage::USERNAME_NOT_VALID);
+        NetworkMessage::ErrorManager::ShowError(NetworkMessage::ErrorManager::USERNAME_NOT_VALID);
         return;
     }
     if (!ui->room_name->hasAcceptableInput()) {
-        NetworkMessage::ShowError(NetworkMessage::ROOMNAME_NOT_VALID);
+        NetworkMessage::ErrorManager::ShowError(NetworkMessage::ErrorManager::ROOMNAME_NOT_VALID);
         return;
     }
     if (!ui->port->hasAcceptableInput()) {
-        NetworkMessage::ShowError(NetworkMessage::PORT_NOT_VALID);
+        NetworkMessage::ErrorManager::ShowError(NetworkMessage::ErrorManager::PORT_NOT_VALID);
         return;
     }
     if (ui->game_list->currentIndex() == -1) {
-        NetworkMessage::ShowError(NetworkMessage::GAME_NOT_SELECTED);
+        NetworkMessage::ErrorManager::ShowError(NetworkMessage::ErrorManager::GAME_NOT_SELECTED);
         return;
     }
     if (auto member = Network::GetRoomMember().lock()) {
@@ -147,7 +147,8 @@ void HostRoomWindow::Host() {
                                         Settings::values.citra_username, game_name.toStdString(),
                                         game_id, CreateVerifyBackend(is_public), ban_list);
             if (!created) {
-                NetworkMessage::ShowError(NetworkMessage::COULD_NOT_CREATE_ROOM);
+                NetworkMessage::ErrorManager::ShowError(
+                    NetworkMessage::ErrorManager::COULD_NOT_CREATE_ROOM);
                 LOG_ERROR(Network, "Could not create room!");
                 ui->host->setEnabled(true);
                 return;

--- a/src/citra_qt/multiplayer/lobby.cpp
+++ b/src/citra_qt/multiplayer/lobby.cpp
@@ -128,7 +128,7 @@ void Lobby::OnJoinRoom(const QModelIndex& source) {
         index = source.parent();
     }
     if (!ui->nickname->hasAcceptableInput()) {
-        NetworkMessage::ShowError(NetworkMessage::USERNAME_NOT_VALID);
+        NetworkMessage::ErrorManager::ShowError(NetworkMessage::ErrorManager::USERNAME_NOT_VALID);
         return;
     }
 

--- a/src/citra_qt/multiplayer/message.cpp
+++ b/src/citra_qt/multiplayer/message.cpp
@@ -8,46 +8,50 @@
 #include "citra_qt/multiplayer/message.h"
 
 namespace NetworkMessage {
-const ConnectionError USERNAME_NOT_VALID(
+const ConnectionError ErrorManager::USERNAME_NOT_VALID(
     QT_TR_NOOP("Username is not valid. Must be 4 to 20 alphanumeric characters."));
-const ConnectionError ROOMNAME_NOT_VALID(
+const ConnectionError ErrorManager::ROOMNAME_NOT_VALID(
     QT_TR_NOOP("Room name is not valid. Must be 4 to 20 alphanumeric characters."));
-const ConnectionError USERNAME_NOT_VALID_SERVER(
+const ConnectionError ErrorManager::USERNAME_NOT_VALID_SERVER(
     QT_TR_NOOP("Username is already in use or not valid. Please choose another."));
-const ConnectionError IP_ADDRESS_NOT_VALID(QT_TR_NOOP("IP is not a valid IPv4 address."));
-const ConnectionError PORT_NOT_VALID(QT_TR_NOOP("Port must be a number between 0 to 65535."));
-const ConnectionError GAME_NOT_SELECTED(QT_TR_NOOP(
+const ConnectionError ErrorManager::IP_ADDRESS_NOT_VALID(
+    QT_TR_NOOP("IP is not a valid IPv4 address."));
+const ConnectionError ErrorManager::PORT_NOT_VALID(
+    QT_TR_NOOP("Port must be a number between 0 to 65535."));
+const ConnectionError ErrorManager::GAME_NOT_SELECTED(QT_TR_NOOP(
     "You must choose a Preferred Game to host a room. If you do not have any games in your game "
     "list yet, add a game folder by clicking on the plus icon in the game list."));
-const ConnectionError NO_INTERNET(
+const ConnectionError ErrorManager::NO_INTERNET(
     QT_TR_NOOP("Unable to find an internet connection. Check your internet settings."));
-const ConnectionError UNABLE_TO_CONNECT(
+const ConnectionError ErrorManager::UNABLE_TO_CONNECT(
     QT_TR_NOOP("Unable to connect to the host. Verify that the connection settings are correct. If "
                "you still cannot connect, contact the room host and verify that the host is "
                "properly configured with the external port forwarded."));
-const ConnectionError ROOM_IS_FULL(
+const ConnectionError ErrorManager::ROOM_IS_FULL(
     QT_TR_NOOP("Unable to connect to the room because it is already full."));
-const ConnectionError COULD_NOT_CREATE_ROOM(
+const ConnectionError ErrorManager::COULD_NOT_CREATE_ROOM(
     QT_TR_NOOP("Creating a room failed. Please retry. Restarting Citra might be necessary."));
-const ConnectionError HOST_BANNED(
+const ConnectionError ErrorManager::HOST_BANNED(
     QT_TR_NOOP("The host of the room has banned you. Speak with the host to unban you "
                "or try a different room."));
-const ConnectionError WRONG_VERSION(
+const ConnectionError ErrorManager::WRONG_VERSION(
     QT_TR_NOOP("Version mismatch! Please update to the latest version of Citra. If the problem "
                "persists, contact the room host and ask them to update the server."));
-const ConnectionError WRONG_PASSWORD(QT_TR_NOOP("Incorrect password."));
-const ConnectionError GENERIC_ERROR(
+const ConnectionError ErrorManager::WRONG_PASSWORD(QT_TR_NOOP("Incorrect password."));
+const ConnectionError ErrorManager::GENERIC_ERROR(
     QT_TR_NOOP("An unknown error occured. If this error continues to occur, please open an issue"));
-const ConnectionError LOST_CONNECTION(QT_TR_NOOP("Connection to room lost. Try to reconnect."));
-const ConnectionError HOST_KICKED(QT_TR_NOOP("You have been kicked by the room host."));
-const ConnectionError MAC_COLLISION(
+const ConnectionError ErrorManager::LOST_CONNECTION(
+    QT_TR_NOOP("Connection to room lost. Try to reconnect."));
+const ConnectionError ErrorManager::HOST_KICKED(
+    QT_TR_NOOP("You have been kicked by the room host."));
+const ConnectionError ErrorManager::MAC_COLLISION(
     QT_TR_NOOP("MAC address is already in use. Please choose another."));
-const ConnectionError CONSOLE_ID_COLLISION(QT_TR_NOOP(
+const ConnectionError ErrorManager::CONSOLE_ID_COLLISION(QT_TR_NOOP(
     "Your Console ID conflicted with someone else's in the room.\n\nPlease go to Emulation "
     "> Configure > System to regenerate your Console ID."));
-const ConnectionError PERMISSION_DENIED(
+const ConnectionError ErrorManager::PERMISSION_DENIED(
     QT_TR_NOOP("You do not have enough permission to perform this action."));
-const ConnectionError NO_SUCH_USER(QT_TR_NOOP(
+const ConnectionError ErrorManager::NO_SUCH_USER(QT_TR_NOOP(
     "The user you are trying to kick/ban could not be found.\nThey may have left the room."));
 
 static bool WarnMessage(const std::string& title, const std::string& text) {
@@ -56,8 +60,8 @@ static bool WarnMessage(const std::string& title, const std::string& text) {
                                                    QMessageBox::Ok | QMessageBox::Cancel);
 }
 
-void ShowError(const ConnectionError& e) {
-    QMessageBox::critical(nullptr, QObject::tr("Error"), QObject::tr(e.GetString().c_str()));
+void ErrorManager::ShowError(const ConnectionError& e) {
+    QMessageBox::critical(nullptr, tr("Error"), tr(e.GetString().c_str()));
 }
 
 bool WarnCloseRoom() {

--- a/src/citra_qt/multiplayer/message.h
+++ b/src/citra_qt/multiplayer/message.h
@@ -20,34 +20,36 @@ private:
     std::string err;
 };
 
-/// When the nickname is considered invalid by the client
-extern const ConnectionError USERNAME_NOT_VALID;
-extern const ConnectionError ROOMNAME_NOT_VALID;
-/// When the nickname is considered invalid by the room server
-extern const ConnectionError USERNAME_NOT_VALID_SERVER;
-extern const ConnectionError IP_ADDRESS_NOT_VALID;
-extern const ConnectionError PORT_NOT_VALID;
-extern const ConnectionError GAME_NOT_SELECTED;
-extern const ConnectionError NO_INTERNET;
-extern const ConnectionError UNABLE_TO_CONNECT;
-extern const ConnectionError ROOM_IS_FULL;
-extern const ConnectionError COULD_NOT_CREATE_ROOM;
-extern const ConnectionError HOST_BANNED;
-extern const ConnectionError WRONG_VERSION;
-extern const ConnectionError WRONG_PASSWORD;
-extern const ConnectionError GENERIC_ERROR;
-extern const ConnectionError LOST_CONNECTION;
-extern const ConnectionError HOST_KICKED;
-extern const ConnectionError MAC_COLLISION;
-extern const ConnectionError CONSOLE_ID_COLLISION;
-extern const ConnectionError PERMISSION_DENIED;
-extern const ConnectionError NO_SUCH_USER;
-
-/**
- *  Shows a standard QMessageBox with a error message
- */
-void ShowError(const ConnectionError& e);
-
+class ErrorManager : QObject {
+    Q_OBJECT
+public:
+    /// When the nickname is considered invalid by the client
+    static const ConnectionError USERNAME_NOT_VALID;
+    static const ConnectionError ROOMNAME_NOT_VALID;
+    /// When the nickname is considered invalid by the room server
+    static const ConnectionError USERNAME_NOT_VALID_SERVER;
+    static const ConnectionError IP_ADDRESS_NOT_VALID;
+    static const ConnectionError PORT_NOT_VALID;
+    static const ConnectionError GAME_NOT_SELECTED;
+    static const ConnectionError NO_INTERNET;
+    static const ConnectionError UNABLE_TO_CONNECT;
+    static const ConnectionError ROOM_IS_FULL;
+    static const ConnectionError COULD_NOT_CREATE_ROOM;
+    static const ConnectionError HOST_BANNED;
+    static const ConnectionError WRONG_VERSION;
+    static const ConnectionError WRONG_PASSWORD;
+    static const ConnectionError GENERIC_ERROR;
+    static const ConnectionError LOST_CONNECTION;
+    static const ConnectionError HOST_KICKED;
+    static const ConnectionError MAC_COLLISION;
+    static const ConnectionError CONSOLE_ID_COLLISION;
+    static const ConnectionError PERMISSION_DENIED;
+    static const ConnectionError NO_SUCH_USER;
+    /**
+     *  Shows a standard QMessageBox with a error message
+     */
+    static void ShowError(const ConnectionError& e);
+};
 /**
  * Show a standard QMessageBox with a warning message about leaving the room
  * return true if the user wants to close the network connection

--- a/src/citra_qt/multiplayer/state.cpp
+++ b/src/citra_qt/multiplayer/state.cpp
@@ -131,43 +131,44 @@ void MultiplayerState::OnNetworkError(const Network::RoomMember::Error& error) {
     LOG_DEBUG(Frontend, "Network Error: {}", Network::GetErrorStr(error));
     switch (error) {
     case Network::RoomMember::Error::LostConnection:
-        NetworkMessage::ShowError(NetworkMessage::LOST_CONNECTION);
+        NetworkMessage::ErrorManager::ShowError(NetworkMessage::ErrorManager::LOST_CONNECTION);
         break;
     case Network::RoomMember::Error::HostKicked:
-        NetworkMessage::ShowError(NetworkMessage::HOST_KICKED);
+        NetworkMessage::ErrorManager::ShowError(NetworkMessage::ErrorManager::HOST_KICKED);
         break;
     case Network::RoomMember::Error::CouldNotConnect:
-        NetworkMessage::ShowError(NetworkMessage::UNABLE_TO_CONNECT);
+        NetworkMessage::ErrorManager::ShowError(NetworkMessage::ErrorManager::UNABLE_TO_CONNECT);
         break;
     case Network::RoomMember::Error::NameCollision:
-        NetworkMessage::ShowError(NetworkMessage::USERNAME_NOT_VALID_SERVER);
+        NetworkMessage::ErrorManager::ShowError(
+            NetworkMessage::ErrorManager::USERNAME_NOT_VALID_SERVER);
         break;
     case Network::RoomMember::Error::MacCollision:
-        NetworkMessage::ShowError(NetworkMessage::MAC_COLLISION);
+        NetworkMessage::ErrorManager::ShowError(NetworkMessage::ErrorManager::MAC_COLLISION);
         break;
     case Network::RoomMember::Error::ConsoleIdCollision:
-        NetworkMessage::ShowError(NetworkMessage::CONSOLE_ID_COLLISION);
+        NetworkMessage::ErrorManager::ShowError(NetworkMessage::ErrorManager::CONSOLE_ID_COLLISION);
         break;
     case Network::RoomMember::Error::RoomIsFull:
-        NetworkMessage::ShowError(NetworkMessage::ROOM_IS_FULL);
+        NetworkMessage::ErrorManager::ShowError(NetworkMessage::ErrorManager::ROOM_IS_FULL);
         break;
     case Network::RoomMember::Error::WrongPassword:
-        NetworkMessage::ShowError(NetworkMessage::WRONG_PASSWORD);
+        NetworkMessage::ErrorManager::ShowError(NetworkMessage::ErrorManager::WRONG_PASSWORD);
         break;
     case Network::RoomMember::Error::WrongVersion:
-        NetworkMessage::ShowError(NetworkMessage::WRONG_VERSION);
+        NetworkMessage::ErrorManager::ShowError(NetworkMessage::ErrorManager::WRONG_VERSION);
         break;
     case Network::RoomMember::Error::HostBanned:
-        NetworkMessage::ShowError(NetworkMessage::HOST_BANNED);
+        NetworkMessage::ErrorManager::ShowError(NetworkMessage::ErrorManager::HOST_BANNED);
         break;
     case Network::RoomMember::Error::UnknownError:
-        NetworkMessage::ShowError(NetworkMessage::UNABLE_TO_CONNECT);
+        NetworkMessage::ErrorManager::ShowError(NetworkMessage::ErrorManager::UNABLE_TO_CONNECT);
         break;
     case Network::RoomMember::Error::PermissionDenied:
-        NetworkMessage::ShowError(NetworkMessage::PERMISSION_DENIED);
+        NetworkMessage::ErrorManager::ShowError(NetworkMessage::ErrorManager::PERMISSION_DENIED);
         break;
     case Network::RoomMember::Error::NoSuchUser:
-        NetworkMessage::ShowError(NetworkMessage::NO_SUCH_USER);
+        NetworkMessage::ErrorManager::ShowError(NetworkMessage::ErrorManager::NO_SUCH_USER);
         break;
     }
 }


### PR DESCRIPTION
Hopefully fixes some warnings from the Qt linguistics tool relating to the lack of context in some tr and QT_TR_NOOP calls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5112)
<!-- Reviewable:end -->
