### PR TITLE
geometry_pipeline: std::move vertex handler in SetVertexHandler()

### DIFF
--- a/src/video_core/geometry_pipeline.cpp
+++ b/src/video_core/geometry_pipeline.cpp
@@ -303,7 +303,7 @@ GeometryPipeline::GeometryPipeline(State& state) : state(state) {}
 GeometryPipeline::~GeometryPipeline() = default;
 
 void GeometryPipeline::SetVertexHandler(Shader::VertexHandler vertex_handler) {
-    this->vertex_handler = vertex_handler;
+    this->vertex_handler = std::move(vertex_handler);
 }
 
 void GeometryPipeline::Setup(Shader::ShaderEngine* shader_engine) {


### PR DESCRIPTION
`std::function` is allowed to internally allocate, so this prevents potential reallocations from occurring, should that case ever happen.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5243)
<!-- Reviewable:end -->
