### PR TITLE
gcc 11 compatibility fix (suggestion)

### DIFF
--- a/src/common/ring_buffer.h
+++ b/src/common/ring_buffer.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <limits>
 #include <algorithm>
 #include <array>
 #include <atomic>

--- a/src/common/ring_buffer.h
+++ b/src/common/ring_buffer.h
@@ -4,12 +4,12 @@
 
 #pragma once
 
-#include <limits>
 #include <algorithm>
 #include <array>
 #include <atomic>
 #include <cstddef>
 #include <cstring>
+#include <limits>
 #include <new>
 #include <type_traits>
 #include <vector>

--- a/src/common/ring_buffer.h
+++ b/src/common/ring_buffer.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <limits>
 #include <algorithm>
 #include <array>
 #include <atomic>

--- a/src/core/hle/service/gsp/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp/gsp_gpu.cpp
@@ -282,29 +282,30 @@ ResultCode SetBufferSwap(u32 screen_id, const FrameBufferInfo& info) {
     u32 base_address = 0x400000;
     PAddr phys_address_left = VirtualToPhysicalAddress(info.address_left);
     PAddr phys_address_right = VirtualToPhysicalAddress(info.address_right);
+    GPU::Regs l_gpu_regs;
     if (info.active_fb == 0) {
-        WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
-                                                framebuffer_config[screen_id].address_left1)),
+        WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_FRAMEBUFFER_REG_INDEX(
+                                                &l_gpu_regs, screen_id, address_left1)),
                          phys_address_left);
-        WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
-                                                framebuffer_config[screen_id].address_right1)),
+        WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_FRAMEBUFFER_REG_INDEX(
+                                                &l_gpu_regs, screen_id, address_right1)),
                          phys_address_right);
     } else {
-        WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
-                                                framebuffer_config[screen_id].address_left2)),
+        WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_FRAMEBUFFER_REG_INDEX(
+                                                &l_gpu_regs, screen_id, address_left2)),
                          phys_address_left);
-        WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
-                                                framebuffer_config[screen_id].address_right2)),
+        WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_FRAMEBUFFER_REG_INDEX(
+                                                &l_gpu_regs, screen_id, address_right2)),
                          phys_address_right);
     }
     WriteSingleHWReg(base_address +
-                         4 * static_cast<u32>(GPU_REG_INDEX(framebuffer_config[screen_id].stride)),
+                         4 * static_cast<u32>(GPU_FRAMEBUFFER_REG_INDEX(&l_gpu_regs, screen_id, stride)),
                      info.stride);
-    WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
-                                            framebuffer_config[screen_id].color_format)),
+    WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_FRAMEBUFFER_REG_INDEX(
+                                            &l_gpu_regs, screen_id, color_format)),
                      info.format);
     WriteSingleHWReg(
-        base_address + 4 * static_cast<u32>(GPU_REG_INDEX(framebuffer_config[screen_id].active_fb)),
+        base_address + 4 * static_cast<u32>(GPU_FRAMEBUFFER_REG_INDEX(&l_gpu_regs, screen_id, active_fb)),
         info.shown_fb);
 
     if (Pica::g_debug_context)

--- a/src/core/hle/service/gsp/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp/gsp_gpu.cpp
@@ -282,61 +282,30 @@ ResultCode SetBufferSwap(u32 screen_id, const FrameBufferInfo& info) {
     u32 base_address = 0x400000;
     PAddr phys_address_left = VirtualToPhysicalAddress(info.address_left);
     PAddr phys_address_right = VirtualToPhysicalAddress(info.address_right);
-    switch(screen_id)
-    {
-        case 0:
-            if (info.active_fb == 0) {
-                WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
-                                                        framebuffer_config[0].address_left1)),
-                                phys_address_left);
-                WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
-                                                        framebuffer_config[0].address_right1)),
-                                phys_address_right);
-            } else {
-                WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
-                                                        framebuffer_config[0].address_left2)),
-                                phys_address_left);
-                WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
-                                                        framebuffer_config[0].address_right2)),
-                                phys_address_right);
-            }
-            WriteSingleHWReg(base_address +
-                                4 * static_cast<u32>(GPU_REG_INDEX(framebuffer_config[0].stride)),
-                            info.stride);
-            WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
-                                                    framebuffer_config[0].color_format)),
-                            info.format);
-            WriteSingleHWReg(
-                base_address + 4 * static_cast<u32>(GPU_REG_INDEX(framebuffer_config[0].active_fb)),
-                info.shown_fb);
-            break;
-        case 1:
-            if (info.active_fb == 0) {
-                WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
-                                                        framebuffer_config[1].address_left1)),
-                                phys_address_left);
-                WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
-                                                        framebuffer_config[1].address_right1)),
-                                phys_address_right);
-            } else {
-                WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
-                                                        framebuffer_config[1].address_left2)),
-                                phys_address_left);
-                WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
-                                                        framebuffer_config[1].address_right2)),
-                                phys_address_right);
-            }
-            WriteSingleHWReg(base_address +
-                                4 * static_cast<u32>(GPU_REG_INDEX(framebuffer_config[1].stride)),
-                            info.stride);
-            WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
-                                                    framebuffer_config[1].color_format)),
-                            info.format);
-            WriteSingleHWReg(
-                base_address + 4 * static_cast<u32>(GPU_REG_INDEX(framebuffer_config[1].active_fb)),
-                info.shown_fb);
-            break;
+    if (info.active_fb == 0) {
+        WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
+                                                framebuffer_config[screen_id].address_left1)),
+                         phys_address_left);
+        WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
+                                                framebuffer_config[screen_id].address_right1)),
+                         phys_address_right);
+    } else {
+        WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
+                                                framebuffer_config[screen_id].address_left2)),
+                         phys_address_left);
+        WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
+                                                framebuffer_config[screen_id].address_right2)),
+                         phys_address_right);
     }
+    WriteSingleHWReg(base_address +
+                         4 * static_cast<u32>(GPU_REG_INDEX(framebuffer_config[screen_id].stride)),
+                     info.stride);
+    WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
+                                            framebuffer_config[screen_id].color_format)),
+                     info.format);
+    WriteSingleHWReg(
+        base_address + 4 * static_cast<u32>(GPU_REG_INDEX(framebuffer_config[screen_id].active_fb)),
+        info.shown_fb);
 
     if (Pica::g_debug_context)
         Pica::g_debug_context->OnEvent(Pica::DebugContext::Event::BufferSwapped, nullptr);

--- a/src/core/hle/service/gsp/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp/gsp_gpu.cpp
@@ -282,30 +282,29 @@ ResultCode SetBufferSwap(u32 screen_id, const FrameBufferInfo& info) {
     u32 base_address = 0x400000;
     PAddr phys_address_left = VirtualToPhysicalAddress(info.address_left);
     PAddr phys_address_right = VirtualToPhysicalAddress(info.address_right);
-    GPU::Regs l_gpu_regs;
     if (info.active_fb == 0) {
         WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_FRAMEBUFFER_REG_INDEX(
-                                                &l_gpu_regs, screen_id, address_left1)),
+                                                screen_id, address_left1)),
                          phys_address_left);
         WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_FRAMEBUFFER_REG_INDEX(
-                                                &l_gpu_regs, screen_id, address_right1)),
+                                                screen_id, address_right1)),
                          phys_address_right);
     } else {
         WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_FRAMEBUFFER_REG_INDEX(
-                                                &l_gpu_regs, screen_id, address_left2)),
+                                                screen_id, address_left2)),
                          phys_address_left);
         WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_FRAMEBUFFER_REG_INDEX(
-                                                &l_gpu_regs, screen_id, address_right2)),
+                                                screen_id, address_right2)),
                          phys_address_right);
     }
     WriteSingleHWReg(base_address +
-                         4 * static_cast<u32>(GPU_FRAMEBUFFER_REG_INDEX(&l_gpu_regs, screen_id, stride)),
+                         4 * static_cast<u32>(GPU_FRAMEBUFFER_REG_INDEX(screen_id, stride)),
                      info.stride);
     WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_FRAMEBUFFER_REG_INDEX(
-                                            &l_gpu_regs, screen_id, color_format)),
+                                            screen_id, color_format)),
                      info.format);
     WriteSingleHWReg(
-        base_address + 4 * static_cast<u32>(GPU_FRAMEBUFFER_REG_INDEX(&l_gpu_regs, screen_id, active_fb)),
+        base_address + 4 * static_cast<u32>(GPU_FRAMEBUFFER_REG_INDEX(screen_id, active_fb)),
         info.shown_fb);
 
     if (Pica::g_debug_context)

--- a/src/core/hle/service/gsp/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp/gsp_gpu.cpp
@@ -282,30 +282,61 @@ ResultCode SetBufferSwap(u32 screen_id, const FrameBufferInfo& info) {
     u32 base_address = 0x400000;
     PAddr phys_address_left = VirtualToPhysicalAddress(info.address_left);
     PAddr phys_address_right = VirtualToPhysicalAddress(info.address_right);
-    if (info.active_fb == 0) {
-        WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
-                                                framebuffer_config[screen_id].address_left1)),
-                         phys_address_left);
-        WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
-                                                framebuffer_config[screen_id].address_right1)),
-                         phys_address_right);
-    } else {
-        WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
-                                                framebuffer_config[screen_id].address_left2)),
-                         phys_address_left);
-        WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
-                                                framebuffer_config[screen_id].address_right2)),
-                         phys_address_right);
+    switch(screen_id)
+    {
+        case 0:
+            if (info.active_fb == 0) {
+                WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
+                                                        framebuffer_config[0].address_left1)),
+                                phys_address_left);
+                WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
+                                                        framebuffer_config[0].address_right1)),
+                                phys_address_right);
+            } else {
+                WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
+                                                        framebuffer_config[0].address_left2)),
+                                phys_address_left);
+                WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
+                                                        framebuffer_config[0].address_right2)),
+                                phys_address_right);
+            }
+            WriteSingleHWReg(base_address +
+                                4 * static_cast<u32>(GPU_REG_INDEX(framebuffer_config[0].stride)),
+                            info.stride);
+            WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
+                                                    framebuffer_config[0].color_format)),
+                            info.format);
+            WriteSingleHWReg(
+                base_address + 4 * static_cast<u32>(GPU_REG_INDEX(framebuffer_config[0].active_fb)),
+                info.shown_fb);
+            break;
+        case 1:
+            if (info.active_fb == 0) {
+                WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
+                                                        framebuffer_config[1].address_left1)),
+                                phys_address_left);
+                WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
+                                                        framebuffer_config[1].address_right1)),
+                                phys_address_right);
+            } else {
+                WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
+                                                        framebuffer_config[1].address_left2)),
+                                phys_address_left);
+                WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
+                                                        framebuffer_config[1].address_right2)),
+                                phys_address_right);
+            }
+            WriteSingleHWReg(base_address +
+                                4 * static_cast<u32>(GPU_REG_INDEX(framebuffer_config[1].stride)),
+                            info.stride);
+            WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
+                                                    framebuffer_config[1].color_format)),
+                            info.format);
+            WriteSingleHWReg(
+                base_address + 4 * static_cast<u32>(GPU_REG_INDEX(framebuffer_config[1].active_fb)),
+                info.shown_fb);
+            break;
     }
-    WriteSingleHWReg(base_address +
-                         4 * static_cast<u32>(GPU_REG_INDEX(framebuffer_config[screen_id].stride)),
-                     info.stride);
-    WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_REG_INDEX(
-                                            framebuffer_config[screen_id].color_format)),
-                     info.format);
-    WriteSingleHWReg(
-        base_address + 4 * static_cast<u32>(GPU_REG_INDEX(framebuffer_config[screen_id].active_fb)),
-        info.shown_fb);
 
     if (Pica::g_debug_context)
         Pica::g_debug_context->OnEvent(Pica::DebugContext::Event::BufferSwapped, nullptr);

--- a/src/core/hle/service/gsp/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp/gsp_gpu.cpp
@@ -300,12 +300,12 @@ ResultCode SetBufferSwap(u32 screen_id, const FrameBufferInfo& info) {
     WriteSingleHWReg(base_address +
                          4 * static_cast<u32>(GPU_FRAMEBUFFER_REG_INDEX(screen_id, stride)),
                      info.stride);
-    WriteSingleHWReg(base_address + 4 * static_cast<u32>(GPU_FRAMEBUFFER_REG_INDEX(
-                                            screen_id, color_format)),
+    WriteSingleHWReg(base_address +
+                         4 * static_cast<u32>(GPU_FRAMEBUFFER_REG_INDEX(screen_id, color_format)),
                      info.format);
-    WriteSingleHWReg(
-        base_address + 4 * static_cast<u32>(GPU_FRAMEBUFFER_REG_INDEX(screen_id, active_fb)),
-        info.shown_fb);
+    WriteSingleHWReg(base_address +
+                         4 * static_cast<u32>(GPU_FRAMEBUFFER_REG_INDEX(screen_id, active_fb)),
+                     info.shown_fb);
 
     if (Pica::g_debug_context)
         Pica::g_debug_context->OnEvent(Pica::DebugContext::Event::BufferSwapped, nullptr);

--- a/src/core/hw/gpu.h
+++ b/src/core/hw/gpu.h
@@ -30,6 +30,11 @@ constexpr double SCREEN_REFRESH_RATE = BASE_CLOCK_RATE_ARM11 / static_cast<doubl
 // Returns index corresponding to the Regs member labeled by field_name
 #define GPU_REG_INDEX(field_name) (offsetof(GPU::Regs, field_name) / sizeof(u32))
 
+// Returns index corresponding to the Regs::FramebufferConfig labeled by field_name
+// gpu_regs_ptr is a pointer to Regs, screen_id is a subscript for Regs::framebuffer_config
+#define GPU_FRAMEBUFFER_REG_INDEX(gpu_regs_ptr, screen_id, field_name) (((char*)((gpu_regs_ptr)->framebuffer_config+screen_id) - (char*)(gpu_regs_ptr) + \
+    offsetof(GPU::Regs::FramebufferConfig, field_name)) / sizeof(u32))
+
 // MMIO region 0x1EFxxxxx
 struct Regs {
 

--- a/src/core/hw/gpu.h
+++ b/src/core/hw/gpu.h
@@ -32,8 +32,11 @@ constexpr double SCREEN_REFRESH_RATE = BASE_CLOCK_RATE_ARM11 / static_cast<doubl
 
 // Returns index corresponding to the Regs::FramebufferConfig labeled by field_name
 // screen_id is a subscript for Regs::framebuffer_config
-#define GPU_FRAMEBUFFER_REG_INDEX(screen_id, field_name) ((offsetof(GPU::Regs, framebuffer_config) + sizeof(GPU::Regs::FramebufferConfig) * (screen_id) + \
-    offsetof(GPU::Regs::FramebufferConfig, field_name)) / sizeof(u32))
+#define GPU_FRAMEBUFFER_REG_INDEX(screen_id, field_name)                                           \
+    ((offsetof(GPU::Regs, framebuffer_config) +                                                    \
+      sizeof(GPU::Regs::FramebufferConfig) * (screen_id) +                                         \
+      offsetof(GPU::Regs::FramebufferConfig, field_name)) /                                        \
+     sizeof(u32))
 
 // MMIO region 0x1EFxxxxx
 struct Regs {

--- a/src/core/hw/gpu.h
+++ b/src/core/hw/gpu.h
@@ -31,8 +31,8 @@ constexpr double SCREEN_REFRESH_RATE = BASE_CLOCK_RATE_ARM11 / static_cast<doubl
 #define GPU_REG_INDEX(field_name) (offsetof(GPU::Regs, field_name) / sizeof(u32))
 
 // Returns index corresponding to the Regs::FramebufferConfig labeled by field_name
-// gpu_regs_ptr is a pointer to Regs, screen_id is a subscript for Regs::framebuffer_config
-#define GPU_FRAMEBUFFER_REG_INDEX(gpu_regs_ptr, screen_id, field_name) (((char*)((gpu_regs_ptr)->framebuffer_config+screen_id) - (char*)(gpu_regs_ptr) + \
+// screen_id is a subscript for Regs::framebuffer_config
+#define GPU_FRAMEBUFFER_REG_INDEX(screen_id, field_name) ((offsetof(GPU::Regs, framebuffer_config) + sizeof(GPU::Regs::FramebufferConfig) * (screen_id) + \
     offsetof(GPU::Regs::FramebufferConfig, field_name)) / sizeof(u32))
 
 // MMIO region 0x1EFxxxxx


### PR DESCRIPTION
I encountered two problems while trying to compile Citra in Fedora 34 using gcc 11.
1. Missing include
2. offsetof macro problem. Looks like in gcc 11 this macro can not be used at runtime anymore, only at compile-time, so runtime variables can not be used as an array subscript. I made a fix for that but it looks a bit clunky. Can someone review it please, may be there's more elegant solution?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5778)
<!-- Reviewable:end -->
