### PR TITLE
core/hw/rsa: Minor cleanup

### DIFF
--- a/src/core/hw/aes/key.cpp
+++ b/src/core/hw/aes/key.cpp
@@ -223,7 +223,7 @@ void LoadNativeFirmKeysOld3DS() {
         return;
     }
 
-    auto rsa = RSA::GetSlot(0);
+    const auto rsa = RSA::GetSlot(0);
     if (!rsa) {
         LOG_ERROR(HW_AES, "RSA slot is missing");
         return;

--- a/src/core/hw/rsa/rsa.cpp
+++ b/src/core/hw/rsa/rsa.cpp
@@ -74,7 +74,7 @@ void InitSlots() {
     std::vector<u8> exponent(256);
     file.ReadArray(exponent.data(), exponent.size());
 
-    rsa_slots[0] = RsaSlot(exponent, modulus);
+    rsa_slots[0] = RsaSlot(std::move(exponent), std::move(modulus));
     // TODO(B3N30): Initalize the other slots. But since they aren't used at all, we can skip them
     // for now
 }

--- a/src/core/hw/rsa/rsa.cpp
+++ b/src/core/hw/rsa/rsa.cpp
@@ -31,7 +31,7 @@ std::vector<u8> HexToBytes(const std::string& hex) {
 constexpr std::size_t SlotSize = 4;
 std::array<RsaSlot, SlotSize> rsa_slots;
 
-std::vector<u8> RsaSlot::GetSignature(const std::vector<u8>& message) {
+std::vector<u8> RsaSlot::GetSignature(const std::vector<u8>& message) const {
     CryptoPP::Integer sig =
         CryptoPP::ModularExponentiation(CryptoPP::Integer(message.data(), message.size()),
                                         CryptoPP::Integer(exponent.data(), exponent.size()),

--- a/src/core/hw/rsa/rsa.h
+++ b/src/core/hw/rsa/rsa.h
@@ -14,7 +14,7 @@ public:
     RsaSlot() = default;
     RsaSlot(std::vector<u8> exponent, std::vector<u8> modulus)
         : init(true), exponent(std::move(exponent)), modulus(std::move(modulus)) {}
-    std::vector<u8> GetSignature(const std::vector<u8>& message);
+    std::vector<u8> GetSignature(const std::vector<u8>& message) const;
 
     explicit operator bool() const {
         // TODO(B3N30): Maybe check if exponent and modulus are vailid

--- a/src/core/hw/rsa/rsa.h
+++ b/src/core/hw/rsa/rsa.h
@@ -16,7 +16,7 @@ public:
         : init(true), exponent(std::move(exponent)), modulus(std::move(modulus)) {}
     std::vector<u8> GetSignature(const std::vector<u8>& message);
 
-    operator bool() const {
+    explicit operator bool() const {
         // TODO(B3N30): Maybe check if exponent and modulus are vailid
         return init;
     }

--- a/src/core/hw/rsa/rsa.h
+++ b/src/core/hw/rsa/rsa.h
@@ -11,9 +11,9 @@ namespace HW::RSA {
 
 class RsaSlot {
 public:
-    RsaSlot() : init(false) {}
-    RsaSlot(const std::vector<u8>& exponent, const std::vector<u8>& modulus)
-        : init(true), exponent(exponent), modulus(modulus) {}
+    RsaSlot() = default;
+    RsaSlot(std::vector<u8> exponent, std::vector<u8> modulus)
+        : init(true), exponent(std::move(exponent)), modulus(std::move(modulus)) {}
     std::vector<u8> GetSignature(const std::vector<u8>& message);
 
     operator bool() const {
@@ -22,7 +22,7 @@ public:
     }
 
 private:
-    bool init;
+    bool init = false;
     std::vector<u8> exponent;
     std::vector<u8> modulus;
 };


### PR DESCRIPTION
Allows calling code to completely eliminate std::vector copies/reallocations in the constructor (and amends code to make use of this).

While we're in the area we can tidy up the interface a little, such as making the `operator bool()` conversion operator explicit, and mark `GetSignature()` as a const member function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5308)
<!-- Reviewable:end -->
