### PR TITLE
Stub QTM_S:GetHeadtrackingInfo

### DIFF
--- a/src/core/hle/service/qtm/qtm_s.cpp
+++ b/src/core/hle/service/qtm/qtm_s.cpp
@@ -12,7 +12,7 @@ namespace Service::QTM {
 
 void QTM_S::GetHeadtrackingInfo(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
-    [[maybe_unused]] u64 unknown = rp.Pop<u64>();
+    [[maybe_unused]] const u64 unknown = rp.Pop<u64>();
 
     std::array<u8, 0x40> data{};
     IPC::RequestBuilder rb = rp.MakeBuilder(17, 0);
@@ -33,4 +33,5 @@ QTM_S::QTM_S() : ServiceFramework("qtm:s", 2) {
 
     RegisterHandlers(functions);
 }
+
 } // namespace Service::QTM

--- a/src/core/hle/service/qtm/qtm_s.cpp
+++ b/src/core/hle/service/qtm/qtm_s.cpp
@@ -10,16 +10,27 @@ SERIALIZE_EXPORT_IMPL(Service::QTM::QTM_S)
 
 namespace Service::QTM {
 
+void QTM_S::GetHeadtrackingInfo(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp(ctx);
+    [[maybe_unused]] u64 unknown = rp.Pop<u64>();
+
+    std::array<u8, 0x40> data{};
+    IPC::RequestBuilder rb = rp.MakeBuilder(17, 0);
+    rb.Push(RESULT_SUCCESS);
+    rb.PushRaw<std::array<u8, 0x40>>(data);
+
+    LOG_DEBUG(Service, "(STUBBED) called");
+}
+
 QTM_S::QTM_S() : ServiceFramework("qtm:s", 2) {
     static const FunctionInfo functions[] = {
         // qtm common commands
         // clang-format off
         {0x0001, nullptr, "GetHeadtrackingInfoRaw"},
-        {0x0002, nullptr, "GetHeadtrackingInfo"},
+        {0x0002, &QTM_S::GetHeadtrackingInfo, "GetHeadtrackingInfo"},
         // clang-format on
     };
 
     RegisterHandlers(functions);
 }
-
 } // namespace Service::QTM

--- a/src/core/hle/service/qtm/qtm_s.h
+++ b/src/core/hle/service/qtm/qtm_s.h
@@ -15,6 +15,8 @@ public:
 
 private:
     SERVICE_SERIALIZATION_SIMPLE
+
+    void GetHeadtrackingInfo(Kernel::HLERequestContext& ctx);
 };
 
 } // namespace Service::QTM


### PR DESCRIPTION
Stubs `QTM_S::GetHeadtrackingInfo`, which helps remove unneccessary logs in system settings (for that same reason, the stub warning is set as `LOG_DEBUG`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/7166)
<!-- Reviewable:end -->
