### PR TITLE
Revert one change from #4844

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -756,7 +756,7 @@ bool RasterizerOpenGL::Draw(bool accelerate, bool is_indexed) {
                 state.texture_units[texture_index].texture_2d = default_texture;
             }
         } else {
-            state.texture_units[texture_index].texture_2d = default_texture;
+            state.texture_units[texture_index].texture_2d = 0;
         }
     }
 


### PR DESCRIPTION
This fixes #5067 by reverting a speculative change made in a previous PR.

From this one can conclude that, for disabled textures, black (0,0,0,1) is the correct colour and clear (0,0,0,0) is not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5186)
<!-- Reviewable:end -->
