### PR TITLE
CMakeLists: Specify EXCLUDE_FROM_ALL for teakra

### DIFF
--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -72,7 +72,7 @@ add_subdirectory(soundtouch)
 target_include_directories(SoundTouch INTERFACE ./soundtouch/include)
 
 # Teakra
-add_subdirectory(teakra)
+add_subdirectory(teakra EXCLUDE_FROM_ALL)
 
 # Xbyak
 if (ARCHITECTURE_x86_64)


### PR DESCRIPTION
Ensures that unused targets introduced in the `add_subdirectory` call don't show up in IDE builds if they aren't used (which is the case for `teakra_c`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5302)
<!-- Reviewable:end -->
