### PR TITLE
Port yuzu-emu/yuzu#3791: "configuration: Add Restore Default and Clear options to hotkeys"

### DIFF
--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -57,7 +57,7 @@ const std::array<std::array<int, 5>, Settings::NativeAnalog::NumAnalogs> Config:
 // This must be in alphabetical order according to action name as it must have the same order as
 // UISetting::values.shortcuts, which is alphabetically ordered.
 // clang-format off
-const std::array<UISettings::Shortcut, 23> default_hotkeys{
+const std::array<UISettings::Shortcut, 23> Config::default_hotkeys{
     {{QStringLiteral("Advance Frame"),            QStringLiteral("Main Window"), {QStringLiteral("\\"), Qt::ApplicationShortcut}},
      {QStringLiteral("Capture Screenshot"),       QStringLiteral("Main Window"), {QStringLiteral("Ctrl+P"), Qt::ApplicationShortcut}},
      {QStringLiteral("Continue/Pause Emulation"), QStringLiteral("Main Window"), {QStringLiteral("F4"), Qt::WindowShortcut}},

--- a/src/citra_qt/configuration/config.h
+++ b/src/citra_qt/configuration/config.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <string>
 #include <QVariant>
+#include "citra_qt/uisettings.h"
 #include "core/settings.h"
 
 class QSettings;
@@ -22,6 +23,7 @@ public:
 
     static const std::array<int, Settings::NativeButton::NumButtons> default_buttons;
     static const std::array<std::array<int, 5>, Settings::NativeAnalog::NumAnalogs> default_analogs;
+    static const std::array<UISettings::Shortcut, 23> default_hotkeys;
 
 private:
     void ReadValues();

--- a/src/citra_qt/configuration/configure_hotkeys.h
+++ b/src/citra_qt/configuration/configure_hotkeys.h
@@ -44,6 +44,10 @@ private:
     bool IsUsedKey(QKeySequence key_sequence) const;
     QList<QKeySequence> GetUsedKeyList() const;
 
+    void RestoreDefaults();
+    void ClearAll();
+    void PopupContextMenu(const QPoint& menu_location);
+
     std::unique_ptr<Ui::ConfigureHotkeys> ui;
 
     /**

--- a/src/citra_qt/configuration/configure_hotkeys.ui
+++ b/src/citra_qt/configuration/configure_hotkeys.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QVBoxLayout" name="verticalLayout_2">
+    <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QLabel" name="label_2">
        <property name="text">
@@ -23,6 +23,37 @@
        </property>
       </widget>
      </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="button_clear_all">
+       <property name="text">
+        <string>Clear All</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="button_restore_defaults">
+       <property name="text">
+        <string>Restore Defaults</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout_2">
      <item>
       <widget class="QTreeView" name="hotkey_list">
        <property name="editTriggers">


### PR DESCRIPTION
See yuzu-emu/yuzu#3791 for more details.

**Original description**:
* This adds Clear and Restore Default for each and all hotkeys:
![image](https://user-images.githubusercontent.com/5352197/80243148-eda4ad00-8666-11ea-8973-40e932090ecf.png)

* Shows which action the key sequence is already assigned to, both if you're trying to set a new one or restore one to default:
![image](https://user-images.githubusercontent.com/5352197/80243306-4aa06300-8667-11ea-9852-856377df52fa.png)
![image](https://user-images.githubusercontent.com/5352197/80243320-54c26180-8667-11ea-9490-2e5d60052ece.png)

* Reorders the hotkeys in config.cpp to actually be in alphabetical order. 

I'm not sure if it's correct to make the key sequence empty, but it works like intended and I'm not getting any errors. It seems Qt deals with that on it's own.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5278)
<!-- Reviewable:end -->
