### PR TITLE
texture_filters: update ScaleForce

### DIFF
--- a/src/video_core/renderer_opengl/texture_filters/scale_force/scale_force.frag
+++ b/src/video_core/renderer_opengl/texture_filters/scale_force/scale_force.frag
@@ -27,11 +27,14 @@
 
 precision mediump float;
 
-in highp vec2 tex_coord;
+in vec2 tex_coord;
 
-out mediump vec4 frag_color;
+out vec4 frag_color;
 
 uniform sampler2D input_texture;
+
+vec2 tex_size;
+vec2 inv_tex_size;
 
 vec4 cubic(float v) {
     vec4 n = vec4(1.0, 2.0, 3.0, 4.0) - v;
@@ -43,10 +46,8 @@ vec4 cubic(float v) {
     return vec4(x, y, z, w) / 6.0;
 }
 
-vec4 textureBicubic(sampler2D sampler, vec2 tex_coords) {
-    vec2 tex_size = vec2(textureSize(sampler, 0));
-    vec2 inv_tex_size = 1.0 / tex_size;
-
+// Bicubic interpolation
+vec4 textureBicubic(vec2 tex_coords) {
     tex_coords = tex_coords * tex_size - 0.5;
 
     vec2 fxy = fract(tex_coords);
@@ -62,10 +63,10 @@ vec4 textureBicubic(sampler2D sampler, vec2 tex_coords) {
 
     offset *= inv_tex_size.xxyy;
 
-    vec4 sample0 = texture(sampler, offset.xz);
-    vec4 sample1 = texture(sampler, offset.yz);
-    vec4 sample2 = texture(sampler, offset.xw);
-    vec4 sample3 = texture(sampler, offset.yw);
+    vec4 sample0 = textureLod(input_texture, offset.xz, 0.0);
+    vec4 sample1 = textureLod(input_texture, offset.yz, 0.0);
+    vec4 sample2 = textureLod(input_texture, offset.xw, 0.0);
+    vec4 sample3 = textureLod(input_texture, offset.yw, 0.0);
 
     float sx = s.x / (s.x + s.y);
     float sy = s.z / (s.z + s.w);
@@ -73,40 +74,82 @@ vec4 textureBicubic(sampler2D sampler, vec2 tex_coords) {
     return mix(mix(sample3, sample2, sx), mix(sample1, sample0, sx), sy);
 }
 
+// Finds the distance between colors in YCbCr space,
+// with a higher priority given to tone rather than luminance.
+// Also handles the alpha channel
 float ColorDist(vec4 a, vec4 b) {
     // https://en.wikipedia.org/wiki/YCbCr#ITU-R_BT.2020_conversion
     const vec3 K = vec3(0.2627, 0.6780, 0.0593);
-    const float luminance_weight = .6;
-    const mat3 MATRIX = mat3(K * luminance_weight, -.5 * K.r / (1.0 - K.b), -.5 * K.g / (1.0 - K.b),
+    const float LUMINANCE_WEIGHT = .6;
+    const mat3 MATRIX = mat3(K * LUMINANCE_WEIGHT, -.5 * K.r / (1.0 - K.b), -.5 * K.g / (1.0 - K.b),
                              .5, .5, -.5 * K.g / (1.0 - K.r), -.5 * K.b / (1.0 - K.r));
-    vec4 diff = a - b;
+    const float LENGTH_ADJUSTMENT = length(vec3(1.0)) / length(vec3(LUMINANCE_WEIGHT, 1.0, 1.0));
+    vec4 diff = abs(a - b);
+    vec2 alpha_product = vec2(a.a * b.a);
     vec3 YCbCr = diff.rgb * MATRIX;
-    float d = length(YCbCr) * length(vec3(1.0)) / length(vec3(luminance_weight, 1.0, 1.0));
-    return sqrt(a.a * b.a * d * d + diff.a * diff.a);
+    float d = dot(YCbCr, YCbCr) * (LENGTH_ADJUSTMENT * LENGTH_ADJUSTMENT);
+    return sqrt(dot(vec2(d + diff.a), alpha_product));
 }
 
-const int radius = 2;
+// Regular Bilinear interpolated texel at tex_coord.
+vec4 center_texel;
+
+// Calculates the effect of the surrounding texels on the final texel's coordinate.
+#define ColorDiff(x, y) {                                                                         \
+    const vec2 offset = vec2(x, y);                                                               \
+    const float weight = pow(length(offset), -length(offset));                                    \
+    vec4 texel = textureLodOffset(input_texture, tex_coord, 0.0, ivec2(x, y));                    \
+    total_offset += vec3(ColorDist(texel, center_texel) * weight) * vec3(offset, 1.0);            \
+}
 
 void main() {
-    vec2 input_size = vec2(textureSize(input_texture, 0));
-    vec4 center_texel = texture(input_texture, tex_coord);
-    vec2 final_offset = vec2(0.0);
-    float total_diff = 0.0;
+    center_texel = textureLod(input_texture, tex_coord, 0.0);
+    tex_size = vec2(textureSize(input_texture, 0));
+    inv_tex_size = 1.0 / tex_size;
 
-    for (int y = -radius; y <= radius; ++y) {
-        for (int x = -radius; x <= radius; ++x) {
-            if (0 == (x | y))
-                continue;
-            vec2 offset = vec2(x, y);
-            float weight = pow(length(offset), -length(offset));
-            vec4 texel = texture(input_texture, tex_coord + offset / input_size);
-            float diff = ColorDist(texel, center_texel) * weight;
-            total_diff += diff;
-            final_offset += diff * offset;
-        }
+    // x and y are the calculated location of the final texel.
+    // z is the sum of all the weighted color differences from surrounding pixels.
+    vec3 total_offset = vec3(0.0);
+
+    ColorDiff(-1, -2);
+    ColorDiff(0, -2);
+    ColorDiff(1, -2);
+
+    ColorDiff(-2, -1);
+    ColorDiff(-1, -1);
+    ColorDiff(0, -1);
+    ColorDiff(1, -1);
+    ColorDiff(2, -1);
+
+    ColorDiff(-2, 0);
+    ColorDiff(-1, 0);
+    // center_tex
+    ColorDiff(1, 0);
+    ColorDiff(2, 0);
+
+    ColorDiff(-2, 1);
+    ColorDiff(-1, 1);
+    ColorDiff(0, 1);
+    ColorDiff(1, 1);
+    ColorDiff(2, 1);
+
+    ColorDiff(-1, 2);
+    ColorDiff(0, 2);
+    ColorDiff(1, 2);
+
+    if(total_offset.z == 0.0){
+        // Doing bicubic filtering just past the edges where the offset is 0 causes black floaters
+        // and it doesn't really matter which filter is used when the colors aren't changing.
+        frag_color = center_texel;
+    } else {
+        // When the image has thin points, they tend to split apart.
+        // This is because the texels all around are different
+        // and total_offset reaches into clear areas.
+        // This works pretty well to keep the offset in bounds for these cases.
+        float clamp_val = length(total_offset.xy) / total_offset.z;
+        vec2 final_offset = clamp(total_offset.xy, -clamp_val, clamp_val);
+
+        final_offset /= vec2(textureSize(input_texture, 0));
+        frag_color = textureBicubic(tex_coord - final_offset);
     }
-
-    float clamp_val = length(final_offset) / total_diff;
-    final_offset = clamp(final_offset, -clamp_val, clamp_val);
-    frag_color = textureBicubic(input_texture, tex_coord - final_offset / input_size);
 }

--- a/src/video_core/renderer_opengl/texture_filters/scale_force/scale_force.frag
+++ b/src/video_core/renderer_opengl/texture_filters/scale_force/scale_force.frag
@@ -1,7 +1,6 @@
 //? #version 320 es
 
 // from https://github.com/BreadFish64/ScaleFish/tree/master/scale_force
-// shader adapted to GLSL 320 es and debugging outputs stripped
 
 // MIT License
 //
@@ -37,8 +36,8 @@ vec2 tex_size;
 vec2 inv_tex_size;
 
 vec4 cubic(float v) {
-    vec4 n = vec4(1.0, 2.0, 3.0, 4.0) - v;
-    vec4 s = n * n * n;
+    vec3 n = vec3(1.0, 2.0, 3.0) - v;
+    vec3 s = n * n * n;
     float x = s.x;
     float y = s.y - 4.0 * s.x;
     float z = s.z - 4.0 * s.y + 6.0 * s.x;
@@ -51,7 +50,7 @@ vec4 textureBicubic(vec2 tex_coords) {
     tex_coords = tex_coords * tex_size - 0.5;
 
     vec2 fxy = fract(tex_coords);
-    tex_coords -= fxy;
+    tex_coords = floor(tex_coords);
 
     vec4 xcubic = cubic(fxy.x);
     vec4 ycubic = cubic(fxy.y);
@@ -74,70 +73,51 @@ vec4 textureBicubic(vec2 tex_coords) {
     return mix(mix(sample3, sample2, sx), mix(sample1, sample0, sx), sy);
 }
 
-// Finds the distance between colors in YCbCr space,
-// with a higher priority given to tone rather than luminance.
-// Also handles the alpha channel
-float ColorDist(vec4 a, vec4 b) {
-    // https://en.wikipedia.org/wiki/YCbCr#ITU-R_BT.2020_conversion
-    const vec3 K = vec3(0.2627, 0.6780, 0.0593);
-    const float LUMINANCE_WEIGHT = .6;
-    const mat3 MATRIX = mat3(K * LUMINANCE_WEIGHT, -.5 * K.r / (1.0 - K.b), -.5 * K.g / (1.0 - K.b),
-                             .5, .5, -.5 * K.g / (1.0 - K.r), -.5 * K.b / (1.0 - K.r));
-    const float LENGTH_ADJUSTMENT = length(vec3(1.0)) / length(vec3(LUMINANCE_WEIGHT, 1.0, 1.0));
-    vec4 diff = abs(a - b);
-    vec2 alpha_product = vec2(a.a * b.a);
-    vec3 YCbCr = diff.rgb * MATRIX;
-    float d = dot(YCbCr, YCbCr) * (LENGTH_ADJUSTMENT * LENGTH_ADJUSTMENT);
-    return sqrt(dot(vec2(d + diff.a), alpha_product));
-}
-
-// Regular Bilinear interpolated texel at tex_coord.
-vec4 center_texel;
-
-// Calculates the effect of the surrounding texels on the final texel's coordinate.
-#define ColorDiff(x, y) {                                                                         \
-    const vec2 offset = vec2(x, y);                                                               \
-    const float weight = pow(length(offset), -length(offset));                                    \
-    vec4 texel = textureLodOffset(input_texture, tex_coord, 0.0, ivec2(x, y));                    \
-    total_offset += vec3(ColorDist(texel, center_texel) * weight) * vec3(offset, 1.0);            \
-}
-
 void main() {
-    center_texel = textureLod(input_texture, tex_coord, 0.0);
+    vec4 center_texel = textureLod(input_texture, tex_coord, 0.0);
     tex_size = vec2(textureSize(input_texture, 0));
     inv_tex_size = 1.0 / tex_size;
 
-    // x and y are the calculated location of the final texel.
-    // z is the sum of all the weighted color differences from surrounding pixels.
-    vec3 total_offset = vec3(0.0);
+    // https://en.wikipedia.org/wiki/YCbCr#ITU-R_BT.2020_conversion
+    const vec3 K = vec3(0.2627, 0.6780, 0.0593);
+    const float LUMINANCE_WEIGHT = .6;
+    const mat3 YCBCR_MATRIX =
+        mat3(K * LUMINANCE_WEIGHT, -.5 * K.r / (1.0 - K.b), -.5 * K.g / (1.0 - K.b), .5, .5,
+             -.5 * K.g / (1.0 - K.r), -.5 * K.b / (1.0 - K.r));
 
-    ColorDiff(-1, -2);
-    ColorDiff(0, -2);
-    ColorDiff(1, -2);
+    mat4x3 center = mat4x3(center_texel.rgb, center_texel.rgb, center_texel.rgb, center_texel.rgb);
+#define BODY(var, direction)                                                                       \
+    mat3x4 var;                                                                                    \
+    {                                                                                              \
+        const int up = direction;                                                                  \
+        vec4 A = textureLodOffset(input_texture, tex_coord, 0.0, ivec2(-up, up));                  \
+        vec4 B = textureLodOffset(input_texture, tex_coord, 0.0, ivec2(0, up));                    \
+        vec4 C = textureLodOffset(input_texture, tex_coord, 0.0, ivec2(up, up));                   \
+        vec4 D = textureLodOffset(input_texture, tex_coord, 0.0, ivec2(-up, 0));                   \
+                                                                                                   \
+        mat4x3 colors = mat4x3(A.rgb, B.rgb, C.rgb, D.rgb) - center;                               \
+                                                                                                   \
+        mat4x3 YCbCr = YCBCR_MATRIX * colors;                                                      \
+                                                                                                   \
+        vec4 color_dist = vec3(1.0) * YCbCr;                                                       \
+        color_dist *= color_dist;                                                                  \
+                                                                                                   \
+        vec4 alpha = vec4(A.a, B.a, C.a, D.a);                                                     \
+                                                                                                   \
+        vec4 real_dist =                                                                           \
+            sqrt((color_dist + abs(center_texel.aaaa - alpha)) * alpha * center_texel.aaaa);       \
+                                                                                                   \
+        var =                                                                                      \
+            matrixCompMult(mat3x4(real_dist, real_dist, real_dist),                                \
+                           mat3x4(vec4(-up, 0, up, -up), vec4(up, up, up, 0), vec4(1, 1, 1, 1)));  \
+    }
 
-    ColorDiff(-2, -1);
-    ColorDiff(-1, -1);
-    ColorDiff(0, -1);
-    ColorDiff(1, -1);
-    ColorDiff(2, -1);
+    BODY(offset_tl, 1);
+    BODY(offset_br, -1);
 
-    ColorDiff(-2, 0);
-    ColorDiff(-1, 0);
-    // center_tex
-    ColorDiff(1, 0);
-    ColorDiff(2, 0);
+    vec3 total_offset = vec4(1.0) * (offset_tl + offset_br);
 
-    ColorDiff(-2, 1);
-    ColorDiff(-1, 1);
-    ColorDiff(0, 1);
-    ColorDiff(1, 1);
-    ColorDiff(2, 1);
-
-    ColorDiff(-1, 2);
-    ColorDiff(0, 2);
-    ColorDiff(1, 2);
-
-    if(total_offset.z == 0.0){
+    if (total_offset.z == 0.0) {
         // Doing bicubic filtering just past the edges where the offset is 0 causes black floaters
         // and it doesn't really matter which filter is used when the colors aren't changing.
         frag_color = center_texel;
@@ -147,9 +127,8 @@ void main() {
         // and total_offset reaches into clear areas.
         // This works pretty well to keep the offset in bounds for these cases.
         float clamp_val = length(total_offset.xy) / total_offset.z;
-        vec2 final_offset = clamp(total_offset.xy, -clamp_val, clamp_val);
+        vec2 final_offset = clamp(total_offset.xy, -clamp_val, clamp_val) * inv_tex_size;
 
-        final_offset /= vec2(textureSize(input_texture, 0));
         frag_color = textureBicubic(tex_coord - final_offset);
     }
 }

--- a/src/video_core/renderer_opengl/texture_filters/scale_force/scale_force.frag
+++ b/src/video_core/renderer_opengl/texture_filters/scale_force/scale_force.frag
@@ -49,8 +49,7 @@ vec4 cubic(float v) {
 vec4 textureBicubic(vec2 tex_coords) {
     tex_coords = tex_coords * tex_size - 0.5;
 
-    vec2 fxy = fract(tex_coords);
-    tex_coords = floor(tex_coords);
+    vec2 fxy = modf(tex_coords, tex_coords);
 
     vec4 xcubic = cubic(fxy.x);
     vec4 ycubic = cubic(fxy.y);
@@ -73,11 +72,11 @@ vec4 textureBicubic(vec2 tex_coords) {
     return mix(mix(sample3, sample2, sx), mix(sample1, sample0, sx), sy);
 }
 
-void main() {
-    vec4 center_texel = textureLod(input_texture, tex_coord, 0.0);
-    tex_size = vec2(textureSize(input_texture, 0));
-    inv_tex_size = 1.0 / tex_size;
+mat4x3 center_matrix;
+vec4 center_alpha;
 
+// Finds the distance between four colors and cc in YCbCr space
+vec4 ColorDist(vec4 A, vec4 B, vec4 C, vec4 D) {
     // https://en.wikipedia.org/wiki/YCbCr#ITU-R_BT.2020_conversion
     const vec3 K = vec3(0.2627, 0.6780, 0.0593);
     const float LUMINANCE_WEIGHT = .6;
@@ -85,49 +84,53 @@ void main() {
         mat3(K * LUMINANCE_WEIGHT, -.5 * K.r / (1.0 - K.b), -.5 * K.g / (1.0 - K.b), .5, .5,
              -.5 * K.g / (1.0 - K.r), -.5 * K.b / (1.0 - K.r));
 
-    mat4x3 center = mat4x3(center_texel.rgb, center_texel.rgb, center_texel.rgb, center_texel.rgb);
-#define BODY(var, direction)                                                                       \
-    mat3x4 var;                                                                                    \
-    {                                                                                              \
-        const int up = direction;                                                                  \
-        vec4 A = textureLodOffset(input_texture, tex_coord, 0.0, ivec2(-up, up));                  \
-        vec4 B = textureLodOffset(input_texture, tex_coord, 0.0, ivec2(0, up));                    \
-        vec4 C = textureLodOffset(input_texture, tex_coord, 0.0, ivec2(up, up));                   \
-        vec4 D = textureLodOffset(input_texture, tex_coord, 0.0, ivec2(-up, 0));                   \
-                                                                                                   \
-        mat4x3 colors = mat4x3(A.rgb, B.rgb, C.rgb, D.rgb) - center;                               \
-                                                                                                   \
-        mat4x3 YCbCr = YCBCR_MATRIX * colors;                                                      \
-                                                                                                   \
-        vec4 color_dist = vec3(1.0) * YCbCr;                                                       \
-        color_dist *= color_dist;                                                                  \
-                                                                                                   \
-        vec4 alpha = vec4(A.a, B.a, C.a, D.a);                                                     \
-                                                                                                   \
-        vec4 real_dist =                                                                           \
-            sqrt((color_dist + abs(center_texel.aaaa - alpha)) * alpha * center_texel.aaaa);       \
-                                                                                                   \
-        var =                                                                                      \
-            matrixCompMult(mat3x4(real_dist, real_dist, real_dist),                                \
-                           mat3x4(vec4(-up, 0, up, -up), vec4(up, up, up, 0), vec4(1, 1, 1, 1)));  \
-    }
+    mat4x3 colors = mat4x3(A.rgb, B.rgb, C.rgb, D.rgb) - center_matrix;
+    mat4x3 YCbCr = YCBCR_MATRIX * colors;
+    vec4 color_dist = vec3(1.0) * YCbCr;
+    color_dist *= color_dist;
+    vec4 alpha = vec4(A.a, B.a, C.a, D.a);
 
-    BODY(offset_tl, 1);
-    BODY(offset_br, -1);
+    return sqrt((color_dist + abs(center_alpha - alpha)) * alpha * center_alpha);
+}
 
-    vec3 total_offset = vec4(1.0) * (offset_tl + offset_br);
+void main() {
+    vec4 bl = textureLodOffset(input_texture, tex_coord, 0.0, ivec2(-1, -1));
+    vec4 bc = textureLodOffset(input_texture, tex_coord, 0.0, ivec2(0, -1));
+    vec4 br = textureLodOffset(input_texture, tex_coord, 0.0, ivec2(1, -1));
+    vec4 cl = textureLodOffset(input_texture, tex_coord, 0.0, ivec2(-1, 0));
+    vec4 cc = textureLod(input_texture, tex_coord, 0.0);
+    vec4 cr = textureLodOffset(input_texture, tex_coord, 0.0, ivec2(1, 0));
+    vec4 tl = textureLodOffset(input_texture, tex_coord, 0.0, ivec2(-1, 1));
+    vec4 tc = textureLodOffset(input_texture, tex_coord, 0.0, ivec2(0, 1));
+    vec4 tr = textureLodOffset(input_texture, tex_coord, 0.0, ivec2(1, 1));
 
-    if (total_offset.z == 0.0) {
+
+    tex_size = vec2(textureSize(input_texture, 0));
+    inv_tex_size = 1.0 / tex_size;
+    center_matrix = mat4x3(cc.rgb, cc.rgb, cc.rgb, cc.rgb);
+    center_alpha = cc.aaaa;
+
+    vec4 offset_tl = ColorDist(tl, tc, tr, cr);
+    vec4 offset_br = ColorDist(br, bc, bl, cl);
+
+    // Calculate how different cc is from the texels around it
+    float total_dist = dot(offset_tl + offset_br, vec4(1.0));
+
+    // Add together all the distances with direction taken into account
+    vec4 tmp = offset_tl - offset_br;
+    vec2 total_offset = tmp.wy + tmp.zz + vec2(-tmp.x, tmp.x);
+
+    if (total_dist == 0.0) {
         // Doing bicubic filtering just past the edges where the offset is 0 causes black floaters
         // and it doesn't really matter which filter is used when the colors aren't changing.
-        frag_color = center_texel;
+        frag_color = cc;
     } else {
         // When the image has thin points, they tend to split apart.
         // This is because the texels all around are different
         // and total_offset reaches into clear areas.
         // This works pretty well to keep the offset in bounds for these cases.
-        float clamp_val = length(total_offset.xy) / total_offset.z;
-        vec2 final_offset = clamp(total_offset.xy, -clamp_val, clamp_val) * inv_tex_size;
+        float clamp_val = length(total_offset) / total_dist;
+        vec2 final_offset = clamp(total_offset, -clamp_val, clamp_val) * inv_tex_size;
 
         frag_color = textureBicubic(tex_coord - final_offset);
     }


### PR DESCRIPTION
The newer version tweaks the color distance algorithm to reduce the "black paint brush" effect at the tips of thin objects.

Before:
![ScaleForce v1](https://user-images.githubusercontent.com/28246325/80259057-5598ca80-864a-11ea-8599-09991757c081.png)

After:
![ScaleForce v2](https://user-images.githubusercontent.com/28246325/80259077-5cbfd880-864a-11ea-955e-e307831a210a.png)

It's also a bit faster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5270)
<!-- Reviewable:end -->
