### PR TITLE
Remove return None() Function

### DIFF
--- a/dist/scripting/citra.py
+++ b/dist/scripting/citra.py
@@ -32,7 +32,7 @@ class Citra:
             expected_type == reply_type and
             reply_data_size == len(raw_reply[4*4:])):
             return raw_reply[4*4:]
-        return None
+        pass
 
     def read_memory(self, read_address, read_size):
         """
@@ -55,7 +55,7 @@ class Citra:
                 read_size -= len(reply_data)
                 read_address += len(reply_data)
             else:
-                return None
+                pass
 
         return result
 


### PR DESCRIPTION
Instead of using return none using pass is better, as it does not return anything and pass just moves on with the code not doing anything.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5702)
<!-- Reviewable:end -->
