### PR TITLE
Invalidate older shader caches

### DIFF
--- a/CMakeModules/GenerateSCMRev.cmake
+++ b/CMakeModules/GenerateSCMRev.cmake
@@ -68,6 +68,8 @@ set(HASH_FILES
     "${VIDEO_CORE}/renderer_opengl/gl_shader_disk_cache.h"
     "${VIDEO_CORE}/renderer_opengl/gl_shader_gen.cpp"
     "${VIDEO_CORE}/renderer_opengl/gl_shader_gen.h"
+    "${VIDEO_CORE}/renderer_opengl/gl_shader_util.cpp"
+    "${VIDEO_CORE}/renderer_opengl/gl_shader_util.h"
     "${VIDEO_CORE}/shader/shader.cpp"
     "${VIDEO_CORE}/shader/shader.h"
     "${VIDEO_CORE}/pica.cpp"

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -32,6 +32,8 @@ add_custom_command(OUTPUT scm_rev.cpp
       "${VIDEO_CORE}/renderer_opengl/gl_shader_disk_cache.h"
       "${VIDEO_CORE}/renderer_opengl/gl_shader_gen.cpp"
       "${VIDEO_CORE}/renderer_opengl/gl_shader_gen.h"
+      "${VIDEO_CORE}/renderer_opengl/gl_shader_util.cpp"
+      "${VIDEO_CORE}/renderer_opengl/gl_shader_util.h"
       "${VIDEO_CORE}/shader/shader.cpp"
       "${VIDEO_CORE}/shader/shader.h"
       "${VIDEO_CORE}/pica.cpp"

--- a/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
@@ -33,6 +33,8 @@ enum class PrecompiledEntryKind : u32 {
 
 constexpr u32 NativeVersion = 1;
 
+// The hash is based on relevant files. The list of files can be found at src/common/CMakeLists.txt
+// and CMakeModules/GenerateSCMRev.cmake
 ShaderCacheVersionHash GetShaderCacheVersionHash() {
     ShaderCacheVersionHash hash{};
     const std::size_t length = std::min(std::strlen(Common::g_shader_cache_version), hash.size());


### PR DESCRIPTION
Shader caches from previous version of citra are creating problems now that the OpenGL version has been bumped to 4.3 (and glsl to 430).
This change should make sure that they're invalidated, and that future changes to glsl will automatically invalidate the caches as well.
The change on the second commit wasn't necessary, but just in case.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6117)
<!-- Reviewable:end -->
