### PR TITLE
sdl2_sink: remove SDL_AUDIO_ALLOW_FREQUENCY_CHANGE flag

### DIFF
--- a/src/audio_core/sdl2_sink.cpp
+++ b/src/audio_core/sdl2_sink.cpp
@@ -46,8 +46,8 @@ SDL2Sink::SDL2Sink(std::string device_name) : impl(std::make_unique<Impl>()) {
         device = device_name.c_str();
     }
 
-    impl->audio_device_id = SDL_OpenAudioDevice(
-        device, false, &desired_audiospec, &obtained_audiospec, SDL_AUDIO_ALLOW_FREQUENCY_CHANGE);
+    impl->audio_device_id =
+        SDL_OpenAudioDevice(device, false, &desired_audiospec, &obtained_audiospec, 0);
     if (impl->audio_device_id <= 0) {
         LOG_CRITICAL(Audio_Sink, "SDL_OpenAudioDevice failed with code {} for device \"{}\"",
                      impl->audio_device_id, device_name);


### PR DESCRIPTION
This is necessary for sdl audio to work properly in sdl as of current dev version (2.0.15)
Check libsdl-org/SDL#4342 and the commit linked there for more details, but basically they fixed a bug with the use of WASAPI's resampler and apparently that bug might be the cause of our audio working normally up to that point.

This change was only tested on windows for now.
As it'll take a while for 2.0.16 to come out and for us to adopt it, merging this change is not very pressing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5779)
<!-- Reviewable:end -->
