### PR TITLE
Port yuzu-emu/yuzu#5217: "citra_qt/main: Save settings when starting guest"

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -1013,6 +1013,11 @@ void GMainWindow::BootGame(const QString& filename) {
         Core::Movie::GetInstance().PrepareForRecording();
     }
 
+    // Save configurations
+    UpdateUISettings();
+    game_list->SaveInterfaceLayout();
+    config->Save();
+
     if (!LoadROM(filename))
         return;
 
@@ -2186,22 +2191,7 @@ void GMainWindow::closeEvent(QCloseEvent* event) {
         return;
     }
 
-    if (!ui->action_Fullscreen->isChecked()) {
-        UISettings::values.geometry = saveGeometry();
-        UISettings::values.renderwindow_geometry = render_window->saveGeometry();
-    }
-    UISettings::values.state = saveState();
-#if MICROPROFILE_ENABLED
-    UISettings::values.microprofile_geometry = microProfileDialog->saveGeometry();
-    UISettings::values.microprofile_visible = microProfileDialog->isVisible();
-#endif
-    UISettings::values.single_window_mode = ui->action_Single_Window_Mode->isChecked();
-    UISettings::values.fullscreen = ui->action_Fullscreen->isChecked();
-    UISettings::values.display_titlebar = ui->action_Display_Dock_Widget_Headers->isChecked();
-    UISettings::values.show_filter_bar = ui->action_Show_Filter_Bar->isChecked();
-    UISettings::values.show_status_bar = ui->action_Show_Status_Bar->isChecked();
-    UISettings::values.first_start = false;
-
+    UpdateUISettings();
     game_list->SaveInterfaceLayout();
     hotkey_registry.SaveHotkeys();
 
@@ -2368,6 +2358,24 @@ void GMainWindow::UpdateWindowTitle() {
     } else {
         setWindowTitle(tr("Citra %1| %2").arg(full_name, game_title));
     }
+}
+
+void GMainWindow::UpdateUISettings() {
+    if (!ui->action_Fullscreen->isChecked()) {
+        UISettings::values.geometry = saveGeometry();
+        UISettings::values.renderwindow_geometry = render_window->saveGeometry();
+    }
+    UISettings::values.state = saveState();
+#if MICROPROFILE_ENABLED
+    UISettings::values.microprofile_geometry = microProfileDialog->saveGeometry();
+    UISettings::values.microprofile_visible = microProfileDialog->isVisible();
+#endif
+    UISettings::values.single_window_mode = ui->action_Single_Window_Mode->isChecked();
+    UISettings::values.fullscreen = ui->action_Fullscreen->isChecked();
+    UISettings::values.display_titlebar = ui->action_Display_Dock_Widget_Headers->isChecked();
+    UISettings::values.show_filter_bar = ui->action_Show_Filter_Bar->isChecked();
+    UISettings::values.show_status_bar = ui->action_Show_Status_Bar->isChecked();
+    UISettings::values.first_start = false;
 }
 
 void GMainWindow::SyncMenuUISettings() {

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -229,6 +229,7 @@ private:
     void UpdateStatusBar();
     void LoadTranslation();
     void UpdateWindowTitle();
+    void UpdateUISettings();
     void RetranslateStatusBar();
     void InstallCIA(QStringList filepaths);
     void HideMouseCursor();


### PR DESCRIPTION
See yuzu-emu/yuzu#5217 for more details.

**Original description**:
Saves UISettings and Settings when booting a guest. Moves updating UISettings::values from GMainWindow::closeEvent into its own function, then reuses it in GMainWindow::BootGame.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5671)
<!-- Reviewable:end -->
