### PR TITLE
citra_qt/cheats: Make window resizable and remove help hint

### DIFF
--- a/src/citra_qt/cheats.cpp
+++ b/src/citra_qt/cheats.cpp
@@ -17,7 +17,7 @@ CheatDialog::CheatDialog(QWidget* parent)
     : QDialog(parent), ui(std::make_unique<Ui::CheatDialog>()) {
     // Setup gui control settings
     ui->setupUi(this);
-    setWindowFlags(Qt::Dialog | Qt::MSWindowsFixedSizeDialogHint);
+    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
     ui->tableCheats->setColumnWidth(0, 30);
     ui->tableCheats->setColumnWidth(2, 85);
     ui->tableCheats->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Fixed);


### PR DESCRIPTION
Fixes https://github.com/citra-emu/citra/issues/5575.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5658)
<!-- Reviewable:end -->
