### PR TITLE
 Port yuzu-emu/yuzu#4798: "udp/client: Take std::function by const reference with TestCommunication()"

### DIFF
--- a/src/input_common/udp/client.cpp
+++ b/src/input_common/udp/client.cpp
@@ -210,8 +210,8 @@ void Client::StartCommunication(const std::string& host, u16 port, u8 pad_index,
 }
 
 void TestCommunication(const std::string& host, u16 port, u8 pad_index, u32 client_id,
-                       std::function<void()> success_callback,
-                       std::function<void()> failure_callback) {
+                       const std::function<void()>& success_callback,
+                       const std::function<void()>& failure_callback) {
     std::thread([=] {
         Common::Event success_event;
         SocketCallback callback{[](Response::Version version) {}, [](Response::PortInfo info) {},

--- a/src/input_common/udp/client.h
+++ b/src/input_common/udp/client.h
@@ -89,7 +89,7 @@ private:
 };
 
 void TestCommunication(const std::string& host, u16 port, u8 pad_index, u32 client_id,
-                       std::function<void()> success_callback,
-                       std::function<void()> failure_callback);
+                       const std::function<void()>& success_callback,
+                       const std::function<void()>& failure_callback);
 
 } // namespace InputCommon::CemuhookUDP


### PR DESCRIPTION
See yuzu-emu/yuzu#4798 for more details.

**Original description:**
Avoids redundant copies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5634)
<!-- Reviewable:end -->
