### PR TITLE
Adjust audio_frame_ticks

### DIFF
--- a/src/audio_core/hle/hle.cpp
+++ b/src/audio_core/hle/hle.cpp
@@ -47,13 +47,11 @@ void DspHle::serialize(Archive& ar, const unsigned int) {
 }
 SERIALIZE_IMPL(DspHle)
 
-// TODO(xperia64): The value below is the "perfect" mathematical ratio
-// of ARM11 cycles per audio frame, as per merry's suggestion
-// samples per frame * teaklite cycles per sample * 2 ARM11 cycles/teaklite cycle
+// The value below is the "perfect" mathematical ratio of ARM11 cycles per audio frame, samples per
+// frame * teaklite cycles per sample * 2 ARM11 cycles/teaklite cycle
 // (160 * 4096 * 2) = (1310720)
 //
-// As per merry, it may be useful to verify this on hardware with the more recently
-// discovered "correct" ARM11 frequency of 268111856 as opposed to 268123480
+// This value has been verified against a rough hardware test with hardware and LLE
 static constexpr u64 audio_frame_ticks = samples_per_frame * 4096 * 2ull; ///< Units: ARM11 cycles
 
 struct DspHle::Impl final {

--- a/src/audio_core/hle/hle.cpp
+++ b/src/audio_core/hle/hle.cpp
@@ -48,18 +48,13 @@ void DspHle::serialize(Archive& ar, const unsigned int) {
 SERIALIZE_IMPL(DspHle)
 
 // TODO(xperia64): The value below is the "perfect" mathematical ratio
-// of ARM11 cycles per audio frame. As per merry, this was calculated to be
-// (ARM11 freq)*(samples per frame)/(sample rate)
-// = (268,111,855.956 Hz) * (160 samples)/(32,728 Hz)
-// = (1310739.946008311...) ~ 1310740
+// of ARM11 cycles per audio frame, as per merry's suggestion
+// samples per frame * teaklite cycles per sample * 2 ARM11 cycles/teaklite cycle
+// (160 * 4096 * 2) = (1310720)
 //
-// This value was originally set to 1310252, which was determined by measuring it on hardware
-// However, as of when this was written, Project Mirai 1/2/DX desync on HLE
-// such that the music track runs ahead of the gameplay.
-// When the value is set to 1310740, all three games are playable
-// The audio track only drifts ~1ms over a 4+ minute song compared to hardware
-// and the button presses match as well as I can determine by playing the game/recording
-static constexpr u64 audio_frame_ticks = 1310740ull; ///< Units: ARM11 cycles
+// As per merry, it may be useful to verify this on hardware with the more recently
+// discovered "correct" ARM11 frequency of 268111856 as opposed to 268123480
+static constexpr u64 audio_frame_ticks = 160 * 4096 * 2ull; ///< Units: ARM11 cycles
 
 struct DspHle::Impl final {
 public:

--- a/src/audio_core/hle/hle.cpp
+++ b/src/audio_core/hle/hle.cpp
@@ -47,7 +47,19 @@ void DspHle::serialize(Archive& ar, const unsigned int) {
 }
 SERIALIZE_IMPL(DspHle)
 
-static constexpr u64 audio_frame_ticks = 1310252ull; ///< Units: ARM11 cycles
+// TODO(xperia64): The value below is the "perfect" mathematical ratio
+// of ARM11 cycles per audio frame. As per merry, this was calculated to be
+// (ARM11 freq)*(samples per frame)/(sample rate)
+// = (268,111,855.956 Hz) * (160 samples)/(32,728 Hz)
+// = (1310739.946008311...) ~ 1310740
+//
+// This value was originally set to 1310252, which was determined by measuring it on hardware
+// However, as of when this was written, Project Mirai 1/2/DX desync on HLE
+// such that the music track runs ahead of the gameplay.
+// When the value is set to 1310740, all three games are playable
+// The audio track only drifts ~1ms over a 4+ minute song compared to hardware
+// and the button presses match as well as I can determine by playing the game/recording
+static constexpr u64 audio_frame_ticks = 1310740ull; ///< Units: ARM11 cycles
 
 struct DspHle::Impl final {
 public:

--- a/src/audio_core/hle/hle.cpp
+++ b/src/audio_core/hle/hle.cpp
@@ -54,7 +54,7 @@ SERIALIZE_IMPL(DspHle)
 //
 // As per merry, it may be useful to verify this on hardware with the more recently
 // discovered "correct" ARM11 frequency of 268111856 as opposed to 268123480
-static constexpr u64 audio_frame_ticks = 160 * 4096 * 2ull; ///< Units: ARM11 cycles
+static constexpr u64 audio_frame_ticks = samples_per_frame * 4096 * 2ull; ///< Units: ARM11 cycles
 
 struct DspHle::Impl final {
 public:


### PR DESCRIPTION
This pull request was created to partially address https://github.com/citra-emu/citra/issues/4562

I am not confident this is the correct solution, but it just happens to fix this issue on the HLE backend from what I can tell. In some ways this PR serves as an information dump regarding the behavior I've observed.

In Project Mirai 2, on the HLE backend, the music track of a given song runs faster than the rest of the gameplay by a significant amount by the end of a 4 minute song, making gameplay very difficult. I found that by adjusting audio_frame_ticks, the speed of the music track relative to the rest of the game could be increased or decreased. By changing it from the hardware-measured 1310252 to the theoretical 1310740 (see commit comments), I found everything seemed to match the hardware well, with minor drift by the end of a song (~1ms or so), and the gameplay sunk up too, making things playable.

The reason I am hesitant to believe this is the correct answer is that it only fixes the Project Mirai series, and only on HLE. Project Mirai's HLE desync is unusual compared to the other rhythm game desync issues noted here, as in all of the other ones (https://github.com/citra-emu/citra/issues/4169, https://github.com/citra-emu/citra/issues/4527, https://github.com/citra-emu/citra/issues/5265), gameplay gets ahead of the music track (i.e. the game is running slightly too fast, or the music track is running slightly too slow), while Project Mirai HLE has that reversed. It also differs from Project Mirai's own LLE desync, which seems to more or less match the behavior of the other rhythm games. I have not yet compared an LLE recording of Project Mirai 2 to hardware yet to determine whether the gameplay is too fast, or the song is too slow there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5266)
<!-- Reviewable:end -->
