### PR TITLE
ci: fix mingw folder name

### DIFF
--- a/.ci/common/post-upload.sh
+++ b/.ci/common/post-upload.sh
@@ -14,7 +14,7 @@ if [ -z $GIT_TAG_NAME ]; then
     RELEASE_NAME=head
 else
     RELEASE_NAME=$(echo $GIT_TAG_NAME | cut -d- -f1)
-    if [ "$NAME" = "MinGW build" ]; then
+    if [ "$NAME" = "linux-mingw" ]; then
         RELEASE_NAME="${RELEASE_NAME}-mingw"
     fi
 fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
       - name: Pack
         run: ./.ci/${{ matrix.image }}/upload.sh
         if: ${{ matrix.image != 'linux-frozen' && matrix.image != 'linux-clang-format' }}
+        env:
+          NAME: ${{ matrix.image }}
       - name: Upload
         uses: actions/upload-artifact@v2
         if: ${{ matrix.image != 'linux-frozen' && matrix.image != 'linux-clang-format' }}


### PR DESCRIPTION
This Pull Request will fix the issue with the Qtifw installer where the directory name is incorrect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5607)
<!-- Reviewable:end -->
