### PR TITLE
Avoid leaking fences during re-presentation

### DIFF
--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -1107,6 +1107,11 @@ void RendererOpenGL::TryPresent(int timeout_ms) {
     glBlitFramebuffer(0, 0, frame->width, frame->height, 0, 0, layout.width, layout.height,
                       GL_COLOR_BUFFER_BIT, GL_LINEAR);
 
+    // Delete the fence if we're re-presenting to avoid leaking fences
+    if(frame->present_fence) {
+        glDeleteSync(frame->present_fence);
+    }
+
     /* insert fence for the main thread to block on */
     frame->present_fence = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
     glFlush();

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -1108,7 +1108,7 @@ void RendererOpenGL::TryPresent(int timeout_ms) {
                       GL_COLOR_BUFFER_BIT, GL_LINEAR);
 
     // Delete the fence if we're re-presenting to avoid leaking fences
-    if(frame->present_fence) {
+    if (frame->present_fence) {
         glDeleteSync(frame->present_fence);
     }
 


### PR DESCRIPTION
When a frame is presented multiple times (i.e. due to the new one not being ready yet), a new presentation fence is created even though the old one hasn't been deleted, because the deletion code only fires if a new frame is available.

On some drivers/configurations that re-present frequently, this leaks resources leading to latent crashes.

The solution is to delete the fence if it already exists before creating a new one.


While this fixes an issue only identified on Android, I'd like to see how it fares on desktop drivers just to be sure we don't hit any bugs there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5713)
<!-- Reviewable:end -->
