### PR TITLE
Port yuzu-emu/yuzu#5139: "game_list_p: Resolve deprecated usage of QVariant operator<"

### DIFF
--- a/src/citra_qt/game_list_p.h
+++ b/src/citra_qt/game_list_p.h
@@ -274,7 +274,8 @@ public:
     }
 
     bool operator<(const QStandardItem& other) const override {
-        return data(CompatNumberRole) < other.data(CompatNumberRole);
+        return data(CompatNumberRole).value<QString>() <
+               other.data(CompatNumberRole).value<QString>();
     }
 };
 


### PR DESCRIPTION
See yuzu-emu/yuzu#5139 for more details.

**Original description**:
This is designated as obsolete in Qt's docs (see: https://doc.qt.io/qt-5/qvariant-obsolete.html#operator-lt), so we directly compare against the data instead of delegating the work to QVariant.

Prevents our code from breaking in the future when we update Qt versions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5648)
<!-- Reviewable:end -->
