### PR TITLE
SDL: Disable hidapi drivers due to compatibility problems with certain controllers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,7 @@ if (ENABLE_SDL2)
     if (CITRA_USE_BUNDLED_SDL2)
         # Detect toolchain and platform
         if ((MSVC_VERSION GREATER_EQUAL 1910 AND MSVC_VERSION LESS 1930) AND ARCHITECTURE_x86_64)
-            set(SDL2_VER "SDL2-2.0.8")
+            set(SDL2_VER "SDL2-2.0.10")
         else()
             message(FATAL_ERROR "No bundled SDL2 binaries for your toolchain. Disable CITRA_USE_BUNDLED_SDL2 and provide your own.")
         endif()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ install:
   - ps: |
         if ($env:BUILD_TYPE -eq 'mingw') {
           $dependencies = "mingw64/mingw-w64-x86_64-cmake mingw64/mingw-w64-x86_64-qt5 mingw64/mingw-w64-x86_64-ffmpeg"
-          C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-SDL2-2.0.5-2-any.pkg.tar.xz"
+          C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-SDL2-2.0.10-1-any.pkg.tar.xz"
           C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S $dependencies"
           # (HACK) ignore errors
           0

--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -472,6 +472,14 @@ SDLState::SDLState() {
     if (SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1") == SDL_FALSE) {
         LOG_ERROR(Input, "Failed to set Hint for background events", SDL_GetError());
     }
+// these hints are only defined on sdl2.0.9 or higher
+#if SDL_VERSION_ATLEAST(2, 0, 9)
+    // This can be set back to 1 when the compatibility problems with the controllers are
+    // solved. There are also hints to toggle the individual drivers.
+    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI, "0");
+    // This hint should probably stay as "0" as long as the hidapi PS4 led issue isn't fixed
+    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS4, "0");
+#endif
 
     SDL_AddEventWatch(&SDLEventWatcher, this);
 


### PR DESCRIPTION
The change of SDL2 from 2.0.8 to 2.0.10 broke compatibility with some controllers that reported as Switch and Xbox One controllers.
Having SDL_HINT_JOYSTICK_HIDAPI set to "0" should get us the same behavior as before the change, as all of the reported problems stem from joysticks that have a hidapi driver implementation.

From some investigation, the current drivers try to write to the controller, for setting rumble, stick calibration, LED behavior and other similar tasks. 
Most or all of the users that had this problem and identified their controllers had non-official versions of the controllers. From the available information some of these controllers don't have some of the features the driver tries to use, and the driver fails to init the joystick in those cases.

Another reported issue caused by the hidapi drivers is #5118. In this case the driver works but always writes (0,0,80) to the lightbar, and there is no way to change the driver behavior.

Looking ahead at the proposed 2.0.12 source code, the compatibility problems should be solved by the changes to the driver to differentiate input-only controllers, but the PS4 lightbar behavior stays the same.
Closes #5118, but the issue might come back if the hidapi drivers are re-enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5123)
<!-- Reviewable:end -->
