### PR TITLE
Fix MakeCurrent and shader issues with AMD 22.7 driver

### DIFF
--- a/src/citra/emu_window/emu_window_sdl2.cpp
+++ b/src/citra/emu_window/emu_window_sdl2.cpp
@@ -30,7 +30,6 @@ SharedContext_SDL2::SharedContext_SDL2() {
 }
 
 SharedContext_SDL2::~SharedContext_SDL2() {
-    DoneCurrent();
     SDL_GL_DeleteContext(context);
     SDL_DestroyWindow(window);
 }
@@ -185,6 +184,7 @@ EmuWindow_SDL2::EmuWindow_SDL2(bool fullscreen) {
 
     window_context = SDL_GL_CreateContext(render_window);
     core_context = CreateSharedContext();
+    last_saved_context = nullptr;
 
     if (window_context == nullptr) {
         LOG_CRITICAL(Frontend, "Failed to create SDL2 GL context: {}", SDL_GetError());
@@ -220,6 +220,14 @@ EmuWindow_SDL2::~EmuWindow_SDL2() {
 
 std::unique_ptr<Frontend::GraphicsContext> EmuWindow_SDL2::CreateSharedContext() const {
     return std::make_unique<SharedContext_SDL2>();
+}
+
+void EmuWindow_SDL2::SaveContext() {
+    last_saved_context = SDL_GL_GetCurrentContext();
+}
+
+void EmuWindow_SDL2::RestoreContext() {
+    SDL_GL_MakeCurrent(render_window, last_saved_context);
 }
 
 void EmuWindow_SDL2::Present() {

--- a/src/citra/emu_window/emu_window_sdl2.h
+++ b/src/citra/emu_window/emu_window_sdl2.h
@@ -49,6 +49,11 @@ public:
     /// Creates a new context that is shared with the current context
     std::unique_ptr<GraphicsContext> CreateSharedContext() const override;
 
+    /// Saves the current context, for the purpose of e.g. creating new shared contexts
+    void SaveContext() override;
+    /// Restores the context previously saved
+    void RestoreContext() override;
+
 private:
     /// Called by PollEvents when a key is pressed or released.
     void OnKeyEvent(int key, u8 state);
@@ -93,6 +98,9 @@ private:
 
     /// The OpenGL context associated with the window
     SDL_GLContext window_context;
+
+    /// Used by SaveContext and RestoreContext
+    SDL_GLContext last_saved_context;
 
     /// The OpenGL context associated with the core
     std::unique_ptr<Frontend::GraphicsContext> core_context;

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -53,6 +53,8 @@ void EmuThread::run() {
 
     emit LoadProgress(VideoCore::LoadCallbackStage::Complete, 0, 0);
 
+    core_context.MakeCurrent();
+
     if (Core::System::GetInstance().frame_limiter.IsFrameAdvancing()) {
         // Usually the loading screen is hidden after the first frame is drawn. In this case
         // we hide it immediately as we need to wait for user input to start the emulation.

--- a/src/core/frontend/emu_window.h
+++ b/src/core/frontend/emu_window.h
@@ -114,12 +114,12 @@ public:
     /**
      * Save current GraphicsContext.
      */
-    virtual void SaveContext() {};
+    virtual void SaveContext(){};
 
     /**
      * Restore saved GraphicsContext.
      */
-    virtual void RestoreContext() {};
+    virtual void RestoreContext(){};
 
     /**
      * Signal that a touch pressed event has occurred (e.g. mouse click pressed)

--- a/src/core/frontend/emu_window.h
+++ b/src/core/frontend/emu_window.h
@@ -112,6 +112,16 @@ public:
     }
 
     /**
+     * Save current GraphicsContext.
+     */
+    virtual void SaveContext() {};
+
+    /**
+     * Restore saved GraphicsContext.
+     */
+    virtual void RestoreContext() {};
+
+    /**
      * Signal that a touch pressed event has occurred (e.g. mouse click pressed)
      * @param framebuffer_x Framebuffer x-coordinate that was pressed
      * @param framebuffer_y Framebuffer y-coordinate that was pressed

--- a/src/video_core/renderer_opengl/gl_shader_util.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_util.cpp
@@ -26,7 +26,7 @@ GLuint LoadShader(const char* source, GLenum type) {
 #extension GL_EXT_clip_cull_distance : enable
 #endif // defined(GL_EXT_clip_cull_distance)
 )"
-                                     : "#version 330\n";
+                                     : "#version 430\n";
 
     const char* debug_type;
     switch (type) {

--- a/src/video_core/renderer_opengl/gl_shader_util.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_util.cpp
@@ -26,7 +26,7 @@ GLuint LoadShader(const char* source, GLenum type) {
 #extension GL_EXT_clip_cull_distance : enable
 #endif // defined(GL_EXT_clip_cull_distance)
 )"
-                                     : "#version 430\n";
+                                     : "#version 330\n";
 
     const char* debug_type;
     switch (type) {


### PR DESCRIPTION
Fixes:
- GLSL version mismatch - see https://docs.gl/sl4/imageSize
- failure when loading shaders from shader cache

Within `ShaderProgramManager::LoadDiskCache`, `SDL_GL_CreateContext` immediately claims the created context for the current thread, causing a `MakeCurrent()` failure when the newly spun worker thread attempts to claim it. 

This may still work by accident if the main thread releases the context first (race condition), otherwise the shaders will fail to compile. It does seem the new driver is more strict when enforcing context/thread pairing.

Either way, the main thread has no current context after this operation, so save and restore functionality has been added.

This fixes issues I've seen on Win10 / RX 5500 XT / Pokemon Alpha Sapphire. It's necessary to remove Citra's shader cache after updating the GPU driver.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6083)
<!-- Reviewable:end -->
