### PR TITLE
Correct output paths for executable binaries in CMakeLists.txt

### DIFF
--- a/.travis/linux/upload.sh
+++ b/.travis/linux/upload.sh
@@ -8,9 +8,9 @@ COMPRESSION_FLAGS="-cJvf"
 
 mkdir "$REV_NAME"
 
-cp build/bin/citra "$REV_NAME"
-cp build/bin/citra-room "$REV_NAME"
-cp build/bin/citra-qt "$REV_NAME"
+cp build/bin/Release/citra "$REV_NAME"
+cp build/bin/Release/citra-room "$REV_NAME"
+cp build/bin/Release/citra-qt "$REV_NAME"
 
 # We need icons on Linux for .desktop entries
 mkdir "$REV_NAME/dist"

--- a/.travis/macos/upload.sh
+++ b/.travis/macos/upload.sh
@@ -8,9 +8,9 @@ COMPRESSION_FLAGS="-czvf"
 
 mkdir "$REV_NAME"
 
-cp build/bin/citra "$REV_NAME"
-cp -r build/bin/citra-qt.app "$REV_NAME"
-cp build/bin/citra-room "$REV_NAME"
+cp build/bin/Release/citra "$REV_NAME"
+cp -r build/bin/Release/citra-qt.app "$REV_NAME"
+cp build/bin/Release/citra-room "$REV_NAME"
 
 # move libs into folder for deployment
 macpack "${REV_NAME}/citra-qt.app/Contents/MacOS/citra-qt" -d "../Frameworks"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # set up output paths for executable binaries
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin/$<CONFIG>)
 
 
 # System imported libraries


### PR DESCRIPTION
I believe this was an oversight to miss out `$<CONFIG>` parameter at [CMakeLists.txt](https://github.com/citra-emu/citra/blob/master/CMakeLists.txt) as `$<CONFIG>` was defined in CMakeModules for both [CopyCitraQt5Deps.cmake](https://github.com/citra-emu/citra/blob/master/CMakeModules/CopyCitraQt5Deps.cmake#L3) & [CopyCitraSDLDeps.cmake](https://github.com/citra-emu/citra/blob/master/CMakeModules/CopyCitraSDLDeps.cmake#L3) files.

This fixes the issue for executables binaries copied to the `bin` folder instead of its subfolder after local compile finish with *Microsoft Visual Studio Community 2019 Preview* (Version 16.6.0 Preview 5.0) and thus causing the executable fail to launch within debugging environment due to failing to locate the dlls.

Supersedes PR #5323

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5332)
<!-- Reviewable:end -->
