### PR TITLE
Port yuzu-emu/yuzu#4887: "microprofile: Silence warning in headers"

### DIFF
--- a/externals/microprofile/microprofile.h
+++ b/externals/microprofile/microprofile.h
@@ -927,7 +927,11 @@ typedef HANDLE MicroProfileThread;
 DWORD _stdcall ThreadTrampoline(void* pFunc)
 {
     MicroProfileThreadFunc F = (MicroProfileThreadFunc)pFunc;
-    return (uint32_t)F(0);
+
+    // The return value of F will always return a void*, however, this is for
+    // compatibility with pthreads. The underlying "address" of the pointer
+    // is always a 32-bit value, so this cast is safe to perform.
+    return static_cast<DWORD>(reinterpret_cast<uint64_t>(F(0)));
 }
 
 void MicroProfileThreadStart(MicroProfileThread* pThread, MicroProfileThreadFunc Func)


### PR DESCRIPTION
See yuzu-emu/yuzu#4887 for more details.

**Original description**:
Silences a truncation warning by making the truncation explicit and documenting the reason for it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5603)
<!-- Reviewable:end -->
