### PR TITLE
CreateThread invalid processor ID return error instead of assert.

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1245,7 +1245,7 @@ ResultCode SVC::CreateThread(Handle* out_handle, u32 entry_point, u32 arg, VAddr
         // processorid. If this is implemented, make sure to check process->no_thread_restrictions.
         break;
     default:
-        ASSERT_MSG(false, "Unsupported thread processor ID: {}", processor_id);
+        return ERR_OUT_OF_RANGE;
         break;
     }
 


### PR DESCRIPTION
Mimics official kernel behaviour by returning an `ERR_OUT_OF_RANGE` error instead of causing the emulator to crash by an `ASSERT`. Some Luma3DS builds allows custom flags in the processorID, and an application is able to test if they are implemented by checking the svc return value.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6354)
<!-- Reviewable:end -->
