### PR TITLE
Interpolate circle pad motion

### DIFF
--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <cstddef>
 #include <memory>
+#include <vector>
 #include <boost/serialization/version.hpp>
 #include "common/bit_field.h"
 #include "common/common_funcs.h"
@@ -317,6 +318,14 @@ private:
     // The HID module of a 3DS does not store the PadState.
     // Storing this here was necessary for emulation specific tasks like cheats or scripting.
     PadState state;
+
+    // xperia64: These are used to averate the previous N raw circle pad inputs with the current raw
+    // input to simulate the sluggishness of a real 3DS circle pad
+    // The Theatrhythm games rely on the circle pad being fairly slow to move, and from empircal
+    // testing, need a minimum of 3 averaging to not drop inputs
+    static constexpr s16 CIRCLE_PAD_AVERAGING = 3;
+    std::vector<s16> circle_pad_old_x = std::vector<s16>(CIRCLE_PAD_AVERAGING - 1, 0);
+    std::vector<s16> circle_pad_old_y = std::vector<s16>(CIRCLE_PAD_AVERAGING - 1, 0);
 
     u32 next_pad_index = 0;
     u32 next_touch_index = 0;


### PR DESCRIPTION
Another attempt at fixing https://github.com/citra-emu/citra/issues/2066

Rather than decreasing the maximum range, interpolate the circle pad by averaging it with the previous two inputs.

I have confirmed on hardware using Luma3DS InputRedirection that Theatrhythm is bugged if you recreate the same "perfect" input conditions that Citra provides, i.e. circle pad center calibrated to 0 where the circle pad value can jump to any any other value in one step. This is generally not an issue on a real 3DS because the circle pad is sluggish, and takes longer than the roughly measured ~4ms update cycle of HID and ~2.5ms sampling rate of CODEC (the circle pad ADC).

CIRCLE_PAD_AVERAGING is set to 3, as I found Theatrhythm would still drop input when setting it lower. (CIRCLE_PAD_AVERAGING of 3 means it averages the current raw pad input with the previous two raw pad inputs before passing it along).


I've also corrected the maximum input range (again), this time measured from a 3DS. This value was obtained by performing system setting circle pad calibration with Input Redirector set to a very large range, and examining the values read by a homebrew. I've also corrected rounding in the conversion, as the 3DS clearly rounds rather than truncates.

TODO (these can probably be done in a separate PR if even needed):
Is there anything that should be similarly updated on the Circle Pad Pro side of things (IR)?
How does the N3DS nub work? Does it technically go through the IR API or something else that would need to be updated too? (Since I can't get it to register in some input testing homebrew)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5350)
<!-- Reviewable:end -->
