### PR TITLE
Revert #5530 "Port yuzu-emu/yuzu#4539"

### DIFF
--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -919,7 +919,7 @@ IOFile::IOFile() = default;
 
 IOFile::IOFile(const std::string& filename, const char openmode[], int flags)
     : filename(filename), openmode(openmode), flags(flags) {
-    void(Open());
+    Open();
 }
 
 IOFile::~IOFile() {


### PR DESCRIPTION
There was no such warning in the first place. Yuzu has Open marked as [[nodiscard]], but Citra doesn't.
Whether a function that's only called twice with both results discarded should be marked as nodiscard is a different discussion, but the changed proposed omitted the call to the Open function. (Tested on MSVC, but should also be the cause of the failed tests on GCC)

I suppose the intention was `(void)Open();` or `static_cast<void>(Open())`, both of which work fine.

Fixes tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5664)
<!-- Reviewable:end -->
