### PR TITLE
explicitly set timebase for video stream

### DIFF
--- a/src/core/dumping/ffmpeg_backend.cpp
+++ b/src/core/dumping/ffmpeg_backend.cpp
@@ -156,6 +156,8 @@ bool FFmpegVideoStream::Init(FFmpegMuxer& muxer, const Layout::FramebufferLayout
         return false;
     }
 
+    stream->time_base = codec_context->time_base;
+
     // Allocate frames
     current_frame.reset(av_frame_alloc());
     scaled_frame.reset(av_frame_alloc());


### PR DESCRIPTION
Dolphin does it here

https://github.com/dolphin-emu/dolphin/blob/e932a1bfb71c73da48bb75f660b40b5f2c9de4a1/Source/Core/VideoCommon/FrameDump.cpp#L305

fixes #5965

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6005)
<!-- Reviewable:end -->
