### PR TITLE
[DO NOT MERGE] audio_core: Enable warnings as errors

### DIFF
--- a/src/audio_core/CMakeLists.txt
+++ b/src/audio_core/CMakeLists.txt
@@ -35,6 +35,24 @@ add_library(audio_core STATIC
 
 create_target_directory_groups(audio_core)
 
+if (NOT MSVC)
+    target_compile_options(audio_core PRIVATE
+        -Werror=conversion
+        -Werror=ignored-qualifiers
+        -Werror=implicit-fallthrough
+        -Werror=reorder
+        -Werror=sign-compare
+        -Werror=shadow
+        -Werror=unused-parameter
+        -Werror=unused-variable
+
+        $<$<CXX_COMPILER_ID:GNU>:-Werror=unused-but-set-parameter>
+        $<$<CXX_COMPILER_ID:GNU>:-Werror=unused-but-set-variable>
+
+        -Wno-sign-conversion
+    )
+endif()
+
 target_link_libraries(audio_core PUBLIC common)
 target_link_libraries(audio_core PRIVATE SoundTouch teakra)
 


### PR DESCRIPTION
Those definitions were taken from yuzu and should help to prevent bugs in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5636)
<!-- Reviewable:end -->
