### PR TITLE
Delete the old log file before rotating

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -145,6 +145,9 @@ void ColorConsoleBackend::Write(const Entry& entry) {
 }
 
 FileBackend::FileBackend(const std::string& filename) : bytes_written(0) {
+    if (FileUtil::Exists(filename + ".old.txt")) {
+        FileUtil::Delete(filename + ".old.txt");
+    }
     if (FileUtil::Exists(filename)) {
         FileUtil::Rename(filename, filename + ".old.txt");
     }


### PR DESCRIPTION
I think this is needed for Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5675)
<!-- Reviewable:end -->
