### PR TITLE
Remove citra-room dependence on core

### DIFF
--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -21,6 +21,7 @@
 #include "jni/config.h"
 #include "jni/default_ini.h"
 #include "jni/input_manager.h"
+#include "network/network_settings.h"
 
 Config::Config() {
     // TODO: Don't hardcode the path; let the frontend decide where to put the config files.
@@ -260,12 +261,12 @@ void Config::ReadValues() {
     }
 
     // Web Service
-    Settings::values.enable_telemetry =
+    NetSettings::values.enable_telemetry =
         sdl2_config->GetBoolean("WebService", "enable_telemetry", true);
-    Settings::values.web_api_url =
+    NetSettings::values.web_api_url =
         sdl2_config->GetString("WebService", "web_api_url", "https://api.citra-emu.org");
-    Settings::values.citra_username = sdl2_config->GetString("WebService", "citra_username", "");
-    Settings::values.citra_token = sdl2_config->GetString("WebService", "citra_token", "");
+    NetSettings::values.citra_username = sdl2_config->GetString("WebService", "citra_username", "");
+    NetSettings::values.citra_token = sdl2_config->GetString("WebService", "citra_token", "");
 
     // Update CFG file based on settings
     UpdateCFG();

--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -18,6 +18,7 @@
 #include "core/settings.h"
 #include "input_common/main.h"
 #include "input_common/udp/client.h"
+#include "network/network_settings.h"
 
 Config::Config() {
     // TODO: Don't hardcode the path; let the frontend decide where to put the config files.
@@ -275,12 +276,12 @@ void Config::ReadValues() {
     }
 
     // Web Service
-    Settings::values.enable_telemetry =
+    NetSettings::values.enable_telemetry =
         sdl2_config->GetBoolean("WebService", "enable_telemetry", true);
-    Settings::values.web_api_url =
+    NetSettings::values.web_api_url =
         sdl2_config->GetString("WebService", "web_api_url", "https://api.citra-emu.org");
-    Settings::values.citra_username = sdl2_config->GetString("WebService", "citra_username", "");
-    Settings::values.citra_token = sdl2_config->GetString("WebService", "citra_token", "");
+    NetSettings::values.citra_username = sdl2_config->GetString("WebService", "citra_username", "");
+    NetSettings::values.citra_token = sdl2_config->GetString("WebService", "citra_token", "");
 
     // Video Dumping
     Settings::values.output_format =

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -15,6 +15,7 @@
 #include "input_common/main.h"
 #include "input_common/udp/client.h"
 #include "network/network.h"
+#include "network/network_settings.h"
 
 Config::Config() {
     // TODO: Don't hardcode the path; let the frontend decide where to put the config files.
@@ -702,15 +703,15 @@ void Config::ReadUpdaterValues() {
 void Config::ReadWebServiceValues() {
     qt_config->beginGroup(QStringLiteral("WebService"));
 
-    Settings::values.enable_telemetry =
+    NetSettings::values.enable_telemetry =
         ReadSetting(QStringLiteral("enable_telemetry"), true).toBool();
-    Settings::values.web_api_url =
+    NetSettings::values.web_api_url =
         ReadSetting(QStringLiteral("web_api_url"), QStringLiteral("https://api.citra-emu.org"))
             .toString()
             .toStdString();
-    Settings::values.citra_username =
+    NetSettings::values.citra_username =
         ReadSetting(QStringLiteral("citra_username")).toString().toStdString();
-    Settings::values.citra_token =
+    NetSettings::values.citra_token =
         ReadSetting(QStringLiteral("citra_token")).toString().toStdString();
 
     qt_config->endGroup();
@@ -1160,14 +1161,14 @@ void Config::SaveUpdaterValues() {
 void Config::SaveWebServiceValues() {
     qt_config->beginGroup(QStringLiteral("WebService"));
 
-    WriteSetting(QStringLiteral("enable_telemetry"), Settings::values.enable_telemetry, true);
+    WriteSetting(QStringLiteral("enable_telemetry"), NetSettings::values.enable_telemetry, true);
     WriteSetting(QStringLiteral("web_api_url"),
-                 QString::fromStdString(Settings::values.web_api_url),
+                 QString::fromStdString(NetSettings::values.web_api_url),
                  QStringLiteral("https://api.citra-emu.org"));
     WriteSetting(QStringLiteral("citra_username"),
-                 QString::fromStdString(Settings::values.citra_username));
+                 QString::fromStdString(NetSettings::values.citra_username));
     WriteSetting(QStringLiteral("citra_token"),
-                 QString::fromStdString(Settings::values.citra_token));
+                 QString::fromStdString(NetSettings::values.citra_token));
 
     qt_config->endGroup();
 }

--- a/src/citra_qt/configuration/configure_web.cpp
+++ b/src/citra_qt/configuration/configure_web.cpp
@@ -7,8 +7,8 @@
 #include <QtConcurrent/QtConcurrentRun>
 #include "citra_qt/configuration/configure_web.h"
 #include "citra_qt/uisettings.h"
-#include "core/settings.h"
 #include "core/telemetry_session.h"
+#include "network/network_settings.h"
 #include "ui_configure_web.h"
 
 static constexpr char token_delimiter{':'};
@@ -70,16 +70,16 @@ void ConfigureWeb::SetConfiguration() {
         tr("<a href='https://citra-emu.org/wiki/citra-web-service/'><span style=\"text-decoration: "
            "underline; color:#039be5;\">What is my token?</span></a>"));
 
-    ui->toggle_telemetry->setChecked(Settings::values.enable_telemetry);
+    ui->toggle_telemetry->setChecked(NetSettings::values.enable_telemetry);
 
-    if (Settings::values.citra_username.empty()) {
+    if (NetSettings::values.citra_username.empty()) {
         ui->username->setText(tr("Unspecified"));
     } else {
-        ui->username->setText(QString::fromStdString(Settings::values.citra_username));
+        ui->username->setText(QString::fromStdString(NetSettings::values.citra_username));
     }
 
     ui->edit_token->setText(QString::fromStdString(
-        GenerateDisplayToken(Settings::values.citra_username, Settings::values.citra_token)));
+        GenerateDisplayToken(NetSettings::values.citra_username, NetSettings::values.citra_token)));
 
     // Connect after setting the values, to avoid calling OnLoginChanged now
     connect(ui->edit_token, &QLineEdit::textChanged, this, &ConfigureWeb::OnLoginChanged);
@@ -91,12 +91,13 @@ void ConfigureWeb::SetConfiguration() {
 }
 
 void ConfigureWeb::ApplyConfiguration() {
-    Settings::values.enable_telemetry = ui->toggle_telemetry->isChecked();
+    NetSettings::values.enable_telemetry = ui->toggle_telemetry->isChecked();
     UISettings::values.enable_discord_presence = ui->toggle_discordrpc->isChecked();
     if (user_verified) {
-        Settings::values.citra_username =
+        NetSettings::values.citra_username =
             UsernameFromDisplayToken(ui->edit_token->text().toStdString());
-        Settings::values.citra_token = TokenFromDisplayToken(ui->edit_token->text().toStdString());
+        NetSettings::values.citra_token =
+            TokenFromDisplayToken(ui->edit_token->text().toStdString());
     } else {
         QMessageBox::warning(
             this, tr("Token not verified"),

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -85,6 +85,7 @@
 #include "core/savestate.h"
 #include "core/settings.h"
 #include "game_list_p.h"
+#include "network/network_settings.h"
 #include "ui_main.h"
 #include "video_core/renderer_base.h"
 #include "video_core/video_core.h"
@@ -130,7 +131,7 @@ void GMainWindow::ShowTelemetryCallout() {
            "data is collected</a> to help improve Citra. "
            "<br/><br/>Would you like to share your usage data with us?");
     if (QMessageBox::question(this, tr("Telemetry"), telemetry_message) != QMessageBox::Yes) {
-        Settings::values.enable_telemetry = false;
+        NetSettings::values.enable_telemetry = false;
         Settings::Apply();
     }
 }
@@ -1623,7 +1624,7 @@ void GMainWindow::OnLoadComplete() {
 }
 
 void GMainWindow::OnMenuReportCompatibility() {
-    if (!Settings::values.citra_token.empty() && !Settings::values.citra_username.empty()) {
+    if (!NetSettings::values.citra_token.empty() && !NetSettings::values.citra_username.empty()) {
         CompatDB compatdb{this};
         compatdb.exec();
     } else {

--- a/src/citra_qt/multiplayer/chat_room.cpp
+++ b/src/citra_qt/multiplayer/chat_room.cpp
@@ -20,7 +20,7 @@
 #include "citra_qt/multiplayer/chat_room.h"
 #include "citra_qt/multiplayer/message.h"
 #include "common/logging/log.h"
-#include "core/announce_multiplayer_session.h"
+#include "network/announce_multiplayer_session.h"
 #include "ui_chat_room.h"
 #ifdef ENABLE_WEB_SERVICE
 #include "web_service/web_backend.h"

--- a/src/citra_qt/multiplayer/chat_room.h
+++ b/src/citra_qt/multiplayer/chat_room.h
@@ -16,7 +16,7 @@ namespace Ui {
 class ChatRoom;
 }
 
-namespace Core {
+namespace Network {
 class AnnounceMultiplayerSession;
 }
 

--- a/src/citra_qt/multiplayer/client_room.cpp
+++ b/src/citra_qt/multiplayer/client_room.cpp
@@ -16,7 +16,7 @@
 #include "citra_qt/multiplayer/moderation_dialog.h"
 #include "citra_qt/multiplayer/state.h"
 #include "common/logging/log.h"
-#include "core/announce_multiplayer_session.h"
+#include "network/announce_multiplayer_session.h"
 #include "ui_client_room.h"
 
 ClientRoomWindow::ClientRoomWindow(QWidget* parent)

--- a/src/citra_qt/multiplayer/direct_connect.cpp
+++ b/src/citra_qt/multiplayer/direct_connect.cpp
@@ -16,8 +16,8 @@
 #include "citra_qt/multiplayer/validation.h"
 #include "citra_qt/uisettings.h"
 #include "core/hle/service/cfg/cfg.h"
-#include "core/settings.h"
 #include "network/network.h"
+#include "network/network_settings.h"
 #include "ui_direct_connect.h"
 
 enum class ConnectionType : u8 { TraversalServer, IP };
@@ -34,9 +34,9 @@ DirectConnectWindow::DirectConnectWindow(QWidget* parent)
 
     ui->nickname->setValidator(validation.GetNickname());
     ui->nickname->setText(UISettings::values.nickname);
-    if (ui->nickname->text().isEmpty() && !Settings::values.citra_username.empty()) {
+    if (ui->nickname->text().isEmpty() && !NetSettings::values.citra_username.empty()) {
         // Use Citra Web Service user name as nickname by default
-        ui->nickname->setText(QString::fromStdString(Settings::values.citra_username));
+        ui->nickname->setText(QString::fromStdString(NetSettings::values.citra_username));
     }
     ui->ip->setValidator(validation.GetIP());
     ui->ip->setText(UISettings::values.ip);
@@ -92,7 +92,6 @@ void DirectConnectWindow::Connect() {
     UISettings::values.port = (ui->port->isModified() && !ui->port->text().isEmpty())
                                   ? ui->port->text()
                                   : UISettings::values.port;
-    Settings::Apply();
 
     // attempt to connect in a different thread
     QFuture<void> f = QtConcurrent::run([&] {

--- a/src/citra_qt/multiplayer/host_room.cpp
+++ b/src/citra_qt/multiplayer/host_room.cpp
@@ -21,7 +21,7 @@
 #include "common/logging/log.h"
 #include "core/announce_multiplayer_session.h"
 #include "core/hle/service/cfg/cfg.h"
-#include "core/settings.h"
+#include "network/network_settings.h"
 #include "ui_host_room.h"
 #ifdef ENABLE_WEB_SERVICE
 #include "web_service/verify_user_jwt.h"
@@ -53,9 +53,9 @@ HostRoomWindow::HostRoomWindow(QWidget* parent, QStandardItemModel* list,
 
     // Restore the settings:
     ui->username->setText(UISettings::values.room_nickname);
-    if (ui->username->text().isEmpty() && !Settings::values.citra_username.empty()) {
+    if (ui->username->text().isEmpty() && !NetSettings::values.citra_username.empty()) {
         // Use Citra Web Service user name as nickname by default
-        ui->username->setText(QString::fromStdString(Settings::values.citra_username));
+        ui->username->setText(QString::fromStdString(NetSettings::values.citra_username));
     }
     ui->room_name->setText(UISettings::values.room_name);
     ui->port->setText(UISettings::values.room_port);
@@ -92,7 +92,8 @@ std::unique_ptr<Network::VerifyUser::Backend> HostRoomWindow::CreateVerifyBacken
     std::unique_ptr<Network::VerifyUser::Backend> verify_backend;
     if (use_validation) {
 #ifdef ENABLE_WEB_SERVICE
-        verify_backend = std::make_unique<WebService::VerifyUserJWT>(Settings::values.web_api_url);
+        verify_backend =
+            std::make_unique<WebService::VerifyUserJWT>(NetSettings::values.web_api_url);
 #else
         verify_backend = std::make_unique<Network::VerifyUser::NullBackend>();
 #endif
@@ -144,7 +145,7 @@ void HostRoomWindow::Host() {
             bool created = room->Create(ui->room_name->text().toStdString(),
                                         ui->room_description->toPlainText().toStdString(), "", port,
                                         password, ui->max_player->value(),
-                                        Settings::values.citra_username, game_name.toStdString(),
+                                        NetSettings::values.citra_username, game_name.toStdString(),
                                         game_id, CreateVerifyBackend(is_public), ban_list);
             if (!created) {
                 NetworkMessage::ErrorManager::ShowError(
@@ -182,8 +183,9 @@ void HostRoomWindow::Host() {
         std::string token;
 #ifdef ENABLE_WEB_SERVICE
         if (is_public) {
-            WebService::Client client(Settings::values.web_api_url, Settings::values.citra_username,
-                                      Settings::values.citra_token);
+            WebService::Client client(NetSettings::values.web_api_url,
+                                      NetSettings::values.citra_username,
+                                      NetSettings::values.citra_token);
             if (auto room = Network::GetRoom().lock()) {
                 token = client.GetExternalJWT(room->GetVerifyUID()).returned_data;
             }
@@ -210,7 +212,6 @@ void HostRoomWindow::Host() {
                                            ? ui->port->text()
                                            : QString::number(Network::DefaultRoomPort);
         UISettings::values.room_description = ui->room_description->toPlainText();
-        Settings::Apply();
         ui->host->setEnabled(true);
         close();
     }

--- a/src/citra_qt/multiplayer/host_room.cpp
+++ b/src/citra_qt/multiplayer/host_room.cpp
@@ -19,8 +19,8 @@
 #include "citra_qt/multiplayer/validation.h"
 #include "citra_qt/uisettings.h"
 #include "common/logging/log.h"
-#include "core/announce_multiplayer_session.h"
 #include "core/hle/service/cfg/cfg.h"
+#include "network/announce_multiplayer_session.h"
 #include "network/network_settings.h"
 #include "ui_host_room.h"
 #ifdef ENABLE_WEB_SERVICE
@@ -28,7 +28,7 @@
 #endif
 
 HostRoomWindow::HostRoomWindow(QWidget* parent, QStandardItemModel* list,
-                               std::shared_ptr<Core::AnnounceMultiplayerSession> session)
+                               std::shared_ptr<Network::AnnounceMultiplayerSession> session)
     : QDialog(parent, Qt::WindowTitleHint | Qt::WindowCloseButtonHint | Qt::WindowSystemMenuHint),
       ui(std::make_unique<Ui::HostRoom>()), announce_multiplayer_session(session) {
     ui->setupUi(this);

--- a/src/citra_qt/multiplayer/host_room.h
+++ b/src/citra_qt/multiplayer/host_room.h
@@ -17,7 +17,7 @@ namespace Ui {
 class HostRoom;
 }
 
-namespace Core {
+namespace Network {
 class AnnounceMultiplayerSession;
 }
 
@@ -35,7 +35,7 @@ class HostRoomWindow : public QDialog {
 
 public:
     explicit HostRoomWindow(QWidget* parent, QStandardItemModel* list,
-                            std::shared_ptr<Core::AnnounceMultiplayerSession> session);
+                            std::shared_ptr<Network::AnnounceMultiplayerSession> session);
     ~HostRoomWindow();
 
     /**
@@ -50,7 +50,7 @@ private:
     std::unique_ptr<Network::VerifyUser::Backend> CreateVerifyBackend(bool use_validation) const;
 
     std::unique_ptr<Ui::HostRoom> ui;
-    std::weak_ptr<Core::AnnounceMultiplayerSession> announce_multiplayer_session;
+    std::weak_ptr<Network::AnnounceMultiplayerSession> announce_multiplayer_session;
     QStandardItemModel* game_list;
     ComboBoxProxyModel* proxy;
     Validation validation;

--- a/src/citra_qt/multiplayer/lobby.cpp
+++ b/src/citra_qt/multiplayer/lobby.cpp
@@ -24,7 +24,7 @@
 #endif
 
 Lobby::Lobby(QWidget* parent, QStandardItemModel* list,
-             std::shared_ptr<Core::AnnounceMultiplayerSession> session)
+             std::shared_ptr<Network::AnnounceMultiplayerSession> session)
     : QDialog(parent, Qt::WindowTitleHint | Qt::WindowCloseButtonHint | Qt::WindowSystemMenuHint),
       ui(std::make_unique<Ui::Lobby>()), announce_multiplayer_session(session) {
     ui->setupUi(this);

--- a/src/citra_qt/multiplayer/lobby.cpp
+++ b/src/citra_qt/multiplayer/lobby.cpp
@@ -16,8 +16,8 @@
 #include "citra_qt/uisettings.h"
 #include "common/logging/log.h"
 #include "core/hle/service/cfg/cfg.h"
-#include "core/settings.h"
 #include "network/network.h"
+#include "network/network_settings.h"
 #include "ui_lobby.h"
 #ifdef ENABLE_WEB_SERVICE
 #include "web_service/web_backend.h"
@@ -58,9 +58,9 @@ Lobby::Lobby(QWidget* parent, QStandardItemModel* list,
 
     ui->nickname->setValidator(validation.GetNickname());
     ui->nickname->setText(UISettings::values.nickname);
-    if (ui->nickname->text().isEmpty() && !Settings::values.citra_username.empty()) {
+    if (ui->nickname->text().isEmpty() && !NetSettings::values.citra_username.empty()) {
         // Use Citra Web Service user name as nickname by default
-        ui->nickname->setText(QString::fromStdString(Settings::values.citra_username));
+        ui->nickname->setText(QString::fromStdString(NetSettings::values.citra_username));
     }
 
     // UI Buttons
@@ -155,9 +155,11 @@ void Lobby::OnJoinRoom(const QModelIndex& source) {
     QFuture<void> f = QtConcurrent::run([nickname, ip, port, password, verify_UID] {
         std::string token;
 #ifdef ENABLE_WEB_SERVICE
-        if (!Settings::values.citra_username.empty() && !Settings::values.citra_token.empty()) {
-            WebService::Client client(Settings::values.web_api_url, Settings::values.citra_username,
-                                      Settings::values.citra_token);
+        if (!NetSettings::values.citra_username.empty() &&
+            !NetSettings::values.citra_token.empty()) {
+            WebService::Client client(NetSettings::values.web_api_url,
+                                      NetSettings::values.citra_username,
+                                      NetSettings::values.citra_token);
             token = client.GetExternalJWT(verify_UID).returned_data;
             if (token.empty()) {
                 LOG_ERROR(WebService, "Could not get external JWT, verification may fail");
@@ -179,7 +181,6 @@ void Lobby::OnJoinRoom(const QModelIndex& source) {
     UISettings::values.nickname = ui->nickname->text();
     UISettings::values.ip = proxy->data(connection_index, LobbyItemHost::HostIPRole).toString();
     UISettings::values.port = proxy->data(connection_index, LobbyItemHost::HostPortRole).toString();
-    Settings::Apply();
 }
 
 void Lobby::ResetModel() {

--- a/src/citra_qt/multiplayer/lobby.h
+++ b/src/citra_qt/multiplayer/lobby.h
@@ -11,7 +11,7 @@
 #include <QStandardItemModel>
 #include "citra_qt/multiplayer/validation.h"
 #include "common/announce_multiplayer_room.h"
-#include "core/announce_multiplayer_session.h"
+#include "network/announce_multiplayer_session.h"
 #include "network/network.h"
 
 namespace Ui {
@@ -30,7 +30,7 @@ class Lobby : public QDialog {
 
 public:
     explicit Lobby(QWidget* parent, QStandardItemModel* list,
-                   std::shared_ptr<Core::AnnounceMultiplayerSession> session);
+                   std::shared_ptr<Network::AnnounceMultiplayerSession> session);
     ~Lobby() override;
 
     /**
@@ -91,7 +91,7 @@ private:
     LobbyFilterProxyModel* proxy{};
 
     QFutureWatcher<AnnounceMultiplayerRoom::RoomList> room_list_watcher;
-    std::weak_ptr<Core::AnnounceMultiplayerSession> announce_multiplayer_session;
+    std::weak_ptr<Network::AnnounceMultiplayerSession> announce_multiplayer_session;
     QFutureWatcher<void>* watcher;
     Validation validation;
 };

--- a/src/citra_qt/multiplayer/state.cpp
+++ b/src/citra_qt/multiplayer/state.cpp
@@ -37,7 +37,7 @@ MultiplayerState::MultiplayerState(QWidget* parent, QStandardItemModel* game_lis
     qRegisterMetaType<Network::RoomMember::State>();
     qRegisterMetaType<Network::RoomMember::Error>();
     qRegisterMetaType<Common::WebResult>();
-    announce_multiplayer_session = std::make_shared<Core::AnnounceMultiplayerSession>();
+    announce_multiplayer_session = std::make_shared<Network::AnnounceMultiplayerSession>();
     announce_multiplayer_session->BindErrorCallback(
         [this](const Common::WebResult& result) { emit AnnounceFailed(result); });
     connect(this, &MultiplayerState::AnnounceFailed, this, &MultiplayerState::OnAnnounceFailed);

--- a/src/citra_qt/multiplayer/state.h
+++ b/src/citra_qt/multiplayer/state.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <QWidget>
-#include "core/announce_multiplayer_session.h"
+#include "network/announce_multiplayer_session.h"
 #include "network/network.h"
 
 class QStandardItemModel;
@@ -80,7 +80,7 @@ private:
     QStandardItemModel* game_list_model = nullptr;
     QAction* leave_room;
     QAction* show_room;
-    std::shared_ptr<Core::AnnounceMultiplayerSession> announce_multiplayer_session;
+    std::shared_ptr<Network::AnnounceMultiplayerSession> announce_multiplayer_session;
     Network::RoomMember::State current_state = Network::RoomMember::State::Uninitialized;
     bool has_mod_perms = false;
     Network::RoomMember::CallbackHandle<Network::RoomMember::State> state_callback_handle;

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,7 +1,5 @@
 add_library(core STATIC
     3ds.h
-    announce_multiplayer_session.cpp
-    announce_multiplayer_session.h
     arm/arm_interface.h
     arm/dyncom/arm_dyncom.cpp
     arm/dyncom/arm_dyncom.h

--- a/src/core/announce_multiplayer_session.cpp
+++ b/src/core/announce_multiplayer_session.cpp
@@ -8,8 +8,8 @@
 #include "announce_multiplayer_session.h"
 #include "common/announce_multiplayer_room.h"
 #include "common/assert.h"
-#include "core/settings.h"
 #include "network/network.h"
+#include "network/network_settings.h"
 
 #ifdef ENABLE_WEB_SERVICE
 #include "web_service/announce_room_json.h"
@@ -22,9 +22,9 @@ static constexpr std::chrono::seconds announce_time_interval(15);
 
 AnnounceMultiplayerSession::AnnounceMultiplayerSession() {
 #ifdef ENABLE_WEB_SERVICE
-    backend = std::make_unique<WebService::RoomJson>(Settings::values.web_api_url,
-                                                     Settings::values.citra_username,
-                                                     Settings::values.citra_token);
+    backend = std::make_unique<WebService::RoomJson>(NetSettings::values.web_api_url,
+                                                     NetSettings::values.citra_username,
+                                                     NetSettings::values.citra_token);
 #else
     backend = std::make_unique<AnnounceMultiplayerRoom::NullBackend>();
 #endif
@@ -155,9 +155,9 @@ void AnnounceMultiplayerSession::UpdateCredentials() {
     ASSERT_MSG(!IsRunning(), "Credentials can only be updated when session is not running");
 
 #ifdef ENABLE_WEB_SERVICE
-    backend = std::make_unique<WebService::RoomJson>(Settings::values.web_api_url,
-                                                     Settings::values.citra_username,
-                                                     Settings::values.citra_token);
+    backend = std::make_unique<WebService::RoomJson>(NetSettings::values.web_api_url,
+                                                     NetSettings::values.citra_username,
+                                                     NetSettings::values.citra_token);
 #endif
 }
 

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -230,12 +230,6 @@ struct Values {
     std::string log_filter;
     std::unordered_map<std::string, bool> lle_modules;
 
-    // WebService
-    bool enable_telemetry;
-    std::string web_api_url;
-    std::string citra_username;
-    std::string citra_token;
-
     // Video Dumping
     std::string output_format;
     std::string format_options;

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -12,6 +12,7 @@
 #include "core/core.h"
 #include "core/settings.h"
 #include "core/telemetry_session.h"
+#include "network/network_settings.h"
 
 #ifdef ENABLE_WEB_SERVICE
 #include "web_service/telemetry_json.h"
@@ -70,7 +71,7 @@ u64 RegenerateTelemetryId() {
 
 bool VerifyLogin(const std::string& username, const std::string& token) {
 #ifdef ENABLE_WEB_SERVICE
-    return WebService::VerifyLogin(Settings::values.web_api_url, username, token);
+    return WebService::VerifyLogin(NetSettings::values.web_api_url, username, token);
 #else
     return false;
 #endif
@@ -86,16 +87,16 @@ TelemetrySession::~TelemetrySession() {
     AddField(Telemetry::FieldType::Session, "Shutdown_Time", shutdown_time);
 
 #ifdef ENABLE_WEB_SERVICE
-    auto backend = std::make_unique<WebService::TelemetryJson>(Settings::values.web_api_url,
-                                                               Settings::values.citra_username,
-                                                               Settings::values.citra_token);
+    auto backend = std::make_unique<WebService::TelemetryJson>(NetSettings::values.web_api_url,
+                                                               NetSettings::values.citra_username,
+                                                               NetSettings::values.citra_token);
 #else
     auto backend = std::make_unique<Telemetry::NullVisitor>();
 #endif
 
     // Complete the session, submitting to the web service backend if necessary
     field_collection.Accept(*backend);
-    if (Settings::values.enable_telemetry) {
+    if (NetSettings::values.enable_telemetry) {
         backend->Complete();
     }
 }
@@ -154,9 +155,9 @@ void TelemetrySession::AddInitialInfo(Loader::AppLoader& app_loader) {
 
 bool TelemetrySession::SubmitTestcase() {
 #ifdef ENABLE_WEB_SERVICE
-    auto backend = std::make_unique<WebService::TelemetryJson>(Settings::values.web_api_url,
-                                                               Settings::values.citra_username,
-                                                               Settings::values.citra_token);
+    auto backend = std::make_unique<WebService::TelemetryJson>(NetSettings::values.web_api_url,
+                                                               NetSettings::values.citra_username,
+                                                               NetSettings::values.citra_token);
     field_collection.Accept(*backend);
     return backend->SubmitTestcase();
 #else

--- a/src/dedicated_room/CMakeLists.txt
+++ b/src/dedicated_room/CMakeLists.txt
@@ -7,13 +7,13 @@ add_executable(citra-room
 
 create_target_directory_groups(citra-room)
 
-target_link_libraries(citra-room PRIVATE common core network)
+target_link_libraries(citra-room PRIVATE common network)
 if (ENABLE_WEB_SERVICE)
     target_compile_definitions(citra-room PRIVATE -DENABLE_WEB_SERVICE)
     target_link_libraries(citra-room PRIVATE web_service)
 endif()
 
-target_link_libraries(citra-room PRIVATE cryptopp glad)
+target_link_libraries(citra-room PRIVATE cryptopp)
 if (MSVC)
     target_link_libraries(citra-room PRIVATE getopt)
 endif()

--- a/src/dedicated_room/citra-room.cpp
+++ b/src/dedicated_room/citra-room.cpp
@@ -26,7 +26,7 @@
 #include "common/logging/log.h"
 #include "common/scm_rev.h"
 #include "common/string_util.h"
-#include "core/announce_multiplayer_session.h"
+#include "network/announce_multiplayer_session.h"
 #include "network/network.h"
 #include "network/network_settings.h"
 #include "network/room.h"
@@ -342,7 +342,7 @@ int main(int argc, char** argv) {
             return -1;
         }
         std::cout << "Room is open. Close with Q+Enter...\n\n";
-        auto announce_session = std::make_unique<Core::AnnounceMultiplayerSession>();
+        auto announce_session = std::make_unique<Network::AnnounceMultiplayerSession>();
         if (announce) {
             announce_session->Start();
         }

--- a/src/dedicated_room/citra-room.cpp
+++ b/src/dedicated_room/citra-room.cpp
@@ -10,7 +10,6 @@
 #include <string>
 #include <thread>
 #include <cryptopp/base64.h>
-#include <glad/glad.h>
 
 #ifdef _WIN32
 // windows.h needs to be included before shellapi.h
@@ -28,9 +27,8 @@
 #include "common/scm_rev.h"
 #include "common/string_util.h"
 #include "core/announce_multiplayer_session.h"
-#include "core/core.h"
-#include "core/settings.h"
 #include "network/network.h"
+#include "network/network_settings.h"
 #include "network/room.h"
 #include "network/verify_user.h"
 
@@ -170,9 +168,6 @@ int main(int argc, char** argv) {
     int option_index = 0;
     char* endarg;
 
-    // This is just to be able to link against core
-    gladLoadGL();
-
     std::string room_name;
     std::string room_description;
     std::string password;
@@ -300,15 +295,15 @@ int main(int argc, char** argv) {
     if (announce) {
         if (username.empty()) {
             std::cout << "Hosting a public room\n\n";
-            Settings::values.web_api_url = web_api_url;
-            Settings::values.citra_username = UsernameFromDisplayToken(token);
-            username = Settings::values.citra_username;
-            Settings::values.citra_token = TokenFromDisplayToken(token);
+            NetSettings::values.web_api_url = web_api_url;
+            NetSettings::values.citra_username = UsernameFromDisplayToken(token);
+            username = NetSettings::values.citra_username;
+            NetSettings::values.citra_token = TokenFromDisplayToken(token);
         } else {
             std::cout << "Hosting a public room\n\n";
-            Settings::values.web_api_url = web_api_url;
-            Settings::values.citra_username = username;
-            Settings::values.citra_token = token;
+            NetSettings::values.web_api_url = web_api_url;
+            NetSettings::values.citra_username = username;
+            NetSettings::values.citra_token = token;
         }
     }
     if (!announce && enable_citra_mods) {
@@ -327,7 +322,8 @@ int main(int argc, char** argv) {
     std::unique_ptr<Network::VerifyUser::Backend> verify_backend;
     if (announce) {
 #ifdef ENABLE_WEB_SERVICE
-        verify_backend = std::make_unique<WebService::VerifyUserJWT>(Settings::values.web_api_url);
+        verify_backend =
+            std::make_unique<WebService::VerifyUserJWT>(NetSettings::values.web_api_url);
 #else
         std::cout
             << "Citra Web Services is not available with this build: validation is disabled.\n\n";

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_library(network STATIC
     network.cpp
     network.h
+    network_settings.cpp
+    network_settings.h
     packet.cpp
     packet.h
     room.cpp

--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -1,4 +1,6 @@
 add_library(network STATIC
+    announce_multiplayer_session.cpp
+    announce_multiplayer_session.h
     network.cpp
     network.h
     network_settings.cpp

--- a/src/network/announce_multiplayer_session.cpp
+++ b/src/network/announce_multiplayer_session.cpp
@@ -15,7 +15,7 @@
 #include "web_service/announce_room_json.h"
 #endif
 
-namespace Core {
+namespace Network {
 
 // Time between room is announced to web_service
 static constexpr std::chrono::seconds announce_time_interval(15);
@@ -161,4 +161,4 @@ void AnnounceMultiplayerSession::UpdateCredentials() {
 #endif
 }
 
-} // namespace Core
+} // namespace Network

--- a/src/network/announce_multiplayer_session.h
+++ b/src/network/announce_multiplayer_session.h
@@ -15,10 +15,8 @@
 #include "common/thread.h"
 
 namespace Network {
-class Room;
-}
 
-namespace Core {
+class Room;
 
 /**
  * Instruments AnnounceMultiplayerRoom::Backend.
@@ -93,4 +91,4 @@ private:
     void AnnounceMultiplayerLoop();
 };
 
-} // namespace Core
+} // namespace Network

--- a/src/network/network_settings.cpp
+++ b/src/network/network_settings.cpp
@@ -1,0 +1,11 @@
+// Copyright 2020 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "network/network_settings.h"
+
+namespace NetSettings {
+
+Values values = {};
+
+}

--- a/src/network/network_settings.h
+++ b/src/network/network_settings.h
@@ -1,0 +1,19 @@
+// Copyright 2020 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <string>
+
+namespace NetSettings {
+
+struct Values {
+    // WebService
+    bool enable_telemetry;
+    std::string web_api_url;
+    std::string citra_username;
+    std::string citra_token;
+} extern values;
+
+} // namespace NetSettings


### PR DESCRIPTION
Moves the related settings to an independent file, and move announce_multiplayer_session to network instead of core.
Should also remove the dependence on glad.

There should be no actual behaviour changes, but some testing would be nice.

Decreases the size of the resulting citra-room executable by 10~15MB
(Measuring on MSVC, there's a 12.300KB reduction in size, about a 85% reduction in the size of the citra-room executable. 
I don't remember if the initial report above was measured on mingw, but I'd guess there's probably a similar relative reduction in size)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5519)
<!-- Reviewable:end -->
