### PR TITLE
gl_rasterizer: Silence various compilation warnings

### DIFF
--- a/src/video_core/regs_shader.h
+++ b/src/video_core/regs_shader.h
@@ -43,10 +43,10 @@ struct ShaderRegs {
     u32 input_attribute_to_register_map_low;
     u32 input_attribute_to_register_map_high;
 
-    unsigned int GetRegisterForAttribute(unsigned int attribute_index) const {
-        u64 map = ((u64)input_attribute_to_register_map_high << 32) |
-                  (u64)input_attribute_to_register_map_low;
-        return (map >> (attribute_index * 4)) & 0b1111;
+    u32 GetRegisterForAttribute(std::size_t attribute_index) const {
+        const u64 map = (static_cast<u64>(input_attribute_to_register_map_high) << 32) |
+                        static_cast<u64>(input_attribute_to_register_map_low);
+        return static_cast<u32>((map >> (attribute_index * 4)) & 0b1111);
     }
 
     BitField<0, 16, u32> output_mask;

--- a/src/video_core/renderer_base.cpp
+++ b/src/video_core/renderer_base.cpp
@@ -22,7 +22,7 @@ void RendererBase::RefreshRasterizerSetting() {
         opengl_rasterizer_active = hw_renderer_enabled;
 
         if (hw_renderer_enabled) {
-            rasterizer = std::make_unique<OpenGL::RasterizerOpenGL>(render_window);
+            rasterizer = std::make_unique<OpenGL::RasterizerOpenGL>();
         } else {
             rasterizer = std::make_unique<VideoCore::SWRasterizer>();
         }

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -290,9 +290,9 @@ RasterizerOpenGL::VertexArrayInfo RasterizerOpenGL::AnalyzeVertexArray(bool is_i
         vertex_max = regs.pipeline.vertex_offset + regs.pipeline.num_vertices - 1;
     }
 
-    u32 vertex_num = vertex_max - vertex_min + 1;
+    const u32 vertex_num = vertex_max - vertex_min + 1;
     u32 vs_input_size = 0;
-    for (auto& loader : vertex_attributes.attribute_loaders) {
+    for (const auto& loader : vertex_attributes.attribute_loaders) {
         if (loader.component_count != 0) {
             vs_input_size += loader.byte_count * vertex_num;
         }
@@ -1338,7 +1338,7 @@ void RasterizerOpenGL::NotifyPicaRegisterChanged(u32 id) {
     case PICA_REG_INDEX(lighting.lut_data[5]):
     case PICA_REG_INDEX(lighting.lut_data[6]):
     case PICA_REG_INDEX(lighting.lut_data[7]): {
-        auto& lut_config = regs.lighting.lut_config;
+        const auto& lut_config = regs.lighting.lut_config;
         uniform_block_data.lighting_lut_dirty[lut_config.type] = true;
         uniform_block_data.lighting_lut_dirty_any = true;
         break;

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -40,7 +40,7 @@ MICROPROFILE_DEFINE(OpenGL_Blits, "OpenGL", "Blits", MP_RGB(100, 100, 255));
 MICROPROFILE_DEFINE(OpenGL_CacheManagement, "OpenGL", "Cache Mgmt", MP_RGB(100, 255, 100));
 
 static bool IsVendorAmd() {
-    std::string gpu_vendor{reinterpret_cast<char const*>(glGetString(GL_VENDOR))};
+    const std::string_view gpu_vendor{reinterpret_cast<char const*>(glGetString(GL_VENDOR))};
     return gpu_vendor == "ATI Technologies Inc." || gpu_vendor == "Advanced Micro Devices, Inc.";
 }
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -44,12 +44,11 @@ static bool IsVendorAmd() {
     return gpu_vendor == "ATI Technologies Inc." || gpu_vendor == "Advanced Micro Devices, Inc.";
 }
 
-RasterizerOpenGL::RasterizerOpenGL(Frontend::EmuWindow& window)
-    : is_amd(IsVendorAmd()), shader_dirty(true),
-      vertex_buffer(GL_ARRAY_BUFFER, VERTEX_BUFFER_SIZE, is_amd),
+RasterizerOpenGL::RasterizerOpenGL()
+    : is_amd(IsVendorAmd()), vertex_buffer(GL_ARRAY_BUFFER, VERTEX_BUFFER_SIZE, is_amd),
       uniform_buffer(GL_UNIFORM_BUFFER, UNIFORM_BUFFER_SIZE, false),
       index_buffer(GL_ELEMENT_ARRAY_BUFFER, INDEX_BUFFER_SIZE, false),
-      texture_buffer(GL_TEXTURE_BUFFER, TEXTURE_BUFFER_SIZE, false), emu_window{window} {
+      texture_buffer(GL_TEXTURE_BUFFER, TEXTURE_BUFFER_SIZE, false) {
 
     allow_shadow = GLAD_GL_ARB_shader_image_load_store && GLAD_GL_ARB_shader_image_size &&
                    GLAD_GL_ARB_framebuffer_no_attachments;

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -271,17 +271,17 @@ RasterizerOpenGL::VertexArrayInfo RasterizerOpenGL::AnalyzeVertexArray(bool is_i
     u32 vertex_max;
     if (is_indexed) {
         const auto& index_info = regs.pipeline.index_array;
-        PAddr address = vertex_attributes.GetPhysicalBaseAddress() + index_info.offset;
+        const PAddr address = vertex_attributes.GetPhysicalBaseAddress() + index_info.offset;
         const u8* index_address_8 = VideoCore::g_memory->GetPhysicalPointer(address);
         const u16* index_address_16 = reinterpret_cast<const u16*>(index_address_8);
-        bool index_u16 = index_info.format != 0;
+        const bool index_u16 = index_info.format != 0;
 
         vertex_min = 0xFFFF;
         vertex_max = 0;
-        std::size_t size = regs.pipeline.num_vertices * (index_u16 ? 2 : 1);
+        const u32 size = regs.pipeline.num_vertices * (index_u16 ? 2 : 1);
         res_cache.FlushRegion(address, size, nullptr);
         for (u32 index = 0; index < regs.pipeline.num_vertices; ++index) {
-            u32 vertex = index_u16 ? index_address_16[index] : index_address_8[index];
+            const u32 vertex = index_u16 ? index_address_16[index] : index_address_8[index];
             vertex_min = std::min(vertex_min, vertex);
             vertex_max = std::max(vertex_max, vertex);
         }
@@ -362,15 +362,15 @@ void RasterizerOpenGL::SetupVertexArray(u8* array_ptr, GLintptr buffer_offset,
     for (std::size_t i = 0; i < enable_attributes.size(); ++i) {
         if (enable_attributes[i] != hw_vao_enabled_attributes[i]) {
             if (enable_attributes[i]) {
-                glEnableVertexAttribArray(i);
+                glEnableVertexAttribArray(static_cast<GLuint>(i));
             } else {
-                glDisableVertexAttribArray(i);
+                glDisableVertexAttribArray(static_cast<GLuint>(i));
             }
             hw_vao_enabled_attributes[i] = enable_attributes[i];
         }
 
         if (vertex_attributes.IsDefaultAttribute(i)) {
-            u32 reg = regs.vs.GetRegisterForAttribute(i);
+            const u32 reg = regs.vs.GetRegisterForAttribute(i);
             if (!enable_attributes[reg]) {
                 const auto& attr = Pica::g_state.input_default_attributes.attr[i];
                 glVertexAttrib4f(reg, attr.x.ToFloat32(), attr.y.ToFloat32(), attr.z.ToFloat32(),
@@ -797,15 +797,16 @@ bool RasterizerOpenGL::Draw(bool accelerate, bool is_indexed) {
         std::size_t max_vertices = 3 * (VERTEX_BUFFER_SIZE / (3 * sizeof(HardwareVertex)));
         for (std::size_t base_vertex = 0; base_vertex < vertex_batch.size();
              base_vertex += max_vertices) {
-            std::size_t vertices = std::min(max_vertices, vertex_batch.size() - base_vertex);
-            std::size_t vertex_size = vertices * sizeof(HardwareVertex);
+            const std::size_t vertices = std::min(max_vertices, vertex_batch.size() - base_vertex);
+            const std::size_t vertex_size = vertices * sizeof(HardwareVertex);
             u8* vbo;
             GLintptr offset;
             std::tie(vbo, offset, std::ignore) =
                 vertex_buffer.Map(vertex_size, sizeof(HardwareVertex));
             std::memcpy(vbo, vertex_batch.data() + base_vertex, vertex_size);
             vertex_buffer.Unmap(vertex_size);
-            glDrawArrays(GL_TRIANGLES, offset / sizeof(HardwareVertex), (GLsizei)vertices);
+            glDrawArrays(GL_TRIANGLES, static_cast<GLint>(offset / sizeof(HardwareVertex)),
+                         static_cast<GLsizei>(vertices));
         }
     }
 
@@ -1563,8 +1564,8 @@ void RasterizerOpenGL::SamplerInfo::Create() {
 
     // default is 1000 and -1000
     // Other attributes have correct defaults
-    glSamplerParameterf(sampler.handle, GL_TEXTURE_MAX_LOD, lod_max);
-    glSamplerParameterf(sampler.handle, GL_TEXTURE_MIN_LOD, lod_min);
+    glSamplerParameterf(sampler.handle, GL_TEXTURE_MAX_LOD, static_cast<float>(lod_max));
+    glSamplerParameterf(sampler.handle, GL_TEXTURE_MIN_LOD, static_cast<float>(lod_min));
 }
 
 void RasterizerOpenGL::SamplerInfo::SyncWithConfig(
@@ -1614,12 +1615,12 @@ void RasterizerOpenGL::SamplerInfo::SyncWithConfig(
 
     if (lod_min != config.lod.min_level) {
         lod_min = config.lod.min_level;
-        glSamplerParameterf(s, GL_TEXTURE_MIN_LOD, lod_min);
+        glSamplerParameterf(s, GL_TEXTURE_MIN_LOD, static_cast<float>(lod_min));
     }
 
     if (lod_max != config.lod.max_level) {
         lod_max = config.lod.max_level;
-        glSamplerParameterf(s, GL_TEXTURE_MAX_LOD, lod_max);
+        glSamplerParameterf(s, GL_TEXTURE_MAX_LOD, static_cast<float>(lod_max));
     }
 
     if (!GLES && lod_bias != config.lod.bias) {
@@ -1836,13 +1837,16 @@ void RasterizerOpenGL::SyncCombinerColor() {
     }
 }
 
-void RasterizerOpenGL::SyncTevConstColor(int stage_index,
+void RasterizerOpenGL::SyncTevConstColor(std::size_t stage_index,
                                          const Pica::TexturingRegs::TevStageConfig& tev_stage) {
-    auto const_color = PicaToGL::ColorRGBA8(tev_stage.const_color);
-    if (const_color != uniform_block_data.data.const_color[stage_index]) {
-        uniform_block_data.data.const_color[stage_index] = const_color;
-        uniform_block_data.dirty = true;
+    const auto const_color = PicaToGL::ColorRGBA8(tev_stage.const_color);
+
+    if (const_color == uniform_block_data.data.const_color[stage_index]) {
+        return;
     }
+
+    uniform_block_data.data.const_color[stage_index] = const_color;
+    uniform_block_data.dirty = true;
 }
 
 void RasterizerOpenGL::SyncGlobalAmbient() {
@@ -1989,7 +1993,7 @@ void RasterizerOpenGL::SyncAndUploadLUTs() {
                     std::memcpy(buffer + bytes_used, new_data.data(),
                                 new_data.size() * sizeof(GLvec2));
                     uniform_block_data.data.lighting_lut_offset[index / 4][index % 4] =
-                        (offset + bytes_used) / sizeof(GLvec2);
+                        static_cast<GLint>((offset + bytes_used) / sizeof(GLvec2));
                     uniform_block_data.dirty = true;
                     bytes_used += new_data.size() * sizeof(GLvec2);
                 }
@@ -2011,7 +2015,8 @@ void RasterizerOpenGL::SyncAndUploadLUTs() {
         if (new_data != fog_lut_data || invalidate) {
             fog_lut_data = new_data;
             std::memcpy(buffer + bytes_used, new_data.data(), new_data.size() * sizeof(GLvec2));
-            uniform_block_data.data.fog_lut_offset = (offset + bytes_used) / sizeof(GLvec2);
+            uniform_block_data.data.fog_lut_offset =
+                static_cast<GLint>((offset + bytes_used) / sizeof(GLvec2));
             uniform_block_data.dirty = true;
             bytes_used += new_data.size() * sizeof(GLvec2);
         }
@@ -2030,7 +2035,7 @@ void RasterizerOpenGL::SyncAndUploadLUTs() {
         if (new_data != lut_data || invalidate) {
             lut_data = new_data;
             std::memcpy(buffer + bytes_used, new_data.data(), new_data.size() * sizeof(GLvec2));
-            lut_offset = (offset + bytes_used) / sizeof(GLvec2);
+            lut_offset = static_cast<GLint>((offset + bytes_used) / sizeof(GLvec2));
             uniform_block_data.dirty = true;
             bytes_used += new_data.size() * sizeof(GLvec2);
         }
@@ -2071,7 +2076,8 @@ void RasterizerOpenGL::SyncAndUploadLUTs() {
         if (new_data != proctex_lut_data || invalidate) {
             proctex_lut_data = new_data;
             std::memcpy(buffer + bytes_used, new_data.data(), new_data.size() * sizeof(GLvec4));
-            uniform_block_data.data.proctex_lut_offset = (offset + bytes_used) / sizeof(GLvec4);
+            uniform_block_data.data.proctex_lut_offset =
+                static_cast<GLint>((offset + bytes_used) / sizeof(GLvec4));
             uniform_block_data.dirty = true;
             bytes_used += new_data.size() * sizeof(GLvec4);
         }
@@ -2093,7 +2099,7 @@ void RasterizerOpenGL::SyncAndUploadLUTs() {
             proctex_diff_lut_data = new_data;
             std::memcpy(buffer + bytes_used, new_data.data(), new_data.size() * sizeof(GLvec4));
             uniform_block_data.data.proctex_diff_lut_offset =
-                (offset + bytes_used) / sizeof(GLvec4);
+                static_cast<GLint>((offset + bytes_used) / sizeof(GLvec4));
             uniform_block_data.dirty = true;
             bytes_used += new_data.size() * sizeof(GLvec4);
         }

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -168,7 +168,7 @@ RasterizerOpenGL::RasterizerOpenGL()
     SyncEntireState();
 }
 
-RasterizerOpenGL::~RasterizerOpenGL() {}
+RasterizerOpenGL::~RasterizerOpenGL() = default;
 
 void RasterizerOpenGL::LoadDiskResources(const std::atomic_bool& stop_loading,
                                          const VideoCore::DiskResourceLoadCallback& callback) {

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -38,7 +38,7 @@ class ShaderProgramManager;
 
 class RasterizerOpenGL : public VideoCore::RasterizerInterface {
 public:
-    explicit RasterizerOpenGL(Frontend::EmuWindow& renderer);
+    explicit RasterizerOpenGL();
     ~RasterizerOpenGL() override;
 
     void LoadDiskResources(const std::atomic_bool& stop_loading,
@@ -268,11 +268,9 @@ private:
 
     RasterizerCacheOpenGL res_cache;
 
-    Frontend::EmuWindow& emu_window;
-
     std::vector<HardwareVertex> vertex_batch;
 
-    bool shader_dirty;
+    bool shader_dirty = true;
 
     struct {
         UniformData data;

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -195,7 +195,8 @@ private:
     void SyncCombinerColor();
 
     /// Syncs the TEV constant color to match the PICA register
-    void SyncTevConstColor(int tev_index, const Pica::TexturingRegs::TevStageConfig& tev_stage);
+    void SyncTevConstColor(std::size_t tev_index,
+                           const Pica::TexturingRegs::TevStageConfig& tev_stage);
 
     /// Syncs the lighting global ambient color to match the PICA register
     void SyncGlobalAmbient();


### PR DESCRIPTION
Resolves truncation warnings by either amending interfaces to properly handle the type being passed in, or make said truncations explicit. This also resolves a warning related to unused private class member variables and a -Wreorder warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5298)
<!-- Reviewable:end -->
