### PR TITLE
Don't translate save/load state hotkey text for the map

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -566,9 +566,9 @@ void GMainWindow::InitializeHotkeys() {
                     OnCaptureScreenshot();
                 }
             });
-    connect(hotkey_registry.GetHotkey(main_window, ui.action_Load_from_Newest_Slot->text(), this),
+    connect(hotkey_registry.GetHotkey(main_window, QStringLiteral("Save to Oldest Slot"), this),
             &QShortcut::activated, ui.action_Load_from_Newest_Slot, &QAction::trigger);
-    connect(hotkey_registry.GetHotkey(main_window, ui.action_Save_to_Oldest_Slot->text(), this),
+    connect(hotkey_registry.GetHotkey(main_window, QStringLiteral("Load from Newest Slot"), this),
             &QShortcut::activated, ui.action_Save_to_Oldest_Slot, &QAction::trigger);
 }
 

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -566,9 +566,9 @@ void GMainWindow::InitializeHotkeys() {
                     OnCaptureScreenshot();
                 }
             });
-    connect(hotkey_registry.GetHotkey(main_window, QStringLiteral("Save to Oldest Slot"), this),
-            &QShortcut::activated, ui.action_Load_from_Newest_Slot, &QAction::trigger);
     connect(hotkey_registry.GetHotkey(main_window, QStringLiteral("Load from Newest Slot"), this),
+            &QShortcut::activated, ui.action_Load_from_Newest_Slot, &QAction::trigger);
+    connect(hotkey_registry.GetHotkey(main_window, QStringLiteral("Save to Oldest Slot"), this),
             &QShortcut::activated, ui.action_Save_to_Oldest_Slot, &QAction::trigger);
 }
 


### PR DESCRIPTION
Fixes an issue with duplicate configuration entries when Citra is set to a language that has save/load state translated.

As a side note, it would appear there's no way to translate shortcut action text correctly until shortcut keys/names are decoupled from their display text.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5504)
<!-- Reviewable:end -->
