### PR TITLE
Port yuzu-emu/yuzu#3091: "core: Make most implicit type conversion warnings errors on MSVC"

### DIFF
--- a/externals/httplib/README.md
+++ b/externals/httplib/README.md
@@ -1,4 +1,4 @@
-From https://github.com/yhirose/cpp-httplib/commit/b251668522dd459d2c6a75c10390a11b640be708
+From https://github.com/yhirose/cpp-httplib/tree/fce8e6fefdab4ad48bc5b25c98e5ebfda4f3cf53
 
 MIT License
 
@@ -13,4 +13,3 @@ It's extremely easy to setup. Just include httplib.h file in your code!
 Inspired by Sinatra and express.
 
 © 2017 Yuji Hirose
-

--- a/src/common/thread_queue_list.h
+++ b/src/common/thread_queue_list.h
@@ -34,7 +34,7 @@ struct ThreadQueueList {
             }
         }
 
-        return -1;
+        return UINT_MAX;
     }
 
     T get_first() {

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -464,6 +464,23 @@ if (ENABLE_FFMPEG_VIDEO_DUMPER)
     )
 endif()
 
+if (MSVC)
+    target_compile_options(core PRIVATE
+        # 'expression' : signed/unsigned mismatch
+        /we4018
+        # 'argument' : conversion from 'type1' to 'type2', possible loss of data (floating-point)
+        /we4244
+        # 'conversion' : conversion from 'type1' to 'type2', signed/unsigned mismatch
+        /we4245
+        # 'operator': conversion from 'type1:field_bits' to 'type2:field_bits', possible loss of data
+        /we4254
+        # 'var' : conversion from 'size_t' to 'type', possible loss of data
+        /we4267
+        # 'context' : truncation from 'type1' to 'type2'
+        /we4305
+    )
+endif()
+
 create_target_directory_groups(core)
 
 target_link_libraries(core PUBLIC common PRIVATE audio_core network video_core)

--- a/src/core/arm/skyeye_common/vfp/vfpdouble.cpp
+++ b/src/core/arm/skyeye_common/vfp/vfpdouble.cpp
@@ -1245,5 +1245,5 @@ u32 vfp_double_cpdo(ARMul_State* state, u32 inst, u32 fpscr) {
     return exceptions;
 
 invalid:
-    return ~0;
+    return UINT32_MAX;
 }

--- a/src/core/arm/skyeye_common/vfp/vfpsingle.cpp
+++ b/src/core/arm/skyeye_common/vfp/vfpsingle.cpp
@@ -599,7 +599,7 @@ static u32 vfp_single_ftoui(ARMul_State* state, int sd, int unused, s32 m, u32 f
         } else if (rmode == FPSCR_ROUND_TOZERO) {
             incr = 0;
         } else if ((rmode == FPSCR_ROUND_PLUSINF) ^ (vsm.sign != 0)) {
-            incr = ~0;
+            incr = UINT32_MAX;
         }
 
         if ((rem + incr) < rem) {
@@ -688,7 +688,7 @@ static u32 vfp_single_ftosi(ARMul_State* state, int sd, int unused, s32 m, u32 f
         } else if (rmode == FPSCR_ROUND_TOZERO) {
             incr = 0;
         } else if ((rmode == FPSCR_ROUND_PLUSINF) ^ (vsm.sign != 0)) {
-            incr = ~0;
+            incr = UINT32_MAX;
         }
 
         if ((rem + incr) < rem && d < 0xffffffff)

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -178,7 +178,7 @@ public:
         return *cpu_cores[core_id];
     };
 
-    u32 GetNumCores() const {
+    std::size_t GetNumCores() const {
         return cpu_cores.size();
     }
 

--- a/src/core/dumping/backend.h
+++ b/src/core/dumping/backend.h
@@ -19,7 +19,7 @@ class VideoFrame {
 public:
     std::size_t width;
     std::size_t height;
-    u32 stride;
+    std::size_t stride;
     std::vector<u8> data;
 
     VideoFrame(std::size_t width_ = 0, std::size_t height_ = 0, u8* data_ = nullptr);

--- a/src/core/file_sys/archive_extsavedata.cpp
+++ b/src/core/file_sys/archive_extsavedata.cpp
@@ -266,7 +266,7 @@ ResultCode ArchiveFactory_ExtSaveData::Format(const Path& path,
 
     if (!file.IsOpen()) {
         // TODO(Subv): Find the correct error code
-        return ResultCode(-1);
+        return RESULT_UNKNOWN;
     }
 
     file.WriteBytes(&format_info, sizeof(format_info));

--- a/src/core/file_sys/archive_ncch.cpp
+++ b/src/core/file_sys/archive_ncch.cpp
@@ -182,21 +182,21 @@ ResultCode NCCHArchive::DeleteFile(const Path& path) const {
 ResultCode NCCHArchive::RenameFile(const Path& src_path, const Path& dest_path) const {
     LOG_CRITICAL(Service_FS, "Attempted to rename a file within an NCCH archive ({}).", GetName());
     // TODO(wwylele): Use correct error code
-    return ResultCode(-1);
+    return RESULT_UNKNOWN;
 }
 
 ResultCode NCCHArchive::DeleteDirectory(const Path& path) const {
     LOG_CRITICAL(Service_FS, "Attempted to delete a directory from an NCCH archive ({}).",
                  GetName());
     // TODO(wwylele): Use correct error code
-    return ResultCode(-1);
+    return RESULT_UNKNOWN;
 }
 
 ResultCode NCCHArchive::DeleteDirectoryRecursively(const Path& path) const {
     LOG_CRITICAL(Service_FS, "Attempted to delete a directory from an NCCH archive ({}).",
                  GetName());
     // TODO(wwylele): Use correct error code
-    return ResultCode(-1);
+    return RESULT_UNKNOWN;
 }
 
 ResultCode NCCHArchive::CreateFile(const Path& path, u64 size) const {
@@ -209,20 +209,20 @@ ResultCode NCCHArchive::CreateFile(const Path& path, u64 size) const {
 ResultCode NCCHArchive::CreateDirectory(const Path& path) const {
     LOG_CRITICAL(Service_FS, "Attempted to create a directory in an NCCH archive ({}).", GetName());
     // TODO(wwylele): Use correct error code
-    return ResultCode(-1);
+    return RESULT_UNKNOWN;
 }
 
 ResultCode NCCHArchive::RenameDirectory(const Path& src_path, const Path& dest_path) const {
     LOG_CRITICAL(Service_FS, "Attempted to rename a file within an NCCH archive ({}).", GetName());
     // TODO(wwylele): Use correct error code
-    return ResultCode(-1);
+    return RESULT_UNKNOWN;
 }
 
 ResultVal<std::unique_ptr<DirectoryBackend>> NCCHArchive::OpenDirectory(const Path& path) const {
     LOG_CRITICAL(Service_FS, "Attempted to open a directory within an NCCH archive ({}).",
                  GetName().c_str());
     // TODO(shinyquagsire23): Use correct error code
-    return ResultCode(-1);
+    return RESULT_UNKNOWN;
 }
 
 u64 NCCHArchive::GetFreeBytes() const {
@@ -302,7 +302,7 @@ ResultVal<ArchiveFormatInfo> ArchiveFactory_NCCH::GetFormatInfo(const Path& path
                                                                 u64 program_id) const {
     // TODO(Subv): Implement
     LOG_ERROR(Service_FS, "Unimplemented GetFormatInfo archive {}", GetName());
-    return ResultCode(-1);
+    return RESULT_UNKNOWN;
 }
 
 } // namespace FileSys

--- a/src/core/file_sys/archive_sdmc.cpp
+++ b/src/core/file_sys/archive_sdmc.cpp
@@ -402,6 +402,6 @@ ResultVal<ArchiveFormatInfo> ArchiveFactory_SDMC::GetFormatInfo(const Path& path
                                                                 u64 program_id) const {
     // TODO(Subv): Implement
     LOG_ERROR(Service_FS, "Unimplemented GetFormatInfo archive {}", GetName());
-    return ResultCode(-1);
+    return RESULT_UNKNOWN;
 }
 } // namespace FileSys

--- a/src/core/file_sys/archive_sdmcwriteonly.cpp
+++ b/src/core/file_sys/archive_sdmcwriteonly.cpp
@@ -85,14 +85,14 @@ ResultCode ArchiveFactory_SDMCWriteOnly::Format(const Path& path,
                                                 u64 program_id) {
     // TODO(wwylele): hwtest this
     LOG_ERROR(Service_FS, "Attempted to format a SDMC write-only archive.");
-    return ResultCode(-1);
+    return RESULT_UNKNOWN;
 }
 
 ResultVal<ArchiveFormatInfo> ArchiveFactory_SDMCWriteOnly::GetFormatInfo(const Path& path,
                                                                          u64 program_id) const {
     // TODO(Subv): Implement
     LOG_ERROR(Service_FS, "Unimplemented GetFormatInfo archive {}", GetName());
-    return ResultCode(-1);
+    return RESULT_UNKNOWN;
 }
 
 } // namespace FileSys

--- a/src/core/file_sys/archive_systemsavedata.cpp
+++ b/src/core/file_sys/archive_systemsavedata.cpp
@@ -76,7 +76,7 @@ ResultVal<ArchiveFormatInfo> ArchiveFactory_SystemSaveData::GetFormatInfo(const 
                                                                           u64 program_id) const {
     // TODO(Subv): Implement
     LOG_ERROR(Service_FS, "Unimplemented GetFormatInfo archive {}", GetName());
-    return ResultCode(-1);
+    return RESULT_UNKNOWN;
 }
 
 } // namespace FileSys

--- a/src/core/file_sys/disk_archive.cpp
+++ b/src/core/file_sys/disk_archive.cpp
@@ -54,8 +54,7 @@ bool DiskFile::Close() const {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 DiskDirectory::DiskDirectory(const std::string& path) {
-    unsigned size = FileUtil::ScanDirectoryTree(path, directory);
-    directory.size = size;
+    directory.size = FileUtil::ScanDirectoryTree(path, directory);
     directory.isDirectory = true;
     children_iterator = directory.children.begin();
 }

--- a/src/core/file_sys/ivfc_archive.cpp
+++ b/src/core/file_sys/ivfc_archive.cpp
@@ -41,21 +41,21 @@ ResultCode IVFCArchive::DeleteFile(const Path& path) const {
 ResultCode IVFCArchive::RenameFile(const Path& src_path, const Path& dest_path) const {
     LOG_CRITICAL(Service_FS, "Attempted to rename a file within an IVFC archive ({}).", GetName());
     // TODO(wwylele): Use correct error code
-    return ResultCode(-1);
+    return RESULT_UNKNOWN;
 }
 
 ResultCode IVFCArchive::DeleteDirectory(const Path& path) const {
     LOG_CRITICAL(Service_FS, "Attempted to delete a directory from an IVFC archive ({}).",
                  GetName());
     // TODO(wwylele): Use correct error code
-    return ResultCode(-1);
+    return RESULT_UNKNOWN;
 }
 
 ResultCode IVFCArchive::DeleteDirectoryRecursively(const Path& path) const {
     LOG_CRITICAL(Service_FS, "Attempted to delete a directory from an IVFC archive ({}).",
                  GetName());
     // TODO(wwylele): Use correct error code
-    return ResultCode(-1);
+    return RESULT_UNKNOWN;
 }
 
 ResultCode IVFCArchive::CreateFile(const Path& path, u64 size) const {
@@ -68,13 +68,13 @@ ResultCode IVFCArchive::CreateFile(const Path& path, u64 size) const {
 ResultCode IVFCArchive::CreateDirectory(const Path& path) const {
     LOG_CRITICAL(Service_FS, "Attempted to create a directory in an IVFC archive ({}).", GetName());
     // TODO(wwylele): Use correct error code
-    return ResultCode(-1);
+    return RESULT_UNKNOWN;
 }
 
 ResultCode IVFCArchive::RenameDirectory(const Path& src_path, const Path& dest_path) const {
     LOG_CRITICAL(Service_FS, "Attempted to rename a file within an IVFC archive ({}).", GetName());
     // TODO(wwylele): Use correct error code
-    return ResultCode(-1);
+    return RESULT_UNKNOWN;
 }
 
 ResultVal<std::unique_ptr<DirectoryBackend>> IVFCArchive::OpenDirectory(const Path& path) const {

--- a/src/core/file_sys/patch.cpp
+++ b/src/core/file_sys/patch.cpp
@@ -15,8 +15,8 @@
 namespace FileSys::Patch {
 
 bool ApplyIpsPatch(const std::vector<u8>& ips, std::vector<u8>& buffer) {
-    u32 cursor = 5;
-    u32 patch_length = ips.size() - 3;
+    std::size_t cursor = 5;
+    std::size_t patch_length = ips.size() - 3;
     std::string ips_header(ips.begin(), ips.begin() + 5);
 
     if (ips_header != "PATCH") {

--- a/src/core/file_sys/title_metadata.cpp
+++ b/src/core/file_sys/title_metadata.cpp
@@ -165,19 +165,19 @@ u32 TitleMetadata::GetDLPContentID() const {
     return tmd_chunks[TMDContentIndex::DLP].id;
 }
 
-u32 TitleMetadata::GetContentIDByIndex(u16 index) const {
+u32 TitleMetadata::GetContentIDByIndex(std::size_t index) const {
     return tmd_chunks[index].id;
 }
 
-u16 TitleMetadata::GetContentTypeByIndex(u16 index) const {
+u16 TitleMetadata::GetContentTypeByIndex(std::size_t index) const {
     return tmd_chunks[index].type;
 }
 
-u64 TitleMetadata::GetContentSizeByIndex(u16 index) const {
+u64 TitleMetadata::GetContentSizeByIndex(std::size_t index) const {
     return tmd_chunks[index].size;
 }
 
-std::array<u8, 16> TitleMetadata::GetContentCTRByIndex(u16 index) const {
+std::array<u8, 16> TitleMetadata::GetContentCTRByIndex(std::size_t index) const {
     std::array<u8, 16> ctr{};
     std::memcpy(ctr.data(), &tmd_chunks[index].index, sizeof(u16));
     return ctr;

--- a/src/core/file_sys/title_metadata.h
+++ b/src/core/file_sys/title_metadata.h
@@ -96,10 +96,10 @@ public:
     u32 GetBootContentID() const;
     u32 GetManualContentID() const;
     u32 GetDLPContentID() const;
-    u32 GetContentIDByIndex(u16 index) const;
-    u16 GetContentTypeByIndex(u16 index) const;
-    u64 GetContentSizeByIndex(u16 index) const;
-    std::array<u8, 16> GetContentCTRByIndex(u16 index) const;
+    u32 GetContentIDByIndex(std::size_t index) const;
+    u16 GetContentTypeByIndex(std::size_t index) const;
+    u64 GetContentSizeByIndex(std::size_t index) const;
+    std::array<u8, 16> GetContentCTRByIndex(std::size_t index) const;
 
     void SetTitleID(u64 title_id);
     void SetTitleType(u32 type);

--- a/src/core/hle/applets/erreula.cpp
+++ b/src/core/hle/applets/erreula.cpp
@@ -14,7 +14,7 @@ ResultCode ErrEula::ReceiveParameter(const Service::APT::MessageParameter& param
         LOG_ERROR(Service_APT, "unsupported signal {}", static_cast<u32>(parameter.signal));
         UNIMPLEMENTED();
         // TODO(Subv): Find the right error code
-        return ResultCode(-1);
+        return RESULT_UNKNOWN;
     }
 
     // The LibAppJustStarted message contains a buffer with the size of the framebuffer shared

--- a/src/core/hle/applets/mii_selector.cpp
+++ b/src/core/hle/applets/mii_selector.cpp
@@ -24,7 +24,7 @@ ResultCode MiiSelector::ReceiveParameter(const Service::APT::MessageParameter& p
         LOG_ERROR(Service_APT, "unsupported signal {}", static_cast<u32>(parameter.signal));
         UNIMPLEMENTED();
         // TODO(Subv): Find the right error code
-        return ResultCode(-1);
+        return RESULT_UNKNOWN;
     }
 
     // The LibAppJustStarted message contains a buffer with the size of the framebuffer shared

--- a/src/core/hle/applets/mint.cpp
+++ b/src/core/hle/applets/mint.cpp
@@ -14,7 +14,7 @@ ResultCode Mint::ReceiveParameter(const Service::APT::MessageParameter& paramete
         LOG_ERROR(Service_APT, "unsupported signal {}", static_cast<u32>(parameter.signal));
         UNIMPLEMENTED();
         // TODO(Subv): Find the right error code
-        return ResultCode(-1);
+        return RESULT_UNKNOWN;
     }
 
     // The Request message contains a buffer with the size of the framebuffer shared

--- a/src/core/hle/applets/swkbd.cpp
+++ b/src/core/hle/applets/swkbd.cpp
@@ -87,7 +87,7 @@ ResultCode SoftwareKeyboard::ReceiveParameter(Service::APT::MessageParameter con
         LOG_ERROR(Service_APT, "unsupported signal {}", static_cast<u32>(parameter.signal));
         UNIMPLEMENTED();
         // TODO(Subv): Find the right error code
-        return ResultCode(-1);
+        return RESULT_UNKNOWN;
     }
     }
 }

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -349,15 +349,16 @@ ResultVal<std::shared_ptr<Thread>> KernelSystem::CreateThread(std::string name, 
         auto& vm_manager = owner_process.vm_manager;
 
         // Map the page to the current process' address space.
-        vm_manager.MapBackingMemory(Memory::TLS_AREA_VADDR + available_page * Memory::PAGE_SIZE,
-                                    memory.GetFCRAMPointer(*offset), Memory::PAGE_SIZE,
-                                    MemoryState::Locked);
+        vm_manager.MapBackingMemory(
+            static_cast<VAddr>(Memory::TLS_AREA_VADDR + available_page * Memory::PAGE_SIZE),
+            memory.GetFCRAMPointer(*offset), Memory::PAGE_SIZE, MemoryState::Locked);
     }
 
     // Mark the slot as used
     tls_slots[available_page].set(available_slot);
-    thread->tls_address = Memory::TLS_AREA_VADDR + available_page * Memory::PAGE_SIZE +
-                          available_slot * Memory::TLS_ENTRY_SIZE;
+    thread->tls_address =
+        static_cast<VAddr>(Memory::TLS_AREA_VADDR + available_page * Memory::PAGE_SIZE +
+                           available_slot * Memory::TLS_ENTRY_SIZE);
 
     memory.ZeroBlock(owner_process, thread->tls_address, Memory::TLS_ENTRY_SIZE);
 

--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -240,6 +240,14 @@ constexpr bool operator!=(const ResultCode& a, const ResultCode& b) {
 /// The default success `ResultCode`.
 constexpr ResultCode RESULT_SUCCESS(0);
 
+/**
+ * Placeholder result code used for unknown error codes.
+ *
+ * @note This should only be used when a particular error code
+ *       is not known yet.
+ */
+constexpr ResultCode RESULT_UNKNOWN(UINT32_MAX);
+
 /// Might be returned instead of a dummy success for unimplemented APIs.
 constexpr ResultCode UnimplementedFunction(ErrorModule module) {
     return ResultCode(ErrorDescription::NotImplemented, module, ErrorSummary::NotSupported,
@@ -283,7 +291,7 @@ class ResultVal {
 public:
     /// Constructs an empty `ResultVal` with the given error code. The code must not be a success
     /// code.
-    ResultVal(ResultCode error_code = ResultCode(-1)) : result_code(error_code) {
+    ResultVal(ResultCode error_code = RESULT_UNKNOWN) : result_code(error_code) {
         ASSERT(error_code.IsError());
     }
 

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -582,7 +582,7 @@ void Module::Interface::FindDLCContentInfos(Kernel::HLERequestContext& ctx) {
                           content_requested[i]);
 
                 IPC::RequestBuilder rb = rp.MakeBuilder(1, 4);
-                rb.Push<u32>(-1); // TODO(Steveice10): Find the right error code
+                rb.Push(RESULT_UNKNOWN); // TODO(Steveice10): Find the right error code
                 rb.PushMappedBuffer(content_requested_in);
                 rb.PushMappedBuffer(content_info_out);
                 return;
@@ -688,7 +688,7 @@ void Module::Interface::GetProgramList(Kernel::HLERequestContext& ctx) {
 
     if (media_type > 2) {
         IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
-        rb.Push<u32>(-1); // TODO(shinyquagsire23): Find the right error code
+        rb.Push(RESULT_UNKNOWN); // TODO(shinyquagsire23): Find the right error code
         rb.Push<u32>(0);
         rb.PushMappedBuffer(title_ids_output);
         return;

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -203,7 +203,7 @@ void Module::APTInterface::GetSharedFont(Kernel::HLERequestContext& ctx) {
             apt->shared_font_loaded = true;
         } else {
             LOG_ERROR(Service_APT, "shared font file missing - go dump it from your 3ds");
-            rb.Push<u32>(-1); // TODO: Find the right error code
+            rb.Push(RESULT_UNKNOWN); // TODO: Find the right error code
             rb.Push<u32>(0);
             rb.PushCopyObjects<Kernel::Object>(nullptr);
             apt->system.SetStatus(Core::System::ResultStatus::ErrorSystemFiles, "Shared fonts");

--- a/src/core/hle/service/cecd/cecd.cpp
+++ b/src/core/hle/service/cecd/cecd.cpp
@@ -924,7 +924,7 @@ void Module::CheckAndUpdateFile(const CecDataPathType path_type, const u32 ncch_
     constexpr u32 max_num_boxes = 24;
     constexpr u32 name_size = 16;      // fixed size 16 characters long
     constexpr u32 valid_name_size = 8; // 8 characters are valid, the rest are null
-    const u32 file_size = file_buffer.size();
+    const std::size_t file_size = file_buffer.size();
 
     switch (path_type) {
     case CecDataPathType::MboxList: {

--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -370,7 +370,7 @@ ResultCode Module::SetConfigInfoBlock(u32 block_id, u32 size, u32 flag, const vo
 ResultCode Module::CreateConfigInfoBlk(u32 block_id, u16 size, u16 flags, const void* data) {
     SaveFileConfig* config = reinterpret_cast<SaveFileConfig*>(cfg_config_file_buffer.data());
     if (config->total_entries >= CONFIG_FILE_MAX_BLOCK_ENTRIES)
-        return ResultCode(-1); // TODO(Subv): Find the right error code
+        return RESULT_UNKNOWN; // TODO(Subv): Find the right error code
 
     // Insert the block header with offset 0 for now
     config->block_entries[config->total_entries] = {block_id, 0, size, flags};

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -252,7 +252,7 @@ ResultCode ArchiveManager::DeleteExtSaveData(MediaType media_type, u32 high, u32
         media_type_directory = FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir);
     } else {
         LOG_ERROR(Service_FS, "Unsupported media type {}", static_cast<u32>(media_type));
-        return ResultCode(-1); // TODO(Subv): Find the right error code
+        return RESULT_UNKNOWN; // TODO(Subv): Find the right error code
     }
 
     // Delete all directories (/user, /boss) and the icon file.
@@ -260,7 +260,7 @@ ResultCode ArchiveManager::DeleteExtSaveData(MediaType media_type, u32 high, u32
         FileSys::GetExtDataContainerPath(media_type_directory, media_type == MediaType::NAND);
     std::string extsavedata_path = FileSys::GetExtSaveDataPath(base_path, path);
     if (FileUtil::Exists(extsavedata_path) && !FileUtil::DeleteDirRecursively(extsavedata_path))
-        return ResultCode(-1); // TODO(Subv): Find the right error code
+        return RESULT_UNKNOWN; // TODO(Subv): Find the right error code
     return RESULT_SUCCESS;
 }
 
@@ -272,7 +272,7 @@ ResultCode ArchiveManager::DeleteSystemSaveData(u32 high, u32 low) {
     std::string base_path = FileSys::GetSystemSaveDataContainerPath(nand_directory);
     std::string systemsavedata_path = FileSys::GetSystemSaveDataPath(base_path, path);
     if (!FileUtil::DeleteDirRecursively(systemsavedata_path))
-        return ResultCode(-1); // TODO(Subv): Find the right error code
+        return RESULT_UNKNOWN; // TODO(Subv): Find the right error code
     return RESULT_SUCCESS;
 }
 
@@ -284,7 +284,7 @@ ResultCode ArchiveManager::CreateSystemSaveData(u32 high, u32 low) {
     std::string base_path = FileSys::GetSystemSaveDataContainerPath(nand_directory);
     std::string systemsavedata_path = FileSys::GetSystemSaveDataPath(base_path, path);
     if (!FileUtil::CreateFullPath(systemsavedata_path))
-        return ResultCode(-1); // TODO(Subv): Find the right error code
+        return RESULT_UNKNOWN; // TODO(Subv): Find the right error code
     return RESULT_SUCCESS;
 }
 

--- a/src/core/hle/service/fs/fs_user.h
+++ b/src/core/hle/service/fs/fs_user.h
@@ -541,7 +541,7 @@ private:
      */
     void GetSaveDataSecureValue(Kernel::HLERequestContext& ctx);
 
-    u32 priority = -1; ///< For SetPriority and GetPriority service functions
+    u32 priority = UINT32_MAX; ///< For SetPriority and GetPriority service functions
 
     Core::System& system;
     ArchiveManager& archives;

--- a/src/core/hle/service/http_c.cpp
+++ b/src/core/hle/service/http_c.cpp
@@ -79,10 +79,10 @@ void Context::MakeRequest() {
         client = std::move(ssl_client);
 
         if (auto client_cert = ssl_config.client_cert_ctx.lock()) {
-            SSL_CTX_use_certificate_ASN1(ctx, client_cert->certificate.size(),
+            SSL_CTX_use_certificate_ASN1(ctx, static_cast<int>(client_cert->certificate.size()),
                                          client_cert->certificate.data());
             SSL_CTX_use_PrivateKey_ASN1(EVP_PKEY_RSA, ctx, client_cert->private_key.data(),
-                                        client_cert->private_key.size());
+                                        static_cast<long>(client_cert->private_key.size()));
         }
 
         // TODO(B3N30): Check for SSLOptions-Bits and set the verify method accordingly
@@ -734,7 +734,7 @@ void HTTP_C::OpenDefaultClientCertContext(Kernel::HLERequestContext& ctx) {
     if (!ClCertA.init) {
         LOG_ERROR(Service_HTTP, "called but ClCertA is missing");
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-        rb.Push(static_cast<ResultCode>(-1));
+        rb.Push(RESULT_UNKNOWN);
         return;
     }
 

--- a/src/core/hle/service/nfc/nfc.cpp
+++ b/src/core/hle/service/nfc/nfc.cpp
@@ -126,7 +126,7 @@ void Module::Interface::GetTagInfo(Kernel::HLERequestContext& ctx) {
 
     TagInfo tag_info{};
     tag_info.uuid = nfc->amiibo_data.uuid;
-    tag_info.id_offset_size = tag_info.uuid.size();
+    tag_info.id_offset_size = static_cast<u16_le>(tag_info.uuid.size());
     tag_info.unk1 = 0x0;
     tag_info.unk2 = 0x2;
 

--- a/src/core/hw/lcd.cpp
+++ b/src/core/hw/lcd.cpp
@@ -17,7 +17,7 @@ Regs g_regs;
 template <typename T>
 inline void Read(T& var, const u32 raw_addr) {
     u32 addr = raw_addr - HW::VADDR_LCD;
-    u32 index = addr / 4;
+    std::size_t index = addr / 4;
 
     // Reads other than u32 are untested, so I'd rather have them abort than silently fail
     if (index >= 0x400 || !std::is_same<T, u32>::value) {
@@ -25,7 +25,7 @@ inline void Read(T& var, const u32 raw_addr) {
         return;
     }
 
-    var = g_regs[index];
+    var = static_cast<T>(g_regs[index]);
 }
 
 template <typename T>

--- a/src/core/hw/lcd.h
+++ b/src/core/hw/lcd.h
@@ -41,12 +41,12 @@ struct Regs {
         return sizeof(Regs) / sizeof(u32);
     }
 
-    const u32& operator[](int index) const {
+    const u32& operator[](std::size_t index) const {
         const u32* content = reinterpret_cast<const u32*>(this);
         return content[index];
     }
 
-    u32& operator[](int index) {
+    u32& operator[](size_t index) {
         u32* content = reinterpret_cast<u32*>(this);
         return content[index];
     }


### PR DESCRIPTION
**DO NOT MERGE UNTIL I HAVE FIXED THE OUTSTANDING ISSUES WITH BOOST COMPILATION!**

See yuzu-emu/yuzu#3091 for more details.

**Original description**:
Quite frequently there have been cases where code has been merged into the core that produces warning. In order to prevent this from occurring, we can make the compiler flag these cases and allow our CI to flag down any code that would generate these warnings.

This is beneficial given silent conversions from signed/unsigned can result in logic bugs. This forces one writing changes to be explicit about when signedness conversions and truncations are desirable, rather than leaving it up to readers' interpretation. One such logic bug was found [here](https://github.com/yuzu-emu/yuzu/commit/55d500545f3becd47a203e77043ea488864b530d#diff-026ae30e0e7112cb315ff4a38e14f50fR416) while making the kernel code successfully compile with these warnings as errors.

This set of changes will focus on making it build properly with these changes for MSVC as a starting point for basic coverage.

Most of the diff is related to updating httplib. The amount of lines changed in our code is significantly lower.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5180)
<!-- Reviewable:end -->
