### PR TITLE
Fix macos build

### DIFF
--- a/.ci/macos/deps.sh
+++ b/.ci/macos/deps.sh
@@ -3,5 +3,6 @@
 brew update
 brew unlink python@2 || true
 rm '/usr/local/bin/2to3' || true
-brew install qt5 sdl2 p7zip ccache ffmpeg llvm ninja
+brew install p7zip llvm || true
+brew install qt5 sdl2 ccache ffmpeg ninja
 pip3 install macpack

--- a/.ci/macos/deps.sh
+++ b/.ci/macos/deps.sh
@@ -3,6 +3,5 @@
 brew update
 brew unlink python@2 || true
 rm '/usr/local/bin/2to3' || true
-brew install p7zip llvm || true
-brew install qt5 sdl2 ccache ffmpeg ninja
+brew install qt5 sdl2 p7zip ccache ffmpeg llvm ninja || true
 pip3 install macpack


### PR DESCRIPTION
GitHub's virtual environment provides 7zip and llvm by default, so brew may fail to install them as another version is already installed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5703)
<!-- Reviewable:end -->
