### PR TITLE
video_core/renderer_opengl/gl_rasterizer_cache: Create Format Reinterpretation Framework

### DIFF
--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -61,6 +61,9 @@ add_library(video_core STATIC
     renderer_opengl/texture_filters/texture_filterer.h
     renderer_opengl/texture_filters/xbrz/xbrz_freescale.cpp
     renderer_opengl/texture_filters/xbrz/xbrz_freescale.h
+    #temporary, move these back in alphabetical order before merging
+    renderer_opengl/gl_format_reinterpreter.cpp
+    renderer_opengl/gl_format_reinterpreter.h
     shader/debug_data.h
     shader/shader.cpp
     shader/shader.h

--- a/src/video_core/renderer_opengl/gl_format_reinterpreter.cpp
+++ b/src/video_core/renderer_opengl/gl_format_reinterpreter.cpp
@@ -1,0 +1,299 @@
+// Copyright 2020 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "common/assert.h"
+#include "common/scope_exit.h"
+#include "video_core/renderer_opengl/gl_format_reinterpreter.h"
+#include "video_core/renderer_opengl/gl_rasterizer_cache.h"
+#include "video_core/renderer_opengl/gl_state.h"
+#include "video_core/renderer_opengl/gl_vars.h"
+#include "video_core/renderer_opengl/texture_filters/texture_filterer.h"
+
+#if PROFILE_FORMAT_REINTERPRETATIONS
+#include <fmt/chrono.h>
+#endif
+
+namespace OpenGL {
+
+using PixelFormat = SurfaceParams::PixelFormat;
+
+class RGBA4toRGB5A1 final : public FormatReinterpreterBase {
+    OGLProgram program;
+    GLint dst_size_loc{-1}, src_size_loc{-1}, src_offset_loc{-1};
+    OGLVertexArray vao;
+
+    void Reinterpret(GLuint src_tex, const Common::Rectangle<u32>& src_rect, GLuint read_fb_handle,
+                     GLuint dst_tex, const Common::Rectangle<u32>& dst_rect,
+                     GLuint draw_fb_handle) override {
+        OpenGLState prev_state = OpenGLState::GetCurState();
+        SCOPE_EXIT({ prev_state.Apply(); });
+
+        OpenGLState state;
+        state.texture_units[0].texture_2d = src_tex;
+        state.draw.draw_framebuffer = draw_fb_handle;
+        state.draw.shader_program = program.handle;
+        state.draw.vertex_array = vao.handle;
+        state.viewport = {static_cast<GLint>(dst_rect.left), static_cast<GLint>(dst_rect.bottom),
+                          static_cast<GLsizei>(dst_rect.GetWidth()),
+                          static_cast<GLsizei>(dst_rect.GetHeight())};
+        state.Apply();
+
+        glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, dst_tex,
+                               0);
+        glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, 0,
+                               0);
+
+        glUniform2i(dst_size_loc, dst_rect.GetWidth(), dst_rect.GetHeight());
+        glUniform2i(src_size_loc, src_rect.GetWidth(), src_rect.GetHeight());
+        glUniform2i(src_offset_loc, src_rect.left, src_rect.bottom);
+        glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+    }
+
+public:
+    RGBA4toRGB5A1() {
+        constexpr std::string_view vs_source = R"(
+out vec2 dst_coord;
+
+uniform mediump ivec2 dst_size;
+
+const vec2 vertices[4] =
+    vec2[4](vec2(-1.0, -1.0), vec2(1.0, -1.0), vec2(-1.0, 1.0), vec2(1.0, 1.0));
+
+void main() {
+    gl_Position = vec4(vertices[gl_VertexID], 0.0, 1.0);
+    dst_coord = (vertices[gl_VertexID] / 2.0 + 0.5) * vec2(dst_size);
+}
+)";
+
+        std::string_view fs_source = R"(
+in mediump vec2 dst_coord;
+
+out lowp vec4 frag_color;
+
+uniform lowp sampler2D source;
+uniform mediump ivec2 dst_size;
+uniform mediump ivec2 src_size;
+uniform mediump ivec2 src_offset;
+
+void main() {
+    mediump ivec2 tex_coord;
+    if (src_size == dst_size) {
+        tex_coord = ivec2(dst_coord);
+    } else {
+        highp int tex_index = int(dst_coord.y) * dst_size.x + int(dst_coord.x);
+        mediump int y = tex_index / src_size.x;
+        tex_coord = ivec2(tex_index - y * src_size.x, y);
+    }
+    tex_coord -= src_offset;
+
+    lowp ivec4 rgba4 = ivec4(texelFetch(source, tex_coord, 0) * (exp2(4.0) - 1.0));
+    lowp ivec3 rgb5 =
+        ((rgba4.rgb << ivec3(1, 2, 3)) | (rgba4.gba >> ivec3(3, 2, 1))) & 0x1F;
+    frag_color = vec4(vec3(rgb5) / (exp2(5.0) - 1.0), rgba4.a & 0x01);
+}
+)";
+
+        program.Create(vs_source.data(), fs_source.data());
+        dst_size_loc = glGetUniformLocation(program.handle, "dst_size");
+        src_size_loc = glGetUniformLocation(program.handle, "src_size");
+        src_offset_loc = glGetUniformLocation(program.handle, "src_offset");
+        vao.Create();
+    }
+};
+
+class PixelBufferD24S8toABGR final : public FormatReinterpreterBase {
+
+    void Reinterpret(GLuint src_tex, const Common::Rectangle<u32>& src_rect, GLuint read_fb_handle,
+                     GLuint dst_tex, const Common::Rectangle<u32>& dst_rect,
+                     GLuint draw_fb_handle) override {
+        OpenGLState prev_state = OpenGLState::GetCurState();
+        SCOPE_EXIT({ prev_state.Apply(); });
+
+        OpenGLState state;
+        state.draw.read_framebuffer = read_fb_handle;
+        state.draw.draw_framebuffer = draw_fb_handle;
+        state.Apply();
+
+        glBindBuffer(GL_PIXEL_PACK_BUFFER, d24s8_abgr_buffer.handle);
+
+        GLsizeiptr target_pbo_size =
+            static_cast<GLsizeiptr>(src_rect.GetWidth()) * src_rect.GetHeight() * 4;
+        if (target_pbo_size > d24s8_abgr_buffer_size) {
+            d24s8_abgr_buffer_size = target_pbo_size * 2;
+            glBufferData(GL_PIXEL_PACK_BUFFER, d24s8_abgr_buffer_size, nullptr, GL_STREAM_COPY);
+        }
+
+        glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, 0, 0);
+        glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D,
+                               src_tex, 0);
+        glReadPixels(static_cast<GLint>(src_rect.left), static_cast<GLint>(src_rect.bottom),
+                     static_cast<GLsizei>(src_rect.GetWidth()),
+                     static_cast<GLsizei>(src_rect.GetHeight()), GL_DEPTH_STENCIL,
+                     GL_UNSIGNED_INT_24_8, 0);
+
+        glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+
+        // PBO now contains src_tex in RABG format
+        state.draw.shader_program = d24s8_abgr_shader.handle;
+        state.draw.vertex_array = attributeless_vao.handle;
+        state.viewport.x = static_cast<GLint>(dst_rect.left);
+        state.viewport.y = static_cast<GLint>(dst_rect.bottom);
+        state.viewport.width = static_cast<GLsizei>(dst_rect.GetWidth());
+        state.viewport.height = static_cast<GLsizei>(dst_rect.GetHeight());
+        state.Apply();
+
+        OGLTexture tbo;
+        tbo.Create();
+        glActiveTexture(GL_TEXTURE0);
+        glBindTexture(GL_TEXTURE_BUFFER, tbo.handle);
+        glTexBuffer(GL_TEXTURE_BUFFER, GL_RGBA8, d24s8_abgr_buffer.handle);
+
+        glUniform2f(d24s8_abgr_tbo_size_u_id, static_cast<GLfloat>(src_rect.GetWidth()),
+                    static_cast<GLfloat>(src_rect.GetHeight()));
+        glUniform4f(d24s8_abgr_viewport_u_id, static_cast<GLfloat>(state.viewport.x),
+                    static_cast<GLfloat>(state.viewport.y),
+                    static_cast<GLfloat>(state.viewport.width),
+                    static_cast<GLfloat>(state.viewport.height));
+
+        glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, dst_tex,
+                               0);
+        glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, 0,
+                               0);
+        glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+
+        glBindTexture(GL_TEXTURE_BUFFER, 0);
+    }
+
+public:
+    PixelBufferD24S8toABGR() {
+        attributeless_vao.Create();
+        d24s8_abgr_buffer.Create();
+        d24s8_abgr_buffer_size = 0;
+
+        constexpr std::string_view vs_source = R"(
+const vec2 vertices[4] = vec2[4](vec2(-1.0, -1.0), vec2(1.0, -1.0),
+                                 vec2(-1.0,  1.0), vec2(1.0,  1.0));
+void main() {
+    gl_Position = vec4(vertices[gl_VertexID], 0.0, 1.0);
+}
+)";
+
+        std::string fs_source = GLES ? fragment_shader_precision_OES : "";
+        fs_source += R"(
+uniform samplerBuffer tbo;
+uniform vec2 tbo_size;
+uniform vec4 viewport;
+
+out vec4 color;
+
+void main() {
+    vec2 tbo_coord = (gl_FragCoord.xy - viewport.xy) * tbo_size / viewport.zw;
+    int tbo_offset = int(tbo_coord.y) * int(tbo_size.x) + int(tbo_coord.x);
+    color = texelFetch(tbo, tbo_offset).rabg;
+}
+)";
+        d24s8_abgr_shader.Create(vs_source.data(), fs_source.c_str());
+
+        OpenGLState state = OpenGLState::GetCurState();
+        GLuint old_program = state.draw.shader_program;
+        state.draw.shader_program = d24s8_abgr_shader.handle;
+        state.Apply();
+
+        GLint tbo_u_id = glGetUniformLocation(d24s8_abgr_shader.handle, "tbo");
+        ASSERT(tbo_u_id != -1);
+        glUniform1i(tbo_u_id, 0);
+
+        state.draw.shader_program = old_program;
+        state.Apply();
+
+        d24s8_abgr_tbo_size_u_id = glGetUniformLocation(d24s8_abgr_shader.handle, "tbo_size");
+        ASSERT(d24s8_abgr_tbo_size_u_id != -1);
+        d24s8_abgr_viewport_u_id = glGetUniformLocation(d24s8_abgr_shader.handle, "viewport");
+        ASSERT(d24s8_abgr_viewport_u_id != -1);
+    }
+
+    ~PixelBufferD24S8toABGR() {}
+
+private:
+    OGLVertexArray attributeless_vao;
+    OGLBuffer d24s8_abgr_buffer;
+    GLsizeiptr d24s8_abgr_buffer_size;
+    OGLProgram d24s8_abgr_shader;
+    GLint d24s8_abgr_tbo_size_u_id;
+    GLint d24s8_abgr_viewport_u_id;
+};
+
+FormatReinterpreterOpenGL::FormatReinterpreterOpenGL() {
+    reinterpreters.emplace(PixelFormatPair{PixelFormat::RGBA8, PixelFormat::D24S8},
+                           std::make_unique<PixelBufferD24S8toABGR>());
+    reinterpreters.emplace(PixelFormatPair{PixelFormat::RGB5A1, PixelFormat::RGBA4},
+                           std::make_unique<RGBA4toRGB5A1>());
+}
+
+FormatReinterpreterOpenGL::~FormatReinterpreterOpenGL() = default;
+
+std::pair<FormatReinterpreterOpenGL::ReinterpreterMap::iterator,
+          FormatReinterpreterOpenGL::ReinterpreterMap::iterator>
+FormatReinterpreterOpenGL::GetPossibleReinterpretations(PixelFormat dst_format) {
+    return reinterpreters.equal_range(dst_format);
+}
+
+void OpenGL::FormatReinterpreterOpenGL::Reinterpret(ReinterpreterMap::iterator reinterpreter,
+                                                    GLuint src_tex,
+                                                    const Common::Rectangle<u32>& src_rect,
+                                                    GLuint read_fb_handle, GLuint dst_tex,
+                                                    const Common::Rectangle<u32>& dst_rect,
+                                                    GLuint draw_fb_handle) {
+#if PROFILE_FORMAT_REINTERPRETATIONS
+    ASSERT(GLAD_GL_ARB_timer_query);
+
+    for (auto desc = profile_queue.begin(); desc != profile_queue.end();) {
+        GLint available{false};
+        glGetQueryObjectiv(desc->gpu_time_query, GL_QUERY_RESULT_AVAILABLE, &available);
+
+        if (available) {
+            GLuint64 gpu_time_ns{};
+            glGetQueryObjectui64v(desc->gpu_time_query, GL_QUERY_RESULT, &gpu_time_ns);
+            std::chrono::duration<double, std::milli> gpu_time{
+                std::chrono::duration<GLuint64, std::nano>{gpu_time_ns}};
+
+            LOG_INFO(Render_OpenGL, R"(Reinterpretation Profile
+Format:   {} -> {}
+Rect:     {{{}, {}, {}, {}}} -> {{{}, {}, {}, {}}}
+CPU Time: {}
+GPU Time: {}
+)",
+                     SurfaceParams::PixelFormatAsString(desc->src_format),
+                     SurfaceParams::PixelFormatAsString(desc->dst_format), desc->src_rect.left,
+                     desc->src_rect.bottom, desc->src_rect.GetWidth(), desc->src_rect.GetHeight(),
+                     desc->dst_rect.left, desc->dst_rect.bottom, desc->dst_rect.GetWidth(),
+                     desc->dst_rect.GetHeight(), desc->cpu_time, gpu_time);
+
+            desc = profile_queue.erase(desc);
+        } else {
+            ++desc;
+        }
+    }
+
+    ReinterpretationDescription desc{};
+    desc.src_rect = src_rect;
+    desc.dst_rect = dst_rect;
+    desc.src_format = reinterpreter->first.src_format;
+    desc.dst_format = reinterpreter->first.dst_format;
+    glGenQueries(1, &desc.gpu_time_query);
+    glBeginQuery(GL_TIME_ELAPSED, desc.gpu_time_query);
+    auto start = std::chrono::high_resolution_clock::now();
+#endif
+
+    reinterpreter->second->Reinterpret(src_tex, src_rect, read_fb_handle, dst_tex, dst_rect,
+                                       draw_fb_handle);
+
+#if PROFILE_FORMAT_REINTERPRETATIONS
+    desc.cpu_time = std::chrono::high_resolution_clock::now() - start;
+    glEndQuery(GL_TIME_ELAPSED);
+    profile_queue.emplace_back(std::move(desc));
+#endif
+}
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_format_reinterpreter.cpp
+++ b/src/video_core/renderer_opengl/gl_format_reinterpreter.cpp
@@ -10,46 +10,11 @@
 #include "video_core/renderer_opengl/gl_vars.h"
 #include "video_core/renderer_opengl/texture_filters/texture_filterer.h"
 
-#if PROFILE_FORMAT_REINTERPRETATIONS
-#include <fmt/chrono.h>
-#endif
-
 namespace OpenGL {
 
 using PixelFormat = SurfaceParams::PixelFormat;
 
 class RGBA4toRGB5A1 final : public FormatReinterpreterBase {
-    OGLProgram program;
-    GLint dst_size_loc{-1}, src_size_loc{-1}, src_offset_loc{-1};
-    OGLVertexArray vao;
-
-    void Reinterpret(GLuint src_tex, const Common::Rectangle<u32>& src_rect, GLuint read_fb_handle,
-                     GLuint dst_tex, const Common::Rectangle<u32>& dst_rect,
-                     GLuint draw_fb_handle) override {
-        OpenGLState prev_state = OpenGLState::GetCurState();
-        SCOPE_EXIT({ prev_state.Apply(); });
-
-        OpenGLState state;
-        state.texture_units[0].texture_2d = src_tex;
-        state.draw.draw_framebuffer = draw_fb_handle;
-        state.draw.shader_program = program.handle;
-        state.draw.vertex_array = vao.handle;
-        state.viewport = {static_cast<GLint>(dst_rect.left), static_cast<GLint>(dst_rect.bottom),
-                          static_cast<GLsizei>(dst_rect.GetWidth()),
-                          static_cast<GLsizei>(dst_rect.GetHeight())};
-        state.Apply();
-
-        glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, dst_tex,
-                               0);
-        glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, 0,
-                               0);
-
-        glUniform2i(dst_size_loc, dst_rect.GetWidth(), dst_rect.GetHeight());
-        glUniform2i(src_size_loc, src_rect.GetWidth(), src_rect.GetHeight());
-        glUniform2i(src_offset_loc, src_rect.left, src_rect.bottom);
-        glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
-    }
-
 public:
     RGBA4toRGB5A1() {
         constexpr std::string_view vs_source = R"(
@@ -66,7 +31,7 @@ void main() {
 }
 )";
 
-        std::string_view fs_source = R"(
+        constexpr std::string_view fs_source = R"(
 in mediump vec2 dst_coord;
 
 out lowp vec4 frag_color;
@@ -100,9 +65,90 @@ void main() {
         src_offset_loc = glGetUniformLocation(program.handle, "src_offset");
         vao.Create();
     }
+
+    void Reinterpret(GLuint src_tex, const Common::Rectangle<u32>& src_rect, GLuint read_fb_handle,
+                     GLuint dst_tex, const Common::Rectangle<u32>& dst_rect,
+                     GLuint draw_fb_handle) override {
+        OpenGLState prev_state = OpenGLState::GetCurState();
+        SCOPE_EXIT({ prev_state.Apply(); });
+
+        OpenGLState state;
+        state.texture_units[0].texture_2d = src_tex;
+        state.draw.draw_framebuffer = draw_fb_handle;
+        state.draw.shader_program = program.handle;
+        state.draw.vertex_array = vao.handle;
+        state.viewport = {static_cast<GLint>(dst_rect.left), static_cast<GLint>(dst_rect.bottom),
+                          static_cast<GLsizei>(dst_rect.GetWidth()),
+                          static_cast<GLsizei>(dst_rect.GetHeight())};
+        state.Apply();
+
+        glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, dst_tex,
+                               0);
+        glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, 0,
+                               0);
+
+        glUniform2i(dst_size_loc, dst_rect.GetWidth(), dst_rect.GetHeight());
+        glUniform2i(src_size_loc, src_rect.GetWidth(), src_rect.GetHeight());
+        glUniform2i(src_offset_loc, src_rect.left, src_rect.bottom);
+        glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
+    }
+
+private:
+    OGLProgram program;
+    GLint dst_size_loc{-1}, src_size_loc{-1}, src_offset_loc{-1};
+    OGLVertexArray vao;
 };
 
 class PixelBufferD24S8toABGR final : public FormatReinterpreterBase {
+public:
+    PixelBufferD24S8toABGR() {
+        attributeless_vao.Create();
+        d24s8_abgr_buffer.Create();
+        d24s8_abgr_buffer_size = 0;
+
+        constexpr std::string_view vs_source = R"(
+const vec2 vertices[4] = vec2[4](vec2(-1.0, -1.0), vec2(1.0, -1.0),
+                                 vec2(-1.0,  1.0), vec2(1.0,  1.0));
+void main() {
+    gl_Position = vec4(vertices[gl_VertexID], 0.0, 1.0);
+}
+)";
+
+        std::string fs_source = GLES ? fragment_shader_precision_OES : "";
+        fs_source += R"(
+uniform samplerBuffer tbo;
+uniform vec2 tbo_size;
+uniform vec4 viewport;
+
+out vec4 color;
+
+void main() {
+    vec2 tbo_coord = (gl_FragCoord.xy - viewport.xy) * tbo_size / viewport.zw;
+    int tbo_offset = int(tbo_coord.y) * int(tbo_size.x) + int(tbo_coord.x);
+    color = texelFetch(tbo, tbo_offset).rabg;
+}
+)";
+        d24s8_abgr_shader.Create(vs_source.data(), fs_source.c_str());
+
+        OpenGLState state = OpenGLState::GetCurState();
+        GLuint old_program = state.draw.shader_program;
+        state.draw.shader_program = d24s8_abgr_shader.handle;
+        state.Apply();
+
+        GLint tbo_u_id = glGetUniformLocation(d24s8_abgr_shader.handle, "tbo");
+        ASSERT(tbo_u_id != -1);
+        glUniform1i(tbo_u_id, 0);
+
+        state.draw.shader_program = old_program;
+        state.Apply();
+
+        d24s8_abgr_tbo_size_u_id = glGetUniformLocation(d24s8_abgr_shader.handle, "tbo_size");
+        ASSERT(d24s8_abgr_tbo_size_u_id != -1);
+        d24s8_abgr_viewport_u_id = glGetUniformLocation(d24s8_abgr_shader.handle, "viewport");
+        ASSERT(d24s8_abgr_viewport_u_id != -1);
+    }
+
+    ~PixelBufferD24S8toABGR() {}
 
     void Reinterpret(GLuint src_tex, const Common::Rectangle<u32>& src_rect, GLuint read_fb_handle,
                      GLuint dst_tex, const Common::Rectangle<u32>& dst_rect,
@@ -165,56 +211,6 @@ class PixelBufferD24S8toABGR final : public FormatReinterpreterBase {
         glBindTexture(GL_TEXTURE_BUFFER, 0);
     }
 
-public:
-    PixelBufferD24S8toABGR() {
-        attributeless_vao.Create();
-        d24s8_abgr_buffer.Create();
-        d24s8_abgr_buffer_size = 0;
-
-        constexpr std::string_view vs_source = R"(
-const vec2 vertices[4] = vec2[4](vec2(-1.0, -1.0), vec2(1.0, -1.0),
-                                 vec2(-1.0,  1.0), vec2(1.0,  1.0));
-void main() {
-    gl_Position = vec4(vertices[gl_VertexID], 0.0, 1.0);
-}
-)";
-
-        std::string fs_source = GLES ? fragment_shader_precision_OES : "";
-        fs_source += R"(
-uniform samplerBuffer tbo;
-uniform vec2 tbo_size;
-uniform vec4 viewport;
-
-out vec4 color;
-
-void main() {
-    vec2 tbo_coord = (gl_FragCoord.xy - viewport.xy) * tbo_size / viewport.zw;
-    int tbo_offset = int(tbo_coord.y) * int(tbo_size.x) + int(tbo_coord.x);
-    color = texelFetch(tbo, tbo_offset).rabg;
-}
-)";
-        d24s8_abgr_shader.Create(vs_source.data(), fs_source.c_str());
-
-        OpenGLState state = OpenGLState::GetCurState();
-        GLuint old_program = state.draw.shader_program;
-        state.draw.shader_program = d24s8_abgr_shader.handle;
-        state.Apply();
-
-        GLint tbo_u_id = glGetUniformLocation(d24s8_abgr_shader.handle, "tbo");
-        ASSERT(tbo_u_id != -1);
-        glUniform1i(tbo_u_id, 0);
-
-        state.draw.shader_program = old_program;
-        state.Apply();
-
-        d24s8_abgr_tbo_size_u_id = glGetUniformLocation(d24s8_abgr_shader.handle, "tbo_size");
-        ASSERT(d24s8_abgr_tbo_size_u_id != -1);
-        d24s8_abgr_viewport_u_id = glGetUniformLocation(d24s8_abgr_shader.handle, "viewport");
-        ASSERT(d24s8_abgr_viewport_u_id != -1);
-    }
-
-    ~PixelBufferD24S8toABGR() {}
-
 private:
     OGLVertexArray attributeless_vao;
     OGLBuffer d24s8_abgr_buffer;
@@ -237,63 +233,6 @@ std::pair<FormatReinterpreterOpenGL::ReinterpreterMap::iterator,
           FormatReinterpreterOpenGL::ReinterpreterMap::iterator>
 FormatReinterpreterOpenGL::GetPossibleReinterpretations(PixelFormat dst_format) {
     return reinterpreters.equal_range(dst_format);
-}
-
-void OpenGL::FormatReinterpreterOpenGL::Reinterpret(ReinterpreterMap::iterator reinterpreter,
-                                                    GLuint src_tex,
-                                                    const Common::Rectangle<u32>& src_rect,
-                                                    GLuint read_fb_handle, GLuint dst_tex,
-                                                    const Common::Rectangle<u32>& dst_rect,
-                                                    GLuint draw_fb_handle) {
-#if PROFILE_FORMAT_REINTERPRETATIONS
-    ASSERT(GLAD_GL_ARB_timer_query);
-
-    for (auto desc = profile_queue.begin(); desc != profile_queue.end();) {
-        GLint available{false};
-        glGetQueryObjectiv(desc->gpu_time_query, GL_QUERY_RESULT_AVAILABLE, &available);
-
-        if (available) {
-            GLuint64 gpu_time_ns{};
-            glGetQueryObjectui64v(desc->gpu_time_query, GL_QUERY_RESULT, &gpu_time_ns);
-            std::chrono::duration<double, std::milli> gpu_time{
-                std::chrono::duration<GLuint64, std::nano>{gpu_time_ns}};
-
-            LOG_INFO(Render_OpenGL, R"(Reinterpretation Profile
-Format:   {} -> {}
-Rect:     {{{}, {}, {}, {}}} -> {{{}, {}, {}, {}}}
-CPU Time: {}
-GPU Time: {}
-)",
-                     SurfaceParams::PixelFormatAsString(desc->src_format),
-                     SurfaceParams::PixelFormatAsString(desc->dst_format), desc->src_rect.left,
-                     desc->src_rect.bottom, desc->src_rect.GetWidth(), desc->src_rect.GetHeight(),
-                     desc->dst_rect.left, desc->dst_rect.bottom, desc->dst_rect.GetWidth(),
-                     desc->dst_rect.GetHeight(), desc->cpu_time, gpu_time);
-
-            desc = profile_queue.erase(desc);
-        } else {
-            ++desc;
-        }
-    }
-
-    ReinterpretationDescription desc{};
-    desc.src_rect = src_rect;
-    desc.dst_rect = dst_rect;
-    desc.src_format = reinterpreter->first.src_format;
-    desc.dst_format = reinterpreter->first.dst_format;
-    glGenQueries(1, &desc.gpu_time_query);
-    glBeginQuery(GL_TIME_ELAPSED, desc.gpu_time_query);
-    auto start = std::chrono::high_resolution_clock::now();
-#endif
-
-    reinterpreter->second->Reinterpret(src_tex, src_rect, read_fb_handle, dst_tex, dst_rect,
-                                       draw_fb_handle);
-
-#if PROFILE_FORMAT_REINTERPRETATIONS
-    desc.cpu_time = std::chrono::high_resolution_clock::now() - start;
-    glEndQuery(GL_TIME_ELAPSED);
-    profile_queue.emplace_back(std::move(desc));
-#endif
 }
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_format_reinterpreter.h
+++ b/src/video_core/renderer_opengl/gl_format_reinterpreter.h
@@ -1,0 +1,88 @@
+// Copyright 2020 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <map>
+#include <type_traits>
+#include <glad/glad.h>
+#include "common/common_types.h"
+#include "common/math_util.h"
+#include "video_core/renderer_opengl/gl_resource_manager.h"
+#include "video_core/renderer_opengl/gl_surface_params.h"
+
+#if PROFILE_FORMAT_REINTERPRETATIONS
+#include <chrono>
+#include <list>
+#endif
+
+namespace OpenGL {
+
+class RasterizerCacheOpenGL;
+
+struct PixelFormatPair {
+    const SurfaceParams::PixelFormat dst_format, src_format;
+};
+
+} // namespace OpenGL
+
+namespace std {
+template <>
+struct less<OpenGL::PixelFormatPair> {
+    using is_transparent = void;
+    constexpr bool operator()(OpenGL::PixelFormatPair lhs, OpenGL::PixelFormatPair rhs) const {
+        return std::tie(lhs.dst_format, lhs.src_format) < std::tie(rhs.dst_format, rhs.src_format);
+    }
+    constexpr bool operator()(OpenGL::SurfaceParams::PixelFormat lhs,
+                              OpenGL::PixelFormatPair rhs) const {
+        return lhs < rhs.dst_format;
+    }
+    constexpr bool operator()(OpenGL::PixelFormatPair lhs,
+                              OpenGL::SurfaceParams::PixelFormat rhs) const {
+        return lhs.dst_format < rhs;
+    }
+};
+} // namespace std
+
+namespace OpenGL {
+
+class FormatReinterpreterBase {
+    friend class FormatReinterpreterOpenGL;
+    virtual void Reinterpret(GLuint src_tex, const Common::Rectangle<u32>& src_rect,
+                             GLuint read_fb_handle, GLuint dst_tex,
+                             const Common::Rectangle<u32>& dst_rect, GLuint draw_fb_handle) = 0;
+
+public:
+    virtual ~FormatReinterpreterBase() = default;
+};
+
+class FormatReinterpreterOpenGL : NonCopyable {
+    using ReinterpreterMap = std::map<PixelFormatPair, std::unique_ptr<FormatReinterpreterBase>>;
+
+public:
+    explicit FormatReinterpreterOpenGL();
+    ~FormatReinterpreterOpenGL();
+
+    std::pair<ReinterpreterMap::iterator, ReinterpreterMap::iterator> GetPossibleReinterpretations(
+        SurfaceParams::PixelFormat dst_format);
+
+    void Reinterpret(ReinterpreterMap::iterator reinterpreter, GLuint src_tex,
+                     const Common::Rectangle<u32>& src_rect, GLuint read_fb_handle, GLuint dst_tex,
+                     const Common::Rectangle<u32>& dst_rect, GLuint draw_fb_handle);
+
+private:
+#if PROFILE_FORMAT_REINTERPRETATIONS
+    struct ReinterpretationDescription {
+        Common::Rectangle<u32> src_rect, dst_rect;
+        std::chrono::duration<double, std::milli> cpu_time;
+        GLuint gpu_time_query;
+        SurfaceParams::PixelFormat src_format, dst_format;
+    };
+    std::list<ReinterpretationDescription> profile_queue;
+#endif
+
+    ReinterpreterMap reinterpreters;
+};
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_format_reinterpreter.h
+++ b/src/video_core/renderer_opengl/gl_format_reinterpreter.h
@@ -12,53 +12,41 @@
 #include "video_core/renderer_opengl/gl_resource_manager.h"
 #include "video_core/renderer_opengl/gl_surface_params.h"
 
-#if PROFILE_FORMAT_REINTERPRETATIONS
-#include <chrono>
-#include <list>
-#endif
-
 namespace OpenGL {
 
 class RasterizerCacheOpenGL;
 
 struct PixelFormatPair {
     const SurfaceParams::PixelFormat dst_format, src_format;
+    struct less {
+        using is_transparent = void;
+        constexpr bool operator()(OpenGL::PixelFormatPair lhs, OpenGL::PixelFormatPair rhs) const {
+            return std::tie(lhs.dst_format, lhs.src_format) <
+                   std::tie(rhs.dst_format, rhs.src_format);
+        }
+        constexpr bool operator()(OpenGL::SurfaceParams::PixelFormat lhs,
+                                  OpenGL::PixelFormatPair rhs) const {
+            return lhs < rhs.dst_format;
+        }
+        constexpr bool operator()(OpenGL::PixelFormatPair lhs,
+                                  OpenGL::SurfaceParams::PixelFormat rhs) const {
+            return lhs.dst_format < rhs;
+        }
+    };
 };
-
-} // namespace OpenGL
-
-namespace std {
-template <>
-struct less<OpenGL::PixelFormatPair> {
-    using is_transparent = void;
-    constexpr bool operator()(OpenGL::PixelFormatPair lhs, OpenGL::PixelFormatPair rhs) const {
-        return std::tie(lhs.dst_format, lhs.src_format) < std::tie(rhs.dst_format, rhs.src_format);
-    }
-    constexpr bool operator()(OpenGL::SurfaceParams::PixelFormat lhs,
-                              OpenGL::PixelFormatPair rhs) const {
-        return lhs < rhs.dst_format;
-    }
-    constexpr bool operator()(OpenGL::PixelFormatPair lhs,
-                              OpenGL::SurfaceParams::PixelFormat rhs) const {
-        return lhs.dst_format < rhs;
-    }
-};
-} // namespace std
-
-namespace OpenGL {
 
 class FormatReinterpreterBase {
-    friend class FormatReinterpreterOpenGL;
+public:
+    virtual ~FormatReinterpreterBase() = default;
+
     virtual void Reinterpret(GLuint src_tex, const Common::Rectangle<u32>& src_rect,
                              GLuint read_fb_handle, GLuint dst_tex,
                              const Common::Rectangle<u32>& dst_rect, GLuint draw_fb_handle) = 0;
-
-public:
-    virtual ~FormatReinterpreterBase() = default;
 };
 
 class FormatReinterpreterOpenGL : NonCopyable {
-    using ReinterpreterMap = std::map<PixelFormatPair, std::unique_ptr<FormatReinterpreterBase>>;
+    using ReinterpreterMap =
+        std::map<PixelFormatPair, std::unique_ptr<FormatReinterpreterBase>, PixelFormatPair::less>;
 
 public:
     explicit FormatReinterpreterOpenGL();
@@ -67,21 +55,7 @@ public:
     std::pair<ReinterpreterMap::iterator, ReinterpreterMap::iterator> GetPossibleReinterpretations(
         SurfaceParams::PixelFormat dst_format);
 
-    void Reinterpret(ReinterpreterMap::iterator reinterpreter, GLuint src_tex,
-                     const Common::Rectangle<u32>& src_rect, GLuint read_fb_handle, GLuint dst_tex,
-                     const Common::Rectangle<u32>& dst_rect, GLuint draw_fb_handle);
-
 private:
-#if PROFILE_FORMAT_REINTERPRETATIONS
-    struct ReinterpretationDescription {
-        Common::Rectangle<u32> src_rect, dst_rect;
-        std::chrono::duration<double, std::milli> cpu_time;
-        GLuint gpu_time_query;
-        SurfaceParams::PixelFormat src_format, dst_format;
-    };
-    std::list<ReinterpretationDescription> profile_queue;
-#endif
-
     ReinterpreterMap reinterpreters;
 };
 

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -1675,9 +1675,9 @@ void RasterizerCacheOpenGL::ValidateSurface(const Surface& surface, PAddr addr, 
                     AllocateSurfaceTexture(tmp_tex.handle,
                                            GetFormatTuple(reinterpreter->first.dst_format),
                                            tmp_rect.right, tmp_rect.top);
-                    format_reinterpreter->Reinterpret(
-                        reinterpreter, reinterpret_surface->texture.handle, src_rect,
-                        read_framebuffer.handle, tmp_tex.handle, tmp_rect, draw_framebuffer.handle);
+                    reinterpreter->second->Reinterpret(
+                        reinterpret_surface->texture.handle, src_rect, read_framebuffer.handle,
+                        tmp_tex.handle, tmp_rect, draw_framebuffer.handle);
                     SurfaceParams::SurfaceType type =
                         SurfaceParams::GetFormatType(reinterpreter->first.dst_format);
 
@@ -1688,10 +1688,9 @@ void RasterizerCacheOpenGL::ValidateSurface(const Surface& surface, PAddr addr, 
                                      type, read_framebuffer.handle, draw_framebuffer.handle);
                     }
                 } else {
-                    format_reinterpreter->Reinterpret(
-                        reinterpreter, reinterpret_surface->texture.handle, src_rect,
-                        read_framebuffer.handle, surface->texture.handle, dest_rect,
-                        draw_framebuffer.handle);
+                    reinterpreter->second->Reinterpret(
+                        reinterpret_surface->texture.handle, src_rect, read_framebuffer.handle,
+                        surface->texture.handle, dest_rect, draw_framebuffer.handle);
                 }
                 notify_validated(reinterpret_interval);
                 retry = true;
@@ -1738,8 +1737,11 @@ void RasterizerCacheOpenGL::ValidateSurface(const Surface& surface, PAddr addr, 
                 retry = true;
             }
         }
-        if (retry)
+        if (retry) {
+            LOG_DEBUG(Render_OpenGL, "Region created fully on GPU and reinterpretation is "
+                                     "invalid. Skipping validation");
             continue;
+        }
 
         // Load data from 3DS memory
         FlushRegion(params.addr, params.size);

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -1118,6 +1118,15 @@ Surface RasterizerCacheOpenGL::GetSurface(const SurfaceParams& params, ScaleMatc
             if (expandable != nullptr && expandable->res_scale > target_res_scale) {
                 target_res_scale = expandable->res_scale;
             }
+            // Keep res_scale when reinterpreting d24s8 -> rgba8
+            if (params.pixel_format == PixelFormat::RGBA8) {
+                find_params.pixel_format = PixelFormat::D24S8;
+                expandable = FindMatch<MatchFlags::Expand | MatchFlags::Invalid>(
+                    surface_cache, find_params, match_res_scale);
+                if (expandable != nullptr && expandable->res_scale > target_res_scale) {
+                    target_res_scale = expandable->res_scale;
+                }
+            }
         }
         SurfaceParams new_params = params;
         new_params.res_scale = target_res_scale;
@@ -1739,7 +1748,7 @@ void RasterizerCacheOpenGL::ValidateSurface(const Surface& surface, PAddr addr, 
                                  draw_framebuffer.handle);
         notify_validated(params.GetInterval());
     }
-} // namespace OpenGL
+}
 
 void RasterizerCacheOpenGL::FlushRegion(PAddr addr, u32 size, Surface flush_surface) {
     if (size == 0)

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -32,6 +32,7 @@
 #include "core/settings.h"
 #include "video_core/pica_state.h"
 #include "video_core/renderer_base.h"
+#include "video_core/renderer_opengl/gl_format_reinterpreter.h"
 #include "video_core/renderer_opengl/gl_rasterizer_cache.h"
 #include "video_core/renderer_opengl/gl_state.h"
 #include "video_core/renderer_opengl/gl_vars.h"
@@ -1063,54 +1064,10 @@ RasterizerCacheOpenGL::RasterizerCacheOpenGL() {
     resolution_scale_factor = VideoCore::GetResolutionScaleFactor();
     texture_filterer = std::make_unique<TextureFilterer>(Settings::values.texture_filter_name,
                                                          resolution_scale_factor);
+    format_reinterpreter = std::make_unique<FormatReinterpreterOpenGL>();
 
     read_framebuffer.Create();
     draw_framebuffer.Create();
-
-    attributeless_vao.Create();
-
-    d24s8_abgr_buffer.Create();
-    d24s8_abgr_buffer_size = 0;
-
-    std::string vs_source = R"(
-const vec2 vertices[4] = vec2[4](vec2(-1.0, -1.0), vec2(1.0, -1.0), vec2(-1.0, 1.0), vec2(1.0, 1.0));
-void main() {
-    gl_Position = vec4(vertices[gl_VertexID], 0.0, 1.0);
-}
-)";
-
-    std::string fs_source = GLES ? fragment_shader_precision_OES : "";
-    fs_source += R"(
-uniform samplerBuffer tbo;
-uniform vec2 tbo_size;
-uniform vec4 viewport;
-
-out vec4 color;
-
-void main() {
-    vec2 tbo_coord = (gl_FragCoord.xy - viewport.xy) * tbo_size / viewport.zw;
-    int tbo_offset = int(tbo_coord.y) * int(tbo_size.x) + int(tbo_coord.x);
-    color = texelFetch(tbo, tbo_offset).rabg;
-}
-)";
-    d24s8_abgr_shader.Create(vs_source.c_str(), fs_source.c_str());
-
-    OpenGLState state = OpenGLState::GetCurState();
-    GLuint old_program = state.draw.shader_program;
-    state.draw.shader_program = d24s8_abgr_shader.handle;
-    state.Apply();
-
-    GLint tbo_u_id = glGetUniformLocation(d24s8_abgr_shader.handle, "tbo");
-    ASSERT(tbo_u_id != -1);
-    glUniform1i(tbo_u_id, 0);
-
-    state.draw.shader_program = old_program;
-    state.Apply();
-
-    d24s8_abgr_tbo_size_u_id = glGetUniformLocation(d24s8_abgr_shader.handle, "tbo_size");
-    ASSERT(d24s8_abgr_tbo_size_u_id != -1);
-    d24s8_abgr_viewport_u_id = glGetUniformLocation(d24s8_abgr_shader.handle, "viewport");
-    ASSERT(d24s8_abgr_viewport_u_id != -1);
 }
 
 RasterizerCacheOpenGL::~RasterizerCacheOpenGL() {
@@ -1134,64 +1091,6 @@ bool RasterizerCacheOpenGL::BlitSurfaces(const Surface& src_surface,
     return BlitTextures(src_surface->texture.handle, src_rect, dst_surface->texture.handle,
                         dst_rect, src_surface->type, read_framebuffer.handle,
                         draw_framebuffer.handle);
-}
-
-void RasterizerCacheOpenGL::ConvertD24S8toABGR(GLuint src_tex,
-                                               const Common::Rectangle<u32>& src_rect,
-                                               GLuint dst_tex,
-                                               const Common::Rectangle<u32>& dst_rect) {
-    OpenGLState prev_state = OpenGLState::GetCurState();
-    SCOPE_EXIT({ prev_state.Apply(); });
-
-    OpenGLState state;
-    state.draw.read_framebuffer = read_framebuffer.handle;
-    state.draw.draw_framebuffer = draw_framebuffer.handle;
-    state.Apply();
-
-    glBindBuffer(GL_PIXEL_PACK_BUFFER, d24s8_abgr_buffer.handle);
-
-    GLsizeiptr target_pbo_size = src_rect.GetWidth() * src_rect.GetHeight() * 4;
-    if (target_pbo_size > d24s8_abgr_buffer_size) {
-        d24s8_abgr_buffer_size = target_pbo_size * 2;
-        glBufferData(GL_PIXEL_PACK_BUFFER, d24s8_abgr_buffer_size, nullptr, GL_STREAM_COPY);
-    }
-
-    glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, 0, 0);
-    glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, src_tex,
-                           0);
-    glReadPixels(static_cast<GLint>(src_rect.left), static_cast<GLint>(src_rect.bottom),
-                 static_cast<GLsizei>(src_rect.GetWidth()),
-                 static_cast<GLsizei>(src_rect.GetHeight()), GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8,
-                 0);
-
-    glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
-
-    // PBO now contains src_tex in RABG format
-    state.draw.shader_program = d24s8_abgr_shader.handle;
-    state.draw.vertex_array = attributeless_vao.handle;
-    state.viewport.x = static_cast<GLint>(dst_rect.left);
-    state.viewport.y = static_cast<GLint>(dst_rect.bottom);
-    state.viewport.width = static_cast<GLsizei>(dst_rect.GetWidth());
-    state.viewport.height = static_cast<GLsizei>(dst_rect.GetHeight());
-    state.Apply();
-
-    OGLTexture tbo;
-    tbo.Create();
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_BUFFER, tbo.handle);
-    glTexBuffer(GL_TEXTURE_BUFFER, GL_RGBA8, d24s8_abgr_buffer.handle);
-
-    glUniform2f(d24s8_abgr_tbo_size_u_id, static_cast<GLfloat>(src_rect.GetWidth()),
-                static_cast<GLfloat>(src_rect.GetHeight()));
-    glUniform4f(d24s8_abgr_viewport_u_id, static_cast<GLfloat>(state.viewport.x),
-                static_cast<GLfloat>(state.viewport.y), static_cast<GLfloat>(state.viewport.width),
-                static_cast<GLfloat>(state.viewport.height));
-
-    glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, dst_tex, 0);
-    glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, 0, 0);
-    glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
-
-    glBindTexture(GL_TEXTURE_BUFFER, 0);
 }
 
 Surface RasterizerCacheOpenGL::GetSurface(const SurfaceParams& params, ScaleMatch match_res_scale,
@@ -1218,15 +1117,6 @@ Surface RasterizerCacheOpenGL::GetSurface(const SurfaceParams& params, ScaleMatc
                 surface_cache, find_params, match_res_scale);
             if (expandable != nullptr && expandable->res_scale > target_res_scale) {
                 target_res_scale = expandable->res_scale;
-            }
-            // Keep res_scale when reinterpreting d24s8 -> rgba8
-            if (params.pixel_format == PixelFormat::RGBA8) {
-                find_params.pixel_format = PixelFormat::D24S8;
-                expandable = FindMatch<MatchFlags::Expand | MatchFlags::Invalid>(
-                    surface_cache, find_params, match_res_scale);
-                if (expandable != nullptr && expandable->res_scale > target_res_scale) {
-                    target_res_scale = expandable->res_scale;
-                }
             }
         }
         SurfaceParams new_params = params;
@@ -1721,9 +1611,15 @@ void RasterizerCacheOpenGL::ValidateSurface(const Surface& surface, PAddr addr, 
         return;
     }
 
+    auto validate_regions = surface->invalid_regions & validate_interval;
+    auto notify_validated = [&](SurfaceInterval interval) {
+        surface->invalid_regions.erase(interval);
+        validate_regions.erase(interval);
+    };
+
     while (true) {
-        const auto it = surface->invalid_regions.find(validate_interval);
-        if (it == surface->invalid_regions.end())
+        const auto it = validate_regions.begin();
+        if (it == validate_regions.end())
             break;
 
         const auto interval = *it & validate_interval;
@@ -1735,39 +1631,115 @@ void RasterizerCacheOpenGL::ValidateSurface(const Surface& surface, PAddr addr, 
         if (copy_surface != nullptr) {
             SurfaceInterval copy_interval = params.GetCopyableInterval(copy_surface);
             CopySurface(copy_surface, surface, copy_interval);
-            surface->invalid_regions.erase(copy_interval);
+            notify_validated(copy_interval);
             continue;
         }
 
-        // D24S8 to RGBA8
-        if (surface->pixel_format == PixelFormat::RGBA8) {
-            params.pixel_format = PixelFormat::D24S8;
+        // Try to find surface in cache with different format
+        // that can can be reinterpreted to the requested format.
+        auto [cvt_begin, cvt_end] =
+            format_reinterpreter->GetPossibleReinterpretations(surface->pixel_format);
+        bool retry = false;
+        for (auto reinterpreter = cvt_begin; reinterpreter != cvt_end; ++reinterpreter) {
+            PixelFormat format = reinterpreter->first.src_format;
+            params.pixel_format = format;
             Surface reinterpret_surface =
                 FindMatch<MatchFlags::Copy>(surface_cache, params, ScaleMatch::Ignore, interval);
+
             if (reinterpret_surface != nullptr) {
-                ASSERT(reinterpret_surface->pixel_format == PixelFormat::D24S8);
+                SurfaceInterval reinterpret_interval =
+                    params.GetCopyableInterval(reinterpret_surface);
+                SurfaceParams reinterpret_params = surface->FromInterval(reinterpret_interval);
+                auto src_rect = reinterpret_surface->GetScaledSubRect(reinterpret_params);
+                auto dest_rect = surface->GetScaledSubRect(reinterpret_params);
 
-                SurfaceInterval convert_interval = params.GetCopyableInterval(reinterpret_surface);
-                SurfaceParams convert_params = surface->FromInterval(convert_interval);
-                auto src_rect = reinterpret_surface->GetScaledSubRect(convert_params);
-                auto dest_rect = surface->GetScaledSubRect(convert_params);
+                if (!texture_filterer->IsNull() && reinterpret_surface->res_scale == 1 &&
+                    surface->res_scale == resolution_scale_factor) {
+                    // The destination surface is either a framebuffer, or a filtered texture.
+                    OGLTexture tmp_tex;
+                    tmp_tex.Create();
+                    // Create an intermediate surface to convert to before blitting to the
+                    // destination.
+                    Common::Rectangle<u32> tmp_rect{
+                        0, dest_rect.GetHeight() / resolution_scale_factor,
+                        dest_rect.GetWidth() / resolution_scale_factor, 0};
+                    AllocateSurfaceTexture(tmp_tex.handle,
+                                           GetFormatTuple(reinterpreter->first.dst_format),
+                                           tmp_rect.right, tmp_rect.top);
+                    format_reinterpreter->Reinterpret(
+                        reinterpreter, reinterpret_surface->texture.handle, src_rect,
+                        read_framebuffer.handle, tmp_tex.handle, tmp_rect, draw_framebuffer.handle);
+                    SurfaceParams::SurfaceType type =
+                        SurfaceParams::GetFormatType(reinterpreter->first.dst_format);
 
-                ConvertD24S8toABGR(reinterpret_surface->texture.handle, src_rect,
-                                   surface->texture.handle, dest_rect);
-
-                surface->invalid_regions.erase(convert_interval);
-                continue;
+                    if (!texture_filterer->Filter(tmp_tex.handle, tmp_rect, surface->texture.handle,
+                                                  dest_rect, type, read_framebuffer.handle,
+                                                  draw_framebuffer.handle)) {
+                        BlitTextures(tmp_tex.handle, tmp_rect, surface->texture.handle, dest_rect,
+                                     type, read_framebuffer.handle, draw_framebuffer.handle);
+                    }
+                } else {
+                    format_reinterpreter->Reinterpret(
+                        reinterpreter, reinterpret_surface->texture.handle, src_rect,
+                        read_framebuffer.handle, surface->texture.handle, dest_rect,
+                        draw_framebuffer.handle);
+                }
+                notify_validated(reinterpret_interval);
+                retry = true;
+                break;
             }
         }
+        if (retry)
+            continue;
+
+        // Could not find a matching reinterpreter, check if we need to implement a
+        // reinterpreter
+        static constexpr std::array<PixelFormat, 17> all_formats{
+            PixelFormat::RGBA8, PixelFormat::RGB8,   PixelFormat::RGB5A1, PixelFormat::RGB565,
+            PixelFormat::RGBA4, PixelFormat::IA8,    PixelFormat::RG8,    PixelFormat::I8,
+            PixelFormat::A8,    PixelFormat::IA4,    PixelFormat::I4,     PixelFormat::A4,
+            PixelFormat::ETC1,  PixelFormat::ETC1A4, PixelFormat::D16,    PixelFormat::D24,
+            PixelFormat::D24S8,
+        };
+        retry = true;
+        for (PixelFormat format : all_formats) {
+            if (SurfaceParams::GetFormatBpp(format) == surface->GetFormatBpp()) {
+                params.pixel_format = format;
+                // This could potentially be expensive,
+                // although experimentally it hasn't been too bad
+                Surface test_surface = FindMatch<MatchFlags::Copy>(surface_cache, params,
+                                                                   ScaleMatch::Ignore, interval);
+                if (test_surface != nullptr) {
+                    LOG_ERROR(Render_OpenGL, "Missing reinterpreter: {} -> {}",
+                              SurfaceParams::PixelFormatAsString(format),
+                              SurfaceParams::PixelFormatAsString(surface->pixel_format));
+                    retry = false;
+                }
+            }
+        }
+
+        // No surfaces were found in the cache that had a matching bit-width.
+        // If the region was created entirely on the GPU,
+        // assume it was a developer mistake and skip flushing.
+        if (retry) {
+            retry = false;
+            for (const auto& pair : RangeFromInterval(dirty_regions, interval)) {
+                // Don't actually validate the region, and instead just skip it for now.
+                validate_regions.erase(pair.first & interval);
+                retry = true;
+            }
+        }
+        if (retry)
+            continue;
 
         // Load data from 3DS memory
         FlushRegion(params.addr, params.size);
         surface->LoadGLBuffer(params.addr, params.end);
         surface->UploadGLTexture(surface->GetSubRect(params), read_framebuffer.handle,
                                  draw_framebuffer.handle);
-        surface->invalid_regions.erase(params.GetInterval());
+        notify_validated(params.GetInterval());
     }
-}
+} // namespace OpenGL
 
 void RasterizerCacheOpenGL::FlushRegion(PAddr addr, u32 size, Surface flush_surface) {
     if (size == 0)

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -1646,92 +1646,18 @@ void RasterizerCacheOpenGL::ValidateSurface(const Surface& surface, PAddr addr, 
 
         // Try to find surface in cache with different format
         // that can can be reinterpreted to the requested format.
-        auto [cvt_begin, cvt_end] =
-            format_reinterpreter->GetPossibleReinterpretations(surface->pixel_format);
-        bool retry = false;
-        for (auto reinterpreter = cvt_begin; reinterpreter != cvt_end; ++reinterpreter) {
-            PixelFormat format = reinterpreter->first.src_format;
-            params.pixel_format = format;
-            Surface reinterpret_surface =
-                FindMatch<MatchFlags::Copy>(surface_cache, params, ScaleMatch::Ignore, interval);
-
-            if (reinterpret_surface != nullptr) {
-                SurfaceInterval reinterpret_interval =
-                    params.GetCopyableInterval(reinterpret_surface);
-                SurfaceParams reinterpret_params = surface->FromInterval(reinterpret_interval);
-                auto src_rect = reinterpret_surface->GetScaledSubRect(reinterpret_params);
-                auto dest_rect = surface->GetScaledSubRect(reinterpret_params);
-
-                if (!texture_filterer->IsNull() && reinterpret_surface->res_scale == 1 &&
-                    surface->res_scale == resolution_scale_factor) {
-                    // The destination surface is either a framebuffer, or a filtered texture.
-                    OGLTexture tmp_tex;
-                    tmp_tex.Create();
-                    // Create an intermediate surface to convert to before blitting to the
-                    // destination.
-                    Common::Rectangle<u32> tmp_rect{
-                        0, dest_rect.GetHeight() / resolution_scale_factor,
-                        dest_rect.GetWidth() / resolution_scale_factor, 0};
-                    AllocateSurfaceTexture(tmp_tex.handle,
-                                           GetFormatTuple(reinterpreter->first.dst_format),
-                                           tmp_rect.right, tmp_rect.top);
-                    reinterpreter->second->Reinterpret(
-                        reinterpret_surface->texture.handle, src_rect, read_framebuffer.handle,
-                        tmp_tex.handle, tmp_rect, draw_framebuffer.handle);
-                    SurfaceParams::SurfaceType type =
-                        SurfaceParams::GetFormatType(reinterpreter->first.dst_format);
-
-                    if (!texture_filterer->Filter(tmp_tex.handle, tmp_rect, surface->texture.handle,
-                                                  dest_rect, type, read_framebuffer.handle,
-                                                  draw_framebuffer.handle)) {
-                        BlitTextures(tmp_tex.handle, tmp_rect, surface->texture.handle, dest_rect,
-                                     type, read_framebuffer.handle, draw_framebuffer.handle);
-                    }
-                } else {
-                    reinterpreter->second->Reinterpret(
-                        reinterpret_surface->texture.handle, src_rect, read_framebuffer.handle,
-                        surface->texture.handle, dest_rect, draw_framebuffer.handle);
-                }
-                notify_validated(reinterpret_interval);
-                retry = true;
-                break;
-            }
-        }
-        if (retry)
+        if (ValidateByReinterpretation(surface, params, interval)) {
+            notify_validated(interval);
             continue;
-
+        }
         // Could not find a matching reinterpreter, check if we need to implement a
         // reinterpreter
-        static constexpr std::array<PixelFormat, 17> all_formats{
-            PixelFormat::RGBA8, PixelFormat::RGB8,   PixelFormat::RGB5A1, PixelFormat::RGB565,
-            PixelFormat::RGBA4, PixelFormat::IA8,    PixelFormat::RG8,    PixelFormat::I8,
-            PixelFormat::A8,    PixelFormat::IA4,    PixelFormat::I4,     PixelFormat::A4,
-            PixelFormat::ETC1,  PixelFormat::ETC1A4, PixelFormat::D16,    PixelFormat::D24,
-            PixelFormat::D24S8,
-        };
-        retry = true;
-        for (PixelFormat format : all_formats) {
-            if (SurfaceParams::GetFormatBpp(format) == surface->GetFormatBpp()) {
-                params.pixel_format = format;
-                // This could potentially be expensive,
-                // although experimentally it hasn't been too bad
-                Surface test_surface = FindMatch<MatchFlags::Copy>(surface_cache, params,
-                                                                   ScaleMatch::Ignore, interval);
-                if (test_surface != nullptr) {
-                    LOG_ERROR(Render_OpenGL, "Missing reinterpreter: {} -> {}",
-                              SurfaceParams::PixelFormatAsString(format),
-                              SurfaceParams::PixelFormatAsString(surface->pixel_format));
-                    retry = false;
-                }
-            }
-        }
-
-        // No surfaces were found in the cache that had a matching bit-width.
-        // If the region was created entirely on the GPU,
-        // assume it was a developer mistake and skip flushing.
-        if (retry) {
-            auto range = dirty_regions.equal_range(interval);
-            if (range.first != dirty_regions.end() && (range.first->first & interval) == interval) {
+        if (NoUnimplementedReinterpretations(surface, params, interval) &&
+            !IntervalHasInvalidPixelFormat(params, interval)) {
+            // No surfaces were found in the cache that had a matching bit-width.
+            // If the region was created entirely on the GPU,
+            // assume it was a developer mistake and skip flushing.
+            if (boost::icl::contains(dirty_regions, interval)) {
                 LOG_DEBUG(Render_OpenGL, "Region created fully on GPU and reinterpretation is "
                                          "invalid. Skipping validation");
                 validate_regions.erase(interval);
@@ -1746,6 +1672,99 @@ void RasterizerCacheOpenGL::ValidateSurface(const Surface& surface, PAddr addr, 
                                  draw_framebuffer.handle);
         notify_validated(params.GetInterval());
     }
+}
+
+bool RasterizerCacheOpenGL::NoUnimplementedReinterpretations(const Surface& surface,
+                                                             SurfaceParams& params,
+                                                             const SurfaceInterval& interval) {
+    static constexpr std::array<PixelFormat, 17> all_formats{
+        PixelFormat::RGBA8, PixelFormat::RGB8,   PixelFormat::RGB5A1, PixelFormat::RGB565,
+        PixelFormat::RGBA4, PixelFormat::IA8,    PixelFormat::RG8,    PixelFormat::I8,
+        PixelFormat::A8,    PixelFormat::IA4,    PixelFormat::I4,     PixelFormat::A4,
+        PixelFormat::ETC1,  PixelFormat::ETC1A4, PixelFormat::D16,    PixelFormat::D24,
+        PixelFormat::D24S8,
+    };
+    bool implemented = true;
+    for (PixelFormat format : all_formats) {
+        if (SurfaceParams::GetFormatBpp(format) == surface->GetFormatBpp()) {
+            params.pixel_format = format;
+            // This could potentially be expensive,
+            // although experimentally it hasn't been too bad
+            Surface test_surface =
+                FindMatch<MatchFlags::Copy>(surface_cache, params, ScaleMatch::Ignore, interval);
+            if (test_surface != nullptr) {
+                LOG_WARNING(Render_OpenGL, "Missing pixel_format reinterpreter: {} -> {}",
+                            SurfaceParams::PixelFormatAsString(format),
+                            SurfaceParams::PixelFormatAsString(surface->pixel_format));
+                implemented = false;
+            }
+        }
+    }
+    return implemented;
+}
+
+bool RasterizerCacheOpenGL::IntervalHasInvalidPixelFormat(SurfaceParams& params,
+                                                          const SurfaceInterval& interval) {
+    params.pixel_format = PixelFormat::Invalid;
+    for (const auto& set : RangeFromInterval(surface_cache, interval))
+        for (const auto& surface : set.second)
+            if (surface->pixel_format == PixelFormat::Invalid) {
+                LOG_WARNING(Render_OpenGL, "Surface found with invalid pixel format");
+                return true;
+            }
+    return false;
+}
+
+bool RasterizerCacheOpenGL::ValidateByReinterpretation(const Surface& surface,
+                                                       SurfaceParams& params,
+                                                       const SurfaceInterval& interval) {
+    auto [cvt_begin, cvt_end] =
+        format_reinterpreter->GetPossibleReinterpretations(surface->pixel_format);
+    for (auto reinterpreter = cvt_begin; reinterpreter != cvt_end; ++reinterpreter) {
+        PixelFormat format = reinterpreter->first.src_format;
+        params.pixel_format = format;
+        Surface reinterpret_surface =
+            FindMatch<MatchFlags::Copy>(surface_cache, params, ScaleMatch::Ignore, interval);
+
+        if (reinterpret_surface != nullptr) {
+            SurfaceInterval reinterpret_interval = params.GetCopyableInterval(reinterpret_surface);
+            SurfaceParams reinterpret_params = surface->FromInterval(reinterpret_interval);
+            auto src_rect = reinterpret_surface->GetScaledSubRect(reinterpret_params);
+            auto dest_rect = surface->GetScaledSubRect(reinterpret_params);
+
+            if (!texture_filterer->IsNull() && reinterpret_surface->res_scale == 1 &&
+                surface->res_scale == resolution_scale_factor) {
+                // The destination surface is either a framebuffer, or a filtered texture.
+                OGLTexture tmp_tex;
+                tmp_tex.Create();
+                // Create an intermediate surface to convert to before blitting to the
+                // destination.
+                Common::Rectangle<u32> tmp_rect{0, dest_rect.GetHeight() / resolution_scale_factor,
+                                                dest_rect.GetWidth() / resolution_scale_factor, 0};
+                AllocateSurfaceTexture(tmp_tex.handle,
+                                       GetFormatTuple(reinterpreter->first.dst_format),
+                                       tmp_rect.right, tmp_rect.top);
+                reinterpreter->second->Reinterpret(reinterpret_surface->texture.handle, src_rect,
+                                                   read_framebuffer.handle, tmp_tex.handle,
+                                                   tmp_rect, draw_framebuffer.handle);
+                SurfaceParams::SurfaceType type =
+                    SurfaceParams::GetFormatType(reinterpreter->first.dst_format);
+
+                if (!texture_filterer->Filter(tmp_tex.handle, tmp_rect, surface->texture.handle,
+                                              dest_rect, type, read_framebuffer.handle,
+                                              draw_framebuffer.handle)) {
+                    BlitTextures(tmp_tex.handle, tmp_rect, surface->texture.handle, dest_rect, type,
+                                 read_framebuffer.handle, draw_framebuffer.handle);
+                }
+            } else {
+                reinterpreter->second->Reinterpret(reinterpret_surface->texture.handle, src_rect,
+                                                   read_framebuffer.handle, surface->texture.handle,
+                                                   dest_rect, draw_framebuffer.handle);
+            }
+            return true;
+        }
+    }
+    return false;
 }
 
 void RasterizerCacheOpenGL::FlushRegion(PAddr addr, u32 size, Surface flush_surface) {

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -1730,17 +1730,13 @@ void RasterizerCacheOpenGL::ValidateSurface(const Surface& surface, PAddr addr, 
         // If the region was created entirely on the GPU,
         // assume it was a developer mistake and skip flushing.
         if (retry) {
-            retry = false;
-            for (const auto& pair : RangeFromInterval(dirty_regions, interval)) {
-                // Don't actually validate the region, and instead just skip it for now.
-                validate_regions.erase(pair.first & interval);
-                retry = true;
+            auto range = dirty_regions.equal_range(interval);
+            if (range.first != dirty_regions.end() && (range.first->first & interval) == interval) {
+                LOG_DEBUG(Render_OpenGL, "Region created fully on GPU and reinterpretation is "
+                                         "invalid. Skipping validation");
+                validate_regions.erase(interval);
+                continue;
             }
-        }
-        if (retry) {
-            LOG_DEBUG(Render_OpenGL, "Region created fully on GPU and reinterpretation is "
-                                     "invalid. Skipping validation");
-            continue;
         }
 
         // Load data from 3DS memory

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -34,6 +34,7 @@ namespace OpenGL {
 
 class RasterizerCacheOpenGL;
 class TextureFilterer;
+class FormatReinterpreterOpenGL;
 
 struct TextureCubeConfig {
     PAddr px;
@@ -240,9 +241,6 @@ public:
     bool BlitSurfaces(const Surface& src_surface, const Common::Rectangle<u32>& src_rect,
                       const Surface& dst_surface, const Common::Rectangle<u32>& dst_rect);
 
-    void ConvertD24S8toABGR(GLuint src_tex, const Common::Rectangle<u32>& src_rect, GLuint dst_tex,
-                            const Common::Rectangle<u32>& dst_rect);
-
     /// Copy one surface's region to another
     void CopySurface(const Surface& src_surface, const Surface& dst_surface,
                      SurfaceInterval copy_interval);
@@ -308,18 +306,13 @@ private:
     OGLFramebuffer read_framebuffer;
     OGLFramebuffer draw_framebuffer;
 
-    OGLVertexArray attributeless_vao;
-    OGLBuffer d24s8_abgr_buffer;
-    GLsizeiptr d24s8_abgr_buffer_size;
-    OGLProgram d24s8_abgr_shader;
-    GLint d24s8_abgr_tbo_size_u_id;
-    GLint d24s8_abgr_viewport_u_id;
     u16 resolution_scale_factor;
 
     std::unordered_map<TextureCubeConfig, CachedTextureCube> texture_cube_cache;
 
 public:
     std::unique_ptr<TextureFilterer> texture_filterer;
+    std::unique_ptr<FormatReinterpreterOpenGL> format_reinterpreter;
 };
 
 struct FormatTuple {

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -286,6 +286,18 @@ private:
     /// Update surface's texture for given region when necessary
     void ValidateSurface(const Surface& surface, PAddr addr, u32 size);
 
+    // Returns false if there is a surface in the cache at the interval with the same bit-width,
+    bool NoUnimplementedReinterpretations(const OpenGL::Surface& surface,
+                                          OpenGL::SurfaceParams& params,
+                                          const OpenGL::SurfaceInterval& interval);
+
+    // Return true if a surface with an invalid pixel format exists at the interval
+    bool IntervalHasInvalidPixelFormat(SurfaceParams& params, const SurfaceInterval& interval);
+
+    // Attempt to find a reinterpretable surface in the cache and use it to copy for validation
+    bool ValidateByReinterpretation(const Surface& surface, SurfaceParams& params,
+                                    const SurfaceInterval& interval);
+
     /// Create a new surface
     Surface CreateSurface(const SurfaceParams& params);
 

--- a/src/video_core/renderer_opengl/gl_surface_params.h
+++ b/src/video_core/renderer_opengl/gl_surface_params.h
@@ -91,6 +91,47 @@ public:
         return GetFormatBpp(pixel_format);
     }
 
+    static std::string_view PixelFormatAsString(PixelFormat format) {
+        switch (format) {
+        case PixelFormat::RGBA8:
+            return "RGBA8";
+        case PixelFormat::RGB8:
+            return "RGB8";
+        case PixelFormat::RGB5A1:
+            return "RGB5A1";
+        case PixelFormat::RGB565:
+            return "RGB565";
+        case PixelFormat::RGBA4:
+            return "RGBA4";
+        case PixelFormat::IA8:
+            return "IA8";
+        case PixelFormat::RG8:
+            return "RG8";
+        case PixelFormat::I8:
+            return "I8";
+        case PixelFormat::A8:
+            return "A8";
+        case PixelFormat::IA4:
+            return "IA4";
+        case PixelFormat::I4:
+            return "I4";
+        case PixelFormat::A4:
+            return "A4";
+        case PixelFormat::ETC1:
+            return "ETC1";
+        case PixelFormat::ETC1A4:
+            return "ETC1A4";
+        case PixelFormat::D16:
+            return "D16";
+        case PixelFormat::D24:
+            return "D24";
+        case PixelFormat::D24S8:
+            return "D24S8";
+        default:
+            return "Not a real pixel format";
+        }
+    }
+
     static PixelFormat PixelFormatFromTextureFormat(Pica::TexturingRegs::TextureFormat format) {
         return ((unsigned int)format < 14) ? (PixelFormat)format : PixelFormat::Invalid;
     }


### PR DESCRIPTION
Succeeds #4902 and #4089

Adds RGBA4 -> RGB5A1 reinterpretation commonly used by virtual console
If no matching surface can be found, ValidateSurface checks for a surface in the cache which is reinterpretable to the requested format.
If that fails, the cache is checked for any surface with a matching bit-width. If one is found, the region is flushed.
If not, the region is checked against dirty_regions to see if it was created entirely on the GPU.
If not, then the surface is flushed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5170)
<!-- Reviewable:end -->
