### PR TITLE
Resolve C4101 warning

### DIFF
--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -262,7 +262,7 @@ void Config::ReadValues() {
 
         try {
             days = std::stoll(day_string);
-        } catch (std::exception& e) {
+        } catch (std::logic_error&) {
             LOG_ERROR(Config, "Failed to parse days in init_time_offset. Using 0");
             days = 0;
         }


### PR DESCRIPTION
and catch logic_error instead of exception, as stoll should only throw std::invalid_argument and std::out_of_range, and both inherit from it.

Fixes the current CI issues.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6196)
<!-- Reviewable:end -->
