### PR TITLE
Port yuzu-emu/yuzu#4221: "cmake: stop linking against QGL"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,7 +186,7 @@ if (ENABLE_QT)
         set(QT_PREFIX_HINT)
     endif()
 
-    find_package(Qt5 REQUIRED COMPONENTS Widgets OpenGL Multimedia ${QT_PREFIX_HINT})
+    find_package(Qt5 REQUIRED COMPONENTS Widgets Multimedia ${QT_PREFIX_HINT})
 
     if (ENABLE_QT_TRANSLATION)
         find_package(Qt5 REQUIRED COMPONENTS LinguistTools ${QT_PREFIX_HINT})

--- a/CMakeModules/CopyCitraQt5Deps.cmake
+++ b/CMakeModules/CopyCitraQt5Deps.cmake
@@ -16,7 +16,6 @@ function(copy_citra_Qt5_deps target_dir)
         icuuc*.dll
         Qt5Core$<$<CONFIG:Debug>:d>.*
         Qt5Gui$<$<CONFIG:Debug>:d>.*
-        Qt5OpenGL$<$<CONFIG:Debug>:d>.*
         Qt5Widgets$<$<CONFIG:Debug>:d>.*
         Qt5Multimedia$<$<CONFIG:Debug>:d>.*
         Qt5Network$<$<CONFIG:Debug>:d>.*

--- a/src/citra_qt/CMakeLists.txt
+++ b/src/citra_qt/CMakeLists.txt
@@ -246,7 +246,7 @@ endif()
 create_target_directory_groups(citra-qt)
 
 target_link_libraries(citra-qt PRIVATE audio_core common core input_common network video_core)
-target_link_libraries(citra-qt PRIVATE Boost::boost glad nihstro-headers Qt5::OpenGL Qt5::Widgets Qt5::Multimedia)
+target_link_libraries(citra-qt PRIVATE Boost::boost glad nihstro-headers Qt5::Widgets Qt5::Multimedia)
 target_link_libraries(citra-qt PRIVATE ${PLATFORM_LIBRARIES} Threads::Threads)
 
 target_compile_definitions(citra-qt PRIVATE


### PR DESCRIPTION
See yuzu-emu/yuzu#4221 for more details.

**Original description**:
Removed in yuzu-emu/yuzu#2017

<details><summary>Naive headers check</summary>

```
$ rg QtOpenGL
$ rg QGL
externals/mbedtls/tests/data_files/rsa_pkcs8_pbes2_pbkdf2_4096_des_sha384.pem
40:VeR7oKrhopTLxLwWkbAZNau3h3LoWwPatgwmPX4OBAge9xGeo5BAm23DQGLtokYj

src/core/frontend/emu_window.h
62: * (e.g. SDL, QGLWidget, GLFW, etc...).

$ pkg info -l qt5-opengl | fgrep include/
	/usr/local/include/qt5/QtCore/modules/qconfig-opengl.h
	/usr/local/include/qt5/QtOpenGL/5.14.2/QtOpenGL/private/qgl2pexvertexarray_p.h
	/usr/local/include/qt5/QtOpenGL/5.14.2/QtOpenGL/private/qgl_p.h
	/usr/local/include/qt5/QtOpenGL/5.14.2/QtOpenGL/private/qglcustomshaderstage_p.h
	/usr/local/include/qt5/QtOpenGL/5.14.2/QtOpenGL/private/qglengineshadermanager_p.h
	/usr/local/include/qt5/QtOpenGL/5.14.2/QtOpenGL/private/qglengineshadersource_p.h
	/usr/local/include/qt5/QtOpenGL/5.14.2/QtOpenGL/private/qglframebufferobject_p.h
	/usr/local/include/qt5/QtOpenGL/5.14.2/QtOpenGL/private/qglgradientcache_p.h
	/usr/local/include/qt5/QtOpenGL/5.14.2/QtOpenGL/private/qglpaintdevice_p.h
	/usr/local/include/qt5/QtOpenGL/5.14.2/QtOpenGL/private/qglpixelbuffer_p.h
	/usr/local/include/qt5/QtOpenGL/5.14.2/QtOpenGL/private/qglshadercache_p.h
	/usr/local/include/qt5/QtOpenGL/5.14.2/QtOpenGL/private/qgraphicsshadereffect_p.h
	/usr/local/include/qt5/QtOpenGL/5.14.2/QtOpenGL/private/qpaintengineex_opengl2_p.h
	/usr/local/include/qt5/QtOpenGL/5.14.2/QtOpenGL/private/qtextureglyphcache_gl_p.h
	/usr/local/include/qt5/QtOpenGL/QGL
	/usr/local/include/qt5/QtOpenGL/QGLBuffer
	/usr/local/include/qt5/QtOpenGL/QGLColormap
	/usr/local/include/qt5/QtOpenGL/QGLContext
	/usr/local/include/qt5/QtOpenGL/QGLFormat
	/usr/local/include/qt5/QtOpenGL/QGLFramebufferObject
	/usr/local/include/qt5/QtOpenGL/QGLFramebufferObjectFormat
	/usr/local/include/qt5/QtOpenGL/QGLFunctions
	/usr/local/include/qt5/QtOpenGL/QGLFunctionsPrivate
	/usr/local/include/qt5/QtOpenGL/QGLPixelBuffer
	/usr/local/include/qt5/QtOpenGL/QGLShader
	/usr/local/include/qt5/QtOpenGL/QGLShaderProgram
	/usr/local/include/qt5/QtOpenGL/QGLWidget
	/usr/local/include/qt5/QtOpenGL/QtOpenGL
	/usr/local/include/qt5/QtOpenGL/QtOpenGLDepends
	/usr/local/include/qt5/QtOpenGL/QtOpenGLVersion
	/usr/local/include/qt5/QtOpenGL/qgl.h
	/usr/local/include/qt5/QtOpenGL/qglbuffer.h
	/usr/local/include/qt5/QtOpenGL/qglcolormap.h
	/usr/local/include/qt5/QtOpenGL/qglframebufferobject.h
	/usr/local/include/qt5/QtOpenGL/qglfunctions.h
	/usr/local/include/qt5/QtOpenGL/qglpixelbuffer.h
	/usr/local/include/qt5/QtOpenGL/qglshaderprogram.h
	/usr/local/include/qt5/QtOpenGL/qtopenglglobal.h
	/usr/local/include/qt5/QtOpenGL/qtopenglversion.h
```
</details>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5453)
<!-- Reviewable:end -->
