### PR TITLE
flatpak: Update runtime version

### DIFF
--- a/.travis/linux-flatpak/generate-data.sh
+++ b/.travis/linux-flatpak/generate-data.sh
@@ -43,7 +43,7 @@ cat > /tmp/org.citra.$REPO_NAME.json <<EOF
 {
     "app-id": "org.citra.$REPO_NAME",
     "runtime": "org.kde.Platform",
-    "runtime-version": "5.12",
+    "runtime-version": "5.13",
     "sdk": "org.kde.Sdk",
     "command": "citra-qt",
     "rename-desktop-file": "citra.desktop",


### PR DESCRIPTION
The docker image has been updated to 5.13 but the build script here wasn't. Maybe this was the issue preventing our flatpak from building recently

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5157)
<!-- Reviewable:end -->
