### PR TITLE
CI: Install SDL2 and FFMPEG built for macos 10.13

### DIFF
--- a/.ci/macos/build.sh
+++ b/.ci/macos/build.sh
@@ -3,20 +3,25 @@
 set -o pipefail
 
 export Qt5_DIR=$(brew --prefix)/opt/qt5
-export PATH="/usr/local/opt/ccache/libexec:/usr/local/opt/llvm/bin:$PATH"
+export PATH="/usr/local/opt/ccache/libexec:$PATH"
 # ccache configurations
 export CCACHE_CPP2=yes
 export CCACHE_SLOPPINESS=time_macros
 
 export CC="ccache clang"
 export CXX="ccache clang++"
-export LDFLAGS="-L/usr/local/opt/llvm/lib"
-export CPPFLAGS="-I/usr/local/opt/llvm/include"
 
 ccache -s
 
 mkdir build && cd build
-cmake .. -DCMAKE_BUILD_TYPE=Release -DENABLE_QT_TRANSLATION=ON -DCITRA_ENABLE_COMPATIBILITY_REPORTING=${ENABLE_COMPATIBILITY_REPORTING:-"OFF"} -DENABLE_COMPATIBILITY_LIST_DOWNLOAD=ON -DUSE_DISCORD_PRESENCE=ON -DENABLE_FFMPEG_AUDIO_DECODER=ON -DENABLE_FFMPEG_VIDEO_DUMPER=ON -GNinja
+cmake .. -DCMAKE_BUILD_TYPE=Release \
+    -DENABLE_QT_TRANSLATION=ON \
+    -DCITRA_ENABLE_COMPATIBILITY_REPORTING=${ENABLE_COMPATIBILITY_REPORTING:-"OFF"} \
+    -DENABLE_COMPATIBILITY_LIST_DOWNLOAD=ON \
+    -DUSE_DISCORD_PRESENCE=ON \
+    -DENABLE_FFMPEG_AUDIO_DECODER=ON \
+    -DENABLE_FFMPEG_VIDEO_DUMPER=ON \
+    -GNinja
 ninja
 
 ccache -s

--- a/.ci/macos/deps.sh
+++ b/.ci/macos/deps.sh
@@ -3,5 +3,21 @@
 brew update
 brew unlink python@2 || true
 rm '/usr/local/bin/2to3' || true
-brew install qt5 sdl2 p7zip ccache ffmpeg llvm ninja || true
+brew install qt5 p7zip ccache ninja || true
 pip3 install macpack
+
+export SDL_VER=2.0.16
+export FFMPEG_VER=4.4
+
+mkdir tmp
+cd tmp/
+
+# install SDL
+wget https://github.com/SachinVin/ext-macos-bin/raw/main/sdl2/sdl-${SDL_VER}.7z
+7z x sdl-${SDL_VER}.7z
+cp -rv $(pwd)/sdl-${SDL_VER}/* /
+
+# install FFMPEG
+wget https://github.com/SachinVin/ext-macos-bin/raw/main/ffmpeg/ffmpeg-${FFMPEG_VER}.7z
+7z x ffmpeg-${FFMPEG_VER}.7z
+cp -rv $(pwd)/ffmpeg-${FFMPEG_VER}/* /


### PR DESCRIPTION
Install externals built for MacOS 10.13, instead of the ones from homebrew that were built for 10.15,
This should hopefully fix newer builds on older mac, also removed the LDFLAGS for the same reason, we can just use the libraries provided by Apple's clang. Fortunately Qt seems to be compiled for 10.12(for whatever reason), so there's no change there.

[Here's ](https://github.com/SachinVin/ext-macos-bin/blob/main/.github/workflows/ci.yml) the CI script used to build, let me know if something can be changed/improved.

Should fix #5606 and #5879.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5854)
<!-- Reviewable:end -->
