### PR TITLE
#6041 Fix

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -2268,6 +2268,7 @@ void GMainWindow::OnCoreError(Core::System::ResultStatus result, std::string det
     QString status_message;
 
     QString title, message;
+    QMessageBox::Icon error_severity_icon;
     if (result == Core::System::ResultStatus::ErrorSystemFiles) {
         const QString common_message =
             tr("%1 is missing. Please <a "
@@ -2283,9 +2284,11 @@ void GMainWindow::OnCoreError(Core::System::ResultStatus result, std::string det
 
         title = tr("System Archive Not Found");
         status_message = tr("System Archive Missing");
+        error_severity_icon = QMessageBox::Icon::Critical;
     } else if (result == Core::System::ResultStatus::ErrorSavestate) {
         title = tr("Save/load Error");
         message = QString::fromStdString(details);
+        error_severity_icon = QMessageBox::Icon::Warning;
     } else {
         title = tr("Fatal Error");
         message =
@@ -2294,30 +2297,39 @@ void GMainWindow::OnCoreError(Core::System::ResultStatus result, std::string det
                "the log</a> for details."
                "<br/>Continuing emulation may result in crashes and bugs.");
         status_message = tr("Fatal Error encountered");
+        error_severity_icon = QMessageBox::Icon::Critical;
     }
 
     QMessageBox message_box;
     message_box.setWindowTitle(title);
     message_box.setText(message);
-    message_box.setIcon(QMessageBox::Icon::Critical);
-    message_box.addButton(tr("Continue"), QMessageBox::RejectRole);
-    QPushButton* abort_button = message_box.addButton(tr("Abort"), QMessageBox::AcceptRole);
-    if (result != Core::System::ResultStatus::ShutdownRequested)
-        message_box.exec();
+    message_box.setIcon(error_severity_icon);
+    if(error_severity_icon == QMessageBox::Icon::Critical) {
+        message_box.addButton(tr("Continue"), QMessageBox::RejectRole);
+        QPushButton *abort_button = message_box.addButton(tr("Quit Game"), QMessageBox::AcceptRole);
+        if (result != Core::System::ResultStatus::ShutdownRequested)
+            message_box.exec();
 
-    if (result == Core::System::ResultStatus::ShutdownRequested ||
-        message_box.clickedButton() == abort_button) {
-        if (emu_thread) {
-            ShutdownGame();
+        if (result == Core::System::ResultStatus::ShutdownRequested ||
+            message_box.clickedButton() == abort_button) {
+            if (emu_thread) {
+                ShutdownGame();
+                return;
+            }
         }
     } else {
-        // Only show the message if the game is still running.
-        if (emu_thread) {
-            emu_thread->SetRunning(true);
-            message_label->setText(status_message);
-            message_label->setVisible(true);
-            message_label_used_for_movie = false;
-        }
+        //This block should run when the error isn't too big of a deal
+        //e.g. when a save state can't be saved or loaded
+        message_box.addButton(tr("OK"), QMessageBox::RejectRole);
+        message_box.exec();
+    }
+
+    // Only show the message if the game is still running.
+    if (emu_thread) {
+        emu_thread->SetRunning(true);
+        message_label->setText(status_message);
+        message_label->setVisible(true);
+        message_label_used_for_movie = false;
     }
 }
 

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -2304,9 +2304,9 @@ void GMainWindow::OnCoreError(Core::System::ResultStatus result, std::string det
     message_box.setWindowTitle(title);
     message_box.setText(message);
     message_box.setIcon(error_severity_icon);
-    if(error_severity_icon == QMessageBox::Icon::Critical) {
+    if (error_severity_icon == QMessageBox::Icon::Critical) {
         message_box.addButton(tr("Continue"), QMessageBox::RejectRole);
-        QPushButton *abort_button = message_box.addButton(tr("Quit Game"), QMessageBox::AcceptRole);
+        QPushButton* abort_button = message_box.addButton(tr("Quit Game"), QMessageBox::AcceptRole);
         if (result != Core::System::ResultStatus::ShutdownRequested)
             message_box.exec();
 
@@ -2318,8 +2318,8 @@ void GMainWindow::OnCoreError(Core::System::ResultStatus result, std::string det
             }
         }
     } else {
-        //This block should run when the error isn't too big of a deal
-        //e.g. when a save state can't be saved or loaded
+        // This block should run when the error isn't too big of a deal
+        // e.g. when a save state can't be saved or loaded
         message_box.addButton(tr("OK"), QMessageBox::RejectRole);
         message_box.exec();
     }

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -125,7 +125,7 @@ System::ResultStatus System::RunLoop(bool tight_loop) {
         frame_limiter.WaitOnce();
         return ResultStatus::Success;
     }
-case Signal::Save: {
+    case Signal::Save: {
         LOG_INFO(Core, "Begin save");
         try {
             System::SaveState(param);

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -125,7 +125,7 @@ System::ResultStatus System::RunLoop(bool tight_loop) {
         frame_limiter.WaitOnce();
         return ResultStatus::Success;
     }
-    case Signal::Save: {
+case Signal::Save: {
         LOG_INFO(Core, "Begin save");
         try {
             System::SaveState(param);


### PR DESCRIPTION
This fixes #6041 by changing OnCoreError. Instead of there being an "Abort/Continue" prompt when a savestate fails to save or load, it just brings up a warning box.

I also changed "Abort/Continue" to "Quit Game/Continue" for better clarity

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6236)
<!-- Reviewable:end -->
