### PR TITLE
Services/FS: Stubbed GetSdmcArchiveResource and GetNandArchiveResource.

### DIFF
--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -288,6 +288,16 @@ ResultCode ArchiveManager::CreateSystemSaveData(u32 high, u32 low) {
     return RESULT_SUCCESS;
 }
 
+ResultVal<ArchiveResource> ArchiveManager::GetArchiveResource(MediaType media_type) const {
+    // TODO(Subv): Implement querying the actual size information for these storages.
+    ArchiveResource resource{};
+    resource.sector_size_in_bytes = 512;
+    resource.cluster_size_in_bytes = 16384;
+    resource.partition_capacity_in_clusters = 0x80000; // 8GiB capacity
+    resource.free_space_in_clusters = 0x80000;         // 8GiB free
+    return MakeResult(resource);
+}
+
 void ArchiveManager::RegisterArchiveTypes() {
     // TODO(Subv): Add the other archive types (see here for the known types:
     // http://3dbrew.org/wiki/FS:OpenArchive#Archive_idcodes).

--- a/src/core/hle/service/fs/archive.h
+++ b/src/core/hle/service/fs/archive.h
@@ -49,6 +49,14 @@ enum class MediaType : u32 { NAND = 0, SDMC = 1, GameCard = 2 };
 
 typedef u64 ArchiveHandle;
 
+struct ArchiveResource {
+    u32 sector_size_in_bytes;
+    u32 cluster_size_in_bytes;
+    u32 partition_capacity_in_clusters;
+    u32 free_space_in_clusters;
+};
+static_assert(sizeof(ArchiveResource) == 0x10, "ArchiveResource has incorrect size");
+
 using FileSys::ArchiveBackend;
 using FileSys::ArchiveFactory;
 
@@ -229,6 +237,13 @@ public:
      * @return ResultCode 0 on success or the corresponding code on error
      */
     ResultCode CreateSystemSaveData(u32 high, u32 low);
+
+    /**
+     * Returns capacity and free space information about the given media type.
+     * @param media_type The media type to obtain the information about.
+     * @return The capacity information of the media type, or an error code if failed.
+     */
+    ResultVal<ArchiveResource> GetArchiveResource(MediaType media_type) const;
 
     /// Registers a new NCCH file with the SelfNCCH archive factory
     void RegisterSelfNCCH(Loader::AppLoader& app_loader);

--- a/src/core/hle/service/fs/fs_user.h
+++ b/src/core/hle/service/fs/fs_user.h
@@ -292,6 +292,32 @@ private:
     void GetFreeBytes(Kernel::HLERequestContext& ctx);
 
     /**
+     * FS_User::GetSdmcArchiveResource service function.
+     *  Inputs:
+     *      0 : 0x08140000
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     *      2 : Sector byte-size
+     *      3 : Cluster byte-size
+     *      4 : Partition capacity in clusters
+     *      5 : Available free space in clusters
+     */
+    void GetSdmcArchiveResource(Kernel::HLERequestContext& ctx);
+
+    /**
+     * FS_User::GetNandArchiveResource service function.
+     *  Inputs:
+     *      0 : 0x08150000
+     *  Outputs:
+     *      1 : Result of function, 0 on success, otherwise error code
+     *      2 : Sector byte-size
+     *      3 : Cluster byte-size
+     *      4 : Partition capacity in clusters
+     *      5 : Available free space in clusters
+     */
+    void GetNandArchiveResource(Kernel::HLERequestContext& ctx);
+
+    /**
      * FS_User::CreateExtSaveData service function
      *  Inputs:
      *      0 : 0x08510242


### PR DESCRIPTION
Also rewritten how GetArchiveResource works so that they all use the same interface.
We should decide what to do with these at some point.

Related to #3131 and #3110

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5213)
<!-- Reviewable:end -->
