### PR TITLE
Fix savestates compatibility

### DIFF
--- a/src/video_core/primitive_assembly.h
+++ b/src/video_core/primitive_assembly.h
@@ -69,8 +69,8 @@ private:
     template <class Archive>
     void serialize(Archive& ar, const unsigned int version) {
         ar& topology;
+        ar& buffer_index;
         ar& boost::serialization::make_array(buffer.data(), buffer.size());
-        ar& buffer;
         ar& strip_ready;
         ar& winding;
     }

--- a/src/video_core/primitive_assembly.h
+++ b/src/video_core/primitive_assembly.h
@@ -7,6 +7,7 @@
 #include <array>
 #include <functional>
 #include <boost/serialization/access.hpp>
+#include <boost/serialization/array.hpp>
 #include "video_core/regs_pipeline.h"
 
 namespace Pica {
@@ -68,7 +69,7 @@ private:
     template <class Archive>
     void serialize(Archive& ar, const unsigned int version) {
         ar& topology;
-        ar& buffer_index;
+        ar& boost::serialization::make_array(buffer.data(), buffer.size());
         ar& buffer;
         ar& strip_ready;
         ar& winding;


### PR DESCRIPTION
This fixes a bug introduced in #5240 by incorporating Lioncache's solution with `make_array`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5256)
<!-- Reviewable:end -->
