### PR TITLE
citra_qt: ask for confirmation when changing games from the game list

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -1320,7 +1320,9 @@ void GMainWindow::UpdateSaveStates() {
 }
 
 void GMainWindow::OnGameListLoadFile(QString game_path) {
-    BootGame(game_path);
+    if (ConfirmChangeGame()) {
+        BootGame(game_path);
+    }
 }
 
 void GMainWindow::OnGameListOpenFolder(u64 data_id, GameListOpenTarget target) {


### PR DESCRIPTION
If a game is already running, Citra currently asks for confirmation before opening a new game dropped on the window, but not before opening a new game chosen from the game list. This PR adds confirmation to the latter case.

(Yes, I did this by accident.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6186)
<!-- Reviewable:end -->
