### PR TITLE
Qt: Implement more hotkeys for secondary window

### DIFF
--- a/src/citra_qt/main.h
+++ b/src/citra_qt/main.h
@@ -203,6 +203,8 @@ private slots:
     void ToggleScreenLayout();
     void OnSwapScreens();
     void OnRotateScreens();
+    void TriggerSwapScreens();
+    void TriggerRotateScreens();
     void OnCheats();
     void ShowFullscreen();
     void HideFullscreen();


### PR DESCRIPTION
Allows secondary window to recognize `Toggle Screen Layout`, `Swap Screens`,  and `Rotate Screens Upright` hotkeys.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6198)
<!-- Reviewable:end -->
