### PR TITLE
service: nfc: Start adapter communication on scan

### DIFF
--- a/src/core/hle/service/nfc/nfc_device.cpp
+++ b/src/core/hle/service/nfc/nfc_device.cpp
@@ -217,7 +217,10 @@ ResultCode NfcDevice::StartDetection(TagProtocol allowed_protocol) {
         return ResultCommandInvalidForState;
     }
 
-    // TODO: Set console in search mode here
+    // Ensure external device is active
+    if (communication_state == CommunicationState::Idle) {
+        StartCommunication();
+    }
 
     device_state = DeviceState::SearchingForTag;
     allowed_protocols = allowed_protocol;


### PR DESCRIPTION
`StartCommunication` doesn't have to be explicitly enabled by the game. This can be enabled automatically by `StartDetection`

Fixes https://github.com/citra-emu/citra/issues/6667.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6671)
<!-- Reviewable:end -->
