### PR TITLE
Actually return true if InitMFDLL succeeded

### DIFF
--- a/src/audio_core/hle/wmf_decoder_utils.cpp
+++ b/src/audio_core/hle/wmf_decoder_utils.cpp
@@ -446,6 +446,8 @@ bool InitMFDLL() {
         LOG_ERROR(Audio_DSP, "Cannot load function MFCreateMediaType");
         return false;
     }
+
+    return true;
 }
 
 Symbol<HRESULT(ULONG, DWORD)> MFStartup;


### PR DESCRIPTION
Should fix the WMF issues encountered when building with current MinGW versions.

This was always undefined behavior and a coincidence that it ever worked.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5470)
<!-- Reviewable:end -->
