### PR TITLE
citra_qt/system: Add N3DS mode checkbox and enable it by default

### DIFF
--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -201,7 +201,7 @@ void Config::ReadValues() {
         sdl2_config->GetBoolean("Data Storage", "use_virtual_sd", true);
 
     // System
-    Settings::values.is_new_3ds = sdl2_config->GetBoolean("System", "is_new_3ds", false);
+    Settings::values.is_new_3ds = sdl2_config->GetBoolean("System", "is_new_3ds", true);
     Settings::values.region_value =
         sdl2_config->GetInteger("System", "region_value", Settings::REGION_VALUE_AUTO_SELECT);
     Settings::values.init_clock =

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -244,7 +244,7 @@ use_virtual_sd =
 
 [System]
 # The system model that Citra will try to emulate
-# 0: Old 3DS (default), 1: New 3DS
+# 0: Old 3DS, 1: New 3DS (default)
 is_new_3ds =
 
 # The system region that Citra will use during emulation

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -482,7 +482,7 @@ void Config::ReadShortcutValues() {
 void Config::ReadSystemValues() {
     qt_config->beginGroup(QStringLiteral("System"));
 
-    Settings::values.is_new_3ds = ReadSetting(QStringLiteral("is_new_3ds"), false).toBool();
+    Settings::values.is_new_3ds = ReadSetting(QStringLiteral("is_new_3ds"), true).toBool();
     Settings::values.region_value =
         ReadSetting(QStringLiteral("region_value"), Settings::REGION_VALUE_AUTO_SELECT).toInt();
     Settings::values.init_clock = static_cast<Settings::InitClock>(
@@ -921,7 +921,7 @@ void Config::SaveShortcutValues() {
 void Config::SaveSystemValues() {
     qt_config->beginGroup(QStringLiteral("System"));
 
-    WriteSetting(QStringLiteral("is_new_3ds"), Settings::values.is_new_3ds, false);
+    WriteSetting(QStringLiteral("is_new_3ds"), Settings::values.is_new_3ds, true);
     WriteSetting(QStringLiteral("region_value"), Settings::values.region_value,
                  Settings::REGION_VALUE_AUTO_SELECT);
     WriteSetting(QStringLiteral("init_clock"), static_cast<u32>(Settings::values.init_clock),

--- a/src/citra_qt/configuration/configure_system.cpp
+++ b/src/citra_qt/configuration/configure_system.cpp
@@ -277,6 +277,8 @@ void ConfigureSystem::SetConfiguration() {
     ui->slider_clock_speed->setValue(SettingsToSlider(Settings::values.cpu_clock_percentage));
     ui->clock_display_label->setText(
         QStringLiteral("%1%").arg(Settings::values.cpu_clock_percentage));
+
+    ui->toggle_new_3ds->setChecked(Settings::values.is_new_3ds);
 }
 
 void ConfigureSystem::ReadSystemSettings() {
@@ -374,6 +376,8 @@ void ConfigureSystem::ApplyConfiguration() {
         Settings::values.init_clock =
             static_cast<Settings::InitClock>(ui->combo_init_clock->currentIndex());
         Settings::values.init_time = ui->edit_init_time->dateTime().toTime_t();
+
+        Settings::values.is_new_3ds = ui->toggle_new_3ds->isChecked();
     }
 
     Settings::values.cpu_clock_percentage = SliderToSettings(ui->slider_clock_speed->value());

--- a/src/citra_qt/configuration/configure_system.ui
+++ b/src/citra_qt/configuration/configure_system.ui
@@ -22,14 +22,74 @@
         <string>System Settings</string>
        </property>
        <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_username">
-          <property name="text">
-           <string>Username</string>
+        <item row="4" column="1">
+         <widget class="QComboBox" name="combo_language">
+          <property name="toolTip">
+           <string>Note: this can be overridden when region setting is auto-select</string>
           </property>
+          <item>
+           <property name="text">
+            <string>Japanese (日本語)</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>English</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>French (français)</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>German (Deutsch)</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Italian (italiano)</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Spanish (español)</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Simplified Chinese (简体中文)</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Korean (한국어)</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Dutch (Nederlands)</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Portuguese (português)</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Russian (Русский)</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Traditional Chinese (正體中文)</string>
+           </property>
+          </item>
          </widget>
         </item>
-        <item row="0" column="1">
+        <item row="2" column="1">
          <widget class="QLineEdit" name="edit_username">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -42,14 +102,33 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_birthday">
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_username">
           <property name="text">
-           <string>Birthday</string>
+           <string>Username</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="1">
+        <item row="5" column="1">
+         <widget class="QComboBox" name="combo_sound">
+          <item>
+           <property name="text">
+            <string>Mono</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Stereo</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Surround</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="3" column="1">
          <layout class="QHBoxLayout" name="horizontalLayout_birthday2">
           <item>
            <widget class="QComboBox" name="combo_birthmonth">
@@ -120,124 +199,38 @@
           </item>
          </layout>
         </item>
-        <item row="2" column="0">
+        <item row="4" column="0">
          <widget class="QLabel" name="label_language">
           <property name="text">
            <string>Language</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="1">
-         <widget class="QComboBox" name="combo_language">
-          <property name="toolTip">
-           <string>Note: this can be overridden when region setting is auto-select</string>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_birthday">
+          <property name="text">
+           <string>Birthday</string>
           </property>
-          <item>
-           <property name="text">
-            <string>Japanese (日本語)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>English</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>French (français)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>German (Deutsch)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Italian (italiano)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Spanish (español)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Simplified Chinese (简体中文)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Korean (한국어)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Dutch (Nederlands)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Portuguese (português)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Russian (Русский)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Traditional Chinese (正體中文)</string>
-           </property>
-          </item>
          </widget>
         </item>
-        <item row="3" column="0">
+        <item row="5" column="0">
          <widget class="QLabel" name="label_sound">
           <property name="text">
            <string>Sound output mode</string>
           </property>
          </widget>
         </item>
-        <item row="3" column="1">
-         <widget class="QComboBox" name="combo_sound">
-          <item>
-           <property name="text">
-            <string>Mono</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Stereo</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Surround</string>
-           </property>
-          </item>
-         </widget>
+        <item row="6" column="1">
+         <widget class="QComboBox" name="combo_country"/>
         </item>
-        <item row="4" column="0">
+        <item row="6" column="0">
          <widget class="QLabel" name="label_country">
           <property name="text">
            <string>Country</string>
           </property>
          </widget>
         </item>
-        <item row="4" column="1">
-         <widget class="QComboBox" name="combo_country"/>
-        </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="label_init_clock">
-          <property name="text">
-           <string>Clock</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
+        <item row="7" column="1">
          <widget class="QComboBox" name="combo_init_clock">
           <item>
            <property name="text">
@@ -251,42 +244,35 @@
           </item>
          </widget>
         </item>
-        <item row="6" column="0">
+        <item row="7" column="0">
+         <widget class="QLabel" name="label_init_clock">
+          <property name="text">
+           <string>Clock</string>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="0">
          <widget class="QLabel" name="label_init_time">
           <property name="text">
            <string>Startup time</string>
           </property>
          </widget>
         </item>
-        <item row="6" column="1">
-         <widget class="QDateTimeEdit" name="edit_init_time">
-          <property name="displayFormat">
-           <string>yyyy-MM-ddTHH:mm:ss</string>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="0">
-         <widget class="QLabel" name="label_play_coins">
-          <property name="text">
-           <string>Play Coins:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="1">
+        <item row="9" column="1">
          <widget class="QSpinBox" name="spinBox_play_coins">
           <property name="maximum">
            <number>300</number>
           </property>
          </widget>
         </item>
-        <item row="8" column="0">
-         <widget class="QLabel" name="label_console_id">
+        <item row="9" column="0">
+         <widget class="QLabel" name="label_play_coins">
           <property name="text">
-           <string>Console ID:</string>
+           <string>Play Coins:</string>
           </property>
          </widget>
         </item>
-        <item row="8" column="1">
+        <item row="12" column="1">
          <widget class="QPushButton" name="button_regenerate_console_id">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -299,6 +285,27 @@
           </property>
           <property name="text">
            <string>Regenerate</string>
+          </property>
+         </widget>
+        </item>
+        <item row="12" column="0">
+         <widget class="QLabel" name="label_console_id">
+          <property name="text">
+           <string>Console ID:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="1">
+         <widget class="QDateTimeEdit" name="edit_init_time">
+          <property name="displayFormat">
+           <string>yyyy-MM-ddTHH:mm:ss</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QCheckBox" name="toggle_new_3ds">
+          <property name="text">
+           <string>Enable New 3DS mode</string>
           </property>
          </widget>
         </item>

--- a/src/core/hle/service/ptm/ptm.cpp
+++ b/src/core/hle/service/ptm/ptm.cpp
@@ -117,15 +117,10 @@ void Module::Interface::GetSoftwareClosedFlag(Kernel::HLERequestContext& ctx) {
 void CheckNew3DS(IPC::RequestBuilder& rb) {
     const bool is_new_3ds = Settings::values.is_new_3ds;
 
-    if (is_new_3ds) {
-        LOG_CRITICAL(Service_PTM, "The option 'is_new_3ds' is enabled as part of the 'System' "
-                                  "settings. Citra does not fully support New 3DS emulation yet!");
-    }
-
     rb.Push(RESULT_SUCCESS);
     rb.Push(is_new_3ds);
 
-    LOG_WARNING(Service_PTM, "(STUBBED) called isNew3DS = 0x{:08x}", static_cast<u32>(is_new_3ds));
+    LOG_DEBUG(Service_PTM, "called isNew3DS = 0x{:08x}", static_cast<u32>(is_new_3ds));
 }
 
 void Module::Interface::CheckNew3DS(Kernel::HLERequestContext& ctx) {


### PR DESCRIPTION
This change should be fairly self-explanatory.
For all users who haven't messed with this setting before, it is no enabled by default.
Also a checkbox is added to the System settings to be able to toggle it.
I will add a screenshot as soon as I get QT Automoc to run again locally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5117)
<!-- Reviewable:end -->
