### PR TITLE
cubeb_sink: Change a log from INFO to DEBUG level

### DIFF
--- a/src/audio_core/cubeb_sink.cpp
+++ b/src/audio_core/cubeb_sink.cpp
@@ -159,7 +159,7 @@ void CubebSink::Impl::LogCallback(char const* format, ...) {
 #endif
     va_end(args);
     buffer.back() = '\0';
-    LOG_INFO(Audio_Sink, "{}", buffer.data());
+    LOG_DEBUG(Audio_Sink, "{}", buffer.data());
 }
 
 std::vector<std::string> ListCubebSinkDevices() {


### PR DESCRIPTION
Cubeb is the default and sometimes this log can create a lot of spam, example log from a user: [citra_log.txt](https://github.com/citra-emu/citra/files/5104830/citra_log.txt) which makes supporting users more difficult so let's change the log level for this to DEBUG.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5518)
<!-- Reviewable:end -->
