### PR TITLE
Merge generic microphone input changes required for Android

### DIFF
--- a/src/audio_core/cubeb_input.cpp
+++ b/src/audio_core/cubeb_input.cpp
@@ -86,7 +86,7 @@ void CubebInput::StartSampling(const Frontend::Mic::Parameters& params) {
     input_params.format = CUBEB_SAMPLE_S16LE;
     input_params.rate = params.sample_rate;
 
-    u32 latency_frames;
+    u32 latency_frames = 512; // Firefox default
     if (cubeb_get_min_latency(impl->ctx, &input_params, &latency_frames) != CUBEB_OK) {
         LOG_ERROR(Audio, "Could not get minimum latency");
     }
@@ -189,4 +189,11 @@ std::vector<std::string> ListCubebInputDevices() {
     cubeb_destroy(ctx);
     return device_list;
 }
+
+CubebFactory::~CubebFactory() = default;
+
+std::unique_ptr<Frontend::Mic::Interface> CubebFactory::Create(std::string mic_device_name) {
+    return std::make_unique<CubebInput>(std::move(mic_device_name));
+}
+
 } // namespace AudioCore

--- a/src/audio_core/cubeb_input.h
+++ b/src/audio_core/cubeb_input.h
@@ -31,4 +31,11 @@ private:
 
 std::vector<std::string> ListCubebInputDevices();
 
+class CubebFactory final : public Frontend::Mic::RealMicFactory {
+public:
+    ~CubebFactory() override;
+
+    std::unique_ptr<Frontend::Mic::Interface> Create(std::string mic_device_name) override;
+};
+
 } // namespace AudioCore

--- a/src/core/frontend/mic.h
+++ b/src/core/frontend/mic.h
@@ -115,4 +115,23 @@ private:
     std::vector<u8> CACHE_16_BIT;
 };
 
+/// Factory for creating a real Mic input device;
+class RealMicFactory {
+public:
+    virtual ~RealMicFactory();
+
+    virtual std::unique_ptr<Interface> Create(std::string mic_device_name) = 0;
+};
+
+class NullFactory final : public RealMicFactory {
+public:
+    ~NullFactory() override;
+
+    std::unique_ptr<Interface> Create(std::string mic_device_name) override;
+};
+
+void RegisterRealMicFactory(std::unique_ptr<RealMicFactory> factory);
+
+std::unique_ptr<Interface> CreateRealMic(std::string mic_device_name);
+
 } // namespace Frontend::Mic

--- a/src/core/hle/service/mic_u.cpp
+++ b/src/core/hle/service/mic_u.cpp
@@ -3,9 +3,6 @@
 // Refer to the license.txt file included.
 
 #include <boost/serialization/weak_ptr.hpp>
-#ifdef HAVE_CUBEB
-#include "audio_core/cubeb_input.h"
-#endif
 #include "common/archives.h"
 #include "common/logging/log.h"
 #include "core/core.h"
@@ -359,11 +356,7 @@ struct MIC_U::Impl {
             new_mic = std::make_unique<Frontend::Mic::NullMic>();
             break;
         case Settings::MicInputType::Real:
-#if HAVE_CUBEB
-            new_mic = std::make_unique<AudioCore::CubebInput>(Settings::values.mic_input_device);
-#else
-            new_mic = std::make_unique<Frontend::Mic::NullMic>();
-#endif
+            new_mic = Frontend::Mic::CreateRealMic(Settings::values.mic_input_device);
             break;
         case Settings::MicInputType::Static:
             new_mic = std::make_unique<Frontend::Mic::StaticMic>();


### PR DESCRIPTION
Merges the generic parts of https://github.com/citra-emu/citra-android/commit/5e52853078765cbcdc48b217ceeb7658c185d37b and https://github.com/citra-emu/citra-android/commit/c6e363532b0882269810c9f7f39a19878f757006

Required for Android microphone support, changes seem fine for desktop.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5624)
<!-- Reviewable:end -->
