### PR TITLE
core: Resolve -Wreorder warnings

### DIFF
--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -21,7 +21,7 @@ class HLERequestContext::ThreadCallback : public Kernel::WakeupCallback {
 public:
     ThreadCallback(std::shared_ptr<HLERequestContext> context_,
                    std::shared_ptr<HLERequestContext::WakeupCallback> callback_)
-        : context(std::move(context_)), callback(std::move(callback_)) {}
+        : callback(std::move(callback_)), context(std::move(context_)) {}
     void WakeUp(ThreadWakeupReason reason, std::shared_ptr<Thread> thread,
                 std::shared_ptr<WaitObject> object) {
         ASSERT(thread->status == ThreadStatus::WaitHleEvent);

--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -38,7 +38,7 @@ bool VirtualMemoryArea::CanBeMergedWith(const VirtualMemoryArea& next) const {
 }
 
 VMManager::VMManager(Memory::MemorySystem& memory)
-    : memory(memory), page_table(std::make_shared<Memory::PageTable>()) {
+    : page_table(std::make_shared<Memory::PageTable>()), memory(memory) {
     Reset();
 }
 


### PR DESCRIPTION
Ensures the initialization order matches the actual order that the class member variables will be initialized in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5316)
<!-- Reviewable:end -->
