### PR TITLE
Use unique_ptr on all ui objects from .ui files

### DIFF
--- a/src/citra_qt/aboutdialog.cpp
+++ b/src/citra_qt/aboutdialog.cpp
@@ -9,7 +9,7 @@
 
 AboutDialog::AboutDialog(QWidget* parent)
     : QDialog(parent, Qt::WindowTitleHint | Qt::WindowCloseButtonHint | Qt::WindowSystemMenuHint),
-      ui(new Ui::AboutDialog) {
+      ui(std::make_unique<Ui::AboutDialog>()) {
     ui->setupUi(this);
     ui->labelLogo->setPixmap(QIcon::fromTheme(QStringLiteral("citra")).pixmap(200));
     ui->labelBuildInfo->setText(ui->labelBuildInfo->text().arg(

--- a/src/citra_qt/configuration/configure_debug.cpp
+++ b/src/citra_qt/configuration/configure_debug.cpp
@@ -15,7 +15,8 @@
 #include "core/settings.h"
 #include "ui_configure_debug.h"
 
-ConfigureDebug::ConfigureDebug(QWidget* parent) : QWidget(parent), ui(new Ui::ConfigureDebug) {
+ConfigureDebug::ConfigureDebug(QWidget* parent)
+    : QWidget(parent), ui(std::make_unique<Ui::ConfigureDebug>()) {
     ui->setupUi(this);
     SetConfiguration();
 

--- a/src/citra_qt/configuration/configure_dialog.cpp
+++ b/src/citra_qt/configuration/configure_dialog.cpp
@@ -11,7 +11,7 @@
 #include "ui_configure.h"
 
 ConfigureDialog::ConfigureDialog(QWidget* parent, HotkeyRegistry& registry, bool enable_web_config)
-    : QDialog(parent), ui(new Ui::ConfigureDialog), registry(registry) {
+    : QDialog(parent), ui(std::make_unique<Ui::ConfigureDialog>()), registry(registry) {
     ui->setupUi(this);
     ui->hotkeysTab->Populate(registry);
     ui->webTab->SetWebServiceConfigEnabled(enable_web_config);

--- a/src/citra_qt/configuration/configure_enhancements.cpp
+++ b/src/citra_qt/configuration/configure_enhancements.cpp
@@ -11,7 +11,7 @@
 #include "video_core/renderer_opengl/texture_filters/texture_filterer.h"
 
 ConfigureEnhancements::ConfigureEnhancements(QWidget* parent)
-    : QWidget(parent), ui(new Ui::ConfigureEnhancements) {
+    : QWidget(parent), ui(std::make_unique<Ui::ConfigureEnhancements>()) {
     ui->setupUi(this);
 
     for (const auto& filter : OpenGL::TextureFilterer::GetFilterNames())
@@ -128,6 +128,4 @@ void ConfigureEnhancements::ApplyConfiguration() {
     Settings::values.bg_blue = static_cast<float>(bg_color.blueF());
 }
 
-ConfigureEnhancements::~ConfigureEnhancements() {
-    delete ui;
-}
+ConfigureEnhancements::~ConfigureEnhancements() {}

--- a/src/citra_qt/configuration/configure_enhancements.h
+++ b/src/citra_qt/configuration/configure_enhancements.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <memory>
 #include <QWidget>
 
 namespace Settings {
@@ -29,6 +30,6 @@ private:
     void updateShaders(Settings::StereoRenderOption stereo_option);
     void updateTextureFilter(int index);
 
-    Ui::ConfigureEnhancements* ui;
+    std::unique_ptr<Ui::ConfigureEnhancements> ui;
     QColor bg_color;
 };

--- a/src/citra_qt/configuration/configure_general.cpp
+++ b/src/citra_qt/configuration/configure_general.cpp
@@ -21,7 +21,7 @@ static constexpr int SettingsToSlider(int value) {
 }
 
 ConfigureGeneral::ConfigureGeneral(QWidget* parent)
-    : QWidget(parent), ui(new Ui::ConfigureGeneral) {
+    : QWidget(parent), ui(std::make_unique<Ui::ConfigureGeneral>()) {
 
     ui->setupUi(this);
 

--- a/src/citra_qt/configuration/configure_graphics.cpp
+++ b/src/citra_qt/configuration/configure_graphics.cpp
@@ -13,7 +13,7 @@
 #include "video_core/renderer_opengl/post_processing_opengl.h"
 
 ConfigureGraphics::ConfigureGraphics(QWidget* parent)
-    : QWidget(parent), ui(new Ui::ConfigureGraphics) {
+    : QWidget(parent), ui(std::make_unique<Ui::ConfigureGraphics>()) {
     ui->setupUi(this);
     SetConfiguration();
 

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -6,8 +6,11 @@
 #include <memory>
 #include <utility>
 #include <QInputDialog>
+#include <QKeyEvent>
+#include <QLabel>
 #include <QMenu>
 #include <QMessageBox>
+#include <QSlider>
 #include <QTimer>
 #include "citra_qt/configuration/config.h"
 #include "citra_qt/configuration/configure_input.h"

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -13,6 +13,7 @@
 #include "citra_qt/configuration/configure_input.h"
 #include "citra_qt/configuration/configure_motion_touch.h"
 #include "common/param_package.h"
+#include "ui_configure_input.h"
 
 const std::array<std::string, ConfigureInput::ANALOG_SUB_BUTTONS_NUM>
     ConfigureInput::analog_sub_buttons{{

--- a/src/citra_qt/configuration/configure_input.h
+++ b/src/citra_qt/configuration/configure_input.h
@@ -10,16 +10,16 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
-#include <QKeyEvent>
 #include <QKeySequence>
-#include <QLabel>
-#include <QSlider>
 #include <QWidget>
 #include "common/param_package.h"
 #include "core/settings.h"
 #include "input_common/main.h"
 
+class QKeyEvent;
+class QLabel;
 class QPushButton;
+class QSlider;
 class QString;
 class QTimer;
 

--- a/src/citra_qt/configuration/configure_input.h
+++ b/src/citra_qt/configuration/configure_input.h
@@ -12,12 +12,12 @@
 #include <unordered_map>
 #include <QKeyEvent>
 #include <QKeySequence>
+#include <QLabel>
 #include <QSlider>
 #include <QWidget>
 #include "common/param_package.h"
 #include "core/settings.h"
 #include "input_common/main.h"
-#include "ui_configure_input.h"
 
 class QPushButton;
 class QString;

--- a/src/citra_qt/configuration/configure_system.cpp
+++ b/src/citra_qt/configuration/configure_system.cpp
@@ -228,7 +228,8 @@ static constexpr int SettingsToSlider(int value) {
     return (value - 5) / 5;
 }
 
-ConfigureSystem::ConfigureSystem(QWidget* parent) : QWidget(parent), ui(new Ui::ConfigureSystem) {
+ConfigureSystem::ConfigureSystem(QWidget* parent)
+    : QWidget(parent), ui(std::make_unique<Ui::ConfigureSystem>()) {
     ui->setupUi(this);
     connect(ui->combo_birthmonth,
             static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,

--- a/src/citra_qt/configuration/configure_ui.cpp
+++ b/src/citra_qt/configuration/configure_ui.cpp
@@ -7,7 +7,8 @@
 #include "citra_qt/uisettings.h"
 #include "ui_configure_ui.h"
 
-ConfigureUi::ConfigureUi(QWidget* parent) : QWidget(parent), ui(new Ui::ConfigureUi) {
+ConfigureUi::ConfigureUi(QWidget* parent)
+    : QWidget(parent), ui(std::make_unique<Ui::ConfigureUi>()) {
     ui->setupUi(this);
     InitializeLanguageComboBox();
 

--- a/src/citra_qt/debugger/registers.cpp
+++ b/src/citra_qt/debugger/registers.cpp
@@ -7,11 +7,13 @@
 #include "citra_qt/util/util.h"
 #include "core/arm/arm_interface.h"
 #include "core/core.h"
+#include "ui_registers.h"
 
-RegistersWidget::RegistersWidget(QWidget* parent) : QDockWidget(parent) {
-    cpu_regs_ui.setupUi(this);
+RegistersWidget::RegistersWidget(QWidget* parent)
+    : QDockWidget(parent), cpu_regs_ui(std::make_unique<Ui::ARMRegisters>()) {
+    cpu_regs_ui->setupUi(this);
 
-    tree = cpu_regs_ui.treeWidget;
+    tree = cpu_regs_ui->treeWidget;
     tree->addTopLevelItem(core_registers = new QTreeWidgetItem(QStringList(tr("Registers"))));
     tree->addTopLevelItem(vfp_registers = new QTreeWidgetItem(QStringList(tr("VFP Registers"))));
     tree->addTopLevelItem(vfp_system_registers =
@@ -56,6 +58,8 @@ RegistersWidget::RegistersWidget(QWidget* parent) : QDockWidget(parent) {
     }
     setEnabled(false);
 }
+
+RegistersWidget::~RegistersWidget() {}
 
 void RegistersWidget::OnDebugModeEntered() {
     if (!Core::System::GetInstance().IsPoweredOn())

--- a/src/citra_qt/debugger/registers.cpp
+++ b/src/citra_qt/debugger/registers.cpp
@@ -59,7 +59,7 @@ RegistersWidget::RegistersWidget(QWidget* parent)
     setEnabled(false);
 }
 
-RegistersWidget::~RegistersWidget() {}
+RegistersWidget::~RegistersWidget() = default;
 
 void RegistersWidget::OnDebugModeEntered() {
     if (!Core::System::GetInstance().IsPoweredOn())

--- a/src/citra_qt/debugger/registers.h
+++ b/src/citra_qt/debugger/registers.h
@@ -4,18 +4,23 @@
 
 #pragma once
 
+#include <memory>
 #include <QDockWidget>
-#include "ui_registers.h"
 
 class QTreeWidget;
 class QTreeWidgetItem;
 class EmuThread;
+
+namespace Ui {
+class ARMRegisters;
+}
 
 class RegistersWidget : public QDockWidget {
     Q_OBJECT
 
 public:
     explicit RegistersWidget(QWidget* parent = nullptr);
+    ~RegistersWidget();
 
 public slots:
     void OnDebugModeEntered();
@@ -31,7 +36,7 @@ private:
     void CreateVFPSystemRegisterChildren();
     void UpdateVFPSystemRegisterValues();
 
-    Ui::ARMRegisters cpu_regs_ui;
+    std::unique_ptr<Ui::ARMRegisters> cpu_regs_ui;
 
     QTreeWidget* tree;
 

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -149,7 +149,8 @@ static void InitializeLogging() {
 }
 
 GMainWindow::GMainWindow()
-    : config(new Config()), emu_thread(nullptr), ui(std::make_unique<Ui::MainWindow>()) {
+    : config(std::make_unique<Config>()), emu_thread(nullptr),
+      ui(std::make_unique<Ui::MainWindow>()) {
     InitializeLogging();
     Debugger::ToggleConsole();
     Settings::LogSettings();

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -83,6 +83,7 @@
 #include "core/savestate.h"
 #include "core/settings.h"
 #include "game_list_p.h"
+#include "ui_main.h"
 #include "video_core/renderer_base.h"
 #include "video_core/video_core.h"
 
@@ -147,7 +148,8 @@ static void InitializeLogging() {
 #endif
 }
 
-GMainWindow::GMainWindow() : config(new Config()), emu_thread(nullptr) {
+GMainWindow::GMainWindow()
+    : config(new Config()), emu_thread(nullptr), ui(std::make_unique<Ui::MainWindow>()) {
     InitializeLogging();
     Debugger::ToggleConsole();
     Settings::LogSettings();
@@ -160,7 +162,7 @@ GMainWindow::GMainWindow() : config(new Config()), emu_thread(nullptr) {
 
     Pica::g_debug_context = Pica::DebugContext::Construct();
     setAcceptDrops(true);
-    ui.setupUi(this);
+    ui->setupUi(this);
     statusBar()->hide();
 
     default_theme_paths = QIcon::themeSearchPaths();
@@ -201,12 +203,12 @@ GMainWindow::GMainWindow() : config(new Config()), emu_thread(nullptr) {
     ShowTelemetryCallout();
 
     // make sure menubar has the arrow cursor instead of inheriting from this
-    ui.menubar->setCursor(QCursor());
+    ui->menubar->setCursor(QCursor());
     statusBar()->setCursor(QCursor());
 
     mouse_hide_timer.setInterval(default_mouse_timeout);
     connect(&mouse_hide_timer, &QTimer::timeout, this, &GMainWindow::HideMouseCursor);
-    connect(ui.menubar, &QMenuBar::hovered, this, &GMainWindow::ShowMouseCursor);
+    connect(ui->menubar, &QMenuBar::hovered, this, &GMainWindow::ShowMouseCursor);
 
     if (UISettings::values.check_for_update_on_start) {
         CheckForUpdates();
@@ -229,21 +231,21 @@ GMainWindow::~GMainWindow() {
 
 void GMainWindow::InitializeWidgets() {
 #ifdef CITRA_ENABLE_COMPATIBILITY_REPORTING
-    ui.action_Report_Compatibility->setVisible(true);
+    ui->action_Report_Compatibility->setVisible(true);
 #endif
     render_window = new GRenderWindow(this, emu_thread.get());
     render_window->hide();
 
     game_list = new GameList(this);
-    ui.horizontalLayout->addWidget(game_list);
+    ui->horizontalLayout->addWidget(game_list);
 
     game_list_placeholder = new GameListPlaceholder(this);
-    ui.horizontalLayout->addWidget(game_list_placeholder);
+    ui->horizontalLayout->addWidget(game_list_placeholder);
     game_list_placeholder->setVisible(false);
 
     loading_screen = new LoadingScreen(this);
     loading_screen->hide();
-    ui.horizontalLayout->addWidget(loading_screen);
+    ui->horizontalLayout->addWidget(loading_screen);
     connect(loading_screen, &LoadingScreen::Hidden, [&] {
         loading_screen->Clear();
         if (emulation_running) {
@@ -252,8 +254,8 @@ void GMainWindow::InitializeWidgets() {
         }
     });
 
-    multiplayer_state = new MultiplayerState(this, game_list->GetModel(), ui.action_Leave_Room,
-                                             ui.action_Show_Room);
+    multiplayer_state = new MultiplayerState(this, game_list->GetModel(), ui->action_Leave_Room,
+                                             ui->action_Show_Room);
     multiplayer_state->setVisible(false);
 
     // Setup updater
@@ -298,17 +300,17 @@ void GMainWindow::InitializeWidgets() {
     setStyleSheet(QStringLiteral("QStatusBar::item{border: none;}"));
 
     QActionGroup* actionGroup_ScreenLayouts = new QActionGroup(this);
-    actionGroup_ScreenLayouts->addAction(ui.action_Screen_Layout_Default);
-    actionGroup_ScreenLayouts->addAction(ui.action_Screen_Layout_Single_Screen);
-    actionGroup_ScreenLayouts->addAction(ui.action_Screen_Layout_Large_Screen);
-    actionGroup_ScreenLayouts->addAction(ui.action_Screen_Layout_Side_by_Side);
+    actionGroup_ScreenLayouts->addAction(ui->action_Screen_Layout_Default);
+    actionGroup_ScreenLayouts->addAction(ui->action_Screen_Layout_Single_Screen);
+    actionGroup_ScreenLayouts->addAction(ui->action_Screen_Layout_Large_Screen);
+    actionGroup_ScreenLayouts->addAction(ui->action_Screen_Layout_Side_by_Side);
 }
 
 void GMainWindow::InitializeDebugWidgets() {
-    connect(ui.action_Create_Pica_Surface_Viewer, &QAction::triggered, this,
+    connect(ui->action_Create_Pica_Surface_Viewer, &QAction::triggered, this,
             &GMainWindow::OnCreateGraphicsSurfaceViewer);
 
-    QMenu* debug_menu = ui.menu_View_Debugging;
+    QMenu* debug_menu = ui->menu_View_Debugging;
 
 #if MICROPROFILE_ENABLED
     microProfileDialog = new MicroProfileDialog(this);
@@ -386,16 +388,16 @@ void GMainWindow::InitializeRecentFileMenuActions() {
         actions_recent_files[i]->setVisible(false);
         connect(actions_recent_files[i], &QAction::triggered, this, &GMainWindow::OnMenuRecentFile);
 
-        ui.menu_recent_files->addAction(actions_recent_files[i]);
+        ui->menu_recent_files->addAction(actions_recent_files[i]);
     }
-    ui.menu_recent_files->addSeparator();
+    ui->menu_recent_files->addSeparator();
     QAction* action_clear_recent_files = new QAction(this);
     action_clear_recent_files->setText(tr("Clear Recent Files"));
     connect(action_clear_recent_files, &QAction::triggered, this, [this] {
         UISettings::values.recent_files.clear();
         UpdateRecentFiles();
     });
-    ui.menu_recent_files->addAction(action_clear_recent_files);
+    ui->menu_recent_files->addAction(action_clear_recent_files);
 
     UpdateRecentFiles();
 }
@@ -405,28 +407,28 @@ void GMainWindow::InitializeSaveStateMenuActions() {
         actions_load_state[i] = new QAction(this);
         actions_load_state[i]->setData(i + 1);
         connect(actions_load_state[i], &QAction::triggered, this, &GMainWindow::OnLoadState);
-        ui.menu_Load_State->addAction(actions_load_state[i]);
+        ui->menu_Load_State->addAction(actions_load_state[i]);
 
         actions_save_state[i] = new QAction(this);
         actions_save_state[i]->setData(i + 1);
         connect(actions_save_state[i], &QAction::triggered, this, &GMainWindow::OnSaveState);
-        ui.menu_Save_State->addAction(actions_save_state[i]);
+        ui->menu_Save_State->addAction(actions_save_state[i]);
     }
 
-    connect(ui.action_Load_from_Newest_Slot, &QAction::triggered, [this] {
+    connect(ui->action_Load_from_Newest_Slot, &QAction::triggered, [this] {
         UpdateSaveStates();
         if (newest_slot != 0) {
             actions_load_state[newest_slot - 1]->trigger();
         }
     });
-    connect(ui.action_Save_to_Oldest_Slot, &QAction::triggered, [this] {
+    connect(ui->action_Save_to_Oldest_Slot, &QAction::triggered, [this] {
         UpdateSaveStates();
         actions_save_state[oldest_slot - 1]->trigger();
     });
 
-    connect(ui.menu_Load_State->menuAction(), &QAction::hovered, this,
+    connect(ui->menu_Load_State->menuAction(), &QAction::hovered, this,
             &GMainWindow::UpdateSaveStates);
-    connect(ui.menu_Save_State->menuAction(), &QAction::hovered, this,
+    connect(ui->menu_Save_State->menuAction(), &QAction::hovered, this,
             &GMainWindow::UpdateSaveStates);
 
     UpdateSaveStates();
@@ -443,24 +445,24 @@ void GMainWindow::InitializeHotkeys() {
     const QString toggle_status_bar = QStringLiteral("Toggle Status Bar");
     const QString fullscreen = QStringLiteral("Fullscreen");
 
-    ui.action_Show_Filter_Bar->setShortcut(
+    ui->action_Show_Filter_Bar->setShortcut(
         hotkey_registry.GetKeySequence(main_window, toggle_filter_bar));
-    ui.action_Show_Filter_Bar->setShortcutContext(
+    ui->action_Show_Filter_Bar->setShortcutContext(
         hotkey_registry.GetShortcutContext(main_window, toggle_filter_bar));
 
-    ui.action_Show_Status_Bar->setShortcut(
+    ui->action_Show_Status_Bar->setShortcut(
         hotkey_registry.GetKeySequence(main_window, toggle_status_bar));
-    ui.action_Show_Status_Bar->setShortcutContext(
+    ui->action_Show_Status_Bar->setShortcutContext(
         hotkey_registry.GetShortcutContext(main_window, toggle_status_bar));
 
     connect(hotkey_registry.GetHotkey(main_window, load_file, this), &QShortcut::activated,
-            ui.action_Load_File, &QAction::trigger);
+            ui->action_Load_File, &QAction::trigger);
 
     connect(hotkey_registry.GetHotkey(main_window, stop_emulation, this), &QShortcut::activated,
-            ui.action_Stop, &QAction::trigger);
+            ui->action_Stop, &QAction::trigger);
 
     connect(hotkey_registry.GetHotkey(main_window, exit_citra, this), &QShortcut::activated,
-            ui.action_Exit, &QAction::trigger);
+            ui->action_Exit, &QAction::trigger);
 
     connect(
         hotkey_registry.GetHotkey(main_window, QStringLiteral("Continue/Pause Emulation"), this),
@@ -480,21 +482,21 @@ void GMainWindow::InitializeHotkeys() {
                 BootGame(QString(game_path));
             });
     connect(hotkey_registry.GetHotkey(main_window, QStringLiteral("Swap Screens"), render_window),
-            &QShortcut::activated, ui.action_Screen_Layout_Swap_Screens, &QAction::trigger);
+            &QShortcut::activated, ui->action_Screen_Layout_Swap_Screens, &QAction::trigger);
     connect(hotkey_registry.GetHotkey(main_window, QStringLiteral("Rotate Screens Upright"),
                                       render_window),
-            &QShortcut::activated, ui.action_Screen_Layout_Upright_Screens, &QAction::trigger);
+            &QShortcut::activated, ui->action_Screen_Layout_Upright_Screens, &QAction::trigger);
     connect(hotkey_registry.GetHotkey(main_window, QStringLiteral("Toggle Screen Layout"),
                                       render_window),
             &QShortcut::activated, this, &GMainWindow::ToggleScreenLayout);
     connect(hotkey_registry.GetHotkey(main_window, fullscreen, render_window),
-            &QShortcut::activated, ui.action_Fullscreen, &QAction::trigger);
+            &QShortcut::activated, ui->action_Fullscreen, &QAction::trigger);
     connect(hotkey_registry.GetHotkey(main_window, fullscreen, render_window),
-            &QShortcut::activatedAmbiguously, ui.action_Fullscreen, &QAction::trigger);
+            &QShortcut::activatedAmbiguously, ui->action_Fullscreen, &QAction::trigger);
     connect(hotkey_registry.GetHotkey(main_window, QStringLiteral("Exit Fullscreen"), this),
             &QShortcut::activated, this, [&] {
                 if (emulation_running) {
-                    ui.action_Fullscreen->setChecked(false);
+                    ui->action_Fullscreen->setChecked(false);
                     ToggleFullscreen();
                 }
             });
@@ -552,18 +554,18 @@ void GMainWindow::InitializeHotkeys() {
                 UpdateStatusBar();
             });
     connect(hotkey_registry.GetHotkey(main_window, QStringLiteral("Toggle Frame Advancing"), this),
-            &QShortcut::activated, ui.action_Enable_Frame_Advancing, &QAction::trigger);
+            &QShortcut::activated, ui->action_Enable_Frame_Advancing, &QAction::trigger);
     connect(hotkey_registry.GetHotkey(main_window, QStringLiteral("Advance Frame"), this),
-            &QShortcut::activated, ui.action_Advance_Frame, &QAction::trigger);
+            &QShortcut::activated, ui->action_Advance_Frame, &QAction::trigger);
     connect(hotkey_registry.GetHotkey(main_window, QStringLiteral("Load Amiibo"), this),
             &QShortcut::activated, this, [&] {
-                if (ui.action_Load_Amiibo->isEnabled()) {
+                if (ui->action_Load_Amiibo->isEnabled()) {
                     OnLoadAmiibo();
                 }
             });
     connect(hotkey_registry.GetHotkey(main_window, QStringLiteral("Remove Amiibo"), this),
             &QShortcut::activated, this, [&] {
-                if (ui.action_Remove_Amiibo->isEnabled()) {
+                if (ui->action_Remove_Amiibo->isEnabled()) {
                     OnRemoveAmiibo();
                 }
             });
@@ -574,14 +576,14 @@ void GMainWindow::InitializeHotkeys() {
                 }
             });
     connect(hotkey_registry.GetHotkey(main_window, QStringLiteral("Load from Newest Slot"), this),
-            &QShortcut::activated, ui.action_Load_from_Newest_Slot, &QAction::trigger);
+            &QShortcut::activated, ui->action_Load_from_Newest_Slot, &QAction::trigger);
     connect(hotkey_registry.GetHotkey(main_window, QStringLiteral("Save to Oldest Slot"), this),
-            &QShortcut::activated, ui.action_Save_to_Oldest_Slot, &QAction::trigger);
+            &QShortcut::activated, ui->action_Save_to_Oldest_Slot, &QAction::trigger);
 }
 
 void GMainWindow::ShowUpdaterWidgets() {
-    ui.action_Check_For_Updates->setVisible(UISettings::values.updater_found);
-    ui.action_Open_Maintenance_Tool->setVisible(UISettings::values.updater_found);
+    ui->action_Check_For_Updates->setVisible(UISettings::values.updater_found);
+    ui->action_Open_Maintenance_Tool->setVisible(UISettings::values.updater_found);
 
     connect(updater, &Updater::CheckUpdatesDone, this, &GMainWindow::OnUpdateFound);
 }
@@ -606,24 +608,24 @@ void GMainWindow::RestoreUIState() {
     microProfileDialog->restoreGeometry(UISettings::values.microprofile_geometry);
     microProfileDialog->setVisible(UISettings::values.microprofile_visible);
 #endif
-    ui.action_Cheats->setEnabled(false);
+    ui->action_Cheats->setEnabled(false);
 
     game_list->LoadInterfaceLayout();
 
-    ui.action_Single_Window_Mode->setChecked(UISettings::values.single_window_mode);
+    ui->action_Single_Window_Mode->setChecked(UISettings::values.single_window_mode);
     ToggleWindowMode();
 
-    ui.action_Fullscreen->setChecked(UISettings::values.fullscreen);
+    ui->action_Fullscreen->setChecked(UISettings::values.fullscreen);
     SyncMenuUISettings();
 
-    ui.action_Display_Dock_Widget_Headers->setChecked(UISettings::values.display_titlebar);
-    OnDisplayTitleBars(ui.action_Display_Dock_Widget_Headers->isChecked());
+    ui->action_Display_Dock_Widget_Headers->setChecked(UISettings::values.display_titlebar);
+    OnDisplayTitleBars(ui->action_Display_Dock_Widget_Headers->isChecked());
 
-    ui.action_Show_Filter_Bar->setChecked(UISettings::values.show_filter_bar);
-    game_list->setFilterVisible(ui.action_Show_Filter_Bar->isChecked());
+    ui->action_Show_Filter_Bar->setChecked(UISettings::values.show_filter_bar);
+    game_list->setFilterVisible(ui->action_Show_Filter_Bar->isChecked());
 
-    ui.action_Show_Status_Bar->setChecked(UISettings::values.show_status_bar);
-    statusBar()->setVisible(ui.action_Show_Status_Bar->isChecked());
+    ui->action_Show_Status_Bar->setChecked(UISettings::values.show_status_bar);
+    statusBar()->setVisible(ui->action_Show_Status_Bar->isChecked());
 }
 
 void GMainWindow::OnAppFocusStateChanged(Qt::ApplicationState state) {
@@ -634,11 +636,11 @@ void GMainWindow::OnAppFocusStateChanged(Qt::ApplicationState state) {
         state != Qt::ApplicationActive) {
         LOG_DEBUG(Frontend, "ApplicationState unusual flag: {} ", state);
     }
-    if (ui.action_Pause->isEnabled() &&
+    if (ui->action_Pause->isEnabled() &&
         (state & (Qt::ApplicationHidden | Qt::ApplicationInactive))) {
         auto_paused = true;
         OnPauseGame();
-    } else if (ui.action_Start->isEnabled() && auto_paused && state == Qt::ApplicationActive) {
+    } else if (ui->action_Start->isEnabled() && auto_paused && state == Qt::ApplicationActive) {
         auto_paused = false;
         OnStartGame();
     }
@@ -674,116 +676,117 @@ void GMainWindow::ConnectWidgetEvents() {
 
 void GMainWindow::ConnectMenuEvents() {
     // File
-    connect(ui.action_Load_File, &QAction::triggered, this, &GMainWindow::OnMenuLoadFile);
-    connect(ui.action_Install_CIA, &QAction::triggered, this, &GMainWindow::OnMenuInstallCIA);
-    connect(ui.action_Exit, &QAction::triggered, this, &QMainWindow::close);
-    connect(ui.action_Load_Amiibo, &QAction::triggered, this, &GMainWindow::OnLoadAmiibo);
-    connect(ui.action_Remove_Amiibo, &QAction::triggered, this, &GMainWindow::OnRemoveAmiibo);
+    connect(ui->action_Load_File, &QAction::triggered, this, &GMainWindow::OnMenuLoadFile);
+    connect(ui->action_Install_CIA, &QAction::triggered, this, &GMainWindow::OnMenuInstallCIA);
+    connect(ui->action_Exit, &QAction::triggered, this, &QMainWindow::close);
+    connect(ui->action_Load_Amiibo, &QAction::triggered, this, &GMainWindow::OnLoadAmiibo);
+    connect(ui->action_Remove_Amiibo, &QAction::triggered, this, &GMainWindow::OnRemoveAmiibo);
 
     // Emulation
-    connect(ui.action_Start, &QAction::triggered, this, &GMainWindow::OnStartGame);
-    connect(ui.action_Pause, &QAction::triggered, this, &GMainWindow::OnPauseGame);
-    connect(ui.action_Stop, &QAction::triggered, this, &GMainWindow::OnStopGame);
-    connect(ui.action_Restart, &QAction::triggered, this, [this] { BootGame(QString(game_path)); });
-    connect(ui.action_Report_Compatibility, &QAction::triggered, this,
+    connect(ui->action_Start, &QAction::triggered, this, &GMainWindow::OnStartGame);
+    connect(ui->action_Pause, &QAction::triggered, this, &GMainWindow::OnPauseGame);
+    connect(ui->action_Stop, &QAction::triggered, this, &GMainWindow::OnStopGame);
+    connect(ui->action_Restart, &QAction::triggered, this,
+            [this] { BootGame(QString(game_path)); });
+    connect(ui->action_Report_Compatibility, &QAction::triggered, this,
             &GMainWindow::OnMenuReportCompatibility);
-    connect(ui.action_Configure, &QAction::triggered, this, &GMainWindow::OnConfigure);
-    connect(ui.action_Cheats, &QAction::triggered, this, &GMainWindow::OnCheats);
+    connect(ui->action_Configure, &QAction::triggered, this, &GMainWindow::OnConfigure);
+    connect(ui->action_Cheats, &QAction::triggered, this, &GMainWindow::OnCheats);
 
     // View
-    connect(ui.action_Single_Window_Mode, &QAction::triggered, this,
+    connect(ui->action_Single_Window_Mode, &QAction::triggered, this,
             &GMainWindow::ToggleWindowMode);
-    connect(ui.action_Display_Dock_Widget_Headers, &QAction::triggered, this,
+    connect(ui->action_Display_Dock_Widget_Headers, &QAction::triggered, this,
             &GMainWindow::OnDisplayTitleBars);
-    connect(ui.action_Show_Filter_Bar, &QAction::triggered, this, &GMainWindow::OnToggleFilterBar);
-    connect(ui.action_Show_Status_Bar, &QAction::triggered, statusBar(), &QStatusBar::setVisible);
+    connect(ui->action_Show_Filter_Bar, &QAction::triggered, this, &GMainWindow::OnToggleFilterBar);
+    connect(ui->action_Show_Status_Bar, &QAction::triggered, statusBar(), &QStatusBar::setVisible);
 
     // Multiplayer
-    connect(ui.action_View_Lobby, &QAction::triggered, multiplayer_state,
+    connect(ui->action_View_Lobby, &QAction::triggered, multiplayer_state,
             &MultiplayerState::OnViewLobby);
-    connect(ui.action_Start_Room, &QAction::triggered, multiplayer_state,
+    connect(ui->action_Start_Room, &QAction::triggered, multiplayer_state,
             &MultiplayerState::OnCreateRoom);
-    connect(ui.action_Leave_Room, &QAction::triggered, multiplayer_state,
+    connect(ui->action_Leave_Room, &QAction::triggered, multiplayer_state,
             &MultiplayerState::OnCloseRoom);
-    connect(ui.action_Connect_To_Room, &QAction::triggered, multiplayer_state,
+    connect(ui->action_Connect_To_Room, &QAction::triggered, multiplayer_state,
             &MultiplayerState::OnDirectConnectToRoom);
-    connect(ui.action_Show_Room, &QAction::triggered, multiplayer_state,
+    connect(ui->action_Show_Room, &QAction::triggered, multiplayer_state,
             &MultiplayerState::OnOpenNetworkRoom);
 
-    ui.action_Fullscreen->setShortcut(
+    ui->action_Fullscreen->setShortcut(
         hotkey_registry
             .GetHotkey(QStringLiteral("Main Window"), QStringLiteral("Fullscreen"), this)
             ->key());
-    ui.action_Screen_Layout_Swap_Screens->setShortcut(
+    ui->action_Screen_Layout_Swap_Screens->setShortcut(
         hotkey_registry
             .GetHotkey(QStringLiteral("Main Window"), QStringLiteral("Swap Screens"), this)
             ->key());
-    ui.action_Screen_Layout_Swap_Screens->setShortcutContext(Qt::WidgetWithChildrenShortcut);
-    ui.action_Screen_Layout_Upright_Screens->setShortcut(
+    ui->action_Screen_Layout_Swap_Screens->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+    ui->action_Screen_Layout_Upright_Screens->setShortcut(
         hotkey_registry
             .GetHotkey(QStringLiteral("Main Window"), QStringLiteral("Rotate Screens Upright"),
                        this)
             ->key());
-    ui.action_Screen_Layout_Upright_Screens->setShortcutContext(Qt::WidgetWithChildrenShortcut);
-    connect(ui.action_Fullscreen, &QAction::triggered, this, &GMainWindow::ToggleFullscreen);
-    connect(ui.action_Screen_Layout_Default, &QAction::triggered, this,
+    ui->action_Screen_Layout_Upright_Screens->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+    connect(ui->action_Fullscreen, &QAction::triggered, this, &GMainWindow::ToggleFullscreen);
+    connect(ui->action_Screen_Layout_Default, &QAction::triggered, this,
             &GMainWindow::ChangeScreenLayout);
-    connect(ui.action_Screen_Layout_Single_Screen, &QAction::triggered, this,
+    connect(ui->action_Screen_Layout_Single_Screen, &QAction::triggered, this,
             &GMainWindow::ChangeScreenLayout);
-    connect(ui.action_Screen_Layout_Large_Screen, &QAction::triggered, this,
+    connect(ui->action_Screen_Layout_Large_Screen, &QAction::triggered, this,
             &GMainWindow::ChangeScreenLayout);
-    connect(ui.action_Screen_Layout_Side_by_Side, &QAction::triggered, this,
+    connect(ui->action_Screen_Layout_Side_by_Side, &QAction::triggered, this,
             &GMainWindow::ChangeScreenLayout);
-    connect(ui.action_Screen_Layout_Swap_Screens, &QAction::triggered, this,
+    connect(ui->action_Screen_Layout_Swap_Screens, &QAction::triggered, this,
             &GMainWindow::OnSwapScreens);
-    connect(ui.action_Screen_Layout_Upright_Screens, &QAction::triggered, this,
+    connect(ui->action_Screen_Layout_Upright_Screens, &QAction::triggered, this,
             &GMainWindow::OnRotateScreens);
 
     // Movie
-    connect(ui.action_Record_Movie, &QAction::triggered, this, &GMainWindow::OnRecordMovie);
-    connect(ui.action_Play_Movie, &QAction::triggered, this, &GMainWindow::OnPlayMovie);
-    connect(ui.action_Stop_Recording_Playback, &QAction::triggered, this,
+    connect(ui->action_Record_Movie, &QAction::triggered, this, &GMainWindow::OnRecordMovie);
+    connect(ui->action_Play_Movie, &QAction::triggered, this, &GMainWindow::OnPlayMovie);
+    connect(ui->action_Stop_Recording_Playback, &QAction::triggered, this,
             &GMainWindow::OnStopRecordingPlayback);
-    connect(ui.action_Enable_Frame_Advancing, &QAction::triggered, this, [this] {
+    connect(ui->action_Enable_Frame_Advancing, &QAction::triggered, this, [this] {
         if (emulation_running) {
             Core::System::GetInstance().frame_limiter.SetFrameAdvancing(
-                ui.action_Enable_Frame_Advancing->isChecked());
-            ui.action_Advance_Frame->setEnabled(ui.action_Enable_Frame_Advancing->isChecked());
+                ui->action_Enable_Frame_Advancing->isChecked());
+            ui->action_Advance_Frame->setEnabled(ui->action_Enable_Frame_Advancing->isChecked());
         }
     });
-    connect(ui.action_Advance_Frame, &QAction::triggered, this, [this] {
+    connect(ui->action_Advance_Frame, &QAction::triggered, this, [this] {
         if (emulation_running) {
-            ui.action_Enable_Frame_Advancing->setChecked(true);
-            ui.action_Advance_Frame->setEnabled(true);
+            ui->action_Enable_Frame_Advancing->setChecked(true);
+            ui->action_Advance_Frame->setEnabled(true);
             Core::System::GetInstance().frame_limiter.SetFrameAdvancing(true);
             Core::System::GetInstance().frame_limiter.AdvanceFrame();
         }
     });
-    connect(ui.action_Capture_Screenshot, &QAction::triggered, this,
+    connect(ui->action_Capture_Screenshot, &QAction::triggered, this,
             &GMainWindow::OnCaptureScreenshot);
 
 #ifdef ENABLE_FFMPEG_VIDEO_DUMPER
-    connect(ui.action_Dump_Video, &QAction::triggered, [this] {
-        if (ui.action_Dump_Video->isChecked()) {
+    connect(ui->action_Dump_Video, &QAction::triggered, [this] {
+        if (ui->action_Dump_Video->isChecked()) {
             OnStartVideoDumping();
         } else {
             OnStopVideoDumping();
         }
     });
 #else
-    ui.action_Dump_Video->setEnabled(false);
+    ui->action_Dump_Video->setEnabled(false);
 #endif
 
     // Help
-    connect(ui.action_Open_Citra_Folder, &QAction::triggered, this,
+    connect(ui->action_Open_Citra_Folder, &QAction::triggered, this,
             &GMainWindow::OnOpenCitraFolder);
-    connect(ui.action_FAQ, &QAction::triggered, []() {
+    connect(ui->action_FAQ, &QAction::triggered, []() {
         QDesktopServices::openUrl(QUrl(QStringLiteral("https://citra-emu.org/wiki/faq/")));
     });
-    connect(ui.action_About, &QAction::triggered, this, &GMainWindow::OnMenuAboutCitra);
-    connect(ui.action_Check_For_Updates, &QAction::triggered, this,
+    connect(ui->action_About, &QAction::triggered, this, &GMainWindow::OnMenuAboutCitra);
+    connect(ui->action_Check_For_Updates, &QAction::triggered, this,
             &GMainWindow::OnCheckForUpdates);
-    connect(ui.action_Open_Maintenance_Tool, &QAction::triggered, this,
+    connect(ui->action_Open_Maintenance_Tool, &QAction::triggered, this,
             &GMainWindow::OnOpenUpdater);
 }
 
@@ -1038,7 +1041,7 @@ void GMainWindow::BootGame(const QString& filename) {
 
     // Update the GUI
     registersWidget->OnDebugModeEntered();
-    if (ui.action_Single_Window_Mode->isChecked()) {
+    if (ui->action_Single_Window_Mode->isChecked()) {
         game_list->hide();
         game_list_placeholder->hide();
     }
@@ -1047,7 +1050,7 @@ void GMainWindow::BootGame(const QString& filename) {
     if (UISettings::values.hide_mouse) {
         mouse_hide_timer.start();
         setMouseTracking(true);
-        ui.centralwidget->setMouseTracking(true);
+        ui->centralwidget->setMouseTracking(true);
     }
 
     // show and hide the render_window to create the context
@@ -1058,7 +1061,7 @@ void GMainWindow::BootGame(const QString& filename) {
     loading_screen->show();
 
     emulation_running = true;
-    if (ui.action_Fullscreen->isChecked()) {
+    if (ui->action_Fullscreen->isChecked()) {
         ShowFullscreen();
     }
 
@@ -1071,7 +1074,7 @@ void GMainWindow::BootGame(const QString& filename) {
             QMessageBox::critical(
                 this, tr("Citra"),
                 tr("Could not start video dumping.<br>Refer to the log for details."));
-            ui.action_Dump_Video->setChecked(false);
+            ui->action_Dump_Video->setChecked(false);
         }
         video_dumping_on_start = false;
         video_dumping_path.clear();
@@ -1084,7 +1087,7 @@ void GMainWindow::ShutdownGame() {
         return;
     }
 
-    if (ui.action_Fullscreen->isChecked()) {
+    if (ui->action_Fullscreen->isChecked()) {
         HideFullscreen();
     }
 
@@ -1126,19 +1129,19 @@ void GMainWindow::ShutdownGame() {
     disconnect(render_window, &GRenderWindow::Closed, this, &GMainWindow::OnStopGame);
 
     // Update the GUI
-    ui.action_Start->setEnabled(false);
-    ui.action_Start->setText(tr("Start"));
-    ui.action_Pause->setEnabled(false);
-    ui.action_Stop->setEnabled(false);
-    ui.action_Restart->setEnabled(false);
-    ui.action_Cheats->setEnabled(false);
-    ui.action_Load_Amiibo->setEnabled(false);
-    ui.action_Remove_Amiibo->setEnabled(false);
-    ui.action_Report_Compatibility->setEnabled(false);
-    ui.action_Enable_Frame_Advancing->setEnabled(false);
-    ui.action_Enable_Frame_Advancing->setChecked(false);
-    ui.action_Advance_Frame->setEnabled(false);
-    ui.action_Capture_Screenshot->setEnabled(false);
+    ui->action_Start->setEnabled(false);
+    ui->action_Start->setText(tr("Start"));
+    ui->action_Pause->setEnabled(false);
+    ui->action_Stop->setEnabled(false);
+    ui->action_Restart->setEnabled(false);
+    ui->action_Cheats->setEnabled(false);
+    ui->action_Load_Amiibo->setEnabled(false);
+    ui->action_Remove_Amiibo->setEnabled(false);
+    ui->action_Report_Compatibility->setEnabled(false);
+    ui->action_Enable_Frame_Advancing->setEnabled(false);
+    ui->action_Enable_Frame_Advancing->setChecked(false);
+    ui->action_Advance_Frame->setEnabled(false);
+    ui->action_Capture_Screenshot->setEnabled(false);
     render_window->hide();
     loading_screen->hide();
     loading_screen->Clear();
@@ -1149,7 +1152,7 @@ void GMainWindow::ShutdownGame() {
     game_list->setFilterFocus();
 
     setMouseTracking(false);
-    ui.centralwidget->setMouseTracking(false);
+    ui->centralwidget->setMouseTracking(false);
 
     // Disable status bar updates
     status_bar_update_timer.stop();
@@ -1203,19 +1206,19 @@ void GMainWindow::UpdateRecentFiles() {
     }
 
     // Enable the recent files menu if the list isn't empty
-    ui.menu_recent_files->setEnabled(num_recent_files != 0);
+    ui->menu_recent_files->setEnabled(num_recent_files != 0);
 }
 
 void GMainWindow::UpdateSaveStates() {
     if (!Core::System::GetInstance().IsPoweredOn()) {
-        ui.menu_Load_State->setEnabled(false);
-        ui.menu_Save_State->setEnabled(false);
+        ui->menu_Load_State->setEnabled(false);
+        ui->menu_Save_State->setEnabled(false);
         return;
     }
 
-    ui.menu_Load_State->setEnabled(true);
-    ui.menu_Save_State->setEnabled(true);
-    ui.action_Load_from_Newest_Slot->setEnabled(false);
+    ui->menu_Load_State->setEnabled(true);
+    ui->menu_Save_State->setEnabled(true);
+    ui->action_Load_from_Newest_Slot->setEnabled(false);
 
     oldest_slot = newest_slot = 0;
     oldest_slot_time = std::numeric_limits<u64>::max();
@@ -1241,7 +1244,7 @@ void GMainWindow::UpdateSaveStates() {
         actions_load_state[savestate.slot - 1]->setText(text);
         actions_save_state[savestate.slot - 1]->setText(text);
 
-        ui.action_Load_from_Newest_Slot->setEnabled(true);
+        ui->action_Load_from_Newest_Slot->setEnabled(true);
 
         if (savestate.time > newest_slot_time) {
             newest_slot = savestate.slot;
@@ -1414,7 +1417,7 @@ void GMainWindow::OnGameListAddDirectory() {
 }
 
 void GMainWindow::OnGameListShowList(bool show) {
-    if (emulation_running && ui.action_Single_Window_Mode->isChecked())
+    if (emulation_running && ui->action_Single_Window_Mode->isChecked())
         return;
     game_list->setVisible(show);
     game_list_placeholder->setVisible(!show);
@@ -1448,7 +1451,7 @@ void GMainWindow::OnMenuInstallCIA() {
 }
 
 void GMainWindow::InstallCIA(QStringList filepaths) {
-    ui.action_Install_CIA->setEnabled(false);
+    ui->action_Install_CIA->setEnabled(false);
     game_list->setDirectoryWatcherEnabled(false);
     progress_bar->show();
     progress_bar->setMaximum(INT_MAX);
@@ -1504,7 +1507,7 @@ void GMainWindow::OnCIAInstallFinished() {
     progress_bar->hide();
     progress_bar->setValue(0);
     game_list->setDirectoryWatcherEnabled(true);
-    ui.action_Install_CIA->setEnabled(true);
+    ui->action_Install_CIA->setEnabled(true);
     game_list->PopulateAsync(UISettings::values.game_dirs);
 }
 
@@ -1541,17 +1544,17 @@ void GMainWindow::OnStartGame() {
     qRegisterMetaType<std::string>("std::string");
     connect(emu_thread.get(), &EmuThread::ErrorThrown, this, &GMainWindow::OnCoreError);
 
-    ui.action_Start->setEnabled(false);
-    ui.action_Start->setText(tr("Continue"));
+    ui->action_Start->setEnabled(false);
+    ui->action_Start->setText(tr("Continue"));
 
-    ui.action_Pause->setEnabled(true);
-    ui.action_Stop->setEnabled(true);
-    ui.action_Restart->setEnabled(true);
-    ui.action_Cheats->setEnabled(true);
-    ui.action_Load_Amiibo->setEnabled(true);
-    ui.action_Report_Compatibility->setEnabled(true);
-    ui.action_Enable_Frame_Advancing->setEnabled(true);
-    ui.action_Capture_Screenshot->setEnabled(true);
+    ui->action_Pause->setEnabled(true);
+    ui->action_Stop->setEnabled(true);
+    ui->action_Restart->setEnabled(true);
+    ui->action_Cheats->setEnabled(true);
+    ui->action_Load_Amiibo->setEnabled(true);
+    ui->action_Report_Compatibility->setEnabled(true);
+    ui->action_Enable_Frame_Advancing->setEnabled(true);
+    ui->action_Capture_Screenshot->setEnabled(true);
 
     discord_rpc->Update();
 
@@ -1561,10 +1564,10 @@ void GMainWindow::OnStartGame() {
 void GMainWindow::OnPauseGame() {
     emu_thread->SetRunning(false);
     Camera::QtMultimediaCameraHandler::StopCameras();
-    ui.action_Start->setEnabled(true);
-    ui.action_Pause->setEnabled(false);
-    ui.action_Stop->setEnabled(true);
-    ui.action_Capture_Screenshot->setEnabled(false);
+    ui->action_Start->setEnabled(true);
+    ui->action_Pause->setEnabled(false);
+    ui->action_Stop->setEnabled(true);
+    ui->action_Capture_Screenshot->setEnabled(false);
 
     AllowOSSleep();
 }
@@ -1592,7 +1595,7 @@ void GMainWindow::ToggleFullscreen() {
     if (!emulation_running) {
         return;
     }
-    if (ui.action_Fullscreen->isChecked()) {
+    if (ui->action_Fullscreen->isChecked()) {
         ShowFullscreen();
     } else {
         HideFullscreen();
@@ -1600,9 +1603,9 @@ void GMainWindow::ToggleFullscreen() {
 }
 
 void GMainWindow::ShowFullscreen() {
-    if (ui.action_Single_Window_Mode->isChecked()) {
+    if (ui->action_Single_Window_Mode->isChecked()) {
         UISettings::values.geometry = saveGeometry();
-        ui.menubar->hide();
+        ui->menubar->hide();
         statusBar()->hide();
         showFullScreen();
     } else {
@@ -1612,9 +1615,9 @@ void GMainWindow::ShowFullscreen() {
 }
 
 void GMainWindow::HideFullscreen() {
-    if (ui.action_Single_Window_Mode->isChecked()) {
-        statusBar()->setVisible(ui.action_Show_Status_Bar->isChecked());
-        ui.menubar->show();
+    if (ui->action_Single_Window_Mode->isChecked()) {
+        statusBar()->setVisible(ui->action_Show_Status_Bar->isChecked());
+        ui->menubar->show();
         showNormal();
         restoreGeometry(UISettings::values.geometry);
     } else {
@@ -1624,10 +1627,10 @@ void GMainWindow::HideFullscreen() {
 }
 
 void GMainWindow::ToggleWindowMode() {
-    if (ui.action_Single_Window_Mode->isChecked()) {
+    if (ui->action_Single_Window_Mode->isChecked()) {
         // Render in the main window...
         render_window->BackupGeometry();
-        ui.horizontalLayout->addWidget(render_window);
+        ui->horizontalLayout->addWidget(render_window);
         render_window->setFocusPolicy(Qt::StrongFocus);
         if (emulation_running) {
             render_window->setVisible(true);
@@ -1637,7 +1640,7 @@ void GMainWindow::ToggleWindowMode() {
 
     } else {
         // Render in a separate window...
-        ui.horizontalLayout->removeWidget(render_window);
+        ui->horizontalLayout->removeWidget(render_window);
         render_window->setParent(nullptr);
         render_window->setFocusPolicy(Qt::NoFocus);
         if (emulation_running) {
@@ -1651,13 +1654,13 @@ void GMainWindow::ToggleWindowMode() {
 void GMainWindow::ChangeScreenLayout() {
     Settings::LayoutOption new_layout = Settings::LayoutOption::Default;
 
-    if (ui.action_Screen_Layout_Default->isChecked()) {
+    if (ui->action_Screen_Layout_Default->isChecked()) {
         new_layout = Settings::LayoutOption::Default;
-    } else if (ui.action_Screen_Layout_Single_Screen->isChecked()) {
+    } else if (ui->action_Screen_Layout_Single_Screen->isChecked()) {
         new_layout = Settings::LayoutOption::SingleScreen;
-    } else if (ui.action_Screen_Layout_Large_Screen->isChecked()) {
+    } else if (ui->action_Screen_Layout_Large_Screen->isChecked()) {
         new_layout = Settings::LayoutOption::LargeScreen;
-    } else if (ui.action_Screen_Layout_Side_by_Side->isChecked()) {
+    } else if (ui->action_Screen_Layout_Side_by_Side->isChecked()) {
         new_layout = Settings::LayoutOption::SideScreen;
     }
 
@@ -1689,12 +1692,12 @@ void GMainWindow::ToggleScreenLayout() {
 }
 
 void GMainWindow::OnSwapScreens() {
-    Settings::values.swap_screen = ui.action_Screen_Layout_Swap_Screens->isChecked();
+    Settings::values.swap_screen = ui->action_Screen_Layout_Swap_Screens->isChecked();
     Settings::Apply();
 }
 
 void GMainWindow::OnRotateScreens() {
-    Settings::values.upright_screen = ui.action_Screen_Layout_Upright_Screens->isChecked();
+    Settings::values.upright_screen = ui->action_Screen_Layout_Upright_Screens->isChecked();
     Settings::Apply();
 }
 
@@ -1746,11 +1749,11 @@ void GMainWindow::OnConfigure() {
         config->Save();
         if (UISettings::values.hide_mouse && emulation_running) {
             setMouseTracking(true);
-            ui.centralwidget->setMouseTracking(true);
+            ui->centralwidget->setMouseTracking(true);
             mouse_hide_timer.start();
         } else {
             setMouseTracking(false);
-            ui.centralwidget->setMouseTracking(false);
+            ui->centralwidget->setMouseTracking(false);
         }
     } else {
         Settings::values.input_profiles = old_input_profiles;
@@ -1799,7 +1802,7 @@ void GMainWindow::LoadAmiibo(const QString& filename) {
     }
 
     nfc->LoadAmiibo(amiibo_data);
-    ui.action_Remove_Amiibo->setEnabled(true);
+    ui->action_Remove_Amiibo->setEnabled(true);
 }
 
 void GMainWindow::OnRemoveAmiibo() {
@@ -1811,7 +1814,7 @@ void GMainWindow::OnRemoveAmiibo() {
     }
 
     nfc->RemoveAmiibo();
-    ui.action_Remove_Amiibo->setEnabled(false);
+    ui->action_Remove_Amiibo->setEnabled(false);
 }
 
 void GMainWindow::OnOpenCitraFolder() {
@@ -1820,8 +1823,8 @@ void GMainWindow::OnOpenCitraFolder() {
 }
 
 void GMainWindow::OnToggleFilterBar() {
-    game_list->setFilterVisible(ui.action_Show_Filter_Bar->isChecked());
-    if (ui.action_Show_Filter_Bar->isChecked()) {
+    game_list->setFilterVisible(ui->action_Show_Filter_Bar->isChecked());
+    if (ui->action_Show_Filter_Bar->isChecked()) {
         game_list->setFilterFocus();
     } else {
         game_list->clearFilter();
@@ -1859,9 +1862,9 @@ void GMainWindow::OnRecordMovie() {
         QMessageBox::information(this, tr("Record Movie"),
                                  tr("Recording will start once you boot a game."));
     }
-    ui.action_Record_Movie->setEnabled(false);
-    ui.action_Play_Movie->setEnabled(false);
-    ui.action_Stop_Recording_Playback->setEnabled(true);
+    ui->action_Record_Movie->setEnabled(false);
+    ui->action_Play_Movie->setEnabled(false);
+    ui->action_Stop_Recording_Playback->setEnabled(true);
 }
 
 bool GMainWindow::ValidateMovie(const QString& path, u64 program_id) {
@@ -1953,9 +1956,9 @@ void GMainWindow::OnPlayMovie() {
     Core::Movie::GetInstance().StartPlayback(path.toStdString(), [this] {
         QMetaObject::invokeMethod(this, "OnMoviePlaybackCompleted");
     });
-    ui.action_Record_Movie->setEnabled(false);
-    ui.action_Play_Movie->setEnabled(false);
-    ui.action_Stop_Recording_Playback->setEnabled(true);
+    ui->action_Record_Movie->setEnabled(false);
+    ui->action_Play_Movie->setEnabled(false);
+    ui->action_Stop_Recording_Playback->setEnabled(true);
 }
 
 void GMainWindow::OnStopRecordingPlayback() {
@@ -1971,9 +1974,9 @@ void GMainWindow::OnStopRecordingPlayback() {
                                      tr("The movie is successfully saved."));
         }
     }
-    ui.action_Record_Movie->setEnabled(true);
-    ui.action_Play_Movie->setEnabled(true);
-    ui.action_Stop_Recording_Playback->setEnabled(false);
+    ui->action_Record_Movie->setEnabled(true);
+    ui->action_Play_Movie->setEnabled(true);
+    ui->action_Stop_Recording_Playback->setEnabled(false);
 }
 
 void GMainWindow::OnCaptureScreenshot() {
@@ -1996,7 +1999,7 @@ void GMainWindow::OnCaptureScreenshot() {
 void GMainWindow::OnStartVideoDumping() {
     DumpingDialog dialog(this);
     if (dialog.exec() != QDialog::DialogCode::Accepted) {
-        ui.action_Dump_Video->setChecked(false);
+        ui->action_Dump_Video->setChecked(false);
         return;
     }
     const auto path = dialog.GetFilePath();
@@ -2007,7 +2010,7 @@ void GMainWindow::OnStartVideoDumping() {
             QMessageBox::critical(
                 this, tr("Citra"),
                 tr("Could not start video dumping.<br>Refer to the log for details."));
-            ui.action_Dump_Video->setChecked(false);
+            ui->action_Dump_Video->setChecked(false);
         }
     } else {
         video_dumping_on_start = true;
@@ -2016,7 +2019,7 @@ void GMainWindow::OnStartVideoDumping() {
 }
 
 void GMainWindow::OnStopVideoDumping() {
-    ui.action_Dump_Video->setChecked(false);
+    ui->action_Dump_Video->setChecked(false);
 
     if (video_dumping_on_start) {
         video_dumping_on_start = false;
@@ -2180,7 +2183,7 @@ void GMainWindow::closeEvent(QCloseEvent* event) {
         return;
     }
 
-    if (!ui.action_Fullscreen->isChecked()) {
+    if (!ui->action_Fullscreen->isChecked()) {
         UISettings::values.geometry = saveGeometry();
         UISettings::values.renderwindow_geometry = render_window->saveGeometry();
     }
@@ -2189,11 +2192,11 @@ void GMainWindow::closeEvent(QCloseEvent* event) {
     UISettings::values.microprofile_geometry = microProfileDialog->saveGeometry();
     UISettings::values.microprofile_visible = microProfileDialog->isVisible();
 #endif
-    UISettings::values.single_window_mode = ui.action_Single_Window_Mode->isChecked();
-    UISettings::values.fullscreen = ui.action_Fullscreen->isChecked();
-    UISettings::values.display_titlebar = ui.action_Display_Dock_Widget_Headers->isChecked();
-    UISettings::values.show_filter_bar = ui.action_Show_Filter_Bar->isChecked();
-    UISettings::values.show_status_bar = ui.action_Show_Status_Bar->isChecked();
+    UISettings::values.single_window_mode = ui->action_Single_Window_Mode->isChecked();
+    UISettings::values.fullscreen = ui->action_Fullscreen->isChecked();
+    UISettings::values.display_titlebar = ui->action_Display_Dock_Widget_Headers->isChecked();
+    UISettings::values.show_filter_bar = ui->action_Show_Filter_Bar->isChecked();
+    UISettings::values.show_status_bar = ui->action_Show_Status_Bar->isChecked();
     UISettings::values.first_start = false;
 
     game_list->SaveInterfaceLayout();
@@ -2275,7 +2278,7 @@ bool GMainWindow::ConfirmChangeGame() {
 }
 
 void GMainWindow::filterBarSetChecked(bool state) {
-    ui.action_Show_Filter_Bar->setChecked(state);
+    ui->action_Show_Filter_Bar->setChecked(state);
     emit(OnToggleFilterBar());
 }
 
@@ -2339,19 +2342,19 @@ void GMainWindow::OnLanguageChanged(const QString& locale) {
 
     UISettings::values.language = locale;
     LoadTranslation();
-    ui.retranslateUi(this);
+    ui->retranslateUi(this);
     RetranslateStatusBar();
     UpdateWindowTitle();
 
     if (emulation_running)
-        ui.action_Start->setText(tr("Continue"));
+        ui->action_Start->setText(tr("Continue"));
 }
 
 void GMainWindow::OnMoviePlaybackCompleted() {
     QMessageBox::information(this, tr("Playback Completed"), tr("Movie playback completed."));
-    ui.action_Record_Movie->setEnabled(true);
-    ui.action_Play_Movie->setEnabled(true);
-    ui.action_Stop_Recording_Playback->setEnabled(false);
+    ui->action_Record_Movie->setEnabled(true);
+    ui->action_Play_Movie->setEnabled(true);
+    ui->action_Stop_Recording_Playback->setEnabled(false);
 }
 
 void GMainWindow::UpdateWindowTitle() {
@@ -2365,16 +2368,16 @@ void GMainWindow::UpdateWindowTitle() {
 }
 
 void GMainWindow::SyncMenuUISettings() {
-    ui.action_Screen_Layout_Default->setChecked(Settings::values.layout_option ==
-                                                Settings::LayoutOption::Default);
-    ui.action_Screen_Layout_Single_Screen->setChecked(Settings::values.layout_option ==
-                                                      Settings::LayoutOption::SingleScreen);
-    ui.action_Screen_Layout_Large_Screen->setChecked(Settings::values.layout_option ==
-                                                     Settings::LayoutOption::LargeScreen);
-    ui.action_Screen_Layout_Side_by_Side->setChecked(Settings::values.layout_option ==
-                                                     Settings::LayoutOption::SideScreen);
-    ui.action_Screen_Layout_Swap_Screens->setChecked(Settings::values.swap_screen);
-    ui.action_Screen_Layout_Upright_Screens->setChecked(Settings::values.upright_screen);
+    ui->action_Screen_Layout_Default->setChecked(Settings::values.layout_option ==
+                                                 Settings::LayoutOption::Default);
+    ui->action_Screen_Layout_Single_Screen->setChecked(Settings::values.layout_option ==
+                                                       Settings::LayoutOption::SingleScreen);
+    ui->action_Screen_Layout_Large_Screen->setChecked(Settings::values.layout_option ==
+                                                      Settings::LayoutOption::LargeScreen);
+    ui->action_Screen_Layout_Side_by_Side->setChecked(Settings::values.layout_option ==
+                                                      Settings::LayoutOption::SideScreen);
+    ui->action_Screen_Layout_Swap_Screens->setChecked(Settings::values.swap_screen);
+    ui->action_Screen_Layout_Upright_Screens->setChecked(Settings::values.upright_screen);
 }
 
 void GMainWindow::RetranslateStatusBar() {

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -15,7 +15,6 @@
 #include "core/core.h"
 #include "core/hle/service/am/am.h"
 #include "core/savestate.h"
-#include "ui_main.h"
 
 class AboutDialog;
 class Config;
@@ -47,6 +46,10 @@ class WaitTreeWidget;
 
 namespace DiscordRPC {
 class DiscordInterface;
+}
+
+namespace Ui {
+class MainWindow;
 }
 
 class GMainWindow : public QMainWindow {
@@ -230,7 +233,7 @@ private:
     void HideMouseCursor();
     void ShowMouseCursor();
 
-    Ui::MainWindow ui;
+    std::unique_ptr<Ui::MainWindow> ui;
 
     GRenderWindow* render_window;
 

--- a/src/citra_qt/multiplayer/lobby.cpp
+++ b/src/citra_qt/multiplayer/lobby.cpp
@@ -18,6 +18,7 @@
 #include "core/hle/service/cfg/cfg.h"
 #include "core/settings.h"
 #include "network/network.h"
+#include "ui_lobby.h"
 #ifdef ENABLE_WEB_SERVICE
 #include "web_service/web_backend.h"
 #endif
@@ -80,6 +81,8 @@ Lobby::Lobby(QWidget* parent, QStandardItemModel* list,
     // refreshroomlist signal from places that open the lobby
     RefreshLobby();
 }
+
+Lobby::~Lobby() = default;
 
 void Lobby::UpdateGameList(QStandardItemModel* list) {
     game_list->clear();

--- a/src/citra_qt/multiplayer/lobby.h
+++ b/src/citra_qt/multiplayer/lobby.h
@@ -13,7 +13,10 @@
 #include "common/announce_multiplayer_room.h"
 #include "core/announce_multiplayer_session.h"
 #include "network/network.h"
-#include "ui_lobby.h"
+
+namespace Ui {
+class Lobby;
+}
 
 class LobbyModel;
 class LobbyFilterProxyModel;
@@ -28,7 +31,7 @@ class Lobby : public QDialog {
 public:
     explicit Lobby(QWidget* parent, QStandardItemModel* list,
                    std::shared_ptr<Core::AnnounceMultiplayerSession> session);
-    ~Lobby() = default;
+    ~Lobby() override;
 
     /**
      * Updates the lobby with a new game list model.


### PR DESCRIPTION
The files citra_qt/main.h and citra_qt/debugger/registers.h were the only two instances where the Ui classes weren't forward declared.
The forward declaration may reduce the size of the resulting header.
While we're at it, change the other instances that used raw pointers, or that used new instead of make_unique even though a unique_ptr is used, to be consistent with the other instances.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5511)
<!-- Reviewable:end -->
