### PR TITLE
http/ac: Fix failing assert and stub GetConnectingProxyEnable

### DIFF
--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -153,7 +153,7 @@ void Module::Interface::RegisterDisconnectEvent(Kernel::HLERequestContext& ctx) 
 
 void Module::Interface::GetConnectingProxyEnable(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
-    bool proxy_enabled = false;
+    constexpr bool proxy_enabled = false;
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
     rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -151,6 +151,17 @@ void Module::Interface::RegisterDisconnectEvent(Kernel::HLERequestContext& ctx) 
     LOG_WARNING(Service_AC, "(STUBBED) called");
 }
 
+void Module::Interface::GetConnectingProxyEnable(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp(ctx);
+    bool proxy_enabled = false;
+
+    IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
+    rb.Push(RESULT_SUCCESS);
+    rb.Push(proxy_enabled);
+
+    LOG_WARNING(Service_AC, "(STUBBED) called");
+}
+
 void Module::Interface::IsConnected(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
     u32 unk = rp.Pop<u32>();

--- a/src/core/hle/service/ac/ac.h
+++ b/src/core/hle/service/ac/ac.h
@@ -121,6 +121,14 @@ public:
         void RegisterDisconnectEvent(Kernel::HLERequestContext& ctx);
 
         /**
+         * AC::GetConnectingProxyEnable service function
+         *  Outputs:
+         *      1 : Result of function, 0 on success, otherwise error code
+         *      2 : bool, is proxy enabled
+         */
+        void GetConnectingProxyEnable(Kernel::HLERequestContext& ctx);
+
+        /**
          * AC::IsConnected service function
          *  Outputs:
          *      1 : Result of function, 0 on success, otherwise error code

--- a/src/core/hle/service/ac/ac_i.cpp
+++ b/src/core/hle/service/ac/ac_i.cpp
@@ -27,6 +27,7 @@ AC_I::AC_I(std::shared_ptr<Module> ac) : Module::Interface(std::move(ac), "ac:i"
         {0x0027, &AC_I::GetInfraPriority, "GetInfraPriority"},
         {0x002D, &AC_I::SetRequestEulaVersion, "SetRequestEulaVersion"},
         {0x0030, &AC_I::RegisterDisconnectEvent, "RegisterDisconnectEvent"},
+        {0x0036, &AC_I::GetConnectingProxyEnable, "GetConnectingProxyEnable"},
         {0x003C, nullptr, "GetAPSSIDList"},
         {0x003E, &AC_I::IsConnected, "IsConnected"},
         {0x0040, &AC_I::SetClientVersion, "SetClientVersion"},

--- a/src/core/hle/service/ac/ac_u.cpp
+++ b/src/core/hle/service/ac/ac_u.cpp
@@ -27,6 +27,7 @@ AC_U::AC_U(std::shared_ptr<Module> ac) : Module::Interface(std::move(ac), "ac:u"
         {0x0027, &AC_U::GetInfraPriority, "GetInfraPriority"},
         {0x002D, &AC_U::SetRequestEulaVersion, "SetRequestEulaVersion"},
         {0x0030, &AC_U::RegisterDisconnectEvent, "RegisterDisconnectEvent"},
+        {0x0036, &AC_U::GetConnectingProxyEnable, "GetConnectingProxyEnable"},
         {0x003C, nullptr, "GetAPSSIDList"},
         {0x003E, &AC_U::IsConnected, "IsConnected"},
         {0x0040, &AC_U::SetClientVersion, "SetClientVersion"},

--- a/src/core/hle/service/http/http_c.cpp
+++ b/src/core/hle/service/http/http_c.cpp
@@ -272,6 +272,7 @@ void HTTP_C::ReceiveDataImpl(Kernel::HLERequestContext& ctx, bool timeout) {
     } else {
         LOG_WARNING(Service_HTTP, "(STUBBED) called");
     }
+    [[maybe_unused]] Kernel::MappedBuffer& buffer = rp.PopMappedBuffer();
 
     if (!PerformStateChecks(ctx, rp, context_handle)) {
         return;


### PR DESCRIPTION
This allows the old 3DS browser (SPIDER) to connect to the internet and browse the web.

Screenshot:
![imagen](https://github.com/citra-emu/citra/assets/112760654/50a45f06-aed3-438d-9e07-bde46aed397d)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/6864)
<!-- Reviewable:end -->
