### PR TITLE
Android: Sign and publish APKs on GitHub

### DIFF
--- a/.ci/android/build.sh
+++ b/.ci/android/build.sh
@@ -1,12 +1,15 @@
 #!/bin/bash -ex
 
 export NDK_CCACHE=$(which ccache)
+[ "$GITHUB_REPOSITORY" = "citra-emu/citra-canary" ] &&
+   BUILD_FLAVOR=canary ||
+   BUILD_FLAVOR=nightly
 
 ccache -s
 
 cd src/android
 chmod +x ./gradlew
-./gradlew bundleRelease
-./gradlew assembleRelease
+./gradlew assemble${BUILD_FLAVOR}Release
+./gradlew bundle${BUILD_FLAVOR}Release
 
 ccache -s

--- a/.ci/android/upload.sh
+++ b/.ci/android/upload.sh
@@ -3,8 +3,11 @@
 . ./.ci/common/pre-upload.sh
 
 REV_NAME="citra-${GITDATE}-${GITREV}"
+[ "${GITHUB_REPOSITORY}" = "citra-emu/citra-canary" ] &&
+   BUILD_FLAVOR=canary ||
+   BUILD_FLAVOR=nightly
 
-cp src/android/app/build/outputs/apk/release/app-release.apk \
+cp src/android/app/build/outputs/apk/${BUILD_FLAVOR}/release/app-${BUILD_FLAVOR}-release.apk \
   "artifacts/${REV_NAME}.apk"
-cp src/android/app/build/outputs/bundle/release/app-release.aab \
+cp src/android/app/build/outputs/bundle/${BUILD_FLAVOR}Release/app-${BUILD_FLAVOR}-release.aab \
   "artifacts/${REV_NAME}.aab"

--- a/.ci/android/upload.sh
+++ b/.ci/android/upload.sh
@@ -11,3 +11,13 @@ cp src/android/app/build/outputs/apk/${BUILD_FLAVOR}/release/app-${BUILD_FLAVOR}
   "artifacts/${REV_NAME}.apk"
 cp src/android/app/build/outputs/bundle/${BUILD_FLAVOR}Release/app-${BUILD_FLAVOR}-release.aab \
   "artifacts/${REV_NAME}.aab"
+
+if [ ! -z "${ANDROID_KEYSTORE_B64}" ]
+then
+  echo "Signing apk..."
+  base64 --decode <<< "${ANDROID_KEYSTORE_B64}" > ks.jks
+
+  java -jar $(which apksigner) sign --ks ks.jks \
+    --ks-key-alias "${ANDROID_KEY_ALIAS}" \
+    --ks-pass env:ANDROID_KEYSTORE_PASS "artifacts/${REV_NAME}.apk"
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,10 +129,14 @@ jobs:
       - name: Deps
         run: |
           sudo apt-get update
-          sudo apt-get install ccache -y
+          sudo apt-get install ccache apksigner -y
       - name: Build
         run: ./.ci/android/build.sh
-      - name: Copy artifacts
+      - name: Copy and sign artifacts
+        env:
+          ANDROID_KEYSTORE_B64: ${{ secrets.ANDROID_KEYSTORE_B64 }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEYSTORE_PASS: ${{ secrets.ANDROID_KEYSTORE_PASS }}
         run: ./.ci/android/upload.sh
       - name: Upload
         uses: actions/upload-artifact@v3
@@ -153,7 +157,7 @@ jobs:
           TRANSIFEX_API_TOKEN: ${{ secrets.TRANSIFEX_API_TOKEN }}
   release:
     runs-on: ubuntu-latest
-    needs: [build, macos]
+    needs: [build, macos, android]
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
     steps:
       - uses: actions/download-artifact@v3
@@ -174,4 +178,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          asset_paths: '["./**/*.tar.*","./**/*.7z","./**/*.zip"]'
+          asset_paths: '["./**/*.tar.*","./**/*.7z","./**/*.zip","./**/*.apk","./**/*.aab"]'

--- a/src/android/app/build.gradle
+++ b/src/android/app/build.gradle
@@ -83,6 +83,17 @@ android {
         }
     }
 
+    flavorDimensions "version"
+    productFlavors {
+        canary {
+            dimension "version"
+            applicationIdSuffix ".canary"
+        }
+        nightly {
+            dimension "version"
+        }
+    }
+
     externalNativeBuild {
         cmake {
             version "3.18.1"
@@ -138,6 +149,11 @@ def getVersion() {
                 .replaceAll(/(-0)?-[^-]+$/, "")
     } catch (Exception) {
         logger.error('Cannot find git, defaulting to dummy version number')
+    }
+
+    if (System.getenv("GITHUB_ACTIONS") != null) {
+        def gitTag = System.getenv("GIT_TAG_NAME")
+        versionName = gitTag ?: versionName
     }
 
     return versionName


### PR DESCRIPTION
it has been long overdue, this PR fixes the android version always displaying the commit hash instead of the tag associated with the release.
Added product flavours to append `.canary` so that, canary builds can be installed alongside nightly/playstore releases.
@bunnei I'll need your help to setup the secrets, I'll DM you the details.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6108)
<!-- Reviewable:end -->
