### PR TITLE
Android: Offload CIA installation to background thread 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install ccache glslang-dev glslang-tools apksigner -y
       - name: Build
-        run: ./.ci/android/build.sh
+        run: JAVA_HOME=$JAVA_HOME_17_X64 ./.ci/android/build.sh
       - name: Copy and sign artifacts
         env:
           ANDROID_KEYSTORE_B64: ${{ secrets.ANDROID_KEYSTORE_B64 }}

--- a/src/android/app/build.gradle
+++ b/src/android/app/build.gradle
@@ -129,6 +129,7 @@ dependencies {
     implementation "androidx.slidingpanelayout:slidingpanelayout:1.2.0"
     implementation 'com.google.android.material:material:1.6.1'
     implementation 'androidx.core:core-splashscreen:1.0.0'
+    implementation "androidx.work:work-runtime:2.8.1"
 
     // For loading huge screenshots from the disk.
     implementation 'com.squareup.picasso:picasso:2.71828'

--- a/src/android/app/build.gradle
+++ b/src/android/app/build.gradle
@@ -10,7 +10,7 @@ def buildType
 def abiFilter = "arm64-v8a" //, "x86"
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
     ndkVersion "25.1.8937393"
 
     compileOptions {
@@ -100,6 +100,7 @@ android {
             path "../../../CMakeLists.txt"
         }
     }
+    namespace 'org.citra.citra_emu'
 
     defaultConfig {
         externalNativeBuild {

--- a/src/android/app/src/main/java/org/citra/citra_emu/CitraApplication.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/CitraApplication.java
@@ -23,16 +23,33 @@ public class CitraApplication extends Application {
     private void createNotificationChannel() {
         // Create the NotificationChannel, but only on API 26+ because
         // the NotificationChannel class is new and not in the support library
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return;
+        }
+        NotificationManager notificationManager = getSystemService(NotificationManager.class);
+        {
+            // General notification
             CharSequence name = getString(R.string.app_notification_channel_name);
             String description = getString(R.string.app_notification_channel_description);
-            NotificationChannel channel = new NotificationChannel(getString(R.string.app_notification_channel_id), name, NotificationManager.IMPORTANCE_LOW);
+            NotificationChannel channel = new NotificationChannel(
+                    getString(R.string.app_notification_channel_id), name,
+                    NotificationManager.IMPORTANCE_LOW);
             channel.setDescription(description);
             channel.setSound(null, null);
             channel.setVibrationPattern(null);
-            // Register the channel with the system; you can't change the importance
-            // or other notification behaviors after this
-            NotificationManager notificationManager = getSystemService(NotificationManager.class);
+
+            notificationManager.createNotificationChannel(channel);
+        }
+        {
+            // CIA Install notifications
+            NotificationChannel channel = new NotificationChannel(
+                    getString(R.string.cia_install_notification_channel_id),
+                    getString(R.string.cia_install_notification_channel_name),
+                    NotificationManager.IMPORTANCE_DEFAULT);
+            channel.setDescription(getString(R.string.cia_install_notification_channel_description));
+            channel.setSound(null, null);
+            channel.setVibrationPattern(null);
+
             notificationManager.createNotificationChannel(channel);
         }
     }

--- a/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/NativeLibrary.java
@@ -589,8 +589,6 @@ public final class NativeLibrary {
 
     public static native void RemoveAmiibo();
 
-    public static native void InstallCIAS(String[] path);
-
     public static final int SAVESTATE_SLOT_COUNT = 10;
 
     public static final class SavestateInfo {

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/CiaInstallWorker.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/CiaInstallWorker.java
@@ -5,8 +5,6 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
-import android.os.Handler;
-import android.os.Looper;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
@@ -15,14 +13,7 @@ import androidx.work.ForegroundInfo;
 import androidx.work.Worker;
 import androidx.work.WorkerParameters;
 
-import com.google.common.util.concurrent.ListenableFuture;
-
-import org.citra.citra_emu.CitraApplication;
 import org.citra.citra_emu.R;
-import org.citra.citra_emu.ui.main.MainActivity;
-
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 public class CiaInstallWorker extends Worker {
     private final Context mContext = getApplicationContext();
@@ -55,7 +46,9 @@ public class CiaInstallWorker extends Worker {
 
     private static long mLastNotifiedTime = 0;
 
-    private static int mStatusNotificationId = 0xC1A0001;
+    private static final int SUMMARY_NOTIFICATION_ID = 0xC1A0000;
+    private static final int PROGRESS_NOTIFICATION_ID = SUMMARY_NOTIFICATION_ID + 1;
+    private static int mStatusNotificationId = SUMMARY_NOTIFICATION_ID + 2;
 
     public CiaInstallWorker(
             @NonNull Context context,
@@ -113,7 +106,7 @@ public class CiaInstallWorker extends Worker {
         }
         // Even if newer versions of Android don't show the group summary text that you design,
         // you always need to manually set a summary to enable grouped notifications.
-        mNotificationManager.notify(0xC1A0000, mSummaryNotification);
+        mNotificationManager.notify(SUMMARY_NOTIFICATION_ID, mSummaryNotification);
         mNotificationManager.notify(mStatusNotificationId++, mInstallStatusBuilder.build());
     }
     @NonNull
@@ -139,7 +132,7 @@ public class CiaInstallWorker extends Worker {
             InstallStatus res = InstallCIA(file);
             notifyInstallStatus(filename, res);
         }
-        mNotificationManager.cancel(0xC1A);
+        mNotificationManager.cancel(PROGRESS_NOTIFICATION_ID);
 
         return Result.success();
     }
@@ -154,13 +147,13 @@ public class CiaInstallWorker extends Worker {
         }
         mLastNotifiedTime = currentTime;
         mInstallProgressBuilder.setProgress(max, progress, false);
-        mNotificationManager.notify(0xC1A, mInstallProgressBuilder.build());
+        mNotificationManager.notify(PROGRESS_NOTIFICATION_ID, mInstallProgressBuilder.build());
     }
 
     @NonNull
     @Override
     public ForegroundInfo getForegroundInfo() {
-        return new ForegroundInfo(0xC1A, mInstallProgressBuilder.build());
+        return new ForegroundInfo(PROGRESS_NOTIFICATION_ID, mInstallProgressBuilder.build());
     }
 
     private native InstallStatus InstallCIA(String path);

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/CiaInstallWorker.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/CiaInstallWorker.java
@@ -1,0 +1,167 @@
+package org.citra.citra_emu.utils;
+
+import android.app.Notification;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Handler;
+import android.os.Looper;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.core.app.NotificationCompat;
+import androidx.work.ForegroundInfo;
+import androidx.work.Worker;
+import androidx.work.WorkerParameters;
+
+import com.google.common.util.concurrent.ListenableFuture;
+
+import org.citra.citra_emu.CitraApplication;
+import org.citra.citra_emu.R;
+import org.citra.citra_emu.ui.main.MainActivity;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class CiaInstallWorker extends Worker {
+    private final Context mContext = getApplicationContext();
+
+    private final NotificationManager mNotificationManager =
+            mContext.getSystemService(NotificationManager.class);
+
+    static final String GROUP_KEY_CIA_INSTALL_STATUS = "org.citra.citra_emu.CIA_INSTALL_STATUS";
+
+    private final NotificationCompat.Builder mInstallProgressBuilder = new NotificationCompat.Builder(
+            mContext, mContext.getString(R.string.cia_install_notification_channel_id))
+            .setContentTitle(mContext.getString(R.string.install_cia_title))
+            .setContentIntent(PendingIntent.getBroadcast(mContext, 0,
+                    new Intent("CitraDoNothing"), PendingIntent.FLAG_IMMUTABLE))
+            .setSmallIcon(R.drawable.ic_stat_notification_logo);
+
+    private final NotificationCompat.Builder mInstallStatusBuilder = new NotificationCompat.Builder(
+            mContext, mContext.getString(R.string.cia_install_notification_channel_id))
+            .setContentTitle(mContext.getString(R.string.install_cia_title))
+            .setSmallIcon(R.drawable.ic_stat_notification_logo)
+            .setGroup(GROUP_KEY_CIA_INSTALL_STATUS);
+
+    private final Notification mSummaryNotification =
+            new NotificationCompat.Builder(mContext, mContext.getString(R.string.cia_install_notification_channel_id))
+                    .setContentTitle(mContext.getString(R.string.install_cia_title))
+                    .setSmallIcon(R.drawable.ic_stat_notification_logo)
+                    .setGroup(GROUP_KEY_CIA_INSTALL_STATUS)
+                    .setGroupSummary(true)
+                    .build();
+
+    private static long mLastNotifiedTime = 0;
+
+    private static int mStatusNotificationId = 0xC1A0001;
+
+    public CiaInstallWorker(
+            @NonNull Context context,
+            @NonNull WorkerParameters params) {
+        super(context, params);
+    }
+
+    enum InstallStatus {
+        Success,
+        ErrorFailedToOpenFile,
+        ErrorFileNotFound,
+        ErrorAborted,
+        ErrorInvalid,
+        ErrorEncrypted,
+    }
+
+    private void notifyInstallStatus(String filename, InstallStatus status) {
+        switch(status){
+            case Success:
+                mInstallStatusBuilder.setContentTitle(
+                        mContext.getString(R.string.cia_install_notification_success_title));
+                mInstallStatusBuilder.setContentText(
+                        mContext.getString(R.string.cia_install_success, filename));
+                break;
+            case ErrorAborted:
+                mInstallStatusBuilder.setContentTitle(
+                        mContext.getString(R.string.cia_install_notification_error_title));
+                mInstallStatusBuilder.setStyle(new NotificationCompat.BigTextStyle()
+                                .bigText(mContext.getString(
+                                         R.string.cia_install_error_aborted, filename)));
+                break;
+            case ErrorInvalid:
+                mInstallStatusBuilder.setContentTitle(
+                        mContext.getString(R.string.cia_install_notification_error_title));
+                mInstallStatusBuilder.setContentText(
+                        mContext.getString(R.string.cia_install_error_invalid, filename));
+                break;
+            case ErrorEncrypted:
+                mInstallStatusBuilder.setContentTitle(
+                        mContext.getString(R.string.cia_install_notification_error_title));
+                mInstallStatusBuilder.setStyle(new NotificationCompat.BigTextStyle()
+                        .bigText(mContext.getString(
+                                 R.string.cia_install_error_encrypted, filename)));
+                break;
+            case ErrorFailedToOpenFile:
+                // TODO:
+            case ErrorFileNotFound:
+                // shouldn't happen
+            default:
+                mInstallStatusBuilder.setContentTitle(
+                        mContext.getString(R.string.cia_install_notification_error_title));
+                mInstallStatusBuilder.setStyle(new NotificationCompat.BigTextStyle()
+                        .bigText(mContext.getString(R.string.cia_install_error_unknown, filename)));
+                break;
+        }
+        // Even if newer versions of Android don't show the group summary text that you design,
+        // you always need to manually set a summary to enable grouped notifications.
+        mNotificationManager.notify(0xC1A0000, mSummaryNotification);
+        mNotificationManager.notify(mStatusNotificationId++, mInstallStatusBuilder.build());
+    }
+    @NonNull
+    @Override
+    public Result doWork() {
+        String[] selectedFiles = getInputData().getStringArray("CIA_FILES");
+        assert selectedFiles != null;
+        final CharSequence toastText = mContext.getResources().getQuantityString(R.plurals.cia_install_toast,
+                selectedFiles.length, selectedFiles.length);
+
+        getApplicationContext().getMainExecutor().execute(() -> Toast.makeText(mContext, toastText,
+                Toast.LENGTH_LONG).show());
+
+        // Issue the initial notification with zero progress
+        mInstallProgressBuilder.setOngoing(true);
+        setProgressCallback(100, 0);
+
+        int i = 0;
+        for (String file : selectedFiles) {
+            String filename = FileUtil.getFilename(mContext, file);
+            mInstallProgressBuilder.setContentText(mContext.getString(
+                    R.string.cia_install_notification_installing, filename, ++i, selectedFiles.length));
+            InstallStatus res = InstallCIA(file);
+            notifyInstallStatus(filename, res);
+        }
+        mNotificationManager.cancel(0xC1A);
+
+        return Result.success();
+    }
+    public void setProgressCallback(int max, int progress) {
+        long currentTime = System.currentTimeMillis();
+        // Android applies a rate limit when updating a notification.
+        // If you post updates to a single notification too frequently,
+        // such as many in less than one second, the system might drop updates.
+        // TODO: consider moving to C++ side
+        if (currentTime - mLastNotifiedTime < 500 /* ms */){
+            return;
+        }
+        mLastNotifiedTime = currentTime;
+        mInstallProgressBuilder.setProgress(max, progress, false);
+        mNotificationManager.notify(0xC1A, mInstallProgressBuilder.build());
+    }
+
+    @NonNull
+    @Override
+    public ForegroundInfo getForegroundInfo() {
+        return new ForegroundInfo(0xC1A, mInstallProgressBuilder.build());
+    }
+
+    private native InstallStatus InstallCIA(String path);
+}

--- a/src/android/app/src/main/java/org/citra/citra_emu/utils/DiskShaderCacheProgress.java
+++ b/src/android/app/src/main/java/org/citra/citra_emu/utils/DiskShaderCacheProgress.java
@@ -2,7 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-package org.citra.citra_emu.disk_shader_cache;
+package org.citra.citra_emu.utils;
 
 import android.app.Activity;
 import android.app.Dialog;

--- a/src/android/app/src/main/jni/id_cache.h
+++ b/src/android/app/src/main/jni/id_cache.h
@@ -15,8 +15,6 @@ JNIEnv* GetEnvForThread();
 
 jclass GetCoreErrorClass();
 jclass GetSavestateInfoClass();
-jclass GetDiskCacheProgressClass();
-jclass GetDiskCacheLoadCallbackStageClass();
 
 jclass GetNativeLibraryClass();
 jmethodID GetOnCoreError();
@@ -28,7 +26,6 @@ jmethodID GetLandscapeScreenLayout();
 jmethodID GetExitEmulationActivity();
 jmethodID GetRequestCameraPermission();
 jmethodID GetRequestMicPermission();
-jmethodID GetDiskCacheLoadProgress();
 
 jclass GetCheatClass();
 jfieldID GetCheatPointer();
@@ -38,6 +35,8 @@ jfieldID GetCheatEnginePointer();
 
 jfieldID GetGameInfoPointer();
 
+jclass GetDiskCacheProgressClass();
+jmethodID GetDiskCacheLoadProgress();
 jobject GetJavaLoadCallbackStage(VideoCore::LoadCallbackStage stage);
 
 } // namespace IDCache

--- a/src/android/app/src/main/jni/id_cache.h
+++ b/src/android/app/src/main/jni/id_cache.h
@@ -9,6 +9,10 @@
 #include <jni.h>
 #include "video_core/rasterizer_interface.h"
 
+namespace Service::AM {
+enum class InstallStatus : u32;
+} // namespace Service::AM
+
 namespace IDCache {
 
 JNIEnv* GetEnvForThread();
@@ -38,6 +42,10 @@ jfieldID GetGameInfoPointer();
 jclass GetDiskCacheProgressClass();
 jmethodID GetDiskCacheLoadProgress();
 jobject GetJavaLoadCallbackStage(VideoCore::LoadCallbackStage stage);
+
+jclass GetCiaInstallHelperClass();
+jmethodID GetCiaInstallHelperSetProgress();
+jobject GetJavaCiaInstallStatus(Service::AM::InstallStatus status);
 
 } // namespace IDCache
 

--- a/src/android/app/src/main/jni/native.h
+++ b/src/android/app/src/main/jni/native.h
@@ -146,10 +146,6 @@ JNIEXPORT jboolean Java_org_citra_citra_1emu_NativeLibrary_LoadAmiibo(JNIEnv* en
 
 JNIEXPORT void Java_org_citra_citra_1emu_NativeLibrary_RemoveAmiibo(JNIEnv* env, jclass clazz);
 
-JNIEXPORT void JNICALL Java_org_citra_citra_1emu_NativeLibrary_InstallCIAS(JNIEnv* env,
-                                                                           jclass clazz,
-                                                                           jobjectArray path);
-
 JNIEXPORT jobjectArray JNICALL
 Java_org_citra_citra_1emu_NativeLibrary_GetSavestateInfo(JNIEnv* env, jclass clazz);
 
@@ -161,6 +157,10 @@ JNIEXPORT void JNICALL Java_org_citra_citra_1emu_NativeLibrary_LoadState(JNIEnv*
 
 JNIEXPORT void JNICALL Java_org_citra_citra_1emu_NativeLibrary_LogDeviceInfo(JNIEnv* env,
                                                                              jclass clazz);
+
+JNIEXPORT jobject JNICALL Java_org_citra_citra_1emu_NativeLibrary_InstallCIA(JNIEnv* env,
+                                                                             jclass clazz,
+                                                                             jstring file);
 
 #ifdef __cplusplus
 }

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -262,4 +262,22 @@
     <string name="cheats_error_no_name">Name can\'t be empty</string>
     <string name="cheats_error_no_code_lines">Code can\'t be empty</string>
     <string name="cheats_error_on_line">Error on line %1$d</string>
+
+    <!-- CIA Install -->
+    <plurals name="cia_install_toast">
+        <item quantity="one">Installing %d file. See notification for more details.</item>
+        <item quantity="other">Installing %d files. See notification for more details.</item>
+    </plurals>
+    <string name="cia_install_notification_channel_name" translatable="false">Citra CIA Install</string>
+    <string name="cia_install_notification_channel_id" translatable="false">citra-cia</string>
+    <string name="cia_install_notification_channel_description">Citra notifications during CIA Install</string>
+    <string name="cia_install_notification_title">Installing CIA</string>
+    <string name="cia_install_notification_installing">Installing %s (%d/%d)</string>
+    <string name="cia_install_notification_success_title">Successfully installed CIA</string>
+    <string name="cia_install_notification_error_title">Failed to install CIA</string>
+    <string name="cia_install_success">\"%s\" has been installed successfully</string>
+    <string name="cia_install_error_aborted">The installation of \"%s\" was aborted.\n Please see the log for more details</string>
+    <string name="cia_install_error_invalid">\"%s\" is not a valid CIA</string>
+    <string name="cia_install_error_encrypted">\"%s\" must be decrypted before being used with Citra.\n A real 3DS is required</string>
+    <string name="cia_install_error_unknown">An unknown error occurred while installing \"%s\".\n Please see the log for more details</string>
 </resources>

--- a/src/android/build.gradle
+++ b/src/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.0.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/src/android/gradle.properties
+++ b/src/android/gradle.properties
@@ -14,3 +14,6 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 android.native.buildOutput=verbose
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/src/android/gradle/wrapper/gradle-wrapper.properties
+++ b/src/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip


### PR DESCRIPTION
Known issues - 
- ~~Installing a cia while another is already in progress will crash~~ Seems to work fine with WorkManager, needs some more testing
- SleepingSnake's issue where starting a game corrupts the update, known to happen Pokémon USUM, doesn't seem to happen with Animal crossing
- ~~"Swiping the app away" from the recent apps, will interrupt the CIA install and corrupt the update~~ Should be fixed with WorkManager edit: Doesn't seem to work with some Chinese phones
- ~~Moving citra to the background will continue installation, but unsure for how long~~ Should be fixed with WorkManager

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6508)
<!-- Reviewable:end -->
