### PR TITLE
Port yuzu-emu/yuzu#3630: "common/file_util: Allow access to files on network shares"

### DIFF
--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -902,7 +902,14 @@ std::string SanitizePath(std::string_view path_, DirectorySeparator directory_se
     }
 
     std::replace(path.begin(), path.end(), type1, type2);
-    path.erase(std::unique(path.begin(), path.end(),
+
+    auto start = path.begin();
+#ifdef _WIN32
+    // allow network paths which start with a double backslash (e.g. \\server\share)
+    if (start != path.end())
+        ++start;
+#endif
+    path.erase(std::unique(start, path.end(),
                            [type2](char c1, char c2) { return c1 == type2 && c2 == type2; }),
                path.end());
     return std::string(RemoveTrailingSlash(path));


### PR DESCRIPTION
See yuzu-emu/yuzu#3630 for more details.

**Original description**: 
On Windows, network shares use paths like \\server\share\file which were being broken by FileUtil::SanitizePath() removing double slashes.

Changed the code in SanitizePath to permit a double-backslash if it occurs at the start of a filepath (on Windows only).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5224)
<!-- Reviewable:end -->
