### PR TITLE
Add "scale" slider for analog input in config

### DIFF
--- a/src/citra_qt/configuration/configure_input.h
+++ b/src/citra_qt/configuration/configure_input.h
@@ -75,10 +75,10 @@ private:
     /// Analog inputs are also represented each with a single button, used to configure with an
     /// actual analog stick
     std::array<QPushButton*, Settings::NativeAnalog::NumAnalogs> analog_map_stick;
-    std::array<QSlider*, Settings::NativeAnalog::NumAnalogs>
-        analog_map_deadzone_and_modifier_slider;
-    std::array<QLabel*, Settings::NativeAnalog::NumAnalogs>
-        analog_map_deadzone_and_modifier_slider_label;
+    std::array<QSlider*, Settings::NativeAnalog::NumAnalogs> analog_map_scale_slider;
+    std::array<QLabel*, Settings::NativeAnalog::NumAnalogs> analog_map_scale_slider_label;
+    std::array<QSlider*, Settings::NativeAnalog::NumAnalogs> analog_map_deadzone_slider;
+    std::array<QLabel*, Settings::NativeAnalog::NumAnalogs> analog_map_deadzone_slider_label;
 
     static const std::array<std::string, ANALOG_SUB_BUTTONS_NUM> analog_sub_buttons;
 

--- a/src/citra_qt/configuration/configure_input.ui
+++ b/src/citra_qt/configuration/configure_input.ui
@@ -453,14 +453,42 @@
          </layout>
         </item>
         <item row="3" column="1" colspan="2">
-         <layout class="QVBoxLayout" name="sliderCirclePadDeadzoneAndModifierVerticalLayout">
+         <layout class="QVBoxLayout" name="sliderCirclePadScaleVerticalLayout">
           <item>
-           <layout class="QHBoxLayout" name="sliderCirclePadDeadzoneAndModifierHorizontalLayout">
+           <layout class="QHBoxLayout" name="sliderCirclePadScaleHorizontalLayout">
             <property name="sizeConstraint">
              <enum>QLayout::SetDefaultConstraint</enum>
             </property>
             <item>
-             <widget class="QLabel" name="labelCirclePadDeadzoneAndModifier">
+             <widget class="QLabel" name="labelCirclePadScale">
+              <property name="text">
+               <string>Modifier Scale: 0</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignHCenter</set>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QSlider" name="sliderCirclePadScale">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="4" column="1" colspan="2">
+         <layout class="QVBoxLayout" name="sliderCirclePadDeadzoneVerticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="sliderCirclePadDeadzoneHorizontalLayout">
+            <property name="sizeConstraint">
+              <enum>QLayout::SetDefaultConstraint</enum>
+            </property>
+            <item>
+             <widget class="QLabel" name="labelCirclePadDeadzone">
               <property name="text">
                <string>Deadzone: 0</string>
               </property>
@@ -472,7 +500,7 @@
            </layout>
           </item>
           <item>
-           <widget class="QSlider" name="sliderCirclePadDeadzoneAndModifier">
+           <widget class="QSlider" name="sliderCirclePadDeadzone">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
@@ -575,14 +603,42 @@
          </layout>
         </item>
         <item row="3" column="0" colspan="2">
-         <layout class="QVBoxLayout" name="sliderCStickDeadzoneAndModifierVerticalLayout">
+         <layout class="QVBoxLayout" name="sliderCStickScaleVerticalLayout">
           <property name="sizeConstraint">
            <enum>QLayout::SetDefaultConstraint</enum>
           </property>
           <item>
-           <layout class="QHBoxLayout" name="sliderCStickDeadzoneAndModifierHorizontalLayout">
+           <layout class="QHBoxLayout" name="sliderCStickScaleHorizontalLayout">
             <item>
-             <widget class="QLabel" name="labelCStickDeadzoneAndModifier">
+             <widget class="QLabel" name="labelCStickScale">
+              <property name="text">
+               <string>Modifier Scale: 0</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignHCenter</set>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QSlider" name="sliderCStickScale">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="4" column="0" colspan="2">
+         <layout class="QVBoxLayout" name="sliderCStickDeadzoneVerticalLayout">
+          <property name="sizeConstraint">
+           <enum>QLayout::SetDefaultConstraint</enum>
+          </property>
+          <item>
+           <layout class="QHBoxLayout" name="sliderCStickDeadzoneHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelCStickDeadzone">
               <property name="text">
                <string>Deadzone: 0</string>
               </property>
@@ -594,7 +650,7 @@
            </layout>
           </item>
           <item>
-           <widget class="QSlider" name="sliderCStickDeadzoneAndModifier">
+           <widget class="QSlider" name="sliderCStickDeadzone">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>

--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -638,15 +638,17 @@ private:
 
 class SDLAnalog final : public Input::AnalogDevice {
 public:
-    SDLAnalog(std::shared_ptr<SDLJoystick> joystick_, int axis_x_, int axis_y_, float deadzone_)
-        : joystick(std::move(joystick_)), axis_x(axis_x_), axis_y(axis_y_), deadzone(deadzone_) {}
+    SDLAnalog(std::shared_ptr<SDLJoystick> joystick_, int axis_x_, int axis_y_, float deadzone_,
+              float scale_)
+        : joystick(std::move(joystick_)), axis_x(axis_x_), axis_y(axis_y_), deadzone(deadzone_),
+          scale(scale_) {}
 
     std::tuple<float, float> GetStatus() const override {
         const auto [x, y] = joystick->GetAnalog(axis_x, axis_y);
         const float r = std::sqrt((x * x) + (y * y));
         if (r > deadzone) {
-            return std::make_tuple(x / r * (r - deadzone) / (1 - deadzone),
-                                   y / r * (r - deadzone) / (1 - deadzone));
+            return std::make_tuple(x / r * (r - deadzone) / (1 - deadzone) * scale,
+                                   y / r * (r - deadzone) / (1 - deadzone) * scale);
         }
         return std::make_tuple<float, float>(0.0f, 0.0f);
     }
@@ -656,6 +658,7 @@ private:
     const int axis_x;
     const int axis_y;
     const float deadzone;
+    const float scale;
 };
 
 /// A button device factory that creates button devices from SDL joystick
@@ -751,13 +754,14 @@ public:
         const int axis_x = params.Get("axis_x", 0);
         const int axis_y = params.Get("axis_y", 1);
         float deadzone = std::clamp(params.Get("deadzone", 0.0f), 0.0f, .99f);
+        float scale = params.Get("scale", 1.0f);
 
         auto joystick = state.GetSDLJoystickByGUID(guid, port);
 
         // This is necessary so accessing GetAxis with axis_x and axis_y won't crash
         joystick->SetAxis(axis_x, 0);
         joystick->SetAxis(axis_y, 0);
-        return std::make_unique<SDLAnalog>(joystick, axis_x, axis_y, deadzone);
+        return std::make_unique<SDLAnalog>(joystick, axis_x, axis_y, deadzone, scale);
     }
 
 private:


### PR DESCRIPTION
Was having an issue where Citra was only using about 75% of my controller's sticks' range, making some games tough to play without sacrificing analog movement (for example, the gravestone-pushing near the start of ALBW requires you to be moving at full speed). This PR is to add a quick 0%–200% scale slider to the controls screen whose value is used as a multiplier for the joystick's X and Y axes.

It worked immediately for me after setting the scale above 135%. I dunno if anyone else has ever had a similar problem, but this still seems like a "nice to have" thing for anyone that might want to tweak their controller's sensitivity -- the same idea is basically there in Cemu (the Range slider) and Dolphin (the stick-calibration feature), for example.

Also, not sure how to handle translating the new string this adds, but it hopefully won't be too difficult because a form of the word "scale" should already exist in the translations of "modifier scale".

Not sure if I've overlooked anything important. Feedback appreciated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5732)
<!-- Reviewable:end -->
