### PR TITLE
Port yuzu-emu/yuzu#4347: "settings: Make use of std::string_view over std::string for logging"

### DIFF
--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <string_view>
 #include <utility>
 #include "audio_core/dsp_interface.h"
 #include "core/core.h"
@@ -68,57 +69,56 @@ void Apply() {
     }
 }
 
-template <typename T>
-void LogSetting(const std::string& name, const T& value) {
-    LOG_INFO(Config, "{}: {}", name, value);
-}
-
 void LogSettings() {
+    const auto log_setting = [](std::string_view name, const auto& value) {
+        LOG_INFO(Config, "{}: {}", name, value);
+    };
+
     LOG_INFO(Config, "Citra Configuration:");
-    LogSetting("Core_UseCpuJit", Settings::values.use_cpu_jit);
-    LogSetting("Renderer_UseGLES", Settings::values.use_gles);
-    LogSetting("Renderer_UseHwRenderer", Settings::values.use_hw_renderer);
-    LogSetting("Renderer_UseHwShader", Settings::values.use_hw_shader);
-    LogSetting("Renderer_SeparableShader", Settings::values.separable_shader);
-    LogSetting("Renderer_ShadersAccurateMul", Settings::values.shaders_accurate_mul);
-    LogSetting("Renderer_UseShaderJit", Settings::values.use_shader_jit);
-    LogSetting("Renderer_UseResolutionFactor", Settings::values.resolution_factor);
-    LogSetting("Renderer_FrameLimit", Settings::values.frame_limit);
-    LogSetting("Renderer_UseFrameLimitAlternate", Settings::values.use_frame_limit_alternate);
-    LogSetting("Renderer_FrameLimitAlternate", Settings::values.frame_limit_alternate);
-    LogSetting("Renderer_PostProcessingShader", Settings::values.pp_shader_name);
-    LogSetting("Renderer_FilterMode", Settings::values.filter_mode);
-    LogSetting("Renderer_TextureFilterName", Settings::values.texture_filter_name);
-    LogSetting("Stereoscopy_Render3d", static_cast<int>(Settings::values.render_3d));
-    LogSetting("Stereoscopy_Factor3d", Settings::values.factor_3d);
-    LogSetting("Layout_LayoutOption", static_cast<int>(Settings::values.layout_option));
-    LogSetting("Layout_SwapScreen", Settings::values.swap_screen);
-    LogSetting("Layout_UprightScreen", Settings::values.upright_screen);
-    LogSetting("Utility_DumpTextures", Settings::values.dump_textures);
-    LogSetting("Utility_CustomTextures", Settings::values.custom_textures);
-    LogSetting("Utility_UseDiskShaderCache", Settings::values.use_disk_shader_cache);
-    LogSetting("Audio_EnableDspLle", Settings::values.enable_dsp_lle);
-    LogSetting("Audio_EnableDspLleMultithread", Settings::values.enable_dsp_lle_multithread);
-    LogSetting("Audio_OutputEngine", Settings::values.sink_id);
-    LogSetting("Audio_EnableAudioStretching", Settings::values.enable_audio_stretching);
-    LogSetting("Audio_OutputDevice", Settings::values.audio_device_id);
-    LogSetting("Audio_InputDeviceType", static_cast<int>(Settings::values.mic_input_type));
-    LogSetting("Audio_InputDevice", Settings::values.mic_input_device);
+    log_setting("Core_UseCpuJit", values.use_cpu_jit);
+    log_setting("Renderer_UseGLES", values.use_gles);
+    log_setting("Renderer_UseHwRenderer", values.use_hw_renderer);
+    log_setting("Renderer_UseHwShader", values.use_hw_shader);
+    log_setting("Renderer_SeparableShader", values.separable_shader);
+    log_setting("Renderer_ShadersAccurateMul", values.shaders_accurate_mul);
+    log_setting("Renderer_UseShaderJit", values.use_shader_jit);
+    log_setting("Renderer_UseResolutionFactor", values.resolution_factor);
+    log_setting("Renderer_FrameLimit", values.frame_limit);
+    log_setting("Renderer_UseFrameLimitAlternate", values.use_frame_limit_alternate);
+    log_setting("Renderer_FrameLimitAlternate", values.frame_limit_alternate);
+    log_setting("Renderer_PostProcessingShader", values.pp_shader_name);
+    log_setting("Renderer_FilterMode", values.filter_mode);
+    log_setting("Renderer_TextureFilterName", values.texture_filter_name);
+    log_setting("Stereoscopy_Render3d", static_cast<int>(values.render_3d));
+    log_setting("Stereoscopy_Factor3d", values.factor_3d);
+    log_setting("Layout_LayoutOption", static_cast<int>(values.layout_option));
+    log_setting("Layout_SwapScreen", values.swap_screen);
+    log_setting("Layout_UprightScreen", values.upright_screen);
+    log_setting("Utility_DumpTextures", values.dump_textures);
+    log_setting("Utility_CustomTextures", values.custom_textures);
+    log_setting("Utility_UseDiskShaderCache", values.use_disk_shader_cache);
+    log_setting("Audio_EnableDspLle", values.enable_dsp_lle);
+    log_setting("Audio_EnableDspLleMultithread", values.enable_dsp_lle_multithread);
+    log_setting("Audio_OutputEngine", values.sink_id);
+    log_setting("Audio_EnableAudioStretching", values.enable_audio_stretching);
+    log_setting("Audio_OutputDevice", values.audio_device_id);
+    log_setting("Audio_InputDeviceType", static_cast<int>(values.mic_input_type));
+    log_setting("Audio_InputDevice", values.mic_input_device);
     using namespace Service::CAM;
-    LogSetting("Camera_OuterRightName", Settings::values.camera_name[OuterRightCamera]);
-    LogSetting("Camera_OuterRightConfig", Settings::values.camera_config[OuterRightCamera]);
-    LogSetting("Camera_OuterRightFlip", Settings::values.camera_flip[OuterRightCamera]);
-    LogSetting("Camera_InnerName", Settings::values.camera_name[InnerCamera]);
-    LogSetting("Camera_InnerConfig", Settings::values.camera_config[InnerCamera]);
-    LogSetting("Camera_InnerFlip", Settings::values.camera_flip[InnerCamera]);
-    LogSetting("Camera_OuterLeftName", Settings::values.camera_name[OuterLeftCamera]);
-    LogSetting("Camera_OuterLeftConfig", Settings::values.camera_config[OuterLeftCamera]);
-    LogSetting("Camera_OuterLeftFlip", Settings::values.camera_flip[OuterLeftCamera]);
-    LogSetting("DataStorage_UseVirtualSd", Settings::values.use_virtual_sd);
-    LogSetting("System_IsNew3ds", Settings::values.is_new_3ds);
-    LogSetting("System_RegionValue", Settings::values.region_value);
-    LogSetting("Debugging_UseGdbstub", Settings::values.use_gdbstub);
-    LogSetting("Debugging_GdbstubPort", Settings::values.gdbstub_port);
+    log_setting("Camera_OuterRightName", values.camera_name[OuterRightCamera]);
+    log_setting("Camera_OuterRightConfig", values.camera_config[OuterRightCamera]);
+    log_setting("Camera_OuterRightFlip", values.camera_flip[OuterRightCamera]);
+    log_setting("Camera_InnerName", values.camera_name[InnerCamera]);
+    log_setting("Camera_InnerConfig", values.camera_config[InnerCamera]);
+    log_setting("Camera_InnerFlip", values.camera_flip[InnerCamera]);
+    log_setting("Camera_OuterLeftName", values.camera_name[OuterLeftCamera]);
+    log_setting("Camera_OuterLeftConfig", values.camera_config[OuterLeftCamera]);
+    log_setting("Camera_OuterLeftFlip", values.camera_flip[OuterLeftCamera]);
+    log_setting("DataStorage_UseVirtualSd", values.use_virtual_sd);
+    log_setting("System_IsNew3ds", values.is_new_3ds);
+    log_setting("System_RegionValue", values.region_value);
+    log_setting("Debugging_UseGdbstub", values.use_gdbstub);
+    log_setting("Debugging_GdbstubPort", values.gdbstub_port);
 }
 
 void LoadProfile(int index) {


### PR DESCRIPTION
See yuzu-emu/yuzu#4347 for more details.

**Original description**:
In all usages of `LogSetting()`, string literals are provided. `std::string_view` is better suited here, as we won't churn a bunch of
string allocations every time the settings are logged out.

While we're at it, we can fold `LogSetting()` into `LogSettings()`, given it's only ever used there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5464)
<!-- Reviewable:end -->
