### PR TITLE
add mono_render_left_eye option

### DIFF
--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -137,6 +137,7 @@ void Config::ReadValues() {
     Settings::values.texture_filter_name =
         sdl2_config->GetString("Renderer", "texture_filter_name", "none");
 
+    Settings::values.mono_render_left_eye = sdl2_config->GetBoolean("Renderer", "mono_render_left_eye", false);
     Settings::values.render_3d = static_cast<Settings::StereoRenderOption>(
         sdl2_config->GetInteger("Renderer", "render_3d", 0));
     Settings::values.factor_3d =

--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -138,7 +138,7 @@ void Config::ReadValues() {
         sdl2_config->GetString("Renderer", "texture_filter_name", "none");
 
     Settings::values.mono_render_left_eye =
-        sdl2_config->GetBoolean("Renderer", "mono_render_left_eye", false);
+        sdl2_config->GetBoolean("Renderer", "mono_render_left_eye", true);
     Settings::values.render_3d = static_cast<Settings::StereoRenderOption>(
         sdl2_config->GetInteger("Renderer", "render_3d", 0));
     Settings::values.factor_3d =

--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -137,7 +137,8 @@ void Config::ReadValues() {
     Settings::values.texture_filter_name =
         sdl2_config->GetString("Renderer", "texture_filter_name", "none");
 
-    Settings::values.mono_render_left_eye = sdl2_config->GetBoolean("Renderer", "mono_render_left_eye", false);
+    Settings::values.mono_render_left_eye =
+        sdl2_config->GetBoolean("Renderer", "mono_render_left_eye", false);
     Settings::values.render_3d = static_cast<Settings::StereoRenderOption>(
         sdl2_config->GetInteger("Renderer", "render_3d", 0));
     Settings::values.factor_3d =

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -166,6 +166,10 @@ render_3d =
 # 0 - 100: Intensity. 0 (default)
 factor_3d =
 
+# Change Default Eye to Render When in Monoscopic Mode
+# 0 (default): Right, 1: Left
+mono_render_left_eye =
+
 # The name of the post processing shader to apply.
 # Loaded from shaders if render_3d is off or side by side.
 # Loaded from shaders/anaglyph if render_3d is anaglyph

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -349,7 +349,7 @@ void Config::ReadLayoutValues() {
         ReadSetting(QStringLiteral("render_3d"), 0).toInt());
     Settings::values.factor_3d = ReadSetting(QStringLiteral("factor_3d"), 0).toInt();
     Settings::values.mono_render_left_eye =
-        ReadSetting(QStringLiteral("mono_render_left_eye"), false).toBool();
+        ReadSetting(QStringLiteral("mono_render_left_eye"), true).toBool();
     Settings::values.pp_shader_name =
         ReadSetting(QStringLiteral("pp_shader_name"),
                     (Settings::values.render_3d == Settings::StereoRenderOption::Anaglyph)

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -348,6 +348,8 @@ void Config::ReadLayoutValues() {
     Settings::values.render_3d = static_cast<Settings::StereoRenderOption>(
         ReadSetting(QStringLiteral("render_3d"), 0).toInt());
     Settings::values.factor_3d = ReadSetting(QStringLiteral("factor_3d"), 0).toInt();
+    Settings::values.mono_render_left_eye =
+        ReadSetting(QStringLiteral("mono_render_left_eye"), false).toBool();
     Settings::values.pp_shader_name =
         ReadSetting(QStringLiteral("pp_shader_name"),
                     (Settings::values.render_3d == Settings::StereoRenderOption::Anaglyph)
@@ -901,6 +903,8 @@ void Config::SaveLayoutValues() {
 
     WriteSetting(QStringLiteral("render_3d"), static_cast<int>(Settings::values.render_3d), 0);
     WriteSetting(QStringLiteral("factor_3d"), Settings::values.factor_3d.load(), 0);
+    WriteSetting(QStringLiteral("mono_render_left_eye"), Settings::values.mono_render_left_eye,
+                 false);
     WriteSetting(QStringLiteral("pp_shader_name"),
                  QString::fromStdString(Settings::values.pp_shader_name),
                  (Settings::values.render_3d == Settings::StereoRenderOption::Anaglyph)

--- a/src/citra_qt/configuration/configure_enhancements.cpp
+++ b/src/citra_qt/configuration/configure_enhancements.cpp
@@ -53,6 +53,7 @@ void ConfigureEnhancements::SetConfiguration() {
     ui->resolution_factor_combobox->setCurrentIndex(Settings::values.resolution_factor);
     ui->render_3d_combobox->setCurrentIndex(static_cast<int>(Settings::values.render_3d));
     ui->factor_3d->setValue(Settings::values.factor_3d);
+    ui->mono_render_left_eye->setChecked(Settings::values.mono_render_left_eye);
     updateShaders(Settings::values.render_3d);
     ui->toggle_linear_filter->setChecked(Settings::values.filter_mode);
     int tex_filter_idx = ui->texture_filter_combobox->findText(
@@ -107,6 +108,7 @@ void ConfigureEnhancements::ApplyConfiguration() {
     Settings::values.render_3d =
         static_cast<Settings::StereoRenderOption>(ui->render_3d_combobox->currentIndex());
     Settings::values.factor_3d = ui->factor_3d->value();
+    Settings::values.mono_render_left_eye = ui->mono_render_left_eye->isChecked();
     Settings::values.pp_shader_name =
         ui->shader_combobox->itemText(ui->shader_combobox->currentIndex()).toStdString();
     Settings::values.filter_mode = ui->toggle_linear_filter->isChecked();

--- a/src/citra_qt/configuration/configure_enhancements.ui
+++ b/src/citra_qt/configuration/configure_enhancements.ui
@@ -207,6 +207,20 @@
         </item>
        </layout>
       </item>
+       <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_9">
+           <item>
+           <widget class="QCheckBox" name="mono_render_left_eye">
+             <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If false, right eye will be used. Useful if using ReShade&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="text">
+               <string>Render Left Eye in Monoscopic Mode</string>
+             </property>
+           </widget>
+           </item>
+         </layout>
+       </item>
      </layout>
     </widget>
    </item>
@@ -350,6 +364,7 @@
   <tabstop>texture_filter_combobox</tabstop>
   <tabstop>render_3d_combobox</tabstop>
   <tabstop>factor_3d</tabstop>
+  <tabstop>mono_render_left_eye</tabstop>
   <tabstop>layout_combobox</tabstop>
   <tabstop>swap_screen</tabstop>
   <tabstop>upright_screen</tabstop>

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -96,6 +96,7 @@ void LogSettings() {
     log_setting("Renderer_TextureFilterName", values.texture_filter_name);
     log_setting("Stereoscopy_Render3d", values.render_3d);
     log_setting("Stereoscopy_Factor3d", values.factor_3d);
+    log_setting("Stereoscopy_MonoRenderLeftEye", values.mono_render_left_eye);
     log_setting("Layout_LayoutOption", values.layout_option);
     log_setting("Layout_SwapScreen", values.swap_screen);
     log_setting("Layout_UprightScreen", values.upright_screen);

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -195,6 +195,8 @@ struct Values {
     StereoRenderOption render_3d;
     std::atomic<u8> factor_3d;
 
+    bool mono_render_left_eye;
+
     int cardboard_screen_size;
     int cardboard_x_shift;
     int cardboard_y_shift;

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -149,6 +149,8 @@ void TelemetrySession::AddInitialInfo(Loader::AppLoader& app_loader) {
              static_cast<int>(Settings::values.render_3d));
     AddField(Telemetry::FieldType::UserConfig, "Renderer_Factor3d",
              Settings::values.factor_3d.load());
+    AddField(Telemetry::FieldType::UserConfig, "Renderer_MonoRenderLeftEye",
+             Settings::values.mono_render_left_eye);
     AddField(Telemetry::FieldType::UserConfig, "System_IsNew3ds", Settings::values.is_new_3ds);
     AddField(Telemetry::FieldType::UserConfig, "System_RegionValue", Settings::values.region_value);
 }

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -991,7 +991,8 @@ void RendererOpenGL::DrawScreens(const Layout::FramebufferLayout& layout, bool f
     if (layout.top_screen_enabled) {
         if (layout.is_rotated) {
             if (Settings::values.render_3d == Settings::StereoRenderOption::Off) {
-                DrawSingleScreenRotated(screen_infos[0], (float)top_screen.left,
+                int eye = Settings::values.mono_render_left_eye ? 0 : 1;
+                DrawSingleScreenRotated(screen_infos[eye], (float)top_screen.left,
                                         (float)top_screen.top, (float)top_screen.GetWidth(),
                                         (float)top_screen.GetHeight());
             } else if (Settings::values.render_3d == Settings::StereoRenderOption::SideBySide) {
@@ -1020,7 +1021,8 @@ void RendererOpenGL::DrawScreens(const Layout::FramebufferLayout& layout, bool f
             }
         } else {
             if (Settings::values.render_3d == Settings::StereoRenderOption::Off) {
-                DrawSingleScreen(screen_infos[0], (float)top_screen.left, (float)top_screen.top,
+                int eye = Settings::values.mono_render_left_eye ? 0 : 1;
+                DrawSingleScreen(screen_infos[eye], (float)top_screen.left, (float)top_screen.top,
                                  (float)top_screen.GetWidth(), (float)top_screen.GetHeight());
             } else if (Settings::values.render_3d == Settings::StereoRenderOption::SideBySide) {
                 DrawSingleScreen(screen_infos[0], (float)top_screen.left / 2, (float)top_screen.top,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1683122/193303627-34a2574f-cd44-447d-b63f-26dbfb0f295f.png)

defaults to false, (right eye)
can be set to true (left eye)

partially addresses https://github.com/citra-emu/citra/issues/4881 by making sure the rgb output in mono mode matches the depth buffer (which is usually the right eye, since it is written last)

i still need to figure out a good way to grab other depth passes, either entirely in ReShade, or by adding some kind of option to expose them from Citra. :G

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6140)
<!-- Reviewable:end -->
