### PR TITLE
Port yuzu-emu/yuzu#5158: "video_core: Remove unnecessary enum class casting in logging messages"

### DIFF
--- a/src/video_core/regs_framebuffer.h
+++ b/src/video_core/regs_framebuffer.h
@@ -200,7 +200,7 @@ struct FramebufferRegs {
         case ColorFormat::RGBA4:
             return 2;
         default:
-            LOG_CRITICAL(HW_GPU, "Unknown color format {}", static_cast<u32>(format));
+            LOG_CRITICAL(HW_GPU, "Unknown color format {}", format);
             UNIMPLEMENTED();
         }
     }
@@ -265,7 +265,7 @@ struct FramebufferRegs {
             return 4;
         }
 
-        ASSERT_MSG(false, "Unknown depth format {}", static_cast<u32>(format));
+        ASSERT_MSG(false, "Unknown depth format {}", format);
     }
 
     // Returns the number of bits per depth component of the specified depth format
@@ -278,7 +278,7 @@ struct FramebufferRegs {
             return 24;
         }
 
-        ASSERT_MSG(false, "Unknown depth format {}", static_cast<u32>(format));
+        ASSERT_MSG(false, "Unknown depth format {}", format);
     }
 
     INSERT_PADDING_WORDS(0x10); // Gas related registers

--- a/src/video_core/regs_lighting.h
+++ b/src/video_core/regs_lighting.h
@@ -127,7 +127,7 @@ struct LightingRegs {
                             "sampler should be one of Distribution0, Distribution1, "
                             "SpotlightAttenuation, Fresnel, ReflectRed, ReflectGreen or "
                             "ReflectBlue, instead got %i",
-                            static_cast<int>(config));
+                            config);
         }
     }
 

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -747,8 +747,7 @@ void CachedSurface::DumpTexture(GLuint target_tex, u64 tex_hash) {
         return;
     }
 
-    dump_path += fmt::format("tex1_{}x{}_{:016X}_{}.png", width, height, tex_hash,
-                             static_cast<u32>(pixel_format));
+    dump_path += fmt::format("tex1_{}x{}_{:016X}_{}.png", width, height, tex_hash, pixel_format);
     if (!custom_tex_cache.IsTextureDumped(tex_hash) && !FileUtil::Exists(dump_path)) {
         custom_tex_cache.SetTextureDumped(tex_hash);
 

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -561,9 +561,9 @@ private:
                 const CompareOp op_y = instr.common.compare_op.y.Value();
 
                 if (cmp_ops.find(op_x) == cmp_ops.end()) {
-                    LOG_ERROR(HW_GPU, "Unknown compare mode {:x}", static_cast<int>(op_x));
+                    LOG_ERROR(HW_GPU, "Unknown compare mode {:x}", op_x);
                 } else if (cmp_ops.find(op_y) == cmp_ops.end()) {
-                    LOG_ERROR(HW_GPU, "Unknown compare mode {:x}", static_cast<int>(op_y));
+                    LOG_ERROR(HW_GPU, "Unknown compare mode {:x}", op_y);
                 } else if (op_x != op_y) {
                     shader.AddLine("conditional_code.x = {}.x {} {}.x;", src1,
                                    cmp_ops.find(op_x)->second.first, src2);

--- a/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
@@ -161,7 +161,7 @@ std::optional<std::vector<ShaderDiskCacheRaw>> ShaderDiskCache::LoadTransferable
         }
         default:
             LOG_ERROR(Render_OpenGL, "Unknown transferable shader cache entry kind={} - skipping",
-                      static_cast<u32>(kind));
+                      kind);
             return std::nullopt;
         }
     }

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -278,8 +278,7 @@ void PicaGSConfigCommonRaw::Init(const Pica::Regs& regs) {
             if (static_cast<std::size_t>(semantic) < 24) {
                 semantic_maps[static_cast<std::size_t>(semantic)] = {attrib, comp};
             } else if (semantic != VSOutputAttributes::INVALID) {
-                LOG_ERROR(Render_OpenGL, "Invalid/unknown semantic id: {}",
-                          static_cast<u32>(semantic));
+                LOG_ERROR(Render_OpenGL, "Invalid/unknown semantic id: {}", semantic);
             }
         }
     }
@@ -316,8 +315,7 @@ static std::string SampleTexture(const PicaFSConfig& config, unsigned texture_un
         case TexturingRegs::TextureConfig::Disabled:
             return "vec4(0.0)";
         default:
-            LOG_CRITICAL(HW_GPU, "Unhandled texture type {:x}",
-                         static_cast<int>(state.texture0_type));
+            LOG_CRITICAL(HW_GPU, "Unhandled texture type {:x}", state.texture0_type);
             UNIMPLEMENTED();
             return "texture(tex0, texcoord0)";
         }
@@ -380,7 +378,7 @@ static void AppendSource(std::string& out, const PicaFSConfig& config,
         break;
     default:
         out += "vec4(0.0)";
-        LOG_CRITICAL(Render_OpenGL, "Unknown source op {}", static_cast<u32>(source));
+        LOG_CRITICAL(Render_OpenGL, "Unknown source op {}", source);
         break;
     }
 }
@@ -438,7 +436,7 @@ static void AppendColorModifier(std::string& out, const PicaFSConfig& config,
         break;
     default:
         out += "vec3(0.0)";
-        LOG_CRITICAL(Render_OpenGL, "Unknown color modifier op {}", static_cast<u32>(modifier));
+        LOG_CRITICAL(Render_OpenGL, "Unknown color modifier op {}", modifier);
         break;
     }
 }
@@ -487,7 +485,7 @@ static void AppendAlphaModifier(std::string& out, const PicaFSConfig& config,
         break;
     default:
         out += "0.0";
-        LOG_CRITICAL(Render_OpenGL, "Unknown alpha modifier op {}", static_cast<u32>(modifier));
+        LOG_CRITICAL(Render_OpenGL, "Unknown alpha modifier op {}", modifier);
         break;
     }
 }
@@ -529,8 +527,7 @@ static void AppendColorCombiner(std::string& out, TevStageConfig::Operation oper
         break;
     default:
         out += "vec3(0.0)";
-        LOG_CRITICAL(Render_OpenGL, "Unknown color combiner operation: {}",
-                     static_cast<u32>(operation));
+        LOG_CRITICAL(Render_OpenGL, "Unknown color combiner operation: {}", operation);
         break;
     }
     out += ", vec3(0.0), vec3(1.0))"; // Clamp result to 0.0, 1.0
@@ -568,8 +565,7 @@ static void AppendAlphaCombiner(std::string& out, TevStageConfig::Operation oper
         break;
     default:
         out += "0.0";
-        LOG_CRITICAL(Render_OpenGL, "Unknown alpha combiner operation: {}",
-                     static_cast<u32>(operation));
+        LOG_CRITICAL(Render_OpenGL, "Unknown alpha combiner operation: {}", operation);
         break;
     }
     out += ", 0.0, 1.0)";
@@ -599,7 +595,7 @@ static void AppendAlphaTestCondition(std::string& out, FramebufferRegs::CompareF
 
     default:
         out += "false";
-        LOG_CRITICAL(Render_OpenGL, "Unknown alpha test condition {}", static_cast<u32>(func));
+        LOG_CRITICAL(Render_OpenGL, "Unknown alpha test condition {}", func);
         break;
     }
 }
@@ -831,8 +827,7 @@ static void WriteLighting(std::string& out, const PicaFSConfig& config) {
                                                   "{}.position) + {}.dist_atten_bias, 0.0, 1.0)",
                                                   light_src, light_src, light_src);
             const auto sampler = LightingRegs::DistanceAttenuationSampler(light_config.num);
-            dist_atten =
-                fmt::format("LookupLightingLUTUnsigned({}, {})", static_cast<u32>(sampler), index);
+            dist_atten = fmt::format("LookupLightingLUTUnsigned({}, {})", sampler, index);
         }
 
         if (light_config.geometric_factor_0 || light_config.geometric_factor_1) {
@@ -985,7 +980,7 @@ static void AppendProcTexShiftOffset(std::string& out, std::string_view v, ProcT
         out += fmt::format("{} * float(((int({}) + 1) / 2) % 2)", offset, v);
         break;
     default:
-        LOG_CRITICAL(HW_GPU, "Unknown shift mode {}", static_cast<u32>(mode));
+        LOG_CRITICAL(HW_GPU, "Unknown shift mode {}", mode);
         out += "0.0";
         break;
     }
@@ -1010,7 +1005,7 @@ static void AppendProcTexClamp(std::string& out, std::string_view var, ProcTexCl
         out += fmt::format("{0} = {0} > 0.5 ? 1.0 : 0.0;\n", var);
         break;
     default:
-        LOG_CRITICAL(HW_GPU, "Unknown clamp mode {}", static_cast<u32>(mode));
+        LOG_CRITICAL(HW_GPU, "Unknown clamp mode {}", mode);
         out += fmt::format("{0} = min({0}, 1.0);\n", var);
         break;
     }
@@ -1041,7 +1036,7 @@ static void AppendProcTexCombineAndMap(std::string& out, ProcTexCombiner combine
         case TexturingRegs::ProcTexCombiner::RMax:
             return "min(((u + v) * 0.5 + sqrt(u * u + v * v)) * 0.5, 1.0)";
         default:
-            LOG_CRITICAL(HW_GPU, "Unknown combiner {}", static_cast<u32>(combiner));
+            LOG_CRITICAL(HW_GPU, "Unknown combiner {}", combiner);
             return "0.0";
         }
     }();
@@ -1592,10 +1587,8 @@ ShaderDecompiler::ProgramResult GenerateTrivialVertexShader(bool separable_shade
                     "layout(location = {}) in float vert_texcoord0_w;\n"
                     "layout(location = {}) in vec4 vert_normquat;\n"
                     "layout(location = {}) in vec3 vert_view;\n",
-                    static_cast<int>(ATTRIBUTE_POSITION), static_cast<int>(ATTRIBUTE_COLOR),
-                    static_cast<int>(ATTRIBUTE_TEXCOORD0), static_cast<int>(ATTRIBUTE_TEXCOORD1),
-                    static_cast<int>(ATTRIBUTE_TEXCOORD2), static_cast<int>(ATTRIBUTE_TEXCOORD0_W),
-                    static_cast<int>(ATTRIBUTE_NORMQUAT), static_cast<int>(ATTRIBUTE_VIEW));
+                    ATTRIBUTE_POSITION, ATTRIBUTE_COLOR, ATTRIBUTE_TEXCOORD0, ATTRIBUTE_TEXCOORD1,
+                    ATTRIBUTE_TEXCOORD2, ATTRIBUTE_TEXCOORD0_W, ATTRIBUTE_NORMQUAT, ATTRIBUTE_VIEW);
 
     out += GetVertexInterfaceDeclaration(true, separable_shader);
 

--- a/src/video_core/renderer_opengl/gl_shader_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_manager.cpp
@@ -524,7 +524,7 @@ void ShaderProgramManager::LoadDiskCache(const std::atomic_bool& stop_loading,
                         // Unsupported shader type got stored somehow so nuke the cache
 
                         LOG_CRITICAL(Frontend, "failed to load raw programtype {}",
-                                     static_cast<u32>(raw.GetProgramType()));
+                                     raw.GetProgramType());
                         compilation_failed = true;
                         return;
                     }
@@ -585,8 +585,7 @@ void ShaderProgramManager::LoadDiskCache(const std::atomic_bool& stop_loading,
                 result = std::move(r);
             } else {
                 // Unsupported shader type got stored somehow so nuke the cache
-                LOG_ERROR(Frontend, "failed to load raw programtype {}",
-                          static_cast<u32>(raw.GetProgramType()));
+                LOG_ERROR(Frontend, "failed to load raw programtype {}", raw.GetProgramType());
                 compilation_failed = true;
                 return;
             }

--- a/src/video_core/renderer_opengl/pica_to_gl.h
+++ b/src/video_core/renderer_opengl/pica_to_gl.h
@@ -38,7 +38,7 @@ inline GLenum TextureMagFilterMode(TextureFilter mode) {
     if (mode == TextureFilter::Nearest) {
         return GL_NEAREST;
     }
-    LOG_CRITICAL(Render_OpenGL, "Unknown texture filtering mode {}", static_cast<u32>(mode));
+    LOG_CRITICAL(Render_OpenGL, "Unknown texture filtering mode {}", mode);
     UNIMPLEMENTED();
     return GL_LINEAR;
 }
@@ -59,8 +59,7 @@ inline GLenum TextureMinFilterMode(TextureFilter min, TextureFilter mip) {
             return GL_NEAREST_MIPMAP_NEAREST;
         }
     }
-    LOG_CRITICAL(Render_OpenGL, "Unknown texture filtering mode {} and {}", static_cast<u32>(min),
-                 static_cast<u32>(mip));
+    LOG_CRITICAL(Render_OpenGL, "Unknown texture filtering mode {} and {}", min, mip);
     UNIMPLEMENTED();
     return GL_LINEAR_MIPMAP_LINEAR;
 }

--- a/src/video_core/swrasterizer/framebuffer.cpp
+++ b/src/video_core/swrasterizer/framebuffer.cpp
@@ -297,7 +297,7 @@ Common::Vec4<u8> EvaluateBlendEquation(const Common::Vec4<u8>& src,
         break;
 
     default:
-        LOG_CRITICAL(HW_GPU, "Unknown RGB blend equation 0x{:x}", static_cast<u8>(equation));
+        LOG_CRITICAL(HW_GPU, "Unknown RGB blend equation 0x{:x}", equation);
         UNIMPLEMENTED();
     }
 

--- a/src/video_core/swrasterizer/lighting.cpp
+++ b/src/video_core/swrasterizer/lighting.cpp
@@ -143,7 +143,7 @@ std::tuple<Common::Vec4<u8>, Common::Vec4<u8>> ComputeFragmentsColors(
                 }
                 break;
             default:
-                LOG_CRITICAL(HW_GPU, "Unknown lighting LUT input {}", static_cast<u32>(input));
+                LOG_CRITICAL(HW_GPU, "Unknown lighting LUT input {}", input);
                 UNIMPLEMENTED();
                 result = 0.0f;
             }

--- a/src/video_core/swrasterizer/proctex.cpp
+++ b/src/video_core/swrasterizer/proctex.cpp
@@ -76,7 +76,7 @@ static float GetShiftOffset(float v, ProcTexShift mode, ProcTexClamp clamp_mode)
     case ProcTexShift::Even:
         return offset * ((((int)v + 1) / 2) % 2);
     default:
-        LOG_CRITICAL(HW_GPU, "Unknown shift mode {}", static_cast<u32>(mode));
+        LOG_CRITICAL(HW_GPU, "Unknown shift mode {}", mode);
         return 0;
     }
 };
@@ -106,7 +106,7 @@ static void ClampCoord(float& coord, ProcTexClamp mode) {
             coord = 1.0f;
         break;
     default:
-        LOG_CRITICAL(HW_GPU, "Unknown clamp mode {}", static_cast<u32>(mode));
+        LOG_CRITICAL(HW_GPU, "Unknown clamp mode {}", mode);
         coord = std::min(coord, 1.0f);
         break;
     }
@@ -147,7 +147,7 @@ static float CombineAndMap(float u, float v, ProcTexCombiner combiner,
         f = std::min(((u + v) * 0.5f + std::sqrt(u * u + v * v)) * 0.5f, 1.0f);
         break;
     default:
-        LOG_CRITICAL(HW_GPU, "Unknown combiner {}", static_cast<u32>(combiner));
+        LOG_CRITICAL(HW_GPU, "Unknown combiner {}", combiner);
         f = 0.0f;
         break;
     }

--- a/src/video_core/swrasterizer/rasterizer.cpp
+++ b/src/video_core/swrasterizer/rasterizer.cpp
@@ -847,7 +847,7 @@ static void ProcessTriangleInternal(const Vertex& v0, const Vertex& v1, const Ve
                         return std::min(combiner_output.a(), static_cast<u8>(255 - dest.a()));
 
                     default:
-                        LOG_CRITICAL(HW_GPU, "Unknown blend factor {:x}", static_cast<u32>(factor));
+                        LOG_CRITICAL(HW_GPU, "Unknown blend factor {:x}", factor);
                         UNIMPLEMENTED();
                         break;
                     }


### PR DESCRIPTION
See yuzu-emu/yuzu#5158 for more details.

**Original description**:
fmt now automatically prints the numeric value of an enum class member by default, so we don't need to use casts any more.

Reduces the line noise in our code a bit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5657)
<!-- Reviewable:end -->
