### PR TITLE
applets/swkbd: Fix button order received from button_text

### DIFF
--- a/src/citra_qt/applets/swkbd.cpp
+++ b/src/citra_qt/applets/swkbd.cpp
@@ -49,7 +49,7 @@ QtKeyboardDialog::QtKeyboardDialog(QWidget* parent, QtKeyboard* keyboard_)
         break;
     case ButtonConfig::Dual:
         buttons->addButton(config.has_custom_button_text
-                               ? QString::fromStdString(config.button_text[1])
+                               ? QString::fromStdString(config.button_text[2])
                                : tr(SWKBD_BUTTON_OKAY),
                            QDialogButtonBox::ButtonRole::AcceptRole);
         buttons->addButton(config.has_custom_button_text
@@ -59,7 +59,7 @@ QtKeyboardDialog::QtKeyboardDialog(QWidget* parent, QtKeyboard* keyboard_)
         break;
     case ButtonConfig::Single:
         buttons->addButton(config.has_custom_button_text
-                               ? QString::fromStdString(config.button_text[0])
+                               ? QString::fromStdString(config.button_text[2])
                                : tr(SWKBD_BUTTON_OKAY),
                            QDialogButtonBox::ButtonRole::AcceptRole);
         break;

--- a/src/core/hle/applets/swkbd.cpp
+++ b/src/core/hle/applets/swkbd.cpp
@@ -201,8 +201,7 @@ Frontend::KeyboardConfig SoftwareKeyboard::ToFrontendConfig(
                      });
     if (frontend_config.has_custom_button_text) {
         for (const auto& text : config.button_text) {
-            if (text.front() != 0)
-                frontend_config.button_text.push_back(Common::UTF16BufferToUTF8(text));
+            frontend_config.button_text.push_back(Common::UTF16BufferToUTF8(text));
         }
     }
     frontend_config.filters.prevent_digit =

--- a/src/core/hle/applets/swkbd.cpp
+++ b/src/core/hle/applets/swkbd.cpp
@@ -201,7 +201,8 @@ Frontend::KeyboardConfig SoftwareKeyboard::ToFrontendConfig(
                      });
     if (frontend_config.has_custom_button_text) {
         for (const auto& text : config.button_text) {
-            frontend_config.button_text.push_back(Common::UTF16BufferToUTF8(text));
+            if (text.front() != 0)
+                frontend_config.button_text.push_back(Common::UTF16BufferToUTF8(text));
         }
     }
     frontend_config.filters.prevent_digit =


### PR DESCRIPTION
Fixes #5359

If an app sends custom button texts, none of them should be empty. Leaving an empty element will mess with the index, causing the frontend to add the wrong button text. This can also be merged to [citra-android](https://github.com/citra-emu/citra-android) as the issue is related to the core, not the frontend.

[Working button text](https://i.imgur.com/kvnJfoX.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5362)
<!-- Reviewable:end -->
