### PR TITLE
primitive_assembly: Minor changes

### DIFF
--- a/src/video_core/primitive_assembly.cpp
+++ b/src/video_core/primitive_assembly.cpp
@@ -15,7 +15,7 @@ PrimitiveAssembler<VertexType>::PrimitiveAssembler(PipelineRegs::TriangleTopolog
 
 template <typename VertexType>
 void PrimitiveAssembler<VertexType>::SubmitVertex(const VertexType& vtx,
-                                                  TriangleHandler triangle_handler) {
+                                                  const TriangleHandler& triangle_handler) {
     switch (topology) {
     case PipelineRegs::TriangleTopology::List:
     case PipelineRegs::TriangleTopology::Shader:

--- a/src/video_core/primitive_assembly.cpp
+++ b/src/video_core/primitive_assembly.cpp
@@ -11,7 +11,7 @@ namespace Pica {
 
 template <typename VertexType>
 PrimitiveAssembler<VertexType>::PrimitiveAssembler(PipelineRegs::TriangleTopology topology)
-    : topology(topology), buffer_index(0) {}
+    : topology(topology) {}
 
 template <typename VertexType>
 void PrimitiveAssembler<VertexType>::SubmitVertex(const VertexType& vtx,

--- a/src/video_core/primitive_assembly.h
+++ b/src/video_core/primitive_assembly.h
@@ -29,7 +29,7 @@ struct PrimitiveAssembler {
      * NOTE: We could specify the triangle handler in the constructor, but this way we can
      * keep event and handler code next to each other.
      */
-    void SubmitVertex(const VertexType& vtx, TriangleHandler triangle_handler);
+    void SubmitVertex(const VertexType& vtx, const TriangleHandler& triangle_handler);
 
     /**
      * Invert the vertex order of the next triangle. Called by geometry shader emitter.

--- a/src/video_core/primitive_assembly.h
+++ b/src/video_core/primitive_assembly.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <array>
 #include <functional>
 #include <boost/serialization/access.hpp>
 #include "video_core/regs_pipeline.h"
@@ -59,8 +60,8 @@ struct PrimitiveAssembler {
 private:
     PipelineRegs::TriangleTopology topology;
 
-    int buffer_index;
-    VertexType buffer[2];
+    int buffer_index = 0;
+    std::array<VertexType, 2> buffer;
     bool strip_ready = false;
     bool winding = false;
 

--- a/src/video_core/primitive_assembly.h
+++ b/src/video_core/primitive_assembly.h
@@ -20,7 +20,7 @@ struct PrimitiveAssembler {
     using TriangleHandler =
         std::function<void(const VertexType& v0, const VertexType& v1, const VertexType& v2)>;
 
-    PrimitiveAssembler(
+    explicit PrimitiveAssembler(
         PipelineRegs::TriangleTopology topology = PipelineRegs::TriangleTopology::List);
 
     /*


### PR DESCRIPTION
Makes use of `std::array` and also makes the constructor explicit. We can also make the triangle handler so that the std::function doesn't need to be copied unnecessarily (since it's not stored anywhere).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5240)
<!-- Reviewable:end -->
