### PR TITLE
Fix telemetry-related exit crash from use-after-free

### DIFF
--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -1210,9 +1210,9 @@ VideoCore::ResultStatus RendererOpenGL::Init() {
     LOG_INFO(Render_OpenGL, "GL_RENDERER: {}", gpu_model);
 
     auto& telemetry_session = Core::System::GetInstance().TelemetrySession();
-    telemetry_session.AddField(Telemetry::FieldType::UserSystem, "GPU_Vendor", gpu_vendor);
-    telemetry_session.AddField(Telemetry::FieldType::UserSystem, "GPU_Model", gpu_model);
-    telemetry_session.AddField(Telemetry::FieldType::UserSystem, "GPU_OpenGL_Version", gl_version);
+    telemetry_session.AddField(Telemetry::FieldType::UserSystem, "GPU_Vendor", std::string(gpu_vendor));
+    telemetry_session.AddField(Telemetry::FieldType::UserSystem, "GPU_Model", std::string(gpu_model));
+    telemetry_session.AddField(Telemetry::FieldType::UserSystem, "GPU_OpenGL_Version", std::string(gl_version));
 
     if (!strcmp(gpu_vendor, "GDI Generic")) {
         return VideoCore::ResultStatus::ErrorGenericDrivers;

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -1210,9 +1210,12 @@ VideoCore::ResultStatus RendererOpenGL::Init() {
     LOG_INFO(Render_OpenGL, "GL_RENDERER: {}", gpu_model);
 
     auto& telemetry_session = Core::System::GetInstance().TelemetrySession();
-    telemetry_session.AddField(Telemetry::FieldType::UserSystem, "GPU_Vendor", std::string(gpu_vendor));
-    telemetry_session.AddField(Telemetry::FieldType::UserSystem, "GPU_Model", std::string(gpu_model));
-    telemetry_session.AddField(Telemetry::FieldType::UserSystem, "GPU_OpenGL_Version", std::string(gl_version));
+    telemetry_session.AddField(Telemetry::FieldType::UserSystem, "GPU_Vendor",
+                               std::string(gpu_vendor));
+    telemetry_session.AddField(Telemetry::FieldType::UserSystem, "GPU_Model",
+                               std::string(gpu_model));
+    telemetry_session.AddField(Telemetry::FieldType::UserSystem, "GPU_OpenGL_Version",
+                               std::string(gl_version));
 
     if (!strcmp(gpu_vendor, "GDI Generic")) {
         return VideoCore::ResultStatus::ErrorGenericDrivers;


### PR DESCRIPTION
AddField is implemented using std::move.

However, the memory backing these three `const char*` fields are local in scope to this function. When Citra (SDL2 at least) attempts to use these fields on exit, the memory may already be unmapped/invalid. To fix this, just convert them to a string.

I couldn't find a good way to discriminate between `const char[]` and `const char*` in the AddField templating system, so for now we just need to be careful and keep this in mind. I did check and as far as I can tell, all of the other `const char*`-like fields passed to AddField are globals that won't be freed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5617)
<!-- Reviewable:end -->
