### PR TITLE
Port yuzu-emu/yuzu#5166: "core: Remove unnecessary enum casts in log calls"

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -132,8 +132,8 @@ public:
         case Dynarmic::A32::Exception::PreloadDataWithIntentToWrite:
             return;
         }
-        ASSERT_MSG(false, "ExceptionRaised(exception = {}, pc = {:08X}, code = {:08X})",
-                   static_cast<std::size_t>(exception), pc, MemoryReadCode(pc));
+        ASSERT_MSG(false, "ExceptionRaised(exception = {}, pc = {:08X}, code = {:08X})", exception,
+                   pc, MemoryReadCode(pc));
     }
 
     void AddTicks(std::uint64_t ticks) override {
@@ -206,7 +206,7 @@ u32 ARM_Dynarmic::GetVFPSystemReg(VFPSystemRegister reg) const {
     case VFP_FPEXC:
         return fpexc;
     default:
-        UNREACHABLE_MSG("Unknown VFP system register: {}", static_cast<size_t>(reg));
+        UNREACHABLE_MSG("Unknown VFP system register: {}", reg);
     }
 }
 
@@ -219,7 +219,7 @@ void ARM_Dynarmic::SetVFPSystemReg(VFPSystemRegister reg, u32 value) {
         fpexc = value;
         return;
     default:
-        UNREACHABLE_MSG("Unknown VFP system register: {}", static_cast<size_t>(reg));
+        UNREACHABLE_MSG("Unknown VFP system register: {}", reg);
     }
 }
 
@@ -238,7 +238,7 @@ u32 ARM_Dynarmic::GetCP15Register(CP15Register reg) const {
     case CP15_THREAD_URO:
         return cp15_state.cp15_thread_uro;
     default:
-        UNREACHABLE_MSG("Unknown CP15 register: {}", static_cast<size_t>(reg));
+        UNREACHABLE_MSG("Unknown CP15 register: {}", reg);
     }
 }
 
@@ -251,7 +251,7 @@ void ARM_Dynarmic::SetCP15Register(CP15Register reg, u32 value) {
         cp15_state.cp15_thread_uro = value;
         return;
     default:
-        UNREACHABLE_MSG("Unknown CP15 register: {}", static_cast<size_t>(reg));
+        UNREACHABLE_MSG("Unknown CP15 register: {}", reg);
     }
 }
 

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -290,7 +290,7 @@ System::ResultStatus System::Load(Frontend::EmuWindow& emu_window, const std::st
     const Loader::ResultStatus load_result{app_loader->Load(process)};
     kernel->SetCurrentProcess(process);
     if (Loader::ResultStatus::Success != load_result) {
-        LOG_CRITICAL(Core, "Failed to load ROM (Error {})!", static_cast<u32>(load_result));
+        LOG_CRITICAL(Core, "Failed to load ROM (Error {})!", load_result);
         System::Shutdown();
 
         switch (load_result) {

--- a/src/core/file_sys/archive_ncch.cpp
+++ b/src/core/file_sys/archive_ncch.cpp
@@ -111,8 +111,7 @@ ResultVal<std::unique_ptr<FileBackend>> NCCHArchive::OpenFile(const Path& path,
         std::unique_ptr<DelayGenerator> delay_generator = std::make_unique<ExeFSDelayGenerator>();
         file = std::make_unique<NCCHFile>(std::move(buffer), std::move(delay_generator));
     } else {
-        LOG_ERROR(Service_FS, "Unknown NCCH archive type {}!",
-                  static_cast<u32>(openfile_path.filepath_type));
+        LOG_ERROR(Service_FS, "Unknown NCCH archive type {}!", openfile_path.filepath_type);
         result = Loader::ResultStatus::Error;
     }
 

--- a/src/core/file_sys/archive_other_savedata.cpp
+++ b/src/core/file_sys/archive_other_savedata.cpp
@@ -27,7 +27,7 @@ namespace {
 template <typename T>
 ResultVal<std::tuple<MediaType, u64>> ParsePath(const Path& path, T program_id_reader) {
     if (path.GetType() != LowPathType::Binary) {
-        LOG_ERROR(Service_FS, "Wrong path type {}", static_cast<int>(path.GetType()));
+        LOG_ERROR(Service_FS, "Wrong path type {}", path.GetType());
         return ERROR_INVALID_PATH;
     }
 
@@ -42,7 +42,7 @@ ResultVal<std::tuple<MediaType, u64>> ParsePath(const Path& path, T program_id_r
     auto media_type = static_cast<MediaType>(data[0]);
 
     if (media_type != MediaType::SDMC && media_type != MediaType::GameCard) {
-        LOG_ERROR(Service_FS, "Unsupported media type {}", static_cast<u32>(media_type));
+        LOG_ERROR(Service_FS, "Unsupported media type {}", media_type);
 
         // Note: this is strange, but the error code was verified with a real 3DS
         return ERROR_UNSUPPORTED_OPEN_FLAGS;

--- a/src/core/file_sys/archive_selfncch.cpp
+++ b/src/core/file_sys/archive_selfncch.cpp
@@ -133,7 +133,7 @@ public:
             return OpenExeFS(filename);
         }
         default:
-            LOG_ERROR(Service_FS, "Unknown file type {}!", static_cast<u32>(file_path.type));
+            LOG_ERROR(Service_FS, "Unknown file type {}!", file_path.type);
             return ERROR_INVALID_PATH;
         }
     }

--- a/src/core/frontend/applets/swkbd.cpp
+++ b/src/core/frontend/applets/swkbd.cpp
@@ -87,7 +87,7 @@ ValidationError SoftwareKeyboard::ValidateInput(const std::string& input) const 
     default:
         // TODO(jroweboy): What does hardware do in this case?
         LOG_CRITICAL(Frontend, "Application requested unknown validation method. Method: {}",
-                     static_cast<u32>(config.accept_mode));
+                     config.accept_mode);
         UNREACHABLE();
     }
 

--- a/src/core/gdbstub/gdbstub.cpp
+++ b/src/core/gdbstub/gdbstub.cpp
@@ -413,7 +413,7 @@ static void RemoveBreakpoint(BreakpointType type, VAddr addr) {
     }
 
     LOG_DEBUG(Debug_GDBStub, "gdb: removed a breakpoint: {:08x} bytes at {:08x} of type {}",
-              bp->second.len, bp->second.addr, static_cast<int>(type));
+              bp->second.len, bp->second.addr, type);
 
     if (type == BreakpointType::Execute) {
         Core::System::GetInstance().Memory().WriteBlock(
@@ -473,7 +473,7 @@ bool CheckBreakpoint(VAddr addr, BreakpointType type) {
         LOG_DEBUG(Debug_GDBStub,
                   "Found breakpoint type {} @ {:08x}, range: {:08x}"
                   " - {:08x} ({:x} bytes)",
-                  static_cast<int>(type), addr, bp->second.addr, bp->second.addr + len, len);
+                  type, addr, bp->second.addr, bp->second.addr + len, len);
         return true;
     }
 
@@ -948,8 +948,8 @@ static bool CommitBreakpoint(BreakpointType type, VAddr addr, u32 len) {
     }
     p.insert({addr, breakpoint});
 
-    LOG_DEBUG(Debug_GDBStub, "gdb: added {} breakpoint: {:08x} bytes at {:08x}\n",
-              static_cast<int>(type), breakpoint.len, breakpoint.addr);
+    LOG_DEBUG(Debug_GDBStub, "gdb: added {} breakpoint: {:08x} bytes at {:08x}\n", type,
+              breakpoint.len, breakpoint.addr);
 
     return true;
 }

--- a/src/core/hle/applets/applet.cpp
+++ b/src/core/hle/applets/applet.cpp
@@ -62,7 +62,7 @@ ResultCode Applet::Create(Service::APT::AppletId id,
         applets[id] = std::make_shared<Mint>(id, std::move(manager));
         break;
     default:
-        LOG_ERROR(Service_APT, "Could not create applet {}", static_cast<u32>(id));
+        LOG_ERROR(Service_APT, "Could not create applet {}", id);
         // TODO(Subv): Find the right error code
         return ResultCode(ErrorDescription::NotFound, ErrorModule::Applet,
                           ErrorSummary::NotSupported, ErrorLevel::Permanent);
@@ -82,7 +82,7 @@ std::shared_ptr<Applet> Applet::Get(Service::APT::AppletId id) {
 static void AppletUpdateEvent(u64 applet_id, s64 cycles_late) {
     Service::APT::AppletId id = static_cast<Service::APT::AppletId>(applet_id);
     std::shared_ptr<Applet> applet = Applet::Get(id);
-    ASSERT_MSG(applet != nullptr, "Applet doesn't exist! applet_id={:08X}", static_cast<u32>(id));
+    ASSERT_MSG(applet != nullptr, "Applet doesn't exist! applet_id={:08X}", id);
 
     applet->Update();
 

--- a/src/core/hle/applets/erreula.cpp
+++ b/src/core/hle/applets/erreula.cpp
@@ -11,7 +11,7 @@ namespace HLE::Applets {
 
 ResultCode ErrEula::ReceiveParameter(const Service::APT::MessageParameter& parameter) {
     if (parameter.signal != Service::APT::SignalType::Request) {
-        LOG_ERROR(Service_APT, "unsupported signal {}", static_cast<u32>(parameter.signal));
+        LOG_ERROR(Service_APT, "unsupported signal {}", parameter.signal);
         UNIMPLEMENTED();
         // TODO(Subv): Find the right error code
         return ResultCode(-1);

--- a/src/core/hle/applets/mii_selector.cpp
+++ b/src/core/hle/applets/mii_selector.cpp
@@ -21,7 +21,7 @@ namespace HLE::Applets {
 
 ResultCode MiiSelector::ReceiveParameter(const Service::APT::MessageParameter& parameter) {
     if (parameter.signal != Service::APT::SignalType::Request) {
-        LOG_ERROR(Service_APT, "unsupported signal {}", static_cast<u32>(parameter.signal));
+        LOG_ERROR(Service_APT, "unsupported signal {}", parameter.signal);
         UNIMPLEMENTED();
         // TODO(Subv): Find the right error code
         return ResultCode(-1);

--- a/src/core/hle/applets/mint.cpp
+++ b/src/core/hle/applets/mint.cpp
@@ -11,7 +11,7 @@ namespace HLE::Applets {
 
 ResultCode Mint::ReceiveParameter(const Service::APT::MessageParameter& parameter) {
     if (parameter.signal != Service::APT::SignalType::Request) {
-        LOG_ERROR(Service_APT, "unsupported signal {}", static_cast<u32>(parameter.signal));
+        LOG_ERROR(Service_APT, "unsupported signal {}", parameter.signal);
         UNIMPLEMENTED();
         // TODO(Subv): Find the right error code
         return ResultCode(-1);

--- a/src/core/hle/applets/swkbd.cpp
+++ b/src/core/hle/applets/swkbd.cpp
@@ -84,7 +84,7 @@ ResultCode SoftwareKeyboard::ReceiveParameter(Service::APT::MessageParameter con
     }
 
     default: {
-        LOG_ERROR(Service_APT, "unsupported signal {}", static_cast<u32>(parameter.signal));
+        LOG_ERROR(Service_APT, "unsupported signal {}", parameter.signal);
         UNIMPLEMENTED();
         // TODO(Subv): Find the right error code
         return ResultCode(-1);
@@ -143,8 +143,7 @@ void SoftwareKeyboard::Update() {
         config.return_code = SoftwareKeyboardResult::None;
         break;
     default:
-        LOG_CRITICAL(Applet_SWKBD, "Unknown button config {}",
-                     static_cast<u32>(config.num_buttons_m1));
+        LOG_CRITICAL(Applet_SWKBD, "Unknown button config {}", config.num_buttons_m1);
         UNREACHABLE();
     }
 

--- a/src/core/hle/kernel/address_arbiter.cpp
+++ b/src/core/hle/kernel/address_arbiter.cpp
@@ -156,7 +156,7 @@ ResultCode AddressArbiter::ArbitrateAddress(std::shared_ptr<Thread> thread, Arbi
     }
 
     default:
-        LOG_ERROR(Kernel, "unknown type={}", static_cast<u32>(type));
+        LOG_ERROR(Kernel, "unknown type={}", type);
         return ERR_INVALID_ENUM_VALUE_FND;
     }
 

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -354,7 +354,7 @@ ResultCode Process::LinearFree(VAddr target, u32 size) {
 ResultCode Process::Map(VAddr target, VAddr source, u32 size, VMAPermission perms,
                         bool privileged) {
     LOG_DEBUG(Kernel, "Map memory target={:08X}, source={:08X}, size={:08X}, perms={:08X}", target,
-              source, size, static_cast<u8>(perms));
+              source, size, perms);
     if (source < Memory::HEAP_VADDR || source + size > Memory::HEAP_VADDR_END ||
         source + size < source) {
         LOG_ERROR(Kernel, "Invalid source address");
@@ -409,7 +409,7 @@ ResultCode Process::Map(VAddr target, VAddr source, u32 size, VMAPermission perm
 ResultCode Process::Unmap(VAddr target, VAddr source, u32 size, VMAPermission perms,
                           bool privileged) {
     LOG_DEBUG(Kernel, "Unmap memory target={:08X}, source={:08X}, size={:08X}, perms={:08X}",
-              target, source, size, static_cast<u8>(perms));
+              target, source, size, perms);
     if (source < Memory::HEAP_VADDR || source + size > Memory::HEAP_VADDR_END ||
         source + size < source) {
         LOG_ERROR(Kernel, "Invalid source address");

--- a/src/core/hle/kernel/shared_page.cpp
+++ b/src/core/hle/kernel/shared_page.cpp
@@ -50,8 +50,7 @@ static std::chrono::seconds GetInitTime() {
     case Settings::InitClock::FixedTime:
         return std::chrono::seconds(Settings::values.init_time);
     default:
-        UNREACHABLE_MSG("Invalid InitClock value ({})",
-                        static_cast<u32>(Settings::values.init_clock));
+        UNREACHABLE_MSG("Invalid InitClock value ({})", Settings::values.init_clock);
     }
 }
 

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -965,8 +965,8 @@ void Module::Interface::GetDLCContentInfoCount(Kernel::HLERequestContext& ctx) {
         rb.Push<u32>(static_cast<u32>(tmd.GetContentCount()));
     } else {
         rb.Push<u32>(1); // Number of content infos plus one
-        LOG_WARNING(Service_AM, "(STUBBED) called media_type={}, title_id=0x{:016x}",
-                    static_cast<u32>(media_type), title_id);
+        LOG_WARNING(Service_AM, "(STUBBED) called media_type={}, title_id=0x{:016x}", media_type,
+                    title_id);
     }
 }
 
@@ -1069,7 +1069,7 @@ void Module::Interface::BeginImportProgram(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS); // No error
     rb.PushCopyObjects(file->Connect());
 
-    LOG_WARNING(Service_AM, "(STUBBED) media_type={}", static_cast<u32>(media_type));
+    LOG_WARNING(Service_AM, "(STUBBED) media_type={}", media_type);
 }
 
 void Module::Interface::BeginImportProgramTemporarily(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/apt/applet_manager.cpp
+++ b/src/core/hle/service/apt/applet_manager.cpp
@@ -79,7 +79,7 @@ static u64 GetTitleIdForApplet(AppletId id, u32 region_value) {
                                 return data.applet_ids[0] == id || data.applet_ids[1] == id;
                             });
 
-    ASSERT_MSG(itr != applet_titleids.end(), "Unknown applet id 0x{:#05X}", static_cast<u32>(id));
+    ASSERT_MSG(itr != applet_titleids.end(), "Unknown applet id 0x{:#05X}", id);
 
     return itr->title_ids[region_value];
 }
@@ -173,7 +173,7 @@ void AppletManager::CancelAndSendParameter(const MessageParameter& parameter) {
     auto* const slot_data = GetAppletSlotData(static_cast<AppletId>(parameter.destination_id));
     if (slot_data == nullptr) {
         LOG_DEBUG(Service_APT, "No applet was registered with the id {:03X}",
-                  static_cast<u32>(parameter.destination_id));
+                  parameter.destination_id);
         return;
     }
 
@@ -338,8 +338,7 @@ ResultCode AppletManager::PrepareToStartLibraryApplet(AppletId applet_id) {
     // If we weren't able to load the native applet title, try to fallback to an HLE implementation.
     auto applet = HLE::Applets::Applet::Get(applet_id);
     if (applet) {
-        LOG_WARNING(Service_APT, "applet has already been started id={:08X}",
-                    static_cast<u32>(applet_id));
+        LOG_WARNING(Service_APT, "applet has already been started id={:08X}", applet_id);
         return RESULT_SUCCESS;
     } else {
         return HLE::Applets::Applet::Create(applet_id, shared_from_this());
@@ -365,8 +364,7 @@ ResultCode AppletManager::PreloadLibraryApplet(AppletId applet_id) {
     // If we weren't able to load the native applet title, try to fallback to an HLE implementation.
     auto applet = HLE::Applets::Applet::Get(applet_id);
     if (applet) {
-        LOG_WARNING(Service_APT, "applet has already been started id={:08X}",
-                    static_cast<u32>(applet_id));
+        LOG_WARNING(Service_APT, "applet has already been started id={:08X}", applet_id);
         return RESULT_SUCCESS;
     } else {
         return HLE::Applets::Applet::Create(applet_id, shared_from_this());
@@ -455,8 +453,7 @@ ResultVal<AppletManager::AppletInfo> AppletManager::GetAppletInfo(AppletId app_i
             return ResultCode(ErrorDescription::NotFound, ErrorModule::Applet,
                               ErrorSummary::NotFound, ErrorLevel::Status);
         }
-        LOG_WARNING(Service_APT, "Using HLE applet info for applet {:03X}",
-                    static_cast<u32>(app_id));
+        LOG_WARNING(Service_APT, "Using HLE applet info for applet {:03X}", app_id);
         // TODO(Subv): Get the title id for the current applet and write it in the response[2-3]
         return MakeResult<AppletInfo>({0, Service::FS::MediaType::NAND, true, true, 0});
     }

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -78,8 +78,7 @@ void Module::APTInterface::Initialize(Kernel::HLERequestContext& ctx) {
     AppletId app_id = rp.PopEnum<AppletId>();
     u32 attributes = rp.Pop<u32>();
 
-    LOG_DEBUG(Service_APT, "called app_id={:#010X}, attributes={:#010X}", static_cast<u32>(app_id),
-              attributes);
+    LOG_DEBUG(Service_APT, "called app_id={:#010X}, attributes={:#010X}", app_id, attributes);
 
     auto result = apt->applet_manager->Initialize(app_id, attributes);
     if (result.Failed()) {
@@ -347,7 +346,7 @@ void Module::APTInterface::IsRegistered(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS); // No error
     rb.Push(apt->applet_manager->IsRegistered(app_id));
 
-    LOG_DEBUG(Service_APT, "called app_id={:#010X}", static_cast<u32>(app_id));
+    LOG_DEBUG(Service_APT, "called app_id={:#010X}", app_id);
 }
 
 void Module::APTInterface::InquireNotification(Kernel::HLERequestContext& ctx) {
@@ -371,8 +370,7 @@ void Module::APTInterface::SendParameter(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_APT,
               "called src_app_id={:#010X}, dst_app_id={:#010X}, signal_type={:#010X},"
               "buffer_size={:#010X}",
-              static_cast<u32>(src_app_id), static_cast<u32>(dst_app_id),
-              static_cast<u32>(signal_type), buffer_size);
+              src_app_id, dst_app_id, signal_type, buffer_size);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
 
@@ -391,8 +389,7 @@ void Module::APTInterface::ReceiveParameter(Kernel::HLERequestContext& ctx) {
     const auto app_id = rp.PopEnum<AppletId>();
     const u32 buffer_size = rp.Pop<u32>();
 
-    LOG_DEBUG(Service_APT, "called app_id={:#010X}, buffer_size={:#010X}", static_cast<u32>(app_id),
-              buffer_size);
+    LOG_DEBUG(Service_APT, "called app_id={:#010X}, buffer_size={:#010X}", app_id, buffer_size);
 
     auto next_parameter = apt->applet_manager->ReceiveParameter(app_id);
 
@@ -419,8 +416,7 @@ void Module::APTInterface::GlanceParameter(Kernel::HLERequestContext& ctx) {
     const auto app_id = rp.PopEnum<AppletId>();
     const u32 buffer_size = rp.Pop<u32>();
 
-    LOG_DEBUG(Service_APT, "called app_id={:#010X}, buffer_size={:#010X}", static_cast<u32>(app_id),
-              buffer_size);
+    LOG_DEBUG(Service_APT, "called app_id={:#010X}, buffer_size={:#010X}", app_id, buffer_size);
 
     auto next_parameter = apt->applet_manager->GlanceParameter(app_id);
 
@@ -458,8 +454,7 @@ void Module::APTInterface::CancelParameter(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_APT,
               "called check_sender={}, sender_appid={:#010X}, "
               "check_receiver={}, receiver_appid={:#010X}",
-              check_sender, static_cast<u32>(sender_appid), check_receiver,
-              static_cast<u32>(receiver_appid));
+              check_sender, sender_appid, check_receiver, receiver_appid);
 }
 
 void Module::APTInterface::PrepareToDoApplicationJump(Kernel::HLERequestContext& ctx) {
@@ -469,7 +464,7 @@ void Module::APTInterface::PrepareToDoApplicationJump(Kernel::HLERequestContext&
     u8 media_type = rp.Pop<u8>();
 
     LOG_WARNING(Service_APT, "(STUBBED) called title_id={:016X}, media_type={:#01X}, flags={:#08X}",
-                title_id, media_type, static_cast<u8>(flags));
+                title_id, media_type, flags);
 
     ResultCode result = apt->applet_manager->PrepareToDoApplicationJump(
         title_id, static_cast<FS::MediaType>(media_type), flags);
@@ -630,7 +625,7 @@ void Module::APTInterface::PrepareToStartLibraryApplet(Kernel::HLERequestContext
     IPC::RequestParser rp(ctx, 0x18, 1, 0); // 0x180040
     AppletId applet_id = rp.PopEnum<AppletId>();
 
-    LOG_DEBUG(Service_APT, "called, applet_id={:08X}", static_cast<u32>(applet_id));
+    LOG_DEBUG(Service_APT, "called, applet_id={:08X}", applet_id);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     rb.Push(apt->applet_manager->PrepareToStartLibraryApplet(applet_id));
@@ -654,7 +649,7 @@ void Module::APTInterface::PreloadLibraryApplet(Kernel::HLERequestContext& ctx) 
     IPC::RequestParser rp(ctx, 0x16, 1, 0); // 0x160040
     AppletId applet_id = rp.PopEnum<AppletId>();
 
-    LOG_DEBUG(Service_APT, "called, applet_id={:08X}", static_cast<u32>(applet_id));
+    LOG_DEBUG(Service_APT, "called, applet_id={:08X}", applet_id);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     rb.Push(apt->applet_manager->PreloadLibraryApplet(applet_id));
@@ -667,7 +662,7 @@ void Module::APTInterface::FinishPreloadingLibraryApplet(Kernel::HLERequestConte
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     rb.Push(apt->applet_manager->FinishPreloadingLibraryApplet(applet_id));
 
-    LOG_WARNING(Service_APT, "(STUBBED) called, applet_id={:#05X}", static_cast<u32>(applet_id));
+    LOG_WARNING(Service_APT, "(STUBBED) called, applet_id={:#05X}", applet_id);
 }
 
 void Module::APTInterface::StartLibraryApplet(Kernel::HLERequestContext& ctx) {
@@ -678,7 +673,7 @@ void Module::APTInterface::StartLibraryApplet(Kernel::HLERequestContext& ctx) {
     std::shared_ptr<Kernel::Object> object = rp.PopGenericObject();
     const std::vector<u8> buffer = rp.PopStaticBuffer();
 
-    LOG_DEBUG(Service_APT, "called, applet_id={:08X}", static_cast<u32>(applet_id));
+    LOG_DEBUG(Service_APT, "called, applet_id={:08X}", applet_id);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     rb.Push(apt->applet_manager->StartLibraryApplet(applet_id, std::move(object), buffer));
@@ -805,7 +800,7 @@ void Module::APTInterface::SetScreenCapPostPermission(Kernel::HLERequestContext&
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     rb.Push(RESULT_SUCCESS); // No error
     LOG_WARNING(Service_APT, "(STUBBED) called, screen_capture_post_permission={}",
-                static_cast<u32>(apt->screen_capture_post_permission));
+                apt->screen_capture_post_permission);
 }
 
 void Module::APTInterface::GetScreenCapPostPermission(Kernel::HLERequestContext& ctx) {
@@ -815,14 +810,14 @@ void Module::APTInterface::GetScreenCapPostPermission(Kernel::HLERequestContext&
     rb.Push(RESULT_SUCCESS); // No error
     rb.Push(static_cast<u32>(apt->screen_capture_post_permission));
     LOG_WARNING(Service_APT, "(STUBBED) called, screen_capture_post_permission={}",
-                static_cast<u32>(apt->screen_capture_post_permission));
+                apt->screen_capture_post_permission);
 }
 
 void Module::APTInterface::GetAppletInfo(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x6, 1, 0); // 0x60040
     auto app_id = rp.PopEnum<AppletId>();
 
-    LOG_DEBUG(Service_APT, "called, app_id={}", static_cast<u32>(app_id));
+    LOG_DEBUG(Service_APT, "called, app_id={}", app_id);
 
     auto info = apt->applet_manager->GetAppletInfo(app_id);
     if (info.Failed()) {
@@ -846,7 +841,7 @@ void Module::APTInterface::GetStartupArgument(Kernel::HLERequestContext& ctx) {
     const auto startup_argument_type = static_cast<StartupArgumentType>(rp.Pop<u8>());
 
     LOG_WARNING(Service_APT, "called, startup_argument_type={}, parameter_size={:#010X}",
-                static_cast<u32>(startup_argument_type), parameter_size);
+                startup_argument_type, parameter_size);
 
     if (parameter_size > max_parameter_size) {
         LOG_ERROR(Service_APT,
@@ -1018,8 +1013,7 @@ void Module::APTInterface::IsTitleAllowed(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS);
     rb.Push(true);
 
-    LOG_DEBUG(Service_APT, "called, title_id={:016X} media_type={}", program_id,
-              static_cast<u32>(media_type));
+    LOG_DEBUG(Service_APT, "called, title_id={:016X} media_type={}", program_id, media_type);
 }
 
 Module::APTInterface::APTInterface(std::shared_ptr<Module> apt, const char* name, u32 max_session)

--- a/src/core/hle/service/cam/cam.cpp
+++ b/src/core/hle/service/cam/cam.cpp
@@ -763,7 +763,7 @@ void Module::Interface::FlipImage(Kernel::HLERequestContext& ctx) {
     }
 
     LOG_DEBUG(Service_CAM, "called, camera_select={}, flip={}, context_select={}",
-              camera_select.m_val, static_cast<int>(flip), context_select.m_val);
+              camera_select.m_val, flip, context_select.m_val);
 }
 
 void Module::Interface::SetDetailSize(Kernel::HLERequestContext& ctx) {
@@ -847,7 +847,7 @@ void Module::Interface::SetFrameRate(Kernel::HLERequestContext& ctx) {
     }
 
     LOG_WARNING(Service_CAM, "(STUBBED) called, camera_select={}, frame_rate={}",
-                camera_select.m_val, static_cast<int>(frame_rate));
+                camera_select.m_val, frame_rate);
 }
 
 void Module::Interface::SetEffect(Kernel::HLERequestContext& ctx) {
@@ -874,7 +874,7 @@ void Module::Interface::SetEffect(Kernel::HLERequestContext& ctx) {
     }
 
     LOG_DEBUG(Service_CAM, "called, camera_select={}, effect={}, context_select={}",
-              camera_select.m_val, static_cast<int>(effect), context_select.m_val);
+              camera_select.m_val, effect, context_select.m_val);
 }
 
 void Module::Interface::SetOutputFormat(Kernel::HLERequestContext& ctx) {
@@ -901,7 +901,7 @@ void Module::Interface::SetOutputFormat(Kernel::HLERequestContext& ctx) {
     }
 
     LOG_DEBUG(Service_CAM, "called, camera_select={}, format={}, context_select={}",
-              camera_select.m_val, static_cast<int>(format), context_select.m_val);
+              camera_select.m_val, format, context_select.m_val);
 }
 
 void Module::Interface::SynchronizeVsyncTiming(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/cecd/cecd.cpp
+++ b/src/core/hle/service/cecd/cecd.cpp
@@ -124,9 +124,8 @@ void Module::Interface::Open(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_CECD,
               "called, ncch_program_id={:#010x}, path_type={:#04x}, path={}, "
               "open_mode: raw={:#x}, unknown={}, read={}, write={}, create={}, check={}",
-              ncch_program_id, static_cast<u32>(path_type), path.AsString(), open_mode.raw,
-              open_mode.unknown, open_mode.read, open_mode.write, open_mode.create,
-              open_mode.check);
+              ncch_program_id, path_type, path.AsString(), open_mode.raw, open_mode.unknown,
+              open_mode.read, open_mode.write, open_mode.create, open_mode.check);
 }
 
 void Module::Interface::Read(Kernel::HLERequestContext& ctx) {
@@ -138,7 +137,7 @@ void Module::Interface::Read(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_CECD,
               "SessionData: ncch_program_id={:#010x}, data_path_type={:#04x}, "
               "path={}, open_mode: raw={:#x}, unknown={}, read={}, write={}, create={}, check={}",
-              session_data->ncch_program_id, static_cast<u32>(session_data->data_path_type),
+              session_data->ncch_program_id, session_data->data_path_type,
               session_data->path.AsString(), session_data->open_mode.raw,
               session_data->open_mode.unknown, session_data->open_mode.read,
               session_data->open_mode.write, session_data->open_mode.create,
@@ -343,7 +342,7 @@ void Module::Interface::Write(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_CECD,
               "SessionData: ncch_program_id={:#010x}, data_path_type={:#04x}, "
               "path={}, open_mode: raw={:#x}, unknown={}, read={}, write={}, create={}, check={}",
-              session_data->ncch_program_id, static_cast<u32>(session_data->data_path_type),
+              session_data->ncch_program_id, session_data->data_path_type,
               session_data->path.AsString(), session_data->open_mode.raw,
               session_data->open_mode.unknown, session_data->open_mode.read,
               session_data->open_mode.write, session_data->open_mode.create,
@@ -581,8 +580,7 @@ void Module::Interface::Delete(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_CECD,
               "called, ncch_program_id={:#010x}, path_type={:#04x}, path={}, "
               "is_outbox={}, message_id_size={:#x}",
-              ncch_program_id, static_cast<u32>(path_type), path.AsString(), is_outbox,
-              message_id_size);
+              ncch_program_id, path_type, path.AsString(), is_outbox, message_id_size);
 }
 
 void Module::Interface::SetData(Kernel::HLERequestContext& ctx) {
@@ -647,7 +645,7 @@ void Module::Interface::ReadData(Kernel::HLERequestContext& ctx) {
         dest_buffer.Write(buffer.data(), 0, buffer.size());
         break;
     default:
-        LOG_ERROR(Service_CECD, "Unknown system info type={:#x}", static_cast<u32>(info_type));
+        LOG_ERROR(Service_CECD, "Unknown system info type={:#x}", info_type);
     }
 
     rb.Push(RESULT_SUCCESS);
@@ -656,7 +654,7 @@ void Module::Interface::ReadData(Kernel::HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_CECD,
               "called, dest_buffer_size={:#x}, info_type={:#x}, param_buffer_size={:#x}",
-              dest_buffer_size, static_cast<u32>(info_type), param_buffer_size);
+              dest_buffer_size, info_type, param_buffer_size);
 }
 
 void Module::Interface::Start(Kernel::HLERequestContext& ctx) {
@@ -778,8 +776,8 @@ void Module::Interface::OpenAndWrite(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_CECD,
               "called, ncch_program_id={:#010x}, path_type={:#04x}, path={}, buffer_size={:#x} "
               "open_mode: raw={:#x}, unknown={}, read={}, write={}, create={}, check={}",
-              ncch_program_id, static_cast<u32>(path_type), path.AsString(), buffer_size,
-              open_mode.raw, open_mode.unknown, open_mode.read, open_mode.write, open_mode.create,
+              ncch_program_id, path_type, path.AsString(), buffer_size, open_mode.raw,
+              open_mode.unknown, open_mode.read, open_mode.write, open_mode.create,
               open_mode.check);
 }
 
@@ -831,8 +829,8 @@ void Module::Interface::OpenAndRead(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_CECD,
               "called, ncch_program_id={:#010x}, path_type={:#04x}, path={}, buffer_size={:#x} "
               "open_mode: raw={:#x}, unknown={}, read={}, write={}, create={}, check={}",
-              ncch_program_id, static_cast<u32>(path_type), path.AsString(), buffer_size,
-              open_mode.raw, open_mode.unknown, open_mode.read, open_mode.write, open_mode.create,
+              ncch_program_id, path_type, path.AsString(), buffer_size, open_mode.raw,
+              open_mode.unknown, open_mode.read, open_mode.write, open_mode.create,
               open_mode.check);
 }
 

--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -656,7 +656,7 @@ void Module::SetPreferredRegionCodes(const std::vector<u32>& region_codes) {
     if (Settings::values.region_value == Settings::REGION_VALUE_AUTO_SELECT) {
         if (current_language != adjusted_language) {
             LOG_WARNING(Service_CFG, "System language {} does not fit the region. Adjusted to {}",
-                        static_cast<int>(current_language), static_cast<int>(adjusted_language));
+                        current_language, adjusted_language);
             SetSystemLanguage(adjusted_language);
         }
     }

--- a/src/core/hle/service/csnd/csnd_snd.cpp
+++ b/src/core/hle/service/csnd/csnd_snd.cpp
@@ -387,8 +387,7 @@ void CSND_SND::ExecuteCommands(Kernel::HLERequestContext& ctx) {
             break;
         }
         default:
-            LOG_ERROR(Service_CSND, "Unimplemented command ID 0x{:X}",
-                      static_cast<u16>(command.command_id));
+            LOG_ERROR(Service_CSND, "Unimplemented command ID 0x{:X}", command.command_id);
         }
     }
 

--- a/src/core/hle/service/dsp/dsp_dsp.cpp
+++ b/src/core/hle/service/dsp/dsp_dsp.cpp
@@ -306,8 +306,7 @@ void DSP_DSP::ForceHeadphoneOut(Kernel::HLERequestContext& ctx) {
 // that's waiting for an interrupt event. Immediately after this interrupt event, userland
 // normally updates the state in the next region and increments the relevant frame counter by two.
 void DSP_DSP::SignalInterrupt(InterruptType type, DspPipe pipe) {
-    LOG_DEBUG(Service_DSP, "called, type={}, pipe={}", static_cast<u32>(type),
-              static_cast<u32>(pipe));
+    LOG_DEBUG(Service_DSP, "called, type={}, pipe={}", type, pipe);
     const auto& event = GetInterruptEvent(type, pipe);
     if (event)
         event->Signal();
@@ -325,7 +324,7 @@ std::shared_ptr<Kernel::Event>& DSP_DSP::GetInterruptEvent(InterruptType type, D
         return pipes[pipe_index];
     }
     }
-    UNREACHABLE_MSG("Invalid interrupt type = {}", static_cast<std::size_t>(type));
+    UNREACHABLE_MSG("Invalid interrupt type = {}", type);
 }
 
 bool DSP_DSP::HasTooManyEventsRegistered() const {

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -49,7 +49,7 @@ ArchiveBackend* ArchiveManager::GetArchive(ArchiveHandle handle) {
 ResultVal<ArchiveHandle> ArchiveManager::OpenArchive(ArchiveIdCode id_code,
                                                      const FileSys::Path& archive_path,
                                                      u64 program_id) {
-    LOG_TRACE(Service_FS, "Opening archive with id code 0x{:08X}", static_cast<u32>(id_code));
+    LOG_TRACE(Service_FS, "Opening archive with id code 0x{:08X}", id_code);
 
     auto itr = id_code_map.find(id_code);
     if (itr == id_code_map.end()) {
@@ -85,7 +85,7 @@ ResultCode ArchiveManager::RegisterArchiveType(std::unique_ptr<FileSys::ArchiveF
 
     auto& archive = result.first->second;
     LOG_DEBUG(Service_FS, "Registered archive {} with id code 0x{:08X}", archive->GetName(),
-              static_cast<u32>(id_code));
+              id_code);
     return RESULT_SUCCESS;
 }
 
@@ -267,7 +267,7 @@ ResultCode ArchiveManager::DeleteExtSaveData(MediaType media_type, u32 high, u32
     } else if (media_type == MediaType::SDMC) {
         media_type_directory = FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir);
     } else {
-        LOG_ERROR(Service_FS, "Unsupported media type {}", static_cast<u32>(media_type));
+        LOG_ERROR(Service_FS, "Unsupported media type {}", media_type);
         return ResultCode(-1); // TODO(Subv): Find the right error code
     }
 

--- a/src/core/hle/service/fs/fs_user.cpp
+++ b/src/core/hle/service/fs/fs_user.cpp
@@ -99,8 +99,7 @@ void FS_USER::OpenFileDirectly(Kernel::HLERequestContext& ctx) {
     const FileSys::Path file_path(filename_type, std::move(filename));
 
     LOG_DEBUG(Service_FS, "archive_id=0x{:08X} archive_path={} file_path={}, mode={} attributes={}",
-              static_cast<u32>(archive_id), archive_path.DebugStr(), file_path.DebugStr(), mode.hex,
-              attributes);
+              archive_id, archive_path.DebugStr(), file_path.DebugStr(), mode.hex, attributes);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
 
@@ -111,7 +110,7 @@ void FS_USER::OpenFileDirectly(Kernel::HLERequestContext& ctx) {
     if (archive_handle.Failed()) {
         LOG_ERROR(Service_FS,
                   "Failed to get a handle for archive archive_id=0x{:08X} archive_path={}",
-                  static_cast<u32>(archive_id), archive_path.DebugStr());
+                  archive_id, archive_path.DebugStr());
         rb.Push(archive_handle.Code());
         rb.PushMoveObjects<Kernel::Object>(nullptr);
         return;
@@ -144,7 +143,7 @@ void FS_USER::DeleteFile(Kernel::HLERequestContext& ctx) {
 
     const FileSys::Path file_path(filename_type, std::move(filename));
 
-    LOG_DEBUG(Service_FS, "type={} size={} data={}", static_cast<u32>(filename_type), filename_size,
+    LOG_DEBUG(Service_FS, "type={} size={} data={}", filename_type, filename_size,
               file_path.DebugStr());
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
@@ -171,8 +170,8 @@ void FS_USER::RenameFile(Kernel::HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_FS,
               "src_type={} src_size={} src_data={} dest_type={} dest_size={} dest_data={}",
-              static_cast<u32>(src_filename_type), src_filename_size, src_file_path.DebugStr(),
-              static_cast<u32>(dest_filename_type), dest_filename_size, dest_file_path.DebugStr());
+              src_filename_type, src_filename_size, src_file_path.DebugStr(), dest_filename_type,
+              dest_filename_size, dest_file_path.DebugStr());
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     rb.Push(archives.RenameFileBetweenArchives(src_archive_handle, src_file_path,
@@ -191,7 +190,7 @@ void FS_USER::DeleteDirectory(Kernel::HLERequestContext& ctx) {
 
     const FileSys::Path dir_path(dirname_type, std::move(dirname));
 
-    LOG_DEBUG(Service_FS, "type={} size={} data={}", static_cast<u32>(dirname_type), dirname_size,
+    LOG_DEBUG(Service_FS, "type={} size={} data={}", dirname_type, dirname_size,
               dir_path.DebugStr());
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
@@ -210,7 +209,7 @@ void FS_USER::DeleteDirectoryRecursively(Kernel::HLERequestContext& ctx) {
 
     const FileSys::Path dir_path(dirname_type, std::move(dirname));
 
-    LOG_DEBUG(Service_FS, "type={} size={} data={}", static_cast<u32>(dirname_type), dirname_size,
+    LOG_DEBUG(Service_FS, "type={} size={} data={}", dirname_type, dirname_size,
               dir_path.DebugStr());
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
@@ -231,8 +230,8 @@ void FS_USER::CreateFile(Kernel::HLERequestContext& ctx) {
 
     const FileSys::Path file_path(filename_type, std::move(filename));
 
-    LOG_DEBUG(Service_FS, "type={} attributes={} size={:x} data={}",
-              static_cast<u32>(filename_type), attributes, file_size, file_path.DebugStr());
+    LOG_DEBUG(Service_FS, "type={} attributes={} size={:x} data={}", filename_type, attributes,
+              file_size, file_path.DebugStr());
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     rb.Push(archives.CreateFileInArchive(archive_handle, file_path, file_size));
@@ -249,7 +248,7 @@ void FS_USER::CreateDirectory(Kernel::HLERequestContext& ctx) {
     ASSERT(dirname.size() == dirname_size);
     const FileSys::Path dir_path(dirname_type, std::move(dirname));
 
-    LOG_DEBUG(Service_FS, "type={} size={} data={}", static_cast<u32>(dirname_type), dirname_size,
+    LOG_DEBUG(Service_FS, "type={} size={} data={}", dirname_type, dirname_size,
               dir_path.DebugStr());
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
@@ -275,8 +274,8 @@ void FS_USER::RenameDirectory(Kernel::HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_FS,
               "src_type={} src_size={} src_data={} dest_type={} dest_size={} dest_data={}",
-              static_cast<u32>(src_dirname_type), src_dirname_size, src_dir_path.DebugStr(),
-              static_cast<u32>(dest_dirname_type), dest_dirname_size, dest_dir_path.DebugStr());
+              src_dirname_type, src_dirname_size, src_dir_path.DebugStr(), dest_dirname_type,
+              dest_dirname_size, dest_dir_path.DebugStr());
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     rb.Push(archives.RenameDirectoryBetweenArchives(src_archive_handle, src_dir_path,
@@ -293,7 +292,7 @@ void FS_USER::OpenDirectory(Kernel::HLERequestContext& ctx) {
 
     const FileSys::Path dir_path(dirname_type, std::move(dirname));
 
-    LOG_DEBUG(Service_FS, "type={} size={} data={}", static_cast<u32>(dirname_type), dirname_size,
+    LOG_DEBUG(Service_FS, "type={} size={} data={}", dirname_type, dirname_size,
               dir_path.DebugStr());
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
@@ -307,7 +306,7 @@ void FS_USER::OpenDirectory(Kernel::HLERequestContext& ctx) {
         rb.PushMoveObjects(client);
     } else {
         LOG_ERROR(Service_FS, "failed to get a handle for directory type={} size={} data={}",
-                  static_cast<u32>(dirname_type), dirname_size, dir_path.DebugStr());
+                  dirname_type, dirname_size, dir_path.DebugStr());
         rb.PushMoveObjects<Kernel::Object>(nullptr);
     }
 }
@@ -321,7 +320,7 @@ void FS_USER::OpenArchive(Kernel::HLERequestContext& ctx) {
     ASSERT(archivename.size() == archivename_size);
     const FileSys::Path archive_path(archivename_type, std::move(archivename));
 
-    LOG_DEBUG(Service_FS, "archive_id=0x{:08X} archive_path={}", static_cast<u32>(archive_id),
+    LOG_DEBUG(Service_FS, "archive_id=0x{:08X} archive_path={}", archive_id,
               archive_path.DebugStr());
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 0);
@@ -335,7 +334,7 @@ void FS_USER::OpenArchive(Kernel::HLERequestContext& ctx) {
         rb.Push<u64>(0);
         LOG_ERROR(Service_FS,
                   "failed to get a handle for archive archive_id=0x{:08X} archive_path={}",
-                  static_cast<u32>(archive_id), archive_path.DebugStr());
+                  archive_id, archive_path.DebugStr());
     }
 }
 
@@ -384,8 +383,7 @@ void FS_USER::FormatSaveData(Kernel::HLERequestContext& ctx) {
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     if (archive_id != FS::ArchiveIdCode::SaveData) {
-        LOG_ERROR(Service_FS, "tried to format an archive different than SaveData, {}",
-                  static_cast<u32>(archive_id));
+        LOG_ERROR(Service_FS, "tried to format an archive different than SaveData, {}", archive_id);
         rb.Push(FileSys::ERROR_INVALID_PATH);
         return;
     }
@@ -526,7 +524,7 @@ void FS_USER::DeleteExtSaveData(Kernel::HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_FS,
               "called, save_low={:08X} save_high={:08X} media_type={:08X} unknown={:08X}", save_low,
-              save_high, static_cast<u32>(media_type), unknown);
+              save_high, media_type, unknown);
 }
 
 void FS_USER::CardSlotIsInserted(Kernel::HLERequestContext& ctx) {
@@ -634,7 +632,7 @@ void FS_USER::GetArchiveResource(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x849, 1, 0);
     auto media_type = rp.PopEnum<MediaType>();
 
-    LOG_WARNING(Service_FS, "(STUBBED) called Media type=0x{:08X}", static_cast<u32>(media_type));
+    LOG_WARNING(Service_FS, "(STUBBED) called Media type=0x{:08X}", media_type);
 
     auto resource = archives.GetArchiveResource(media_type);
     if (resource.Failed()) {
@@ -743,8 +741,7 @@ void FS_USER::ObsoletedDeleteExtSaveData(Kernel::HLERequestContext& ctx) {
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     rb.Push(archives.DeleteExtSaveData(media_type, 0, save_low));
 
-    LOG_DEBUG(Service_FS, "called, save_low={:08X} media_type={:08X}", save_low,
-              static_cast<u32>(media_type));
+    LOG_DEBUG(Service_FS, "called, save_low={:08X} media_type={:08X}", save_low, media_type);
 }
 
 void FS_USER::GetSpecialContentIndex(Kernel::HLERequestContext& ctx) {
@@ -753,8 +750,8 @@ void FS_USER::GetSpecialContentIndex(Kernel::HLERequestContext& ctx) {
     const u64 title_id = rp.Pop<u64>();
     const auto type = rp.PopEnum<SpecialContentType>();
 
-    LOG_DEBUG(Service_FS, "called, media_type={:08X} type={:08X}, title_id={:016X}",
-              static_cast<u32>(media_type), static_cast<u32>(type), title_id);
+    LOG_DEBUG(Service_FS, "called, media_type={:08X} type={:08X}, title_id={:016X}", media_type,
+              type, title_id);
 
     ResultVal<u16> index;
     if (media_type == MediaType::GameCard) {

--- a/src/core/hle/service/http_c.cpp
+++ b/src/core/hle/service/http_c.cpp
@@ -314,8 +314,7 @@ void HTTP_C::CreateContext(Kernel::HLERequestContext& ctx) {
     std::string url(url_size, '\0');
     buffer.Read(&url[0], 0, url_size - 1);
 
-    LOG_DEBUG(Service_HTTP, "called, url_size={}, url={}, method={}", url_size, url,
-              static_cast<u32>(method));
+    LOG_DEBUG(Service_HTTP, "called, url_size={}, url={}, method={}", url_size, url, method);
 
     auto* session_data = GetSessionData(ctx.Session());
     ASSERT(session_data);
@@ -352,7 +351,7 @@ void HTTP_C::CreateContext(Kernel::HLERequestContext& ctx) {
     }
 
     if (method == RequestMethod::None || static_cast<u32>(method) >= TotalRequestMethods) {
-        LOG_ERROR(Service_HTTP, "invalid request method={}", static_cast<u32>(method));
+        LOG_ERROR(Service_HTTP, "invalid request method={}", method);
 
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
         rb.Push(ResultCode(ErrCodes::InvalidRequestMethod, ErrorModule::HTTP,

--- a/src/core/hle/service/mic_u.cpp
+++ b/src/core/hle/service/mic_u.cpp
@@ -221,8 +221,7 @@ struct MIC_U::Impl {
         LOG_TRACE(Service_MIC,
                   "called, encoding={}, sample_rate={}, "
                   "audio_buffer_offset={}, audio_buffer_size={}, audio_buffer_loop={}",
-                  static_cast<u32>(encoding), static_cast<u32>(sample_rate), audio_buffer_offset,
-                  audio_buffer_size, audio_buffer_loop);
+                  encoding, sample_rate, audio_buffer_offset, audio_buffer_size, audio_buffer_loop);
     }
 
     void AdjustSampling(Kernel::HLERequestContext& ctx) {
@@ -232,7 +231,7 @@ struct MIC_U::Impl {
 
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
         rb.Push(RESULT_SUCCESS);
-        LOG_TRACE(Service_MIC, "sample_rate={}", static_cast<u32>(sample_rate));
+        LOG_TRACE(Service_MIC, "sample_rate={}", sample_rate);
     }
 
     void StopSampling(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/ndm/ndm_u.cpp
+++ b/src/core/hle/service/ndm/ndm_u.cpp
@@ -18,8 +18,7 @@ void NDM_U::EnterExclusiveState(Kernel::HLERequestContext& ctx) {
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     rb.Push(RESULT_SUCCESS);
-    LOG_WARNING(Service_NDM, "(STUBBED) exclusive_state=0x{:08X}",
-                static_cast<u32>(exclusive_state));
+    LOG_WARNING(Service_NDM, "(STUBBED) exclusive_state=0x{:08X}", exclusive_state);
 }
 
 void NDM_U::LeaveExclusiveState(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/nfc/nfc.cpp
+++ b/src/core/hle/service/nfc/nfc.cpp
@@ -68,7 +68,7 @@ void Module::Interface::Initialize(Kernel::HLERequestContext& ctx) {
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     if (nfc->nfc_tag_state != TagState::NotInitialized) {
-        LOG_ERROR(Service_NFC, "Invalid TagState {}", static_cast<int>(nfc->nfc_tag_state));
+        LOG_ERROR(Service_NFC, "Invalid TagState {}", nfc->nfc_tag_state);
         rb.Push(ResultCode(ErrCodes::CommandInvalidForState, ErrorModule::NFC,
                            ErrorSummary::InvalidState, ErrorLevel::Status));
         return;
@@ -114,7 +114,7 @@ void Module::Interface::StartTagScanning(Kernel::HLERequestContext& ctx) {
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     if (nfc->nfc_tag_state != TagState::NotScanning &&
         nfc->nfc_tag_state != TagState::TagOutOfRange) {
-        LOG_ERROR(Service_NFC, "Invalid TagState {}", static_cast<int>(nfc->nfc_tag_state));
+        LOG_ERROR(Service_NFC, "Invalid TagState {}", nfc->nfc_tag_state);
         rb.Push(ResultCode(ErrCodes::CommandInvalidForState, ErrorModule::NFC,
                            ErrorSummary::InvalidState, ErrorLevel::Status));
         return;
@@ -132,7 +132,7 @@ void Module::Interface::GetTagInfo(Kernel::HLERequestContext& ctx) {
 
     if (nfc->nfc_tag_state != TagState::TagInRange &&
         nfc->nfc_tag_state != TagState::TagDataLoaded && nfc->nfc_tag_state != TagState::Unknown6) {
-        LOG_ERROR(Service_NFC, "Invalid TagState {}", static_cast<int>(nfc->nfc_tag_state));
+        LOG_ERROR(Service_NFC, "Invalid TagState {}", nfc->nfc_tag_state);
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
         rb.Push(ResultCode(ErrCodes::CommandInvalidForState, ErrorModule::NFC,
                            ErrorSummary::InvalidState, ErrorLevel::Status));
@@ -179,7 +179,7 @@ void Module::Interface::StopTagScanning(Kernel::HLERequestContext& ctx) {
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     if (nfc->nfc_tag_state == TagState::NotInitialized ||
         nfc->nfc_tag_state == TagState::NotScanning) {
-        LOG_ERROR(Service_NFC, "Invalid TagState {}", static_cast<int>(nfc->nfc_tag_state));
+        LOG_ERROR(Service_NFC, "Invalid TagState {}", nfc->nfc_tag_state);
         rb.Push(ResultCode(ErrCodes::CommandInvalidForState, ErrorModule::NFC,
                            ErrorSummary::InvalidState, ErrorLevel::Status));
         return;
@@ -208,7 +208,7 @@ void Module::Interface::ResetTagScanState(Kernel::HLERequestContext& ctx) {
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     if (nfc->nfc_tag_state != TagState::TagDataLoaded && nfc->nfc_tag_state != TagState::Unknown6) {
-        LOG_ERROR(Service_NFC, "Invalid TagState {}", static_cast<int>(nfc->nfc_tag_state));
+        LOG_ERROR(Service_NFC, "Invalid TagState {}", nfc->nfc_tag_state);
         rb.Push(ResultCode(ErrCodes::CommandInvalidForState, ErrorModule::NFC,
                            ErrorSummary::InvalidState, ErrorLevel::Status));
         return;
@@ -225,7 +225,7 @@ void Module::Interface::GetTagInRangeEvent(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x0B, 0, 0);
 
     if (nfc->nfc_tag_state != TagState::NotScanning) {
-        LOG_ERROR(Service_NFC, "Invalid TagState {}", static_cast<int>(nfc->nfc_tag_state));
+        LOG_ERROR(Service_NFC, "Invalid TagState {}", nfc->nfc_tag_state);
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
         rb.Push(ResultCode(ErrCodes::CommandInvalidForState, ErrorModule::NFC,
                            ErrorSummary::InvalidState, ErrorLevel::Status));
@@ -242,7 +242,7 @@ void Module::Interface::GetTagOutOfRangeEvent(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x0C, 0, 0);
 
     if (nfc->nfc_tag_state != TagState::NotScanning) {
-        LOG_ERROR(Service_NFC, "Invalid TagState {}", static_cast<int>(nfc->nfc_tag_state));
+        LOG_ERROR(Service_NFC, "Invalid TagState {}", nfc->nfc_tag_state);
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
         rb.Push(ResultCode(ErrCodes::CommandInvalidForState, ErrorModule::NFC,
                            ErrorSummary::InvalidState, ErrorLevel::Status));
@@ -278,7 +278,7 @@ void Module::Interface::Unknown0x1A(Kernel::HLERequestContext& ctx) {
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     if (nfc->nfc_tag_state != TagState::TagInRange) {
-        LOG_ERROR(Service_NFC, "Invalid TagState {}", static_cast<int>(nfc->nfc_tag_state));
+        LOG_ERROR(Service_NFC, "Invalid TagState {}", nfc->nfc_tag_state);
         rb.Push(ResultCode(ErrCodes::CommandInvalidForState, ErrorModule::NFC,
                            ErrorSummary::InvalidState, ErrorLevel::Status));
         return;
@@ -294,7 +294,7 @@ void Module::Interface::GetIdentificationBlock(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x1B, 0, 0);
 
     if (nfc->nfc_tag_state != TagState::TagDataLoaded && nfc->nfc_tag_state != TagState::Unknown6) {
-        LOG_ERROR(Service_NFC, "Invalid TagState {}", static_cast<int>(nfc->nfc_tag_state));
+        LOG_ERROR(Service_NFC, "Invalid TagState {}", nfc->nfc_tag_state);
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
         rb.Push(ResultCode(ErrCodes::CommandInvalidForState, ErrorModule::NFC,
                            ErrorSummary::InvalidState, ErrorLevel::Status));

--- a/src/core/hle/service/ps/ps_ps.cpp
+++ b/src/core/hle/service/ps/ps_ps.cpp
@@ -54,7 +54,7 @@ void PS_PS::EncryptDecryptAes(Kernel::HLERequestContext& ctx) {
     auto source = rp.PopMappedBuffer();
     auto destination = rp.PopMappedBuffer();
 
-    LOG_DEBUG(Service_PS, "called algorithm={} key_type={}", static_cast<u8>(algorithm), key_type);
+    LOG_DEBUG(Service_PS, "called algorithm={} key_type={}", algorithm, key_type);
 
     // TODO(zhaowenlan1779): Tests on a real 3DS shows that no error is returned in this case
     // and encrypted data is actually returned, but the key used is unknown.

--- a/src/core/hle/service/y2r_u.cpp
+++ b/src/core/hle/service/y2r_u.cpp
@@ -85,7 +85,7 @@ void Y2R_U::SetInputFormat(Kernel::HLERequestContext& ctx) {
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     rb.Push(RESULT_SUCCESS);
 
-    LOG_DEBUG(Service_Y2R, "called input_format={}", static_cast<u8>(conversion.input_format));
+    LOG_DEBUG(Service_Y2R, "called input_format={}", conversion.input_format);
 }
 
 void Y2R_U::GetInputFormat(Kernel::HLERequestContext& ctx) {
@@ -95,7 +95,7 @@ void Y2R_U::GetInputFormat(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS);
     rb.PushEnum(conversion.input_format);
 
-    LOG_DEBUG(Service_Y2R, "called input_format={}", static_cast<u8>(conversion.input_format));
+    LOG_DEBUG(Service_Y2R, "called input_format={}", conversion.input_format);
 }
 
 void Y2R_U::SetOutputFormat(Kernel::HLERequestContext& ctx) {
@@ -106,7 +106,7 @@ void Y2R_U::SetOutputFormat(Kernel::HLERequestContext& ctx) {
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     rb.Push(RESULT_SUCCESS);
 
-    LOG_DEBUG(Service_Y2R, "called output_format={}", static_cast<u8>(conversion.output_format));
+    LOG_DEBUG(Service_Y2R, "called output_format={}", conversion.output_format);
 }
 
 void Y2R_U::GetOutputFormat(Kernel::HLERequestContext& ctx) {
@@ -116,7 +116,7 @@ void Y2R_U::GetOutputFormat(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS);
     rb.PushEnum(conversion.output_format);
 
-    LOG_DEBUG(Service_Y2R, "called output_format={}", static_cast<u8>(conversion.output_format));
+    LOG_DEBUG(Service_Y2R, "called output_format={}", conversion.output_format);
 }
 
 void Y2R_U::SetRotation(Kernel::HLERequestContext& ctx) {
@@ -127,7 +127,7 @@ void Y2R_U::SetRotation(Kernel::HLERequestContext& ctx) {
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     rb.Push(RESULT_SUCCESS);
 
-    LOG_DEBUG(Service_Y2R, "called rotation={}", static_cast<u8>(conversion.rotation));
+    LOG_DEBUG(Service_Y2R, "called rotation={}", conversion.rotation);
 }
 
 void Y2R_U::GetRotation(Kernel::HLERequestContext& ctx) {
@@ -137,7 +137,7 @@ void Y2R_U::GetRotation(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS);
     rb.PushEnum(conversion.rotation);
 
-    LOG_DEBUG(Service_Y2R, "called rotation={}", static_cast<u8>(conversion.rotation));
+    LOG_DEBUG(Service_Y2R, "called rotation={}", conversion.rotation);
 }
 
 void Y2R_U::SetBlockAlignment(Kernel::HLERequestContext& ctx) {
@@ -148,8 +148,7 @@ void Y2R_U::SetBlockAlignment(Kernel::HLERequestContext& ctx) {
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     rb.Push(RESULT_SUCCESS);
 
-    LOG_DEBUG(Service_Y2R, "called block_alignment={}",
-              static_cast<u8>(conversion.block_alignment));
+    LOG_DEBUG(Service_Y2R, "called block_alignment={}", conversion.block_alignment);
 }
 
 void Y2R_U::GetBlockAlignment(Kernel::HLERequestContext& ctx) {
@@ -159,8 +158,7 @@ void Y2R_U::GetBlockAlignment(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS);
     rb.PushEnum(conversion.block_alignment);
 
-    LOG_DEBUG(Service_Y2R, "called block_alignment={}",
-              static_cast<u8>(conversion.block_alignment));
+    LOG_DEBUG(Service_Y2R, "called block_alignment={}", conversion.block_alignment);
 }
 
 void Y2R_U::SetSpacialDithering(Kernel::HLERequestContext& ctx) {
@@ -586,10 +584,9 @@ cleanup:
     LOG_DEBUG(Service_Y2R,
               "called input_format={} output_format={} rotation={} block_alignment={} "
               "input_line_width={} input_lines={} standard_coefficient={} reserved={} alpha={:X}",
-              static_cast<u8>(params.input_format), static_cast<u8>(params.output_format),
-              static_cast<u8>(params.rotation), static_cast<u8>(params.block_alignment),
-              params.input_line_width, params.input_lines,
-              static_cast<u8>(params.standard_coefficient), params.padding, params.alpha);
+              params.input_format, params.output_format, params.rotation, params.block_alignment,
+              params.input_line_width, params.input_lines, params.standard_coefficient,
+              params.padding, params.alpha);
 }
 
 void Y2R_U::PingProcess(Kernel::HLERequestContext& ctx) {

--- a/src/core/hw/gpu.cpp
+++ b/src/core/hw/gpu.cpp
@@ -65,7 +65,7 @@ static Common::Vec4<u8> DecodePixel(Regs::PixelFormat input_format, const u8* sr
         return Color::DecodeRGBA4(src_pixel);
 
     default:
-        LOG_ERROR(HW_GPU, "Unknown source framebuffer format {:x}", static_cast<u32>(input_format));
+        LOG_ERROR(HW_GPU, "Unknown source framebuffer format {:x}", input_format);
         return {0, 0, 0, 0};
     }
 }

--- a/src/core/movie.cpp
+++ b/src/core/movie.cpp
@@ -147,7 +147,7 @@ void Movie::Play(Service::HID::PadState& pad_state, s16& circle_pad_x, s16& circ
     if (s.type != ControllerStateType::PadAndCircle) {
         LOG_ERROR(Movie,
                   "Expected to read type {}, but found {}. Your playback will be out of sync",
-                  static_cast<int>(ControllerStateType::PadAndCircle), static_cast<int>(s.type));
+                  static_cast<int>(ControllerStateType::PadAndCircle), s.type);
         return;
     }
 
@@ -178,7 +178,7 @@ void Movie::Play(Service::HID::TouchDataEntry& touch_data) {
     if (s.type != ControllerStateType::Touch) {
         LOG_ERROR(Movie,
                   "Expected to read type {}, but found {}. Your playback will be out of sync",
-                  static_cast<int>(ControllerStateType::Touch), static_cast<int>(s.type));
+                  static_cast<int>(ControllerStateType::Touch), s.type);
         return;
     }
 
@@ -195,7 +195,7 @@ void Movie::Play(Service::HID::AccelerometerDataEntry& accelerometer_data) {
     if (s.type != ControllerStateType::Accelerometer) {
         LOG_ERROR(Movie,
                   "Expected to read type {}, but found {}. Your playback will be out of sync",
-                  static_cast<int>(ControllerStateType::Accelerometer), static_cast<int>(s.type));
+                  static_cast<int>(ControllerStateType::Accelerometer), s.type);
         return;
     }
 
@@ -212,7 +212,7 @@ void Movie::Play(Service::HID::GyroscopeDataEntry& gyroscope_data) {
     if (s.type != ControllerStateType::Gyroscope) {
         LOG_ERROR(Movie,
                   "Expected to read type {}, but found {}. Your playback will be out of sync",
-                  static_cast<int>(ControllerStateType::Gyroscope), static_cast<int>(s.type));
+                  static_cast<int>(ControllerStateType::Gyroscope), s.type);
         return;
     }
 
@@ -229,7 +229,7 @@ void Movie::Play(Service::IR::PadState& pad_state, s16& c_stick_x, s16& c_stick_
     if (s.type != ControllerStateType::IrRst) {
         LOG_ERROR(Movie,
                   "Expected to read type {}, but found {}. Your playback will be out of sync",
-                  static_cast<int>(ControllerStateType::IrRst), static_cast<int>(s.type));
+                  static_cast<int>(ControllerStateType::IrRst), s.type);
         return;
     }
 
@@ -245,9 +245,9 @@ void Movie::Play(Service::IR::ExtraHIDResponse& extra_hid_response) {
     current_byte += sizeof(ControllerState);
 
     if (s.type != ControllerStateType::ExtraHidResponse) {
-        LOG_ERROR(
-            Movie, "Expected to read type {}, but found {}. Your playback will be out of sync",
-            static_cast<int>(ControllerStateType::ExtraHidResponse), static_cast<int>(s.type));
+        LOG_ERROR(Movie,
+                  "Expected to read type {}, but found {}. Your playback will be out of sync",
+                  static_cast<int>(ControllerStateType::ExtraHidResponse), s.type);
         return;
     }
 

--- a/src/core/rpc/server.cpp
+++ b/src/core/rpc/server.cpp
@@ -31,8 +31,8 @@ void Server::Stop() {
 void Server::NewRequestCallback(std::unique_ptr<RPC::Packet> new_request) {
     if (new_request) {
         LOG_INFO(RPC_Server, "Received request version={} id={} type={} size={}",
-                 new_request->GetVersion(), new_request->GetId(),
-                 static_cast<u32>(new_request->GetPacketType()), new_request->GetPacketDataSize());
+                 new_request->GetVersion(), new_request->GetId(), new_request->GetPacketType(),
+                 new_request->GetPacketDataSize());
     } else {
         LOG_INFO(RPC_Server, "Received end packet");
     }

--- a/src/core/rpc/udp_server.cpp
+++ b/src/core/rpc/udp_server.cpp
@@ -73,8 +73,7 @@ private:
             LOG_WARNING(RPC_Server, "Failed to send reply: {}", error.message());
         } else {
             LOG_INFO(RPC_Server, "Sent reply version({}) id=({}) type=({}) size=({})",
-                     reply_packet.GetVersion(), reply_packet.GetId(),
-                     static_cast<u32>(reply_packet.GetPacketType()),
+                     reply_packet.GetVersion(), reply_packet.GetId(), reply_packet.GetPacketType(),
                      reply_packet.GetPacketDataSize());
         }
     }

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -92,9 +92,9 @@ void LogSettings() {
     log_setting("Renderer_PostProcessingShader", values.pp_shader_name);
     log_setting("Renderer_FilterMode", values.filter_mode);
     log_setting("Renderer_TextureFilterName", values.texture_filter_name);
-    log_setting("Stereoscopy_Render3d", static_cast<int>(values.render_3d));
+    log_setting("Stereoscopy_Render3d", values.render_3d);
     log_setting("Stereoscopy_Factor3d", values.factor_3d);
-    log_setting("Layout_LayoutOption", static_cast<int>(values.layout_option));
+    log_setting("Layout_LayoutOption", values.layout_option);
     log_setting("Layout_SwapScreen", values.swap_screen);
     log_setting("Layout_UprightScreen", values.upright_screen);
     log_setting("Utility_DumpTextures", values.dump_textures);
@@ -105,7 +105,7 @@ void LogSettings() {
     log_setting("Audio_OutputEngine", values.sink_id);
     log_setting("Audio_EnableAudioStretching", values.enable_audio_stretching);
     log_setting("Audio_OutputDevice", values.audio_device_id);
-    log_setting("Audio_InputDeviceType", static_cast<int>(values.mic_input_type));
+    log_setting("Audio_InputDeviceType", values.mic_input_type);
     log_setting("Audio_InputDevice", values.mic_input_device);
     using namespace Service::CAM;
     log_setting("Camera_OuterRightName", values.camera_name[OuterRightCamera]);


### PR DESCRIPTION
See yuzu-emu/yuzu#5166 for more details.

**Original description**:
Follows the video core PR. fmt doesn't require casts for enum classes anymore, so we can remove quite a few casts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5660)
<!-- Reviewable:end -->
