### PR TITLE
Fix software renderer for empty texture addresses

### DIFF
--- a/src/video_core/swrasterizer/rasterizer.cpp
+++ b/src/video_core/swrasterizer/rasterizer.cpp
@@ -323,7 +323,10 @@ static void ProcessTriangleInternal(const Vertex& v0, const Vertex& v1, const Ve
                 if (!texture.enabled)
                     continue;
 
-                DEBUG_ASSERT(0 != texture.config.address);
+                if (texture.config.address == 0) {
+                    texture_color[i] = {0, 0, 0, 255};
+                    continue;
+                }
 
                 int coordinate_i =
                     (i == 2 && regs.texturing.main_config.texture2_use_coord1) ? 1 : i;


### PR DESCRIPTION
The software renderer was crashing when I was trying to run Pokemon Y. Apparently this is because an empty texture address should result in a clear color being used for the texture however only the gl renderer did this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5893)
<!-- Reviewable:end -->
