### PR TITLE
gl_resource_manager: Make use of noexcept on move assignment and move constructors

### DIFF
--- a/src/video_core/renderer_opengl/gl_resource_manager.h
+++ b/src/video_core/renderer_opengl/gl_resource_manager.h
@@ -41,13 +41,13 @@ class OGLTexture : private NonCopyable {
 public:
     OGLTexture() = default;
 
-    OGLTexture(OGLTexture&& o) : handle(std::exchange(o.handle, 0)) {}
+    OGLTexture(OGLTexture&& o) noexcept : handle(std::exchange(o.handle, 0)) {}
 
     ~OGLTexture() {
         Release();
     }
 
-    OGLTexture& operator=(OGLTexture&& o) {
+    OGLTexture& operator=(OGLTexture&& o) noexcept {
         Release();
         handle = std::exchange(o.handle, 0);
         return *this;
@@ -66,13 +66,13 @@ class OGLSampler : private NonCopyable {
 public:
     OGLSampler() = default;
 
-    OGLSampler(OGLSampler&& o) : handle(std::exchange(o.handle, 0)) {}
+    OGLSampler(OGLSampler&& o) noexcept : handle(std::exchange(o.handle, 0)) {}
 
     ~OGLSampler() {
         Release();
     }
 
-    OGLSampler& operator=(OGLSampler&& o) {
+    OGLSampler& operator=(OGLSampler&& o) noexcept {
         Release();
         handle = std::exchange(o.handle, 0);
         return *this;
@@ -91,13 +91,13 @@ class OGLShader : private NonCopyable {
 public:
     OGLShader() = default;
 
-    OGLShader(OGLShader&& o) : handle(std::exchange(o.handle, 0)) {}
+    OGLShader(OGLShader&& o) noexcept : handle(std::exchange(o.handle, 0)) {}
 
     ~OGLShader() {
         Release();
     }
 
-    OGLShader& operator=(OGLShader&& o) {
+    OGLShader& operator=(OGLShader&& o) noexcept {
         Release();
         handle = std::exchange(o.handle, 0);
         return *this;
@@ -114,13 +114,13 @@ class OGLProgram : private NonCopyable {
 public:
     OGLProgram() = default;
 
-    OGLProgram(OGLProgram&& o) : handle(std::exchange(o.handle, 0)) {}
+    OGLProgram(OGLProgram&& o) noexcept : handle(std::exchange(o.handle, 0)) {}
 
     ~OGLProgram() {
         Release();
     }
 
-    OGLProgram& operator=(OGLProgram&& o) {
+    OGLProgram& operator=(OGLProgram&& o) noexcept {
         Release();
         handle = std::exchange(o.handle, 0);
         return *this;


### PR DESCRIPTION
Several standard constructors generally check if objects can be moved in a non-throwing manner (usually via `std::move_if_noexcept`) to preserve its exception guarantees. This means that if these were used with certain containers any reallocations internally would cause resource churn, as copies would be necessary instead of moves.

This way, if they're every used in that manner, the right behavior is always performed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5242)
<!-- Reviewable:end -->
