### PR TITLE
Qt: Fix intermittent crash on exit

### DIFF
--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -587,8 +587,8 @@ bool GRenderWindow::event(QEvent* event) {
 
 void GRenderWindow::focusOutEvent(QFocusEvent* event) {
     QWidget::focusOutEvent(event);
-    if (auto* keyboard_p = InputCommon::GetKeyboard()) {
-        keyboard_p->ReleaseAllKeys();
+    if (auto* keyboard = InputCommon::GetKeyboard(); keyboard) {
+        keyboard->ReleaseAllKeys();
     }
     has_focus = false;
 }

--- a/src/citra_qt/bootmanager.cpp
+++ b/src/citra_qt/bootmanager.cpp
@@ -587,7 +587,9 @@ bool GRenderWindow::event(QEvent* event) {
 
 void GRenderWindow::focusOutEvent(QFocusEvent* event) {
     QWidget::focusOutEvent(event);
-    InputCommon::GetKeyboard()->ReleaseAllKeys();
+    if (auto* keyboard_p = InputCommon::GetKeyboard()) {
+        keyboard_p->ReleaseAllKeys();
+    }
     has_focus = false;
 }
 


### PR DESCRIPTION
Often when exiting citra after launching a game, citra will actually crash with a null-pointer exception. This isn't a big deal as the user is trying to quit anyway; but if the log hasn't been flushed yet, it can end up being truncated and important info being lost.

Fixes https://github.com/citra-emu/citra/issues/6585.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6612)
<!-- Reviewable:end -->
