### PR TITLE
Use gtimeout on Mac OS job to incrementally build up ccache 

### DIFF
--- a/.travis/macos/build.sh
+++ b/.travis/macos/build.sh
@@ -13,6 +13,12 @@ export CPPFLAGS="-I/usr/local/opt/llvm/include"
 
 mkdir build && cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release -DENABLE_QT_TRANSLATION=ON -DCITRA_ENABLE_COMPATIBILITY_REPORTING=${ENABLE_COMPATIBILITY_REPORTING:-"OFF"} -DENABLE_COMPATIBILITY_LIST_DOWNLOAD=ON -DUSE_DISCORD_PRESENCE=ON -DENABLE_FFMPEG_AUDIO_DECODER=ON -DENABLE_FFMPEG_VIDEO_DUMPER=ON
-make -j4
+# make -j4 takes more than 50 minutes when there is no ccache available on Travis CI
+# and when Travis CI timeouts a job after 50 minutes it won't store any ccache get so far.
+# To avoid to be stuck forever with failing build, gtimeout will stop make command before
+# Travis CI timeouts, and this will allow Travis CI to successfully store any ccache get so far,
+# and iterating this process, the ccache will build up till the make command will succeed.
+# 50 minutes == 3000 seconds; ~1000 seconds are needed by deps.sh; hence:
+gtimeout 1500 make -j4
 
 ctest -VV -C Release


### PR DESCRIPTION
Fixes #5481

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5497)
<!-- Reviewable:end -->
