### PR TITLE
web_service: infect other targets with OpenSSL exports

### DIFF
--- a/src/network/CMakeLists.txt
+++ b/src/network/CMakeLists.txt
@@ -13,4 +13,12 @@ add_library(network STATIC
 
 create_target_directory_groups(network)
 
+if (ENABLE_WEB_SERVICE)
+    target_compile_definitions(network PRIVATE -DENABLE_WEB_SERVICE -DCPPHTTPLIB_OPENSSL_SUPPORT)
+    target_link_libraries(network PRIVATE web_service httplib)
+    if (ANDROID)
+        target_link_libraries(network PRIVATE ifaddrs)
+    endif()
+endif()
+
 target_link_libraries(network PRIVATE common enet Boost::serialization)

--- a/src/web_service/CMakeLists.txt
+++ b/src/web_service/CMakeLists.txt
@@ -14,7 +14,8 @@ add_library(web_service STATIC
 create_target_directory_groups(web_service)
 
 target_compile_definitions(web_service PRIVATE -DCPPHTTPLIB_OPENSSL_SUPPORT)
-target_link_libraries(web_service PRIVATE common network json-headers ${OPENSSL_LIBS} httplib cpp-jwt)
+target_link_libraries(web_service PRIVATE common network json-headers httplib cpp-jwt)
+target_link_libraries(web_service PUBLIC ${OPENSSL_LIBS})
 if (ANDROID)
     target_link_libraries(web_service PRIVATE ifaddrs)
 elseif(WIN32)


### PR DESCRIPTION
This pull request exports OpenSSL linkage from the `web_service` target.

This is useful when #5519 is merged.

This patch has been tested in https://github.com/citra-emu/citra-multiplayer-dedicated for nearly half a year now, so should be safe to merge.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6045)
<!-- Reviewable:end -->
