### PR TITLE
common: include algorithm in thread_queue_list.h

### DIFF
--- a/src/common/thread_queue_list.h
+++ b/src/common/thread_queue_list.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <deque>
 


### PR DESCRIPTION
The CI builds are failing because the compiler can't find std::find.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5147)
<!-- Reviewable:end -->
