### PR TITLE
Port yuzu-emu/yuzu#4531: "yuzu: Make use of qOverload where applicable"

### DIFF
--- a/src/citra_qt/debugger/profiler.cpp
+++ b/src/citra_qt/debugger/profiler.cpp
@@ -108,8 +108,7 @@ MicroProfileWidget::MicroProfileWidget(QWidget* parent) : QWidget(parent) {
     MicroProfileSetDisplayMode(1); // Timers screen
     MicroProfileInitUI();
 
-    connect(&update_timer, &QTimer::timeout, this,
-            static_cast<void (MicroProfileWidget::*)()>(&MicroProfileWidget::update));
+    connect(&update_timer, &QTimer::timeout, this, qOverload<>(&MicroProfileWidget::update));
 }
 
 void MicroProfileWidget::paintEvent(QPaintEvent* ev) {


### PR DESCRIPTION
See yuzu-emu/yuzu#4531 for more details.

**Original description**:
Eliminates a verbose function cast.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5532)
<!-- Reviewable:end -->
