### PR TITLE
post_processing_opengl: Make use of std::string_view with GetPostProcessingShaderCode()

### DIFF
--- a/src/video_core/renderer_opengl/post_processing_opengl.cpp
+++ b/src/video_core/renderer_opengl/post_processing_opengl.cpp
@@ -150,7 +150,7 @@ std::vector<std::string> GetPostProcessingShaderList(bool anaglyph) {
     return shader_names;
 }
 
-std::string GetPostProcessingShaderCode(bool anaglyph, std::string shader) {
+std::string GetPostProcessingShaderCode(bool anaglyph, std::string_view shader) {
     std::string shader_dir = FileUtil::GetUserPath(FileUtil::UserPath::ShaderDir);
     std::string shader_path;
 

--- a/src/video_core/renderer_opengl/post_processing_opengl.h
+++ b/src/video_core/renderer_opengl/post_processing_opengl.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace OpenGL {
@@ -18,6 +19,6 @@ std::vector<std::string> GetPostProcessingShaderList(bool anaglyph);
 // If anaglyph is true, it searches the shaders/anaglyph directory rather than
 // the shaders directory
 // If the shader cannot be loaded, an empty string is returned
-std::string GetPostProcessingShaderCode(bool anaglyph, std::string shader_name);
+std::string GetPostProcessingShaderCode(bool anaglyph, std::string_view shader_name);
 
 } // namespace OpenGL


### PR DESCRIPTION
Same behavior, but doesn't result in an allocating copy of the passed in string. Particularly given the string is only compared against other existing strings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5248)
<!-- Reviewable:end -->
