### PR TITLE
Multi-threaded HLE IO operations

### DIFF
--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -295,11 +295,35 @@ public:
     }
 
     template <typename T>
+    std::size_t PReadArray(T* data, std::size_t length, std::size_t offset) {
+        static_assert(std::is_trivially_copyable_v<T>,
+                      "Given array does not consist of trivially copyable objects");
+
+        std::size_t items_read = PReadImpl(data, length, sizeof(T), offset);
+        if (items_read != length)
+            m_good = false;
+
+        return items_read;
+    }
+
+    template <typename T>
     std::size_t WriteArray(const T* data, std::size_t length) {
         static_assert(std::is_trivially_copyable_v<T>,
                       "Given array does not consist of trivially copyable objects");
 
         std::size_t items_written = WriteImpl(data, length, sizeof(T));
+        if (items_written != length)
+            m_good = false;
+
+        return items_written;
+    }
+
+    template <typename T>
+    std::size_t PWriteArray(const T* data, std::size_t length, std::size_t offset) {
+        static_assert(std::is_trivially_copyable_v<T>,
+                      "Given array does not consist of trivially copyable objects");
+
+        std::size_t items_written = PWriteImpl(data, length, sizeof(T), offset);
         if (items_written != length)
             m_good = false;
 
@@ -313,9 +337,21 @@ public:
     }
 
     template <typename T>
+    std::size_t PReadBytes(T* data, std::size_t length, std::size_t offset) {
+        static_assert(std::is_trivially_copyable_v<T>, "T must be trivially copyable");
+        return PReadArray(reinterpret_cast<char*>(data), length, offset);
+    }
+
+    template <typename T>
     std::size_t WriteBytes(const T* data, std::size_t length) {
         static_assert(std::is_trivially_copyable_v<T>, "T must be trivially copyable");
         return WriteArray(reinterpret_cast<const char*>(data), length);
+    }
+
+    template <typename T>
+    std::size_t PWriteBytes(const T* data, std::size_t length, std::size_t offset) {
+        static_assert(std::is_trivially_copyable_v<T>, "T must be trivially copyable");
+        return PWriteArray(reinterpret_cast<const char*>(data), length, offset);
     }
 
     template <typename T>
@@ -354,7 +390,11 @@ public:
 
 private:
     std::size_t ReadImpl(void* data, std::size_t length, std::size_t data_size);
+    std::size_t PReadImpl(void* data, std::size_t length, std::size_t data_size,
+                          std::size_t offset);
     std::size_t WriteImpl(const void* data, std::size_t length, std::size_t data_size);
+    std::size_t PWriteImpl(const void* data, std::size_t length, std::size_t data_size,
+                           std::size_t offset);
 
     bool Open();
 

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -223,8 +223,6 @@ System::ResultStatus System::RunLoop(bool tight_loop) {
         }
     }
 
-    kernel->SignalAllHLEParallelEvents();
-
     if (GDBStub::IsServerEnabled()) {
         GDBStub::SetCpuStepFlag(false);
     }

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -223,6 +223,8 @@ System::ResultStatus System::RunLoop(bool tight_loop) {
         }
     }
 
+    kernel->SignalAllHLEParallelEvents();
+
     if (GDBStub::IsServerEnabled()) {
         GDBStub::SetCpuStepFlag(false);
     }

--- a/src/core/core_timing.cpp
+++ b/src/core/core_timing.cpp
@@ -174,22 +174,6 @@ void Timing::Timer::MoveEvents() {
     }
 }
 
-u32 Timing::Timer::StartAdjust() {
-    ASSERT((adjust_value_curr_handle & 1) == 0); // Should always be even
-    adjust_value_last = std::chrono::steady_clock::now();
-    return ++adjust_value_curr_handle;
-}
-
-void Timing::Timer::EndAdjust(u32 start_adjust_handle) {
-    std::chrono::time_point<std::chrono::steady_clock> new_timer = std::chrono::steady_clock::now();
-    ASSERT(new_timer >= adjust_value_last && start_adjust_handle == adjust_value_curr_handle);
-    AddTicks(nsToCycles(static_cast<float>(
-        std::chrono::duration_cast<std::chrono::nanoseconds>(new_timer - adjust_value_last)
-            .count() /
-        cpu_clock_scale)));
-    ++adjust_value_curr_handle;
-}
-
 s64 Timing::Timer::GetMaxSliceLength() const {
     const auto& next_event = event_queue.begin();
     if (next_event != event_queue.end()) {

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -203,11 +203,6 @@ public:
 
         void MoveEvents();
 
-        // Use these two functions to adjust the guest system tick on host blocking operations, so
-        // that the guest can tell how much time passed during the host call.
-        u32 StartAdjust();
-        void EndAdjust(u32 start_adjust_handle);
-
     private:
         friend class Timing;
         // The queue is a min-heap using std::make_heap/push_heap/pop_heap.
@@ -233,8 +228,6 @@ public:
         s64 executed_ticks = 0;
         u64 idled_cycles = 0;
 
-        std::chrono::time_point<std::chrono::steady_clock> adjust_value_last;
-        u32 adjust_value_curr_handle = 0;
         // Stores a scaling for the internal clockspeed. Changing this number results in
         // under/overclocking the guest cpu
         double cpu_clock_scale = 1.0;

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -262,6 +262,10 @@ public:
                        std::uintptr_t user_data = 0,
                        std::size_t core_id = std::numeric_limits<std::size_t>::max());
 
+    void ScheduleEventTS(s64 cycles_into_future, const TimingEventType* event_type,
+                         std::uintptr_t user_data = 0,
+                         std::size_t core_id = std::numeric_limits<std::size_t>::max());
+
     void UnscheduleEvent(const TimingEventType* event_type, std::uintptr_t user_data);
 
     /// We only permit one event of each type in the queue at a time.

--- a/src/core/file_sys/archive_ncch.cpp
+++ b/src/core/file_sys/archive_ncch.cpp
@@ -252,11 +252,21 @@ ResultVal<std::size_t> NCCHFile::Read(const u64 offset, const std::size_t length
     return MakeResult<std::size_t>(copy_size);
 }
 
+ResultVal<std::size_t> NCCHFile::PRead(const u64 offset, const std::size_t length,
+                                       u8* buffer) const {
+    return Read(offset, length, buffer);
+}
+
 ResultVal<std::size_t> NCCHFile::Write(const u64 offset, const std::size_t length, const bool flush,
                                        const u8* buffer) {
     LOG_ERROR(Service_FS, "Attempted to write to NCCH file");
     // TODO(shinyquagsire23): Find error code
     return MakeResult<std::size_t>(0);
+}
+
+ResultVal<std::size_t> NCCHFile::PWrite(const u64 offset, const std::size_t length,
+                                        const bool flush, const u8* buffer) {
+    return Write(offset, length, flush, buffer);
 }
 
 u64 NCCHFile::GetSize() const {

--- a/src/core/file_sys/archive_ncch.h
+++ b/src/core/file_sys/archive_ncch.h
@@ -85,8 +85,11 @@ public:
     explicit NCCHFile(std::vector<u8> buffer, std::unique_ptr<DelayGenerator> delay_generator_);
 
     ResultVal<std::size_t> Read(u64 offset, std::size_t length, u8* buffer) const override;
+    ResultVal<std::size_t> PRead(u64 offset, std::size_t length, u8* buffer) const override;
     ResultVal<std::size_t> Write(u64 offset, std::size_t length, bool flush,
                                  const u8* buffer) override;
+    ResultVal<std::size_t> PWrite(u64 offset, std::size_t length, bool flush,
+                                  const u8* buffer) override;
     u64 GetSize() const override;
     bool SetSize(u64 size) const override;
     bool Close() const override {

--- a/src/core/file_sys/archive_selfncch.cpp
+++ b/src/core/file_sys/archive_selfncch.cpp
@@ -55,10 +55,19 @@ public:
         return MakeResult<std::size_t>(data->size());
     }
 
+    ResultVal<std::size_t> PRead(u64 offset, std::size_t length, u8* buffer) const override {
+        return Read(offset, length, buffer);
+    }
+
     ResultVal<std::size_t> Write(u64 offset, std::size_t length, bool flush,
                                  const u8* buffer) override {
         LOG_ERROR(Service_FS, "The file is read-only!");
         return ERROR_UNSUPPORTED_OPEN_FLAGS;
+    }
+
+    ResultVal<std::size_t> PWrite(u64 offset, std::size_t length, bool flush,
+                                  const u8* buffer) override {
+        return Write(offset, length, flush, buffer);
     }
 
     u64 GetSize() const override {

--- a/src/core/file_sys/disk_archive.cpp
+++ b/src/core/file_sys/disk_archive.cpp
@@ -29,6 +29,14 @@ ResultVal<std::size_t> DiskFile::Read(const u64 offset, const std::size_t length
     return MakeResult<std::size_t>(file->ReadBytes(buffer, length));
 }
 
+ResultVal<std::size_t> DiskFile::PRead(const u64 offset, const std::size_t length,
+                                       u8* buffer) const {
+    if (!mode.read_flag)
+        return ERROR_INVALID_OPEN_FLAGS;
+
+    return MakeResult<std::size_t>(file->PReadBytes(buffer, length, offset));
+}
+
 ResultVal<std::size_t> DiskFile::Write(const u64 offset, const std::size_t length, const bool flush,
                                        const u8* buffer) {
     if (!mode.write_flag)
@@ -36,6 +44,17 @@ ResultVal<std::size_t> DiskFile::Write(const u64 offset, const std::size_t lengt
 
     file->Seek(offset, SEEK_SET);
     std::size_t written = file->WriteBytes(buffer, length);
+    if (flush)
+        file->Flush();
+    return MakeResult<std::size_t>(written);
+}
+
+ResultVal<std::size_t> DiskFile::PWrite(const u64 offset, const std::size_t length,
+                                        const bool flush, const u8* buffer) {
+    if (!mode.write_flag)
+        return ERROR_INVALID_OPEN_FLAGS;
+
+    std::size_t written = file->PWriteBytes(buffer, length, offset);
     if (flush)
         file->Flush();
     return MakeResult<std::size_t>(written);

--- a/src/core/file_sys/disk_archive.h
+++ b/src/core/file_sys/disk_archive.h
@@ -33,8 +33,11 @@ public:
     }
 
     ResultVal<std::size_t> Read(u64 offset, std::size_t length, u8* buffer) const override;
+    ResultVal<std::size_t> PRead(u64 offset, std::size_t length, u8* buffer) const override;
     ResultVal<std::size_t> Write(u64 offset, std::size_t length, bool flush,
                                  const u8* buffer) override;
+    ResultVal<std::size_t> PWrite(u64 offset, std::size_t length, bool flush,
+                                  const u8* buffer) override;
     u64 GetSize() const override;
     bool SetSize(u64 size) const override;
     bool Close() const override;

--- a/src/core/file_sys/file_backend.h
+++ b/src/core/file_sys/file_backend.h
@@ -32,6 +32,15 @@ public:
     virtual ResultVal<std::size_t> Read(u64 offset, std::size_t length, u8* buffer) const = 0;
 
     /**
+     * Read data from the file thread safe
+     * @param offset Offset in bytes to start reading data from
+     * @param length Length in bytes of data to read from file
+     * @param buffer Buffer to read data into
+     * @return Number of bytes read, or error code
+     */
+    virtual ResultVal<std::size_t> PRead(u64 offset, std::size_t length, u8* buffer) const = 0;
+
+    /**
      * Write data to the file
      * @param offset Offset in bytes to start writing data to
      * @param length Length in bytes of data to write to file
@@ -41,6 +50,17 @@ public:
      */
     virtual ResultVal<std::size_t> Write(u64 offset, std::size_t length, bool flush,
                                          const u8* buffer) = 0;
+
+    /**
+     * Write data to the file thread safe
+     * @param offset Offset in bytes to start writing data to
+     * @param length Length in bytes of data to write to file
+     * @param flush The flush parameters (0 == do not flush)
+     * @param buffer Buffer to read data from
+     * @return Number of bytes written, or error code
+     */
+    virtual ResultVal<std::size_t> PWrite(u64 offset, std::size_t length, bool flush,
+                                          const u8* buffer) = 0;
 
     /**
      * Get the amount of time a 3ds needs to read those data

--- a/src/core/file_sys/ivfc_archive.cpp
+++ b/src/core/file_sys/ivfc_archive.cpp
@@ -107,11 +107,22 @@ ResultVal<std::size_t> IVFCFile::Read(const u64 offset, const std::size_t length
     return MakeResult<std::size_t>(romfs_file->ReadFile(offset, length, buffer));
 }
 
+ResultVal<std::size_t> IVFCFile::PRead(const u64 offset, const std::size_t length,
+                                       u8* buffer) const {
+    LOG_TRACE(Service_FS, "called offset={}, length={}", offset, length);
+    return MakeResult<std::size_t>(romfs_file->PReadFile(offset, length, buffer));
+}
+
 ResultVal<std::size_t> IVFCFile::Write(const u64 offset, const std::size_t length, const bool flush,
                                        const u8* buffer) {
     LOG_ERROR(Service_FS, "Attempted to write to IVFC file");
     // TODO(Subv): Find error code
     return MakeResult<std::size_t>(0);
+}
+
+ResultVal<std::size_t> IVFCFile::PWrite(const u64 offset, const std::size_t length,
+                                        const bool flush, const u8* buffer) {
+    return Write(offset, length, flush, buffer);
 }
 
 u64 IVFCFile::GetSize() const {
@@ -140,11 +151,21 @@ ResultVal<std::size_t> IVFCFileInMemory::Read(const u64 offset, const std::size_
     return MakeResult<std::size_t>(read_length);
 }
 
+ResultVal<std::size_t> IVFCFileInMemory::PRead(const u64 offset, const std::size_t length,
+                                               u8* buffer) const {
+    return Read(offset, length, buffer);
+}
+
 ResultVal<std::size_t> IVFCFileInMemory::Write(const u64 offset, const std::size_t length,
                                                const bool flush, const u8* buffer) {
     LOG_ERROR(Service_FS, "Attempted to write to IVFC file");
     // TODO(Subv): Find error code
     return MakeResult<std::size_t>(0);
+}
+
+ResultVal<std::size_t> IVFCFileInMemory::PWrite(const u64 offset, const std::size_t length,
+                                                const bool flush, const u8* buffer) {
+    return Write(offset, length, flush, buffer);
 }
 
 u64 IVFCFileInMemory::GetSize() const {

--- a/src/core/file_sys/ivfc_archive.h
+++ b/src/core/file_sys/ivfc_archive.h
@@ -125,8 +125,11 @@ public:
     IVFCFile(std::shared_ptr<RomFSReader> file, std::unique_ptr<DelayGenerator> delay_generator_);
 
     ResultVal<std::size_t> Read(u64 offset, std::size_t length, u8* buffer) const override;
+    ResultVal<std::size_t> PRead(u64 offset, std::size_t length, u8* buffer) const override;
     ResultVal<std::size_t> Write(u64 offset, std::size_t length, bool flush,
                                  const u8* buffer) override;
+    ResultVal<std::size_t> PWrite(u64 offset, std::size_t length, bool flush,
+                                  const u8* buffer) override;
     u64 GetSize() const override;
     bool SetSize(u64 size) const override;
     bool Close() const override {
@@ -163,8 +166,11 @@ public:
                      std::unique_ptr<DelayGenerator> delay_generator_);
 
     ResultVal<std::size_t> Read(u64 offset, std::size_t length, u8* buffer) const override;
+    ResultVal<std::size_t> PRead(u64 offset, std::size_t length, u8* buffer) const override;
     ResultVal<std::size_t> Write(u64 offset, std::size_t length, bool flush,
                                  const u8* buffer) override;
+    ResultVal<std::size_t> PWrite(u64 offset, std::size_t length, bool flush,
+                                  const u8* buffer) override;
     u64 GetSize() const override;
     bool SetSize(u64 size) const override;
     bool Close() const override {

--- a/src/core/file_sys/layered_fs.h
+++ b/src/core/file_sys/layered_fs.h
@@ -50,6 +50,7 @@ public:
 
     std::size_t GetSize() const override;
     std::size_t ReadFile(std::size_t offset, std::size_t length, u8* buffer) override;
+    std::size_t PReadFile(std::size_t offset, std::size_t length, u8* buffer) override;
 
     bool DumpRomFS(const std::string& target_path);
 

--- a/src/core/file_sys/romfs_reader.cpp
+++ b/src/core/file_sys/romfs_reader.cpp
@@ -22,4 +22,17 @@ std::size_t DirectRomFSReader::ReadFile(std::size_t offset, std::size_t length, 
     return read_length;
 }
 
+std::size_t DirectRomFSReader::PReadFile(std::size_t offset, std::size_t length, u8* buffer) {
+    if (length == 0)
+        return 0; // Crypto++ does not like zero size buffer
+    std::size_t read_length = std::min(length, static_cast<std::size_t>(data_size) - offset);
+    read_length = file.PReadBytes(buffer, read_length, file_offset + offset);
+    if (is_encrypted) {
+        CryptoPP::CTR_Mode<CryptoPP::AES>::Decryption d(key.data(), key.size(), ctr.data());
+        d.Seek(crypto_offset + offset);
+        d.ProcessData(buffer, buffer, read_length);
+    }
+    return read_length;
+}
+
 } // namespace FileSys

--- a/src/core/file_sys/romfs_reader.h
+++ b/src/core/file_sys/romfs_reader.h
@@ -18,6 +18,7 @@ public:
 
     virtual std::size_t GetSize() const = 0;
     virtual std::size_t ReadFile(std::size_t offset, std::size_t length, u8* buffer) = 0;
+    virtual std::size_t PReadFile(std::size_t offset, std::size_t length, u8* buffer) = 0;
 
 private:
     template <class Archive>
@@ -47,6 +48,7 @@ public:
     }
 
     std::size_t ReadFile(std::size_t offset, std::size_t length, u8* buffer) override;
+    std::size_t PReadFile(std::size_t offset, std::size_t length, u8* buffer) override;
 
 private:
     bool is_encrypted;

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -4,6 +4,9 @@
 
 #include <algorithm>
 #include <vector>
+#include <boost/asio/post.hpp>
+#include <boost/asio/thread_pool.hpp>
+#undef CreateEvent
 #include "common/assert.h"
 #include "common/common_types.h"
 #include "core/core.h"
@@ -91,6 +94,10 @@ std::shared_ptr<Event> HLERequestContext::SleepClientThread(
         thread->WakeAfterDelay(timeout.count());
 
     return event;
+}
+
+void HLERequestContext::AppendToThreadPool(const std::function<void(void)>& func) {
+    boost::asio::post(kernel.GetHLEThreadPool(), func);
 }
 
 HLERequestContext::HLERequestContext() : kernel(Core::Global<KernelSystem>()) {}

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -4,7 +4,7 @@
 
 #include <algorithm>
 #include <vector>
-#include <boost/asio/post.hpp>
+#include <boost/asio/defer.hpp>
 #include <boost/asio/thread_pool.hpp>
 #undef CreateEvent
 #include "common/assert.h"
@@ -97,7 +97,7 @@ std::shared_ptr<Event> HLERequestContext::SleepClientThread(
 }
 
 void HLERequestContext::AppendToThreadPool(const std::function<void(void)>& func) {
-    boost::asio::post(kernel.GetHLEThreadPool(), func);
+    boost::asio::defer(kernel.GetHLEThreadPool(), func);
 }
 
 HLERequestContext::HLERequestContext() : kernel(Core::Global<KernelSystem>()) {}

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -244,9 +244,9 @@ public:
 
 private:
     template <typename ResultFunctor>
-    class ParalelWakeUp : public WakeupCallback {
+    class ParallelWakeUp : public WakeupCallback {
     public:
-        explicit ParalelWakeUp(ResultFunctor res_functor) : functor(res_functor) {}
+        explicit ParallelWakeUp(ResultFunctor res_functor) : functor(res_functor) {}
 
         void WakeUp(std::shared_ptr<Kernel::Thread> thread, Kernel::HLERequestContext& ctx,
                     Kernel::ThreadWakeupReason reason) {
@@ -261,11 +261,11 @@ private:
 
 public:
     template <typename ParallelFunctor, typename ResultFunctor>
-    void RunInParalelPool(ParallelFunctor paralel_section, ResultFunctor result_function,
+    void RunInParallelPool(ParallelFunctor paralel_section, ResultFunctor result_function,
                           bool really_parallel = true) {
         really_parallel = really_parallel && kernel.HasParallelHLE();
 
-        auto parallel_wakeup = std::make_shared<ParalelWakeUp<ResultFunctor>>(result_function);
+        auto parallel_wakeup = std::make_shared<ParallelWakeUp<ResultFunctor>>(result_function);
 
         if (really_parallel) {
             this->SleepClientThread("RunInPool", std::chrono::nanoseconds(-1), parallel_wakeup);

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -262,7 +262,7 @@ private:
 public:
     template <typename ParallelFunctor, typename ResultFunctor>
     void RunInParallelPool(ParallelFunctor paralel_section, ResultFunctor result_function,
-                          bool really_parallel = true) {
+                           bool really_parallel = true) {
         really_parallel = really_parallel && kernel.HasParallelHLE();
 
         auto parallel_wakeup = std::make_shared<ParallelWakeUp<ResultFunctor>>(result_function);

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -18,6 +18,7 @@
 #include "common/common_types.h"
 #include "common/serialization/boost_small_vector.hpp"
 #include "common/swap.h"
+#include "core/core.h"
 #include "core/hle/ipc.h"
 #include "core/hle/kernel/object.h"
 #include "core/hle/kernel/server_session.h"

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -159,21 +159,6 @@ void KernelSystem::ResetThreadIDs() {
     next_thread_id = 0;
 }
 
-void KernelSystem::PushHLEParallelEvent(const std::shared_ptr<Event>& event) {
-    std::lock_guard<std::mutex> guard(hle_parallel_events_mutex);
-    hle_parallel_events.push(event);
-}
-
-void KernelSystem::SignalAllHLEParallelEvents() {
-    if (!hle_parallel_events.empty()) {
-        std::lock_guard<std::mutex> guard(hle_parallel_events_mutex);
-        while (!hle_parallel_events.empty()) {
-            hle_parallel_events.front()->Signal();
-            hle_parallel_events.pop();
-        }
-    }
-}
-
 template <class Archive>
 void KernelSystem::serialize(Archive& ar, const unsigned int file_version) {
     ar& memory_regions;

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -39,7 +39,7 @@ KernelSystem::KernelSystem(Memory::MemorySystem& memory, Core::Timing& timing,
     }
     timer_manager = std::make_unique<TimerManager>(timing);
     ipc_recorder = std::make_unique<IPCDebugger::Recorder>();
-    hle_thread_pool = std::make_unique<boost::asio::thread_pool>();
+    hle_thread_pool = std::make_unique<boost::asio::thread_pool>(16);
     stored_processes.assign(num_cores, nullptr);
 
     next_thread_id = 1;

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -286,10 +286,6 @@ public:
         return *hle_thread_pool;
     }
 
-    void PushHLEParallelEvent(const std::shared_ptr<Event>& event);
-
-    void SignalAllHLEParallelEvents();
-
     /// Map of named ports managed by the kernel, which can be retrieved using the ConnectToPort
     std::unordered_map<std::string, std::shared_ptr<ClientPort>> named_ports;
 
@@ -336,8 +332,6 @@ private:
     u32 next_thread_id;
 
     std::unique_ptr<boost::asio::thread_pool> hle_thread_pool;
-    std::queue<std::shared_ptr<Event>> hle_parallel_events;
-    std::mutex hle_parallel_events_mutex;
 
     friend class boost::serialization::access;
     template <class Archive>

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -238,6 +238,15 @@ void Thread::WakeAfterDelay(s64 nanoseconds) {
                                                thread_manager.ThreadWakeupEventType, thread_id);
 }
 
+void Thread::WakeAfterDelayTS(s64 nanoseconds) {
+    // Don't schedule a wakeup if the thread wants to wait forever
+    if (nanoseconds == -1)
+        return;
+
+    thread_manager.kernel.timing.ScheduleEventTS(
+        nsToCycles(nanoseconds), thread_manager.ThreadWakeupEventType, thread_id, core_id);
+}
+
 void Thread::ResumeFromWait() {
     ASSERT_MSG(wait_objects.empty(), "Thread is waking up while waiting for objects");
 

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -236,6 +236,12 @@ public:
     void WakeAfterDelay(s64 nanoseconds);
 
     /**
+     * Schedules an event to wake up the specified thread after the specified delay, thread safe
+     * @param nanoseconds The time this thread will be allowed to sleep for
+     */
+    void WakeAfterDelayTS(s64 nanoseconds);
+
+    /**
      * Sets the result after the thread awakens (from either WaitSynchronization SVC)
      * @param result Value to set to the returned result
      */

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -102,8 +102,7 @@ void Module::Interface::GetWifiStatus(Kernel::HLERequestContext& ctx) {
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
     rb.Push(RESULT_SUCCESS);
-    rb.Push<u32>(can_reach_internet ? (Settings::values.is_new_3ds ? 2 : 1)
-                                    : 0); // Connection type set to none
+    rb.Push<u32>(can_reach_internet ? (Settings::values.is_new_3ds ? 2 : 1) : 0);
 
     LOG_WARNING(Service_AC, "(STUBBED) called");
 }

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -6,6 +6,7 @@
 #include "common/archives.h"
 #include "common/common_types.h"
 #include "common/logging/log.h"
+#include "common/settings.h"
 #include "core/core.h"
 #include "core/hle/ipc.h"
 #include "core/hle/ipc_helpers.h"
@@ -15,6 +16,7 @@
 #include "core/hle/service/ac/ac.h"
 #include "core/hle/service/ac/ac_i.h"
 #include "core/hle/service/ac/ac_u.h"
+#include "core/hle/service/soc_u.h"
 #include "core/memory.h"
 
 namespace Service::AC {
@@ -94,9 +96,14 @@ void Module::Interface::GetWifiStatus(Kernel::HLERequestContext& ctx) {
     // TODO(purpasmart96): This function is only a stub,
     // it returns a valid result without implementing full functionality.
 
+    std::shared_ptr<SOC::SOC_U> socu_module = SOC::GetService(Core::System::GetInstance());
+    SOC::SOC_U::InterfaceInfo interface_info;
+    bool can_reach_internet = socu_module->GetDefaultInterfaceInfo(&interface_info);
+
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
     rb.Push(RESULT_SUCCESS);
-    rb.Push<u32>(0); // Connection type set to none
+    rb.Push<u32>(can_reach_internet ? (Settings::values.is_new_3ds ? 2 : 1)
+                                    : 0); // Connection type set to none
 
     LOG_WARNING(Service_AC, "(STUBBED) called");
 }

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -92,10 +92,13 @@ void Module::Interface::GetCloseResult(Kernel::HLERequestContext& ctx) {
 
 void Module::Interface::GetWifiStatus(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0xD, 0, 0);
+    bool can_reach_internet = false;
 
     std::shared_ptr<SOC::SOC_U> socu_module = SOC::GetService(Core::System::GetInstance());
-    SOC::SOC_U::InterfaceInfo interface_info;
-    bool can_reach_internet = socu_module->GetDefaultInterfaceInfo(&interface_info);
+    if (socu_module) {
+        SOC::SOC_U::InterfaceInfo interface_info;
+        can_reach_internet = socu_module->GetDefaultInterfaceInfo(&interface_info);
+    }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
     rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -106,8 +106,6 @@ void Module::Interface::GetWifiStatus(Kernel::HLERequestContext& ctx) {
                                                             ? WifiStatus::STATUS_CONNECTED_N3DS
                                                             : WifiStatus::STATUS_CONNECTED_O3DS)
                                                      : WifiStatus::STATUS_DISCONNECTED));
-
-    LOG_WARNING(Service_AC, "(STUBBED) called");
 }
 
 void Module::Interface::GetInfraPriority(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -96,8 +96,7 @@ void Module::Interface::GetWifiStatus(Kernel::HLERequestContext& ctx) {
 
     std::shared_ptr<SOC::SOC_U> socu_module = SOC::GetService(Core::System::GetInstance());
     if (socu_module) {
-        SOC::SOC_U::InterfaceInfo interface_info;
-        can_reach_internet = socu_module->GetDefaultInterfaceInfo(&interface_info);
+        can_reach_internet = socu_module->GetDefaultInterfaceInfo().has_value();
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -93,16 +93,16 @@ void Module::Interface::GetCloseResult(Kernel::HLERequestContext& ctx) {
 void Module::Interface::GetWifiStatus(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0xD, 0, 0);
 
-    // TODO(purpasmart96): This function is only a stub,
-    // it returns a valid result without implementing full functionality.
-
     std::shared_ptr<SOC::SOC_U> socu_module = SOC::GetService(Core::System::GetInstance());
     SOC::SOC_U::InterfaceInfo interface_info;
     bool can_reach_internet = socu_module->GetDefaultInterfaceInfo(&interface_info);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
     rb.Push(RESULT_SUCCESS);
-    rb.Push<u32>(can_reach_internet ? (Settings::values.is_new_3ds ? 2 : 1) : 0);
+    rb.Push<u32>(static_cast<u32>(can_reach_internet ? (Settings::values.is_new_3ds
+                                                            ? WifiStatus::STATUS_CONNECTED_N3DS
+                                                            : WifiStatus::STATUS_CONNECTED_O3DS)
+                                                     : WifiStatus::STATUS_DISCONNECTED));
 
     LOG_WARNING(Service_AC, "(STUBBED) called");
 }

--- a/src/core/hle/service/ac/ac.h
+++ b/src/core/hle/service/ac/ac.h
@@ -142,6 +142,12 @@ public:
     };
 
 protected:
+    enum class WifiStatus {
+        STATUS_DISCONNECTED = 0,
+        STATUS_CONNECTED_O3DS = 1,
+        STATUS_CONNECTED_N3DS = 2,
+    };
+
     struct ACConfig {
         std::array<u8, 0x200> data;
     };

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -92,6 +92,11 @@ ResultVal<std::size_t> CIAFile::Read(u64 offset, std::size_t length, u8* buffer)
     return MakeResult<std::size_t>(length);
 }
 
+ResultVal<std::size_t> CIAFile::PRead(u64 offset, std::size_t length, u8* buffer) const {
+    UNIMPLEMENTED();
+    return MakeResult<std::size_t>(length);
+}
+
 ResultCode CIAFile::WriteTicket() {
     container.LoadTicket(data, container.GetTicketOffset());
 
@@ -265,6 +270,13 @@ ResultVal<std::size_t> CIAFile::Write(u64 offset, std::size_t length, bool flush
         return result;
 
     return MakeResult<std::size_t>(length);
+}
+
+ResultVal<std::size_t> CIAFile::PWrite(u64 offset, std::size_t length, bool flush,
+                                       const u8* buffer) {
+    // Thread safety not needed, as normally you don't write a cia file from
+    // multiple threads
+    return Write(offset, length, flush, buffer);
 }
 
 u64 CIAFile::GetSize() const {
@@ -1151,9 +1163,18 @@ public:
         return file->backend->Read(offset + file_offset, length, buffer);
     }
 
+    ResultVal<std::size_t> PRead(u64 offset, std::size_t length, u8* buffer) const override {
+        return file->backend->PRead(offset + file_offset, length, buffer);
+    }
+
     ResultVal<std::size_t> Write(u64 offset, std::size_t length, bool flush,
                                  const u8* buffer) override {
         return file->backend->Write(offset + file_offset, length, flush, buffer);
+    }
+
+    ResultVal<std::size_t> PWrite(u64 offset, std::size_t length, bool flush,
+                                  const u8* buffer) override {
+        return file->backend->PWrite(offset + file_offset, length, flush, buffer);
     }
 
     u64 GetSize() const override {

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -73,11 +73,14 @@ public:
     ~CIAFile();
 
     ResultVal<std::size_t> Read(u64 offset, std::size_t length, u8* buffer) const override;
+    ResultVal<std::size_t> PRead(u64 offset, std::size_t length, u8* buffer) const override;
     ResultCode WriteTicket();
     ResultCode WriteTitleMetadata();
     ResultVal<std::size_t> WriteContentData(u64 offset, std::size_t length, const u8* buffer);
     ResultVal<std::size_t> Write(u64 offset, std::size_t length, bool flush,
                                  const u8* buffer) override;
+    ResultVal<std::size_t> PWrite(u64 offset, std::size_t length, bool flush,
+                                  const u8* buffer) override;
     u64 GetSize() const override;
     bool SetSize(u64 size) const override;
     bool Close() const override;

--- a/src/core/hle/service/fs/file.cpp
+++ b/src/core/hle/service/fs/file.cpp
@@ -91,7 +91,7 @@ void File::Read(Kernel::HLERequestContext& ctx) {
                   offset, length, backend->GetSize());
     }
 
-    ctx.RunInParalelPool(
+    ctx.RunInParallelPool(
         [parallel_data](std::shared_ptr<Kernel::Thread>& thread, Kernel::HLERequestContext& ctx) {
             parallel_data->read = parallel_data->own->backend->PRead(
                 parallel_data->offset, parallel_data->data.size(), parallel_data->data.data());
@@ -161,7 +161,7 @@ void File::Write(Kernel::HLERequestContext& ctx) {
     std::shared_ptr<ResultVal<std::size_t>> written_ptr =
         std::make_shared<ResultVal<std::size_t>>();
 
-    ctx.RunInParalelPool(
+    ctx.RunInParallelPool(
         [parallel_data](std::shared_ptr<Kernel::Thread>& thread, Kernel::HLERequestContext& ctx) {
             std::vector<u8> data(parallel_data->length);
             parallel_data->buffer.Read(data.data(), 0, data.size());

--- a/src/core/hle/service/fs/file.cpp
+++ b/src/core/hle/service/fs/file.cpp
@@ -106,10 +106,11 @@ void File::Read(Kernel::HLERequestContext& ctx) {
             }
 
             return std::max(
-                0LL, (std::chrono::nanoseconds(
-                          parallel_data->own->backend->GetReadDelayNs(parallel_data->data.size())) -
-                      (post_timer - pre_timer))
-                         .count());
+                0LL, static_cast<long long int>(
+                         (std::chrono::nanoseconds(parallel_data->own->backend->GetReadDelayNs(
+                              parallel_data->data.size())) -
+                          (post_timer - pre_timer))
+                             .count()));
         },
         [parallel_data](std::shared_ptr<Kernel::Thread>& thread, Kernel::HLERequestContext& ctx) {
             IPC::RequestBuilder rb(ctx, 0x0802, 2, 2);

--- a/src/core/hle/service/fs/fs_user.cpp
+++ b/src/core/hle/service/fs/fs_user.cpp
@@ -202,8 +202,8 @@ void FS_USER::DeleteFile(Kernel::HLERequestContext& ctx) {
 
     ctx.RunInParallelPool(
         [parallel_data](std::shared_ptr<Kernel::Thread>& thread, Kernel::HLERequestContext& ctx) {
-            parallel_data->res = parallel_data->own->archives.DeleteFileFromArchive(parallel_data->archive_handle,
-                                                               parallel_data->file_path);
+            parallel_data->res = parallel_data->own->archives.DeleteFileFromArchive(
+                parallel_data->archive_handle, parallel_data->file_path);
             return 0;
         },
         [parallel_data](std::shared_ptr<Kernel::Thread>& thread, Kernel::HLERequestContext& ctx) {
@@ -402,7 +402,6 @@ void FS_USER::CreateDirectory(Kernel::HLERequestContext& ctx) {
     parallel_data->own = this;
     parallel_data->archive_handle = archive_handle;
     parallel_data->dir_path = FileSys::Path(dirname_type, std::move(dirname));
-
 
     LOG_DEBUG(Service_FS, "type={} size={} data={}", dirname_type, dirname_size,
               parallel_data->dir_path.DebugStr());

--- a/src/core/hle/service/soc_u.cpp
+++ b/src/core/hle/service/soc_u.cpp
@@ -35,10 +35,12 @@
 #else
 #include <cerrno>
 #include <fcntl.h>
+#include <ifaddrs.h>
 #include <netdb.h>
 #include <netinet/in.h>
 #include <poll.h>
 #include <sys/socket.h>
+#include <sys/types.h>
 #include <unistd.h>
 #endif
 
@@ -1146,6 +1148,7 @@ void SOC_U::GetAddrInfoImpl(Kernel::HLERequestContext& ctx) {
                 // if the buffer is not big enough. However the count returned is always correct.
                 CTRAddrInfo ctr_addr = CTRAddrInfo::FromPlatform(*cur);
                 std::memcpy(out_buff.data() + pos, &ctr_addr, sizeof(ctr_addr));
+                pos += sizeof(ctr_addr);
             }
             cur = cur->ai_next;
             count++;

--- a/src/core/hle/service/soc_u.cpp
+++ b/src/core/hle/service/soc_u.cpp
@@ -511,7 +511,7 @@ void SOC_U::Fcntl(Kernel::HLERequestContext& ctx) {
         if (ctr_arg & 4) // O_NONBLOCK
             flags |= O_NONBLOCK;
 
-        iter->second.blocking = ((ctr_arg & 4) == 0);
+        fd_info->second.blocking = ((ctr_arg & 4) == 0);
 
         int ret = ::fcntl(fd_info->second.socket_fd, F_SETFL, flags);
         if (ret == SOCKET_ERROR_VALUE) {
@@ -855,8 +855,6 @@ void SOC_U::Poll(Kernel::HLERequestContext& ctx) {
 
         ret = TranslateError(GET_ERRNO);
     }
-
-    size_t test = platform_pollfd.size();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
     rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/soc_u.cpp
+++ b/src/core/hle/service/soc_u.cpp
@@ -824,7 +824,7 @@ void SOC_U::Poll(Kernel::HLERequestContext& ctx) {
     parallel_data->nfds = nfds;
     parallel_data->timeout = timeout;
 
-    ctx.RunInParalelPool(
+    ctx.RunInParallelPool(
         [parallel_data](std::shared_ptr<Kernel::Thread>& thread, Kernel::HLERequestContext& ctx) {
             std::vector<CTRPollFD> ctr_fds(parallel_data->nfds);
             std::memcpy(ctr_fds.data(), parallel_data->input_fds.data(),

--- a/src/core/hle/service/soc_u.h
+++ b/src/core/hle/service/soc_u.h
@@ -74,6 +74,7 @@ private:
     void Accept(Kernel::HLERequestContext& ctx);
     void GetHostId(Kernel::HLERequestContext& ctx);
     void Close(Kernel::HLERequestContext& ctx);
+    void SendToOther(Kernel::HLERequestContext& ctx);
     void SendTo(Kernel::HLERequestContext& ctx);
     void RecvFromOther(Kernel::HLERequestContext& ctx);
     void RecvFrom(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/soc_u.h
+++ b/src/core/hle/service/soc_u.h
@@ -40,6 +40,15 @@ public:
     SOC_U();
     ~SOC_U();
 
+    struct InterfaceInfo {
+        u32 address;
+        u32 netmask;
+        u32 broadcast;
+    };
+
+    // Gets the interface info that is able to reach the internet.
+    bool GetDefaultInterfaceInfo(InterfaceInfo* out_info);
+
 private:
     static constexpr ResultCode ERR_INVALID_HANDLE =
         ResultCode(ErrorDescription::InvalidHandle, ErrorModule::SOC, ErrorSummary::InvalidArgument,
@@ -103,6 +112,13 @@ private:
     friend struct CTRPollFD;
     std::unordered_map<u32, SocketHolder> open_sockets;
 
+    /// Cache interface info for the current session
+    /// These two fields are not saved to savestates on purpose
+    /// as network interfaces may change and it's better to.
+    /// obtain them again between play sessions.
+    bool interface_info_cached = false;
+    InterfaceInfo interface_info;
+
     template <class Archive>
     void serialize(Archive& ar, const unsigned int) {
         ar& boost::serialization::base_object<Kernel::SessionRequestHandler>(*this);
@@ -111,6 +127,8 @@ private:
     }
     friend class boost::serialization::access;
 };
+
+std::shared_ptr<SOC_U> GetService(Core::System& system);
 
 void InstallInterfaces(Core::System& system);
 

--- a/src/core/hle/service/soc_u.h
+++ b/src/core/hle/service/soc_u.h
@@ -121,11 +121,6 @@ private:
         return next_socket_id++;
     }
 
-    // System timer adjust
-    std::chrono::time_point<std::chrono::steady_clock> adjust_value_last;
-    void PreTimerAdjust();
-    void PostTimerAdjust(Kernel::HLERequestContext& ctx, const std::string& caller_method);
-
     /// Close all open sockets
     void CleanupSockets();
 

--- a/src/core/hle/service/soc_u.h
+++ b/src/core/hle/service/soc_u.h
@@ -45,6 +45,19 @@ private:
         ResultCode(ErrorDescription::InvalidHandle, ErrorModule::SOC, ErrorSummary::InvalidArgument,
                    ErrorLevel::Permanent);
 
+    struct HostByNameData {
+        static const u32 max_entries = 24;
+
+        u16_le addr_type;
+        u16_le addr_len;
+        u16_le addr_count;
+        u16_le alias_count;
+        char hName[256];
+        char aliases[max_entries][256];
+        u8 addreses[max_entries][16];
+    };
+    static_assert(sizeof(HostByNameData) == 0x1A88, "Invalid HostByNameData size");
+
     void Socket(Kernel::HLERequestContext& ctx);
     void Bind(Kernel::HLERequestContext& ctx);
     void Fcntl(Kernel::HLERequestContext& ctx);
@@ -58,12 +71,14 @@ private:
     void Poll(Kernel::HLERequestContext& ctx);
     void GetSockName(Kernel::HLERequestContext& ctx);
     void Shutdown(Kernel::HLERequestContext& ctx);
+    void GetHostByName(Kernel::HLERequestContext& ctx);
     void GetPeerName(Kernel::HLERequestContext& ctx);
     void Connect(Kernel::HLERequestContext& ctx);
     void InitializeSockets(Kernel::HLERequestContext& ctx);
     void ShutdownSockets(Kernel::HLERequestContext& ctx);
     void GetSockOpt(Kernel::HLERequestContext& ctx);
     void SetSockOpt(Kernel::HLERequestContext& ctx);
+    void GetNetworkOpt(Kernel::HLERequestContext& ctx);
 
     // Some platforms seem to have GetAddrInfo and GetNameInfo defined as macros,
     // so we have to use a different name here.


### PR DESCRIPTION
This pull requests implements HLE multi-threading capabilities. A new method in `HLERequestContext` was added to support this: `RunInParallelPool`. This method takes two functions, the first one will be run in another thread, while the second one will be run once the result is ready to be placed in the IPC request and return control to the game.

The idea is to relay blocking or intensive IO operations to another thread, instead of pausing the entire emulator thread. When a game requests an IO operation, the game thread will be put to sleep until the HLE IO operation completes in another thread. This gives the game the opportunity to do other work while its fs thread is waiting for the IO operation to finish.

I'm creating this draft PR as I want some feedback with the developers who are more familiar with how HLE stuff works, as this feature is far from being completed or stable. A toggle in the UI will probably be added, as users with faster hard drives will notice that the thread overhead is even bigger than just doing the blocking IO directly.

Please, if you are going to review general C++ aspects of the code, ignore the contents of the `fs_user.cpp` file, as it's not finished. instead, look at the implementation in `file.cpp` which is the code design I'm looking forward to.

This PR relies in #6267 
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6282)
<!-- Reviewable:end -->
