### PR TITLE
Fix use-after-free when running game with custom textures via command line parameter

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -2998,6 +2998,10 @@ int main(int argc, char* argv[]) {
     setlocale(LC_ALL, "C");
 
     auto& system{Core::System::GetInstance()};
+
+    // Register Qt image interface
+    system.RegisterImageInterface(std::make_shared<QtImageInterface>());
+
     GMainWindow main_window(system);
 
     // Register frontend applets
@@ -3005,9 +3009,6 @@ int main(int argc, char* argv[]) {
 
     system.RegisterMiiSelector(std::make_shared<QtMiiSelector>(main_window));
     system.RegisterSoftwareKeyboard(std::make_shared<QtKeyboard>(main_window));
-
-    // Register Qt image interface
-    system.RegisterImageInterface(std::make_shared<QtImageInterface>());
 
 #ifdef __APPLE__
     // Register microphone permission check.


### PR DESCRIPTION
The `CustomTexManager` stores a reference to the current `ImageInterface` when created. Calling `RegisterImageInterface` afterwards, overwrites and frees the previous image interface, but the reference in `CustomTexManager` will still be used, even though it is now invalid.

As far as I know this only happens when directly launching a game via command line parameter. In that case, the `GMainWindow` constructor starts the game immediately and `System::Init` will create a default fallback image interface, since none was registered before. Only after this, the `QtImageInterface` is registered, which frees the default image interface. If a game uses custom textures, this results in an immediate use-after-free and in my case a crash.

As a simple fix, I moved the `RegisterImageInterface` call up to before the main window constructor. As far as I can tell, this should have no further impact. This fixes the crash for me.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/7090)
<!-- Reviewable:end -->
