### PR TITLE
[WIP] Services/FS: Return 0xC8A04555 when trying to open a savedata archive that does not exist.

### DIFF
--- a/src/core/file_sys/errors.h
+++ b/src/core/file_sys/errors.h
@@ -23,7 +23,7 @@ enum {
     InvalidOpenFlags = 230,
     DirectoryNotEmpty = 240,
     NotAFile = 250,
-    NotFormatted = 340, ///< This is used by the FS service when creating a SaveData archive
+    NotFormatted = 341, ///< This is used by the FS service when creating a SaveData archive
     ExeFSSectionNotFound = 567,
     CommandNotAllowed = 630,
     InvalidReadFlag = 700,


### PR DESCRIPTION
This is in an attempt to fix Fractured Soul not creating the required files on the savedata upon first start.

This is just a test, the real 3DS seems to return this on some unknown circumstances, as verified by @Dragios using https://github.com/wwylele/3DS-FS-Tester

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5221)
<!-- Reviewable:end -->
