### PR TITLE
[DO NOT MERGE] core: Add warnings as errors

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -470,6 +470,37 @@ if (ENABLE_FFMPEG_VIDEO_DUMPER)
     )
 endif()
 
+if (MSVC)
+    target_compile_options(core PRIVATE
+        # 'expression' : signed/unsigned mismatch
+        /we4018
+        # 'argument' : conversion from 'type1' to 'type2', possible loss of data (floating-point)
+        /we4244
+        # 'conversion' : conversion from 'type1' to 'type2', signed/unsigned mismatch
+        /we4245
+        # 'operator': conversion from 'type1:field_bits' to 'type2:field_bits', possible loss of data
+        /we4254
+        # 'var' : conversion from 'size_t' to 'type', possible loss of data
+        /we4267
+        # 'context' : truncation from 'type1' to 'type2'
+        /we4305
+    )
+else()
+    target_compile_options(core PRIVATE
+        -Werror=conversion
+        -Werror=ignored-qualifiers
+        -Werror=implicit-fallthrough
+        -Werror=reorder
+        -Werror=sign-compare
+        -Werror=unused-variable
+
+        $<$<CXX_COMPILER_ID:GNU>:-Werror=unused-but-set-parameter>
+        $<$<CXX_COMPILER_ID:GNU>:-Werror=unused-but-set-variable>
+
+        -Wno-sign-conversion
+    )
+endif()
+
 create_target_directory_groups(core)
 
 target_link_libraries(core PUBLIC common PRIVATE audio_core network video_core)


### PR DESCRIPTION
Those definitions were taken from yuzu and should help to prevent bugs in the future.
Supersedes https://github.com/citra-emu/citra/pull/5180.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5637)
<!-- Reviewable:end -->
