### PR TITLE
Add support for SDL controller accelerometer/gyro events

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,7 @@ if (ENABLE_SDL2)
     if (CITRA_USE_BUNDLED_SDL2)
         # Detect toolchain and platform
         if ((MSVC_VERSION GREATER_EQUAL 1910 AND MSVC_VERSION LESS 1930) AND ARCHITECTURE_x86_64)
-            set(SDL2_VER "SDL2-2.0.12")
+            set(SDL2_VER "SDL2-2.0.16")
         else()
             message(FATAL_ERROR "No bundled SDL2 binaries for your toolchain. Disable CITRA_USE_BUNDLED_SDL2 and provide your own.")
         endif()

--- a/src/citra_qt/configuration/configure_motion_touch.h
+++ b/src/citra_qt/configuration/configure_motion_touch.h
@@ -8,11 +8,13 @@
 #include <QDialog>
 #include "common/param_package.h"
 #include "core/settings.h"
+#include "input_common/main.h"
 #include "input_common/udp/udp.h"
 
 class QVBoxLayout;
 class QLabel;
 class QPushButton;
+class QTimer;
 
 namespace Ui {
 class ConfigureMotionTouch;
@@ -63,9 +65,20 @@ private:
     void SetConfiguration();
     void UpdateUiDisplay();
     void ConnectEvents();
+    void SetPollingResult(const Common::ParamPackage& params, bool abort);
     bool CanCloseDialog();
 
     std::unique_ptr<Ui::ConfigureMotionTouch> ui;
+
+    // Used for SDL input polling
+    std::string guid;
+    int port;
+    std::unique_ptr<QTimer> timeout_timer;
+    std::unique_ptr<QTimer> poll_timer;
+    std::vector<std::unique_ptr<InputCommon::Polling::DevicePoller>> device_pollers;
+
+    /// This will be the the setting function when an input is awaiting configuration.
+    std::optional<std::function<void(const Common::ParamPackage&)>> input_setter;
 
     // Coordinate system of the CemuhookUDP touch provider
     int min_x, min_y, max_x, max_y;

--- a/src/citra_qt/configuration/configure_motion_touch.ui
+++ b/src/citra_qt/configuration/configure_motion_touch.ui
@@ -67,6 +67,24 @@
         </item>
        </layout>
       </item>
+      <item>
+       <layout class="QHBoxLayout">
+        <item>
+         <widget class="QLabel" name="motion_controller_label">
+          <property name="text">
+           <string>Controller:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="motion_controller_button">
+          <property name="text">
+           <string>Configure</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/input_common/sdl/sdl_impl.h
+++ b/src/input_common/sdl/sdl_impl.h
@@ -22,6 +22,7 @@ class SDLJoystick;
 class SDLGameController;
 class SDLButtonFactory;
 class SDLAnalogFactory;
+class SDLMotionFactory;
 
 class SDLState : public State {
 public:
@@ -73,6 +74,7 @@ private:
 
     std::shared_ptr<SDLButtonFactory> button_factory;
     std::shared_ptr<SDLAnalogFactory> analog_factory;
+    std::shared_ptr<SDLMotionFactory> motion_factory;
 
     bool start_thread = false;
     std::atomic<bool> initialized = false;


### PR DESCRIPTION
This introduces support for SDL 2.0.14's new motion control support.

Some items of interest:
- ~~I wasn't sure how to make the motion device configurable, since it can't just use guid/port like button/analog can. Marked this with a FIXME in the changeset.~~ Fixed!
- New string means new localizations... I don't suppose "SDL" needs localization, but any config options for bullet 1 probably would.
- ~~Coordinate system conversion probably needs a sanity check - I tested with some games and it seemed fine locally, but the tests didn't explicitly check all 6 values.~~ Fixed!

Also, apologies if I goofed up the style, I'm not terribly good with modern C++...

Fixes #5850

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5851)
<!-- Reviewable:end -->
