### PR TITLE
Check for OpenGL extensions

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -61,6 +61,11 @@ RasterizerOpenGL::RasterizerOpenGL()
                     "Shadow might not be able to render because of unsupported OpenGL extensions.");
     }
 
+    if (!GLAD_GL_ARB_copy_image) {
+        LOG_WARNING(Render_OpenGL,
+                    "ARB_copy_image not supported. Some games might produce artifacts.");
+    }
+
     // Clipping plane 0 is always enabled for PICA fixed clip plane z <= 0
     state.clip_distance[0] = true;
 
@@ -772,7 +777,7 @@ bool RasterizerOpenGL::Draw(bool accelerate, bool is_indexed) {
     }
 
     OGLTexture temp_tex;
-    if (need_duplicate_texture) {
+    if (need_duplicate_texture && GLAD_GL_ARB_copy_image) {
         // The game is trying to use a surface as a texture and framebuffer at the same time
         // which causes unpredictable behavior on the host.
         // Making a copy to sample from eliminates this issue and seems to be fairly cheap.

--- a/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
@@ -365,6 +365,10 @@ void ShaderDiskCache::SaveDecompiled(u64 unique_identifier,
 void ShaderDiskCache::SaveDump(u64 unique_identifier, GLuint program) {
     if (!IsUsable())
         return;
+    if (!GLAD_GL_ARB_get_program_binary) {
+        LOG_WARNING(Render_OpenGL, "ARB_get_program_binary is not supported. Problems may occur if "
+                                   "use_disk_shader_cache is ON.");
+    }
 
     GLint binary_length{};
     glGetProgramiv(program, GL_PROGRAM_BINARY_LENGTH, &binary_length);


### PR DESCRIPTION
Check for GL_ARB_copy_image and GL_ARB_get_program_binary.
The `glCopyImageSubData` and `glGetProgramBinary` functions are not supported by OpenGL 3.3, so we need to check for the extensions.
More information about the extensions [here](https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_copy_image.txt) and [here](https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_get_program_binary.txt)

For `glGetProgramBinary` it logs a warning, while for `glCopyImageSubData` it disables the duplicate texture (like it was done for texture barrier before)
The `glCopyImageSubData` check should help mainly mac users (and maybe some intel users too), as the function was introduced by #5420 on nightly 1588, and we have been suggesting for mac users who experience problems to use nightly 1587, so I'm suspecting the crashing issues are due to lack of support for the extension.
I haven't tested these changes as I don't have the affected hardware.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5756)
<!-- Reviewable:end -->
