### PR TITLE
Added a search path in FindSDL2 for Ubuntu (Budgie) 20.04

### DIFF
--- a/externals/cmake-modules/FindSDL2.cmake
+++ b/externals/cmake-modules/FindSDL2.cmake
@@ -128,6 +128,7 @@ SET(SDL2_SEARCH_PATHS
     /Library/Frameworks
     /usr/local
     /usr
+    /usr/include/SDL # Budgie
     /sw # Fink
     /opt/local # DarwinPorts
     /opt/csw # Blastwave


### PR DESCRIPTION
For some reason, cmake was unable to find SDL2 on my Ubuntu (20.04) Budgie machine. I also work with SDL2 and have always been able to build with it provided that the full path was part of the SDL2 search paths. Adding it to this file made it possible to build Citra on my setup. 

For reference, here's my `uname -a`.

`Linux x 5.4.0-14-generic #17-Ubuntu SMP Thu Feb 6 22:47:59 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux`.

I also tried adding only `/usr/include` to the search path, but it won't find the directory since it's called `SDL` instead of `SDL2`. Not sure why, but installing SDL2 on this setup doesn't label the directory correctly. The other way I managed to build was to create a symlink `/usr/include/SDL2 => /usr/include/SDL`, but I figured it'd be more developer-friendly if the search path was part of the FindSDL2.cmake :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5124)
<!-- Reviewable:end -->
