### PR TITLE
Fix WMF AAC Decoder Bug

### DIFF
--- a/src/audio_core/hle/wmf_decoder.cpp
+++ b/src/audio_core/hle/wmf_decoder.cpp
@@ -163,9 +163,10 @@ MFOutputState WMFDecoder::Impl::DecodingLoop(ADTSData adts_header,
             }
         }
 
-        // in case of "ok" only, just return quickly
+        // If we return OK here, the decoder won't be in a state to receive new data and will fail
+        // on the next call; instead treat it like the HaveMoreData case
         if (output_status == MFOutputState::OK)
-            return MFOutputState::OK;
+            continue;
 
         // for status = 2, reset MF
         if (output_status == MFOutputState::NeedReconfig) {


### PR DESCRIPTION
WMF seemed buggy, and produced an unpleasant blip of static (at least in Rhythm Heaven) when AAC streams started, whereas other decoders like FDK didn't have this issue.

Loosely based on the pattern of output_status's I saw in DecodingLoop, as well as this blog post: https://alax.info/blog/1883, I replaced the return in the loop with a continue.

Effectively, if you exit and return when output_status is "OK" or "HaveMoreData", WMF seems to always return a meaningless "NeedMoreInput" during the next call to ReceiveSample regardless of whether it actually "needs more input" or not. If you continue and clear the "NeedMoreInput" state early as was happening with the "HaveMoreData" case, everything works seems to work out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5404)
<!-- Reviewable:end -->
