### PR TITLE
applets/swkbd: Properly handle button_text

### DIFF
--- a/src/citra_qt/applets/swkbd.cpp
+++ b/src/citra_qt/applets/swkbd.cpp
@@ -34,33 +34,21 @@ QtKeyboardDialog::QtKeyboardDialog(QWidget* parent, QtKeyboard* keyboard_)
     // Initialize buttons
     switch (config.button_config) {
     case ButtonConfig::Triple:
-        buttons->addButton(config.has_custom_button_text
-                               ? QString::fromStdString(config.button_text[2])
-                               : tr(SWKBD_BUTTON_OKAY),
-                           QDialogButtonBox::ButtonRole::AcceptRole);
-        buttons->addButton(config.has_custom_button_text
-                               ? QString::fromStdString(config.button_text[1])
-                               : tr(SWKBD_BUTTON_FORGOT),
+        buttons->addButton(config.button_text[1].empty()
+                               ? tr(SWKBD_BUTTON_FORGOT)
+                               : QString::fromStdString(config.button_text[1]),
                            QDialogButtonBox::ButtonRole::HelpRole);
-        buttons->addButton(config.has_custom_button_text
-                               ? QString::fromStdString(config.button_text[0])
-                               : tr(SWKBD_BUTTON_CANCEL),
-                           QDialogButtonBox::ButtonRole::RejectRole);
-        break;
+    // fallthrough
     case ButtonConfig::Dual:
-        buttons->addButton(config.has_custom_button_text
-                               ? QString::fromStdString(config.button_text[2])
-                               : tr(SWKBD_BUTTON_OKAY),
-                           QDialogButtonBox::ButtonRole::AcceptRole);
-        buttons->addButton(config.has_custom_button_text
-                               ? QString::fromStdString(config.button_text[0])
-                               : tr(SWKBD_BUTTON_CANCEL),
+        buttons->addButton(config.button_text[0].empty()
+                               ? tr(SWKBD_BUTTON_CANCEL)
+                               : QString::fromStdString(config.button_text[0]),
                            QDialogButtonBox::ButtonRole::RejectRole);
-        break;
+    // fallthrough
     case ButtonConfig::Single:
-        buttons->addButton(config.has_custom_button_text
-                               ? QString::fromStdString(config.button_text[2])
-                               : tr(SWKBD_BUTTON_OKAY),
+        buttons->addButton(config.button_text[2].empty()
+                               ? tr(SWKBD_BUTTON_OKAY)
+                               : QString::fromStdString(config.button_text[2]),
                            QDialogButtonBox::ButtonRole::AcceptRole);
         break;
     case ButtonConfig::None:

--- a/src/citra_qt/applets/swkbd.cpp
+++ b/src/citra_qt/applets/swkbd.cpp
@@ -38,13 +38,13 @@ QtKeyboardDialog::QtKeyboardDialog(QWidget* parent, QtKeyboard* keyboard_)
                                ? tr(SWKBD_BUTTON_FORGOT)
                                : QString::fromStdString(config.button_text[1]),
                            QDialogButtonBox::ButtonRole::HelpRole);
-    // fallthrough
+        [[fallthrough]];
     case ButtonConfig::Dual:
         buttons->addButton(config.button_text[0].empty()
                                ? tr(SWKBD_BUTTON_CANCEL)
                                : QString::fromStdString(config.button_text[0]),
                            QDialogButtonBox::ButtonRole::RejectRole);
-    // fallthrough
+        [[fallthrough]];
     case ButtonConfig::Single:
         buttons->addButton(config.button_text[2].empty()
                                ? tr(SWKBD_BUTTON_OKAY)

--- a/src/core/frontend/applets/swkbd.h
+++ b/src/core/frontend/applets/swkbd.h
@@ -38,12 +38,11 @@ constexpr char SWKBD_BUTTON_FORGOT[] = "I Forgot";
 /// later learn is needed can be added here and filled in by the backend HLE applet
 struct KeyboardConfig {
     ButtonConfig button_config;
-    AcceptedInput accept_mode;   /// What kinds of input are accepted (blank/empty/fixed width)
-    bool multiline_mode;         /// True if the keyboard accepts multiple lines of input
-    u16 max_text_length;         /// Maximum number of letters allowed if its a text input
-    u16 max_digits;              /// Maximum number of numbers allowed if its a number input
-    std::string hint_text;       /// Displayed in the field as a hint before
-    bool has_custom_button_text; /// If true, use the button_text instead
+    AcceptedInput accept_mode; /// What kinds of input are accepted (blank/empty/fixed width)
+    bool multiline_mode;       /// True if the keyboard accepts multiple lines of input
+    u16 max_text_length;       /// Maximum number of letters allowed if its a text input
+    u16 max_digits;            /// Maximum number of numbers allowed if its a number input
+    std::string hint_text;     /// Displayed in the field as a hint before
     std::vector<std::string> button_text; /// Contains the button text that the caller provides
     struct Filters {
         bool prevent_digit;     /// Limit maximum digit count to max_digits

--- a/src/core/hle/applets/swkbd.cpp
+++ b/src/core/hle/applets/swkbd.cpp
@@ -194,15 +194,8 @@ Frontend::KeyboardConfig SoftwareKeyboard::ToFrontendConfig(
     frontend_config.max_text_length = config.max_text_length;
     frontend_config.max_digits = config.max_digits;
     frontend_config.hint_text = Common::UTF16BufferToUTF8(config.hint_text);
-    frontend_config.has_custom_button_text =
-        !std::all_of(config.button_text.begin(), config.button_text.end(),
-                     [](std::array<u16, HLE::Applets::MAX_BUTTON_TEXT_LEN + 1> x) {
-                         return std::all_of(x.begin(), x.end(), [](u16 x) { return x == 0; });
-                     });
-    if (frontend_config.has_custom_button_text) {
-        for (const auto& text : config.button_text) {
-            frontend_config.button_text.push_back(Common::UTF16BufferToUTF8(text));
-        }
+    for (const auto& text : config.button_text) {
+        frontend_config.button_text.push_back(Common::UTF16BufferToUTF8(text));
     }
     frontend_config.filters.prevent_digit =
         static_cast<bool>(config.filter_flags & SoftwareKeyboardFilter::Digits);


### PR DESCRIPTION
I'm not sure why we decided to have a boolean here, but apparently that wasn't the correct behaviour. According to HW tests, the Software Keyboard simply displays the default text when the button text provided is empty (**not necessarily all zero**). For example, if you set a text for one of the buttons and leave others empty, the button you set will have your text, while others will have their default texts. Removed the boolean and updated frontend code to make it correct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5381)
<!-- Reviewable:end -->
