### PR TITLE
video_core: Amend misplaced forward declarations

### DIFF
--- a/src/video_core/renderer_base.h
+++ b/src/video_core/renderer_base.h
@@ -13,10 +13,6 @@ namespace Frontend {
 class EmuWindow;
 }
 
-namespace FrameDumper {
-class Backend;
-}
-
 class RendererBase : NonCopyable {
 public:
     explicit RendererBase(Frontend::EmuWindow& window);

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -33,9 +33,8 @@ namespace Frontend {
 class EmuWindow;
 }
 
-class ShaderProgramManager;
-
 namespace OpenGL {
+class ShaderProgramManager;
 
 class RasterizerOpenGL : public VideoCore::RasterizerInterface {
 public:


### PR DESCRIPTION
ShaderProgramManager was placed within the wrong namespace. Backend simply isn't necessary, so it can be removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5239)
<!-- Reviewable:end -->
