### PR TITLE
SOC: Fix setting TTL to default value when TTL = 0

### DIFF
--- a/src/core/hle/service/soc/soc_u.cpp
+++ b/src/core/hle/service/soc/soc_u.cpp
@@ -301,7 +301,7 @@ std::pair<int, int> SOC_U::TranslateSockOpt(int level, int opt) {
     return std::make_pair(SOL_SOCKET, opt);
 }
 
-static void TranslateSockOptDataToPlatform(std::vector<u8>& out, const std::vector<u8>& in,
+void SOC_U::TranslateSockOptDataToPlatform(std::vector<u8>& out, const std::vector<u8>& in,
                                            int platform_level, int platform_opt) {
     // linger structure may be different between 3DS and platform
     if (platform_level == SOL_SOCKET && platform_opt == SO_LINGER &&
@@ -330,6 +330,10 @@ static void TranslateSockOptDataToPlatform(std::vector<u8>& out, const std::vect
             in.size(), platform_level, platform_opt);
         out = in;
         return;
+    }
+    // Setting TTL to 0 means resetting it to the default value.
+    if (platform_level == IPPROTO_IP && platform_opt == IP_TTL && value == 0) {
+        value = SOC_TTL_DEFAULT;
     }
     out.resize(sizeof(int));
     std::memcpy(out.data(), &value, sizeof(int));

--- a/src/core/hle/service/soc/soc_u.cpp
+++ b/src/core/hle/service/soc/soc_u.cpp
@@ -301,7 +301,7 @@ std::pair<int, int> SOC_U::TranslateSockOpt(int level, int opt) {
     return std::make_pair(SOL_SOCKET, opt);
 }
 
-void SOC_U::TranslateSockOptDataToPlatform(std::vector<u8>& out, const std::vector<u8>& in,
+static void SOC_U::TranslateSockOptDataToPlatform(std::vector<u8>& out, const std::vector<u8>& in,
                                            int platform_level, int platform_opt) {
     // linger structure may be different between 3DS and platform
     if (platform_level == SOL_SOCKET && platform_opt == SO_LINGER &&

--- a/src/core/hle/service/soc/soc_u.cpp
+++ b/src/core/hle/service/soc/soc_u.cpp
@@ -301,7 +301,7 @@ std::pair<int, int> SOC_U::TranslateSockOpt(int level, int opt) {
     return std::make_pair(SOL_SOCKET, opt);
 }
 
-static void SOC_U::TranslateSockOptDataToPlatform(std::vector<u8>& out, const std::vector<u8>& in,
+void SOC_U::TranslateSockOptDataToPlatform(std::vector<u8>& out, const std::vector<u8>& in,
                                            int platform_level, int platform_opt) {
     // linger structure may be different between 3DS and platform
     if (platform_level == SOL_SOCKET && platform_opt == SO_LINGER &&

--- a/src/core/hle/service/soc/soc_u.h
+++ b/src/core/hle/service/soc/soc_u.h
@@ -66,7 +66,7 @@ private:
     static const std::unordered_map<u64, std::pair<int, int>> sockopt_map;
     static std::pair<int, int> TranslateSockOpt(int level, int opt);
     static void TranslateSockOptDataToPlatform(std::vector<u8>& out, const std::vector<u8>& in,
-                                        int platform_level, int platform_opt);
+                                               int platform_level, int platform_opt);
     bool GetSocketBlocking(const SocketHolder& socket_holder);
     u32 SetSocketBlocking(SocketHolder& socket_holder, bool blocking);
 

--- a/src/core/hle/service/soc/soc_u.h
+++ b/src/core/hle/service/soc/soc_u.h
@@ -61,8 +61,12 @@ private:
     static constexpr u32 SOC_SOL_CONFIG = 0xFFFE;
     static constexpr u32 SOC_SOL_SOCKET = 0xFFFF;
 
+    static constexpr int SOC_TTL_DEFAULT = 64;
+
     static const std::unordered_map<u64, std::pair<int, int>> sockopt_map;
     static std::pair<int, int> TranslateSockOpt(int level, int opt);
+    void TranslateSockOptDataToPlatform(std::vector<u8>& out, const std::vector<u8>& in,
+                                        int platform_level, int platform_opt);
     bool GetSocketBlocking(const SocketHolder& socket_holder);
     u32 SetSocketBlocking(SocketHolder& socket_holder, bool blocking);
 

--- a/src/core/hle/service/soc/soc_u.h
+++ b/src/core/hle/service/soc/soc_u.h
@@ -65,7 +65,7 @@ private:
 
     static const std::unordered_map<u64, std::pair<int, int>> sockopt_map;
     static std::pair<int, int> TranslateSockOpt(int level, int opt);
-    void TranslateSockOptDataToPlatform(std::vector<u8>& out, const std::vector<u8>& in,
+    static void TranslateSockOptDataToPlatform(std::vector<u8>& out, const std::vector<u8>& in,
                                         int platform_level, int platform_opt);
     bool GetSocketBlocking(const SocketHolder& socket_holder);
     u32 SetSocketBlocking(SocketHolder& socket_holder, bool blocking);


### PR DESCRIPTION
Setting the TTL value of a socket to 0 with `setsockopt` means to set it to a default value, which corresponds to value 64 (verified by checking the soc module code).
Credits to @m4xw for figuring it out!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6835)
<!-- Reviewable:end -->
