### PR TITLE
Port yuzu-emu/yuzu#3261: "core/memory + arm/dynarmic: Use a global offset within our arm page table"

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -299,6 +299,7 @@ std::unique_ptr<Dynarmic::A32::Jit> ARM_Dynarmic::MakeJit() {
     Dynarmic::A32::UserConfig config;
     config.callbacks = cb.get();
     config.page_table = &current_page_table->pointers;
+    config.absolute_offset_page_table = true;
     config.coprocessors[15] = std::make_shared<DynarmicCP15>(interpreter_state);
     config.define_unpredictable_behaviour = true;
     return std::make_unique<Dynarmic::A32::Jit>(config);

--- a/src/core/arm/dynarmic/arm_dynarmic_cp15.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_cp15.cpp
@@ -14,10 +14,10 @@ DynarmicCP15::DynarmicCP15(const std::shared_ptr<ARMul_State>& state) : interpre
 
 DynarmicCP15::~DynarmicCP15() = default;
 
-boost::optional<Callback> DynarmicCP15::CompileInternalOperation(bool two, unsigned opc1,
+std::optional<Callback> DynarmicCP15::CompileInternalOperation(bool two, unsigned opc1,
                                                                  CoprocReg CRd, CoprocReg CRn,
                                                                  CoprocReg CRm, unsigned opc2) {
-    return boost::none;
+    return std::nullopt;
 }
 
 CallbackOrAccessOneWord DynarmicCP15::CompileSendOneWord(bool two, unsigned opc1, CoprocReg CRn,
@@ -38,7 +38,7 @@ CallbackOrAccessOneWord DynarmicCP15::CompileSendOneWord(bool two, unsigned opc1
             // This is a dummy write, we ignore the value written here.
             return &interpreter_state->CP15[CP15_DATA_MEMORY_BARRIER];
         default:
-            return boost::blank{};
+            return std::monostate{};
         }
     }
 
@@ -46,11 +46,11 @@ CallbackOrAccessOneWord DynarmicCP15::CompileSendOneWord(bool two, unsigned opc1
         return &interpreter_state->CP15[CP15_THREAD_UPRW];
     }
 
-    return boost::blank{};
+    return std::monostate{};
 }
 
 CallbackOrAccessTwoWords DynarmicCP15::CompileSendTwoWords(bool two, unsigned opc, CoprocReg CRm) {
-    return boost::blank{};
+    return std::monostate{};
 }
 
 CallbackOrAccessOneWord DynarmicCP15::CompileGetOneWord(bool two, unsigned opc1, CoprocReg CRn,
@@ -64,25 +64,25 @@ CallbackOrAccessOneWord DynarmicCP15::CompileGetOneWord(bool two, unsigned opc1,
         case 3:
             return &interpreter_state->CP15[CP15_THREAD_URO];
         default:
-            return boost::blank{};
+            return std::monostate{};
         }
     }
 
-    return boost::blank{};
+    return std::monostate{};
 }
 
 CallbackOrAccessTwoWords DynarmicCP15::CompileGetTwoWords(bool two, unsigned opc, CoprocReg CRm) {
-    return boost::blank{};
+    return std::monostate{};
 }
 
-boost::optional<Callback> DynarmicCP15::CompileLoadWords(bool two, bool long_transfer,
+std::optional<Callback> DynarmicCP15::CompileLoadWords(bool two, bool long_transfer,
                                                          CoprocReg CRd,
-                                                         boost::optional<u8> option) {
-    return boost::none;
+                                                         std::optional<u8> option) {
+    return std::nullopt;
 }
 
-boost::optional<Callback> DynarmicCP15::CompileStoreWords(bool two, bool long_transfer,
+std::optional<Callback> DynarmicCP15::CompileStoreWords(bool two, bool long_transfer,
                                                           CoprocReg CRd,
-                                                          boost::optional<u8> option) {
-    return boost::none;
+                                                          std::optional<u8> option) {
+    return std::nullopt;
 }

--- a/src/core/arm/dynarmic/arm_dynarmic_cp15.h
+++ b/src/core/arm/dynarmic/arm_dynarmic_cp15.h
@@ -17,7 +17,7 @@ public:
     explicit DynarmicCP15(const std::shared_ptr<ARMul_State>&);
     ~DynarmicCP15() override;
 
-    boost::optional<Callback> CompileInternalOperation(bool two, unsigned opc1, CoprocReg CRd,
+    std::optional<Callback> CompileInternalOperation(bool two, unsigned opc1, CoprocReg CRd,
                                                        CoprocReg CRn, CoprocReg CRm,
                                                        unsigned opc2) override;
     CallbackOrAccessOneWord CompileSendOneWord(bool two, unsigned opc1, CoprocReg CRn,
@@ -26,10 +26,10 @@ public:
     CallbackOrAccessOneWord CompileGetOneWord(bool two, unsigned opc1, CoprocReg CRn, CoprocReg CRm,
                                               unsigned opc2) override;
     CallbackOrAccessTwoWords CompileGetTwoWords(bool two, unsigned opc, CoprocReg CRm) override;
-    boost::optional<Callback> CompileLoadWords(bool two, bool long_transfer, CoprocReg CRd,
-                                               boost::optional<u8> option) override;
-    boost::optional<Callback> CompileStoreWords(bool two, bool long_transfer, CoprocReg CRd,
-                                                boost::optional<u8> option) override;
+    std::optional<Callback> CompileLoadWords(bool two, bool long_transfer, CoprocReg CRd,
+                                               std::optional<u8> option) override;
+    std::optional<Callback> CompileStoreWords(bool two, bool long_transfer, CoprocReg CRd,
+                                                std::optional<u8> option) override;
 
 private:
     std::shared_ptr<ARMul_State> interpreter_state;


### PR DESCRIPTION
This saves us two x64 instructions per load/store instruction.
original author - @degasus

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5145)
<!-- Reviewable:end -->
