### PR TITLE
Improve core timing accuracy

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -174,6 +174,10 @@ System::ResultStatus System::RunLoop(bool tight_loop) {
             } else {
                 current_core_to_execute->Step();
             }
+            if (current_core_to_execute->GetTimer()->GetTicks() > timing->GetGlobalTicks()) {
+                timing->AddToGlobalTicks(timing->GetGlobalTicks() -
+                                         current_core_to_execute->GetTimer()->GetTicks());
+            }
         }
     } else {
         // Now all cores are at the same global time. So we will run them one after the other
@@ -203,9 +207,12 @@ System::ResultStatus System::RunLoop(bool tight_loop) {
                 } else {
                     cpu_core->Step();
                 }
+                if (cpu_core->GetTimer()->GetTicks() > timing->GetGlobalTicks()) {
+                    timing->AddToGlobalTicks(timing->GetGlobalTicks() -
+                                             cpu_core->GetTimer()->GetTicks());
+                }
             }
         }
-        timing->AddToGlobalTicks(max_slice);
     }
 
     if (GDBStub::IsServerEnabled()) {

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -148,8 +148,11 @@ System::ResultStatus System::RunLoop(bool tight_loop) {
     for (auto& cpu_core : cpu_cores) {
         if (cpu_core->GetTimer().GetTicks() < global_ticks) {
             s64 delay = global_ticks - cpu_core->GetTimer().GetTicks();
-            cpu_core->GetTimer().RunEvents();
-            cpu_core->GetTimer().Advance(delay);
+            kernel->SetRunningCPU(cpu_core);
+            cpu_core->GetTimer().Advance();
+            cpu_core->PrepareReschedule();
+            kernel->GetThreadManager(cpu_core->GetID()).Reschedule();
+            cpu_core->GetTimer().SetNextSlice(delay);
             if (max_delay < delay) {
                 max_delay = delay;
                 current_core_to_execute = cpu_core.get();
@@ -157,8 +160,8 @@ System::ResultStatus System::RunLoop(bool tight_loop) {
         }
     }
 
-    if (max_delay > 0) {
-        LOG_TRACE(Core_ARM11, "Core {} running (delayed) for {} ticks",
+    if (max_delay > 100) {
+        LOG_CRITICAL(Core_ARM11, "Core {} running (delayed) for {} ticks",
                   current_core_to_execute->GetID(),
                   current_core_to_execute->GetTimer().GetDowncount());
         if (running_core != current_core_to_execute) {
@@ -182,13 +185,15 @@ System::ResultStatus System::RunLoop(bool tight_loop) {
         // TODO: Make special check for idle since we can easily revert the time of idle cores
         s64 max_slice = Timing::MAX_SLICE_LENGTH;
         for (const auto& cpu_core : cpu_cores) {
-            cpu_core->GetTimer().RunEvents();
+            kernel->SetRunningCPU(cpu_core);
+            cpu_core->GetTimer().Advance();
+            cpu_core->PrepareReschedule();
+            kernel->GetThreadManager(cpu_core->GetID()).Reschedule();
             max_slice = std::min(max_slice, cpu_core->GetTimer().GetMaxSliceLength());
         }
         for (auto& cpu_core : cpu_cores) {
-            cpu_core->GetTimer().Advance(max_slice);
-        }
-        for (auto& cpu_core : cpu_cores) {
+            cpu_core->GetTimer().SetNextSlice(max_slice);
+            auto start_ticks = cpu_core->GetTimer().GetTicks();
             LOG_TRACE(Core_ARM11, "Core {} running for {} ticks", cpu_core->GetID(),
                       cpu_core->GetTimer().GetDowncount());
             running_core = cpu_core.get();
@@ -206,6 +211,7 @@ System::ResultStatus System::RunLoop(bool tight_loop) {
                     cpu_core->Step();
                 }
             }
+            max_slice = cpu_core->GetTimer().GetTicks() - start_ticks;
         }
     }
 

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -160,7 +160,11 @@ System::ResultStatus System::RunLoop(bool tight_loop) {
         }
     }
 
-    if (max_delay > 100) {
+    // jit sometimes overshoot by a few ticks which might lead to a minimal desync in the cores.
+    // This small difference shouldn't make it necessary to sync the cores and would only cost
+    // performance. Thus we don't sync delays below min_delay
+    static constexpr s64 min_delay = 100;
+    if (max_delay > min_delay) {
         LOG_CRITICAL(Core_ARM11, "Core {} running (delayed) for {} ticks",
                   current_core_to_execute->GetID(),
                   current_core_to_execute->GetTimer().GetDowncount());

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -165,7 +165,7 @@ System::ResultStatus System::RunLoop(bool tight_loop) {
     // performance. Thus we don't sync delays below min_delay
     static constexpr s64 min_delay = 100;
     if (max_delay > min_delay) {
-        LOG_CRITICAL(Core_ARM11, "Core {} running (delayed) for {} ticks",
+        LOG_TRACE(Core_ARM11, "Core {} running (delayed) for {} ticks",
                      current_core_to_execute->GetID(),
                      current_core_to_execute->GetTimer().GetDowncount());
         if (running_core != current_core_to_execute) {

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -148,7 +148,7 @@ System::ResultStatus System::RunLoop(bool tight_loop) {
     for (auto& cpu_core : cpu_cores) {
         if (cpu_core->GetTimer().GetTicks() < global_ticks) {
             s64 delay = global_ticks - cpu_core->GetTimer().GetTicks();
-            kernel->SetRunningCPU(cpu_core);
+            kernel->SetRunningCPU(cpu_core.get());
             cpu_core->GetTimer().Advance();
             cpu_core->PrepareReschedule();
             kernel->GetThreadManager(cpu_core->GetID()).Reschedule();
@@ -166,8 +166,8 @@ System::ResultStatus System::RunLoop(bool tight_loop) {
     static constexpr s64 min_delay = 100;
     if (max_delay > min_delay) {
         LOG_CRITICAL(Core_ARM11, "Core {} running (delayed) for {} ticks",
-                  current_core_to_execute->GetID(),
-                  current_core_to_execute->GetTimer().GetDowncount());
+                     current_core_to_execute->GetID(),
+                     current_core_to_execute->GetTimer().GetDowncount());
         if (running_core != current_core_to_execute) {
             running_core = current_core_to_execute;
             kernel->SetRunningCPU(running_core);
@@ -189,7 +189,7 @@ System::ResultStatus System::RunLoop(bool tight_loop) {
         // TODO: Make special check for idle since we can easily revert the time of idle cores
         s64 max_slice = Timing::MAX_SLICE_LENGTH;
         for (const auto& cpu_core : cpu_cores) {
-            kernel->SetRunningCPU(cpu_core);
+            kernel->SetRunningCPU(cpu_core.get());
             cpu_core->GetTimer().Advance();
             cpu_core->PrepareReschedule();
             kernel->GetThreadManager(cpu_core->GetID()).Reschedule();

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -148,6 +148,7 @@ System::ResultStatus System::RunLoop(bool tight_loop) {
     for (auto& cpu_core : cpu_cores) {
         if (cpu_core->GetTimer().GetTicks() < global_ticks) {
             s64 delay = global_ticks - cpu_core->GetTimer().GetTicks();
+            cpu_core->GetTimer().RunEvents();
             cpu_core->GetTimer().Advance(delay);
             if (max_delay < delay) {
                 max_delay = delay;
@@ -174,10 +175,6 @@ System::ResultStatus System::RunLoop(bool tight_loop) {
             } else {
                 current_core_to_execute->Step();
             }
-            if (current_core_to_execute->GetTimer()->GetTicks() > timing->GetGlobalTicks()) {
-                timing->AddToGlobalTicks(timing->GetGlobalTicks() -
-                                         current_core_to_execute->GetTimer()->GetTicks());
-            }
         }
     } else {
         // Now all cores are at the same global time. So we will run them one after the other
@@ -185,6 +182,7 @@ System::ResultStatus System::RunLoop(bool tight_loop) {
         // TODO: Make special check for idle since we can easily revert the time of idle cores
         s64 max_slice = Timing::MAX_SLICE_LENGTH;
         for (const auto& cpu_core : cpu_cores) {
+            cpu_core->GetTimer().RunEvents();
             max_slice = std::min(max_slice, cpu_core->GetTimer().GetMaxSliceLength());
         }
         for (auto& cpu_core : cpu_cores) {
@@ -206,10 +204,6 @@ System::ResultStatus System::RunLoop(bool tight_loop) {
                     cpu_core->Run();
                 } else {
                     cpu_core->Step();
-                }
-                if (cpu_core->GetTimer()->GetTicks() > timing->GetGlobalTicks()) {
-                    timing->AddToGlobalTicks(timing->GetGlobalTicks() -
-                                             cpu_core->GetTimer()->GetTicks());
                 }
             }
         }

--- a/src/core/core_timing.cpp
+++ b/src/core/core_timing.cpp
@@ -111,11 +111,14 @@ s64 Timing::GetTicks() const {
 }
 
 s64 Timing::GetGlobalTicks() const {
-    return global_timer;
+    const auto& timer = std::max_element(timers.cbegin(), timers.cend(), [](const auto& a, const auto& b) {
+        return a->GetTicks() > b->GetTicks();
+    });
+    return (*timer)->GetTicks();
 }
 
 std::chrono::microseconds Timing::GetGlobalTimeUs() const {
-    return std::chrono::microseconds{GetTicks() * 1000000 / BASE_CLOCK_RATE_ARM11};
+    return std::chrono::microseconds{GetGlobalTicks() * 1000000 / BASE_CLOCK_RATE_ARM11};
 }
 
 std::shared_ptr<Timing::Timer> Timing::GetTimer(std::size_t cpu_id) {
@@ -161,25 +164,20 @@ void Timing::Timer::MoveEvents() {
 }
 
 s64 Timing::Timer::GetMaxSliceLength() const {
-    auto next_event = std::find_if(event_queue.begin(), event_queue.end(),
-                                   [&](const Event& e) { return e.time - executed_ticks > 0; });
+    const auto& next_event = event_queue.begin();
     if (next_event != event_queue.end()) {
+        ASSERT(next_event->time - executed_ticks > 0);
         return next_event->time - executed_ticks;
     }
     return MAX_SLICE_LENGTH;
 }
 
-void Timing::Timer::Advance(s64 max_slice_length) {
-    MoveEvents();
-
+void Timing::Timer::RunEvents() {
     s64 cycles_executed = slice_length - downcount;
-    idled_cycles = 0;
-    executed_ticks += cycles_executed;
-    slice_length = max_slice_length;
 
     is_timer_sane = true;
 
-    while (!event_queue.empty() && event_queue.front().time <= executed_ticks) {
+    while (!event_queue.empty() && event_queue.front().time <= executed_ticks + cycles_executed) {
         Event evt = std::move(event_queue.front());
         std::pop_heap(event_queue.begin(), event_queue.end(), std::greater<>());
         event_queue.pop_back();
@@ -191,6 +189,15 @@ void Timing::Timer::Advance(s64 max_slice_length) {
     }
 
     is_timer_sane = false;
+}
+
+void Timing::Timer::Advance(s64 max_slice_length) {
+    MoveEvents();
+
+    s64 cycles_executed = slice_length - downcount;
+    idled_cycles = 0;
+    executed_ticks += cycles_executed;
+    slice_length = max_slice_length;
 
     // Still events left (scheduled in the future)
     if (!event_queue.empty()) {

--- a/src/core/core_timing.cpp
+++ b/src/core/core_timing.cpp
@@ -113,7 +113,7 @@ s64 Timing::GetTicks() const {
 s64 Timing::GetGlobalTicks() const {
     const auto& timer =
         std::max_element(timers.cbegin(), timers.cend(), [](const auto& a, const auto& b) {
-            return a->GetTicks() > b->GetTicks();
+            return a->GetTicks() < b->GetTicks();
         });
     return (*timer)->GetTicks();
 }
@@ -173,13 +173,14 @@ s64 Timing::Timer::GetMaxSliceLength() const {
     return MAX_SLICE_LENGTH;
 }
 
-void Timing::Timer::RunEvents() {
+void Timing::Timer::Advance() {
     MoveEvents();
 
     s64 cycles_executed = slice_length - downcount;
     idled_cycles = 0;
     executed_ticks += cycles_executed;
     slice_length = 0;
+    downcount = 0;
 
     is_timer_sane = true;
 
@@ -197,7 +198,7 @@ void Timing::Timer::RunEvents() {
     is_timer_sane = false;
 }
 
-void Timing::Timer::Advance(s64 max_slice_length) {
+void Timing::Timer::SetNextSlice(s64 max_slice_length) {
     slice_length = max_slice_length;
 
     // Still events left (scheduled in the future)

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -180,9 +180,9 @@ public:
 
         s64 GetMaxSliceLength() const;
 
-        void RunEvents();
+        void Advance();
 
-        void Advance(s64 max_slice_length = MAX_SLICE_LENGTH);
+        void SetNextSlice(s64 max_slice_length = MAX_SLICE_LENGTH);
 
         void Idle();
 

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -272,7 +272,6 @@ public:
     std::shared_ptr<Timer> GetTimer(std::size_t cpu_id);
 
 private:
-
     // unordered_map stores each element separately as a linked list node so pointers to
     // elements remain stable regardless of rehashes/resizing.
     std::unordered_map<std::string, TimingEventType> event_types = {};

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -180,6 +180,8 @@ public:
 
         s64 GetMaxSliceLength() const;
 
+        void RunEvents();
+
         void Advance(s64 max_slice_length = MAX_SLICE_LENGTH);
 
         void Idle();
@@ -260,10 +262,6 @@ public:
 
     s64 GetGlobalTicks() const;
 
-    void AddToGlobalTicks(s64 ticks) {
-        global_timer += ticks;
-    }
-
     /**
      * Updates the value of the cpu clock scaling to the new percentage.
      */
@@ -274,7 +272,6 @@ public:
     std::shared_ptr<Timer> GetTimer(std::size_t cpu_id);
 
 private:
-    s64 global_timer = 0;
 
     // unordered_map stores each element separately as a linked list node so pointers to
     // elements remain stable regardless of rehashes/resizing.
@@ -290,7 +287,6 @@ private:
     template <class Archive>
     void serialize(Archive& ar, const unsigned int file_version) {
         // event_types set during initialization of other things
-        ar& global_timer;
         ar& timers;
         if (file_version == 0) {
             std::shared_ptr<Timer> x;

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -171,7 +171,13 @@ public:
         BOOST_SERIALIZATION_SPLIT_MEMBER()
     };
 
-    static constexpr int MAX_SLICE_LENGTH = 20000;
+    // currently Service::HID::pad_update_ticks is the smallest interval for an event that gets
+    // always scheduled. Therfore we use this as orientation for the MAX_SLICE_LENGTH
+    // For performance bigger slice length are desired, though this will lead to cores desync
+    // But we never want to schedule events into the current slice, because then cores might to
+    // run small slices to sync up again. This is especially important for events that are always
+    // scheduled and repated.
+    static constexpr int MAX_SLICE_LENGTH = BASE_CLOCK_RATE_ARM11 / 234;
 
     class Timer {
     public:

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -235,6 +235,7 @@ public:
         void serialize(Archive& ar, const unsigned int) {
             MoveEvents();
             // NOTE: ts_queue should be empty now
+            // TODO(SaveState): Remove the next two lines when we break compatibility
             s64 x;
             ar& x; // to keep compatibility with old save states that stored global_timer
             ar& event_queue;

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -229,6 +229,8 @@ public:
         void serialize(Archive& ar, const unsigned int) {
             MoveEvents();
             // NOTE: ts_queue should be empty now
+            s64 x;
+            ar& x; // to keep compatibility with old save states that stored global_timer
             ar& event_queue;
             ar& event_fifo_id;
             ar& slice_length;

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -111,7 +111,7 @@ void ThreadManager::SwitchContext(Thread* new_thread) {
     // Save context for previous thread
     if (previous_thread) {
         previous_process = previous_thread->owner_process;
-        previous_thread->last_running_ticks = timing.GetGlobalTicks();
+        previous_thread->last_running_ticks = cpu->GetTimer()->GetTicks();
         cpu->SaveContext(previous_thread->context);
 
         if (previous_thread->status == ThreadStatus::Running) {
@@ -344,7 +344,7 @@ ResultVal<std::shared_ptr<Thread>> KernelSystem::CreateThread(
     thread->entry_point = entry_point;
     thread->stack_top = stack_top;
     thread->nominal_priority = thread->current_priority = priority;
-    thread->last_running_ticks = timing.GetGlobalTicks();
+    thread->last_running_ticks = timing.GetTimer(processor_id)->GetTicks();
     thread->processor_id = processor_id;
     thread->wait_objects.clear();
     thread->wait_address = 0;

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -111,7 +111,7 @@ void ThreadManager::SwitchContext(Thread* new_thread) {
     // Save context for previous thread
     if (previous_thread) {
         previous_process = previous_thread->owner_process;
-        previous_thread->last_running_ticks = cpu->GetTimer()->GetTicks();
+        previous_thread->last_running_ticks = cpu->GetTimer().GetTicks();
         cpu->SaveContext(previous_thread->context);
 
         if (previous_thread->status == ThreadStatus::Running) {

--- a/src/tests/core/core_timing.cpp
+++ b/src/tests/core/core_timing.cpp
@@ -36,6 +36,8 @@ static void AdvanceAndCheck(Core::Timing& timing, u32 idx, int downcount, int ex
 
     timing.GetTimer(0)->AddTicks(timing.GetTimer(0)->GetDowncount() -
                                  cpu_downcount); // Pretend we executed X cycles of instructions.
+
+    timing.GetTimer(0)->RunEvents();
     timing.GetTimer(0)->Advance();
 
     REQUIRE(decltype(callbacks_ran_flags)().set(idx) == callbacks_ran_flags);
@@ -52,6 +54,7 @@ TEST_CASE("CoreTiming[BasicOrder]", "[core]") {
     Core::TimingEventType* cb_e = timing.RegisterEvent("callbackE", CallbackTemplate<4>);
 
     // Enter slice 0
+    timing.GetTimer(0)->RunEvents();
     timing.GetTimer(0)->Advance();
 
     // D -> B -> C -> A -> E
@@ -105,6 +108,7 @@ TEST_CASE("CoreTiming[SharedSlot]", "[core]") {
     timing.ScheduleEvent(1000, cb_e, CB_IDS[4], 0);
 
     // Enter slice 0
+    timing.GetTimer(0)->RunEvents();
     timing.GetTimer(0)->Advance();
     REQUIRE(1000 == timing.GetTimer(0)->GetDowncount());
 
@@ -112,6 +116,7 @@ TEST_CASE("CoreTiming[SharedSlot]", "[core]") {
     counter = 0;
     lateness = 0;
     timing.GetTimer(0)->AddTicks(timing.GetTimer(0)->GetDowncount());
+    timing.GetTimer(0)->RunEvents();
     timing.GetTimer(0)->Advance();
     REQUIRE(MAX_SLICE_LENGTH == timing.GetTimer(0)->GetDowncount());
     REQUIRE(0x1FULL == callbacks_ran_flags.to_ullong());
@@ -124,6 +129,7 @@ TEST_CASE("CoreTiming[PredictableLateness]", "[core]") {
     Core::TimingEventType* cb_b = timing.RegisterEvent("callbackB", CallbackTemplate<1>);
 
     // Enter slice 0
+    timing.GetTimer(0)->RunEvents();
     timing.GetTimer(0)->Advance();
 
     timing.ScheduleEvent(100, cb_a, CB_IDS[0], 0);
@@ -160,6 +166,7 @@ TEST_CASE("CoreTiming[ChainScheduling]", "[core]") {
         });
 
     // Enter slice 0
+    timing.GetTimer(0)->RunEvents();
     timing.GetTimer(0)->Advance();
 
     timing.ScheduleEvent(800, cb_a, CB_IDS[0], 0);
@@ -174,6 +181,7 @@ TEST_CASE("CoreTiming[ChainScheduling]", "[core]") {
     REQUIRE(2 == reschedules);
 
     timing.GetTimer(0)->AddTicks(timing.GetTimer(0)->GetDowncount());
+    timing.GetTimer(0)->RunEvents();
     timing.GetTimer(0)->Advance(); // cb_rs
     REQUIRE(1 == reschedules);
     REQUIRE(200 == timing.GetTimer(0)->GetDowncount());
@@ -181,6 +189,7 @@ TEST_CASE("CoreTiming[ChainScheduling]", "[core]") {
     AdvanceAndCheck(timing, 2, 800); // cb_c
 
     timing.GetTimer(0)->AddTicks(timing.GetTimer(0)->GetDowncount());
+    timing.GetTimer(0)->RunEvents();
     timing.GetTimer(0)->Advance(); // cb_rs
     REQUIRE(0 == reschedules);
     REQUIRE(MAX_SLICE_LENGTH == timing.GetTimer(0)->GetDowncount());

--- a/src/tests/core/core_timing.cpp
+++ b/src/tests/core/core_timing.cpp
@@ -13,7 +13,8 @@
 
 // Numbers are chosen randomly to make sure the correct one is given.
 static constexpr std::array<u64, 5> CB_IDS{{42, 144, 93, 1026, UINT64_C(0xFFFF7FFFF7FFFF)}};
-static constexpr int MAX_SLICE_LENGTH = BASE_CLOCK_RATE_ARM11 / 234; // Copied from CoreTiming internals
+static constexpr int MAX_SLICE_LENGTH =
+    BASE_CLOCK_RATE_ARM11 / 234; // Copied from CoreTiming internals
 
 static std::bitset<CB_IDS.size()> callbacks_ran_flags;
 static u64 expected_callback = 0;

--- a/src/tests/core/core_timing.cpp
+++ b/src/tests/core/core_timing.cpp
@@ -13,7 +13,7 @@
 
 // Numbers are chosen randomly to make sure the correct one is given.
 static constexpr std::array<u64, 5> CB_IDS{{42, 144, 93, 1026, UINT64_C(0xFFFF7FFFF7FFFF)}};
-static constexpr int MAX_SLICE_LENGTH = 20000; // Copied from CoreTiming internals
+static constexpr int MAX_SLICE_LENGTH = BASE_CLOCK_RATE_ARM11 / 234; // Copied from CoreTiming internals
 
 static std::bitset<CB_IDS.size()> callbacks_ran_flags;
 static u64 expected_callback = 0;

--- a/src/tests/core/core_timing.cpp
+++ b/src/tests/core/core_timing.cpp
@@ -37,8 +37,8 @@ static void AdvanceAndCheck(Core::Timing& timing, u32 idx, int downcount, int ex
     timing.GetTimer(0)->AddTicks(timing.GetTimer(0)->GetDowncount() -
                                  cpu_downcount); // Pretend we executed X cycles of instructions.
 
-    timing.GetTimer(0)->RunEvents();
     timing.GetTimer(0)->Advance();
+    timing.GetTimer(0)->SetNextSlice();
 
     REQUIRE(decltype(callbacks_ran_flags)().set(idx) == callbacks_ran_flags);
     REQUIRE(downcount == timing.GetTimer(0)->GetDowncount());
@@ -54,8 +54,8 @@ TEST_CASE("CoreTiming[BasicOrder]", "[core]") {
     Core::TimingEventType* cb_e = timing.RegisterEvent("callbackE", CallbackTemplate<4>);
 
     // Enter slice 0
-    timing.GetTimer(0)->RunEvents();
     timing.GetTimer(0)->Advance();
+    timing.GetTimer(0)->SetNextSlice();
 
     // D -> B -> C -> A -> E
     timing.ScheduleEvent(1000, cb_a, CB_IDS[0], 0);
@@ -108,16 +108,16 @@ TEST_CASE("CoreTiming[SharedSlot]", "[core]") {
     timing.ScheduleEvent(1000, cb_e, CB_IDS[4], 0);
 
     // Enter slice 0
-    timing.GetTimer(0)->RunEvents();
     timing.GetTimer(0)->Advance();
+    timing.GetTimer(0)->SetNextSlice();
     REQUIRE(1000 == timing.GetTimer(0)->GetDowncount());
 
     callbacks_ran_flags = 0;
     counter = 0;
     lateness = 0;
     timing.GetTimer(0)->AddTicks(timing.GetTimer(0)->GetDowncount());
-    timing.GetTimer(0)->RunEvents();
     timing.GetTimer(0)->Advance();
+    timing.GetTimer(0)->SetNextSlice();
     REQUIRE(MAX_SLICE_LENGTH == timing.GetTimer(0)->GetDowncount());
     REQUIRE(0x1FULL == callbacks_ran_flags.to_ullong());
 }
@@ -129,8 +129,8 @@ TEST_CASE("CoreTiming[PredictableLateness]", "[core]") {
     Core::TimingEventType* cb_b = timing.RegisterEvent("callbackB", CallbackTemplate<1>);
 
     // Enter slice 0
-    timing.GetTimer(0)->RunEvents();
     timing.GetTimer(0)->Advance();
+    timing.GetTimer(0)->SetNextSlice();
 
     timing.ScheduleEvent(100, cb_a, CB_IDS[0], 0);
     timing.ScheduleEvent(200, cb_b, CB_IDS[1], 0);
@@ -166,8 +166,8 @@ TEST_CASE("CoreTiming[ChainScheduling]", "[core]") {
         });
 
     // Enter slice 0
-    timing.GetTimer(0)->RunEvents();
     timing.GetTimer(0)->Advance();
+    timing.GetTimer(0)->SetNextSlice();
 
     timing.ScheduleEvent(800, cb_a, CB_IDS[0], 0);
     timing.ScheduleEvent(1000, cb_b, CB_IDS[1], 0);
@@ -181,16 +181,16 @@ TEST_CASE("CoreTiming[ChainScheduling]", "[core]") {
     REQUIRE(2 == reschedules);
 
     timing.GetTimer(0)->AddTicks(timing.GetTimer(0)->GetDowncount());
-    timing.GetTimer(0)->RunEvents();
-    timing.GetTimer(0)->Advance(); // cb_rs
+    timing.GetTimer(0)->Advance();
+    timing.GetTimer(0)->SetNextSlice(); // cb_rs
     REQUIRE(1 == reschedules);
     REQUIRE(200 == timing.GetTimer(0)->GetDowncount());
 
     AdvanceAndCheck(timing, 2, 800); // cb_c
 
     timing.GetTimer(0)->AddTicks(timing.GetTimer(0)->GetDowncount());
-    timing.GetTimer(0)->RunEvents();
-    timing.GetTimer(0)->Advance(); // cb_rs
+    timing.GetTimer(0)->Advance();
+    timing.GetTimer(0)->SetNextSlice(); // cb_rs
     REQUIRE(0 == reschedules);
     REQUIRE(MAX_SLICE_LENGTH == timing.GetTimer(0)->GetDowncount());
 }


### PR DESCRIPTION
We didn't calculate the global time precisely especially when dynarmic didn't execute exactly the slice length or when we reduced the slice length because a event was scheduled in the current slice

I also removed the usage of the global time in thread creation and switch context to use the cpus ticks instead

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5257)
<!-- Reviewable:end -->
