### PR TITLE
Unbreak build on FreeBSD

### DIFF
--- a/src/video_core/renderer_opengl/texture_filters/bicubic/bicubic.cpp
+++ b/src/video_core/renderer_opengl/texture_filters/bicubic/bicubic.cpp
@@ -48,7 +48,7 @@ void Bicubic::scale(CachedSurface& surface, const Common::Rectangle<u32>& rect,
     glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
                            cur_state.texture_units[0].texture_2d, 0);
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
-    glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, NULL, 0);
+    glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, 0, 0);
 
     cur_state.Apply();
 }

--- a/src/video_core/renderer_opengl/texture_filters/xbrz/xbrz_freescale.cpp
+++ b/src/video_core/renderer_opengl/texture_filters/xbrz/xbrz_freescale.cpp
@@ -92,7 +92,7 @@ void XbrzFreescale::scale(CachedSurface& surface, const Common::Rectangle<u32>& 
     glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
                            cur_state.texture_units[0].texture_2d, 0);
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
-    glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, NULL, 0);
+    glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, 0, 0);
 
     cur_state.Apply();
 }


### PR DESCRIPTION
Regressed by #5017. [FreeBSD](https://github.com/freebsd/freebsd/commit/c8ed04c26b6758354853a6bed4629f71d0d01a7d) and [OpenBSD](https://github.com/openbsd/src/commit/6ecde746dea9a5d17abf3bafa06c232b9189b33b) define `NULL` via `nullptr` in C++11 mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5137)
<!-- Reviewable:end -->
