### PR TITLE
Add descriptions for camera and microphone usage on macos

### DIFF
--- a/src/citra_qt/Info.plist
+++ b/src/citra_qt/Info.plist
@@ -36,5 +36,9 @@
 	<string>NSApplication</string>
 	<key>NSHighResolutionCapable</key>
 	<string>True</string>
+	<key>NSCameraUsageDescription</key>
+	<string>This app requires camera access to emulate the 3DS's cameras.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>This app requires microphone access to emulate the 3DS's microphone.</string>
 </dict>
 </plist>


### PR DESCRIPTION
Attempting to fix #5567.

Starting from macOS 10.14, users need to grant permissions for applications to use media capture (camera and microphone).

The application *must* provide a description in its Info.plist or it will be terminated due to privacy violation upon attempting to initialize camera/microphone.

Ideally these two strings should be translated, but since this is not really compatible with Qt's localization system and likely requires separate configuration, I'm currently not that interested in messing with it.

Reference: https://developer.apple.com/documentation/avfoundation/cameras_and_media_capture/requesting_authorization_for_media_capture_on_macos

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5568)
<!-- Reviewable:end -->
