### PR TITLE
Lower log level of CSND::ExecuteCommands stub warning

### DIFF
--- a/src/core/hle/service/csnd/csnd_snd.cpp
+++ b/src/core/hle/service/csnd/csnd_snd.cpp
@@ -235,7 +235,7 @@ void CSND_SND::Shutdown(Kernel::HLERequestContext& ctx) {
 void CSND_SND::ExecuteCommands(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
     const u32 addr = rp.Pop<u32>();
-    LOG_WARNING(Service_CSND, "(STUBBED) called, addr=0x{:08X}", addr);
+    LOG_DEBUG(Service_CSND, "(STUBBED) called, addr=0x{:08X}", addr);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     if (!shared_memory) {


### PR DESCRIPTION
Applets were spamming the logs with `CSND::ExecuteCommands`, which made it very annoying to read what happened before an applet was opened.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/7163)
<!-- Reviewable:end -->
