### PR TITLE
[WIP] APT: fix CheckNew3DSApp

### DIFF
--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -40,6 +40,8 @@ void Module::serialize(Archive& ar, const unsigned int) {
     ar& shared_font_relocated;
     ar& lock;
     ar& cpu_percent;
+    // TODO(B3N30): remove this when we break compatibility with old save states
+    u8 unknown_ns_state_field;
     ar& unknown_ns_state_field;
     ar& screen_capture_buffer;
     ar& screen_capture_post_permission;
@@ -488,7 +490,7 @@ void Module::APTInterface::PrepareToStartApplication(Kernel::HLERequestContext& 
     u32 flags = rp.Pop<u32>();
 
     if (flags & 0x00000100) {
-        apt->unknown_ns_state_field = 1;
+        apt->screen_capture_post_permission = ScreencapPostPermission::NoExplicitSetting;
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
@@ -901,14 +903,14 @@ void Module::APTInterface::CheckNew3DSApp(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x101, 0, 0); // 0x01010000
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    if (apt->unknown_ns_state_field) {
+    if (apt->screen_capture_post_permission != ScreencapPostPermission::CleanThePermission) {
         rb.Push(RESULT_SUCCESS);
         rb.Push<u32>(0);
     } else {
         PTM::CheckNew3DS(rb);
     }
 
-    LOG_WARNING(Service_APT, "(STUBBED) called");
+    LOG_DEBUG(Service_APT, "called");
 }
 
 void Module::APTInterface::CheckNew3DS(Kernel::HLERequestContext& ctx) {
@@ -917,7 +919,7 @@ void Module::APTInterface::CheckNew3DS(Kernel::HLERequestContext& ctx) {
 
     PTM::CheckNew3DS(rb);
 
-    LOG_WARNING(Service_APT, "(STUBBED) called");
+    LOG_DEBUG(Service_APT, "called");
 }
 
 void Module::APTInterface::IsTitleAllowed(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/apt/apt.h
+++ b/src/core/hle/service/apt/apt.h
@@ -630,10 +630,8 @@ public:
          *      2: u8 output: 0 = Old3DS, 1 = New3DS.
          *  Note:
          *  This uses PTMSYSM:CheckNew3DS.
-         *  When a certain NS state field is non-zero, the output value is zero,
+         *  When screen_capture_post_permission is non-zero, the output value is zero,
          *  Otherwise the output is from PTMSYSM:CheckNew3DS.
-         *  Normally this NS state field is zero, however this state field is set to 1
-         *  when APT:PrepareToStartApplication is used with flags bit8 is set.
          */
         void CheckNew3DSApp(Kernel::HLERequestContext& ctx);
 
@@ -685,9 +683,6 @@ private:
     std::shared_ptr<Kernel::Mutex> lock;
 
     u32 cpu_percent = 0; ///< CPU time available to the running application
-
-    // APT::CheckNew3DSApp will check this unknown_ns_state_field to determine processing mode
-    u8 unknown_ns_state_field = 0;
 
     std::vector<u8> screen_capture_buffer;
     std::array<u8, SysMenuArgSize> sys_menu_arg_buffer;


### PR DESCRIPTION
From the commit history it seems like it was missed to update the unknown_ns_state_field used for CheckNew3DSApp when RE showed it is screen_capture_post_permission.

I haven't verified on HW that my assumptions are actually correct, thus the WIP

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5310)
<!-- Reviewable:end -->
