### PR TITLE
Improve tab ordering

### DIFF
--- a/src/citra_qt/cheats.ui
+++ b/src/citra_qt/cheats.ui
@@ -42,6 +42,12 @@
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
       </spacer>
      </item>
      <item>
@@ -59,14 +65,6 @@
       <layout class="QVBoxLayout">
        <item>
         <widget class="QLabel" name="labelAvailableCheats">
-         <property name="geometry">
-          <rect>
-           <x>10</x>
-           <y>60</y>
-           <width>121</width>
-           <height>16</height>
-          </rect>
-         </property>
          <property name="text">
           <string>Available Cheats:</string>
          </property>
@@ -77,11 +75,11 @@
          <property name="editTriggers">
           <set>QAbstractItemView::NoEditTriggers</set>
          </property>
-         <property name="selectionBehavior">
-          <enum>QAbstractItemView::SelectRows</enum>
-         </property>
          <property name="selectionMode">
           <enum>QAbstractItemView::SingleSelection</enum>
+         </property>
+         <property name="selectionBehavior">
+          <enum>QAbstractItemView::SelectRows</enum>
          </property>
          <property name="showGrid">
           <bool>false</bool>
@@ -123,25 +121,31 @@
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
            </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
           </spacer>
          </item>
          <item>
           <widget class="QPushButton" name="buttonSave">
-           <property name="text">
-            <string>Save</string>
-           </property>
            <property name="enabled">
             <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Save</string>
            </property>
           </widget>
          </item>
          <item>
           <widget class="QPushButton" name="buttonDelete">
-           <property name="text">
-            <string>Delete</string>
-           </property>
            <property name="enabled">
             <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Delete</string>
            </property>
           </widget>
          </item>
@@ -196,6 +200,12 @@
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
       </spacer>
      </item>
      <item>
@@ -209,6 +219,16 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>buttonAddCheat</tabstop>
+  <tabstop>tableCheats</tabstop>
+  <tabstop>lineName</tabstop>
+  <tabstop>textNotes</tabstop>
+  <tabstop>textCode</tabstop>
+  <tabstop>buttonSave</tabstop>
+  <tabstop>buttonDelete</tabstop>
+  <tabstop>buttonClose</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/citra_qt/configuration/configure_audio.ui
+++ b/src/citra_qt/configuration/configure_audio.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>329</width>
-    <height>332</height>
+    <height>344</height>
    </rect>
   </property>
   <layout class="QVBoxLayout">
@@ -205,6 +205,15 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>emulation_combo_box</tabstop>
+  <tabstop>output_sink_combo_box</tabstop>
+  <tabstop>toggle_audio_stretching</tabstop>
+  <tabstop>audio_device_combo_box</tabstop>
+  <tabstop>volume_slider</tabstop>
+  <tabstop>input_type_combo_box</tabstop>
+  <tabstop>input_device_combo_box</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/citra_qt/configuration/configure_camera.ui
+++ b/src/citra_qt/configuration/configure_camera.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>300</height>
+    <height>489</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -186,11 +186,11 @@
        <layout class="QHBoxLayout" name="horizontalLayout_7">
         <item>
          <widget class="QLabel" name="system_camera_label">
-          <property name="frameShape">
-           <enum>QFrame::NoFrame</enum>
-          </property>
           <property name="toolTip">
            <string>Select the system camera to use</string>
+          </property>
+          <property name="frameShape">
+           <enum>QFrame::NoFrame</enum>
           </property>
           <property name="text">
            <string>Camera:</string>
@@ -227,11 +227,11 @@
        <layout class="QHBoxLayout" name="horizontalLayout_8">
         <item>
          <widget class="QLabel" name="camera_flip_label">
-          <property name="frameShape">
-           <enum>QFrame::NoFrame</enum>
-          </property>
           <property name="toolTip">
            <string>Select the image flip to apply</string>
+          </property>
+          <property name="frameShape">
+           <enum>QFrame::NoFrame</enum>
           </property>
           <property name="text">
            <string>Flip:</string>
@@ -342,6 +342,18 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>camera_selection</tabstop>
+  <tabstop>camera_mode</tabstop>
+  <tabstop>camera_position</tabstop>
+  <tabstop>image_source</tabstop>
+  <tabstop>camera_file</tabstop>
+  <tabstop>toolButton</tabstop>
+  <tabstop>system_camera</tabstop>
+  <tabstop>camera_flip</tabstop>
+  <tabstop>prompt_before_load</tabstop>
+  <tabstop>preview_button</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/citra_qt/configuration/configure_debug.ui
+++ b/src/citra_qt/configuration/configure_debug.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
+    <width>443</width>
     <height>300</height>
    </rect>
   </property>
@@ -137,6 +137,14 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>toggle_gdbstub</tabstop>
+  <tabstop>gdbport_spinbox</tabstop>
+  <tabstop>log_filter_edit</tabstop>
+  <tabstop>toggle_console</tabstop>
+  <tabstop>open_log_button</tabstop>
+  <tabstop>toggle_cpu_jit</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/src/citra_qt/configuration/configure_enhancements.ui
+++ b/src/citra_qt/configuration/configure_enhancements.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>595</height>
+    <height>634</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -343,6 +343,21 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>resolution_factor_combobox</tabstop>
+  <tabstop>toggle_linear_filter</tabstop>
+  <tabstop>shader_combobox</tabstop>
+  <tabstop>texture_filter_combobox</tabstop>
+  <tabstop>render_3d_combobox</tabstop>
+  <tabstop>factor_3d</tabstop>
+  <tabstop>layout_combobox</tabstop>
+  <tabstop>swap_screen</tabstop>
+  <tabstop>upright_screen</tabstop>
+  <tabstop>bg_button</tabstop>
+  <tabstop>toggle_custom_textures</tabstop>
+  <tabstop>toggle_dump_textures</tabstop>
+  <tabstop>toggle_preload_textures</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/citra_qt/configuration/configure_general.ui
+++ b/src/citra_qt/configuration/configure_general.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>408</width>
-    <height>396</height>
+    <height>436</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -237,6 +237,18 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>toggle_check_exit</tabstop>
+  <tabstop>toggle_background_pause</tabstop>
+  <tabstop>toggle_hide_mouse</tabstop>
+  <tabstop>toggle_update_check</tabstop>
+  <tabstop>toggle_auto_update</tabstop>
+  <tabstop>region_combobox</tabstop>
+  <tabstop>frame_limit</tabstop>
+  <tabstop>toggle_alternate_speed</tabstop>
+  <tabstop>frame_limit_alternate</tabstop>
+  <tabstop>button_reset_defaults</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/citra_qt/configuration/configure_graphics.ui
+++ b/src/citra_qt/configuration/configure_graphics.ui
@@ -118,16 +118,16 @@
       <string>Advanced</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
-       <item>
-         <widget class="QCheckBox" name="toggle_disk_shader_cache">
-           <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Reduce stuttering by storing and loading generated shaders to disk.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-           <property name="text">
-             <string>Use Disk Shader Cache</string>
-           </property>
-         </widget>
-       </item>
+      <item>
+       <widget class="QCheckBox" name="toggle_disk_shader_cache">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Reduce stuttering by storing and loading generated shaders to disk.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Use Disk Shader Cache</string>
+        </property>
+       </widget>
+      </item>
       <item>
        <widget class="QCheckBox" name="toggle_vsync_new">
         <property name="toolTip">
@@ -156,6 +156,15 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>toggle_hw_renderer</tabstop>
+  <tabstop>toggle_hw_shader</tabstop>
+  <tabstop>toggle_separable_shader</tabstop>
+  <tabstop>toggle_accurate_mul</tabstop>
+  <tabstop>toggle_shader_jit</tabstop>
+  <tabstop>toggle_disk_shader_cache</tabstop>
+  <tabstop>toggle_vsync_new</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/citra_qt/configuration/configure_input.ui
+++ b/src/citra_qt/configuration/configure_input.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>374</width>
-    <height>670</height>
+    <width>441</width>
+    <height>727</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -816,6 +816,46 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>profile</tabstop>
+  <tabstop>buttonNew</tabstop>
+  <tabstop>buttonDelete</tabstop>
+  <tabstop>buttonRename</tabstop>
+  <tabstop>buttonA</tabstop>
+  <tabstop>buttonB</tabstop>
+  <tabstop>buttonX</tabstop>
+  <tabstop>buttonY</tabstop>
+  <tabstop>buttonDpadLeft</tabstop>
+  <tabstop>buttonDpadRight</tabstop>
+  <tabstop>buttonDpadUp</tabstop>
+  <tabstop>buttonDpadDown</tabstop>
+  <tabstop>buttonCircleLeft</tabstop>
+  <tabstop>buttonCircleRight</tabstop>
+  <tabstop>buttonCircleUp</tabstop>
+  <tabstop>buttonCircleDown</tabstop>
+  <tabstop>buttonCircleAnalog</tabstop>
+  <tabstop>sliderCirclePadDeadzoneAndModifier</tabstop>
+  <tabstop>buttonCStickLeft</tabstop>
+  <tabstop>buttonCStickRight</tabstop>
+  <tabstop>buttonCStickUp</tabstop>
+  <tabstop>buttonCStickDown</tabstop>
+  <tabstop>buttonCStickAnalog</tabstop>
+  <tabstop>sliderCStickDeadzoneAndModifier</tabstop>
+  <tabstop>buttonL</tabstop>
+  <tabstop>buttonR</tabstop>
+  <tabstop>buttonZL</tabstop>
+  <tabstop>buttonZR</tabstop>
+  <tabstop>buttonStart</tabstop>
+  <tabstop>buttonSelect</tabstop>
+  <tabstop>buttonHome</tabstop>
+  <tabstop>buttonCircleMod</tabstop>
+  <tabstop>buttonDebug</tabstop>
+  <tabstop>buttonGpio14</tabstop>
+  <tabstop>buttonMotionTouch</tabstop>
+  <tabstop>buttonAutoMap</tabstop>
+  <tabstop>buttonClearAll</tabstop>
+  <tabstop>buttonRestoreDefaults</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/citra_qt/configuration/configure_system.ui
+++ b/src/citra_qt/configuration/configure_system.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>471</width>
-    <height>555</height>
+    <width>520</width>
+    <height>564</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -406,6 +406,20 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>toggle_new_3ds</tabstop>
+  <tabstop>edit_username</tabstop>
+  <tabstop>combo_birthmonth</tabstop>
+  <tabstop>combo_birthday</tabstop>
+  <tabstop>combo_language</tabstop>
+  <tabstop>combo_sound</tabstop>
+  <tabstop>combo_country</tabstop>
+  <tabstop>combo_init_clock</tabstop>
+  <tabstop>edit_init_time</tabstop>
+  <tabstop>spinBox_play_coins</tabstop>
+  <tabstop>button_regenerate_console_id</tabstop>
+  <tabstop>slider_clock_speed</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/citra_qt/configuration/configure_web.ui
+++ b/src/citra_qt/configuration/configure_web.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>926</width>
+    <width>996</width>
     <height>561</height>
    </rect>
   </property>
@@ -55,7 +55,7 @@
            </widget>
           </item>
           <item row="0" column="1" colspan="3">
-           <widget class="QLabel" name="username" />
+           <widget class="QLabel" name="username"/>
           </item>
           <item row="1" column="0">
            <widget class="QLabel" name="label_token">
@@ -65,8 +65,7 @@
            </widget>
           </item>
           <item row="1" column="4">
-           <widget class="QLabel" name="label_token_verified">
-           </widget>
+           <widget class="QLabel" name="label_token_verified"/>
           </item>
           <item row="0" column="0">
            <widget class="QLabel" name="label_username">
@@ -173,20 +172,20 @@
     </layout>
    </item>
    <item>
-     <widget class="QGroupBox" name="discord_group">
-      <property name="title">
-       <string>Discord Presence</string>
-      </property>
-      <layout class="QVBoxLayout" name="verticalLayout_21">
-       <item>
-        <widget class="QCheckBox" name="toggle_discordrpc">
-         <property name="text">
-          <string>Show Current Game in your Discord Status</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
+    <widget class="QGroupBox" name="discord_group">
+     <property name="title">
+      <string>Discord Presence</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_21">
+      <item>
+       <widget class="QCheckBox" name="toggle_discordrpc">
+        <property name="text">
+         <string>Show Current Game in your Discord Status</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item>
     <spacer name="verticalSpacer">
@@ -203,6 +202,13 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>edit_token</tabstop>
+  <tabstop>button_verify_login</tabstop>
+  <tabstop>toggle_telemetry</tabstop>
+  <tabstop>button_regenerate_telemetry_id</tabstop>
+  <tabstop>toggle_discordrpc</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/citra_qt/debugger/ipc/record_dialog.ui
+++ b/src/citra_qt/debugger/ipc/record_dialog.ui
@@ -2,9 +2,6 @@
 <ui version="4.0">
  <class>RecordDialog</class>
  <widget class="QDialog" name="RecordDialog">
-  <property name="windowTitle">
-   <string>View Record</string>
-  </property>
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -13,17 +10,20 @@
     <height>500</height>
    </rect>
   </property>
+  <property name="windowTitle">
+   <string>View Record</string>
+  </property>
   <layout class="QVBoxLayout">
    <item>
     <layout class="QHBoxLayout">
      <item>
-      <widget class="QGroupBox">
+      <widget class="QGroupBox" name="groupBox">
        <property name="title">
         <string>Client</string>
        </property>
        <layout class="QFormLayout">
         <item row="0" column="0">
-         <widget class="QLabel">
+         <widget class="QLabel" name="label">
           <property name="text">
            <string>Process:</string>
           </property>
@@ -37,7 +37,7 @@
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel">
+         <widget class="QLabel" name="label">
           <property name="text">
            <string>Thread:</string>
           </property>
@@ -51,7 +51,7 @@
          </widget>
         </item>
         <item row="2" column="0">
-         <widget class="QLabel">
+         <widget class="QLabel" name="label">
           <property name="text">
            <string>Session:</string>
           </property>
@@ -68,13 +68,13 @@
       </widget>
      </item>
      <item>
-      <widget class="QGroupBox">
+      <widget class="QGroupBox" name="groupBox">
        <property name="title">
         <string>Server</string>
        </property>
        <layout class="QFormLayout">
         <item row="0" column="0">
-         <widget class="QLabel">
+         <widget class="QLabel" name="label">
           <property name="text">
            <string>Process:</string>
           </property>
@@ -88,7 +88,7 @@
          </widget>
         </item>
         <item row="1" column="0">
-         <widget class="QLabel">
+         <widget class="QLabel" name="label">
           <property name="text">
            <string>Thread:</string>
           </property>
@@ -102,7 +102,7 @@
          </widget>
         </item>
         <item row="2" column="0">
-         <widget class="QLabel">
+         <widget class="QLabel" name="label">
           <property name="text">
            <string>Session:</string>
           </property>
@@ -121,13 +121,13 @@
     </layout>
    </item>
    <item>
-    <widget class="QGroupBox">
+    <widget class="QGroupBox" name="groupBox">
      <property name="title">
       <string>General</string>
      </property>
      <layout class="QFormLayout">
       <item row="0" column="0">
-       <widget class="QLabel">
+       <widget class="QLabel" name="label">
         <property name="text">
          <string>Client Port:</string>
         </property>
@@ -141,7 +141,7 @@
        </widget>
       </item>
       <item row="1" column="0">
-       <widget class="QLabel">
+       <widget class="QLabel" name="label">
         <property name="text">
          <string>Service:</string>
         </property>
@@ -155,7 +155,7 @@
        </widget>
       </item>
       <item row="2" column="0">
-       <widget class="QLabel">
+       <widget class="QLabel" name="label">
         <property name="text">
          <string>Function:</string>
         </property>
@@ -172,7 +172,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox">
+    <widget class="QGroupBox" name="groupBox">
      <property name="title">
       <string>Command Buffer</string>
      </property>
@@ -180,7 +180,7 @@
       <item>
        <layout class="QHBoxLayout">
         <item>
-         <widget class="QLabel">
+         <widget class="QLabel" name="label">
           <property name="text">
            <string>Select:</string>
           </property>
@@ -229,6 +229,12 @@
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
       </spacer>
      </item>
      <item>
@@ -242,4 +248,20 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>clientProcess</tabstop>
+  <tabstop>clientThread</tabstop>
+  <tabstop>clientSession</tabstop>
+  <tabstop>serverProcess</tabstop>
+  <tabstop>serverThread</tabstop>
+  <tabstop>serverSession</tabstop>
+  <tabstop>clientPort</tabstop>
+  <tabstop>service</tabstop>
+  <tabstop>function</tabstop>
+  <tabstop>cmdbufSelection</tabstop>
+  <tabstop>cmdbuf</tabstop>
+  <tabstop>okButton</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
 </ui>


### PR DESCRIPTION
This changes the tab order for the elements of multiple widgets, particularly in some of the configuration pages, to be a more natural ordering (top to bottom, left to right, respecting grouped elements). Right now certain pages are very confusing to navigate with the keyboard using tab/shift+tab, which is bad from an accessibility and UX perspective.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6019)
<!-- Reviewable:end -->
