### PR TITLE
Avoid leaking cubeb input stream

### DIFF
--- a/src/audio_core/cubeb_input.cpp
+++ b/src/audio_core/cubeb_input.cpp
@@ -37,7 +37,7 @@ CubebInput::~CubebInput() {
     if (!impl->ctx)
         return;
 
-    if (cubeb_stream_stop(impl->stream) != CUBEB_OK) {
+    if (impl->stream && cubeb_stream_stop(impl->stream) != CUBEB_OK) {
         LOG_ERROR(Audio, "Error stopping cubeb input stream.");
     }
 
@@ -103,8 +103,11 @@ void CubebInput::StartSampling(const Frontend::Mic::Parameters& params) {
 }
 
 void CubebInput::StopSampling() {
+    // TODO(xperia64): Destroy the stream for now to avoid a leak because StartSampling reinitializes the stream every time
     if (impl->stream) {
         cubeb_stream_stop(impl->stream);
+        cubeb_stream_destroy(impl->stream);
+        impl->stream = nullptr;
     }
     is_sampling = false;
 }

--- a/src/audio_core/cubeb_input.cpp
+++ b/src/audio_core/cubeb_input.cpp
@@ -37,8 +37,12 @@ CubebInput::~CubebInput() {
     if (!impl->ctx)
         return;
 
-    if (impl->stream && cubeb_stream_stop(impl->stream) != CUBEB_OK) {
-        LOG_ERROR(Audio, "Error stopping cubeb input stream.");
+    if (impl->stream) {
+        if (cubeb_stream_stop(impl->stream) != CUBEB_OK) {
+            LOG_ERROR(Audio, "Error stopping cubeb input stream.");
+        }
+
+        cubeb_stream_destroy(impl->stream);
     }
 
     cubeb_destroy(impl->ctx);
@@ -103,7 +107,8 @@ void CubebInput::StartSampling(const Frontend::Mic::Parameters& params) {
 }
 
 void CubebInput::StopSampling() {
-    // TODO(xperia64): Destroy the stream for now to avoid a leak because StartSampling reinitializes the stream every time
+    // TODO(xperia64): Destroy the stream for now to avoid a leak because StartSampling
+    // reinitializes the stream every time
     if (impl->stream) {
         cubeb_stream_stop(impl->stream);
         cubeb_stream_destroy(impl->stream);


### PR DESCRIPTION
Games that access the microphone can end up calling StartSampling and StopSampling many times over.

Previously, cubeb_input.cpp created the input stream every time StartSampling was called, causing it to leak as StopSampling only stopped the stream, rather than destroying and releasing it.

For now, let's destroy the stream in StopSampling until this can be improved further.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5356)
<!-- Reviewable:end -->
