### PR TITLE
Fix shader cache invalidation when reading state

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -435,9 +435,9 @@ System::ResultStatus System::Init(Frontend::EmuWindow& emu_window,
         registered_image_interface = std::make_shared<Frontend::ImageInterface>();
     }
 
-    if(!custom_tex_manager){
-        custom_tex_manager = std::make_unique<VideoCore::CustomTexManager>(*this);
-    }
+    if (!custom_tex_manager) {
+         custom_tex_manager = std::make_unique<VideoCore::CustomTexManager>(*this);
+     }
 
     VideoCore::Init(emu_window, secondary_window, *this);
 

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -435,7 +435,9 @@ System::ResultStatus System::Init(Frontend::EmuWindow& emu_window,
         registered_image_interface = std::make_shared<Frontend::ImageInterface>();
     }
 
-    custom_tex_manager = std::make_unique<VideoCore::CustomTexManager>(*this);
+    if(!custom_tex_manager){
+        custom_tex_manager = std::make_unique<VideoCore::CustomTexManager>(*this);
+    }
 
     VideoCore::Init(emu_window, secondary_window, *this);
 
@@ -549,15 +551,15 @@ void System::Shutdown(bool is_deserializing) {
     // Shutdown emulation session
     is_powered_on = false;
 
-    VideoCore::Shutdown();
     HW::Shutdown();
     if (!is_deserializing) {
         GDBStub::Shutdown();
         perf_stats.reset();
         cheat_engine.reset();
         app_loader.reset();
+        custom_tex_manager.reset();
+        VideoCore::Shutdown();
     }
-    custom_tex_manager.reset();
     telemetry_session.reset();
 #ifdef ENABLE_SCRIPTING
     rpc_server.reset();

--- a/src/video_core/video_core.cpp
+++ b/src/video_core/video_core.cpp
@@ -29,6 +29,7 @@ Memory::MemorySystem* g_memory;
 /// Initialize the video core
 void Init(Frontend::EmuWindow& emu_window, Frontend::EmuWindow* secondary_window,
           Core::System& system) {
+    if (g_renderer)return;
     g_memory = &system.Memory();
     Pica::Init();
 

--- a/src/video_core/video_core.cpp
+++ b/src/video_core/video_core.cpp
@@ -29,7 +29,8 @@ Memory::MemorySystem* g_memory;
 /// Initialize the video core
 void Init(Frontend::EmuWindow& emu_window, Frontend::EmuWindow* secondary_window,
           Core::System& system) {
-    if (g_renderer)return;
+    if (g_renderer)
+        return;
     g_memory = &system.Memory();
     Pica::Init();
 


### PR DESCRIPTION
Currently we will only load the shader cache and texture cache when the game is running. When we load the state, the rendering engine and custom texture cache objects will be re-created, which will cause the loaded cache to be invalid.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/7084)
<!-- Reviewable:end -->
