### PR TITLE
loader: check for overflow of seg_sizes[] in 3dsx loader

### DIFF
--- a/src/core/loader/3dsx.cpp
+++ b/src/core/loader/3dsx.cpp
@@ -111,6 +111,11 @@ static THREEDSX_Error Load3DSXFile(FileUtil::IOFile& file, u32 base_addr,
     loadinfo.seg_sizes[0] = (hdr.code_seg_size + 0xFFF) & ~0xFFF;
     loadinfo.seg_sizes[1] = (hdr.rodata_seg_size + 0xFFF) & ~0xFFF;
     loadinfo.seg_sizes[2] = (hdr.data_seg_size + 0xFFF) & ~0xFFF;
+    // prevent integer overflow leading to heap-buffer-overflow
+    if (loadinfo.seg_sizes[0] < hdr.code_seg_size || loadinfo.seg_sizes[1] < hdr.rodata_seg_size ||
+        loadinfo.seg_sizes[2] < hdr.data_seg_size) {
+        return ERROR_READ;
+    }
     u32 offsets[2] = {loadinfo.seg_sizes[0], loadinfo.seg_sizes[0] + loadinfo.seg_sizes[1]};
     u32 n_reloc_tables = hdr.reloc_hdr_size / sizeof(u32);
     std::vector<u8> program_image(loadinfo.seg_sizes[0] + loadinfo.seg_sizes[1] +


### PR DESCRIPTION
I stumbled upon a bug with the 3dsx loader implementation:

1. Set the `hdr.code_seg_size` in your 3dsx file to something like `0xFFFFFFFF`.
2. `seg_sizes[0] = (hdr.code_seg_size + 0xFFF) & ~0xFFF` will then be equal to 0, as it overflows then clears the least significant bytes.
3. `program_image` is initialized with the values in `seg_sizes[]`, as such it's size will be smaller than the actual header values.
4. Finally the file is read using `hdr.code_seg_size` as a size, reading `0xFFFFFFFF` bytes into a far smaller vector, leading to a heap-buffer-overflow.

I haven't checked if this can be exploited to achieve code execution, but my initial guess is no, though this could change in the future or if chained with another bug.

I have an example 3dsx file that will trigger this (it will scream if you compile with ASAN), but Github won't let me upload it, I can do it later if somebody wants to reproduce, this is my ASAN output while triggering the bug:
```==8835==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x621000874d00 at pc 0x559eee751bf3 bp 0x7ffefa126cb0 sp 0x7ffefa126470
WRITE of size 4308 at 0x621000874d00 thread T0
    #0 0x559eee751bf2 in __interceptor_fread.part.0 asan_interceptors.cpp.o
    #1 0x559eeefd51b5 in unsigned long FileUtil::IOFile::ReadArray<char>(char*, unsigned long) /home/arias/citra/src/./common/file_util.h:290:34
    #2 0x559eeefd51b5 in unsigned long FileUtil::IOFile::ReadBytes<unsigned char>(unsigned char*, unsigned long) /home/arias/citra/src/./common/file_util.h:312:16
    #3 0x559eeefd51b5 in Loader::Load3DSXFile(FileUtil::IOFile&, unsigned int, std::__1::shared_ptr<Kernel::CodeSet>*) /home/arias/citra/src/core/loader/3dsx.cpp:138:14
    #4 0x559eeefd51b5 in Loader::AppLoader_THREEDSX::Load(std::__1::shared_ptr<Kernel::Process>&) /home/arias/citra/src/core/loader/3dsx.cpp:266:9
    #5 0x559eee892449 in Core::System::Load(Frontend::EmuWindow&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) /home/arias/citra/src/core/core.cpp:290:56
    #6 0x559eee7ed5e9 in main /home/arias/citra/src/citra/citra.cpp:365:57
    #7 0x7f41dee5f28f  (/usr/lib/libc.so.6+0x2928f) (BuildId: 60df1df31f02a7b23da83e8ef923359885b81492)
    #8 0x7f41dee5f349 in __libc_start_main (/usr/lib/libc.so.6+0x29349) (BuildId: 60df1df31f02a7b23da83e8ef923359885b81492)
    #9 0x559eee6eaac4 in _start /build/glibc/src/glibc/csu/../sysdeps/x86_64/start.S:115

0x621000874d00 is located 0 bytes to the right of 4096-byte region [0x621000873d00,0x621000874d00)
allocated by thread T0 here:
    #0 0x559eee7e38d2 in operator new(unsigned long) (/home/arias/citra/build/bin/Release/citra+0x5038d2)
    #1 0x559eee904c4e in void* std::__1::__libcpp_operator_new<unsigned long>(unsigned long) /usr/bin/../include/c++/v1/new:245:10
    #2 0x559eee904c4e in std::__1::__libcpp_allocate(unsigned long, unsigned long) /usr/bin/../include/c++/v1/new:271:10
    #3 0x559eee904c4e in std::__1::allocator<unsigned char>::allocate(unsigned long) /usr/bin/../include/c++/v1/__memory/allocator.h:105:38
    #4 0x559eee904c4e in std::__1::allocator_traits<std::__1::allocator<unsigned char> >::allocate(std::__1::allocator<unsigned char>&, unsigned long) /usr/bin/../include/c++/v1/__memory/allocator_traits.h:262:20
    #5 0x559eee904c4e in std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::__vallocate(unsigned long) /usr/bin/../include/c++/v1/vector:922:37
    #6 0x559eee904c4e in std::__1::vector<unsigned char, std::__1::allocator<unsigned char> >::vector(unsigned long) /usr/bin/../include/c++/v1/vector:1053:9
    #7 0x559eee892449 in Core::System::Load(Frontend::EmuWindow&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) /home/arias/citra/src/core/core.cpp:290:56
    #8 0x559eee7ed5e9 in main /home/arias/citra/src/citra/citra.cpp:365:57
    #9 0x7f41dee5f28f  (/usr/lib/libc.so.6+0x2928f) (BuildId: 60df1df31f02a7b23da83e8ef923359885b81492)

SUMMARY: AddressSanitizer: heap-buffer-overflow asan_interceptors.cpp.o in __interceptor_fread.part.0
Shadow bytes around the buggy address:
  0x0c4280106950: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c4280106960: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c4280106970: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c4280106980: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c4280106990: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0c42801069a0:[fa]fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c42801069b0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c42801069c0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c42801069d0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c42801069e0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c42801069f0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==8835==ABORTING```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6075)
<!-- Reviewable:end -->
