### PR TITLE
Convert Input Count to Frame Count

### DIFF
--- a/src/core/movie.cpp
+++ b/src/core/movie.cpp
@@ -221,14 +221,11 @@ Movie::PlayMode Movie::GetPlayMode() const {
     return play_mode;
 }
 
-//The coefficient below converts input count to frame count
-constexpr double FRAME_CONVERT_CONST = 0.255689103308912;
-
 u64 Movie::GetCurrentInputIndex() const {
-    return nearbyint(current_input * FRAME_CONVERT_CONST);
+    return nearbyint(current_input / 234.0 * GPU::SCREEN_REFRESH_RATE);
 }
 u64 Movie::GetTotalInputCount() const {
-    return nearbyint(total_input * FRAME_CONVERT_CONST);
+    return nearbyint(total_input / 234.0 * GPU::SCREEN_REFRESH_RATE);
 }
 
 void Movie::CheckInputEnd() {

--- a/src/core/movie.cpp
+++ b/src/core/movie.cpp
@@ -221,11 +221,13 @@ Movie::PlayMode Movie::GetPlayMode() const {
     return play_mode;
 }
 
+//The coefficient below converts input count to frame count
+    
 u64 Movie::GetCurrentInputIndex() const {
-    return current_input;
+    return nearbyint(current_input * 0.255689103308912);
 }
 u64 Movie::GetTotalInputCount() const {
-    return total_input;
+    return nearbyint(total_input * 0.255689103308912);
 }
 
 void Movie::CheckInputEnd() {

--- a/src/core/movie.cpp
+++ b/src/core/movie.cpp
@@ -223,7 +223,7 @@ Movie::PlayMode Movie::GetPlayMode() const {
 
 //The coefficient below converts input count to frame count
 constexpr double FRAME_CONVERT_CONST = 0.255689103308912;
-    
+
 u64 Movie::GetCurrentInputIndex() const {
     return nearbyint(current_input * FRAME_CONVERT_CONST);
 }

--- a/src/core/movie.cpp
+++ b/src/core/movie.cpp
@@ -22,6 +22,7 @@
 #include "core/hle/service/hid/hid.h"
 #include "core/hle/service/ir/extra_hid.h"
 #include "core/hle/service/ir/ir_rst.h"
+#include "core/hw/gpu.h"
 #include "core/movie.h"
 
 namespace Core {

--- a/src/core/movie.cpp
+++ b/src/core/movie.cpp
@@ -222,12 +222,13 @@ Movie::PlayMode Movie::GetPlayMode() const {
 }
 
 //The coefficient below converts input count to frame count
+constexpr double FRAME_CONVERT_CONST = 0.255689103308912;
     
 u64 Movie::GetCurrentInputIndex() const {
-    return nearbyint(current_input * 0.255689103308912);
+    return nearbyint(current_input * FRAME_CONVERT_CONST);
 }
 u64 Movie::GetTotalInputCount() const {
-    return nearbyint(total_input * 0.255689103308912);
+    return nearbyint(total_input * FRAME_CONVERT);
 }
 
 void Movie::CheckInputEnd() {

--- a/src/core/movie.cpp
+++ b/src/core/movie.cpp
@@ -228,7 +228,7 @@ u64 Movie::GetCurrentInputIndex() const {
     return nearbyint(current_input * FRAME_CONVERT_CONST);
 }
 u64 Movie::GetTotalInputCount() const {
-    return nearbyint(total_input * FRAME_CONVERT);
+    return nearbyint(total_input * FRAME_CONVERT_CONST);
 }
 
 void Movie::CheckInputEnd() {


### PR DESCRIPTION
While recording or playing a movie file, the left side of the status bar currently displays an input counter which shows how many times the emulator has polled for button inputs during the movie. This information is far less easily understandable and less useful for TASing compared to a frame count. The frame count has a linear relationship with input count that can be expressed with Frame Count = 0.255689103308912 * Input Count. Simply put, instead of having a counter that goes up by 3 or 4 every frame, this makes it a counter that goes up by exactly 1 every frame.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5954)
<!-- Reviewable:end -->
