### PR TITLE
fix(net): prevent gibberish padding on linux

### DIFF
--- a/src/network/room.cpp
+++ b/src/network/room.cpp
@@ -912,7 +912,7 @@ void Room::RoomImpl::HandleChatPacket(const ENetEvent* event) {
     }
 
     // Limit the size of chat messages to MaxMessageSize
-    message.resize(MaxMessageSize);
+    message.resize(std::min(static_cast<u32>(message.size()), MaxMessageSize));
 
     Packet out_packet;
     out_packet << static_cast<u8>(IdChatMessage);


### PR DESCRIPTION
Resolves #3551.

# Before
![1617106271](https://user-images.githubusercontent.com/21071787/112996365-1caa8500-913a-11eb-945f-028c75f40e51.png)
![1617106292](https://user-images.githubusercontent.com/21071787/112996369-1d431b80-913a-11eb-974b-a1a0b2b1694e.png)
# After
![1617108880](https://user-images.githubusercontent.com/21071787/112996391-216f3900-913a-11eb-8609-a0dbed6c94b1.png)
![1617108887](https://user-images.githubusercontent.com/21071787/112996392-2207cf80-913a-11eb-89e0-11070bbce543.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5747)
<!-- Reviewable:end -->
