### PR TITLE
Textures loading screen

### DIFF
--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -62,6 +62,10 @@ void EmuThread::run() {
     const auto scope = core_context.Acquire();
     Core::System& system = Core::System::GetInstance();
 
+    if (Settings::values.custom_textures) {
+        system.CustomTexManager().FindCustomTextures();
+    }
+
     if (Settings::values.preload_textures) {
         emit LoadProgress(VideoCore::LoadCallbackStage::Preload, 0, 0);
         system.CustomTexManager().PreloadTextures(

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -60,10 +60,17 @@ static GMainWindow* GetMainWindow() {
 void EmuThread::run() {
     MicroProfileOnThreadCreate("EmuThread");
     const auto scope = core_context.Acquire();
+    Core::System& system = Core::System::GetInstance();
+
+    if (Settings::values.preload_textures) {
+        emit LoadProgress(VideoCore::LoadCallbackStage::Preload, 0, 0);
+        system.CustomTexManager().PreloadTextures(
+            stop_run, [this](VideoCore::LoadCallbackStage stage, std::size_t value,
+                             std::size_t total) { emit LoadProgress(stage, value, total); });
+    }
 
     emit LoadProgress(VideoCore::LoadCallbackStage::Prepare, 0, 0);
 
-    Core::System& system = Core::System::GetInstance();
     system.Renderer().Rasterizer()->LoadDiskResources(
         stop_run, [this](VideoCore::LoadCallbackStage stage, std::size_t value, std::size_t total) {
             emit LoadProgress(stage, value, total);

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -23,6 +23,7 @@
 #include "input_common/keyboard.h"
 #include "input_common/main.h"
 #include "input_common/motion_emu.h"
+#include "video_core/custom_textures/custom_tex_manager.h"
 #include "video_core/renderer_base.h"
 #include "video_core/video_core.h"
 

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -62,10 +62,6 @@ void EmuThread::run() {
     const auto scope = core_context.Acquire();
     Core::System& system = Core::System::GetInstance();
 
-    if (Settings::values.custom_textures) {
-        system.CustomTexManager().FindCustomTextures();
-    }
-
     if (Settings::values.preload_textures) {
         emit LoadProgress(VideoCore::LoadCallbackStage::Preload, 0, 0);
         system.CustomTexManager().PreloadTextures(

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -80,7 +80,6 @@ private:
     std::atomic<bool> stop_run{false};
     std::mutex running_mutex;
     std::condition_variable running_cv;
-    std::size_t number_textures;
 
     Frontend::GraphicsContext& core_context;
 

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -12,6 +12,7 @@
 #include <QWidget>
 #include "core/core.h"
 #include "core/frontend/emu_window.h"
+#include "video_core/custom_textures/custom_tex_manager.h"
 
 class QKeyEvent;
 class QTouchEvent;
@@ -79,6 +80,7 @@ private:
     std::atomic<bool> stop_run{false};
     std::mutex running_mutex;
     std::condition_variable running_cv;
+    std::size_t number_textures;
 
     Frontend::GraphicsContext& core_context;
 

--- a/src/citra_qt/bootmanager.h
+++ b/src/citra_qt/bootmanager.h
@@ -12,7 +12,6 @@
 #include <QWidget>
 #include "core/core.h"
 #include "core/frontend/emu_window.h"
-#include "video_core/custom_textures/custom_tex_manager.h"
 
 class QKeyEvent;
 class QTouchEvent;

--- a/src/citra_qt/loading_screen.cpp
+++ b/src/citra_qt/loading_screen.cpp
@@ -62,6 +62,8 @@ QProgressBar::chunk {
 // Definitions for the differences in text and styling for each stage
 const static std::unordered_map<VideoCore::LoadCallbackStage, const char*> stage_translations{
     {VideoCore::LoadCallbackStage::Prepare, QT_TRANSLATE_NOOP("LoadingScreen", "Loading...")},
+    {VideoCore::LoadCallbackStage::Preload,
+     QT_TRANSLATE_NOOP("LoadingScreen", "Preloading Textures %1 / %2")},
     {VideoCore::LoadCallbackStage::Decompile,
      QT_TRANSLATE_NOOP("LoadingScreen", "Preparing Shaders %1 / %2")},
     {VideoCore::LoadCallbackStage::Build,
@@ -70,6 +72,7 @@ const static std::unordered_map<VideoCore::LoadCallbackStage, const char*> stage
 };
 const static std::unordered_map<VideoCore::LoadCallbackStage, const char*> progressbar_style{
     {VideoCore::LoadCallbackStage::Prepare, PROGRESSBAR_STYLE_PREPARE},
+    {VideoCore::LoadCallbackStage::Preload, PROGRESSBAR_STYLE_BUILD},
     {VideoCore::LoadCallbackStage::Decompile, PROGRESSBAR_STYLE_DECOMPILE},
     {VideoCore::LoadCallbackStage::Build, PROGRESSBAR_STYLE_BUILD},
     {VideoCore::LoadCallbackStage::Complete, PROGRESSBAR_STYLE_COMPLETE},
@@ -186,7 +189,8 @@ void LoadingScreen::OnLoadProgress(VideoCore::LoadCallbackStage stage, std::size
     // update labels and progress bar
     const auto& stg = tr(stage_translations.at(stage));
     if (stage == VideoCore::LoadCallbackStage::Decompile ||
-        stage == VideoCore::LoadCallbackStage::Build) {
+        stage == VideoCore::LoadCallbackStage::Build ||
+        stage == VideoCore::LoadCallbackStage::Preload) {
         ui->stage->setText(stg.arg(value).arg(total));
     } else {
         ui->stage->setText(stg);

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -323,9 +323,6 @@ System::ResultStatus System::Load(Frontend::EmuWindow& emu_window, const std::st
     if (Settings::values.custom_textures) {
         custom_tex_manager->FindCustomTextures();
     }
-    if (Settings::values.preload_textures) {
-        custom_tex_manager->PreloadTextures();
-    }
     if (Settings::values.dump_textures) {
         custom_tex_manager->WriteConfig();
     }
@@ -554,6 +551,7 @@ void System::Shutdown(bool is_deserializing) {
         cheat_engine.reset();
         app_loader.reset();
     }
+    custom_tex_manager.reset();
     telemetry_session.reset();
     rpc_server.reset();
     archive_manager.reset();

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -320,6 +320,9 @@ System::ResultStatus System::Load(Frontend::EmuWindow& emu_window, const std::st
     }
     perf_stats = std::make_unique<PerfStats>(title_id);
 
+    if (Settings::values.custom_textures) {
+        custom_tex_manager->FindCustomTextures();
+    }
     if (Settings::values.dump_textures) {
         custom_tex_manager->WriteConfig();
     }

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -320,9 +320,6 @@ System::ResultStatus System::Load(Frontend::EmuWindow& emu_window, const std::st
     }
     perf_stats = std::make_unique<PerfStats>(title_id);
 
-    if (Settings::values.custom_textures) {
-        custom_tex_manager->FindCustomTextures();
-    }
     if (Settings::values.dump_textures) {
         custom_tex_manager->WriteConfig();
     }

--- a/src/video_core/custom_textures/custom_tex_manager.h
+++ b/src/video_core/custom_textures/custom_tex_manager.h
@@ -10,6 +10,7 @@
 #include <unordered_set>
 #include "common/thread_worker.h"
 #include "video_core/custom_textures/material.h"
+#include "video_core/rasterizer_interface.h"
 
 namespace Core {
 class System;
@@ -43,7 +44,8 @@ public:
     void WriteConfig();
 
     /// Preloads all registered custom textures
-    void PreloadTextures();
+    void PreloadTextures(const std::atomic_bool& stop_run,
+                         const VideoCore::DiskResourceLoadCallback& callback);
 
     /// Saves the provided pixel data described by params to disk as png
     void DumpTexture(const SurfaceParams& params, u32 level, std::span<u8> data, u64 data_hash);

--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -21,6 +21,7 @@ namespace VideoCore {
 
 enum class LoadCallbackStage {
     Prepare,
+    Preload,
     Decompile,
     Build,
     Complete,


### PR DESCRIPTION
Hello There This Pull request adds a loading screen for the preloading textures. Preloading textures have some problems this pull request solves: 
- citra freezing, windows OS has (citra is not responding) issue
- Cannot stop the emulation while textures are preloading, you have to kill citra process.

 This PR can allows us to look at the progression of the preloading textures.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6478)
<!-- Reviewable:end -->
