### PR TITLE
Use cubic mapping for volume control

### DIFF
--- a/src/audio_core/dsp_interface.cpp
+++ b/src/audio_core/dsp_interface.cpp
@@ -87,8 +87,7 @@ void DspInterface::OutputCallback(s16* buffer, std::size_t num_frames) {
     // Implementation of the hardware volume slider with a dynamic range of 60 dB
     const float linear_volume = std::clamp(Settings::values.volume, 0.0f, 1.0f);
     if (linear_volume != 1.0) {
-        const float volume_scale_factor =
-            linear_volume == 0 ? 0 : std::exp(6.90775f * linear_volume) * 0.001f;
+        const float volume_scale_factor = linear_volume * linear_volume * linear_volume;
         for (std::size_t i = 0; i < num_frames; i++) {
             buffer[i * 2 + 0] = static_cast<s16>(buffer[i * 2 + 0] * volume_scale_factor);
             buffer[i * 2 + 1] = static_cast<s16>(buffer[i * 2 + 1] * volume_scale_factor);

--- a/src/audio_core/dsp_interface.cpp
+++ b/src/audio_core/dsp_interface.cpp
@@ -84,7 +84,8 @@ void DspInterface::OutputCallback(s16* buffer, std::size_t num_frames) {
         std::memcpy(buffer + 2 * i, &last_frame[0], 2 * sizeof(s16));
     }
 
-    // Implementation of the hardware volume slider with a dynamic range of 60 dB
+    // Implementation of the hardware volume slider
+    // A cubic curve is used to approximate a linear change in human-perceived loudness
     const float linear_volume = std::clamp(Settings::values.volume, 0.0f, 1.0f);
     if (linear_volume != 1.0) {
         const float volume_scale_factor = linear_volume * linear_volume * linear_volume;


### PR DESCRIPTION
This changes the mapping the volume control slider to audio scaling factor from logarithmic to cubic. I am by no means a picky person when it comes to audio, but I found the volume too sensitive when adjusting in the mid-to-full loudness range. Looking into what Citra uses, I compared it to some other open source programs and found that most of them were using an exponential formula (specifically cubic, x^3) instead of a logarithmic one. These include [VLC](https://git.videolan.org/?p=vlc.git;a=blob;f=modules/audio_output/waveout.c;hb=a18c4d65700229eff926ef1381524bb21a7aab95#l907), [PulseAudio](https://github.com/pulseaudio/pulseaudio/blob/d851021cf59256a7e56d905ca55974153edd4a75/src/pulse/volume.c#L291), and at least sometimes in [MPV](https://github.com/mpv-player/mpv/blob/deedc3d418f03222d8b7cb64de51fc383ca356f1/audio/out/ao_pipewire.c#L196).

You can see a comparison of the current formula and the new one I am proposing [here](https://www.wolframalpha.com/input?i=e%5E%286.90775*x%29*0.001%2C+x%5E3+for+0+%3C+x+%3C+1). As you can see it's less steep of a curve, but still curved to account for the human perception of loudness. Here's an audio sample for comparison as well, recorded from Citra without and with this change:
<table><thead>
 <tr>
  <th>Volume</th>
  <th>Logarithmic (Current)</th>
  <th>Cubic (Proposed)</th>
 </tr>
</thead><tbody>
 <tr>
  <th>100%</th>
  <td colspan=2><video src="https://user-images.githubusercontent.com/3461051/167589876-fc5ae760-523e-413e-92eb-f3eb550f9df8.mp4" /></td>
 </tr>
 <tr>
  <th>75%</th>
  <td><video src="https://user-images.githubusercontent.com/3461051/167591483-284136a3-1dec-4eba-acf0-1abdaf966cce.mp4" /></td>
  <td><video src="https://user-images.githubusercontent.com/3461051/167591633-c90a1c7f-c5f8-4cb5-ba2d-48399607567a.mp4" /></td>
 </tr>
 <tr>
  <th>50%</th>
  <td><video src="https://user-images.githubusercontent.com/3461051/167591714-3c3279e7-8af7-4a2c-a655-89465a0f7df1.mp4" /></td>
  <td><video src="https://user-images.githubusercontent.com/3461051/167591799-9c03bb36-1758-430e-a1ff-3dfdcb5e988c.mp4" /></td>
 </tr>
 <tr>
  <th>25%</th>
  <td><video src="https://user-images.githubusercontent.com/3461051/167591884-67f41056-9c8a-4148-bba8-0a9ff5feb8b0.mp4" /></td>
  <td><video src="https://user-images.githubusercontent.com/3461051/167591941-0142bee2-5298-4a48-85c7-c88bb1f14dd9.mp4" /></td>
 </tr>
 <tr>
  <th>0%</th>
  <td colspan=2>I think you know what this sounds like 🤨</td>
 </tr>
</tbody></table>

In my (very subjective) opinion, the new algorithm at the 50% point sounds much closer to what I would expect 50% of the 100% clip to sound like, while the 25% is not too loud as it would be if it was linear. At 75% the difference is not as significant and both sound are within a reasonable range to my ears.

Futher reading (both of which advocate for exponential volume controls):
- [Audio GUI Design](https://www.robotplanet.dk/audio/audio_gui_design/)
- [Programming Volume Controls](https://www.dr-lex.be/info-stuff/volumecontrols.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6020)
<!-- Reviewable:end -->
