### PR TITLE
Update zstd to v1.4.8

### DIFF
--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -81,6 +81,7 @@ add_subdirectory(teakra EXCLUDE_FROM_ALL)
 
 # Zstandard
 add_subdirectory(zstd/build/cmake EXCLUDE_FROM_ALL)
+target_include_directories(libzstd_static INTERFACE $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/externals/zstd/lib>)
 
 # ENet
 add_subdirectory(enet)

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -81,7 +81,6 @@ add_subdirectory(teakra EXCLUDE_FROM_ALL)
 
 # Zstandard
 add_subdirectory(zstd/build/cmake EXCLUDE_FROM_ALL)
-target_include_directories(libzstd_static INTERFACE ./zstd/lib)
 
 # ENet
 add_subdirectory(enet)

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -131,7 +131,6 @@ create_target_directory_groups(common)
 
 target_link_libraries(common PUBLIC fmt microprofile Boost::boost Boost::serialization)
 target_link_libraries(common PRIVATE libzstd_static)
-target_include_directories(common PRIVATE ${CMAKE_SOURCE_DIR}/externals/zstd/lib)
 if (ARCHITECTURE_x86_64)
     target_link_libraries(common PRIVATE xbyak)
 endif()

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -131,6 +131,7 @@ create_target_directory_groups(common)
 
 target_link_libraries(common PUBLIC fmt microprofile Boost::boost Boost::serialization)
 target_link_libraries(common PRIVATE libzstd_static)
+target_include_directories(common PRIVATE ${CMAKE_SOURCE_DIR}/externals/zstd/lib)
 if (ARCHITECTURE_x86_64)
     target_link_libraries(common PRIVATE xbyak)
 endif()


### PR DESCRIPTION
Silences a warning on newer CMake versions about CMake < 2.8.12 support.
The update may also result in a 5% increase in decompression performance, according to https://github.com/facebook/zstd/releases/tag/v1.4.5

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5668)
<!-- Reviewable:end -->
