### PR TITLE
GSP: Only process the command queue for the thread with active GPU rights

### DIFF
--- a/src/core/hle/service/gsp/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp/gsp_gpu.cpp
@@ -632,20 +632,18 @@ void GSP_GPU::SetLcdForceBlack(Kernel::HLERequestContext& ctx) {
 void GSP_GPU::TriggerCmdReqQueue(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0xC, 0, 0);
 
-    // Iterate through each thread's command queue...
-    for (unsigned thread_id = 0; thread_id < 0x4; ++thread_id) {
-        CommandBuffer* command_buffer = (CommandBuffer*)GetCommandBuffer(shared_memory, thread_id);
+    CommandBuffer* command_buffer =
+        (CommandBuffer*)GetCommandBuffer(shared_memory, active_thread_id);
 
-        // Iterate through each command...
-        for (unsigned i = 0; i < command_buffer->number_commands; ++i) {
-            g_debugger.GXCommandProcessed((u8*)&command_buffer->commands[i]);
+    // Iterate through each command...
+    for (unsigned i = 0; i < command_buffer->number_commands; ++i) {
+        g_debugger.GXCommandProcessed((u8*)&command_buffer->commands[i]);
 
-            // Decode and execute command
-            ExecuteCommand(command_buffer->commands[i], thread_id);
+        // Decode and execute command
+        ExecuteCommand(command_buffer->commands[i], active_thread_id);
 
-            // Indicates that command has completed
-            command_buffer->number_commands.Assign(command_buffer->number_commands - 1);
-        }
+        // Indicates that command has completed
+        command_buffer->number_commands.Assign(command_buffer->number_commands - 1);
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);

--- a/src/core/hle/service/gsp/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp/gsp_gpu.cpp
@@ -87,9 +87,9 @@ u32 GSP_GPU::GetUnusedThreadId() {
 }
 
 /// Gets a pointer to a thread command buffer in GSP shared memory
-static inline u8* GetCommandBuffer(std::shared_ptr<Kernel::SharedMemory> shared_memory,
-                                   u32 thread_id) {
-    return shared_memory->GetPointer(0x800 + (thread_id * sizeof(CommandBuffer)));
+static inline CommandBuffer& GetCommandBuffer(std::shared_ptr<Kernel::SharedMemory> shared_memory,
+                                              u32 thread_id) {
+    return reinterpret_cast<CommandBuffer*>(shared_memory->GetPointer(0x800))[thread_id];
 }
 
 FrameBufferUpdate* GSP_GPU::GetFrameBufferInfo(u32 thread_id, u32 screen_index) {
@@ -632,18 +632,17 @@ void GSP_GPU::SetLcdForceBlack(Kernel::HLERequestContext& ctx) {
 void GSP_GPU::TriggerCmdReqQueue(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0xC, 0, 0);
 
-    CommandBuffer* command_buffer =
-        (CommandBuffer*)GetCommandBuffer(shared_memory, active_thread_id);
+    CommandBuffer& command_buffer = GetCommandBuffer(shared_memory, active_thread_id);
 
     // Iterate through each command...
-    for (unsigned i = 0; i < command_buffer->number_commands; ++i) {
-        g_debugger.GXCommandProcessed((u8*)&command_buffer->commands[i]);
+    for (unsigned i = 0; i < command_buffer.number_commands; ++i) {
+        g_debugger.GXCommandProcessed(command_buffer.commands[i]);
 
         // Decode and execute command
-        ExecuteCommand(command_buffer->commands[i], active_thread_id);
+        ExecuteCommand(command_buffer.commands[i], active_thread_id);
 
         // Indicates that command has completed
-        command_buffer->number_commands.Assign(command_buffer->number_commands - 1);
+        command_buffer.number_commands.Assign(command_buffer.number_commands - 1);
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);

--- a/src/video_core/gpu_debugger.h
+++ b/src/video_core/gpu_debugger.h
@@ -44,17 +44,14 @@ public:
         friend class GraphicsDebugger;
     };
 
-    void GXCommandProcessed(u8* command_data) {
+    void GXCommandProcessed(const Service::GSP::Command& command_data) {
         if (observers.empty())
             return;
 
-        gx_command_history.emplace_back();
-        Service::GSP::Command& cmd = gx_command_history.back();
-
-        memcpy(&cmd, command_data, sizeof(Service::GSP::Command));
+        gx_command_history.emplace_back(command_data);
 
         ForEachObserver([this](DebuggerObserver* observer) {
-            observer->GXCommandProcessed(static_cast<int>(this->gx_command_history.size()));
+            observer->GXCommandProcessed(static_cast<int>(gx_command_history.size()));
         });
     }
 


### PR DESCRIPTION
This reason for looping through threads 0-3 is not documented in the code but it was written six years ago; so it was probably a shortcut.
Processing commands only for the active thread works as intended and logically makes sense.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5342)
<!-- Reviewable:end -->
