### PR TITLE
nwm: Eliminate signed conversion warnings

### DIFF
--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -1314,23 +1314,23 @@ void NWM_UDS::DecryptBeaconData(Kernel::HLERequestContext& ctx, u16 command_id) 
 
     // TODO(Subv): Verify the MD5 hash of the data and return 0xE1211005 if invalid.
 
-    u8 num_nodes = net_info.max_nodes;
+    const std::size_t num_nodes = net_info.max_nodes;
 
     std::vector<NodeInfo> nodes;
+    nodes.reserve(num_nodes);
 
-    for (int i = 0; i < num_nodes; ++i) {
+    for (std::size_t i = 0; i < num_nodes; ++i) {
         BeaconNodeInfo info;
         std::memcpy(&info, beacon_data.data() + sizeof(beacon_header) + i * sizeof(info),
                     sizeof(info));
 
         // Deserialize the node information.
-        NodeInfo node{};
+        auto& node = nodes.emplace_back();
         node.friend_code_seed = info.friend_code_seed;
         node.network_node_id = info.network_node_id;
-        for (int i = 0; i < info.username.size(); ++i)
+        for (std::size_t i = 0; i < info.username.size(); ++i) {
             node.username[i] = info.username[i];
-
-        nodes.push_back(node);
+        }
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);

--- a/src/core/hle/service/nwm/uds_beacon.cpp
+++ b/src/core/hle/service/nwm/uds_beacon.cpp
@@ -197,8 +197,9 @@ std::vector<u8> GeneratedEncryptedData(const NetworkInfo& network_info, const No
         BeaconNodeInfo info{};
         info.friend_code_seed = node.friend_code_seed;
         info.network_node_id = node.network_node_id;
-        for (int i = 0; i < info.username.size(); ++i)
+        for (std::size_t i = 0; i < info.username.size(); ++i) {
             info.username[i] = node.username[i];
+        }
 
         buffer.insert(buffer.end(), reinterpret_cast<u8*>(&info),
                       reinterpret_cast<u8*>(&info) + sizeof(info));


### PR DESCRIPTION
While we're at it, we can also improve some of the allocations and copying that would be going on in one case by preallocating and then emplacing before modifying.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5393)
<!-- Reviewable:end -->
