### PR TITLE
service/apt: Fix deliver arg hmac size

### DIFF
--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -532,7 +532,7 @@ void Module::APTInterface::ReceiveDeliverArg(Kernel::HLERequestContext& ctx) {
 
     auto arg = apt->applet_manager->ReceiveDeliverArg().value_or(AppletManager::DeliverArg{});
     arg.param.resize(param_size);
-    arg.hmac.resize(std::max<std::size_t>(hmac_size, 0x20));
+    arg.hmac.resize(std::min<std::size_t>(hmac_size, 0x20));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(4, 4);
     rb.Push(RESULT_SUCCESS);


### PR DESCRIPTION
I'm not sure why I wrote the original code anyway but this fixes Mii Maker.

Turned out to be a typo lol.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5626)
<!-- Reviewable:end -->
