### PR TITLE
Common: remove a mod from AlignUp

### DIFF
--- a/src/common/alignment.h
+++ b/src/common/alignment.h
@@ -10,7 +10,9 @@ namespace Common {
 template <typename T>
 constexpr T AlignUp(T value, std::size_t size) {
     static_assert(std::is_unsigned_v<T>, "T must be an unsigned value.");
-    return static_cast<T>(value + (size - value % size) % size);
+    auto mod{value % size};
+    value -= mod;
+    return static_cast<T>(mod == T{0} ? value : value + size);
 }
 
 template <typename T>


### PR DESCRIPTION
In cases where the size is not a known constant when inlining, `AlignUp<std::size_t>` currently generates two 64-bit div instructions.
This generates one div and a cmov which is significantly cheaper.
https://godbolt.org/z/S848QG

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5441)
<!-- Reviewable:end -->
