### PR TITLE
Implement Reverse Interlaced 3D

### DIFF
--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -143,7 +143,8 @@ void Config::ReadValues() {
     std::string default_shader = "none (builtin)";
     if (Settings::values.render_3d == Settings::StereoRenderOption::Anaglyph)
         default_shader = "dubois (builtin)";
-    else if (Settings::values.render_3d == Settings::StereoRenderOption::Interlaced)
+    else if (Settings::values.render_3d == Settings::StereoRenderOption::Interlaced ||
+             Settings::values.render_3d == Settings::StereoRenderOption::ReverseInterlaced)
         default_shader = "horizontal (builtin)";
     Settings::values.pp_shader_name =
         sdl2_config->GetString("Renderer", "pp_shader_name", default_shader);

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -159,7 +159,7 @@ bg_blue =
 bg_green =
 
 # Whether and how Stereoscopic 3D should be rendered
-# 0 (default): Off, 1: Side by Side, 2: Anaglyph, 3: Interlaced
+# 0 (default): Off, 1: Side by Side, 2: Anaglyph, 3: Interlaced, 4: Reverse Interlaced
 render_3d =
 
 # Change 3D Intensity

--- a/src/citra_qt/configuration/configure_enhancements.cpp
+++ b/src/citra_qt/configuration/configure_enhancements.cpp
@@ -85,7 +85,8 @@ void ConfigureEnhancements::updateShaders(Settings::StereoRenderOption stereo_op
 
     if (stereo_option == Settings::StereoRenderOption::Anaglyph)
         ui->shader_combobox->addItem(QStringLiteral("dubois (builtin)"));
-    else if (stereo_option == Settings::StereoRenderOption::Interlaced)
+    else if (stereo_option == Settings::StereoRenderOption::Interlaced ||
+             stereo_option == Settings::StereoRenderOption::ReverseInterlaced)
         ui->shader_combobox->addItem(QStringLiteral("horizontal (builtin)"));
     else
         ui->shader_combobox->addItem(QStringLiteral("none (builtin)"));

--- a/src/citra_qt/configuration/configure_enhancements.ui
+++ b/src/citra_qt/configuration/configure_enhancements.ui
@@ -171,6 +171,11 @@
             <string>Interlaced</string>
            </property>
           </item>
+          <item>
+           <property name="text">
+            <string>Reverse Interlaced</string>
+           </property>
+          </item>
          </widget>
         </item>
        </layout>

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -32,7 +32,7 @@ enum class MicInputType {
     Static,
 };
 
-enum class StereoRenderOption { Off, SideBySide, Anaglyph, Interlaced };
+enum class StereoRenderOption { Off, SideBySide, Anaglyph, Interlaced, ReverseInterlaced };
 
 namespace NativeButton {
 enum Values {

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -311,6 +311,25 @@ void main() {
 }
 )";
 
+static const char fragment_shader_reverse_interlaced[] = R"(
+
+in vec2 frag_tex_coord;
+out vec4 color;
+
+uniform vec4 o_resolution;
+
+uniform sampler2D color_texture;
+uniform sampler2D color_texture_r;
+
+void main() {
+    float screen_row = o_resolution.x * frag_tex_coord.x;
+    if (int(screen_row) % 2 == 1)
+        color = texture(color_texture, frag_tex_coord);
+    else
+        color = texture(color_texture_r, frag_tex_coord);
+}
+)";
+
 /**
  * Vertex structure that the drawn screen rectangles are composed of.
  */
@@ -705,6 +724,19 @@ void RendererOpenGL::ReloadShader() {
                 shader_data += shader_text;
             }
         }
+    } else if (Settings::values.render_3d == Settings::StereoRenderOption::ReverseInterlaced) {
+        if (Settings::values.pp_shader_name == "horizontal (builtin)") {
+            shader_data += fragment_shader_reverse_interlaced;
+        } else {
+            std::string shader_text =
+                OpenGL::GetPostProcessingShaderCode(true, Settings::values.pp_shader_name);
+            if (shader_text.empty()) {
+                // Should probably provide some information that the shader couldn't load
+                shader_data += fragment_shader_reverse_interlaced;
+            } else {
+                shader_data += shader_text;
+            }
+        }
     } else {
         if (Settings::values.pp_shader_name == "none (builtin)") {
             shader_data += fragment_shader;
@@ -725,7 +757,8 @@ void RendererOpenGL::ReloadShader() {
     uniform_modelview_matrix = glGetUniformLocation(shader.handle, "modelview_matrix");
     uniform_color_texture = glGetUniformLocation(shader.handle, "color_texture");
     if (Settings::values.render_3d == Settings::StereoRenderOption::Anaglyph ||
-        Settings::values.render_3d == Settings::StereoRenderOption::Interlaced) {
+        Settings::values.render_3d == Settings::StereoRenderOption::Interlaced ||
+        Settings::values.render_3d == Settings::StereoRenderOption::ReverseInterlaced) {
         uniform_color_texture_r = glGetUniformLocation(shader.handle, "color_texture_r");
     }
     uniform_i_resolution = glGetUniformLocation(shader.handle, "i_resolution");
@@ -973,7 +1006,8 @@ void RendererOpenGL::DrawScreens(const Layout::FramebufferLayout& layout, bool f
 
     const bool stereo_single_screen =
         Settings::values.render_3d == Settings::StereoRenderOption::Anaglyph ||
-        Settings::values.render_3d == Settings::StereoRenderOption::Interlaced;
+        Settings::values.render_3d == Settings::StereoRenderOption::Interlaced ||
+        Settings::values.render_3d == Settings::StereoRenderOption::ReverseInterlaced;
 
     // Bind a second texture for the right eye if in Anaglyph mode
     if (stereo_single_screen) {

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -302,28 +302,11 @@ uniform vec4 o_resolution;
 uniform sampler2D color_texture;
 uniform sampler2D color_texture_r;
 
-void main() {
-    float screen_row = o_resolution.x * frag_tex_coord.x;
-    if (int(screen_row) % 2 == 0)
-        color = texture(color_texture, frag_tex_coord);
-    else
-        color = texture(color_texture_r, frag_tex_coord);
-}
-)";
-
-static const char fragment_shader_reverse_interlaced[] = R"(
-
-in vec2 frag_tex_coord;
-out vec4 color;
-
-uniform vec4 o_resolution;
-
-uniform sampler2D color_texture;
-uniform sampler2D color_texture_r;
+uniform int reverse_interlaced;
 
 void main() {
     float screen_row = o_resolution.x * frag_tex_coord.x;
-    if (int(screen_row) % 2 == 1)
+    if (int(screen_row) % 2 == reverse_interlaced)
         color = texture(color_texture, frag_tex_coord);
     else
         color = texture(color_texture_r, frag_tex_coord);
@@ -711,7 +694,8 @@ void RendererOpenGL::ReloadShader() {
                 shader_data += shader_text;
             }
         }
-    } else if (Settings::values.render_3d == Settings::StereoRenderOption::Interlaced) {
+    } else if (Settings::values.render_3d == Settings::StereoRenderOption::Interlaced ||
+               Settings::values.render_3d == Settings::StereoRenderOption::ReverseInterlaced) {
         if (Settings::values.pp_shader_name == "horizontal (builtin)") {
             shader_data += fragment_shader_interlaced;
         } else {
@@ -720,19 +704,6 @@ void RendererOpenGL::ReloadShader() {
             if (shader_text.empty()) {
                 // Should probably provide some information that the shader couldn't load
                 shader_data += fragment_shader_interlaced;
-            } else {
-                shader_data += shader_text;
-            }
-        }
-    } else if (Settings::values.render_3d == Settings::StereoRenderOption::ReverseInterlaced) {
-        if (Settings::values.pp_shader_name == "horizontal (builtin)") {
-            shader_data += fragment_shader_reverse_interlaced;
-        } else {
-            std::string shader_text =
-                OpenGL::GetPostProcessingShaderCode(true, Settings::values.pp_shader_name);
-            if (shader_text.empty()) {
-                // Should probably provide some information that the shader couldn't load
-                shader_data += fragment_shader_reverse_interlaced;
             } else {
                 shader_data += shader_text;
             }
@@ -760,6 +731,15 @@ void RendererOpenGL::ReloadShader() {
         Settings::values.render_3d == Settings::StereoRenderOption::Interlaced ||
         Settings::values.render_3d == Settings::StereoRenderOption::ReverseInterlaced) {
         uniform_color_texture_r = glGetUniformLocation(shader.handle, "color_texture_r");
+    }
+    if (Settings::values.render_3d == Settings::StereoRenderOption::Interlaced ||
+        Settings::values.render_3d == Settings::StereoRenderOption::ReverseInterlaced) {
+        GLuint uniform_reverse_interlaced =
+            glGetUniformLocation(shader.handle, "reverse_interlaced");
+        if (Settings::values.render_3d == Settings::StereoRenderOption::ReverseInterlaced)
+            glUniform1i(uniform_reverse_interlaced, 1);
+        else
+            glUniform1i(uniform_reverse_interlaced, 0);
     }
     uniform_i_resolution = glGetUniformLocation(shader.handle, "i_resolution");
     uniform_o_resolution = glGetUniformLocation(shader.handle, "o_resolution");


### PR DESCRIPTION
Add Reverse Interlaced 3D option for users with passive 3D displays that render each eye in the reverse order from normal interlaced. (e.g. LG OLED 3DTVs)

This is a simple extension of: #5018 and adds to the interlaced options mentioned in #4255

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5580)
<!-- Reviewable:end -->
