### PR TITLE
Unlock RW access to opened files on windows

### DIFF
--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -24,6 +24,7 @@
 // windows.h needs to be included before other windows headers
 #include <direct.h> // getcwd
 #include <io.h>
+#include <share.h>
 #include <shellapi.h>
 #include <shlobj.h> // for SHGetFolderPath
 #include <tchar.h>

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -1058,14 +1058,13 @@ bool IOFile::Open() {
     Close();
 
 #ifdef _WIN32
-    if (flags != 0) {
-        m_file = _wfsopen(Common::UTF8ToUTF16W(filename).c_str(),
-                          Common::UTF8ToUTF16W(openmode).c_str(), flags);
-        m_good = m_file != nullptr;
-    } else {
-        m_good = _wfopen_s(&m_file, Common::UTF8ToUTF16W(filename).c_str(),
-                           Common::UTF8ToUTF16W(openmode).c_str()) == 0;
+    if (flags == 0) {
+        flags = _SH_DENYNO;
     }
+    m_file = _wfsopen(Common::UTF8ToUTF16W(filename).c_str(),
+                      Common::UTF8ToUTF16W(openmode).c_str(), flags);
+    m_good = m_file != nullptr;
+
 #elif ANDROID
     // Check whether filepath is startsWith content
     AndroidStorage::AndroidOpenMode android_open_mode = AndroidStorage::ParseOpenmode(openmode);


### PR DESCRIPTION
Adds the flag `_SH_DENYNO` to `_wfsopen` on Windows, which allows opening the file multiple times without it being locked. Fixes  games failing to open the same file multiple times without closing it first.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/7161)
<!-- Reviewable:end -->
