### PR TITLE
WIP - Scheduling rewrite

### DIFF
--- a/src/audio_core/hle/hle.cpp
+++ b/src/audio_core/hle/hle.cpp
@@ -99,6 +99,11 @@ private:
     public:
         AudioTickCallback(Impl& parent_) : parent(parent_) {}
 
+        const std::string& Name() const override {
+            static auto str = "AudioCore::DspHle::tick_event";
+            return str;
+        }
+
         void Execute(Core::Timing& timing, u64 userdata, Ticks cycles_late) override {
             if (parent.Tick()) {
                 // TODO(merry): Signal all the other interrupts as appropriate.
@@ -114,7 +119,7 @@ private:
         }
     };
 
-    std::unique_ptr<AudioTickCallback> tick_event{new AudoTickCallback(*this)};
+    std::unique_ptr<AudioTickCallback> tick_event{new AudioTickCallback(*this)};
 
     std::unique_ptr<HLE::DecoderBase> decoder{};
 

--- a/src/audio_core/lle/lle.cpp
+++ b/src/audio_core/lle/lle.cpp
@@ -178,7 +178,7 @@ struct DspLle::Impl final {
 
     public:
         TeakraSliceEvent(Impl& parent_) : parent(parent_) {}
-        const std::string& Name() override {
+        const std::string& Name() const override {
             return "DSP slice";
         }
         void Execute(Core::Timing& timing, u64 userdata, Ticks late) {
@@ -332,7 +332,8 @@ struct DspLle::Impl final {
 
         // TODO: load special segment
 
-        Core::System::GetInstance().CoreTiming().ScheduleEvent(TeakraSlice, teakra_slice_event, 0);
+        Core::System::GetInstance().CoreTiming().ScheduleEvent(teakra_slice_event.get(),
+                                                               Ticks(TeakraSlice), 0);
 
         if (multithread) {
             teakra_thread = std::thread(&Impl::TeakraThread, this);
@@ -377,7 +378,7 @@ struct DspLle::Impl final {
 
         teakra.RecvData(2); // discard the value
 
-        Core::System::GetInstance().CoreTiming().UnscheduleEvent(teakra_slice_event, 0);
+        Core::System::GetInstance().CoreTiming().UnscheduleEvent(teakra_slice_event.get(), 0);
         StopTeakraThread();
     }
 };

--- a/src/common/common_types.h
+++ b/src/common/common_types.h
@@ -24,6 +24,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <cstdint>
 
 #ifdef _MSC_VER
@@ -49,6 +50,9 @@ typedef double f64; ///< 64-bit floating point
 // conversion between each other.
 typedef u32 VAddr; ///< Represents a pointer in the userspace virtual address space.
 typedef u32 PAddr; ///< Represents a pointer in the ARM11 physical address space.
+
+using nanoseconds = std::chrono::nanoseconds;
+using milliseconds = std::chrono::milliseconds;
 
 // An inheritable class to disallow the copy constructor and operator= functions
 class NonCopyable {

--- a/src/core/arm/arm_interface.h
+++ b/src/core/arm/arm_interface.h
@@ -22,8 +22,7 @@ struct PageTable;
 /// Generic ARM11 CPU interface
 class ARM_Interface : NonCopyable {
 public:
-    explicit ARM_Interface(u32 id, std::shared_ptr<Core::Timing::Timer> timer)
-        : timer(timer), id(id){};
+    explicit ARM_Interface(u32 id, std::shared_ptr<Core::Timing> timer) : timer(timer), id(id){};
     virtual ~ARM_Interface() {}
 
     class ThreadContext {
@@ -228,11 +227,11 @@ public:
 
     virtual void PurgeState() = 0;
 
-    Core::Timing::Timer& GetTimer() {
+    Core::Timing& GetTimer() {
         return *timer;
     }
 
-    const Core::Timing::Timer& GetTimer() const {
+    const Core::Timing& GetTimer() const {
         return *timer;
     }
 
@@ -244,7 +243,7 @@ protected:
     // This us used for serialization. Returning nullptr is valid if page tables are not used.
     virtual std::shared_ptr<Memory::PageTable> GetPageTable() const = 0;
 
-    std::shared_ptr<Core::Timing::Timer> timer;
+    std::shared_ptr<Core::Timing> timer;
 
 private:
     u32 id;

--- a/src/core/arm/arm_interface.h
+++ b/src/core/arm/arm_interface.h
@@ -19,10 +19,14 @@ namespace Memory {
 struct PageTable;
 };
 
+namespace Core {
+class Timing;
+}
+
 /// Generic ARM11 CPU interface
 class ARM_Interface : NonCopyable {
 public:
-    explicit ARM_Interface(u32 id, std::shared_ptr<Core::Timing> timer) : timer(timer), id(id){};
+    explicit ARM_Interface(Core::Timing& timer) : timer(timer){};
     virtual ~ARM_Interface() {}
 
     class ThreadContext {
@@ -227,33 +231,25 @@ public:
 
     virtual void PurgeState() = 0;
 
-    Core::Timing& GetTimer() {
-        return *timer;
-    }
-
-    const Core::Timing& GetTimer() const {
-        return *timer;
-    }
-
-    u32 GetID() const {
-        return id;
-    }
+    // u32 GetID() const {
+    //     return id;
+    // }
 
 protected:
     // This us used for serialization. Returning nullptr is valid if page tables are not used.
     virtual std::shared_ptr<Memory::PageTable> GetPageTable() const = 0;
 
-    std::shared_ptr<Core::Timing> timer;
+    Core::Timing& timer;
 
 private:
-    u32 id;
+    // u32 id;
 
     friend class boost::serialization::access;
 
     template <class Archive>
     void save(Archive& ar, const unsigned int file_version) const {
         ar << timer;
-        ar << id;
+        // ar << id;
         const auto page_table = GetPageTable();
         ar << page_table;
         for (int i = 0; i < 15; i++) {
@@ -295,7 +291,7 @@ private:
     void load(Archive& ar, const unsigned int file_version) {
         PurgeState();
         ar >> timer;
-        ar >> id;
+        // ar >> id;
         std::shared_ptr<Memory::PageTable> page_table{};
         ar >> page_table;
         SetPageTable(page_table);

--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -137,10 +137,10 @@ public:
     }
 
     void AddTicks(std::uint64_t ticks) override {
-        parent.GetTimer().AddTicks(ticks);
+        parent.timer.AddTicks(ticks);
     }
     std::uint64_t GetTicksRemaining() override {
-        s64 ticks = parent.GetTimer().GetDowncount();
+        s64 ticks = parent.timer.GetDowncount();
         return static_cast<u64>(ticks <= 0 ? 0 : ticks);
     }
 
@@ -150,7 +150,7 @@ public:
 };
 
 ARM_Dynarmic::ARM_Dynarmic(Core::System* system, Memory::MemorySystem& memory, u32 id,
-                           std::shared_ptr<Core::Timing::Timer> timer)
+                           Core::Timing& timer)
     : ARM_Interface(id, timer), system(*system), memory(memory),
       cb(std::make_unique<DynarmicUserCallbacks>(*this)) {
     SetPageTable(memory.GetCurrentPageTable());
@@ -312,8 +312,8 @@ void ARM_Dynarmic::SetPageTable(const std::shared_ptr<Memory::PageTable>& page_t
 }
 
 void ARM_Dynarmic::ServeBreak() {
-    Kernel::Thread* thread = system.Kernel().GetCurrentThreadManager().GetCurrentThread();
-    SaveContext(thread->context);
+    auto thread = system.Kernel().GetCurrentThreadManager().GetCurrentThread();
+    thread->SaveContext();
     GDBStub::Break();
     GDBStub::SendTrap(thread, 5);
 }

--- a/src/core/arm/dynarmic/arm_dynarmic.h
+++ b/src/core/arm/dynarmic/arm_dynarmic.h
@@ -24,8 +24,7 @@ class DynarmicUserCallbacks;
 
 class ARM_Dynarmic final : public ARM_Interface {
 public:
-    ARM_Dynarmic(Core::System* system, Memory::MemorySystem& memory, u32 id,
-                 std::shared_ptr<Core::Timing::Timer> timer);
+    ARM_Dynarmic(Core::System* system, Memory::MemorySystem& memory, Core::Timing& timer);
     ~ARM_Dynarmic() override;
 
     void Run() override;

--- a/src/core/arm/dyncom/arm_dyncom.cpp
+++ b/src/core/arm/dyncom/arm_dyncom.cpp
@@ -69,17 +69,16 @@ private:
 };
 
 ARM_DynCom::ARM_DynCom(Core::System* system, Memory::MemorySystem& memory,
-                       PrivilegeMode initial_mode, u32 id,
-                       std::shared_ptr<Core::Timing::Timer> timer)
-    : ARM_Interface(id, timer), system(system) {
-    state = std::make_unique<ARMul_State>(system, memory, initial_mode);
+                       PrivilegeMode initial_mode, Core::Timing& core)
+    : ARM_Interface(core), system(system) {
+    state = std::make_unique<ARMul_State>(system, memory, initial_mode, core);
 }
 
 ARM_DynCom::~ARM_DynCom() {}
 
 void ARM_DynCom::Run() {
     DEBUG_ASSERT(system != nullptr);
-    ExecuteInstructions(std::max<s64>(timer->GetDowncount(), 0));
+    ExecuteInstructions(std::max<s64>(timer.GetDowncount(), 0));
 }
 
 void ARM_DynCom::Step() {
@@ -157,7 +156,7 @@ void ARM_DynCom::ExecuteInstructions(u64 num_instructions) {
     state->NumInstrsToExecute = num_instructions;
     unsigned ticks_executed = InterpreterMainLoop(state.get());
     if (system != nullptr) {
-        timer->AddTicks(ticks_executed);
+        timer.AddTicks(ticks_executed);
     }
     state->ServeBreak();
 }

--- a/src/core/arm/dyncom/arm_dyncom.h
+++ b/src/core/arm/dyncom/arm_dyncom.h
@@ -21,8 +21,7 @@ class MemorySystem;
 class ARM_DynCom final : public ARM_Interface {
 public:
     explicit ARM_DynCom(Core::System* system, Memory::MemorySystem& memory,
-                        PrivilegeMode initial_mode, u32 id,
-                        std::shared_ptr<Core::Timing::Timer> timer);
+                        PrivilegeMode initial_mode, Core::Timing& timer);
     ~ARM_DynCom() override;
 
     void Run() override;

--- a/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
+++ b/src/core/arm/dyncom/arm_dyncom_interpreter.cpp
@@ -3865,7 +3865,7 @@ SWI_INST : {
     if (inst_base->cond == ConditionCode::AL || CondPassed(cpu, inst_base->cond)) {
         DEBUG_ASSERT(cpu->system != nullptr);
         swi_inst* const inst_cream = (swi_inst*)inst_base->component;
-        cpu->system->GetRunningCore().GetTimer().AddTicks(num_instrs);
+        cpu->timer.AddTicks(num_instrs);
         cpu->NumInstrsToExecute =
             num_instrs >= cpu->NumInstrsToExecute ? 0 : cpu->NumInstrsToExecute - num_instrs;
         num_instrs = 0;

--- a/src/core/arm/skyeye_common/armstate.cpp
+++ b/src/core/arm/skyeye_common/armstate.cpp
@@ -11,8 +11,8 @@
 #include "core/memory.h"
 
 ARMul_State::ARMul_State(Core::System* system, Memory::MemorySystem& memory,
-                         PrivilegeMode initial_mode)
-    : system(system), memory(memory) {
+                         PrivilegeMode initial_mode, Core::Timing& timer)
+    : system(system), memory(memory), timer(timer) {
     Reset();
     ChangePrivilegeMode(initial_mode);
 }
@@ -607,8 +607,8 @@ void ARMul_State::ServeBreak() {
     }
 
     DEBUG_ASSERT(system != nullptr);
-    Kernel::Thread* thread = system->Kernel().GetCurrentThreadManager().GetCurrentThread();
-    system->GetRunningCore().SaveContext(thread->context);
+    auto thread = system->Kernel().GetCurrentThreadManager().GetCurrentThread();
+    thread->SaveContext();
 
     if (last_bkpt_hit || GDBStub::IsMemoryBreak() || GDBStub::GetCpuStepFlag()) {
         last_bkpt_hit = false;

--- a/src/core/arm/skyeye_common/armstate.h
+++ b/src/core/arm/skyeye_common/armstate.h
@@ -148,7 +148,7 @@ enum {
 struct ARMul_State final {
 public:
     explicit ARMul_State(Core::System* system, Memory::MemorySystem& memory,
-                         PrivilegeMode initial_mode);
+                         PrivilegeMode initial_mode, Core::Timing& timer);
 
     void ChangePrivilegeMode(u32 new_mode);
     void Reset();
@@ -208,6 +208,7 @@ public:
 
     Core::System* system;
     Memory::MemorySystem& memory;
+    Core::Timing& timer;
 
     std::array<u32, 16> Reg{}; // The current register file
     std::array<u32, 2> Reg_usr{};

--- a/src/core/cheats/cheats.h
+++ b/src/core/cheats/cheats.h
@@ -35,10 +35,10 @@ public:
 
 private:
     void LoadCheatFile();
-    void RunCallback(u64 userdata, int cycles_late);
+    class RunCallback;
     std::vector<std::shared_ptr<CheatBase>> cheats_list;
     mutable std::shared_mutex cheats_list_mutex;
-    Core::TimingEventType* event;
+    std::unique_ptr<RunCallback> event;
     Core::System& system;
 };
 } // namespace Cheats

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -149,10 +149,7 @@ public:
      * @returns True if the emulated system is powered on, otherwise false.
      */
     bool IsPoweredOn() const {
-        return cpu_cores.size() > 0 &&
-               std::all_of(cpu_cores.begin(), cpu_cores.end(),
-                           [](std::shared_ptr<ARM_Interface> ptr) { return ptr != nullptr; });
-        ;
+        return timing != nullptr;
     }
 
     /**
@@ -164,7 +161,7 @@ public:
     }
 
     /// Prepare the core emulation for a reschedule
-    void PrepareReschedule();
+    // void PrepareReschedule();
 
     PerfStats::Results GetAndResetPerfStats();
 
@@ -174,7 +171,7 @@ public:
      */
 
     ARM_Interface& GetRunningCore() {
-        return *running_core;
+        return timing->CurrentCore().CPU();
     };
 
     /**
@@ -184,16 +181,16 @@ public:
      */
 
     ARM_Interface& GetCore(u32 core_id) {
-        return *cpu_cores[core_id];
+        return timing->GetCore(core_id).CPU();
     };
 
     u32 GetNumCores() const {
-        return static_cast<u32>(cpu_cores.size());
+        return timing->CoreCount();
     }
 
     void InvalidateCacheRange(u32 start_address, std::size_t length) {
-        for (const auto& cpu : cpu_cores) {
-            cpu->InvalidateCacheRange(start_address, length);
+        for (u32 i = 0; i < timing->CoreCount(); i++) {
+            timing->GetCore(i).CPU().InvalidateCacheRange(start_address, length);
         }
     }
 
@@ -320,13 +317,13 @@ private:
                       u32 num_cores);
 
     /// Reschedule the core emulation
-    void Reschedule();
+    // void Reschedule();
 
     /// AppLoader used to load the current executing application
     std::unique_ptr<Loader::AppLoader> app_loader;
 
     /// ARM11 CPU core
-    std::vector<std::shared_ptr<ARM_Interface>> cpu_cores;
+    // std::vector<std::shared_ptr<ARM_Interface>> cpu_cores;
     ARM_Interface* running_core = nullptr;
 
     /// DSP core

--- a/src/core/core_timing.cpp
+++ b/src/core/core_timing.cpp
@@ -3,211 +3,315 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
-#include <cinttypes>
-#include <tuple>
-#include "common/assert.h"
-#include "common/logging/log.h"
+#include <queue>
+// #include <cinttypes>
+// #include <tuple>
+// #include "common/assert.h"
+// #include "common/logging/log.h"
 #include "core/core_timing.h"
 
 namespace Core {
 
-// Sort by time, unless the times are the same, in which case sort by the order added to the queue
-bool Timing::Event::operator>(const Timing::Event& right) const {
-    return std::tie(time, fifo_order) > std::tie(right.time, right.fifo_order);
-}
-
-bool Timing::Event::operator<(const Timing::Event& right) const {
-    return std::tie(time, fifo_order) < std::tie(right.time, right.fifo_order);
-}
-
-Timing::Timing(std::size_t num_cores, u32 cpu_clock_percentage) {
-    timers.resize(num_cores);
-    for (std::size_t i = 0; i < num_cores; ++i) {
-        timers[i] = std::make_shared<Timer>();
+template <class T>
+class min_queue : public std::priority_queue<T, std::vector<T>, std::greater<T>> {
+public:
+    template <class Pr>
+    bool remove(Pr pred) {
+        auto it = std::remove_if(c.begin(), c.end(), pr);
+        if (it != c.end()) {
+            c.erase(it, c.end());
+            std::make_heap(c.begin(), c.end(), comp);
+            return true;
+        }
+        return false;
     }
-    UpdateClockSpeed(cpu_clock_percentage);
-    current_timer = timers[0].get();
-}
+};
 
-void Timing::UpdateClockSpeed(u32 cpu_clock_percentage) {
-    for (auto& timer : timers) {
-        timer->cpu_clock_scale = 100.0 / cpu_clock_percentage;
-    }
-}
+class Timing::EventQueue : public min_queue<Timing::EventInstance> {};
 
-TimingEventType* Timing::RegisterEvent(const std::string& name, TimedCallback callback) {
-    // check for existing type with same name.
-    // we want event type names to remain unique so that we can use them for serialization.
-    auto info = event_types.emplace(name, TimingEventType{});
-    TimingEventType* event_type = &info.first->second;
-    event_type->name = &info.first->first;
-    if (callback != nullptr) {
-        event_type->callback = callback;
-    }
-    return event_type;
-}
-
-void Timing::ScheduleEvent(s64 cycles_into_future, const TimingEventType* event_type, u64 userdata,
-                           std::size_t core_id) {
-    ASSERT(event_type != nullptr);
-    Timing::Timer* timer = nullptr;
-    if (core_id == std::numeric_limits<std::size_t>::max()) {
-        timer = current_timer;
-    } else {
-        ASSERT(core_id < timers.size());
-        timer = timers.at(core_id).get();
-    }
-
-    s64 timeout = timer->GetTicks() + cycles_into_future;
-    if (current_timer == timer) {
-        // If this event needs to be scheduled before the next advance(), force one early
-        if (!timer->is_timer_sane)
-            timer->ForceExceptionCheck(cycles_into_future);
-
-        timer->event_queue.emplace_back(
-            Event{timeout, timer->event_fifo_id++, userdata, event_type});
-        std::push_heap(timer->event_queue.begin(), timer->event_queue.end(), std::greater<>());
-    } else {
-        timer->ts_queue.Push(Event{static_cast<s64>(timer->GetTicks() + cycles_into_future), 0,
-                                   userdata, event_type});
+Timing::Timing(u32 core_count, std::function<ARM_Interface*()> constructor)
+    : events(new EventQueue) {
+    for (u32 i = 0; i < core_count; i++) {
+        cores.emplace_back(i, std::unique_ptr<ARM_Interface>(constructor()));
     }
 }
 
-void Timing::UnscheduleEvent(const TimingEventType* event_type, u64 userdata) {
-    for (auto timer : timers) {
-        auto itr = std::remove_if(
-            timer->event_queue.begin(), timer->event_queue.end(),
-            [&](const Event& e) { return e.type == event_type && e.userdata == userdata; });
+void Timing::RunSlice() {
+    // We assume:
+    //  * Threads don't, e.g. write memory at the same time
+    //  * Events end with b) a thread waking up, or b) some other change
+    //  * Events don't schedule other events to execute immediately
 
-        // Removing random items breaks the invariant so we have to re-establish it.
-        if (itr != timer->event_queue.end()) {
-            timer->event_queue.erase(itr, timer->event_queue.end());
-            std::make_heap(timer->event_queue.begin(), timer->event_queue.end(), std::greater<>());
+    // Run events scheduled for 'now'. Threshold chosen to reduce small slices.
+    while (TimeToNextEvent() < Ticks(100)) {
+        auto next_event = events->top();
+        next_event.event_type->Execute(next_event.userdata, Time_Current() - next_event.time);
+        events->pop();
+    }
+    // the max slice time is fairly arbitrary, as it represents the largest duration by which cores
+    // can be out of sync. The real maximum value without sacrificing accuracy will depend on
+    // software.
+    current_slice_length = Ticks(BASE_CLOCK_RATE_ARM11 / 234);
+    // Only run the slice til the next event:
+    if (TimeToNextEvent() < current_slice_length) {
+        current_slice_length = TimeToNextEvent();
+    }
+    // No cores have run yet, so it's OK to schedule any events we want during this segment
+    max_core_time = Time_LB();
+    for (auto& core : cores) {
+        current_core_id = core.core_id;
+        auto cycles_run = core.RunSegment(current_slice_length);
+        // Uniquely for the first core, we cut the slice if an event was scheduled before the
+        // segment's end. This allows other cores to respond to events scheduled on it. For
+        // subsequent cores, however, this isn't practical because core 0 (at least) will be ahead
+        // in time already.
+        // TODO: Implement core re-ordering
+        if (core.CanCutSlice()) {
+            current_slice_length = std::min(current_slice_length, cycles_run);
+            max_core_time = cycles_run + Time_LB();
         }
     }
-    // TODO:remove events from ts_queue
 }
 
-void Timing::RemoveEvent(const TimingEventType* event_type) {
-    for (auto timer : timers) {
-        auto itr = std::remove_if(timer->event_queue.begin(), timer->event_queue.end(),
-                                  [&](const Event& e) { return e.type == event_type; });
+Ticks Timing::TimeToNextEvent() const {
+    if (events->empty()) {
+        return Ticks(std::numeric_limits<s64>::max);
+    }
+    return events->top().time - Time_LB();
+}
 
-        // Removing random items breaks the invariant so we have to re-establish it.
-        if (itr != timer->event_queue.end()) {
-            timer->event_queue.erase(itr, timer->event_queue.end());
-            std::make_heap(timer->event_queue.begin(), timer->event_queue.end(), std::greater<>());
+void Timing::ScheduleEvent(Event* event, Ticks cycles_into_future, u64 userdata) {
+    ASSERT(cycles_into_future > Ticks(0));
+
+    if ((Time_Current() + cycles_into_future) < Time_UB()) {
+        LOG_WARNING(Core, "Event {} was scheduled {} cycles too soon for all cores to respond",
+                    event->Name(), Time_UB() - (Time_Current() + cycles_into_future));
+    }
+
+    // Try to continue the current execution:
+    auto& core = cores[current_core_id];
+    if (Cycles(cycles_into_future, 1.0) < core.cycles_remaining) {
+        // If we're idle, try executing the event now to see if it'll wake us up
+        if (core.AllThreadsIdle()) {
+            core.AddCycles(Cycles(cycles_into_future, 1.0));
+            event->Execute(userdata, Ticks(0));
+            core.Reschedule();
+            return;
         }
-    }
-    // TODO:remove events from ts_queue
-}
-
-void Timing::SetCurrentTimer(std::size_t core_id) {
-    current_timer = timers[core_id].get();
-}
-
-s64 Timing::GetTicks() const {
-    return current_timer->GetTicks();
-}
-
-s64 Timing::GetGlobalTicks() const {
-    return global_timer;
-}
-
-std::chrono::microseconds Timing::GetGlobalTimeUs() const {
-    return std::chrono::microseconds{GetTicks() * 1000000 / BASE_CLOCK_RATE_ARM11};
-}
-
-std::shared_ptr<Timing::Timer> Timing::GetTimer(std::size_t cpu_id) {
-    return timers[cpu_id];
-}
-
-Timing::Timer::Timer() = default;
-
-Timing::Timer::~Timer() {
-    MoveEvents();
-}
-
-u64 Timing::Timer::GetTicks() const {
-    u64 ticks = static_cast<u64>(executed_ticks);
-    if (!is_timer_sane) {
-        ticks += slice_length - downcount;
-    }
-    return ticks;
-}
-
-void Timing::Timer::AddTicks(u64 ticks) {
-    downcount -= static_cast<u64>(ticks * cpu_clock_scale);
-}
-
-u64 Timing::Timer::GetIdleTicks() const {
-    return static_cast<u64>(idled_cycles);
-}
-
-void Timing::Timer::ForceExceptionCheck(s64 cycles) {
-    cycles = std::max<s64>(0, cycles);
-    if (downcount > cycles) {
-        slice_length -= downcount - cycles;
-        downcount = cycles;
-    }
-}
-
-void Timing::Timer::MoveEvents() {
-    for (Event ev; ts_queue.Pop(ev);) {
-        ev.fifo_order = event_fifo_id++;
-        event_queue.emplace_back(std::move(ev));
-        std::push_heap(event_queue.begin(), event_queue.end(), std::greater<>());
-    }
-}
-
-s64 Timing::Timer::GetMaxSliceLength() const {
-    auto next_event = std::find_if(event_queue.begin(), event_queue.end(),
-                                   [&](const Event& e) { return e.time - executed_ticks > 0; });
-    if (next_event != event_queue.end()) {
-        return next_event->time - executed_ticks;
-    }
-    return MAX_SLICE_LENGTH;
-}
-
-void Timing::Timer::Advance(s64 max_slice_length) {
-    MoveEvents();
-
-    s64 cycles_executed = slice_length - downcount;
-    idled_cycles = 0;
-    executed_ticks += cycles_executed;
-    slice_length = max_slice_length;
-
-    is_timer_sane = true;
-
-    while (!event_queue.empty() && event_queue.front().time <= executed_ticks) {
-        Event evt = std::move(event_queue.front());
-        std::pop_heap(event_queue.begin(), event_queue.end(), std::greater<>());
-        event_queue.pop_back();
-        if (evt.type->callback != nullptr) {
-            evt.type->callback(evt.userdata, executed_ticks - evt.time);
-        } else {
-            LOG_ERROR(Core, "Event '{}' has no callback", *evt.type->name);
-        }
+        // If a thread is running, end the block ASAP so we can run a more
+        // precise slice.
+        core.EndBlock();
     }
 
-    is_timer_sane = false;
-
-    // Still events left (scheduled in the future)
-    if (!event_queue.empty()) {
-        slice_length = static_cast<int>(
-            std::min<s64>(event_queue.front().time - executed_ticks, max_slice_length));
-    }
-
-    downcount = slice_length;
+    // Push the resultant event onto the heap
+    auto scheduled_time = Time_Current() + cycles_into_future;
+    events->emplace(EventInstance{event, scheduled_time, userdata});
 }
 
-void Timing::Timer::Idle() {
-    idled_cycles += downcount;
-    downcount = 0;
+void Timing::UnscheduleEvent(Event* event, u64 userdata) {
+    events->remove([=](const auto& e) { return e.event_type == event && e.userdata == userdata; });
 }
 
-s64 Timing::Timer::GetDowncount() const {
-    return downcount;
-}
+// // Sort by time, unless the times are the same, in which case sort by the order added to the
+// queue bool Timing::Event::operator>(const Timing::Event& right) const {
+//     return std::tie(time, fifo_order) > std::tie(right.time, right.fifo_order);
+// }
+
+// bool Timing::Event::operator<(const Timing::Event& right) const {
+//     return std::tie(time, fifo_order) < std::tie(right.time, right.fifo_order);
+// }
+
+// Timing::Timing(std::size_t num_cores, u32 cpu_clock_percentage) {
+//     timers.resize(num_cores);
+//     for (std::size_t i = 0; i < num_cores; ++i) {
+//         timers[i] = std::make_shared<Timer>();
+//     }
+//     UpdateClockSpeed(cpu_clock_percentage);
+//     current_timer = timers[0].get();
+// }
+
+// void Timing::UpdateClockSpeed(u32 cpu_clock_percentage) {
+//     for (auto& timer : timers) {
+//         timer->cpu_clock_scale = 100.0 / cpu_clock_percentage;
+//     }
+// }
+
+// TimingEventType* Timing::RegisterEvent(const std::string& name, TimedCallback callback) {
+//     // check for existing type with same name.
+//     // we want event type names to remain unique so that we can use them for serialization.
+//     auto info = event_types.emplace(name, TimingEventType{});
+//     TimingEventType* event_type = &info.first->second;
+//     event_type->name = &info.first->first;
+//     if (callback != nullptr) {
+//         event_type->callback = callback;
+//     }
+//     return event_type;
+// }
+
+// void Timing::ScheduleEvent(s64 cycles_into_future, const TimingEventType* event_type, u64
+// userdata,
+//                            std::size_t core_id) {
+//     ASSERT(event_type != nullptr);
+//     Timing::Timer* timer = nullptr;
+//     if (core_id == std::numeric_limits<std::size_t>::max()) {
+//         timer = current_timer;
+//     } else {
+//         ASSERT(core_id < timers.size());
+//         timer = timers.at(core_id).get();
+//     }
+
+//     s64 timeout = timer->GetTicks() + cycles_into_future;
+//     if (current_timer == timer) {
+//         // If this event needs to be scheduled before the next advance(), force one early
+//         if (!timer->is_timer_sane)
+//             timer->ForceExceptionCheck(cycles_into_future);
+
+//         timer->event_queue.emplace_back(
+//             Event{timeout, timer->event_fifo_id++, userdata, event_type});
+//         std::push_heap(timer->event_queue.begin(), timer->event_queue.end(), std::greater<>());
+//     } else {
+//         timer->ts_queue.Push(Event{static_cast<s64>(timer->GetTicks() + cycles_into_future), 0,
+//                                    userdata, event_type});
+//     }
+// }
+
+// void Timing::UnscheduleEvent(const TimingEventType* event_type, u64 userdata) {
+//     for (auto timer : timers) {
+//         auto itr = std::remove_if(
+//             timer->event_queue.begin(), timer->event_queue.end(),
+//             [&](const Event& e) { return e.type == event_type && e.userdata == userdata; });
+
+//         // Removing random items breaks the invariant so we have to re-establish it.
+//         if (itr != timer->event_queue.end()) {
+//             timer->event_queue.erase(itr, timer->event_queue.end());
+//             std::make_heap(timer->event_queue.begin(), timer->event_queue.end(),
+//             std::greater<>());
+//         }
+//     }
+//     // TODO:remove events from ts_queue
+// }
+
+// void Timing::RemoveEvent(const TimingEventType* event_type) {
+//     for (auto timer : timers) {
+//         auto itr = std::remove_if(timer->event_queue.begin(), timer->event_queue.end(),
+//                                   [&](const Event& e) { return e.type == event_type; });
+
+//         // Removing random items breaks the invariant so we have to re-establish it.
+//         if (itr != timer->event_queue.end()) {
+//             timer->event_queue.erase(itr, timer->event_queue.end());
+//             std::make_heap(timer->event_queue.begin(), timer->event_queue.end(),
+//             std::greater<>());
+//         }
+//     }
+//     // TODO:remove events from ts_queue
+// }
+
+// void Timing::SetCurrentTimer(std::size_t core_id) {
+//     current_timer = timers[core_id].get();
+// }
+
+// s64 Timing::GetTicks() const {
+//     return current_timer->GetTicks();
+// }
+
+// s64 Timing::GetGlobalTicks() const {
+//     return global_timer;
+// }
+
+// std::chrono::microseconds Timing::GetGlobalTimeUs() const {
+//     return std::chrono::microseconds{GetTicks() * 1000000 / BASE_CLOCK_RATE_ARM11};
+// }
+
+// std::shared_ptr<Timing::Timer> Timing::GetTimer(std::size_t cpu_id) {
+//     return timers[cpu_id];
+// }
+
+// Timing::Timer::Timer() = default;
+
+// Timing::Timer::~Timer() {
+//     MoveEvents();
+// }
+
+// u64 Timing::Timer::GetTicks() const {
+//     u64 ticks = static_cast<u64>(executed_ticks);
+//     if (!is_timer_sane) {
+//         ticks += slice_length - downcount;
+//     }
+//     return ticks;
+// }
+
+// void Timing::Timer::AddTicks(u64 ticks) {
+//     downcount -= static_cast<u64>(ticks * cpu_clock_scale);
+// }
+
+// u64 Timing::Timer::GetIdleTicks() const {
+//     return static_cast<u64>(idled_cycles);
+// }
+
+// void Timing::Timer::ForceExceptionCheck(s64 cycles) {
+//     cycles = std::max<s64>(0, cycles);
+//     if (downcount > cycles) {
+//         slice_length -= downcount - cycles;
+//         downcount = cycles;
+//     }
+// }
+
+// void Timing::Timer::MoveEvents() {
+//     for (Event ev; ts_queue.Pop(ev);) {
+//         ev.fifo_order = event_fifo_id++;
+//         event_queue.emplace_back(std::move(ev));
+//         std::push_heap(event_queue.begin(), event_queue.end(), std::greater<>());
+//     }
+// }
+
+// s64 Timing::Timer::GetMaxSliceLength() const {
+//     auto next_event = std::find_if(event_queue.begin(), event_queue.end(),
+//                                    [&](const Event& e) { return e.time - executed_ticks > 0; });
+//     if (next_event != event_queue.end()) {
+//         return next_event->time - executed_ticks;
+//     }
+//     return MAX_SLICE_LENGTH;
+// }
+
+// void Timing::Timer::Advance(s64 max_slice_length) {
+//     MoveEvents();
+
+//     s64 cycles_executed = slice_length - downcount;
+//     idled_cycles = 0;
+//     executed_ticks += cycles_executed;
+//     slice_length = max_slice_length;
+
+//     is_timer_sane = true;
+
+//     while (!event_queue.empty() && event_queue.front().time <= executed_ticks) {
+//         Event evt = std::move(event_queue.front());
+//         std::pop_heap(event_queue.begin(), event_queue.end(), std::greater<>());
+//         event_queue.pop_back();
+//         if (evt.type->callback != nullptr) {
+//             evt.type->callback(evt.userdata, executed_ticks - evt.time);
+//         } else {
+//             LOG_ERROR(Core, "Event '{}' has no callback", *evt.type->name);
+//         }
+//     }
+
+//     is_timer_sane = false;
+
+//     // Still events left (scheduled in the future)
+//     if (!event_queue.empty()) {
+//         slice_length = static_cast<int>(
+//             std::min<s64>(event_queue.front().time - executed_ticks, max_slice_length));
+//     }
+
+//     downcount = slice_length;
+// }
+
+// void Timing::Timer::Idle() {
+//     idled_cycles += downcount;
+//     downcount = 0;
+// }
+
+// s64 Timing::Timer::GetDowncount() const {
+//     return downcount;
+// }
 
 } // namespace Core

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -17,18 +17,26 @@
  *   ScheduleEvent(periodInCycles - cyclesLate, callback, "whatever")
  */
 
-#include <chrono>
-#include <functional>
 #include <limits>
-#include <string>
-#include <unordered_map>
 #include <vector>
-#include <boost/serialization/split_member.hpp>
-#include <boost/serialization/vector.hpp>
+#include <boost/container/flat_set.hpp>
 #include "common/common_types.h"
-#include "common/logging/log.h"
-#include "common/threadsafe_queue.h"
-#include "core/global.h"
+#include "core/arm/arm_interface.h"
+#include "core/hle/kernel/process.h"
+#include "core/hle/kernel/wait_object.h"
+
+// #include <chrono>
+// #include <functional>
+// #include <limits>
+// #include <string>
+// #include <unordered_map>
+// #include <vector>
+// #include <boost/serialization/split_member.hpp>
+// #include <boost/serialization/vector.hpp>
+// #include "common/common_types.h"
+// #include "common/logging/log.h"
+// #include "common/threadsafe_queue.h"
+// #include "core/global.h"
 
 // The timing we get from the assembly is 268,111,855.956 Hz
 // It is possible that this number isn't just an integer because the compiler could have
@@ -37,272 +45,384 @@
 constexpr u64 BASE_CLOCK_RATE_ARM11 = 268111856;
 constexpr u64 MAX_VALUE_TO_MULTIPLY = std::numeric_limits<s64>::max() / BASE_CLOCK_RATE_ARM11;
 
-constexpr s64 msToCycles(int ms) {
-    // since ms is int there is no way to overflow
-    return BASE_CLOCK_RATE_ARM11 * static_cast<s64>(ms) / 1000;
-}
+// constexpr s64 msToCycles(int ms) {
+//     // since ms is int there is no way to overflow
+//     return BASE_CLOCK_RATE_ARM11 * static_cast<s64>(ms) / 1000;
+// }
 
-constexpr s64 msToCycles(float ms) {
-    return static_cast<s64>(BASE_CLOCK_RATE_ARM11 * (0.001f) * ms);
-}
+// constexpr s64 msToCycles(float ms) {
+//     return static_cast<s64>(BASE_CLOCK_RATE_ARM11 * (0.001f) * ms);
+// }
 
-constexpr s64 msToCycles(double ms) {
-    return static_cast<s64>(BASE_CLOCK_RATE_ARM11 * (0.001) * ms);
-}
+// constexpr s64 msToCycles(double ms) {
+//     return static_cast<s64>(BASE_CLOCK_RATE_ARM11 * (0.001) * ms);
+// }
 
-constexpr s64 usToCycles(float us) {
-    return static_cast<s64>(BASE_CLOCK_RATE_ARM11 * (0.000001f) * us);
-}
+// constexpr s64 usToCycles(float us) {
+//     return static_cast<s64>(BASE_CLOCK_RATE_ARM11 * (0.000001f) * us);
+// }
 
-constexpr s64 usToCycles(int us) {
-    return (BASE_CLOCK_RATE_ARM11 * static_cast<s64>(us) / 1000000);
-}
+// constexpr s64 usToCycles(int us) {
+//     return (BASE_CLOCK_RATE_ARM11 * static_cast<s64>(us) / 1000000);
+// }
 
-inline s64 usToCycles(s64 us) {
-    if (us / 1000000 > static_cast<s64>(MAX_VALUE_TO_MULTIPLY)) {
-        LOG_ERROR(Core_Timing, "Integer overflow, use max value");
-        return std::numeric_limits<s64>::max();
+// inline s64 usToCycles(s64 us) {
+//     if (us / 1000000 > static_cast<s64>(MAX_VALUE_TO_MULTIPLY)) {
+//         LOG_ERROR(Core_Timing, "Integer overflow, use max value");
+//         return std::numeric_limits<s64>::max();
+//     }
+//     if (us > static_cast<s64>(MAX_VALUE_TO_MULTIPLY)) {
+//         LOG_DEBUG(Core_Timing, "Time very big, do rounding");
+//         return BASE_CLOCK_RATE_ARM11 * (us / 1000000);
+//     }
+//     return (BASE_CLOCK_RATE_ARM11 * us) / 1000000;
+// }
+
+// inline s64 usToCycles(u64 us) {
+//     if (us / 1000000 > MAX_VALUE_TO_MULTIPLY) {
+//         LOG_ERROR(Core_Timing, "Integer overflow, use max value");
+//         return std::numeric_limits<s64>::max();
+//     }
+//     if (us > MAX_VALUE_TO_MULTIPLY) {
+//         LOG_DEBUG(Core_Timing, "Time very big, do rounding");
+//         return BASE_CLOCK_RATE_ARM11 * static_cast<s64>(us / 1000000);
+//     }
+//     return (BASE_CLOCK_RATE_ARM11 * static_cast<s64>(us)) / 1000000;
+// }
+
+// constexpr s64 nsToCycles(float ns) {
+//     return static_cast<s64>(BASE_CLOCK_RATE_ARM11 * (0.000000001f) * ns);
+// }
+
+// constexpr s64 nsToCycles(int ns) {
+//     return BASE_CLOCK_RATE_ARM11 * static_cast<s64>(ns) / 1000000000;
+// }
+
+// inline s64 nsToCycles(s64 ns) {
+//     if (ns / 1000000000 > static_cast<s64>(MAX_VALUE_TO_MULTIPLY)) {
+//         LOG_ERROR(Core_Timing, "Integer overflow, use max value");
+//         return std::numeric_limits<s64>::max();
+//     }
+//     if (ns > static_cast<s64>(MAX_VALUE_TO_MULTIPLY)) {
+//         LOG_DEBUG(Core_Timing, "Time very big, do rounding");
+//         return BASE_CLOCK_RATE_ARM11 * (ns / 1000000000);
+//     }
+//     return (BASE_CLOCK_RATE_ARM11 * ns) / 1000000000;
+// }
+
+// inline s64 nsToCycles(u64 ns) {
+//     if (ns / 1000000000 > MAX_VALUE_TO_MULTIPLY) {
+//         LOG_ERROR(Core_Timing, "Integer overflow, use max value");
+//         return std::numeric_limits<s64>::max();
+//     }
+//     if (ns > MAX_VALUE_TO_MULTIPLY) {
+//         LOG_DEBUG(Core_Timing, "Time very big, do rounding");
+//         return BASE_CLOCK_RATE_ARM11 * (static_cast<s64>(ns) / 1000000000);
+//     }
+//     return (BASE_CLOCK_RATE_ARM11 * static_cast<s64>(ns)) / 1000000000;
+// }
+
+// constexpr u64 cyclesToNs(s64 cycles) {
+//     return cycles * 1000000000 / BASE_CLOCK_RATE_ARM11;
+// }
+
+// constexpr s64 cyclesToUs(s64 cycles) {
+//     return cycles * 1000000 / BASE_CLOCK_RATE_ARM11;
+// }
+
+// constexpr u64 cyclesToMs(s64 cycles) {
+//     return cycles * 1000 / BASE_CLOCK_RATE_ARM11;
+// }
+
+struct Ticks {
+    constexpr explicit Ticks(s64 _count) : count(_count) {}
+    constexpr explicit operator s64() {
+        return count;
     }
-    if (us > static_cast<s64>(MAX_VALUE_TO_MULTIPLY)) {
-        LOG_DEBUG(Core_Timing, "Time very big, do rounding");
-        return BASE_CLOCK_RATE_ARM11 * (us / 1000000);
+    constexpr Ticks(nanoseconds ns) : count(ns.count() * BASE_CLOCK_RATE_ARM11 / std::nano::den) {
+        if (ns.count() > MAX_VALUE_TO_MULTIPLY) {
+            count = std::numeric_limits<s64>::max();
+        }
     }
-    return (BASE_CLOCK_RATE_ARM11 * us) / 1000000;
-}
+    constexpr Ticks(milliseconds ms) : Ticks(nanoseconds(ms)) {}
+    // constexpr Ticks(Cycles cycles, float scale_factor)
+    //     : count(static_cast<s64>(s64(cycles) / scale_factor)) {}
 
-inline s64 usToCycles(u64 us) {
-    if (us / 1000000 > MAX_VALUE_TO_MULTIPLY) {
-        LOG_ERROR(Core_Timing, "Integer overflow, use max value");
-        return std::numeric_limits<s64>::max();
+    constexpr bool operator<(const Ticks& right) const {
+        return count < right.count;
     }
-    if (us > MAX_VALUE_TO_MULTIPLY) {
-        LOG_DEBUG(Core_Timing, "Time very big, do rounding");
-        return BASE_CLOCK_RATE_ARM11 * static_cast<s64>(us / 1000000);
+    constexpr bool operator>(const Ticks& right) const {
+        return count > right.count;
     }
-    return (BASE_CLOCK_RATE_ARM11 * static_cast<s64>(us)) / 1000000;
-}
-
-constexpr s64 nsToCycles(float ns) {
-    return static_cast<s64>(BASE_CLOCK_RATE_ARM11 * (0.000000001f) * ns);
-}
-
-constexpr s64 nsToCycles(int ns) {
-    return BASE_CLOCK_RATE_ARM11 * static_cast<s64>(ns) / 1000000000;
-}
-
-inline s64 nsToCycles(s64 ns) {
-    if (ns / 1000000000 > static_cast<s64>(MAX_VALUE_TO_MULTIPLY)) {
-        LOG_ERROR(Core_Timing, "Integer overflow, use max value");
-        return std::numeric_limits<s64>::max();
+    constexpr Ticks operator+(const Ticks& right) const {
+        return Ticks(count + right.count);
     }
-    if (ns > static_cast<s64>(MAX_VALUE_TO_MULTIPLY)) {
-        LOG_DEBUG(Core_Timing, "Time very big, do rounding");
-        return BASE_CLOCK_RATE_ARM11 * (ns / 1000000000);
+    constexpr Ticks operator-(const Ticks& right) const {
+        return Ticks(count - right.count);
     }
-    return (BASE_CLOCK_RATE_ARM11 * ns) / 1000000000;
-}
 
-inline s64 nsToCycles(u64 ns) {
-    if (ns / 1000000000 > MAX_VALUE_TO_MULTIPLY) {
-        LOG_ERROR(Core_Timing, "Integer overflow, use max value");
-        return std::numeric_limits<s64>::max();
+private:
+    s64 count;
+};
+
+struct Cycles {
+    constexpr explicit Cycles(s64 _count) : count(_count) {}
+    constexpr explicit operator s64() {
+        return count;
     }
-    if (ns > MAX_VALUE_TO_MULTIPLY) {
-        LOG_DEBUG(Core_Timing, "Time very big, do rounding");
-        return BASE_CLOCK_RATE_ARM11 * (static_cast<s64>(ns) / 1000000000);
+    constexpr Cycles(Ticks ticks, float scale_factor)
+        : count(static_cast<s64>(s64(ticks) * scale_factor)) {}
+
+    constexpr bool operator<(const Cycles& right) const {
+        return count < right.count;
     }
-    return (BASE_CLOCK_RATE_ARM11 * static_cast<s64>(ns)) / 1000000000;
-}
+    constexpr bool operator>(const Cycles& right) const {
+        return count > right.count;
+    }
+    constexpr Cycles operator+(const Cycles& right) const {
+        return Cycles(count + right.count);
+    }
+    constexpr Cycles operator-(const Cycles& right) const {
+        return Cycles(count - right.count);
+    }
 
-constexpr u64 cyclesToNs(s64 cycles) {
-    return cycles * 1000000000 / BASE_CLOCK_RATE_ARM11;
-}
-
-constexpr s64 cyclesToUs(s64 cycles) {
-    return cycles * 1000000 / BASE_CLOCK_RATE_ARM11;
-}
-
-constexpr u64 cyclesToMs(s64 cycles) {
-    return cycles * 1000 / BASE_CLOCK_RATE_ARM11;
-}
+private:
+    s64 count;
+};
 
 namespace Core {
 
-using TimedCallback = std::function<void(u64 userdata, int cycles_late)>;
-
-struct TimingEventType {
-    TimedCallback callback;
-    const std::string* name;
+class Event {
+public:
+    virtual const std::string& Name() = 0;
+    virtual void Execute(Timing& timing, u64 userdata, Ticks cycles_late) = 0;
 };
 
 class Timing {
 
 public:
-    struct Event {
-        s64 time;
-        u64 fifo_order;
-        u64 userdata;
-        const TimingEventType* type;
+    Timing(u32 core_count, std::function<ARM_Interface*()> constructor);
 
-        bool operator>(const Event& right) const;
-        bool operator<(const Event& right) const;
-
-    private:
-        template <class Archive>
-        void save(Archive& ar, const unsigned int) const {
-            ar& time;
-            ar& fifo_order;
-            ar& userdata;
-            std::string name = *(type->name);
-            ar << name;
-        }
-
-        template <class Archive>
-        void load(Archive& ar, const unsigned int) {
-            ar& time;
-            ar& fifo_order;
-            ar& userdata;
-            std::string name;
-            ar >> name;
-            type = Global<Timing>().RegisterEvent(name, nullptr);
-        }
-        friend class boost::serialization::access;
-
-        BOOST_SERIALIZATION_SPLIT_MEMBER()
-    };
-
-    static constexpr int MAX_SLICE_LENGTH = 20000;
-
-    class Timer {
-    public:
-        Timer();
-        ~Timer();
-
-        s64 GetMaxSliceLength() const;
-
-        void Advance(s64 max_slice_length = MAX_SLICE_LENGTH);
-
-        void Idle();
-
-        u64 GetTicks() const;
-        u64 GetIdleTicks() const;
-
-        void AddTicks(u64 ticks);
-
-        s64 GetDowncount() const;
-
-        void ForceExceptionCheck(s64 cycles);
-
-        void MoveEvents();
-
-    private:
-        friend class Timing;
-        // The queue is a min-heap using std::make_heap/push_heap/pop_heap.
-        // We don't use std::priority_queue because we need to be able to serialize, unserialize and
-        // erase arbitrary events (RemoveEvent()) regardless of the queue order. These aren't
-        // accomodated by the standard adaptor class.
-        std::vector<Event> event_queue;
-        u64 event_fifo_id = 0;
-        // the queue for storing the events from other threads threadsafe until they will be added
-        // to the event_queue by the emu thread
-        Common::MPSCQueue<Event> ts_queue;
-        // Are we in a function that has been called from Advance()
-        // If events are sheduled from a function that gets called from Advance(),
-        // don't change slice_length and downcount.
-        // The time between CoreTiming being intialized and the first call to Advance() is
-        // considered the slice boundary between slice -1 and slice 0. Dispatcher loops must call
-        // Advance() before executing the first cycle of each slice to prepare the slice length and
-        // downcount for that slice.
-        bool is_timer_sane = true;
-
-        s64 slice_length = MAX_SLICE_LENGTH;
-        s64 downcount = MAX_SLICE_LENGTH;
-        s64 executed_ticks = 0;
-        u64 idled_cycles = 0;
-        // Stores a scaling for the internal clockspeed. Changing this number results in
-        // under/overclocking the guest cpu
-        double cpu_clock_scale = 1.0;
-
-        template <class Archive>
-        void serialize(Archive& ar, const unsigned int) {
-            MoveEvents();
-            // NOTE: ts_queue should be empty now
-            ar& event_queue;
-            ar& event_fifo_id;
-            ar& slice_length;
-            ar& downcount;
-            ar& executed_ticks;
-            ar& idled_cycles;
-        }
-        friend class boost::serialization::access;
-    };
-
-    explicit Timing(std::size_t num_cores, u32 cpu_clock_percentage);
-
-    ~Timing(){};
-
-    /**
-     * Returns the event_type identifier. if name is not unique, it will assert.
-     */
-    TimingEventType* RegisterEvent(const std::string& name, TimedCallback callback);
-
-    void ScheduleEvent(s64 cycles_into_future, const TimingEventType* event_type, u64 userdata = 0,
-                       std::size_t core_id = std::numeric_limits<std::size_t>::max());
-
-    void UnscheduleEvent(const TimingEventType* event_type, u64 userdata);
-
-    /// We only permit one event of each type in the queue at a time.
-    void RemoveEvent(const TimingEventType* event_type);
-
-    void SetCurrentTimer(std::size_t core_id);
-
-    s64 GetTicks() const;
-
-    s64 GetGlobalTicks() const;
-
-    void AddToGlobalTicks(s64 ticks) {
-        global_timer += ticks;
+    Kernel::ThreadManager& GetCore(int core_id) const;
+    void ScheduleEvent(Event* event, Ticks cycles_into_future, u64 userdata = 0);
+    void UnscheduleEvent(Event* event, u64 userdata = 0);
+    void RunSlice();
+    Ticks Time_LB() const;
+    Ticks Time_Current() const;
+    Ticks Time_UB() const {
+        return std::max(Time_Current(), max_core_time);
     }
-
-    /**
-     * Updates the value of the cpu clock scaling to the new percentage.
-     */
-    void UpdateClockSpeed(u32 cpu_clock_percentage);
-
-    std::chrono::microseconds GetGlobalTimeUs() const;
-
-    std::shared_ptr<Timer> GetTimer(std::size_t cpu_id);
 
 private:
-    s64 global_timer = 0;
+    struct EventInstance {
+        Event* event_type;
+        Ticks time;
+        u64 userdata;
 
-    // unordered_map stores each element separately as a linked list node so pointers to
-    // elements remain stable regardless of rehashes/resizing.
-    std::unordered_map<std::string, TimingEventType> event_types = {};
-
-    std::vector<std::shared_ptr<Timer>> timers;
-    Timer* current_timer = nullptr;
-
-    // Stores a scaling for the internal clockspeed. Changing this number results in
-    // under/overclocking the guest cpu
-    double cpu_clock_scale = 1.0;
-
-    template <class Archive>
-    void serialize(Archive& ar, const unsigned int file_version) {
-        // event_types set during initialization of other things
-        ar& global_timer;
-        ar& timers;
-        if (file_version == 0) {
-            std::shared_ptr<Timer> x;
-            ar& x;
-            current_timer = x.get();
-        } else {
-            ar& current_timer;
+        bool operator>(const EventInstance& right) const {
+            return time > right.time;
         }
+    };
+
+    Ticks TimeToNextEvent() const;
+
+    Kernel::ThreadManager& ThreadManager() {
+        return cores[current_core_id];
     }
-    friend class boost::serialization::access;
+
+    const Kernel::ThreadManager& ThreadManager() const {
+        return cores[current_core_id];
+    }
+
+    u8 current_core_id;
+    std::vector<Kernel::ThreadManager> cores;
+    class EventQueue;
+    std::unique_ptr<EventQueue> events;
+    Ticks current_slice_length{0};
+    Ticks max_core_time{0};
+
+    friend class Kernel::ThreadManager;
 };
+
+// using TimedCallback = std::function<void(u64 userdata, int cycles_late)>;
+
+// struct TimingEventType {
+//     TimedCallback callback;
+//     const std::string* name;
+// };
+
+// class Timing {
+
+// public:
+//     struct Event {
+//         s64 time;
+//         u64 fifo_order;
+//         u64 userdata;
+//         const TimingEventType* type;
+
+//         bool operator>(const Event& right) const;
+//         bool operator<(const Event& right) const;
+
+//     private:
+//         template <class Archive>
+//         void save(Archive& ar, const unsigned int) const {
+//             ar& time;
+//             ar& fifo_order;
+//             ar& userdata;
+//             std::string name = *(type->name);
+//             ar << name;
+//         }
+
+//         template <class Archive>
+//         void load(Archive& ar, const unsigned int) {
+//             ar& time;
+//             ar& fifo_order;
+//             ar& userdata;
+//             std::string name;
+//             ar >> name;
+//             type = Global<Timing>().RegisterEvent(name, nullptr);
+//         }
+//         friend class boost::serialization::access;
+
+//         BOOST_SERIALIZATION_SPLIT_MEMBER()
+//     };
+
+//     static constexpr int MAX_SLICE_LENGTH = 20000;
+
+//     class Timer {
+//     public:
+//         Timer();
+//         ~Timer();
+
+//         s64 GetMaxSliceLength() const;
+
+//         void Advance(s64 max_slice_length = MAX_SLICE_LENGTH);
+
+//         void Idle();
+
+//         u64 GetTicks() const;
+//         u64 GetIdleTicks() const;
+
+//         void AddTicks(u64 ticks);
+
+//         s64 GetDowncount() const;
+
+//         void ForceExceptionCheck(s64 cycles);
+
+//         void MoveEvents();
+
+//     private:
+//         friend class Timing;
+//         // The queue is a min-heap using std::make_heap/push_heap/pop_heap.
+//         // We don't use std::priority_queue because we need to be able to serialize, unserialize
+//         and
+//         // erase arbitrary events (RemoveEvent()) regardless of the queue order. These aren't
+//         // accomodated by the standard adaptor class.
+//         std::vector<Event> event_queue;
+//         u64 event_fifo_id = 0;
+//         // the queue for storing the events from other threads threadsafe until they will be
+//         added
+//         // to the event_queue by the emu thread
+//         Common::MPSCQueue<Event> ts_queue;
+//         // Are we in a function that has been called from Advance()
+//         // If events are sheduled from a function that gets called from Advance(),
+//         // don't change slice_length and downcount.
+//         // The time between CoreTiming being intialized and the first call to Advance() is
+//         // considered the slice boundary between slice -1 and slice 0. Dispatcher loops must call
+//         // Advance() before executing the first cycle of each slice to prepare the slice length
+//         and
+//         // downcount for that slice.
+//         bool is_timer_sane = true;
+
+//         s64 slice_length = MAX_SLICE_LENGTH;
+//         s64 downcount = MAX_SLICE_LENGTH;
+//         s64 executed_ticks = 0;
+//         u64 idled_cycles = 0;
+//         // Stores a scaling for the internal clockspeed. Changing this number results in
+//         // under/overclocking the guest cpu
+//         double cpu_clock_scale = 1.0;
+
+//         template <class Archive>
+//         void serialize(Archive& ar, const unsigned int) {
+//             MoveEvents();
+//             // NOTE: ts_queue should be empty now
+//             ar& event_queue;
+//             ar& event_fifo_id;
+//             ar& slice_length;
+//             ar& downcount;
+//             ar& executed_ticks;
+//             ar& idled_cycles;
+//         }
+//         friend class boost::serialization::access;
+//     };
+
+//     explicit Timing(std::size_t num_cores, u32 cpu_clock_percentage);
+
+//     ~Timing(){};
+
+//     /**
+//      * Returns the event_type identifier. if name is not unique, it will assert.
+//      */
+//     TimingEventType* RegisterEvent(const std::string& name, TimedCallback callback);
+
+//     void ScheduleEvent(s64 cycles_into_future, const TimingEventType* event_type, u64 userdata =
+//     0,
+//                        std::size_t core_id = std::numeric_limits<std::size_t>::max());
+
+//     void UnscheduleEvent(const TimingEventType* event_type, u64 userdata);
+
+//     /// We only permit one event of each type in the queue at a time.
+//     void RemoveEvent(const TimingEventType* event_type);
+
+//     void SetCurrentTimer(std::size_t core_id);
+
+//     s64 GetTicks() const;
+
+//     s64 GetGlobalTicks() const;
+
+//     void AddToGlobalTicks(s64 ticks) {
+//         global_timer += ticks;
+//     }
+
+//     /**
+//      * Updates the value of the cpu clock scaling to the new percentage.
+//      */
+//     void UpdateClockSpeed(u32 cpu_clock_percentage);
+
+//     std::chrono::microseconds GetGlobalTimeUs() const;
+
+//     std::shared_ptr<Timer> GetTimer(std::size_t cpu_id);
+
+// private:
+//     s64 global_timer = 0;
+
+//     // unordered_map stores each element separately as a linked list node so pointers to
+//     // elements remain stable regardless of rehashes/resizing.
+//     std::unordered_map<std::string, TimingEventType> event_types = {};
+
+//     std::vector<std::shared_ptr<Timer>> timers;
+//     Timer* current_timer = nullptr;
+
+//     // Stores a scaling for the internal clockspeed. Changing this number results in
+//     // under/overclocking the guest cpu
+//     double cpu_clock_scale = 1.0;
+
+//     template <class Archive>
+//     void serialize(Archive& ar, const unsigned int file_version) {
+//         // event_types set during initialization of other things
+//         ar& global_timer;
+//         ar& timers;
+//         if (file_version == 0) {
+//             std::shared_ptr<Timer> x;
+//             ar& x;
+//             current_timer = x.get();
+//         } else {
+//             ar& current_timer;
+//         }
+//     }
+//     friend class boost::serialization::access;
+// };
 
 } // namespace Core
 
-BOOST_CLASS_VERSION(Core::Timing, 1)
+// BOOST_CLASS_VERSION(Core::Timing, 1)

--- a/src/core/gdbstub/gdbstub.cpp
+++ b/src/core/gdbstub/gdbstub.cpp
@@ -167,7 +167,7 @@ static Kernel::Thread* FindThreadById(int id) {
             Core::System::GetInstance().Kernel().GetThreadManager(i).GetThreadList();
         for (auto& thread : threads) {
             if (thread->GetThreadId() == static_cast<u32>(id)) {
-                return thread.get();
+                return thread;
             }
         }
     }

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -219,7 +219,7 @@ public:
     public:
         virtual ~WakeupCallback() = default;
         virtual void WakeUp(std::shared_ptr<Thread> thread, HLERequestContext& context,
-                            ThreadWakeupReason reason) = 0;
+                            Thread::WakeupReason reason) = 0;
 
     private:
         template <class Archive>

--- a/src/core/hle/kernel/ipc_debugger/recorder.cpp
+++ b/src/core/hle/kernel/ipc_debugger/recorder.cpp
@@ -28,7 +28,7 @@ ObjectInfo GetObjectInfo(const Kernel::Thread* thread) {
     if (thread == nullptr) {
         return {};
     }
-    return {thread->GetTypeName(), thread->GetName(), static_cast<int>(thread->GetThreadId())};
+    return {thread->GetTypeName(), thread->GetName(), static_cast<int>(thread->GetObjectId())};
 }
 
 ObjectInfo GetObjectInfo(const Kernel::Process* process) {
@@ -48,7 +48,7 @@ bool Recorder::IsEnabled() const {
 
 void Recorder::RegisterRequest(const std::shared_ptr<Kernel::ClientSession>& client_session,
                                const std::shared_ptr<Kernel::Thread>& client_thread) {
-    const u32 thread_id = client_thread->GetThreadId();
+    const u32 thread_id = client_thread->GetObjectId();
 
     RequestRecord record = {/* id */ ++record_count,
                             /* status */ RequestStatus::Sent,
@@ -69,7 +69,7 @@ void Recorder::SetRequestInfo(const std::shared_ptr<Kernel::Thread>& client_thre
                               std::vector<u32> untranslated_cmdbuf,
                               std::vector<u32> translated_cmdbuf,
                               const std::shared_ptr<Kernel::Thread>& server_thread) {
-    const u32 thread_id = client_thread->GetThreadId();
+    const u32 thread_id = client_thread->GetObjectId();
     if (!record_map.count(thread_id)) {
         // This is possible when the recorder is enabled after application started
         LOG_ERROR(Kernel, "No request is assoicated with the thread");
@@ -82,7 +82,7 @@ void Recorder::SetRequestInfo(const std::shared_ptr<Kernel::Thread>& client_thre
     record.translated_request_cmdbuf = std::move(translated_cmdbuf);
 
     if (server_thread) {
-        record.server_process = GetObjectInfo(server_thread->owner_process.get());
+        record.server_process = GetObjectInfo(&server_thread->Process());
         record.server_thread = GetObjectInfo(server_thread.get());
     } else {
         record.is_hle = true;
@@ -106,7 +106,7 @@ void Recorder::SetRequestInfo(const std::shared_ptr<Kernel::Thread>& client_thre
 void Recorder::SetReplyInfo(const std::shared_ptr<Kernel::Thread>& client_thread,
                             std::vector<u32> untranslated_cmdbuf,
                             std::vector<u32> translated_cmdbuf) {
-    const u32 thread_id = client_thread->GetThreadId();
+    const u32 thread_id = client_thread->GetObjectId();
     if (!record_map.count(thread_id)) {
         // This is possible when the recorder is enabled after application started
         LOG_ERROR(Kernel, "No request is assoicated with the thread");
@@ -126,7 +126,7 @@ void Recorder::SetReplyInfo(const std::shared_ptr<Kernel::Thread>& client_thread
 }
 
 void Recorder::SetHLEUnimplemented(const std::shared_ptr<Kernel::Thread>& client_thread) {
-    const u32 thread_id = client_thread->GetThreadId();
+    const u32 thread_id = client_thread->GetObjectId();
     if (!record_map.count(thread_id)) {
         // This is possible when the recorder is enabled after application started
         LOG_ERROR(Kernel, "No request is assoicated with the thread");

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -165,7 +165,7 @@ void KernelSystem::serialize(Archive& ar, const unsigned int file_version) {
     ar&* timer_manager.get();
     ar& next_process_id;
     ar& process_list;
-    ar& current_process;
+    // ar& current_process;
     // NB: core count checked in 'core'
     // for (auto& thread_manager : thread_managers) {
     //     ar&* thread_manager.get();

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -33,7 +33,7 @@ KernelSystem::KernelSystem(Memory::MemorySystem& memory, Core::Timing& timing, u
     // for (u32 core_id = 0; core_id < num_cores; ++core_id) {
     //     thread_managers.push_back(std::make_unique<ThreadManager>(*this, core_id));
     // }
-    timer_manager = std::make_unique<TimerManager>(timing);
+    // timer_manager = std::make_unique<TimerManager>(timing);
     ipc_recorder = std::make_unique<IPCDebugger::Recorder>();
     // stored_processes.assign(num_cores, nullptr);
 
@@ -118,13 +118,13 @@ const ThreadManager& KernelSystem::GetCurrentThreadManager() const {
     return timing.CurrentCore();
 }
 
-TimerManager& KernelSystem::GetTimerManager() {
-    return *timer_manager;
-}
+// TimerManager& KernelSystem::GetTimerManager() {
+//     return *timer_manager;
+// }
 
-const TimerManager& KernelSystem::GetTimerManager() const {
-    return *timer_manager;
-}
+// const TimerManager& KernelSystem::GetTimerManager() const {
+//     return *timer_manager;
+// }
 
 SharedPage::Handler& KernelSystem::GetSharedPageHandler() {
     return *shared_page_handler;
@@ -162,7 +162,7 @@ void KernelSystem::serialize(Archive& ar, const unsigned int file_version) {
     // NB: subsystem references and prepare_reschedule_callback are constant
     ar&* resource_limits.get();
     ar& next_object_id;
-    ar&* timer_manager.get();
+    // ar&* timer_manager.get();
     ar& next_process_id;
     ar& process_list;
     // ar& current_process;

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -225,8 +225,8 @@ public:
     ThreadManager& GetCurrentThreadManager();
     const ThreadManager& GetCurrentThreadManager() const;
 
-    TimerManager& GetTimerManager();
-    const TimerManager& GetTimerManager() const;
+    // TimerManager& GetTimerManager();
+    // const TimerManager& GetTimerManager() const;
 
     void MapSharedPages(VMManager& address_space);
 
@@ -277,7 +277,7 @@ private:
     // timer manager.
     // TODO (wwylele): refactor the cleanup sequence to make this less complicated and sensitive.
 
-    std::unique_ptr<TimerManager> timer_manager;
+    // std::unique_ptr<TimerManager> timer_manager;
 
     // TODO(Subv): Start the process ids from 10 for now, as lower PIDs are
     // reserved for low-level services

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -84,8 +84,7 @@ enum class MemoryRegion : u16 {
 
 class KernelSystem {
 public:
-    explicit KernelSystem(Memory::MemorySystem& memory, Core::Timing& timing,
-                          std::function<void()> prepare_reschedule_callback, u32 system_mode,
+    explicit KernelSystem(Memory::MemorySystem& memory, Core::Timing& timing, u32 system_mode,
                           u32 num_cores, u8 n3ds_mode);
     ~KernelSystem();
 
@@ -211,14 +210,14 @@ public:
     std::shared_ptr<Process> GetProcessById(u32 process_id) const;
 
     std::shared_ptr<Process> GetCurrentProcess() const;
-    void SetCurrentProcess(std::shared_ptr<Process> process);
-    void SetCurrentProcessForCPU(std::shared_ptr<Process> process, u32 core_id);
+    // void SetCurrentProcess(std::shared_ptr<Process> process);
+    // void SetCurrentProcessForCPU(std::shared_ptr<Process> process, u32 core_id);
 
-    void SetCurrentMemoryPageTable(std::shared_ptr<Memory::PageTable> page_table);
+    // void SetCurrentMemoryPageTable(std::shared_ptr<Memory::PageTable> page_table);
 
-    void SetCPUs(std::vector<std::shared_ptr<ARM_Interface>> cpu);
+    // void SetCPUs(std::vector<std::shared_ptr<ARM_Interface>> cpu);
 
-    void SetRunningCPU(ARM_Interface* cpu);
+    // void SetRunningCPU(ARM_Interface* cpu);
 
     ThreadManager& GetThreadManager(u32 core_id);
     const ThreadManager& GetThreadManager(u32 core_id) const;
@@ -246,9 +245,9 @@ public:
     /// Adds a port to the named port table
     void AddNamedPort(std::string name, std::shared_ptr<ClientPort> port);
 
-    void PrepareReschedule() {
-        prepare_reschedule_callback();
-    }
+    // void PrepareReschedule() {
+    //     prepare_reschedule_callback();
+    // }
 
     u32 NewThreadId();
 
@@ -266,7 +265,7 @@ public:
 private:
     void MemoryInit(u32 mem_type, u8 n3ds_mode);
 
-    std::function<void()> prepare_reschedule_callback;
+    // std::function<void()> prepare_reschedule_callback;
 
     std::unique_ptr<ResourceLimitList> resource_limits;
     std::atomic<u32> next_object_id{0};
@@ -287,10 +286,10 @@ private:
     // Lists all processes that exist in the current session.
     std::vector<std::shared_ptr<Process>> process_list;
 
-    std::shared_ptr<Process> current_process;
-    std::vector<std::shared_ptr<Process>> stored_processes;
+    // std::shared_ptr<Process> current_process;
+    // std::vector<std::shared_ptr<Process>> stored_processes;
 
-    std::vector<std::unique_ptr<ThreadManager>> thread_managers;
+    // std::vector<std::unique_ptr<ThreadManager>> thread_managers;
 
     std::shared_ptr<ConfigMem::Handler> config_mem_handler;
     std::shared_ptr<SharedPage::Handler> shared_page_handler;

--- a/src/core/hle/kernel/mutex.cpp
+++ b/src/core/hle/kernel/mutex.cpp
@@ -18,14 +18,14 @@ SERIALIZE_EXPORT_IMPL(Kernel::Mutex)
 
 namespace Kernel {
 
-void ReleaseThreadMutexes(Thread* thread) {
-    for (auto& mtx : thread->held_mutexes) {
-        mtx->lock_count = 0;
-        mtx->holding_thread = nullptr;
-        mtx->WakeupAllWaitingThreads();
-    }
-    thread->held_mutexes.clear();
-}
+// void ReleaseThreadMutexes(Thread* thread) {
+//     for (auto& mtx : thread->held_mutexes) {
+//         mtx->lock_count = 0;
+//         mtx->holding_thread = nullptr;
+//         mtx->WakeupAllWaitingThreads();
+//     }
+//     thread->held_mutexes.clear();
+// }
 
 Mutex::Mutex(KernelSystem& kernel) : WaitObject(kernel), kernel(kernel) {}
 Mutex::~Mutex() {}
@@ -39,7 +39,7 @@ std::shared_ptr<Mutex> KernelSystem::CreateMutex(bool initial_locked, std::strin
 
     // Acquire mutex with current thread if initialized as locked
     if (initial_locked)
-        mutex->Acquire(thread_managers[current_cpu->GetID()]->GetCurrentThread());
+        mutex->Acquire(timing.CurrentCore().GetCurrentThread());
 
     return mutex;
 }
@@ -53,11 +53,12 @@ void Mutex::Acquire(Thread* thread) {
 
     // Actually "acquire" the mutex only if we don't already have it
     if (lock_count == 0) {
-        priority = thread->current_priority;
-        thread->held_mutexes.insert(SharedFrom(this));
+        // priority = thread->current_priority;
+        thread->OnAcquireMutex(this);
+        // thread->held_mutexes.insert(SharedFrom(this));
         holding_thread = SharedFrom(thread);
-        thread->UpdatePriority();
-        kernel.PrepareReschedule();
+        // thread->UpdatePriority();
+        // kernel.PrepareReschedule();
     }
 
     lock_count++;
@@ -70,7 +71,7 @@ ResultCode Mutex::Release(Thread* thread) {
             LOG_ERROR(
                 Kernel,
                 "Tried to release a mutex (owned by thread id {}) from a different thread id {}",
-                holding_thread->thread_id, thread->thread_id);
+                holding_thread->GetThreadId(), thread->GetThreadId());
         }
         return ResultCode(ErrCodes::WrongLockingThread, ErrorModule::Kernel,
                           ErrorSummary::InvalidArgument, ErrorLevel::Permanent);
@@ -86,42 +87,43 @@ ResultCode Mutex::Release(Thread* thread) {
 
     // Yield to the next thread only if we've fully released the mutex
     if (lock_count == 0) {
-        holding_thread->held_mutexes.erase(SharedFrom(this));
-        holding_thread->UpdatePriority();
+        // holding_thread->held_mutexes.erase(SharedFrom(this));
+        // holding_thread->UpdatePriority();
+        holding_thread->OnReleaseMutex(this);
         holding_thread = nullptr;
         WakeupAllWaitingThreads();
-        kernel.PrepareReschedule();
+        // kernel.PrepareReschedule();
     }
 
     return RESULT_SUCCESS;
 }
 
-void Mutex::AddWaitingThread(std::shared_ptr<Thread> thread) {
-    WaitObject::AddWaitingThread(thread);
-    thread->pending_mutexes.insert(SharedFrom(this));
-    UpdatePriority();
-}
+// void Mutex::AddWaitingThread(std::shared_ptr<Thread> thread) {
+//     WaitObject::AddWaitingThread(thread);
+//     thread->pending_mutexes.insert(SharedFrom(this));
+//     UpdatePriority();
+// }
 
-void Mutex::RemoveWaitingThread(Thread* thread) {
-    WaitObject::RemoveWaitingThread(thread);
-    thread->pending_mutexes.erase(SharedFrom(this));
-    UpdatePriority();
-}
+// void Mutex::RemoveWaitingThread(Thread* thread) {
+//     WaitObject::RemoveWaitingThread(thread);
+//     thread->pending_mutexes.erase(SharedFrom(this));
+//     UpdatePriority();
+// }
 
-void Mutex::UpdatePriority() {
-    if (!holding_thread)
-        return;
+// void Mutex::UpdatePriority() {
+//     if (!holding_thread)
+//         return;
 
-    u32 best_priority = ThreadPrioLowest;
-    for (auto& waiter : GetWaitingThreads()) {
-        if (waiter->current_priority < best_priority)
-            best_priority = waiter->current_priority;
-    }
+//     u32 best_priority = ThreadPrioLowest;
+//     for (auto& waiter : GetWaitingThreads()) {
+//         if (waiter->current_priority < best_priority)
+//             best_priority = waiter->current_priority;
+//     }
 
-    if (best_priority != priority) {
-        priority = best_priority;
-        holding_thread->UpdatePriority();
-    }
-}
+//     if (best_priority != priority) {
+//         priority = best_priority;
+//         holding_thread->UpdatePriority();
+//     }
+// }
 
 } // namespace Kernel

--- a/src/core/hle/kernel/mutex.h
+++ b/src/core/hle/kernel/mutex.h
@@ -68,7 +68,7 @@ private:
     void serialize(Archive& ar, const unsigned int file_version) {
         ar& boost::serialization::base_object<WaitObject>(*this);
         ar& lock_count;
-        ar& priority;
+        // ar& priority;
         ar& name;
         ar& holding_thread;
     }

--- a/src/core/hle/kernel/mutex.h
+++ b/src/core/hle/kernel/mutex.h
@@ -36,22 +36,22 @@ public:
         return HANDLE_TYPE;
     }
 
-    int lock_count;   ///< Number of times the mutex has been acquired
-    u32 priority;     ///< The priority of the mutex, used for priority inheritance.
-    std::string name; ///< Name of mutex (optional)
+    int lock_count; ///< Number of times the mutex has been acquired
+    // u32 priority;     ///< The priority of the mutex, used for priority inheritance.
+    std::string name;                       ///< Name of mutex (optional)
     std::shared_ptr<Thread> holding_thread; ///< Thread that has acquired the mutex
 
     /**
      * Elevate the mutex priority to the best priority
      * among the priorities of all its waiting threads.
      */
-    void UpdatePriority();
+    // void UpdatePriority();
 
     bool ShouldWait(const Thread* thread) const override;
     void Acquire(Thread* thread) override;
 
-    void AddWaitingThread(std::shared_ptr<Thread> thread) override;
-    void RemoveWaitingThread(Thread* thread) override;
+    // void AddWaitingThread(std::shared_ptr<Thread> thread) override;
+    // void RemoveWaitingThread(Thread* thread) override;
 
     /**
      * Attempts to release the mutex from the specified thread.
@@ -78,7 +78,7 @@ private:
  * Releases all the mutexes held by the specified thread
  * @param thread Thread that is holding the mutexes
  */
-void ReleaseThreadMutexes(Thread* thread);
+// void ReleaseThreadMutexes(Thread* thread);
 
 } // namespace Kernel
 

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1213,7 +1213,8 @@ ResultCode SVC::SetTimer(Handle handle, s64 initial, s64 interval) {
     if (timer == nullptr)
         return ERR_INVALID_HANDLE;
 
-    timer->Set(initial, interval);
+    timer->Set(nanoseconds(initial),
+               interval > 0 ? std::optional<Ticks>(nanoseconds(interval)) : std::nullopt);
 
     return RESULT_SUCCESS;
 }

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -716,7 +716,7 @@ ResultCode SVC::ReplyAndReceive(s32* index, VAddr handles_address, s32 handle_co
         ASSERT(translation_result.IsSuccess());
 
         // Note: The scheduler is not invoked here.
-        request_thread->ResumeFromWait();
+        request_thread->WakeUp();
     }
 
     if (handle_count == 0) {

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -30,245 +30,6 @@ SERIALIZE_EXPORT_IMPL(Kernel::Thread)
 
 namespace Kernel {
 
-template <class Archive>
-void Thread::serialize(Archive& ar, const unsigned int file_version) {
-    ar& boost::serialization::base_object<WaitObject>(*this);
-    ar&* context.get();
-    ar& thread_id;
-    ar& status;
-    ar& entry_point;
-    ar& stack_top;
-    ar& nominal_priority;
-    ar& current_priority;
-    ar& last_running_ticks;
-    ar& processor_id;
-    ar& tls_address;
-    ar& held_mutexes;
-    ar& pending_mutexes;
-    ar& owner_process;
-    ar& wait_objects;
-    ar& wait_address;
-    ar& name;
-    ar& wakeup_callback;
-}
-
-SERIALIZE_IMPL(Thread)
-
-bool Thread::ShouldWait(const Thread* thread) const {
-    return status != ThreadStatus::Dead;
-}
-
-void Thread::Acquire(Thread* thread) {
-    ASSERT_MSG(!ShouldWait(thread), "object unavailable!");
-}
-
-Thread::Thread(KernelSystem& kernel, u32 core_id)
-    : WaitObject(kernel), context(kernel.GetThreadManager(core_id).NewContext()), core_id(core_id),
-      thread_manager(kernel.GetThreadManager(core_id)) {}
-Thread::~Thread() {}
-
-Thread* ThreadManager::GetCurrentThread() const {
-    return current_thread.get();
-}
-
-void Thread::Stop() {
-    // Cancel any outstanding wakeup events for this thread
-    thread_manager.kernel.timing.UnscheduleEvent(thread_manager.ThreadWakeupEventType, thread_id);
-    thread_manager.wakeup_callback_table.erase(thread_id);
-
-    // Clean up thread from ready queue
-    // This is only needed when the thread is termintated forcefully (SVC TerminateProcess)
-    if (status == ThreadStatus::Ready) {
-        thread_manager.ready_queue.remove(current_priority, this);
-    }
-
-    status = ThreadStatus::Dead;
-
-    WakeupAllWaitingThreads();
-
-    // Clean up any dangling references in objects that this thread was waiting for
-    for (auto& wait_object : wait_objects) {
-        wait_object->RemoveWaitingThread(this);
-    }
-    wait_objects.clear();
-
-    // Release all the mutexes that this thread holds
-    ReleaseThreadMutexes(this);
-
-    // Mark the TLS slot in the thread's page as free.
-    u32 tls_page = (tls_address - Memory::TLS_AREA_VADDR) / Memory::PAGE_SIZE;
-    u32 tls_slot =
-        ((tls_address - Memory::TLS_AREA_VADDR) % Memory::PAGE_SIZE) / Memory::TLS_ENTRY_SIZE;
-    owner_process->tls_slots[tls_page].reset(tls_slot);
-}
-
-void ThreadManager::SwitchContext(Thread* new_thread) {
-    Thread* previous_thread = GetCurrentThread();
-    std::shared_ptr<Process> previous_process = nullptr;
-
-    Core::Timing& timing = kernel.timing;
-
-    // Save context for previous thread
-    if (previous_thread) {
-        previous_process = previous_thread->owner_process;
-        previous_thread->last_running_ticks = timing.GetGlobalTicks();
-        cpu->SaveContext(previous_thread->context);
-
-        if (previous_thread->status == ThreadStatus::Running) {
-            // This is only the case when a reschedule is triggered without the current thread
-            // yielding execution (i.e. an event triggered, system core time-sliced, etc)
-            ready_queue.push_front(previous_thread->current_priority, previous_thread);
-            previous_thread->status = ThreadStatus::Ready;
-        }
-    }
-
-    // Load context of new thread
-    if (new_thread) {
-        ASSERT_MSG(new_thread->status == ThreadStatus::Ready,
-                   "Thread must be ready to become running.");
-
-        // Cancel any outstanding wakeup events for this thread
-        timing.UnscheduleEvent(ThreadWakeupEventType, new_thread->thread_id);
-
-        current_thread = SharedFrom(new_thread);
-
-        ready_queue.remove(new_thread->current_priority, new_thread);
-        new_thread->status = ThreadStatus::Running;
-
-        if (previous_process != current_thread->owner_process) {
-            kernel.SetCurrentProcessForCPU(current_thread->owner_process, cpu->GetID());
-        }
-
-        cpu->LoadContext(new_thread->context);
-        cpu->SetCP15Register(CP15_THREAD_URO, new_thread->GetTLSAddress());
-    } else {
-        current_thread = nullptr;
-        // Note: We do not reset the current process and current page table when idling because
-        // technically we haven't changed processes, our threads are just paused.
-    }
-}
-
-Thread* ThreadManager::PopNextReadyThread() {
-    Thread* next = nullptr;
-    Thread* thread = GetCurrentThread();
-
-    if (thread && thread->status == ThreadStatus::Running) {
-        // We have to do better than the current thread.
-        // This call returns null when that's not possible.
-        next = ready_queue.pop_first_better(thread->current_priority);
-        if (!next) {
-            // Otherwise just keep going with the current thread
-            next = thread;
-        }
-    } else {
-        next = ready_queue.pop_first();
-    }
-
-    return next;
-}
-
-void ThreadManager::WaitCurrentThread_Sleep() {
-    Thread* thread = GetCurrentThread();
-    thread->status = ThreadStatus::WaitSleep;
-}
-
-void ThreadManager::ExitCurrentThread() {
-    Thread* thread = GetCurrentThread();
-    thread->Stop();
-    thread_list.erase(std::remove_if(thread_list.begin(), thread_list.end(),
-                                     [thread](const auto& p) { return p.get() == thread; }),
-                      thread_list.end());
-}
-
-void ThreadManager::ThreadWakeupCallback(u64 thread_id, s64 cycles_late) {
-    std::shared_ptr<Thread> thread = SharedFrom(wakeup_callback_table.at(thread_id));
-    if (thread == nullptr) {
-        LOG_CRITICAL(Kernel, "Callback fired for invalid thread {:08X}", thread_id);
-        return;
-    }
-
-    if (thread->status == ThreadStatus::WaitSynchAny ||
-        thread->status == ThreadStatus::WaitSynchAll || thread->status == ThreadStatus::WaitArb ||
-        thread->status == ThreadStatus::WaitHleEvent) {
-
-        // Invoke the wakeup callback before clearing the wait objects
-        if (thread->wakeup_callback)
-            thread->wakeup_callback->WakeUp(ThreadWakeupReason::Timeout, thread, nullptr);
-
-        // Remove the thread from each of its waiting objects' waitlists
-        for (auto& object : thread->wait_objects)
-            object->RemoveWaitingThread(thread.get());
-        thread->wait_objects.clear();
-    }
-
-    thread->ResumeFromWait();
-}
-
-void Thread::WakeAfterDelay(s64 nanoseconds) {
-    // Don't schedule a wakeup if the thread wants to wait forever
-    if (nanoseconds == -1)
-        return;
-
-    thread_manager.kernel.timing.ScheduleEvent(nsToCycles(nanoseconds),
-                                               thread_manager.ThreadWakeupEventType, thread_id);
-}
-
-void Thread::ResumeFromWait() {
-    ASSERT_MSG(wait_objects.empty(), "Thread is waking up while waiting for objects");
-
-    switch (status) {
-    case ThreadStatus::WaitSynchAll:
-    case ThreadStatus::WaitSynchAny:
-    case ThreadStatus::WaitHleEvent:
-    case ThreadStatus::WaitArb:
-    case ThreadStatus::WaitSleep:
-    case ThreadStatus::WaitIPC:
-    case ThreadStatus::Dormant:
-        break;
-
-    case ThreadStatus::Ready:
-        // The thread's wakeup callback must have already been cleared when the thread was first
-        // awoken.
-        ASSERT(wakeup_callback == nullptr);
-        // If the thread is waiting on multiple wait objects, it might be awoken more than once
-        // before actually resuming. We can ignore subsequent wakeups if the thread status has
-        // already been set to ThreadStatus::Ready.
-        return;
-
-    case ThreadStatus::Running:
-        DEBUG_ASSERT_MSG(false, "Thread with object id {} has already resumed.", GetObjectId());
-        return;
-    case ThreadStatus::Dead:
-        // This should never happen, as threads must complete before being stopped.
-        DEBUG_ASSERT_MSG(false, "Thread with object id {} cannot be resumed because it's DEAD.",
-                         GetObjectId());
-        return;
-    }
-
-    wakeup_callback = nullptr;
-
-    thread_manager.ready_queue.push_back(current_priority, this);
-    status = ThreadStatus::Ready;
-    thread_manager.kernel.PrepareReschedule();
-}
-
-void ThreadManager::DebugThreadQueue() {
-    Thread* thread = GetCurrentThread();
-    if (!thread) {
-        LOG_DEBUG(Kernel, "Current: NO CURRENT THREAD");
-    } else {
-        LOG_DEBUG(Kernel, "0x{:02X} {} (current)", thread->current_priority,
-                  GetCurrentThread()->GetObjectId());
-    }
-
-    for (auto& t : thread_list) {
-        u32 priority = ready_queue.contains(t.get());
-        if (priority != -1) {
-            LOG_DEBUG(Kernel, "0x{:02X} {}", priority, t->GetObjectId());
-        }
-    }
-}
-
 /**
  * Finds a free location for the TLS section of a thread.
  * @param tls_slots The TLS page array of the thread's owner process.
@@ -295,214 +56,864 @@ static std::tuple<std::size_t, std::size_t, bool> GetFreeThreadLocalSlot(
     return std::make_tuple(0, 0, true);
 }
 
-/**
- * Resets a thread context, making it ready to be scheduled and run by the CPU
- * @param context Thread context to reset
- * @param stack_top Address of the top of the stack
- * @param entry_point Address of entry point for execution
- * @param arg User argument for thread
- */
-static void ResetThreadContext(const std::unique_ptr<ARM_Interface::ThreadContext>& context,
-                               u32 stack_top, u32 entry_point, u32 arg) {
-    context->Reset();
-    context->SetCpuRegister(0, arg);
-    context->SetProgramCounter(entry_point);
-    context->SetStackPointer(stack_top);
-    context->SetCpsr(USER32MODE | ((entry_point & 1) << 5)); // Usermode and THUMB mode
-}
-
-ResultVal<std::shared_ptr<Thread>> KernelSystem::CreateThread(
-    std::string name, VAddr entry_point, u32 priority, u32 arg, s32 processor_id, VAddr stack_top,
-    std::shared_ptr<Process> owner_process) {
-    // Check if priority is in ranged. Lowest priority -> highest priority id.
-    if (priority > ThreadPrioLowest) {
-        LOG_ERROR(Kernel_SVC, "Invalid thread priority: {}", priority);
-        return ERR_OUT_OF_RANGE;
-    }
-
-    if (processor_id > ThreadProcessorIdMax) {
-        LOG_ERROR(Kernel_SVC, "Invalid processor id: {}", processor_id);
-        return ERR_OUT_OF_RANGE_KERNEL;
-    }
-
-    // TODO(yuriks): Other checks, returning 0xD9001BEA
-
-    if (!Memory::IsValidVirtualAddress(*owner_process, entry_point)) {
-        LOG_ERROR(Kernel_SVC, "(name={}): invalid entry {:08x}", name, entry_point);
-        // TODO: Verify error
-        return ResultCode(ErrorDescription::InvalidAddress, ErrorModule::Kernel,
-                          ErrorSummary::InvalidArgument, ErrorLevel::Permanent);
-    }
-
-    auto thread{std::make_shared<Thread>(*this, processor_id)};
-
-    thread_managers[processor_id]->thread_list.push_back(thread);
-    thread_managers[processor_id]->ready_queue.prepare(priority);
-
-    thread->thread_id = NewThreadId();
-    thread->status = ThreadStatus::Dormant;
-    thread->entry_point = entry_point;
-    thread->stack_top = stack_top;
-    thread->nominal_priority = thread->current_priority = priority;
-    thread->last_running_ticks = timing.GetGlobalTicks();
-    thread->processor_id = processor_id;
-    thread->wait_objects.clear();
-    thread->wait_address = 0;
-    thread->name = std::move(name);
-    thread_managers[processor_id]->wakeup_callback_table[thread->thread_id] = thread.get();
-    thread->owner_process = owner_process;
-
+static std::optional<VAddr> AllocateTLS(KernelSystem& kernel, Process& process) {
     // Find the next available TLS index, and mark it as used
-    auto& tls_slots = owner_process->tls_slots;
+    auto& tls_slots = process.tls_slots;
 
     auto [available_page, available_slot, needs_allocation] = GetFreeThreadLocalSlot(tls_slots);
 
     if (needs_allocation) {
         // There are no already-allocated pages with free slots, lets allocate a new one.
         // TLS pages are allocated from the BASE region in the linear heap.
-        auto memory_region = GetMemoryRegion(MemoryRegion::BASE);
+        auto memory_region = kernel.GetMemoryRegion(MemoryRegion::BASE);
 
         // Allocate some memory from the end of the linear heap for this region.
         auto offset = memory_region->LinearAllocate(Memory::PAGE_SIZE);
         if (!offset) {
             LOG_ERROR(Kernel_SVC,
                       "Not enough space in region to allocate a new TLS page for thread");
-            return ERR_OUT_OF_MEMORY;
+            return {};
         }
-        owner_process->memory_used += Memory::PAGE_SIZE;
+        process.memory_used += Memory::PAGE_SIZE;
 
         tls_slots.emplace_back(0); // The page is completely available at the start
         available_page = tls_slots.size() - 1;
         available_slot = 0; // Use the first slot in the new page
 
-        auto& vm_manager = owner_process->vm_manager;
+        auto& vm_manager = process.vm_manager;
 
         // Map the page to the current process' address space.
         vm_manager.MapBackingMemory(Memory::TLS_AREA_VADDR + available_page * Memory::PAGE_SIZE,
-                                    memory.GetFCRAMRef(*offset), Memory::PAGE_SIZE,
+                                    kernel.memory.GetFCRAMRef(*offset), Memory::PAGE_SIZE,
                                     MemoryState::Locked);
     }
 
     // Mark the slot as used
     tls_slots[available_page].set(available_slot);
-    thread->tls_address = Memory::TLS_AREA_VADDR + available_page * Memory::PAGE_SIZE +
-                          available_slot * Memory::TLS_ENTRY_SIZE;
+    auto tls_address = Memory::TLS_AREA_VADDR + available_page * Memory::PAGE_SIZE +
+                       available_slot * Memory::TLS_ENTRY_SIZE;
 
-    memory.ZeroBlock(*owner_process, thread->tls_address, Memory::TLS_ENTRY_SIZE);
+    kernel.memory.ZeroBlock(process, tls_address, Memory::TLS_ENTRY_SIZE);
+    return tls_address;
+}
 
-    // TODO(peachum): move to ScheduleThread() when scheduler is added so selected core is used
-    // to initialize the context
-    ResetThreadContext(thread->context, stack_top, entry_point, arg);
+std::shared_ptr<Thread> ThreadManager::CreateThread(
+    KernelSystem& kernel, std::string name, VAddr entry_point, u32 priority, u32 arg,
+    VAddr stack_top, std::shared_ptr<Kernel::Process> owner_process) {
+    auto tls_address = AllocateTLS(kernel, *owner_process);
+    auto thread = new Thread(*this, std::move(name), std::move(owner_process), tls_address);
+    auto& context = *thread->context;
+    context.SetCpuRegister(0, arg);
+    context.SetProgramCounter(entry_point);
+    context.SetStackPointer(stack_top);
+    context.SetCpsr(USER32MODE | ((entry_point & 1) << 5)); // Usermode and THUMB mode
+    return {thread};
+}
 
-    thread_managers[processor_id]->ready_queue.push_back(thread->current_priority, thread.get());
-    thread->status = ThreadStatus::Ready;
+class Thread::WakeupEvent : public Core::Event {
+    Thread& parent;
 
-    return MakeResult<std::shared_ptr<Thread>>(std::move(thread));
+public:
+    explicit WakeupEvent(Thread& parent_) : parent(parent_) {}
+
+    const std::string& Name() override {
+        return "Thread wakeup";
+    }
+
+    void Execute(u64 userdata, Ticks cycles_late) {
+        parent.WakeUp();
+    }
+};
+
+Thread::Thread(ThreadManager& core_, std::string name_, std::shared_ptr<Kernel::Process> process_,
+               VAddr tls_address_)
+    : Kernel::WaitObject(nullptr), core(core_), name(std::move(name_)),
+      wakeup_event(new Thread::WakeupEvent(*this)), process(std::move(process_)),
+      context(core.cpu->NewContext()), tls_address(tls_address_) {}
+
+Thread::~Thread() {
+    Stop();
+}
+
+Ticks ThreadManager::RunSegment(::Ticks segment_length) {
+    cycles_remaining = Cycles(segment_length, 1.0);
+    Cycles defer_cycles{0};
+    do {
+        if (Reschedule()) {
+            // TODO: Change CPU interface
+            CPU().Run(cycles_remaining);
+        } else {
+            // If idle, just advance time by the requested cycle count
+            cycles_remaining = Cycles(0);
+        }
+        // Un-defer any cycles from the last sub-segment
+        cycles_remaining = cycles_remaining + defer_cycles;
+        defer_cycles = Cycles(0);
+
+        // A block can end early for the following reasons:
+        //  * An event was scheduled while idle, and executing it didn't cause our core to continue
+        //  * An event was scheduled while running
+        //  * All threads have yielded and none are ready to run
+        auto time_to_event = Cycles(root.TimeToNextEvent(), 1.0);
+        if (CanCutSlice()) {
+            // If we can cut the slice, we should do so at this point.
+            cycles_remaining = std::min(time_to_event, cycles_remaining);
+        } else if (time_to_event < cycles_remaining) {
+            // Event was scheduled by this core, very soon, and we can't cut the slice.
+            // So we need to schedule a smaller segment
+            defer_cycles = cycles_remaining - time_to_event;
+            cycles_remaining = time_to_event;
+        }
+
+    } while (cycles_remaining > Cycles(0));
+}
+
+bool ThreadManager::Reschedule() {
+
+    // The 3ds uses cooperative multithreading. Never interrupt a thread that's already running.
+    if (thread->status == Thread::Status::Running) {
+        return true;
+    }
+
+    // Sort the thread list to find the highest priority ready one
+    std::sort(threads.begin(), threads.end());
+
+    // If there are no threads ready, end the block
+    auto next_thread = threads.begin();
+    if (next_thread == threads.end() || (*next_thread)->status != Thread::Status::Ready) {
+        EndBlock();
+        return false;
+    }
+
+    // If there was no change, we're good!
+    if (*next_thread == thread) {
+        return true;
+    }
+
+    // Now that we've found us a thread to run, we can change the CPU context inline
+    CPU().SaveContext(thread->context);
+    thread = *next_thread;
+    CPU().LoadContext(thread->context);
+    cpu->SetCP15Register(CP15_THREAD_URO, thread->tls_address);
+    return true;
+}
+
+bool ThreadManager::AllThreadsIdle() const {
+    // TODO: Also check WaitObjects?
+    return std::find_if(threads.begin(), threads.end(), [](const Kernel::Thread* thread) {
+        return thread->status <= Thread::Status::Ready;
+    });
+}
+
+void ThreadManager::EndBlock() {
+    CPU().PrepareReschedule();
+}
+
+void ThreadManager::RemoveThread(Kernel::Thread* thread) {}
+
+ResultCode ThreadManager::WaitOne(Kernel::WaitObject* object, std::chrono::nanoseconds timeout) {
+    ASSERT(thread->status == Thread::Status::Running);
+
+    // Check if we can sync immediately
+    if (!object->ShouldWait(thread)) {
+        object->Acquire(thread);
+        thread->context->SetCpuRegister(0, RESULT_SUCCESS.raw);
+        return RESULT_SUCCESS;
+    }
+
+    // Schedule the timeout
+    if (timeout.count() == 0) {
+        return RESULT_TIMEOUT;
+    } else {
+        root.ScheduleEvent(thread->wakeup_event.get(), timeout);
+    }
+
+    // Wait on the object
+    thread->waiting_on = {object};
+    object->AddWaitingThread(Kernel::SharedFrom(thread));
+    thread->status = Thread::Status::WaitSyncAll;
+    Reschedule();
+    return RESULT_SUCCESS;
+}
+
+ResultCode ThreadManager::WaitAny(std::vector<Kernel::WaitObject*> objects,
+                                  std::chrono::nanoseconds timeout) {
+    ASSERT(thread->status == Thread::Status::Running);
+
+    // Check if we can sync immediately
+    auto active_obj =
+        std::find_if(objects.begin(), objects.end(),
+                     [this](const Kernel::WaitObject* obj) { return !obj->ShouldWait(thread); });
+    if (active_obj != objects.end()) {
+        (*active_obj)->Acquire(thread);
+        thread->context->SetCpuRegister(0, RESULT_SUCCESS.raw);
+        thread->context->SetCpuRegister(1, active_obj - objects.begin());
+        return RESULT_SUCCESS;
+    }
+
+    // Schedule the timeout
+    if (timeout.count() == 0) {
+        auto inactive_obj =
+            std::find_if(objects.begin(), objects.end(),
+                         [this](const Kernel::WaitObject* obj) { return obj->ShouldWait(thread); });
+        if (inactive_obj != objects.end()) {
+            return RESULT_TIMEOUT;
+        }
+    } else {
+        root.ScheduleEvent(thread->wakeup_event.get(), timeout);
+    }
+
+    thread->waiting_on = objects;
+    for (auto obj : objects) {
+        obj->AddWaitingThread(Kernel::SharedFrom(thread));
+    }
+    thread->status = Thread::Status::WaitSyncAny;
+    Reschedule();
+    return RESULT_SUCCESS;
+}
+
+ResultCode ThreadManager::WaitAll(std::vector<Kernel::WaitObject*> objects,
+                                  std::chrono::nanoseconds timeout) {
+    ASSERT(thread->status == Thread::Status::Running);
+
+    // Check if we can sync immediately
+    auto inactive_obj =
+        std::find_if(objects.begin(), objects.end(),
+                     [this](const Kernel::WaitObject* obj) { return obj->ShouldWait(thread); });
+    if (inactive_obj == objects.end()) {
+        for (auto obj : objects) {
+            obj->Acquire(thread);
+        }
+        thread->context->SetCpuRegister(0, RESULT_SUCCESS.raw);
+        return RESULT_SUCCESS;
+    }
+
+    // Schedule the timeout
+    if (timeout.count() == 0) {
+        auto active_obj =
+            std::find_if(objects.begin(), objects.end(), [this](const Kernel::WaitObject* obj) {
+                return !obj->ShouldWait(thread);
+            });
+        if (active_obj == objects.end()) {
+            return RESULT_TIMEOUT;
+        }
+    } else {
+        root.ScheduleEvent(thread->wakeup_event.get(), timeout);
+    }
+
+    // Wait on the objects
+    thread->waiting_on = objects;
+    for (auto obj : objects) {
+        obj->AddWaitingThread(Kernel::SharedFrom(thread));
+    }
+    thread->status = Thread::Status::WaitSyncAll;
+    Reschedule();
+    return RESULT_SUCCESS;
+}
+
+void ThreadManager::Sleep() {
+    ASSERT(thread->status == Thread::Status::Running);
+    thread->status = Thread::Status::WaitSleep;
+    Reschedule();
+}
+
+void ThreadManager::Sleep(std::chrono::nanoseconds duration) {
+    ASSERT(thread->status == Thread::Status::Running);
+    if (duration.count() > 0) {
+        root.ScheduleEvent(thread->wakeup_event.get(), duration);
+        thread->status = Thread::Status::WaitSleep;
+    } else {
+        thread->status = Thread::Status::Ready;
+    }
+    Reschedule();
+}
+
+void ThreadManager::Stop() {
+    ASSERT(thread->status == Thread::Status::Running);
+    thread->Stop();
+}
+
+void Thread::Stop() {
+    if (status != Thread::Status::Destroyed) {
+        status = Thread::Status::Destroyed;
+
+        for (auto mutex : held_mutexes) {
+            mutex->Release(this);
+        }
+        held_mutexes.clear();
+
+        core.threads.erase(std::remove(core.threads.begin(), core.threads.end(), this),
+                           core.threads.end());
+
+        // Mark the TLS slot in the thread's page as free.
+        u32 tls_page = (tls_address - Memory::TLS_AREA_VADDR) / Memory::PAGE_SIZE;
+        u32 tls_slot =
+            ((tls_address - Memory::TLS_AREA_VADDR) % Memory::PAGE_SIZE) / Memory::TLS_ENTRY_SIZE;
+        process->tls_slots[tls_page].reset(tls_slot);
+    }
+}
+
+bool Thread::IsWokenBy(const Kernel::WaitObject* object) {
+
+    if (status == Thread::Status::WaitSyncAny) {
+        return std::find(waiting_on.begin(), waiting_on.end(), object) != waiting_on.end();
+    } else if (status == Thread::Status::WaitSyncAll) {
+        return std::find_if(waiting_on.begin(), waiting_on.end(),
+                            [&](const Kernel::WaitObject* obj) {
+                                return obj == object || !obj->ShouldWait(this);
+                            }) == waiting_on.end();
+    } else {
+        return false;
+    }
+}
+
+void Thread::ResumeFromWait(Kernel::WaitObject* object) {
+    if (status == Status::WaitSyncAll) {
+        for (auto obj : waiting_on) {
+            obj->Acquire(this);
+        }
+    } else if (status == Status::WaitSyncAny) {
+        auto it = std::find(waiting_on.begin(), waiting_on.end(), object);
+        auto idx = it - waiting_on.begin();
+        object->Acquire(this);
+        context->SetCpuRegister(1, static_cast<u32>(idx));
+    } else {
+        ASSERT(false);
+    }
+    context->SetCpuRegister(0, RESULT_SUCCESS.raw);
+
+    // Clear waiting objects/threads
+    for (auto obj : waiting_on) {
+        obj->RemoveWaitingThread(this);
+    }
+    waiting_on.clear();
+    core.root.UnscheduleEvent(wakeup_event.get());
+    status = Thread::Status::Ready;
 }
 
 void Thread::SetPriority(u32 priority) {
-    ASSERT_MSG(priority <= ThreadPrioLowest && priority >= ThreadPrioHighest,
-               "Invalid priority value.");
-    // If thread was ready, adjust queues
-    if (status == ThreadStatus::Ready)
-        thread_manager.ready_queue.move(this, current_priority, priority);
-    else
-        thread_manager.ready_queue.prepare(priority);
-
-    nominal_priority = current_priority = priority;
-}
-
-void Thread::UpdatePriority() {
-    u32 best_priority = nominal_priority;
-    for (auto& mutex : held_mutexes) {
-        if (mutex->priority < best_priority)
-            best_priority = mutex->priority;
-    }
-    BoostPriority(best_priority);
-}
-
-void Thread::BoostPriority(u32 priority) {
-    // If thread was ready, adjust queues
-    if (status == ThreadStatus::Ready)
-        thread_manager.ready_queue.move(this, current_priority, priority);
-    else
-        thread_manager.ready_queue.prepare(priority);
-    current_priority = priority;
-}
-
-std::shared_ptr<Thread> SetupMainThread(KernelSystem& kernel, u32 entry_point, u32 priority,
-                                        std::shared_ptr<Process> owner_process) {
-    // Initialize new "main" thread
-    auto thread_res =
-        kernel.CreateThread("main", entry_point, priority, 0, owner_process->ideal_processor,
-                            Memory::HEAP_VADDR_END, owner_process);
-
-    std::shared_ptr<Thread> thread = std::move(thread_res).Unwrap();
-
-    thread->context->SetFpscr(FPSCR_DEFAULT_NAN | FPSCR_FLUSH_TO_ZERO | FPSCR_ROUND_TOZERO |
-                              FPSCR_IXC); // 0x03C00010
-
-    // Note: The newly created thread will be run when the scheduler fires.
-    return thread;
-}
-
-bool ThreadManager::HaveReadyThreads() {
-    return ready_queue.get_first() != nullptr;
-}
-
-void ThreadManager::Reschedule() {
-    Thread* cur = GetCurrentThread();
-    Thread* next = PopNextReadyThread();
-
-    if (cur && next) {
-        LOG_TRACE(Kernel, "context switch {} -> {}", cur->GetObjectId(), next->GetObjectId());
-    } else if (cur) {
-        LOG_TRACE(Kernel, "context switch {} -> idle", cur->GetObjectId());
-    } else if (next) {
-        LOG_TRACE(Kernel, "context switch idle -> {}", next->GetObjectId());
-    } else {
-        LOG_TRACE(Kernel, "context switch idle -> idle, do nothing");
-        return;
-    }
-
-    SwitchContext(next);
-}
-
-void Thread::SetWaitSynchronizationResult(ResultCode result) {
-    context->SetCpuRegister(0, result.raw);
-}
-
-void Thread::SetWaitSynchronizationOutput(s32 output) {
-    context->SetCpuRegister(1, output);
-}
-
-s32 Thread::GetWaitObjectIndex(const WaitObject* object) const {
-    ASSERT_MSG(!wait_objects.empty(), "Thread is not waiting for anything");
-    const auto match = std::find_if(wait_objects.rbegin(), wait_objects.rend(),
-                                    [object](const auto& p) { return p.get() == object; });
-    return static_cast<s32>(std::distance(match, wait_objects.rend()) - 1);
-}
-
-VAddr Thread::GetCommandBufferAddress() const {
-    // Offset from the start of TLS at which the IPC command buffer begins.
-    constexpr u32 command_header_offset = 0x80;
-    return GetTLSAddress() + command_header_offset;
-}
-
-ThreadManager::ThreadManager(Kernel::KernelSystem& kernel, u32 core_id) : kernel(kernel) {
-    ThreadWakeupEventType = kernel.timing.RegisterEvent(
-        "ThreadWakeupCallback_" + std::to_string(core_id),
-        [this](u64 thread_id, s64 cycle_late) { ThreadWakeupCallback(thread_id, cycle_late); });
-}
-
-ThreadManager::~ThreadManager() {
-    for (auto& t : thread_list) {
-        t->Stop();
+    nominal_priority = priority;
+    for (auto obj : waiting_on) {
+        auto mutex = dynamic_cast<Kernel::Mutex*>(obj);
+        if (mutex && mutex->holding_thread) {
+            mutex->holding_thread->real_priority.reset();
+        }
     }
 }
 
-const std::vector<std::shared_ptr<Thread>>& ThreadManager::GetThreadList() {
-    return thread_list;
+void Thread::WakeUp() {
+    switch (status) {
+    case Status::WaitSyncAny:
+        context->SetCpuRegister(1, 0);
+    case Status::WaitSyncAll:
+        context->SetCpuRegister(0, RESULT_TIMEOUT.raw);
+    case Status::WaitSleep:
+        status = Thread::Status::Ready;
+    }
 }
+
+void Thread::OnAcquireMutex(Kernel::Mutex* mutex) {
+    for (auto waiting_thread : mutex->GetWaitingThreads()) {
+        waiting_thread->real_priority.reset();
+    }
+    held_mutexes.insert(mutex);
+}
+
+void Thread::OnReleaseMutex(Kernel::Mutex* mutex) {
+    held_mutexes.erase(mutex);
+    for (auto waiting_thread : mutex->GetWaitingThreads()) {
+        waiting_thread->real_priority.reset();
+    }
+}
+
+u32 Thread::GetPriority() {
+    if (!real_priority.has_value()) {
+        u32 priority = nominal_priority;
+        real_priority = priority;
+        for (auto mutex : held_mutexes) {
+            for (auto waiting_thread : mutex->GetWaitingThreads()) {
+                priority = std::min(priority, waiting_thread->GetPriority());
+            }
+        }
+        real_priority = priority;
+    }
+    return real_priority.value();
+}
+
+// template <class Archive>
+// void Thread::serialize(Archive& ar, const unsigned int file_version) {
+//     ar& boost::serialization::base_object<WaitObject>(*this);
+//     ar&* context.get();
+//     ar& thread_id;
+//     ar& status;
+//     ar& entry_point;
+//     ar& stack_top;
+//     ar& nominal_priority;
+//     ar& current_priority;
+//     ar& last_running_ticks;
+//     ar& processor_id;
+//     ar& tls_address;
+//     ar& held_mutexes;
+//     ar& pending_mutexes;
+//     ar& owner_process;
+//     ar& wait_objects;
+//     ar& wait_address;
+//     ar& name;
+//     ar& wakeup_callback;
+// }
+
+// SERIALIZE_IMPL(Thread)
+
+// bool Thread::ShouldWait(const Thread* thread) const {
+//     return status != ThreadStatus::Dead;
+// }
+
+// void Thread::Acquire(Thread* thread) {
+//     ASSERT_MSG(!ShouldWait(thread), "object unavailable!");
+// }
+
+// Thread::Thread(KernelSystem& kernel, u32 core_id)
+//     : WaitObject(kernel), context(kernel.GetThreadManager(core_id).NewContext()),
+//     core_id(core_id),
+//       thread_manager(kernel.GetThreadManager(core_id)) {}
+// Thread::~Thread() {}
+
+// Thread* ThreadManager::GetCurrentThread() const {
+//     return current_thread.get();
+// }
+
+// void Thread::Stop() {
+//     // Cancel any outstanding wakeup events for this thread
+//     thread_manager.kernel.timing.UnscheduleEvent(thread_manager.ThreadWakeupEventType,
+//     thread_id); thread_manager.wakeup_callback_table.erase(thread_id);
+
+//     // Clean up thread from ready queue
+//     // This is only needed when the thread is termintated forcefully (SVC TerminateProcess)
+//     if (status == ThreadStatus::Ready) {
+//         thread_manager.ready_queue.remove(current_priority, this);
+//     }
+
+//     status = ThreadStatus::Dead;
+
+//     WakeupAllWaitingThreads();
+
+//     // Clean up any dangling references in objects that this thread was waiting for
+//     for (auto& wait_object : wait_objects) {
+//         wait_object->RemoveWaitingThread(this);
+//     }
+//     wait_objects.clear();
+
+//     // Release all the mutexes that this thread holds
+//     ReleaseThreadMutexes(this);
+
+//     // Mark the TLS slot in the thread's page as free.
+//     u32 tls_page = (tls_address - Memory::TLS_AREA_VADDR) / Memory::PAGE_SIZE;
+//     u32 tls_slot =
+//         ((tls_address - Memory::TLS_AREA_VADDR) % Memory::PAGE_SIZE) / Memory::TLS_ENTRY_SIZE;
+//     owner_process->tls_slots[tls_page].reset(tls_slot);
+// }
+
+// void ThreadManager::SwitchContext(Thread* new_thread) {
+//     Thread* previous_thread = GetCurrentThread();
+//     std::shared_ptr<Process> previous_process = nullptr;
+
+//     Core::Timing& timing = kernel.timing;
+
+//     // Save context for previous thread
+//     if (previous_thread) {
+//         previous_process = previous_thread->owner_process;
+//         previous_thread->last_running_ticks = timing.GetGlobalTicks();
+//         cpu->SaveContext(previous_thread->context);
+
+//         if (previous_thread->status == ThreadStatus::Running) {
+//             // This is only the case when a reschedule is triggered without the current thread
+//             // yielding execution (i.e. an event triggered, system core time-sliced, etc)
+//             ready_queue.push_front(previous_thread->current_priority, previous_thread);
+//             previous_thread->status = ThreadStatus::Ready;
+//         }
+//     }
+
+//     // Load context of new thread
+//     if (new_thread) {
+//         ASSERT_MSG(new_thread->status == ThreadStatus::Ready,
+//                    "Thread must be ready to become running.");
+
+//         // Cancel any outstanding wakeup events for this thread
+//         timing.UnscheduleEvent(ThreadWakeupEventType, new_thread->thread_id);
+
+//         current_thread = SharedFrom(new_thread);
+
+//         ready_queue.remove(new_thread->current_priority, new_thread);
+//         new_thread->status = ThreadStatus::Running;
+
+//         if (previous_process != current_thread->owner_process) {
+//             kernel.SetCurrentProcessForCPU(current_thread->owner_process, cpu->GetID());
+//         }
+
+//         cpu->LoadContext(new_thread->context);
+//         cpu->SetCP15Register(CP15_THREAD_URO, new_thread->GetTLSAddress());
+//     } else {
+//         current_thread = nullptr;
+//         // Note: We do not reset the current process and current page table when idling because
+//         // technically we haven't changed processes, our threads are just paused.
+//     }
+// }
+
+// Thread* ThreadManager::PopNextReadyThread() {
+//     Thread* next = nullptr;
+//     Thread* thread = GetCurrentThread();
+
+//     if (thread && thread->status == ThreadStatus::Running) {
+//         // We have to do better than the current thread.
+//         // This call returns null when that's not possible.
+//         next = ready_queue.pop_first_better(thread->current_priority);
+//         if (!next) {
+//             // Otherwise just keep going with the current thread
+//             next = thread;
+//         }
+//     } else {
+//         next = ready_queue.pop_first();
+//     }
+
+//     return next;
+// }
+
+// void ThreadManager::WaitCurrentThread_Sleep() {
+//     Thread* thread = GetCurrentThread();
+//     thread->status = ThreadStatus::WaitSleep;
+// }
+
+// void ThreadManager::ExitCurrentThread() {
+//     Thread* thread = GetCurrentThread();
+//     thread->Stop();
+//     thread_list.erase(std::remove_if(thread_list.begin(), thread_list.end(),
+//                                      [thread](const auto& p) { return p.get() == thread; }),
+//                       thread_list.end());
+// }
+
+// void ThreadManager::ThreadWakeupCallback(u64 thread_id, s64 cycles_late) {
+//     std::shared_ptr<Thread> thread = SharedFrom(wakeup_callback_table.at(thread_id));
+//     if (thread == nullptr) {
+//         LOG_CRITICAL(Kernel, "Callback fired for invalid thread {:08X}", thread_id);
+//         return;
+//     }
+
+//     if (thread->status == ThreadStatus::WaitSynchAny ||
+//         thread->status == ThreadStatus::WaitSynchAll || thread->status == ThreadStatus::WaitArb
+//         || thread->status == ThreadStatus::WaitHleEvent) {
+
+//         // Invoke the wakeup callback before clearing the wait objects
+//         if (thread->wakeup_callback)
+//             thread->wakeup_callback->WakeUp(ThreadWakeupReason::Timeout, thread, nullptr);
+
+//         // Remove the thread from each of its waiting objects' waitlists
+//         for (auto& object : thread->wait_objects)
+//             object->RemoveWaitingThread(thread.get());
+//         thread->wait_objects.clear();
+//     }
+
+//     thread->ResumeFromWait();
+// }
+
+// void Thread::WakeAfterDelay(s64 nanoseconds) {
+//     // Don't schedule a wakeup if the thread wants to wait forever
+//     if (nanoseconds == -1)
+//         return;
+
+//     thread_manager.kernel.timing.ScheduleEvent(nsToCycles(nanoseconds),
+//                                                thread_manager.ThreadWakeupEventType, thread_id);
+// }
+
+// void Thread::ResumeFromWait() {
+//     ASSERT_MSG(wait_objects.empty(), "Thread is waking up while waiting for objects");
+
+//     switch (status) {
+//     case ThreadStatus::WaitSynchAll:
+//     case ThreadStatus::WaitSynchAny:
+//     case ThreadStatus::WaitHleEvent:
+//     case ThreadStatus::WaitArb:
+//     case ThreadStatus::WaitSleep:
+//     case ThreadStatus::WaitIPC:
+//     case ThreadStatus::Dormant:
+//         break;
+
+//     case ThreadStatus::Ready:
+//         // The thread's wakeup callback must have already been cleared when the thread was first
+//         // awoken.
+//         ASSERT(wakeup_callback == nullptr);
+//         // If the thread is waiting on multiple wait objects, it might be awoken more than once
+//         // before actually resuming. We can ignore subsequent wakeups if the thread status has
+//         // already been set to ThreadStatus::Ready.
+//         return;
+
+//     case ThreadStatus::Running:
+//         DEBUG_ASSERT_MSG(false, "Thread with object id {} has already resumed.", GetObjectId());
+//         return;
+//     case ThreadStatus::Dead:
+//         // This should never happen, as threads must complete before being stopped.
+//         DEBUG_ASSERT_MSG(false, "Thread with object id {} cannot be resumed because it's DEAD.",
+//                          GetObjectId());
+//         return;
+//     }
+
+//     wakeup_callback = nullptr;
+
+//     thread_manager.ready_queue.push_back(current_priority, this);
+//     status = ThreadStatus::Ready;
+//     thread_manager.kernel.PrepareReschedule();
+// }
+
+// void ThreadManager::DebugThreadQueue() {
+//     Thread* thread = GetCurrentThread();
+//     if (!thread) {
+//         LOG_DEBUG(Kernel, "Current: NO CURRENT THREAD");
+//     } else {
+//         LOG_DEBUG(Kernel, "0x{:02X} {} (current)", thread->current_priority,
+//                   GetCurrentThread()->GetObjectId());
+//     }
+
+//     for (auto& t : thread_list) {
+//         u32 priority = ready_queue.contains(t.get());
+//         if (priority != -1) {
+//             LOG_DEBUG(Kernel, "0x{:02X} {}", priority, t->GetObjectId());
+//         }
+//     }
+// }
+
+// /**
+//  * Finds a free location for the TLS section of a thread.
+//  * @param tls_slots The TLS page array of the thread's owner process.
+//  * Returns a tuple of (page, slot, alloc_needed) where:
+//  * page: The index of the first allocated TLS page that has free slots.
+//  * slot: The index of the first free slot in the indicated page.
+//  * alloc_needed: Whether there's a need to allocate a new TLS page (All pages are full).
+//  */
+// static std::tuple<std::size_t, std::size_t, bool> GetFreeThreadLocalSlot(
+//     const std::vector<std::bitset<8>>& tls_slots) {
+//     // Iterate over all the allocated pages, and try to find one where not all slots are used.
+//     for (std::size_t page = 0; page < tls_slots.size(); ++page) {
+//         const auto& page_tls_slots = tls_slots[page];
+//         if (!page_tls_slots.all()) {
+//             // We found a page with at least one free slot, find which slot it is
+//             for (std::size_t slot = 0; slot < page_tls_slots.size(); ++slot) {
+//                 if (!page_tls_slots.test(slot)) {
+//                     return std::make_tuple(page, slot, false);
+//                 }
+//             }
+//         }
+//     }
+
+//     return std::make_tuple(0, 0, true);
+// }
+
+// /**
+//  * Resets a thread context, making it ready to be scheduled and run by the CPU
+//  * @param context Thread context to reset
+//  * @param stack_top Address of the top of the stack
+//  * @param entry_point Address of entry point for execution
+//  * @param arg User argument for thread
+//  */
+// static void ResetThreadContext(const std::unique_ptr<ARM_Interface::ThreadContext>& context,
+//                                u32 stack_top, u32 entry_point, u32 arg) {
+//     context->Reset();
+//     context->SetCpuRegister(0, arg);
+//     context->SetProgramCounter(entry_point);
+//     context->SetStackPointer(stack_top);
+//     context->SetCpsr(USER32MODE | ((entry_point & 1) << 5)); // Usermode and THUMB mode
+// }
+
+// ResultVal<std::shared_ptr<Thread>> KernelSystem::CreateThread(
+//     std::string name, VAddr entry_point, u32 priority, u32 arg, s32 processor_id, VAddr
+//     stack_top, std::shared_ptr<Process> owner_process) {
+//     // Check if priority is in ranged. Lowest priority -> highest priority id.
+//     if (priority > ThreadPrioLowest) {
+//         LOG_ERROR(Kernel_SVC, "Invalid thread priority: {}", priority);
+//         return ERR_OUT_OF_RANGE;
+//     }
+
+//     if (processor_id > ThreadProcessorIdMax) {
+//         LOG_ERROR(Kernel_SVC, "Invalid processor id: {}", processor_id);
+//         return ERR_OUT_OF_RANGE_KERNEL;
+//     }
+
+//     // TODO(yuriks): Other checks, returning 0xD9001BEA
+
+//     if (!Memory::IsValidVirtualAddress(*owner_process, entry_point)) {
+//         LOG_ERROR(Kernel_SVC, "(name={}): invalid entry {:08x}", name, entry_point);
+//         // TODO: Verify error
+//         return ResultCode(ErrorDescription::InvalidAddress, ErrorModule::Kernel,
+//                           ErrorSummary::InvalidArgument, ErrorLevel::Permanent);
+//     }
+
+//     auto thread{std::make_shared<Thread>(*this, processor_id)};
+
+//     thread_managers[processor_id]->thread_list.push_back(thread);
+//     thread_managers[processor_id]->ready_queue.prepare(priority);
+
+//     thread->thread_id = NewThreadId();
+//     thread->status = ThreadStatus::Dormant;
+//     thread->entry_point = entry_point;
+//     thread->stack_top = stack_top;
+//     thread->nominal_priority = thread->current_priority = priority;
+//     thread->last_running_ticks = timing.GetGlobalTicks();
+//     thread->processor_id = processor_id;
+//     thread->wait_objects.clear();
+//     thread->wait_address = 0;
+//     thread->name = std::move(name);
+//     thread_managers[processor_id]->wakeup_callback_table[thread->thread_id] = thread.get();
+//     thread->owner_process = owner_process;
+
+//     // Find the next available TLS index, and mark it as used
+//     auto& tls_slots = owner_process->tls_slots;
+
+//     auto [available_page, available_slot, needs_allocation] = GetFreeThreadLocalSlot(tls_slots);
+
+//     if (needs_allocation) {
+//         // There are no already-allocated pages with free slots, lets allocate a new one.
+//         // TLS pages are allocated from the BASE region in the linear heap.
+//         auto memory_region = GetMemoryRegion(MemoryRegion::BASE);
+
+//         // Allocate some memory from the end of the linear heap for this region.
+//         auto offset = memory_region->LinearAllocate(Memory::PAGE_SIZE);
+//         if (!offset) {
+//             LOG_ERROR(Kernel_SVC,
+//                       "Not enough space in region to allocate a new TLS page for thread");
+//             return ERR_OUT_OF_MEMORY;
+//         }
+//         owner_process->memory_used += Memory::PAGE_SIZE;
+
+//         tls_slots.emplace_back(0); // The page is completely available at the start
+//         available_page = tls_slots.size() - 1;
+//         available_slot = 0; // Use the first slot in the new page
+
+//         auto& vm_manager = owner_process->vm_manager;
+
+//         // Map the page to the current process' address space.
+//         vm_manager.MapBackingMemory(Memory::TLS_AREA_VADDR + available_page * Memory::PAGE_SIZE,
+//                                     memory.GetFCRAMRef(*offset), Memory::PAGE_SIZE,
+//                                     MemoryState::Locked);
+//     }
+
+//     // Mark the slot as used
+//     tls_slots[available_page].set(available_slot);
+//     thread->tls_address = Memory::TLS_AREA_VADDR + available_page * Memory::PAGE_SIZE +
+//                           available_slot * Memory::TLS_ENTRY_SIZE;
+
+//     memory.ZeroBlock(*owner_process, thread->tls_address, Memory::TLS_ENTRY_SIZE);
+
+//     // TODO(peachum): move to ScheduleThread() when scheduler is added so selected core is used
+//     // to initialize the context
+//     ResetThreadContext(thread->context, stack_top, entry_point, arg);
+
+//     thread_managers[processor_id]->ready_queue.push_back(thread->current_priority, thread.get());
+//     thread->status = ThreadStatus::Ready;
+
+//     return MakeResult<std::shared_ptr<Thread>>(std::move(thread));
+// }
+
+// void Thread::SetPriority(u32 priority) {
+//     ASSERT_MSG(priority <= ThreadPrioLowest && priority >= ThreadPrioHighest,
+//                "Invalid priority value.");
+//     // If thread was ready, adjust queues
+//     if (status == ThreadStatus::Ready)
+//         thread_manager.ready_queue.move(this, current_priority, priority);
+//     else
+//         thread_manager.ready_queue.prepare(priority);
+
+//     nominal_priority = current_priority = priority;
+// }
+
+// void Thread::UpdatePriority() {
+//     u32 best_priority = nominal_priority;
+//     for (auto& mutex : held_mutexes) {
+//         if (mutex->priority < best_priority)
+//             best_priority = mutex->priority;
+//     }
+//     BoostPriority(best_priority);
+// }
+
+// void Thread::BoostPriority(u32 priority) {
+//     // If thread was ready, adjust queues
+//     if (status == ThreadStatus::Ready)
+//         thread_manager.ready_queue.move(this, current_priority, priority);
+//     else
+//         thread_manager.ready_queue.prepare(priority);
+//     current_priority = priority;
+// }
+
+// std::shared_ptr<Thread> SetupMainThread(KernelSystem& kernel, u32 entry_point, u32 priority,
+//                                         std::shared_ptr<Process> owner_process) {
+//     // Initialize new "main" thread
+//     auto thread_res =
+//         kernel.CreateThread("main", entry_point, priority, 0, owner_process->ideal_processor,
+//                             Memory::HEAP_VADDR_END, owner_process);
+
+//     std::shared_ptr<Thread> thread = std::move(thread_res).Unwrap();
+
+//     thread->context->SetFpscr(FPSCR_DEFAULT_NAN | FPSCR_FLUSH_TO_ZERO | FPSCR_ROUND_TOZERO |
+//                               FPSCR_IXC); // 0x03C00010
+
+//     // Note: The newly created thread will be run when the scheduler fires.
+//     return thread;
+// }
+
+// bool ThreadManager::HaveReadyThreads() {
+//     return ready_queue.get_first() != nullptr;
+// }
+
+// void ThreadManager::Reschedule() {
+//     Thread* cur = GetCurrentThread();
+//     Thread* next = PopNextReadyThread();
+
+//     if (cur && next) {
+//         LOG_TRACE(Kernel, "context switch {} -> {}", cur->GetObjectId(), next->GetObjectId());
+//     } else if (cur) {
+//         LOG_TRACE(Kernel, "context switch {} -> idle", cur->GetObjectId());
+//     } else if (next) {
+//         LOG_TRACE(Kernel, "context switch idle -> {}", next->GetObjectId());
+//     } else {
+//         LOG_TRACE(Kernel, "context switch idle -> idle, do nothing");
+//         return;
+//     }
+
+//     SwitchContext(next);
+// }
+
+// void Thread::SetWaitSynchronizationResult(ResultCode result) {
+//     context->SetCpuRegister(0, result.raw);
+// }
+
+// void Thread::SetWaitSynchronizationOutput(s32 output) {
+//     context->SetCpuRegister(1, output);
+// }
+
+// s32 Thread::GetWaitObjectIndex(const WaitObject* object) const {
+//     ASSERT_MSG(!wait_objects.empty(), "Thread is not waiting for anything");
+//     const auto match = std::find_if(wait_objects.rbegin(), wait_objects.rend(),
+//                                     [object](const auto& p) { return p.get() == object; });
+//     return static_cast<s32>(std::distance(match, wait_objects.rend()) - 1);
+// }
+
+// VAddr Thread::GetCommandBufferAddress() const {
+//     // Offset from the start of TLS at which the IPC command buffer begins.
+//     constexpr u32 command_header_offset = 0x80;
+//     return GetTLSAddress() + command_header_offset;
+// }
+
+// ThreadManager::ThreadManager(Kernel::KernelSystem& kernel, u32 core_id) : kernel(kernel) {
+//     ThreadWakeupEventType = kernel.timing.RegisterEvent(
+//         "ThreadWakeupCallback_" + std::to_string(core_id),
+//         [this](u64 thread_id, s64 cycle_late) { ThreadWakeupCallback(thread_id, cycle_late); });
+// }
+
+// ThreadManager::~ThreadManager() {
+//     for (auto& t : thread_list) {
+//         t->Stop();
+//     }
+// }
+
+// const std::vector<std::shared_ptr<Thread>>& ThreadManager::GetThreadList() {
+//     return thread_list;
+// }
 
 } // namespace Kernel

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -545,16 +545,16 @@ private:
 //     void serialize(Archive& ar, const unsigned int file_version);
 // };
 
-// /**
-//  * Sets up the primary application thread
-//  * @param kernel The kernel instance on which the thread is created
-//  * @param entry_point The address at which the thread should start execution
-//  * @param priority The priority to give the main thread
-//  * @param owner_process The parent process for the main thread
-//  * @return A shared pointer to the main thread
-//  */
-// std::shared_ptr<Thread> SetupMainThread(KernelSystem& kernel, u32 entry_point, u32 priority,
-//                                         std::shared_ptr<Process> owner_process);
+/**
+ * Sets up the primary application thread
+ * @param kernel The kernel instance on which the thread is created
+ * @param entry_point The address at which the thread should start execution
+ * @param priority The priority to give the main thread
+ * @param owner_process The parent process for the main thread
+ * @return A shared pointer to the main thread
+ */
+std::shared_ptr<Thread> SetupMainThread(KernelSystem& kernel, u32 entry_point, u32 priority,
+                                        std::shared_ptr<Process> owner_process);
 
 } // namespace Kernel
 

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -99,9 +99,14 @@ public:
                           FPSCR_IXC); // 0x03C00010
     }
 
+    // TODO: Use sequential IDs
     u32 GetThreadId() const {
         return GetObjectId();
     }
+    bool IsWokenBy(const Kernel::WaitObject* object);
+
+    // TODO: Move to private
+    const std::unique_ptr<ARM_Interface::ThreadContext> context;
 
 private:
     int Order() {
@@ -112,7 +117,6 @@ private:
 
     ThreadManager& core;
     const std::string name;
-    const std::unique_ptr<ARM_Interface::ThreadContext> context;
     const std::shared_ptr<Kernel::Process> process;
     const std::unique_ptr<WakeupEvent> wakeup_event;
     const VAddr tls_address;
@@ -129,7 +133,6 @@ private:
 
     void Stop();
     void SetStatus(Status status);
-    bool IsWokenBy(const Kernel::WaitObject* object);
 
     friend class ThreadManager;
 

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -4,70 +4,94 @@
 
 #pragma once
 
+// #include <memory>
+// #include <string>
+// #include <unordered_map>
+// #include <vector>
+// #include <boost/container/flat_set.hpp>
+// #include <boost/serialization/export.hpp>
+// #include <boost/serialization/shared_ptr.hpp>
+// #include <boost/serialization/unordered_map.hpp>
+// #include <boost/serialization/vector.hpp>
+// #include "common/common_types.h"
+// #include "common/thread_queue_list.h"
+// #include "core/arm/arm_interface.h"
+// #include "core/core_timing.h"
+// #include "core/hle/kernel/object.h"
+// #include "core/hle/kernel/wait_object.h"
+// #include "core/hle/result.h"
+
 #include <memory>
 #include <string>
-#include <unordered_map>
 #include <vector>
 #include <boost/container/flat_set.hpp>
-#include <boost/serialization/export.hpp>
-#include <boost/serialization/shared_ptr.hpp>
-#include <boost/serialization/unordered_map.hpp>
-#include <boost/serialization/vector.hpp>
+#include <queue>
 #include "common/common_types.h"
-#include "common/thread_queue_list.h"
 #include "core/arm/arm_interface.h"
 #include "core/core_timing.h"
-#include "core/hle/kernel/object.h"
+#include "core/hle/kernel/process.h"
 #include "core/hle/kernel/wait_object.h"
-#include "core/hle/result.h"
 
 namespace Kernel {
 
-class Mutex;
-class Process;
+class Thread : public WaitObject {
 
-enum ThreadPriority : u32 {
-    ThreadPrioHighest = 0,      ///< Highest thread priority
-    ThreadPrioUserlandMax = 24, ///< Highest thread priority for userland apps
-    ThreadPrioDefault = 48,     ///< Default thread priority for userland apps
-    ThreadPrioLowest = 63,      ///< Lowest thread priority
+public:
+    enum Status : u32 { Running, Ready, WaitSleep, WaitSyncAll, WaitSyncAny, Created, Destroyed };
+    enum Priority : u32 { Highest = 0, UserlandMax = 24, Default = 48, Lowest = 63 };
+    enum class WakeupReason {
+        Signal, // The thread was woken up by WakeupAllWaitingThreads due to an object signal.
+        Timeout // The thread was woken up due to a wait timeout.
+    };
+
+    explicit Thread(ThreadManager& core, std::string name, std::shared_ptr<Kernel::Process> process,
+                    VAddr tls_address);
+    virtual ~Thread();
+
+    bool operator>(Thread& right) {
+        return Order() > right.Order();
+    }
+
+    void ResumeFromWait(Kernel::WaitObject* object);
+    void SetPriority(u32 value);
+    u32 GetPriority();
+
+    void OnAcquireMutex(Kernel::Mutex* mutex);
+    void OnReleaseMutex(Kernel::Mutex* mutex);
+
+private:
+    int Order() {
+        return status * (Priority::Lowest + 1) + GetPriority();
+    }
+
+    class WakeupEvent;
+
+    ThreadManager& core;
+    const std::string name;
+    const std::unique_ptr<ARM_Interface::ThreadContext> context;
+    const std::shared_ptr<Kernel::Process> process;
+    const std::unique_ptr<WakeupEvent> wakeup_event;
+    const VAddr tls_address;
+
+    std::vector<Kernel::WaitObject*> waiting_on{};
+    boost::container::flat_set<Kernel::Mutex*> held_mutexes{};
+    Status status = Status::Created;
+    u32 nominal_priority = Priority::Default;
+    std::optional<u32> real_priority{};
+
+    void WakeUp();
+    void Stop();
+    void SetStatus(Status status);
+    bool IsWokenBy(const Kernel::WaitObject* object);
+
+    friend class ThreadManager;
 };
-
-enum ThreadProcessorId : s32 {
-    ThreadProcessorIdDefault = -2, ///< Run thread on default core specified by exheader
-    ThreadProcessorIdAll = -1,     ///< Run thread on either core
-    ThreadProcessorId0 = 0,        ///< Run thread on core 0 (AppCore)
-    ThreadProcessorId1 = 1,        ///< Run thread on core 1 (SysCore)
-    ThreadProcessorId2 = 2,        ///< Run thread on core 2 (additional n3ds core)
-    ThreadProcessorId3 = 3,        ///< Run thread on core 3 (additional n3ds core)
-    ThreadProcessorIdMax = 4,      ///< Processor ID must be less than this
-};
-
-enum class ThreadStatus {
-    Running,      ///< Currently running
-    Ready,        ///< Ready to run
-    WaitArb,      ///< Waiting on an address arbiter
-    WaitSleep,    ///< Waiting due to a SleepThread SVC
-    WaitIPC,      ///< Waiting for the reply from an IPC request
-    WaitSynchAny, ///< Waiting due to WaitSynch1 or WaitSynchN with wait_all = false
-    WaitSynchAll, ///< Waiting due to WaitSynchronizationN with wait_all = true
-    WaitHleEvent, ///< Waiting due to an HLE handler pausing the thread
-    Dormant,      ///< Created but not yet made ready
-    Dead          ///< Run to completion, or forcefully terminated
-};
-
-enum class ThreadWakeupReason {
-    Signal, // The thread was woken up by WakeupAllWaitingThreads due to an object signal.
-    Timeout // The thread was woken up due to a wait timeout.
-};
-
-class Thread;
 
 class WakeupCallback {
 public:
     virtual ~WakeupCallback() = default;
-    virtual void WakeUp(ThreadWakeupReason reason, std::shared_ptr<Thread> thread,
-                        std::shared_ptr<WaitObject> object) = 0;
+    virtual void WakeUp(std::shared_ptr<Thread> thread, std::shared_ptr<WaitObject> object,
+                        Thread::WakeupReason reason) = 0;
 
 private:
     template <class Archive>
@@ -76,291 +100,411 @@ private:
 };
 
 class ThreadManager {
+
 public:
-    explicit ThreadManager(Kernel::KernelSystem& kernel, u32 core_id);
-    ~ThreadManager();
+    explicit ThreadManager(u32 core_id, std::unique_ptr<ARM_Interface> cpu);
 
-    /**
-     * Gets the current thread
-     */
-    Thread* GetCurrentThread() const;
-
-    /**
-     * Reschedules to the next available thread (call after current thread is suspended)
-     */
-    void Reschedule();
-
-    /**
-     * Prints the thread queue for debugging purposes
-     */
-    void DebugThreadQueue();
-
-    /**
-     * Returns whether there are any threads that are ready to run.
-     */
-    bool HaveReadyThreads();
-
-    /**
-     * Waits the current thread on a sleep
-     */
-    void WaitCurrentThread_Sleep();
-
-    /**
-     * Stops the current thread and removes it from the thread_list
-     */
-    void ExitCurrentThread();
-
-    /**
-     * Get a const reference to the thread list for debug use
-     */
-    const std::vector<std::shared_ptr<Thread>>& GetThreadList();
-
-    void SetCPU(ARM_Interface& cpu) {
-        this->cpu = &cpu;
-    }
-
-    std::unique_ptr<ARM_Interface::ThreadContext> NewContext() {
-        return cpu->NewContext();
-    }
-
-private:
-    /**
-     * Switches the CPU's active thread context to that of the specified thread
-     * @param new_thread The thread to switch to
-     */
-    void SwitchContext(Thread* new_thread);
-
-    /**
-     * Pops and returns the next thread from the thread queue
-     * @return A pointer to the next ready thread
-     */
-    Thread* PopNextReadyThread();
-
-    /**
-     * Callback that will wake up the thread it was scheduled for
-     * @param thread_id The ID of the thread that's been awoken
-     * @param cycles_late The number of CPU cycles that have passed since the desired wakeup time
-     */
-    void ThreadWakeupCallback(u64 thread_id, s64 cycles_late);
-
-    Kernel::KernelSystem& kernel;
-    ARM_Interface* cpu;
-
-    std::shared_ptr<Thread> current_thread;
-    Common::ThreadQueueList<Thread*, ThreadPrioLowest + 1> ready_queue;
-    std::unordered_map<u64, Thread*> wakeup_callback_table;
-
-    /// Event type for the thread wake up event
-    Core::TimingEventType* ThreadWakeupEventType = nullptr;
-
-    // Lists all threadsthat aren't deleted.
-    std::vector<std::shared_ptr<Thread>> thread_list;
-
-    friend class Thread;
-    friend class KernelSystem;
-
-    friend class boost::serialization::access;
-    template <class Archive>
-    void serialize(Archive& ar, const unsigned int file_version) {
-        ar& current_thread;
-        ar& ready_queue;
-        ar& wakeup_callback_table;
-        ar& thread_list;
-    }
-};
-
-class Thread final : public WaitObject {
-public:
-    explicit Thread(KernelSystem&, u32 core_id);
-    ~Thread() override;
-
-    std::string GetName() const override {
-        return name;
-    }
-    std::string GetTypeName() const override {
-        return "Thread";
-    }
-
-    static constexpr HandleType HANDLE_TYPE = HandleType::Thread;
-    HandleType GetHandleType() const override {
-        return HANDLE_TYPE;
-    }
-
-    bool ShouldWait(const Thread* thread) const override;
-    void Acquire(Thread* thread) override;
-
-    /**
-     * Gets the thread's current priority
-     * @return The current thread's priority
-     */
-    u32 GetPriority() const {
-        return current_priority;
-    }
-
-    /**
-     * Sets the thread's current priority
-     * @param priority The new priority
-     */
-    void SetPriority(u32 priority);
-
-    /**
-     * Boost's a thread's priority to the best priority among the thread's held mutexes.
-     * This prevents priority inversion via priority inheritance.
-     */
-    void UpdatePriority();
-
-    /**
-     * Temporarily boosts the thread's priority until the next time it is scheduled
-     * @param priority The new priority
-     */
-    void BoostPriority(u32 priority);
-
-    /**
-     * Gets the thread's thread ID
-     * @return The thread's ID
-     */
-    u32 GetThreadId() const {
-        return thread_id;
-    }
-
-    /**
-     * Resumes a thread from waiting
-     */
-    void ResumeFromWait();
-
-    /**
-     * Schedules an event to wake up the specified thread after the specified delay
-     * @param nanoseconds The time this thread will be allowed to sleep for
-     */
-    void WakeAfterDelay(s64 nanoseconds);
-
-    /**
-     * Sets the result after the thread awakens (from either WaitSynchronization SVC)
-     * @param result Value to set to the returned result
-     */
-    void SetWaitSynchronizationResult(ResultCode result);
-
-    /**
-     * Sets the output parameter value after the thread awakens (from WaitSynchronizationN SVC only)
-     * @param output Value to set to the output parameter
-     */
-    void SetWaitSynchronizationOutput(s32 output);
-
-    /**
-     * Retrieves the index that this particular object occupies in the list of objects
-     * that the thread passed to WaitSynchronizationN, starting the search from the last element.
-     * It is used to set the output value of WaitSynchronizationN when the thread is awakened.
-     * When a thread wakes up due to an object signal, the kernel will use the index of the last
-     * matching object in the wait objects list in case of having multiple instances of the same
-     * object in the list.
-     * @param object Object to query the index of.
-     */
-    s32 GetWaitObjectIndex(const WaitObject* object) const;
-
-    /**
-     * Stops a thread, invalidating it from further use
-     */
+    ResultCode WaitOne(Kernel::WaitObject* object, std::chrono::nanoseconds timeout);
+    ResultCode WaitAny(std::vector<Kernel::WaitObject*> objects, std::chrono::nanoseconds timeout);
+    ResultCode WaitAll(std::vector<Kernel::WaitObject*> objects, std::chrono::nanoseconds timeout);
+    void Sleep(std::chrono::nanoseconds nanoseconds);
+    void Sleep();
     void Stop();
 
-    /*
-     * Returns the Thread Local Storage address of the current thread
-     * @returns VAddr of the thread's TLS
-     */
-    VAddr GetTLSAddress() const {
-        return tls_address;
+    Kernel::Process& Process() {
+        return *thread->process;
+    }
+    const Kernel::Process& Process() const {
+        return *thread->process;
+    }
+    Kernel::Thread& Thread() {
+        return *thread;
+    }
+    const Kernel::Thread& Thread() const {
+        return *thread;
+    }
+    ARM_Interface& CPU() {
+        return *cpu;
+    }
+    const ARM_Interface& CPU() const {
+        return *cpu;
     }
 
-    /*
-     * Returns the address of the current thread's command buffer, located in the TLS.
-     * @returns VAddr of the thread's command buffer.
-     */
-    VAddr GetCommandBufferAddress() const;
+    std::shared_ptr<Kernel::Thread> CreateThread(KernelSystem& kernel, std::string name,
+                                                 VAddr entry_point, u32 priority, u32 arg,
+                                                 VAddr stack_top,
+                                                 std::shared_ptr<Kernel::Process> owner_process);
 
-    /**
-     * Returns whether this thread is waiting for all the objects in
-     * its wait list to become ready, as a result of a WaitSynchronizationN call
-     * with wait_all = true.
-     */
-    bool IsSleepingOnWaitAll() const {
-        return status == ThreadStatus::WaitSynchAll;
+    void AddCycles(Cycles count) {
+        cycles_remaining = cycles_remaining - count;
     }
-
-    std::unique_ptr<ARM_Interface::ThreadContext> context;
-
-    u32 thread_id;
-
-    ThreadStatus status;
-    VAddr entry_point;
-    VAddr stack_top;
-
-    u32 nominal_priority; ///< Nominal thread priority, as set by the emulated application
-    u32 current_priority; ///< Current thread priority, can be temporarily changed
-
-    u64 last_running_ticks; ///< CPU tick when thread was last running
-
-    s32 processor_id;
-
-    VAddr tls_address; ///< Virtual address of the Thread Local Storage of the thread
-
-    /// Mutexes currently held by this thread, which will be released when it exits.
-    boost::container::flat_set<std::shared_ptr<Mutex>> held_mutexes{};
-
-    /// Mutexes that this thread is currently waiting for.
-    boost::container::flat_set<std::shared_ptr<Mutex>> pending_mutexes{};
-
-    std::shared_ptr<Process> owner_process{}; ///< Process that owns this thread
-
-    /// Objects that the thread is waiting on, in the same order as they were
-    // passed to WaitSynchronization1/N.
-    std::vector<std::shared_ptr<WaitObject>> wait_objects{};
-
-    VAddr wait_address; ///< If waiting on an AddressArbiter, this is the arbitration address
-
-    std::string name{};
-
-    // Callback that will be invoked when the thread is resumed from a waiting state. If the thread
-    // was waiting via WaitSynchronizationN then the object will be the last object that became
-    // available. In case of a timeout, the object will be nullptr.
-    std::shared_ptr<WakeupCallback> wakeup_callback{};
-
-    const u32 core_id;
 
 private:
-    ThreadManager& thread_manager;
+    u32 core_id;
+    Core::Timing& root;
+    Kernel::Thread* thread;
+    std::unique_ptr<ARM_Interface> cpu;
+    std::vector<Kernel::Thread*> threads;
+    Cycles cycles_remaining{0};
+    Cycles delay_cycles{0};
+    ::Ticks segment_end{0};
 
-    friend class boost::serialization::access;
-    template <class Archive>
-    void serialize(Archive& ar, const unsigned int file_version);
+    bool Reschedule();
+    Ticks RunSegment(Ticks segment_length);
+
+    bool CanCutSlice() const {
+        return core_id == 0;
+    }
+    void EndBlock();
+
+    bool AllThreadsIdle() const;
+    void RemoveThread(Kernel::Thread* thread);
+
+    friend class Core::Timing;
+    friend class Thread;
 };
 
-/**
- * Sets up the primary application thread
- * @param kernel The kernel instance on which the thread is created
- * @param entry_point The address at which the thread should start execution
- * @param priority The priority to give the main thread
- * @param owner_process The parent process for the main thread
- * @return A shared pointer to the main thread
- */
-std::shared_ptr<Thread> SetupMainThread(KernelSystem& kernel, u32 entry_point, u32 priority,
-                                        std::shared_ptr<Process> owner_process);
+// class Mutex;
+// class Process;
+
+// enum ThreadPriority : u32 {
+//     ThreadPrioHighest = 0,      ///< Highest thread priority
+//     ThreadPrioUserlandMax = 24, ///< Highest thread priority for userland apps
+//     ThreadPrioDefault = 48,     ///< Default thread priority for userland apps
+//     ThreadPrioLowest = 63,      ///< Lowest thread priority
+// };
+
+// enum ThreadProcessorId : s32 {
+//     ThreadProcessorIdDefault = -2, ///< Run thread on default core specified by exheader
+//     ThreadProcessorIdAll = -1,     ///< Run thread on either core
+//     ThreadProcessorId0 = 0,        ///< Run thread on core 0 (AppCore)
+//     ThreadProcessorId1 = 1,        ///< Run thread on core 1 (SysCore)
+//     ThreadProcessorId2 = 2,        ///< Run thread on core 2 (additional n3ds core)
+//     ThreadProcessorId3 = 3,        ///< Run thread on core 3 (additional n3ds core)
+//     ThreadProcessorIdMax = 4,      ///< Processor ID must be less than this
+// };
+
+// enum class ThreadStatus {
+//     Running,      ///< Currently running
+//     Ready,        ///< Ready to run
+//     WaitArb,      ///< Waiting on an address arbiter
+//     WaitSleep,    ///< Waiting due to a SleepThread SVC
+//     WaitIPC,      ///< Waiting for the reply from an IPC request
+//     WaitSynchAny, ///< Waiting due to WaitSynch1 or WaitSynchN with wait_all = false
+//     WaitSynchAll, ///< Waiting due to WaitSynchronizationN with wait_all = true
+//     WaitHleEvent, ///< Waiting due to an HLE handler pausing the thread
+//     Dormant,      ///< Created but not yet made ready
+//     Dead          ///< Run to completion, or forcefully terminated
+// };
+
+// enum class ThreadWakeupReason {
+//     Signal, // The thread was woken up by WakeupAllWaitingThreads due to an object signal.
+//     Timeout // The thread was woken up due to a wait timeout.
+// };
+
+// class Thread;
+
+// class WakeupCallback {
+// public:
+//     virtual ~WakeupCallback() = default;
+//     virtual void WakeUp(ThreadWakeupReason reason, std::shared_ptr<Thread> thread,
+//                         std::shared_ptr<WaitObject> object) = 0;
+
+// private:
+//     template <class Archive>
+//     void serialize(Archive& ar, const unsigned int) {}
+//     friend class boost::serialization::access;
+// };
+
+// class ThreadManager {
+// public:
+//     explicit ThreadManager(Kernel::KernelSystem& kernel, u32 core_id);
+//     ~ThreadManager();
+
+//     /**
+//      * Gets the current thread
+//      */
+//     Thread* GetCurrentThread() const;
+
+//     /**
+//      * Reschedules to the next available thread (call after current thread is suspended)
+//      */
+//     void Reschedule();
+
+//     /**
+//      * Prints the thread queue for debugging purposes
+//      */
+//     void DebugThreadQueue();
+
+//     /**
+//      * Returns whether there are any threads that are ready to run.
+//      */
+//     bool HaveReadyThreads();
+
+//     /**
+//      * Waits the current thread on a sleep
+//      */
+//     void WaitCurrentThread_Sleep();
+
+//     /**
+//      * Stops the current thread and removes it from the thread_list
+//      */
+//     void ExitCurrentThread();
+
+//     /**
+//      * Get a const reference to the thread list for debug use
+//      */
+//     const std::vector<std::shared_ptr<Thread>>& GetThreadList();
+
+//     void SetCPU(ARM_Interface& cpu) {
+//         this->cpu = &cpu;
+//     }
+
+//     std::unique_ptr<ARM_Interface::ThreadContext> NewContext() {
+//         return cpu->NewContext();
+//     }
+
+// private:
+//     /**
+//      * Switches the CPU's active thread context to that of the specified thread
+//      * @param new_thread The thread to switch to
+//      */
+//     void SwitchContext(Thread* new_thread);
+
+//     /**
+//      * Pops and returns the next thread from the thread queue
+//      * @return A pointer to the next ready thread
+//      */
+//     Thread* PopNextReadyThread();
+
+//     /**
+//      * Callback that will wake up the thread it was scheduled for
+//      * @param thread_id The ID of the thread that's been awoken
+//      * @param cycles_late The number of CPU cycles that have passed since the desired wakeup time
+//      */
+//     void ThreadWakeupCallback(u64 thread_id, s64 cycles_late);
+
+//     Kernel::KernelSystem& kernel;
+//     ARM_Interface* cpu;
+
+//     std::shared_ptr<Thread> current_thread;
+//     Common::ThreadQueueList<Thread*, ThreadPrioLowest + 1> ready_queue;
+//     std::unordered_map<u64, Thread*> wakeup_callback_table;
+
+//     /// Event type for the thread wake up event
+//     Core::TimingEventType* ThreadWakeupEventType = nullptr;
+
+//     // Lists all threadsthat aren't deleted.
+//     std::vector<std::shared_ptr<Thread>> thread_list;
+
+//     friend class Thread;
+//     friend class KernelSystem;
+
+//     friend class boost::serialization::access;
+//     template <class Archive>
+//     void serialize(Archive& ar, const unsigned int file_version) {
+//         ar& current_thread;
+//         ar& ready_queue;
+//         ar& wakeup_callback_table;
+//         ar& thread_list;
+//     }
+// };
+
+// class Thread final : public WaitObject {
+// public:
+//     explicit Thread(KernelSystem&, u32 core_id);
+//     ~Thread() override;
+
+//     std::string GetName() const override {
+//         return name;
+//     }
+//     std::string GetTypeName() const override {
+//         return "Thread";
+//     }
+
+//     static constexpr HandleType HANDLE_TYPE = HandleType::Thread;
+//     HandleType GetHandleType() const override {
+//         return HANDLE_TYPE;
+//     }
+
+//     bool ShouldWait(const Thread* thread) const override;
+//     void Acquire(Thread* thread) override;
+
+//     /**
+//      * Gets the thread's current priority
+//      * @return The current thread's priority
+//      */
+//     u32 GetPriority() const {
+//         return current_priority;
+//     }
+
+//     /**
+//      * Sets the thread's current priority
+//      * @param priority The new priority
+//      */
+//     void SetPriority(u32 priority);
+
+//     /**
+//      * Boost's a thread's priority to the best priority among the thread's held mutexes.
+//      * This prevents priority inversion via priority inheritance.
+//      */
+//     void UpdatePriority();
+
+//     /**
+//      * Temporarily boosts the thread's priority until the next time it is scheduled
+//      * @param priority The new priority
+//      */
+//     void BoostPriority(u32 priority);
+
+//     /**
+//      * Gets the thread's thread ID
+//      * @return The thread's ID
+//      */
+//     u32 GetThreadId() const {
+//         return thread_id;
+//     }
+
+//     /**
+//      * Resumes a thread from waiting
+//      */
+//     void ResumeFromWait();
+
+//     /**
+//      * Schedules an event to wake up the specified thread after the specified delay
+//      * @param nanoseconds The time this thread will be allowed to sleep for
+//      */
+//     void WakeAfterDelay(s64 nanoseconds);
+
+//     /**
+//      * Sets the result after the thread awakens (from either WaitSynchronization SVC)
+//      * @param result Value to set to the returned result
+//      */
+//     void SetWaitSynchronizationResult(ResultCode result);
+
+//     /**
+//      * Sets the output parameter value after the thread awakens (from WaitSynchronizationN SVC
+//      only)
+//      * @param output Value to set to the output parameter
+//      */
+//     void SetWaitSynchronizationOutput(s32 output);
+
+//     /**
+//      * Retrieves the index that this particular object occupies in the list of objects
+//      * that the thread passed to WaitSynchronizationN, starting the search from the last element.
+//      * It is used to set the output value of WaitSynchronizationN when the thread is awakened.
+//      * When a thread wakes up due to an object signal, the kernel will use the index of the last
+//      * matching object in the wait objects list in case of having multiple instances of the same
+//      * object in the list.
+//      * @param object Object to query the index of.
+//      */
+//     s32 GetWaitObjectIndex(const WaitObject* object) const;
+
+//     /**
+//      * Stops a thread, invalidating it from further use
+//      */
+//     void Stop();
+
+//     /*
+//      * Returns the Thread Local Storage address of the current thread
+//      * @returns VAddr of the thread's TLS
+//      */
+//     VAddr GetTLSAddress() const {
+//         return tls_address;
+//     }
+
+//     /*
+//      * Returns the address of the current thread's command buffer, located in the TLS.
+//      * @returns VAddr of the thread's command buffer.
+//      */
+//     VAddr GetCommandBufferAddress() const;
+
+//     /**
+//      * Returns whether this thread is waiting for all the objects in
+//      * its wait list to become ready, as a result of a WaitSynchronizationN call
+//      * with wait_all = true.
+//      */
+//     bool IsSleepingOnWaitAll() const {
+//         return status == ThreadStatus::WaitSynchAll;
+//     }
+
+//     std::unique_ptr<ARM_Interface::ThreadContext> context;
+
+//     u32 thread_id;
+
+//     ThreadStatus status;
+//     VAddr entry_point;
+//     VAddr stack_top;
+
+//     u32 nominal_priority; ///< Nominal thread priority, as set by the emulated application
+//     u32 current_priority; ///< Current thread priority, can be temporarily changed
+
+//     u64 last_running_ticks; ///< CPU tick when thread was last running
+
+//     s32 processor_id;
+
+//     VAddr tls_address; ///< Virtual address of the Thread Local Storage of the thread
+
+//     /// Mutexes currently held by this thread, which will be released when it exits.
+//     boost::container::flat_set<std::shared_ptr<Mutex>> held_mutexes{};
+
+//     /// Mutexes that this thread is currently waiting for.
+//     boost::container::flat_set<std::shared_ptr<Mutex>> pending_mutexes{};
+
+//     std::shared_ptr<Process> owner_process{}; ///< Process that owns this thread
+
+//     /// Objects that the thread is waiting on, in the same order as they were
+//     // passed to WaitSynchronization1/N.
+//     std::vector<std::shared_ptr<WaitObject>> wait_objects{};
+
+//     VAddr wait_address; ///< If waiting on an AddressArbiter, this is the arbitration address
+
+//     std::string name{};
+
+//     // Callback that will be invoked when the thread is resumed from a waiting state. If the
+//     thread
+//     // was waiting via WaitSynchronizationN then the object will be the last object that became
+//     // available. In case of a timeout, the object will be nullptr.
+//     std::shared_ptr<WakeupCallback> wakeup_callback{};
+
+//     const u32 core_id;
+
+// private:
+//     ThreadManager& thread_manager;
+
+//     friend class boost::serialization::access;
+//     template <class Archive>
+//     void serialize(Archive& ar, const unsigned int file_version);
+// };
+
+// /**
+//  * Sets up the primary application thread
+//  * @param kernel The kernel instance on which the thread is created
+//  * @param entry_point The address at which the thread should start execution
+//  * @param priority The priority to give the main thread
+//  * @param owner_process The parent process for the main thread
+//  * @return A shared pointer to the main thread
+//  */
+// std::shared_ptr<Thread> SetupMainThread(KernelSystem& kernel, u32 entry_point, u32 priority,
+//                                         std::shared_ptr<Process> owner_process);
 
 } // namespace Kernel
 
-BOOST_CLASS_EXPORT_KEY(Kernel::Thread)
+// BOOST_CLASS_EXPORT_KEY(Kernel::Thread)
 
-namespace boost::serialization {
+// namespace boost::serialization {
 
-template <class Archive>
-inline void save_construct_data(Archive& ar, const Kernel::Thread* t,
-                                const unsigned int file_version) {
-    ar << t->core_id;
-}
+// template <class Archive>
+// inline void save_construct_data(Archive& ar, const Kernel::Thread* t,
+//                                 const unsigned int file_version) {
+//     ar << t->core_id;
+// }
 
-template <class Archive>
-inline void load_construct_data(Archive& ar, Kernel::Thread* t, const unsigned int file_version) {
-    u32 core_id;
-    ar >> core_id;
-    ::new (t) Kernel::Thread(Core::Global<Kernel::KernelSystem>(), core_id);
-}
+// template <class Archive>
+// inline void load_construct_data(Archive& ar, Kernel::Thread* t, const unsigned int file_version)
+// {
+//     u32 core_id;
+//     ar >> core_id;
+//     ::new (t) Kernel::Thread(Core::Global<Kernel::KernelSystem>(), core_id);
+// }
 
-} // namespace boost::serialization
+// } // namespace boost::serialization

--- a/src/core/hle/kernel/timer.cpp
+++ b/src/core/hle/kernel/timer.cpp
@@ -18,10 +18,10 @@ SERIALIZE_EXPORT_IMPL(Kernel::Timer)
 namespace Kernel {
 
 Timer::Timer(KernelSystem& kernel)
-    : WaitObject(kernel), kernel(kernel), timer_manager(kernel.GetTimerManager()) {}
+    : WaitObject(kernel), kernel(kernel), timer_event(new Callback(*this)) {}
 Timer::~Timer() {
     Cancel();
-    timer_manager.timer_callback_table.erase(callback_id);
+    // timer_manager.timer_callback_table.erase(callback_id);
 }
 
 std::shared_ptr<Timer> KernelSystem::CreateTimer(ResetType reset_type, std::string name) {
@@ -30,10 +30,10 @@ std::shared_ptr<Timer> KernelSystem::CreateTimer(ResetType reset_type, std::stri
     timer->reset_type = reset_type;
     timer->signaled = false;
     timer->name = std::move(name);
-    timer->initial_delay = 0;
-    timer->interval_delay = 0;
-    timer->callback_id = ++timer_manager->next_timer_callback_id;
-    timer_manager->timer_callback_table[timer->callback_id] = timer.get();
+    timer->initial_delay = Ticks(0);
+    timer->interval_delay = Ticks(0);
+    // timer->callback_id = ++timer_manager->next_timer_callback_id;
+    // timer_manager->timer_callback_table[timer->callback_id] = timer.get();
 
     return timer;
 }
@@ -49,24 +49,23 @@ void Timer::Acquire(Thread* thread) {
         signaled = false;
 }
 
-void Timer::Set(s64 initial, s64 interval) {
+void Timer::Set(Ticks initial, std::optional<Ticks> interval) {
     // Ensure we get rid of any previous scheduled event
     Cancel();
 
     initial_delay = initial;
     interval_delay = interval;
 
-    if (initial == 0) {
+    if (initial < Ticks(1)) {
         // Immediately invoke the callback
-        Signal(0);
+        Signal(Ticks(0));
     } else {
-        kernel.timing.ScheduleEvent(nsToCycles(initial), timer_manager.timer_callback_event_type,
-                                    callback_id);
+        kernel.timing.ScheduleEvent(timer_event.get(), initial);
     }
 }
 
 void Timer::Cancel() {
-    kernel.timing.UnscheduleEvent(timer_manager.timer_callback_event_type, callback_id);
+    kernel.timing.UnscheduleEvent(timer_event.get());
 }
 
 void Timer::Clear() {
@@ -80,7 +79,7 @@ void Timer::WakeupAllWaitingThreads() {
         signaled = false;
 }
 
-void Timer::Signal(s64 cycles_late) {
+void Timer::Signal(Ticks cycles_late) {
     LOG_TRACE(Kernel, "Timer {} fired", GetObjectId());
 
     signaled = true;
@@ -88,30 +87,34 @@ void Timer::Signal(s64 cycles_late) {
     // Resume all waiting threads
     WakeupAllWaitingThreads();
 
-    if (interval_delay != 0) {
+    if (interval_delay.has_value()) {
         // Reschedule the timer with the interval delay
-        kernel.timing.ScheduleEvent(nsToCycles(interval_delay) - cycles_late,
-                                    timer_manager.timer_callback_event_type, callback_id);
+        kernel.timing.ScheduleEvent(timer_event.get(), interval_delay.value() - cycles_late);
     }
 }
 
 /// The timer callback event, called when a timer is fired
-void TimerManager::TimerCallback(u64 callback_id, s64 cycles_late) {
-    std::shared_ptr<Timer> timer = SharedFrom(timer_callback_table.at(callback_id));
+class Timer::Callback : public Core::Event {
+    Timer& parent;
 
-    if (timer == nullptr) {
-        LOG_CRITICAL(Kernel, "Callback fired for invalid timer {:016x}", callback_id);
-        return;
+public:
+    explicit Callback(Timer& parent_) : parent(parent_) {}
+
+    const std::string& Name() const override {
+        static const std::string name = "TimerCallback";
+        return name;
     }
 
-    timer->Signal(cycles_late);
-}
+    void Execute(Core::Timing& timing, u64 callback_id, Ticks cycles_late) override {
+        parent.Signal(cycles_late);
+    }
+};
 
-TimerManager::TimerManager(Core::Timing& timing) : timing(timing) {
-    timer_callback_event_type =
-        timing.RegisterEvent("TimerCallback", [this](u64 thread_id, s64 cycle_late) {
-            TimerCallback(thread_id, cycle_late);
-        });
-}
+// TimerManager::TimerManager(Core::Timing& timing) : timing(timing) {
+//     timer_callback_event_type =
+//         timing.RegisterEvent("TimerCallback", [this](u64 thread_id, s64 cycle_late) {
+//             TimerCallback(thread_id, cycle_late);
+//         });
+// }
 
 } // namespace Kernel

--- a/src/core/hw/hw.cpp
+++ b/src/core/hw/hw.cpp
@@ -83,7 +83,7 @@ template void Write<u16>(u32 addr, const u16 data);
 template void Write<u8>(u32 addr, const u8 data);
 
 /// Update hardware
-void Update() {}
+// void Update() {}
 
 /// Initialize hardware
 void Init(Memory::MemorySystem& memory) {


### PR DESCRIPTION
Making this a PR so folks can see what I'm doing.

## What's the point of this?

In some games (notably, LM2), while they perform very accurately (with B3n30's timing fix) they are still rather slow. Notably this isn't due to the rate of instructions, but the lack thereof relative to what the game requires. The current scheduler runs in 'slices', the length of which is determined by a variety of things, including the current thread yielding for whatever reason. Since LM2 does a lot of IPC, it sleeps the current thread for many short periods, resulting in slices that are very short (a few dozen instructions). This adds a bunch of overhead to the emulation, killing performance. Underclocking fixes this by reducing the number of yields relative to the number of frames, resulting in more instructions being executed per slice. Playing around with the IPC delay also has an effect.

## So how are you fixing it?

This PR is a multi-pronged approach:
* Avoid ending the current slice. If the current thread yields, try to reschedule without leaving the JIT. If all threads yield, try to execute the event to see if it wakes anyone up.
* Reduce overhead in the main execution loop. Only reschedule when needed, and make the rescheduling faster by assuming no pre-emption (which is only maybe not true for the syscore, and can be added later if needed).
* Formalize how timing conflicts between cores are handled. It is always possible for a later core to schedule an event for a timepoint that a previous core has already passed. By considering this situation in the abstract, it is possible to make appropriate tradeoffs between performance and accuracy (accepting that we can never be 100% accurate in this area without going cycle-by-cycle).
* Use a higher-level scheduling API. Rather than SVCs manually managing thread state, this is now the job of the ThreadManager. This allows us to make more intelligent scheduling decisions rather than forcibly ending the JIT slice every time.

## Is that it?

I'm taking the opportunity to refactor a few constructs, making better use of encapsulation etc. For instance timing events are now individual objects, removing the need for some global 'managers' like TimerManager, and the concept of global event registration.

I've also decided to remove the general-purpose WakeupCallbacks in favour of special-casing the situations they were used in. The whole system is fairly special-case anyway so this doesn't sacrifice much, and it generally reduces complexity as it's more straightforward to understand what happens when. NB this doesn't apply to IPC continuation callbacks which are still needed, there's just one fewer wrapper layer.