### PR TITLE
savedata_archive: Make GetFreeBytes return a more accurate value

### DIFF
--- a/src/core/file_sys/savedata_archive.cpp
+++ b/src/core/file_sys/savedata_archive.cpp
@@ -351,8 +351,8 @@ ResultVal<std::unique_ptr<DirectoryBackend>> SaveDataArchive::OpenDirectory(
 }
 
 u64 SaveDataArchive::GetFreeBytes() const {
-    // TODO: Stubbed to return 1GiB
-    return 1024 * 1024 * 1024;
+    // TODO: Stubbed to return 32MiB
+    return 1024 * 1024 * 32;
 }
 
 } // namespace FileSys


### PR DESCRIPTION
Previously, we were returning a value that was way too big, causing an integer overflow in Fractured Souls.
According to wwylele, the biggest observed save size for 3DS is 1MB, so this new value should leave plenty of room, even if games use a bigger size.

Fixes https://github.com/citra-emu/citra/issues/1320.
Thanks to xperia64, Subv, wwylele, Hamish and B3N30 for investigating this on Discord.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5282)
<!-- Reviewable:end -->
