### PR TITLE
file-sys: Make use of std::string_view where applicable

### DIFF
--- a/src/core/file_sys/archive_extsavedata.cpp
+++ b/src/core/file_sys/archive_extsavedata.cpp
@@ -185,7 +185,7 @@ struct ExtSaveDataArchivePath {
 
 static_assert(sizeof(ExtSaveDataArchivePath) == 12, "Incorrect path size");
 
-std::string GetExtSaveDataPath(const std::string& mount_point, const Path& path) {
+std::string GetExtSaveDataPath(std::string_view mount_point, const Path& path) {
     std::vector<u8> vec_data = path.AsBinary();
 
     ExtSaveDataArchivePath path_data;
@@ -194,16 +194,16 @@ std::string GetExtSaveDataPath(const std::string& mount_point, const Path& path)
     return fmt::format("{}{:08X}/{:08X}/", mount_point, path_data.save_high, path_data.save_low);
 }
 
-std::string GetExtDataContainerPath(const std::string& mount_point, bool shared) {
-    if (shared)
+std::string GetExtDataContainerPath(std::string_view mount_point, bool shared) {
+    if (shared) {
         return fmt::format("{}data/{}/extdata/", mount_point, SYSTEM_ID);
-
+    }
     return fmt::format("{}Nintendo 3DS/{}/{}/extdata/", mount_point, SYSTEM_ID, SDCARD_ID);
 }
 
-std::string GetExtDataPathFromId(const std::string& mount_point, u64 extdata_id) {
-    u32 high = static_cast<u32>(extdata_id >> 32);
-    u32 low = static_cast<u32>(extdata_id & 0xFFFFFFFF);
+std::string GetExtDataPathFromId(std::string_view mount_point, u64 extdata_id) {
+    const u32 high = static_cast<u32>(extdata_id >> 32);
+    const u32 low = static_cast<u32>(extdata_id & 0xFFFFFFFF);
 
     return fmt::format("{}{:08x}/{:08x}/", GetExtDataContainerPath(mount_point, false), high, low);
 }

--- a/src/core/file_sys/archive_extsavedata.h
+++ b/src/core/file_sys/archive_extsavedata.h
@@ -74,7 +74,7 @@ private:
  * @param path The path that identifies the requested concrete ExtSaveData archive.
  * @returns The complete path to the specified extdata archive in the host filesystem
  */
-std::string GetExtSaveDataPath(const std::string& mount_point, const Path& path);
+std::string GetExtSaveDataPath(std::string_view mount_point, const Path& path);
 
 /**
  * Constructs a path to the concrete ExtData archive in the host filesystem based on the
@@ -83,7 +83,7 @@ std::string GetExtSaveDataPath(const std::string& mount_point, const Path& path)
  * @param extdata_id The id of the ExtSaveData
  * @returns The complete path to the specified extdata archive in the host filesystem
  */
-std::string GetExtDataPathFromId(const std::string& mount_point, u64 extdata_id);
+std::string GetExtDataPathFromId(std::string_view mount_point, u64 extdata_id);
 
 /**
  * Constructs a path to the base folder to hold concrete ExtSaveData archives in the host file
@@ -92,7 +92,7 @@ std::string GetExtDataPathFromId(const std::string& mount_point, u64 extdata_id)
  * @param shared Whether this ExtSaveData container is for SharedExtSaveDatas or not.
  * @returns The path to the base ExtSaveData archives' folder in the host file system
  */
-std::string GetExtDataContainerPath(const std::string& mount_point, bool shared);
+std::string GetExtDataContainerPath(std::string_view mount_point, bool shared);
 
 /**
  * Constructs a FileSys::Path object that refers to the ExtData archive identified by

--- a/src/core/file_sys/archive_systemsavedata.cpp
+++ b/src/core/file_sys/archive_systemsavedata.cpp
@@ -22,7 +22,7 @@ SERIALIZE_EXPORT_IMPL(FileSys::ArchiveFactory_SystemSaveData)
 
 namespace FileSys {
 
-std::string GetSystemSaveDataPath(const std::string& mount_point, const Path& path) {
+std::string GetSystemSaveDataPath(std::string_view mount_point, const Path& path) {
     const std::vector<u8> vec_data = path.AsBinary();
     u32 save_low;
     u32 save_high;
@@ -31,7 +31,7 @@ std::string GetSystemSaveDataPath(const std::string& mount_point, const Path& pa
     return fmt::format("{}{:08X}/{:08X}/", mount_point, save_low, save_high);
 }
 
-std::string GetSystemSaveDataContainerPath(const std::string& mount_point) {
+std::string GetSystemSaveDataContainerPath(std::string_view mount_point) {
     return fmt::format("{}data/{}/sysdata/", mount_point, SYSTEM_ID);
 }
 

--- a/src/core/file_sys/archive_systemsavedata.h
+++ b/src/core/file_sys/archive_systemsavedata.h
@@ -50,7 +50,7 @@ private:
  * @param path The path that identifies the requested concrete SystemSaveData archive.
  * @returns The complete path to the specified SystemSaveData archive in the host filesystem
  */
-std::string GetSystemSaveDataPath(const std::string& mount_point, const Path& path);
+std::string GetSystemSaveDataPath(std::string_view mount_point, const Path& path);
 
 /**
  * Constructs a path to the base folder to hold concrete SystemSaveData archives in the host file
@@ -58,7 +58,7 @@ std::string GetSystemSaveDataPath(const std::string& mount_point, const Path& pa
  * @param mount_point The base folder where this folder resides, ie. SDMC or NAND.
  * @returns The path to the base SystemSaveData archives' folder in the host file system
  */
-std::string GetSystemSaveDataContainerPath(const std::string& mount_point);
+std::string GetSystemSaveDataContainerPath(std::string_view mount_point);
 
 /**
  * Constructs a FileSys::Path object that refers to the SystemSaveData archive identified by

--- a/src/core/file_sys/path_parser.cpp
+++ b/src/core/file_sys/path_parser.cpp
@@ -57,8 +57,8 @@ PathParser::PathParser(const Path& path) {
     is_root = level == 0;
 }
 
-PathParser::HostStatus PathParser::GetHostStatus(const std::string& mount_point) const {
-    auto path = mount_point;
+PathParser::HostStatus PathParser::GetHostStatus(std::string_view mount_point) const {
+    std::string path{mount_point};
     if (!FileUtil::IsDirectory(path))
         return InvalidMountPoint;
     if (path_sequence.empty()) {
@@ -85,8 +85,8 @@ PathParser::HostStatus PathParser::GetHostStatus(const std::string& mount_point)
     return FileFound;
 }
 
-std::string PathParser::BuildHostPath(const std::string& mount_point) const {
-    std::string path = mount_point;
+std::string PathParser::BuildHostPath(std::string_view mount_point) const {
+    std::string path{mount_point};
     for (auto& node : path_sequence) {
         if (path.back() != '/')
             path += '/';

--- a/src/core/file_sys/path_parser.h
+++ b/src/core/file_sys/path_parser.h
@@ -47,10 +47,10 @@ public:
     };
 
     /// Checks the status of the specified file / directory by the Path on the host file system.
-    HostStatus GetHostStatus(const std::string& mount_point) const;
+    HostStatus GetHostStatus(std::string_view mount_point) const;
 
     /// Builds a full path on the host file system.
-    std::string BuildHostPath(const std::string& mount_point) const;
+    std::string BuildHostPath(std::string_view mount_point) const;
 
 private:
     std::vector<std::string> path_sequence;

--- a/src/core/file_sys/title_metadata.cpp
+++ b/src/core/file_sys/title_metadata.cpp
@@ -33,7 +33,7 @@ Loader::ResultStatus TitleMetadata::Load(const std::string& file_path) {
     return result;
 }
 
-Loader::ResultStatus TitleMetadata::Load(const std::vector<u8> file_data, std::size_t offset) {
+Loader::ResultStatus TitleMetadata::Load(const std::vector<u8>& file_data, std::size_t offset) {
     std::size_t total_size = static_cast<std::size_t>(file_data.size() - offset);
     if (total_size < sizeof(u32_be))
         return Loader::ResultStatus::Error;

--- a/src/core/file_sys/title_metadata.h
+++ b/src/core/file_sys/title_metadata.h
@@ -85,7 +85,7 @@ public:
 #pragma pack(pop)
 
     Loader::ResultStatus Load(const std::string& file_path);
-    Loader::ResultStatus Load(const std::vector<u8> file_data, std::size_t offset = 0);
+    Loader::ResultStatus Load(const std::vector<u8>& file_data, std::size_t offset = 0);
     Loader::ResultStatus Save(const std::string& file_path);
 
     u64 GetTitleID() const;


### PR DESCRIPTION
Same behavior, but allows the interfaces to be used with non-allocating string types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5306)
<!-- Reviewable:end -->
