### PR TITLE
Port yuzu-emu/yuzu#6484: "update submodule discord-rpc to latest [now deprecated]"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -39,7 +39,7 @@
     url = https://github.com/kinetiknz/cubeb.git
 [submodule "discord-rpc"]
     path = externals/discord-rpc
-    url = https://github.com/discordapp/discord-rpc.git
+    url = https://github.com/discord/discord-rpc.git
 [submodule "cpp-jwt"]
     path = externals/cpp-jwt
     url = https://github.com/arun11299/cpp-jwt.git


### PR DESCRIPTION
See yuzu-emu/yuzu#6484 for more details.

**Original description:**
This PR updates the discord-rpc submodule to last upstream commit, before it was deprecated in favour of Discord's new GameSDK. Since the new SDK is closed-source, we can't upgrade to it.

However, Discord RPC still uses the same underlying code for Rich Presence and hence RPC compatibilty is not broken (yet!).

The changes from last-updated commit include few minor bugfixes and readme changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5810)
<!-- Reviewable:end -->
