### PR TITLE
Replace `&vec[0]` with `vec.data()`

### DIFF
--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -784,7 +784,7 @@ std::size_t ReadFileToString(bool text_file, const std::string& filename, std::s
         return 0;
 
     str.resize(static_cast<u32>(file.GetSize()));
-    return file.ReadArray(&str[0], str.size());
+    return file.ReadArray(str.data(), str.size());
 }
 
 void SplitFilename83(const std::string& filename, std::array<char, 9>& short_name,

--- a/src/core/file_sys/ncch_container.cpp
+++ b/src/core/file_sys/ncch_container.cpp
@@ -554,15 +554,16 @@ Loader::ResultStatus NCCHContainer::LoadSectionExeFS(const char* name, std::vect
                 // Decompress .code section...
                 u32 decompressed_size = LZSS_GetDecompressedSize(&temp_buffer[0], section.size);
                 buffer.resize(decompressed_size);
-                if (!LZSS_Decompress(&temp_buffer[0], section.size, &buffer[0], decompressed_size))
+                if (!LZSS_Decompress(&temp_buffer[0], section.size, buffer.data(),
+                                     decompressed_size))
                     return Loader::ResultStatus::ErrorInvalidFormat;
             } else {
                 // Section is uncompressed...
                 buffer.resize(section.size);
-                if (exefs_file.ReadBytes(&buffer[0], section.size) != section.size)
+                if (exefs_file.ReadBytes(buffer.data(), section.size) != section.size)
                     return Loader::ResultStatus::Error;
                 if (is_encrypted) {
-                    dec.ProcessData(&buffer[0], &buffer[0], section.size);
+                    dec.ProcessData(buffer.data(), buffer.data(), section.size);
                 }
             }
 
@@ -641,7 +642,7 @@ Loader::ResultStatus NCCHContainer::LoadOverrideExeFSSection(const char* name,
             buffer.resize(section_size);
 
             section_file.Seek(0, SEEK_SET);
-            if (section_file.ReadBytes(&buffer[0], section_size) == section_size) {
+            if (section_file.ReadBytes(buffer.data(), section_size) == section_size) {
                 LOG_WARNING(Service_FS, "File {} overriding built-in ExeFS file", path);
                 return Loader::ResultStatus::Success;
             }

--- a/src/core/loader/3dsx.cpp
+++ b/src/core/loader/3dsx.cpp
@@ -342,7 +342,7 @@ ResultStatus AppLoader_THREEDSX::ReadIcon(std::vector<u8>& buffer) {
         file.Seek(hdr.smdh_offset, SEEK_SET);
         buffer.resize(hdr.smdh_size);
 
-        if (file.ReadBytes(&buffer[0], hdr.smdh_size) != hdr.smdh_size)
+        if (file.ReadBytes(buffer.data(), hdr.smdh_size) != hdr.smdh_size)
             return ResultStatus::Error;
 
         return ResultStatus::Success;


### PR DESCRIPTION
When the vector is empty, using `&vec[0]` involves undefined behaviour. While that works fine most of the time, Flatpak builds aborted on an assertion or sth around `__builtin_expect`.

I searched for such occurences across the codebase with the regex `(?<!&)&\w+\[0\]` and fixed those that would potentially cause issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5817)
<!-- Reviewable:end -->
