### PR TITLE
kernel/shared_page: Silence missing return warning in GetInitTime()

### DIFF
--- a/src/core/hle/kernel/shared_page.cpp
+++ b/src/core/hle/kernel/shared_page.cpp
@@ -5,6 +5,7 @@
 #include <chrono>
 #include <cstring>
 #include "common/archives.h"
+#include "common/assert.h"
 #include "core/core.h"
 #include "core/core_timing.h"
 #include "core/hle/kernel/shared_page.h"
@@ -30,8 +31,8 @@ template void load_construct_data<iarchive>(iarchive& ar, SharedPage::Handler* t
 namespace SharedPage {
 
 static std::chrono::seconds GetInitTime() {
-    u64 override_init_time = Core::Movie::GetInstance().GetOverrideInitTime();
-    if (override_init_time) {
+    const u64 override_init_time = Core::Movie::GetInstance().GetOverrideInitTime();
+    if (override_init_time != 0) {
         // Override the clock init time with the one in the movie
         return std::chrono::seconds(override_init_time);
     }
@@ -48,6 +49,9 @@ static std::chrono::seconds GetInitTime() {
     }
     case Settings::InitClock::FixedTime:
         return std::chrono::seconds(Settings::values.init_time);
+    default:
+        UNREACHABLE_MSG("Invalid InitClock value ({})",
+                        static_cast<u32>(Settings::values.init_clock));
     }
 }
 


### PR DESCRIPTION
We can use `UNREACHABLE_MSG` to indicate that this path isn't intended to be reached, as it would indicate a wrong enum value.

While we're in the same area we can make the immutability of `override_init_time` explicit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5238)
<!-- Reviewable:end -->
