### PR TITLE
service/fs: Update file size on write

### DIFF
--- a/src/core/hle/service/fs/file.cpp
+++ b/src/core/hle/service/fs/file.cpp
@@ -90,7 +90,7 @@ void File::Write(Kernel::HLERequestContext& ctx) {
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
 
-    const FileSessionSlot* file = GetSessionData(ctx.Session());
+    FileSessionSlot* file = GetSessionData(ctx.Session());
 
     // Subfiles can not be written to
     if (file->subfile) {
@@ -103,6 +103,10 @@ void File::Write(Kernel::HLERequestContext& ctx) {
     std::vector<u8> data(length);
     buffer.Read(data.data(), 0, data.size());
     ResultVal<std::size_t> written = backend->Write(offset, data.size(), flush != 0, data.data());
+
+    // Update file size
+    file->size = backend->GetSize();
+
     if (written.Failed()) {
         rb.Push(written.Code());
         rb.Push<u32>(0);


### PR DESCRIPTION
Fixes #4566, fixes #3627

The file's size is stored in FileSessionSlot and retrieved when the game calls GetSize. However, it is not updated when the file is written to, which can possibly change the file size. Therefore, this can cause GetSize to return incorrect results.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5120)
<!-- Reviewable:end -->
