### PR TITLE
Add LGTM static analyzer config file

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,13 @@
+path_classifiers:
+  library: "externals"
+extraction:
+  cpp:
+    prepare:
+      packages:
+      - "libsdl2-dev"
+      - "qtmultimedia5-dev"
+      - "clang-format"
+      - "libtbb-dev"
+      - "libjack-jackd2-dev"
+      - "doxygen"
+      - "graphviz"

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -6,7 +6,7 @@ extraction:
       packages:
       - "libsdl2-dev"
       - "qtmultimedia5-dev"
-      - "clang-format"
+      - "clang-format-6.0"
       - "libtbb-dev"
       - "libjack-jackd2-dev"
       - "doxygen"


### PR DESCRIPTION
Refer to #5494 for some example issues found. LGTM analysis for this repo can be viewed [here](https://lgtm.com/projects/g/citra-emu/citra/alerts/?mode=tree). Note: this doesn't affect existing CI routines in any way.

Added config file makes static analysis results much easier to read and also speeds up analysis process by preinstalling used packages.

Potential addition:

```YAML
queries:
  include: "*"
```

This enables all warning types as opposed to default only. It might be a good idea to enable later on once default ones are addressed.

Additionally, it's worth taking a look at https://lgtm.com/projects/g/citra-emu/citra/ci/. Automatic check for new alerts introduced by PRs and alerts count/code quality badges are available.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5495)
<!-- Reviewable:end -->
