### PR TITLE
Update ci.yml to separate macos release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,10 +110,8 @@ jobs:
           TRANSIFEX_API_TOKEN: ${{ secrets.TRANSIFEX_API_TOKEN }}
   release:
     runs-on: ubuntu-latest
-    needs: [build, macos]
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
     steps:
-      - uses: actions/download-artifact@v2
       - name: Query tag name
         uses: little-core-labs/get-git-tag@v3.0.2
         id: tagName
@@ -126,6 +124,29 @@ jobs:
           release_name: ${{ steps.tagName.outputs.tag }}
           draft: false
           prerelease: false
+  release-build:
+    runs-on: ubuntu-latest
+    needs: [release, build]
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: linux-mingw
+      - uses: actions/download-artifact@v2
+        with:
+          name: linux-fresh
+      - name: Upload artifacts
+        uses: alexellis/upload-assets@0.2.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          asset_paths: '["./**/*.tar.*","./**/*.7z","./**/*.zip"]'
+  release-macos:
+    runs-on: ubuntu-latest
+    needs: [release, macos]
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: macos
       - name: Upload artifacts
         uses: alexellis/upload-assets@0.2.3
         env:


### PR DESCRIPTION
Currently if the macos build fails, the whole release is skipped.
Separating the artifact uploads would allow the windows and linux builds to be released even if macos fails.

I have no idea on how to test and make sure this works, so tagging @liushuyu to check on it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5662)
<!-- Reviewable:end -->
