### PR TITLE
Port yuzu-emu/yuzu#4539: "common: Silence two discarded result warnings"

### DIFF
--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -915,11 +915,11 @@ std::string SanitizePath(std::string_view path_, DirectorySeparator directory_se
     return std::string(RemoveTrailingSlash(path));
 }
 
-IOFile::IOFile() {}
+IOFile::IOFile() = default;
 
 IOFile::IOFile(const std::string& filename, const char openmode[], int flags)
     : filename(filename), openmode(openmode), flags(flags) {
-    Open();
+    void(Open());
 }
 
 IOFile::~IOFile() {


### PR DESCRIPTION
See yuzu-emu/yuzu#4539 for more details.

**Original description**:
These are intentionally discarded internally, since the rest of the public API allows querying success. We want all non-internal uses of
these functions to be explicitly checked, so we can signify that we intentionally want to discard the return values here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5530)
<!-- Reviewable:end -->
