### PR TITLE
Reenable hidapi for SDL2.0.12 and up

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,7 @@ if (ENABLE_SDL2)
     if (CITRA_USE_BUNDLED_SDL2)
         # Detect toolchain and platform
         if ((MSVC_VERSION GREATER_EQUAL 1910 AND MSVC_VERSION LESS 1930) AND ARCHITECTURE_x86_64)
-            set(SDL2_VER "SDL2-2.0.10")
+            set(SDL2_VER "SDL2-2.0.12")
         else()
             message(FATAL_ERROR "No bundled SDL2 binaries for your toolchain. Disable CITRA_USE_BUNDLED_SDL2 and provide your own.")
         endif()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ install:
   - ps: |
         if ($env:BUILD_TYPE -eq 'mingw') {
           $dependencies = "mingw64/mingw-w64-x86_64-cmake mingw64/mingw-w64-x86_64-qt5 mingw64/mingw-w64-x86_64-ffmpeg"
-          C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-SDL2-2.0.10-1-any.pkg.tar.xz"
+          C:\msys64\usr\bin\bash -lc "pacman --noconfirm -U http://repo.msys2.org/mingw/x86_64/mingw-w64-x86_64-SDL2-2.0.12-1-any.pkg.tar.xz"
           C:\msys64\usr\bin\bash -lc "pacman --noconfirm -S $dependencies"
           # (HACK) ignore errors
           0

--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -474,11 +474,10 @@ SDLState::SDLState() {
     }
 // these hints are only defined on sdl2.0.9 or higher
 #if SDL_VERSION_ATLEAST(2, 0, 9)
-    // This can be set back to 1 when the compatibility problems with the controllers are
-    // solved. There are also hints to toggle the individual drivers.
+#if !SDL_VERSION_ATLEAST(2, 0, 12)
+    // There are also hints to toggle the individual drivers if needed.
     SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI, "0");
-    // This hint should probably stay as "0" as long as the hidapi PS4 led issue isn't fixed
-    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS4, "0");
+#endif
 #endif
 
     SDL_AddEventWatch(&SDLEventWatcher, this);


### PR DESCRIPTION
As explained in #5123, many controllers are broken by the hidapi driver implementations on SDL versions 2.0.9 and 2.0.10.
As of 2.0.12 most of these problems seem to have been fixed, so we may consider to update it (citra-emu/build-environments#23)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5179)
<!-- Reviewable:end -->
