### PR TITLE
[WIP] NCCHContainer: support for partitions if container is NCSD

### DIFF
--- a/src/core/file_sys/archive_ncch.cpp
+++ b/src/core/file_sys/archive_ncch.cpp
@@ -90,7 +90,7 @@ ResultVal<std::unique_ptr<FileBackend>> NCCHArchive::OpenFile(const Path& path,
 
     std::string file_path =
         Service::AM::GetTitleContentPath(media_type, title_id, openfile_path.content_index);
-    auto ncch_container = NCCHContainer(file_path);
+    auto ncch_container = NCCHContainer(file_path, 0, openfile_path.content_index);
 
     Loader::ResultStatus result;
     std::unique_ptr<FileBackend> file;

--- a/src/core/file_sys/ncch_container.cpp
+++ b/src/core/file_sys/ncch_container.cpp
@@ -114,14 +114,16 @@ static bool LZSS_Decompress(const u8* compressed, u32 compressed_size, u8* decom
     return true;
 }
 
-NCCHContainer::NCCHContainer(const std::string& filepath, u32 ncch_offset)
-    : ncch_offset(ncch_offset), filepath(filepath) {
+NCCHContainer::NCCHContainer(const std::string& filepath, u32 ncch_offset, u32 partition)
+    : ncch_offset(ncch_offset), partition(partition) , filepath(filepath){
     file = FileUtil::IOFile(filepath, "rb");
 }
 
-Loader::ResultStatus NCCHContainer::OpenFile(const std::string& filepath, u32 ncch_offset) {
+Loader::ResultStatus NCCHContainer::OpenFile(const std::string& filepath, u32 ncch_offset,
+                                             u32 partition) {
     this->filepath = filepath;
     this->ncch_offset = ncch_offset;
+    this->partition = partition;
     file = FileUtil::IOFile(filepath, "rb");
 
     if (!file.IsOpen()) {
@@ -150,8 +152,13 @@ Loader::ResultStatus NCCHContainer::LoadHeader() {
 
     // Skip NCSD header and load first NCCH (NCSD is just a container of NCCH files)...
     if (Loader::MakeMagic('N', 'C', 'S', 'D') == ncch_header.magic) {
-        LOG_DEBUG(Service_FS, "Only loading the first (bootable) NCCH within the NCSD file!");
-        ncch_offset += 0x4000;
+        NCSD_Header ncsd_header;
+        file.Seek(ncch_offset, SEEK_SET);
+        file.ReadBytes(&ncsd_header, sizeof(NCSD_Header));
+        ASSERT(Loader::MakeMagic('N', 'C', 'S', 'D') == ncsd_header.magic);
+        ASSERT(partition < 8);
+        ncch_offset = ncsd_header.partitions[partition].offset * kBlockSize;
+        LOG_ERROR(Service_FS, "{}", ncch_offset);
         file.Seek(ncch_offset, SEEK_SET);
         file.ReadBytes(&ncch_header, sizeof(NCCH_Header));
     }
@@ -178,8 +185,12 @@ Loader::ResultStatus NCCHContainer::Load() {
 
         // Skip NCSD header and load first NCCH (NCSD is just a container of NCCH files)...
         if (Loader::MakeMagic('N', 'C', 'S', 'D') == ncch_header.magic) {
-            LOG_DEBUG(Service_FS, "Only loading the first (bootable) NCCH within the NCSD file!");
-            ncch_offset += 0x4000;
+            NCSD_Header ncsd_header;
+            file.Seek(ncch_offset, SEEK_SET);
+            file.ReadBytes(&ncsd_header, sizeof(NCSD_Header));
+            ASSERT(Loader::MakeMagic('N', 'C', 'S', 'D') == ncsd_header.magic);
+            ASSERT(partition < 8);
+            ncch_offset = ncsd_header.partitions[partition].offset * kBlockSize;
             file.Seek(ncch_offset, SEEK_SET);
             file.ReadBytes(&ncch_header, sizeof(NCCH_Header));
         }

--- a/src/core/file_sys/ncch_container.cpp
+++ b/src/core/file_sys/ncch_container.cpp
@@ -115,7 +115,7 @@ static bool LZSS_Decompress(const u8* compressed, u32 compressed_size, u8* decom
 }
 
 NCCHContainer::NCCHContainer(const std::string& filepath, u32 ncch_offset, u32 partition)
-    : ncch_offset(ncch_offset), partition(partition) , filepath(filepath){
+    : ncch_offset(ncch_offset), partition(partition), filepath(filepath) {
     file = FileUtil::IOFile(filepath, "rb");
 }
 

--- a/src/core/file_sys/ncch_container.h
+++ b/src/core/file_sys/ncch_container.h
@@ -15,6 +15,31 @@
 #include "core/core.h"
 #include "core/file_sys/romfs_reader.h"
 
+enum NCSDContentIndex { Main = 0, Manual = 1, DLP = 2, New3DSUpdate = 6, Update = 7 };
+
+struct NCSD_Partitions {
+    u32 offset;
+    u32 size;
+};
+
+struct NCSD_Header {
+    u8 signature[0x100];
+    u32_le magic;
+    u32_le media_size;
+    u8 media_id[8];
+    u8 partition_fs_type[8];
+    u8 partition_crypt_type[8];
+    NCSD_Partitions partitions[8];
+    u8 extended_header_hash[0x20];
+    u32_le additional_header_size;
+    u32_le sector_zero_offset;
+    u8 partition_flags[8];
+    u8 partition_id_table[0x40];
+    u8 reserved[0x30];
+};
+
+static_assert(sizeof(NCSD_Header) == 0x200, "NCCH header structure size is wrong");
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 /// NCCH header (Note: "NCCH" appears to be a publicly unknown acronym)
 
@@ -205,10 +230,11 @@ namespace FileSys {
  */
 class NCCHContainer {
 public:
-    NCCHContainer(const std::string& filepath, u32 ncch_offset = 0);
+    NCCHContainer(const std::string& filepath, u32 ncch_offset = 0, u32 partition = 0);
     NCCHContainer() {}
 
-    Loader::ResultStatus OpenFile(const std::string& filepath, u32 ncch_offset = 0);
+    Loader::ResultStatus OpenFile(const std::string& filepath, u32 ncch_offset = 0,
+                                  u32 partition = 0);
 
     /**
      * Ensure NCCH header is loaded and ready for reading sections
@@ -335,6 +361,7 @@ private:
 
     u32 ncch_offset = 0; // Offset to NCCH header, can be 0 for NCCHs or non-zero for CIAs/NCSDs
     u32 exefs_offset = 0;
+    u32 partition = 0;
 
     std::string filepath;
     FileUtil::IOFile file;

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -31,6 +31,7 @@
 #include "core/hle/service/am/am_sys.h"
 #include "core/hle/service/am/am_u.h"
 #include "core/hle/service/fs/archive.h"
+#include "core/hle/service/fs/fs_user.h"
 #include "core/loader/loader.h"
 #include "core/loader/smdh.h"
 
@@ -466,14 +467,16 @@ std::string GetTitleMetadataPath(Service::FS::MediaType media_type, u64 tid, boo
 
 std::string GetTitleContentPath(Service::FS::MediaType media_type, u64 tid, u16 index,
                                 bool update) {
-    std::string content_path = GetTitlePath(media_type, tid) + "content/";
 
     if (media_type == Service::FS::MediaType::GameCard) {
-        // TODO(shinyquagsire23): get current app file if TID matches?
-        LOG_ERROR(Service_AM, "Request for gamecard partition {} content path unimplemented!",
-                  static_cast<u32>(index));
-        return "";
+        // TODO(B3N30): check if TID matches
+        auto fs_user =
+            Core::System::GetInstance().ServiceManager().GetService<Service::FS::FS_USER>(
+                "fs:USER");
+        return fs_user->GetCurrentGamecardPath();
     }
+
+    std::string content_path = GetTitlePath(media_type, tid) + "content/";
 
     std::string tmd_path = GetTitleMetadataPath(media_type, tid, update);
 
@@ -509,9 +512,11 @@ std::string GetTitlePath(Service::FS::MediaType media_type, u64 tid) {
         return fmt::format("{}{:08x}/{:08x}/", GetMediaTitlePath(media_type), high, low);
 
     if (media_type == Service::FS::MediaType::GameCard) {
-        // TODO(shinyquagsire23): get current app path if TID matches?
-        LOG_ERROR(Service_AM, "Request for gamecard title path unimplemented!");
-        return "";
+        // TODO(B3N30): check if TID matches
+        auto fs_user =
+            Core::System::GetInstance().ServiceManager().GetService<Service::FS::FS_USER>(
+                "fs:USER");
+        return fs_user->GetCurrentGamecardPath();
     }
 
     return "";
@@ -528,9 +533,11 @@ std::string GetMediaTitlePath(Service::FS::MediaType media_type) {
                            SDCARD_ID);
 
     if (media_type == Service::FS::MediaType::GameCard) {
-        // TODO(shinyquagsire23): get current app parent folder if TID matches?
-        LOG_ERROR(Service_AM, "Request for gamecard parent path unimplemented!");
-        return "";
+        // TODO(B3N30): check if TID matchess
+        auto fs_user =
+            Core::System::GetInstance().ServiceManager().GetService<Service::FS::FS_USER>(
+                "fs:USER");
+        return fs_user->GetCurrentGamecardPath();
     }
 
     return "";

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -31,6 +31,16 @@
 
 namespace Service::FS {
 
+MediaType GetMediaTypeFromPath(const std::string& path) {
+    if (path.rfind(FileUtil::GetUserPath(FileUtil::UserPath::NANDDir), 0) == 0) {
+        return MediaType::NAND;
+    }
+    if (path.rfind(FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir), 0) == 0) {
+        return MediaType::SDMC;
+    }
+    return MediaType::GameCard;
+}
+
 ArchiveBackend* ArchiveManager::GetArchive(ArchiveHandle handle) {
     auto itr = handle_map.find(handle);
     return (itr == handle_map.end()) ? nullptr : itr->second.get();

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -31,7 +31,7 @@
 
 namespace Service::FS {
 
-MediaType GetMediaTypeFromPath(const std::string& path) {
+MediaType GetMediaTypeFromPath(std::string_view path) {
     if (path.rfind(FileUtil::GetUserPath(FileUtil::UserPath::NANDDir), 0) == 0) {
         return MediaType::NAND;
     }

--- a/src/core/hle/service/fs/archive.h
+++ b/src/core/hle/service/fs/archive.h
@@ -48,6 +48,14 @@ enum class ArchiveIdCode : u32 {
 /// Media types for the archives
 enum class MediaType : u32 { NAND = 0, SDMC = 1, GameCard = 2 };
 
+MediaType GetMediaTypeFromPath(const std::string& path);
+
+enum class SpecialContentType : u8 {
+    Update = 1,
+    Manual = 2,
+    DLPChild = 3,
+};
+
 typedef u64 ArchiveHandle;
 
 struct ArchiveResource {

--- a/src/core/hle/service/fs/archive.h
+++ b/src/core/hle/service/fs/archive.h
@@ -48,7 +48,7 @@ enum class ArchiveIdCode : u32 {
 /// Media types for the archives
 enum class MediaType : u32 { NAND = 0, SDMC = 1, GameCard = 2 };
 
-MediaType GetMediaTypeFromPath(const std::string& path);
+MediaType GetMediaTypeFromPath(std::string_view path);
 
 enum class SpecialContentType : u8 {
     Update = 1,

--- a/src/core/hle/service/fs/fs_user.cpp
+++ b/src/core/hle/service/fs/fs_user.cpp
@@ -845,7 +845,7 @@ ResultVal<u16> FS_USER::GetSpecialContentIndexFromGameCard(u64 title_id, Special
     // TODO(B3N30) check if on real 3DS NCSD is checked if partition exists
 
     if (type > SpecialContentType::DLPChild) {
-        // maybe type 4 is n3ds update/partition 6 but this needs more research
+        // Maybe type 4 is New 3DS update/partition 6 but this needs more research
         // TODO(B3N30): Find correct result code
         return ResultCode(-1);
     }

--- a/src/core/hle/service/fs/fs_user.cpp
+++ b/src/core/hle/service/fs/fs_user.cpp
@@ -760,7 +760,7 @@ void FS_USER::GetSpecialContentIndex(Kernel::HLERequestContext& ctx) {
     if (media_type == MediaType::GameCard) {
         index = GetSpecialContentIndexFromGameCard(title_id, type);
     } else {
-        index = GetSpecialContentIndexFromTDM(media_type, title_id, type);
+        index = GetSpecialContentIndexFromTMD(media_type, title_id, type);
     }
 
     if (index.Succeeded()) {
@@ -831,10 +831,10 @@ void FS_USER::GetSaveDataSecureValue(Kernel::HLERequestContext& ctx) {
 
 void FS_USER::Register(u32 process_id, u64 program_id, const std::string& filepath) {
     const MediaType media_type = GetMediaTypeFromPath(filepath);
-    program_info_map.insert_or_assign(process_id, ProgramInfo{program_id, media_type};
+    program_info_map.insert_or_assign(process_id, ProgramInfo{program_id, media_type});
     if (media_type == MediaType::GameCard) {
         current_gamecard_path = filepath;
-    }ƒ
+    }
 }
 
 std::string FS_USER::GetCurrentGamecardPath() const {
@@ -862,7 +862,7 @@ ResultVal<u16> FS_USER::GetSpecialContentIndexFromGameCard(u64 title_id, Special
     }
 }
 
-ResultVal<u16> FS_USER::GetSpecialContentIndexFromTDM(MediaType media_type, u64 title_id,
+ResultVal<u16> FS_USER::GetSpecialContentIndexFromTMD(MediaType media_type, u64 title_id,
                                                       SpecialContentType type) {
     if (type > SpecialContentType::DLPChild) {
         // TODO(B3N30): Find correct result code

--- a/src/core/hle/service/fs/fs_user.cpp
+++ b/src/core/hle/service/fs/fs_user.cpp
@@ -877,7 +877,7 @@ ResultVal<u16> FS_USER::GetSpecialContentIndexFromTMD(MediaType media_type, u64 
         return ResultCode(-1);
     }
 
-    // TODO(B3N30): Does real 3ds check if content exists in tmd?
+    // TODO(B3N30): Does real 3DS check if content exists in TMD?
 
     switch (type) {
     case SpecialContentType::Manual:

--- a/src/core/hle/service/fs/fs_user.h
+++ b/src/core/hle/service/fs/fs_user.h
@@ -599,7 +599,7 @@ private:
     void GetSaveDataSecureValue(Kernel::HLERequestContext& ctx);
 
     static ResultVal<u16> GetSpecialContentIndexFromGameCard(u64 title_id, SpecialContentType type);
-    static ResultVal<u16> GetSpecialContentIndexFromTDM(MediaType media_type, u64 title_id,
+    static ResultVal<u16> GetSpecialContentIndexFromTMD(MediaType media_type, u64 title_id,
                                                         SpecialContentType type);
 
     struct ProgramInfo {

--- a/src/core/hle/service/fs/fs_user.h
+++ b/src/core/hle/service/fs/fs_user.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <unordered_map>
 #include <boost/serialization/base_object.hpp>
 #include "common/common_types.h"
 #include "core/hle/service/service.h"
@@ -37,6 +38,10 @@ private:
 class FS_USER final : public ServiceFramework<FS_USER, ClientSlot> {
 public:
     explicit FS_USER(Core::System& system);
+
+    // On real HW this is part of FS:Reg. But since that module is only used by loader and pm, which
+    // we HLEed, we can just directly use it here
+    void Register(u32 process_id, u64 program_id, MediaType media_type);
 
 private:
     void Initialize(Kernel::HLERequestContext& ctx);
@@ -576,6 +581,13 @@ private:
      *      3-4 : Secure Value
      */
     void GetSaveDataSecureValue(Kernel::HLERequestContext& ctx);
+
+    struct ProgramInfo {
+        u64 program_id;
+        MediaType media_type;
+    };
+
+    std::unordered_map<u32, ProgramInfo> program_info_map;
 
     u32 priority = -1; ///< For SetPriority and GetPriority service functions
 

--- a/src/core/hle/service/fs/fs_user.h
+++ b/src/core/hle/service/fs/fs_user.h
@@ -41,7 +41,9 @@ public:
 
     // On real HW this is part of FS:Reg. But since that module is only used by loader and pm, which
     // we HLEed, we can just directly use it here
-    void Register(u32 process_id, u64 program_id, MediaType media_type);
+    void Register(u32 process_id, u64 program_id, const std::string& filepath);
+
+    std::string GetCurrentGamecardPath() const;
 
 private:
     void Initialize(Kernel::HLERequestContext& ctx);
@@ -531,6 +533,20 @@ private:
     void ObsoletedDeleteExtSaveData(Kernel::HLERequestContext& ctx);
 
     /**
+     * FS_User::GetSpecialContentIndex service function.
+     *  Inputs:
+     *      0 : 0x083A0100
+     *      1 : Media type
+     *    2-3 : Program ID
+     *      4 : Special content type
+     *  Outputs:
+     *      0 : 0x083A0080
+     *      1 : Result of function, 0 on success, otherwise error code
+     *      2 : Special content index
+     */
+    void GetSpecialContentIndex(Kernel::HLERequestContext& ctx);
+
+    /**
      * FS_User::GetNumSeeds service function.
      *  Inputs:
      *      0 : 0x087D0000
@@ -582,12 +598,17 @@ private:
      */
     void GetSaveDataSecureValue(Kernel::HLERequestContext& ctx);
 
+    static ResultVal<u16> GetSpecialContentIndexFromGameCard(u64 title_id, SpecialContentType type);
+    static ResultVal<u16> GetSpecialContentIndexFromTDM(MediaType media_type, u64 title_id,
+                                                        SpecialContentType type);
+
     struct ProgramInfo {
         u64 program_id;
         MediaType media_type;
     };
 
     std::unordered_map<u32, ProgramInfo> program_info_map;
+    std::string current_gamecard_path;
 
     u32 priority = -1; ///< For SetPriority and GetPriority service functions
 

--- a/src/core/loader/3dsx.cpp
+++ b/src/core/loader/3dsx.cpp
@@ -278,8 +278,7 @@ ResultStatus AppLoader_THREEDSX::Load(std::shared_ptr<Kernel::Process>& process)
     // On real HW this is done with FS:Reg, but we can be lazy
     auto fs_user =
         Core::System::GetInstance().ServiceManager().GetService<Service::FS::FS_USER>("fs:USER");
-    fs_user->Register(process->GetObjectId(), process->codeset->program_id,
-                      Service::FS::GetMediaTypeFromPath(filepath));
+    fs_user->Register(process->GetObjectId(), process->codeset->program_id, filepath);
 
     process->Run(48, Kernel::DEFAULT_STACK_SIZE);
 

--- a/src/core/loader/3dsx.cpp
+++ b/src/core/loader/3dsx.cpp
@@ -9,6 +9,7 @@
 #include "core/hle/kernel/process.h"
 #include "core/hle/kernel/resource_limit.h"
 #include "core/hle/service/fs/archive.h"
+#include "core/hle/service/fs/fs_user.h"
 #include "core/loader/3dsx.h"
 #include "core/memory.h"
 
@@ -273,6 +274,12 @@ ResultStatus AppLoader_THREEDSX::Load(std::shared_ptr<Kernel::Process>& process)
     // Attach the default resource limit (APPLICATION) to the process
     process->resource_limit = Core::System::GetInstance().Kernel().ResourceLimit().GetForCategory(
         Kernel::ResourceLimitCategory::APPLICATION);
+
+    // On real HW this is done with FS:Reg, but we can be lazy
+    auto fs_user =
+        Core::System::GetInstance().ServiceManager().GetService<Service::FS::FS_USER>("fs:USER");
+    fs_user->Register(process->GetObjectId(), process->codeset->program_id,
+                      Service::FS::GetMediaTypeFromPath(filepath));
 
     process->Run(48, Kernel::DEFAULT_STACK_SIZE);
 

--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -21,6 +21,7 @@
 #include "core/hle/service/am/am.h"
 #include "core/hle/service/cfg/cfg.h"
 #include "core/hle/service/fs/archive.h"
+#include "core/hle/service/fs/fs_user.h"
 #include "core/loader/ncch.h"
 #include "core/loader/smdh.h"
 #include "core/memory.h"
@@ -142,6 +143,12 @@ ResultStatus AppLoader_NCCH::LoadExec(std::shared_ptr<Kernel::Process>& process)
 
         s32 priority = overlay_ncch->exheader_header.arm11_system_local_caps.priority;
         u32 stack_size = overlay_ncch->exheader_header.codeset_info.stack_size;
+
+        // On real HW this is done with FS:Reg, but we can be lazy
+        auto fs_user = Core::System::GetInstance().ServiceManager().GetService<Service::FS::FS_USER>("fs:USER");
+        fs_user->Register(process->process_id, process->codeset->program_id,
+                          Service::FS::GetMediaTypeFromPath(filepath));
+
         process->Run(priority, stack_size);
         return ResultStatus::Success;
     }

--- a/src/core/loader/ncch.cpp
+++ b/src/core/loader/ncch.cpp
@@ -145,9 +145,10 @@ ResultStatus AppLoader_NCCH::LoadExec(std::shared_ptr<Kernel::Process>& process)
         u32 stack_size = overlay_ncch->exheader_header.codeset_info.stack_size;
 
         // On real HW this is done with FS:Reg, but we can be lazy
-        auto fs_user = Core::System::GetInstance().ServiceManager().GetService<Service::FS::FS_USER>("fs:USER");
-        fs_user->Register(process->process_id, process->codeset->program_id,
-                          Service::FS::GetMediaTypeFromPath(filepath));
+        auto fs_user =
+            Core::System::GetInstance().ServiceManager().GetService<Service::FS::FS_USER>(
+                "fs:USER");
+        fs_user->Register(process->process_id, process->codeset->program_id, filepath);
 
         process->Run(priority, stack_size);
         return ResultStatus::Success;


### PR DESCRIPTION
This allows games to open other partitions than partition 0 from NCSDs (aka .3ds files).

For that the NCSD header is parsed instead of being skipped. To open another partition we need to keep track of which (3ds) file is currently open on which process. On real HW the loader does something similar by registering the process and media type with FS:Reg::Register. 

We can skip the FS:Reg module and just store the information in FS_User, since there we need it.

I also added the FS_USER::GetSpecialContentIndex changes in here since they rely on the NCSD changes. So this superseds #5329

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5345)
<!-- Reviewable:end -->
