### PR TITLE
Add HLERequestContext::RunAsync

### DIFF
--- a/src/core/core_timing.cpp
+++ b/src/core/core_timing.cpp
@@ -47,7 +47,7 @@ TimingEventType* Timing::RegisterEvent(const std::string& name, TimedCallback ca
 }
 
 void Timing::ScheduleEvent(s64 cycles_into_future, const TimingEventType* event_type,
-                           std::uintptr_t user_data, std::size_t core_id) {
+                           std::uintptr_t user_data, std::size_t core_id, bool thread_safe) {
     if (event_queue_locked) {
         return;
     }
@@ -61,44 +61,30 @@ void Timing::ScheduleEvent(s64 cycles_into_future, const TimingEventType* event_
         timer = timers.at(core_id).get();
     }
 
-    s64 timeout = timer->GetTicks() + cycles_into_future;
-    if (current_timer == timer) {
-        // If this event needs to be scheduled before the next advance(), force one early
-        if (!timer->is_timer_sane)
-            timer->ForceExceptionCheck(cycles_into_future);
+    if (thread_safe) {
+        // Events scheduled with in thread safe mode come after blocking operations with
+        // unpredictable timings in the host machine, so there is no need to be cycle accurate.
+        // To prevent the event from scheduling before the next advance(), we set a minimum time
+        // of MAX_SLICE_LENGTH * 2 cycles into the future.
+        cycles_into_future = std::max(static_cast<s64>(MAX_SLICE_LENGTH * 2), cycles_into_future);
 
-        timer->event_queue.emplace_back(
-            Event{timeout, timer->event_fifo_id++, user_data, event_type});
-        std::push_heap(timer->event_queue.begin(), timer->event_queue.end(), std::greater<>());
-    } else {
         timer->ts_queue.Push(Event{static_cast<s64>(timer->GetTicks() + cycles_into_future), 0,
                                    user_data, event_type});
-    }
-}
-
-void Timing::ScheduleEventTS(s64 cycles_into_future, const TimingEventType* event_type,
-                             std::uintptr_t user_data, std::size_t core_id) {
-    if (event_queue_locked) {
-        return;
-    }
-
-    ASSERT(event_type != nullptr);
-    Timing::Timer* timer = nullptr;
-    if (core_id == std::numeric_limits<std::size_t>::max()) {
-        timer = current_timer;
     } else {
-        ASSERT(core_id < timers.size());
-        timer = timers.at(core_id).get();
+        s64 timeout = timer->GetTicks() + cycles_into_future;
+        if (current_timer == timer) {
+            // If this event needs to be scheduled before the next advance(), force one early
+            if (!timer->is_timer_sane)
+                timer->ForceExceptionCheck(cycles_into_future);
+
+            timer->event_queue.emplace_back(
+                Event{timeout, timer->event_fifo_id++, user_data, event_type});
+            std::push_heap(timer->event_queue.begin(), timer->event_queue.end(), std::greater<>());
+        } else {
+            timer->ts_queue.Push(Event{static_cast<s64>(timer->GetTicks() + cycles_into_future), 0,
+                                       user_data, event_type});
+        }
     }
-
-    // Events scheduled with this thread safe version come after blocking operations with
-    // unpredictable timings in the host machine, so there is no need to be cycle accurate.
-    // To prevent the event from scheduling before the next advance(), we set a minimum time
-    // of MAX_SLICE_LENGTH * 2 cycles into the future.
-    cycles_into_future = std::max(static_cast<s64>(MAX_SLICE_LENGTH * 2), cycles_into_future);
-
-    timer->ts_queue.Push(
-        Event{static_cast<s64>(timer->GetTicks() + cycles_into_future), 0, user_data, event_type});
 }
 
 void Timing::UnscheduleEvent(const TimingEventType* event_type, std::uintptr_t user_data) {

--- a/src/core/core_timing.cpp
+++ b/src/core/core_timing.cpp
@@ -76,6 +76,31 @@ void Timing::ScheduleEvent(s64 cycles_into_future, const TimingEventType* event_
     }
 }
 
+void Timing::ScheduleEventTS(s64 cycles_into_future, const TimingEventType* event_type,
+                             std::uintptr_t user_data, std::size_t core_id) {
+    if (event_queue_locked) {
+        return;
+    }
+
+    ASSERT(event_type != nullptr);
+    Timing::Timer* timer = nullptr;
+    if (core_id == std::numeric_limits<std::size_t>::max()) {
+        timer = current_timer;
+    } else {
+        ASSERT(core_id < timers.size());
+        timer = timers.at(core_id).get();
+    }
+
+    // Events scheduled with this thread safe version come after blocking operations with
+    // unpredictable timings in the host machine, so there is no need to be cycle accurate.
+    // To prevent the event from scheduling before the next advance(), we set a minimum time
+    // of MAX_SLICE_LENGTH * 2 cycles into the future.
+    cycles_into_future = std::max(static_cast<s64>(MAX_SLICE_LENGTH * 2), cycles_into_future);
+
+    timer->ts_queue.Push(
+        Event{static_cast<s64>(timer->GetTicks() + cycles_into_future), 0, user_data, event_type});
+}
+
 void Timing::UnscheduleEvent(const TimingEventType* event_type, std::uintptr_t user_data) {
     if (event_queue_locked) {
         return;

--- a/src/core/core_timing.cpp
+++ b/src/core/core_timing.cpp
@@ -47,7 +47,7 @@ TimingEventType* Timing::RegisterEvent(const std::string& name, TimedCallback ca
 }
 
 void Timing::ScheduleEvent(s64 cycles_into_future, const TimingEventType* event_type,
-                           std::uintptr_t user_data, std::size_t core_id, bool thread_safe) {
+                           std::uintptr_t user_data, std::size_t core_id, bool thread_safe_mode) {
     if (event_queue_locked) {
         return;
     }
@@ -61,8 +61,8 @@ void Timing::ScheduleEvent(s64 cycles_into_future, const TimingEventType* event_
         timer = timers.at(core_id).get();
     }
 
-    if (thread_safe) {
-        // Events scheduled with in thread safe mode come after blocking operations with
+    if (thread_safe_mode) {
+        // Events scheduled in thread safe mode come after blocking operations with
         // unpredictable timings in the host machine, so there is no need to be cycle accurate.
         // To prevent the event from scheduling before the next advance(), we set a minimum time
         // of MAX_SLICE_LENGTH * 2 cycles into the future.

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -254,14 +254,12 @@ public:
      */
     TimingEventType* RegisterEvent(const std::string& name, TimedCallback callback);
 
+    // Make sure to use thread_safe = true if called from a different thread than the
+    // emulator thread, such as coroutines.
     void ScheduleEvent(s64 cycles_into_future, const TimingEventType* event_type,
                        std::uintptr_t user_data = 0,
-                       std::size_t core_id = std::numeric_limits<std::size_t>::max());
-
-    // Thread safe version of the above function.
-    void ScheduleEventTS(s64 cycles_into_future, const TimingEventType* event_type,
-                         std::uintptr_t user_data = 0,
-                         std::size_t core_id = std::numeric_limits<std::size_t>::max());
+                       std::size_t core_id = std::numeric_limits<std::size_t>::max(),
+                       bool thread_safe = false);
 
     void UnscheduleEvent(const TimingEventType* event_type, std::uintptr_t user_data);
 

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -254,12 +254,12 @@ public:
      */
     TimingEventType* RegisterEvent(const std::string& name, TimedCallback callback);
 
-    // Make sure to use thread_safe = true if called from a different thread than the
+    // Make sure to use thread_safe_mode = true if called from a different thread than the
     // emulator thread, such as coroutines.
     void ScheduleEvent(s64 cycles_into_future, const TimingEventType* event_type,
                        std::uintptr_t user_data = 0,
                        std::size_t core_id = std::numeric_limits<std::size_t>::max(),
-                       bool thread_safe = false);
+                       bool thread_safe_mode = false);
 
     void UnscheduleEvent(const TimingEventType* event_type, std::uintptr_t user_data);
 

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -258,6 +258,11 @@ public:
                        std::uintptr_t user_data = 0,
                        std::size_t core_id = std::numeric_limits<std::size_t>::max());
 
+    // Thread safe version of the above function.
+    void ScheduleEventTS(s64 cycles_into_future, const TimingEventType* event_type,
+                         std::uintptr_t user_data = 0,
+                         std::size_t core_id = std::numeric_limits<std::size_t>::max());
+
     void UnscheduleEvent(const TimingEventType* event_type, std::uintptr_t user_data);
 
     /// We only permit one event of each type in the queue at a time.

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -306,7 +306,7 @@ public:
                     }))));
 
         } else {
-            s64 sleepfor = async_section(*this);
+            s64 sleep_for = async_section(*this);
             if (sleepfor > 0) {
                 auto parallel_wakeup = std::make_shared<AsyncWakeUpCallback<ResultFunctor>>(
                     result_function, std::move(std::future<void>()));

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -301,16 +301,16 @@ public:
                 std::make_shared<AsyncWakeUpCallback<ResultFunctor>>(
                     result_function,
                     std::move(std::async(std::launch::async, [this, async_section] {
-                        s64 sleepfor = async_section(*this);
-                        this->thread->WakeAfterDelay(sleepfor, true);
+                        s64 sleep_for = async_section(*this);
+                        this->thread->WakeAfterDelay(sleep_for, true);
                     }))));
 
         } else {
             s64 sleep_for = async_section(*this);
-            if (sleepfor > 0) {
+            if (sleep_for > 0) {
                 auto parallel_wakeup = std::make_shared<AsyncWakeUpCallback<ResultFunctor>>(
                     result_function, std::move(std::future<void>()));
-                this->SleepClientThread("RunAsync", std::chrono::nanoseconds(sleepfor),
+                this->SleepClientThread("RunAsync", std::chrono::nanoseconds(sleep_for),
                                         parallel_wakeup);
             } else {
                 result_function(*this);

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -302,7 +302,7 @@ public:
                     result_function,
                     std::move(std::async(std::launch::async, [this, async_section] {
                         s64 sleepfor = async_section(*this);
-                        this->thread->WakeAfterDelayTS(sleepfor);
+                        this->thread->WakeAfterDelay(sleepfor);
                     }))));
 
         } else {

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <array>
 #include <chrono>
+#include <future>
 #include <memory>
 #include <string>
 #include <vector>
@@ -246,6 +247,76 @@ public:
     std::shared_ptr<Event> SleepClientThread(const std::string& reason,
                                              std::chrono::nanoseconds timeout,
                                              std::shared_ptr<WakeupCallback> callback);
+
+private:
+    template <typename ResultFunctor>
+    class AsyncWakeUpCallback : public WakeupCallback {
+    public:
+        explicit AsyncWakeUpCallback(ResultFunctor res_functor, std::future<void> fut)
+            : functor(res_functor) {
+            future = std::move(fut);
+        }
+
+        void WakeUp(std::shared_ptr<Kernel::Thread> thread, Kernel::HLERequestContext& ctx,
+                    Kernel::ThreadWakeupReason reason) {
+            functor(ctx);
+        }
+
+    private:
+        ResultFunctor functor;
+        std::future<void> future;
+
+        template <class Archive>
+        void serialize(Archive& ar, const unsigned int) {
+            if (!Archive::is_loading::value && future.valid()) {
+                future.wait();
+            }
+            ar& functor;
+        }
+        friend class boost::serialization::access;
+    };
+
+public:
+    /**
+     * Puts the game thread to sleep and calls the specified async_section asynchronously.
+     * Once the execution of the async section finishes, result_function is called. Use this
+     * mechanism to run blocking IO operations, so that other game threads are allowed to run
+     * while the one performing the blocking operation waits.
+     * @param async_section Callable that takes Kernel::HLERequestContext& as argument
+     * and returns the amount of nanoseconds to wait before calling result_function.
+     * This callable is ran asynchronously.
+     * @param result_function Callable that takes Kernel::HLERequestContext& as argument
+     * and doesn't return anything. This callable is ran from the emulator thread
+     * and can be used to set the IPC result.
+     * @param really_async If set to false, it will call both async_section and result_function
+     * from the emulator thread.
+     */
+    template <typename AsyncFunctor, typename ResultFunctor>
+    void RunAsync(AsyncFunctor async_section, ResultFunctor result_function,
+                  bool really_async = true) {
+
+        if (really_async) {
+            this->SleepClientThread(
+                "RunAsync", std::chrono::nanoseconds(-1),
+                std::make_shared<AsyncWakeUpCallback<ResultFunctor>>(
+                    result_function,
+                    std::move(std::async(std::launch::async, [this, async_section] {
+                        s64 sleepfor = async_section(*this);
+                        this->thread->WakeAfterDelayTS(sleepfor);
+                    }))));
+
+        } else {
+            s64 sleepfor = async_section(*this);
+            if (sleepfor > 0) {
+                auto parallel_wakeup = std::make_shared<AsyncWakeUpCallback<ResultFunctor>>(
+                    result_function, std::move(std::future<void>()));
+                this->SleepClientThread("RunAsync", std::chrono::nanoseconds(sleepfor),
+                                        parallel_wakeup);
+            } else {
+                result_function(*this);
+            }
+        }
+    }
 
     /**
      * Resolves a object id from the request command buffer into a pointer to an object. See the

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -302,7 +302,7 @@ public:
                     result_function,
                     std::move(std::async(std::launch::async, [this, async_section] {
                         s64 sleepfor = async_section(*this);
-                        this->thread->WakeAfterDelay(sleepfor);
+                        this->thread->WakeAfterDelay(sleepfor, true);
                     }))));
 
         } else {

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -244,22 +244,15 @@ void ThreadManager::ThreadWakeupCallback(u64 thread_id, s64 cycles_late) {
     thread->ResumeFromWait();
 }
 
-void Thread::WakeAfterDelay(s64 nanoseconds) {
+void Thread::WakeAfterDelay(s64 nanoseconds, bool thread_safe) {
     // Don't schedule a wakeup if the thread wants to wait forever
     if (nanoseconds == -1)
         return;
+    size_t core = thread_safe ? core_id : std::numeric_limits<std::size_t>::max();
 
     thread_manager.kernel.timing.ScheduleEvent(nsToCycles(nanoseconds),
-                                               thread_manager.ThreadWakeupEventType, thread_id);
-}
-
-void Thread::WakeAfterDelayTS(s64 nanoseconds) {
-    // Don't schedule a wakeup if the thread wants to wait forever
-    if (nanoseconds == -1)
-        return;
-
-    thread_manager.kernel.timing.ScheduleEventTS(
-        nsToCycles(nanoseconds), thread_manager.ThreadWakeupEventType, thread_id, core_id);
+                                               thread_manager.ThreadWakeupEventType, thread_id,
+                                               core, thread_safe);
 }
 
 void Thread::ResumeFromWait() {

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -253,6 +253,15 @@ void Thread::WakeAfterDelay(s64 nanoseconds) {
                                                thread_manager.ThreadWakeupEventType, thread_id);
 }
 
+void Thread::WakeAfterDelayTS(s64 nanoseconds) {
+    // Don't schedule a wakeup if the thread wants to wait forever
+    if (nanoseconds == -1)
+        return;
+
+    thread_manager.kernel.timing.ScheduleEventTS(
+        nsToCycles(nanoseconds), thread_manager.ThreadWakeupEventType, thread_id, core_id);
+}
+
 void Thread::ResumeFromWait() {
     ASSERT_MSG(wait_objects.empty(), "Thread is waking up while waiting for objects");
 

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -244,15 +244,15 @@ void ThreadManager::ThreadWakeupCallback(u64 thread_id, s64 cycles_late) {
     thread->ResumeFromWait();
 }
 
-void Thread::WakeAfterDelay(s64 nanoseconds, bool thread_safe) {
+void Thread::WakeAfterDelay(s64 nanoseconds, bool thread_safe_mode) {
     // Don't schedule a wakeup if the thread wants to wait forever
     if (nanoseconds == -1)
         return;
-    size_t core = thread_safe ? core_id : std::numeric_limits<std::size_t>::max();
+    size_t core = thread_safe_mode ? core_id : std::numeric_limits<std::size_t>::max();
 
     thread_manager.kernel.timing.ScheduleEvent(nsToCycles(nanoseconds),
                                                thread_manager.ThreadWakeupEventType, thread_id,
-                                               core, thread_safe);
+                                               core, thread_safe_mode);
 }
 
 void Thread::ResumeFromWait() {

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -242,6 +242,12 @@ public:
     void WakeAfterDelay(s64 nanoseconds);
 
     /**
+     * Schedules an event to wake up the specified thread after the specified delay, thread safe
+     * @param nanoseconds The time this thread will be allowed to sleep for
+     */
+    void WakeAfterDelayTS(s64 nanoseconds);
+
+    /**
      * Sets the result after the thread awakens (from either WaitSynchronization SVC)
      * @param result Value to set to the returned result
      */

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -238,7 +238,8 @@ public:
     /**
      * Schedules an event to wake up the specified thread after the specified delay
      * @param nanoseconds The time this thread will be allowed to sleep for
-     * @param thread_safe Set to true if called from a different thread than the emulator thread, such as coroutines.
+     * @param thread_safe Set to true if called from a different thread than the emulator thread,
+     * such as coroutines.
      */
     void WakeAfterDelay(s64 nanoseconds, bool thread_safe = false);
 

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -238,14 +238,9 @@ public:
     /**
      * Schedules an event to wake up the specified thread after the specified delay
      * @param nanoseconds The time this thread will be allowed to sleep for
+     * @param thread_safe Set to true if called from a different thread than the emulator thread, such as coroutines.
      */
-    void WakeAfterDelay(s64 nanoseconds);
-
-    /**
-     * Schedules an event to wake up the specified thread after the specified delay, thread safe
-     * @param nanoseconds The time this thread will be allowed to sleep for
-     */
-    void WakeAfterDelayTS(s64 nanoseconds);
+    void WakeAfterDelay(s64 nanoseconds, bool thread_safe = false);
 
     /**
      * Sets the result after the thread awakens (from either WaitSynchronization SVC)

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -238,10 +238,10 @@ public:
     /**
      * Schedules an event to wake up the specified thread after the specified delay
      * @param nanoseconds The time this thread will be allowed to sleep for
-     * @param thread_safe Set to true if called from a different thread than the emulator thread,
-     * such as coroutines.
+     * @param thread_safe_mode Set to true if called from a different thread than the emulator
+     * thread, such as coroutines.
      */
-    void WakeAfterDelay(s64 nanoseconds, bool thread_safe = false);
+    void WakeAfterDelay(s64 nanoseconds, bool thread_safe_mode = false);
 
     /**
      * Sets the result after the thread awakens (from either WaitSynchronization SVC)


### PR DESCRIPTION
Takes the parallel HLE concept from the following draft PR: #6282

A new method in `HLERequestContext` was added to support HLE multi-threading capabilities: `RunAsync`. This method takes two functions, the first one will be run asynchronously, while the second one will be run in the emulator thread once the result is ready to be placed in the IPC response and return control to the game. Two functions are needed because most HLE objects are not thread safe, so the result cannot be placed into the IPC response directly.

The idea is to relay blocking or intensive IO operations to another thread, instead of pausing the entire emulator thread. With this change, when a game requests an IO operation, the requesting game thread will be put to sleep until the HLE IO operation completes. This gives the game the opportunity to do other work while it's waiting for the IO operation to finish. Without this change, the entire emulator would block on the IO operation, causing stutter in the game.

This PR will be needed for proper online support, as some games such as smash bros use blocking sockets, which would make the emulator completely freeze. Work in progress HTTPC modifications will also need this, a PR using this change will come shortly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/7027)
<!-- Reviewable:end -->
