### PR TITLE
swrasterizer/proctex: Take regs by const reference

### DIFF
--- a/src/video_core/swrasterizer/proctex.cpp
+++ b/src/video_core/swrasterizer/proctex.cpp
@@ -112,8 +112,8 @@ static void ClampCoord(float& coord, ProcTexClamp mode) {
     }
 }
 
-float CombineAndMap(float u, float v, ProcTexCombiner combiner,
-                    const std::array<State::ProcTex::ValueEntry, 128>& map_table) {
+static float CombineAndMap(float u, float v, ProcTexCombiner combiner,
+                           const std::array<State::ProcTex::ValueEntry, 128>& map_table) {
     float f;
     switch (combiner) {
     case ProcTexCombiner::U:

--- a/src/video_core/swrasterizer/proctex.cpp
+++ b/src/video_core/swrasterizer/proctex.cpp
@@ -45,7 +45,7 @@ static float NoiseRand2D(unsigned int x, unsigned int y) {
     return -1.0f + v2 * 2.0f / 15.0f;
 }
 
-static float NoiseCoef(float u, float v, TexturingRegs regs, State::ProcTex state) {
+static float NoiseCoef(float u, float v, const TexturingRegs& regs, const State::ProcTex& state) {
     const float freq_u = float16::FromRaw(regs.proctex_noise_frequency.u).ToFloat32();
     const float freq_v = float16::FromRaw(regs.proctex_noise_frequency.v).ToFloat32();
     const float phase_u = float16::FromRaw(regs.proctex_noise_u.phase).ToFloat32();
@@ -154,7 +154,7 @@ static float CombineAndMap(float u, float v, ProcTexCombiner combiner,
     return LookupLUT(map_table, f);
 }
 
-Common::Vec4<u8> ProcTex(float u, float v, TexturingRegs regs, State::ProcTex state) {
+Common::Vec4<u8> ProcTex(float u, float v, const TexturingRegs& regs, const State::ProcTex& state) {
     u = std::abs(u);
     v = std::abs(v);
 

--- a/src/video_core/swrasterizer/proctex.h
+++ b/src/video_core/swrasterizer/proctex.h
@@ -9,6 +9,6 @@
 namespace Pica::Rasterizer {
 
 /// Generates procedural texture color for the given coordinates
-Common::Vec4<u8> ProcTex(float u, float v, TexturingRegs regs, State::ProcTex state);
+Common::Vec4<u8> ProcTex(float u, float v, const TexturingRegs& regs, const State::ProcTex& state);
 
 } // namespace Pica::Rasterizer


### PR DESCRIPTION
Avoids unnecessarily copying 512 bytes and 3584 bytes upon every invocation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5247)
<!-- Reviewable:end -->
