### PR TITLE
Update teakra, adjust TeakraSlice for new audio frame period

### DIFF
--- a/src/audio_core/lle/lle.cpp
+++ b/src/audio_core/lle/lle.cpp
@@ -146,7 +146,7 @@ struct DspLle::Impl final {
     std::size_t stop_generation;
 
     static constexpr u32 DspDataOffset = 0x40000;
-    static constexpr u32 TeakraSlice = 20000;
+    static constexpr u32 TeakraSlice = 16384;
 
     void TeakraThread() {
         while (true) {


### PR DESCRIPTION
This PR is the equivalent of https://github.com/citra-emu/citra/pull/5266 for the LLE backend.

Previously, Teakra assumed a period of 4100. This was found to be incorrect, and was updated to 4096. While this Teakra update did correct the overall audio sync, it dropped audio entirely from time to time, resulting in large discontinuities in the audio. I found this was related to the TeakraSlice value in the LLE audio backend, and found a value that appears to prevent drop outs with the Teakra update.

This PR is a WIP because I am unsure how the TeakraSlice value should be derived, if it can be at all. It appears the drop outs are caused by Teakra getting "out-of-phase" with the rest of Citra, as if it's exiting before it finishes handing off samples, and carefully selecting a slice value can keep Teakra "in-phase". The value I selected in this update is 16384, or 4096 * 4. The old value of 20000 did not work, nor did 4096 * 5.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5402)
<!-- Reviewable:end -->
