### PR TITLE
Enable fdk decoder for flatpak version

### DIFF
--- a/.ci/linux-flatpak/generate-data.sh
+++ b/.ci/linux-flatpak/generate-data.sh
@@ -87,7 +87,8 @@ cat > /tmp/org.citra.$REPO_NAME.json <<EOF
                 "-DENABLE_QT_TRANSLATION=ON",
                 "-DCITRA_ENABLE_COMPATIBILITY_REPORTING=ON",
                 "-DENABLE_COMPATIBILITY_LIST_DOWNLOAD=ON",
-                "-DENABLE_FFMPEG_VIDEO_DUMPER=ON"
+                "-DENABLE_FFMPEG_VIDEO_DUMPER=ON",
+                "-DENABLE_FDK=ON"
             ],
             "cleanup": [
               "/bin/citra",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ CMAKE_DEPENDENT_OPTION(COMPILE_WITH_DWARF "Add DWARF debugging information" ON "
 
 option(USE_SYSTEM_BOOST "Use the system Boost libs (instead of the bundled ones)" OFF)
 
-option(ENABLE_FDK "Use FDK AAC decoder" OFF)
+CMAKE_DEPENDENT_OPTION(ENABLE_FDK "Use FDK AAC decoder" OFF "NOT ENABLE_FFMPEG_AUDIO_DECODER;NOT ENABLE_MF" OFF)
 
 if(NOT EXISTS ${PROJECT_SOURCE_DIR}/.git/hooks/pre-commit)
     message(STATUS "Copying pre-commit hook")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ CMAKE_DEPENDENT_OPTION(COMPILE_WITH_DWARF "Add DWARF debugging information" ON "
 
 option(USE_SYSTEM_BOOST "Use the system Boost libs (instead of the bundled ones)" OFF)
 
-CMAKE_DEPENDENT_OPTION(ENABLE_FDK "Use FDK AAC decoder" OFF "NOT ENABLE_FFMPEG_AUDIO_DECODER;NOT ENABLE_MF" OFF)
+option(ENABLE_FDK "Use FDK AAC decoder" OFF)
 
 if(NOT EXISTS ${PROJECT_SOURCE_DIR}/.git/hooks/pre-commit)
     message(STATUS "Copying pre-commit hook")

--- a/src/audio_core/hle/fdk_decoder.cpp
+++ b/src/audio_core/hle/fdk_decoder.cpp
@@ -39,14 +39,6 @@ FDKDecoder::Impl::Impl(Memory::MemorySystem& memory) : memory(memory) {
         LOG_ERROR(Audio_DSP, "Failed to retrieve fdk_aac library information!");
         return;
     }
-    // This segment: identify the broken fdk_aac implementation
-    // and refuse to initialize if identified as broken (check for module IDs)
-    // although our AAC samples do not contain SBC feature, this is a way to detect
-    // watered down version of fdk_aac implementations
-    if (FDKlibInfo_getCapabilities(decoder_info, FDK_SBRDEC) == 0) {
-        LOG_ERROR(Audio_DSP, "Bad fdk_aac library found! Initialization aborted!");
-        return;
-    }
 
     LOG_INFO(Audio_DSP, "Using fdk_aac version {} (build date: {})", decoder_info[0].versionStr,
              decoder_info[0].build_date);


### PR DESCRIPTION
Fixes missing audio in games that require AAC decoder. I tested it with Pokemon X and the music played correctly. Since flatpak runtimes are supposed to be consistent across different Linux distributions, it's unlikely to cause any incompatibility.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5609)
<!-- Reviewable:end -->
