### PR TITLE
service/frd: return cfg username on GetMyScreenName

### DIFF
--- a/src/core/hle/service/frd/frd.h
+++ b/src/core/hle/service/frd/frd.h
@@ -50,7 +50,7 @@ struct Profile {
 
 class Module final {
 public:
-    Module();
+    explicit Module(Core::System& system);
     ~Module();
 
     class Interface : public ServiceFramework<Interface> {
@@ -153,6 +153,7 @@ public:
 private:
     FriendKey my_friend_key = {0, 0, 0ull};
     MyPresence my_presence = {};
+    Core::System& system;
 
     template <class Archive>
     void serialize(Archive& ar, const unsigned int) {
@@ -165,3 +166,5 @@ private:
 void InstallInterfaces(Core::System& system);
 
 } // namespace Service::FRD
+
+SERVICE_CONSTRUCT(Service::FRD::Module)


### PR DESCRIPTION
Some games apparently use this for the multiplayer display name.
According to [this post](https://community.citra-emu.org/t/name-specified-in-system-settings-doesnt-change-multiplayer-name/414197) on the forums, some examples of games that do that are Mario Sports Superstars and Metroid Prime Federation Force.
I don't have any affected games so I haven't tested this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5792)
<!-- Reviewable:end -->
