### PR TITLE
video_core: reduce string allocations in shader decompiler

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -199,7 +199,7 @@ public:
     void AddLine(std::string_view text) {
         DEBUG_ASSERT(scope >= 0);
         if (!text.empty()) {
-            shader_source.resize(shader_source.size() + static_cast<std::size_t>(scope) * 4, ' ');
+            shader_source.append(static_cast<std::size_t>(scope) * 4, ' ');
         }
         shader_source += text;
         shader_source += '\n';

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -196,12 +196,13 @@ private:
 
 class ShaderWriter {
 public:
-    void AddLine(const std::string& text) {
+    void AddLine(std::string_view text) {
         DEBUG_ASSERT(scope >= 0);
         if (!text.empty()) {
-            shader_source += std::string(static_cast<std::size_t>(scope) * 4, ' ');
+            shader_source.resize(shader_source.size() + static_cast<std::size_t>(scope) * 4, ' ');
         }
-        shader_source += text + '\n';
+        shader_source += text;
+        shader_source += '\n';
     }
 
     std::string MoveResult() {


### PR DESCRIPTION
Uses string_view for AddLine so std::strings aren't created from constant string.
Resizes the source string to add indentation rather than concatenating a new one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5261)
<!-- Reviewable:end -->
