### PR TITLE
Silence some noisy switch case warning

### DIFF
--- a/src/core/arm/arm_interface.h
+++ b/src/core/arm/arm_interface.h
@@ -277,6 +277,8 @@ private:
             case VFP_FPSCR:
             case VFP_FPEXC:
                 r = GetVFPSystemReg(reg);
+            default:
+                break;
             }
             ar << r;
         }
@@ -287,6 +289,8 @@ private:
             case CP15_THREAD_UPRW:
             case CP15_THREAD_URO:
                 r = GetCP15Register(reg);
+            default:
+                break;
             }
             ar << r;
         }
@@ -321,6 +325,8 @@ private:
             case VFP_FPSCR:
             case VFP_FPEXC:
                 SetVFPSystemReg(reg, r);
+            default:
+                break;
             }
         }
         for (std::size_t i = 0; i < CP15Register::CP15_REGISTER_COUNT; i++) {
@@ -330,6 +336,8 @@ private:
             case CP15_THREAD_UPRW:
             case CP15_THREAD_URO:
                 SetCP15Register(reg, r);
+            default:
+                break;
             }
         }
     }

--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -205,8 +205,9 @@ u32 ARM_Dynarmic::GetVFPSystemReg(VFPSystemRegister reg) const {
         return jit->Fpscr();
     case VFP_FPEXC:
         return fpexc;
+    default:
+        UNREACHABLE_MSG("Unknown VFP system register: {}", static_cast<size_t>(reg));
     }
-    UNREACHABLE_MSG("Unknown VFP system register: {}", static_cast<size_t>(reg));
 }
 
 void ARM_Dynarmic::SetVFPSystemReg(VFPSystemRegister reg, u32 value) {
@@ -217,8 +218,9 @@ void ARM_Dynarmic::SetVFPSystemReg(VFPSystemRegister reg, u32 value) {
     case VFP_FPEXC:
         fpexc = value;
         return;
+    default:
+        UNREACHABLE_MSG("Unknown VFP system register: {}", static_cast<size_t>(reg));
     }
-    UNREACHABLE_MSG("Unknown VFP system register: {}", static_cast<size_t>(reg));
 }
 
 u32 ARM_Dynarmic::GetCPSR() const {
@@ -235,8 +237,9 @@ u32 ARM_Dynarmic::GetCP15Register(CP15Register reg) const {
         return cp15_state.cp15_thread_uprw;
     case CP15_THREAD_URO:
         return cp15_state.cp15_thread_uro;
+    default:
+        UNREACHABLE_MSG("Unknown CP15 register: {}", static_cast<size_t>(reg));
     }
-    UNREACHABLE_MSG("Unknown CP15 register: {}", static_cast<size_t>(reg));
 }
 
 void ARM_Dynarmic::SetCP15Register(CP15Register reg, u32 value) {
@@ -247,8 +250,9 @@ void ARM_Dynarmic::SetCP15Register(CP15Register reg, u32 value) {
     case CP15_THREAD_URO:
         cp15_state.cp15_thread_uro = value;
         return;
+    default:
+        UNREACHABLE_MSG("Unknown CP15 register: {}", static_cast<size_t>(reg));
     }
-    UNREACHABLE_MSG("Unknown CP15 register: {}", static_cast<size_t>(reg));
 }
 
 std::unique_ptr<ARM_Interface::ThreadContext> ARM_Dynarmic::NewContext() const {

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -189,6 +189,8 @@ private:
                          labels);
                 return exit_method = SeriesExit(both, after_call);
             }
+            default:
+                break;
             }
         }
         return exit_method = ExitMethod::AlwaysReturn;


### PR DESCRIPTION
Silences some of the loudest switch-related warnings by explicitly handling the default case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5549)
<!-- Reviewable:end -->
