### PR TITLE
UDS: Only return beacons that have the desired wlan_comm_id

### DIFF
--- a/src/core/hle/service/nwm/nwm_uds.h
+++ b/src/core/hle/service/nwm/nwm_uds.h
@@ -433,10 +433,10 @@ private:
     void BeaconBroadcastCallback(u64 userdata, s64 cycles_late);
 
     /**
-     * Returns a list of received 802.11 beacon frames from the specified sender since the last
-     * call.
+     * Returns a list of received 802.11 beacon frames from the specified sender and with the
+     * specified wlan_comm_id since the last call.
      */
-    std::list<Network::WifiPacket> GetReceivedBeacons(const MacAddress& sender);
+    std::list<Network::WifiPacket> GetReceivedBeacons(const MacAddress& sender, u32 wlan_comm_id);
 
     /*
      * Returns an available index in the nodes array for the

--- a/src/core/hle/service/nwm/uds_beacon.cpp
+++ b/src/core/hle/service/nwm/uds_beacon.cpp
@@ -24,9 +24,6 @@ constexpr u64 DefaultNetworkUptime = 900000000; // 15 minutes in microseconds.
 // broadcasting a Super Smash Bros. 4 lobby.
 constexpr u16 DefaultExtraCapabilities = 0x0431;
 
-// Size of the SSID broadcast by an UDS beacon frame.
-constexpr u8 UDSBeaconSSIDSize = 8;
-
 // The maximum size of the data stored in the EncryptedData0 tag (24).
 constexpr u32 EncryptedDataSizeCutoff = 0xFA;
 

--- a/src/core/hle/service/nwm/uds_beacon.h
+++ b/src/core/hle/service/nwm/uds_beacon.h
@@ -16,6 +16,9 @@ namespace Service::NWM {
 using MacAddress = std::array<u8, 6>;
 constexpr std::array<u8, 3> NintendoOUI = {0x00, 0x1F, 0x32};
 
+// Size of the SSID broadcast by an UDS beacon frame.
+constexpr u8 UDSBeaconSSIDSize = 8;
+
 /**
  * Internal vendor-specific tag ids as stored inside
  * VendorSpecific blocks in the Beacon frames.
@@ -122,6 +125,14 @@ struct BeaconData {
 #pragma pack(pop)
 
 static_assert(sizeof(BeaconData) == 0x12, "BeaconData has incorrect size.");
+
+struct DecryptedBeacon {
+    BeaconFrameHeader header;
+    TagHeader ssid_header;
+    std::array<u8, UDSBeaconSSIDSize> ssid;
+    DummyTag dummy;
+    NetworkInfoTag network_info;
+};
 
 /**
  * Decrypts the beacon data buffer for the network described by `network_info`.


### PR DESCRIPTION
Continuation of the work of Valentin Vanelslande.

**Original description**:
Fixes #3965
All my games with multiplayer work after this change.
Doesn't need a multiplayer version bump.
Video: https://youtu.be/zPld1v2nME4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5355)
<!-- Reviewable:end -->
