### PR TITLE
citra_qt: Add options to open/clear the shader cache

### DIFF
--- a/src/citra_qt/game_list.h
+++ b/src/citra_qt/game_list.h
@@ -37,6 +37,7 @@ enum class GameListOpenTarget {
     TEXTURE_DUMP = 4,
     TEXTURE_LOAD = 5,
     MODS = 6,
+    SHADER_CACHE = 7
 };
 
 class GameList : public QWidget {

--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -6,12 +6,12 @@
 
 #include <array>
 #include <memory>
+#include <QFileInfo>
 #include <QMainWindow>
 #include <QTimer>
 #include <QTranslator>
 #include "citra_qt/compatibility_list.h"
 #include "citra_qt/hotkeys.h"
-#include "common/announce_multiplayer_room.h"
 #include "core/core.h"
 #include "core/hle/service/am/am.h"
 #include "core/savestate.h"
@@ -131,6 +131,7 @@ private:
     void ShowUpdaterWidgets();
     void ShowUpdatePrompt();
     void ShowNoUpdatePrompt();
+    void ShowFileInShell(const QFileInfo& file_info);
     void CheckForUpdates();
     void SetDiscordEnabled(bool state);
     void LoadAmiibo(const QString& filename);


### PR DESCRIPTION
This PR adds menu options relating to shader cache control for individual games. It adds two options "Open Shader Cache Location" which opens the file browser with the file highlighted and "Clear Disk Shader Cache" which deletes the file. Both options are hidden when a precompiled file does not exist as a visual hint to the support staff.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6118)
<!-- Reviewable:end -->
