### PR TITLE
[WIP] Add option to download system files from Nintendo Update Service

### DIFF
--- a/src/citra_qt/configuration/configure_system.cpp
+++ b/src/citra_qt/configuration/configure_system.cpp
@@ -4,11 +4,14 @@
 
 #include <cstring>
 #include <QMessageBox>
+#include <QProgressDialog>
 #include "citra_qt/configuration/configure_system.h"
 #include "citra_qt/uisettings.h"
 #include "core/core.h"
+#include "core/hle/service/am/am.h"
 #include "core/hle/service/cfg/cfg.h"
 #include "core/hle/service/ptm/ptm.h"
+#include "core/hw/aes/key.h"
 #include "core/settings.h"
 #include "ui_configure_system.h"
 
@@ -217,6 +220,545 @@ static const std::array<const char*, 187> country_names = {
     QT_TRANSLATE_NOOP("ConfigureSystem", "Bermuda"), // 180-186
 };
 
+struct Title {
+    enum Mode { All, Recommended, Minimal };
+    std::string name;
+    std::array<u32, 6> lower_title_id;
+    Mode mode = Mode::All;
+};
+
+static const std::array<Title, 9> systemFirmware = {
+    {{"Safe Mode Native Firmware",
+      {{0x00000003, 0x00000003, 0x00000003, 0x00000003, 0x00000003, 0x00000003}},
+      Title::Mode::Minimal},
+     {"New_3DS Safe Mode Native Firmware",
+      {{0x20000003, 0x20000003, 0x20000003, 0x20000003, 0x20000003, 0x20000003}},
+      Title::Mode::Minimal},
+     {"Native Firmware",
+      {{0x00000002, 0x00000002, 0x00000002, 0x00000002, 0x00000002, 0x00000002}},
+      Title::Mode::Minimal},
+     {"New_3DS Native Firmware",
+      {{0x20000002, 0x20000002, 0x20000002, 0x20000002, 0x20000002, 0x20000002}},
+      Title::Mode::Minimal}}};
+static const std::array<Title, 17> systemApplications = {
+    {{"System Settings",
+      {{0x00020000, 0x00021000, 0x00022000, 0x00026000, 0x00027000, 0x00028000}},
+      Title::Mode::All},
+     {"Download Play",
+      {{0x00020100, 0x00021100, 0x00022100, 0x00026100, 0x00027100, 0x00028100}},
+      Title::Mode::Recommended},
+     {"Activity Log",
+      {{0x00020200, 0x00021200, 0x00022200, 0x00026200, 0x00027200, 0x00028200}},
+      Title::Mode::All},
+     {"Health and Safety Information",
+      {{0x00020300, 0x00021300, 0x00022300, 0x00026300, 0x00027300, 0x00028300}},
+      Title::Mode::All},
+     {"New_3DS Health and Safety Information",
+      {{0x20020300, 0x20021300, 0x20022300, 0x0, 0x20027300, 0x0}},
+      Title::Mode::All},
+     {"Nintendo 3DS Camera",
+      {{0x00020400, 0x00021400, 0x00022400, 0x00026400, 0x00027400, 0x00028400}},
+      Title::Mode::All},
+     {"Nintendo 3DS Sound",
+      {{0x00020500, 0x00021500, 0x00022500, 0x00026500, 0x00027500, 0x00028500}},
+      Title::Mode::All},
+     {"Mii Maker",
+      {{0x00020700, 0x00021700, 0x00022700, 0x00026700, 0x00027700, 0x00028700}},
+      Title::Mode::Recommended},
+     {"StreetPass Mii Plaza",
+      {{0x00020800, 0x00021800, 0x00022800, 0x00026800, 0x00027800, 0x00028800}},
+      Title::Mode::All},
+     {"eShop",
+      {{0x00020900, 0x00021900, 0x00022900, 0x0, 0x00027900, 0x00028900}},
+      Title::Mode::Recommended},
+     {"System Transfer",
+      {{0x00020A00, 0x00021A00, 0x00022A00, 0x0, 0x00027A00, 0x00028A00}},
+      Title::Mode::All},
+     {"Nintendo Zone", {{0x00020B00, 0x00021B00, 0x00022B00, 0x0, 0x0, 0x0}}, Title::Mode::All},
+     {"Face Raiders",
+      {{0x00020D00, 0x00021D00, 0x00022D00, 0x00026D00, 0x00027D00, 0x00028D00}},
+      Title::Mode::All},
+     {"New_3DS Face Raiders",
+      {{0x20020D00, 0x20021D00, 0x20022D00, 0x0, 0x20027D00, 0x0}},
+      Title::Mode::All},
+     {"AR Games",
+      {{0x00020E00, 0x00021E00, 0x00022E00, 0x00026E00, 0x00027E00, 0x00028E00}},
+      Title::Mode::All},
+     {"Nintendo Network ID Settings",
+      {{0x0002BF00, 0x0002C000, 0x0002C100, 0x0, 0x0, 0x0}},
+      Title::Mode::Recommended},
+     {"microSD Management",
+      {{0x20023100, 0x20024100, 0x20025100, 0x0, 0x0, 0x0}},
+      Title::Mode::All}}};
+
+static const std::array<Title, 7> systemDataArchives = {
+    {{"ClCertA",
+      {{0x00010002, 0x00010002, 0x00010002, 0x00010002, 0x00010002, 0x00010002}},
+      Title::Mode::Recommended},
+     {"NS CFA",
+      {{0x00010702, 0x00010702, 0x00010702, 0x00010702, 0x00010702, 0x00010702}},
+      Title::Mode::All},
+     {"dummy.txt",
+      {{0x00010802, 0x00010802, 0x00010802, 0x00010802, 0x00010802, 0x00010802}},
+      Title::Mode::All},
+     {"CFA web-browser data",
+      {{0x00018002, 0x00018002, 0x00018002, 0x00018002, 0x00018002, 0x00018002}},
+      Title::Mode::All},
+     {"local web-browser data",
+      {{0x00018102, 0x00018102, 0x00018102, 0x00018102, 0x00018102, 0x00018102}},
+      Title::Mode::All},
+     {"webkit/OSS CROs",
+      {{0x00018202, 0x00018202, 0x00018202, 0x00018202, 0x00018202, 0x00018202}},
+      Title::Mode::All},
+     {"Fangate_updater",
+      {{0x00019002, 0x00019002, 0x00019002, 0x00019002, 0x00019002, 0x00019002}},
+      Title::Mode::All}}};
+
+static const std::array<Title, 27> systemApplets = {
+    {{"Test Menu",
+      {{0x00008102, 0x00008102, 0x00008102, 0x00008102, 0x00008102, 0x00008102}},
+      Title::Mode::All},
+     {"Home Menu",
+      {{0x00008202, 0x00008F02, 0x00009802, 0x0000A102, 0x0000A902, 0x0000B102}},
+      Title::Mode::All},
+     {"Camera applet",
+      {{0x00008402, 0x00009002, 0x00009902, 0x0000A202, 0x0000AA02, 0x0000B202}},
+      Title::Mode::All},
+     {"Instruction Manual",
+      {{0x00008602, 0x00009202, 0x00009B02, 0x0000A402, 0x0000AC02, 0x0000B402}},
+      Title::Mode::Recommended},
+     {"Game Notes",
+      {{0x00008702, 0x00009302, 0x00009C02, 0x0000A502, 0x0000AD02, 0x0000B502}},
+      Title::Mode::All},
+     {"Internet Browser",
+      {{0x00008802, 0x00009402, 0x00009D02, 0x0000A602, 0x0000AE02, 0x0000B602}},
+      Title::Mode::All},
+     {"New 3DS Internet Browser",
+      {{0x20008802, 0x20009402, 0x20009D02, 0x0, 0x2000AE02, 0x0}},
+      Title::Mode::All},
+     {"Fatal error viewer",
+      {{0x00008A02, 0x00008A02, 0x00008A02, 0x00008A02, 0x00008A02, 0x00008A02}},
+      Title::Mode::All},
+     {"Safe Mode Fatal error viewer",
+      {{0x00008A03, 0x00008A03, 0x00008A03, 0x00008A03, 0x00008A03, 0x00008A03}},
+      Title::Mode::All},
+     {"New 3DS Safe Mode Fatal error viewer",
+      {{0x20008A03, 0x20008A03, 0x20008A03, 0x0, 0x20008A03, 0x0}},
+      Title::Mode::All},
+     {"Friend List",
+      {{0x00008D02, 0x00009602, 0x00009F02, 0x0000A702, 0x0000AF02, 0x0000B702}},
+      Title::Mode::Recommended},
+     {"Notifications",
+      {{0x00008E02, 0x000009702, 0x0000A002, 0x0000A802, 0x0000B002, 0x0000B802}},
+      Title::Mode::All},
+     {"Software Keyboard",
+      {{0x00000C002, 0x0000C802, 0x0000D002, 0x0000D802, 0x0000DE02, 0x0000E402}},
+      Title::Mode::Recommended},
+     {"Safe Mode Software Keyboard",
+      {{0x00000C003, 0x0000C803, 0x0000D003, 0x0000D803, 0x0000DE03, 0x0000E403}},
+      Title::Mode::All},
+     {"New 3DS Safe Mode Software Keyboard",
+      {{0x2000C003, 0x2000C803, 0x2000D003, 0x0, 0x2000DE03, 0x0}},
+      Title::Mode::All},
+     {"Mii picker",
+      {{0x0000C102, 0x0000C902, 0x0000D102, 0x0000D902, 0x0000DF02, 0x0000E502}},
+      Title::Mode::Recommended},
+     {"Picture picker",
+      {{0x0000C302, 0x0000CB02, 0x0000D302, 0x0000DB02, 0x0000E102, 0x0000E702}},
+      Title::Mode::All},
+     {"Voice memo picker",
+      {{0x0000C402, 0x0000CC02, 0x0000D402, 0x0000DC02, 0x0000E202, 0x0000E802}},
+      Title::Mode::All},
+     {"Error display",
+      {{0x0000C502, 0x0000C502, 0x0000C502, 0x0000CF02, 0x0000CF02, 0x0000CF02}},
+      Title::Mode::All},
+     {"Safe mode error display",
+      {{0x0000C503, 0x0000C503, 0x0000C503, 0x0000CF03, 0x0000CF03, 0x0000CF03}},
+      Title::Mode::All},
+     {"New 3DS safe mode error display",
+      {{0x2000C503, 0x2000C503, 0x2000C503, 0x0, 0x2000CF03, 0x0}},
+      Title::Mode::All},
+     {"Circle Pad Pro test/calibration applet",
+      {{0x0000CD02, 0x0000CD02, 0x0000CD02, 0x0000D502, 0x0000D502, 0x0000D502}},
+      Title::Mode::All},
+     {"eShop applet",
+      {{0x0000C602, 0x0000CE02, 0x0000D602, 0x0, 0x0000E302, 0x0000E902}},
+      Title::Mode::Recommended},
+     {"Miiverse", {{0x0000BC02, 0x0000BC02, 0x0000BC02, 0x0, 0x0, 0x0}}, Title::Mode::All},
+     {"Miiverse system library",
+      {{0x0000F602, 0x0000F602, 0x0000F602, 0x0, 0x0, 0x0}},
+      Title::Mode::All},
+     {"Miiverse-posting applet",
+      {{0x00008302, 0x00008B02, 0x0000BA02, 0x0, 0x0, 0x0}},
+      Title::Mode::All},
+     {"Amiibo Settings",
+      {{0x00009502, 0x00009E02, 0x0000B902, 0x0, 0x00008C02, 0x0000BF02}},
+      Title::Mode::All}}};
+
+static const std::array<Title, 25> sharedDataArchives = {
+    {{"CFL_Res.dat",
+      {{0x00010202, 0x00010202, 0x00010202, 0x00010202, 0x00010202, 0x00010202}},
+      Title::Mode::All},
+     {"Region Manifest",
+      {{0x00010402, 0x00010402, 0x00010402, 0x00010402, 0x00010402, 0x00010402}},
+      Title::Mode::All},
+     {"Non-Nintendo TLS Root-CA Certificates",
+      {{0x00010602, 0x00010602, 0x00010602, 0x00010602, 0x00010602, 0x00010602}},
+      Title::Mode::Recommended},
+     {"CHN/CN Dictionary", {{0x0, 0x0, 0x0, 0x00011002, 0x0, 0x0}}, Title::Mode::All},
+     {"TWN/TN dictionary", {{0x0, 0x0, 0x0, 0x0, 0x0, 0x00011102}}, Title::Mode::All},
+     {"NL/NL dictionary", {{0x0, 0x0, 0x00011202, 0x0, 0x0, 0x0}}, Title::Mode::All},
+     {"EN/GB dictionary", {{0x0, 0x0, 0x00011302, 0x0, 0x0, 0x0}}, Title::Mode::All},
+     {"EN/US dictionary", {{0x0, 0x00011402, 0x0, 0x0, 0x0, 0x0}}, Title::Mode::All},
+     {"FR/FR/regular dictionary", {{0x0, 0x0, 0x00011502, 0x0, 0x0, 0x0}}, Title::Mode::All},
+     {"FR/CA/regular dictionary", {{0x0, 0x00011602, 0x0, 0x0, 0x0, 0x0}}, Title::Mode::All},
+     {"DE/regular dictionary", {{0x0, 0x0, 0x00011702, 0x0, 0x0, 0x0}}, Title::Mode::All},
+     {"IT/IT dictionary", {{0x0, 0x0, 0x00011802, 0x0, 0x0, 0x0}}, Title::Mode::All},
+     {"JA_small/32 dictionary", {{0x00011902, 0x0, 0x0, 0x0, 0x0, 0x0}}, Title::Mode::All},
+     {"KO/KO dictionary", {{0x0, 0x0, 0x0, 0x0, 0x00011A02, 0x0}}, Title::Mode::All},
+     {"PT/PT/regular dictionary", {{0x0, 0x0, 0x00011B02, 0x0, 0x0, 0x0}}, Title::Mode::All},
+     {"RU/regular dictionary", {{0x0, 0x0, 0x00011C02, 0x0, 0x0, 0x0}}, Title::Mode::All},
+     {"ES/ES dictionary", {{0x0, 0x00011D02, 0x00011D02, 0x0, 0x0, 0x0}}, Title::Mode::All},
+     {"PT/BR/regular dictionary", {{0x0, 0x00011E02, 0x0, 0x0, 0x0, 0x0}}, Title::Mode::All},
+     {"error strings",
+      {{0x00012202, 0x00012302, 0x00012102, 0x00012402, 0x00012502, 0x00012602}},
+      Title::Mode::All},
+     {"eula", {{0x00013202, 0x00013302, 0x00013102, 0x00013502, 0x0, 0x0}}, Title::Mode::All},
+     {"JPN/EUR/USA System Font",
+      {{0x00014002, 0x00014002, 0x00014002, 0x00014002, 0x00014002, 0x00014002}},
+      Title::Mode::Recommended},
+     {"CHN System Font",
+      {{0x00014102, 0x00014102, 0x00014102, 0x00014102, 0x00014102, 0x00014102}},
+      Title::Mode::Recommended},
+     {"KOR System Font",
+      {{0x00014202, 0x00014202, 0x00014202, 0x00014202, 0x00014202, 0x00014202}},
+      Title::Mode::Recommended},
+     {"TWN System Font",
+      {{0x00014302, 0x00014302, 0x00014302, 0x00014302, 0x00014302, 0x00014302}},
+      Title::Mode::Recommended},
+     {"rate",
+      {{0x00015202, 0x00015302, 0x00015102, 0x0, 0x0015502, 0x00015602}},
+      Title::Mode::All}}};
+
+static const std::array<Title, 5> systemDataArchives2 = {
+    {{"bad word list",
+      {{0x00010302, 0x00010302, 0x00010302, 0x00010302, 0x00010302, 0x00010302}},
+      Title::Mode::All},
+     {"Nintendo Zone hotspot list",
+      {{0x00010502, 0x00010502, 0x00010502, 0x00010502, 0x00010502, 0x00010502}},
+      Title::Mode::All},
+     {"NVer",
+      {{0x00016102, 0x00016202, 0x00016302, 0x00016402, 0x00016502, 0x00016602}},
+      Title::Mode::All},
+     {"New_3DS NVer",
+      {{0x20016102, 0x20016202, 0x20016302, 0x0, 0x20016502, 0x0}},
+      Title::Mode::All},
+     {"CVer",
+      {{0x00017102, 0x00017202, 0x00017302, 0x00017402, 0x00017502, 0x00017602}},
+      Title::Mode::All}}};
+
+static const std::array<Title, 100> systemModules = {
+    {{"sm",
+      {{0x00001002, 0x00001002, 0x00001002, 0x00001002, 0x00001002, 0x00001002}},
+      Title::Mode::All},
+     {"Safe Mode sm",
+      {{0x00001003, 0x00001003, 0x00001003, 0x00001003, 0x00001003, 0x00001003}},
+      Title::Mode::All},
+     {"fs",
+      {{0x00001102, 0x00001102, 0x00001102, 0x00001102, 0x00001102, 0x00001102}},
+      Title::Mode::All},
+     {"Safe Mode fs",
+      {{0x00001103, 0x00001103, 0x00001103, 0x00001103, 0x00001103, 0x00001103}},
+      Title::Mode::All},
+     {"pm",
+      {{0x00001202, 0x00001202, 0x00001202, 0x00001202, 0x00001202, 0x00001202}},
+      Title::Mode::All},
+     {"Safe Mode pm",
+      {{0x00001203, 0x00001203, 0x00001203, 0x00001203, 0x00001203, 0x00001203}},
+      Title::Mode::All},
+     {"loader",
+      {{0x00001302, 0x00001302, 0x00001302, 0x00001302, 0x00001302, 0x00001302}},
+      Title::Mode::All},
+     {"Safe Mode loader",
+      {{0x00001303, 0x00001303, 0x00001303, 0x00001303, 0x00001303, 0x00001303}},
+      Title::Mode::All},
+     {"pxi",
+      {{0x00001402, 0x00001402, 0x00001402, 0x00001402, 0x00001402, 0x00001402}},
+      Title::Mode::All},
+     {"Safe Mode pxi",
+      {{0x00001403, 0x00001403, 0x00001403, 0x00001403, 0x00001403, 0x00001403}},
+      Title::Mode::All},
+     {"AM ( Application Manager )",
+      {{0x00001502, 0x00001502, 0x00001502, 0x00001502, 0x00001502, 0x00001502}},
+      Title::Mode::All},
+     {"Safe Mode AM",
+      {{0x00001503, 0x00001503, 0x00001503, 0x00001503, 0x00001503, 0x00001503}},
+      Title::Mode::All},
+     {"New_3DS Safe Mode AM",
+      {{0x20001503, 0x20001503, 0x20001503, 0x20001503, 0x20001503, 0x20001503}},
+      Title::Mode::All},
+     {"Camera",
+      {{0x00001602, 0x00001602, 0x00001602, 0x00001602, 0x00001602, 0x00001602}},
+      Title::Mode::All},
+     {"New_3DS Camera",
+      {{0x20001602, 0x20001602, 0x20001602, 0x20001602, 0x20001602, 0x20001602}},
+      Title::Mode::All},
+     {"Config (cfg)",
+      {{0x00001702, 0x00001702, 0x00001702, 0x00001702, 0x00001702, 0x00001702}},
+      Title::Mode::All},
+     {"Safe Mode Config (cfg)",
+      {{0x00001703, 0x00001703, 0x00001703, 0x00001703, 0x00001703, 0x00001703}},
+      Title::Mode::All},
+     {"New_3DS Safe Mode Config (cfg)",
+      {{0x20001703, 0x20001703, 0x20001703, 0x20001703, 0x20001703, 0x20001703}},
+      Title::Mode::All},
+     {"Codec",
+      {{0x00001802, 0x00001802, 0x00001802, 0x00001802, 0x00001802, 0x00001802}},
+      Title::Mode::All},
+     {"Safe Mode Codec",
+      {{0x00001803, 0x00001803, 0x00001803, 0x00001803, 0x00001803, 0x00001803}},
+      Title::Mode::All},
+     {"New_3DS Safe Mode Codec",
+      {{0x20001803, 0x20001803, 0x20001803, 0x20001803, 0x20001803, 0x20001803}},
+      Title::Mode::All},
+     {"DSP",
+      {{0x00001A02, 0x00001A02, 0x00001A02, 0x00001A02, 0x00001A02, 0x00001A02}},
+      Title::Mode::All},
+     {"Safe Mode DSP",
+      {{0x00001A03, 0x00001A03, 0x00001A03, 0x00001A03, 0x00001A03, 0x00001A03}},
+      Title::Mode::All},
+     {"New_3DS Safe Mode DSP",
+      {{0x20001A03, 0x20001A03, 0x20001A03, 0x20001A03, 0x20001A03, 0x20001A03}},
+      Title::Mode::All},
+     {"GPIO",
+      {{0x00001B02, 0x00001B02, 0x00001B02, 0x00001B02, 0x00001B02, 0x00001B02}},
+      Title::Mode::All},
+     {"Safe Mode GPIO",
+      {{0x00001B03, 0x00001B03, 0x00001B03, 0x00001B03, 0x00001B03, 0x00001B03}},
+      Title::Mode::All},
+     {"New_3DS Safe Mode GPIO",
+      {{0x20001B03, 0x20001B03, 0x20001B03, 0x20001B03, 0x20001B03, 0x20001B03}},
+      Title::Mode::All},
+     {"GSP",
+      {{0x00001C02, 0x00001C02, 0x00001C02, 0x00001C02, 0x00001C02, 0x00001C02}},
+      Title::Mode::All},
+     {"New_3DS GSP",
+      {{0x20001C02, 0x20001C02, 0x20001C02, 0x20001C02, 0x20001C02, 0x20001C02}},
+      Title::Mode::All},
+     {"Safe Mode GSP",
+      {{0x00001C03, 0x00001C03, 0x00001C03, 0x00001C03, 0x00001C03, 0x00001C03}},
+      Title::Mode::All},
+     {"New_3DS Safe Mode GSP",
+      {{0x20001C03, 0x20001C03, 0x20001C03, 0x20001C03, 0x20001C03, 0x20001C03}},
+      Title::Mode::All},
+     {"HID (Human Interface Devices)",
+      {{0x00001D02, 0x00001D02, 0x00001D02, 0x00001D02, 0x00001D02, 0x00001D02}},
+      Title::Mode::All},
+     {"Safe Mode HID",
+      {{0x00001D03, 0x00001D03, 0x00001D03, 0x00001D03, 0x00001D03, 0x00001D03}},
+      Title::Mode::All},
+     {"New_3DS Safe Mode HID",
+      {{0x20001D03, 0x20001D03, 0x20001D03, 0x20001D03, 0x20001D03, 0x20001D03}},
+      Title::Mode::All},
+     {"i2c",
+      {{0x00001E02, 0x00001E02, 0x00001E02, 0x00001E02, 0x00001E02, 0x00001E02}},
+      Title::Mode::All},
+     {"New_3DS i2c",
+      {{0x20001E02, 0x20001E02, 0x20001E02, 0x20001E02, 0x20001E02, 0x20001E02}},
+      Title::Mode::All},
+     {"Safe Mode i2c",
+      {{0x00001E03, 0x00001E03, 0x00001E03, 0x00001E03, 0x00001E03, 0x00001E03}},
+      Title::Mode::All},
+     {"New_3DS Safe Mode i2c",
+      {{0x20001E03, 0x20001E03, 0x20001E03, 0x20001E03, 0x20001E03, 0x20001E03}},
+      Title::Mode::All},
+     {"MCU",
+      {{0x00001F02, 0x00001F02, 0x00001F02, 0x00001F02, 0x00001F02, 0x00001F02}},
+      Title::Mode::All},
+     {"New_3DS MCU",
+      {{0x20001F02, 0x20001F02, 0x20001F02, 0x20001F02, 0x20001F02, 0x20001F02}},
+      Title::Mode::All},
+     {"Safe Mode MCU",
+      {{0x00001F03, 0x00001F03, 0x00001F03, 0x00001F03, 0x00001F03, 0x00001F03}},
+      Title::Mode::All},
+     {"New_3DS Safe Mode MCU",
+      {{0x20001F03, 0x20001F03, 0x20001F03, 0x20001F03, 0x20001F03, 0x20001F03}},
+      Title::Mode::All},
+     {"MIC (Microphone)",
+      {{0x00002002, 0x00002002, 0x00002002, 0x00002002, 0x00002002, 0x00002002}},
+      Title::Mode::All},
+     {"PDN",
+      {{0x00002102, 0x00002102, 0x00002102, 0x00002102, 0x00002102, 0x00002102}},
+      Title::Mode::All},
+     {"Safe Mode PDN",
+      {{0x00002103, 0x00002103, 0x00002103, 0x00002103, 0x00002103, 0x00002103}},
+      Title::Mode::All},
+     {"New_3DS Safe Mode PDN",
+      {{0x20002103, 0x20002103, 0x20002103, 0x20002103, 0x20002103, 0x20002103}},
+      Title::Mode::All},
+     {"PTM (Play time, pedometer, and battery manager)",
+      {{0x00002202, 0x00002202, 0x00002202, 0x00002202, 0x00002202, 0x00002202}},
+      Title::Mode::All},
+     {"New_3DS PTM (Play time, pedometer, and battery manager)",
+      {{0x20002202, 0x20002202, 0x20002202, 0x20002202, 0x20002202, 0x20002202}},
+      Title::Mode::All},
+     {"Safe Mode PTM",
+      {{0x00002203, 0x00002203, 0x00002203, 0x00002203, 0x00002203, 0x00002203}},
+      Title::Mode::All},
+     {"New_3DS Safe Mode PTM",
+      {{0x20002203, 0x20002203, 0x20002203, 0x20002203, 0x20002203, 0x20002203}},
+      Title::Mode::All},
+     {"spi",
+      {{0x00002302, 0x00002302, 0x00002302, 0x00002302, 0x00002302, 0x00002302}},
+      Title::Mode::All},
+     {"New_3DS spi",
+      {{0x20002302, 0x20002302, 0x20002302, 0x20002302, 0x20002302, 0x20002302}},
+      Title::Mode::All},
+     {"Safe Mode spi",
+      {{0x00002303, 0x00002303, 0x00002303, 0x00002303, 0x00002303, 0x00002303}},
+      Title::Mode::All},
+     {"New_3DS Safe Mode spi",
+      {{0x20002303, 0x20002303, 0x20002303, 0x20002303, 0x20002303, 0x20002303}},
+      Title::Mode::All},
+     {"AC (Network manager)",
+      {{0x00002402, 0x00002402, 0x00002402, 0x00002402, 0x00002402, 0x00002402}},
+      Title::Mode::All},
+     {"Safe Mode AC",
+      {{0x00002403, 0x00002403, 0x00002403, 0x00002403, 0x00002403, 0x00002403}},
+      Title::Mode::All},
+     {"New_3DS Safe Mode AC",
+      {{0x20002403, 0x20002403, 0x20002403, 0x20002403, 0x20002403, 0x20002403}},
+      Title::Mode::All},
+     {"Cecd (StreetPass)",
+      {{0x00002602, 0x00002602, 0x00002602, 0x00002602, 0x00002602, 0x00002602}},
+      Title::Mode::All},
+     {"CSND",
+      {{0x00002702, 0x00002702, 0x00002702, 0x00002702, 0x00002702, 0x00002702}},
+      Title::Mode::All},
+     {"Safe Mode CSND",
+      {{0x00002703, 0x00002703, 0x00002703, 0x00002703, 0x00002703, 0x00002703}},
+      Title::Mode::All},
+     {"New_3DS Safe Mode CSND",
+      {{0x20002703, 0x20002703, 0x20002703, 0x20002703, 0x20002703, 0x20002703}},
+      Title::Mode::All},
+     {"DLP (Download Play)",
+      {{0x00002802, 0x00002802, 0x00002802, 0x00002802, 0x00002802, 0x00002802}},
+      Title::Mode::Recommended},
+     {"HTTP",
+      {{0x00002902, 0x00002902, 0x00002902, 0x00002902, 0x00002902, 0x00002902}},
+      Title::Mode::All},
+     {"Safe Mode HTTP",
+      {{0x00002903, 0x00002903, 0x00002903, 0x00002903, 0x00002903, 0x00002903}},
+      Title::Mode::All},
+     {"New_3DS Safe Mode HTTP",
+      {{0x20002903, 0x20002903, 0x20002903, 0x20002903, 0x20002903, 0x20002903}},
+      Title::Mode::All},
+     {"MP",
+      {{0x00002A02, 0x00002A02, 0x00002A02, 0x00002A02, 0x00002A02, 0x00002A02}},
+      Title::Mode::All},
+     {"Safe Mode MP",
+      {{0x00002A03, 0x00002A03, 0x00002A03, 0x00002A03, 0x00002A03, 0x00002A03}},
+      Title::Mode::All},
+     {"NDM",
+      {{0x00002B02, 0x00002B02, 0x00002B02, 0x00002B02, 0x00002B02, 0x00002B02}},
+      Title::Mode::All},
+     {"NIM",
+      {{0x00002C02, 0x00002C02, 0x00002C02, 0x00002C02, 0x00002C02, 0x00002C02}},
+      Title::Mode::All},
+     {"Safe Mode NIM",
+      {{0x00002C03, 0x00002C03, 0x00002C03, 0x00002C03, 0x00002C03, 0x00002C03}},
+      Title::Mode::All},
+     {"New_3DS Safe Mode NIM",
+      {{0x20002C03, 0x20002C03, 0x20002C03, 0x20002C03, 0x20002C03, 0x20002C03}},
+      Title::Mode::All},
+     {"NWM ( Low-level wifi manager )",
+      {{0x00002D02, 0x00002D02, 0x00002D02, 0x00002D02, 0x00002D02, 0x00002D02}},
+      Title::Mode::All},
+     {"Safe Mode NWM",
+      {{0x00002D03, 0x00002D03, 0x00002D03, 0x00002D03, 0x00002D03, 0x00002D03}},
+      Title::Mode::All},
+     {"New_3DS Safe Mode NWM",
+      {{0x20002D03, 0x20002D03, 0x20002D03, 0x20002D03, 0x20002D03, 0x20002D03}},
+      Title::Mode::All},
+     {"Sockets",
+      {{0x00002E02, 0x00002E02, 0x00002E02, 0x00002E02, 0x00002E02, 0x00002E02}},
+      Title::Mode::All},
+     {"Safe Mode Sockets",
+      {{0x00002E03, 0x00002E03, 0x00002E03, 0x00002E03, 0x00002E03, 0x00002E03}},
+      Title::Mode::All},
+     {"New_3DS Safe Mode Sockets",
+      {{0x20002E03, 0x20002E03, 0x20002E03, 0x20002E03, 0x20002E03, 0x20002E03}},
+      Title::Mode::All},
+     {"SSL",
+      {{0x00002F02, 0x00002F02, 0x00002F02, 0x00002F02, 0x00002F02, 0x00002F02}},
+      Title::Mode::All},
+     {"Safe Mode SSL",
+      {{0x00002F03, 0x00002F03, 0x00002F03, 0x00002F03, 0x00002F03, 0x00002F03}},
+      Title::Mode::All},
+     {"New_3DS Safe Mode SSL",
+      {{0x20002F03, 0x20002F03, 0x20002F03, 0x20002F03, 0x20002F03, 0x20002F03}},
+      Title::Mode::All},
+     {"Process9",
+      {{0x00003000, 0x00003000, 0x00003000, 0x00003000, 0x00003000, 0x00003000}},
+      Title::Mode::All},
+     {"PS ( Process Manager )",
+      {{0x00003102, 0x00003102, 0x00003102, 0x00003102, 0x00003102, 0x00003102}},
+      Title::Mode::All},
+     {"Safe Mode PS",
+      {{0x00003103, 0x00003103, 0x00003103, 0x00003103, 0x00003103, 0x00003103}},
+      Title::Mode::All},
+     {"New_3DS Safe Mode PS",
+      {{0x20003103, 0x20003103, 0x20003103, 0x20003103, 0x20003103, 0x20003103}},
+      Title::Mode::All},
+     {"friends (Friends list)",
+      {{0x00003202, 0x00003202, 0x00003202, 0x00003202, 0x00003202, 0x00003202}},
+      Title::Mode::All},
+     {"Safe Mode friends (Friends list)",
+      {{0x00003203, 0x00003203, 0x00003203, 0x00003203, 0x00003203, 0x00003203}},
+      Title::Mode::All},
+     {"New_3DS Safe Mode friends (Friends list)",
+      {{0x20003203, 0x20003203, 0x20003203, 0x20003203, 0x20003203, 0x20003203}},
+      Title::Mode::All},
+     {"IR (Infrared)",
+      {{0x00003302, 0x00003302, 0x00003302, 0x00003302, 0x00003302, 0x00003302}},
+      Title::Mode::All},
+     {"Safe Mode IR",
+      {{0x00003303, 0x00003303, 0x00003303, 0x00003303, 0x00003303, 0x00003303}},
+      Title::Mode::All},
+     {"New_3DS Safe Mode IR",
+      {{0x20003303, 0x20003303, 0x20003303, 0x20003303, 0x20003303, 0x20003303}},
+      Title::Mode::All},
+     {"BOSS (SpotPass)",
+      {{0x00003402, 0x00003402, 0x00003402, 0x00003402, 0x00003402, 0x00003402}},
+      Title::Mode::All},
+     {"News (Notifications)",
+      {{0x00003502, 0x00003502, 0x00003502, 0x00003502, 0x00003502, 0x00003502}},
+      Title::Mode::All},
+     {"RO",
+      {{0x00003702, 0x00003702, 0x00003702, 0x00003702, 0x00003702, 0x00003702}},
+      Title::Mode::All},
+     {"act",
+      {{0x00003802, 0x00003802, 0x00003802, 0x00003802, 0x00003802, 0x00003802}},
+      Title::Mode::All},
+     {"nfc",
+      {{0x00004002, 0x00004002, 0x00004002, 0x00004002, 0x00004002, 0x00004002}},
+      Title::Mode::All},
+     {"New_3DS mvd",
+      {{0x20004102, 0x20004102, 0x20004102, 0x20004102, 0x20004102, 0x20004102}},
+      Title::Mode::All},
+     {"New_3DS qtm",
+      {{0x20004202, 0x20004202, 0x20004202, 0x20004202, 0x20004202, 0x20004202}},
+      Title::Mode::All},
+     {"NS",
+      {{0x00008002, 0x00008002, 0x00008002, 0x00008002, 0x00008002, 0x00008002}},
+      Title::Mode::All},
+     {"Safe Mode NS",
+      {{0x00008003, 0x00008003, 0x00008003, 0x00008003, 0x00008003, 0x00008003}},
+      Title::Mode::All},
+     {"New_3DS Safe Mode NS",
+      {{0x20008003, 0x20008003, 0x20008003, 0x20008003, 0x20008003, 0x20008003}},
+      Title::Mode::All}}};
+
 ConfigureSystem::ConfigureSystem(QWidget* parent) : QWidget(parent), ui(new Ui::ConfigureSystem) {
     ui->setupUi(this);
     connect(ui->combo_birthmonth,
@@ -227,10 +769,35 @@ ConfigureSystem::ConfigureSystem(QWidget* parent) : QWidget(parent), ui(new Ui::
             &ConfigureSystem::UpdateInitTime);
     connect(ui->button_regenerate_console_id, &QPushButton::clicked, this,
             &ConfigureSystem::RefreshConsoleID);
+    connect(ui->button_start_download, &QPushButton::clicked, this,
+            &ConfigureSystem::DownloadFromNUS);
     for (u8 i = 0; i < country_names.size(); i++) {
         if (std::strcmp(country_names.at(i), "") != 0) {
             ui->combo_country->addItem(tr(country_names.at(i)), i);
         }
+    }
+
+    ui->combo_download_mode->setCurrentIndex(1); // set to Recommended
+    bool keysAvailable = true;
+    HW::AES::InitKeys(true);
+    for (std::size_t i = 0; i < HW::AES::MaxCommonKeySlot; i++) {
+        HW::AES::SelectCommonKeyIndex(i);
+        if (!HW::AES::IsNormalKeyAvailable(HW::AES::KeySlotID::TicketCommonKey)) {
+            keysAvailable = false;
+            break;
+        }
+    }
+    if (!keysAvailable) {
+        ui->button_start_download->setEnabled(false);
+        ui->combo_download_mode->setEnabled(false);
+        ui->label_nus_download->setText(
+            tr("Citra is missing keys to download system files. <br><a "
+               "href='https://citra-emu.org/wiki/aes-keys/'><span style=\"text-decoration: "
+               "underline; color:#039be5;\">How to get keys?</span></a>"));
+    } else {
+        ui->button_start_download->setEnabled(true);
+        ui->combo_download_mode->setEnabled(true);
+        ui->label_nus_download->setText(tr("Download System Files from Nitendo servers"));
     }
 
     ConfigureTime();
@@ -427,4 +994,98 @@ void ConfigureSystem::RefreshConsoleID() {
 
 void ConfigureSystem::RetranslateUI() {
     ui->retranslateUi(this);
+}
+
+void ConfigureSystem::DownloadFromNUS() {
+    int mode = ui->combo_download_mode->currentIndex();
+    u32 region_value = cfg->GetRegionValue();
+    if (region_value == 0) {
+        region_value = 2;
+    } else {
+        --region_value;
+    }
+
+    auto TitlesWithMode = [mode, region_value](const Title& title) {
+        return mode <= title.mode && title.lower_title_id[region_value] != 0;
+    };
+    std::size_t numTitles =
+        std::count_if(systemFirmware.begin(), systemFirmware.end(), TitlesWithMode);
+    numTitles +=
+        std::count_if(systemApplications.begin(), systemApplications.end(), TitlesWithMode);
+    numTitles +=
+        std::count_if(systemDataArchives.begin(), systemDataArchives.end(), TitlesWithMode);
+    numTitles += std::count_if(systemApplets.begin(), systemApplets.end(), TitlesWithMode);
+    numTitles +=
+        std::count_if(sharedDataArchives.begin(), sharedDataArchives.end(), TitlesWithMode);
+    numTitles +=
+        std::count_if(systemDataArchives2.begin(), systemDataArchives2.end(), TitlesWithMode);
+    numTitles += std::count_if(systemModules.begin(), systemModules.end(), TitlesWithMode);
+
+    QProgressDialog progress(tr("Downloading files..."), tr("Abort"), 0, numTitles, this);
+    progress.setWindowModality(Qt::WindowModal);
+
+    u32 upperTitleID;
+    std::size_t count = 0;
+    bool failed = false;
+    auto InstallIfMode = [mode, region_value, &progress, &upperTitleID, &count,
+                          &failed](const Title& title, int version = -1) {
+        if (progress.wasCanceled())
+            return;
+        if (mode <= title.mode && title.lower_title_id[region_value] != 0) {
+            progress.setValue(count++);
+            u64 title_id = (static_cast<u64>(upperTitleID) << 32) +
+                           static_cast<u64>(title.lower_title_id[region_value]);
+            LOG_DEBUG(Service_AM, "Downloading {:X}", title_id);
+            if (Service::AM::InstallFromNus(title_id, version) !=
+                Service::AM::InstallStatus::Success) {
+                failed = true;
+            }
+        }
+    };
+
+    // Install save mode firms with v1.0 first
+    if (!progress.wasCanceled()) {
+        upperTitleID = 0x00040138;
+        constexpr int SAFE_MODE_NATIVE_FIRM_V1_VERSION = 432;
+        InstallIfMode(systemFirmware[0], SAFE_MODE_NATIVE_FIRM_V1_VERSION);
+        HW::AES::InitKeys(true);
+    }
+    if (!progress.wasCanceled()) {
+        upperTitleID = 0x00040138;
+        std::for_each(systemFirmware.begin() + 1, systemFirmware.end(), InstallIfMode);
+        HW::AES::InitKeys(true);
+    }
+    if (!progress.wasCanceled()) {
+        upperTitleID = 0x00040010;
+        std::for_each(systemApplications.begin(), systemApplications.end(), InstallIfMode);
+    }
+    if (!progress.wasCanceled()) {
+        upperTitleID = 0x0004001B;
+        std::for_each(systemDataArchives.begin(), systemDataArchives.end(), InstallIfMode);
+    }
+    if (!progress.wasCanceled()) {
+        upperTitleID = 0x00040030;
+        std::for_each(systemApplets.begin(), systemApplets.end(), InstallIfMode);
+    }
+    if (!progress.wasCanceled()) {
+        upperTitleID = 0x0004009B;
+        std::for_each(sharedDataArchives.begin(), sharedDataArchives.end(), InstallIfMode);
+    }
+    if (!progress.wasCanceled()) {
+        upperTitleID = 0x000400DB;
+        std::for_each(systemDataArchives2.begin(), systemDataArchives2.end(), InstallIfMode);
+    }
+    if (!progress.wasCanceled()) {
+        upperTitleID = 0x00040130;
+        std::for_each(systemModules.begin(), systemModules.end(), InstallIfMode);
+    }
+    if (!progress.wasCanceled()) {
+        progress.setValue(count);
+        progress.cancel();
+    }
+    if (failed) {
+        QMessageBox msgBox;
+        msgBox.setText(tr("Downloading system files failed"));
+        msgBox.exec();
+    }
 }

--- a/src/citra_qt/configuration/configure_system.h
+++ b/src/citra_qt/configuration/configure_system.h
@@ -37,6 +37,8 @@ private:
     void UpdateInitTime(int init_clock);
     void RefreshConsoleID();
 
+    void DownloadFromNUS();
+
     std::unique_ptr<Ui::ConfigureSystem> ui;
     bool enabled = false;
 

--- a/src/citra_qt/configuration/configure_system.ui
+++ b/src/citra_qt/configuration/configure_system.ui
@@ -303,6 +303,52 @@
           </property>
          </widget>
         </item>
+        <item row="9" column="0">
+         <widget class="QLabel" name="label_nus_download">
+          <property name="text">
+           <string>Download System Files from Nitendo servers</string>
+          </property>
+         </widget>
+        </item>
+        <item row="9" column="1">
+         <layout class="QHBoxLayout" name="horizontalLayout_nus_download">
+          <item>
+           <widget class="QComboBox" name="combo_download_mode">
+            <item>
+             <property name="text">
+              <string>All</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Recommended</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Minimal</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="button_start_download">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="layoutDirection">
+             <enum>Qt::RightToLeft</enum>
+            </property>
+            <property name="text">
+             <string>Download</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
        </layout>
       </widget>
      </item>

--- a/src/core/file_sys/cia_container.cpp
+++ b/src/core/file_sys/cia_container.cpp
@@ -16,8 +16,6 @@
 
 namespace FileSys {
 
-constexpr u32 CIA_SECTION_ALIGNMENT = 0x40;
-
 Loader::ResultStatus CIAContainer::Load(const FileBackend& backend) {
     std::vector<u8> header_data(sizeof(Header));
 

--- a/src/core/file_sys/cia_container.h
+++ b/src/core/file_sys/cia_container.h
@@ -29,6 +29,7 @@ constexpr std::size_t CIA_CONTENT_BITS_SIZE = (CIA_CONTENT_MAX_COUNT / 8);
 constexpr std::size_t CIA_HEADER_SIZE = 0x2020;
 constexpr std::size_t CIA_DEPENDENCY_SIZE = 0x300;
 constexpr std::size_t CIA_METADATA_SIZE = 0x400;
+constexpr u32 CIA_SECTION_ALIGNMENT = 0x40;
 
 /**
  * Helper which implements an interface to read and write CTR Installable Archive (CIA) files.
@@ -69,7 +70,6 @@ public:
 
     void Print() const;
 
-private:
     struct Header {
         u32_le header_size;
         u16_le type;
@@ -87,10 +87,14 @@ private:
             // The bits in the content index are arranged w/ index 0 as the MSB, 7 as the LSB, etc.
             return (content_present[index >> 3] & (0x80 >> (index & 7)));
         }
+        void setContentPresent(u16 index) {
+            content_present[index >> 3] |= (0x80 >> (index & 7));
+        }
     };
 
     static_assert(sizeof(Header) == CIA_HEADER_SIZE, "CIA Header structure size is wrong");
 
+private:
     struct Metadata {
         std::array<u64_le, 0x30> dependencies;
         std::array<u8, 0x180> reserved;

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -9,6 +9,7 @@
 #include <cryptopp/aes.h>
 #include <cryptopp/modes.h>
 #include <fmt/format.h>
+#include "common/alignment.h"
 #include "common/file_util.h"
 #include "common/logging/log.h"
 #include "common/string_util.h"
@@ -32,6 +33,9 @@
 #include "core/hle/service/fs/archive.h"
 #include "core/loader/loader.h"
 #include "core/loader/smdh.h"
+#ifdef ENABLE_WEB_SERVICE
+#include "web_service/nus_download.h"
+#endif
 
 namespace Service::AM {
 
@@ -139,6 +143,8 @@ ResultCode CIAFile::WriteTitleMetadata() {
             decryption_state->content[i].SetKeyWithIV(title_key->data(), title_key->size(),
                                                       ctr.data());
         }
+    } else {
+        LOG_ERROR(Service_AM, "Can't get title key from ticket");
     }
 
     install_state = CIAInstallState::TMDLoaded;
@@ -180,6 +186,11 @@ ResultVal<std::size_t> CIAFile::WriteContentData(u64 offset, std::size_t length,
 
             if (tmd.GetContentTypeByIndex(static_cast<u16>(i)) &
                 FileSys::TMDContentTypeFlag::Encrypted) {
+                if (decryption_state->content.size() <= i) {
+                    // TODO: There is probably no correct error to return here. What error should be
+                    // returned?
+                    return FileSys::ERROR_INSUFFICIENT_SPACE;
+                }
                 decryption_state->content[i].ProcessData(temp.data(), temp.data(), temp.size());
             }
 
@@ -235,7 +246,7 @@ ResultVal<std::size_t> CIAFile::Write(u64 offset, std::size_t length, bool flush
         std::size_t buf_offset = buf_loaded - offset;
         std::size_t buf_copy_size =
             std::min(length, static_cast<std::size_t>(container.GetContentOffset() - offset)) -
-            buf_loaded;
+            buf_offset;
         std::size_t buf_max_size = std::min(offset + length, container.GetContentOffset());
         data.resize(buf_max_size);
         memcpy(data.data() + copy_offset, buffer + buf_offset, buf_copy_size);
@@ -378,6 +389,94 @@ InstallStatus InstallCIA(const std::string& path,
 
     LOG_ERROR(Service_AM, "CIA file {} is invalid!", path);
     return InstallStatus::ErrorInvalid;
+}
+
+InstallStatus InstallFromNus(u64 title_id, int version) {
+#ifdef ENABLE_WEB_SERVICE
+    Service::AM::CIAFile installFile(Service::AM::GetTitleMediaType(title_id));
+    std::string path = fmt::format("/ccs/download/{:016X}/tmd", title_id);
+    if (version != -1)
+        path += fmt::format(".{}", version);
+    auto tmdResponse = WebService::NUS::Download(path);
+    if (!tmdResponse) {
+        LOG_ERROR(Service_AM, "Failed to download tmd for {:016X}", title_id);
+        return InstallStatus::ErrorFileNotFound;
+    }
+    FileSys::TitleMetadata tmd;
+    tmd.Load(*tmdResponse);
+
+    path = fmt::format("/ccs/download/{:016X}/cetk", title_id);
+    auto cetkResponse = WebService::NUS::Download(path);
+    if (!cetkResponse) {
+        LOG_ERROR(Service_AM, "Failed to download cetk for {:016X}", title_id);
+        return InstallStatus::ErrorFileNotFound;
+        ;
+    }
+
+    std::vector<u8> content;
+    const auto content_count = tmd.GetContentCount();
+    for (std::size_t i = 0; i < content_count; ++i) {
+        std::string filename = fmt::format("{:08x}", tmd.GetContentIDByIndex(i));
+        path = fmt::format("/ccs/download/{:016X}/{}", title_id, filename);
+        auto tempResponse = WebService::NUS::Download(path);
+        if (!tempResponse) {
+            LOG_ERROR(Service_NIM, "Failed to download content for {:016X}", title_id);
+            return InstallStatus::ErrorFileNotFound;
+            ;
+        }
+        content.insert(content.end(), tempResponse->begin(), tempResponse->end());
+    }
+
+    FileSys::CIAContainer::Header fakeHeader;
+    fakeHeader.header_size = sizeof(fakeHeader);
+    fakeHeader.type = 0;
+    fakeHeader.version = 0;
+    fakeHeader.cert_size = 0;
+    fakeHeader.tik_size = cetkResponse->size();
+    fakeHeader.tmd_size = tmdResponse->size();
+    fakeHeader.meta_size = 0;
+    for (std::size_t i = 0; i < content_count; ++i) {
+        fakeHeader.setContentPresent(i);
+    }
+    std::vector<u8> header_data(sizeof(fakeHeader));
+    std::memcpy(header_data.data(), &fakeHeader, sizeof(fakeHeader));
+
+    std::size_t current_offset = 0;
+    auto WriteToCiaFileAligned = [&installFile, &current_offset](std::vector<u8>& data) {
+        u64 offset = Common::AlignUp(current_offset + data.size(), FileSys::CIA_SECTION_ALIGNMENT);
+        data.resize(offset - current_offset, 0);
+        auto result = installFile.Write(current_offset, data.size(), true, data.data());
+        if (result.Failed()) {
+            LOG_ERROR(Service_AM, "CIA file installation aborted with error code {:08x}",
+                      result.Code().raw);
+            return InstallStatus::ErrorAborted;
+        }
+        current_offset += data.size();
+        return InstallStatus::Success;
+    };
+    auto result = WriteToCiaFileAligned(header_data);
+    if (result != InstallStatus::Success) {
+        return result;
+    }
+
+    result = WriteToCiaFileAligned(*cetkResponse);
+    if (result != InstallStatus::Success) {
+        return result;
+    }
+
+    result = WriteToCiaFileAligned(*tmdResponse);
+    if (result != InstallStatus::Success) {
+        return result;
+    }
+
+    result = WriteToCiaFileAligned(content);
+    if (result != InstallStatus::Success) {
+        return result;
+    }
+    return InstallStatus::Success;
+#else
+    return InstallStatus::ErrorFileNotFound;
+#endif
 }
 
 Service::FS::MediaType GetTitleMediaType(u64 titleId) {

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -106,6 +106,13 @@ InstallStatus InstallCIA(const std::string& path,
                          std::function<ProgressCallback>&& update_callback = nullptr);
 
 /**
+ * Downloads and installs title form the Nintendo Update Service.
+ * @param title_id the title_id to download
+ * @returns  whether the install was successful or error code
+ */
+InstallStatus InstallFromNus(u64 title_id, int version = -1);
+
+/**
  * Get the mediatype for an installed title
  * @param titleId the installed title ID
  * @returns MediaType which the installed title will reside on

--- a/src/core/hw/aes/key.cpp
+++ b/src/core/hw/aes/key.cpp
@@ -86,7 +86,7 @@ struct KeySlot {
 };
 
 std::array<KeySlot, KeySlotID::MaxKeySlotID> key_slots;
-std::array<std::optional<AESKey>, 6> common_key_y_slots;
+std::array<std::optional<AESKey>, MaxCommonKeySlot> common_key_y_slots;
 
 enum class FirmwareType : u32 {
     ARM9 = 0,  // uses NDMA
@@ -439,15 +439,15 @@ void LoadPresetKeys() {
 
 } // namespace
 
-void InitKeys() {
+void InitKeys(bool force) {
     static bool initialized = false;
-    if (initialized)
+    if (initialized && !force)
         return;
+    initialized = true;
+    LoadPresetKeys();
     LoadBootromKeys();
     LoadNativeFirmKeysOld3DS();
     LoadNativeFirmKeysNew3DS();
-    LoadPresetKeys();
-    initialized = true;
 }
 
 void SetKeyX(std::size_t slot_id, const AESKey& key) {

--- a/src/core/hw/aes/key.h
+++ b/src/core/hw/aes/key.h
@@ -48,11 +48,13 @@ enum KeySlotID : std::size_t {
     MaxKeySlotID = 0x40,
 };
 
+constexpr std::size_t MaxCommonKeySlot = 6;
+
 constexpr std::size_t AES_BLOCK_SIZE = 16;
 
 using AESKey = std::array<u8, AES_BLOCK_SIZE>;
 
-void InitKeys();
+void InitKeys(bool force = false);
 
 void SetGeneratorConstant(const AESKey& key);
 void SetKeyX(std::size_t slot_id, const AESKey& key);

--- a/src/web_service/CMakeLists.txt
+++ b/src/web_service/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_library(web_service STATIC
     announce_room_json.cpp
     announce_room_json.h
+    nus_download.cpp
+    nus_download.h
     telemetry_json.cpp
     telemetry_json.h
     verify_login.cpp

--- a/src/web_service/nus_download.cpp
+++ b/src/web_service/nus_download.cpp
@@ -1,0 +1,66 @@
+// Copyright 2020 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <memory>
+#include <LUrlParser.h>
+#include <httplib.h>
+#include "common/logging/log.h"
+#include "web_service/nus_download.h"
+
+namespace WebService::NUS {
+
+std::optional<std::vector<u8>> Download(const std::string& path) {
+    constexpr auto HOST = "http://nus.cdn.c.shop.nintendowifi.net";
+    constexpr int HTTP_PORT = 80;
+    constexpr int HTTPS_PORT = 443;
+    std::unique_ptr<httplib::Client> cli;
+
+    auto parsedUrl = LUrlParser::clParseURL::ParseURL(HOST);
+    int port;
+    if (parsedUrl.m_Scheme == "http") {
+        if (!parsedUrl.GetPort(&port)) {
+            port = HTTP_PORT;
+        }
+        cli = std::make_unique<httplib::Client>(parsedUrl.m_Host.c_str(), port);
+    } else if (parsedUrl.m_Scheme == "https") {
+        if (!parsedUrl.GetPort(&port)) {
+            port = HTTPS_PORT;
+        }
+        cli = std::make_unique<httplib::SSLClient>(parsedUrl.m_Host.c_str(), port);
+    } else {
+        LOG_ERROR(WebService, "Bad URL scheme {}", parsedUrl.m_Scheme);
+        return {};
+    }
+
+    if (cli == nullptr) {
+        LOG_ERROR(WebService, "Invalid URL {}{}", HOST, path);
+        return {};
+    }
+
+    httplib::Request request;
+    request.method = "GET";
+    request.path = path;
+
+    httplib::Response response;
+
+    if (!cli->send(request, response)) {
+        LOG_ERROR(WebService, "GET to {}{} returned null", HOST, path);
+        return {};
+    }
+
+    if (response.status >= 400) {
+        LOG_ERROR(WebService, "GET to {}{} returned error status code: {}", HOST, path,
+                  response.status);
+        return {};
+    }
+
+    auto content_type = response.headers.find("content-type");
+
+    if (content_type == response.headers.end()) {
+        LOG_ERROR(WebService, "GET to {}{} returned no content", HOST, path);
+        return {};
+    }
+    return std::vector<u8>(response.body.begin(), response.body.end());
+}
+} // namespace WebService::NUS

--- a/src/web_service/nus_download.h
+++ b/src/web_service/nus_download.h
@@ -1,0 +1,14 @@
+// Copyright 2020 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <optional>
+#include <vector>
+#include "common/common_types.h"
+
+namespace WebService::NUS {
+
+std::optional<std::vector<u8>> Download(const std::string& path);
+}


### PR DESCRIPTION
Common Keys are required for this to work (derived from save mode native firm) as well as keys from bootrom. Only the files for the currently selected region will get installed.

I added 3 options:

- minimal: Just all files for generating keys
- recommended: minimal + files where we have replacements (applets, shared fonts, etc), but user experience can be better with + some files we might require later to do some LLE like DLP
- all: all system files available (takes some time ;-) )

UI changes:
![Bildschirmfoto 2020-03-25 um 17 27 01](https://user-images.githubusercontent.com/26032316/77561090-8ad0c200-6ebe-11ea-84e6-12bc57b0fe60.png)
![Bildschirmfoto 2020-03-25 um 17 27 50](https://user-images.githubusercontent.com/26032316/77561115-9328fd00-6ebe-11ea-9551-55344da468c6.png)
![Bildschirmfoto 2020-03-25 um 17 29 03](https://user-images.githubusercontent.com/26032316/77561131-9a500b00-6ebe-11ea-9d03-8f8ccbf0c1dd.png)

UI is really basic and can probably get improved. I was also considering a 4th option (custom) that lets you select the files to download from a tree view. But this can be part of an follow up PR

TODO: 
- [ ] Let download run in background
- [ ] Disable game_list_watcher during download to avoid crashes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5144)
<!-- Reviewable:end -->
