### PR TITLE
Look at direction of analog axis travel instead of instantaneous sample

### DIFF
--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -594,8 +594,17 @@ public:
         while (state.event_queue.Pop(event)) {
             switch (event.type) {
             case SDL_JOYAXISMOTION:
-                if (std::abs(event.jaxis.value / 32767.0) < 0.5) {
+                if (axis_memory.find(event.jaxis.axis) == axis_memory.end())
+                {
+                    axis_memory[event.jaxis.axis] = event.jaxis.value;
                     break;
+                } else {
+                    if (std::abs((event.jaxis.value - axis_memory[event.jaxis.axis]) / 32767.0) < 0.5) {
+                        break;
+                    } else {
+                        event.jaxis.value = std::copysign(32767, event.jaxis.value - axis_memory[event.jaxis.axis]);
+                        axis_memory.clear();
+                    }
                 }
             case SDL_JOYBUTTONUP:
             case SDL_JOYHATMOTION:
@@ -604,6 +613,9 @@ public:
         }
         return {};
     }
+
+private:
+    std::map<int, int> axis_memory;
 };
 
 class SDLAnalogPoller final : public SDLPoller {

--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -594,15 +594,16 @@ public:
         while (state.event_queue.Pop(event)) {
             switch (event.type) {
             case SDL_JOYAXISMOTION:
-                if (axis_memory.find(event.jaxis.axis) == axis_memory.end())
-                {
+                if (axis_memory.find(event.jaxis.axis) == axis_memory.end()) {
                     axis_memory[event.jaxis.axis] = event.jaxis.value;
                     break;
                 } else {
-                    if (std::abs((event.jaxis.value - axis_memory[event.jaxis.axis]) / 32767.0) < 0.5) {
+                    if (std::abs((event.jaxis.value - axis_memory[event.jaxis.axis]) / 32767.0) <
+                        0.5) {
                         break;
                     } else {
-                        event.jaxis.value = std::copysign(32767, event.jaxis.value - axis_memory[event.jaxis.axis]);
+                        event.jaxis.value =
+                            std::copysign(32767, event.jaxis.value - axis_memory[event.jaxis.axis]);
                         axis_memory.clear();
                     }
                 }

--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -594,7 +594,7 @@ public:
         while (state.event_queue.Pop(event)) {
             switch (event.type) {
             case SDL_JOYAXISMOTION:
-                if (axis_memory.find(event.jaxis.axis) == axis_memory.end()) {
+                if (!axis_memory.count(event.jaxis.axis)) {
                     axis_memory[event.jaxis.axis] = event.jaxis.value;
                     break;
                 } else {
@@ -616,7 +616,7 @@ public:
     }
 
 private:
-    std::map<int, int> axis_memory;
+    std::unordered_map<int, int> axis_memory;
 };
 
 class SDLAnalogPoller final : public SDLPoller {

--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -594,17 +594,40 @@ public:
         while (state.event_queue.Pop(event)) {
             switch (event.type) {
             case SDL_JOYAXISMOTION:
-                if (!axis_memory.count(event.jaxis.axis)) {
-                    axis_memory[event.jaxis.axis] = event.jaxis.value;
+                if (!axis_memory.count(event.jaxis.which) ||
+                    !axis_memory[event.jaxis.which].count(event.jaxis.axis)) {
+                    axis_memory[event.jaxis.which][event.jaxis.axis] = event.jaxis.value;
+                    axis_event_count[event.jaxis.which][event.jaxis.axis] = 1;
                     break;
                 } else {
-                    if (std::abs((event.jaxis.value - axis_memory[event.jaxis.axis]) / 32767.0) <
-                        0.5) {
+                    axis_event_count[event.jaxis.which][event.jaxis.axis]++;
+                    // The joystick and axis exist in our map if we take this branch, so no checks
+                    // needed
+                    if (std::abs(
+                            (event.jaxis.value - axis_memory[event.jaxis.which][event.jaxis.axis]) /
+                            32767.0) < 0.5) {
                         break;
                     } else {
-                        event.jaxis.value =
-                            std::copysign(32767, event.jaxis.value - axis_memory[event.jaxis.axis]);
+                        if (axis_event_count[event.jaxis.which][event.jaxis.axis] == 2 &&
+                            IsAxisAtPole(event.jaxis.value) &&
+                            IsAxisAtPole(axis_memory[event.jaxis.which][event.jaxis.axis])) {
+                            // If we have exactly two events and both are near a pole, this is
+                            // likely a digital input masquerading as an analog axis; Instead of
+                            // trying to look at the direction the axis travelled, assume the first
+                            // event was press and the second was release; This should handle most
+                            // digital axes while deferring to the direction of travel for analog
+                            // axes
+                            event.jaxis.value = std::copysign(
+                                32767, axis_memory[event.jaxis.which][event.jaxis.axis]);
+                        } else {
+                            // There are more than two events, so this is likely a true analog axis,
+                            // check the direction it travelled
+                            event.jaxis.value = std::copysign(
+                                32767, event.jaxis.value -
+                                           axis_memory[event.jaxis.which][event.jaxis.axis]);
+                        }
                         axis_memory.clear();
+                        axis_event_count.clear();
                     }
                 }
             case SDL_JOYBUTTONUP:
@@ -616,7 +639,14 @@ public:
     }
 
 private:
-    std::unordered_map<int, int> axis_memory;
+    // Determine whether an axis value is close to an extreme or center
+    // Some controllers have a digital D-Pad as a pair of analog sticks, with 3 possible values per
+    // axis, which is why the center must be considered a pole
+    bool IsAxisAtPole(int16_t value) {
+        return std::abs(value) >= 32767 || std::abs(value) < 327;
+    }
+    std::unordered_map<SDL_JoystickID, std::unordered_map<uint8_t, int16_t>> axis_memory;
+    std::unordered_map<SDL_JoystickID, std::unordered_map<uint8_t, uint32_t>> axis_event_count;
 };
 
 class SDLAnalogPoller final : public SDLPoller {


### PR DESCRIPTION
When mapping an analog trigger to a button, take two samples of an axis to determine the direction it's being moved, and override the event value to be saturated in that direction if it's been moved enough to count as an event.

Should improve https://github.com/citra-emu/citra/issues/4166 and https://github.com/citra-emu/citra/issues/5488, and possibly https://github.com/citra-emu/citra/issues/3791 by making the controller mapping process less confusing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5509)
<!-- Reviewable:end -->
