### PR TITLE
gl_shader_gen: Minor interface cleanup

### DIFF
--- a/src/common/hash.h
+++ b/src/common/hash.h
@@ -17,7 +17,7 @@ namespace Common {
  * @param len Length of data (in bytes) to compute hash over
  * @returns 64-bit hash value that was computed over the data block
  */
-static inline u64 ComputeHash64(const void* data, std::size_t len) {
+static inline u64 ComputeHash64(const void* data, std::size_t len) noexcept {
     return CityHash64(static_cast<const char*>(data), len);
 }
 
@@ -27,7 +27,7 @@ static inline u64 ComputeHash64(const void* data, std::size_t len) {
  * by memsetting the struct to 0 before filling it in.
  */
 template <typename T>
-static inline u64 ComputeStructHash64(const T& data) {
+static inline u64 ComputeStructHash64(const T& data) noexcept {
     static_assert(std::is_trivially_copyable_v<T>,
                   "Type passed to ComputeStructHash64 must be trivially copyable");
     return ComputeHash64(&data, sizeof(data));
@@ -50,20 +50,20 @@ struct HashableStruct {
         T state;
     };
 
-    HashableStruct() {
+    HashableStruct() noexcept {
         // Memset structure to zero padding bits, so that they will be deterministic when hashing
         std::memset(&state, 0, sizeof(T));
     }
 
-    bool operator==(const HashableStruct<T>& o) const {
+    bool operator==(const HashableStruct<T>& o) const noexcept {
         return std::memcmp(&state, &o.state, sizeof(T)) == 0;
     };
 
-    bool operator!=(const HashableStruct<T>& o) const {
+    bool operator!=(const HashableStruct<T>& o) const noexcept {
         return !(*this == o);
     };
 
-    std::size_t Hash() const {
+    std::size_t Hash() const noexcept {
         return Common::ComputeStructHash64(state);
     }
 };

--- a/src/video_core/renderer_opengl/gl_shader_gen.h
+++ b/src/video_core/renderer_opengl/gl_shader_gen.h
@@ -170,7 +170,7 @@ struct PicaVSConfig : Common::HashableStruct<PicaShaderConfigCommon> {
     explicit PicaVSConfig(const Pica::ShaderRegs& regs, Pica::Shader::ShaderSetup& setup) {
         state.Init(regs, setup);
     }
-    explicit PicaVSConfig(PicaShaderConfigCommon& conf) {
+    explicit PicaVSConfig(const PicaShaderConfigCommon& conf) {
         state = conf;
     }
 };

--- a/src/video_core/renderer_opengl/gl_shader_gen.h
+++ b/src/video_core/renderer_opengl/gl_shader_gen.h
@@ -237,21 +237,21 @@ ShaderDecompiler::ProgramResult GenerateFragmentShader(const PicaFSConfig& confi
 namespace std {
 template <>
 struct hash<OpenGL::PicaFSConfig> {
-    std::size_t operator()(const OpenGL::PicaFSConfig& k) const {
+    std::size_t operator()(const OpenGL::PicaFSConfig& k) const noexcept {
         return k.Hash();
     }
 };
 
 template <>
 struct hash<OpenGL::PicaVSConfig> {
-    std::size_t operator()(const OpenGL::PicaVSConfig& k) const {
+    std::size_t operator()(const OpenGL::PicaVSConfig& k) const noexcept {
         return k.Hash();
     }
 };
 
 template <>
 struct hash<OpenGL::PicaFixedGSConfig> {
-    std::size_t operator()(const OpenGL::PicaFixedGSConfig& k) const {
+    std::size_t operator()(const OpenGL::PicaFixedGSConfig& k) const noexcept {
         return k.Hash();
     }
 };


### PR DESCRIPTION
Marks a reference parameter as a const reference and also marks the hash implementations as noexcept, given they shouldn't throw.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5290)
<!-- Reviewable:end -->
