### PR TITLE
[DO NOT MERGE] video_core: Enable compiler warnings as error

### DIFF
--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -147,3 +147,21 @@ target_link_libraries(video_core PRIVATE glad nihstro-headers Boost::serializati
 if (ARCHITECTURE_x86_64)
     target_link_libraries(video_core PUBLIC xbyak)
 endif()
+
+if (MSVC)
+    target_compile_options(video_core PRIVATE /we4267)
+else()
+    target_compile_options(video_core PRIVATE
+        -Werror=conversion
+        -Wno-error=sign-conversion
+        -Werror=pessimizing-move
+        -Werror=redundant-move
+        -Werror=switch
+        -Werror=type-limits
+        -Werror=unused-variable
+
+        $<$<CXX_COMPILER_ID:GNU>:-Werror=class-memaccess>
+        $<$<CXX_COMPILER_ID:GNU>:-Werror=unused-but-set-parameter>
+        $<$<CXX_COMPILER_ID:GNU>:-Werror=unused-but-set-variable>
+    )
+endif()


### PR DESCRIPTION
Enables a bunch of warnings as errors so potential bugs can be spotted more easily.
The list of warnings has been directly taken from yuzu.
I'm planning to chop away at them and fix CI in this PR in the near future.

Supersedes https://github.com/citra-emu/citra/pull/5064.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5633)
<!-- Reviewable:end -->
