### PR TITLE
soc_u: Prevent undefined behavior with CTRPollFD

### DIFF
--- a/src/core/hle/service/soc_u.cpp
+++ b/src/core/hle/service/soc_u.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <type_traits>
 #include <vector>
 #include "common/archives.h"
 #include "common/assert.h"
@@ -199,11 +200,6 @@ struct CTRPollFD {
         BitField<4, 1, u32> pollout;
         BitField<5, 1, u32> pollnval;
 
-        Events& operator=(const Events& other) {
-            hex = other.hex;
-            return *this;
-        }
-
         /// Translates the resulting events of a Poll operation from platform-specific to 3ds
         /// specific
         static Events TranslateTo3DS(u32 input_event) {
@@ -263,6 +259,8 @@ struct CTRPollFD {
         return result;
     }
 };
+static_assert(std::is_trivially_copyable_v<CTRPollFD>,
+              "CTRPollFD is used with std::memcpy and must be trivially copyable");
 
 /// Union to represent the 3ds' sockaddr structure
 union CTRSockAddr {


### PR DESCRIPTION
This class is memcpy-ed and memcpy has the requirement that data passed to it must be trivially copyable, otherwise the behavior is undefined.

This is trivial to resolve as BitField was made trivially copyable a while ago, so this explicit copy assignment operator isn't necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5315)
<!-- Reviewable:end -->
