### PR TITLE
citra_android: Theme adjustments

### DIFF
--- a/src/android/app/src/main/res/layout/activity_cheats.xml
+++ b/src/android/app/src/main/res/layout/activity_cheats.xml
@@ -4,7 +4,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="?attr/colorSurface">
 
     <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:id="@+id/coordinator_cheats"

--- a/src/android/app/src/main/res/layout/activity_main.xml
+++ b/src/android/app/src/main/res/layout/activity_main.xml
@@ -4,7 +4,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/coordinator_main"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="?attr/colorSurface">
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appbar"

--- a/src/android/app/src/main/res/values-night/citra_colors.xml
+++ b/src/android/app/src/main/res/values-night/citra_colors.xml
@@ -19,7 +19,7 @@
     <color name="citra_onErrorContainer">#FFDAD6</color>
     <color name="citra_background">#1E1B16</color>
     <color name="citra_onBackground">#E9E1D9</color>
-    <color name="citra_surface">#1E1B16</color>
+    <color name="citra_surface">#1C1C1B</color>
     <color name="citra_onSurface">#E9E1D9</color>
     <color name="citra_surfaceVariant">#4D4639</color>
     <color name="citra_onSurfaceVariant">#D0C5B4</color>

--- a/src/android/app/src/main/res/values/styles.xml
+++ b/src/android/app/src/main/res/values/styles.xml
@@ -28,4 +28,13 @@
         <item name="labelBehavior">gone</item>
     </style>
 
+    <style name="Widget.Citra.FloatingActionButton" parent="Widget.Material3.FloatingActionButton.Primary">
+        <item name="materialThemeOverlay">@style/ThemeOverlay.Citra.FloatingActionButton</item>
+    </style>
+
+    <style name="ThemeOverlay.Citra.FloatingActionButton" parent="">
+        <item name="colorContainer">@color/citra_primary</item>
+        <item name="colorOnContainer">@color/citra_onPrimary</item>
+    </style>
+
 </resources>

--- a/src/android/app/src/main/res/values/themes.xml
+++ b/src/android/app/src/main/res/values/themes.xml
@@ -45,6 +45,7 @@
         <item name="popupMenuStyle">@style/CitraShapedPopup</item>
         <item name="popupTheme">@style/CitraPopup</item>
         <item name="sliderStyle">@style/CitraSlider</item>
+        <item name="floatingActionButtonStyle">@style/Widget.Citra.FloatingActionButton</item>
     </style>
 
 </resources>


### PR DESCRIPTION
A few fixes and adjustments to make the current theme appear more consistent.

For the cheats activity top app bar color, the difference is *very* subtle but it wasn't the surface color before.

MainActivity BG color -
Before -
![Screenshot_20230415-145413.png](https://user-images.githubusercontent.com/14132249/232248313-9066219d-2617-4cd1-b156-c0d16dd4d182.png)

After - 
![Screenshot_20230415-145501.png](https://user-images.githubusercontent.com/14132249/232248321-c8ff4178-7ffc-473d-ab2c-7813e3c400f9.png)

New FAB color
Before -
![Screenshot_20230415-145623.png](https://user-images.githubusercontent.com/14132249/232248449-636ac6a3-1267-4e10-aebe-f654c19865a0.png)

After -
![Screenshot_20230415-145652.png](https://user-images.githubusercontent.com/14132249/232248461-31749ac3-4ccd-493f-84d1-e5217e836091.png)

New Dark Mode BG -
![Screenshot_20230415-145932.png](https://user-images.githubusercontent.com/14132249/232248594-4ddfd926-28c9-4144-87a4-66594edd1944.png)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6439)
<!-- Reviewable:end -->
