### PR TITLE
Check fd before using dup

### DIFF
--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -1187,6 +1187,8 @@ void OpenFStream<std::ios_base::in>(
     boost_iostreams<boost::iostreams::file_descriptor_source>& fstream,
     const std::string& filename) {
     IOFile file(filename, "r");
+    if (file.GetFd() == -1)
+        return;
     int fd = dup(file.GetFd());
     if (fd == -1)
         return;
@@ -1199,6 +1201,8 @@ template <>
 void OpenFStream<std::ios_base::out>(
     boost_iostreams<boost::iostreams::file_descriptor_sink>& fstream, const std::string& filename) {
     IOFile file(filename, "w");
+    if (file.GetFd() == -1)
+        return;
     int fd = dup(file.GetFd());
     if (fd == -1)
         return;


### PR DESCRIPTION
MSVC dup doesn't seem to like being passed a -1 file descriptor and crashes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6368)
<!-- Reviewable:end -->
