### PR TITLE
gl_rasterizer: Amend missing return value in branch in SetupGeometryShader()

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -390,12 +390,14 @@ bool RasterizerOpenGL::SetupVertexShader() {
 bool RasterizerOpenGL::SetupGeometryShader() {
     MICROPROFILE_SCOPE(OpenGL_GS);
     const auto& regs = Pica::g_state.regs;
-    if (regs.pipeline.use_gs == Pica::PipelineRegs::UseGS::No) {
-        shader_program_manager->UseFixedGeometryShader(regs);
-        return true;
-    } else {
+
+    if (regs.pipeline.use_gs != Pica::PipelineRegs::UseGS::No) {
         LOG_ERROR(Render_OpenGL, "Accelerate draw doesn't support geometry shader");
+        return false;
     }
+
+    shader_program_manager->UseFixedGeometryShader(regs);
+    return true;
 }
 
 bool RasterizerOpenGL::AccelerateDrawBatch(bool is_indexed) {


### PR DESCRIPTION
Previously undefined behavior was being invoked in the case that geometry shaders weren't supported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5297)
<!-- Reviewable:end -->
