### PR TITLE
Fix "hide mouse on inactivity" for popout window

### DIFF
--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -297,7 +297,7 @@ void GRenderWindow::mousePressEvent(QMouseEvent* event) {
     } else if (event->button() == Qt::RightButton) {
         InputCommon::GetMotionEmu()->BeginTilt(pos.x(), pos.y());
     }
-    QWidget::mousePressEvent(event);
+    emit MouseActivity();
 }
 
 void GRenderWindow::mouseMoveEvent(QMouseEvent* event) {
@@ -308,7 +308,7 @@ void GRenderWindow::mouseMoveEvent(QMouseEvent* event) {
     const auto [x, y] = ScaleTouch(pos);
     this->TouchMoved(x, y);
     InputCommon::GetMotionEmu()->Tilt(pos.x(), pos.y());
-    QWidget::mouseMoveEvent(event);
+    emit MouseActivity();
 }
 
 void GRenderWindow::mouseReleaseEvent(QMouseEvent* event) {
@@ -319,6 +319,7 @@ void GRenderWindow::mouseReleaseEvent(QMouseEvent* event) {
         this->TouchReleased();
     else if (event->button() == Qt::RightButton)
         InputCommon::GetMotionEmu()->EndTilt();
+    emit MouseActivity();
 }
 
 void GRenderWindow::TouchBeginEvent(const QTouchEvent* event) {

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -199,6 +199,9 @@ signals:
      */
     void FirstFrameDisplayed();
 
+    /// Emitted on mouse activity. Used to signal that the mouse should be shown if it's hidden
+    void MouseActivity();
+
 private:
     std::pair<u32, u32> ScaleTouch(QPointF pos) const;
     void TouchBeginEvent(const QTouchEvent* event);

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -203,13 +203,9 @@ GMainWindow::GMainWindow()
     // Show one-time "callout" messages to the user
     ShowTelemetryCallout();
 
-    // make sure menubar has the arrow cursor instead of inheriting from this
-    ui->menubar->setCursor(QCursor());
-    statusBar()->setCursor(QCursor());
-
     mouse_hide_timer.setInterval(default_mouse_timeout);
     connect(&mouse_hide_timer, &QTimer::timeout, this, &GMainWindow::HideMouseCursor);
-    connect(ui->menubar, &QMenuBar::hovered, this, &GMainWindow::ShowMouseCursor);
+    connect(ui->menubar, &QMenuBar::hovered, this, &GMainWindow::OnMouseActivity);
 
     if (UISettings::values.check_for_update_on_start) {
         CheckForUpdates();
@@ -1026,6 +1022,8 @@ void GMainWindow::BootGame(const QString& filename) {
     emu_thread->start();
 
     connect(render_window, &GRenderWindow::Closed, this, &GMainWindow::OnStopGame);
+    connect(render_window, &GRenderWindow::MouseActivity, this, &GMainWindow::OnMouseActivity);
+
     // BlockingQueuedConnection is important here, it makes sure we've finished refreshing our views
     // before the CPU continues
     connect(emu_thread.get(), &EmuThread::DebugModeEntered, registersWidget,
@@ -1051,7 +1049,6 @@ void GMainWindow::BootGame(const QString& filename) {
     if (UISettings::values.hide_mouse) {
         mouse_hide_timer.start();
         setMouseTracking(true);
-        ui->centralwidget->setMouseTracking(true);
     }
 
     // show and hide the render_window to create the context
@@ -1153,7 +1150,6 @@ void GMainWindow::ShutdownGame() {
     game_list->setFilterFocus();
 
     setMouseTracking(false);
-    ui->centralwidget->setMouseTracking(false);
 
     // Disable status bar updates
     status_bar_update_timer.stop();
@@ -1750,11 +1746,9 @@ void GMainWindow::OnConfigure() {
         config->Save();
         if (UISettings::values.hide_mouse && emulation_running) {
             setMouseTracking(true);
-            ui->centralwidget->setMouseTracking(true);
             mouse_hide_timer.start();
         } else {
             setMouseTracking(false);
-            ui->centralwidget->setMouseTracking(false);
         }
     } else {
         Settings::values.input_profiles = old_input_profiles;
@@ -2089,22 +2083,30 @@ void GMainWindow::HideMouseCursor() {
         ShowMouseCursor();
         return;
     }
-    setCursor(QCursor(Qt::BlankCursor));
+    render_window->setCursor(QCursor(Qt::BlankCursor));
 }
 
 void GMainWindow::ShowMouseCursor() {
-    unsetCursor();
+    render_window->unsetCursor();
     if (emu_thread != nullptr && UISettings::values.hide_mouse) {
         mouse_hide_timer.start();
     }
 }
 
-void GMainWindow::mouseMoveEvent(QMouseEvent* event) {
+void GMainWindow::OnMouseActivity() {
     ShowMouseCursor();
 }
 
+void GMainWindow::mouseMoveEvent(QMouseEvent* event) {
+    OnMouseActivity();
+}
+
 void GMainWindow::mousePressEvent(QMouseEvent* event) {
-    ShowMouseCursor();
+    OnMouseActivity();
+}
+
+void GMainWindow::mouseReleaseEvent(QMouseEvent* event) {
+    OnMouseActivity();
 }
 
 void GMainWindow::OnCoreError(Core::System::ResultStatus result, std::string details) {

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -221,6 +221,7 @@ private slots:
     void OnCheckForUpdates();
     void OnOpenUpdater();
     void OnLanguageChanged(const QString& locale);
+    void OnMouseActivity();
 
 private:
     bool ValidateMovie(const QString& path, u64 program_id = 0);
@@ -313,6 +314,7 @@ protected:
     void dragMoveEvent(QDragMoveEvent* event) override;
     void mouseMoveEvent(QMouseEvent* event) override;
     void mousePressEvent(QMouseEvent* event) override;
+    void mouseReleaseEvent(QMouseEvent* event) override;
 };
 
 Q_DECLARE_METATYPE(std::size_t);


### PR DESCRIPTION
The feature wasn't working when the "single window mode" was off.
Changed the cursor setting to only affect the render_window and moved to a signal/slot model to trigger showing the mouse.

The previous implementation relied on the bubbling of the event from the render_window to the main window, but that does not happen when "single window mode" is off. Cursor inheritance from the main window to the render_window also doesn't happen when "single window mode" is off.

Refer to #5094 for the initial implementation.

Should fix #5413 by preventing the move QMouseEvent from bubbling up to the main window

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5476)
<!-- Reviewable:end -->
