### PR TITLE
kernel: Set system error status on svcBreak.

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1137,6 +1137,7 @@ void SVC::Break(u8 break_reason) {
         break;
     }
     LOG_CRITICAL(Debug_Emulated, "Break reason: {}", reason_str);
+    system.SetStatus(Core::System::ResultStatus::ErrorUnknown);
 }
 
 /// Used to output a message on a debug hardware unit - does nothing on a retail unit


### PR DESCRIPTION
Alternative to https://github.com/citra-emu/citra/pull/6333 based on comments there.

Sets the system status to error on svcBreak to trigger the fatal error dialog, same as when ```ERR_F::ThrowFatalError``` is called. This allows the user to choose whether to continue execution or quit the game, rather than silently continuing with no indication of error.

Tested using N3DS Internet Browser which I know currently hits an svcBreak early on. Before nothing would happen and it would continue running, now it throws up the error pop-up with choice as expected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6364)
<!-- Reviewable:end -->
