### PR TITLE
Port yuzu-emu/yuzu#4097: "Fix framebuffer size on fractional scaling display."

### DIFF
--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -266,7 +266,7 @@ QByteArray GRenderWindow::saveGeometry() {
 }
 
 qreal GRenderWindow::windowPixelRatio() const {
-    return devicePixelRatio();
+    return devicePixelRatioF();
 }
 
 std::pair<u32, u32> GRenderWindow::ScaleTouch(const QPointF pos) const {


### PR DESCRIPTION
See yuzu-emu/yuzu#4097 for more details.

**Original description**:
Fix OpenGL renderer framebuffer size on fractional scaling display by using devicePixelRatioF().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5435)
<!-- Reviewable:end -->
