### PR TITLE
Actually save the input when clearing/resetting to default

### DIFF
--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -367,6 +367,9 @@ void ConfigureInput::RestoreDefaults() {
         }
     }
     UpdateButtonLabels();
+
+    ApplyConfiguration();
+    Settings::SaveProfile(Settings::values.current_input_profile_index);
 }
 
 void ConfigureInput::ClearAll() {
@@ -378,6 +381,9 @@ void ConfigureInput::ClearAll() {
         analogs_param[analog_id].Clear();
     }
     UpdateButtonLabels();
+
+    ApplyConfiguration();
+    Settings::SaveProfile(Settings::values.current_input_profile_index);
 }
 
 void ConfigureInput::UpdateButtonLabels() {


### PR DESCRIPTION
Previously I would have to reset the input to default every single time I opened Citra if I just wanted the default keyboard binds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5376)
<!-- Reviewable:end -->
