### PR TITLE
added optimised versions (unrolled and SIMD) of ConvertYUVToRGB

### DIFF
--- a/src/core/hw/y2r.cpp
+++ b/src/core/hw/y2r.cpp
@@ -15,6 +15,10 @@
 #include "core/hw/y2r.h"
 #include "core/memory.h"
 
+#ifdef __SSE4_1__
+#include <immintrin.h>
+#endif
+
 namespace HW::Y2R {
 
 using namespace Service::Y2R;
@@ -23,56 +27,427 @@ static const std::size_t MAX_TILES = 1024 / 8;
 static const std::size_t TILE_SIZE = 8 * 8;
 using ImageTile = std::array<u32, TILE_SIZE>;
 
-/// Converts a image strip from the source YUV format into individual 8x8 RGB32 tiles.
-static void ConvertYUVToRGB(InputFormat input_format, const u8* input_Y, const u8* input_U,
-                            const u8* input_V, ImageTile output[], unsigned int width,
-                            unsigned int height, const CoefficientSet& coefficients) {
+// The following section uses SSE 4.1 as it is available on most X86 CPUs
+// and is easy to port to ARM NEON
+#ifdef __SSE4_1__
+
+// This function uses SIMD intrinsics to speed up the conversion
+// The floating point method is simpler in this case
+static void ConvertYUVToRGB_YUV422_420(InputFormat input_format, const u8* __restrict__ input_Y,
+                                       const u8* __restrict__ input_U,
+                                       const u8* __restrict__ input_V, ImageTile output[],
+                                       unsigned int width, unsigned int height,
+                                       const CoefficientSet& coefficients) {
+
+    // Floating point coefficients are used. The function argument is kept to match the
+    // non vectorised version of this function
+    // R = Y + 1.402 * (V-128)
+    // G = Y -0.344*(U-128) - 0.714*(V-128)
+    // B = Y +  1.772*(U-128)
+    __m128 c0, c1, c2, c3;
+    c0 = _mm_set1_ps(1.402f);
+    c1 = _mm_set1_ps(-0.344f);
+    c2 = _mm_set1_ps(-0.714f);
+    c3 = _mm_set1_ps(1.772f);
+
+    __m128 zero_float = _mm_setzero_ps();
+    __m128i zero_int = _mm_setzero_si128();
+    __m128i half_byte_int = _mm_set1_epi16(128);
+    __m128 max_byte_float = _mm_set1_ps(255.0f);
+    __m128i uv_mask_lo = _mm_set_epi8(7, 7, 6, 6, 5, 5, 4, 4, 3, 3, 2, 2, 1, 1, 0, 0);
 
     for (unsigned int y = 0; y < height; ++y) {
-        for (unsigned int x = 0; x < width; ++x) {
-            s32 Y = 0;
-            s32 U = 0;
-            s32 V = 0;
+        for (unsigned int x = 0; x < width; x += 16) {
+            int y_offset, uv_offset;
             switch (input_format) {
             case InputFormat::YUV422_Indiv8:
             case InputFormat::YUV422_Indiv16:
-                Y = input_Y[y * width + x];
-                U = input_U[(y * width + x) / 2];
-                V = input_V[(y * width + x) / 2];
+                y_offset = y * width + x;
+                uv_offset = (y * width + x) / 2;
                 break;
             case InputFormat::YUV420_Indiv8:
             case InputFormat::YUV420_Indiv16:
-                Y = input_Y[y * width + x];
-                U = input_U[((y / 2) * width + x) / 2];
-                V = input_V[((y / 2) * width + x) / 2];
+                y_offset = y * width + x;
+                uv_offset = ((y / 2) * width + x) / 2;
                 break;
-            case InputFormat::YUYV422_Interleaved:
-                Y = input_Y[(y * width + x) * 2];
-                U = input_Y[(y * width + (x / 2) * 2) * 2 + 1];
-                V = input_Y[(y * width + (x / 2) * 2) * 2 + 3];
+            default:
+                y_offset = 0;
+                uv_offset = 0;
                 break;
             }
 
-            // This conversion process is bit-exact with hardware, as far as could be tested.
-            auto& c = coefficients;
-            s32 cY = c[0] * Y;
+            // No assumption here on the alignement of the pointers,
+            // sticking with the unaligned load/stores
+            // We load unsigned 8bit integers and need to convert them to 32bit floats
+            // They are first converted to signed 16bit integers, then to signed 32bit integers
+            __m128i Y_vec = _mm_loadu_si128(reinterpret_cast<__m128i const*>(input_Y + y_offset));
+            __m128i Y_vec_lo = _mm_cvtepu8_epi16(Y_vec);
+            __m128i Y_vec_hi = _mm_unpackhi_epi8(Y_vec, zero_int);
 
-            s32 r = cY + c[1] * V;
-            s32 g = cY - c[2] * V - c[3] * U;
-            s32 b = cY + c[4] * U;
+            __m128i U_vec = _mm_loadu_si128(reinterpret_cast<__m128i const*>(input_U + uv_offset));
+            // The uv_mask_lo is used to double the values in the vector
+            U_vec = _mm_shuffle_epi8(U_vec, uv_mask_lo);
+            __m128i U_vec_lo = _mm_cvtepu8_epi16(U_vec);
+            __m128i U_vec_hi = _mm_unpackhi_epi8(U_vec, zero_int);
 
-            const s32 rounding_offset = 0x18;
-            r = (r >> 3) + c[5] + rounding_offset;
-            g = (g >> 3) + c[6] + rounding_offset;
-            b = (b >> 3) + c[7] + rounding_offset;
+            __m128i V_vec = _mm_loadu_si128(reinterpret_cast<__m128i const*>(input_V + uv_offset));
+            V_vec = _mm_shuffle_epi8(V_vec, uv_mask_lo);
+            __m128i V_vec_lo = _mm_cvtepu8_epi16(V_vec);
+            __m128i V_vec_hi = _mm_unpackhi_epi8(V_vec, zero_int);
+
+            // subtracting 128 to U and V when they are still in 16bit form,
+            // which should be faster than doing it on 32bit floats
+            U_vec_lo = _mm_sub_epi16(U_vec_lo, half_byte_int);
+            U_vec_hi = _mm_sub_epi16(U_vec_hi, half_byte_int);
+
+            V_vec_lo = _mm_sub_epi16(V_vec_lo, half_byte_int);
+            V_vec_hi = _mm_sub_epi16(V_vec_hi, half_byte_int);
+
+            __m128 Y0to3 = _mm_cvtepi32_ps(_mm_cvtepi16_epi32(Y_vec_lo));
+            __m128 Y4to7 =
+                _mm_cvtepi32_ps(_mm_cvtepi16_epi32(_mm_unpackhi_epi64(Y_vec_lo, zero_int)));
+            __m128 Y8to11 = _mm_cvtepi32_ps(_mm_cvtepi16_epi32(Y_vec_hi));
+            __m128 Y12to15 =
+                _mm_cvtepi32_ps(_mm_cvtepi16_epi32(_mm_unpackhi_epi64(Y_vec_hi, zero_int)));
+
+            __m128 U0to3 = _mm_cvtepi32_ps(_mm_cvtepi16_epi32(U_vec_lo));
+            __m128 U4to7 =
+                _mm_cvtepi32_ps(_mm_cvtepi16_epi32(_mm_unpackhi_epi64(U_vec_lo, zero_int)));
+            __m128 U8to11 = _mm_cvtepi32_ps(_mm_cvtepi16_epi32(U_vec_hi));
+            __m128 U12to15 =
+                _mm_cvtepi32_ps(_mm_cvtepi16_epi32(_mm_unpackhi_epi64(U_vec_hi, zero_int)));
+
+            __m128 V0to3 = _mm_cvtepi32_ps(_mm_cvtepi16_epi32(V_vec_lo));
+            __m128 V4to7 =
+                _mm_cvtepi32_ps(_mm_cvtepi16_epi32(_mm_unpackhi_epi64(V_vec_lo, zero_int)));
+            __m128 V8to11 = _mm_cvtepi32_ps(_mm_cvtepi16_epi32(V_vec_hi));
+            __m128 V12to15 =
+                _mm_cvtepi32_ps(_mm_cvtepi16_epi32(_mm_unpackhi_epi64(V_vec_hi, zero_int)));
+
+            __m128 r0to3 = _mm_add_ps(_mm_mul_ps(c0, V0to3), Y0to3);
+            __m128 r4to7 = _mm_add_ps(_mm_mul_ps(c0, V4to7), Y4to7);
+            __m128 r8to11 = _mm_add_ps(_mm_mul_ps(c0, V8to11), Y8to11);
+            __m128 r12to15 = _mm_add_ps(_mm_mul_ps(c0, V12to15), Y12to15);
+
+            __m128 g0to3 = _mm_add_ps(Y0to3, _mm_mul_ps(c1, U0to3));
+            __m128 g4to7 = _mm_add_ps(Y4to7, _mm_mul_ps(c1, U4to7));
+            __m128 g8to11 = _mm_add_ps(Y8to11, _mm_mul_ps(c1, U8to11));
+            __m128 g12to15 = _mm_add_ps(Y12to15, _mm_mul_ps(c1, U12to15));
+            g0to3 = _mm_add_ps(g0to3, _mm_mul_ps(c2, V0to3));
+            g4to7 = _mm_add_ps(g4to7, _mm_mul_ps(c2, V4to7));
+            g8to11 = _mm_add_ps(g8to11, _mm_mul_ps(c2, V8to11));
+            g12to15 = _mm_add_ps(g12to15, _mm_mul_ps(c2, V12to15));
+
+            __m128 b0to3 = _mm_add_ps(_mm_mul_ps(c3, U0to3), Y0to3);
+            __m128 b4to7 = _mm_add_ps(_mm_mul_ps(c3, U4to7), Y4to7);
+            __m128 b8to11 = _mm_add_ps(_mm_mul_ps(c3, U8to11), Y8to11);
+            __m128 b12to15 = _mm_add_ps(_mm_mul_ps(c3, U12to15), Y12to15);
+
+            // clamp the values between 0.0f and 255.0f
+            r0to3 = _mm_min_ps(r0to3, max_byte_float);
+            r4to7 = _mm_min_ps(r4to7, max_byte_float);
+            r8to11 = _mm_min_ps(r8to11, max_byte_float);
+            r12to15 = _mm_min_ps(r12to15, max_byte_float);
+
+            g0to3 = _mm_min_ps(g0to3, max_byte_float);
+            g4to7 = _mm_min_ps(g4to7, max_byte_float);
+            g8to11 = _mm_min_ps(g8to11, max_byte_float);
+            g12to15 = _mm_min_ps(g12to15, max_byte_float);
+
+            b0to3 = _mm_min_ps(b0to3, max_byte_float);
+            b4to7 = _mm_min_ps(b4to7, max_byte_float);
+            b8to11 = _mm_min_ps(b8to11, max_byte_float);
+            b12to15 = _mm_min_ps(b12to15, max_byte_float);
+
+            r0to3 = _mm_max_ps(r0to3, zero_float);
+            r4to7 = _mm_max_ps(r4to7, zero_float);
+            r8to11 = _mm_max_ps(r8to11, zero_float);
+            r12to15 = _mm_max_ps(r12to15, zero_float);
+
+            g0to3 = _mm_max_ps(g0to3, zero_float);
+            g4to7 = _mm_max_ps(g4to7, zero_float);
+            g8to11 = _mm_max_ps(g8to11, zero_float);
+            g12to15 = _mm_max_ps(g12to15, zero_float);
+
+            b0to3 = _mm_max_ps(b0to3, zero_float);
+            b4to7 = _mm_max_ps(b4to7, zero_float);
+            b8to11 = _mm_max_ps(b8to11, zero_float);
+            b12to15 = _mm_max_ps(b12to15, zero_float);
+
+            // convert back to integer and apply bit shifting to get the final 32bit output
+            __m128i out0to3 = _mm_or_si128(_mm_slli_epi32(_mm_cvtps_epi32(r0to3), 24),
+                                           _mm_slli_epi32(_mm_cvtps_epi32(g0to3), 16));
+            out0to3 = _mm_or_si128(_mm_slli_epi32(_mm_cvtps_epi32(b0to3), 8), out0to3);
+
+            __m128i out4to7 = _mm_or_si128(_mm_slli_epi32(_mm_cvtps_epi32(r4to7), 24),
+                                           _mm_slli_epi32(_mm_cvtps_epi32(g4to7), 16));
+            out4to7 = _mm_or_si128(_mm_slli_epi32(_mm_cvtps_epi32(b4to7), 8), out4to7);
+
+            __m128i out8to11 = _mm_or_si128(_mm_slli_epi32(_mm_cvtps_epi32(r8to11), 24),
+                                            _mm_slli_epi32(_mm_cvtps_epi32(g8to11), 16));
+            out8to11 = _mm_or_si128(_mm_slli_epi32(_mm_cvtps_epi32(b8to11), 8), out8to11);
+
+            __m128i out12to15 = _mm_or_si128(_mm_slli_epi32(_mm_cvtps_epi32(r12to15), 24),
+                                             _mm_slli_epi32(_mm_cvtps_epi32(g12to15), 16));
+            out12to15 = _mm_or_si128(_mm_slli_epi32(_mm_cvtps_epi32(b12to15), 8), out12to15);
 
             unsigned int tile = x / 8;
             unsigned int tile_x = x % 8;
-            u32* out = &output[tile][y * 8 + tile_x];
-            *out = ((u32)std::clamp(r >> 5, 0, 0xFF) << 24) |
-                   ((u32)std::clamp(g >> 5, 0, 0xFF) << 16) |
-                   ((u32)std::clamp(b >> 5, 0, 0xFF) << 8);
+
+            // since SSE is 128bit wide we compute 16 pixels in parallel (input), which
+            // becomes 4 128bit wide int32 vector, hence 4 stores
+            _mm_storeu_si128(reinterpret_cast<__m128i*>(&output[tile][y * 8 + tile_x]), out0to3);
+            _mm_storeu_si128(reinterpret_cast<__m128i*>(&output[tile][y * 8 + tile_x + 4]),
+                             out4to7);
+            _mm_storeu_si128(reinterpret_cast<__m128i*>(&output[tile + 1][y * 8 + tile_x]),
+                             out8to11);
+            _mm_storeu_si128(reinterpret_cast<__m128i*>(&output[tile + 1][y * 8 + tile_x + 4]),
+                             out12to15);
         }
+    }
+}
+
+#else
+
+static void ConvertYUVToRGB_YUV422_420(InputFormat input_format, const u8* __restrict__ input_Y,
+                                       const u8* __restrict__ input_U,
+                                       const u8* __restrict__ input_V, ImageTile output[],
+                                       unsigned int width, unsigned int height,
+                                       const CoefficientSet& coefficients) {
+    auto& c = coefficients;
+    const s32 rounding_offset = 0x18;
+
+    for (unsigned int y = 0; y < height; ++y) {
+        for (unsigned int x = 0; x < width; x += 8) {
+            s32 Y0, Y1, Y2, Y3, Y4, Y5, Y6, Y7;
+            s32 U0, U2, U4, U6;
+            s32 V0, V2, V4, V6;
+            int y_offset, uv_offset;
+
+            switch (input_format) {
+            case InputFormat::YUV422_Indiv8:
+            case InputFormat::YUV422_Indiv16:
+                y_offset = y * width + x;
+                uv_offset = (y * width + x) / 2;
+                break;
+            case InputFormat::YUV420_Indiv8:
+            case InputFormat::YUV420_Indiv16:
+                y_offset = y * width + x;
+                uv_offset = ((y / 2) * width + x) / 2;
+                break;
+            default:
+                y_offset = 0;
+                uv_offset = 0;
+                break;
+            }
+
+            Y0 = input_Y[y_offset];
+            Y1 = input_Y[y_offset + 1];
+            Y2 = input_Y[y_offset + 2];
+            Y3 = input_Y[y_offset + 3];
+            Y4 = input_Y[y_offset + 4];
+            Y5 = input_Y[y_offset + 5];
+            Y6 = input_Y[y_offset + 6];
+            Y7 = input_Y[y_offset + 7];
+
+            U0 = input_U[uv_offset];
+            U2 = input_U[uv_offset + 1];
+            U4 = input_U[uv_offset + 2];
+            U6 = input_U[uv_offset + 3];
+
+            V0 = input_V[uv_offset];
+            V2 = input_V[uv_offset + 1];
+            V4 = input_V[uv_offset + 2];
+            V6 = input_V[uv_offset + 3];
+
+            s32 cY0 = c[0] * Y0;
+            s32 cY1 = c[0] * Y1;
+            s32 cY2 = c[0] * Y2;
+            s32 cY3 = c[0] * Y3;
+            s32 cY4 = c[0] * Y4;
+            s32 cY5 = c[0] * Y5;
+            s32 cY6 = c[0] * Y6;
+            s32 cY7 = c[0] * Y7;
+
+            s32 r0 = ((cY0 + c[1] * V0) >> 3) + c[5] + rounding_offset;
+            s32 r1 = ((cY1 + c[1] * V0) >> 3) + c[5] + rounding_offset;
+            s32 r2 = ((cY2 + c[1] * V2) >> 3) + c[5] + rounding_offset;
+            s32 r3 = ((cY3 + c[1] * V2) >> 3) + c[5] + rounding_offset;
+            s32 r4 = ((cY4 + c[1] * V4) >> 3) + c[5] + rounding_offset;
+            s32 r5 = ((cY5 + c[1] * V4) >> 3) + c[5] + rounding_offset;
+            s32 r6 = ((cY6 + c[1] * V6) >> 3) + c[5] + rounding_offset;
+            s32 r7 = ((cY7 + c[1] * V6) >> 3) + c[5] + rounding_offset;
+
+            s32 g0 = ((cY0 - c[2] * V0 - c[3] * U0) >> 3) + c[6] + rounding_offset;
+            s32 g1 = ((cY1 - c[2] * V0 - c[3] * U0) >> 3) + c[6] + rounding_offset;
+            s32 g2 = ((cY2 - c[2] * V2 - c[3] * U2) >> 3) + c[6] + rounding_offset;
+            s32 g3 = ((cY3 - c[2] * V2 - c[3] * U2) >> 3) + c[6] + rounding_offset;
+            s32 g4 = ((cY4 - c[2] * V4 - c[3] * U4) >> 3) + c[6] + rounding_offset;
+            s32 g5 = ((cY5 - c[2] * V4 - c[3] * U4) >> 3) + c[6] + rounding_offset;
+            s32 g6 = ((cY6 - c[2] * V6 - c[3] * U6) >> 3) + c[6] + rounding_offset;
+            s32 g7 = ((cY7 - c[2] * V6 - c[3] * U6) >> 3) + c[6] + rounding_offset;
+
+            s32 b0 = ((cY0 + c[4] * U0) >> 3) + c[7] + rounding_offset;
+            s32 b1 = ((cY1 + c[4] * U0) >> 3) + c[7] + rounding_offset;
+            s32 b2 = ((cY2 + c[4] * U2) >> 3) + c[7] + rounding_offset;
+            s32 b3 = ((cY3 + c[4] * U2) >> 3) + c[7] + rounding_offset;
+            s32 b4 = ((cY4 + c[4] * U4) >> 3) + c[7] + rounding_offset;
+            s32 b5 = ((cY5 + c[4] * U4) >> 3) + c[7] + rounding_offset;
+            s32 b6 = ((cY6 + c[4] * U6) >> 3) + c[7] + rounding_offset;
+            s32 b7 = ((cY7 + c[4] * U6) >> 3) + c[7] + rounding_offset;
+
+            unsigned int tile = x >> 3;
+            unsigned int tile_x = x % 8;
+
+            int out_offset = y * 8 + tile_x;
+            output[tile][out_offset] = ((u32)std::clamp(r0 >> 5, 0, 0xFF) << 24) |
+                                       ((u32)std::clamp(g0 >> 5, 0, 0xFF) << 16) |
+                                       ((u32)std::clamp(b0 >> 5, 0, 0xFF) << 8);
+            output[tile][out_offset + 1] = ((u32)std::clamp(r1 >> 5, 0, 0xFF) << 24) |
+                                           ((u32)std::clamp(g1 >> 5, 0, 0xFF) << 16) |
+                                           ((u32)std::clamp(b1 >> 5, 0, 0xFF) << 8);
+            output[tile][out_offset + 2] = ((u32)std::clamp(r2 >> 5, 0, 0xFF) << 24) |
+                                           ((u32)std::clamp(g2 >> 5, 0, 0xFF) << 16) |
+                                           ((u32)std::clamp(b2 >> 5, 0, 0xFF) << 8);
+            output[tile][out_offset + 3] = ((u32)std::clamp(r3 >> 5, 0, 0xFF) << 24) |
+                                           ((u32)std::clamp(g3 >> 5, 0, 0xFF) << 16) |
+                                           ((u32)std::clamp(b3 >> 5, 0, 0xFF) << 8);
+            output[tile][out_offset + 4] = ((u32)std::clamp(r4 >> 5, 0, 0xFF) << 24) |
+                                           ((u32)std::clamp(g4 >> 5, 0, 0xFF) << 16) |
+                                           ((u32)std::clamp(b4 >> 5, 0, 0xFF) << 8);
+            output[tile][out_offset + 5] = ((u32)std::clamp(r5 >> 5, 0, 0xFF) << 24) |
+                                           ((u32)std::clamp(g5 >> 5, 0, 0xFF) << 16) |
+                                           ((u32)std::clamp(b5 >> 5, 0, 0xFF) << 8);
+            output[tile][out_offset + 6] = ((u32)std::clamp(r6 >> 5, 0, 0xFF) << 24) |
+                                           ((u32)std::clamp(g6 >> 5, 0, 0xFF) << 16) |
+                                           ((u32)std::clamp(b6 >> 5, 0, 0xFF) << 8);
+            output[tile][out_offset + 7] = ((u32)std::clamp(r7 >> 5, 0, 0xFF) << 24) |
+                                           ((u32)std::clamp(g7 >> 5, 0, 0xFF) << 16) |
+                                           ((u32)std::clamp(b7 >> 5, 0, 0xFF) << 8);
+        }
+    }
+}
+
+#endif
+
+static void ConvertYUVToRGB_YUV422_Interleaved(const u8* input_Y, const u8* input_U,
+                                               const u8* input_V, ImageTile output[],
+                                               unsigned int width, unsigned int height,
+                                               const CoefficientSet& coefficients) {
+    auto& c = coefficients;
+    const s32 rounding_offset = 0x18;
+
+    for (unsigned int y = 0; y < height; ++y) {
+        for (unsigned int x = 0; x < width; x += 8) {
+            s32 Y0, Y1, Y2, Y3, Y4, Y5, Y6, Y7;
+            s32 U0, U2, U4, U6;
+            s32 V0, V2, V4, V6;
+            Y0 = input_Y[(y * width + x) * 2];
+            Y1 = input_Y[(y * width + x) * 2 + 2];
+            Y2 = input_Y[(y * width + x) * 2 + 4];
+            Y3 = input_Y[(y * width + x) * 2 + 6];
+            Y4 = input_Y[(y * width + x) * 2 + 8];
+            Y5 = input_Y[(y * width + x) * 2 + 10];
+            Y6 = input_Y[(y * width + x) * 2 + 12];
+            Y7 = input_Y[(y * width + x) * 2 + 14];
+
+            U0 = input_Y[(y * width + (x / 2) * 2) * 2 + 1];
+            U2 = input_Y[(y * width + (x / 2) * 2) * 2 + 5];
+            U4 = input_Y[(y * width + (x / 2) * 2) * 2 + 9];
+            U6 = input_Y[(y * width + (x / 2) * 2) * 2 + 13];
+
+            V0 = input_Y[(y * width + (x / 2) * 2) * 2 + 3];
+            V2 = input_Y[(y * width + (x / 2) * 2) * 2 + 7];
+            V4 = input_Y[(y * width + (x / 2) * 2) * 2 + 11];
+            V6 = input_Y[(y * width + (x / 2) * 2) * 2 + 15];
+
+            // This conversion process is bit-exact with hardware, as far as could be tested.
+
+            s32 cY0 = c[0] * Y0;
+            s32 cY1 = c[0] * Y1;
+            s32 cY2 = c[0] * Y2;
+            s32 cY3 = c[0] * Y3;
+            s32 cY4 = c[0] * Y4;
+            s32 cY5 = c[0] * Y5;
+            s32 cY6 = c[0] * Y6;
+            s32 cY7 = c[0] * Y7;
+
+            s32 r0 = ((cY0 + c[1] * V0) >> 3) + c[5] + rounding_offset;
+            s32 r1 = ((cY1 + c[1] * V0) >> 3) + c[5] + rounding_offset;
+            s32 r2 = ((cY2 + c[1] * V2) >> 3) + c[5] + rounding_offset;
+            s32 r3 = ((cY3 + c[1] * V2) >> 3) + c[5] + rounding_offset;
+            s32 r4 = ((cY4 + c[1] * V4) >> 3) + c[5] + rounding_offset;
+            s32 r5 = ((cY5 + c[1] * V4) >> 3) + c[5] + rounding_offset;
+            s32 r6 = ((cY6 + c[1] * V6) >> 3) + c[5] + rounding_offset;
+            s32 r7 = ((cY7 + c[1] * V6) >> 3) + c[5] + rounding_offset;
+
+            s32 g0 = ((cY0 - c[2] * V0 - c[3] * U0) >> 3) + c[6] + rounding_offset;
+            s32 g1 = ((cY1 - c[2] * V0 - c[3] * U0) >> 3) + c[6] + rounding_offset;
+            s32 g2 = ((cY2 - c[2] * V2 - c[3] * U2) >> 3) + c[6] + rounding_offset;
+            s32 g3 = ((cY3 - c[2] * V2 - c[3] * U2) >> 3) + c[6] + rounding_offset;
+            s32 g4 = ((cY4 - c[2] * V4 - c[3] * U4) >> 3) + c[6] + rounding_offset;
+            s32 g5 = ((cY5 - c[2] * V4 - c[3] * U4) >> 3) + c[6] + rounding_offset;
+            s32 g6 = ((cY6 - c[2] * V6 - c[3] * U6) >> 3) + c[6] + rounding_offset;
+            s32 g7 = ((cY7 - c[2] * V6 - c[3] * U6) >> 3) + c[6] + rounding_offset;
+
+            s32 b0 = ((cY0 + c[4] * U0) >> 3) + c[7] + rounding_offset;
+            s32 b1 = ((cY1 + c[4] * U0) >> 3) + c[7] + rounding_offset;
+            s32 b2 = ((cY2 + c[4] * U2) >> 3) + c[7] + rounding_offset;
+            s32 b3 = ((cY3 + c[4] * U2) >> 3) + c[7] + rounding_offset;
+            s32 b4 = ((cY4 + c[4] * U4) >> 3) + c[7] + rounding_offset;
+            s32 b5 = ((cY5 + c[4] * U4) >> 3) + c[7] + rounding_offset;
+            s32 b6 = ((cY6 + c[4] * U6) >> 3) + c[7] + rounding_offset;
+            s32 b7 = ((cY7 + c[4] * U6) >> 3) + c[7] + rounding_offset;
+
+            unsigned int tile = x >> 3;
+            unsigned int tile_x = x % 8;
+
+            output[tile][y * 8 + tile_x] = ((u32)std::clamp(r0 >> 5, 0, 0xFF) << 24) |
+                                           ((u32)std::clamp(g0 >> 5, 0, 0xFF) << 16) |
+                                           ((u32)std::clamp(b0 >> 5, 0, 0xFF) << 8);
+            output[tile][y * 8 + tile_x + 1] = ((u32)std::clamp(r1 >> 5, 0, 0xFF) << 24) |
+                                               ((u32)std::clamp(g1 >> 5, 0, 0xFF) << 16) |
+                                               ((u32)std::clamp(b1 >> 5, 0, 0xFF) << 8);
+            output[tile][y * 8 + tile_x + 2] = ((u32)std::clamp(r2 >> 5, 0, 0xFF) << 24) |
+                                               ((u32)std::clamp(g2 >> 5, 0, 0xFF) << 16) |
+                                               ((u32)std::clamp(b2 >> 5, 0, 0xFF) << 8);
+            output[tile][y * 8 + tile_x + 3] = ((u32)std::clamp(r3 >> 5, 0, 0xFF) << 24) |
+                                               ((u32)std::clamp(g3 >> 5, 0, 0xFF) << 16) |
+                                               ((u32)std::clamp(b3 >> 5, 0, 0xFF) << 8);
+            output[tile][y * 8 + tile_x + 4] = ((u32)std::clamp(r4 >> 5, 0, 0xFF) << 24) |
+                                               ((u32)std::clamp(g4 >> 5, 0, 0xFF) << 16) |
+                                               ((u32)std::clamp(b4 >> 5, 0, 0xFF) << 8);
+            output[tile][y * 8 + tile_x + 5] = ((u32)std::clamp(r5 >> 5, 0, 0xFF) << 24) |
+                                               ((u32)std::clamp(g5 >> 5, 0, 0xFF) << 16) |
+                                               ((u32)std::clamp(b5 >> 5, 0, 0xFF) << 8);
+            output[tile][y * 8 + tile_x + 6] = ((u32)std::clamp(r6 >> 5, 0, 0xFF) << 24) |
+                                               ((u32)std::clamp(g6 >> 5, 0, 0xFF) << 16) |
+                                               ((u32)std::clamp(b6 >> 5, 0, 0xFF) << 8);
+            output[tile][y * 8 + tile_x + 7] = ((u32)std::clamp(r7 >> 5, 0, 0xFF) << 24) |
+                                               ((u32)std::clamp(g7 >> 5, 0, 0xFF) << 16) |
+                                               ((u32)std::clamp(b7 >> 5, 0, 0xFF) << 8);
+        }
+    }
+}
+
+/// Converts a image strip from the source YUV format into individual 8x8 RGB32 tiles.
+static void ConvertYUVToRGB(InputFormat input_format, const u8* __restrict__ input_Y,
+                            const u8* __restrict__ input_U, const u8* __restrict__ input_V,
+                            ImageTile output[], unsigned int width, unsigned int height,
+                            const CoefficientSet& coefficients) {
+    switch (input_format) {
+    case InputFormat::YUV422_Indiv8:
+    case InputFormat::YUV422_Indiv16:
+    case InputFormat::YUV420_Indiv8:
+    case InputFormat::YUV420_Indiv16:
+        ConvertYUVToRGB_YUV422_420(input_format, input_Y, input_U, input_V, output, width, height,
+                                   coefficients);
+        break;
+    case InputFormat::YUYV422_Interleaved:
+        ConvertYUVToRGB_YUV422_Interleaved(input_Y, input_U, input_V, output, width, height,
+                                           coefficients);
+    default:
+        break;
     }
 }
 


### PR DESCRIPTION
Dear all,

I have improved the ConvertYUVToRGB function.
The first version mainly uses loop unrolling and gave a 30% gain on the PerformConversion function on my machine.
For x86 CPUs I have written an SSE based version which makes the PerformConversion 2 to 3 times faster than the original.
ARM based CPUs could also benefit from it, using regular NEON, or adding sse2neon as external dependency so that the SSE function could be kept as is.
The SSE function uses floating point arithmetic instead of the original fixed point, and the results are coherent with [yuv_rgb_converter](http://www.mikekohn.net/file_formats/yuv_rgb_converter.php).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5835)
<!-- Reviewable:end -->
