### PR TITLE
Update zstd and improve savestates logging

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -113,9 +113,10 @@ System::ResultStatus System::RunLoop(bool tight_loop) {
     case Signal::Shutdown:
         return ResultStatus::ShutdownRequested;
     case Signal::Load: {
-        LOG_INFO(Core, "Begin load");
+        const u32 slot = param;
+        LOG_INFO(Core, "Begin load of slot {}", slot);
         try {
-            System::LoadState(param);
+            System::LoadState(slot);
             LOG_INFO(Core, "Load completed");
         } catch (const std::exception& e) {
             LOG_ERROR(Core, "Error loading: {}", e.what());
@@ -126,9 +127,10 @@ System::ResultStatus System::RunLoop(bool tight_loop) {
         return ResultStatus::Success;
     }
     case Signal::Save: {
-        LOG_INFO(Core, "Begin save");
+        const u32 slot = param;
+        LOG_INFO(Core, "Begin save to slot {}", slot);
         try {
-            System::SaveState(param);
+            System::SaveState(slot);
             LOG_INFO(Core, "Save completed");
         } catch (const std::exception& e) {
             LOG_ERROR(Core, "Error saving: {}", e.what());

--- a/src/core/savestate.h
+++ b/src/core/savestate.h
@@ -9,8 +9,6 @@
 
 namespace Core {
 
-struct CSTHeader;
-
 struct SaveStateInfo {
     u32 slot;
     u64 time;


### PR DESCRIPTION
Updates zstd to the latest (v1.5.5), which may result in minor speed increases when saving or loading save states.

The better logging will make identifying the revision of loaded save states easier, helping the support team when dealing with users with incompatible save states.
The save state validation at the time of loading is not strictly necessary, as they are already validated in the `ListSaveStates` function, but it'll log the revision if the state is from a different Citra version. I also do not doubt the capacity of a user to somehow hit these new checks.

One of the minor changes intends to ensure the reserved bytes of the header are initialized with zero, which may help future efforts to add new fields to the header.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6419)
<!-- Reviewable:end -->
