### PR TITLE
Merge ARM64 Dynarmic

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
     url = https://github.com/philsquared/Catch.git
 [submodule "dynarmic"]
     path = externals/dynarmic
-    url = https://github.com/MerryMage/dynarmic.git
+    url = https://github.com/citra-emu/dynarmic.git
 [submodule "xbyak"]
     path = externals/xbyak
     url = https://github.com/herumi/xbyak.git

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -30,11 +30,16 @@ target_include_directories(catch-single-include INTERFACE catch/single_include)
 # Crypto++
 add_subdirectory(cryptopp)
 
-# Dynarmic
+# Xbyak
 if (ARCHITECTURE_x86_64)
-    # Dynarmic will skip defining xbyak if it's already defined, we then define it below
     add_library(xbyak INTERFACE)
-    option(DYNARMIC_TESTS OFF)
+    target_include_directories(xbyak SYSTEM INTERFACE ./xbyak/xbyak)
+    target_compile_definitions(xbyak INTERFACE XBYAK_NO_OP_NAMES)
+endif()
+
+# Dynarmic
+if (ARCHITECTURE_x86_64 OR ARCHITECTURE_ARM64)
+    set(DYNARMIC_TESTS OFF)
     set(DYNARMIC_NO_BUNDLED_FMT ON)
     set(DYNARMIC_FRONTENDS "A32")
     add_subdirectory(dynarmic)
@@ -73,14 +78,6 @@ target_include_directories(SoundTouch INTERFACE ./soundtouch/include)
 
 # Teakra
 add_subdirectory(teakra EXCLUDE_FROM_ALL)
-
-# Xbyak
-if (ARCHITECTURE_x86_64)
-    # Defined before "dynarmic" above
-    # add_library(xbyak INTERFACE)
-    target_include_directories(xbyak INTERFACE ./xbyak/xbyak)
-    target_compile_definitions(xbyak INTERFACE XBYAK_NO_OP_NAMES)
-endif()
 
 # Zstandard
 add_subdirectory(zstd/build/cmake EXCLUDE_FROM_ALL)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -487,7 +487,7 @@ if (ENABLE_WEB_SERVICE)
     endif()
 endif()
 
-if (ARCHITECTURE_x86_64)
+if (ARCHITECTURE_x86_64 OR ARCHITECTURE_ARM64)
     target_sources(core PRIVATE
         arm/dynarmic/arm_dynarmic.cpp
         arm/dynarmic/arm_dynarmic.h

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -13,7 +13,7 @@
 #include "common/logging/log.h"
 #include "common/texture.h"
 #include "core/arm/arm_interface.h"
-#ifdef ARCHITECTURE_x86_64
+#if defined(ARCHITECTURE_x86_64) || defined(ARCHITECTURE_ARM64)
 #include "core/arm/dynarmic/arm_dynarmic.h"
 #endif
 #include "core/arm/dyncom/arm_dyncom.h"
@@ -365,7 +365,7 @@ System::ResultStatus System::Init(Frontend::EmuWindow& emu_window, u32 system_mo
         *memory, *timing, [this] { PrepareReschedule(); }, system_mode, num_cores, n3ds_mode);
 
     if (Settings::values.use_cpu_jit) {
-#ifdef ARCHITECTURE_x86_64
+#if defined(ARCHITECTURE_x86_64) || defined(ARCHITECTURE_ARM64)
         for (u32 i = 0; i < num_cores; ++i) {
             cpu_cores.push_back(
                 std::make_shared<ARM_Dynarmic>(this, *memory, i, timing->GetTimer(i)));


### PR DESCRIPTION
- Migrates the dynarmic submodule to a fork under citra-emu
- Includes dynarmic rebased onto the latest Citra-compatible version (e.g. https://github.com/citra-emu/citra/pull/5618)
- Reorders externals/CMakeLists.txt xbyak and dynarmic sections to closer match Yuzu (the externals/CMakeLists.txt in citra-android didn't make a whole lot of sense, as xbyak should not be required on ARM64)
- Enables dynarmic in the core on ARM64

This branch has been tested to compile and run on both an x86_64 desktop and the Jetson TX2 ARM64 board with the dynarmic enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5620)
<!-- Reviewable:end -->
