### PR TITLE
video_core: Attempt to remove the accurate multiplication setting

### DIFF
--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -119,7 +119,7 @@ void Config::ReadValues() {
     Settings::values.use_hw_shader = sdl2_config->GetBoolean("Renderer", "use_hw_shader", true);
 #endif
     Settings::values.shaders_accurate_mul =
-        sdl2_config->GetBoolean("Renderer", "shaders_accurate_mul", false);
+        sdl2_config->GetBoolean("Renderer", "shaders_accurate_mul", true);
     Settings::values.use_shader_jit = sdl2_config->GetBoolean("Renderer", "use_shader_jit", true);
     Settings::values.resolution_factor =
         static_cast<u16>(sdl2_config->GetInteger("Renderer", "resolution_factor", 1));

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -438,7 +438,7 @@ void Config::ReadRendererValues() {
     Settings::values.use_hw_shader = ReadSetting(QStringLiteral("use_hw_shader"), true).toBool();
 #endif
     Settings::values.shaders_accurate_mul =
-        ReadSetting(QStringLiteral("shaders_accurate_mul"), false).toBool();
+        ReadSetting(QStringLiteral("shaders_accurate_mul"), true).toBool();
     Settings::values.use_shader_jit = ReadSetting(QStringLiteral("use_shader_jit"), true).toBool();
     Settings::values.use_vsync_new = ReadSetting(QStringLiteral("use_vsync_new"), true).toBool();
     Settings::values.resolution_factor =

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -784,8 +784,10 @@ private:
             shader.AddLine("vec4 sanitize_mul(vec4 lhs, vec4 rhs) {");
             ++shader.scope;
             shader.AddLine("vec4 product = lhs * rhs;");
-            shader.AddLine("return mix(product, mix(mix(vec4(0.0), product, isnan(rhs)), product, "
-                           "isnan(lhs)), isnan(product));");
+            shader.AddLine(
+                "bvec4 condition = equal(ivec4(0), ivec4(isnan(lhs)) & ivec4(isnan(rhs)) & "
+                "ivec4(not(isnan(product))));");
+            shader.AddLine("return mix(vec4(0.0), product, condition);");
             --shader.scope;
             shader.AddLine("}\n");
         }


### PR DESCRIPTION
## Why?
The accurate multiplication setting has very little performance impact, but sanitize_mul doesn't work properly on some GPUs. We obviously want games to work correctly all the time, so ideally we would get rid of this setting. Removing it would also simplify the shader cache and resolve a bug where it grows constantly with accurate multiplication off.
## How?
From my understanding, the problems on some GPUS happen because `mix` with NaN inputs is undefined behavior. The current iteration of this PR doesn't get rid of mix entirely, but if it's necessary, this should definitely work:
```glsl
    bvec4 condition = equal(ivec4(0), ivec4(isnan(lhs)) & ivec4(isnan(rhs)) & ivec4(not(isnan(product))));
    return vec4(
    condition.x ? 0.0 : product.x,
    condition.y ? 0.0 : product.y,
    condition.z ? 0.0 : product.z,
    condition.w ? 0.0 : product.w
    );
```
I'm just less confident in some drivers' abilities to optimize this, despite the Mali Compiler claiming it's .1 cycle faster.

In its current state, this PR only enables accurate multiplication by default so we can get user reports if it's not working. If this fixes the problems, the next steps will be 

- [ ]  Remove the setting
- [ ]  Gut any related code from the disk shader cache.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5216)
<!-- Reviewable:end -->
