### PR TITLE
Fix flatpak crash when hardware shader is enabled

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_manager.cpp
@@ -267,7 +267,8 @@ public:
             auto [iter, new_shader] = shader_cache.emplace(program, OGLShaderStage{separable});
             OGLShaderStage& cached_shader = iter->second;
             if (new_shader) {
-                result.code = program;
+                result.emplace();
+                result->code = program;
                 cached_shader.Create(program.c_str(), ShaderType);
             }
             shader_map[key] = &cached_shader;

--- a/src/video_core/renderer_opengl/gl_shader_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_manager.cpp
@@ -254,7 +254,7 @@ public:
     explicit ShaderDoubleCache(bool separable) : separable(separable) {}
     std::tuple<GLuint, std::optional<ShaderDecompiler::ProgramResult>> Get(
         const KeyConfigType& key, const Pica::Shader::ShaderSetup& setup) {
-        std::optional<ShaderDecompiler::ProgramResult> result{};
+        ShaderDecompiler::ProgramResult result{};
         auto map_it = shader_map.find(key);
         if (map_it == shader_map.end()) {
             auto program_opt = CodeGenerator(setup, key, separable);
@@ -267,7 +267,7 @@ public:
             auto [iter, new_shader] = shader_cache.emplace(program, OGLShaderStage{separable});
             OGLShaderStage& cached_shader = iter->second;
             if (new_shader) {
-                result->code = program;
+                result.code = program;
                 cached_shader.Create(program.c_str(), ShaderType);
             }
             shader_map[key] = &cached_shader;

--- a/src/video_core/renderer_opengl/gl_shader_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_manager.cpp
@@ -254,7 +254,7 @@ public:
     explicit ShaderDoubleCache(bool separable) : separable(separable) {}
     std::tuple<GLuint, std::optional<ShaderDecompiler::ProgramResult>> Get(
         const KeyConfigType& key, const Pica::Shader::ShaderSetup& setup) {
-        ShaderDecompiler::ProgramResult result{};
+        std::optional<ShaderDecompiler::ProgramResult> result{};
         auto map_it = shader_map.find(key);
         if (map_it == shader_map.end()) {
             auto program_opt = CodeGenerator(setup, key, separable);


### PR DESCRIPTION
Fixes a known issue in which the flatpak application crashes with hardware shader enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5608)
<!-- Reviewable:end -->
