### PR TITLE
configure_input: fix modifier scale saving

### DIFF
--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -375,9 +375,7 @@ void ConfigureInput::RestoreDefaults() {
                 Config::default_analogs[analog_id][sub_button_id])};
             SetAnalogButton(params, analogs_param[analog_id], analog_sub_buttons[sub_button_id]);
         }
-        if (analogs_param[analog_id].Get("modifier_scale", 0.5f) != 0.5f) {
-            analogs_param[analog_id].Set("modifier_scale", 0.5f);
-        }
+        analogs_param[analog_id].Set("modifier_scale", 0.5f);
     }
     UpdateButtonLabels();
 

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -266,6 +266,8 @@ ConfigureInput::ConfigureInput(QWidget* parent)
                     tr("Modifier Scale: %1%").arg(slider_value));
                 analogs_param[analog_id].Set("modifier_scale", slider_value / 100.0f);
             }
+            ApplyConfiguration();
+            Settings::SaveProfile(ui->profile->currentIndex());
         });
     }
 
@@ -372,6 +374,9 @@ void ConfigureInput::RestoreDefaults() {
             Common::ParamPackage params{InputCommon::GenerateKeyboardParam(
                 Config::default_analogs[analog_id][sub_button_id])};
             SetAnalogButton(params, analogs_param[analog_id], analog_sub_buttons[sub_button_id]);
+        }
+        if (analogs_param[analog_id].Get("modifier_scale", 0.5f) != 0.5f) {
+            analogs_param[analog_id].Set("modifier_scale", 0.5f);
         }
     }
     UpdateButtonLabels();


### PR DESCRIPTION
Should fix #5705

Actually apply and save the configurations when the modifier scale or deadzone is modified.

Also change the Restore Defaults to affect the modifier scale.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5707)
<!-- Reviewable:end -->
