### PR TITLE
Port yuzu-emu/yuzu#3670: "CMakeLists: Make -Wreorder a compile-time error"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,6 +52,7 @@ if (MSVC)
 else()
     add_compile_options(
         -Wall
+        -Werror=reorder
         -Wno-attributes
     )
 


### PR DESCRIPTION
See yuzu-emu/yuzu#3670 for more details.

**Original description**:
This can result in silent logic bugs within code, and given the amount of times these kind of warnings are caused, they should be flagged at compile-time so no new code is submitted with them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5215)
<!-- Reviewable:end -->
