### PR TITLE
Show an error if CIA contend is encrypted

### DIFF
--- a/src/citra_qt/game_list_worker.cpp
+++ b/src/citra_qt/game_list_worker.cpp
@@ -47,12 +47,16 @@ void GameListWorker::AddFstEntriesToGameList(const std::string& dir_path, unsign
         if (!is_dir && HasSupportedFileExtension(physical_name)) {
             std::unique_ptr<Loader::AppLoader> loader = Loader::GetLoader(physical_name);
             if (!loader)
+            {
                 return true;
+            }
 
             bool executable = false;
-            loader->IsExecutable(executable);
-            if (!executable)
+            auto res  = loader->IsExecutable(executable);
+            if (!executable && res != Loader::ResultStatus::ErrorEncrypted)
+            {
                 return true;
+            }
 
             u64 program_id = 0;
             loader->ReadProgramId(program_id);

--- a/src/citra_qt/game_list_worker.cpp
+++ b/src/citra_qt/game_list_worker.cpp
@@ -46,15 +46,13 @@ void GameListWorker::AddFstEntriesToGameList(const std::string& dir_path, unsign
         const bool is_dir = FileUtil::IsDirectory(physical_name);
         if (!is_dir && HasSupportedFileExtension(physical_name)) {
             std::unique_ptr<Loader::AppLoader> loader = Loader::GetLoader(physical_name);
-            if (!loader)
-            {
+            if (!loader) {
                 return true;
             }
 
             bool executable = false;
-            auto res  = loader->IsExecutable(executable);
-            if (!executable && res != Loader::ResultStatus::ErrorEncrypted)
-            {
+            auto res = loader->IsExecutable(executable);
+            if (!executable && res != Loader::ResultStatus::ErrorEncrypted) {
                 return true;
             }
 

--- a/src/citra_qt/game_list_worker.cpp
+++ b/src/citra_qt/game_list_worker.cpp
@@ -51,7 +51,7 @@ void GameListWorker::AddFstEntriesToGameList(const std::string& dir_path, unsign
             }
 
             bool executable = false;
-            auto res = loader->IsExecutable(executable);
+            const auto res = loader->IsExecutable(executable);
             if (!executable && res != Loader::ResultStatus::ErrorEncrypted) {
                 return true;
             }

--- a/src/core/file_sys/ncch_container.cpp
+++ b/src/core/file_sys/ncch_container.cpp
@@ -137,7 +137,6 @@ Loader::ResultStatus NCCHContainer::LoadHeader() {
     if (has_header)
         return Loader::ResultStatus::Success;
     if (!file.IsOpen()) {
-
         return Loader::ResultStatus::Error;
     }
 

--- a/src/core/file_sys/ncch_container.cpp
+++ b/src/core/file_sys/ncch_container.cpp
@@ -133,8 +133,37 @@ Loader::ResultStatus NCCHContainer::OpenFile(const std::string& filepath, u32 nc
     return Loader::ResultStatus::Success;
 }
 
+Loader::ResultStatus NCCHContainer::LoadHeader() {
+    if (has_header)
+        return Loader::ResultStatus::Success;
+    if (!file.IsOpen()) {
+
+        return Loader::ResultStatus::Error;
+    }
+
+    // Reset read pointer in case this file has been read before.
+    file.Seek(ncch_offset, SEEK_SET);
+
+    if (file.ReadBytes(&ncch_header, sizeof(NCCH_Header)) != sizeof(NCCH_Header))
+        return Loader::ResultStatus::Error;
+
+    // Skip NCSD header and load first NCCH (NCSD is just a container of NCCH files)...
+    if (Loader::MakeMagic('N', 'C', 'S', 'D') == ncch_header.magic) {
+        LOG_DEBUG(Service_FS, "Only loading the first (bootable) NCCH within the NCSD file!");
+        ncch_offset += 0x4000;
+        file.Seek(ncch_offset, SEEK_SET);
+        file.ReadBytes(&ncch_header, sizeof(NCCH_Header));
+    }
+
+    // Verify we are loading the correct file type...
+    if (Loader::MakeMagic('N', 'C', 'C', 'H') != ncch_header.magic)
+        return Loader::ResultStatus::ErrorInvalidFormat;
+
+    has_header = true;
+    return Loader::ResultStatus::Success;
+}
+
 Loader::ResultStatus NCCHContainer::Load() {
-    LOG_INFO(Service_FS, "Loading NCCH from file {}", filepath);
     if (is_loaded)
         return Loader::ResultStatus::Success;
 
@@ -697,7 +726,7 @@ Loader::ResultStatus NCCHContainer::ReadOverrideRomFS(std::shared_ptr<RomFSReade
 }
 
 Loader::ResultStatus NCCHContainer::ReadProgramId(u64_le& program_id) {
-    Loader::ResultStatus result = Load();
+    Loader::ResultStatus result = LoadHeader();
     if (result != Loader::ResultStatus::Success)
         return result;
 

--- a/src/core/file_sys/ncch_container.cpp
+++ b/src/core/file_sys/ncch_container.cpp
@@ -134,8 +134,9 @@ Loader::ResultStatus NCCHContainer::OpenFile(const std::string& filepath, u32 nc
 }
 
 Loader::ResultStatus NCCHContainer::LoadHeader() {
-    if (has_header)
+    if (has_header) {
         return Loader::ResultStatus::Success;
+    }
     if (!file.IsOpen()) {
         return Loader::ResultStatus::Error;
     }
@@ -143,8 +144,9 @@ Loader::ResultStatus NCCHContainer::LoadHeader() {
     // Reset read pointer in case this file has been read before.
     file.Seek(ncch_offset, SEEK_SET);
 
-    if (file.ReadBytes(&ncch_header, sizeof(NCCH_Header)) != sizeof(NCCH_Header))
+    if (file.ReadBytes(&ncch_header, sizeof(NCCH_Header)) != sizeof(NCCH_Header)) {
         return Loader::ResultStatus::Error;
+    }
 
     // Skip NCSD header and load first NCCH (NCSD is just a container of NCCH files)...
     if (Loader::MakeMagic('N', 'C', 'S', 'D') == ncch_header.magic) {
@@ -155,8 +157,9 @@ Loader::ResultStatus NCCHContainer::LoadHeader() {
     }
 
     // Verify we are loading the correct file type...
-    if (Loader::MakeMagic('N', 'C', 'C', 'H') != ncch_header.magic)
+    if (Loader::MakeMagic('N', 'C', 'C', 'H') != ncch_header.magic) {
         return Loader::ResultStatus::ErrorInvalidFormat;
+    }
 
     has_header = true;
     return Loader::ResultStatus::Success;

--- a/src/core/file_sys/ncch_container.h
+++ b/src/core/file_sys/ncch_container.h
@@ -211,6 +211,12 @@ public:
     Loader::ResultStatus OpenFile(const std::string& filepath, u32 ncch_offset = 0);
 
     /**
+     * Ensure NCCH header is loaded and ready for reading sections
+     * @return ResultStatus result of function
+     */
+    Loader::ResultStatus LoadHeader();
+
+    /**
      * Ensure ExeFS and exheader is loaded and ready for reading sections
      * @return ResultStatus result of function
      */

--- a/src/core/file_sys/ticket.cpp
+++ b/src/core/file_sys/ticket.cpp
@@ -47,6 +47,7 @@ std::optional<std::array<u8, 16>> Ticket::GetTitleKey() const {
     std::memcpy(ctr.data(), &ticket_body.title_id, sizeof(u64));
     HW::AES::SelectCommonKeyIndex(ticket_body.common_key_index);
     if (!HW::AES::IsNormalKeyAvailable(HW::AES::KeySlotID::TicketCommonKey)) {
+        LOG_ERROR(Service_FS, "CommonKey {} missing", ticket_body.common_key_index);
         return {};
     }
     auto key = HW::AES::GetNormalKey(HW::AES::KeySlotID::TicketCommonKey);

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -9,9 +9,9 @@
 #include <cryptopp/aes.h>
 #include <cryptopp/modes.h>
 #include <fmt/format.h>
+#include "common/common_paths.h"
 #include "common/file_util.h"
 #include "common/logging/log.h"
-#include "common/common_paths.h"
 #include "common/string_util.h"
 #include "core/core.h"
 #include "core/file_sys/errors.h"
@@ -36,13 +36,13 @@
 
 namespace {
 bool HasSupportedFileExtension(std::string path) {
-    static const std::array<std::string, 7> extensions = {{".3ds", ".3dsx", ".elf", ".axf",
-    ".cci", ".cxi" ".app"
-    }};
+    static const std::array<std::string, 7> extensions = {{".3ds", ".3dsx", ".elf", ".axf", ".cci",
+                                                           ".cxi"
+                                                           ".app"}};
     const auto file_ext = FileUtil::GetExtensionFromFilename(path);
     return std::find(extensions.begin(), extensions.end(), file_ext) != extensions.end();
 }
-}
+} // namespace
 
 namespace Service::AM {
 
@@ -385,32 +385,28 @@ InstallStatus InstallCIA(const std::string& path,
 
         LOG_INFO(Service_AM, "Installed {} successfully.", path);
 
-        const FileUtil::DirectoryEntryCallable callback = [&callback](u64* num_entries_out,
-                                                        const std::string& directory,
-                                                        const std::string& virtual_name) -> bool {
+        const FileUtil::DirectoryEntryCallable callback =
+            [&callback](u64* num_entries_out, const std::string& directory,
+                        const std::string& virtual_name) -> bool {
             const std::string physical_name = directory + DIR_SEP + virtual_name;
             const bool is_dir = FileUtil::IsDirectory(physical_name);
             if (!is_dir && HasSupportedFileExtension(physical_name)) {
                 std::unique_ptr<Loader::AppLoader> loader = Loader::GetLoader(physical_name);
-                if (!loader)
-                {
-                return true;
+                if (!loader) {
+                    return true;
                 }
 
                 bool executable = false;
-                auto res  = loader->IsExecutable(executable);
-                if (res == Loader::ResultStatus::ErrorEncrypted)
-                {
+                auto res = loader->IsExecutable(executable);
+                if (res == Loader::ResultStatus::ErrorEncrypted) {
                     return false;
                 }
                 return true;
             } else {
                 return FileUtil::ForeachDirectoryEntry(nullptr, physical_name, callback);
             }
-
         };
-        if (!FileUtil::ForeachDirectoryEntry(nullptr, path, callback))
-        {
+        if (!FileUtil::ForeachDirectoryEntry(nullptr, path, callback)) {
             LOG_ERROR(Service_AM, "CIA {} contained encrypted files.", path);
             return InstallStatus::ErrorEncrypted;
         }

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -396,7 +396,7 @@ InstallStatus InstallCIA(const std::string& path,
                 }
 
                 bool executable = false;
-                auto res = loader->IsExecutable(executable);
+                const auto res = loader->IsExecutable(executable);
                 if (res == Loader::ResultStatus::ErrorEncrypted) {
                     return false;
                 }

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -36,9 +36,8 @@
 
 namespace {
 bool HasSupportedFileExtension(std::string path) {
-    static const std::array<std::string, 7> extensions = {{".3ds", ".3dsx", ".elf", ".axf", ".cci",
-                                                           ".cxi"
-                                                           ".app"}};
+    static const std::array<std::string, 7> extensions = {
+        {".3ds", ".3dsx", ".elf", ".axf", ".cci", ".cxi", ".app"}};
     const auto file_ext = FileUtil::GetExtensionFromFilename(path);
     return std::find(extensions.begin(), extensions.end(), file_ext) != extensions.end();
 }

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -34,15 +34,6 @@
 #include "core/loader/loader.h"
 #include "core/loader/smdh.h"
 
-namespace {
-bool HasSupportedFileExtension(std::string path) {
-    static const std::array<std::string, 7> extensions = {
-        {".3ds", ".3dsx", ".elf", ".axf", ".cci", ".cxi", ".app"}};
-    const auto file_ext = FileUtil::GetExtensionFromFilename(path);
-    return std::find(extensions.begin(), extensions.end(), file_ext) != extensions.end();
-}
-} // namespace
-
 namespace Service::AM {
 
 constexpr u16 PLATFORM_CTR = 0x0004;
@@ -389,7 +380,7 @@ InstallStatus InstallCIA(const std::string& path,
                         const std::string& virtual_name) -> bool {
             const std::string physical_name = directory + DIR_SEP + virtual_name;
             const bool is_dir = FileUtil::IsDirectory(physical_name);
-            if (!is_dir && HasSupportedFileExtension(physical_name)) {
+            if (!is_dir) {
                 std::unique_ptr<Loader::AppLoader> loader = Loader::GetLoader(physical_name);
                 if (!loader) {
                     return true;
@@ -405,7 +396,12 @@ InstallStatus InstallCIA(const std::string& path,
                 return FileUtil::ForeachDirectoryEntry(nullptr, physical_name, callback);
             }
         };
-        if (!FileUtil::ForeachDirectoryEntry(nullptr, path, callback)) {
+        if (!FileUtil::ForeachDirectoryEntry(
+                nullptr,
+                GetTitlePath(
+                    Service::AM::GetTitleMediaType(container.GetTitleMetadata().GetTitleID()),
+                    container.GetTitleMetadata().GetTitleID()),
+                callback)) {
             LOG_ERROR(Service_AM, "CIA {} contained encrypted files.", path);
             return InstallStatus::ErrorEncrypted;
         }

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -11,6 +11,7 @@
 #include <fmt/format.h>
 #include "common/file_util.h"
 #include "common/logging/log.h"
+#include "common/common_paths.h"
 #include "common/string_util.h"
 #include "core/core.h"
 #include "core/file_sys/errors.h"
@@ -32,6 +33,16 @@
 #include "core/hle/service/fs/archive.h"
 #include "core/loader/loader.h"
 #include "core/loader/smdh.h"
+
+namespace {
+bool HasSupportedFileExtension(std::string path) {
+    static const std::array<std::string, 7> extensions = {{".3ds", ".3dsx", ".elf", ".axf",
+    ".cci", ".cxi" ".app"
+    }};
+    const auto file_ext = FileUtil::GetExtensionFromFilename(path);
+    return std::find(extensions.begin(), extensions.end(), file_ext) != extensions.end();
+}
+}
 
 namespace Service::AM {
 
@@ -373,6 +384,36 @@ InstallStatus InstallCIA(const std::string& path,
         installFile.Close();
 
         LOG_INFO(Service_AM, "Installed {} successfully.", path);
+
+        const FileUtil::DirectoryEntryCallable callback = [&callback](u64* num_entries_out,
+                                                        const std::string& directory,
+                                                        const std::string& virtual_name) -> bool {
+            const std::string physical_name = directory + DIR_SEP + virtual_name;
+            const bool is_dir = FileUtil::IsDirectory(physical_name);
+            if (!is_dir && HasSupportedFileExtension(physical_name)) {
+                std::unique_ptr<Loader::AppLoader> loader = Loader::GetLoader(physical_name);
+                if (!loader)
+                {
+                return true;
+                }
+
+                bool executable = false;
+                auto res  = loader->IsExecutable(executable);
+                if (res == Loader::ResultStatus::ErrorEncrypted)
+                {
+                    return false;
+                }
+                return true;
+            } else {
+                return FileUtil::ForeachDirectoryEntry(nullptr, physical_name, callback);
+            }
+
+        };
+        if (!FileUtil::ForeachDirectoryEntry(nullptr, path, callback))
+        {
+            LOG_ERROR(Service_AM, "CIA {} contained encrypted files.", path);
+            return InstallStatus::ErrorEncrypted;
+        }
         return InstallStatus::Success;
     }
 


### PR DESCRIPTION
We already show an error if the cia is encrypted but not if the cia itself isn't encrypted but it's content is.
This lead to a lot of confusion where users thought they successfully installed the cia, but then nothing appeared in the game list. Now the encryption error is also shown if the cia contained any executable that Citra isn't able to decrypt (e.g. due to missing aes keys).

In addition any executable that is encrypted and Citra can't decrypt is still shown in the game list (if executables without icons are visible). Such executables will still be shown in an ugly way (no proper title, icon, region etc), since we can't access the SMDH.

As a last change in that PR I removed a debugging line we added that showed the path of each NCCH file, since it was only added to debug an issue where loading encrypted NCCHs caused a crash.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5130)
<!-- Reviewable:end -->
