### PR TITLE
bootmanager: fix memory leaks when loading save states

### DIFF
--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -104,7 +104,7 @@ void EmuThread::run() {
 }
 
 OpenGLWindow::OpenGLWindow(QWindow* parent, QWidget* event_handler, QOpenGLContext* shared_context)
-    : QWindow(parent), context(new QOpenGLContext(shared_context->parent())),
+    : QWindow(parent), context(std::make_unique<QOpenGLContext>(shared_context->parent())),
       event_handler(event_handler) {
 
     // disable vsync for any shared contexts
@@ -447,8 +447,8 @@ std::unique_ptr<Frontend::GraphicsContext> GRenderWindow::CreateSharedContext() 
 }
 
 GLContext::GLContext(QOpenGLContext* shared_context)
-    : context(new QOpenGLContext(shared_context->parent())),
-      surface(new QOffscreenSurface(nullptr)) {
+    : context(std::make_unique<QOpenGLContext>(shared_context->parent())),
+      surface(std::make_unique<QOffscreenSurface>(nullptr)) {
 
     // disable vsync for any shared contexts
     auto format = shared_context->format();
@@ -463,7 +463,7 @@ GLContext::GLContext(QOpenGLContext* shared_context)
 }
 
 void GLContext::MakeCurrent() {
-    context->makeCurrent(surface);
+    context->makeCurrent(surface.get());
 }
 
 void GLContext::DoneCurrent() {

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -6,6 +6,7 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <memory>
 #include <mutex>
 #include <QThread>
 #include <QWidget>
@@ -36,8 +37,8 @@ public:
     void DoneCurrent() override;
 
 private:
-    QOpenGLContext* context;
-    QOffscreenSurface* surface;
+    std::unique_ptr<QOpenGLContext> context;
+    std::unique_ptr<QOffscreenSurface> surface;
 };
 
 class EmuThread final : public QThread {
@@ -138,7 +139,7 @@ protected:
     void exposeEvent(QExposeEvent* event) override;
 
 private:
-    QOpenGLContext* context;
+    std::unique_ptr<QOpenGLContext> context;
     QWidget* event_handler;
 };
 


### PR DESCRIPTION
This Pull Request should fix #5523.

After analyzing the memory leaks report generated by the address sanitizer, it seems like the memory leaks were originated from https://github.com/citra-emu/citra/blob/3f13e1cc2419fac837952c44d7be9db78b054a2f/src/citra_qt/bootmanager.cpp#L449-L451.

The fix is simply to add a destructor to the `GLContext` in the `bootmanager`.

After the fix, the memory leaks report no longer shows this particular memory leak anymore.

Note that, during testing, the `citra-qt` crashed once for reasons unknown. I wasn't able to reproduce this crash despite ~20 more attempts. I suggest when testing this change, try to abuse the save state system as much as possible to see if you can reproduce the crash.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5644)
<!-- Reviewable:end -->
