### PR TITLE
Fix compilation with boost 1.74.0

### DIFF
--- a/src/core/frontend/applets/mii_selector.h
+++ b/src/core/frontend/applets/mii_selector.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <string>
+#include <boost/serialization/version.hpp>
 #include "core/hle/applets/mii_selector.h"
 
 namespace Frontend {


### PR DESCRIPTION
The serialization module was heavily changed and it now this header needs to be included as it is relied in many other parts of citra.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5565)
<!-- Reviewable:end -->
