### PR TITLE
service/ir: Remove erroneous forward declaration

### DIFF
--- a/src/core/hle/service/ir/ir.h
+++ b/src/core/hle/service/ir/ir.h
@@ -8,10 +8,6 @@ namespace Core {
 class System;
 }
 
-namespace SM {
-class ServiceManager;
-}
-
 namespace Service::IR {
 
 void InstallInterfaces(Core::System& system);


### PR DESCRIPTION
This can be removed as it's not used. Even if it were however, it would be an incorrect forward declaration, as `ServiceManager` exists within the `Service::SM` namespace, not the top-level `SM` namespace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5303)
<!-- Reviewable:end -->
