### PR TITLE
Port yuzu-emu/yuzu#5342: "yuzu: Migrate off of setMargin() to setContentsMargins()"

### DIFF
--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -195,7 +195,7 @@ GRenderWindow::GRenderWindow(QWidget* parent_, EmuThread* emu_thread)
                             QString::fromUtf8(Common::g_scm_desc)));
     setAttribute(Qt::WA_AcceptTouchEvents);
     auto layout = new QHBoxLayout(this);
-    layout->setMargin(0);
+    layout->setContentsMargins(0, 0, 0, 0);
     setLayout(layout);
     InputCommon::Init();
 

--- a/src/citra_qt/game_list.cpp
+++ b/src/citra_qt/game_list.cpp
@@ -134,7 +134,7 @@ void GameListSearchField::setFocus() {
 GameListSearchField::GameListSearchField(GameList* parent) : QWidget{parent} {
     auto* const key_release_eater = new KeyReleaseEater(parent, this);
     layout_filter = new QHBoxLayout;
-    layout_filter->setMargin(8);
+    layout_filter->setContentsMargins(8, 8, 8, 8);
     label_filter = new QLabel;
     label_filter->setText(tr("Filter:"));
     edit_filter = new QLineEdit;


### PR DESCRIPTION
See yuzu-emu/yuzu#5342 for more details.

**Original description**:
setMargin() has been deprecated since Qt 5, and replaced with setContentsMargins(). We can move to setContentsMargins() to stay forward compatible with Qt 6.0 whenever we update to it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5693)
<!-- Reviewable:end -->
