### PR TITLE
Add 3D slider value to the HID shared page

### DIFF
--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -224,6 +224,7 @@ void Module::UpdatePadCallback(u64 userdata, s64 cycles_late) {
 
     // TODO(xperia64): How the 3D Slider is updated by the HID module needs to be RE'd
     // and possibly moved to its own Core::Timing event.
+    mem->pad.sliderstate_3d = (Settings::values.factor_3d / 100.0f);
     system.Kernel().GetSharedPageHandler().Set3DSlider(Settings::values.factor_3d / 100.0f);
 
     // Reschedule recurrent event

--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -110,7 +110,9 @@ struct SharedMem {
         s64 index_reset_ticks_previous; ///< Previous `index_reset_ticks`
         u32 index;                      ///< Index of the last updated pad state entry
 
-        INSERT_PADDING_WORDS(0x2);
+        INSERT_PADDING_WORDS(0x1);
+
+        float sliderstate_3d;
 
         PadState current_state; ///< Current state of the pad buttons
 

--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -112,7 +112,7 @@ struct SharedMem {
 
         INSERT_PADDING_WORDS(0x1);
 
-        float sliderstate_3d;
+        f32 sliderstate_3d;
 
         PadState current_state; ///< Current state of the pad buttons
 


### PR DESCRIPTION
At least for HID::SPVR, as in the System Settings app, the 3D slider's current value is present at offset 0x18 on the HID Shared Page.

Gets the settings app passed the "slide the 3d slider all the way up" part.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5676)
<!-- Reviewable:end -->
