### PR TITLE
Update FPS to roughly match the actual 3DS rate

### DIFF
--- a/src/core/cheats/cheats.cpp
+++ b/src/core/cheats/cheats.cpp
@@ -11,10 +11,11 @@
 #include "core/core.h"
 #include "core/core_timing.h"
 #include "core/hle/kernel/process.h"
+#include "core/hw/gpu.h"
 
 namespace Cheats {
 
-constexpr u64 run_interval_ticks = BASE_CLOCK_RATE_ARM11 / 60;
+constexpr u64 run_interval_ticks = GPU::frame_ticks;
 
 CheatEngine::CheatEngine(Core::System& system_) : system(system_) {
     LoadCheatFile();

--- a/src/core/dumping/ffmpeg_backend.cpp
+++ b/src/core/dumping/ffmpeg_backend.cpp
@@ -124,8 +124,11 @@ bool FFmpegVideoStream::Init(FFmpegMuxer& muxer, const Layout::FramebufferLayout
     codec_context->bit_rate = Settings::values.video_bitrate;
     codec_context->width = layout.width;
     codec_context->height = layout.height;
-    codec_context->time_base.num = 1;
-    codec_context->time_base.den = 60;
+    // TODO(xperia64): Replace with the core timing derived refresh rate
+    //                 Verify that an FPS of 59.83... can actually be requested
+    //                 (this doesn't seem to be working currently)
+    codec_context->time_base.num = 1000000;
+    codec_context->time_base.den = 59833997;
     codec_context->gop_size = 12;
     codec_context->pix_fmt = codec->pix_fmts ? codec->pix_fmts[0] : AV_PIX_FMT_YUV420P;
     if (format_context->oformat->flags & AVFMT_GLOBALHEADER)

--- a/src/core/dumping/ffmpeg_backend.cpp
+++ b/src/core/dumping/ffmpeg_backend.cpp
@@ -9,6 +9,7 @@
 #include "common/param_package.h"
 #include "common/string_util.h"
 #include "core/dumping/ffmpeg_backend.h"
+#include "core/hw/gpu.h"
 #include "core/settings.h"
 #include "video_core/renderer_base.h"
 #include "video_core/video_core.h"
@@ -127,8 +128,8 @@ bool FFmpegVideoStream::Init(FFmpegMuxer& muxer, const Layout::FramebufferLayout
     // TODO(xperia64): Replace with the core timing derived refresh rate
     //                 Verify that an FPS of 59.83... can actually be requested
     //                 (this doesn't seem to be working currently)
-    codec_context->time_base.num = 1000000;
-    codec_context->time_base.den = 59833997;
+    codec_context->time_base.num = static_cast<int>(GPU::frame_ticks);
+    codec_context->time_base.den = static_cast<int>(BASE_CLOCK_RATE_ARM11);
     codec_context->gop_size = 12;
     codec_context->pix_fmt = codec->pix_fmts ? codec->pix_fmts[0] : AV_PIX_FMT_YUV420P;
     if (format_context->oformat->flags & AVFMT_GLOBALHEADER)

--- a/src/core/dumping/ffmpeg_backend.cpp
+++ b/src/core/dumping/ffmpeg_backend.cpp
@@ -128,8 +128,8 @@ bool FFmpegVideoStream::Init(FFmpegMuxer& muxer, const Layout::FramebufferLayout
     // TODO(xperia64): While these numbers from core timing work fine, certain video codecs do not
     // support the strange resulting timebase (280071/16756991); Addressing this issue would require
     // resampling the video
-    // Known working: mjpeg, libx264
-    // Known not working: mpeg2, mpeg4
+    // List of codecs known broken by this change: mpeg1, mpeg2, mpeg4, libxvid
+    // See https://github.com/citra-emu/citra/pull/5273#issuecomment-643023325 for more information
     codec_context->time_base.num = static_cast<int>(GPU::frame_ticks);
     codec_context->time_base.den = static_cast<int>(BASE_CLOCK_RATE_ARM11);
     codec_context->gop_size = 12;

--- a/src/core/dumping/ffmpeg_backend.cpp
+++ b/src/core/dumping/ffmpeg_backend.cpp
@@ -125,9 +125,11 @@ bool FFmpegVideoStream::Init(FFmpegMuxer& muxer, const Layout::FramebufferLayout
     codec_context->bit_rate = Settings::values.video_bitrate;
     codec_context->width = layout.width;
     codec_context->height = layout.height;
-    // TODO(xperia64): Replace with the core timing derived refresh rate
-    //                 Verify that an FPS of 59.83... can actually be requested
-    //                 (this doesn't seem to be working currently)
+    // TODO(xperia64): While these numbers from core timing work fine, certain video codecs do not
+    // support the strange resulting timebase (280071/16756991); Addressing this issue would require
+    // resampling the video
+    // Known working: mjpeg, libx264
+    // Known not working: mpeg2, mpeg4
     codec_context->time_base.num = static_cast<int>(GPU::frame_ticks);
     codec_context->time_base.den = static_cast<int>(BASE_CLOCK_RATE_ARM11);
     codec_context->gop_size = 12;

--- a/src/core/hw/gpu.cpp
+++ b/src/core/hw/gpu.cpp
@@ -30,8 +30,6 @@ namespace GPU {
 Regs g_regs;
 Memory::MemorySystem* g_memory;
 
-/// 268MHz CPU clocks / 60Hz frames per second
-const u64 frame_ticks = static_cast<u64>(BASE_CLOCK_RATE_ARM11 / SCREEN_REFRESH_RATE);
 /// Event id for CoreTiming
 static Core::TimingEventType* vblank_event;
 

--- a/src/core/hw/gpu.h
+++ b/src/core/hw/gpu.h
@@ -19,7 +19,10 @@ class MemorySystem;
 
 namespace GPU {
 
-constexpr float SCREEN_REFRESH_RATE = 60;
+// TODO(xperia64): This should be defined by the number of
+// ARM11 cycles per vblank interval once that value is measured
+// and not the other way around
+constexpr double SCREEN_REFRESH_RATE = 59.833997376556916;
 
 // Returns index corresponding to the Regs member labeled by field_name
 #define GPU_REG_INDEX(field_name) (offsetof(GPU::Regs, field_name) / sizeof(u32))

--- a/src/core/hw/gpu.h
+++ b/src/core/hw/gpu.h
@@ -12,6 +12,7 @@
 #include "common/bit_field.h"
 #include "common/common_funcs.h"
 #include "common/common_types.h"
+#include "core/core_timing.h"
 
 namespace Memory {
 class MemorySystem;
@@ -19,10 +20,12 @@ class MemorySystem;
 
 namespace GPU {
 
-// TODO(xperia64): This should be defined by the number of
-// ARM11 cycles per vblank interval once that value is measured
-// and not the other way around
-constexpr double SCREEN_REFRESH_RATE = 59.833997376556916;
+// Measured on hardware to be 2240568 timer cycles or 4481136 ARM11 cycles
+constexpr u64 frame_ticks = 4481136ull;
+
+// Refresh rate defined by ratio of ARM11 frequency to ARM11 ticks per frame
+// (268,111,856) / (4,481,136) = 59.83122493939037Hz
+constexpr double SCREEN_REFRESH_RATE = BASE_CLOCK_RATE_ARM11 / static_cast<double>(frame_ticks);
 
 // Returns index corresponding to the Regs member labeled by field_name
 #define GPU_REG_INDEX(field_name) (offsetof(GPU::Regs, field_name) / sizeof(u32))


### PR DESCRIPTION
Fixes #4169, #5265, and presumably #4527. Probably other games too.
All fixed with HLE audio only for now; LLE appears to have other bugs.
This doesn't appear to affect/break my other desync fix in #5266

Since the beginning of Citra, the screen refresh rate had a placeholder value of 60Hz. The 3DS screen refresh rate is fairly well known to be roughly 59.83Hz. This is a large enough difference that heavily affects rhythm games.

TODO List for this [WIP] PR:
- [x] Measure the actual hardware frame interval in ARM11 cycles and place that here OR figure out the math behind it: https://github.com/citra-emu/citra/blob/master/src/core/hw/gpu.cpp#L34
- [x] Update https://github.com/citra-emu/citra/blob/master/src/core/hw/gpu.h#L22 to be a function of that interval, and all other places the screen refresh rate matters
- [x] Fix FFmpeg video dumping; It used a hardcoded 60FPS and I'm having trouble making it output 59.83 correctly
- [x] Investigate the impact of this change on things like TAS movies, savestates, etc.
- [x] Verify everything is still fixed after making all of the above changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5273)
<!-- Reviewable:end -->
