### PR TITLE
Port yuzu-emu/yuzu#4733: "qt/game_list: Give GameListSearchField::KeyReleaseEater a parent"

### DIFF
--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -32,7 +32,8 @@
 #include "core/file_sys/archive_source_sd_savedata.h"
 #include "core/hle/service/fs/archive.h"
 
-GameListSearchField::KeyReleaseEater::KeyReleaseEater(GameList* gamelist) : gamelist{gamelist} {}
+GameListSearchField::KeyReleaseEater::KeyReleaseEater(GameList* gamelist, QObject* parent)
+    : QObject(parent), gamelist{gamelist} {}
 
 // EventFilter in order to process systemkeys while editing the searchfield
 bool GameListSearchField::KeyReleaseEater::eventFilter(QObject* obj, QEvent* event) {
@@ -128,7 +129,7 @@ void GameListSearchField::setFocus() {
 }
 
 GameListSearchField::GameListSearchField(GameList* parent) : QWidget{parent} {
-    auto* const key_release_eater = new KeyReleaseEater(parent);
+    auto* const key_release_eater = new KeyReleaseEater(parent, this);
     layout_filter = new QHBoxLayout;
     layout_filter->setMargin(8);
     label_filter = new QLabel;

--- a/src/citra_qt/game_list_p.h
+++ b/src/citra_qt/game_list_p.h
@@ -432,7 +432,7 @@ public:
 private:
     class KeyReleaseEater : public QObject {
     public:
-        explicit KeyReleaseEater(GameList* gamelist);
+        explicit KeyReleaseEater(GameList* gamelist, QObject* parent = nullptr);
 
     private:
         GameList* gamelist = nullptr;


### PR DESCRIPTION
See yuzu-emu/yuzu#4733 for more details.

**Original description**:
This fixes a memory leak as KeyReleaseEater's destructor was never called.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5574)
<!-- Reviewable:end -->
