### PR TITLE
Services/APT: Implemented the GetCaptureInfo function.

### DIFF
--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -671,6 +671,18 @@ void Module::APTInterface::ReceiveCaptureBufferInfo(Kernel::HLERequestContext& c
     rb.PushStaticBuffer(std::move(apt->screen_capture_buffer), 0);
 }
 
+void Module::APTInterface::GetCaptureInfo(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp(ctx, 0x4A, 1, 0); // 0x004A0040
+    const u32 size = rp.Pop<u32>();
+    ASSERT(size == 0x20);
+
+    IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
+    rb.Push(RESULT_SUCCESS);
+    rb.Push(static_cast<u32>(apt->screen_capture_buffer.size()));
+    // This service function does not clear the capture buffer.
+    rb.PushStaticBuffer(apt->screen_capture_buffer, 0);
+}
+
 void Module::APTInterface::SetScreenCapPostPermission(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x55, 1, 0); // 0x00550040
 

--- a/src/core/hle/service/apt/apt.h
+++ b/src/core/hle/service/apt/apt.h
@@ -546,6 +546,20 @@ public:
         void ReceiveCaptureBufferInfo(Kernel::HLERequestContext& ctx);
 
         /**
+         * APT::GetCaptureInfo service function
+         *  Inputs:
+         *      0 : Command header [0x004A0040]
+         *      1 : Size
+         *      64 : Size << 14 | 2
+         *      65 : void*, CaptureBufferInfo
+         *  Outputs:
+         *      0 : Header code
+         *      1 : Result code
+         *      2 : Actual Size
+         */
+        void GetCaptureInfo(Kernel::HLERequestContext& ctx);
+
+        /**
          * APT::GetStartupArgument service function
          *  Inputs:
          *      1 : Parameter Size (capped to 0x300)

--- a/src/core/hle/service/apt/apt_s.cpp
+++ b/src/core/hle/service/apt/apt_s.cpp
@@ -82,7 +82,7 @@ APT_S::APT_S(std::shared_ptr<Module> apt)
         {0x00470104, &APT_S::Unwrap, "Unwrap"},
         {0x00480100, nullptr, "GetProgramInfo"},
         {0x00490180, nullptr, "Reboot"},
-        {0x004A0040, nullptr, "GetCaptureInfo"},
+        {0x004A0040, &APT_S::GetCaptureInfo, "GetCaptureInfo"},
         {0x004B00C2, &APT_S::AppletUtility, "AppletUtility"},
         {0x004C0000, nullptr, "SetFatalErrDispMode"},
         {0x004D0080, nullptr, "GetAppletProgramInfo"},

--- a/src/core/hle/service/apt/apt_u.cpp
+++ b/src/core/hle/service/apt/apt_u.cpp
@@ -82,7 +82,7 @@ APT_U::APT_U(std::shared_ptr<Module> apt)
         {0x00470104, &APT_U::Unwrap, "Unwrap"},
         {0x00480100, nullptr, "GetProgramInfo"},
         {0x00490180, nullptr, "Reboot"},
-        {0x004A0040, nullptr, "GetCaptureInfo"},
+        {0x004A0040, &APT_U::GetCaptureInfo, "GetCaptureInfo"},
         {0x004B00C2, &APT_U::AppletUtility, "AppletUtility"},
         {0x004C0000, nullptr, "SetFatalErrDispMode"},
         {0x004D0080, nullptr, "GetAppletProgramInfo"},


### PR DESCRIPTION
This one is similar to the ReceiveCaptureBufferInfo function except it doesn't clear the capture buffer, according to 3dbrew.

This function is used by the Home Menu

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5194)
<!-- Reviewable:end -->
