### PR TITLE
Port yuzu-emu/yuzu#9058: "New transifex client needs migrating to"

### DIFF
--- a/.ci/transifex/docker.sh
+++ b/.ci/transifex/docker.sh
@@ -1,13 +1,5 @@
 #!/bin/bash -e
 
-# Setup RC file for tx
-cat << EOF > ~/.transifexrc
-[https://www.transifex.com]
-rest_hostname = https://rest.api.transifex.com
-token         = $TRANSIFEX_API_TOKEN
-EOF
-
-
 set -x
 
 cat << 'EOF' > /usr/bin/tx

--- a/.ci/transifex/docker.sh
+++ b/.ci/transifex/docker.sh
@@ -3,9 +3,8 @@
 # Setup RC file for tx
 cat << EOF > ~/.transifexrc
 [https://www.transifex.com]
-hostname = https://www.transifex.com
-username = api
-password = $TRANSIFEX_API_TOKEN
+rest_hostname = https://rest.api.transifex.com
+token         = $TRANSIFEX_API_TOKEN
 EOF
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,10 +218,11 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+          fetch-depth: 0
       - name: Update Translation
         run: ./.ci/transifex/docker.sh
         env:
-          TRANSIFEX_API_TOKEN: ${{ secrets.TRANSIFEX_API_TOKEN }}
+          TX_TOKEN: ${{ secrets.TRANSIFEX_API_TOKEN }}
   release:
     runs-on: ubuntu-latest
     needs: [build, android, macos-universal, source, windows]


### PR DESCRIPTION
See https://github.com/yuzu-emu/yuzu/pull/9058 for more details.

Original description:
Currently we're using the python client which uses an API that they claim will sunset Nov 30, 2022. The new client is written in go, and might be stable.

`tx push -s` actually appears to work properly, some of the other commands require tweaking, like instead of suggesting `tx pull -a` in dist/languages we need to suggest `tx pull -t -a`

I'm going to bother @lat9nq about adding the new client to https://github.com/yuzu-emu/build-environments/blob/master/linux-transifex/Dockerfile

Maybe

RUN wget https://github.com/transifex/cli/releases/latest/download/tx-linux-amd64.tar.gz && tar xf tx-linux-amd64.tar.gz tx && mv tx /usr/bin/tx && rm tx-linux-amd64.tar.gz

is valid, or maybe not

Also `apt-get install -y curl zip unzip` should get moved over to the docker file, now that I think about it.

Extra bonus information
pull everything: `tx pull -t -a`

Any language translated more than 47%: `tx pull -t -a --minimum-perc 47`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6389)
<!-- Reviewable:end -->
