### PR TITLE
renderer_opengl: Resolve compiler truncation warnings

### DIFF
--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -485,14 +485,14 @@ void RendererOpenGL::RenderToMailbox(const Layout::FramebufferLayout& layout,
         // delete the draw fence if the frame wasn't presented
         if (frame->render_fence) {
             glDeleteSync(frame->render_fence);
-            frame->render_fence = 0;
+            frame->render_fence = nullptr;
         }
 
         // wait for the presentation to be done
         if (frame->present_fence) {
             glWaitSync(frame->present_fence, 0, GL_TIMEOUT_IGNORED);
             glDeleteSync(frame->present_fence);
-            frame->present_fence = 0;
+            frame->present_fence = nullptr;
         }
     }
 
@@ -530,8 +530,8 @@ void RendererOpenGL::LoadFBToScreenInfo(const GPU::Regs::FramebufferConfig& fram
             : (!right_eye ? framebuffer.address_left2 : framebuffer.address_right2);
 
     LOG_TRACE(Render_OpenGL, "0x{:08x} bytes from 0x{:08x}({}x{}), fmt {:x}",
-              framebuffer.stride * framebuffer.height, framebuffer_addr, (int)framebuffer.width,
-              (int)framebuffer.height, (int)framebuffer.format);
+              framebuffer.stride * framebuffer.height, framebuffer_addr, framebuffer.width.Value(),
+              framebuffer.height.Value(), framebuffer.format);
 
     int bpp = GPU::Regs::BytesPerPixel(framebuffer.color_format);
     std::size_t pixel_stride = framebuffer.stride / bpp;
@@ -800,11 +800,11 @@ void RendererOpenGL::DrawSingleScreenRotated(const ScreenInfo& screen_info, floa
     // As this is the "DrawSingleScreenRotated" function, the output resolution dimensions have been
     // swapped. If a non-rotated draw-screen function were to be added for book-mode games, those
     // should probably be set to the standard (w, h, 1.0 / w, 1.0 / h) ordering.
-    u16 scale_factor = VideoCore::GetResolutionScaleFactor();
-    glUniform4f(uniform_i_resolution, screen_info.texture.width * scale_factor,
-                screen_info.texture.height * scale_factor,
-                1.0 / (screen_info.texture.width * scale_factor),
-                1.0 / (screen_info.texture.height * scale_factor));
+    const u16 scale_factor = VideoCore::GetResolutionScaleFactor();
+    glUniform4f(uniform_i_resolution, static_cast<float>(screen_info.texture.width * scale_factor),
+                static_cast<float>(screen_info.texture.height * scale_factor),
+                1.0f / static_cast<float>(screen_info.texture.width * scale_factor),
+                1.0f / static_cast<float>(screen_info.texture.height * scale_factor));
     glUniform4f(uniform_o_resolution, h, w, 1.0f / h, 1.0f / w);
     state.texture_units[0].texture_2d = screen_info.display_texture;
     state.texture_units[0].sampler = filter_sampler.handle;
@@ -829,11 +829,11 @@ void RendererOpenGL::DrawSingleScreen(const ScreenInfo& screen_info, float x, fl
         ScreenRectVertex(x + w, y + h, texcoords.top, texcoords.left),
     }};
 
-    u16 scale_factor = VideoCore::GetResolutionScaleFactor();
-    glUniform4f(uniform_i_resolution, screen_info.texture.width * scale_factor,
-                screen_info.texture.height * scale_factor,
-                1.0 / (screen_info.texture.width * scale_factor),
-                1.0 / (screen_info.texture.height * scale_factor));
+    const u16 scale_factor = VideoCore::GetResolutionScaleFactor();
+    glUniform4f(uniform_i_resolution, static_cast<float>(screen_info.texture.width * scale_factor),
+                static_cast<float>(screen_info.texture.height * scale_factor),
+                1.0f / static_cast<float>(screen_info.texture.width * scale_factor),
+                1.0f / static_cast<float>(screen_info.texture.height * scale_factor));
     glUniform4f(uniform_o_resolution, w, h, 1.0f / w, 1.0f / h);
     state.texture_units[0].texture_2d = screen_info.display_texture;
     state.texture_units[0].sampler = filter_sampler.handle;
@@ -863,11 +863,12 @@ void RendererOpenGL::DrawSingleScreenStereoRotated(const ScreenInfo& screen_info
         ScreenRectVertex(x + w, y + h, texcoords.top, texcoords.right),
     }};
 
-    u16 scale_factor = VideoCore::GetResolutionScaleFactor();
-    glUniform4f(uniform_i_resolution, screen_info_l.texture.width * scale_factor,
-                screen_info_l.texture.height * scale_factor,
-                1.0 / (screen_info_l.texture.width * scale_factor),
-                1.0 / (screen_info_l.texture.height * scale_factor));
+    const u16 scale_factor = VideoCore::GetResolutionScaleFactor();
+    glUniform4f(uniform_i_resolution,
+                static_cast<float>(screen_info_l.texture.width * scale_factor),
+                static_cast<float>(screen_info_l.texture.height * scale_factor),
+                1.0f / static_cast<float>(screen_info_l.texture.width * scale_factor),
+                1.0f / static_cast<float>(screen_info_l.texture.height * scale_factor));
     glUniform4f(uniform_o_resolution, h, w, 1.0f / h, 1.0f / w);
     state.texture_units[0].texture_2d = screen_info_l.display_texture;
     state.texture_units[1].texture_2d = screen_info_r.display_texture;
@@ -897,11 +898,12 @@ void RendererOpenGL::DrawSingleScreenStereo(const ScreenInfo& screen_info_l,
         ScreenRectVertex(x + w, y + h, texcoords.top, texcoords.left),
     }};
 
-    u16 scale_factor = VideoCore::GetResolutionScaleFactor();
-    glUniform4f(uniform_i_resolution, screen_info_l.texture.width * scale_factor,
-                screen_info_l.texture.height * scale_factor,
-                1.0 / (screen_info_l.texture.width * scale_factor),
-                1.0 / (screen_info_l.texture.height * scale_factor));
+    const u16 scale_factor = VideoCore::GetResolutionScaleFactor();
+    glUniform4f(uniform_i_resolution,
+                static_cast<float>(screen_info_l.texture.width * scale_factor),
+                static_cast<float>(screen_info_l.texture.height * scale_factor),
+                1.0f / static_cast<float>(screen_info_l.texture.width * scale_factor),
+                1.0f / static_cast<float>(screen_info_l.texture.height * scale_factor));
     glUniform4f(uniform_o_resolution, w, h, 1.0f / w, 1.0f / h);
     state.texture_units[0].texture_2d = screen_info_l.display_texture;
     state.texture_units[1].texture_2d = screen_info_r.display_texture;


### PR DESCRIPTION
Resolves numerous truncation warnings on MSVC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5291)
<!-- Reviewable:end -->
