### PR TITLE
gdbstub: Fix some gdbstub jankiness

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -50,6 +50,10 @@ System::ResultStatus System::RunLoop(bool tight_loop) {
     }
 
     if (GDBStub::IsServerEnabled()) {
+        Kernel::Thread* thread = kernel->GetCurrentThreadManager().GetCurrentThread();
+        if (thread && running_core) {
+            running_core->SaveContext(thread->context);
+        }
         GDBStub::HandlePacket();
 
         // If the loop is halted and we want to step, use a tiny (1) number of instructions to

--- a/src/core/gdbstub/gdbstub.cpp
+++ b/src/core/gdbstub/gdbstub.cpp
@@ -1264,10 +1264,9 @@ void SendTrap(Kernel::Thread* thread, int trap) {
         return;
     }
 
-    if (!halt_loop || current_thread == thread) {
-        current_thread = thread;
-        SendSignal(thread, trap);
-    }
+    current_thread = thread;
+    SendSignal(thread, trap);
+
     halt_loop = true;
     send_trap = false;
 }


### PR DESCRIPTION
1. Ensure that register information available to gdbstub is most up-to-date.
2. There's no reason to check for `current_thread == thread` when emitting a trap packet.
   Doing this results in random hangs whenever a step happens upon a thread switch.

Not sure whether (1) is actually necessary. I'm planning on a refactoring of the JIT which will eventually make it a moot point anyway (using contexts directly instead of needing to Load/Store them).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5185)
<!-- Reviewable:end -->
