### PR TITLE
Implement APT command 0x0103

### DIFF
--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -1013,7 +1013,7 @@ void Module::APTInterface::CheckNew3DSThingy(Kernel::HLERequestContext& ctx) {
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
 
     rb.Push(RESULT_SUCCESS);
-    rb.Push(static_cast<u8>(Settings::values.is_new_3ds) + 1);
+    rb.Push<u8>(Settings::values.is_new_3ds ? 2 : 1);
 
     LOG_WARNING(Service_APT, "(STUBBED) called");
 }

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -1008,7 +1008,7 @@ void Module::APTInterface::CheckNew3DS(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service_APT, "(STUBBED) called");
 }
 
-void Module::APTInterface::CheckNew3DSThingy(Kernel::HLERequestContext& ctx) {
+void Module::APTInterface::Unknown0x0103(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x103, 0, 0); // 0x01030000
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
 

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -28,6 +28,7 @@
 #include "core/hle/service/service.h"
 #include "core/hw/aes/ccm.h"
 #include "core/hw/aes/key.h"
+#include "core/settings.h"
 
 SERVICE_CONSTRUCT_IMPL(Service::APT::Module)
 
@@ -1003,6 +1004,16 @@ void Module::APTInterface::CheckNew3DS(Kernel::HLERequestContext& ctx) {
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
 
     PTM::CheckNew3DS(rb);
+
+    LOG_WARNING(Service_APT, "(STUBBED) called");
+}
+
+void Module::APTInterface::CheckNew3DSThingy(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp(ctx, 0x103, 0, 0); // 0x01030000
+    IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
+
+    rb.Push(RESULT_SUCCESS);
+    rb.Push(static_cast<u8>(Settings::values.is_new_3ds) + 1);
 
     LOG_WARNING(Service_APT, "(STUBBED) called");
 }

--- a/src/core/hle/service/apt/apt.h
+++ b/src/core/hle/service/apt/apt.h
@@ -691,6 +691,15 @@ public:
         void CheckNew3DS(Kernel::HLERequestContext& ctx);
 
         /**
+         * APT::CheckNew3DSThingy service function
+         *  Outputs:
+         *      1: Result code, 0 on success otherwise error code
+         *      2: u8 output: 2 = New3DS+valid/initialized (in Smash4), 1 = Old3DS or you did
+         * something wrong with NS???
+         */
+        void CheckNew3DSThingy(Kernel::HLERequestContext& ctx);
+
+        /**
          * APT::IsTitleAllowed service function
          *  Inputs:
          *      0 : Header Code[0x01050100]

--- a/src/core/hle/service/apt/apt.h
+++ b/src/core/hle/service/apt/apt.h
@@ -691,13 +691,12 @@ public:
         void CheckNew3DS(Kernel::HLERequestContext& ctx);
 
         /**
-         * APT::CheckNew3DSThingy service function
+         * APT::Unknown0x0103 service function. Determines whether Smash 4 allows C-Stick
          *  Outputs:
          *      1: Result code, 0 on success otherwise error code
-         *      2: u8 output: 2 = New3DS+valid/initialized (in Smash4), 1 = Old3DS or you did
-         * something wrong with NS???
+         *      2: u8 output: 2 = New3DS+valid/initialized (in Smash 4), 1 = Old3DS or invalid
          */
-        void CheckNew3DSThingy(Kernel::HLERequestContext& ctx);
+        void Unknown0x0103(Kernel::HLERequestContext& ctx);
 
         /**
          * APT::IsTitleAllowed service function

--- a/src/core/hle/service/apt/apt_a.cpp
+++ b/src/core/hle/service/apt/apt_a.cpp
@@ -99,6 +99,7 @@ APT_A::APT_A(std::shared_ptr<Module> apt)
         {0x00580002, nullptr, "GetProgramID"},
         {0x01010000, &APT_A::CheckNew3DSApp, "CheckNew3DSApp"},
         {0x01020000, &APT_A::CheckNew3DS, "CheckNew3DS"},
+        {0x01030000, &APT_A::CheckNew3DSThingy, "CheckNew3DSThingy"}, // TODO Name me before merging
         {0x01040000, nullptr, "IsStandardMemoryLayout"},
         {0x01050100, &APT_A::IsTitleAllowed, "IsTitleAllowed"},
     };

--- a/src/core/hle/service/apt/apt_a.cpp
+++ b/src/core/hle/service/apt/apt_a.cpp
@@ -99,7 +99,7 @@ APT_A::APT_A(std::shared_ptr<Module> apt)
         {0x00580002, nullptr, "GetProgramID"},
         {0x01010000, &APT_A::CheckNew3DSApp, "CheckNew3DSApp"},
         {0x01020000, &APT_A::CheckNew3DS, "CheckNew3DS"},
-        {0x01030000, &APT_A::CheckNew3DSThingy, "CheckNew3DSThingy"}, // TODO Name me before merging
+        {0x01030000, &APT_A::Unknown0x0103, "Unknown0x0103"},
         {0x01040000, nullptr, "IsStandardMemoryLayout"},
         {0x01050100, &APT_A::IsTitleAllowed, "IsTitleAllowed"},
     };

--- a/src/core/hle/service/apt/apt_s.cpp
+++ b/src/core/hle/service/apt/apt_s.cpp
@@ -99,6 +99,7 @@ APT_S::APT_S(std::shared_ptr<Module> apt)
         {0x00580002, nullptr, "GetProgramID"},
         {0x01010000, &APT_S::CheckNew3DSApp, "CheckNew3DSApp"},
         {0x01020000, &APT_S::CheckNew3DS, "CheckNew3DS"},
+        {0x01030000, &APT_S::CheckNew3DSThingy, "CheckNew3DSThingy"}, // TODO Name me before merging
         {0x01040000, nullptr, "IsStandardMemoryLayout"},
         {0x01050100, &APT_S::IsTitleAllowed, "IsTitleAllowed"},
     };

--- a/src/core/hle/service/apt/apt_s.cpp
+++ b/src/core/hle/service/apt/apt_s.cpp
@@ -99,7 +99,7 @@ APT_S::APT_S(std::shared_ptr<Module> apt)
         {0x00580002, nullptr, "GetProgramID"},
         {0x01010000, &APT_S::CheckNew3DSApp, "CheckNew3DSApp"},
         {0x01020000, &APT_S::CheckNew3DS, "CheckNew3DS"},
-        {0x01030000, &APT_S::CheckNew3DSThingy, "CheckNew3DSThingy"}, // TODO Name me before merging
+        {0x01030000, &APT_S::Unknown0x0103, "Unknown0x0103"},
         {0x01040000, nullptr, "IsStandardMemoryLayout"},
         {0x01050100, &APT_S::IsTitleAllowed, "IsTitleAllowed"},
     };

--- a/src/core/hle/service/apt/apt_u.cpp
+++ b/src/core/hle/service/apt/apt_u.cpp
@@ -98,6 +98,7 @@ APT_U::APT_U(std::shared_ptr<Module> apt)
         {0x00580002, nullptr, "GetProgramID"},
         {0x01010000, &APT_U::CheckNew3DSApp, "CheckNew3DSApp"},
         {0x01020000, &APT_U::CheckNew3DS, "CheckNew3DS"},
+        {0x01030000, &APT_U::CheckNew3DSThingy, "CheckNew3DSThingy"}, // TODO Name me before merging
     };
     RegisterHandlers(functions);
 }

--- a/src/core/hle/service/apt/apt_u.cpp
+++ b/src/core/hle/service/apt/apt_u.cpp
@@ -98,7 +98,7 @@ APT_U::APT_U(std::shared_ptr<Module> apt)
         {0x00580002, nullptr, "GetProgramID"},
         {0x01010000, &APT_U::CheckNew3DSApp, "CheckNew3DSApp"},
         {0x01020000, &APT_U::CheckNew3DS, "CheckNew3DS"},
-        {0x01030000, &APT_U::CheckNew3DSThingy, "CheckNew3DSThingy"}, // TODO Name me before merging
+        {0x01030000, &APT_U::Unknown0x0103, "Unknown0x0103"},
     };
     RegisterHandlers(functions);
 }


### PR DESCRIPTION
An attempt at stubbing command 0x01030000 here: https://www.3dbrew.org/wiki/NS_and_APT_Services

This allows the New3DS controls (C-Stick, ZL, ZR) to work in Smash4 when New3DS mode in Citra is set.

This is a very minimalist stub and this command has no actual name that I'm aware of.


As per the wiki, the value appears to be some sort of enum, with 1 meaning "don't use the N3DS controls" or something (which I get in a 3dsx homebrew that calls the command on both O3DS and N3DS), and according to smash, 2 and 4 mean the N3DS controls are valid. My N3DSXL provides 2 as the result in Smash4, and I have no idea what 4 is.

This command is called before Smash4 even attempts to initialize the HID services for the N3DS controls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5478)
<!-- Reviewable:end -->
