### PR TITLE
citra_qt/configure_input: Account for analog buttons when checking for used buttons

### DIFF
--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -355,7 +355,8 @@ QList<QKeySequence> ConfigureInput::GetUsedKeyboardKeys() {
         auto analog_param = analogs_param[analog_id];
         if (analog_param.Get("engine", "") == "analog_from_button") {
             for (int sub_button_id = 0; sub_button_id < ANALOG_SUB_BUTTONS_NUM; sub_button_id++) {
-                auto sub_button = Common::ParamPackage{analog_param.Get(analog_sub_buttons[sub_button_id], "")};
+                auto sub_button =
+                    Common::ParamPackage{analog_param.Get(analog_sub_buttons[sub_button_id], "")};
                 list << QKeySequence(sub_button.Get("code", 0));
             }
         }

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -355,7 +355,8 @@ QList<QKeySequence> ConfigureInput::GetUsedKeyboardKeys() {
         auto analog_param = analogs_param[analog_id];
         if (analog_param.Get("engine", "") == "analog_from_button") {
             for (int sub_button_id = 0; sub_button_id < ANALOG_SUB_BUTTONS_NUM; ++sub_button_id) {
-                const Common::ParamPackage sub_button{analog_param.Get(analog_sub_buttons[sub_button_id], "")};
+                const Common::ParamPackage sub_button{
+                    analog_param.Get(analog_sub_buttons[sub_button_id], "")};
                 list << QKeySequence(sub_button.Get("code", 0));
             }
         }

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -351,10 +351,10 @@ QList<QKeySequence> ConfigureInput::GetUsedKeyboardKeys() {
         }
     }
 
-    for (int analog_id = 0; analog_id < Settings::NativeAnalog::NumAnalogs; analog_id++) {
+    for (int analog_id = 0; analog_id < Settings::NativeAnalog::NumAnalogs; ++analog_id) {
         auto analog_param = analogs_param[analog_id];
         if (analog_param.Get("engine", "") == "analog_from_button") {
-            for (int sub_button_id = 0; sub_button_id < ANALOG_SUB_BUTTONS_NUM; sub_button_id++) {
+            for (int sub_button_id = 0; sub_button_id < ANALOG_SUB_BUTTONS_NUM; ++sub_button_id) {
                 auto sub_button =
                     Common::ParamPackage{analog_param.Get(analog_sub_buttons[sub_button_id], "")};
                 list << QKeySequence(sub_button.Get("code", 0));

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -350,6 +350,17 @@ QList<QKeySequence> ConfigureInput::GetUsedKeyboardKeys() {
             list << QKeySequence(button_param.Get("code", 0));
         }
     }
+
+    for (int analog_id = 0; analog_id < Settings::NativeAnalog::NumAnalogs; analog_id++) {
+        auto analog_param = analogs_param[analog_id];
+        if (analog_param.Get("engine", "") == "analog_from_button") {
+            for (int sub_button_id = 0; sub_button_id < ANALOG_SUB_BUTTONS_NUM; sub_button_id++) {
+                auto sub_button = Common::ParamPackage{analog_param.Get(analog_sub_buttons[sub_button_id], "")};
+                list << QKeySequence(sub_button.Get("code", 0));
+            }
+        }
+    }
+
     return list;
 }
 

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -355,8 +355,7 @@ QList<QKeySequence> ConfigureInput::GetUsedKeyboardKeys() {
         auto analog_param = analogs_param[analog_id];
         if (analog_param.Get("engine", "") == "analog_from_button") {
             for (int sub_button_id = 0; sub_button_id < ANALOG_SUB_BUTTONS_NUM; ++sub_button_id) {
-                auto sub_button =
-                    Common::ParamPackage{analog_param.Get(analog_sub_buttons[sub_button_id], "")};
+                const Common::ParamPackage sub_button{analog_param.Get(analog_sub_buttons[sub_button_id], "")};
                 list << QKeySequence(sub_button.Get("code", 0));
             }
         }


### PR DESCRIPTION
circle mod and buttons assigned as analog_from_buttons weren't being accounted for.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5755)
<!-- Reviewable:end -->
