### PR TITLE
layered_fs: Make LoadFile and LoadDirectory less recursive

### DIFF
--- a/src/core/file_sys/layered_fs.h
+++ b/src/core/file_sys/layered_fs.h
@@ -65,11 +65,13 @@ private:
 
     std::string ReadName(u32 offset, u32 name_length);
 
-    // Loads the current directory, then its siblings, and then its children.
-    void LoadDirectory(Directory& current, u32 offset);
+    // Loads the current directory, then its children.
+    // Returns offset of the next sibling directory to load (0xFFFFFFFF if the last directory)
+    u32 LoadDirectory(Directory& current, u32 offset);
 
-    // Load the file at offset, and then its siblings.
-    void LoadFile(Directory& parent, u32 offset);
+    // Load the file at offset.
+    // Returns offset of the next sibling file to load (0xFFFFFFFF if the last file)
+    u32 LoadFile(Directory& parent, u32 offset);
 
     // Load replace/create relocations
     void LoadRelocations();


### PR DESCRIPTION
Fixes #5467.

The deep recursion has caused issues in certain games with large numbers of files, especially with MSVC builds. (other builds are likely using techniques like tail call optimization)

Previously the recursion depth is about equal to the number of files present. With this the depth should be about equal to the maximum depth of the directory structure of the RomFS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5566)
<!-- Reviewable:end -->
