### PR TITLE
core/memory: Resolve sign conversion in serialize()

### DIFF
--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -144,7 +144,7 @@ private:
         ar& pointers.refs;
         ar& special_regions;
         ar& attributes;
-        for (auto i = 0; i < PAGE_TABLE_NUM_ENTRIES; i++) {
+        for (std::size_t i = 0; i < PAGE_TABLE_NUM_ENTRIES; i++) {
             pointers.raw[i] = pointers.refs[i].GetPtr();
         }
     }


### PR DESCRIPTION
`auto i = 0` deduces to an int, which was being compared with a size_t within the loop condition.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5232)
<!-- Reviewable:end -->
