### PR TITLE
Avoid incorrect casts to QDropEvent

### DIFF
--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -172,9 +172,7 @@ bool OpenGLWindow::event(QEvent* event) {
     case QEvent::Drop:
         GetMainWindow()->DropAction(static_cast<QDropEvent*>(event));
         return true;
-    case QEvent::DragResponse:
     case QEvent::DragEnter:
-    case QEvent::DragLeave:
     case QEvent::DragMove:
         GetMainWindow()->AcceptDropEvent(static_cast<QDropEvent*>(event));
         return true;


### PR DESCRIPTION
QDragLeaveEvent does not inherit QDropEvent, and can cause a segfault when cast incorrectly.

QEvent::DragResponse appears to be an internal event that likely does not need to be handled. I wasn't able to get it to happen on my machine (Linux/X11), however since there's no QDragResponseEvent, it likely does not inherit QDropEvent either.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5516)
<!-- Reviewable:end -->
