### PR TITLE
Disable disk shader cache when GL_ARB_get_program_binary is unsupported

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
@@ -365,10 +365,6 @@ void ShaderDiskCache::SaveDecompiled(u64 unique_identifier,
 void ShaderDiskCache::SaveDump(u64 unique_identifier, GLuint program) {
     if (!IsUsable())
         return;
-    if (!GLAD_GL_ARB_get_program_binary) {
-        LOG_WARNING(Render_OpenGL, "ARB_get_program_binary is not supported. Problems may occur if "
-                                   "use_disk_shader_cache is ON.");
-    }
 
     GLint binary_length{};
     glGetProgramiv(program, GL_PROGRAM_BINARY_LENGTH, &binary_length);

--- a/src/video_core/renderer_opengl/gl_shader_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_manager.cpp
@@ -442,6 +442,12 @@ void ShaderProgramManager::LoadDiskCache(const std::atomic_bool& stop_loading,
                   "Cannot load disk cache as separate shader programs are unsupported!");
         return;
     }
+    if (!GLAD_GL_ARB_get_program_binary) {
+        LOG_ERROR(Render_OpenGL,
+                  "Cannot load disk cache as ARB_get_program_binary is not supported!");
+        return;
+    }
+
     auto& disk_cache = impl->disk_cache;
     const auto transferable = disk_cache.LoadTransferable();
     if (!transferable) {


### PR DESCRIPTION
#5756 added a warning for `GL_ARB_get_program_binary` but it seems like citra crashes before the warning can be logged, with this we straight up disable the shader cache when the extension is not supported. 

At least according to gpuinfo.org(I'm not sure if there is a more up to date DB somewhere else), only ~20% of devices don't support the extension, and most of them seem to be very old GPUs; So, there might not actually be any modern GPUs that support the functionality without supporting the extension.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5785)
<!-- Reviewable:end -->
