### PR TITLE
Port yuzu-emu/yuzu#3954: "main: Log host system memory parameters"

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -213,6 +213,10 @@ GMainWindow::GMainWindow()
     LOG_INFO(Frontend, "Host CPU: {}", cpu_string);
 #endif
     LOG_INFO(Frontend, "Host OS: {}", QSysInfo::prettyProductName().toStdString());
+    LOG_INFO(Frontend, "Host RAM: {:.2f} GB",
+             Common::GetMemInfo().TotalPhysicalMemory / 1024.0f / 1024 / 1024);
+    LOG_INFO(Frontend, "Host Swap: {:.2f} GB",
+             Common::GetMemInfo().TotalSwapMemory / 1024.0f / 1024 / 1024);
     UpdateWindowTitle();
 
     show();

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -65,6 +65,7 @@
 #include "common/logging/filter.h"
 #include "common/logging/log.h"
 #include "common/logging/text_formatter.h"
+#include "common/memory_detect.h"
 #include "common/microprofile.h"
 #include "common/scm_rev.h"
 #include "common/scope_exit.h"

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -61,6 +61,7 @@
 #include "common/common_paths.h"
 #include "common/detached_tasks.h"
 #include "common/file_util.h"
+#include "common/literals.h"
 #include "common/logging/backend.h"
 #include "common/logging/filter.h"
 #include "common/logging/log.h"
@@ -214,10 +215,10 @@ GMainWindow::GMainWindow()
     LOG_INFO(Frontend, "Host CPU: {}", cpu_string);
 #endif
     LOG_INFO(Frontend, "Host OS: {}", QSysInfo::prettyProductName().toStdString());
-    LOG_INFO(Frontend, "Host RAM: {:.2f} GB",
-             Common::GetMemInfo().TotalPhysicalMemory / 1024.0f / 1024 / 1024);
-    LOG_INFO(Frontend, "Host Swap: {:.2f} GB",
-             Common::GetMemInfo().TotalSwapMemory / 1024.0f / 1024 / 1024);
+    const auto& mem_info = Common::GetMemInfo();
+    using namespace Common::Literals;
+    LOG_INFO(Frontend, "Host RAM: {:.2f} GiB", mem_info.total_physical_memory / f64{1_GiB});
+    LOG_INFO(Frontend, "Host Swap: {:.2f} GiB", mem_info.total_swap_memory / f64{1_GiB});
     UpdateWindowTitle();
 
     show();

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -83,6 +83,8 @@ add_library(common STATIC
     logging/text_formatter.cpp
     logging/text_formatter.h
     math_util.h
+    memory_detect.cpp
+    memory_detect.h
     memory_ref.h
     memory_ref.cpp
     microprofile.cpp

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -74,6 +74,7 @@ add_library(common STATIC
     file_util.h
     hash.h
     linear_disk_cache.h
+    literals.h
     logging/backend.cpp
     logging/backend.h
     logging/filter.cpp

--- a/src/common/literals.h
+++ b/src/common/literals.h
@@ -1,0 +1,31 @@
+// Copyright 2021 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "common/common_types.h"
+
+namespace Common::Literals {
+
+constexpr u64 operator""_KiB(unsigned long long int x) {
+    return 1024ULL * x;
+}
+
+constexpr u64 operator""_MiB(unsigned long long int x) {
+    return 1024_KiB * x;
+}
+
+constexpr u64 operator""_GiB(unsigned long long int x) {
+    return 1024_MiB * x;
+}
+
+constexpr u64 operator""_TiB(unsigned long long int x) {
+    return 1024_GiB * x;
+}
+
+constexpr u64 operator""_PiB(unsigned long long int x) {
+    return 1024_TiB * x;
+}
+
+} // namespace Common::Literals

--- a/src/common/memory_detect.cpp
+++ b/src/common/memory_detect.cpp
@@ -33,10 +33,13 @@ static MemoryInfo Detect() {
 #elif defined(__APPLE__)
     u64 ramsize;
     struct xsw_usage vmusage;
+    std::size_t sizeof_ramsize = sizeof(ramsize);
+    std::size_t sizeof_vmusage = sizeof(vmusage);
     // hw and vm are defined in sysctl.h
     // https://github.com/apple/darwin-xnu/blob/master/bsd/sys/sysctl.h#L471
-    sysctlbyname(hw.memsize, &ramsize, sizeof(ramsize), NULL, 0);
-    sysctlbyname(vm.swapusage, &vmusage, sizeof(vmusage), NULL, 0);
+    // sysctlbyname(const char *, void *, size_t *, void *, size_t);
+    sysctlbyname("hw.memsize", &ramsize, &sizeof_ramsize, NULL, 0);
+    sysctlbyname("vm.swapusage", &vmusage, &sizeof_vmusage, NULL, 0);
     mem_info.TotalPhysicalMemory = ramsize;
     mem_info.TotalSwapMemory = vmusage.xsu_total;
 #else

--- a/src/common/memory_detect.cpp
+++ b/src/common/memory_detect.cpp
@@ -1,0 +1,57 @@
+// Copyright 2020 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#ifdef _WIN32
+// clang-format off
+#include <windows.h>
+#include <sysinfoapi.h>
+// clang-format on
+#else
+#include <sys/types.h>
+#ifdef __APPLE__
+#include <sys/sysctl.h>
+#else
+#include <sys/sysinfo.h>
+#endif
+#endif
+
+#include "common/memory_detect.h"
+
+namespace Common {
+
+// Detects the RAM and Swapfile sizes
+static MemoryInfo Detect() {
+    MemoryInfo mem_info{};
+
+#ifdef _WIN32
+    MEMORYSTATUSEX memorystatus;
+    memorystatus.dwLength = sizeof(memorystatus);
+    GlobalMemoryStatusEx(&memorystatus);
+    mem_info.TotalPhysicalMemory = memorystatus.ullTotalPhys;
+    mem_info.TotalSwapMemory = memorystatus.ullTotalPageFile - mem_info.TotalPhysicalMemory;
+#elif defined(__APPLE__)
+    u64 ramsize;
+    struct xsw_usage vmusage;
+    // hw and vm are defined in sysctl.h
+    // https://github.com/apple/darwin-xnu/blob/master/bsd/sys/sysctl.h#L471
+    sysctlbyname(hw.memsize, &ramsize, sizeof(ramsize), NULL, 0);
+    sysctlbyname(vm.swapusage, &vmusage, sizeof(vmusage), NULL, 0);
+    mem_info.TotalPhysicalMemory = ramsize;
+    mem_info.TotalSwapMemory = vmusage.xsu_total;
+#else
+    struct sysinfo meminfo;
+    sysinfo(&meminfo);
+    mem_info.TotalPhysicalMemory = meminfo.totalram;
+    mem_info.TotalSwapMemory = meminfo.totalswap;
+#endif
+
+    return mem_info;
+}
+
+const MemoryInfo& GetMemInfo() {
+    static MemoryInfo mem_info = Detect();
+    return mem_info;
+}
+
+} // namespace Common

--- a/src/common/memory_detect.cpp
+++ b/src/common/memory_detect.cpp
@@ -40,16 +40,16 @@ static MemoryInfo Detect() {
     // hw and vm are defined in sysctl.h
     // https://github.com/apple/darwin-xnu/blob/master/bsd/sys/sysctl.h#L471
     // sysctlbyname(const char *, void *, size_t *, void *, size_t);
-    sysctlbyname("hw.memsize", &ramsize, &sizeof_ramsize, NULL, 0);
-    sysctlbyname("vm.swapusage", &vmusage, &sizeof_vmusage, NULL, 0);
+    sysctlbyname("hw.memsize", &ramsize, &sizeof_ramsize, nullptr, 0);
+    sysctlbyname("vm.swapusage", &vmusage, &sizeof_vmusage, nullptr, 0);
     mem_info.TotalPhysicalMemory = ramsize;
     mem_info.TotalSwapMemory = vmusage.xsu_total;
 #elif defined(__FreeBSD__)
     u_long physmem, swap_total;
     std::size_t sizeof_u_long = sizeof(u_long);
     // sysctlbyname(const char *, void *, size_t *, const void *, size_t);
-    sysctlbyname("hw.physmem", &physmem, &sizeof_u_long, NULL, 0);
-    sysctlbyname("vm.swap_total", &swap_total, &sizeof_u_long, NULL, 0);
+    sysctlbyname("hw.physmem", &physmem, &sizeof_u_long, nullptr, 0);
+    sysctlbyname("vm.swap_total", &swap_total, &sizeof_u_long, nullptr, 0);
     mem_info.TotalPhysicalMemory = physmem;
     mem_info.TotalSwapMemory = swap_total;
 #elif defined(__linux__)

--- a/src/common/memory_detect.cpp
+++ b/src/common/memory_detect.cpp
@@ -3,10 +3,9 @@
 // Refer to the license.txt file included.
 
 #ifdef _WIN32
-// clang-format off
 #include <windows.h>
+// Depends on <windows.h> coming first
 #include <sysinfoapi.h>
-// clang-format on
 #else
 #include <sys/types.h>
 #if defined(__APPLE__) || defined(__FreeBSD__)
@@ -23,15 +22,15 @@
 namespace Common {
 
 // Detects the RAM and Swapfile sizes
-static MemoryInfo Detect() {
+const MemoryInfo GetMemInfo() {
     MemoryInfo mem_info{};
 
 #ifdef _WIN32
     MEMORYSTATUSEX memorystatus;
     memorystatus.dwLength = sizeof(memorystatus);
     GlobalMemoryStatusEx(&memorystatus);
-    mem_info.TotalPhysicalMemory = memorystatus.ullTotalPhys;
-    mem_info.TotalSwapMemory = memorystatus.ullTotalPageFile - mem_info.TotalPhysicalMemory;
+    mem_info.total_physical_memory = memorystatus.ullTotalPhys;
+    mem_info.total_swap_memory = memorystatus.ullTotalPageFile - mem_info.total_physical_memory;
 #elif defined(__APPLE__)
     u64 ramsize;
     struct xsw_usage vmusage;
@@ -42,31 +41,26 @@ static MemoryInfo Detect() {
     // sysctlbyname(const char *, void *, size_t *, void *, size_t);
     sysctlbyname("hw.memsize", &ramsize, &sizeof_ramsize, nullptr, 0);
     sysctlbyname("vm.swapusage", &vmusage, &sizeof_vmusage, nullptr, 0);
-    mem_info.TotalPhysicalMemory = ramsize;
-    mem_info.TotalSwapMemory = vmusage.xsu_total;
+    mem_info.total_physical_memory = ramsize;
+    mem_info.total_swap_memory = vmusage.xsu_total;
 #elif defined(__FreeBSD__)
     u_long physmem, swap_total;
     std::size_t sizeof_u_long = sizeof(u_long);
     // sysctlbyname(const char *, void *, size_t *, const void *, size_t);
     sysctlbyname("hw.physmem", &physmem, &sizeof_u_long, nullptr, 0);
     sysctlbyname("vm.swap_total", &swap_total, &sizeof_u_long, nullptr, 0);
-    mem_info.TotalPhysicalMemory = physmem;
-    mem_info.TotalSwapMemory = swap_total;
+    mem_info.total_physical_memory = physmem;
+    mem_info.total_swap_memory = swap_total;
 #elif defined(__linux__)
     struct sysinfo meminfo;
     sysinfo(&meminfo);
-    mem_info.TotalPhysicalMemory = meminfo.totalram;
-    mem_info.TotalSwapMemory = meminfo.totalswap;
+    mem_info.total_physical_memory = meminfo.totalram;
+    mem_info.total_swap_memory = meminfo.totalswap;
 #else
-    mem_info.TotalPhysicalMemory = sysconf(_SC_PHYS_PAGES) * sysconf(_SC_PAGE_SIZE);
-    mem_info.TotalSwapMemory = 0;
+    mem_info.total_physical_memory = sysconf(_SC_PHYS_PAGES) * sysconf(_SC_PAGE_SIZE);
+    mem_info.total_swap_memory = 0;
 #endif
 
-    return mem_info;
-}
-
-const MemoryInfo& GetMemInfo() {
-    static MemoryInfo mem_info = Detect();
     return mem_info;
 }
 

--- a/src/common/memory_detect.h
+++ b/src/common/memory_detect.h
@@ -1,0 +1,22 @@
+// Copyright 2020 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "common/common_types.h"
+
+namespace Common {
+
+struct MemoryInfo {
+    u64 TotalPhysicalMemory{};
+    u64 TotalSwapMemory{};
+};
+
+/**
+ * Gets the memory info of the host system
+ * @return Reference to a MemoryInfo struct with the physical and swap memory sizes in bytes
+ */
+const MemoryInfo& GetMemInfo();
+
+} // namespace Common

--- a/src/common/memory_detect.h
+++ b/src/common/memory_detect.h
@@ -9,14 +9,14 @@
 namespace Common {
 
 struct MemoryInfo {
-    u64 TotalPhysicalMemory{};
-    u64 TotalSwapMemory{};
+    u64 total_physical_memory{};
+    u64 total_swap_memory{};
 };
 
 /**
  * Gets the memory info of the host system
  * @return Reference to a MemoryInfo struct with the physical and swap memory sizes in bytes
  */
-const MemoryInfo& GetMemInfo();
+[[nodiscard]] const MemoryInfo GetMemInfo();
 
 } // namespace Common


### PR DESCRIPTION
See yuzu-emu/yuzu#3954 for more details.

**Original description**:
Logs both physical memory and swap(file) sizes. These values are useful when giving support as yuzu requires a large pagefile/swap(file) in cases of low physical memory (less than 8 GB) to prevent early crashes.

Tested on both Windows and Linux, ~~macOS is untested.~~

**Update**: macOS is unit tested and verified to work on macOS High Sierra 10.13.6

In the log, it will show these 2 lines:

```
Host RAM: 15.85 GB
Host Swap: 16.00 GB
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5380)
<!-- Reviewable:end -->
