### PR TITLE
Keep keyboard state independent of acquired buttons

### DIFF
--- a/src/input_common/keyboard.cpp
+++ b/src/input_common/keyboard.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <algorithm>
 #include <atomic>
 #include <list>
 #include <mutex>
@@ -68,8 +69,7 @@ Keyboard::Keyboard() : key_button_list{std::make_shared<KeyButtonList>()} {}
 std::unique_ptr<Input::ButtonDevice> Keyboard::Create(const Common::ParamPackage& params) {
     int key_code = params.Get("code", 0);
     auto& pair = key_button_list->AddKeyButton(key_code);
-    std::unique_ptr<KeyButton> button = std::make_unique<KeyButton>(pair.status);
-    return std::move(button);
+    return std::make_unique<KeyButton>(pair.status);
 }
 
 void Keyboard::PressKey(int key_code) {


### PR DESCRIPTION
This fixes a glitch where keyboard-mapped buttons would become un-pressed when loading a savestate (because the state was held in each ButtonDevice, which would get destroyed on load).

There is apparently a similar issue with SDL devices, but I'm stumped on that one as the Devices don't hold any state of their own there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5255)
<!-- Reviewable:end -->
