### PR TITLE
Add flag to disable seperable shaders for osx Intel GPUs. 

### DIFF
--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -115,7 +115,8 @@ void Config::ReadValues() {
     // Separable shader is broken on macos with Intel GPU thanks to poor drivers.
     // We still want to provide this option for test/development purposes, but disable it by
     // default.
-    Settings::values.separable_shader = sdl2_config->GetBoolean("Renderer", "separable_shader", false);
+    Settings::values.separable_shader =
+        sdl2_config->GetBoolean("Renderer", "separable_shader", false);
 #endif
     Settings::values.shaders_accurate_mul =
         sdl2_config->GetBoolean("Renderer", "shaders_accurate_mul", false);

--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -110,13 +110,12 @@ void Config::ReadValues() {
     // Renderer
     Settings::values.use_gles = sdl2_config->GetBoolean("Renderer", "use_gles", false);
     Settings::values.use_hw_renderer = sdl2_config->GetBoolean("Renderer", "use_hw_renderer", true);
+    Settings::values.use_hw_shader = sdl2_config->GetBoolean("Renderer", "use_hw_shader", true);
 #ifdef __APPLE__
     // Hardware shader is broken on macos thanks to poor drivers.
     // We still want to provide this option for test/development purposes, but disable it by
     // default.
-    Settings::values.use_hw_shader = sdl2_config->GetBoolean("Renderer", "use_hw_shader", false);
-#else
-    Settings::values.use_hw_shader = sdl2_config->GetBoolean("Renderer", "use_hw_shader", true);
+    Settings::values.seperable_shader = sdl2_config->GetBoolean("Renderer", "seperable_shader", false);
 #endif
     Settings::values.shaders_accurate_mul =
         sdl2_config->GetBoolean("Renderer", "shaders_accurate_mul", false);

--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -112,10 +112,10 @@ void Config::ReadValues() {
     Settings::values.use_hw_renderer = sdl2_config->GetBoolean("Renderer", "use_hw_renderer", true);
     Settings::values.use_hw_shader = sdl2_config->GetBoolean("Renderer", "use_hw_shader", true);
 #ifdef __APPLE__
-    // Hardware shader is broken on macos thanks to poor drivers.
+    // Separable shader is broken on macos with Intel GPU thanks to poor drivers.
     // We still want to provide this option for test/development purposes, but disable it by
     // default.
-    Settings::values.seperable_shader = sdl2_config->GetBoolean("Renderer", "seperable_shader", false);
+    Settings::values.separable_shader = sdl2_config->GetBoolean("Renderer", "separable_shader", false);
 #endif
     Settings::values.shaders_accurate_mul =
         sdl2_config->GetBoolean("Renderer", "shaders_accurate_mul", false);

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -110,6 +110,10 @@ use_hw_renderer =
 # 0: Software, 1 (default): Hardware
 use_hw_shader =
 
+# Whether to use seperable shaders to emulate 3DS shaders (macOS only)
+# 0: Off (Default), 1 : On
+seperable_shader =
+
 # Whether to use accurate multiplication in hardware shaders
 # 0: Off (Default. Faster, but causes issues in some games) 1: On (Slower, but correct)
 shaders_accurate_mul =

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -110,9 +110,9 @@ use_hw_renderer =
 # 0: Software, 1 (default): Hardware
 use_hw_shader =
 
-# Whether to use seperable shaders to emulate 3DS shaders (macOS only)
+# Whether to use separable shaders to emulate 3DS shaders (macOS only)
 # 0: Off (Default), 1 : On
-seperable_shader =
+separable_shader =
 
 # Whether to use accurate multiplication in hardware shaders
 # 0: Off (Default. Faster, but causes issues in some games) 1: On (Slower, but correct)

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -436,7 +436,7 @@ void Config::ReadRendererValues() {
     // Hardware shader is broken on macos thanks to poor drivers.
     // We still want to provide this option for test/development purposes, but disable it by
     // default.
-    Settings::values.seperable_shader = ReadSetting(QStringLiteral("seperable_shader"), false).toBool();
+    Settings::values.separable_shader = ReadSetting(QStringLiteral("separable_shader"), false).toBool();
 #endif
     Settings::values.shaders_accurate_mul =
         ReadSetting(QStringLiteral("shaders_accurate_mul"), false).toBool();
@@ -919,7 +919,7 @@ void Config::SaveRendererValues() {
 #ifdef __APPLE__
     // Hardware shader is broken on macos thanks to poor drivers.
     // TODO: enable this for none Intel GPUs
-    WriteSetting(QStringLiteral("use_seperable_shader"), Settings::values.seperable_shader, false);
+    WriteSetting(QStringLiteral("use_separable_shader"), Settings::values.separable_shader, false);
 #endif
     WriteSetting(QStringLiteral("shaders_accurate_mul"), Settings::values.shaders_accurate_mul,
                  false);

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -431,13 +431,12 @@ void Config::ReadRendererValues() {
 
     Settings::values.use_hw_renderer =
         ReadSetting(QStringLiteral("use_hw_renderer"), true).toBool();
+    Settings::values.use_hw_shader = ReadSetting(QStringLiteral("use_hw_shader"), true).toBool();
 #ifdef __APPLE__
     // Hardware shader is broken on macos thanks to poor drivers.
     // We still want to provide this option for test/development purposes, but disable it by
     // default.
-    Settings::values.use_hw_shader = ReadSetting(QStringLiteral("use_hw_shader"), false).toBool();
-#else
-    Settings::values.use_hw_shader = ReadSetting(QStringLiteral("use_hw_shader"), true).toBool();
+    Settings::values.seperable_shader = ReadSetting(QStringLiteral("seperable_shader"), false).toBool();
 #endif
     Settings::values.shaders_accurate_mul =
         ReadSetting(QStringLiteral("shaders_accurate_mul"), false).toBool();
@@ -916,13 +915,11 @@ void Config::SaveRendererValues() {
     qt_config->beginGroup(QStringLiteral("Renderer"));
 
     WriteSetting(QStringLiteral("use_hw_renderer"), Settings::values.use_hw_renderer, true);
+    WriteSetting(QStringLiteral("use_hw_shader"), Settings::values.use_hw_shader, true);
 #ifdef __APPLE__
     // Hardware shader is broken on macos thanks to poor drivers.
-    // We still want to provide this option for test/development purposes, but disable it by
-    // default.
-    WriteSetting(QStringLiteral("use_hw_shader"), Settings::values.use_hw_shader, false);
-#else
-    WriteSetting(QStringLiteral("use_hw_shader"), Settings::values.use_hw_shader, true);
+    // TODO: enable this for none Intel GPUs
+    WriteSetting(QStringLiteral("use_seperable_shader"), Settings::values.seperable_shader, false);
 #endif
     WriteSetting(QStringLiteral("shaders_accurate_mul"), Settings::values.shaders_accurate_mul,
                  false);

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -433,10 +433,11 @@ void Config::ReadRendererValues() {
         ReadSetting(QStringLiteral("use_hw_renderer"), true).toBool();
     Settings::values.use_hw_shader = ReadSetting(QStringLiteral("use_hw_shader"), true).toBool();
 #ifdef __APPLE__
-    // Hardware shader is broken on macos thanks to poor drivers.
+    // Hardware shader is broken on macos with Intel GPUs thanks to poor drivers.
     // We still want to provide this option for test/development purposes, but disable it by
     // default.
-    Settings::values.separable_shader = ReadSetting(QStringLiteral("separable_shader"), false).toBool();
+    Settings::values.separable_shader =
+        ReadSetting(QStringLiteral("separable_shader"), false).toBool();
 #endif
     Settings::values.shaders_accurate_mul =
         ReadSetting(QStringLiteral("shaders_accurate_mul"), false).toBool();

--- a/src/citra_qt/configuration/configure_graphics.cpp
+++ b/src/citra_qt/configuration/configure_graphics.cpp
@@ -30,14 +30,22 @@ ConfigureGraphics::ConfigureGraphics(QWidget* parent)
 #ifdef __APPLE__
     connect(ui->toggle_hw_shader, &QCheckBox::stateChanged, this, [this](int state) {
         if (state == Qt::Checked) {
+            ui->toggle_seperable_shader->setEnabled(true);
+        }
+    });
+    connect(ui->toggle_seperable_shader, &QCheckBox::stateChanged, this, [this](int state) {
+        if (state == Qt::Checked) {
             QMessageBox::warning(
                 this, tr("Hardware Shader Warning"),
-                tr("Hardware Shader support is broken on macOS, and will cause graphical issues "
+                tr("Seperable Shader support is broken on macOS with Intel GPUs, and will cause graphical issues "
                    "like showing a black screen.<br><br>The option is only there for "
                    "test/development purposes. If you experience graphical issues with Hardware "
                    "Shader, please turn it off."));
         }
     });
+#else
+    // TODO(B3N30): Hide this for macs with none Intel GPUs, too.
+    ui->toggle_seperable_shader->visible(false);
 #endif
 }
 
@@ -46,6 +54,7 @@ ConfigureGraphics::~ConfigureGraphics() = default;
 void ConfigureGraphics::SetConfiguration() {
     ui->toggle_hw_renderer->setChecked(Settings::values.use_hw_renderer);
     ui->toggle_hw_shader->setChecked(Settings::values.use_hw_shader);
+    ui->toggle_seperable_shader->setChecked(Settings::values.seperable_shader);
     ui->toggle_accurate_mul->setChecked(Settings::values.shaders_accurate_mul);
     ui->toggle_shader_jit->setChecked(Settings::values.use_shader_jit);
     ui->toggle_vsync_new->setChecked(Settings::values.use_vsync_new);
@@ -54,6 +63,7 @@ void ConfigureGraphics::SetConfiguration() {
 void ConfigureGraphics::ApplyConfiguration() {
     Settings::values.use_hw_renderer = ui->toggle_hw_renderer->isChecked();
     Settings::values.use_hw_shader = ui->toggle_hw_shader->isChecked();
+    Settings::values.seperable_shader = ui->toggle_seperable_shader->isChecked();
     Settings::values.shaders_accurate_mul = ui->toggle_accurate_mul->isChecked();
     Settings::values.use_shader_jit = ui->toggle_shader_jit->isChecked();
     Settings::values.use_vsync_new = ui->toggle_vsync_new->isChecked();

--- a/src/citra_qt/configuration/configure_graphics.cpp
+++ b/src/citra_qt/configuration/configure_graphics.cpp
@@ -37,7 +37,8 @@ ConfigureGraphics::ConfigureGraphics(QWidget* parent)
         if (state == Qt::Checked) {
             QMessageBox::warning(
                 this, tr("Hardware Shader Warning"),
-                tr("Separable Shader support is broken on macOS with Intel GPUs, and will cause graphical issues "
+                tr("Separable Shader support is broken on macOS with Intel GPUs, and will cause "
+                   "graphical issues "
                    "like showing a black screen.<br><br>The option is only there for "
                    "test/development purposes. If you experience graphical issues with Hardware "
                    "Shader, please turn it off."));

--- a/src/citra_qt/configuration/configure_graphics.cpp
+++ b/src/citra_qt/configuration/configure_graphics.cpp
@@ -30,14 +30,14 @@ ConfigureGraphics::ConfigureGraphics(QWidget* parent)
 #ifdef __APPLE__
     connect(ui->toggle_hw_shader, &QCheckBox::stateChanged, this, [this](int state) {
         if (state == Qt::Checked) {
-            ui->toggle_seperable_shader->setEnabled(true);
+            ui->toggle_separable_shader->setEnabled(true);
         }
     });
-    connect(ui->toggle_seperable_shader, &QCheckBox::stateChanged, this, [this](int state) {
+    connect(ui->toggle_separable_shader, &QCheckBox::stateChanged, this, [this](int state) {
         if (state == Qt::Checked) {
             QMessageBox::warning(
                 this, tr("Hardware Shader Warning"),
-                tr("Seperable Shader support is broken on macOS with Intel GPUs, and will cause graphical issues "
+                tr("Separable Shader support is broken on macOS with Intel GPUs, and will cause graphical issues "
                    "like showing a black screen.<br><br>The option is only there for "
                    "test/development purposes. If you experience graphical issues with Hardware "
                    "Shader, please turn it off."));
@@ -45,7 +45,7 @@ ConfigureGraphics::ConfigureGraphics(QWidget* parent)
     });
 #else
     // TODO(B3N30): Hide this for macs with none Intel GPUs, too.
-    ui->toggle_seperable_shader->visible(false);
+    ui->toggle_separable_shader->setVisible(false);
 #endif
 }
 
@@ -54,7 +54,7 @@ ConfigureGraphics::~ConfigureGraphics() = default;
 void ConfigureGraphics::SetConfiguration() {
     ui->toggle_hw_renderer->setChecked(Settings::values.use_hw_renderer);
     ui->toggle_hw_shader->setChecked(Settings::values.use_hw_shader);
-    ui->toggle_seperable_shader->setChecked(Settings::values.seperable_shader);
+    ui->toggle_separable_shader->setChecked(Settings::values.separable_shader);
     ui->toggle_accurate_mul->setChecked(Settings::values.shaders_accurate_mul);
     ui->toggle_shader_jit->setChecked(Settings::values.use_shader_jit);
     ui->toggle_vsync_new->setChecked(Settings::values.use_vsync_new);
@@ -63,7 +63,7 @@ void ConfigureGraphics::SetConfiguration() {
 void ConfigureGraphics::ApplyConfiguration() {
     Settings::values.use_hw_renderer = ui->toggle_hw_renderer->isChecked();
     Settings::values.use_hw_shader = ui->toggle_hw_shader->isChecked();
-    Settings::values.seperable_shader = ui->toggle_seperable_shader->isChecked();
+    Settings::values.separable_shader = ui->toggle_separable_shader->isChecked();
     Settings::values.shaders_accurate_mul = ui->toggle_accurate_mul->isChecked();
     Settings::values.use_shader_jit = ui->toggle_shader_jit->isChecked();
     Settings::values.use_vsync_new = ui->toggle_vsync_new->isChecked();

--- a/src/citra_qt/configuration/configure_graphics.ui
+++ b/src/citra_qt/configuration/configure_graphics.ui
@@ -77,6 +77,13 @@
              <number>0</number>
             </property>
             <item>
+             <widget class="QCheckBox" name="toggle_seperable_shader">
+              <property name="text">
+               <string>Seperable Shader (Intel GPUs only)</string>
+              </property>
+             </widget>
+            </item>
+            <item>
              <widget class="QCheckBox" name="toggle_accurate_mul">
               <property name="toolTip">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Correctly handle all edge cases in multiplication operation in shaders. &lt;/p&gt;&lt;p&gt;Some games requires this to be enabled for the hardware shader to render properly.&lt;/p&gt;&lt;p&gt;However this would reduce performance in most games.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>

--- a/src/citra_qt/configuration/configure_graphics.ui
+++ b/src/citra_qt/configuration/configure_graphics.ui
@@ -77,9 +77,9 @@
              <number>0</number>
             </property>
             <item>
-             <widget class="QCheckBox" name="toggle_seperable_shader">
+             <widget class="QCheckBox" name="toggle_separable_shader">
               <property name="text">
-               <string>Seperable Shader (Intel GPUs only)</string>
+               <string>Separable Shader (Intel GPUs only)</string>
               </property>
              </widget>
             </item>

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -27,7 +27,7 @@ void Apply() {
     VideoCore::g_hw_renderer_enabled = values.use_hw_renderer;
     VideoCore::g_shader_jit_enabled = values.use_shader_jit;
     VideoCore::g_hw_shader_enabled = values.use_hw_shader;
-    VideoCore::g_seperable_shader_enabled = values.seperable_shader;
+    VideoCore::g_separable_shader_enabled = values.separable_shader;
     VideoCore::g_hw_shader_accurate_mul = values.shaders_accurate_mul;
     VideoCore::g_use_disk_shader_cache = values.use_disk_shader_cache;
 
@@ -79,7 +79,7 @@ void LogSettings() {
     LogSetting("Renderer_UseGLES", Settings::values.use_gles);
     LogSetting("Renderer_UseHwRenderer", Settings::values.use_hw_renderer);
     LogSetting("Renderer_UseHwShader", Settings::values.use_hw_shader);
-    LogSetting("Renderer_SeperableShader", Settings::values.seperable_shader);
+    LogSetting("Renderer_SeparableShader", Settings::values.separable_shader);
     LogSetting("Renderer_ShadersAccurateMul", Settings::values.shaders_accurate_mul);
     LogSetting("Renderer_UseShaderJit", Settings::values.use_shader_jit);
     LogSetting("Renderer_UseResolutionFactor", Settings::values.resolution_factor);

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -27,6 +27,7 @@ void Apply() {
     VideoCore::g_hw_renderer_enabled = values.use_hw_renderer;
     VideoCore::g_shader_jit_enabled = values.use_shader_jit;
     VideoCore::g_hw_shader_enabled = values.use_hw_shader;
+    VideoCore::g_seperable_shader_enabled = values.seperable_shader;
     VideoCore::g_hw_shader_accurate_mul = values.shaders_accurate_mul;
     VideoCore::g_use_disk_shader_cache = values.use_disk_shader_cache;
 
@@ -78,6 +79,7 @@ void LogSettings() {
     LogSetting("Renderer_UseGLES", Settings::values.use_gles);
     LogSetting("Renderer_UseHwRenderer", Settings::values.use_hw_renderer);
     LogSetting("Renderer_UseHwShader", Settings::values.use_hw_shader);
+    LogSetting("Renderer_SeperableShader", Settings::values.seperable_shader);
     LogSetting("Renderer_ShadersAccurateMul", Settings::values.shaders_accurate_mul);
     LogSetting("Renderer_UseShaderJit", Settings::values.use_shader_jit);
     LogSetting("Renderer_UseResolutionFactor", Settings::values.resolution_factor);

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -142,7 +142,7 @@ struct Values {
     bool use_gles;
     bool use_hw_renderer;
     bool use_hw_shader;
-    bool seperable_shader;
+    bool separable_shader;
     bool use_disk_shader_cache;
     bool shaders_accurate_mul;
     bool use_shader_jit;

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -142,6 +142,7 @@ struct Values {
     bool use_gles;
     bool use_hw_renderer;
     bool use_hw_shader;
+    bool seperable_shader;
     bool use_disk_shader_cache;
     bool shaders_accurate_mul;
     bool use_shader_jit;

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -168,7 +168,7 @@ RasterizerOpenGL::RasterizerOpenGL(Frontend::EmuWindow& window)
 #ifdef __APPLE__
     if (IsVendorIntel()) {
         shader_program_manager = std::make_unique<ShaderProgramManager>(
-            VideoCore::g_seperable_shader_enabled ? GLAD_GL_ARB_separate_shader_objects : false,
+            VideoCore::g_separable_shader_enabled ? GLAD_GL_ARB_separate_shader_objects : false,
             is_amd);
     } else {
         shader_program_manager =

--- a/src/video_core/video_core.cpp
+++ b/src/video_core/video_core.cpp
@@ -23,6 +23,7 @@ std::unique_ptr<RendererBase> g_renderer; ///< Renderer plugin
 std::atomic<bool> g_hw_renderer_enabled;
 std::atomic<bool> g_shader_jit_enabled;
 std::atomic<bool> g_hw_shader_enabled;
+std::atomic<bool> g_seperable_shader_enabled;
 std::atomic<bool> g_hw_shader_accurate_mul;
 std::atomic<bool> g_use_disk_shader_cache;
 std::atomic<bool> g_renderer_bg_color_update_requested;

--- a/src/video_core/video_core.cpp
+++ b/src/video_core/video_core.cpp
@@ -23,7 +23,7 @@ std::unique_ptr<RendererBase> g_renderer; ///< Renderer plugin
 std::atomic<bool> g_hw_renderer_enabled;
 std::atomic<bool> g_shader_jit_enabled;
 std::atomic<bool> g_hw_shader_enabled;
-std::atomic<bool> g_seperable_shader_enabled;
+std::atomic<bool> g_separable_shader_enabled;
 std::atomic<bool> g_hw_shader_accurate_mul;
 std::atomic<bool> g_use_disk_shader_cache;
 std::atomic<bool> g_renderer_bg_color_update_requested;

--- a/src/video_core/video_core.h
+++ b/src/video_core/video_core.h
@@ -31,6 +31,7 @@ extern std::unique_ptr<RendererBase> g_renderer; ///< Renderer plugin
 extern std::atomic<bool> g_hw_renderer_enabled;
 extern std::atomic<bool> g_shader_jit_enabled;
 extern std::atomic<bool> g_hw_shader_enabled;
+extern std::atomic<bool> g_seperable_shader_enabled;
 extern std::atomic<bool> g_hw_shader_accurate_mul;
 extern std::atomic<bool> g_use_disk_shader_cache;
 extern std::atomic<bool> g_renderer_bg_color_update_requested;

--- a/src/video_core/video_core.h
+++ b/src/video_core/video_core.h
@@ -31,7 +31,7 @@ extern std::unique_ptr<RendererBase> g_renderer; ///< Renderer plugin
 extern std::atomic<bool> g_hw_renderer_enabled;
 extern std::atomic<bool> g_shader_jit_enabled;
 extern std::atomic<bool> g_hw_shader_enabled;
-extern std::atomic<bool> g_seperable_shader_enabled;
+extern std::atomic<bool> g_separable_shader_enabled;
 extern std::atomic<bool> g_hw_shader_accurate_mul;
 extern std::atomic<bool> g_use_disk_shader_cache;
 extern std::atomic<bool> g_renderer_bg_color_update_requested;


### PR DESCRIPTION
This is an OSX only change:

On OSX with Intel GPUs it seems seperable shaders are broken.

So this change enables HW shaders by default but adds a flag to disable seperable shaders. This flag only matters on OSX systems with Intel GPUs. There the option is default off, enabling it will bring a warning msgBox.
![Bildschirmfoto 2020-04-18 um 13 38 47](https://user-images.githubusercontent.com/26032316/79636764-59c07600-817a-11ea-8515-2cd86a529b39.png)

The checkbox is only visible on OSX. On all other systems this option isn't visible
Changing this option in the ini file has no effect on other systems

TODO:
- [ ] Hide the checkbox for seperable shader on OSX systems without an Intel GPU

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5230)
<!-- Reviewable:end -->
