### PR TITLE
Fix plvpwaa dlc error

### DIFF
--- a/src/core/file_sys/archive_extsavedata.cpp
+++ b/src/core/file_sys/archive_extsavedata.cpp
@@ -262,8 +262,8 @@ ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_ExtSaveData::Open(cons
     return MakeResult<std::unique_ptr<ArchiveBackend>>(std::move(archive));
 }
 
-ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_ExtSaveData::OpenSpotpass(const Path& path,
-                                                                            u64 program_id) {
+ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_ExtSaveData::OpenSpotpass(
+    const Path& path, u64 program_id) {
     std::string fullpath = GetExtSaveDataPath(mount_point, GetCorrectedPath(path)) + "boss/";
     if (!FileUtil::Exists(fullpath)) {
         // TODO(Subv): Verify the archive behavior of SharedExtSaveData compared to ExtSaveData.

--- a/src/core/file_sys/archive_extsavedata.h
+++ b/src/core/file_sys/archive_extsavedata.h
@@ -27,6 +27,7 @@ public:
     }
 
     ResultVal<std::unique_ptr<ArchiveBackend>> Open(const Path& path, u64 program_id) override;
+    ResultVal<std::unique_ptr<ArchiveBackend>> OpenSpotpass(const Path& path, u64 program_id);
     ResultCode Format(const Path& path, const FileSys::ArchiveFormatInfo& format_info,
                       u64 program_id) override;
     ResultVal<ArchiveFormatInfo> GetFormatInfo(const Path& path, u64 program_id) const override;

--- a/src/core/hle/service/boss/boss.cpp
+++ b/src/core/hle/service/boss/boss.cpp
@@ -342,7 +342,7 @@ u32 Module::Interface::GetOutputEntries(u32 filter, u32 max_entries, auto* buffe
     }
     buffer->Write(output_entries.data(), 0, sizeof(u32) * output_entries.size());
     LOG_DEBUG(Service_BOSS, "{} usable entries returned", output_entries.size());
-    return static_cast<u32>output_entries.size();
+    return static_cast<u32> output_entries.size();
 }
 
 void Module::Interface::GetNsDataIdList(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/boss/boss.cpp
+++ b/src/core/hle/service/boss/boss.cpp
@@ -342,7 +342,7 @@ u32 Module::Interface::GetOutputEntries(u32 filter, u32 max_entries, auto* buffe
     }
     buffer->Write(output_entries.data(), 0, sizeof(u32) * output_entries.size());
     LOG_DEBUG(Service_BOSS, "{} usable entries returned", output_entries.size());
-    return static_cast<u32> (output_entries.size());
+    return static_cast<u32>(output_entries.size());
 }
 
 void Module::Interface::GetNsDataIdList(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/boss/boss.cpp
+++ b/src/core/hle/service/boss/boss.cpp
@@ -216,7 +216,7 @@ void Module::Interface::GetNsDataIdList1(Kernel::HLERequestContext& ctx) {
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 2);
     rb.Push(RESULT_SUCCESS);
-    rb.Push<u16>(0); /// Actual number of output entries
+    rb.Push<u16>(1); /// Actual number of output entries
     rb.Push<u16>(0); /// Last word-index copied to output in the internal NsDataId list.
     rb.PushMappedBuffer(buffer);
 

--- a/src/core/hle/service/boss/boss.cpp
+++ b/src/core/hle/service/boss/boss.cpp
@@ -216,7 +216,17 @@ void Module::Interface::GetNsDataIdList1(Kernel::HLERequestContext& ctx) {
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 2);
     rb.Push(RESULT_SUCCESS);
-    rb.Push<u16>(1); /// Actual number of output entries
+	
+	u64_le programid = 0;
+    Core::System::GetInstance().GetAppLoader().ReadProgramId(programid);
+	if(programid == 0x0004000000078B00 || programid==0X0004000000100500 || programid==0x0004000000100600 || programid==0x0004000000100700){
+		LOG_WARNING(Service_BOSS,"PLvPWAA detected! Setting number of output entries to 1.");
+		rb.Push<u16>(1); /// Spoof at least one entry for PLvPWAA
+	}
+	else {
+		rb.Push<u16>(0); /// Actual number of output entries
+	}
+	
     rb.Push<u16>(0); /// Last word-index copied to output in the internal NsDataId list.
     rb.PushMappedBuffer(buffer);
 

--- a/src/core/hle/service/boss/boss.cpp
+++ b/src/core/hle/service/boss/boss.cpp
@@ -190,41 +190,146 @@ void Module::Interface::GetStepIdList(Kernel::HLERequestContext& ctx) {
 
     LOG_WARNING(Service_BOSS, "(STUBBED) size={:#010X}", size);
 }
-
-u32 Module::Interface::GetOutputEntriesCount() {
-    u32 entry_count = 0;
-
+auto Module::Interface::GetBossDataDir() {
     u64 extdata_id = 0;
     Core::System::GetInstance().GetAppLoader().ReadExtdataId(extdata_id);
-
-    LOG_DEBUG(Service_BOSS, "Extdata ID={:#018X}", extdata_id);
-
-    std::string sd_directory{FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir)};
-
-    FileSys::ArchiveFactory_ExtSaveData extdata_archive_factory(sd_directory, false);
-
-    std::string extdata_directory{FileSys::GetExtDataPathFromId(sd_directory, extdata_id)};
-
-    LOG_DEBUG(Service_BOSS, "Extdata dir={}", extdata_directory);
 
     const u32 high = static_cast<u32>(extdata_id >> 32);
     const u32 low = static_cast<u32>(extdata_id & 0xFFFFFFFF);
 
-    FileSys::Path extdata_path{FileSys::ConstructExtDataBinaryPath(1, high, low)};
+    return FileSys::ConstructExtDataBinaryPath(1, high, low);
+}
+std::vector<NsDataEntry> Module::Interface::GetNsDataEntries(u32 max_entries) {
+    std::vector<NsDataEntry> ns_data;
+    u32 entry_count = 0;
+    u32 files_to_read = 100;
+    FileSys::Entry boss_files[100];
 
-    auto archive_result = extdata_archive_factory.OpenSpotpass(extdata_path, 0);
+    entry_count = GetBossExtDataFiles(files_to_read, boss_files);
+
+    if (entry_count > max_entries) {
+        LOG_WARNING(Service_BOSS, "Number of output entries has exceeded maximum");
+        entry_count = max_entries;
+    }
+
+    for (u32 i = 0; i < entry_count; i++) {
+        if (boss_files[i].is_directory || boss_files[i].file_size < 52) {
+            LOG_WARNING(Service_BOSS, "Directory or too-short file in spotpass extdata");
+            continue;
+        }
+
+        NsDataEntry entry;
+        std::string filename{Common::UTF16ToUTF8(boss_files[i].filename)};
+        filename = "/" + filename;
+        FileSys::Path file_path = filename.c_str();
+        LOG_DEBUG(Service_BOSS, "Spotpass filename={}", filename);
+        entry.filename = filename;
+
+        FileSys::Mode mode{};
+        mode.read_flag.Assign(1);
+        FileSys::ArchiveFactory_ExtSaveData extdata_archive_factory(
+            FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir), false);
+        FileSys::Path boss_path{GetBossDataDir()};
+        auto archive_result = extdata_archive_factory.OpenSpotpass(boss_path, 0);
+
+        if (archive_result.Succeeded()) {
+            LOG_DEBUG(Service_BOSS, "Spotpass Extdata opened successfully!");
+            auto boss_archive = std::move(archive_result).Unwrap().get();
+            auto file_result = boss_archive->OpenFile(file_path, mode);
+
+            if (file_result.Succeeded()) {
+                auto file = std::move(file_result).Unwrap();
+                LOG_DEBUG(Service_BOSS, "Opening Spotpass file succeeded!");
+
+                // File header info from
+                // https://www.3dbrew.org/wiki/SpotPass#Payload_Content_Header It looks like the
+                // non-shared spotpass data on sd does not include the SHA hash and its
+                // signature in the header So the total header is only 52 bytes long
+                u8 header_length[1];
+                file->Read(0, 1, header_length);
+                if (header_length[0] != 0x18) {
+                    LOG_WARNING(Service_BOSS, "Incorrect header length or non-spotpass file");
+                    continue;
+                }
+
+                u64 program_id = 0;
+                Core::System::GetInstance().GetAppLoader().ReadProgramId(program_id);
+                u8 spotpass_program_id_array[8];
+                u64 spotpass_program_id = 0;
+                file->Read(0x18, 8, spotpass_program_id_array);
+                std::memcpy(&spotpass_program_id, spotpass_program_id_array, 8);
+                spotpass_program_id = Common::swap64(spotpass_program_id);
+                if (spotpass_program_id != program_id) {
+                    LOG_WARNING(Service_BOSS,
+                                "Mismatched program ID in spotpass data. Was expecting "
+                                "{:#018X}, found {:#018X}",
+                                program_id, spotpass_program_id);
+                    continue;
+                }
+                entry.program_id = program_id;
+
+                u8 ns_datatype_array[4];
+                u32 ns_datatype = 0;
+                file->Read(0x24, 4, ns_datatype_array);
+                std::memcpy(&ns_datatype, ns_datatype_array, 4);
+                ns_datatype = Common::swap32(ns_datatype);
+                LOG_DEBUG(Service_BOSS, "Datatype is {:#010X}", ns_datatype);
+                entry.datatype = ns_datatype;
+
+                u8 ns_data_size_array[4];
+                u32 ns_data_size = 0;
+                file->Read(0x28, 4, ns_data_size_array);
+                std::memcpy(&ns_data_size, ns_data_size_array, 4);
+                ns_data_size = Common::swap32(ns_data_size);
+                // Check the payload size is correct, excluding header
+                if (ns_data_size != boss_files[i].file_size - 0x34) {
+                    LOG_WARNING(Service_BOSS,
+                                "Mismatched file size, was expecting {:#010X}, found {:#010X}",
+                                ns_data_size, boss_files[i].file_size - 0x34);
+                    continue;
+                }
+                LOG_DEBUG(Service_BOSS, "Payload size is {:#010X}", ns_data_size);
+                entry.payload_size = ns_data_size;
+
+                u8 ns_data_id_array[4];
+                u32 ns_data_id = 0;
+                file->Read(0x2C, 4, ns_data_id_array);
+                std::memcpy(&ns_data_id, ns_data_id_array, 4);
+                ns_data_id = Common::swap32(ns_data_id);
+                LOG_DEBUG(Service_BOSS, "NsDataID is {:#010X}", ns_data_id);
+                entry.ns_data_id = ns_data_id;
+
+                ns_data.push_back(entry);
+            } else {
+                LOG_WARNING(Service_BOSS, "Opening Spotpass file failed.");
+            }
+        } else {
+            LOG_WARNING(Service_BOSS, "Extdata opening failed");
+        }
+    }
+    return ns_data;
+}
+
+u32 Module::Interface::GetBossExtDataFiles(u32 files_to_read, auto* files) {
+    u32 entry_count = 0;
+
+    FileSys::ArchiveFactory_ExtSaveData extdata_archive_factory(
+        FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir), false);
+
+    FileSys::Path boss_path{GetBossDataDir()};
+
+    auto archive_result = extdata_archive_factory.OpenSpotpass(boss_path, 0);
     if (archive_result.Succeeded()) {
         LOG_DEBUG(Service_BOSS, "Spotpass Extdata opened successfully!");
-        auto archive = std::move(archive_result).Unwrap();
+        auto boss_archive = std::move(archive_result).Unwrap().get();
 
         FileSys::Path dir_path = "/";
 
-        auto dir_result = archive->OpenDirectory(dir_path);
+        auto dir_result = boss_archive->OpenDirectory(dir_path);
         if (dir_result.Succeeded()) {
             LOG_DEBUG(Service_BOSS, "Spotpass Extdata directory opened successfully!");
             auto dir = std::move(dir_result).Unwrap();
-            FileSys::Entry boss_files[10];
-            entry_count = dir->Read(10, boss_files);
+            entry_count = dir->Read(files_to_read, files);
             LOG_DEBUG(Service_BOSS, "Spotpass Extdata directory contains {} files", entry_count);
         } else {
             LOG_WARNING(Service_BOSS, "Extdata directory opened unsuccessfully :(");
@@ -232,6 +337,18 @@ u32 Module::Interface::GetOutputEntriesCount() {
     } else {
         LOG_WARNING(Service_BOSS, "Extdata opening failed");
     }
+    return entry_count;
+}
+
+u32 Module::Interface::GetOutputEntries(u32 filter, u32 max_entries, auto* buffer) {
+    std::vector<NsDataEntry> ns_data = GetNsDataEntries(max_entries);
+    std::vector<u32> output_entries;
+    u32 entry_count = ns_data.size();
+    for (u32 i = 0; i < entry_count; i++) {
+        output_entries.push_back(ns_data[i].ns_data_id);
+    }
+    buffer->Write(&output_entries[0], 0, sizeof(u32) * entry_count);
+    LOG_DEBUG(Service_BOSS, "{} usable entries returned", entry_count);
     return entry_count;
 }
 
@@ -243,9 +360,7 @@ void Module::Interface::GetNsDataIdList(Kernel::HLERequestContext& ctx) {
     const u32 start_ns_data_id = rp.Pop<u32>();
     auto& buffer = rp.PopMappedBuffer();
 
-    const u32 entries_count = GetOutputEntriesCount();
-    u32 output_entries[std::min(max_entries, entries_count)];
-    buffer.Write(output_entries, 0, sizeof(output_entries));
+    const u32 entries_count = GetOutputEntries(filter, max_entries, &buffer);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 2);
     rb.Push(RESULT_SUCCESS);
@@ -267,9 +382,7 @@ void Module::Interface::GetNsDataIdList1(Kernel::HLERequestContext& ctx) {
     const u32 start_ns_data_id = rp.Pop<u32>();
     auto& buffer = rp.PopMappedBuffer();
 
-    const u32 entries_count = GetOutputEntriesCount();
-    u32 output_entries[std::min(max_entries, entries_count)];
-    buffer.Write(output_entries, 0, sizeof(output_entries));
+    const u32 entries_count = GetOutputEntries(filter, max_entries, &buffer);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 2);
     rb.Push(RESULT_SUCCESS);
@@ -291,9 +404,7 @@ void Module::Interface::GetNsDataIdList2(Kernel::HLERequestContext& ctx) {
     const u32 start_ns_data_id = rp.Pop<u32>();
     auto& buffer = rp.PopMappedBuffer();
 
-    const u32 entries_count = GetOutputEntriesCount();
-    u32 output_entries[std::min(max_entries, entries_count)];
-    buffer.Write(output_entries, 0, sizeof(output_entries));
+    const u32 entries_count = GetOutputEntries(filter, max_entries, &buffer);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 2);
     rb.Push(RESULT_SUCCESS);
@@ -315,9 +426,7 @@ void Module::Interface::GetNsDataIdList3(Kernel::HLERequestContext& ctx) {
     const u32 start_ns_data_id = rp.Pop<u32>();
     auto& buffer = rp.PopMappedBuffer();
 
-    const u32 entries_count = GetOutputEntriesCount();
-    u32 output_entries[std::min(max_entries, entries_count)];
-    buffer.Write(output_entries, 0, sizeof(output_entries));
+    const u32 entries_count = GetOutputEntries(filter, max_entries, &buffer);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 2);
     rb.Push(RESULT_SUCCESS);
@@ -601,10 +710,59 @@ void Module::Interface::ReadNsData(Kernel::HLERequestContext& ctx) {
     const u32 size = rp.Pop<u32>();
     auto& buffer = rp.PopMappedBuffer();
 
+    std::vector<NsDataEntry> ns_data = GetNsDataEntries(100);
+
+    // This is the error code for NsDataID not found
+    u32 result = 0xC8A0F843;
+    u32 read_size = 0;
+
+    for (u32 i = 0; i < ns_data.size(); i++) {
+        NsDataEntry entry = ns_data[i];
+        if (entry.ns_data_id == ns_data_id) {
+            FileSys::ArchiveFactory_ExtSaveData extdata_archive_factory(
+                FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir), false);
+            FileSys::Path boss_path{GetBossDataDir()};
+            auto archive_result = extdata_archive_factory.OpenSpotpass(boss_path, 0);
+
+            if (archive_result.Succeeded()) {
+                LOG_DEBUG(Service_BOSS, "Spotpass Extdata opened successfully!");
+                auto boss_archive = std::move(archive_result).Unwrap().get();
+                FileSys::Path file_path = entry.filename.c_str();
+                FileSys::Mode mode{};
+                mode.read_flag.Assign(1);
+                auto file_result = boss_archive->OpenFile(file_path, mode);
+
+                if (file_result.Succeeded()) {
+                    auto file = std::move(file_result).Unwrap();
+                    LOG_DEBUG(Service_BOSS, "Opening Spotpass file succeeded!");
+                    if (entry.payload_size < size + offset) {
+                        LOG_WARNING(Service_BOSS,
+                                    "Request to read {:#010X} bytes at offset {:#010X}, payload "
+                                    "length is {:#010X}",
+                                    size, offset, entry.payload_size);
+                        continue;
+                    }
+                    u8* ns_data_array = new u8[size];
+                    file->Read(0x34 + offset, size, ns_data_array);
+                    buffer.Write(ns_data_array, 0, size);
+                    delete[] ns_data_array;
+                    result = 0;
+                    read_size = size;
+                    LOG_DEBUG(Service_BOSS, "Read {:#010X} bytes from file {}", read_size,
+                              entry.filename);
+                } else {
+                    LOG_WARNING(Service_BOSS, "Opening Spotpass file failed.");
+                }
+            } else {
+                LOG_WARNING(Service_BOSS, "Opening Spotpass Extdata failed.");
+            }
+        }
+    }
+
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 2);
-    rb.Push(RESULT_SUCCESS);
-    rb.Push<u32>(size); /// Should be actual read size
-    rb.Push<u32>(0);    /// unknown
+    rb.Push(result);
+    rb.Push<u32>(read_size); /// Should be actual read size
+    rb.Push<u32>(0);         /// unknown
     rb.PushMappedBuffer(buffer);
 
     LOG_WARNING(Service_BOSS, "(STUBBED) ns_data_id={:#010X}, offset={:#018X}, size={:#010X}",

--- a/src/core/hle/service/boss/boss.cpp
+++ b/src/core/hle/service/boss/boss.cpp
@@ -342,7 +342,7 @@ u32 Module::Interface::GetOutputEntries(u32 filter, u32 max_entries, auto* buffe
     }
     buffer->Write(output_entries.data(), 0, sizeof(u32) * output_entries.size());
     LOG_DEBUG(Service_BOSS, "{} usable entries returned", output_entries.size());
-    return output_entries.size();
+    return static_cast<u32>output_entries.size();
 }
 
 void Module::Interface::GetNsDataIdList(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/boss/boss.cpp
+++ b/src/core/hle/service/boss/boss.cpp
@@ -342,7 +342,7 @@ u32 Module::Interface::GetOutputEntries(u32 filter, u32 max_entries, auto* buffe
     }
     buffer->Write(output_entries.data(), 0, sizeof(u32) * output_entries.size());
     LOG_DEBUG(Service_BOSS, "{} usable entries returned", output_entries.size());
-    return static_cast<u32> output_entries.size();
+    return static_cast<u32> (output_entries.size());
 }
 
 void Module::Interface::GetNsDataIdList(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/boss/boss.cpp
+++ b/src/core/hle/service/boss/boss.cpp
@@ -9,6 +9,11 @@
 #include "core/hle/service/boss/boss.h"
 #include "core/hle/service/boss/boss_p.h"
 #include "core/hle/service/boss/boss_u.h"
+#include "common/file_util.h"
+#include "common/string_util.h"
+#include "core/file_sys/archive_extsavedata.h"
+#include "core/file_sys/file_backend.h"
+#include "core/file_sys/directory_backend.h"
 
 namespace Service::BOSS {
 
@@ -186,6 +191,52 @@ void Module::Interface::GetStepIdList(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service_BOSS, "(STUBBED) size={:#010X}", size);
 }
 
+u32 Module::Interface::GetOutputEntriesCount(){
+    u32 entry_count = 0;
+
+    u64 extdata_id = 0;
+    Core::System::GetInstance().GetAppLoader().ReadExtdataId(extdata_id);
+
+    LOG_DEBUG(Service_BOSS, "Extdata ID={:#018X}",extdata_id);
+
+    std::string sd_directory{FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir)};
+
+    FileSys::ArchiveFactory_ExtSaveData extdata_archive_factory(sd_directory, false);
+
+    std::string extdata_directory{FileSys::GetExtDataPathFromId(sd_directory,extdata_id)};
+
+    LOG_DEBUG(Service_BOSS,"Extdata dir={}", extdata_directory);
+
+    const u32 high = static_cast<u32>(extdata_id >> 32);
+    const u32 low = static_cast<u32>(extdata_id & 0xFFFFFFFF);
+
+    FileSys::Path extdata_path{FileSys::ConstructExtDataBinaryPath(1,high,low)};
+
+    auto archive_result = extdata_archive_factory.OpenSpotpass(extdata_path, 0);
+    if (archive_result.Succeeded()) {
+        LOG_DEBUG(Service_BOSS,"Spotpass Extdata opened successfully!");
+        auto archive = std::move(archive_result).Unwrap();
+
+        FileSys::Path dir_path = "/";
+
+        auto dir_result = archive->OpenDirectory(dir_path);
+        if (dir_result.Succeeded()) {
+            LOG_DEBUG(Service_BOSS,"Spotpass Extdata directory opened successfully!");
+            auto dir = std::move(dir_result).Unwrap();
+            FileSys::Entry boss_files[10];
+            entry_count = dir->Read(10,boss_files);
+            LOG_DEBUG(Service_BOSS,"Spotpass Extdata directory contains {} files", entry_count);
+        }
+        else {
+            LOG_WARNING(Service_BOSS,"Extdata directory opened unsuccessfully :(");
+        }
+    }
+    else {
+        LOG_WARNING(Service_BOSS,"Extdata opening failed");
+    }
+    return entry_count;
+}
+
 void Module::Interface::GetNsDataIdList(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx, 0x10, 4, 2);
     const u32 filter = rp.Pop<u32>();
@@ -196,7 +247,7 @@ void Module::Interface::GetNsDataIdList(Kernel::HLERequestContext& ctx) {
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 2);
     rb.Push(RESULT_SUCCESS);
-    rb.Push<u16>(0); /// Actual number of output entries
+    rb.Push<u16>(GetOutputEntriesCount()); /// Actual number of output entries
     rb.Push<u16>(0); /// Last word-index copied to output in the internal NsDataId list.
     rb.PushMappedBuffer(buffer);
 
@@ -216,17 +267,7 @@ void Module::Interface::GetNsDataIdList1(Kernel::HLERequestContext& ctx) {
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 2);
     rb.Push(RESULT_SUCCESS);
-	
-	u64_le programid = 0;
-    Core::System::GetInstance().GetAppLoader().ReadProgramId(programid);
-	if(programid == 0x0004000000078B00 || programid==0X0004000000100500 || programid==0x0004000000100600 || programid==0x0004000000100700){
-		LOG_WARNING(Service_BOSS,"PLvPWAA detected! Setting number of output entries to 1.");
-		rb.Push<u16>(1); /// Spoof at least one entry for PLvPWAA
-	}
-	else {
-		rb.Push<u16>(0); /// Actual number of output entries
-	}
-	
+    rb.Push<u16>(GetOutputEntriesCount()); /// Actual number of output entries
     rb.Push<u16>(0); /// Last word-index copied to output in the internal NsDataId list.
     rb.PushMappedBuffer(buffer);
 
@@ -246,7 +287,7 @@ void Module::Interface::GetNsDataIdList2(Kernel::HLERequestContext& ctx) {
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 2);
     rb.Push(RESULT_SUCCESS);
-    rb.Push<u16>(0); /// Actual number of output entries
+    rb.Push<u16>(GetOutputEntriesCount()); /// Actual number of output entries
     rb.Push<u16>(0); /// Last word-index copied to output in the internal NsDataId list.
     rb.PushMappedBuffer(buffer);
 
@@ -266,7 +307,7 @@ void Module::Interface::GetNsDataIdList3(Kernel::HLERequestContext& ctx) {
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 2);
     rb.Push(RESULT_SUCCESS);
-    rb.Push<u16>(0); /// Actual number of output entries
+    rb.Push<u16>(GetOutputEntriesCount()); /// Actual number of output entries
     rb.Push<u16>(0); /// Last word-index copied to output in the internal NsDataId list.
     rb.PushMappedBuffer(buffer);
 

--- a/src/core/hle/service/boss/boss.h
+++ b/src/core/hle/service/boss/boss.h
@@ -963,6 +963,8 @@ public:
         u8 ns_data_new_flag_privileged;
         u8 output_flag;
 
+        u32 GetOutputEntriesCount();
+
         template <class Archive>
         void serialize(Archive& ar, const unsigned int) {
             ar& new_arrival_flag;

--- a/src/core/hle/service/boss/boss.h
+++ b/src/core/hle/service/boss/boss.h
@@ -15,13 +15,33 @@ class System;
 }
 
 namespace Service::BOSS {
+// File header info from
+// https://www.3dbrew.org/wiki/SpotPass#Payload_Content_Header
+// So the total header is only 52 bytes long
 
-struct NsDataEntry {
-    std::string filename;
+const u64 boss_header_length = 0x34;
+// 52 bytes doesn't align nicely into 8-byte words
+#pragma pack(push, 4)
+struct BossHeader {
+    u8 header_length;
+    u8 zero1[11];
+    u32 unknown;
+    u32 download_date;
+    u8 zero2[4];
     u64 program_id;
+    u8 zero3[4];
     u32 datatype;
     u32 payload_size;
     u32 ns_data_id;
+    u32 version;
+};
+#pragma pack(pop)
+
+static_assert(sizeof(BossHeader) == 0x34, "BossHeaderstruct isn't exactly 0x34 bytes long!");
+
+struct NsDataEntry {
+    std::string filename;
+    BossHeader header;
 };
 
 class Module final {

--- a/src/core/hle/service/boss/boss.h
+++ b/src/core/hle/service/boss/boss.h
@@ -16,6 +16,14 @@ class System;
 
 namespace Service::BOSS {
 
+struct NsDataEntry {
+    std::string filename;
+    u64 program_id;
+    u32 datatype;
+    u32 payload_size;
+    u32 ns_data_id;
+};
+
 class Module final {
 public:
     explicit Module(Core::System& system);
@@ -963,7 +971,10 @@ public:
         u8 ns_data_new_flag_privileged;
         u8 output_flag;
 
-        u32 GetOutputEntriesCount();
+        auto GetBossDataDir();
+        std::vector<NsDataEntry> GetNsDataEntries(u32 max_entries);
+        u32 GetBossExtDataFiles(u32 files_to_read, auto* boss_files);
+        u32 GetOutputEntries(u32 filter, u32 max_entries, auto* buffer);
 
         template <class Archive>
         void serialize(Archive& ar, const unsigned int) {


### PR DESCRIPTION
Return 1 for the number of output entries in the GetNsDataIdList1 stub. This fixes the extra content for Professor Layton vs Phoenix Wright Ace Attorney as the game expects the boss extdata to not be empty. Might break other games if they attempt to do anything with the ns data. (although the readnsdata and deletensdata methods are both still stubbed)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6436)
<!-- Reviewable:end -->
