### PR TITLE
FE: Awakening bloom hack

### DIFF
--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -490,6 +490,7 @@ void Config::ReadRendererValues() {
     Settings::values.use_shader_jit = ReadSetting(QStringLiteral("use_shader_jit"), true).toBool();
     Settings::values.use_disk_shader_cache =
         ReadSetting(QStringLiteral("use_disk_shader_cache"), true).toBool();
+    Settings::values.use_bloom_hack = ReadSetting(QStringLiteral("use_bloom_hack"), true).toBool();
     Settings::values.use_vsync_new = ReadSetting(QStringLiteral("use_vsync_new"), true).toBool();
     Settings::values.resolution_factor =
         static_cast<u16>(ReadSetting(QStringLiteral("resolution_factor"), 1).toInt());
@@ -999,6 +1000,7 @@ void Config::SaveRendererValues() {
     WriteSetting(QStringLiteral("use_shader_jit"), Settings::values.use_shader_jit, true);
     WriteSetting(QStringLiteral("use_disk_shader_cache"), Settings::values.use_disk_shader_cache,
                  true);
+    WriteSetting(QStringLiteral("use_bloom_hack"), Settings::values.use_bloom_hack, true);
     WriteSetting(QStringLiteral("use_vsync_new"), Settings::values.use_vsync_new, true);
     WriteSetting(QStringLiteral("resolution_factor"), Settings::values.resolution_factor, 1);
     WriteSetting(QStringLiteral("frame_limit"), Settings::values.frame_limit, 100);

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -32,6 +32,7 @@ void Apply() {
     VideoCore::g_separable_shader_enabled = values.separable_shader;
     VideoCore::g_hw_shader_accurate_mul = values.shaders_accurate_mul;
     VideoCore::g_use_disk_shader_cache = values.use_disk_shader_cache;
+    VideoCore::g_use_bloom_hack = values.use_bloom_hack;
 
     if (VideoCore::g_renderer) {
         VideoCore::g_renderer->UpdateCurrentFramebufferLayout();
@@ -92,6 +93,7 @@ void LogSettings() {
     log_setting("Renderer_PostProcessingShader", values.pp_shader_name);
     log_setting("Renderer_FilterMode", values.filter_mode);
     log_setting("Renderer_TextureFilterName", values.texture_filter_name);
+    log_setting("Renderer_UseBloomHack", values.use_bloom_hack);
     log_setting("Stereoscopy_Render3d", values.render_3d);
     log_setting("Stereoscopy_Factor3d", values.factor_3d);
     log_setting("Layout_LayoutOption", values.layout_option);

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -154,6 +154,7 @@ struct Values {
     bool use_hw_shader;
     bool separable_shader;
     bool use_disk_shader_cache;
+    bool use_bloom_hack;
     bool shaders_accurate_mul;
     bool use_shader_jit;
     u16 resolution_factor;

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -1532,7 +1532,16 @@ bool RasterizerOpenGL::AccelerateTextureCopy(const GPU::Regs::DisplayTransferCon
     dst_params.stride = dst_params.width + src_surface->PixelsInBytes(
                                                src_surface->is_tiled ? output_gap / 8 : output_gap);
     dst_params.height = src_rect.GetHeight() / src_surface->res_scale;
-    dst_params.res_scale = src_surface->res_scale;
+
+    // Some games (e.g., FE: Awakening) `TexturCopy` at a resolution lower than the native 3DS
+    // resolution to simulate bloom, rendering these at an upscaled resolution creates ghosting
+    // artifacts.
+    if (VideoCore::g_use_bloom_hack && src_surface->res_scale > 1 &&
+        (dst_params.height < 400 || dst_params.width < 240)) {
+        dst_params.res_scale = 1;
+    } else {
+        dst_params.res_scale = src_surface->res_scale;
+    }
     dst_params.UpdateParams();
 
     // Since we are going to invalidate the gap if there is one, we will have to load it first

--- a/src/video_core/video_core.cpp
+++ b/src/video_core/video_core.cpp
@@ -26,6 +26,7 @@ std::atomic<bool> g_hw_shader_enabled;
 std::atomic<bool> g_separable_shader_enabled;
 std::atomic<bool> g_hw_shader_accurate_mul;
 std::atomic<bool> g_use_disk_shader_cache;
+std::atomic<bool> g_use_bloom_hack;
 std::atomic<bool> g_renderer_bg_color_update_requested;
 std::atomic<bool> g_renderer_sampler_update_requested;
 std::atomic<bool> g_renderer_shader_update_requested;

--- a/src/video_core/video_core.h
+++ b/src/video_core/video_core.h
@@ -34,6 +34,7 @@ extern std::atomic<bool> g_hw_shader_enabled;
 extern std::atomic<bool> g_separable_shader_enabled;
 extern std::atomic<bool> g_hw_shader_accurate_mul;
 extern std::atomic<bool> g_use_disk_shader_cache;
+extern std::atomic<bool> g_use_bloom_hack;
 extern std::atomic<bool> g_renderer_bg_color_update_requested;
 extern std::atomic<bool> g_renderer_sampler_update_requested;
 extern std::atomic<bool> g_renderer_shader_update_requested;


### PR DESCRIPTION
Implements the "bloom hack" to render low-res screen textures at the resolution the game requests instead of upscaling it. This is similar to what PPSSPP does (https://github.com/hrydgard/ppsspp/pull/7365), I don't know how useful it is to have a setting based on resolution like PPSSPP, so it is a simple toggle for now.

This hack is extremely game specific and does not resolve/improve ghosting in games like Pokemon and Majora's Mask, I've only tested this with Fire Emblem: Awakening, but I expect it to work with other FE games as well. Given this specificity, I'm a bit conflicted on whether it should be merged into Citra... Opening this PR anyway for documentation I guess. 

For those curious, FE: Awakening uses the `TextureCopy`  once at "native" res of `416x216`, two more times at lower res of `128x128` and `32x16` to render the scene and the bloom. 

If we decide to merge this, some things that need to be taken care of
- [ ] Add the UI stuff
- [ ] Default the setting to `false` (currently `true` for testing)
- [ ] Add option to the SDL config
- [ ] Anything else that comes up

The issue is closed, but "fixes" #4875

4x Scaling w/ Bloom hack
![bloom_hack](https://user-images.githubusercontent.com/26602104/124384843-c2006680-dcf0-11eb-8bd5-70d3d0a9636e.png)


<details>
    <summary>More screenshots</summary>

4x Scaling w/o Bloom hack
![no bloom hack - Copy](https://user-images.githubusercontent.com/26602104/124384864-e52b1600-dcf0-11eb-9134-0a93f3aaf4e2.png)

1x Scaling
![no bloom hack 1x](https://user-images.githubusercontent.com/26602104/124384876-ef4d1480-dcf0-11eb-9556-61ae2f4b7edd.png)
</details>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5808)
<!-- Reviewable:end -->
