### PR TITLE
Debuggers/Qt: Show the threads process names and ids in the WaitTree widget

### DIFF
--- a/src/citra_qt/debugger/wait_tree.cpp
+++ b/src/citra_qt/debugger/wait_tree.cpp
@@ -216,6 +216,7 @@ std::vector<std::unique_ptr<WaitTreeItem>> WaitTreeThread::GetChildren() const {
     std::vector<std::unique_ptr<WaitTreeItem>> list(WaitTreeWaitObject::GetChildren());
 
     const auto& thread = static_cast<const Kernel::Thread&>(object);
+    const auto* process = thread.owner_process;
 
     QString processor;
     switch (thread.processor_id) {
@@ -238,6 +239,10 @@ std::vector<std::unique_ptr<WaitTreeItem>> WaitTreeThread::GetChildren() const {
 
     list.push_back(std::make_unique<WaitTreeText>(tr("processor = %1").arg(processor)));
     list.push_back(std::make_unique<WaitTreeText>(tr("thread id = %1").arg(thread.GetThreadId())));
+    list.push_back(
+        std::make_unique<WaitTreeText>(tr("process = %1 (%2)")
+                                           .arg(QString::fromStdString(process->GetName()))
+                                           .arg(process->process_id)));
     list.push_back(std::make_unique<WaitTreeText>(tr("priority = %1(current) / %2(normal)")
                                                       .arg(thread.current_priority)
                                                       .arg(thread.nominal_priority)));


### PR DESCRIPTION
It's easier to debug LLE bugs when you can actually see which thread belongs to which process in the wait list.
<img width="379" alt="image" src="https://user-images.githubusercontent.com/357072/79075731-3a2cd780-7cba-11ea-9fab-246402cca6bd.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5201)
<!-- Reviewable:end -->
