### PR TITLE
citra_android: fix config is getting overwritten by default

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/utils/SettingsFile.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/utils/SettingsFile.java
@@ -233,7 +233,7 @@ public final class SettingsFile {
                 writeSection(writer, section);
             }
             inputStream.close();
-            OutputStream outputStream = context.getContentResolver().openOutputStream(ini.getUri());
+            OutputStream outputStream = context.getContentResolver().openOutputStream(ini.getUri(), "wt");
             writer.store(outputStream);
             outputStream.flush();
             outputStream.close();

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/DocumentsTree.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/DocumentsTree.java
@@ -144,7 +144,7 @@ public class DocumentsTree {
             document.isDirectory = destination.isDirectory();
             document.loaded = true;
             InputStream input = context.getContentResolver().openInputStream(sourceNode.uri);
-            OutputStream output = context.getContentResolver().openOutputStream(destination.getUri());
+            OutputStream output = context.getContentResolver().openOutputStream(destination.getUri(), "wt");
             byte[] buffer = new byte[1024];
             int len;
             while ((len = input.read(buffer)) != -1) {

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/FileUtil.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/FileUtil.java
@@ -273,7 +273,7 @@ public class FileUtil {
             }
             if (destination == null) return false;
             InputStream input = context.getContentResolver().openInputStream(sourceUri);
-            OutputStream output = context.getContentResolver().openOutputStream(destination.getUri());
+            OutputStream output = context.getContentResolver().openOutputStream(destination.getUri(), "wt");
             byte[] buffer = new byte[1024];
             int len;
             while ((len = input.read(buffer)) != -1) {


### PR DESCRIPTION
## Summary 

This PR fixes: #6406.

As mentioned in the thread, 'openOutputStream' writes without truncation unless an open mode is specified. This PR specifies the open mode as 'wt' to ensure that the open mode is write with truncation.


## Thanks

Please feel free to critique, and thanks for your code review 😄 .

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6408)
<!-- Reviewable:end -->
