### PR TITLE
file_sys: prevent saving absolute paths to savestates

### DIFF
--- a/src/core/file_sys/archive_backend.cpp
+++ b/src/core/file_sys/archive_backend.cpp
@@ -7,10 +7,13 @@
 #include <sstream>
 #include "common/logging/log.h"
 #include "common/string_util.h"
+#include "common/file_util.h"
 #include "core/file_sys/archive_backend.h"
 #include "core/memory.h"
 
 namespace FileSys {
+
+std::string ArchiveBackend::base_path = FileUtil::GetUserPath(FileUtil::UserPath::UserDir);
 
 Path::Path(LowPathType type, std::vector<u8> data) : type(type) {
     switch (type) {

--- a/src/core/file_sys/archive_backend.cpp
+++ b/src/core/file_sys/archive_backend.cpp
@@ -5,9 +5,9 @@
 #include <cstddef>
 #include <iomanip>
 #include <sstream>
+#include "common/file_util.h"
 #include "common/logging/log.h"
 #include "common/string_util.h"
-#include "common/file_util.h"
 #include "core/file_sys/archive_backend.h"
 #include "core/memory.h"
 

--- a/src/core/file_sys/archive_backend.cpp
+++ b/src/core/file_sys/archive_backend.cpp
@@ -14,6 +14,8 @@
 namespace FileSys {
 
 std::string ArchiveBackend::base_path = FileUtil::GetUserPath(FileUtil::UserPath::UserDir);
+std::string ArchiveFactory::sdmc_directory = FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir);
+std::string ArchiveFactory::nand_directory = FileUtil::GetUserPath(FileUtil::UserPath::NANDDir);
 
 Path::Path(LowPathType type, std::vector<u8> data) : type(type) {
     switch (type) {

--- a/src/core/file_sys/archive_backend.h
+++ b/src/core/file_sys/archive_backend.h
@@ -241,6 +241,9 @@ public:
      */
     virtual ResultVal<ArchiveFormatInfo> GetFormatInfo(const Path& path, u64 program_id) const = 0;
 
+    static std::string sdmc_directory;
+    static std::string nand_directory;
+private:
     template <class Archive>
     void serialize(Archive& ar, const unsigned int) {}
     friend class boost::serialization::access;

--- a/src/core/file_sys/archive_backend.h
+++ b/src/core/file_sys/archive_backend.h
@@ -198,6 +198,7 @@ public:
 protected:
     std::unique_ptr<DelayGenerator> delay_generator;
     static std::string base_path;
+
 private:
     template <class Archive>
     void serialize(Archive& ar, const unsigned int) {
@@ -243,6 +244,7 @@ public:
 
     static std::string sdmc_directory;
     static std::string nand_directory;
+
 private:
     template <class Archive>
     void serialize(Archive& ar, const unsigned int) {}

--- a/src/core/file_sys/archive_backend.h
+++ b/src/core/file_sys/archive_backend.h
@@ -197,7 +197,7 @@ public:
 
 protected:
     std::unique_ptr<DelayGenerator> delay_generator;
-
+    static std::string base_path;
 private:
     template <class Archive>
     void serialize(Archive& ar, const unsigned int) {

--- a/src/core/file_sys/archive_sdmc.cpp
+++ b/src/core/file_sys/archive_sdmc.cpp
@@ -81,7 +81,8 @@ ResultVal<std::unique_ptr<FileBackend>> SDMCArchive::OpenFileBase(const Path& pa
 
     switch (path_parser.GetHostStatus(ArchiveBackend::base_path + mount_point)) {
     case PathParser::InvalidMountPoint:
-        LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}", ArchiveBackend::base_path + mount_point);
+        LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}",
+                     ArchiveBackend::base_path + mount_point);
         return ERROR_NOT_FOUND;
     case PathParser::PathNotFound:
     case PathParser::FileInPath:
@@ -127,7 +128,8 @@ ResultCode SDMCArchive::DeleteFile(const Path& path) const {
 
     switch (path_parser.GetHostStatus(ArchiveBackend::base_path + mount_point)) {
     case PathParser::InvalidMountPoint:
-        LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}", ArchiveBackend::base_path + mount_point);
+        LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}",
+                     ArchiveBackend::base_path + mount_point);
         return ERROR_NOT_FOUND;
     case PathParser::PathNotFound:
     case PathParser::FileInPath:
@@ -165,8 +167,10 @@ ResultCode SDMCArchive::RenameFile(const Path& src_path, const Path& dest_path) 
         return ERROR_INVALID_PATH;
     }
 
-    const auto src_path_full = path_parser_src.BuildHostPath(ArchiveBackend::base_path + mount_point);
-    const auto dest_path_full = path_parser_dest.BuildHostPath(ArchiveBackend::base_path + mount_point);
+    const auto src_path_full =
+        path_parser_src.BuildHostPath(ArchiveBackend::base_path + mount_point);
+    const auto dest_path_full =
+        path_parser_dest.BuildHostPath(ArchiveBackend::base_path + mount_point);
 
     if (FileUtil::Rename(src_path_full, dest_path_full)) {
         return RESULT_SUCCESS;
@@ -218,12 +222,14 @@ static ResultCode DeleteDirectoryHelper(const Path& path, const std::string& mou
 }
 
 ResultCode SDMCArchive::DeleteDirectory(const Path& path) const {
-    return DeleteDirectoryHelper(path, ArchiveBackend::base_path + mount_point, FileUtil::DeleteDir);
+    return DeleteDirectoryHelper(path, ArchiveBackend::base_path + mount_point,
+                                 FileUtil::DeleteDir);
 }
 
 ResultCode SDMCArchive::DeleteDirectoryRecursively(const Path& path) const {
     return DeleteDirectoryHelper(
-        path, ArchiveBackend::base_path + mount_point, [](const std::string& p) { return FileUtil::DeleteDirRecursively(p); });
+        path, ArchiveBackend::base_path + mount_point,
+        [](const std::string& p) { return FileUtil::DeleteDirRecursively(p); });
 }
 
 ResultCode SDMCArchive::CreateFile(const FileSys::Path& path, u64 size) const {
@@ -238,7 +244,8 @@ ResultCode SDMCArchive::CreateFile(const FileSys::Path& path, u64 size) const {
 
     switch (path_parser.GetHostStatus(ArchiveBackend::base_path + mount_point)) {
     case PathParser::InvalidMountPoint:
-        LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}", ArchiveBackend::base_path + mount_point);
+        LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}",
+                     ArchiveBackend::base_path + mount_point);
         return ERROR_NOT_FOUND;
     case PathParser::PathNotFound:
     case PathParser::FileInPath:
@@ -283,7 +290,8 @@ ResultCode SDMCArchive::CreateDirectory(const Path& path) const {
 
     switch (path_parser.GetHostStatus(ArchiveBackend::base_path + mount_point)) {
     case PathParser::InvalidMountPoint:
-        LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}", ArchiveBackend::base_path + mount_point);
+        LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}",
+                     ArchiveBackend::base_path + mount_point);
         return ERROR_NOT_FOUND;
     case PathParser::PathNotFound:
     case PathParser::FileInPath:
@@ -301,7 +309,8 @@ ResultCode SDMCArchive::CreateDirectory(const Path& path) const {
         return RESULT_SUCCESS;
     }
 
-    LOG_CRITICAL(Service_FS, "(unreachable) Unknown error creating {}", ArchiveBackend::base_path + mount_point);
+    LOG_CRITICAL(Service_FS, "(unreachable) Unknown error creating {}",
+                 ArchiveBackend::base_path + mount_point);
     return ResultCode(ErrorDescription::NoData, ErrorModule::FS, ErrorSummary::Canceled,
                       ErrorLevel::Status);
 }
@@ -322,8 +331,10 @@ ResultCode SDMCArchive::RenameDirectory(const Path& src_path, const Path& dest_p
         return ERROR_INVALID_PATH;
     }
 
-    const auto src_path_full = path_parser_src.BuildHostPath(ArchiveBackend::base_path + mount_point);
-    const auto dest_path_full = path_parser_dest.BuildHostPath(ArchiveBackend::base_path + mount_point);
+    const auto src_path_full =
+        path_parser_src.BuildHostPath(ArchiveBackend::base_path + mount_point);
+    const auto dest_path_full =
+        path_parser_dest.BuildHostPath(ArchiveBackend::base_path + mount_point);
 
     if (FileUtil::Rename(src_path_full, dest_path_full)) {
         return RESULT_SUCCESS;
@@ -347,7 +358,8 @@ ResultVal<std::unique_ptr<DirectoryBackend>> SDMCArchive::OpenDirectory(const Pa
 
     switch (path_parser.GetHostStatus(ArchiveBackend::base_path + mount_point)) {
     case PathParser::InvalidMountPoint:
-        LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}", ArchiveBackend::base_path + mount_point);
+        LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}",
+                     ArchiveBackend::base_path + mount_point);
         return ERROR_NOT_FOUND;
     case PathParser::PathNotFound:
     case PathParser::NotFound:

--- a/src/core/file_sys/archive_sdmc.cpp
+++ b/src/core/file_sys/archive_sdmc.cpp
@@ -77,11 +77,11 @@ ResultVal<std::unique_ptr<FileBackend>> SDMCArchive::OpenFileBase(const Path& pa
         return ERROR_INVALID_OPEN_FLAGS;
     }
 
-    const auto full_path = path_parser.BuildHostPath(mount_point);
+    const auto full_path = path_parser.BuildHostPath(ArchiveBackend::base_path + mount_point);
 
-    switch (path_parser.GetHostStatus(mount_point)) {
+    switch (path_parser.GetHostStatus(ArchiveBackend::base_path + mount_point)) {
     case PathParser::InvalidMountPoint:
-        LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}", mount_point);
+        LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}", ArchiveBackend::base_path + mount_point);
         return ERROR_NOT_FOUND;
     case PathParser::PathNotFound:
     case PathParser::FileInPath:
@@ -123,11 +123,11 @@ ResultCode SDMCArchive::DeleteFile(const Path& path) const {
         return ERROR_INVALID_PATH;
     }
 
-    const auto full_path = path_parser.BuildHostPath(mount_point);
+    const auto full_path = path_parser.BuildHostPath(ArchiveBackend::base_path + mount_point);
 
-    switch (path_parser.GetHostStatus(mount_point)) {
+    switch (path_parser.GetHostStatus(ArchiveBackend::base_path + mount_point)) {
     case PathParser::InvalidMountPoint:
-        LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}", mount_point);
+        LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}", ArchiveBackend::base_path + mount_point);
         return ERROR_NOT_FOUND;
     case PathParser::PathNotFound:
     case PathParser::FileInPath:
@@ -165,8 +165,8 @@ ResultCode SDMCArchive::RenameFile(const Path& src_path, const Path& dest_path) 
         return ERROR_INVALID_PATH;
     }
 
-    const auto src_path_full = path_parser_src.BuildHostPath(mount_point);
-    const auto dest_path_full = path_parser_dest.BuildHostPath(mount_point);
+    const auto src_path_full = path_parser_src.BuildHostPath(ArchiveBackend::base_path + mount_point);
+    const auto dest_path_full = path_parser_dest.BuildHostPath(ArchiveBackend::base_path + mount_point);
 
     if (FileUtil::Rename(src_path_full, dest_path_full)) {
         return RESULT_SUCCESS;
@@ -218,12 +218,12 @@ static ResultCode DeleteDirectoryHelper(const Path& path, const std::string& mou
 }
 
 ResultCode SDMCArchive::DeleteDirectory(const Path& path) const {
-    return DeleteDirectoryHelper(path, mount_point, FileUtil::DeleteDir);
+    return DeleteDirectoryHelper(path, ArchiveBackend::base_path + mount_point, FileUtil::DeleteDir);
 }
 
 ResultCode SDMCArchive::DeleteDirectoryRecursively(const Path& path) const {
     return DeleteDirectoryHelper(
-        path, mount_point, [](const std::string& p) { return FileUtil::DeleteDirRecursively(p); });
+        path, ArchiveBackend::base_path + mount_point, [](const std::string& p) { return FileUtil::DeleteDirRecursively(p); });
 }
 
 ResultCode SDMCArchive::CreateFile(const FileSys::Path& path, u64 size) const {
@@ -234,11 +234,11 @@ ResultCode SDMCArchive::CreateFile(const FileSys::Path& path, u64 size) const {
         return ERROR_INVALID_PATH;
     }
 
-    const auto full_path = path_parser.BuildHostPath(mount_point);
+    const auto full_path = path_parser.BuildHostPath(ArchiveBackend::base_path + mount_point);
 
-    switch (path_parser.GetHostStatus(mount_point)) {
+    switch (path_parser.GetHostStatus(ArchiveBackend::base_path + mount_point)) {
     case PathParser::InvalidMountPoint:
-        LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}", mount_point);
+        LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}", ArchiveBackend::base_path + mount_point);
         return ERROR_NOT_FOUND;
     case PathParser::PathNotFound:
     case PathParser::FileInPath:
@@ -279,11 +279,11 @@ ResultCode SDMCArchive::CreateDirectory(const Path& path) const {
         return ERROR_INVALID_PATH;
     }
 
-    const auto full_path = path_parser.BuildHostPath(mount_point);
+    const auto full_path = path_parser.BuildHostPath(ArchiveBackend::base_path + mount_point);
 
-    switch (path_parser.GetHostStatus(mount_point)) {
+    switch (path_parser.GetHostStatus(ArchiveBackend::base_path + mount_point)) {
     case PathParser::InvalidMountPoint:
-        LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}", mount_point);
+        LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}", ArchiveBackend::base_path + mount_point);
         return ERROR_NOT_FOUND;
     case PathParser::PathNotFound:
     case PathParser::FileInPath:
@@ -297,11 +297,11 @@ ResultCode SDMCArchive::CreateDirectory(const Path& path) const {
         break; // Expected 'success' case
     }
 
-    if (FileUtil::CreateDir(mount_point + path.AsString())) {
+    if (FileUtil::CreateDir(ArchiveBackend::base_path + mount_point + path.AsString())) {
         return RESULT_SUCCESS;
     }
 
-    LOG_CRITICAL(Service_FS, "(unreachable) Unknown error creating {}", mount_point);
+    LOG_CRITICAL(Service_FS, "(unreachable) Unknown error creating {}", ArchiveBackend::base_path + mount_point);
     return ResultCode(ErrorDescription::NoData, ErrorModule::FS, ErrorSummary::Canceled,
                       ErrorLevel::Status);
 }
@@ -322,8 +322,8 @@ ResultCode SDMCArchive::RenameDirectory(const Path& src_path, const Path& dest_p
         return ERROR_INVALID_PATH;
     }
 
-    const auto src_path_full = path_parser_src.BuildHostPath(mount_point);
-    const auto dest_path_full = path_parser_dest.BuildHostPath(mount_point);
+    const auto src_path_full = path_parser_src.BuildHostPath(ArchiveBackend::base_path + mount_point);
+    const auto dest_path_full = path_parser_dest.BuildHostPath(ArchiveBackend::base_path + mount_point);
 
     if (FileUtil::Rename(src_path_full, dest_path_full)) {
         return RESULT_SUCCESS;
@@ -343,11 +343,11 @@ ResultVal<std::unique_ptr<DirectoryBackend>> SDMCArchive::OpenDirectory(const Pa
         return ERROR_INVALID_PATH;
     }
 
-    const auto full_path = path_parser.BuildHostPath(mount_point);
+    const auto full_path = path_parser.BuildHostPath(ArchiveBackend::base_path + mount_point);
 
-    switch (path_parser.GetHostStatus(mount_point)) {
+    switch (path_parser.GetHostStatus(ArchiveBackend::base_path + mount_point)) {
     case PathParser::InvalidMountPoint:
-        LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}", mount_point);
+        LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}", ArchiveBackend::base_path + mount_point);
         return ERROR_NOT_FOUND;
     case PathParser::PathNotFound:
     case PathParser::NotFound:

--- a/src/core/file_sys/archive_sdmc.cpp
+++ b/src/core/file_sys/archive_sdmc.cpp
@@ -370,8 +370,7 @@ u64 SDMCArchive::GetFreeBytes() const {
     return 1024 * 1024 * 1024;
 }
 
-ArchiveFactory_SDMC::ArchiveFactory_SDMC(const std::string& sdmc_directory)
-    : sdmc_directory(sdmc_directory) {
+ArchiveFactory_SDMC::ArchiveFactory_SDMC() {
 
     LOG_DEBUG(Service_FS, "Directory {} set as SDMC.", sdmc_directory);
 }

--- a/src/core/file_sys/archive_sdmc.h
+++ b/src/core/file_sys/archive_sdmc.h
@@ -58,7 +58,7 @@ protected:
 /// File system interface to the SDMC archive
 class ArchiveFactory_SDMC final : public ArchiveFactory {
 public:
-    explicit ArchiveFactory_SDMC(const std::string& mount_point);
+    explicit ArchiveFactory_SDMC();
 
     /**
      * Initialize the archive.
@@ -76,13 +76,9 @@ public:
     ResultVal<ArchiveFormatInfo> GetFormatInfo(const Path& path, u64 program_id) const override;
 
 private:
-    std::string sdmc_directory;
-
-    ArchiveFactory_SDMC() = default;
     template <class Archive>
     void serialize(Archive& ar, const unsigned int) {
         ar& boost::serialization::base_object<ArchiveFactory>(*this);
-        ar& sdmc_directory;
     }
     friend class boost::serialization::access;
 };

--- a/src/core/file_sys/archive_sdmcwriteonly.cpp
+++ b/src/core/file_sys/archive_sdmcwriteonly.cpp
@@ -58,8 +58,7 @@ ResultVal<std::unique_ptr<DirectoryBackend>> SDMCWriteOnlyArchive::OpenDirectory
     return ERROR_UNSUPPORTED_OPEN_FLAGS;
 }
 
-ArchiveFactory_SDMCWriteOnly::ArchiveFactory_SDMCWriteOnly(const std::string& mount_point)
-    : sdmc_directory(mount_point) {
+ArchiveFactory_SDMCWriteOnly::ArchiveFactory_SDMCWriteOnly() {
     LOG_DEBUG(Service_FS, "Directory {} set as SDMCWriteOnly.", sdmc_directory);
 }
 

--- a/src/core/file_sys/archive_sdmcwriteonly.h
+++ b/src/core/file_sys/archive_sdmcwriteonly.h
@@ -44,7 +44,7 @@ private:
 /// File system interface to the SDMC write-only archive
 class ArchiveFactory_SDMCWriteOnly final : public ArchiveFactory {
 public:
-    explicit ArchiveFactory_SDMCWriteOnly(const std::string& mount_point);
+    explicit ArchiveFactory_SDMCWriteOnly();
 
     /**
      * Initialize the archive.
@@ -62,13 +62,9 @@ public:
     ResultVal<ArchiveFormatInfo> GetFormatInfo(const Path& path, u64 program_id) const override;
 
 private:
-    std::string sdmc_directory;
-
-    ArchiveFactory_SDMCWriteOnly() = default;
     template <class Archive>
     void serialize(Archive& ar, const unsigned int) {
         ar& boost::serialization::base_object<ArchiveFactory>(*this);
-        ar& sdmc_directory;
     }
     friend class boost::serialization::access;
 };

--- a/src/core/file_sys/archive_source_sd_savedata.cpp
+++ b/src/core/file_sys/archive_source_sd_savedata.cpp
@@ -18,11 +18,11 @@ SERIALIZE_EXPORT_IMPL(FileSys::ArchiveSource_SDSaveData)
 
 namespace FileSys {
 
-namespace {
-
 std::string GetSaveDataContainerPath(const std::string& sdmc_directory) {
     return fmt::format("{}Nintendo 3DS/{}/{}/title/", sdmc_directory, SYSTEM_ID, SDCARD_ID);
 }
+
+namespace {
 
 std::string GetSaveDataPath(const std::string& mount_location, u64 program_id) {
     u32 high = static_cast<u32>(program_id >> 32);

--- a/src/core/file_sys/archive_source_sd_savedata.cpp
+++ b/src/core/file_sys/archive_source_sd_savedata.cpp
@@ -44,7 +44,9 @@ ArchiveSource_SDSaveData::ArchiveSource_SDSaveData(const std::string& sdmc_direc
 }
 
 ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveSource_SDSaveData::Open(u64 program_id) {
-    std::string concrete_mount_point = GetSaveDataPath(mount_point, program_id);
+    const std::string concrete_mount_point = GetSaveDataPath(mount_point, program_id);
+    std::string relative_mount_point =
+        GetSaveDataPath(GetSaveDataContainerPath("sdmc/"), program_id);
     if (!FileUtil::Exists(concrete_mount_point)) {
         // When a SaveData archive is created for the first time, it is not yet formatted and the
         // save file/directory structure expected by the game has not yet been initialized.
@@ -53,7 +55,7 @@ ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveSource_SDSaveData::Open(u64 pr
         return ERR_NOT_FORMATTED;
     }
 
-    auto archive = std::make_unique<SaveDataArchive>(std::move(concrete_mount_point));
+    auto archive = std::make_unique<SaveDataArchive>(std::move(relative_mount_point));
     return MakeResult<std::unique_ptr<ArchiveBackend>>(std::move(archive));
 }
 

--- a/src/core/file_sys/archive_source_sd_savedata.h
+++ b/src/core/file_sys/archive_source_sd_savedata.h
@@ -16,6 +16,8 @@
 
 namespace FileSys {
 
+std::string GetSaveDataContainerPath(const std::string& sdmc_directory);
+
 /// A common source of SD save data archive
 class ArchiveSource_SDSaveData {
 public:
@@ -33,7 +35,9 @@ private:
     ArchiveSource_SDSaveData() = default;
     template <class Archive>
     void serialize(Archive& ar, const unsigned int) {
-        ar& mount_point;
+        if (Archive::is_loading::value) {
+            mount_point = GetSaveDataContainerPath(ArchiveFactory::sdmc_directory);
+        }
     }
     friend class boost::serialization::access;
 };

--- a/src/core/file_sys/archive_systemsavedata.cpp
+++ b/src/core/file_sys/archive_systemsavedata.cpp
@@ -52,12 +52,9 @@ Path ConstructSystemSaveDataBinaryPath(u32 high, u32 low) {
     return {std::move(binary_path)};
 }
 
-ArchiveFactory_SystemSaveData::ArchiveFactory_SystemSaveData(const std::string& nand_path)
-    : base_path(GetSystemSaveDataContainerPath(nand_path)) {}
-
 ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_SystemSaveData::Open(const Path& path,
                                                                                u64 program_id) {
-    const std::string fullpath = GetSystemSaveDataPath(base_path, path);
+    const std::string fullpath = GetSystemSaveDataPath(GetSystemSaveDataContainerPath(ArchiveFactory::nand_directory), path);
     std::string relative_path =
         GetSystemSaveDataPath(GetSystemSaveDataContainerPath("nand/"), path);
     if (!FileUtil::Exists(fullpath)) {
@@ -71,7 +68,7 @@ ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_SystemSaveData::Open(c
 ResultCode ArchiveFactory_SystemSaveData::Format(const Path& path,
                                                  const FileSys::ArchiveFormatInfo& format_info,
                                                  u64 program_id) {
-    std::string fullpath = GetSystemSaveDataPath(base_path, path);
+    std::string fullpath = GetSystemSaveDataPath(GetSystemSaveDataContainerPath(ArchiveFactory::nand_directory), path);
     FileUtil::DeleteDirRecursively(fullpath);
     FileUtil::CreateFullPath(fullpath);
     return RESULT_SUCCESS;

--- a/src/core/file_sys/archive_systemsavedata.cpp
+++ b/src/core/file_sys/archive_systemsavedata.cpp
@@ -54,7 +54,8 @@ Path ConstructSystemSaveDataBinaryPath(u32 high, u32 low) {
 
 ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_SystemSaveData::Open(const Path& path,
                                                                                u64 program_id) {
-    const std::string fullpath = GetSystemSaveDataPath(GetSystemSaveDataContainerPath(ArchiveFactory::nand_directory), path);
+    const std::string fullpath =
+        GetSystemSaveDataPath(GetSystemSaveDataContainerPath(ArchiveFactory::nand_directory), path);
     std::string relative_path =
         GetSystemSaveDataPath(GetSystemSaveDataContainerPath("nand/"), path);
     if (!FileUtil::Exists(fullpath)) {
@@ -68,7 +69,8 @@ ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_SystemSaveData::Open(c
 ResultCode ArchiveFactory_SystemSaveData::Format(const Path& path,
                                                  const FileSys::ArchiveFormatInfo& format_info,
                                                  u64 program_id) {
-    std::string fullpath = GetSystemSaveDataPath(GetSystemSaveDataContainerPath(ArchiveFactory::nand_directory), path);
+    std::string fullpath =
+        GetSystemSaveDataPath(GetSystemSaveDataContainerPath(ArchiveFactory::nand_directory), path);
     FileUtil::DeleteDirRecursively(fullpath);
     FileUtil::CreateFullPath(fullpath);
     return RESULT_SUCCESS;

--- a/src/core/file_sys/archive_systemsavedata.cpp
+++ b/src/core/file_sys/archive_systemsavedata.cpp
@@ -57,12 +57,14 @@ ArchiveFactory_SystemSaveData::ArchiveFactory_SystemSaveData(const std::string& 
 
 ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_SystemSaveData::Open(const Path& path,
                                                                                u64 program_id) {
-    std::string fullpath = GetSystemSaveDataPath(base_path, path);
+    const std::string fullpath = GetSystemSaveDataPath(base_path, path);
+    std::string relative_path =
+        GetSystemSaveDataPath(GetSystemSaveDataContainerPath("nand/"), path);
     if (!FileUtil::Exists(fullpath)) {
         // TODO(Subv): Check error code, this one is probably wrong
         return ERR_NOT_FORMATTED;
     }
-    auto archive = std::make_unique<SaveDataArchive>(fullpath);
+    auto archive = std::make_unique<SaveDataArchive>(relative_path);
     return MakeResult<std::unique_ptr<ArchiveBackend>>(std::move(archive));
 }
 

--- a/src/core/file_sys/archive_systemsavedata.h
+++ b/src/core/file_sys/archive_systemsavedata.h
@@ -20,7 +20,7 @@ namespace FileSys {
 /// File system interface to the SystemSaveData archive
 class ArchiveFactory_SystemSaveData final : public ArchiveFactory {
 public:
-    explicit ArchiveFactory_SystemSaveData(const std::string& mount_point);
+    explicit ArchiveFactory_SystemSaveData() = default;
 
     ResultVal<std::unique_ptr<ArchiveBackend>> Open(const Path& path, u64 program_id) override;
     ResultCode Format(const Path& path, const FileSys::ArchiveFormatInfo& format_info,
@@ -32,13 +32,9 @@ public:
     }
 
 private:
-    std::string base_path;
-
-    ArchiveFactory_SystemSaveData() = default;
     template <class Archive>
     void serialize(Archive& ar, const unsigned int) {
         ar& boost::serialization::base_object<ArchiveFactory>(*this);
-        ar& base_path;
     }
     friend class boost::serialization::access;
 };

--- a/src/core/file_sys/savedata_archive.cpp
+++ b/src/core/file_sys/savedata_archive.cpp
@@ -63,7 +63,8 @@ ResultVal<std::unique_ptr<FileBackend>> SaveDataArchive::OpenFile(const Path& pa
 
     switch (path_parser.GetHostStatus(ArchiveBackend::base_path + mount_point)) {
     case PathParser::InvalidMountPoint:
-        LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}", ArchiveBackend::base_path + mount_point);
+        LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}",
+                     ArchiveBackend::base_path + mount_point);
         return ERROR_FILE_NOT_FOUND;
     case PathParser::PathNotFound:
         LOG_ERROR(Service_FS, "Path not found {}", full_path);
@@ -109,7 +110,8 @@ ResultCode SaveDataArchive::DeleteFile(const Path& path) const {
 
     switch (path_parser.GetHostStatus(ArchiveBackend::base_path + mount_point)) {
     case PathParser::InvalidMountPoint:
-        LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}", ArchiveBackend::base_path + mount_point);
+        LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}",
+                     ArchiveBackend::base_path + mount_point);
         return ERROR_FILE_NOT_FOUND;
     case PathParser::PathNotFound:
         LOG_ERROR(Service_FS, "Path not found {}", full_path);
@@ -147,8 +149,10 @@ ResultCode SaveDataArchive::RenameFile(const Path& src_path, const Path& dest_pa
         return ERROR_INVALID_PATH;
     }
 
-    const auto src_path_full = path_parser_src.BuildHostPath(ArchiveBackend::base_path + mount_point);
-    const auto dest_path_full = path_parser_dest.BuildHostPath(ArchiveBackend::base_path + mount_point);
+    const auto src_path_full =
+        path_parser_src.BuildHostPath(ArchiveBackend::base_path + mount_point);
+    const auto dest_path_full =
+        path_parser_dest.BuildHostPath(ArchiveBackend::base_path + mount_point);
 
     if (FileUtil::Rename(src_path_full, dest_path_full)) {
         return RESULT_SUCCESS;
@@ -200,13 +204,14 @@ static ResultCode DeleteDirectoryHelper(const Path& path, const std::string& mou
 }
 
 ResultCode SaveDataArchive::DeleteDirectory(const Path& path) const {
-    return DeleteDirectoryHelper(path, ArchiveBackend::base_path + mount_point, FileUtil::DeleteDir);
+    return DeleteDirectoryHelper(path, ArchiveBackend::base_path + mount_point,
+                                 FileUtil::DeleteDir);
 }
 
 ResultCode SaveDataArchive::DeleteDirectoryRecursively(const Path& path) const {
-    return DeleteDirectoryHelper(path, ArchiveBackend::base_path + mount_point, [](const std::string& p) {
-        return FileUtil::DeleteDirRecursively(p);
-    });
+    return DeleteDirectoryHelper(
+        path, ArchiveBackend::base_path + mount_point,
+        [](const std::string& p) { return FileUtil::DeleteDirRecursively(p); });
 }
 
 ResultCode SaveDataArchive::CreateFile(const FileSys::Path& path, u64 size) const {
@@ -221,7 +226,8 @@ ResultCode SaveDataArchive::CreateFile(const FileSys::Path& path, u64 size) cons
 
     switch (path_parser.GetHostStatus(ArchiveBackend::base_path + mount_point)) {
     case PathParser::InvalidMountPoint:
-        LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}", ArchiveBackend::base_path + mount_point);
+        LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}",
+                     ArchiveBackend::base_path + mount_point);
         return ERROR_FILE_NOT_FOUND;
     case PathParser::PathNotFound:
         LOG_ERROR(Service_FS, "Path not found {}", full_path);
@@ -266,7 +272,8 @@ ResultCode SaveDataArchive::CreateDirectory(const Path& path) const {
 
     switch (path_parser.GetHostStatus(ArchiveBackend::base_path + mount_point)) {
     case PathParser::InvalidMountPoint:
-        LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}", ArchiveBackend::base_path + mount_point);
+        LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}",
+                     ArchiveBackend::base_path + mount_point);
         return ERROR_FILE_NOT_FOUND;
     case PathParser::PathNotFound:
         LOG_ERROR(Service_FS, "Path not found {}", full_path);
@@ -308,8 +315,10 @@ ResultCode SaveDataArchive::RenameDirectory(const Path& src_path, const Path& de
         return ERROR_INVALID_PATH;
     }
 
-    const auto src_path_full = path_parser_src.BuildHostPath(ArchiveBackend::base_path + mount_point);
-    const auto dest_path_full = path_parser_dest.BuildHostPath(ArchiveBackend::base_path + mount_point);
+    const auto src_path_full =
+        path_parser_src.BuildHostPath(ArchiveBackend::base_path + mount_point);
+    const auto dest_path_full =
+        path_parser_dest.BuildHostPath(ArchiveBackend::base_path + mount_point);
 
     if (FileUtil::Rename(src_path_full, dest_path_full)) {
         return RESULT_SUCCESS;
@@ -334,7 +343,8 @@ ResultVal<std::unique_ptr<DirectoryBackend>> SaveDataArchive::OpenDirectory(
 
     switch (path_parser.GetHostStatus(ArchiveBackend::base_path + mount_point)) {
     case PathParser::InvalidMountPoint:
-        LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}", ArchiveBackend::base_path + mount_point);
+        LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}",
+                     ArchiveBackend::base_path + mount_point);
         return ERROR_FILE_NOT_FOUND;
     case PathParser::PathNotFound:
     case PathParser::NotFound:

--- a/src/core/hle/service/cecd/cecd.cpp
+++ b/src/core/hle/service/cecd/cecd.cpp
@@ -1381,7 +1381,7 @@ Module::Module(Core::System& system) : system(system) {
         system.Kernel().CreateEvent(Kernel::ResetType::OneShot, "CECD::change_state_event");
 
     const std::string& nand_directory = FileUtil::GetUserPath(FileUtil::UserPath::NANDDir);
-    FileSys::ArchiveFactory_SystemSaveData systemsavedata_factory(nand_directory);
+    FileSys::ArchiveFactory_SystemSaveData systemsavedata_factory;
 
     // Open the SystemSaveData archive 0x00010026
     FileSys::Path archive_path(cecd_system_savedata_id);

--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -561,7 +561,7 @@ ResultCode Module::FormatConfig() {
 
 ResultCode Module::LoadConfigNANDSaveFile() {
     const std::string& nand_directory = FileUtil::GetUserPath(FileUtil::UserPath::NANDDir);
-    FileSys::ArchiveFactory_SystemSaveData systemsavedata_factory(nand_directory);
+    FileSys::ArchiveFactory_SystemSaveData systemsavedata_factory;
 
     // Open the SystemSaveData archive 0x00010017
     FileSys::Path archive_path(cfg_system_savedata_id);

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -362,8 +362,7 @@ void ArchiveManager::RegisterArchiveTypes() {
     auto savedatacheck_factory = std::make_unique<FileSys::ArchiveFactory_NCCH>();
     RegisterArchiveType(std::move(savedatacheck_factory), ArchiveIdCode::NCCH);
 
-    auto systemsavedata_factory =
-        std::make_unique<FileSys::ArchiveFactory_SystemSaveData>();
+    auto systemsavedata_factory = std::make_unique<FileSys::ArchiveFactory_SystemSaveData>();
     RegisterArchiveType(std::move(systemsavedata_factory), ArchiveIdCode::SystemSaveData);
 
     auto selfncch_factory = std::make_unique<FileSys::ArchiveFactory_SelfNCCH>();

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -324,13 +324,13 @@ void ArchiveManager::RegisterArchiveTypes() {
 
     std::string sdmc_directory = FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir);
     std::string nand_directory = FileUtil::GetUserPath(FileUtil::UserPath::NANDDir);
-    auto sdmc_factory = std::make_unique<FileSys::ArchiveFactory_SDMC>(sdmc_directory);
+    auto sdmc_factory = std::make_unique<FileSys::ArchiveFactory_SDMC>();
     if (sdmc_factory->Initialize())
         RegisterArchiveType(std::move(sdmc_factory), ArchiveIdCode::SDMC);
     else
         LOG_ERROR(Service_FS, "Can't instantiate SDMC archive with path {}", sdmc_directory);
 
-    auto sdmcwo_factory = std::make_unique<FileSys::ArchiveFactory_SDMCWriteOnly>(sdmc_directory);
+    auto sdmcwo_factory = std::make_unique<FileSys::ArchiveFactory_SDMCWriteOnly>();
     if (sdmcwo_factory->Initialize())
         RegisterArchiveType(std::move(sdmcwo_factory), ArchiveIdCode::SDMCWriteOnly);
     else
@@ -363,7 +363,7 @@ void ArchiveManager::RegisterArchiveTypes() {
     RegisterArchiveType(std::move(savedatacheck_factory), ArchiveIdCode::NCCH);
 
     auto systemsavedata_factory =
-        std::make_unique<FileSys::ArchiveFactory_SystemSaveData>(nand_directory);
+        std::make_unique<FileSys::ArchiveFactory_SystemSaveData>();
     RegisterArchiveType(std::move(systemsavedata_factory), ArchiveIdCode::SystemSaveData);
 
     auto selfncch_factory = std::make_unique<FileSys::ArchiveFactory_SelfNCCH>();


### PR DESCRIPTION
Should fix #5651, but more testing is needed.
It will definitely break compatibility with previous savestates, but that's a regular happening and trying to prevent it is more trouble than it's worth.