### PR TITLE
.github: add a new issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-feature-request.md
@@ -1,3 +1,12 @@
+---
+name: Bug Report / Feature Request
+about: Tech support does not belong here. You should only file an issue here if you think you have experienced an actual bug with Citra or you are requesting a feature you believe would make Citra better.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
 <!---
 
 Please read the FAQ:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Citra Discord
+    url: https://citra-emu.org/discord/
+    about: If you are experiencing an issue with Citra, and you need tech support, or if you have a general question, try asking in the official Citra Discord linked here. Piracy is not allowed.
+  - name: Community forums
+    url: https://community.citra-emu.org
+    about: This is an alternative place for tech support, however helpers there are not as active.
+  - name: Citra Android
+    url: https://github.com/citra-emu/citra-android
+    about: If you need tech support on Citra Android, you should use either of the above two options. If you want to file an issue, you should go to the Android repo linked here.


### PR DESCRIPTION
Hopefully this will decrease the number of users using GitHub issues for tech support requests.

Adds links to the discord, forums, and android repo for users reporting android bugs. There is a hyperlink at the bottom of the template page for those who want to create an actual issue.

<img src="https://i.imgur.com/o28DHHR.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5364)
<!-- Reviewable:end -->
