### PR TITLE
Download TWL titles from NUS and list them in AM.

### DIFF
--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -698,9 +698,19 @@ void Module::ScanForTitles(Service::FS::MediaType media_type) {
             if (tid_string.length() == TITLE_ID_VALID_LENGTH) {
                 const u64 tid = std::stoull(tid_string, nullptr, 16);
 
-                FileSys::NCCHContainer container(GetTitleContentPath(media_type, tid));
-                if (container.Load() == Loader::ResultStatus::Success)
-                    am_title_list[static_cast<u32>(media_type)].push_back(tid);
+                if (tid & TWL_TITLE_ID_FLAG) {
+                    // TODO(PabloMK7) Move to TWL Nand, for now only check that
+                    // the contents exists in CTR Nand as this is a SRL file
+                    // instead of NCCH.
+                    if (FileUtil::Exists(GetTitleContentPath(media_type, tid))) {
+                        am_title_list[static_cast<u32>(media_type)].push_back(tid);
+                    }
+                } else {
+                    FileSys::NCCHContainer container(GetTitleContentPath(media_type, tid));
+                    if (container.Load() == Loader::ResultStatus::Success) {
+                        am_title_list[static_cast<u32>(media_type)].push_back(tid);
+                    }
+                }
             }
         }
     }

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -646,6 +646,8 @@ std::string GetTitleContentPath(Service::FS::MediaType media_type, u64 tid, std:
 }
 
 std::string GetTitlePath(Service::FS::MediaType media_type, u64 tid) {
+    // TODO(PabloMK7) TWL titles should be in TWL Nand. Assuming CTR Nand for now.
+
     u32 high = static_cast<u32>(tid >> 32);
     u32 low = static_cast<u32>(tid & 0xFFFFFFFF);
 

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -68,6 +68,8 @@ enum class InstallStatus : u32 {
 // Title ID valid length
 constexpr std::size_t TITLE_ID_VALID_LENGTH = 16;
 
+constexpr u64 TWL_TITLE_ID_FLAG = 0x0000800000000000ULL;
+
 // Progress callback for InstallCIA, receives bytes written and total bytes
 using ProgressCallback = void(std::size_t, std::size_t);
 

--- a/src/core/system_titles.cpp
+++ b/src/core/system_titles.cpp
@@ -1130,7 +1130,6 @@ static const std::array<SystemTitleCategory, NUM_SYSTEM_TITLE_CATEGORIES>
                                                0x20000202, 0x20000202, 0x20000202},
                          },
                      }},
-                // TODO(PabloMK7) Move to TWL Nand, for now keep in CTR NAND
                 {.name = "TWL System Applications",
                  .title_id_high = 0x00048005,
                  .titles =

--- a/src/core/system_titles.cpp
+++ b/src/core/system_titles.cpp
@@ -21,7 +21,7 @@ struct SystemTitleCategory {
     std::vector<SystemTitle> titles;
 };
 
-static constexpr u32 NUM_SYSTEM_TITLE_CATEGORIES = 7;
+static constexpr u32 NUM_SYSTEM_TITLE_CATEGORIES = 9;
 
 static constexpr u64 home_menu_title_id_high = 0x00040030;
 static constexpr SystemTitle home_menu_title = {
@@ -1128,6 +1128,65 @@ static const std::array<SystemTitleCategory, NUM_SYSTEM_TITLE_CATEGORIES>
                              .sets = SystemTitleSet::New3ds,
                              .title_id_lows = {0x20000202, 0x20000202, 0x20000202, 0x20000202,
                                                0x20000202, 0x20000202, 0x20000202},
+                         },
+                     }},
+                // TODO(PabloMK7) Move to TWL Nand, for now keep in CTR NAND
+                {.name = "TWL System Applications",
+                 .title_id_high = 0x00048005,
+                 .titles =
+                     {
+                         {
+                             .name = "DS Internet",
+                             .sets = SystemTitleSet::Old3ds,
+                             .title_id_lows = {0x42383841, 0x42383841, 0x42383841, 0x42383841,
+                                               0x42383841, 0x42383841, 0x42383841},
+                         },
+                         {
+                             .name = "DS Internet",
+                             .sets = SystemTitleSet::New3ds,
+                             .title_id_lows = {0x42383841, 0x42383841, 0x42383841, 0x42383841,
+                                               0x42383841, 0x42383841, 0x42383841},
+                         },
+                         {
+                             .name = "DS Download Play",
+                             .sets = SystemTitleSet::Old3ds,
+                             .title_id_lows = {0x484E4441, 0x484E4441, 0x484E4441, 0x484E4441,
+                                               0x484E4443, 0x484E444B, 0x484E4441},
+                         },
+                         {
+                             .name = "DS Download Play",
+                             .sets = SystemTitleSet::New3ds,
+                             .title_id_lows = {0x484E4441, 0x484E4441, 0x484E4441, 0x484E4441,
+                                               0x484E4443, 0x484E444B, 0x484E4441},
+                         },
+                     }},
+                {.name = "TWL System Data Archives",
+                 .title_id_high = 0x0004800F,
+                 .titles =
+                     {
+                         {
+                             .name = "DS Card Whitelist",
+                             .sets = SystemTitleSet::Old3ds,
+                             .title_id_lows = {0x484E4841, 0x484E4841, 0x484E4841, 0x484E4841,
+                                               0x484E4841, 0x484E4841, 0x484E4841},
+                         },
+                         {
+                             .name = "DS Card Whitelist",
+                             .sets = SystemTitleSet::New3ds,
+                             .title_id_lows = {0x484E4841, 0x484E4841, 0x484E4841, 0x484E4841,
+                                               0x484E4841, 0x484E4841, 0x484E4841},
+                         },
+                         {
+                             .name = "DS Version Data",
+                             .sets = SystemTitleSet::Old3ds,
+                             .title_id_lows = {0x484E4C41, 0x484E4C41, 0x484E4C41, 0x484E4C41,
+                                               0x484E4C41, 0x484E4C41, 0x484E4C41},
+                         },
+                         {
+                             .name = "DS Version Data",
+                             .sets = SystemTitleSet::New3ds,
+                             .title_id_lows = {0x484E4C41, 0x484E4C41, 0x484E4C41, 0x484E4C41,
+                                               0x484E4C41, 0x484E4C41, 0x484E4C41},
                          },
                      }},
             }};

--- a/src/core/system_titles.cpp
+++ b/src/core/system_titles.cpp
@@ -1137,25 +1137,11 @@ static const std::array<SystemTitleCategory, NUM_SYSTEM_TITLE_CATEGORIES>
                      {
                          {
                              .name = "DS Internet",
-                             .sets = SystemTitleSet::Old3ds,
-                             .title_id_lows = {0x42383841, 0x42383841, 0x42383841, 0x42383841,
-                                               0x42383841, 0x42383841, 0x42383841},
-                         },
-                         {
-                             .name = "DS Internet",
-                             .sets = SystemTitleSet::New3ds,
                              .title_id_lows = {0x42383841, 0x42383841, 0x42383841, 0x42383841,
                                                0x42383841, 0x42383841, 0x42383841},
                          },
                          {
                              .name = "DS Download Play",
-                             .sets = SystemTitleSet::Old3ds,
-                             .title_id_lows = {0x484E4441, 0x484E4441, 0x484E4441, 0x484E4441,
-                                               0x484E4443, 0x484E444B, 0x484E4441},
-                         },
-                         {
-                             .name = "DS Download Play",
-                             .sets = SystemTitleSet::New3ds,
                              .title_id_lows = {0x484E4441, 0x484E4441, 0x484E4441, 0x484E4441,
                                                0x484E4443, 0x484E444B, 0x484E4441},
                          },
@@ -1166,25 +1152,11 @@ static const std::array<SystemTitleCategory, NUM_SYSTEM_TITLE_CATEGORIES>
                      {
                          {
                              .name = "DS Card Whitelist",
-                             .sets = SystemTitleSet::Old3ds,
-                             .title_id_lows = {0x484E4841, 0x484E4841, 0x484E4841, 0x484E4841,
-                                               0x484E4841, 0x484E4841, 0x484E4841},
-                         },
-                         {
-                             .name = "DS Card Whitelist",
-                             .sets = SystemTitleSet::New3ds,
                              .title_id_lows = {0x484E4841, 0x484E4841, 0x484E4841, 0x484E4841,
                                                0x484E4841, 0x484E4841, 0x484E4841},
                          },
                          {
                              .name = "DS Version Data",
-                             .sets = SystemTitleSet::Old3ds,
-                             .title_id_lows = {0x484E4C41, 0x484E4C41, 0x484E4C41, 0x484E4C41,
-                                               0x484E4C41, 0x484E4C41, 0x484E4C41},
-                         },
-                         {
-                             .name = "DS Version Data",
-                             .sets = SystemTitleSet::New3ds,
                              .title_id_lows = {0x484E4C41, 0x484E4C41, 0x484E4C41, 0x484E4C41,
                                                0x484E4C41, 0x484E4C41, 0x484E4C41},
                          },


### PR DESCRIPTION
Adds the TWL tiles that are shipped by default with system updates to the NUS download list. Also, AM is modified so it can list those titles if they are installed. Normally, the titles are stored in TWL NAND, but since we don't have it, they are stored in CTR NAND for now.

This allows the lle NIM module to properly detect the latest system version is installed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/7162)
<!-- Reviewable:end -->
