### PR TITLE
Port yuzu-emu/yuzu#4698: "General: Make use of std::nullopt where applicable"

### DIFF
--- a/src/audio_core/hle/decoder.cpp
+++ b/src/audio_core/hle/decoder.cpp
@@ -55,7 +55,7 @@ std::optional<BinaryResponse> NullDecoder::ProcessRequest(const BinaryRequest& r
         return response;
     default:
         LOG_ERROR(Audio_DSP, "Got unknown binary request: {}", static_cast<u16>(request.cmd));
-        return {};
+        return std::nullopt;
     }
 };
 } // namespace AudioCore::HLE

--- a/src/audio_core/hle/wmf_decoder.cpp
+++ b/src/audio_core/hle/wmf_decoder.cpp
@@ -104,7 +104,7 @@ WMFDecoder::Impl::~Impl() {
 std::optional<BinaryResponse> WMFDecoder::Impl::ProcessRequest(const BinaryRequest& request) {
     if (request.codec != DecoderCodec::AAC) {
         LOG_ERROR(Audio_DSP, "Got unknown codec {}", static_cast<u16>(request.codec));
-        return {};
+        return std::nullopt;
     }
 
     switch (request.cmd) {
@@ -123,7 +123,7 @@ std::optional<BinaryResponse> WMFDecoder::Impl::ProcessRequest(const BinaryReque
     }
     default:
         LOG_ERROR(Audio_DSP, "Got unknown binary request: {}", static_cast<u16>(request.cmd));
-        return {};
+        return std::nullopt;
     }
 }
 
@@ -205,7 +205,7 @@ std::optional<BinaryResponse> WMFDecoder::Impl::Decode(const BinaryRequest& requ
     if (request.src_addr < Memory::FCRAM_PADDR ||
         request.src_addr + request.size > Memory::FCRAM_PADDR + Memory::FCRAM_SIZE) {
         LOG_ERROR(Audio_DSP, "Got out of bounds src_addr {:08x}", request.src_addr);
-        return {};
+        return std::nullopt;
     }
     u8* data = memory.GetFCRAMPointer(request.src_addr - Memory::FCRAM_PADDR);
 
@@ -269,7 +269,7 @@ std::optional<BinaryResponse> WMFDecoder::Impl::Decode(const BinaryRequest& requ
             request.dst_addr_ch0 + out_streams[0].size() >
                 Memory::FCRAM_PADDR + Memory::FCRAM_SIZE) {
             LOG_ERROR(Audio_DSP, "Got out of bounds dst_addr_ch0 {:08x}", request.dst_addr_ch0);
-            return {};
+            return std::nullopt;
         }
         std::memcpy(memory.GetFCRAMPointer(request.dst_addr_ch0 - Memory::FCRAM_PADDR),
                     out_streams[0].data(), out_streams[0].size());
@@ -280,7 +280,7 @@ std::optional<BinaryResponse> WMFDecoder::Impl::Decode(const BinaryRequest& requ
             request.dst_addr_ch1 + out_streams[1].size() >
                 Memory::FCRAM_PADDR + Memory::FCRAM_SIZE) {
             LOG_ERROR(Audio_DSP, "Got out of bounds dst_addr_ch1 {:08x}", request.dst_addr_ch1);
-            return {};
+            return std::nullopt;
         }
         std::memcpy(memory.GetFCRAMPointer(request.dst_addr_ch1 - Memory::FCRAM_PADDR),
                     out_streams[1].data(), out_streams[1].size());

--- a/src/core/hle/kernel/memory.cpp
+++ b/src/core/hle/kernel/memory.cpp
@@ -234,7 +234,7 @@ std::optional<u32> MemoryRegionInfo::LinearAllocate(u32 size) {
     }
 
     // No sufficient block found
-    return {};
+    return std::nullopt;
 }
 
 void MemoryRegionInfo::Free(u32 offset, u32 size) {

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -928,7 +928,7 @@ std::optional<ProgramResult> DecompileProgram(const Pica::Shader::ProgramCode& p
         return {ProgramResult{generator.MoveShaderCode()}};
     } catch (const DecompileFail& exception) {
         LOG_INFO(HW_GPU, "Shader decompilation failed: {}", exception.what());
-        return {};
+        return std::nullopt;
     }
 }
 

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -1651,7 +1651,7 @@ std::optional<ShaderDecompiler::ProgramResult> GenerateVertexShader(
         get_output_reg, config.state.sanitize_mul);
 
     if (!program_source_opt)
-        return {};
+        return std::nullopt;
 
     std::string& program_source = program_source_opt->code;
 


### PR DESCRIPTION
See https://github.com/yuzu-emu/yuzu/pull/4698 for more details.

**Original description**:
Allows some implementations to avoid completely zeroing out the internal buffer of the optional, and instead only set the validity byte within the structure.

This also makes it consistent how we return empty optionals.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5570)
<!-- Reviewable:end -->
