### PR TITLE
pica_state: Make use of std::array where applicable

### DIFF
--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -4,6 +4,7 @@
 
 #include <array>
 #include <cstddef>
+#include <cstring>
 #include <memory>
 #include <utility>
 #include "common/assert.h"
@@ -86,8 +87,11 @@ static void WriteUniformFloatReg(ShaderRegs& config, Shader::ShaderSetup& setup,
 
             // NOTE: The destination component order indeed is "backwards"
             if (uniform_setup.IsFloat32()) {
-                for (auto i : {0, 1, 2, 3})
-                    uniform[3 - i] = float24::FromFloat32(*(float*)(&uniform_write_buffer[i]));
+                for (auto i : {0, 1, 2, 3}) {
+                    float buffer_value;
+                    std::memcpy(&buffer_value, &uniform_write_buffer[i], sizeof(float));
+                    uniform[3 - i] = float24::FromFloat32(buffer_value);
+                }
             } else {
                 // TODO: Untested
                 uniform.w = float24::FromRaw(uniform_write_buffer[0] >> 8);

--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -31,7 +31,7 @@
 namespace Pica::CommandProcessor {
 
 // Expand a 4-bit mask to 4-byte mask, e.g. 0b0101 -> 0x00FF00FF
-static const u32 expand_bits_to_bytes[] = {
+constexpr std::array<u32, 16> expand_bits_to_bytes{
     0x00000000, 0x000000ff, 0x0000ff00, 0x0000ffff, 0x00ff0000, 0x00ff00ff, 0x00ffff00, 0x00ffffff,
     0xff000000, 0xff0000ff, 0xff00ff00, 0xff00ffff, 0xffff0000, 0xffff00ff, 0xffffff00, 0xffffffff,
 };
@@ -62,7 +62,8 @@ static void WriteUniformIntReg(Shader::ShaderSetup& setup, unsigned index,
 }
 
 static void WriteUniformFloatReg(ShaderRegs& config, Shader::ShaderSetup& setup,
-                                 int& float_regs_counter, u32 uniform_write_buffer[4], u32 value) {
+                                 int& float_regs_counter, std::array<u32, 4>& uniform_write_buffer,
+                                 u32 value) {
     auto& uniform_setup = config.uniform_setup;
 
     // TODO: Does actual hardware indeed keep an intermediate buffer or does

--- a/src/video_core/pica.cpp
+++ b/src/video_core/pica.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <cstring>
+#include <type_traits>
 #include "core/global.h"
 #include "video_core/geometry_pipeline.h"
 #include "video_core/pica.h"
@@ -31,6 +32,8 @@ void Shutdown() {
 
 template <typename T>
 void Zero(T& o) {
+    static_assert(std::is_trivially_copyable_v<T>,
+                  "It's undefined behavior to memset a non-trivially copyable type");
     memset(&o, 0, sizeof(o));
 }
 
@@ -59,10 +62,10 @@ void State::Reset() {
     Zero(immediate);
     primitive_assembler.Reconfigure(PipelineRegs::TriangleTopology::List);
     vs_float_regs_counter = 0;
-    Zero(vs_uniform_write_buffer);
+    vs_uniform_write_buffer.fill(0);
     gs_float_regs_counter = 0;
-    Zero(gs_uniform_write_buffer);
+    gs_uniform_write_buffer.fill(0);
     default_attr_counter = 0;
-    Zero(default_attr_write_buffer);
+    default_attr_write_buffer.fill(0);
 }
 } // namespace Pica

--- a/src/video_core/pica_state.h
+++ b/src/video_core/pica_state.h
@@ -197,13 +197,13 @@ struct State {
     PrimitiveAssembler<Shader::OutputVertex> primitive_assembler;
 
     int vs_float_regs_counter = 0;
-    u32 vs_uniform_write_buffer[4]{};
+    std::array<u32, 4> vs_uniform_write_buffer{};
 
     int gs_float_regs_counter = 0;
-    u32 gs_uniform_write_buffer[4]{};
+    std::array<u32, 4> gs_uniform_write_buffer{};
 
     int default_attr_counter = 0;
-    u32 default_attr_write_buffer[3]{};
+    std::array<u32, 3> default_attr_write_buffer{};
 
 private:
     friend class boost::serialization::access;
@@ -223,11 +223,14 @@ private:
         ar& geometry_pipeline;
         ar& primitive_assembler;
         ar& vs_float_regs_counter;
-        ar& vs_uniform_write_buffer;
+        ar& boost::serialization::make_array(vs_uniform_write_buffer.data(),
+                                             vs_uniform_write_buffer.size());
         ar& gs_float_regs_counter;
-        ar& gs_uniform_write_buffer;
+        ar& boost::serialization::make_array(gs_uniform_write_buffer.data(),
+                                             gs_uniform_write_buffer.size());
         ar& default_attr_counter;
-        ar& default_attr_write_buffer;
+        ar& boost::serialization::make_array(default_attr_write_buffer.data(),
+                                             default_attr_write_buffer.size());
         boost::serialization::split_member(ar, *this, file_version);
     }
 


### PR DESCRIPTION
Prevents any implicit array to pointer decay and also makes the interface of `WriteUniformFloatReg` always take a correctly sized array.

While we're at it we can make `Zero()` a little safer to use by checking if the to-be-zeroed type is trivially copyable. We can also resolve undefined behavior related to type punning in `WriteUniformFloatReg` as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5241)
<!-- Reviewable:end -->
