### PR TITLE
gl_shader_gen.cpp: Fix define for ALLOW_SHADOW for new AMD drivers

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -1235,13 +1235,15 @@ ShaderDecompiler::ProgramResult GenerateFragmentShader(const PicaFSConfig& confi
 
     if (GLES) {
         out += R"(
-#define ALLOW_SHADOW (defined(CITRA_GLES))
+#define ALLOW_SHADOW 1
 )";
     } else {
         out += R"(
 #extension GL_ARB_shader_image_load_store : enable
 #extension GL_ARB_shader_image_size : enable
-#define ALLOW_SHADOW (defined(GL_ARB_shader_image_load_store) && defined(GL_ARB_shader_image_size))
+#if defined(GL_ARB_shader_image_load_store) && defined(GL_ARB_shader_image_size)
+#define ALLOW_SHADOW 1
+#endif
 )";
     }
 
@@ -1270,7 +1272,7 @@ uniform samplerBuffer texture_buffer_lut_lf;
 uniform samplerBuffer texture_buffer_lut_rg;
 uniform samplerBuffer texture_buffer_lut_rgba;
 
-#if ALLOW_SHADOW
+#ifdef ALLOW_SHADOW
 layout(r32ui) uniform readonly uimage2D shadow_texture_px;
 layout(r32ui) uniform readonly uimage2D shadow_texture_nx;
 layout(r32ui) uniform readonly uimage2D shadow_texture_py;
@@ -1332,7 +1334,7 @@ float getLod(vec2 coord) {
     return log2(max(d.x, d.y));
 }
 
-#if ALLOW_SHADOW
+#ifdef ALLOW_SHADOW
 
 uvec2 DecodeShadow(uint pixel) {
     return uvec2(pixel >> 8, pixel & 0xFFu);
@@ -1559,7 +1561,7 @@ vec4 secondary_fragment_color = vec4(0.0);
 
     if (state.shadow_rendering) {
         out += R"(
-#if ALLOW_SHADOW
+#ifdef ALLOW_SHADOW
 uint d = uint(clamp(depth, 0.0, 1.0) * float(0xFFFFFF));
 uint s = uint(last_tex_env_out.g * float(0xFF));
 ivec2 image_coord = ivec2(gl_FragCoord.xy);


### PR DESCRIPTION
The new drivers (22.20+) don't like it when there is a `defined` inside a `#define`.
I don't have AMD hardware, but here's the log from a user.

[citra_log AMD 20.22.txt](https://github.com/citra-emu/citra/files/8986060/citra_log.AMD.20.22.txt)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6060)
<!-- Reviewable:end -->
