### PR TITLE
Fix Address Arbiter serialization

### DIFF
--- a/src/core/hle/kernel/address_arbiter.cpp
+++ b/src/core/hle/kernel/address_arbiter.cpp
@@ -81,12 +81,12 @@ std::shared_ptr<AddressArbiter> KernelSystem::CreateAddressArbiter(std::string n
 
 class AddressArbiter::Callback : public WakeupCallback {
 public:
-    Callback(AddressArbiter& _parent) : parent(_parent) {}
+    explicit Callback(AddressArbiter& _parent) : parent(_parent) {}
     AddressArbiter& parent;
 
     void WakeUp(ThreadWakeupReason reason, std::shared_ptr<Thread> thread,
                 std::shared_ptr<WaitObject> object) override {
-        parent.WakeUp(reason, thread, object);
+        parent.WakeUp(reason, std::move(thread), std::move(object));
     }
 
 private:

--- a/src/core/hle/kernel/address_arbiter.cpp
+++ b/src/core/hle/kernel/address_arbiter.cpp
@@ -84,7 +84,7 @@ public:
     std::shared_ptr<AddressArbiter> parent;
 
     void WakeUp(ThreadWakeupReason reason, std::shared_ptr<Thread> thread,
-        std::shared_ptr<WaitObject> object) override {
+                std::shared_ptr<WaitObject> object) override {
         parent->WakeUp(reason, thread, object);
     }
 
@@ -103,7 +103,7 @@ void AddressArbiter::WakeUp(ThreadWakeupReason reason, std::shared_ptr<Thread> t
     ASSERT(reason == ThreadWakeupReason::Timeout);
     // Remove the newly-awakened thread from the Arbiter's waiting list.
     waiting_threads.erase(std::remove(waiting_threads.begin(), waiting_threads.end(), thread),
-                            waiting_threads.end());
+                          waiting_threads.end());
 };
 
 ResultCode AddressArbiter::ArbitrateAddress(std::shared_ptr<Thread> thread, ArbitrationType type,

--- a/src/core/hle/kernel/address_arbiter.h
+++ b/src/core/hle/kernel/address_arbiter.h
@@ -59,8 +59,7 @@ public:
     ResultCode ArbitrateAddress(std::shared_ptr<Thread> thread, ArbitrationType type, VAddr address,
                                 s32 value, u64 nanoseconds);
 
-    void WakeUp(ThreadWakeupReason reason, std::shared_ptr<Thread> thread,
-                std::shared_ptr<WaitObject> object);
+    class Callback;
 
 private:
     KernelSystem& kernel;
@@ -78,20 +77,39 @@ private:
     /// Threads waiting for the address arbiter to be signaled.
     std::vector<std::shared_ptr<Thread>> waiting_threads;
 
+    std::shared_ptr<Callback> timeout_callback;
+
+    void WakeUp(ThreadWakeupReason reason, std::shared_ptr<Thread> thread,
+                std::shared_ptr<WaitObject> object);
+
+    class DummyCallback : public WakeupCallback {
+    public:
+        void WakeUp(ThreadWakeupReason reason, std::shared_ptr<Thread> thread,
+                    std::shared_ptr<WaitObject> object) override {}
+    };
+
     friend class boost::serialization::access;
     template <class Archive>
     void serialize(Archive& ar, const unsigned int file_version) {
         ar& boost::serialization::base_object<Object>(*this);
-        if (file_version > 0) {
-            ar& boost::serialization::base_object<WakeupCallback>(*this);
+        if (file_version == 1) {
+            // This rigmarole is needed because in past versions, AddressArbiter inherited WakeupCallback
+            // But it turns out this breaks shared_from_this, so we split it out.
+            // Using a dummy class to deserialize a base_object allows compatibility to be maintained.
+            DummyCallback x;
+            ar& boost::serialization::base_object<WakeupCallback>(x);
         }
         ar& name;
         ar& waiting_threads;
+        if (file_version > 1) {
+            ar& timeout_callback;
+        }
     }
 };
 
 } // namespace Kernel
 
 BOOST_CLASS_EXPORT_KEY(Kernel::AddressArbiter)
-BOOST_CLASS_VERSION(Kernel::AddressArbiter, 1)
+BOOST_CLASS_EXPORT_KEY(Kernel::AddressArbiter::Callback)
+BOOST_CLASS_VERSION(Kernel::AddressArbiter, 2)
 CONSTRUCT_KERNEL_OBJECT(Kernel::AddressArbiter)

--- a/src/core/hle/kernel/address_arbiter.h
+++ b/src/core/hle/kernel/address_arbiter.h
@@ -93,9 +93,10 @@ private:
     void serialize(Archive& ar, const unsigned int file_version) {
         ar& boost::serialization::base_object<Object>(*this);
         if (file_version == 1) {
-            // This rigmarole is needed because in past versions, AddressArbiter inherited WakeupCallback
-            // But it turns out this breaks shared_from_this, so we split it out.
-            // Using a dummy class to deserialize a base_object allows compatibility to be maintained.
+            // This rigmarole is needed because in past versions, AddressArbiter inherited
+            // WakeupCallback But it turns out this breaks shared_from_this, so we split it out.
+            // Using a dummy class to deserialize a base_object allows compatibility to be
+            // maintained.
             DummyCallback x;
             ar& boost::serialization::base_object<WakeupCallback>(x);
         }


### PR DESCRIPTION
There was a bug in AddressArbiter that would break shared_from_this during deserialization, if the savestate was made while waiting on an address, depending on the exact serialization order. This fixes that, allowing saves to be made in games like Detective Pikachu. Compatibility with previous saves has been maintained as much as possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5231)
<!-- Reviewable:end -->
