### PR TITLE
citra_android: fix select root as citra directory cause crash

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/FileUtil.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/FileUtil.java
@@ -426,11 +426,11 @@ public class FileUtil {
 
     public static String getFilenameWithExtensions(Uri uri) {
         String path = uri.getPath();
-        final int slash_index = path.lastIndexOf('/');
-        path = path.substring(slash_index + 1);
+        final int slashIndex = path.lastIndexOf('/');
+        path = path.substring(slashIndex + 1);
         // On Android versions below 10, it is possible to select the storage root, which might result in filenames with a colon.
-        final int colon_index = path.indexOf(':');
-        return path.substring(colon_index + 1);
+        final int colonIndex = path.indexOf(':');
+        return path.substring(colonIndex + 1);
     }
 
     public static double getFreeSpace(Context context, Uri uri) {

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/FileUtil.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/FileUtil.java
@@ -4,7 +4,6 @@ import android.content.ContentResolver;
 import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
-import android.os.Build;
 import android.os.ParcelFileDescriptor;
 import android.provider.DocumentsContract;
 import android.system.Os;
@@ -429,12 +428,9 @@ public class FileUtil {
         String path = uri.getPath();
         final int slash_index = path.lastIndexOf('/');
         path = path.substring(slash_index + 1);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            return path;
-        }
         // On Android versions below 10, it is possible to select the storage root, which might result in filenames with a colon.
         final int colon_index = path.indexOf(':');
-        return path.substring(colon_index + 1) ;
+        return path.substring(colon_index + 1);
     }
 
     public static double getFreeSpace(Context context, Uri uri) {

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/FileUtil.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/FileUtil.java
@@ -4,6 +4,7 @@ import android.content.ContentResolver;
 import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
+import android.os.Build;
 import android.os.ParcelFileDescriptor;
 import android.provider.DocumentsContract;
 import android.system.Os;
@@ -425,9 +426,15 @@ public class FileUtil {
     }
 
     public static String getFilenameWithExtensions(Uri uri) {
-        final String path = uri.getPath();
-        final int index = path.lastIndexOf('/');
-        return path.substring(index + 1);
+        String path = uri.getPath();
+        final int slash_index = path.lastIndexOf('/');
+        path = path.substring(slash_index + 1);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            return path;
+        }
+        // On Android versions below 10, it is possible to select the storage root, which might result in filenames with a colon.
+        final int colon_index = path.indexOf(':');
+        return path.substring(colon_index + 1) ;
     }
 
     public static double getFreeSpace(Context context, Uri uri) {


### PR DESCRIPTION
## Summary

This PR fixes: #6394 .

When selecting internal storage root as citra directory, `getFilenameWithExtensions` might return incorrect value.

## Thanks

Please feel free to critique, and thanks for your code review 😄 .

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6400)
<!-- Reviewable:end -->
