### PR TITLE
gl_rasterizer_cache: Remove all fully invalid surfaces from the cache

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -311,13 +311,21 @@ static constexpr std::array<void (*)(u32, u32, u8*, PAddr, PAddr, PAddr), 18> gl
 };
 
 // Allocate an uninitialized texture of appropriate size and format for the surface
-static void AllocateSurfaceTexture(GLuint texture, const FormatTuple& format_tuple, u32 width,
-                                   u32 height) {
-    OpenGLState cur_state = OpenGLState::GetCurState();
+OGLTexture RasterizerCacheOpenGL::AllocateSurfaceTexture(const FormatTuple& format_tuple, u32 width,
+                                                         u32 height) {
+    auto recycled_tex = host_texture_recycler.find({format_tuple, width, height});
+    if (recycled_tex != host_texture_recycler.end()) {
+        OGLTexture texture = std::move(recycled_tex->second);
+        host_texture_recycler.erase(recycled_tex);
+        return texture;
+    }
+    OGLTexture texture;
+    texture.Create();
 
+    OpenGLState cur_state = OpenGLState::GetCurState();
     // Keep track of previous texture bindings
     GLuint old_tex = cur_state.texture_units[0].texture_2d;
-    cur_state.texture_units[0].texture_2d = texture;
+    cur_state.texture_units[0].texture_2d = texture.handle;
     cur_state.Apply();
     glActiveTexture(GL_TEXTURE0);
 
@@ -332,6 +340,8 @@ static void AllocateSurfaceTexture(GLuint texture, const FormatTuple& format_tup
     // Restore previous texture bindings
     cur_state.texture_units[0].texture_2d = old_tex;
     cur_state.Apply();
+
+    return texture;
 }
 
 static void AllocateTextureCube(GLuint texture, const FormatTuple& format_tuple, u32 width) {
@@ -496,7 +506,12 @@ static bool FillSurface(const Surface& surface, const u8* fill_data,
 
 CachedSurface::~CachedSurface() {
     if (texture.handle) {
-        owner.host_texture_recycler.emplace(*this, std::move(texture));
+        auto tag = is_custom ? HostTextureTag{GetFormatTuple(PixelFormat::RGBA8),
+                                              custom_tex_info.width, custom_tex_info.height}
+                             : HostTextureTag{GetFormatTuple(pixel_format), GetScaledWidth(),
+                                              GetScaledHeight()};
+
+        owner.host_texture_recycler.emplace(tag, std::move(texture));
     }
 }
 
@@ -819,12 +834,11 @@ void CachedSurface::UploadGLTexture(Common::Rectangle<u32> rect, GLuint read_fb_
         x0 = 0;
         y0 = 0;
 
-        unscaled_tex.Create();
         if (is_custom) {
-            AllocateSurfaceTexture(unscaled_tex.handle, GetFormatTuple(PixelFormat::RGBA8),
-                                   custom_tex_info.width, custom_tex_info.height);
+            unscaled_tex = owner.AllocateSurfaceTexture(
+                GetFormatTuple(PixelFormat::RGBA8), custom_tex_info.width, custom_tex_info.height);
         } else {
-            AllocateSurfaceTexture(unscaled_tex.handle, tuple, rect.GetWidth(), rect.GetHeight());
+            unscaled_tex = owner.AllocateSurfaceTexture(tuple, rect.GetWidth(), rect.GetHeight());
         }
         target_tex = unscaled_tex.handle;
     }
@@ -839,8 +853,8 @@ void CachedSurface::UploadGLTexture(Common::Rectangle<u32> rect, GLuint read_fb_
     ASSERT(stride * GetGLBytesPerPixel(pixel_format) % 4 == 0);
     if (is_custom) {
         if (res_scale == 1) {
-            AllocateSurfaceTexture(texture.handle, GetFormatTuple(PixelFormat::RGBA8),
-                                   custom_tex_info.width, custom_tex_info.height);
+            texture = owner.AllocateSurfaceTexture(GetFormatTuple(PixelFormat::RGBA8),
+                                                   custom_tex_info.width, custom_tex_info.height);
             cur_state.texture_units[0].texture_2d = texture.handle;
             cur_state.Apply();
         }
@@ -917,11 +931,9 @@ void CachedSurface::DownloadGLTexture(const Common::Rectangle<u32>& rect, GLuint
         scaled_rect.right *= res_scale;
         scaled_rect.bottom *= res_scale;
 
-        OGLTexture unscaled_tex;
-        unscaled_tex.Create();
-
         Common::Rectangle<u32> unscaled_tex_rect{0, rect.GetHeight(), rect.GetWidth(), 0};
-        AllocateSurfaceTexture(unscaled_tex.handle, tuple, rect.GetWidth(), rect.GetHeight());
+        OGLTexture unscaled_tex =
+            owner.AllocateSurfaceTexture(tuple, rect.GetWidth(), rect.GetHeight());
         BlitTextures(texture.handle, scaled_rect, unscaled_tex.handle, unscaled_tex_rect, type,
                      read_fb_handle, draw_fb_handle);
 
@@ -1741,15 +1753,12 @@ bool RasterizerCacheOpenGL::ValidateByReinterpretation(const Surface& surface,
             if (!texture_filterer->IsNull() && reinterpret_surface->res_scale == 1 &&
                 surface->res_scale == resolution_scale_factor) {
                 // The destination surface is either a framebuffer, or a filtered texture.
-                OGLTexture tmp_tex;
-                tmp_tex.Create();
                 // Create an intermediate surface to convert to before blitting to the
                 // destination.
                 Common::Rectangle<u32> tmp_rect{0, dest_rect.GetHeight() / resolution_scale_factor,
                                                 dest_rect.GetWidth() / resolution_scale_factor, 0};
-                AllocateSurfaceTexture(tmp_tex.handle,
-                                       GetFormatTuple(reinterpreter->first.dst_format),
-                                       tmp_rect.right, tmp_rect.top);
+                OGLTexture tmp_tex = AllocateSurfaceTexture(
+                    GetFormatTuple(reinterpreter->first.dst_format), tmp_rect.right, tmp_rect.top);
                 reinterpreter->second->Reinterpret(reinterpret_surface->texture.handle, src_rect,
                                                    read_framebuffer.handle, tmp_tex.handle,
                                                    tmp_rect, draw_framebuffer.handle);
@@ -1901,15 +1910,9 @@ Surface RasterizerCacheOpenGL::CreateSurface(const SurfaceParams& params) {
 
     surface->invalid_regions.insert(surface->GetInterval());
 
-    auto recycled_texture = host_texture_recycler.find(params);
-    if (recycled_texture == host_texture_recycler.end()) {
-        surface->texture.Create();
-        AllocateSurfaceTexture(surface->texture.handle, GetFormatTuple(surface->pixel_format),
-                               surface->GetScaledWidth(), surface->GetScaledHeight());
-    } else {
-        surface->texture = std::move(recycled_texture->second);
-        host_texture_recycler.erase(recycled_texture);
-    }
+    surface->texture =
+        AllocateSurfaceTexture(GetFormatTuple(surface->pixel_format), surface->GetScaledWidth(),
+                               surface->GetScaledHeight());
 
     return surface;
 }

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -1858,9 +1858,9 @@ void RasterizerCacheOpenGL::InvalidateRegion(PAddr addr, u32 size, const Surface
             cached_surface->invalid_regions.insert(interval);
             cached_surface->InvalidateAllWatcher();
 
-            // Remove only "empty" fill surfaces to avoid destroying and recreating OGL textures
-            if (cached_surface->type == SurfaceType::Fill &&
-                cached_surface->IsSurfaceFullyInvalid()) {
+            // If the surface has no salvageable data it should be removed from the cache to avoid
+            // clogging the data structure
+            if (cached_surface->IsSurfaceFullyInvalid()) {
                 remove_surfaces.emplace(cached_surface);
             }
         }

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -495,7 +495,9 @@ static bool FillSurface(const Surface& surface, const u8* fill_data,
 }
 
 CachedSurface::~CachedSurface() {
-    owner.host_texture_recycler.emplace(*this, std::move(texture));
+    if (texture.handle) {
+        owner.host_texture_recycler.emplace(*this, std::move(texture));
+    }
 }
 
 bool CachedSurface::CanFill(const SurfaceParams& dest_surface,

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -63,7 +63,7 @@ struct HostTextureTag {
     bool operator==(const HostTextureTag& rhs) const noexcept {
         return std::tie(internal_format, format, width, height) ==
                std::tie(rhs.internal_format, rhs.format, rhs.width, rhs.height);
-    };
+    }
 };
 
 struct TextureCubeConfig {


### PR DESCRIPTION
Previously we only did this for fill surfaces. The surfaces were left in the cache to avoid the overhead of reallocating the texture, but certain poorly behaved games (*cough Pilotwings*) make many surfaces that are fully invalidated and never reused. The dead weight in the cache bogged down texture lookup times and other cache management functions. I introduced a map of recycled textures from destroyed surfaces to avoid the aforementioned driver overhead from allocations. Pilotwings now never drops below 60fps average on my machine.
![image](https://user-images.githubusercontent.com/28246325/106693153-760f9100-659b-11eb-9e8e-553779b486cb.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5710)
<!-- Reviewable:end -->
