### PR TITLE
core/memory: Fix #5246

### DIFF
--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -99,14 +99,6 @@ struct PageTable {
             VAddr idx;
         };
 
-        Entry operator[](VAddr idx) {
-            return Entry(*this, idx);
-        }
-
-        u8* operator[](VAddr idx) const {
-            return raw[idx];
-        }
-
         Entry operator[](std::size_t idx) {
             return Entry(*this, static_cast<VAddr>(idx));
         }


### PR DESCRIPTION
We can simplify the overload set to be less confusing (and error-prone), while also unbreaking 32-bit builds.

Fixes #5246

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5250)
<!-- Reviewable:end -->
