### PR TITLE
citra_qt: fix vsync issues

### DIFF
--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -386,7 +386,7 @@ static Frontend::EmuWindow::WindowSystemInfo GetWindowSystemInfo(QWindow* window
     return wsi;
 }
 
-std::shared_ptr<Frontend::GraphicsContext> GRenderWindow::main_context;
+std::unique_ptr<Frontend::GraphicsContext> GRenderWindow::main_context;
 
 GRenderWindow::GRenderWindow(QWidget* parent_, EmuThread* emu_thread, bool is_secondary_)
     : QWidget(parent_), EmuWindow(is_secondary_), emu_thread(emu_thread) {
@@ -667,7 +667,7 @@ bool GRenderWindow::InitializeOpenGL() {
     child_widget->windowHandle()->create();
 
     if (!main_context) {
-        main_context = std::make_shared<OpenGLSharedContext>();
+        main_context = std::make_unique<OpenGLSharedContext>();
     }
 
     auto child_context = CreateSharedContext();

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -5,12 +5,11 @@
 #include <glad/glad.h>
 
 #include <QApplication>
-#include <QDragEnterEvent>
 #include <QHBoxLayout>
 #include <QKeyEvent>
 #include <QMessageBox>
 #include <QPainter>
-#include <fmt/format.h>
+#include <QWindow>
 #include "citra_qt/bootmanager.h"
 #include "citra_qt/main.h"
 #include "common/color.h"

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -162,7 +162,7 @@ public:
 
         // disable vsync for any shared contexts
         auto format = share_context->format();
-        format.setSwapInterval(main_surface ? Settings::values.use_vsync_new.GetValue() : 0);
+        format.setSwapInterval(0);
 
         context = std::make_unique<QOpenGLContext>();
         context->setShareContext(share_context);
@@ -672,6 +672,10 @@ bool GRenderWindow::InitializeOpenGL() {
 
     auto child_context = CreateSharedContext();
     child->SetContext(std::move(child_context));
+
+    auto format = child_widget->windowHandle()->format();
+    format.setSwapInterval(Settings::values.use_vsync_new.GetValue());
+    child_widget->windowHandle()->setFormat(format);
 
     return true;
 #else

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -10,17 +10,12 @@
 #include <mutex>
 #include <QThread>
 #include <QWidget>
-#include <QWindow>
-#include "common/thread.h"
 #include "core/core.h"
 #include "core/frontend/emu_window.h"
 
 class QKeyEvent;
 class QTouchEvent;
-class QOffscreenSurface;
-class QOpenGLContext;
 
-class GMainWindow;
 class GRenderWindow;
 
 namespace VideoCore {

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -192,7 +192,7 @@ private:
     /// Main context that will be shared with all other contexts that are requested.
     /// If this is used in a shared context setting, then this should not be used directly, but
     /// should instead be shared from
-    static std::shared_ptr<Frontend::GraphicsContext> main_context;
+    static std::unique_ptr<Frontend::GraphicsContext> main_context;
 
     /// Temporary storage of the screenshot taken
     QImage screenshot_image;

--- a/src/citra_qt/configuration/configure_graphics.cpp
+++ b/src/citra_qt/configuration/configure_graphics.cpp
@@ -119,7 +119,8 @@ void ConfigureGraphics::SetupPerGameUI() {
         ui->toggle_accurate_mul->setEnabled(Settings::values.shaders_accurate_mul.UsingGlobal());
         ui->toggle_disk_shader_cache->setEnabled(
             Settings::values.use_disk_shader_cache.UsingGlobal());
-        ui->toggle_vsync_new->setEnabled(Settings::values.use_vsync_new.UsingGlobal());
+        ui->toggle_vsync_new->setEnabled(ui->toggle_vsync_new->isEnabled() &&
+                                         Settings::values.use_vsync_new.UsingGlobal());
         return;
     }
 


### PR DESCRIPTION
Since #6347, all qt surfaces have v-sync turned on, which would make it impossible to get higher framerates for speed-up on 60Hz displays, along with a few other oddities, regardless of the v-sync setting.

~~This re-adds the code that changes the default swap interval for all qt surfaces, with a small change to make it more explicit.~~

The opengl surface's swap interval wasn't being changed by the previous code, meaning that it would use the default. This meant vsync was forced to be on, and then the first change I had proposed on this PR had changed it to be off by default.

Now the vsync option actually controls the opengl surface swap interval.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6410)
<!-- Reviewable:end -->
