### PR TITLE
travis: Compile on macOS 10.13 with more up to date compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
     - os: osx
       env: NAME="macos build"
       sudo: false
-      osx_image: xcode10.2
+      osx_image: xcode10
       install: "./.travis/macos/deps.sh"
       script: "./.travis/macos/build.sh"
       after_success: "./.travis/macos/upload.sh"

--- a/.travis/macos/build.sh
+++ b/.travis/macos/build.sh
@@ -4,7 +4,12 @@ set -o pipefail
 
 export MACOSX_DEPLOYMENT_TARGET=10.13
 export Qt5_DIR=$(brew --prefix)/opt/qt5
-export PATH="/usr/local/opt/ccache/libexec:$PATH"
+export PATH="/usr/local/opt/ccache/libexec:/usr/local/opt/llvm/bin:$PATH"
+
+export CC="clang"
+export CXX="clang++"
+export LDFLAGS="-L/usr/local/opt/llvm/lib"
+export CPPFLAGS="-I/usr/local/opt/llvm/include"
 
 mkdir build && cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release -DENABLE_QT_TRANSLATION=ON -DCITRA_ENABLE_COMPATIBILITY_REPORTING=${ENABLE_COMPATIBILITY_REPORTING:-"OFF"} -DENABLE_COMPATIBILITY_LIST_DOWNLOAD=ON -DUSE_DISCORD_PRESENCE=ON -DENABLE_FFMPEG_AUDIO_DECODER=ON -DENABLE_FFMPEG_VIDEO_DUMPER=ON

--- a/.travis/macos/deps.sh
+++ b/.travis/macos/deps.sh
@@ -2,5 +2,5 @@
 
 brew update
 brew unlink python@2
-brew install qt5 sdl2 p7zip ccache ffmpeg
+brew install qt5 sdl2 p7zip ccache ffmpeg llvm
 pip3 install macpack


### PR DESCRIPTION
We currently build on macOS 10.14, while targeting 10.13.

Unfortunately we still link against libraries compiled for 10.14, which can result in interesting crashes on macOS 10.13.

Since we require a more up to date compiler than provided by xcode on 10.13, we pull in a more up to date compiler while building on 10.13.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5317)
<!-- Reviewable:end -->
