### PR TITLE
APT: implement Set and GetWirelessRebootInfo

### DIFF
--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -33,8 +33,6 @@ SERVICE_CONSTRUCT_IMPL(Service::APT::Module)
 
 namespace Service::APT {
 
-std::vector<u8> Module::wireless_reboot_info;
-
 template <class Archive>
 void Module::serialize(Archive& ar, const unsigned int file_version) {
     ar& shared_font_mem;
@@ -47,7 +45,7 @@ void Module::serialize(Archive& ar, const unsigned int file_version) {
     ar& screen_capture_post_permission;
     ar& applet_manager;
     if (file_version > 0) {
-        ar&wireless_reboot_info;
+        ar& wireless_reboot_info;
     }
 }
 
@@ -63,7 +61,7 @@ void Module::NSInterface::SetWirelessRebootInfo(Kernel::HLERequestContext& ctx) 
     u32 size = rp.Pop<u32>();
     auto buffer = rp.PopStaticBuffer();
 
-    APT::Module::wireless_reboot_info = std::move(buffer);
+    apt->wireless_reboot_info = std::move(buffer);
 
     auto rb = rp.MakeBuilder(1, 0);
     rb.Push(RESULT_SUCCESS);
@@ -283,7 +281,7 @@ void Module::APTInterface::GetWirelessRebootInfo(Kernel::HLERequestContext& ctx)
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
     rb.Push(RESULT_SUCCESS);
-    rb.PushStaticBuffer(APT::Module::wireless_reboot_info, 0);
+    rb.PushStaticBuffer(apt->wireless_reboot_info, 0);
 }
 
 void Module::APTInterface::NotifyToWait(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -277,7 +277,7 @@ void Module::APTInterface::GetWirelessRebootInfo(Kernel::HLERequestContext& ctx)
     IPC::RequestParser rp(ctx, 0x45, 1, 0); // 0x00450040
     u32 size = rp.Pop<u32>();
 
-    LOG_WARNING(Service_APT, "(STUBBED) called size={:08X}", size);
+    LOG_WARNING(Service_APT, "called size={:08X}", size);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
     rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/apt/apt.h
+++ b/src/core/hle/service/apt/apt.h
@@ -65,6 +65,8 @@ public:
     explicit Module(Core::System& system);
     ~Module();
 
+    static std::vector<u8> wireless_reboot_info;
+
     class NSInterface : public ServiceFramework<NSInterface> {
     public:
         NSInterface(std::shared_ptr<Module> apt, const char* name, u32 max_session);
@@ -72,6 +74,17 @@ public:
 
     protected:
         std::shared_ptr<Module> apt;
+
+        /**
+         * NS::SetWirelessRebootInfo service function. This sets the wireless reboot info.
+         * Inputs:
+         *     1 : size
+         *     2 : (Size<<14) | 2
+         *     3 : Wireless reboot info buffer ptr
+         * Outputs:
+         *     0 : Result of function, 0 on success, otherwise error code
+         */
+        void SetWirelessRebootInfo(Kernel::HLERequestContext& ctx);
     };
 
     class APTInterface : public ServiceFramework<APTInterface> {
@@ -138,6 +151,16 @@ public:
          *      5 : Output buffer address
          */
         void Unwrap(Kernel::HLERequestContext& ctx);
+
+        /**
+         * APT::GetWirelessRebootInfo service function
+         *  Inputs:
+         *      1 : size
+         *  Outputs:
+         *      1 : Result of function, 0 on success, otherwise error code
+         *      2 : Output parameter buffer ptr
+         */
+        void GetWirelessRebootInfo(Kernel::HLERequestContext& ctx);
 
         /**
          * APT::NotifyToWait service function
@@ -707,3 +730,4 @@ void InstallInterfaces(Core::System& system);
 } // namespace Service::APT
 
 SERVICE_CONSTRUCT(Service::APT::Module)
+BOOST_CLASS_VERSION(Service::APT::Module, 1)

--- a/src/core/hle/service/apt/apt.h
+++ b/src/core/hle/service/apt/apt.h
@@ -65,8 +65,6 @@ public:
     explicit Module(Core::System& system);
     ~Module();
 
-    static std::vector<u8> wireless_reboot_info;
-
     class NSInterface : public ServiceFramework<NSInterface> {
     public:
         NSInterface(std::shared_ptr<Module> apt, const char* name, u32 max_session);
@@ -719,6 +717,8 @@ private:
         ScreencapPostPermission::CleanThePermission; // TODO(JamePeng): verify the initial value
 
     std::shared_ptr<AppletManager> applet_manager;
+
+    std::vector<u8> wireless_reboot_info;
 
     template <class Archive>
     void serialize(Archive& ar, const unsigned int);

--- a/src/core/hle/service/apt/apt_a.cpp
+++ b/src/core/hle/service/apt/apt_a.cpp
@@ -78,7 +78,7 @@ APT_A::APT_A(std::shared_ptr<Module> apt)
         {0x00420080, nullptr, "SleepSystem"},
         {0x00430040, &APT_A::NotifyToWait, "NotifyToWait"},
         {0x00440000, &APT_A::GetSharedFont, "GetSharedFont"},
-        {0x00450040, nullptr, "GetWirelessRebootInfo"},
+        {0x00450040, &APT_A::GetWirelessRebootInfo, "GetWirelessRebootInfo"},
         {0x00460104, &APT_A::Wrap, "Wrap"},
         {0x00470104, &APT_A::Unwrap, "Unwrap"},
         {0x00480100, nullptr, "GetProgramInfo"},

--- a/src/core/hle/service/apt/apt_s.cpp
+++ b/src/core/hle/service/apt/apt_s.cpp
@@ -78,7 +78,7 @@ APT_S::APT_S(std::shared_ptr<Module> apt)
         {0x00420080, nullptr, "SleepSystem"},
         {0x00430040, &APT_S::NotifyToWait, "NotifyToWait"},
         {0x00440000, &APT_S::GetSharedFont, "GetSharedFont"},
-        {0x00450040, nullptr, "GetWirelessRebootInfo"},
+        {0x00450040, &APT_S::GetWirelessRebootInfo, "GetWirelessRebootInfo"},
         {0x00460104, &APT_S::Wrap, "Wrap"},
         {0x00470104, &APT_S::Unwrap, "Unwrap"},
         {0x00480100, nullptr, "GetProgramInfo"},

--- a/src/core/hle/service/apt/apt_u.cpp
+++ b/src/core/hle/service/apt/apt_u.cpp
@@ -78,7 +78,7 @@ APT_U::APT_U(std::shared_ptr<Module> apt)
         {0x00420080, nullptr, "SleepSystem"},
         {0x00430040, &APT_U::NotifyToWait, "NotifyToWait"},
         {0x00440000, &APT_U::GetSharedFont, "GetSharedFont"},
-        {0x00450040, nullptr, "GetWirelessRebootInfo"},
+        {0x00450040, &APT_U::GetWirelessRebootInfo, "GetWirelessRebootInfo"},
         {0x00460104, &APT_U::Wrap, "Wrap"},
         {0x00470104, &APT_U::Unwrap, "Unwrap"},
         {0x00480100, nullptr, "GetProgramInfo"},

--- a/src/core/hle/service/apt/ns_s.cpp
+++ b/src/core/hle/service/apt/ns_s.cpp
@@ -15,7 +15,7 @@ NS_S::NS_S(std::shared_ptr<Service::APT::Module> apt)
         {0x00030000, nullptr, "TerminateApplication"},
         {0x00040040, nullptr, "TerminateProcess"},
         {0x000500C0, nullptr, "LaunchApplicationFIRM"},
-        {0x00060042, nullptr, "SetFIRMParams4A0"},
+        {0x00060042, &NS_S::SetWirelessRebootInfo, "SetWirelessRebootInfo"},
         {0x00070042, nullptr, "CardUpdateInitialize"},
         {0x00080000, nullptr, "CardUpdateShutdown"},
         {0x000D0140, nullptr, "SetTWLBannerHMAC"},


### PR DESCRIPTION
This implements the two APT/NS functions SetWirelessRebootInfo and GetWirelessRebootInfo.

It is used to transmit informations for uds connections over reboot e.g. used for dlp

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5328)
<!-- Reviewable:end -->
