### PR TITLE
screenshot fixes

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -588,7 +588,7 @@ void GMainWindow::InitializeHotkeys() {
             });
     connect(hotkey_registry.GetHotkey(main_window, QStringLiteral("Capture Screenshot"), this),
             &QShortcut::activated, this, [&] {
-                if (emu_thread->IsRunning()) {
+                if (ui->action_Capture_Screenshot->isEnabled()) {
                     OnCaptureScreenshot();
                 }
             });
@@ -1610,7 +1610,6 @@ void GMainWindow::OnPauseGame() {
     ui->action_Start->setEnabled(true);
     ui->action_Pause->setEnabled(false);
     ui->action_Stop->setEnabled(true);
-    ui->action_Capture_Screenshot->setEnabled(false);
 
     AllowOSSleep();
 }
@@ -1958,7 +1957,10 @@ void GMainWindow::OnSaveMovie() {
 }
 
 void GMainWindow::OnCaptureScreenshot() {
-    OnPauseGame();
+    bool running = emu_thread->IsRunning();
+    if(running){
+        OnPauseGame();
+    }
     QString path = UISettings::values.screenshot_path;
     if (!FileUtil::IsDirectory(path.toStdString())) {
         if (!FileUtil::CreateFullPath(path.toStdString())) {
@@ -1975,7 +1977,9 @@ void GMainWindow::OnCaptureScreenshot() {
         QDateTime::currentDateTime().toString(QStringLiteral("dd.MM.yy_hh.mm.ss.z"));
     path.append(QStringLiteral("/%1_%2.png").arg(filename).arg(timestamp));
     render_window->CaptureScreenshot(UISettings::values.screenshot_resolution_factor, path);
-    OnStartGame();
+    if(running){
+        OnStartGame();
+    }
 }
 
 #ifdef ENABLE_FFMPEG_VIDEO_DUMPER

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -1610,6 +1610,7 @@ void GMainWindow::OnPauseGame() {
     ui->action_Start->setEnabled(true);
     ui->action_Pause->setEnabled(false);
     ui->action_Stop->setEnabled(true);
+    ui->action_Capture_Screenshot->setEnabled(false);
 
     AllowOSSleep();
 }
@@ -1957,10 +1958,7 @@ void GMainWindow::OnSaveMovie() {
 }
 
 void GMainWindow::OnCaptureScreenshot() {
-    bool running = emu_thread->IsRunning();
-    if (running) {
-        OnPauseGame();
-    }
+    OnPauseGame();
     QString path = UISettings::values.screenshot_path;
     if (!FileUtil::IsDirectory(path.toStdString())) {
         if (!FileUtil::CreateFullPath(path.toStdString())) {
@@ -1977,9 +1975,7 @@ void GMainWindow::OnCaptureScreenshot() {
         QDateTime::currentDateTime().toString(QStringLiteral("dd.MM.yy_hh.mm.ss.z"));
     path.append(QStringLiteral("/%1_%2.png").arg(filename).arg(timestamp));
     render_window->CaptureScreenshot(UISettings::values.screenshot_resolution_factor, path);
-    if (running) {
-        OnStartGame();
-    }
+    OnStartGame();
 }
 
 #ifdef ENABLE_FFMPEG_VIDEO_DUMPER

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -1958,7 +1958,7 @@ void GMainWindow::OnSaveMovie() {
 
 void GMainWindow::OnCaptureScreenshot() {
     bool running = emu_thread->IsRunning();
-    if(running){
+    if (running) {
         OnPauseGame();
     }
     QString path = UISettings::values.screenshot_path;
@@ -1977,7 +1977,7 @@ void GMainWindow::OnCaptureScreenshot() {
         QDateTime::currentDateTime().toString(QStringLiteral("dd.MM.yy_hh.mm.ss.z"));
     path.append(QStringLiteral("/%1_%2.png").arg(filename).arg(timestamp));
     render_window->CaptureScreenshot(UISettings::values.screenshot_resolution_factor, path);
-    if(running){
+    if (running) {
         OnStartGame();
     }
 }


### PR DESCRIPTION
Fixed an issue where screenshot action can be triggered with hotkey even when no game is loaded.Also removed the screenshot disable on pausing the game(although i am not sure why that was included in the first place!).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6070)
<!-- Reviewable:end -->
