### PR TITLE
fs_user: Resolve sign conversion warning in GetPriority()

### DIFF
--- a/src/core/hle/service/fs/fs_user.cpp
+++ b/src/core/hle/service/fs/fs_user.cpp
@@ -618,7 +618,7 @@ void FS_USER::SetPriority(Kernel::HLERequestContext& ctx) {
 void FS_USER::GetPriority(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x863, 0, 0);
 
-    if (priority == -1) {
+    if (priority == UINT32_MAX) {
         LOG_INFO(Service_FS, "priority was not set, priority=0x{:X}", priority);
     }
 


### PR DESCRIPTION
Prevents a -Wsign-compare warning from occurring.