### PR TITLE
Port yuzu-emu/yuzu#4536: "yuzu: Resolve -Wextra-semi warnings"

### DIFF
--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -391,7 +391,7 @@ bool GameList::isEmpty() const {
             (type == GameListItemType::InstalledDir || type == GameListItemType::SystemDir)) {
             item_model->invisibleRootItem()->removeRow(child->row());
             i--;
-        };
+        }
     }
     return !item_model->invisibleRootItem()->hasChildren();
 }

--- a/src/citra_qt/game_list_worker.cpp
+++ b/src/citra_qt/game_list_worker.cpp
@@ -152,7 +152,8 @@ void GameListWorker::run() {
             AddFstEntriesToGameList(game_dir.path.toStdString(), game_dir.deep_scan ? 256 : 0,
                                     game_list_dir);
         }
-    };
+    }
+
     emit Finished(watch_list);
 }
 

--- a/src/citra_qt/uisettings.h
+++ b/src/citra_qt/uisettings.h
@@ -30,14 +30,14 @@ extern const Themes themes;
 
 struct GameDir {
     QString path;
-    bool deep_scan;
-    bool expanded;
+    bool deep_scan = false;
+    bool expanded = false;
     bool operator==(const GameDir& rhs) const {
         return path == rhs.path;
-    };
+    }
     bool operator!=(const GameDir& rhs) const {
         return !operator==(rhs);
-    };
+    }
 };
 
 enum class GameListIconSize {


### PR DESCRIPTION
See yuzu-emu/yuzu#4536 for more details.

**Original description**:
While we're in the same area, we can ensure GameDir member variables are always initialized to consistent values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5531)
<!-- Reviewable:end -->
