### PR TITLE
Kernel/Process: Fixed scheduling multiple processes in the SysCore using Dynarmic

### DIFF
--- a/src/core/arm/arm_interface.h
+++ b/src/core/arm/arm_interface.h
@@ -11,6 +11,10 @@
 #include "core/arm/skyeye_common/vfp/asm_vfp.h"
 #include "core/core_timing.h"
 
+namespace Memory {
+struct PageTable;
+};
+
 /// Generic ARM11 CPU interface
 class ARM_Interface : NonCopyable {
 public:
@@ -73,7 +77,7 @@ public:
     virtual void InvalidateCacheRange(u32 start_address, std::size_t length) = 0;
 
     /// Notify CPU emulation that page tables have changed
-    virtual void PageTableChanged() = 0;
+    virtual void PageTableChanged(Memory::PageTable* new_page_table) = 0;
 
     /**
      * Set the Program Counter to an address

--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -153,7 +153,7 @@ ARM_Dynarmic::ARM_Dynarmic(Core::System* system, Memory::MemorySystem& memory, u
                            std::shared_ptr<Core::Timing::Timer> timer)
     : ARM_Interface(id, timer), system(*system), memory(memory),
       cb(std::make_unique<DynarmicUserCallbacks>(*this)) {
-    PageTableChanged();
+    PageTableChanged(memory.GetCurrentPageTable());
 }
 
 ARM_Dynarmic::~ARM_Dynarmic() = default;
@@ -287,8 +287,8 @@ void ARM_Dynarmic::InvalidateCacheRange(u32 start_address, std::size_t length) {
     jit->InvalidateCacheRange(start_address, length);
 }
 
-void ARM_Dynarmic::PageTableChanged() {
-    current_page_table = memory.GetCurrentPageTable();
+void ARM_Dynarmic::PageTableChanged(Memory::PageTable* new_page_table) {
+    current_page_table = new_page_table;
 
     auto iter = jits.find(current_page_table);
     if (iter != jits.end()) {

--- a/src/core/arm/dynarmic/arm_dynarmic.h
+++ b/src/core/arm/dynarmic/arm_dynarmic.h
@@ -52,7 +52,7 @@ public:
 
     void ClearInstructionCache() override;
     void InvalidateCacheRange(u32 start_address, std::size_t length) override;
-    void PageTableChanged() override;
+    void PageTableChanged(Memory::PageTable* new_page_table) override;
 
 private:
     void ServeBreak();

--- a/src/core/arm/dyncom/arm_dyncom.cpp
+++ b/src/core/arm/dyncom/arm_dyncom.cpp
@@ -95,7 +95,7 @@ void ARM_DynCom::InvalidateCacheRange(u32, std::size_t) {
     ClearInstructionCache();
 }
 
-void ARM_DynCom::PageTableChanged() {
+void ARM_DynCom::PageTableChanged(Memory::PageTable*) {
     ClearInstructionCache();
 }
 

--- a/src/core/arm/dyncom/arm_dyncom.h
+++ b/src/core/arm/dyncom/arm_dyncom.h
@@ -30,7 +30,7 @@ public:
 
     void ClearInstructionCache() override;
     void InvalidateCacheRange(u32 start_address, std::size_t length) override;
-    void PageTableChanged() override;
+    void PageTableChanged(Memory::PageTable* new_page_table) override;
 
     void SetPC(u32 pc) override;
     u32 GetPC() const override;

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -67,13 +67,15 @@ void KernelSystem::SetCurrentProcessForCPU(std::shared_ptr<Process> process, u32
         SetCurrentMemoryPageTable(&process->vm_manager.page_table);
     } else {
         stored_processes[core_id] = process;
+        thread_managers[core_id]->cpu->PageTableChanged(&process->vm_manager.page_table);
     }
 }
 
 void KernelSystem::SetCurrentMemoryPageTable(Memory::PageTable* page_table) {
     memory.SetCurrentPageTable(page_table);
     if (current_cpu != nullptr) {
-        current_cpu->PageTableChanged(); // notify the CPU the page table in memory has changed
+        // Notify the CPU the page table in memory has changed
+        current_cpu->PageTableChanged(page_table);
     }
 }
 


### PR DESCRIPTION
The page tables were not being properly maintained when switching the current process of core1 (SysCore), this change fixes that.

This should allow LLE applets and sysmodules to boot again under the JIT.
See individual commits for the relevant changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5193)
<!-- Reviewable:end -->
