### PR TITLE
Minor fx

### DIFF
--- a/src/network/room.cpp
+++ b/src/network/room.cpp
@@ -251,7 +251,7 @@ public:
 void Room::RoomImpl::ServerLoop() {
     while (state != State::Closed) {
         ENetEvent event;
-        if (enet_host_service(server, &event, 50) > 0) {
+        if (enet_host_service(server, &event, 16) > 0) {
             switch (event.type) {
             case ENET_EVENT_TYPE_RECEIVE:
                 switch (event.packet->data[0]) {

--- a/src/network/room_member.cpp
+++ b/src/network/room_member.cpp
@@ -159,7 +159,7 @@ void RoomMember::RoomMemberImpl::MemberLoop() {
     while (IsConnected()) {
         std::lock_guard lock(network_mutex);
         ENetEvent event;
-        if (enet_host_service(client, &event, 100) > 0) {
+        if (enet_host_service(client, &event, 16) > 0) {
             switch (event.type) {
             case ENET_EVENT_TYPE_RECEIVE:
                 switch (event.packet->data[0]) {
@@ -251,16 +251,18 @@ void RoomMember::RoomMemberImpl::MemberLoop() {
                 break;
             }
         }
+
+        std::list<Packet> packets;
         {
             std::lock_guard lock(send_list_mutex);
-            for (const auto& packet : send_list) {
-                ENetPacket* enetPacket = enet_packet_create(packet.GetData(), packet.GetDataSize(),
-                                                            ENET_PACKET_FLAG_RELIABLE);
-                enet_peer_send(server, 0, enetPacket);
-            }
-            enet_host_flush(client);
-            send_list.clear();
+            packets.swap(send_list);
         }
+        for (const auto& packet : packets) {
+            ENetPacket* enetPacket = enet_packet_create(packet.GetData(), packet.GetDataSize(),
+                                                        ENET_PACKET_FLAG_RELIABLE);
+            enet_peer_send(server, 0, enetPacket);
+        }
+        enet_host_flush(client);
     }
     Disconnect();
 };

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -111,7 +111,7 @@ out gl_PerVertex {
 }
 
 PicaFSConfig PicaFSConfig::BuildFromRegs(const Pica::Regs& regs) {
-    PicaFSConfig res;
+    PicaFSConfig res{};
 
     auto& state = res.state;
 


### PR DESCRIPTION
make sure `PicaFSConfig` be initialized, prevent garbage data or it may generate a lot of duplicate shaders.
decrease network poll timeout, reduce network latency. use New Super Mario Bros. for test.
externals: update enet

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5804)
<!-- Reviewable:end -->
