### PR TITLE
dumping/ffmpeg_backend: add support for ffmpeg 5.0

### DIFF
--- a/src/audio_core/hle/ffmpeg_decoder.cpp
+++ b/src/audio_core/hle/ffmpeg_decoder.cpp
@@ -52,7 +52,7 @@ private:
 
     Memory::MemorySystem& memory;
 
-    AVCodec* codec;
+    const AVCodec* codec;
     std::unique_ptr<AVCodecContext, AVCodecContextDeleter> av_context;
     std::unique_ptr<AVCodecParserContext, AVCodecParserContextDeleter> parser;
     std::unique_ptr<AVPacket, AVPacketDeleter> av_packet;

--- a/src/core/dumping/ffmpeg_backend.cpp
+++ b/src/core/dumping/ffmpeg_backend.cpp
@@ -758,7 +758,12 @@ void GetOptionList(std::vector<OptionInfo>& out, const AVClass* av_class, bool s
     }
 
     const AVClass* child_class = nullptr;
+#if LIBAVCODEC_VERSION_MAJOR >= 59
+    void* iter = nullptr;
+    while ((child_class = av_opt_child_class_iterate(av_class, &iter))) {
+#else
     while ((child_class = av_opt_child_class_next(av_class, child_class))) {
+#endif
         GetOptionListSingle(out, child_class);
     }
 }


### PR DESCRIPTION
This pull request adds support for the just-released FFmpeg 5.0.

In FFmpeg 5.0, `av_opt_child_class_next` was replaced with `av_opt_child_class_iterate`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/5956)
<!-- Reviewable:end -->
