### PR TITLE
fs_user: std::move vectors where applicable

### DIFF
--- a/src/core/file_sys/archive_backend.cpp
+++ b/src/core/file_sys/archive_backend.cpp
@@ -12,10 +12,10 @@
 
 namespace FileSys {
 
-Path::Path(LowPathType type, const std::vector<u8>& data) : type(type) {
+Path::Path(LowPathType type, std::vector<u8> data) : type(type) {
     switch (type) {
     case LowPathType::Binary: {
-        binary = data;
+        binary = std::move(data);
         break;
     }
 

--- a/src/core/file_sys/archive_backend.h
+++ b/src/core/file_sys/archive_backend.h
@@ -45,7 +45,7 @@ public:
     template <std::size_t size>
     Path(const std::array<u8, size>& binary_data)
         : type(LowPathType::Binary), binary(binary_data.begin(), binary_data.end()) {}
-    Path(LowPathType type, const std::vector<u8>& data);
+    Path(LowPathType type, std::vector<u8> data);
 
     LowPathType GetType() const {
         return type;

--- a/src/core/file_sys/archive_ncch.cpp
+++ b/src/core/file_sys/archive_ncch.cpp
@@ -56,8 +56,8 @@ Path MakeNCCHArchivePath(u64 tid, Service::FS::MediaType media_type) {
     path.media_type = static_cast<u32_le>(media_type);
     path.unknown = 0;
     std::vector<u8> archive(sizeof(path));
-    std::memcpy(&archive[0], &path, sizeof(path));
-    return FileSys::Path(archive);
+    std::memcpy(archive.data(), &path, sizeof(path));
+    return FileSys::Path(std::move(archive));
 }
 
 Path MakeNCCHFilePath(NCCHFileOpenType open_type, u32 content_index, NCCHFilePathType filepath_type,
@@ -68,8 +68,8 @@ Path MakeNCCHFilePath(NCCHFileOpenType open_type, u32 content_index, NCCHFilePat
     path.filepath_type = filepath_type;
     path.exefs_filepath = exefs_filepath;
     std::vector<u8> file(sizeof(path));
-    std::memcpy(&file[0], &path, sizeof(path));
-    return FileSys::Path(file);
+    std::memcpy(file.data(), &path, sizeof(path));
+    return FileSys::Path(std::move(file));
 }
 
 ResultVal<std::unique_ptr<FileBackend>> NCCHArchive::OpenFile(const Path& path,

--- a/src/core/file_sys/archive_systemsavedata.cpp
+++ b/src/core/file_sys/archive_systemsavedata.cpp
@@ -49,7 +49,7 @@ Path ConstructSystemSaveDataBinaryPath(u32 high, u32 low) {
     for (unsigned i = 0; i < 4; ++i)
         binary_path.push_back((low >> (8 * i)) & 0xFF);
 
-    return {binary_path};
+    return {std::move(binary_path)};
 }
 
 ArchiveFactory_SystemSaveData::ArchiveFactory_SystemSaveData(const std::string& nand_path)

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -149,8 +149,8 @@ bool Module::LoadSharedFont() {
     const u64_le shared_font_archive_id_low = 0x0004009b00014002 | ((font_region_code - 1) << 8);
 
     FileSys::NCCHArchive archive(shared_font_archive_id_low, Service::FS::MediaType::NAND);
-    std::vector<u8> romfs_path(20, 0); // 20-byte all zero path for opening RomFS
-    FileSys::Path file_path(romfs_path);
+    // 20-byte all zero path for opening RomFS
+    const FileSys::Path file_path(std::vector<u8>(20, 0));
     FileSys::Mode open_mode = {};
     open_mode.read_flag.Assign(1);
     auto file_result = archive.OpenFile(file_path, open_mode);

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -37,7 +37,8 @@ ArchiveBackend* ArchiveManager::GetArchive(ArchiveHandle handle) {
 }
 
 ResultVal<ArchiveHandle> ArchiveManager::OpenArchive(ArchiveIdCode id_code,
-                                                     FileSys::Path& archive_path, u64 program_id) {
+                                                     const FileSys::Path& archive_path,
+                                                     u64 program_id) {
     LOG_TRACE(Service_FS, "Opening archive with id code 0x{:08X}", static_cast<u32>(id_code));
 
     auto itr = id_code_map.find(id_code);
@@ -207,7 +208,7 @@ ResultCode ArchiveManager::FormatArchive(ArchiveIdCode id_code,
 }
 
 ResultVal<FileSys::ArchiveFormatInfo> ArchiveManager::GetArchiveFormatInfo(
-    ArchiveIdCode id_code, FileSys::Path& archive_path, u64 program_id) {
+    ArchiveIdCode id_code, const FileSys::Path& archive_path, u64 program_id) {
     auto archive = id_code_map.find(id_code);
     if (archive == id_code_map.end()) {
         return UnimplementedFunction(ErrorModule::FS); // TODO(Subv): Find the right error

--- a/src/core/hle/service/fs/archive.h
+++ b/src/core/hle/service/fs/archive.h
@@ -72,7 +72,7 @@ public:
      * @param program_id the program ID of the client that requests the operation
      * @return Handle to the opened archive
      */
-    ResultVal<ArchiveHandle> OpenArchive(ArchiveIdCode id_code, FileSys::Path& archive_path,
+    ResultVal<ArchiveHandle> OpenArchive(ArchiveIdCode id_code, const FileSys::Path& archive_path,
                                          u64 program_id);
 
     /**
@@ -197,7 +197,7 @@ public:
      * @return The format info of the archive, or the corresponding error code if failed.
      */
     ResultVal<FileSys::ArchiveFormatInfo> GetArchiveFormatInfo(ArchiveIdCode id_code,
-                                                               FileSys::Path& archive_path,
+                                                               const FileSys::Path& archive_path,
                                                                u64 program_id);
 
     /**

--- a/src/core/hle/service/fs/fs_user.cpp
+++ b/src/core/hle/service/fs/fs_user.cpp
@@ -53,14 +53,14 @@ void FS_USER::OpenFile(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x0802, 7, 2);
     rp.Skip(1, false); // Transaction.
 
-    ArchiveHandle archive_handle = rp.Pop<u64>();
-    auto filename_type = rp.PopEnum<FileSys::LowPathType>();
-    u32 filename_size = rp.Pop<u32>();
-    FileSys::Mode mode{rp.Pop<u32>()};
-    u32 attributes = rp.Pop<u32>(); // TODO(Link Mauve): do something with those attributes.
+    const auto archive_handle = rp.PopRaw<ArchiveHandle>();
+    const auto filename_type = rp.PopEnum<FileSys::LowPathType>();
+    const auto filename_size = rp.Pop<u32>();
+    const FileSys::Mode mode{rp.Pop<u32>()};
+    const auto attributes = rp.Pop<u32>(); // TODO(Link Mauve): do something with those attributes.
     std::vector<u8> filename = rp.PopStaticBuffer();
     ASSERT(filename.size() == filename_size);
-    FileSys::Path file_path(filename_type, filename);
+    const FileSys::Path file_path(filename_type, std::move(filename));
 
     LOG_DEBUG(Service_FS, "path={}, mode={} attrs={}", file_path.DebugStr(), mode.hex, attributes);
 
@@ -83,19 +83,19 @@ void FS_USER::OpenFileDirectly(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x803, 8, 4);
     rp.Skip(1, false); // Transaction
 
-    auto archive_id = rp.PopEnum<FS::ArchiveIdCode>();
-    auto archivename_type = rp.PopEnum<FileSys::LowPathType>();
-    u32 archivename_size = rp.Pop<u32>();
-    auto filename_type = rp.PopEnum<FileSys::LowPathType>();
-    u32 filename_size = rp.Pop<u32>();
-    FileSys::Mode mode{rp.Pop<u32>()};
-    u32 attributes = rp.Pop<u32>(); // TODO(Link Mauve): do something with those attributes.
+    const auto archive_id = rp.PopEnum<ArchiveIdCode>();
+    const auto archivename_type = rp.PopEnum<FileSys::LowPathType>();
+    const auto archivename_size = rp.Pop<u32>();
+    const auto filename_type = rp.PopEnum<FileSys::LowPathType>();
+    const auto filename_size = rp.Pop<u32>();
+    const FileSys::Mode mode{rp.Pop<u32>()};
+    const auto attributes = rp.Pop<u32>(); // TODO(Link Mauve): do something with those attributes.
     std::vector<u8> archivename = rp.PopStaticBuffer();
     std::vector<u8> filename = rp.PopStaticBuffer();
     ASSERT(archivename.size() == archivename_size);
     ASSERT(filename.size() == filename_size);
-    FileSys::Path archive_path(archivename_type, archivename);
-    FileSys::Path file_path(filename_type, filename);
+    const FileSys::Path archive_path(archivename_type, std::move(archivename));
+    const FileSys::Path file_path(filename_type, std::move(filename));
 
     LOG_DEBUG(Service_FS, "archive_id=0x{:08X} archive_path={} file_path={}, mode={} attributes={}",
               static_cast<u32>(archive_id), archive_path.DebugStr(), file_path.DebugStr(), mode.hex,
@@ -135,13 +135,13 @@ void FS_USER::OpenFileDirectly(Kernel::HLERequestContext& ctx) {
 void FS_USER::DeleteFile(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x804, 5, 2);
     rp.Skip(1, false); // TransactionId
-    ArchiveHandle archive_handle = rp.PopRaw<ArchiveHandle>();
-    auto filename_type = rp.PopEnum<FileSys::LowPathType>();
-    u32 filename_size = rp.Pop<u32>();
+    const auto archive_handle = rp.PopRaw<ArchiveHandle>();
+    const auto filename_type = rp.PopEnum<FileSys::LowPathType>();
+    const auto filename_size = rp.Pop<u32>();
     std::vector<u8> filename = rp.PopStaticBuffer();
     ASSERT(filename.size() == filename_size);
 
-    FileSys::Path file_path(filename_type, filename);
+    const FileSys::Path file_path(filename_type, std::move(filename));
 
     LOG_DEBUG(Service_FS, "type={} size={} data={}", static_cast<u32>(filename_type), filename_size,
               file_path.DebugStr());
@@ -154,19 +154,19 @@ void FS_USER::RenameFile(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x805, 9, 4);
     rp.Skip(1, false); // TransactionId
 
-    ArchiveHandle src_archive_handle = rp.PopRaw<ArchiveHandle>();
-    auto src_filename_type = rp.PopEnum<FileSys::LowPathType>();
-    u32 src_filename_size = rp.Pop<u32>();
-    ArchiveHandle dest_archive_handle = rp.PopRaw<ArchiveHandle>();
-    auto dest_filename_type = rp.PopEnum<FileSys::LowPathType>();
-    u32 dest_filename_size = rp.Pop<u32>();
+    const auto src_archive_handle = rp.PopRaw<ArchiveHandle>();
+    const auto src_filename_type = rp.PopEnum<FileSys::LowPathType>();
+    const auto src_filename_size = rp.Pop<u32>();
+    const auto dest_archive_handle = rp.PopRaw<ArchiveHandle>();
+    const auto dest_filename_type = rp.PopEnum<FileSys::LowPathType>();
+    const auto dest_filename_size = rp.Pop<u32>();
     std::vector<u8> src_filename = rp.PopStaticBuffer();
     std::vector<u8> dest_filename = rp.PopStaticBuffer();
     ASSERT(src_filename.size() == src_filename_size);
     ASSERT(dest_filename.size() == dest_filename_size);
 
-    FileSys::Path src_file_path(src_filename_type, src_filename);
-    FileSys::Path dest_file_path(dest_filename_type, dest_filename);
+    const FileSys::Path src_file_path(src_filename_type, std::move(src_filename));
+    const FileSys::Path dest_file_path(dest_filename_type, std::move(dest_filename));
 
     LOG_DEBUG(Service_FS,
               "src_type={} src_size={} src_data={} dest_type={} dest_size={} dest_data={}",
@@ -182,13 +182,13 @@ void FS_USER::DeleteDirectory(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x806, 5, 2);
 
     rp.Skip(1, false); // TransactionId
-    ArchiveHandle archive_handle = rp.PopRaw<ArchiveHandle>();
-    auto dirname_type = rp.PopEnum<FileSys::LowPathType>();
-    u32 dirname_size = rp.Pop<u32>();
+    const auto archive_handle = rp.PopRaw<ArchiveHandle>();
+    const auto dirname_type = rp.PopEnum<FileSys::LowPathType>();
+    const auto dirname_size = rp.Pop<u32>();
     std::vector<u8> dirname = rp.PopStaticBuffer();
     ASSERT(dirname.size() == dirname_size);
 
-    FileSys::Path dir_path(dirname_type, dirname);
+    const FileSys::Path dir_path(dirname_type, std::move(dirname));
 
     LOG_DEBUG(Service_FS, "type={} size={} data={}", static_cast<u32>(dirname_type), dirname_size,
               dir_path.DebugStr());
@@ -201,13 +201,13 @@ void FS_USER::DeleteDirectoryRecursively(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x807, 5, 2);
 
     rp.Skip(1, false); // TransactionId
-    ArchiveHandle archive_handle = rp.PopRaw<ArchiveHandle>();
-    auto dirname_type = rp.PopEnum<FileSys::LowPathType>();
-    u32 dirname_size = rp.Pop<u32>();
+    const auto archive_handle = rp.PopRaw<ArchiveHandle>();
+    const auto dirname_type = rp.PopEnum<FileSys::LowPathType>();
+    const auto dirname_size = rp.Pop<u32>();
     std::vector<u8> dirname = rp.PopStaticBuffer();
     ASSERT(dirname.size() == dirname_size);
 
-    FileSys::Path dir_path(dirname_type, dirname);
+    const FileSys::Path dir_path(dirname_type, std::move(dirname));
 
     LOG_DEBUG(Service_FS, "type={} size={} data={}", static_cast<u32>(dirname_type), dirname_size,
               dir_path.DebugStr());
@@ -258,19 +258,19 @@ void FS_USER::CreateDirectory(Kernel::HLERequestContext& ctx) {
 void FS_USER::RenameDirectory(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x80A, 9, 4);
     rp.Skip(1, false); // TransactionId
-    ArchiveHandle src_archive_handle = rp.PopRaw<ArchiveHandle>();
-    auto src_dirname_type = rp.PopEnum<FileSys::LowPathType>();
-    u32 src_dirname_size = rp.Pop<u32>();
-    ArchiveHandle dest_archive_handle = rp.PopRaw<ArchiveHandle>();
-    auto dest_dirname_type = rp.PopEnum<FileSys::LowPathType>();
-    u32 dest_dirname_size = rp.Pop<u32>();
+    const auto src_archive_handle = rp.PopRaw<ArchiveHandle>();
+    const auto src_dirname_type = rp.PopEnum<FileSys::LowPathType>();
+    const auto src_dirname_size = rp.Pop<u32>();
+    const auto dest_archive_handle = rp.PopRaw<ArchiveHandle>();
+    const auto dest_dirname_type = rp.PopEnum<FileSys::LowPathType>();
+    const auto dest_dirname_size = rp.Pop<u32>();
     std::vector<u8> src_dirname = rp.PopStaticBuffer();
     std::vector<u8> dest_dirname = rp.PopStaticBuffer();
     ASSERT(src_dirname.size() == src_dirname_size);
     ASSERT(dest_dirname.size() == dest_dirname_size);
 
-    FileSys::Path src_dir_path(src_dirname_type, src_dirname);
-    FileSys::Path dest_dir_path(dest_dirname_type, dest_dirname);
+    const FileSys::Path src_dir_path(src_dirname_type, std::move(src_dirname));
+    const FileSys::Path dest_dir_path(dest_dirname_type, std::move(dest_dirname));
 
     LOG_DEBUG(Service_FS,
               "src_type={} src_size={} src_data={} dest_type={} dest_size={} dest_data={}",
@@ -284,13 +284,13 @@ void FS_USER::RenameDirectory(Kernel::HLERequestContext& ctx) {
 
 void FS_USER::OpenDirectory(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x80B, 4, 2);
-    auto archive_handle = rp.PopRaw<ArchiveHandle>();
-    auto dirname_type = rp.PopEnum<FileSys::LowPathType>();
-    u32 dirname_size = rp.Pop<u32>();
+    const auto archive_handle = rp.PopRaw<ArchiveHandle>();
+    const auto dirname_type = rp.PopEnum<FileSys::LowPathType>();
+    const auto dirname_size = rp.Pop<u32>();
     std::vector<u8> dirname = rp.PopStaticBuffer();
     ASSERT(dirname.size() == dirname_size);
 
-    FileSys::Path dir_path(dirname_type, dirname);
+    const FileSys::Path dir_path(dirname_type, std::move(dirname));
 
     LOG_DEBUG(Service_FS, "type={} size={} data={}", static_cast<u32>(dirname_type), dirname_size,
               dir_path.DebugStr());
@@ -313,19 +313,19 @@ void FS_USER::OpenDirectory(Kernel::HLERequestContext& ctx) {
 
 void FS_USER::OpenArchive(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x80C, 3, 2);
-    auto archive_id = rp.PopEnum<FS::ArchiveIdCode>();
-    auto archivename_type = rp.PopEnum<FileSys::LowPathType>();
-    u32 archivename_size = rp.Pop<u32>();
+    const auto archive_id = rp.PopEnum<FS::ArchiveIdCode>();
+    const auto archivename_type = rp.PopEnum<FileSys::LowPathType>();
+    const auto archivename_size = rp.Pop<u32>();
     std::vector<u8> archivename = rp.PopStaticBuffer();
     ASSERT(archivename.size() == archivename_size);
-    FileSys::Path archive_path(archivename_type, archivename);
+    const FileSys::Path archive_path(archivename_type, std::move(archivename));
 
     LOG_DEBUG(Service_FS, "archive_id=0x{:08X} archive_path={}", static_cast<u32>(archive_id),
               archive_path.DebugStr());
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 0);
     ClientSlot* slot = GetSessionData(ctx.Session());
-    ResultVal<ArchiveHandle> handle =
+    const ResultVal<ArchiveHandle> handle =
         archives.OpenArchive(archive_id, archive_path, slot->program_id);
     rb.Push(handle.Code());
     if (handle.Succeeded()) {
@@ -340,7 +340,7 @@ void FS_USER::OpenArchive(Kernel::HLERequestContext& ctx) {
 
 void FS_USER::CloseArchive(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x80E, 2, 0);
-    auto archive_handle = rp.PopRaw<ArchiveHandle>();
+    const auto archive_handle = rp.PopRaw<ArchiveHandle>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     rb.Push(archives.CloseArchive(archive_handle));
@@ -432,7 +432,7 @@ void FS_USER::FormatThisUserSaveData(Kernel::HLERequestContext& ctx) {
 
 void FS_USER::GetFreeBytes(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x812, 2, 0);
-    ArchiveHandle archive_handle = rp.PopRaw<ArchiveHandle>();
+    const auto archive_handle = rp.PopRaw<ArchiveHandle>();
     ResultVal<u64> bytes_res = archives.GetFreeBytesInArchive(archive_handle);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 0);
@@ -649,13 +649,13 @@ void FS_USER::GetArchiveResource(Kernel::HLERequestContext& ctx) {
 
 void FS_USER::GetFormatInfo(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x845, 3, 2);
-    auto archive_id = rp.PopEnum<FS::ArchiveIdCode>();
-    auto archivename_type = rp.PopEnum<FileSys::LowPathType>();
-    u32 archivename_size = rp.Pop<u32>();
+    const auto archive_id = rp.PopEnum<FS::ArchiveIdCode>();
+    const auto archivename_type = rp.PopEnum<FileSys::LowPathType>();
+    const auto archivename_size = rp.Pop<u32>();
     std::vector<u8> archivename = rp.PopStaticBuffer();
     ASSERT(archivename.size() == archivename_size);
 
-    FileSys::Path archive_path(archivename_type, archivename);
+    const FileSys::Path archive_path(archivename_type, std::move(archivename));
 
     LOG_DEBUG(Service_FS, "archive_path={}", archive_path.DebugStr());
 


### PR DESCRIPTION
Allows removing some allocation churn in some locations by moving std::vectors into Path where applicable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5333)
<!-- Reviewable:end -->
