### PR TITLE
src/CMakeLists: Enable warnings as errors

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,7 +64,15 @@ if (MSVC)
 else()
     add_compile_options(
         -Wall
+        -Werror=implicit-fallthrough
+        -Werror=missing-declarations
+        -Werror=reorder
+        -Werror=unused-result
+        -Wextra
+        -Wmissing-declarations
         -Wno-attributes
+        -Wno-invalid-offsetof
+        -Wno-unused-parameter
     )
 
     if (APPLE AND CMAKE_CXX_COMPILER_ID STREQUAL Clang)


### PR DESCRIPTION
Those definitions were taken from yuzu and should help to prevent bugs in the future.

Supersedes https://github.com/citra-emu/citra/pull/5215.
Supersedes https://github.com/citra-emu/citra/pull/5219.
Supersedes https://github.com/citra-emu/citra/pull/5268.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5638)
<!-- Reviewable:end -->
