### PR TITLE
swkbd: Fix a bug where clicking Cancel hangs the game

### DIFF
--- a/src/citra_qt/applets/swkbd.cpp
+++ b/src/citra_qt/applets/swkbd.cpp
@@ -115,7 +115,7 @@ void QtKeyboard::Execute(const Frontend::KeyboardConfig& config) {
         ok_id = static_cast<u8>(this->config.button_config);
     }
     QMetaObject::invokeMethod(this, "OpenInputDialog", Qt::BlockingQueuedConnection);
-    Finalize(text, button);
+    Finalize(result_text, result_button);
 }
 
 void QtKeyboard::ShowError(const std::string& error) {
@@ -126,14 +126,15 @@ void QtKeyboard::ShowError(const std::string& error) {
 
 void QtKeyboard::OpenInputDialog() {
     QtKeyboardDialog dialog(&parent, this);
-    dialog.setWindowFlags(Qt::Dialog | Qt::CustomizeWindowHint | Qt::WindowTitleHint |
-                          Qt::WindowSystemMenuHint | Qt::WindowCloseButtonHint);
+    dialog.setWindowFlags(dialog.windowFlags() &
+                          ~(Qt::WindowCloseButtonHint | Qt::WindowContextHelpButtonHint));
     dialog.setWindowModality(Qt::WindowModal);
     dialog.exec();
 
-    text = dialog.text.toStdString();
-    button = dialog.button;
-    LOG_INFO(Frontend, "SWKBD input dialog finished, text={}, button={}", text, button);
+    result_text = dialog.text.toStdString();
+    result_button = dialog.button;
+    LOG_INFO(Frontend, "SWKBD input dialog finished, text={}, button={}", result_text,
+             result_button);
 }
 
 void QtKeyboard::ShowErrorDialog(QString message) {

--- a/src/citra_qt/applets/swkbd.cpp
+++ b/src/citra_qt/applets/swkbd.cpp
@@ -115,6 +115,7 @@ void QtKeyboard::Execute(const Frontend::KeyboardConfig& config) {
         ok_id = static_cast<u8>(this->config.button_config);
     }
     QMetaObject::invokeMethod(this, "OpenInputDialog", Qt::BlockingQueuedConnection);
+    Finalize(text, button);
 }
 
 void QtKeyboard::ShowError(const std::string& error) {
@@ -129,9 +130,10 @@ void QtKeyboard::OpenInputDialog() {
                           Qt::WindowSystemMenuHint | Qt::WindowCloseButtonHint);
     dialog.setWindowModality(Qt::WindowModal);
     dialog.exec();
-    LOG_INFO(Frontend, "SWKBD input dialog finished, text={}, button={}", dialog.text.toStdString(),
-             dialog.button);
-    Finalize(dialog.text.toStdString(), dialog.button);
+
+    text = dialog.text.toStdString();
+    button = dialog.button;
+    LOG_INFO(Frontend, "SWKBD input dialog finished, text={}, button={}", text, button);
 }
 
 void QtKeyboard::ShowErrorDialog(QString message) {

--- a/src/citra_qt/applets/swkbd.h
+++ b/src/citra_qt/applets/swkbd.h
@@ -62,8 +62,8 @@ private:
 
     QWidget& parent;
 
-    std::string text;
-    int button;
+    std::string result_text;
+    int result_button;
 
     friend class QtKeyboardDialog;
     friend class QtKeyboardValidator;

--- a/src/citra_qt/applets/swkbd.h
+++ b/src/citra_qt/applets/swkbd.h
@@ -62,6 +62,9 @@ private:
 
     QWidget& parent;
 
+    std::string text;
+    int button;
+
     friend class QtKeyboardDialog;
     friend class QtKeyboardValidator;
 };

--- a/src/core/frontend/applets/swkbd.cpp
+++ b/src/core/frontend/applets/swkbd.cpp
@@ -120,12 +120,15 @@ ValidationError SoftwareKeyboard::ValidateButton(u8 button) const {
 }
 
 ValidationError SoftwareKeyboard::Finalize(const std::string& text, u8 button) {
-    ValidationError error;
-    if ((error = ValidateInput(text)) != ValidationError::None) {
-        return error;
-    }
-    if ((error = ValidateButton(button)) != ValidationError::None) {
-        return error;
+    // Skip check when OK is not pressed
+    if (button == static_cast<u8>(config.button_config)) {
+        ValidationError error;
+        if ((error = ValidateInput(text)) != ValidationError::None) {
+            return error;
+        }
+        if ((error = ValidateButton(button)) != ValidationError::None) {
+            return error;
+        }
     }
     data = {text, button};
     data_ready = true;

--- a/src/core/frontend/applets/swkbd.h
+++ b/src/core/frontend/applets/swkbd.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <atomic>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -133,7 +132,7 @@ protected:
     KeyboardConfig config;
     KeyboardData data;
 
-    std::atomic_bool data_ready = false;
+    bool data_ready = false;
 };
 
 class DefaultKeyboard final : public SoftwareKeyboard {


### PR DESCRIPTION
The text is validated in `Finalize`. If the validation fails, an error is returned and the applet is not actually finalized. This can result in hangs.

This is usually not a problem as the frontend is expected to validate the text passed to `Finalize`. However, when the user clicked on `Cancel`, the text is ignored and the frontend won't do any validation. Therefore, we should skip the validation here as well.

Also fixed a potential data race. All these functions should now be called on the same thread

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5294)
<!-- Reviewable:end -->
