### PR TITLE
citra_android: fix crash while load amiibo

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/activities/EmulationActivity.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/activities/EmulationActivity.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
+import android.net.Uri;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.util.Pair;
@@ -28,6 +29,7 @@ import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.PopupMenu;
 import androidx.core.app.NotificationManagerCompat;
+import androidx.documentfile.provider.DocumentFile;
 import androidx.fragment.app.FragmentActivity;
 
 import org.citra.citra_emu.CitraApplication;
@@ -568,10 +570,11 @@ public final class EmulationActivity extends AppCompatActivity {
     }
 
     private void onAmiiboSelected(String selectedFile) {
-        File file = new File(selectedFile);
         boolean success = false;
         try {
-            byte[] bytes = FileUtil.getBytesFromFile(file);
+            Uri uri = Uri.parse(selectedFile);
+            DocumentFile file = DocumentFile.fromSingleUri(this, uri);
+            byte[] bytes = FileUtil.getBytesFromFile(this, file);
             success = NativeLibrary.LoadAmiibo(bytes);
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/FileUtil.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/FileUtil.java
@@ -380,8 +380,9 @@ public class FileUtil {
         return false;
     }
 
-    public static byte[] getBytesFromFile(File file) throws IOException {
-        final long length = file.length();
+    public static byte[] getBytesFromFile(Context context, DocumentFile file) throws IOException {
+        final Uri uri = file.getUri();
+        final long length = FileUtil.getFileSize(context, uri.toString());
 
         // You cannot create an array using a long type.
         if (length > Integer.MAX_VALUE) {
@@ -394,7 +395,7 @@ public class FileUtil {
         int offset = 0;
         int numRead;
 
-        try (InputStream is = new FileInputStream(file)) {
+        try (InputStream is = context.getContentResolver().openInputStream(uri)) {
             while (offset < bytes.length &&
                    (numRead = is.read(bytes, offset, bytes.length - offset)) >= 0) {
                 offset += numRead;


### PR DESCRIPTION
## Summary

This PR intent to fix the report from https://github.com/citra-emu/citra/issues/6370#issuecomment-1483959431 .

Since `OpenFileResultContract` will return content uri, we will need to use `context.getContentResolver().openInputStream` to open `InputStream` instead of using file.

## Thanks

Please feel free to critique, and thanks for your code review 😄 .

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6373)
<!-- Reviewable:end -->
