### PR TITLE
Avoid deadlock when stopping video dumping

### DIFF
--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -1106,7 +1106,7 @@ void RendererOpenGL::UpdateFramerate() {}
 void RendererOpenGL::PrepareVideoDumping() {
     auto* mailbox = static_cast<OGLVideoDumpingMailbox*>(frame_dumper.mailbox.get());
     {
-        std::unique_lock(mailbox->swap_chain_lock);
+        std::unique_lock lock(mailbox->swap_chain_lock);
         mailbox->quit = false;
     }
     frame_dumper.StartDumping();
@@ -1116,7 +1116,7 @@ void RendererOpenGL::CleanupVideoDumping() {
     frame_dumper.StopDumping();
     auto* mailbox = static_cast<OGLVideoDumpingMailbox*>(frame_dumper.mailbox.get());
     {
-        std::unique_lock(mailbox->swap_chain_lock);
+        std::unique_lock lock(mailbox->swap_chain_lock);
         mailbox->quit = true;
     }
     mailbox->free_cv.notify_one();

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -41,6 +41,11 @@ namespace OpenGL {
 // number but 9 swap textures at 60FPS presentation allows for 800% speed so thats probably fine
 constexpr std::size_t SWAP_CHAIN_SIZE = 9;
 
+class OGLTextureMailboxException : public std::runtime_error {
+public:
+    using std::runtime_error::runtime_error;
+};
+
 class OGLTextureMailbox : public Frontend::TextureMailbox {
 public:
     std::mutex swap_chain_lock;
@@ -168,17 +173,22 @@ public:
 /// This mailbox is different in that it will never discard rendered frames
 class OGLVideoDumpingMailbox : public OGLTextureMailbox {
 public:
+    bool quit = false;
+
     Frontend::Frame* GetRenderFrame() override {
         std::unique_lock<std::mutex> lock(swap_chain_lock);
 
         // If theres no free frames, we will wait until one shows up
         if (free_queue.empty()) {
-            free_cv.wait(lock, [&] { return !free_queue.empty(); });
-        }
+            free_cv.wait(lock, [&] { return (!free_queue.empty() || quit); });
+            if (quit) {
+                throw OGLTextureMailboxException("VideoDumpingMailbox quitting");
+            }
 
-        if (free_queue.empty()) {
-            LOG_CRITICAL(Render_OpenGL, "Could not get free frame");
-            return nullptr;
+            if (free_queue.empty()) {
+                LOG_CRITICAL(Render_OpenGL, "Could not get free frame");
+                return nullptr;
+            }
         }
 
         Frontend::Frame* frame = free_queue.front();
@@ -372,7 +382,11 @@ void RendererOpenGL::SwapBuffers() {
     RenderToMailbox(layout, render_window.mailbox, false);
 
     if (frame_dumper.IsDumping()) {
-        RenderToMailbox(frame_dumper.GetLayout(), frame_dumper.mailbox, true);
+        try {
+            RenderToMailbox(frame_dumper.GetLayout(), frame_dumper.mailbox, true);
+        } catch(const OGLTextureMailboxException& exception) {
+            LOG_DEBUG(Render_OpenGL, "Frame dumper exception caught: {}", exception.what());
+        }
     }
 
     m_current_frame++;
@@ -1090,11 +1104,14 @@ void RendererOpenGL::TryPresent(int timeout_ms) {
 void RendererOpenGL::UpdateFramerate() {}
 
 void RendererOpenGL::PrepareVideoDumping() {
+    dynamic_cast<OGLVideoDumpingMailbox*>(frame_dumper.mailbox.get())->quit = false;
     frame_dumper.StartDumping();
 }
 
 void RendererOpenGL::CleanupVideoDumping() {
     frame_dumper.StopDumping();
+    dynamic_cast<OGLVideoDumpingMailbox*>(frame_dumper.mailbox.get())->quit = true;
+    dynamic_cast<OGLTextureMailbox*>(frame_dumper.mailbox.get())->free_cv.notify_one();
 }
 
 static const char* GetSource(GLenum source) {

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -182,7 +182,7 @@ public:
         // If theres no free frames, we will wait until one shows up
         if (free_queue.empty()) {
             free_cv.wait(lock, [&] { return (!free_queue.empty() || quit.load()); });
-            if (quit) {
+            if (quit.load()) {
                 throw OGLTextureMailboxException("VideoDumpingMailbox quitting");
             }
 


### PR DESCRIPTION
When stopping video dumping, deadlock can occur if the user stopped video dumping after `GetRenderFrame` has been called, but before `TryGetPresentFrame` would've been called in `FrameDumperOpenGL::PresentLoop`.

I'm not 100% happy with this solution, but a `quit` variable and an exception were the best way I could come up with to jump out of `GetRenderFrame`.

Without `quit`, `free_cv` would only wake an continue if `free_queue` contained a new frame. Adding an invalid frame or pushing one in `FrameDumperOpenGL` seemed more hacky than just adding a `quit` flag.

An exception caught when trying to render to the frame dumper mailbox seemed like the cleanest way to jump out of `GetRenderFrame`, as otherwise a null check would need to be added to `RenderToMailbox`, which would be unnecessary if rendering to a vanilla `OGLTextureMailbox`.


Please give me feedback on how I am accessing `quit` and `free_cv` in `PrepareVideoDumping` and `CleanupVideoDumping`. A new method for reset/cleanup in `OGLVideoDumpingMailbox` may be cleaner.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5407)
<!-- Reviewable:end -->
