### PR TITLE
cfg: use a default subregion based on the country

### DIFF
--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -98,7 +98,8 @@ struct ConsoleModelInfo {
 static_assert(sizeof(ConsoleModelInfo) == 4, "ConsoleModelInfo must be exactly 4 bytes");
 
 struct ConsoleCountryInfo {
-    u8 unknown[3];   ///< Unknown data
+    u8 unknown[2];   ///< Unknown data
+    u8 state_code;   ///< The state or province code.
     u8 country_code; ///< The country code of the console
 };
 static_assert(sizeof(ConsoleCountryInfo) == 4, "ConsoleCountryInfo must be exactly 4 bytes");
@@ -112,8 +113,9 @@ constexpr UsernameBlock CONSOLE_USERNAME_BLOCK{u"CITRA", 0, 0};
 constexpr BirthdayBlock PROFILE_BIRTHDAY{3, 25}; // March 25th, 2014
 constexpr u8 SOUND_OUTPUT_MODE = SOUND_SURROUND;
 constexpr u8 UNITED_STATES_COUNTRY_ID = 49;
+constexpr u8 WASHINGTON_DC_STATE_ID = 2;
 /// TODO(Subv): Find what the other bytes are
-constexpr ConsoleCountryInfo COUNTRY_INFO{{0, 0, 0}, UNITED_STATES_COUNTRY_ID};
+constexpr ConsoleCountryInfo COUNTRY_INFO{{0, 0}, WASHINGTON_DC_STATE_ID, UNITED_STATES_COUNTRY_ID};
 
 /**
  * TODO(Subv): Find out what this actually is, these values fix some NaN uniforms in some games,
@@ -716,7 +718,7 @@ SoundOutputMode Module::GetSoundOutputMode() {
 }
 
 void Module::SetCountryCode(u8 country_code) {
-    ConsoleCountryInfo block = {{0, 0, 0}, country_code};
+    ConsoleCountryInfo block = {{0, 0}, default_subregion[country_code], country_code};
     SetConfigInfoBlock(CountryInfoBlockID, sizeof(block), 4, &block);
 }
 
@@ -724,6 +726,17 @@ u8 Module::GetCountryCode() {
     ConsoleCountryInfo block;
     GetConfigInfoBlock(CountryInfoBlockID, sizeof(block), 8, &block);
     return block.country_code;
+}
+
+void Module::SetCountryInfo(u8 country_code, u8 state_code) {
+    ConsoleCountryInfo block = {{0, 0}, state_code, country_code};
+    SetConfigInfoBlock(CountryInfoBlockID, sizeof(block), 4, &block);
+}
+
+u8 Module::GetStateCode() {
+    ConsoleCountryInfo block;
+    GetConfigInfoBlock(CountryInfoBlockID, sizeof(block), 8, &block);
+    return block.state_code;
 }
 
 std::pair<u32, u64> Module::GenerateConsoleUniqueId() const {

--- a/src/core/hle/service/cfg/cfg.h
+++ b/src/core/hle/service/cfg/cfg.h
@@ -93,6 +93,35 @@ static const std::array<u16, 187> country_codes = {{
     C("SM"), C("VA"), C("BM"),                                              // 184-186
 }};
 
+// Based on PKHeX's lists of subregions at
+// https://github.com/kwsch/PKHeX/tree/master/PKHeX.Core/Resources/text/locale3DS/subregions
+static const std::array<u8, 187> default_subregion = {{
+    0, 2, 0,  0, 0, 0, 0, 0, // 0-7
+    1, 2, 2,  1, 1, 1, 2, 2, // 8-15
+    2, 1, 2,  1, 2, 2, 2, 1, // 16-23
+    2, 2, 2,  1, 1, 1, 2, 2, // 24-31
+    2, 2, 2,  1, 2, 1, 1, 2, // 32-39
+    2, 2, 2,  2, 1, 1, 2, 2, // 40-47
+    1, 2, 2,  1, 2, 0, 0, 0, // 48-55
+    0, 0, 0,  0, 0, 0, 0, 0, // 56-63
+    2, 2, 2,  2, 2, 1, 2, 6, // 64-71
+    1, 2, 18, 1, 8, 2, 2, 2, // 72-79
+    2, 1, 2,  2, 1, 2, 1, 2, // 80-87
+    1, 1, 1,  1, 1, 1, 2, 2, // 88-95
+    7, 2, 2,  2, 9, 1, 2, 1, // 96-103
+    2, 2, 2,  2, 2, 2, 2, 1, // 104-111
+    1, 1, 1,  1, 1, 1, 1, 1, // 112-119
+    1, 1, 1,  1, 1, 1, 1, 1, // 120-127
+    2, 0, 0,  0, 0, 0, 0, 0, // 128-135
+    2, 0, 0,  0, 0, 0, 0, 0, // 136-143
+    1, 0, 0,  0, 0, 0, 0, 0, // 144-151
+    0, 1, 0,  0, 2, 0, 0, 0, // 152-159
+    2, 0, 0,  0, 0, 0, 0, 0, // 160-167
+    2, 2, 0,  0, 0, 0, 2, 0, // 168-175
+    0, 0, 0,  0, 0, 0, 0, 0, // 176-183
+    1, 1, 1,                 // 184-186
+}};
+
 class Module final {
 public:
     Module();
@@ -372,6 +401,7 @@ public:
 
     /**
      * Sets the country code in config savegame.
+     * The state code is set to a default value.
      * @param country_code the country code to set
      */
     void SetCountryCode(u8 country_code);
@@ -381,6 +411,19 @@ public:
      * @returns the country code
      */
     u8 GetCountryCode();
+
+    /**
+     * Sets the country and state codes in config savegame.
+     * @param country_code the country code to set
+     * @param state_code the state code to set
+     */
+    void SetCountryInfo(u8 country_code, u8 state_code);
+
+    /**
+     * Gets the state code from config savegame.
+     * @returns the state code
+     */
+    u8 GetStateCode();
 
     /**
      * Generates a new random console unique id.


### PR DESCRIPTION
May fix #5877

Based on [this page](https://www.3dbrew.org/wiki/Config_Savegame#CountryInfo) from 3dbrew.
The current changes add a default subregion for every country on PKHeX's list. The default was chosen simply as the first valid subregion (ends up being the region of the country's capital in most cases I checked).
Currently there's no way to choose the subregion, but a commit in the near future will come to change that.

The subregion list parsed to obtain the subregion data used on this PR was taken from https://github.com/kwsch/PKHeX/tree/master/PKHeX.Core/Resources/text/locale3DS/subregions with permission from @kwsch

For those testing this: the changes should only take place for newly generated config files, or after changing the country on the system configurations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5901)
<!-- Reviewable:end -->
