### PR TITLE
Update cubeb to latest and request a persistent stream session

### DIFF
--- a/src/audio_core/cubeb_sink.cpp
+++ b/src/audio_core/cubeb_sink.cpp
@@ -40,7 +40,7 @@ CubebSink::CubebSink(std::string_view target_device_name) : impl(std::make_uniqu
     params.channels = 2;
     params.layout = CUBEB_LAYOUT_STEREO;
     params.format = CUBEB_SAMPLE_S16NE;
-    params.prefs = CUBEB_STREAM_PREF_NONE;
+    params.prefs = CUBEB_STREAM_PREF_PERSIST;
 
     u32 minimum_latency = 100 * impl->sample_rate / 1000; // Firefox default
     if (cubeb_get_min_latency(impl->ctx, &params, &minimum_latency) != CUBEB_OK) {


### PR DESCRIPTION
When using cubeb, the volume level assigned via windows wouldn't be remembered, annoying some users who controlled volume levels solely using the mixer volumes, instead of changing the master volume or the citra provided internal volume.
The issue happens on Citra as well as Yuzu (see yuzu-emu/yuzu#2935)

A recent cubeb change (kinetiknz/cubeb#599) introduced the CUBEB_STREAM_PREF_PERSIST flag which should fix the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5577)
<!-- Reviewable:end -->
