### PR TITLE
kernel: Update to use atmosphere macros and correct Result

### DIFF
--- a/src/citra_qt/debugger/ipc/recorder.cpp
+++ b/src/citra_qt/debugger/ipc/recorder.cpp
@@ -49,7 +49,7 @@ QString IPCRecorderWidget::GetStatusStr(const IPCDebugger::RequestRecord& record
     case IPCDebugger::RequestStatus::Handling:
         return tr("Handling");
     case IPCDebugger::RequestStatus::Handled:
-        if (record.translated_reply_cmdbuf[1] == RESULT_SUCCESS.raw) {
+        if (record.translated_reply_cmdbuf[1] == ResultSuccess.raw) {
             return tr("Success");
         }
         return tr("Error");
@@ -88,7 +88,7 @@ void IPCRecorderWidget::OnEntryUpdated(IPCDebugger::RequestRecord record) {
 
     if (record.status == IPCDebugger::RequestStatus::HLEUnimplemented ||
         (record.status == IPCDebugger::RequestStatus::Handled &&
-         record.translated_reply_cmdbuf[1] != RESULT_SUCCESS.raw)) { // Unimplemented / Error
+         record.translated_reply_cmdbuf[1] != ResultSuccess.raw)) { // Unimplemented / Error
 
         auto item = ui->main->invisibleRootItem()->child(row_id);
         for (int column = 0; column < item->columnCount(); ++column) {

--- a/src/core/file_sys/archive_backend.h
+++ b/src/core/file_sys/archive_backend.h
@@ -127,7 +127,7 @@ public:
      * @param path Path relative to the archive
      * @return Result of the operation
      */
-    virtual ResultCode DeleteFile(const Path& path) const = 0;
+    virtual Result DeleteFile(const Path& path) const = 0;
 
     /**
      * Rename a File specified by its path
@@ -135,21 +135,21 @@ public:
      * @param dest_path Destination path relative to the archive
      * @return Result of the operation
      */
-    virtual ResultCode RenameFile(const Path& src_path, const Path& dest_path) const = 0;
+    virtual Result RenameFile(const Path& src_path, const Path& dest_path) const = 0;
 
     /**
      * Delete a directory specified by its path
      * @param path Path relative to the archive
      * @return Result of the operation
      */
-    virtual ResultCode DeleteDirectory(const Path& path) const = 0;
+    virtual Result DeleteDirectory(const Path& path) const = 0;
 
     /**
      * Delete a directory specified by its path and anything under it
      * @param path Path relative to the archive
      * @return Result of the operation
      */
-    virtual ResultCode DeleteDirectoryRecursively(const Path& path) const = 0;
+    virtual Result DeleteDirectoryRecursively(const Path& path) const = 0;
 
     /**
      * Create a file specified by its path
@@ -157,14 +157,14 @@ public:
      * @param size The size of the new file, filled with zeroes
      * @return Result of the operation
      */
-    virtual ResultCode CreateFile(const Path& path, u64 size) const = 0;
+    virtual Result CreateFile(const Path& path, u64 size) const = 0;
 
     /**
      * Create a directory specified by its path
      * @param path Path relative to the archive
      * @return Result of the operation
      */
-    virtual ResultCode CreateDirectory(const Path& path) const = 0;
+    virtual Result CreateDirectory(const Path& path) const = 0;
 
     /**
      * Rename a Directory specified by its path
@@ -172,7 +172,7 @@ public:
      * @param dest_path Destination path relative to the archive
      * @return Result of the operation
      */
-    virtual ResultCode RenameDirectory(const Path& src_path, const Path& dest_path) const = 0;
+    virtual Result RenameDirectory(const Path& src_path, const Path& dest_path) const = 0;
 
     /**
      * Open a directory specified by its path
@@ -229,10 +229,10 @@ public:
      * @param path Path to the archive
      * @param format_info Format information for the new archive
      * @param program_id the program ID of the client that requests the operation
-     * @return ResultCode of the operation, 0 on success
+     * @return Result of the operation, 0 on success
      */
-    virtual ResultCode Format(const Path& path, const FileSys::ArchiveFormatInfo& format_info,
-                              u64 program_id) = 0;
+    virtual Result Format(const Path& path, const FileSys::ArchiveFormatInfo& format_info,
+                          u64 program_id) = 0;
 
     /**
      * Retrieves the format info about the archive with the specified path

--- a/src/core/file_sys/archive_extsavedata.cpp
+++ b/src/core/file_sys/archive_extsavedata.cpp
@@ -40,7 +40,7 @@ public:
     ResultVal<std::size_t> Write(u64 offset, std::size_t length, bool flush,
                                  const u8* buffer) override {
         if (offset > size) {
-            return ERR_WRITE_BEYOND_END;
+            return ResultWriteBeyondEnd;
         } else if (offset == size) {
             return 0ULL;
         }
@@ -108,17 +108,17 @@ public:
 
         if (!path_parser.IsValid()) {
             LOG_ERROR(Service_FS, "Invalid path {}", path.DebugStr());
-            return ERROR_INVALID_PATH;
+            return ResultInvalidPath;
         }
 
         if (mode.hex == 0) {
             LOG_ERROR(Service_FS, "Empty open mode");
-            return ERROR_UNSUPPORTED_OPEN_FLAGS;
+            return ResultUnsupportedOpenFlags;
         }
 
         if (mode.create_flag) {
             LOG_ERROR(Service_FS, "Create flag is not supported");
-            return ERROR_UNSUPPORTED_OPEN_FLAGS;
+            return ResultUnsupportedOpenFlags;
         }
 
         const auto full_path = path_parser.BuildHostPath(mount_point);
@@ -126,17 +126,17 @@ public:
         switch (path_parser.GetHostStatus(mount_point)) {
         case PathParser::InvalidMountPoint:
             LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}", mount_point);
-            return ERROR_FILE_NOT_FOUND;
+            return ResultFileNotFound;
         case PathParser::PathNotFound:
             LOG_ERROR(Service_FS, "Path not found {}", full_path);
-            return ERROR_PATH_NOT_FOUND;
+            return ResultPathNotFound;
         case PathParser::FileInPath:
         case PathParser::DirectoryFound:
             LOG_ERROR(Service_FS, "Unexpected file or directory in {}", full_path);
-            return ERROR_UNEXPECTED_FILE_OR_DIRECTORY;
+            return ResultUnexpectedFileOrDirectory;
         case PathParser::NotFound:
             LOG_ERROR(Service_FS, "{} not found", full_path);
-            return ERROR_FILE_NOT_FOUND;
+            return ResultFileNotFound;
         case PathParser::FileFound:
             break; // Expected 'success' case
         }
@@ -144,7 +144,7 @@ public:
         FileUtil::IOFile file(full_path, "r+b");
         if (!file.IsOpen()) {
             LOG_CRITICAL(Service_FS, "(unreachable) Unknown error opening {}", full_path);
-            return ERROR_FILE_NOT_FOUND;
+            return ResultFileNotFound;
         }
 
         Mode rwmode;
@@ -158,7 +158,7 @@ public:
     Result CreateFile(const Path& path, u64 size) const override {
         if (size == 0) {
             LOG_ERROR(Service_FS, "Zero-size file is not supported");
-            return ERROR_UNSUPPORTED_OPEN_FLAGS;
+            return ResultUnsupportedOpenFlags;
         }
         return SaveDataArchive::CreateFile(path, size);
     }
@@ -250,9 +250,9 @@ ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_ExtSaveData::Open(cons
         // TODO(Subv): Verify the archive behavior of SharedExtSaveData compared to ExtSaveData.
         // ExtSaveData seems to return FS_NotFound (120) when the archive doesn't exist.
         if (type != ExtSaveDataType::Shared) {
-            return ERR_NOT_FOUND_INVALID_STATE;
+            return ResultNotFoundInvalidState;
         } else {
-            return ERR_NOT_FORMATTED;
+            return ResultNotFormatted;
         }
     }
     std::unique_ptr<DelayGenerator> delay_generator = std::make_unique<ExtSaveDataDelayGenerator>();
@@ -276,11 +276,11 @@ Result ArchiveFactory_ExtSaveData::Format(const Path& path,
 
     if (!file.IsOpen()) {
         // TODO(Subv): Find the correct error code
-        return RESULT_UNKNOWN;
+        return ResultUnknown;
     }
 
     file.WriteBytes(&format_info, sizeof(format_info));
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 ResultVal<ArchiveFormatInfo> ArchiveFactory_ExtSaveData::GetFormatInfo(const Path& path,
@@ -291,7 +291,7 @@ ResultVal<ArchiveFormatInfo> ArchiveFactory_ExtSaveData::GetFormatInfo(const Pat
     if (!file.IsOpen()) {
         LOG_ERROR(Service_FS, "Could not open metadata information for archive");
         // TODO(Subv): Verify error code
-        return ERR_NOT_FORMATTED;
+        return ResultNotFormatted;
     }
 
     ArchiveFormatInfo info = {};

--- a/src/core/file_sys/archive_extsavedata.cpp
+++ b/src/core/file_sys/archive_extsavedata.cpp
@@ -155,7 +155,7 @@ public:
                                                  std::move(delay_generator));
     }
 
-    ResultCode CreateFile(const Path& path, u64 size) const override {
+    Result CreateFile(const Path& path, u64 size) const override {
         if (size == 0) {
             LOG_ERROR(Service_FS, "Zero-size file is not supported");
             return ERROR_UNSUPPORTED_OPEN_FLAGS;
@@ -259,9 +259,9 @@ ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_ExtSaveData::Open(cons
     return std::make_unique<ExtSaveDataArchive>(fullpath, std::move(delay_generator));
 }
 
-ResultCode ArchiveFactory_ExtSaveData::Format(const Path& path,
-                                              const FileSys::ArchiveFormatInfo& format_info,
-                                              u64 program_id) {
+Result ArchiveFactory_ExtSaveData::Format(const Path& path,
+                                          const FileSys::ArchiveFormatInfo& format_info,
+                                          u64 program_id) {
     auto corrected_path = GetCorrectedPath(path);
 
     // These folders are always created with the ExtSaveData

--- a/src/core/file_sys/archive_extsavedata.h
+++ b/src/core/file_sys/archive_extsavedata.h
@@ -31,8 +31,8 @@ public:
     }
 
     ResultVal<std::unique_ptr<ArchiveBackend>> Open(const Path& path, u64 program_id) override;
-    ResultCode Format(const Path& path, const FileSys::ArchiveFormatInfo& format_info,
-                      u64 program_id) override;
+    Result Format(const Path& path, const FileSys::ArchiveFormatInfo& format_info,
+                  u64 program_id) override;
     ResultVal<ArchiveFormatInfo> GetFormatInfo(const Path& path, u64 program_id) const override;
 
     const std::string& GetMountPoint() const {

--- a/src/core/file_sys/archive_ncch.cpp
+++ b/src/core/file_sys/archive_ncch.cpp
@@ -180,47 +180,47 @@ ResultVal<std::unique_ptr<FileBackend>> NCCHArchive::OpenFile(const Path& path,
     return file;
 }
 
-ResultCode NCCHArchive::DeleteFile(const Path& path) const {
+Result NCCHArchive::DeleteFile(const Path& path) const {
     LOG_CRITICAL(Service_FS, "Attempted to delete a file from an NCCH archive ({}).", GetName());
     // TODO(Subv): Verify error code
-    return ResultCode(ErrorDescription::NoData, ErrorModule::FS, ErrorSummary::Canceled,
-                      ErrorLevel::Status);
+    return Result(ErrorDescription::NoData, ErrorModule::FS, ErrorSummary::Canceled,
+                  ErrorLevel::Status);
 }
 
-ResultCode NCCHArchive::RenameFile(const Path& src_path, const Path& dest_path) const {
+Result NCCHArchive::RenameFile(const Path& src_path, const Path& dest_path) const {
     LOG_CRITICAL(Service_FS, "Attempted to rename a file within an NCCH archive ({}).", GetName());
     // TODO(wwylele): Use correct error code
     return RESULT_UNKNOWN;
 }
 
-ResultCode NCCHArchive::DeleteDirectory(const Path& path) const {
+Result NCCHArchive::DeleteDirectory(const Path& path) const {
     LOG_CRITICAL(Service_FS, "Attempted to delete a directory from an NCCH archive ({}).",
                  GetName());
     // TODO(wwylele): Use correct error code
     return RESULT_UNKNOWN;
 }
 
-ResultCode NCCHArchive::DeleteDirectoryRecursively(const Path& path) const {
+Result NCCHArchive::DeleteDirectoryRecursively(const Path& path) const {
     LOG_CRITICAL(Service_FS, "Attempted to delete a directory from an NCCH archive ({}).",
                  GetName());
     // TODO(wwylele): Use correct error code
     return RESULT_UNKNOWN;
 }
 
-ResultCode NCCHArchive::CreateFile(const Path& path, u64 size) const {
+Result NCCHArchive::CreateFile(const Path& path, u64 size) const {
     LOG_CRITICAL(Service_FS, "Attempted to create a file in an NCCH archive ({}).", GetName());
     // TODO: Verify error code
-    return ResultCode(ErrorDescription::NotAuthorized, ErrorModule::FS, ErrorSummary::NotSupported,
-                      ErrorLevel::Permanent);
+    return Result(ErrorDescription::NotAuthorized, ErrorModule::FS, ErrorSummary::NotSupported,
+                  ErrorLevel::Permanent);
 }
 
-ResultCode NCCHArchive::CreateDirectory(const Path& path) const {
+Result NCCHArchive::CreateDirectory(const Path& path) const {
     LOG_CRITICAL(Service_FS, "Attempted to create a directory in an NCCH archive ({}).", GetName());
     // TODO(wwylele): Use correct error code
     return RESULT_UNKNOWN;
 }
 
-ResultCode NCCHArchive::RenameDirectory(const Path& src_path, const Path& dest_path) const {
+Result NCCHArchive::RenameDirectory(const Path& src_path, const Path& dest_path) const {
     LOG_CRITICAL(Service_FS, "Attempted to rename a file within an NCCH archive ({}).", GetName());
     // TODO(wwylele): Use correct error code
     return RESULT_UNKNOWN;
@@ -292,13 +292,12 @@ ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_NCCH::Open(const Path&
         open_path.tid, static_cast<Service::FS::MediaType>(open_path.media_type & 0xFF));
 }
 
-ResultCode ArchiveFactory_NCCH::Format(const Path& path,
-                                       const FileSys::ArchiveFormatInfo& format_info,
-                                       u64 program_id) {
+Result ArchiveFactory_NCCH::Format(const Path& path, const FileSys::ArchiveFormatInfo& format_info,
+                                   u64 program_id) {
     LOG_ERROR(Service_FS, "Attempted to format a NCCH archive.");
     // TODO: Verify error code
-    return ResultCode(ErrorDescription::NotAuthorized, ErrorModule::FS, ErrorSummary::NotSupported,
-                      ErrorLevel::Permanent);
+    return Result(ErrorDescription::NotAuthorized, ErrorModule::FS, ErrorSummary::NotSupported,
+                  ErrorLevel::Permanent);
 }
 
 ResultVal<ArchiveFormatInfo> ArchiveFactory_NCCH::GetFormatInfo(const Path& path,

--- a/src/core/file_sys/archive_ncch.cpp
+++ b/src/core/file_sys/archive_ncch.cpp
@@ -73,13 +73,13 @@ ResultVal<std::unique_ptr<FileBackend>> NCCHArchive::OpenFile(const Path& path,
                                                               const Mode& mode) const {
     if (path.GetType() != LowPathType::Binary) {
         LOG_ERROR(Service_FS, "Path need to be Binary");
-        return ERROR_INVALID_PATH;
+        return ResultInvalidPath;
     }
 
     std::vector<u8> binary = path.AsBinary();
     if (binary.size() != sizeof(NCCHFilePath)) {
         LOG_ERROR(Service_FS, "Wrong path size {}", binary.size());
-        return ERROR_INVALID_PATH;
+        return ResultInvalidPath;
     }
 
     NCCHFilePath openfile_path;
@@ -174,7 +174,7 @@ ResultVal<std::unique_ptr<FileBackend>> NCCHArchive::OpenFile(const Path& path,
             return std::make_unique<IVFCFileInMemory>(std::move(archive_data), romfs_offset,
                                                       romfs_size, std::move(delay_generator));
         }
-        return ERROR_NOT_FOUND;
+        return ResultNotFound;
     }
 
     return file;
@@ -190,21 +190,21 @@ Result NCCHArchive::DeleteFile(const Path& path) const {
 Result NCCHArchive::RenameFile(const Path& src_path, const Path& dest_path) const {
     LOG_CRITICAL(Service_FS, "Attempted to rename a file within an NCCH archive ({}).", GetName());
     // TODO(wwylele): Use correct error code
-    return RESULT_UNKNOWN;
+    return ResultUnknown;
 }
 
 Result NCCHArchive::DeleteDirectory(const Path& path) const {
     LOG_CRITICAL(Service_FS, "Attempted to delete a directory from an NCCH archive ({}).",
                  GetName());
     // TODO(wwylele): Use correct error code
-    return RESULT_UNKNOWN;
+    return ResultUnknown;
 }
 
 Result NCCHArchive::DeleteDirectoryRecursively(const Path& path) const {
     LOG_CRITICAL(Service_FS, "Attempted to delete a directory from an NCCH archive ({}).",
                  GetName());
     // TODO(wwylele): Use correct error code
-    return RESULT_UNKNOWN;
+    return ResultUnknown;
 }
 
 Result NCCHArchive::CreateFile(const Path& path, u64 size) const {
@@ -217,20 +217,20 @@ Result NCCHArchive::CreateFile(const Path& path, u64 size) const {
 Result NCCHArchive::CreateDirectory(const Path& path) const {
     LOG_CRITICAL(Service_FS, "Attempted to create a directory in an NCCH archive ({}).", GetName());
     // TODO(wwylele): Use correct error code
-    return RESULT_UNKNOWN;
+    return ResultUnknown;
 }
 
 Result NCCHArchive::RenameDirectory(const Path& src_path, const Path& dest_path) const {
     LOG_CRITICAL(Service_FS, "Attempted to rename a file within an NCCH archive ({}).", GetName());
     // TODO(wwylele): Use correct error code
-    return RESULT_UNKNOWN;
+    return ResultUnknown;
 }
 
 ResultVal<std::unique_ptr<DirectoryBackend>> NCCHArchive::OpenDirectory(const Path& path) const {
     LOG_CRITICAL(Service_FS, "Attempted to open a directory within an NCCH archive ({}).",
                  GetName().c_str());
     // TODO(shinyquagsire23): Use correct error code
-    return RESULT_UNKNOWN;
+    return ResultUnknown;
 }
 
 u64 NCCHArchive::GetFreeBytes() const {
@@ -276,13 +276,13 @@ ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_NCCH::Open(const Path&
                                                                      u64 program_id) {
     if (path.GetType() != LowPathType::Binary) {
         LOG_ERROR(Service_FS, "Path need to be Binary");
-        return ERROR_INVALID_PATH;
+        return ResultInvalidPath;
     }
 
     std::vector<u8> binary = path.AsBinary();
     if (binary.size() != sizeof(NCCHArchivePath)) {
         LOG_ERROR(Service_FS, "Wrong path size {}", binary.size());
-        return ERROR_INVALID_PATH;
+        return ResultInvalidPath;
     }
 
     NCCHArchivePath open_path;
@@ -304,7 +304,7 @@ ResultVal<ArchiveFormatInfo> ArchiveFactory_NCCH::GetFormatInfo(const Path& path
                                                                 u64 program_id) const {
     // TODO(Subv): Implement
     LOG_ERROR(Service_FS, "Unimplemented GetFormatInfo archive {}", GetName());
-    return RESULT_UNKNOWN;
+    return ResultUnknown;
 }
 
 } // namespace FileSys

--- a/src/core/file_sys/archive_ncch.h
+++ b/src/core/file_sys/archive_ncch.h
@@ -50,13 +50,13 @@ public:
 
     ResultVal<std::unique_ptr<FileBackend>> OpenFile(const Path& path,
                                                      const Mode& mode) const override;
-    ResultCode DeleteFile(const Path& path) const override;
-    ResultCode RenameFile(const Path& src_path, const Path& dest_path) const override;
-    ResultCode DeleteDirectory(const Path& path) const override;
-    ResultCode DeleteDirectoryRecursively(const Path& path) const override;
-    ResultCode CreateFile(const Path& path, u64 size) const override;
-    ResultCode CreateDirectory(const Path& path) const override;
-    ResultCode RenameDirectory(const Path& src_path, const Path& dest_path) const override;
+    Result DeleteFile(const Path& path) const override;
+    Result RenameFile(const Path& src_path, const Path& dest_path) const override;
+    Result DeleteDirectory(const Path& path) const override;
+    Result DeleteDirectoryRecursively(const Path& path) const override;
+    Result CreateFile(const Path& path, u64 size) const override;
+    Result CreateDirectory(const Path& path) const override;
+    Result RenameDirectory(const Path& src_path, const Path& dest_path) const override;
     ResultVal<std::unique_ptr<DirectoryBackend>> OpenDirectory(const Path& path) const override;
     u64 GetFreeBytes() const override;
 
@@ -114,8 +114,8 @@ public:
     }
 
     ResultVal<std::unique_ptr<ArchiveBackend>> Open(const Path& path, u64 program_id) override;
-    ResultCode Format(const Path& path, const FileSys::ArchiveFormatInfo& format_info,
-                      u64 program_id) override;
+    Result Format(const Path& path, const FileSys::ArchiveFormatInfo& format_info,
+                  u64 program_id) override;
     ResultVal<ArchiveFormatInfo> GetFormatInfo(const Path& path, u64 program_id) const override;
 
 private:

--- a/src/core/file_sys/archive_other_savedata.cpp
+++ b/src/core/file_sys/archive_other_savedata.cpp
@@ -78,8 +78,9 @@ ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_OtherSaveDataPermitted
     return sd_savedata_source->Open(program_id);
 }
 
-ResultCode ArchiveFactory_OtherSaveDataPermitted::Format(
-    const Path& path, const FileSys::ArchiveFormatInfo& format_info, u64 program_id) {
+Result ArchiveFactory_OtherSaveDataPermitted::Format(const Path& path,
+                                                     const FileSys::ArchiveFormatInfo& format_info,
+                                                     u64 program_id) {
     LOG_ERROR(Service_FS, "Attempted to format a OtherSaveDataPermitted archive.");
     return ERROR_INVALID_PATH;
 }
@@ -116,8 +117,9 @@ ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_OtherSaveDataGeneral::
     return sd_savedata_source->Open(program_id);
 }
 
-ResultCode ArchiveFactory_OtherSaveDataGeneral::Format(
-    const Path& path, const FileSys::ArchiveFormatInfo& format_info, u64 /*client_program_id*/) {
+Result ArchiveFactory_OtherSaveDataGeneral::Format(const Path& path,
+                                                   const FileSys::ArchiveFormatInfo& format_info,
+                                                   u64 /*client_program_id*/) {
     MediaType media_type;
     u64 program_id;
     CASCADE_RESULT(std::tie(media_type, program_id), ParsePathGeneral(path));

--- a/src/core/file_sys/archive_other_savedata.cpp
+++ b/src/core/file_sys/archive_other_savedata.cpp
@@ -25,14 +25,14 @@ template <typename T>
 ResultVal<std::tuple<MediaType, u64>> ParsePath(const Path& path, T program_id_reader) {
     if (path.GetType() != LowPathType::Binary) {
         LOG_ERROR(Service_FS, "Wrong path type {}", path.GetType());
-        return ERROR_INVALID_PATH;
+        return ResultInvalidPath;
     }
 
     std::vector<u8> vec_data = path.AsBinary();
 
     if (vec_data.size() != 12) {
         LOG_ERROR(Service_FS, "Wrong path length {}", vec_data.size());
-        return ERROR_INVALID_PATH;
+        return ResultInvalidPath;
     }
 
     const u32* data = reinterpret_cast<const u32*>(vec_data.data());
@@ -42,7 +42,7 @@ ResultVal<std::tuple<MediaType, u64>> ParsePath(const Path& path, T program_id_r
         LOG_ERROR(Service_FS, "Unsupported media type {}", media_type);
 
         // Note: this is strange, but the error code was verified with a real 3DS
-        return ERROR_UNSUPPORTED_OPEN_FLAGS;
+        return ResultUnsupportedOpenFlags;
     }
 
     return std::make_tuple(media_type, program_id_reader(data));
@@ -72,7 +72,7 @@ ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_OtherSaveDataPermitted
 
     if (media_type == MediaType::GameCard) {
         LOG_WARNING(Service_FS, "(stubbed) Unimplemented media type GameCard");
-        return ERROR_GAMECARD_NOT_INSERTED;
+        return ResultGamecardNotInserted;
     }
 
     return sd_savedata_source->Open(program_id);
@@ -82,7 +82,7 @@ Result ArchiveFactory_OtherSaveDataPermitted::Format(const Path& path,
                                                      const FileSys::ArchiveFormatInfo& format_info,
                                                      u64 program_id) {
     LOG_ERROR(Service_FS, "Attempted to format a OtherSaveDataPermitted archive.");
-    return ERROR_INVALID_PATH;
+    return ResultInvalidPath;
 }
 
 ResultVal<ArchiveFormatInfo> ArchiveFactory_OtherSaveDataPermitted::GetFormatInfo(
@@ -93,7 +93,7 @@ ResultVal<ArchiveFormatInfo> ArchiveFactory_OtherSaveDataPermitted::GetFormatInf
 
     if (media_type == MediaType::GameCard) {
         LOG_WARNING(Service_FS, "(stubbed) Unimplemented media type GameCard");
-        return ERROR_GAMECARD_NOT_INSERTED;
+        return ResultGamecardNotInserted;
     }
 
     return sd_savedata_source->GetFormatInfo(program_id);
@@ -111,7 +111,7 @@ ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_OtherSaveDataGeneral::
 
     if (media_type == MediaType::GameCard) {
         LOG_WARNING(Service_FS, "(stubbed) Unimplemented media type GameCard");
-        return ERROR_GAMECARD_NOT_INSERTED;
+        return ResultGamecardNotInserted;
     }
 
     return sd_savedata_source->Open(program_id);
@@ -126,7 +126,7 @@ Result ArchiveFactory_OtherSaveDataGeneral::Format(const Path& path,
 
     if (media_type == MediaType::GameCard) {
         LOG_WARNING(Service_FS, "(stubbed) Unimplemented media type GameCard");
-        return ERROR_GAMECARD_NOT_INSERTED;
+        return ResultGamecardNotInserted;
     }
 
     return sd_savedata_source->Format(program_id, format_info);
@@ -140,7 +140,7 @@ ResultVal<ArchiveFormatInfo> ArchiveFactory_OtherSaveDataGeneral::GetFormatInfo(
 
     if (media_type == MediaType::GameCard) {
         LOG_WARNING(Service_FS, "(stubbed) Unimplemented media type GameCard");
-        return ERROR_GAMECARD_NOT_INSERTED;
+        return ResultGamecardNotInserted;
     }
 
     return sd_savedata_source->GetFormatInfo(program_id);

--- a/src/core/file_sys/archive_other_savedata.h
+++ b/src/core/file_sys/archive_other_savedata.h
@@ -22,8 +22,8 @@ public:
     }
 
     ResultVal<std::unique_ptr<ArchiveBackend>> Open(const Path& path, u64 program_id) override;
-    ResultCode Format(const Path& path, const FileSys::ArchiveFormatInfo& format_info,
-                      u64 program_id) override;
+    Result Format(const Path& path, const FileSys::ArchiveFormatInfo& format_info,
+                  u64 program_id) override;
     ResultVal<ArchiveFormatInfo> GetFormatInfo(const Path& path, u64 program_id) const override;
 
 private:
@@ -49,8 +49,8 @@ public:
     }
 
     ResultVal<std::unique_ptr<ArchiveBackend>> Open(const Path& path, u64 program_id) override;
-    ResultCode Format(const Path& path, const FileSys::ArchiveFormatInfo& format_info,
-                      u64 program_id) override;
+    Result Format(const Path& path, const FileSys::ArchiveFormatInfo& format_info,
+                  u64 program_id) override;
     ResultVal<ArchiveFormatInfo> GetFormatInfo(const Path& path, u64 program_id) const override;
 
 private:

--- a/src/core/file_sys/archive_savedata.cpp
+++ b/src/core/file_sys/archive_savedata.cpp
@@ -21,9 +21,9 @@ ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_SaveData::Open(const P
     return sd_savedata_source->Open(program_id);
 }
 
-ResultCode ArchiveFactory_SaveData::Format(const Path& path,
-                                           const FileSys::ArchiveFormatInfo& format_info,
-                                           u64 program_id) {
+Result ArchiveFactory_SaveData::Format(const Path& path,
+                                       const FileSys::ArchiveFormatInfo& format_info,
+                                       u64 program_id) {
     return sd_savedata_source->Format(program_id, format_info);
 }
 

--- a/src/core/file_sys/archive_savedata.h
+++ b/src/core/file_sys/archive_savedata.h
@@ -20,8 +20,8 @@ public:
     }
 
     ResultVal<std::unique_ptr<ArchiveBackend>> Open(const Path& path, u64 program_id) override;
-    ResultCode Format(const Path& path, const FileSys::ArchiveFormatInfo& format_info,
-                      u64 program_id) override;
+    Result Format(const Path& path, const FileSys::ArchiveFormatInfo& format_info,
+                  u64 program_id) override;
 
     ResultVal<ArchiveFormatInfo> GetFormatInfo(const Path& path, u64 program_id) const override;
 

--- a/src/core/file_sys/archive_sdmc.cpp
+++ b/src/core/file_sys/archive_sdmc.cpp
@@ -112,7 +112,7 @@ ResultVal<std::unique_ptr<FileBackend>> SDMCArchive::OpenFileBase(const Path& pa
     return std::make_unique<DiskFile>(std::move(file), mode, std::move(delay_generator));
 }
 
-ResultCode SDMCArchive::DeleteFile(const Path& path) const {
+Result SDMCArchive::DeleteFile(const Path& path) const {
     const PathParser path_parser(path);
 
     if (!path_parser.IsValid()) {
@@ -146,7 +146,7 @@ ResultCode SDMCArchive::DeleteFile(const Path& path) const {
     return ERROR_NOT_FOUND;
 }
 
-ResultCode SDMCArchive::RenameFile(const Path& src_path, const Path& dest_path) const {
+Result SDMCArchive::RenameFile(const Path& src_path, const Path& dest_path) const {
     const PathParser path_parser_src(src_path);
 
     // TODO: Verify these return codes with HW
@@ -171,13 +171,12 @@ ResultCode SDMCArchive::RenameFile(const Path& src_path, const Path& dest_path) 
 
     // TODO(yuriks): This code probably isn't right, it'll return a Status even if the file didn't
     // exist or similar. Verify.
-    return ResultCode(ErrorDescription::NoData, ErrorModule::FS, // TODO: verify description
-                      ErrorSummary::NothingHappened, ErrorLevel::Status);
+    return Result(ErrorDescription::NoData, ErrorModule::FS, // TODO: verify description
+                  ErrorSummary::NothingHappened, ErrorLevel::Status);
 }
 
 template <typename T>
-static ResultCode DeleteDirectoryHelper(const Path& path, const std::string& mount_point,
-                                        T deleter) {
+static Result DeleteDirectoryHelper(const Path& path, const std::string& mount_point, T deleter) {
     const PathParser path_parser(path);
 
     if (!path_parser.IsValid()) {
@@ -214,16 +213,16 @@ static ResultCode DeleteDirectoryHelper(const Path& path, const std::string& mou
     return ERROR_UNEXPECTED_FILE_OR_DIRECTORY_SDMC;
 }
 
-ResultCode SDMCArchive::DeleteDirectory(const Path& path) const {
+Result SDMCArchive::DeleteDirectory(const Path& path) const {
     return DeleteDirectoryHelper(path, mount_point, FileUtil::DeleteDir);
 }
 
-ResultCode SDMCArchive::DeleteDirectoryRecursively(const Path& path) const {
+Result SDMCArchive::DeleteDirectoryRecursively(const Path& path) const {
     return DeleteDirectoryHelper(
         path, mount_point, [](const std::string& p) { return FileUtil::DeleteDirRecursively(p); });
 }
 
-ResultCode SDMCArchive::CreateFile(const FileSys::Path& path, u64 size) const {
+Result SDMCArchive::CreateFile(const FileSys::Path& path, u64 size) const {
     const PathParser path_parser(path);
 
     if (!path_parser.IsValid()) {
@@ -264,11 +263,11 @@ ResultCode SDMCArchive::CreateFile(const FileSys::Path& path, u64 size) const {
     }
 
     LOG_ERROR(Service_FS, "Too large file");
-    return ResultCode(ErrorDescription::TooLarge, ErrorModule::FS, ErrorSummary::OutOfResource,
-                      ErrorLevel::Info);
+    return Result(ErrorDescription::TooLarge, ErrorModule::FS, ErrorSummary::OutOfResource,
+                  ErrorLevel::Info);
 }
 
-ResultCode SDMCArchive::CreateDirectory(const Path& path) const {
+Result SDMCArchive::CreateDirectory(const Path& path) const {
     const PathParser path_parser(path);
 
     if (!path_parser.IsValid()) {
@@ -299,11 +298,11 @@ ResultCode SDMCArchive::CreateDirectory(const Path& path) const {
     }
 
     LOG_CRITICAL(Service_FS, "(unreachable) Unknown error creating {}", mount_point);
-    return ResultCode(ErrorDescription::NoData, ErrorModule::FS, ErrorSummary::Canceled,
-                      ErrorLevel::Status);
+    return Result(ErrorDescription::NoData, ErrorModule::FS, ErrorSummary::Canceled,
+                  ErrorLevel::Status);
 }
 
-ResultCode SDMCArchive::RenameDirectory(const Path& src_path, const Path& dest_path) const {
+Result SDMCArchive::RenameDirectory(const Path& src_path, const Path& dest_path) const {
     const PathParser path_parser_src(src_path);
 
     // TODO: Verify these return codes with HW
@@ -328,8 +327,8 @@ ResultCode SDMCArchive::RenameDirectory(const Path& src_path, const Path& dest_p
 
     // TODO(yuriks): This code probably isn't right, it'll return a Status even if the file didn't
     // exist or similar. Verify.
-    return ResultCode(ErrorDescription::NoData, ErrorModule::FS, // TODO: verify description
-                      ErrorSummary::NothingHappened, ErrorLevel::Status);
+    return Result(ErrorDescription::NoData, ErrorModule::FS, // TODO: verify description
+                  ErrorSummary::NothingHappened, ErrorLevel::Status);
 }
 
 ResultVal<std::unique_ptr<DirectoryBackend>> SDMCArchive::OpenDirectory(const Path& path) const {
@@ -392,9 +391,8 @@ ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_SDMC::Open(const Path&
     return std::make_unique<SDMCArchive>(sdmc_directory, std::move(delay_generator));
 }
 
-ResultCode ArchiveFactory_SDMC::Format(const Path& path,
-                                       const FileSys::ArchiveFormatInfo& format_info,
-                                       u64 program_id) {
+Result ArchiveFactory_SDMC::Format(const Path& path, const FileSys::ArchiveFormatInfo& format_info,
+                                   u64 program_id) {
     // This is kind of an undesirable operation, so let's just ignore it. :)
     return RESULT_SUCCESS;
 }

--- a/src/core/file_sys/archive_sdmc.h
+++ b/src/core/file_sys/archive_sdmc.h
@@ -29,13 +29,13 @@ public:
 
     ResultVal<std::unique_ptr<FileBackend>> OpenFile(const Path& path,
                                                      const Mode& mode) const override;
-    ResultCode DeleteFile(const Path& path) const override;
-    ResultCode RenameFile(const Path& src_path, const Path& dest_path) const override;
-    ResultCode DeleteDirectory(const Path& path) const override;
-    ResultCode DeleteDirectoryRecursively(const Path& path) const override;
-    ResultCode CreateFile(const Path& path, u64 size) const override;
-    ResultCode CreateDirectory(const Path& path) const override;
-    ResultCode RenameDirectory(const Path& src_path, const Path& dest_path) const override;
+    Result DeleteFile(const Path& path) const override;
+    Result RenameFile(const Path& src_path, const Path& dest_path) const override;
+    Result DeleteDirectory(const Path& path) const override;
+    Result DeleteDirectoryRecursively(const Path& path) const override;
+    Result CreateFile(const Path& path, u64 size) const override;
+    Result CreateDirectory(const Path& path) const override;
+    Result RenameDirectory(const Path& src_path, const Path& dest_path) const override;
     ResultVal<std::unique_ptr<DirectoryBackend>> OpenDirectory(const Path& path) const override;
     u64 GetFreeBytes() const override;
 
@@ -68,8 +68,8 @@ public:
     }
 
     ResultVal<std::unique_ptr<ArchiveBackend>> Open(const Path& path, u64 program_id) override;
-    ResultCode Format(const Path& path, const FileSys::ArchiveFormatInfo& format_info,
-                      u64 program_id) override;
+    Result Format(const Path& path, const FileSys::ArchiveFormatInfo& format_info,
+                  u64 program_id) override;
     ResultVal<ArchiveFormatInfo> GetFormatInfo(const Path& path, u64 program_id) const override;
 
 private:

--- a/src/core/file_sys/archive_sdmcwriteonly.cpp
+++ b/src/core/file_sys/archive_sdmcwriteonly.cpp
@@ -44,7 +44,7 @@ ResultVal<std::unique_ptr<FileBackend>> SDMCWriteOnlyArchive::OpenFile(const Pat
                                                                        const Mode& mode) const {
     if (mode.read_flag) {
         LOG_ERROR(Service_FS, "Read flag is not supported");
-        return ERROR_INVALID_READ_FLAG;
+        return ResultInvalidReadFlag;
     }
     return SDMCArchive::OpenFileBase(path, mode);
 }
@@ -52,7 +52,7 @@ ResultVal<std::unique_ptr<FileBackend>> SDMCWriteOnlyArchive::OpenFile(const Pat
 ResultVal<std::unique_ptr<DirectoryBackend>> SDMCWriteOnlyArchive::OpenDirectory(
     const Path& path) const {
     LOG_ERROR(Service_FS, "Not supported");
-    return ERROR_UNSUPPORTED_OPEN_FLAGS;
+    return ResultUnsupportedOpenFlags;
 }
 
 ArchiveFactory_SDMCWriteOnly::ArchiveFactory_SDMCWriteOnly(const std::string& mount_point)
@@ -86,14 +86,14 @@ Result ArchiveFactory_SDMCWriteOnly::Format(const Path& path,
                                             u64 program_id) {
     // TODO(wwylele): hwtest this
     LOG_ERROR(Service_FS, "Attempted to format a SDMC write-only archive.");
-    return RESULT_UNKNOWN;
+    return ResultUnknown;
 }
 
 ResultVal<ArchiveFormatInfo> ArchiveFactory_SDMCWriteOnly::GetFormatInfo(const Path& path,
                                                                          u64 program_id) const {
     // TODO(Subv): Implement
     LOG_ERROR(Service_FS, "Unimplemented GetFormatInfo archive {}", GetName());
-    return RESULT_UNKNOWN;
+    return ResultUnknown;
 }
 
 } // namespace FileSys

--- a/src/core/file_sys/archive_sdmcwriteonly.cpp
+++ b/src/core/file_sys/archive_sdmcwriteonly.cpp
@@ -81,9 +81,9 @@ ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_SDMCWriteOnly::Open(co
     return std::make_unique<SDMCWriteOnlyArchive>(sdmc_directory, std::move(delay_generator));
 }
 
-ResultCode ArchiveFactory_SDMCWriteOnly::Format(const Path& path,
-                                                const FileSys::ArchiveFormatInfo& format_info,
-                                                u64 program_id) {
+Result ArchiveFactory_SDMCWriteOnly::Format(const Path& path,
+                                            const FileSys::ArchiveFormatInfo& format_info,
+                                            u64 program_id) {
     // TODO(wwylele): hwtest this
     LOG_ERROR(Service_FS, "Attempted to format a SDMC write-only archive.");
     return RESULT_UNKNOWN;

--- a/src/core/file_sys/archive_sdmcwriteonly.h
+++ b/src/core/file_sys/archive_sdmcwriteonly.h
@@ -54,8 +54,8 @@ public:
     }
 
     ResultVal<std::unique_ptr<ArchiveBackend>> Open(const Path& path, u64 program_id) override;
-    ResultCode Format(const Path& path, const FileSys::ArchiveFormatInfo& format_info,
-                      u64 program_id) override;
+    Result Format(const Path& path, const FileSys::ArchiveFormatInfo& format_info,
+                  u64 program_id) override;
     ResultVal<ArchiveFormatInfo> GetFormatInfo(const Path& path, u64 program_id) const override;
 
 private:

--- a/src/core/file_sys/archive_selfncch.cpp
+++ b/src/core/file_sys/archive_selfncch.cpp
@@ -134,37 +134,37 @@ public:
         }
     }
 
-    ResultCode DeleteFile(const Path& path) const override {
+    Result DeleteFile(const Path& path) const override {
         LOG_ERROR(Service_FS, "Unsupported");
         return ERROR_UNSUPPORTED_OPEN_FLAGS;
     }
 
-    ResultCode RenameFile(const Path& src_path, const Path& dest_path) const override {
+    Result RenameFile(const Path& src_path, const Path& dest_path) const override {
         LOG_ERROR(Service_FS, "Unsupported");
         return ERROR_UNSUPPORTED_OPEN_FLAGS;
     }
 
-    ResultCode DeleteDirectory(const Path& path) const override {
+    Result DeleteDirectory(const Path& path) const override {
         LOG_ERROR(Service_FS, "Unsupported");
         return ERROR_UNSUPPORTED_OPEN_FLAGS;
     }
 
-    ResultCode DeleteDirectoryRecursively(const Path& path) const override {
+    Result DeleteDirectoryRecursively(const Path& path) const override {
         LOG_ERROR(Service_FS, "Unsupported");
         return ERROR_UNSUPPORTED_OPEN_FLAGS;
     }
 
-    ResultCode CreateFile(const Path& path, u64 size) const override {
+    Result CreateFile(const Path& path, u64 size) const override {
         LOG_ERROR(Service_FS, "Unsupported");
         return ERROR_UNSUPPORTED_OPEN_FLAGS;
     }
 
-    ResultCode CreateDirectory(const Path& path) const override {
+    Result CreateDirectory(const Path& path) const override {
         LOG_ERROR(Service_FS, "Unsupported");
         return ERROR_UNSUPPORTED_OPEN_FLAGS;
     }
 
-    ResultCode RenameDirectory(const Path& src_path, const Path& dest_path) const override {
+    Result RenameDirectory(const Path& src_path, const Path& dest_path) const override {
         LOG_ERROR(Service_FS, "Unsupported");
         return ERROR_UNSUPPORTED_OPEN_FLAGS;
     }
@@ -296,8 +296,8 @@ ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_SelfNCCH::Open(const P
     return std::make_unique<SelfNCCHArchive>(ncch_data[program_id]);
 }
 
-ResultCode ArchiveFactory_SelfNCCH::Format(const Path&, const FileSys::ArchiveFormatInfo&,
-                                           u64 program_id) {
+Result ArchiveFactory_SelfNCCH::Format(const Path&, const FileSys::ArchiveFormatInfo&,
+                                       u64 program_id) {
     LOG_ERROR(Service_FS, "Attempted to format a SelfNCCH archive.");
     return ERROR_INVALID_PATH;
 }

--- a/src/core/file_sys/archive_selfncch.cpp
+++ b/src/core/file_sys/archive_selfncch.cpp
@@ -39,12 +39,12 @@ public:
     ResultVal<std::size_t> Read(u64 offset, std::size_t length, u8* buffer) const override {
         if (offset != 0) {
             LOG_ERROR(Service_FS, "offset must be zero!");
-            return ERROR_UNSUPPORTED_OPEN_FLAGS;
+            return ResultUnsupportedOpenFlags;
         }
 
         if (length != data->size()) {
             LOG_ERROR(Service_FS, "size must match the file size!");
-            return ERROR_INCORRECT_EXEFS_READ_SIZE;
+            return ResultIncorrectExefsReadSize;
         }
 
         std::memcpy(buffer, data->data(), data->size());
@@ -54,7 +54,7 @@ public:
     ResultVal<std::size_t> Write(u64 offset, std::size_t length, bool flush,
                                  const u8* buffer) override {
         LOG_ERROR(Service_FS, "The file is read-only!");
-        return ERROR_UNSUPPORTED_OPEN_FLAGS;
+        return ResultUnsupportedOpenFlags;
     }
 
     u64 GetSize() const override {
@@ -99,13 +99,13 @@ public:
 
         if (path.GetType() != LowPathType::Binary) {
             LOG_ERROR(Service_FS, "Path need to be Binary");
-            return ERROR_INVALID_PATH;
+            return ResultInvalidPath;
         }
 
         std::vector<u8> binary = path.AsBinary();
         if (binary.size() != sizeof(SelfNCCHFilePath)) {
             LOG_ERROR(Service_FS, "Wrong path size {}", binary.size());
-            return ERROR_INVALID_PATH;
+            return ResultInvalidPath;
         }
 
         SelfNCCHFilePath file_path;
@@ -120,7 +120,7 @@ public:
 
         case SelfNCCHFilePathType::Code:
             LOG_ERROR(Service_FS, "Reading the code section is not supported!");
-            return ERROR_COMMAND_NOT_ALLOWED;
+            return ResultCommandNotAllowed;
 
         case SelfNCCHFilePathType::ExeFS: {
             const auto& raw = file_path.exefs_filename;
@@ -130,48 +130,48 @@ public:
         }
         default:
             LOG_ERROR(Service_FS, "Unknown file type {}!", file_path.type);
-            return ERROR_INVALID_PATH;
+            return ResultInvalidPath;
         }
     }
 
     Result DeleteFile(const Path& path) const override {
         LOG_ERROR(Service_FS, "Unsupported");
-        return ERROR_UNSUPPORTED_OPEN_FLAGS;
+        return ResultUnsupportedOpenFlags;
     }
 
     Result RenameFile(const Path& src_path, const Path& dest_path) const override {
         LOG_ERROR(Service_FS, "Unsupported");
-        return ERROR_UNSUPPORTED_OPEN_FLAGS;
+        return ResultUnsupportedOpenFlags;
     }
 
     Result DeleteDirectory(const Path& path) const override {
         LOG_ERROR(Service_FS, "Unsupported");
-        return ERROR_UNSUPPORTED_OPEN_FLAGS;
+        return ResultUnsupportedOpenFlags;
     }
 
     Result DeleteDirectoryRecursively(const Path& path) const override {
         LOG_ERROR(Service_FS, "Unsupported");
-        return ERROR_UNSUPPORTED_OPEN_FLAGS;
+        return ResultUnsupportedOpenFlags;
     }
 
     Result CreateFile(const Path& path, u64 size) const override {
         LOG_ERROR(Service_FS, "Unsupported");
-        return ERROR_UNSUPPORTED_OPEN_FLAGS;
+        return ResultUnsupportedOpenFlags;
     }
 
     Result CreateDirectory(const Path& path) const override {
         LOG_ERROR(Service_FS, "Unsupported");
-        return ERROR_UNSUPPORTED_OPEN_FLAGS;
+        return ResultUnsupportedOpenFlags;
     }
 
     Result RenameDirectory(const Path& src_path, const Path& dest_path) const override {
         LOG_ERROR(Service_FS, "Unsupported");
-        return ERROR_UNSUPPORTED_OPEN_FLAGS;
+        return ResultUnsupportedOpenFlags;
     }
 
     ResultVal<std::unique_ptr<DirectoryBackend>> OpenDirectory(const Path& path) const override {
         LOG_ERROR(Service_FS, "Unsupported");
-        return ERROR_UNSUPPORTED_OPEN_FLAGS;
+        return ResultUnsupportedOpenFlags;
     }
 
     u64 GetFreeBytes() const override {
@@ -186,7 +186,7 @@ private:
             return std::make_unique<IVFCFile>(ncch_data.romfs_file, std::move(delay_generator));
         } else {
             LOG_INFO(Service_FS, "Unable to read RomFS");
-            return ERROR_ROMFS_NOT_FOUND;
+            return ResultRomfsNotFound;
         }
     }
 
@@ -198,7 +198,7 @@ private:
                                               std::move(delay_generator));
         } else {
             LOG_INFO(Service_FS, "Unable to read update RomFS");
-            return ERROR_ROMFS_NOT_FOUND;
+            return ResultRomfsNotFound;
         }
     }
 
@@ -209,7 +209,7 @@ private:
             }
 
             LOG_WARNING(Service_FS, "Unable to read icon");
-            return ERROR_EXEFS_SECTION_NOT_FOUND;
+            return ResultExefsSectionNotFound;
         }
 
         if (filename == "logo") {
@@ -218,7 +218,7 @@ private:
             }
 
             LOG_WARNING(Service_FS, "Unable to read logo");
-            return ERROR_EXEFS_SECTION_NOT_FOUND;
+            return ResultExefsSectionNotFound;
         }
 
         if (filename == "banner") {
@@ -227,11 +227,11 @@ private:
             }
 
             LOG_WARNING(Service_FS, "Unable to read banner");
-            return ERROR_EXEFS_SECTION_NOT_FOUND;
+            return ResultExefsSectionNotFound;
         }
 
         LOG_ERROR(Service_FS, "Unknown ExeFS section {}!", filename);
-        return ERROR_INVALID_PATH;
+        return ResultInvalidPath;
     }
 
     NCCHData ncch_data;
@@ -299,13 +299,13 @@ ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_SelfNCCH::Open(const P
 Result ArchiveFactory_SelfNCCH::Format(const Path&, const FileSys::ArchiveFormatInfo&,
                                        u64 program_id) {
     LOG_ERROR(Service_FS, "Attempted to format a SelfNCCH archive.");
-    return ERROR_INVALID_PATH;
+    return ResultInvalidPath;
 }
 
 ResultVal<ArchiveFormatInfo> ArchiveFactory_SelfNCCH::GetFormatInfo(const Path&,
                                                                     u64 program_id) const {
     LOG_ERROR(Service_FS, "Attempted to get format info of a SelfNCCH archive");
-    return ERROR_INVALID_PATH;
+    return ResultInvalidPath;
 }
 
 } // namespace FileSys

--- a/src/core/file_sys/archive_selfncch.h
+++ b/src/core/file_sys/archive_selfncch.h
@@ -50,8 +50,8 @@ public:
         return "SelfNCCH";
     }
     ResultVal<std::unique_ptr<ArchiveBackend>> Open(const Path& path, u64 program_id) override;
-    ResultCode Format(const Path& path, const FileSys::ArchiveFormatInfo& format_info,
-                      u64 program_id) override;
+    Result Format(const Path& path, const FileSys::ArchiveFormatInfo& format_info,
+                  u64 program_id) override;
     ResultVal<ArchiveFormatInfo> GetFormatInfo(const Path& path, u64 program_id) const override;
 
 private:

--- a/src/core/file_sys/archive_source_sd_savedata.cpp
+++ b/src/core/file_sys/archive_source_sd_savedata.cpp
@@ -53,8 +53,8 @@ ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveSource_SDSaveData::Open(u64 pr
     return std::make_unique<SaveDataArchive>(std::move(concrete_mount_point));
 }
 
-ResultCode ArchiveSource_SDSaveData::Format(u64 program_id,
-                                            const FileSys::ArchiveFormatInfo& format_info) {
+Result ArchiveSource_SDSaveData::Format(u64 program_id,
+                                        const FileSys::ArchiveFormatInfo& format_info) {
     std::string concrete_mount_point = GetSaveDataPath(mount_point, program_id);
     FileUtil::DeleteDirRecursively(concrete_mount_point);
     FileUtil::CreateFullPath(concrete_mount_point);

--- a/src/core/file_sys/archive_source_sd_savedata.cpp
+++ b/src/core/file_sys/archive_source_sd_savedata.cpp
@@ -47,7 +47,7 @@ ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveSource_SDSaveData::Open(u64 pr
         // save file/directory structure expected by the game has not yet been initialized.
         // Returning the NotFormatted error code will signal the game to provision the SaveData
         // archive with the files and folders that it expects.
-        return ERR_NOT_FORMATTED;
+        return ResultNotFormatted;
     }
 
     return std::make_unique<SaveDataArchive>(std::move(concrete_mount_point));
@@ -65,9 +65,9 @@ Result ArchiveSource_SDSaveData::Format(u64 program_id,
 
     if (file.IsOpen()) {
         file.WriteBytes(&format_info, sizeof(format_info));
-        return RESULT_SUCCESS;
+        return ResultSuccess;
     }
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 ResultVal<ArchiveFormatInfo> ArchiveSource_SDSaveData::GetFormatInfo(u64 program_id) const {
@@ -77,7 +77,7 @@ ResultVal<ArchiveFormatInfo> ArchiveSource_SDSaveData::GetFormatInfo(u64 program
     if (!file.IsOpen()) {
         LOG_ERROR(Service_FS, "Could not open metadata information for archive");
         // TODO(Subv): Verify error code
-        return ERR_NOT_FORMATTED;
+        return ResultNotFormatted;
     }
 
     ArchiveFormatInfo info = {};

--- a/src/core/file_sys/archive_source_sd_savedata.h
+++ b/src/core/file_sys/archive_source_sd_savedata.h
@@ -19,7 +19,7 @@ public:
     explicit ArchiveSource_SDSaveData(const std::string& mount_point);
 
     ResultVal<std::unique_ptr<ArchiveBackend>> Open(u64 program_id);
-    ResultCode Format(u64 program_id, const FileSys::ArchiveFormatInfo& format_info);
+    Result Format(u64 program_id, const FileSys::ArchiveFormatInfo& format_info);
     ResultVal<ArchiveFormatInfo> GetFormatInfo(u64 program_id) const;
 
     static std::string GetSaveDataPathFor(const std::string& mount_point, u64 program_id);

--- a/src/core/file_sys/archive_systemsavedata.cpp
+++ b/src/core/file_sys/archive_systemsavedata.cpp
@@ -57,7 +57,7 @@ ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_SystemSaveData::Open(c
     std::string fullpath = GetSystemSaveDataPath(base_path, path);
     if (!FileUtil::Exists(fullpath)) {
         // TODO(Subv): Check error code, this one is probably wrong
-        return ERROR_NOT_FOUND;
+        return ResultNotFound;
     }
     return std::make_unique<SaveDataArchive>(fullpath);
 }
@@ -68,14 +68,14 @@ Result ArchiveFactory_SystemSaveData::Format(const Path& path,
     std::string fullpath = GetSystemSaveDataPath(base_path, path);
     FileUtil::DeleteDirRecursively(fullpath);
     FileUtil::CreateFullPath(fullpath);
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 ResultVal<ArchiveFormatInfo> ArchiveFactory_SystemSaveData::GetFormatInfo(const Path& path,
                                                                           u64 program_id) const {
     // TODO(Subv): Implement
     LOG_ERROR(Service_FS, "Unimplemented GetFormatInfo archive {}", GetName());
-    return RESULT_UNKNOWN;
+    return ResultUnknown;
 }
 
 } // namespace FileSys

--- a/src/core/file_sys/archive_systemsavedata.cpp
+++ b/src/core/file_sys/archive_systemsavedata.cpp
@@ -62,9 +62,9 @@ ResultVal<std::unique_ptr<ArchiveBackend>> ArchiveFactory_SystemSaveData::Open(c
     return std::make_unique<SaveDataArchive>(fullpath);
 }
 
-ResultCode ArchiveFactory_SystemSaveData::Format(const Path& path,
-                                                 const FileSys::ArchiveFormatInfo& format_info,
-                                                 u64 program_id) {
+Result ArchiveFactory_SystemSaveData::Format(const Path& path,
+                                             const FileSys::ArchiveFormatInfo& format_info,
+                                             u64 program_id) {
     std::string fullpath = GetSystemSaveDataPath(base_path, path);
     FileUtil::DeleteDirRecursively(fullpath);
     FileUtil::CreateFullPath(fullpath);

--- a/src/core/file_sys/archive_systemsavedata.h
+++ b/src/core/file_sys/archive_systemsavedata.h
@@ -20,8 +20,8 @@ public:
     explicit ArchiveFactory_SystemSaveData(const std::string& mount_point);
 
     ResultVal<std::unique_ptr<ArchiveBackend>> Open(const Path& path, u64 program_id) override;
-    ResultCode Format(const Path& path, const FileSys::ArchiveFormatInfo& format_info,
-                      u64 program_id) override;
+    Result Format(const Path& path, const FileSys::ArchiveFormatInfo& format_info,
+                  u64 program_id) override;
     ResultVal<ArchiveFormatInfo> GetFormatInfo(const Path& path, u64 program_id) const override;
 
     std::string GetName() const override {

--- a/src/core/file_sys/disk_archive.cpp
+++ b/src/core/file_sys/disk_archive.cpp
@@ -19,7 +19,7 @@ namespace FileSys {
 ResultVal<std::size_t> DiskFile::Read(const u64 offset, const std::size_t length,
                                       u8* buffer) const {
     if (!mode.read_flag)
-        return ERROR_INVALID_OPEN_FLAGS;
+        return ResultInvalidOpenFlags;
 
     file->Seek(offset, SEEK_SET);
     return file->ReadBytes(buffer, length);
@@ -28,7 +28,7 @@ ResultVal<std::size_t> DiskFile::Read(const u64 offset, const std::size_t length
 ResultVal<std::size_t> DiskFile::Write(const u64 offset, const std::size_t length, const bool flush,
                                        const u8* buffer) {
     if (!mode.write_flag)
-        return ERROR_INVALID_OPEN_FLAGS;
+        return ResultInvalidOpenFlags;
 
     file->Seek(offset, SEEK_SET);
     std::size_t written = file->WriteBytes(buffer, length);

--- a/src/core/file_sys/errors.h
+++ b/src/core/file_sys/errors.h
@@ -35,63 +35,61 @@ enum {
 };
 }
 
-constexpr ResultCode ERROR_INVALID_PATH(ErrCodes::InvalidPath, ErrorModule::FS,
-                                        ErrorSummary::InvalidArgument, ErrorLevel::Usage);
-constexpr ResultCode ERROR_UNSUPPORTED_OPEN_FLAGS(ErrCodes::UnsupportedOpenFlags, ErrorModule::FS,
-                                                  ErrorSummary::NotSupported, ErrorLevel::Usage);
-constexpr ResultCode ERROR_INVALID_OPEN_FLAGS(ErrCodes::InvalidOpenFlags, ErrorModule::FS,
-                                              ErrorSummary::Canceled, ErrorLevel::Status);
-constexpr ResultCode ERROR_INVALID_READ_FLAG(ErrCodes::InvalidReadFlag, ErrorModule::FS,
-                                             ErrorSummary::InvalidArgument, ErrorLevel::Usage);
-constexpr ResultCode ERROR_FILE_NOT_FOUND(ErrCodes::FileNotFound, ErrorModule::FS,
-                                          ErrorSummary::NotFound, ErrorLevel::Status);
-constexpr ResultCode ERROR_PATH_NOT_FOUND(ErrCodes::PathNotFound, ErrorModule::FS,
-                                          ErrorSummary::NotFound, ErrorLevel::Status);
-constexpr ResultCode ERROR_NOT_FOUND(ErrCodes::NotFound, ErrorModule::FS, ErrorSummary::NotFound,
-                                     ErrorLevel::Status);
-constexpr ResultCode ERROR_UNEXPECTED_FILE_OR_DIRECTORY(ErrCodes::UnexpectedFileOrDirectory,
-                                                        ErrorModule::FS, ErrorSummary::NotSupported,
-                                                        ErrorLevel::Usage);
-constexpr ResultCode ERROR_UNEXPECTED_FILE_OR_DIRECTORY_SDMC(ErrCodes::NotAFile, ErrorModule::FS,
-                                                             ErrorSummary::Canceled,
-                                                             ErrorLevel::Status);
-constexpr ResultCode ERROR_DIRECTORY_ALREADY_EXISTS(ErrCodes::DirectoryAlreadyExists,
-                                                    ErrorModule::FS, ErrorSummary::NothingHappened,
-                                                    ErrorLevel::Status);
-constexpr ResultCode ERROR_FILE_ALREADY_EXISTS(ErrCodes::FileAlreadyExists, ErrorModule::FS,
-                                               ErrorSummary::NothingHappened, ErrorLevel::Status);
-constexpr ResultCode ERROR_ALREADY_EXISTS(ErrCodes::AlreadyExists, ErrorModule::FS,
-                                          ErrorSummary::NothingHappened, ErrorLevel::Status);
-constexpr ResultCode ERROR_DIRECTORY_NOT_EMPTY(ErrCodes::DirectoryNotEmpty, ErrorModule::FS,
-                                               ErrorSummary::Canceled, ErrorLevel::Status);
-constexpr ResultCode ERROR_GAMECARD_NOT_INSERTED(ErrCodes::GameCardNotInserted, ErrorModule::FS,
-                                                 ErrorSummary::NotFound, ErrorLevel::Status);
-constexpr ResultCode ERROR_INCORRECT_EXEFS_READ_SIZE(ErrCodes::IncorrectExeFSReadSize,
-                                                     ErrorModule::FS, ErrorSummary::NotSupported,
-                                                     ErrorLevel::Usage);
-constexpr ResultCode ERROR_ROMFS_NOT_FOUND(ErrCodes::RomFSNotFound, ErrorModule::FS,
-                                           ErrorSummary::NotFound, ErrorLevel::Status);
-constexpr ResultCode ERROR_COMMAND_NOT_ALLOWED(ErrCodes::CommandNotAllowed, ErrorModule::FS,
-                                               ErrorSummary::WrongArgument, ErrorLevel::Permanent);
-constexpr ResultCode ERROR_EXEFS_SECTION_NOT_FOUND(ErrCodes::ExeFSSectionNotFound, ErrorModule::FS,
-                                                   ErrorSummary::NotFound, ErrorLevel::Status);
-constexpr ResultCode ERROR_INSUFFICIENT_SPACE(ErrCodes::InsufficientSpace, ErrorModule::FS,
-                                              ErrorSummary::OutOfResource, ErrorLevel::Status);
+constexpr Result ERROR_INVALID_PATH(ErrCodes::InvalidPath, ErrorModule::FS,
+                                    ErrorSummary::InvalidArgument, ErrorLevel::Usage);
+constexpr Result ERROR_UNSUPPORTED_OPEN_FLAGS(ErrCodes::UnsupportedOpenFlags, ErrorModule::FS,
+                                              ErrorSummary::NotSupported, ErrorLevel::Usage);
+constexpr Result ERROR_INVALID_OPEN_FLAGS(ErrCodes::InvalidOpenFlags, ErrorModule::FS,
+                                          ErrorSummary::Canceled, ErrorLevel::Status);
+constexpr Result ERROR_INVALID_READ_FLAG(ErrCodes::InvalidReadFlag, ErrorModule::FS,
+                                         ErrorSummary::InvalidArgument, ErrorLevel::Usage);
+constexpr Result ERROR_FILE_NOT_FOUND(ErrCodes::FileNotFound, ErrorModule::FS,
+                                      ErrorSummary::NotFound, ErrorLevel::Status);
+constexpr Result ERROR_PATH_NOT_FOUND(ErrCodes::PathNotFound, ErrorModule::FS,
+                                      ErrorSummary::NotFound, ErrorLevel::Status);
+constexpr Result ERROR_NOT_FOUND(ErrCodes::NotFound, ErrorModule::FS, ErrorSummary::NotFound,
+                                 ErrorLevel::Status);
+constexpr Result ERROR_UNEXPECTED_FILE_OR_DIRECTORY(ErrCodes::UnexpectedFileOrDirectory,
+                                                    ErrorModule::FS, ErrorSummary::NotSupported,
+                                                    ErrorLevel::Usage);
+constexpr Result ERROR_UNEXPECTED_FILE_OR_DIRECTORY_SDMC(ErrCodes::NotAFile, ErrorModule::FS,
+                                                         ErrorSummary::Canceled,
+                                                         ErrorLevel::Status);
+constexpr Result ERROR_DIRECTORY_ALREADY_EXISTS(ErrCodes::DirectoryAlreadyExists, ErrorModule::FS,
+                                                ErrorSummary::NothingHappened, ErrorLevel::Status);
+constexpr Result ERROR_FILE_ALREADY_EXISTS(ErrCodes::FileAlreadyExists, ErrorModule::FS,
+                                           ErrorSummary::NothingHappened, ErrorLevel::Status);
+constexpr Result ERROR_ALREADY_EXISTS(ErrCodes::AlreadyExists, ErrorModule::FS,
+                                      ErrorSummary::NothingHappened, ErrorLevel::Status);
+constexpr Result ERROR_DIRECTORY_NOT_EMPTY(ErrCodes::DirectoryNotEmpty, ErrorModule::FS,
+                                           ErrorSummary::Canceled, ErrorLevel::Status);
+constexpr Result ERROR_GAMECARD_NOT_INSERTED(ErrCodes::GameCardNotInserted, ErrorModule::FS,
+                                             ErrorSummary::NotFound, ErrorLevel::Status);
+constexpr Result ERROR_INCORRECT_EXEFS_READ_SIZE(ErrCodes::IncorrectExeFSReadSize, ErrorModule::FS,
+                                                 ErrorSummary::NotSupported, ErrorLevel::Usage);
+constexpr Result ERROR_ROMFS_NOT_FOUND(ErrCodes::RomFSNotFound, ErrorModule::FS,
+                                       ErrorSummary::NotFound, ErrorLevel::Status);
+constexpr Result ERROR_COMMAND_NOT_ALLOWED(ErrCodes::CommandNotAllowed, ErrorModule::FS,
+                                           ErrorSummary::WrongArgument, ErrorLevel::Permanent);
+constexpr Result ERROR_EXEFS_SECTION_NOT_FOUND(ErrCodes::ExeFSSectionNotFound, ErrorModule::FS,
+                                               ErrorSummary::NotFound, ErrorLevel::Status);
+constexpr Result ERROR_INSUFFICIENT_SPACE(ErrCodes::InsufficientSpace, ErrorModule::FS,
+                                          ErrorSummary::OutOfResource, ErrorLevel::Status);
 
 /// Returned when a function is passed an invalid archive handle.
-constexpr ResultCode ERR_INVALID_ARCHIVE_HANDLE(ErrCodes::ArchiveNotMounted, ErrorModule::FS,
-                                                ErrorSummary::NotFound,
-                                                ErrorLevel::Status); // 0xC8804465
-constexpr ResultCode ERR_WRITE_BEYOND_END(ErrCodes::WriteBeyondEnd, ErrorModule::FS,
-                                          ErrorSummary::InvalidArgument, ErrorLevel::Usage);
+constexpr Result ERR_INVALID_ARCHIVE_HANDLE(ErrCodes::ArchiveNotMounted, ErrorModule::FS,
+                                            ErrorSummary::NotFound,
+                                            ErrorLevel::Status); // 0xC8804465
+constexpr Result ERR_WRITE_BEYOND_END(ErrCodes::WriteBeyondEnd, ErrorModule::FS,
+                                      ErrorSummary::InvalidArgument, ErrorLevel::Usage);
 
 /**
  * Variant of ERROR_NOT_FOUND returned in some places in the code. Unknown if these usages are
  * correct or a bug.
  */
-constexpr ResultCode ERR_NOT_FOUND_INVALID_STATE(ErrCodes::NotFound, ErrorModule::FS,
-                                                 ErrorSummary::InvalidState, ErrorLevel::Status);
-constexpr ResultCode ERR_NOT_FORMATTED(ErrCodes::NotFormatted, ErrorModule::FS,
-                                       ErrorSummary::InvalidState, ErrorLevel::Status);
+constexpr Result ERR_NOT_FOUND_INVALID_STATE(ErrCodes::NotFound, ErrorModule::FS,
+                                             ErrorSummary::InvalidState, ErrorLevel::Status);
+constexpr Result ERR_NOT_FORMATTED(ErrCodes::NotFormatted, ErrorModule::FS,
+                                   ErrorSummary::InvalidState, ErrorLevel::Status);
 
 } // namespace FileSys

--- a/src/core/file_sys/errors.h
+++ b/src/core/file_sys/errors.h
@@ -35,61 +35,60 @@ enum {
 };
 }
 
-constexpr Result ERROR_INVALID_PATH(ErrCodes::InvalidPath, ErrorModule::FS,
-                                    ErrorSummary::InvalidArgument, ErrorLevel::Usage);
-constexpr Result ERROR_UNSUPPORTED_OPEN_FLAGS(ErrCodes::UnsupportedOpenFlags, ErrorModule::FS,
+constexpr Result ResultInvalidPath(ErrCodes::InvalidPath, ErrorModule::FS,
+                                   ErrorSummary::InvalidArgument, ErrorLevel::Usage);
+constexpr Result ResultUnsupportedOpenFlags(ErrCodes::UnsupportedOpenFlags, ErrorModule::FS,
+                                            ErrorSummary::NotSupported, ErrorLevel::Usage);
+constexpr Result ResultInvalidOpenFlags(ErrCodes::InvalidOpenFlags, ErrorModule::FS,
+                                        ErrorSummary::Canceled, ErrorLevel::Status);
+constexpr Result ResultInvalidReadFlag(ErrCodes::InvalidReadFlag, ErrorModule::FS,
+                                       ErrorSummary::InvalidArgument, ErrorLevel::Usage);
+constexpr Result ResultFileNotFound(ErrCodes::FileNotFound, ErrorModule::FS, ErrorSummary::NotFound,
+                                    ErrorLevel::Status);
+constexpr Result ResultPathNotFound(ErrCodes::PathNotFound, ErrorModule::FS, ErrorSummary::NotFound,
+                                    ErrorLevel::Status);
+constexpr Result ResultNotFound(ErrCodes::NotFound, ErrorModule::FS, ErrorSummary::NotFound,
+                                ErrorLevel::Status);
+constexpr Result ResultUnexpectedFileOrDirectory(ErrCodes::UnexpectedFileOrDirectory,
+                                                 ErrorModule::FS, ErrorSummary::NotSupported,
+                                                 ErrorLevel::Usage);
+constexpr Result ResultUnexpectedFileOrDirectorySdmc(ErrCodes::NotAFile, ErrorModule::FS,
+                                                     ErrorSummary::Canceled, ErrorLevel::Status);
+constexpr Result ResultDirectoryAlreadyExists(ErrCodes::DirectoryAlreadyExists, ErrorModule::FS,
+                                              ErrorSummary::NothingHappened, ErrorLevel::Status);
+constexpr Result ResultFileAlreadyExists(ErrCodes::FileAlreadyExists, ErrorModule::FS,
+                                         ErrorSummary::NothingHappened, ErrorLevel::Status);
+constexpr Result ResultAlreadyExists(ErrCodes::AlreadyExists, ErrorModule::FS,
+                                     ErrorSummary::NothingHappened, ErrorLevel::Status);
+constexpr Result ResultDirectoryNotEmpty(ErrCodes::DirectoryNotEmpty, ErrorModule::FS,
+                                         ErrorSummary::Canceled, ErrorLevel::Status);
+constexpr Result ResultGamecardNotInserted(ErrCodes::GameCardNotInserted, ErrorModule::FS,
+                                           ErrorSummary::NotFound, ErrorLevel::Status);
+constexpr Result ResultIncorrectExefsReadSize(ErrCodes::IncorrectExeFSReadSize, ErrorModule::FS,
                                               ErrorSummary::NotSupported, ErrorLevel::Usage);
-constexpr Result ERROR_INVALID_OPEN_FLAGS(ErrCodes::InvalidOpenFlags, ErrorModule::FS,
-                                          ErrorSummary::Canceled, ErrorLevel::Status);
-constexpr Result ERROR_INVALID_READ_FLAG(ErrCodes::InvalidReadFlag, ErrorModule::FS,
-                                         ErrorSummary::InvalidArgument, ErrorLevel::Usage);
-constexpr Result ERROR_FILE_NOT_FOUND(ErrCodes::FileNotFound, ErrorModule::FS,
-                                      ErrorSummary::NotFound, ErrorLevel::Status);
-constexpr Result ERROR_PATH_NOT_FOUND(ErrCodes::PathNotFound, ErrorModule::FS,
-                                      ErrorSummary::NotFound, ErrorLevel::Status);
-constexpr Result ERROR_NOT_FOUND(ErrCodes::NotFound, ErrorModule::FS, ErrorSummary::NotFound,
-                                 ErrorLevel::Status);
-constexpr Result ERROR_UNEXPECTED_FILE_OR_DIRECTORY(ErrCodes::UnexpectedFileOrDirectory,
-                                                    ErrorModule::FS, ErrorSummary::NotSupported,
-                                                    ErrorLevel::Usage);
-constexpr Result ERROR_UNEXPECTED_FILE_OR_DIRECTORY_SDMC(ErrCodes::NotAFile, ErrorModule::FS,
-                                                         ErrorSummary::Canceled,
-                                                         ErrorLevel::Status);
-constexpr Result ERROR_DIRECTORY_ALREADY_EXISTS(ErrCodes::DirectoryAlreadyExists, ErrorModule::FS,
-                                                ErrorSummary::NothingHappened, ErrorLevel::Status);
-constexpr Result ERROR_FILE_ALREADY_EXISTS(ErrCodes::FileAlreadyExists, ErrorModule::FS,
-                                           ErrorSummary::NothingHappened, ErrorLevel::Status);
-constexpr Result ERROR_ALREADY_EXISTS(ErrCodes::AlreadyExists, ErrorModule::FS,
-                                      ErrorSummary::NothingHappened, ErrorLevel::Status);
-constexpr Result ERROR_DIRECTORY_NOT_EMPTY(ErrCodes::DirectoryNotEmpty, ErrorModule::FS,
-                                           ErrorSummary::Canceled, ErrorLevel::Status);
-constexpr Result ERROR_GAMECARD_NOT_INSERTED(ErrCodes::GameCardNotInserted, ErrorModule::FS,
-                                             ErrorSummary::NotFound, ErrorLevel::Status);
-constexpr Result ERROR_INCORRECT_EXEFS_READ_SIZE(ErrCodes::IncorrectExeFSReadSize, ErrorModule::FS,
-                                                 ErrorSummary::NotSupported, ErrorLevel::Usage);
-constexpr Result ERROR_ROMFS_NOT_FOUND(ErrCodes::RomFSNotFound, ErrorModule::FS,
-                                       ErrorSummary::NotFound, ErrorLevel::Status);
-constexpr Result ERROR_COMMAND_NOT_ALLOWED(ErrCodes::CommandNotAllowed, ErrorModule::FS,
-                                           ErrorSummary::WrongArgument, ErrorLevel::Permanent);
-constexpr Result ERROR_EXEFS_SECTION_NOT_FOUND(ErrCodes::ExeFSSectionNotFound, ErrorModule::FS,
-                                               ErrorSummary::NotFound, ErrorLevel::Status);
-constexpr Result ERROR_INSUFFICIENT_SPACE(ErrCodes::InsufficientSpace, ErrorModule::FS,
-                                          ErrorSummary::OutOfResource, ErrorLevel::Status);
+constexpr Result ResultRomfsNotFound(ErrCodes::RomFSNotFound, ErrorModule::FS,
+                                     ErrorSummary::NotFound, ErrorLevel::Status);
+constexpr Result ResultCommandNotAllowed(ErrCodes::CommandNotAllowed, ErrorModule::FS,
+                                         ErrorSummary::WrongArgument, ErrorLevel::Permanent);
+constexpr Result ResultExefsSectionNotFound(ErrCodes::ExeFSSectionNotFound, ErrorModule::FS,
+                                            ErrorSummary::NotFound, ErrorLevel::Status);
+constexpr Result ResultInsufficientSpace(ErrCodes::InsufficientSpace, ErrorModule::FS,
+                                         ErrorSummary::OutOfResource, ErrorLevel::Status);
 
 /// Returned when a function is passed an invalid archive handle.
-constexpr Result ERR_INVALID_ARCHIVE_HANDLE(ErrCodes::ArchiveNotMounted, ErrorModule::FS,
+constexpr Result ResultInvalidArchiveHandle(ErrCodes::ArchiveNotMounted, ErrorModule::FS,
                                             ErrorSummary::NotFound,
                                             ErrorLevel::Status); // 0xC8804465
-constexpr Result ERR_WRITE_BEYOND_END(ErrCodes::WriteBeyondEnd, ErrorModule::FS,
+constexpr Result ResultWriteBeyondEnd(ErrCodes::WriteBeyondEnd, ErrorModule::FS,
                                       ErrorSummary::InvalidArgument, ErrorLevel::Usage);
 
 /**
- * Variant of ERROR_NOT_FOUND returned in some places in the code. Unknown if these usages are
+ * Variant of ResultNotFound returned in some places in the code. Unknown if these usages are
  * correct or a bug.
  */
-constexpr Result ERR_NOT_FOUND_INVALID_STATE(ErrCodes::NotFound, ErrorModule::FS,
-                                             ErrorSummary::InvalidState, ErrorLevel::Status);
-constexpr Result ERR_NOT_FORMATTED(ErrCodes::NotFormatted, ErrorModule::FS,
-                                   ErrorSummary::InvalidState, ErrorLevel::Status);
+constexpr Result ResultNotFoundInvalidState(ErrCodes::NotFound, ErrorModule::FS,
+                                            ErrorSummary::InvalidState, ErrorLevel::Status);
+constexpr Result ResultNotFormatted(ErrCodes::NotFormatted, ErrorModule::FS,
+                                    ErrorSummary::InvalidState, ErrorLevel::Status);
 
 } // namespace FileSys

--- a/src/core/file_sys/ivfc_archive.cpp
+++ b/src/core/file_sys/ivfc_archive.cpp
@@ -44,21 +44,21 @@ Result IVFCArchive::DeleteFile(const Path& path) const {
 Result IVFCArchive::RenameFile(const Path& src_path, const Path& dest_path) const {
     LOG_CRITICAL(Service_FS, "Attempted to rename a file within an IVFC archive ({}).", GetName());
     // TODO(wwylele): Use correct error code
-    return RESULT_UNKNOWN;
+    return ResultUnknown;
 }
 
 Result IVFCArchive::DeleteDirectory(const Path& path) const {
     LOG_CRITICAL(Service_FS, "Attempted to delete a directory from an IVFC archive ({}).",
                  GetName());
     // TODO(wwylele): Use correct error code
-    return RESULT_UNKNOWN;
+    return ResultUnknown;
 }
 
 Result IVFCArchive::DeleteDirectoryRecursively(const Path& path) const {
     LOG_CRITICAL(Service_FS, "Attempted to delete a directory from an IVFC archive ({}).",
                  GetName());
     // TODO(wwylele): Use correct error code
-    return RESULT_UNKNOWN;
+    return ResultUnknown;
 }
 
 Result IVFCArchive::CreateFile(const Path& path, u64 size) const {
@@ -71,13 +71,13 @@ Result IVFCArchive::CreateFile(const Path& path, u64 size) const {
 Result IVFCArchive::CreateDirectory(const Path& path) const {
     LOG_CRITICAL(Service_FS, "Attempted to create a directory in an IVFC archive ({}).", GetName());
     // TODO(wwylele): Use correct error code
-    return RESULT_UNKNOWN;
+    return ResultUnknown;
 }
 
 Result IVFCArchive::RenameDirectory(const Path& src_path, const Path& dest_path) const {
     LOG_CRITICAL(Service_FS, "Attempted to rename a file within an IVFC archive ({}).", GetName());
     // TODO(wwylele): Use correct error code
-    return RESULT_UNKNOWN;
+    return ResultUnknown;
 }
 
 ResultVal<std::unique_ptr<DirectoryBackend>> IVFCArchive::OpenDirectory(const Path& path) const {

--- a/src/core/file_sys/ivfc_archive.cpp
+++ b/src/core/file_sys/ivfc_archive.cpp
@@ -34,47 +34,47 @@ ResultVal<std::unique_ptr<FileBackend>> IVFCArchive::OpenFile(const Path& path,
     return std::make_unique<IVFCFile>(romfs_file, std::move(delay_generator));
 }
 
-ResultCode IVFCArchive::DeleteFile(const Path& path) const {
+Result IVFCArchive::DeleteFile(const Path& path) const {
     LOG_CRITICAL(Service_FS, "Attempted to delete a file from an IVFC archive ({}).", GetName());
     // TODO(Subv): Verify error code
-    return ResultCode(ErrorDescription::NoData, ErrorModule::FS, ErrorSummary::Canceled,
-                      ErrorLevel::Status);
+    return Result(ErrorDescription::NoData, ErrorModule::FS, ErrorSummary::Canceled,
+                  ErrorLevel::Status);
 }
 
-ResultCode IVFCArchive::RenameFile(const Path& src_path, const Path& dest_path) const {
+Result IVFCArchive::RenameFile(const Path& src_path, const Path& dest_path) const {
     LOG_CRITICAL(Service_FS, "Attempted to rename a file within an IVFC archive ({}).", GetName());
     // TODO(wwylele): Use correct error code
     return RESULT_UNKNOWN;
 }
 
-ResultCode IVFCArchive::DeleteDirectory(const Path& path) const {
+Result IVFCArchive::DeleteDirectory(const Path& path) const {
     LOG_CRITICAL(Service_FS, "Attempted to delete a directory from an IVFC archive ({}).",
                  GetName());
     // TODO(wwylele): Use correct error code
     return RESULT_UNKNOWN;
 }
 
-ResultCode IVFCArchive::DeleteDirectoryRecursively(const Path& path) const {
+Result IVFCArchive::DeleteDirectoryRecursively(const Path& path) const {
     LOG_CRITICAL(Service_FS, "Attempted to delete a directory from an IVFC archive ({}).",
                  GetName());
     // TODO(wwylele): Use correct error code
     return RESULT_UNKNOWN;
 }
 
-ResultCode IVFCArchive::CreateFile(const Path& path, u64 size) const {
+Result IVFCArchive::CreateFile(const Path& path, u64 size) const {
     LOG_CRITICAL(Service_FS, "Attempted to create a file in an IVFC archive ({}).", GetName());
     // TODO: Verify error code
-    return ResultCode(ErrorDescription::NotAuthorized, ErrorModule::FS, ErrorSummary::NotSupported,
-                      ErrorLevel::Permanent);
+    return Result(ErrorDescription::NotAuthorized, ErrorModule::FS, ErrorSummary::NotSupported,
+                  ErrorLevel::Permanent);
 }
 
-ResultCode IVFCArchive::CreateDirectory(const Path& path) const {
+Result IVFCArchive::CreateDirectory(const Path& path) const {
     LOG_CRITICAL(Service_FS, "Attempted to create a directory in an IVFC archive ({}).", GetName());
     // TODO(wwylele): Use correct error code
     return RESULT_UNKNOWN;
 }
 
-ResultCode IVFCArchive::RenameDirectory(const Path& src_path, const Path& dest_path) const {
+Result IVFCArchive::RenameDirectory(const Path& src_path, const Path& dest_path) const {
     LOG_CRITICAL(Service_FS, "Attempted to rename a file within an IVFC archive ({}).", GetName());
     // TODO(wwylele): Use correct error code
     return RESULT_UNKNOWN;

--- a/src/core/file_sys/ivfc_archive.h
+++ b/src/core/file_sys/ivfc_archive.h
@@ -103,13 +103,13 @@ public:
 
     ResultVal<std::unique_ptr<FileBackend>> OpenFile(const Path& path,
                                                      const Mode& mode) const override;
-    ResultCode DeleteFile(const Path& path) const override;
-    ResultCode RenameFile(const Path& src_path, const Path& dest_path) const override;
-    ResultCode DeleteDirectory(const Path& path) const override;
-    ResultCode DeleteDirectoryRecursively(const Path& path) const override;
-    ResultCode CreateFile(const Path& path, u64 size) const override;
-    ResultCode CreateDirectory(const Path& path) const override;
-    ResultCode RenameDirectory(const Path& src_path, const Path& dest_path) const override;
+    Result DeleteFile(const Path& path) const override;
+    Result RenameFile(const Path& src_path, const Path& dest_path) const override;
+    Result DeleteDirectory(const Path& path) const override;
+    Result DeleteDirectoryRecursively(const Path& path) const override;
+    Result CreateFile(const Path& path, u64 size) const override;
+    Result CreateDirectory(const Path& path) const override;
+    Result RenameDirectory(const Path& src_path, const Path& dest_path) const override;
     ResultVal<std::unique_ptr<DirectoryBackend>> OpenDirectory(const Path& path) const override;
     u64 GetFreeBytes() const override;
 

--- a/src/core/file_sys/savedata_archive.cpp
+++ b/src/core/file_sys/savedata_archive.cpp
@@ -43,17 +43,17 @@ ResultVal<std::unique_ptr<FileBackend>> SaveDataArchive::OpenFile(const Path& pa
 
     if (!path_parser.IsValid()) {
         LOG_ERROR(Service_FS, "Invalid path {}", path.DebugStr());
-        return ERROR_INVALID_PATH;
+        return ResultInvalidPath;
     }
 
     if (mode.hex == 0) {
         LOG_ERROR(Service_FS, "Empty open mode");
-        return ERROR_UNSUPPORTED_OPEN_FLAGS;
+        return ResultUnsupportedOpenFlags;
     }
 
     if (mode.create_flag && !mode.write_flag) {
         LOG_ERROR(Service_FS, "Create flag set but write flag not set");
-        return ERROR_UNSUPPORTED_OPEN_FLAGS;
+        return ResultUnsupportedOpenFlags;
     }
 
     const auto full_path = path_parser.BuildHostPath(mount_point);
@@ -61,19 +61,19 @@ ResultVal<std::unique_ptr<FileBackend>> SaveDataArchive::OpenFile(const Path& pa
     switch (path_parser.GetHostStatus(mount_point)) {
     case PathParser::InvalidMountPoint:
         LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}", mount_point);
-        return ERROR_FILE_NOT_FOUND;
+        return ResultFileNotFound;
     case PathParser::PathNotFound:
         LOG_ERROR(Service_FS, "Path not found {}", full_path);
-        return ERROR_PATH_NOT_FOUND;
+        return ResultPathNotFound;
     case PathParser::FileInPath:
     case PathParser::DirectoryFound:
         LOG_ERROR(Service_FS, "Unexpected file or directory in {}", full_path);
-        return ERROR_UNEXPECTED_FILE_OR_DIRECTORY;
+        return ResultUnexpectedFileOrDirectory;
     case PathParser::NotFound:
         if (!mode.create_flag) {
             LOG_ERROR(Service_FS, "Non-existing file {} can't be open without mode create.",
                       full_path);
-            return ERROR_FILE_NOT_FOUND;
+            return ResultFileNotFound;
         } else {
             // Create the file
             FileUtil::CreateEmptyFile(full_path);
@@ -86,7 +86,7 @@ ResultVal<std::unique_ptr<FileBackend>> SaveDataArchive::OpenFile(const Path& pa
     FileUtil::IOFile file(full_path, mode.write_flag ? "r+b" : "rb");
     if (!file.IsOpen()) {
         LOG_CRITICAL(Service_FS, "(unreachable) Unknown error opening {}", full_path);
-        return ERROR_FILE_NOT_FOUND;
+        return ResultFileNotFound;
     }
 
     std::unique_ptr<DelayGenerator> delay_generator = std::make_unique<SaveDataDelayGenerator>();
@@ -98,7 +98,7 @@ Result SaveDataArchive::DeleteFile(const Path& path) const {
 
     if (!path_parser.IsValid()) {
         LOG_ERROR(Service_FS, "Invalid path {}", path.DebugStr());
-        return ERROR_INVALID_PATH;
+        return ResultInvalidPath;
     }
 
     const auto full_path = path_parser.BuildHostPath(mount_point);
@@ -106,25 +106,25 @@ Result SaveDataArchive::DeleteFile(const Path& path) const {
     switch (path_parser.GetHostStatus(mount_point)) {
     case PathParser::InvalidMountPoint:
         LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}", mount_point);
-        return ERROR_FILE_NOT_FOUND;
+        return ResultFileNotFound;
     case PathParser::PathNotFound:
         LOG_ERROR(Service_FS, "Path not found {}", full_path);
-        return ERROR_PATH_NOT_FOUND;
+        return ResultPathNotFound;
     case PathParser::FileInPath:
     case PathParser::DirectoryFound:
     case PathParser::NotFound:
         LOG_ERROR(Service_FS, "File not found {}", full_path);
-        return ERROR_FILE_NOT_FOUND;
+        return ResultFileNotFound;
     case PathParser::FileFound:
         break; // Expected 'success' case
     }
 
     if (FileUtil::Delete(full_path)) {
-        return RESULT_SUCCESS;
+        return ResultSuccess;
     }
 
     LOG_CRITICAL(Service_FS, "(unreachable) Unknown error deleting {}", full_path);
-    return ERROR_FILE_NOT_FOUND;
+    return ResultFileNotFound;
 }
 
 Result SaveDataArchive::RenameFile(const Path& src_path, const Path& dest_path) const {
@@ -133,21 +133,21 @@ Result SaveDataArchive::RenameFile(const Path& src_path, const Path& dest_path) 
     // TODO: Verify these return codes with HW
     if (!path_parser_src.IsValid()) {
         LOG_ERROR(Service_FS, "Invalid src path {}", src_path.DebugStr());
-        return ERROR_INVALID_PATH;
+        return ResultInvalidPath;
     }
 
     const PathParser path_parser_dest(dest_path);
 
     if (!path_parser_dest.IsValid()) {
         LOG_ERROR(Service_FS, "Invalid dest path {}", dest_path.DebugStr());
-        return ERROR_INVALID_PATH;
+        return ResultInvalidPath;
     }
 
     const auto src_path_full = path_parser_src.BuildHostPath(mount_point);
     const auto dest_path_full = path_parser_dest.BuildHostPath(mount_point);
 
     if (FileUtil::Rename(src_path_full, dest_path_full)) {
-        return RESULT_SUCCESS;
+        return ResultSuccess;
     }
 
     // TODO(yuriks): This code probably isn't right, it'll return a Status even if the file didn't
@@ -162,36 +162,36 @@ static Result DeleteDirectoryHelper(const Path& path, const std::string& mount_p
 
     if (!path_parser.IsValid()) {
         LOG_ERROR(Service_FS, "Invalid path {}", path.DebugStr());
-        return ERROR_INVALID_PATH;
+        return ResultInvalidPath;
     }
 
     if (path_parser.IsRootDirectory())
-        return ERROR_DIRECTORY_NOT_EMPTY;
+        return ResultDirectoryNotEmpty;
 
     const auto full_path = path_parser.BuildHostPath(mount_point);
 
     switch (path_parser.GetHostStatus(mount_point)) {
     case PathParser::InvalidMountPoint:
         LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}", mount_point);
-        return ERROR_PATH_NOT_FOUND;
+        return ResultPathNotFound;
     case PathParser::PathNotFound:
     case PathParser::NotFound:
         LOG_ERROR(Service_FS, "Path not found {}", full_path);
-        return ERROR_PATH_NOT_FOUND;
+        return ResultPathNotFound;
     case PathParser::FileInPath:
     case PathParser::FileFound:
         LOG_ERROR(Service_FS, "Unexpected file or directory {}", full_path);
-        return ERROR_UNEXPECTED_FILE_OR_DIRECTORY;
+        return ResultUnexpectedFileOrDirectory;
     case PathParser::DirectoryFound:
         break; // Expected 'success' case
     }
 
     if (deleter(full_path)) {
-        return RESULT_SUCCESS;
+        return ResultSuccess;
     }
 
     LOG_ERROR(Service_FS, "Directory not empty {}", full_path);
-    return ERROR_DIRECTORY_NOT_EMPTY;
+    return ResultDirectoryNotEmpty;
 }
 
 Result SaveDataArchive::DeleteDirectory(const Path& path) const {
@@ -208,7 +208,7 @@ Result SaveDataArchive::CreateFile(const FileSys::Path& path, u64 size) const {
 
     if (!path_parser.IsValid()) {
         LOG_ERROR(Service_FS, "Invalid path {}", path.DebugStr());
-        return ERROR_INVALID_PATH;
+        return ResultInvalidPath;
     }
 
     const auto full_path = path_parser.BuildHostPath(mount_point);
@@ -216,31 +216,31 @@ Result SaveDataArchive::CreateFile(const FileSys::Path& path, u64 size) const {
     switch (path_parser.GetHostStatus(mount_point)) {
     case PathParser::InvalidMountPoint:
         LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}", mount_point);
-        return ERROR_FILE_NOT_FOUND;
+        return ResultFileNotFound;
     case PathParser::PathNotFound:
         LOG_ERROR(Service_FS, "Path not found {}", full_path);
-        return ERROR_PATH_NOT_FOUND;
+        return ResultPathNotFound;
     case PathParser::FileInPath:
         LOG_ERROR(Service_FS, "Unexpected file in path {}", full_path);
-        return ERROR_UNEXPECTED_FILE_OR_DIRECTORY;
+        return ResultUnexpectedFileOrDirectory;
     case PathParser::DirectoryFound:
     case PathParser::FileFound:
         LOG_ERROR(Service_FS, "{} already exists", full_path);
-        return ERROR_FILE_ALREADY_EXISTS;
+        return ResultFileAlreadyExists;
     case PathParser::NotFound:
         break; // Expected 'success' case
     }
 
     if (size == 0) {
         FileUtil::CreateEmptyFile(full_path);
-        return RESULT_SUCCESS;
+        return ResultSuccess;
     }
 
     FileUtil::IOFile file(full_path, "wb");
     // Creates a sparse file (or a normal file on filesystems without the concept of sparse files)
     // We do this by seeking to the right size, then writing a single null byte.
     if (file.Seek(size - 1, SEEK_SET) && file.WriteBytes("", 1) == 1) {
-        return RESULT_SUCCESS;
+        return ResultSuccess;
     }
 
     LOG_ERROR(Service_FS, "Too large file");
@@ -253,7 +253,7 @@ Result SaveDataArchive::CreateDirectory(const Path& path) const {
 
     if (!path_parser.IsValid()) {
         LOG_ERROR(Service_FS, "Invalid path {}", path.DebugStr());
-        return ERROR_INVALID_PATH;
+        return ResultInvalidPath;
     }
 
     const auto full_path = path_parser.BuildHostPath(mount_point);
@@ -261,23 +261,23 @@ Result SaveDataArchive::CreateDirectory(const Path& path) const {
     switch (path_parser.GetHostStatus(mount_point)) {
     case PathParser::InvalidMountPoint:
         LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}", mount_point);
-        return ERROR_FILE_NOT_FOUND;
+        return ResultFileNotFound;
     case PathParser::PathNotFound:
         LOG_ERROR(Service_FS, "Path not found {}", full_path);
-        return ERROR_PATH_NOT_FOUND;
+        return ResultPathNotFound;
     case PathParser::FileInPath:
         LOG_ERROR(Service_FS, "Unexpected file in path {}", full_path);
-        return ERROR_UNEXPECTED_FILE_OR_DIRECTORY;
+        return ResultUnexpectedFileOrDirectory;
     case PathParser::DirectoryFound:
     case PathParser::FileFound:
         LOG_ERROR(Service_FS, "{} already exists", full_path);
-        return ERROR_DIRECTORY_ALREADY_EXISTS;
+        return ResultDirectoryAlreadyExists;
     case PathParser::NotFound:
         break; // Expected 'success' case
     }
 
     if (FileUtil::CreateDir(mount_point + path.AsString())) {
-        return RESULT_SUCCESS;
+        return ResultSuccess;
     }
 
     LOG_CRITICAL(Service_FS, "(unreachable) Unknown error creating {}", mount_point);
@@ -291,21 +291,21 @@ Result SaveDataArchive::RenameDirectory(const Path& src_path, const Path& dest_p
     // TODO: Verify these return codes with HW
     if (!path_parser_src.IsValid()) {
         LOG_ERROR(Service_FS, "Invalid src path {}", src_path.DebugStr());
-        return ERROR_INVALID_PATH;
+        return ResultInvalidPath;
     }
 
     const PathParser path_parser_dest(dest_path);
 
     if (!path_parser_dest.IsValid()) {
         LOG_ERROR(Service_FS, "Invalid dest path {}", dest_path.DebugStr());
-        return ERROR_INVALID_PATH;
+        return ResultInvalidPath;
     }
 
     const auto src_path_full = path_parser_src.BuildHostPath(mount_point);
     const auto dest_path_full = path_parser_dest.BuildHostPath(mount_point);
 
     if (FileUtil::Rename(src_path_full, dest_path_full)) {
-        return RESULT_SUCCESS;
+        return ResultSuccess;
     }
 
     // TODO(yuriks): This code probably isn't right, it'll return a Status even if the file didn't
@@ -320,7 +320,7 @@ ResultVal<std::unique_ptr<DirectoryBackend>> SaveDataArchive::OpenDirectory(
 
     if (!path_parser.IsValid()) {
         LOG_ERROR(Service_FS, "Invalid path {}", path.DebugStr());
-        return ERROR_INVALID_PATH;
+        return ResultInvalidPath;
     }
 
     const auto full_path = path_parser.BuildHostPath(mount_point);
@@ -328,15 +328,15 @@ ResultVal<std::unique_ptr<DirectoryBackend>> SaveDataArchive::OpenDirectory(
     switch (path_parser.GetHostStatus(mount_point)) {
     case PathParser::InvalidMountPoint:
         LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}", mount_point);
-        return ERROR_FILE_NOT_FOUND;
+        return ResultFileNotFound;
     case PathParser::PathNotFound:
     case PathParser::NotFound:
         LOG_ERROR(Service_FS, "Path not found {}", full_path);
-        return ERROR_PATH_NOT_FOUND;
+        return ResultPathNotFound;
     case PathParser::FileInPath:
     case PathParser::FileFound:
         LOG_ERROR(Service_FS, "Unexpected file in path {}", full_path);
-        return ERROR_UNEXPECTED_FILE_OR_DIRECTORY;
+        return ResultUnexpectedFileOrDirectory;
     case PathParser::DirectoryFound:
         break; // Expected 'success' case
     }

--- a/src/core/file_sys/savedata_archive.cpp
+++ b/src/core/file_sys/savedata_archive.cpp
@@ -93,7 +93,7 @@ ResultVal<std::unique_ptr<FileBackend>> SaveDataArchive::OpenFile(const Path& pa
     return std::make_unique<DiskFile>(std::move(file), mode, std::move(delay_generator));
 }
 
-ResultCode SaveDataArchive::DeleteFile(const Path& path) const {
+Result SaveDataArchive::DeleteFile(const Path& path) const {
     const PathParser path_parser(path);
 
     if (!path_parser.IsValid()) {
@@ -127,7 +127,7 @@ ResultCode SaveDataArchive::DeleteFile(const Path& path) const {
     return ERROR_FILE_NOT_FOUND;
 }
 
-ResultCode SaveDataArchive::RenameFile(const Path& src_path, const Path& dest_path) const {
+Result SaveDataArchive::RenameFile(const Path& src_path, const Path& dest_path) const {
     const PathParser path_parser_src(src_path);
 
     // TODO: Verify these return codes with HW
@@ -152,13 +152,12 @@ ResultCode SaveDataArchive::RenameFile(const Path& src_path, const Path& dest_pa
 
     // TODO(yuriks): This code probably isn't right, it'll return a Status even if the file didn't
     // exist or similar. Verify.
-    return ResultCode(ErrorDescription::NoData, ErrorModule::FS, // TODO: verify description
-                      ErrorSummary::NothingHappened, ErrorLevel::Status);
+    return Result(ErrorDescription::NoData, ErrorModule::FS, // TODO: verify description
+                  ErrorSummary::NothingHappened, ErrorLevel::Status);
 }
 
 template <typename T>
-static ResultCode DeleteDirectoryHelper(const Path& path, const std::string& mount_point,
-                                        T deleter) {
+static Result DeleteDirectoryHelper(const Path& path, const std::string& mount_point, T deleter) {
     const PathParser path_parser(path);
 
     if (!path_parser.IsValid()) {
@@ -195,16 +194,16 @@ static ResultCode DeleteDirectoryHelper(const Path& path, const std::string& mou
     return ERROR_DIRECTORY_NOT_EMPTY;
 }
 
-ResultCode SaveDataArchive::DeleteDirectory(const Path& path) const {
+Result SaveDataArchive::DeleteDirectory(const Path& path) const {
     return DeleteDirectoryHelper(path, mount_point, FileUtil::DeleteDir);
 }
 
-ResultCode SaveDataArchive::DeleteDirectoryRecursively(const Path& path) const {
+Result SaveDataArchive::DeleteDirectoryRecursively(const Path& path) const {
     return DeleteDirectoryHelper(
         path, mount_point, [](const std::string& p) { return FileUtil::DeleteDirRecursively(p); });
 }
 
-ResultCode SaveDataArchive::CreateFile(const FileSys::Path& path, u64 size) const {
+Result SaveDataArchive::CreateFile(const FileSys::Path& path, u64 size) const {
     const PathParser path_parser(path);
 
     if (!path_parser.IsValid()) {
@@ -245,11 +244,11 @@ ResultCode SaveDataArchive::CreateFile(const FileSys::Path& path, u64 size) cons
     }
 
     LOG_ERROR(Service_FS, "Too large file");
-    return ResultCode(ErrorDescription::TooLarge, ErrorModule::FS, ErrorSummary::OutOfResource,
-                      ErrorLevel::Info);
+    return Result(ErrorDescription::TooLarge, ErrorModule::FS, ErrorSummary::OutOfResource,
+                  ErrorLevel::Info);
 }
 
-ResultCode SaveDataArchive::CreateDirectory(const Path& path) const {
+Result SaveDataArchive::CreateDirectory(const Path& path) const {
     const PathParser path_parser(path);
 
     if (!path_parser.IsValid()) {
@@ -282,11 +281,11 @@ ResultCode SaveDataArchive::CreateDirectory(const Path& path) const {
     }
 
     LOG_CRITICAL(Service_FS, "(unreachable) Unknown error creating {}", mount_point);
-    return ResultCode(ErrorDescription::NoData, ErrorModule::FS, ErrorSummary::Canceled,
-                      ErrorLevel::Status);
+    return Result(ErrorDescription::NoData, ErrorModule::FS, ErrorSummary::Canceled,
+                  ErrorLevel::Status);
 }
 
-ResultCode SaveDataArchive::RenameDirectory(const Path& src_path, const Path& dest_path) const {
+Result SaveDataArchive::RenameDirectory(const Path& src_path, const Path& dest_path) const {
     const PathParser path_parser_src(src_path);
 
     // TODO: Verify these return codes with HW
@@ -311,8 +310,8 @@ ResultCode SaveDataArchive::RenameDirectory(const Path& src_path, const Path& de
 
     // TODO(yuriks): This code probably isn't right, it'll return a Status even if the file didn't
     // exist or similar. Verify.
-    return ResultCode(ErrorDescription::NoData, ErrorModule::FS, // TODO: verify description
-                      ErrorSummary::NothingHappened, ErrorLevel::Status);
+    return Result(ErrorDescription::NoData, ErrorModule::FS, // TODO: verify description
+                  ErrorSummary::NothingHappened, ErrorLevel::Status);
 }
 
 ResultVal<std::unique_ptr<DirectoryBackend>> SaveDataArchive::OpenDirectory(

--- a/src/core/file_sys/savedata_archive.h
+++ b/src/core/file_sys/savedata_archive.h
@@ -23,13 +23,13 @@ public:
 
     ResultVal<std::unique_ptr<FileBackend>> OpenFile(const Path& path,
                                                      const Mode& mode) const override;
-    ResultCode DeleteFile(const Path& path) const override;
-    ResultCode RenameFile(const Path& src_path, const Path& dest_path) const override;
-    ResultCode DeleteDirectory(const Path& path) const override;
-    ResultCode DeleteDirectoryRecursively(const Path& path) const override;
-    ResultCode CreateFile(const Path& path, u64 size) const override;
-    ResultCode CreateDirectory(const Path& path) const override;
-    ResultCode RenameDirectory(const Path& src_path, const Path& dest_path) const override;
+    Result DeleteFile(const Path& path) const override;
+    Result RenameFile(const Path& src_path, const Path& dest_path) const override;
+    Result DeleteDirectory(const Path& path) const override;
+    Result DeleteDirectoryRecursively(const Path& path) const override;
+    Result CreateFile(const Path& path, u64 size) const override;
+    Result CreateDirectory(const Path& path) const override;
+    Result RenameDirectory(const Path& src_path, const Path& dest_path) const override;
     ResultVal<std::unique_ptr<DirectoryBackend>> OpenDirectory(const Path& path) const override;
     u64 GetFreeBytes() const override;
 

--- a/src/core/hle/applets/applet.cpp
+++ b/src/core/hle/applets/applet.cpp
@@ -66,7 +66,7 @@ Result Applet::Create(Service::APT::AppletId id, Service::APT::AppletId parent, 
     // Schedule the update event
     Core::System::GetInstance().CoreTiming().ScheduleEvent(
         usToCycles(applet_update_interval_us), applet_update_event, static_cast<u64>(id));
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 std::shared_ptr<Applet> Applet::Get(Service::APT::AppletId id) {

--- a/src/core/hle/applets/applet.cpp
+++ b/src/core/hle/applets/applet.cpp
@@ -26,8 +26,8 @@ static Core::TimingEventType* applet_update_event = nullptr;
 /// The interval at which the Applet update callback will be called, 16.6ms
 static const u64 applet_update_interval_us = 16666;
 
-ResultCode Applet::Create(Service::APT::AppletId id, Service::APT::AppletId parent, bool preload,
-                          const std::shared_ptr<Service::APT::AppletManager>& manager) {
+Result Applet::Create(Service::APT::AppletId id, Service::APT::AppletId parent, bool preload,
+                      const std::shared_ptr<Service::APT::AppletManager>& manager) {
     switch (id) {
     case Service::APT::AppletId::SoftwareKeyboard1:
     case Service::APT::AppletId::SoftwareKeyboard2:
@@ -48,8 +48,8 @@ ResultCode Applet::Create(Service::APT::AppletId id, Service::APT::AppletId pare
     default:
         LOG_ERROR(Service_APT, "Could not create applet {}", id);
         // TODO(Subv): Find the right error code
-        return ResultCode(ErrorDescription::NotFound, ErrorModule::Applet,
-                          ErrorSummary::NotSupported, ErrorLevel::Permanent);
+        return Result(ErrorDescription::NotFound, ErrorModule::Applet, ErrorSummary::NotSupported,
+                      ErrorLevel::Permanent);
     }
 
     Service::APT::AppletAttributes attributes;
@@ -104,10 +104,10 @@ bool Applet::IsActive() const {
     return is_active;
 }
 
-ResultCode Applet::ReceiveParameter(const Service::APT::MessageParameter& parameter) {
+Result Applet::ReceiveParameter(const Service::APT::MessageParameter& parameter) {
     switch (parameter.signal) {
     case Service::APT::SignalType::Wakeup: {
-        ResultCode result = Start(parameter);
+        Result result = Start(parameter);
         if (!result.IsError()) {
             is_active = true;
         }

--- a/src/core/hle/applets/applet.h
+++ b/src/core/hle/applets/applet.h
@@ -20,10 +20,10 @@ public:
      * @param id Id of the applet to create.
      * @param parent Id of the applet's parent.
      * @param preload Whether the applet is being preloaded.
-     * @returns ResultCode Whether the operation was successful or not.
+     * @returns Result Whether the operation was successful or not.
      */
-    static ResultCode Create(Service::APT::AppletId id, Service::APT::AppletId parent, bool preload,
-                             const std::shared_ptr<Service::APT::AppletManager>& manager);
+    static Result Create(Service::APT::AppletId id, Service::APT::AppletId parent, bool preload,
+                         const std::shared_ptr<Service::APT::AppletManager>& manager);
 
     /**
      * Retrieves the Applet instance identified by the specified id.
@@ -35,9 +35,9 @@ public:
     /**
      * Handles a parameter from the application.
      * @param parameter Parameter data to handle.
-     * @returns ResultCode Whether the operation was successful or not.
+     * @returns Result Whether the operation was successful or not.
      */
-    ResultCode ReceiveParameter(const Service::APT::MessageParameter& parameter);
+    Result ReceiveParameter(const Service::APT::MessageParameter& parameter);
 
     /**
      * Whether the applet is currently running.
@@ -62,22 +62,22 @@ protected:
     /**
      * Handles a parameter from the application.
      * @param parameter Parameter data to handle.
-     * @returns ResultCode Whether the operation was successful or not.
+     * @returns Result Whether the operation was successful or not.
      */
-    virtual ResultCode ReceiveParameterImpl(const Service::APT::MessageParameter& parameter) = 0;
+    virtual Result ReceiveParameterImpl(const Service::APT::MessageParameter& parameter) = 0;
 
     /**
      * Handles the Applet start event, triggered from the application.
      * @param parameter Parameter data to handle.
-     * @returns ResultCode Whether the operation was successful or not.
+     * @returns Result Whether the operation was successful or not.
      */
-    virtual ResultCode Start(const Service::APT::MessageParameter& parameter) = 0;
+    virtual Result Start(const Service::APT::MessageParameter& parameter) = 0;
 
     /**
      * Sends the LibAppletClosing signal to the application,
      * along with the relevant data buffers.
      */
-    virtual ResultCode Finalize() = 0;
+    virtual Result Finalize() = 0;
 
     Service::APT::AppletId id;                    ///< Id of this Applet
     Service::APT::AppletId parent;                ///< Id of this Applet's parent

--- a/src/core/hle/applets/erreula.cpp
+++ b/src/core/hle/applets/erreula.cpp
@@ -14,7 +14,7 @@ Result ErrEula::ReceiveParameterImpl(const Service::APT::MessageParameter& param
         LOG_ERROR(Service_APT, "unsupported signal {}", parameter.signal);
         UNIMPLEMENTED();
         // TODO(Subv): Find the right error code
-        return Result(-1);
+        return ResultUnknown;
     }
 
     // The LibAppJustStarted message contains a buffer with the size of the framebuffer shared
@@ -40,7 +40,7 @@ Result ErrEula::ReceiveParameterImpl(const Service::APT::MessageParameter& param
         .object = framebuffer_memory,
     });
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result ErrEula::Start(const Service::APT::MessageParameter& parameter) {
@@ -52,14 +52,14 @@ Result ErrEula::Start(const Service::APT::MessageParameter& parameter) {
 
     // Let the application know that we're closing.
     Finalize();
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result ErrEula::Finalize() {
     std::vector<u8> buffer(startup_param.size());
     std::fill(buffer.begin(), buffer.end(), 0);
     CloseApplet(nullptr, buffer);
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 void ErrEula::Update() {}

--- a/src/core/hle/applets/erreula.cpp
+++ b/src/core/hle/applets/erreula.cpp
@@ -9,12 +9,12 @@
 
 namespace HLE::Applets {
 
-ResultCode ErrEula::ReceiveParameterImpl(const Service::APT::MessageParameter& parameter) {
+Result ErrEula::ReceiveParameterImpl(const Service::APT::MessageParameter& parameter) {
     if (parameter.signal != Service::APT::SignalType::Request) {
         LOG_ERROR(Service_APT, "unsupported signal {}", parameter.signal);
         UNIMPLEMENTED();
         // TODO(Subv): Find the right error code
-        return ResultCode(-1);
+        return Result(-1);
     }
 
     // The LibAppJustStarted message contains a buffer with the size of the framebuffer shared
@@ -43,7 +43,7 @@ ResultCode ErrEula::ReceiveParameterImpl(const Service::APT::MessageParameter& p
     return RESULT_SUCCESS;
 }
 
-ResultCode ErrEula::Start(const Service::APT::MessageParameter& parameter) {
+Result ErrEula::Start(const Service::APT::MessageParameter& parameter) {
     startup_param = parameter.buffer;
 
     // TODO(Subv): Set the expected fields in the response buffer before resending it to the
@@ -55,7 +55,7 @@ ResultCode ErrEula::Start(const Service::APT::MessageParameter& parameter) {
     return RESULT_SUCCESS;
 }
 
-ResultCode ErrEula::Finalize() {
+Result ErrEula::Finalize() {
     std::vector<u8> buffer(startup_param.size());
     std::fill(buffer.begin(), buffer.end(), 0);
     CloseApplet(nullptr, buffer);

--- a/src/core/hle/applets/erreula.h
+++ b/src/core/hle/applets/erreula.h
@@ -15,9 +15,9 @@ public:
                      std::weak_ptr<Service::APT::AppletManager> manager)
         : Applet(id, parent, preload, std::move(manager)) {}
 
-    ResultCode ReceiveParameterImpl(const Service::APT::MessageParameter& parameter) override;
-    ResultCode Start(const Service::APT::MessageParameter& parameter) override;
-    ResultCode Finalize() override;
+    Result ReceiveParameterImpl(const Service::APT::MessageParameter& parameter) override;
+    Result Start(const Service::APT::MessageParameter& parameter) override;
+    Result Finalize() override;
     void Update() override;
 
 private:

--- a/src/core/hle/applets/mii_selector.cpp
+++ b/src/core/hle/applets/mii_selector.cpp
@@ -17,12 +17,12 @@
 
 namespace HLE::Applets {
 
-ResultCode MiiSelector::ReceiveParameterImpl(const Service::APT::MessageParameter& parameter) {
+Result MiiSelector::ReceiveParameterImpl(const Service::APT::MessageParameter& parameter) {
     if (parameter.signal != Service::APT::SignalType::Request) {
         LOG_ERROR(Service_APT, "unsupported signal {}", parameter.signal);
         UNIMPLEMENTED();
         // TODO(Subv): Find the right error code
-        return ResultCode(-1);
+        return Result(-1);
     }
 
     // The LibAppJustStarted message contains a buffer with the size of the framebuffer shared
@@ -50,7 +50,7 @@ ResultCode MiiSelector::ReceiveParameterImpl(const Service::APT::MessageParamete
     return RESULT_SUCCESS;
 }
 
-ResultCode MiiSelector::Start(const Service::APT::MessageParameter& parameter) {
+Result MiiSelector::Start(const Service::APT::MessageParameter& parameter) {
     ASSERT_MSG(parameter.buffer.size() == sizeof(config),
                "The size of the parameter (MiiConfig) is wrong");
 
@@ -78,7 +78,7 @@ void MiiSelector::Update() {
     Finalize();
 }
 
-ResultCode MiiSelector::Finalize() {
+Result MiiSelector::Finalize() {
     std::vector<u8> buffer(sizeof(MiiResult));
     std::memcpy(buffer.data(), &result, buffer.size());
     CloseApplet(nullptr, buffer);

--- a/src/core/hle/applets/mii_selector.cpp
+++ b/src/core/hle/applets/mii_selector.cpp
@@ -22,7 +22,7 @@ Result MiiSelector::ReceiveParameterImpl(const Service::APT::MessageParameter& p
         LOG_ERROR(Service_APT, "unsupported signal {}", parameter.signal);
         UNIMPLEMENTED();
         // TODO(Subv): Find the right error code
-        return Result(-1);
+        return ResultUnknown;
     }
 
     // The LibAppJustStarted message contains a buffer with the size of the framebuffer shared
@@ -47,7 +47,7 @@ Result MiiSelector::ReceiveParameterImpl(const Service::APT::MessageParameter& p
         .object = framebuffer_memory,
     });
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result MiiSelector::Start(const Service::APT::MessageParameter& parameter) {
@@ -63,7 +63,7 @@ Result MiiSelector::Start(const Service::APT::MessageParameter& parameter) {
     MiiSelectorConfig frontend_config = ToFrontendConfig(config);
     frontend_applet->Setup(frontend_config);
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 void MiiSelector::Update() {
@@ -82,7 +82,7 @@ Result MiiSelector::Finalize() {
     std::vector<u8> buffer(sizeof(MiiResult));
     std::memcpy(buffer.data(), &result, buffer.size());
     CloseApplet(nullptr, buffer);
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 MiiResult MiiSelector::GetStandardMiiResult() {

--- a/src/core/hle/applets/mii_selector.h
+++ b/src/core/hle/applets/mii_selector.h
@@ -66,9 +66,9 @@ public:
                 std::weak_ptr<Service::APT::AppletManager> manager)
         : Applet(id, parent, preload, std::move(manager)) {}
 
-    ResultCode ReceiveParameterImpl(const Service::APT::MessageParameter& parameter) override;
-    ResultCode Start(const Service::APT::MessageParameter& parameter) override;
-    ResultCode Finalize() override;
+    Result ReceiveParameterImpl(const Service::APT::MessageParameter& parameter) override;
+    Result Start(const Service::APT::MessageParameter& parameter) override;
+    Result Finalize() override;
     void Update() override;
 
     static MiiResult GetStandardMiiResult();

--- a/src/core/hle/applets/mint.cpp
+++ b/src/core/hle/applets/mint.cpp
@@ -9,12 +9,12 @@
 
 namespace HLE::Applets {
 
-ResultCode Mint::ReceiveParameterImpl(const Service::APT::MessageParameter& parameter) {
+Result Mint::ReceiveParameterImpl(const Service::APT::MessageParameter& parameter) {
     if (parameter.signal != Service::APT::SignalType::Request) {
         LOG_ERROR(Service_APT, "unsupported signal {}", parameter.signal);
         UNIMPLEMENTED();
         // TODO(Subv): Find the right error code
-        return ResultCode(-1);
+        return Result(-1);
     }
 
     // The Request message contains a buffer with the size of the framebuffer shared
@@ -43,7 +43,7 @@ ResultCode Mint::ReceiveParameterImpl(const Service::APT::MessageParameter& para
     return RESULT_SUCCESS;
 }
 
-ResultCode Mint::Start(const Service::APT::MessageParameter& parameter) {
+Result Mint::Start(const Service::APT::MessageParameter& parameter) {
     startup_param = parameter.buffer;
 
     // TODO(Subv): Set the expected fields in the response buffer before resending it to the
@@ -55,7 +55,7 @@ ResultCode Mint::Start(const Service::APT::MessageParameter& parameter) {
     return RESULT_SUCCESS;
 }
 
-ResultCode Mint::Finalize() {
+Result Mint::Finalize() {
     std::vector<u8> buffer(startup_param.size());
     std::fill(buffer.begin(), buffer.end(), 0);
     CloseApplet(nullptr, buffer);

--- a/src/core/hle/applets/mint.cpp
+++ b/src/core/hle/applets/mint.cpp
@@ -14,7 +14,7 @@ Result Mint::ReceiveParameterImpl(const Service::APT::MessageParameter& paramete
         LOG_ERROR(Service_APT, "unsupported signal {}", parameter.signal);
         UNIMPLEMENTED();
         // TODO(Subv): Find the right error code
-        return Result(-1);
+        return ResultUnknown;
     }
 
     // The Request message contains a buffer with the size of the framebuffer shared
@@ -40,7 +40,7 @@ Result Mint::ReceiveParameterImpl(const Service::APT::MessageParameter& paramete
         .object = framebuffer_memory,
     });
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result Mint::Start(const Service::APT::MessageParameter& parameter) {
@@ -52,14 +52,14 @@ Result Mint::Start(const Service::APT::MessageParameter& parameter) {
 
     // Let the application know that we're closing
     Finalize();
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result Mint::Finalize() {
     std::vector<u8> buffer(startup_param.size());
     std::fill(buffer.begin(), buffer.end(), 0);
     CloseApplet(nullptr, buffer);
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 void Mint::Update() {}

--- a/src/core/hle/applets/mint.h
+++ b/src/core/hle/applets/mint.h
@@ -15,9 +15,9 @@ public:
                   std::weak_ptr<Service::APT::AppletManager> manager)
         : Applet(id, parent, preload, std::move(manager)) {}
 
-    ResultCode ReceiveParameterImpl(const Service::APT::MessageParameter& parameter) override;
-    ResultCode Start(const Service::APT::MessageParameter& parameter) override;
-    ResultCode Finalize() override;
+    Result ReceiveParameterImpl(const Service::APT::MessageParameter& parameter) override;
+    Result Start(const Service::APT::MessageParameter& parameter) override;
+    Result Finalize() override;
     void Update() override;
 
 private:

--- a/src/core/hle/applets/swkbd.cpp
+++ b/src/core/hle/applets/swkbd.cpp
@@ -19,7 +19,7 @@
 
 namespace HLE::Applets {
 
-ResultCode SoftwareKeyboard::ReceiveParameterImpl(Service::APT::MessageParameter const& parameter) {
+Result SoftwareKeyboard::ReceiveParameterImpl(Service::APT::MessageParameter const& parameter) {
     switch (parameter.signal) {
     case Service::APT::SignalType::Request: {
         // The LibAppJustStarted message contains a buffer with the size of the framebuffer shared
@@ -84,12 +84,12 @@ ResultCode SoftwareKeyboard::ReceiveParameterImpl(Service::APT::MessageParameter
         LOG_ERROR(Service_APT, "unsupported signal {}", parameter.signal);
         UNIMPLEMENTED();
         // TODO(Subv): Find the right error code
-        return ResultCode(-1);
+        return Result(-1);
     }
     }
 }
 
-ResultCode SoftwareKeyboard::Start(Service::APT::MessageParameter const& parameter) {
+Result SoftwareKeyboard::Start(Service::APT::MessageParameter const& parameter) {
     ASSERT_MSG(parameter.buffer.size() == sizeof(config),
                "The size of the parameter (SoftwareKeyboardConfig) is wrong");
 
@@ -166,7 +166,7 @@ void SoftwareKeyboard::DrawScreenKeyboard() {
     // TODO(Subv): Draw the HLE keyboard, for now just do nothing
 }
 
-ResultCode SoftwareKeyboard::Finalize() {
+Result SoftwareKeyboard::Finalize() {
     std::vector<u8> buffer(sizeof(SoftwareKeyboardConfig));
     std::memcpy(buffer.data(), &config, buffer.size());
     CloseApplet(nullptr, buffer);

--- a/src/core/hle/applets/swkbd.cpp
+++ b/src/core/hle/applets/swkbd.cpp
@@ -44,7 +44,7 @@ Result SoftwareKeyboard::ReceiveParameterImpl(Service::APT::MessageParameter con
             .object = framebuffer_memory,
         });
 
-        return RESULT_SUCCESS;
+        return ResultSuccess;
     }
 
     case Service::APT::SignalType::Message: {
@@ -58,7 +58,7 @@ Result SoftwareKeyboard::ReceiveParameterImpl(Service::APT::MessageParameter con
         case SoftwareKeyboardCallbackResult::OK:
             // Finish execution
             Finalize();
-            return RESULT_SUCCESS;
+            return ResultSuccess;
 
         case SoftwareKeyboardCallbackResult::Close:
             // Let the frontend display error and quit
@@ -66,14 +66,14 @@ Result SoftwareKeyboard::ReceiveParameterImpl(Service::APT::MessageParameter con
             config.return_code = SoftwareKeyboardResult::BannedInput;
             config.text_offset = config.text_length = 0;
             Finalize();
-            return RESULT_SUCCESS;
+            return ResultSuccess;
 
         case SoftwareKeyboardCallbackResult::Continue:
             // Let the frontend display error and get input again
             // The input will be sent for validation again on next Update().
             frontend_applet->ShowError(Common::UTF16BufferToUTF8(config.callback_msg));
             frontend_applet->Execute(ToFrontendConfig(config));
-            return RESULT_SUCCESS;
+            return ResultSuccess;
 
         default:
             UNREACHABLE();
@@ -84,7 +84,7 @@ Result SoftwareKeyboard::ReceiveParameterImpl(Service::APT::MessageParameter con
         LOG_ERROR(Service_APT, "unsupported signal {}", parameter.signal);
         UNIMPLEMENTED();
         // TODO(Subv): Find the right error code
-        return Result(-1);
+        return ResultUnknown;
     }
     }
 }
@@ -104,7 +104,7 @@ Result SoftwareKeyboard::Start(Service::APT::MessageParameter const& parameter) 
 
     frontend_applet->Execute(ToFrontendConfig(config));
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 void SoftwareKeyboard::Update() {
@@ -171,7 +171,7 @@ Result SoftwareKeyboard::Finalize() {
     std::memcpy(buffer.data(), &config, buffer.size());
     CloseApplet(nullptr, buffer);
     text_memory = nullptr;
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Frontend::KeyboardConfig SoftwareKeyboard::ToFrontendConfig(

--- a/src/core/hle/applets/swkbd.h
+++ b/src/core/hle/applets/swkbd.h
@@ -179,9 +179,9 @@ public:
                      std::weak_ptr<Service::APT::AppletManager> manager)
         : Applet(id, parent, preload, std::move(manager)) {}
 
-    ResultCode ReceiveParameterImpl(const Service::APT::MessageParameter& parameter) override;
-    ResultCode Start(const Service::APT::MessageParameter& parameter) override;
-    ResultCode Finalize() override;
+    Result ReceiveParameterImpl(const Service::APT::MessageParameter& parameter) override;
+    Result Start(const Service::APT::MessageParameter& parameter) override;
+    Result Finalize() override;
     void Update() override;
 
     /**

--- a/src/core/hle/ipc.h
+++ b/src/core/hle/ipc.h
@@ -20,8 +20,8 @@ constexpr std::size_t MAX_STATIC_BUFFERS = 16;
 // These errors are commonly returned by invalid IPC translations, so alias them here for
 // convenience.
 // TODO(yuriks): These will probably go away once translation is implemented inside the kernel.
-using Kernel::ERR_INVALID_BUFFER_DESCRIPTOR;
-constexpr auto ERR_INVALID_HANDLE = Kernel::ERR_INVALID_HANDLE_OS;
+using Kernel::ResultInvalidBufferDescriptor;
+constexpr auto ResultInvalidHandle = Kernel::ResultInvalidHandleOs;
 
 enum DescriptorType : u32 {
     // Buffer related descriptors types (mask : 0x0F)

--- a/src/core/hle/ipc_helpers.h
+++ b/src/core/hle/ipc_helpers.h
@@ -161,7 +161,7 @@ inline void RequestBuilder::Push(bool value) {
 }
 
 template <>
-inline void RequestBuilder::Push(ResultCode value) {
+inline void RequestBuilder::Push(Result value) {
     Push(value.raw);
 }
 
@@ -371,8 +371,8 @@ inline bool RequestParser::Pop() {
 }
 
 template <>
-inline ResultCode RequestParser::Pop() {
-    return ResultCode{Pop<u32>()};
+inline Result RequestParser::Pop() {
+    return Result{Pop<u32>()};
 }
 
 template <typename T>

--- a/src/core/hle/kernel/address_arbiter.cpp
+++ b/src/core/hle/kernel/address_arbiter.cpp
@@ -108,8 +108,8 @@ void AddressArbiter::WakeUp(ThreadWakeupReason reason, std::shared_ptr<Thread> t
                           waiting_threads.end());
 };
 
-ResultCode AddressArbiter::ArbitrateAddress(std::shared_ptr<Thread> thread, ArbitrationType type,
-                                            VAddr address, s32 value, u64 nanoseconds) {
+Result AddressArbiter::ArbitrateAddress(std::shared_ptr<Thread> thread, ArbitrationType type,
+                                        VAddr address, s32 value, u64 nanoseconds) {
     switch (type) {
 
     // Signal thread(s) waiting for arbitrate address...

--- a/src/core/hle/kernel/address_arbiter.cpp
+++ b/src/core/hle/kernel/address_arbiter.cpp
@@ -178,7 +178,6 @@ ResultCode AddressArbiter::ArbitrateAddress(std::shared_ptr<Thread> thread, Arbi
     // the thread to sleep
     if (type == ArbitrationType::WaitIfLessThanWithTimeout ||
         type == ArbitrationType::DecrementAndWaitIfLessThanWithTimeout) {
-
         return RESULT_TIMEOUT;
     }
     return RESULT_SUCCESS;

--- a/src/core/hle/kernel/address_arbiter.cpp
+++ b/src/core/hle/kernel/address_arbiter.cpp
@@ -171,16 +171,16 @@ Result AddressArbiter::ArbitrateAddress(std::shared_ptr<Thread> thread, Arbitrat
 
     default:
         LOG_ERROR(Kernel, "unknown type={}", type);
-        return ERR_INVALID_ENUM_VALUE_FND;
+        return ResultInvalidEnumValueFnd;
     }
 
     // The calls that use a timeout seem to always return a Timeout error even if they did not put
     // the thread to sleep
     if (type == ArbitrationType::WaitIfLessThanWithTimeout ||
         type == ArbitrationType::DecrementAndWaitIfLessThanWithTimeout) {
-        return RESULT_TIMEOUT;
+        return ResultTimeout;
     }
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 } // namespace Kernel

--- a/src/core/hle/kernel/address_arbiter.h
+++ b/src/core/hle/kernel/address_arbiter.h
@@ -55,8 +55,8 @@ public:
     std::shared_ptr<ResourceLimit> resource_limit;
     std::string name; ///< Name of address arbiter object (optional)
 
-    ResultCode ArbitrateAddress(std::shared_ptr<Thread> thread, ArbitrationType type, VAddr address,
-                                s32 value, u64 nanoseconds);
+    Result ArbitrateAddress(std::shared_ptr<Thread> thread, ArbitrationType type, VAddr address,
+                            s32 value, u64 nanoseconds);
 
     class Callback;
 

--- a/src/core/hle/kernel/client_port.cpp
+++ b/src/core/hle/kernel/client_port.cpp
@@ -20,32 +20,31 @@ namespace Kernel {
 ClientPort::ClientPort(KernelSystem& kernel) : Object(kernel), kernel(kernel) {}
 ClientPort::~ClientPort() = default;
 
-ResultVal<std::shared_ptr<ClientSession>> ClientPort::Connect() {
+ResultCode ClientPort::Connect(std::shared_ptr<ClientSession>& client_session) {
     // Note: Threads do not wait for the server endpoint to call
     // AcceptSession before returning from this call.
 
-    if (active_sessions >= max_sessions) {
-        return ERR_MAX_CONNECTIONS_REACHED;
-    }
+    R_UNLESS(active_sessions < max_sessions, ERR_MAX_CONNECTIONS_REACHED);
     active_sessions++;
 
     // Create a new session pair, let the created sessions inherit the parent port's HLE handler.
     auto [server, client] = kernel.CreateSessionPair(server_port->GetName(), SharedFrom(this));
 
-    if (server_port->hle_handler)
+    if (server_port->hle_handler) {
         server_port->hle_handler->ClientConnected(server);
-    else
+    } else {
         server_port->pending_sessions.push_back(server);
+    }
 
     // Wake the threads waiting on the ServerPort
     server_port->WakeupAllWaitingThreads();
 
-    return client;
+    client_session = client;
+    return RESULT_SUCCESS;
 }
 
 void ClientPort::ConnectionClosed() {
     ASSERT(active_sessions > 0);
-
     --active_sessions;
 }
 

--- a/src/core/hle/kernel/client_port.cpp
+++ b/src/core/hle/kernel/client_port.cpp
@@ -24,7 +24,7 @@ Result ClientPort::Connect(std::shared_ptr<ClientSession>& client_session) {
     // Note: Threads do not wait for the server endpoint to call
     // AcceptSession before returning from this call.
 
-    R_UNLESS(active_sessions < max_sessions, ERR_MAX_CONNECTIONS_REACHED);
+    R_UNLESS(active_sessions < max_sessions, ResultMaxConnectionsReached);
     active_sessions++;
 
     // Create a new session pair, let the created sessions inherit the parent port's HLE handler.
@@ -40,7 +40,7 @@ Result ClientPort::Connect(std::shared_ptr<ClientSession>& client_session) {
     server_port->WakeupAllWaitingThreads();
 
     client_session = client;
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 void ClientPort::ConnectionClosed() {

--- a/src/core/hle/kernel/client_port.cpp
+++ b/src/core/hle/kernel/client_port.cpp
@@ -20,7 +20,7 @@ namespace Kernel {
 ClientPort::ClientPort(KernelSystem& kernel) : Object(kernel), kernel(kernel) {}
 ClientPort::~ClientPort() = default;
 
-Result ClientPort::Connect(std::shared_ptr<ClientSession>& client_session) {
+Result ClientPort::Connect(std::shared_ptr<ClientSession>* out_client_session) {
     // Note: Threads do not wait for the server endpoint to call
     // AcceptSession before returning from this call.
 
@@ -39,7 +39,7 @@ Result ClientPort::Connect(std::shared_ptr<ClientSession>& client_session) {
     // Wake the threads waiting on the ServerPort
     server_port->WakeupAllWaitingThreads();
 
-    client_session = client;
+    *out_client_session = client;
     return ResultSuccess;
 }
 

--- a/src/core/hle/kernel/client_port.cpp
+++ b/src/core/hle/kernel/client_port.cpp
@@ -20,7 +20,7 @@ namespace Kernel {
 ClientPort::ClientPort(KernelSystem& kernel) : Object(kernel), kernel(kernel) {}
 ClientPort::~ClientPort() = default;
 
-ResultCode ClientPort::Connect(std::shared_ptr<ClientSession>& client_session) {
+Result ClientPort::Connect(std::shared_ptr<ClientSession>& client_session) {
     // Note: Threads do not wait for the server endpoint to call
     // AcceptSession before returning from this call.
 

--- a/src/core/hle/kernel/client_port.h
+++ b/src/core/hle/kernel/client_port.h
@@ -46,7 +46,7 @@ public:
      * waiting on it to awake.
      * @returns ClientSession The client endpoint of the created Session pair, or error code.
      */
-    Result Connect(std::shared_ptr<ClientSession>& client_session);
+    Result Connect(std::shared_ptr<ClientSession>* out_client_session);
 
     /**
      * Signifies that a previously active connection has been closed,

--- a/src/core/hle/kernel/client_port.h
+++ b/src/core/hle/kernel/client_port.h
@@ -46,7 +46,7 @@ public:
      * waiting on it to awake.
      * @returns ClientSession The client endpoint of the created Session pair, or error code.
      */
-    ResultVal<std::shared_ptr<ClientSession>> Connect();
+    ResultCode Connect(std::shared_ptr<ClientSession>& client_session);
 
     /**
      * Signifies that a previously active connection has been closed,

--- a/src/core/hle/kernel/client_port.h
+++ b/src/core/hle/kernel/client_port.h
@@ -46,7 +46,7 @@ public:
      * waiting on it to awake.
      * @returns ClientSession The client endpoint of the created Session pair, or error code.
      */
-    ResultCode Connect(std::shared_ptr<ClientSession>& client_session);
+    Result Connect(std::shared_ptr<ClientSession>& client_session);
 
     /**
      * Signifies that a previously active connection has been closed,

--- a/src/core/hle/kernel/client_session.cpp
+++ b/src/core/hle/kernel/client_session.cpp
@@ -44,7 +44,7 @@ ClientSession::~ClientSession() {
     }
 }
 
-ResultCode ClientSession::SendSyncRequest(std::shared_ptr<Thread> thread) {
+Result ClientSession::SendSyncRequest(std::shared_ptr<Thread> thread) {
     // Keep ServerSession alive until we're done working with it.
     std::shared_ptr<ServerSession> server = SharedFrom(parent->server);
     R_UNLESS(server, ERR_SESSION_CLOSED_BY_REMOTE);

--- a/src/core/hle/kernel/client_session.cpp
+++ b/src/core/hle/kernel/client_session.cpp
@@ -47,7 +47,7 @@ ClientSession::~ClientSession() {
 Result ClientSession::SendSyncRequest(std::shared_ptr<Thread> thread) {
     // Keep ServerSession alive until we're done working with it.
     std::shared_ptr<ServerSession> server = SharedFrom(parent->server);
-    R_UNLESS(server, ERR_SESSION_CLOSED_BY_REMOTE);
+    R_UNLESS(server, ResultSessionClosed);
 
     // Signal the server session that new data is available
     return server->HandleSyncRequest(std::move(thread));

--- a/src/core/hle/kernel/client_session.cpp
+++ b/src/core/hle/kernel/client_session.cpp
@@ -47,8 +47,7 @@ ClientSession::~ClientSession() {
 ResultCode ClientSession::SendSyncRequest(std::shared_ptr<Thread> thread) {
     // Keep ServerSession alive until we're done working with it.
     std::shared_ptr<ServerSession> server = SharedFrom(parent->server);
-    if (server == nullptr)
-        return ERR_SESSION_CLOSED_BY_REMOTE;
+    R_UNLESS(server, ERR_SESSION_CLOSED_BY_REMOTE);
 
     // Signal the server session that new data is available
     return server->HandleSyncRequest(std::move(thread));

--- a/src/core/hle/kernel/client_session.h
+++ b/src/core/hle/kernel/client_session.h
@@ -42,9 +42,9 @@ public:
     /**
      * Sends an SyncRequest from the current emulated thread.
      * @param thread Thread that initiated the request.
-     * @return ResultCode of the operation.
+     * @return Result of the operation.
      */
-    ResultCode SendSyncRequest(std::shared_ptr<Thread> thread);
+    Result SendSyncRequest(std::shared_ptr<Thread> thread);
 
     std::string name; ///< Name of client port (optional)
 

--- a/src/core/hle/kernel/errors.h
+++ b/src/core/hle/kernel/errors.h
@@ -31,82 +31,82 @@ enum {
 // WARNING: The kernel is quite inconsistent in it's usage of errors code. Make sure to always
 // double check that the code matches before re-using the constant.
 
-constexpr Result ERR_OUT_OF_HANDLES(ErrCodes::OutOfHandles, ErrorModule::Kernel,
+constexpr Result ResultOutOfHandles(ErrCodes::OutOfHandles, ErrorModule::Kernel,
                                     ErrorSummary::OutOfResource,
                                     ErrorLevel::Permanent); // 0xD8600413
-constexpr Result ERR_SESSION_CLOSED_BY_REMOTE(ErrCodes::SessionClosedByRemote, ErrorModule::OS,
-                                              ErrorSummary::Canceled,
-                                              ErrorLevel::Status); // 0xC920181A
-constexpr Result ERR_PORT_NAME_TOO_LONG(ErrCodes::PortNameTooLong, ErrorModule::OS,
-                                        ErrorSummary::InvalidArgument,
-                                        ErrorLevel::Usage); // 0xE0E0181E
-constexpr Result ERR_WRONG_PERMISSION(ErrCodes::WrongPermission, ErrorModule::OS,
-                                      ErrorSummary::WrongArgument, ErrorLevel::Permanent);
-constexpr Result ERR_INVALID_BUFFER_DESCRIPTOR(ErrCodes::InvalidBufferDescriptor, ErrorModule::OS,
+constexpr Result ResultSessionClosed(ErrCodes::SessionClosedByRemote, ErrorModule::OS,
+                                     ErrorSummary::Canceled,
+                                     ErrorLevel::Status); // 0xC920181A
+constexpr Result ResultPortNameTooLong(ErrCodes::PortNameTooLong, ErrorModule::OS,
+                                       ErrorSummary::InvalidArgument,
+                                       ErrorLevel::Usage); // 0xE0E0181E
+constexpr Result ResultWrongPermission(ErrCodes::WrongPermission, ErrorModule::OS,
+                                       ErrorSummary::WrongArgument, ErrorLevel::Permanent);
+constexpr Result ResultInvalidBufferDescriptor(ErrCodes::InvalidBufferDescriptor, ErrorModule::OS,
                                                ErrorSummary::WrongArgument, ErrorLevel::Permanent);
-constexpr Result ERR_MAX_CONNECTIONS_REACHED(ErrCodes::MaxConnectionsReached, ErrorModule::OS,
+constexpr Result ResultMaxConnectionsReached(ErrCodes::MaxConnectionsReached, ErrorModule::OS,
                                              ErrorSummary::WouldBlock,
                                              ErrorLevel::Temporary); // 0xD0401834
 
-constexpr Result ERR_NOT_AUTHORIZED(ErrorDescription::NotAuthorized, ErrorModule::OS,
-                                    ErrorSummary::WrongArgument,
-                                    ErrorLevel::Permanent); // 0xD9001BEA
-constexpr Result ERR_INVALID_ENUM_VALUE(ErrorDescription::InvalidEnumValue, ErrorModule::Kernel,
+constexpr Result ResultNotAuthorized(ErrorDescription::NotAuthorized, ErrorModule::OS,
+                                     ErrorSummary::WrongArgument,
+                                     ErrorLevel::Permanent); // 0xD9001BEA
+constexpr Result ResultInvalidEnumValue(ErrorDescription::InvalidEnumValue, ErrorModule::Kernel,
                                         ErrorSummary::InvalidArgument,
                                         ErrorLevel::Permanent); // 0xD8E007ED
-constexpr Result ERR_INVALID_ENUM_VALUE_FND(ErrorDescription::InvalidEnumValue, ErrorModule::FND,
-                                            ErrorSummary::InvalidArgument,
-                                            ErrorLevel::Permanent); // 0xD8E093ED
-constexpr Result ERR_INVALID_COMBINATION(ErrorDescription::InvalidCombination, ErrorModule::OS,
-                                         ErrorSummary::InvalidArgument,
-                                         ErrorLevel::Usage); // 0xE0E01BEE
-constexpr Result ERR_INVALID_COMBINATION_KERNEL(ErrorDescription::InvalidCombination,
+constexpr Result ResultInvalidEnumValueFnd(ErrorDescription::InvalidEnumValue, ErrorModule::FND,
+                                           ErrorSummary::InvalidArgument,
+                                           ErrorLevel::Permanent); // 0xD8E093ED
+constexpr Result ResultInvalidCombination(ErrorDescription::InvalidCombination, ErrorModule::OS,
+                                          ErrorSummary::InvalidArgument,
+                                          ErrorLevel::Usage); // 0xE0E01BEE
+constexpr Result ResultInvalidCombinationKernel(ErrorDescription::InvalidCombination,
                                                 ErrorModule::Kernel, ErrorSummary::WrongArgument,
                                                 ErrorLevel::Permanent); // 0xD90007EE
-constexpr Result ERR_MISALIGNED_ADDRESS(ErrorDescription::MisalignedAddress, ErrorModule::OS,
-                                        ErrorSummary::InvalidArgument,
-                                        ErrorLevel::Usage); // 0xE0E01BF1
-constexpr Result ERR_MISALIGNED_SIZE(ErrorDescription::MisalignedSize, ErrorModule::OS,
-                                     ErrorSummary::InvalidArgument,
-                                     ErrorLevel::Usage); // 0xE0E01BF2
-constexpr Result ERR_OUT_OF_MEMORY(ErrorDescription::OutOfMemory, ErrorModule::Kernel,
+constexpr Result ResultMisalignedAddress(ErrorDescription::MisalignedAddress, ErrorModule::OS,
+                                         ErrorSummary::InvalidArgument,
+                                         ErrorLevel::Usage); // 0xE0E01BF1
+constexpr Result ResultMisalignedSize(ErrorDescription::MisalignedSize, ErrorModule::OS,
+                                      ErrorSummary::InvalidArgument,
+                                      ErrorLevel::Usage); // 0xE0E01BF2
+constexpr Result ResultOutOfMemory(ErrorDescription::OutOfMemory, ErrorModule::Kernel,
                                    ErrorSummary::OutOfResource,
                                    ErrorLevel::Permanent); // 0xD86007F3
 /// Returned when out of heap or linear heap memory when allocating
-constexpr Result ERR_OUT_OF_HEAP_MEMORY(ErrorDescription::OutOfMemory, ErrorModule::OS,
-                                        ErrorSummary::OutOfResource,
-                                        ErrorLevel::Status); // 0xC860180A
-constexpr Result ERR_NOT_IMPLEMENTED(ErrorDescription::NotImplemented, ErrorModule::OS,
-                                     ErrorSummary::InvalidArgument,
-                                     ErrorLevel::Usage); // 0xE0E01BF4
-constexpr Result ERR_INVALID_ADDRESS(ErrorDescription::InvalidAddress, ErrorModule::OS,
-                                     ErrorSummary::InvalidArgument,
-                                     ErrorLevel::Usage); // 0xE0E01BF5
-constexpr Result ERR_INVALID_ADDRESS_STATE(ErrorDescription::InvalidAddress, ErrorModule::OS,
+constexpr Result ResultOutOfHeapMemory(ErrorDescription::OutOfMemory, ErrorModule::OS,
+                                       ErrorSummary::OutOfResource,
+                                       ErrorLevel::Status); // 0xC860180A
+constexpr Result ResultNotImplemented(ErrorDescription::NotImplemented, ErrorModule::OS,
+                                      ErrorSummary::InvalidArgument,
+                                      ErrorLevel::Usage); // 0xE0E01BF4
+constexpr Result ResultInvalidAddress(ErrorDescription::InvalidAddress, ErrorModule::OS,
+                                      ErrorSummary::InvalidArgument,
+                                      ErrorLevel::Usage); // 0xE0E01BF5
+constexpr Result ResultInvalidAddressState(ErrorDescription::InvalidAddress, ErrorModule::OS,
                                            ErrorSummary::InvalidState,
                                            ErrorLevel::Usage); // 0xE0A01BF5
-constexpr Result ERR_INVALID_POINTER(ErrorDescription::InvalidPointer, ErrorModule::Kernel,
+constexpr Result ResultInvalidPointer(ErrorDescription::InvalidPointer, ErrorModule::Kernel,
+                                      ErrorSummary::InvalidArgument,
+                                      ErrorLevel::Permanent); // 0xD8E007F6
+constexpr Result ResultInvalidHandle(ErrorDescription::InvalidHandle, ErrorModule::Kernel,
                                      ErrorSummary::InvalidArgument,
-                                     ErrorLevel::Permanent); // 0xD8E007F6
-constexpr Result ERR_INVALID_HANDLE(ErrorDescription::InvalidHandle, ErrorModule::Kernel,
-                                    ErrorSummary::InvalidArgument,
-                                    ErrorLevel::Permanent); // 0xD8E007F7
-/// Alternate code returned instead of ERR_INVALID_HANDLE in some code paths.
-constexpr Result ERR_INVALID_HANDLE_OS(ErrorDescription::InvalidHandle, ErrorModule::OS,
+                                     ErrorLevel::Permanent); // 0xD8E007F7
+/// Alternate code returned instead of ResultInvalidHandle in some code paths.
+constexpr Result ResultInvalidHandleOs(ErrorDescription::InvalidHandle, ErrorModule::OS,
                                        ErrorSummary::WrongArgument,
                                        ErrorLevel::Permanent); // 0xD9001BF7
-constexpr Result ERR_NOT_FOUND(ErrorDescription::NotFound, ErrorModule::Kernel,
-                               ErrorSummary::NotFound, ErrorLevel::Permanent); // 0xD88007FA
-constexpr Result ERR_OUT_OF_RANGE(ErrorDescription::OutOfRange, ErrorModule::OS,
+constexpr Result ResultNotFound(ErrorDescription::NotFound, ErrorModule::Kernel,
+                                ErrorSummary::NotFound, ErrorLevel::Permanent); // 0xD88007FA
+constexpr Result ResultOutOfRange(ErrorDescription::OutOfRange, ErrorModule::OS,
                                   ErrorSummary::InvalidArgument,
                                   ErrorLevel::Usage); // 0xE0E01BFD
-constexpr Result ERR_OUT_OF_RANGE_KERNEL(ErrorDescription::OutOfRange, ErrorModule::Kernel,
-                                         ErrorSummary::InvalidArgument,
-                                         ErrorLevel::Permanent); // 0xD8E007FD
-constexpr Result RESULT_TIMEOUT(ErrorDescription::Timeout, ErrorModule::OS,
-                                ErrorSummary::StatusChanged, ErrorLevel::Info);
+constexpr Result ResultOutOfRangeKernel(ErrorDescription::OutOfRange, ErrorModule::Kernel,
+                                        ErrorSummary::InvalidArgument,
+                                        ErrorLevel::Permanent); // 0xD8E007FD
+constexpr Result ResultTimeout(ErrorDescription::Timeout, ErrorModule::OS,
+                               ErrorSummary::StatusChanged, ErrorLevel::Info);
 /// Returned when Accept() is called on a port with no sessions to be accepted.
-constexpr Result ERR_NO_PENDING_SESSIONS(ErrCodes::NoPendingSessions, ErrorModule::OS,
+constexpr Result ResultNoPendingSessions(ErrCodes::NoPendingSessions, ErrorModule::OS,
                                          ErrorSummary::WouldBlock,
                                          ErrorLevel::Permanent); // 0xD8401823
 

--- a/src/core/hle/kernel/errors.h
+++ b/src/core/hle/kernel/errors.h
@@ -31,85 +31,83 @@ enum {
 // WARNING: The kernel is quite inconsistent in it's usage of errors code. Make sure to always
 // double check that the code matches before re-using the constant.
 
-constexpr ResultCode ERR_OUT_OF_HANDLES(ErrCodes::OutOfHandles, ErrorModule::Kernel,
-                                        ErrorSummary::OutOfResource,
-                                        ErrorLevel::Permanent); // 0xD8600413
-constexpr ResultCode ERR_SESSION_CLOSED_BY_REMOTE(ErrCodes::SessionClosedByRemote, ErrorModule::OS,
-                                                  ErrorSummary::Canceled,
-                                                  ErrorLevel::Status); // 0xC920181A
-constexpr ResultCode ERR_PORT_NAME_TOO_LONG(ErrCodes::PortNameTooLong, ErrorModule::OS,
-                                            ErrorSummary::InvalidArgument,
-                                            ErrorLevel::Usage); // 0xE0E0181E
-constexpr ResultCode ERR_WRONG_PERMISSION(ErrCodes::WrongPermission, ErrorModule::OS,
-                                          ErrorSummary::WrongArgument, ErrorLevel::Permanent);
-constexpr ResultCode ERR_INVALID_BUFFER_DESCRIPTOR(ErrCodes::InvalidBufferDescriptor,
-                                                   ErrorModule::OS, ErrorSummary::WrongArgument,
-                                                   ErrorLevel::Permanent);
-constexpr ResultCode ERR_MAX_CONNECTIONS_REACHED(ErrCodes::MaxConnectionsReached, ErrorModule::OS,
-                                                 ErrorSummary::WouldBlock,
-                                                 ErrorLevel::Temporary); // 0xD0401834
-
-constexpr ResultCode ERR_NOT_AUTHORIZED(ErrorDescription::NotAuthorized, ErrorModule::OS,
-                                        ErrorSummary::WrongArgument,
-                                        ErrorLevel::Permanent); // 0xD9001BEA
-constexpr ResultCode ERR_INVALID_ENUM_VALUE(ErrorDescription::InvalidEnumValue, ErrorModule::Kernel,
-                                            ErrorSummary::InvalidArgument,
-                                            ErrorLevel::Permanent); // 0xD8E007ED
-constexpr ResultCode ERR_INVALID_ENUM_VALUE_FND(ErrorDescription::InvalidEnumValue,
-                                                ErrorModule::FND, ErrorSummary::InvalidArgument,
-                                                ErrorLevel::Permanent); // 0xD8E093ED
-constexpr ResultCode ERR_INVALID_COMBINATION(ErrorDescription::InvalidCombination, ErrorModule::OS,
-                                             ErrorSummary::InvalidArgument,
-                                             ErrorLevel::Usage); // 0xE0E01BEE
-constexpr ResultCode ERR_INVALID_COMBINATION_KERNEL(ErrorDescription::InvalidCombination,
-                                                    ErrorModule::Kernel,
-                                                    ErrorSummary::WrongArgument,
-                                                    ErrorLevel::Permanent); // 0xD90007EE
-constexpr ResultCode ERR_MISALIGNED_ADDRESS(ErrorDescription::MisalignedAddress, ErrorModule::OS,
-                                            ErrorSummary::InvalidArgument,
-                                            ErrorLevel::Usage); // 0xE0E01BF1
-constexpr ResultCode ERR_MISALIGNED_SIZE(ErrorDescription::MisalignedSize, ErrorModule::OS,
-                                         ErrorSummary::InvalidArgument,
-                                         ErrorLevel::Usage); // 0xE0E01BF2
-constexpr ResultCode ERR_OUT_OF_MEMORY(ErrorDescription::OutOfMemory, ErrorModule::Kernel,
-                                       ErrorSummary::OutOfResource,
-                                       ErrorLevel::Permanent); // 0xD86007F3
-/// Returned when out of heap or linear heap memory when allocating
-constexpr ResultCode ERR_OUT_OF_HEAP_MEMORY(ErrorDescription::OutOfMemory, ErrorModule::OS,
-                                            ErrorSummary::OutOfResource,
-                                            ErrorLevel::Status); // 0xC860180A
-constexpr ResultCode ERR_NOT_IMPLEMENTED(ErrorDescription::NotImplemented, ErrorModule::OS,
-                                         ErrorSummary::InvalidArgument,
-                                         ErrorLevel::Usage); // 0xE0E01BF4
-constexpr ResultCode ERR_INVALID_ADDRESS(ErrorDescription::InvalidAddress, ErrorModule::OS,
-                                         ErrorSummary::InvalidArgument,
-                                         ErrorLevel::Usage); // 0xE0E01BF5
-constexpr ResultCode ERR_INVALID_ADDRESS_STATE(ErrorDescription::InvalidAddress, ErrorModule::OS,
-                                               ErrorSummary::InvalidState,
-                                               ErrorLevel::Usage); // 0xE0A01BF5
-constexpr ResultCode ERR_INVALID_POINTER(ErrorDescription::InvalidPointer, ErrorModule::Kernel,
-                                         ErrorSummary::InvalidArgument,
-                                         ErrorLevel::Permanent); // 0xD8E007F6
-constexpr ResultCode ERR_INVALID_HANDLE(ErrorDescription::InvalidHandle, ErrorModule::Kernel,
+constexpr Result ERR_OUT_OF_HANDLES(ErrCodes::OutOfHandles, ErrorModule::Kernel,
+                                    ErrorSummary::OutOfResource,
+                                    ErrorLevel::Permanent); // 0xD8600413
+constexpr Result ERR_SESSION_CLOSED_BY_REMOTE(ErrCodes::SessionClosedByRemote, ErrorModule::OS,
+                                              ErrorSummary::Canceled,
+                                              ErrorLevel::Status); // 0xC920181A
+constexpr Result ERR_PORT_NAME_TOO_LONG(ErrCodes::PortNameTooLong, ErrorModule::OS,
                                         ErrorSummary::InvalidArgument,
-                                        ErrorLevel::Permanent); // 0xD8E007F7
-/// Alternate code returned instead of ERR_INVALID_HANDLE in some code paths.
-constexpr ResultCode ERR_INVALID_HANDLE_OS(ErrorDescription::InvalidHandle, ErrorModule::OS,
-                                           ErrorSummary::WrongArgument,
-                                           ErrorLevel::Permanent); // 0xD9001BF7
-constexpr ResultCode ERR_NOT_FOUND(ErrorDescription::NotFound, ErrorModule::Kernel,
-                                   ErrorSummary::NotFound, ErrorLevel::Permanent); // 0xD88007FA
-constexpr ResultCode ERR_OUT_OF_RANGE(ErrorDescription::OutOfRange, ErrorModule::OS,
-                                      ErrorSummary::InvalidArgument,
-                                      ErrorLevel::Usage); // 0xE0E01BFD
-constexpr ResultCode ERR_OUT_OF_RANGE_KERNEL(ErrorDescription::OutOfRange, ErrorModule::Kernel,
-                                             ErrorSummary::InvalidArgument,
-                                             ErrorLevel::Permanent); // 0xD8E007FD
-constexpr ResultCode RESULT_TIMEOUT(ErrorDescription::Timeout, ErrorModule::OS,
-                                    ErrorSummary::StatusChanged, ErrorLevel::Info);
-/// Returned when Accept() is called on a port with no sessions to be accepted.
-constexpr ResultCode ERR_NO_PENDING_SESSIONS(ErrCodes::NoPendingSessions, ErrorModule::OS,
+                                        ErrorLevel::Usage); // 0xE0E0181E
+constexpr Result ERR_WRONG_PERMISSION(ErrCodes::WrongPermission, ErrorModule::OS,
+                                      ErrorSummary::WrongArgument, ErrorLevel::Permanent);
+constexpr Result ERR_INVALID_BUFFER_DESCRIPTOR(ErrCodes::InvalidBufferDescriptor, ErrorModule::OS,
+                                               ErrorSummary::WrongArgument, ErrorLevel::Permanent);
+constexpr Result ERR_MAX_CONNECTIONS_REACHED(ErrCodes::MaxConnectionsReached, ErrorModule::OS,
                                              ErrorSummary::WouldBlock,
-                                             ErrorLevel::Permanent); // 0xD8401823
+                                             ErrorLevel::Temporary); // 0xD0401834
+
+constexpr Result ERR_NOT_AUTHORIZED(ErrorDescription::NotAuthorized, ErrorModule::OS,
+                                    ErrorSummary::WrongArgument,
+                                    ErrorLevel::Permanent); // 0xD9001BEA
+constexpr Result ERR_INVALID_ENUM_VALUE(ErrorDescription::InvalidEnumValue, ErrorModule::Kernel,
+                                        ErrorSummary::InvalidArgument,
+                                        ErrorLevel::Permanent); // 0xD8E007ED
+constexpr Result ERR_INVALID_ENUM_VALUE_FND(ErrorDescription::InvalidEnumValue, ErrorModule::FND,
+                                            ErrorSummary::InvalidArgument,
+                                            ErrorLevel::Permanent); // 0xD8E093ED
+constexpr Result ERR_INVALID_COMBINATION(ErrorDescription::InvalidCombination, ErrorModule::OS,
+                                         ErrorSummary::InvalidArgument,
+                                         ErrorLevel::Usage); // 0xE0E01BEE
+constexpr Result ERR_INVALID_COMBINATION_KERNEL(ErrorDescription::InvalidCombination,
+                                                ErrorModule::Kernel, ErrorSummary::WrongArgument,
+                                                ErrorLevel::Permanent); // 0xD90007EE
+constexpr Result ERR_MISALIGNED_ADDRESS(ErrorDescription::MisalignedAddress, ErrorModule::OS,
+                                        ErrorSummary::InvalidArgument,
+                                        ErrorLevel::Usage); // 0xE0E01BF1
+constexpr Result ERR_MISALIGNED_SIZE(ErrorDescription::MisalignedSize, ErrorModule::OS,
+                                     ErrorSummary::InvalidArgument,
+                                     ErrorLevel::Usage); // 0xE0E01BF2
+constexpr Result ERR_OUT_OF_MEMORY(ErrorDescription::OutOfMemory, ErrorModule::Kernel,
+                                   ErrorSummary::OutOfResource,
+                                   ErrorLevel::Permanent); // 0xD86007F3
+/// Returned when out of heap or linear heap memory when allocating
+constexpr Result ERR_OUT_OF_HEAP_MEMORY(ErrorDescription::OutOfMemory, ErrorModule::OS,
+                                        ErrorSummary::OutOfResource,
+                                        ErrorLevel::Status); // 0xC860180A
+constexpr Result ERR_NOT_IMPLEMENTED(ErrorDescription::NotImplemented, ErrorModule::OS,
+                                     ErrorSummary::InvalidArgument,
+                                     ErrorLevel::Usage); // 0xE0E01BF4
+constexpr Result ERR_INVALID_ADDRESS(ErrorDescription::InvalidAddress, ErrorModule::OS,
+                                     ErrorSummary::InvalidArgument,
+                                     ErrorLevel::Usage); // 0xE0E01BF5
+constexpr Result ERR_INVALID_ADDRESS_STATE(ErrorDescription::InvalidAddress, ErrorModule::OS,
+                                           ErrorSummary::InvalidState,
+                                           ErrorLevel::Usage); // 0xE0A01BF5
+constexpr Result ERR_INVALID_POINTER(ErrorDescription::InvalidPointer, ErrorModule::Kernel,
+                                     ErrorSummary::InvalidArgument,
+                                     ErrorLevel::Permanent); // 0xD8E007F6
+constexpr Result ERR_INVALID_HANDLE(ErrorDescription::InvalidHandle, ErrorModule::Kernel,
+                                    ErrorSummary::InvalidArgument,
+                                    ErrorLevel::Permanent); // 0xD8E007F7
+/// Alternate code returned instead of ERR_INVALID_HANDLE in some code paths.
+constexpr Result ERR_INVALID_HANDLE_OS(ErrorDescription::InvalidHandle, ErrorModule::OS,
+                                       ErrorSummary::WrongArgument,
+                                       ErrorLevel::Permanent); // 0xD9001BF7
+constexpr Result ERR_NOT_FOUND(ErrorDescription::NotFound, ErrorModule::Kernel,
+                               ErrorSummary::NotFound, ErrorLevel::Permanent); // 0xD88007FA
+constexpr Result ERR_OUT_OF_RANGE(ErrorDescription::OutOfRange, ErrorModule::OS,
+                                  ErrorSummary::InvalidArgument,
+                                  ErrorLevel::Usage); // 0xE0E01BFD
+constexpr Result ERR_OUT_OF_RANGE_KERNEL(ErrorDescription::OutOfRange, ErrorModule::Kernel,
+                                         ErrorSummary::InvalidArgument,
+                                         ErrorLevel::Permanent); // 0xD8E007FD
+constexpr Result RESULT_TIMEOUT(ErrorDescription::Timeout, ErrorModule::OS,
+                                ErrorSummary::StatusChanged, ErrorLevel::Info);
+/// Returned when Accept() is called on a port with no sessions to be accepted.
+constexpr Result ERR_NO_PENDING_SESSIONS(ErrCodes::NoPendingSessions, ErrorModule::OS,
+                                         ErrorSummary::WouldBlock,
+                                         ErrorLevel::Permanent); // 0xD8401823
 
 } // namespace Kernel

--- a/src/core/hle/kernel/event.cpp
+++ b/src/core/hle/kernel/event.cpp
@@ -36,8 +36,9 @@ bool Event::ShouldWait(const Thread* thread) const {
 void Event::Acquire(Thread* thread) {
     ASSERT_MSG(!ShouldWait(thread), "object unavailable!");
 
-    if (reset_type == ResetType::OneShot)
+    if (reset_type == ResetType::OneShot) {
         signaled = false;
+    }
 }
 
 void Event::Signal() {
@@ -52,8 +53,9 @@ void Event::Clear() {
 void Event::WakeupAllWaitingThreads() {
     WaitObject::WakeupAllWaitingThreads();
 
-    if (reset_type == ResetType::Pulse)
+    if (reset_type == ResetType::Pulse) {
         signaled = false;
+    }
 }
 
 } // namespace Kernel

--- a/src/core/hle/kernel/handle_table.cpp
+++ b/src/core/hle/kernel/handle_table.cpp
@@ -32,7 +32,7 @@ Result HandleTable::Create(Handle* out_handle, std::shared_ptr<Object> obj) {
     DEBUG_ASSERT(obj != nullptr);
 
     u16 slot = next_free_slot;
-    R_UNLESS(slot < generations.size(), ERR_OUT_OF_HANDLES);
+    R_UNLESS(slot < generations.size(), ResultOutOfHandles);
     next_free_slot = generations[slot];
 
     u16 generation = next_generation++;
@@ -47,24 +47,24 @@ Result HandleTable::Create(Handle* out_handle, std::shared_ptr<Object> obj) {
     objects[slot] = std::move(obj);
 
     *out_handle = generation | (slot << 15);
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result HandleTable::Duplicate(Handle* out, Handle handle) {
     std::shared_ptr<Object> object = GetGeneric(handle);
-    R_UNLESS(object, ERR_INVALID_HANDLE);
+    R_UNLESS(object, ResultInvalidHandle);
     return Create(out, std::move(object));
 }
 
 Result HandleTable::Close(Handle handle) {
-    R_UNLESS(IsValid(handle), ERR_INVALID_HANDLE);
+    R_UNLESS(IsValid(handle), ResultInvalidHandle);
 
     const u16 slot = GetSlot(handle);
     objects[slot] = nullptr;
 
     generations[slot] = next_free_slot;
     next_free_slot = slot;
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 bool HandleTable::IsValid(Handle handle) const {

--- a/src/core/hle/kernel/handle_table.cpp
+++ b/src/core/hle/kernel/handle_table.cpp
@@ -28,7 +28,7 @@ HandleTable::HandleTable(KernelSystem& kernel) : kernel(kernel) {
 
 HandleTable::~HandleTable() = default;
 
-ResultCode HandleTable::Create(Handle* out_handle, std::shared_ptr<Object> obj) {
+Result HandleTable::Create(Handle* out_handle, std::shared_ptr<Object> obj) {
     DEBUG_ASSERT(obj != nullptr);
 
     u16 slot = next_free_slot;
@@ -50,13 +50,13 @@ ResultCode HandleTable::Create(Handle* out_handle, std::shared_ptr<Object> obj) 
     return RESULT_SUCCESS;
 }
 
-ResultCode HandleTable::Duplicate(Handle* out, Handle handle) {
+Result HandleTable::Duplicate(Handle* out, Handle handle) {
     std::shared_ptr<Object> object = GetGeneric(handle);
     R_UNLESS(object, ERR_INVALID_HANDLE);
     return Create(out, std::move(object));
 }
 
-ResultCode HandleTable::Close(Handle handle) {
+Result HandleTable::Close(Handle handle) {
     R_UNLESS(IsValid(handle), ERR_INVALID_HANDLE);
 
     const u16 slot = GetSlot(handle);

--- a/src/core/hle/kernel/handle_table.cpp
+++ b/src/core/hle/kernel/handle_table.cpp
@@ -28,45 +28,38 @@ HandleTable::HandleTable(KernelSystem& kernel) : kernel(kernel) {
 
 HandleTable::~HandleTable() = default;
 
-ResultVal<Handle> HandleTable::Create(std::shared_ptr<Object> obj) {
+ResultCode HandleTable::Create(Handle* out_handle, std::shared_ptr<Object> obj) {
     DEBUG_ASSERT(obj != nullptr);
 
     u16 slot = next_free_slot;
-    if (slot >= generations.size()) {
-        LOG_ERROR(Kernel, "Unable to allocate Handle, too many slots in use.");
-        return ERR_OUT_OF_HANDLES;
-    }
+    R_UNLESS(slot < generations.size(), ERR_OUT_OF_HANDLES);
     next_free_slot = generations[slot];
 
     u16 generation = next_generation++;
 
     // Overflow count so it fits in the 15 bits dedicated to the generation in the handle.
     // CTR-OS doesn't use generation 0, so skip straight to 1.
-    if (next_generation >= (1 << 15))
+    if (next_generation >= (1 << 15)) {
         next_generation = 1;
+    }
 
     generations[slot] = generation;
     objects[slot] = std::move(obj);
 
-    Handle handle = generation | (slot << 15);
-    return handle;
+    *out_handle = generation | (slot << 15);
+    return RESULT_SUCCESS;
 }
 
-ResultVal<Handle> HandleTable::Duplicate(Handle handle) {
+ResultCode HandleTable::Duplicate(Handle* out, Handle handle) {
     std::shared_ptr<Object> object = GetGeneric(handle);
-    if (object == nullptr) {
-        LOG_ERROR(Kernel, "Tried to duplicate invalid handle: {:08X}", handle);
-        return ERR_INVALID_HANDLE;
-    }
-    return Create(std::move(object));
+    R_UNLESS(object, ERR_INVALID_HANDLE);
+    return Create(out, std::move(object));
 }
 
 ResultCode HandleTable::Close(Handle handle) {
-    if (!IsValid(handle))
-        return ERR_INVALID_HANDLE;
+    R_UNLESS(IsValid(handle), ERR_INVALID_HANDLE);
 
-    u16 slot = GetSlot(handle);
-
+    const u16 slot = GetSlot(handle);
     objects[slot] = nullptr;
 
     generations[slot] = next_free_slot;
@@ -75,9 +68,8 @@ ResultCode HandleTable::Close(Handle handle) {
 }
 
 bool HandleTable::IsValid(Handle handle) const {
-    std::size_t slot = GetSlot(handle);
-    u16 generation = GetGeneration(handle);
-
+    const u16 slot = GetSlot(handle);
+    const u16 generation = GetGeneration(handle);
     return slot < MAX_COUNT && objects[slot] != nullptr && generations[slot] == generation;
 }
 

--- a/src/core/hle/kernel/handle_table.cpp
+++ b/src/core/hle/kernel/handle_table.cpp
@@ -50,10 +50,10 @@ Result HandleTable::Create(Handle* out_handle, std::shared_ptr<Object> obj) {
     return ResultSuccess;
 }
 
-Result HandleTable::Duplicate(Handle* out, Handle handle) {
+Result HandleTable::Duplicate(Handle* out_handle, Handle handle) {
     std::shared_ptr<Object> object = GetGeneric(handle);
     R_UNLESS(object, ResultInvalidHandle);
-    return Create(out, std::move(object));
+    return Create(out_handle, std::move(object));
 }
 
 Result HandleTable::Close(Handle handle) {

--- a/src/core/hle/kernel/handle_table.h
+++ b/src/core/hle/kernel/handle_table.h
@@ -61,7 +61,7 @@ public:
      *           - `ResultInvalidHandle`: an invalid handle was passed in.
      *           - Any errors returned by `Create()`.
      */
-    Result Duplicate(Handle* out, Handle handle);
+    Result Duplicate(Handle* out_handle, Handle handle);
 
     /**
      * Closes a handle, removing it from the table and decreasing the object's ref-count.

--- a/src/core/hle/kernel/handle_table.h
+++ b/src/core/hle/kernel/handle_table.h
@@ -53,7 +53,7 @@ public:
      * @return The created Handle or one of the following errors:
      *           - `ERR_OUT_OF_HANDLES`: the maximum number of handles has been exceeded.
      */
-    ResultVal<Handle> Create(std::shared_ptr<Object> obj);
+    ResultCode Create(Handle* out_handle, std::shared_ptr<Object> obj);
 
     /**
      * Returns a new handle that points to the same object as the passed in handle.
@@ -61,7 +61,7 @@ public:
      *           - `ERR_INVALID_HANDLE`: an invalid handle was passed in.
      *           - Any errors returned by `Create()`.
      */
-    ResultVal<Handle> Duplicate(Handle handle);
+    ResultCode Duplicate(Handle* out, Handle handle);
 
     /**
      * Closes a handle, removing it from the table and decreasing the object's ref-count.

--- a/src/core/hle/kernel/handle_table.h
+++ b/src/core/hle/kernel/handle_table.h
@@ -51,22 +51,22 @@ public:
     /**
      * Allocates a handle for the given object.
      * @return The created Handle or one of the following errors:
-     *           - `ERR_OUT_OF_HANDLES`: the maximum number of handles has been exceeded.
+     *           - `ResultOutOfHandles`: the maximum number of handles has been exceeded.
      */
     Result Create(Handle* out_handle, std::shared_ptr<Object> obj);
 
     /**
      * Returns a new handle that points to the same object as the passed in handle.
      * @return The duplicated Handle or one of the following errors:
-     *           - `ERR_INVALID_HANDLE`: an invalid handle was passed in.
+     *           - `ResultInvalidHandle`: an invalid handle was passed in.
      *           - Any errors returned by `Create()`.
      */
     Result Duplicate(Handle* out, Handle handle);
 
     /**
      * Closes a handle, removing it from the table and decreasing the object's ref-count.
-     * @return `RESULT_SUCCESS` or one of the following errors:
-     *           - `ERR_INVALID_HANDLE`: an invalid handle was passed in.
+     * @return `ResultSuccess` or one of the following errors:
+     *           - `ResultInvalidHandle`: an invalid handle was passed in.
      */
     Result Close(Handle handle);
 

--- a/src/core/hle/kernel/handle_table.h
+++ b/src/core/hle/kernel/handle_table.h
@@ -53,7 +53,7 @@ public:
      * @return The created Handle or one of the following errors:
      *           - `ERR_OUT_OF_HANDLES`: the maximum number of handles has been exceeded.
      */
-    ResultCode Create(Handle* out_handle, std::shared_ptr<Object> obj);
+    Result Create(Handle* out_handle, std::shared_ptr<Object> obj);
 
     /**
      * Returns a new handle that points to the same object as the passed in handle.
@@ -61,14 +61,14 @@ public:
      *           - `ERR_INVALID_HANDLE`: an invalid handle was passed in.
      *           - Any errors returned by `Create()`.
      */
-    ResultCode Duplicate(Handle* out, Handle handle);
+    Result Duplicate(Handle* out, Handle handle);
 
     /**
      * Closes a handle, removing it from the table and decreasing the object's ref-count.
      * @return `RESULT_SUCCESS` or one of the following errors:
      *           - `ERR_INVALID_HANDLE`: an invalid handle was passed in.
      */
-    ResultCode Close(Handle handle);
+    Result Close(Handle handle);
 
     /// Checks if a handle is valid and points to an existing object.
     bool IsValid(Handle handle) const;

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -203,7 +203,7 @@ Result HLERequestContext::PopulateFromIncomingCommandBuffer(const u32_le* src_cm
                                                std::move(translated_cmdbuf));
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result HLERequestContext::WriteToOutgoingCommandBuffer(u32_le* dst_cmdbuf,
@@ -281,7 +281,7 @@ Result HLERequestContext::WriteToOutgoingCommandBuffer(u32_le* dst_cmdbuf,
                                              std::move(translated_cmdbuf));
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 MappedBuffer& HLERequestContext::GetMappedBuffer(u32 id_from_cmdbuf) {

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -126,8 +126,8 @@ void HLERequestContext::AddStaticBuffer(u8 buffer_id, std::vector<u8> data) {
     static_buffers[buffer_id] = std::move(data);
 }
 
-ResultCode HLERequestContext::PopulateFromIncomingCommandBuffer(
-    const u32_le* src_cmdbuf, std::shared_ptr<Process> src_process_) {
+Result HLERequestContext::PopulateFromIncomingCommandBuffer(const u32_le* src_cmdbuf,
+                                                            std::shared_ptr<Process> src_process_) {
     auto& src_process = *src_process_;
     IPC::Header header{src_cmdbuf[0]};
 
@@ -206,8 +206,8 @@ ResultCode HLERequestContext::PopulateFromIncomingCommandBuffer(
     return RESULT_SUCCESS;
 }
 
-ResultCode HLERequestContext::WriteToOutgoingCommandBuffer(u32_le* dst_cmdbuf,
-                                                           Process& dst_process) const {
+Result HLERequestContext::WriteToOutgoingCommandBuffer(u32_le* dst_cmdbuf,
+                                                       Process& dst_process) const {
     IPC::Header header{cmd_buf[0]};
 
     std::size_t untranslated_size = 1u + header.normal_params_size;

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -239,7 +239,7 @@ ResultCode HLERequestContext::WriteToOutgoingCommandBuffer(u32_le* dst_cmdbuf,
                 Handle handle = 0;
                 if (object != nullptr) {
                     // TODO(yuriks): Figure out the proper error handling for if this fails
-                    handle = dst_process.handle_table.Create(object).Unwrap();
+                    R_ASSERT(dst_process.handle_table.Create(std::addressof(handle), object));
                 }
                 dst_cmdbuf[i++] = handle;
             }

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -363,10 +363,10 @@ public:
     MappedBuffer& GetMappedBuffer(u32 id_from_cmdbuf);
 
     /// Populates this context with data from the requesting process/thread.
-    ResultCode PopulateFromIncomingCommandBuffer(const u32_le* src_cmdbuf,
-                                                 std::shared_ptr<Process> src_process);
+    Result PopulateFromIncomingCommandBuffer(const u32_le* src_cmdbuf,
+                                             std::shared_ptr<Process> src_process);
     /// Writes data from this context back to the requesting process/thread.
-    ResultCode WriteToOutgoingCommandBuffer(u32_le* dst_cmdbuf, Process& dst_process) const;
+    Result WriteToOutgoingCommandBuffer(u32_le* dst_cmdbuf, Process& dst_process) const;
 
     /// Reports an unimplemented function.
     void ReportUnimplemented() const;

--- a/src/core/hle/kernel/ipc.cpp
+++ b/src/core/hle/kernel/ipc.cpp
@@ -182,7 +182,7 @@ Result TranslateCommandBuffer(Kernel::KernelSystem& kernel, Memory::MemorySystem
                 Result result =
                     src_process->vm_manager.UnmapRange(page_start - Memory::CITRA_PAGE_SIZE,
                                                        (num_pages + 2) * Memory::CITRA_PAGE_SIZE);
-                ASSERT(result == RESULT_SUCCESS);
+                ASSERT(result == ResultSuccess);
 
                 mapped_buffer_context.erase(found);
 
@@ -215,11 +215,11 @@ Result TranslateCommandBuffer(Kernel::KernelSystem& kernel, Memory::MemorySystem
             ASSERT(dst_process->vm_manager.ChangeMemoryState(
                        low_guard_address, Memory::CITRA_PAGE_SIZE, Kernel::MemoryState::Shared,
                        Kernel::VMAPermission::ReadWrite, Kernel::MemoryState::Reserved,
-                       Kernel::VMAPermission::None) == RESULT_SUCCESS);
+                       Kernel::VMAPermission::None) == ResultSuccess);
             ASSERT(dst_process->vm_manager.ChangeMemoryState(
                        high_guard_address, Memory::CITRA_PAGE_SIZE, Kernel::MemoryState::Shared,
                        Kernel::VMAPermission::ReadWrite, Kernel::MemoryState::Reserved,
-                       Kernel::VMAPermission::None) == RESULT_SUCCESS);
+                       Kernel::VMAPermission::None) == ResultSuccess);
 
             // Get proper mapped buffer address and store it in the cmd buffer.
             target_address += Memory::CITRA_PAGE_SIZE;
@@ -248,6 +248,6 @@ Result TranslateCommandBuffer(Kernel::KernelSystem& kernel, Memory::MemorySystem
 
     memory.WriteBlock(*dst_process, dst_address, cmd_buf.data(), command_size * sizeof(u32));
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 } // namespace Kernel

--- a/src/core/hle/kernel/ipc.cpp
+++ b/src/core/hle/kernel/ipc.cpp
@@ -18,12 +18,11 @@
 
 namespace Kernel {
 
-ResultCode TranslateCommandBuffer(Kernel::KernelSystem& kernel, Memory::MemorySystem& memory,
-                                  std::shared_ptr<Thread> src_thread,
-                                  std::shared_ptr<Thread> dst_thread, VAddr src_address,
-                                  VAddr dst_address,
-                                  std::vector<MappedBufferContext>& mapped_buffer_context,
-                                  bool reply) {
+Result TranslateCommandBuffer(Kernel::KernelSystem& kernel, Memory::MemorySystem& memory,
+                              std::shared_ptr<Thread> src_thread,
+                              std::shared_ptr<Thread> dst_thread, VAddr src_address,
+                              VAddr dst_address,
+                              std::vector<MappedBufferContext>& mapped_buffer_context, bool reply) {
     auto src_process = src_thread->owner_process.lock();
     auto dst_process = dst_thread->owner_process.lock();
     ASSERT(src_process && dst_process);
@@ -60,8 +59,8 @@ ResultCode TranslateCommandBuffer(Kernel::KernelSystem& kernel, Memory::MemorySy
             // Note: The real kernel does not check that the number of handles fits into the command
             // buffer before writing them, only after finishing.
             if (i + num_handles > command_size) {
-                return ResultCode(ErrCodes::CommandTooLarge, ErrorModule::OS,
-                                  ErrorSummary::InvalidState, ErrorLevel::Status);
+                return Result(ErrCodes::CommandTooLarge, ErrorModule::OS,
+                              ErrorSummary::InvalidState, ErrorLevel::Status);
             }
 
             for (u32 j = 0; j < num_handles; ++j) {
@@ -180,7 +179,7 @@ ResultCode TranslateCommandBuffer(Kernel::KernelSystem& kernel, Memory::MemorySy
                        next_vma.meminfo_state == MemoryState::Reserved);
 
                 // Unmap the buffer and guard pages from the source process
-                ResultCode result =
+                Result result =
                     src_process->vm_manager.UnmapRange(page_start - Memory::CITRA_PAGE_SIZE,
                                                        (num_pages + 2) * Memory::CITRA_PAGE_SIZE);
                 ASSERT(result == RESULT_SUCCESS);

--- a/src/core/hle/kernel/ipc.cpp
+++ b/src/core/hle/kernel/ipc.cpp
@@ -88,8 +88,8 @@ ResultCode TranslateCommandBuffer(Kernel::KernelSystem& kernel, Memory::MemorySy
                     continue;
                 }
 
-                auto result = dst_process->handle_table.Create(std::move(object));
-                cmd_buf[i++] = result.ValueOr(0);
+                R_ASSERT(dst_process->handle_table.Create(std::addressof(cmd_buf[i++]),
+                                                          std::move(object)));
             }
             break;
         }

--- a/src/core/hle/kernel/ipc.h
+++ b/src/core/hle/kernel/ipc.h
@@ -40,10 +40,9 @@ private:
 };
 
 /// Performs IPC command buffer translation from one process to another.
-ResultCode TranslateCommandBuffer(KernelSystem& system, Memory::MemorySystem& memory,
-                                  std::shared_ptr<Thread> src_thread,
-                                  std::shared_ptr<Thread> dst_thread, VAddr src_address,
-                                  VAddr dst_address,
-                                  std::vector<MappedBufferContext>& mapped_buffer_context,
-                                  bool reply);
+Result TranslateCommandBuffer(KernelSystem& system, Memory::MemorySystem& memory,
+                              std::shared_ptr<Thread> src_thread,
+                              std::shared_ptr<Thread> dst_thread, VAddr src_address,
+                              VAddr dst_address,
+                              std::vector<MappedBufferContext>& mapped_buffer_context, bool reply);
 } // namespace Kernel

--- a/src/core/hle/kernel/mutex.cpp
+++ b/src/core/hle/kernel/mutex.cpp
@@ -96,7 +96,7 @@ Result Mutex::Release(Thread* thread) {
         kernel.PrepareReschedule();
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 void Mutex::AddWaitingThread(std::shared_ptr<Thread> thread) {

--- a/src/core/hle/kernel/mutex.cpp
+++ b/src/core/hle/kernel/mutex.cpp
@@ -66,7 +66,7 @@ void Mutex::Acquire(Thread* thread) {
     lock_count++;
 }
 
-ResultCode Mutex::Release(Thread* thread) {
+Result Mutex::Release(Thread* thread) {
     // We can only release the mutex if it's held by the calling thread.
     if (thread != holding_thread.get()) {
         if (holding_thread) {
@@ -75,15 +75,15 @@ ResultCode Mutex::Release(Thread* thread) {
                 "Tried to release a mutex (owned by thread id {}) from a different thread id {}",
                 holding_thread->thread_id, thread->thread_id);
         }
-        return ResultCode(ErrCodes::WrongLockingThread, ErrorModule::Kernel,
-                          ErrorSummary::InvalidArgument, ErrorLevel::Permanent);
+        return Result(ErrCodes::WrongLockingThread, ErrorModule::Kernel,
+                      ErrorSummary::InvalidArgument, ErrorLevel::Permanent);
     }
 
     // Note: It should not be possible for the situation where the mutex has a holding thread with a
     // zero lock count to occur. The real kernel still checks for this, so we do too.
     if (lock_count <= 0)
-        return ResultCode(ErrorDescription::InvalidResultValue, ErrorModule::Kernel,
-                          ErrorSummary::InvalidState, ErrorLevel::Permanent);
+        return Result(ErrorDescription::InvalidResultValue, ErrorModule::Kernel,
+                      ErrorSummary::InvalidState, ErrorLevel::Permanent);
 
     lock_count--;
 

--- a/src/core/hle/kernel/mutex.h
+++ b/src/core/hle/kernel/mutex.h
@@ -60,7 +60,7 @@ public:
      * @param thread Thread that wants to release the mutex.
      * @returns The result code of the operation.
      */
-    ResultCode Release(Thread* thread);
+    Result Release(Thread* thread);
 
 private:
     KernelSystem& kernel;

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -249,8 +249,8 @@ VAddr Process::GetLinearHeapLimit() const {
     return GetLinearHeapBase() + memory_region->size;
 }
 
-ResultCode Process::HeapAllocate(VAddr* out_addr, VAddr target, u32 size, VMAPermission perms,
-                                 MemoryState memory_state, bool skip_range_check) {
+Result Process::HeapAllocate(VAddr* out_addr, VAddr target, u32 size, VMAPermission perms,
+                             MemoryState memory_state, bool skip_range_check) {
     LOG_DEBUG(Kernel, "Allocate heap target={:08X}, size={:08X}", target, size);
     if (target < Memory::HEAP_VADDR || target + size > Memory::HEAP_VADDR_END ||
         target + size < target) {
@@ -297,7 +297,7 @@ ResultCode Process::HeapAllocate(VAddr* out_addr, VAddr target, u32 size, VMAPer
     return RESULT_SUCCESS;
 }
 
-ResultCode Process::HeapFree(VAddr target, u32 size) {
+Result Process::HeapFree(VAddr target, u32 size) {
     LOG_DEBUG(Kernel, "Free heap target={:08X}, size={:08X}", target, size);
     if (target < Memory::HEAP_VADDR || target + size > Memory::HEAP_VADDR_END ||
         target + size < target) {
@@ -315,7 +315,7 @@ ResultCode Process::HeapFree(VAddr target, u32 size) {
         holding_memory -= MemoryRegionInfo::Interval(backing_offset, backing_offset + block_size);
     }
 
-    ResultCode result = vm_manager.UnmapRange(target, size);
+    Result result = vm_manager.UnmapRange(target, size);
     ASSERT(result.IsSuccess());
 
     memory_used -= size;
@@ -324,7 +324,7 @@ ResultCode Process::HeapFree(VAddr target, u32 size) {
     return RESULT_SUCCESS;
 }
 
-ResultCode Process::LinearAllocate(VAddr* out_addr, VAddr target, u32 size, VMAPermission perms) {
+Result Process::LinearAllocate(VAddr* out_addr, VAddr target, u32 size, VMAPermission perms) {
     LOG_DEBUG(Kernel, "Allocate linear heap target={:08X}, size={:08X}", target, size);
     u32 physical_offset;
     if (target == 0) {
@@ -372,7 +372,7 @@ ResultCode Process::LinearAllocate(VAddr* out_addr, VAddr target, u32 size, VMAP
     return RESULT_SUCCESS;
 }
 
-ResultCode Process::LinearFree(VAddr target, u32 size) {
+Result Process::LinearFree(VAddr target, u32 size) {
     LOG_DEBUG(Kernel, "Free linear heap target={:08X}, size={:08X}", target, size);
     if (target < GetLinearHeapBase() || target + size > GetLinearHeapLimit() ||
         target + size < target) {
@@ -463,8 +463,7 @@ ResultVal<VAddr> Process::AllocateThreadLocalStorage() {
     return tls_address;
 }
 
-ResultCode Process::Map(VAddr target, VAddr source, u32 size, VMAPermission perms,
-                        bool privileged) {
+Result Process::Map(VAddr target, VAddr source, u32 size, VMAPermission perms, bool privileged) {
     LOG_DEBUG(Kernel, "Map memory target={:08X}, source={:08X}, size={:08X}, perms={:08X}", target,
               source, size, perms);
     if (!privileged && (source < Memory::HEAP_VADDR || source + size > Memory::HEAP_VADDR_END ||
@@ -518,8 +517,7 @@ ResultCode Process::Map(VAddr target, VAddr source, u32 size, VMAPermission perm
 
     return RESULT_SUCCESS;
 }
-ResultCode Process::Unmap(VAddr target, VAddr source, u32 size, VMAPermission perms,
-                          bool privileged) {
+Result Process::Unmap(VAddr target, VAddr source, u32 size, VMAPermission perms, bool privileged) {
     LOG_DEBUG(Kernel, "Unmap memory target={:08X}, source={:08X}, size={:08X}, perms={:08X}",
               target, source, size, perms);
     if (!privileged && (source < Memory::HEAP_VADDR || source + size > Memory::HEAP_VADDR_END ||

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -502,8 +502,8 @@ Result Process::Map(VAddr target, VAddr source, u32 size, VMAPermission perms, b
     VMAPermission source_perm = privileged ? VMAPermission::None : VMAPermission::ReadWrite;
 
     // Mark source region as Aliased
-    CASCADE_CODE(vm_manager.ChangeMemoryState(source, size, MemoryState::Private,
-                                              VMAPermission::ReadWrite, source_state, source_perm));
+    R_TRY(vm_manager.ChangeMemoryState(source, size, MemoryState::Private, VMAPermission::ReadWrite,
+                                       source_state, source_perm));
 
     CASCADE_RESULT(auto backing_blocks, vm_manager.GetBackingBlocksForRange(source, size));
     VAddr interval_target = target;
@@ -549,11 +549,11 @@ Result Process::Unmap(VAddr target, VAddr source, u32 size, VMAPermission perms,
 
     MemoryState source_state = privileged ? MemoryState::Locked : MemoryState::Aliased;
 
-    CASCADE_CODE(vm_manager.UnmapRange(target, size));
+    R_TRY(vm_manager.UnmapRange(target, size));
 
     // Change back source region state. Note that the permission is reprotected according to param
-    CASCADE_CODE(vm_manager.ChangeMemoryState(source, size, source_state, VMAPermission::None,
-                                              MemoryState::Private, perms));
+    R_TRY(vm_manager.ChangeMemoryState(source, size, source_state, VMAPermission::None,
+                                       MemoryState::Private, perms));
 
     return ResultSuccess;
 }

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -231,20 +231,19 @@ public:
     VAddr GetLinearHeapBase() const;
     VAddr GetLinearHeapLimit() const;
 
-    ResultCode HeapAllocate(VAddr* out_addr, VAddr target, u32 size, VMAPermission perms,
-                            MemoryState memory_state = MemoryState::Private,
-                            bool skip_range_check = false);
-    ResultCode HeapFree(VAddr target, u32 size);
+    Result HeapAllocate(VAddr* out_addr, VAddr target, u32 size, VMAPermission perms,
+                        MemoryState memory_state = MemoryState::Private,
+                        bool skip_range_check = false);
+    Result HeapFree(VAddr target, u32 size);
 
-    ResultCode LinearAllocate(VAddr* out_addr, VAddr target, u32 size, VMAPermission perms);
-    ResultCode LinearFree(VAddr target, u32 size);
+    Result LinearAllocate(VAddr* out_addr, VAddr target, u32 size, VMAPermission perms);
+    Result LinearFree(VAddr target, u32 size);
 
     ResultVal<VAddr> AllocateThreadLocalStorage();
 
-    ResultCode Map(VAddr target, VAddr source, u32 size, VMAPermission perms,
-                   bool privileged = false);
-    ResultCode Unmap(VAddr target, VAddr source, u32 size, VMAPermission perms,
-                     bool privileged = false);
+    Result Map(VAddr target, VAddr source, u32 size, VMAPermission perms, bool privileged = false);
+    Result Unmap(VAddr target, VAddr source, u32 size, VMAPermission perms,
+                 bool privileged = false);
 
 private:
     void FreeAllMemory();

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -231,12 +231,12 @@ public:
     VAddr GetLinearHeapBase() const;
     VAddr GetLinearHeapLimit() const;
 
-    ResultVal<VAddr> HeapAllocate(VAddr target, u32 size, VMAPermission perms,
-                                  MemoryState memory_state = MemoryState::Private,
-                                  bool skip_range_check = false);
+    ResultCode HeapAllocate(VAddr* out_addr, VAddr target, u32 size, VMAPermission perms,
+                            MemoryState memory_state = MemoryState::Private,
+                            bool skip_range_check = false);
     ResultCode HeapFree(VAddr target, u32 size);
 
-    ResultVal<VAddr> LinearAllocate(VAddr target, u32 size, VMAPermission perms);
+    ResultCode LinearAllocate(VAddr* out_addr, VAddr target, u32 size, VMAPermission perms);
     ResultCode LinearFree(VAddr target, u32 size);
 
     ResultVal<VAddr> AllocateThreadLocalStorage();

--- a/src/core/hle/kernel/semaphore.cpp
+++ b/src/core/hle/kernel/semaphore.cpp
@@ -26,7 +26,7 @@ ResultVal<std::shared_ptr<Semaphore>> KernelSystem::CreateSemaphore(s32 initial_
                                                                     s32 max_count,
                                                                     std::string name) {
 
-    R_UNLESS(initial_count <= max_count, ERR_INVALID_COMBINATION_KERNEL);
+    R_UNLESS(initial_count <= max_count, ResultInvalidCombinationKernel);
 
     // When the semaphore is created, some slots are reserved for other threads,
     // and the rest is reserved for the caller thread
@@ -49,13 +49,13 @@ void Semaphore::Acquire(Thread* thread) {
 }
 
 Result Semaphore::Release(s32* count, s32 release_count) {
-    R_UNLESS(max_count >= release_count + available_count, ERR_OUT_OF_RANGE_KERNEL);
+    R_UNLESS(max_count >= release_count + available_count, ResultOutOfRangeKernel);
 
     *count = available_count;
     available_count += release_count;
     WakeupAllWaitingThreads();
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 } // namespace Kernel

--- a/src/core/hle/kernel/semaphore.cpp
+++ b/src/core/hle/kernel/semaphore.cpp
@@ -48,10 +48,10 @@ void Semaphore::Acquire(Thread* thread) {
     --available_count;
 }
 
-Result Semaphore::Release(s32* count, s32 release_count) {
+Result Semaphore::Release(s32* out_count, s32 release_count) {
     R_UNLESS(max_count >= release_count + available_count, ResultOutOfRangeKernel);
 
-    *count = available_count;
+    *out_count = available_count;
     available_count += release_count;
     WakeupAllWaitingThreads();
 

--- a/src/core/hle/kernel/semaphore.cpp
+++ b/src/core/hle/kernel/semaphore.cpp
@@ -48,7 +48,7 @@ void Semaphore::Acquire(Thread* thread) {
     --available_count;
 }
 
-ResultCode Semaphore::Release(s32* count, s32 release_count) {
+Result Semaphore::Release(s32* count, s32 release_count) {
     R_UNLESS(max_count >= release_count + available_count, ERR_OUT_OF_RANGE_KERNEL);
 
     *count = available_count;

--- a/src/core/hle/kernel/semaphore.h
+++ b/src/core/hle/kernel/semaphore.h
@@ -47,7 +47,7 @@ public:
      * @param release_count The number of slots to release
      * @return The number of free slots the semaphore had before this call
      */
-    Result Release(s32* count, s32 release_count);
+    Result Release(s32* out_count, s32 release_count);
 
 private:
     friend class boost::serialization::access;

--- a/src/core/hle/kernel/semaphore.h
+++ b/src/core/hle/kernel/semaphore.h
@@ -47,7 +47,7 @@ public:
      * @param release_count The number of slots to release
      * @return The number of free slots the semaphore had before this call
      */
-    ResultVal<s32> Release(s32 release_count);
+    ResultCode Release(s32* count, s32 release_count);
 
 private:
     friend class boost::serialization::access;

--- a/src/core/hle/kernel/semaphore.h
+++ b/src/core/hle/kernel/semaphore.h
@@ -47,7 +47,7 @@ public:
      * @param release_count The number of slots to release
      * @return The number of free slots the semaphore had before this call
      */
-    ResultCode Release(s32* count, s32 release_count);
+    Result Release(s32* count, s32 release_count);
 
 private:
     friend class boost::serialization::access;

--- a/src/core/hle/kernel/server_port.cpp
+++ b/src/core/hle/kernel/server_port.cpp
@@ -24,7 +24,7 @@ namespace Kernel {
 ServerPort::ServerPort(KernelSystem& kernel) : WaitObject(kernel) {}
 ServerPort::~ServerPort() {}
 
-ResultCode ServerPort::Accept(std::shared_ptr<ServerSession>& session) {
+Result ServerPort::Accept(std::shared_ptr<ServerSession>& session) {
     R_UNLESS(!pending_sessions.empty(), ERR_NO_PENDING_SESSIONS);
 
     session = std::move(pending_sessions.back());

--- a/src/core/hle/kernel/server_port.cpp
+++ b/src/core/hle/kernel/server_port.cpp
@@ -25,11 +25,11 @@ ServerPort::ServerPort(KernelSystem& kernel) : WaitObject(kernel) {}
 ServerPort::~ServerPort() {}
 
 Result ServerPort::Accept(std::shared_ptr<ServerSession>& session) {
-    R_UNLESS(!pending_sessions.empty(), ERR_NO_PENDING_SESSIONS);
+    R_UNLESS(!pending_sessions.empty(), ResultNoPendingSessions);
 
     session = std::move(pending_sessions.back());
     pending_sessions.pop_back();
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 bool ServerPort::ShouldWait(const Thread* thread) const {

--- a/src/core/hle/kernel/server_port.cpp
+++ b/src/core/hle/kernel/server_port.cpp
@@ -24,14 +24,12 @@ namespace Kernel {
 ServerPort::ServerPort(KernelSystem& kernel) : WaitObject(kernel) {}
 ServerPort::~ServerPort() {}
 
-ResultVal<std::shared_ptr<ServerSession>> ServerPort::Accept() {
-    if (pending_sessions.empty()) {
-        return ERR_NO_PENDING_SESSIONS;
-    }
+ResultCode ServerPort::Accept(std::shared_ptr<ServerSession>& session) {
+    R_UNLESS(!pending_sessions.empty(), ERR_NO_PENDING_SESSIONS);
 
-    auto session = std::move(pending_sessions.back());
+    session = std::move(pending_sessions.back());
     pending_sessions.pop_back();
-    return session;
+    return RESULT_SUCCESS;
 }
 
 bool ServerPort::ShouldWait(const Thread* thread) const {

--- a/src/core/hle/kernel/server_port.cpp
+++ b/src/core/hle/kernel/server_port.cpp
@@ -24,10 +24,10 @@ namespace Kernel {
 ServerPort::ServerPort(KernelSystem& kernel) : WaitObject(kernel) {}
 ServerPort::~ServerPort() {}
 
-Result ServerPort::Accept(std::shared_ptr<ServerSession>& session) {
+Result ServerPort::Accept(std::shared_ptr<ServerSession>* out_server_session) {
     R_UNLESS(!pending_sessions.empty(), ResultNoPendingSessions);
 
-    session = std::move(pending_sessions.back());
+    *out_server_session = std::move(pending_sessions.back());
     pending_sessions.pop_back();
     return ResultSuccess;
 }

--- a/src/core/hle/kernel/server_port.h
+++ b/src/core/hle/kernel/server_port.h
@@ -41,7 +41,7 @@ public:
      * Accepts a pending incoming connection on this port. If there are no pending sessions, will
      * return ResultNoPendingSessions.
      */
-    Result Accept(std::shared_ptr<ServerSession>& session);
+    Result Accept(std::shared_ptr<ServerSession>* out_server_session);
 
     /**
      * Sets the HLE handler template for the port. ServerSessions crated by connecting to this port

--- a/src/core/hle/kernel/server_port.h
+++ b/src/core/hle/kernel/server_port.h
@@ -41,7 +41,7 @@ public:
      * Accepts a pending incoming connection on this port. If there are no pending sessions, will
      * return ERR_NO_PENDING_SESSIONS.
      */
-    ResultVal<std::shared_ptr<ServerSession>> Accept();
+    ResultCode Accept(std::shared_ptr<ServerSession>& session);
 
     /**
      * Sets the HLE handler template for the port. ServerSessions crated by connecting to this port

--- a/src/core/hle/kernel/server_port.h
+++ b/src/core/hle/kernel/server_port.h
@@ -39,7 +39,7 @@ public:
 
     /**
      * Accepts a pending incoming connection on this port. If there are no pending sessions, will
-     * return ERR_NO_PENDING_SESSIONS.
+     * return ResultNoPendingSessions.
      */
     Result Accept(std::shared_ptr<ServerSession>& session);
 

--- a/src/core/hle/kernel/server_port.h
+++ b/src/core/hle/kernel/server_port.h
@@ -41,7 +41,7 @@ public:
      * Accepts a pending incoming connection on this port. If there are no pending sessions, will
      * return ERR_NO_PENDING_SESSIONS.
      */
-    ResultCode Accept(std::shared_ptr<ServerSession>& session);
+    Result Accept(std::shared_ptr<ServerSession>& session);
 
     /**
      * Sets the HLE handler template for the port. ServerSessions crated by connecting to this port

--- a/src/core/hle/kernel/server_session.cpp
+++ b/src/core/hle/kernel/server_session.cpp
@@ -136,7 +136,7 @@ Result ServerSession::HandleSyncRequest(std::shared_ptr<Thread> thread) {
     // If this ServerSession does not have an HLE implementation, just wake up the threads waiting
     // on it.
     WakeupAllWaitingThreads();
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 KernelSystem::SessionPair KernelSystem::CreateSessionPair(const std::string& name,

--- a/src/core/hle/kernel/server_session.cpp
+++ b/src/core/hle/kernel/server_session.cpp
@@ -77,7 +77,7 @@ void ServerSession::Acquire(Thread* thread) {
     pending_requesting_threads.pop_back();
 }
 
-ResultCode ServerSession::HandleSyncRequest(std::shared_ptr<Thread> thread) {
+Result ServerSession::HandleSyncRequest(std::shared_ptr<Thread> thread) {
     // The ServerSession received a sync request, this means that there's new data available
     // from its ClientSession, so wake up any threads that may be waiting on a svcReplyAndReceive or
     // similar.

--- a/src/core/hle/kernel/server_session.h
+++ b/src/core/hle/kernel/server_session.h
@@ -66,9 +66,9 @@ public:
     /**
      * Handle a sync request from the emulated application.
      * @param thread Thread that initiated the request.
-     * @returns ResultCode from the operation.
+     * @returns Result from the operation.
      */
-    ResultCode HandleSyncRequest(std::shared_ptr<Thread> thread);
+    Result HandleSyncRequest(std::shared_ptr<Thread> thread);
 
     bool ShouldWait(const Thread* thread) const override;
 

--- a/src/core/hle/kernel/shared_memory.cpp
+++ b/src/core/hle/kernel/shared_memory.cpp
@@ -106,8 +106,8 @@ std::shared_ptr<SharedMemory> KernelSystem::CreateSharedMemoryForApplet(
     return shared_memory;
 }
 
-ResultCode SharedMemory::Map(Process& target_process, VAddr address, MemoryPermission permissions,
-                             MemoryPermission other_permissions) {
+Result SharedMemory::Map(Process& target_process, VAddr address, MemoryPermission permissions,
+                         MemoryPermission other_permissions) {
 
     MemoryPermission own_other_permissions =
         &target_process == owner_process.lock().get() ? this->permissions : this->other_permissions;
@@ -141,7 +141,7 @@ ResultCode SharedMemory::Map(Process& target_process, VAddr address, MemoryPermi
 
     // TODO(Subv): Check for the Shared Device Mem flag in the creator process.
     /*if (was_created_with_shared_device_mem && address != 0) {
-        return ResultCode(ErrorDescription::InvalidCombination, ErrorModule::OS,
+        return Result(ErrorDescription::InvalidCombination, ErrorModule::OS,
     ErrorSummary::InvalidArgument, ErrorLevel::Usage);
     }*/
 
@@ -190,7 +190,7 @@ ResultCode SharedMemory::Map(Process& target_process, VAddr address, MemoryPermi
     return RESULT_SUCCESS;
 }
 
-ResultCode SharedMemory::Unmap(Process& target_process, VAddr address) {
+Result SharedMemory::Unmap(Process& target_process, VAddr address) {
     // TODO(Subv): Verify what happens if the application tries to unmap an address that is not
     // mapped to a SharedMemory.
     return target_process.vm_manager.UnmapRange(address, size);

--- a/src/core/hle/kernel/shared_memory.cpp
+++ b/src/core/hle/kernel/shared_memory.cpp
@@ -114,21 +114,21 @@ Result SharedMemory::Map(Process& target_process, VAddr address, MemoryPermissio
 
     // Automatically allocated memory blocks can only be mapped with other_permissions = DontCare
     if (base_address == 0 && other_permissions != MemoryPermission::DontCare) {
-        return ERR_INVALID_COMBINATION;
+        return ResultInvalidCombination;
     }
 
     // Error out if the requested permissions don't match what the creator process allows.
     if (static_cast<u32>(permissions) & ~static_cast<u32>(own_other_permissions)) {
         LOG_ERROR(Kernel, "cannot map id={}, address=0x{:08X} name={}, permissions don't match",
                   GetObjectId(), address, name);
-        return ERR_INVALID_COMBINATION;
+        return ResultInvalidCombination;
     }
 
     // Heap-backed memory blocks can not be mapped with other_permissions = DontCare
     if (base_address != 0 && other_permissions == MemoryPermission::DontCare) {
         LOG_ERROR(Kernel, "cannot map id={}, address=0x{08X} name={}, permissions don't match",
                   GetObjectId(), address, name);
-        return ERR_INVALID_COMBINATION;
+        return ResultInvalidCombination;
     }
 
     // Error out if the provided permissions are not compatible with what the creator process needs.
@@ -136,7 +136,7 @@ Result SharedMemory::Map(Process& target_process, VAddr address, MemoryPermissio
         static_cast<u32>(this->permissions) & ~static_cast<u32>(other_permissions)) {
         LOG_ERROR(Kernel, "cannot map id={}, address=0x{:08X} name={}, permissions don't match",
                   GetObjectId(), address, name);
-        return ERR_WRONG_PERMISSION;
+        return ResultWrongPermission;
     }
 
     // TODO(Subv): Check for the Shared Device Mem flag in the creator process.
@@ -152,7 +152,7 @@ Result SharedMemory::Map(Process& target_process, VAddr address, MemoryPermissio
         if (address < Memory::HEAP_VADDR || address + size >= Memory::SHARED_MEMORY_VADDR_END) {
             LOG_ERROR(Kernel, "cannot map id={}, address=0x{:08X} name={}, invalid address",
                       GetObjectId(), address, name);
-            return ERR_INVALID_ADDRESS;
+            return ResultInvalidAddress;
         }
     }
 
@@ -173,7 +173,7 @@ Result SharedMemory::Map(Process& target_process, VAddr address, MemoryPermissio
                 Kernel,
                 "cannot map id={}, address=0x{:08X} name={}, mapping to already allocated memory",
                 GetObjectId(), address, name);
-            return ERR_INVALID_ADDRESS_STATE;
+            return ResultInvalidAddressState;
         }
     }
 
@@ -187,7 +187,7 @@ Result SharedMemory::Map(Process& target_process, VAddr address, MemoryPermissio
         interval_target += interval.second;
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result SharedMemory::Unmap(Process& target_process, VAddr address) {

--- a/src/core/hle/kernel/shared_memory.cpp
+++ b/src/core/hle/kernel/shared_memory.cpp
@@ -67,9 +67,9 @@ ResultVal<std::shared_ptr<SharedMemory>> KernelSystem::CreateSharedMemory(
         auto& vm_manager = owner_process->vm_manager;
         // The memory is already available and mapped in the owner process.
 
-        CASCADE_CODE(vm_manager.ChangeMemoryState(address, size, MemoryState::Private,
-                                                  VMAPermission::ReadWrite, MemoryState::Locked,
-                                                  SharedMemory::ConvertPermissions(permissions)));
+        R_TRY(vm_manager.ChangeMemoryState(address, size, MemoryState::Private,
+                                           VMAPermission::ReadWrite, MemoryState::Locked,
+                                           SharedMemory::ConvertPermissions(permissions)));
 
         auto backing_blocks = vm_manager.GetBackingBlocksForRange(address, size);
         ASSERT(backing_blocks.Succeeded()); // should success after verifying memory state above

--- a/src/core/hle/kernel/shared_memory.h
+++ b/src/core/hle/kernel/shared_memory.h
@@ -61,8 +61,8 @@ public:
      * @param permissions Memory block map permissions (specified by SVC field)
      * @param other_permissions Memory block map other permissions (specified by SVC field)
      */
-    ResultCode Map(Process& target_process, VAddr address, MemoryPermission permissions,
-                   MemoryPermission other_permissions);
+    Result Map(Process& target_process, VAddr address, MemoryPermission permissions,
+               MemoryPermission other_permissions);
 
     /**
      * Unmaps a shared memory block from the specified address in system memory
@@ -70,7 +70,7 @@ public:
      * @param address Address in system memory where the shared memory block is mapped
      * @return Result code of the unmap operation
      */
-    ResultCode Unmap(Process& target_process, VAddr address);
+    Result Unmap(Process& target_process, VAddr address);
 
     /**
      * Gets a pointer to the shared memory block

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -590,7 +590,7 @@ Result SVC::ConnectToPort(Handle* out_handle, VAddr port_name_address) {
 
     auto client_port = it->second;
     std::shared_ptr<ClientSession> client_session;
-    R_TRY(client_port->Connect(client_session));
+    R_TRY(client_port->Connect(std::addressof(client_session)));
 
     // Return the client session
     return kernel.GetCurrentProcess()->handle_table.Create(out_handle, client_session);
@@ -1659,7 +1659,7 @@ Result SVC::CreateSessionToPort(Handle* out_client_session, Handle client_port_h
     R_UNLESS(client_port, ResultInvalidHandle);
 
     std::shared_ptr<ClientSession> session;
-    R_TRY(client_port->Connect(session));
+    R_TRY(client_port->Connect(std::addressof(session)));
 
     return current_process->handle_table.Create(out_client_session, std::move(session));
 }
@@ -1681,7 +1681,7 @@ Result SVC::AcceptSession(Handle* out_server_session, Handle server_port_handle)
     R_UNLESS(server_port, ResultInvalidHandle);
 
     std::shared_ptr<ServerSession> session;
-    R_TRY(server_port->Accept(session));
+    R_TRY(server_port->Accept(std::addressof(session)));
 
     return current_process->handle_table.Create(out_server_session, std::move(session));
 }

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -366,79 +366,78 @@ private:
 
     // SVC interfaces
 
-    ResultCode ControlMemory(u32* out_addr, u32 addr0, u32 addr1, u32 size, u32 operation,
-                             u32 permissions);
+    Result ControlMemory(u32* out_addr, u32 addr0, u32 addr1, u32 size, u32 operation,
+                         u32 permissions);
     void ExitProcess();
-    ResultCode TerminateProcess(Handle handle);
-    ResultCode MapMemoryBlock(Handle handle, u32 addr, u32 permissions, u32 other_permissions);
-    ResultCode UnmapMemoryBlock(Handle handle, u32 addr);
-    ResultCode ConnectToPort(Handle* out_handle, VAddr port_name_address);
-    ResultCode SendSyncRequest(Handle handle);
-    ResultCode OpenProcess(Handle* out_handle, u32 process_id);
-    ResultCode OpenThread(Handle* out_handle, Handle process_handle, u32 thread_id);
-    ResultCode CloseHandle(Handle handle);
-    ResultCode WaitSynchronization1(Handle handle, s64 nano_seconds);
-    ResultCode WaitSynchronizationN(s32* out, VAddr handles_address, s32 handle_count,
-                                    bool wait_all, s64 nano_seconds);
-    ResultCode ReplyAndReceive(s32* index, VAddr handles_address, s32 handle_count,
-                               Handle reply_target);
-    ResultCode CreateAddressArbiter(Handle* out_handle);
-    ResultCode ArbitrateAddress(Handle handle, u32 address, u32 type, u32 value, s64 nanoseconds);
+    Result TerminateProcess(Handle handle);
+    Result MapMemoryBlock(Handle handle, u32 addr, u32 permissions, u32 other_permissions);
+    Result UnmapMemoryBlock(Handle handle, u32 addr);
+    Result ConnectToPort(Handle* out_handle, VAddr port_name_address);
+    Result SendSyncRequest(Handle handle);
+    Result OpenProcess(Handle* out_handle, u32 process_id);
+    Result OpenThread(Handle* out_handle, Handle process_handle, u32 thread_id);
+    Result CloseHandle(Handle handle);
+    Result WaitSynchronization1(Handle handle, s64 nano_seconds);
+    Result WaitSynchronizationN(s32* out, VAddr handles_address, s32 handle_count, bool wait_all,
+                                s64 nano_seconds);
+    Result ReplyAndReceive(s32* index, VAddr handles_address, s32 handle_count,
+                           Handle reply_target);
+    Result CreateAddressArbiter(Handle* out_handle);
+    Result ArbitrateAddress(Handle handle, u32 address, u32 type, u32 value, s64 nanoseconds);
     void Break(u8 break_reason);
     void OutputDebugString(VAddr address, s32 len);
-    ResultCode GetResourceLimit(Handle* resource_limit, Handle process_handle);
-    ResultCode GetResourceLimitCurrentValues(VAddr values, Handle resource_limit_handle,
-                                             VAddr names, u32 name_count);
-    ResultCode GetResourceLimitLimitValues(VAddr values, Handle resource_limit_handle, VAddr names,
-                                           u32 name_count);
-    ResultCode SetResourceLimitLimitValues(Handle res_limit, VAddr names, VAddr resource_list,
-                                           u32 name_count);
-    ResultCode CreateThread(Handle* out_handle, u32 entry_point, u32 arg, VAddr stack_top,
-                            u32 priority, s32 processor_id);
+    Result GetResourceLimit(Handle* resource_limit, Handle process_handle);
+    Result GetResourceLimitCurrentValues(VAddr values, Handle resource_limit_handle, VAddr names,
+                                         u32 name_count);
+    Result GetResourceLimitLimitValues(VAddr values, Handle resource_limit_handle, VAddr names,
+                                       u32 name_count);
+    Result SetResourceLimitLimitValues(Handle res_limit, VAddr names, VAddr resource_list,
+                                       u32 name_count);
+    Result CreateThread(Handle* out_handle, u32 entry_point, u32 arg, VAddr stack_top, u32 priority,
+                        s32 processor_id);
     void ExitThread();
-    ResultCode GetThreadPriority(u32* priority, Handle handle);
-    ResultCode SetThreadPriority(Handle handle, u32 priority);
-    ResultCode CreateMutex(Handle* out_handle, u32 initial_locked);
-    ResultCode ReleaseMutex(Handle handle);
-    ResultCode GetProcessId(u32* process_id, Handle process_handle);
-    ResultCode GetProcessIdOfThread(u32* process_id, Handle thread_handle);
-    ResultCode GetThreadId(u32* thread_id, Handle handle);
-    ResultCode CreateSemaphore(Handle* out_handle, s32 initial_count, s32 max_count);
-    ResultCode ReleaseSemaphore(s32* count, Handle handle, s32 release_count);
-    ResultCode KernelSetState(u32 kernel_state, u32 varg1, u32 varg2);
-    ResultCode QueryProcessMemory(MemoryInfo* memory_info, PageInfo* page_info,
-                                  Handle process_handle, u32 addr);
-    ResultCode QueryMemory(MemoryInfo* memory_info, PageInfo* page_info, u32 addr);
-    ResultCode CreateEvent(Handle* out_handle, u32 reset_type);
-    ResultCode DuplicateHandle(Handle* out, Handle handle);
-    ResultCode SignalEvent(Handle handle);
-    ResultCode ClearEvent(Handle handle);
-    ResultCode CreateTimer(Handle* out_handle, u32 reset_type);
-    ResultCode ClearTimer(Handle handle);
-    ResultCode SetTimer(Handle handle, s64 initial, s64 interval);
-    ResultCode CancelTimer(Handle handle);
+    Result GetThreadPriority(u32* priority, Handle handle);
+    Result SetThreadPriority(Handle handle, u32 priority);
+    Result CreateMutex(Handle* out_handle, u32 initial_locked);
+    Result ReleaseMutex(Handle handle);
+    Result GetProcessId(u32* process_id, Handle process_handle);
+    Result GetProcessIdOfThread(u32* process_id, Handle thread_handle);
+    Result GetThreadId(u32* thread_id, Handle handle);
+    Result CreateSemaphore(Handle* out_handle, s32 initial_count, s32 max_count);
+    Result ReleaseSemaphore(s32* count, Handle handle, s32 release_count);
+    Result KernelSetState(u32 kernel_state, u32 varg1, u32 varg2);
+    Result QueryProcessMemory(MemoryInfo* memory_info, PageInfo* page_info, Handle process_handle,
+                              u32 addr);
+    Result QueryMemory(MemoryInfo* memory_info, PageInfo* page_info, u32 addr);
+    Result CreateEvent(Handle* out_handle, u32 reset_type);
+    Result DuplicateHandle(Handle* out, Handle handle);
+    Result SignalEvent(Handle handle);
+    Result ClearEvent(Handle handle);
+    Result CreateTimer(Handle* out_handle, u32 reset_type);
+    Result ClearTimer(Handle handle);
+    Result SetTimer(Handle handle, s64 initial, s64 interval);
+    Result CancelTimer(Handle handle);
     void SleepThread(s64 nanoseconds);
     s64 GetSystemTick();
-    ResultCode GetHandleInfo(s64* out, Handle handle, u32 type);
-    ResultCode CreateMemoryBlock(Handle* out_handle, u32 addr, u32 size, u32 my_permission,
-                                 u32 other_permission);
-    ResultCode CreatePort(Handle* server_port, Handle* client_port, VAddr name_address,
-                          u32 max_sessions);
-    ResultCode CreateSessionToPort(Handle* out_client_session, Handle client_port_handle);
-    ResultCode CreateSession(Handle* server_session, Handle* client_session);
-    ResultCode AcceptSession(Handle* out_server_session, Handle server_port_handle);
-    ResultCode GetSystemInfo(s64* out, u32 type, s32 param);
-    ResultCode GetProcessInfo(s64* out, Handle process_handle, u32 type);
-    ResultCode GetThreadInfo(s64* out, Handle thread_handle, u32 type);
-    ResultCode GetProcessList(s32* process_count, VAddr out_process_array,
-                              s32 out_process_array_count);
-    ResultCode InvalidateInstructionCacheRange(u32 addr, u32 size);
-    ResultCode InvalidateEntireInstructionCache();
+    Result GetHandleInfo(s64* out, Handle handle, u32 type);
+    Result CreateMemoryBlock(Handle* out_handle, u32 addr, u32 size, u32 my_permission,
+                             u32 other_permission);
+    Result CreatePort(Handle* server_port, Handle* client_port, VAddr name_address,
+                      u32 max_sessions);
+    Result CreateSessionToPort(Handle* out_client_session, Handle client_port_handle);
+    Result CreateSession(Handle* server_session, Handle* client_session);
+    Result AcceptSession(Handle* out_server_session, Handle server_port_handle);
+    Result GetSystemInfo(s64* out, u32 type, s32 param);
+    Result GetProcessInfo(s64* out, Handle process_handle, u32 type);
+    Result GetThreadInfo(s64* out, Handle thread_handle, u32 type);
+    Result GetProcessList(s32* process_count, VAddr out_process_array, s32 out_process_array_count);
+    Result InvalidateInstructionCacheRange(u32 addr, u32 size);
+    Result InvalidateEntireInstructionCache();
     u32 ConvertVaToPa(u32 addr);
-    ResultCode MapProcessMemoryEx(Handle dst_process_handle, u32 dst_address,
-                                  Handle src_process_handle, u32 src_address, u32 size);
-    ResultCode UnmapProcessMemoryEx(Handle process, u32 dst_address, u32 size);
-    ResultCode ControlProcess(Handle process_handle, u32 process_OP, u32 varg2, u32 varg3);
+    Result MapProcessMemoryEx(Handle dst_process_handle, u32 dst_address, Handle src_process_handle,
+                              u32 src_address, u32 size);
+    Result UnmapProcessMemoryEx(Handle process, u32 dst_address, u32 size);
+    Result ControlProcess(Handle process_handle, u32 process_OP, u32 varg2, u32 varg3);
 
     struct FunctionDef {
         using Func = void (SVC::*)();
@@ -453,8 +452,8 @@ private:
 };
 
 /// Map application or GSP heap memory
-ResultCode SVC::ControlMemory(u32* out_addr, u32 addr0, u32 addr1, u32 size, u32 operation,
-                              u32 permissions) {
+Result SVC::ControlMemory(u32* out_addr, u32 addr0, u32 addr1, u32 size, u32 operation,
+                          u32 permissions) {
     LOG_DEBUG(Kernel_SVC,
               "called operation=0x{:08X}, addr0=0x{:08X}, addr1=0x{:08X}, "
               "size=0x{:X}, permissions=0x{:08X}",
@@ -522,7 +521,7 @@ void SVC::ExitProcess() {
     kernel.TerminateProcess(kernel.GetCurrentProcess());
 }
 
-ResultCode SVC::TerminateProcess(Handle handle) {
+Result SVC::TerminateProcess(Handle handle) {
     std::shared_ptr<Process> process =
         kernel.GetCurrentProcess()->handle_table.Get<Process>(handle);
     R_UNLESS(process, ERR_INVALID_HANDLE);
@@ -532,7 +531,7 @@ ResultCode SVC::TerminateProcess(Handle handle) {
 }
 
 /// Maps a memory block to specified address
-ResultCode SVC::MapMemoryBlock(Handle handle, u32 addr, u32 permissions, u32 other_permissions) {
+Result SVC::MapMemoryBlock(Handle handle, u32 addr, u32 permissions, u32 other_permissions) {
     LOG_TRACE(Kernel_SVC,
               "called memblock=0x{:08X}, addr=0x{:08X}, mypermissions=0x{:08X}, "
               "otherpermission={}",
@@ -561,7 +560,7 @@ ResultCode SVC::MapMemoryBlock(Handle handle, u32 addr, u32 permissions, u32 oth
     return ERR_INVALID_COMBINATION;
 }
 
-ResultCode SVC::UnmapMemoryBlock(Handle handle, u32 addr) {
+Result SVC::UnmapMemoryBlock(Handle handle, u32 addr) {
     LOG_TRACE(Kernel_SVC, "called memblock=0x{:08X}, addr=0x{:08X}", handle, addr);
 
     // TODO(Subv): Return E0A01BF5 if the address is not in the application's heap
@@ -575,7 +574,7 @@ ResultCode SVC::UnmapMemoryBlock(Handle handle, u32 addr) {
 }
 
 /// Connect to an OS service given the port name, returns the handle to the port to out
-ResultCode SVC::ConnectToPort(Handle* out_handle, VAddr port_name_address) {
+Result SVC::ConnectToPort(Handle* out_handle, VAddr port_name_address) {
     R_UNLESS(memory.IsValidVirtualAddress(*kernel.GetCurrentProcess(), port_name_address),
              ERR_NOT_FOUND);
 
@@ -598,7 +597,7 @@ ResultCode SVC::ConnectToPort(Handle* out_handle, VAddr port_name_address) {
 }
 
 /// Makes a blocking IPC call to an OS service.
-ResultCode SVC::SendSyncRequest(Handle handle) {
+Result SVC::SendSyncRequest(Handle handle) {
     std::shared_ptr<ClientSession> session =
         kernel.GetCurrentProcess()->handle_table.Get<ClientSession>(handle);
     R_UNLESS(session, ERR_INVALID_HANDLE);
@@ -616,19 +615,19 @@ ResultCode SVC::SendSyncRequest(Handle handle) {
     return session->SendSyncRequest(thread);
 }
 
-ResultCode SVC::OpenProcess(Handle* out_handle, u32 process_id) {
+Result SVC::OpenProcess(Handle* out_handle, u32 process_id) {
     std::shared_ptr<Process> process = kernel.GetProcessById(process_id);
     if (!process) {
         // Result 0xd9001818 (process not found?)
-        return ResultCode(24, ErrorModule::OS, ErrorSummary::WrongArgument, ErrorLevel::Permanent);
+        return Result(24, ErrorModule::OS, ErrorSummary::WrongArgument, ErrorLevel::Permanent);
     }
     return kernel.GetCurrentProcess()->handle_table.Create(out_handle, process);
 }
 
-ResultCode SVC::OpenThread(Handle* out_handle, Handle process_handle, u32 thread_id) {
+Result SVC::OpenThread(Handle* out_handle, Handle process_handle, u32 thread_id) {
     // Result 0xd9001819 (thread not found?)
-    constexpr static ResultCode ResultThreadNotFound(
-        25, ErrorModule::OS, ErrorSummary::WrongArgument, ErrorLevel::Permanent);
+    constexpr static Result ResultThreadNotFound(25, ErrorModule::OS, ErrorSummary::WrongArgument,
+                                                 ErrorLevel::Permanent);
 
     if (process_handle == 0) {
         LOG_ERROR(Kernel_SVC, "Uninplemented svcOpenThread process_handle=0");
@@ -651,14 +650,14 @@ ResultCode SVC::OpenThread(Handle* out_handle, Handle process_handle, u32 thread
 }
 
 /// Close a handle
-ResultCode SVC::CloseHandle(Handle handle) {
+Result SVC::CloseHandle(Handle handle) {
     LOG_TRACE(Kernel_SVC, "Closing handle 0x{:08X}", handle);
     return kernel.GetCurrentProcess()->handle_table.Close(handle);
 }
 
-static ResultCode ReceiveIPCRequest(Kernel::KernelSystem& kernel, Memory::MemorySystem& memory,
-                                    std::shared_ptr<ServerSession> server_session,
-                                    std::shared_ptr<Thread> thread);
+static Result ReceiveIPCRequest(Kernel::KernelSystem& kernel, Memory::MemorySystem& memory,
+                                std::shared_ptr<ServerSession> server_session,
+                                std::shared_ptr<Thread> thread);
 
 class SVC_SyncCallback : public Kernel::WakeupCallback {
 public:
@@ -703,7 +702,7 @@ public:
         ASSERT(thread->status == ThreadStatus::WaitSynchAny);
         ASSERT(reason == ThreadWakeupReason::Signal);
 
-        ResultCode result = RESULT_SUCCESS;
+        Result result = RESULT_SUCCESS;
 
         if (object->GetHandleType() == HandleType::ServerSession) {
             auto server_session = DynamicObjectCast<ServerSession>(object);
@@ -727,7 +726,7 @@ private:
 };
 
 /// Wait for a handle to synchronize, timeout after the specified nanoseconds
-ResultCode SVC::WaitSynchronization1(Handle handle, s64 nano_seconds) {
+Result SVC::WaitSynchronization1(Handle handle, s64 nano_seconds) {
     auto object = kernel.GetCurrentProcess()->handle_table.Get<WaitObject>(handle);
     Thread* thread = kernel.GetCurrentThreadManager().GetCurrentThread();
     R_UNLESS(object, ERR_INVALID_HANDLE);
@@ -760,8 +759,8 @@ ResultCode SVC::WaitSynchronization1(Handle handle, s64 nano_seconds) {
 }
 
 /// Wait for the given handles to synchronize, timeout after the specified nanoseconds
-ResultCode SVC::WaitSynchronizationN(s32* out, VAddr handles_address, s32 handle_count,
-                                     bool wait_all, s64 nano_seconds) {
+Result SVC::WaitSynchronizationN(s32* out, VAddr handles_address, s32 handle_count, bool wait_all,
+                                 s64 nano_seconds) {
     Thread* thread = kernel.GetCurrentThreadManager().GetCurrentThread();
     R_UNLESS(memory.IsValidVirtualAddress(*kernel.GetCurrentProcess(), handles_address),
              ERR_INVALID_POINTER);
@@ -873,15 +872,15 @@ ResultCode SVC::WaitSynchronizationN(s32* out, VAddr handles_address, s32 handle
     }
 }
 
-static ResultCode ReceiveIPCRequest(Kernel::KernelSystem& kernel, Memory::MemorySystem& memory,
-                                    std::shared_ptr<ServerSession> server_session,
-                                    std::shared_ptr<Thread> thread) {
+static Result ReceiveIPCRequest(Kernel::KernelSystem& kernel, Memory::MemorySystem& memory,
+                                std::shared_ptr<ServerSession> server_session,
+                                std::shared_ptr<Thread> thread) {
     R_UNLESS(server_session->parent->client, ERR_SESSION_CLOSED_BY_REMOTE);
 
     VAddr target_address = thread->GetCommandBufferAddress();
     VAddr source_address = server_session->currently_handling->GetCommandBufferAddress();
 
-    ResultCode translation_result = TranslateCommandBuffer(
+    Result translation_result = TranslateCommandBuffer(
         kernel, memory, server_session->currently_handling, thread, source_address, target_address,
         server_session->mapped_buffer_context, false);
 
@@ -901,8 +900,8 @@ static ResultCode ReceiveIPCRequest(Kernel::KernelSystem& kernel, Memory::Memory
 }
 
 /// In a single operation, sends a IPC reply and waits for a new request.
-ResultCode SVC::ReplyAndReceive(s32* index, VAddr handles_address, s32 handle_count,
-                                Handle reply_target) {
+Result SVC::ReplyAndReceive(s32* index, VAddr handles_address, s32 handle_count,
+                            Handle reply_target) {
     R_UNLESS(memory.IsValidVirtualAddress(*kernel.GetCurrentProcess(), handles_address),
              ERR_INVALID_POINTER);
 
@@ -945,7 +944,7 @@ ResultCode SVC::ReplyAndReceive(s32* index, VAddr handles_address, s32 handle_co
         VAddr source_address = thread->GetCommandBufferAddress();
         VAddr target_address = request_thread->GetCommandBufferAddress();
 
-        ResultCode translation_result = TranslateCommandBuffer(
+        Result translation_result = TranslateCommandBuffer(
             kernel, memory, SharedFrom(thread), request_thread, source_address, target_address,
             session->mapped_buffer_context, true);
 
@@ -962,7 +961,7 @@ ResultCode SVC::ReplyAndReceive(s32* index, VAddr handles_address, s32 handle_co
         R_SUCCEED_IF(reply_target != 0 && header.command_id != 0xFFFF);
         // The kernel uses this value as a placeholder for the real error, and returns it when we
         // pass no handles and do not perform any reply.
-        return ResultCode(0xE7E3FFFF);
+        return Result(0xE7E3FFFF);
     }
 
     // Find the first object that is acquirable in the provided list of objects
@@ -1007,13 +1006,13 @@ ResultCode SVC::ReplyAndReceive(s32* index, VAddr handles_address, s32 handle_co
 }
 
 /// Create an address arbiter (to allocate access to shared resources)
-ResultCode SVC::CreateAddressArbiter(Handle* out_handle) {
+Result SVC::CreateAddressArbiter(Handle* out_handle) {
     // Update address arbiter count in resource limit.
     const auto current_process = kernel.GetCurrentProcess();
     const auto& resource_limit = current_process->resource_limit;
     if (!resource_limit->Reserve(ResourceLimitType::AddressArbiter, 1)) {
-        return ResultCode(ErrCodes::OutOfAddressArbiters, ErrorModule::OS,
-                          ErrorSummary::OutOfResource, ErrorLevel::Status);
+        return Result(ErrCodes::OutOfAddressArbiters, ErrorModule::OS, ErrorSummary::OutOfResource,
+                      ErrorLevel::Status);
     }
 
     // Create address arbiter.
@@ -1023,7 +1022,7 @@ ResultCode SVC::CreateAddressArbiter(Handle* out_handle) {
 }
 
 /// Arbitrate address
-ResultCode SVC::ArbitrateAddress(Handle handle, u32 address, u32 type, u32 value, s64 nanoseconds) {
+Result SVC::ArbitrateAddress(Handle handle, u32 address, u32 type, u32 value, s64 nanoseconds) {
     LOG_TRACE(Kernel_SVC, "called handle=0x{:08X}, address=0x{:08X}, type=0x{:08X}, value=0x{:08X}",
               handle, address, type, value);
 
@@ -1085,7 +1084,7 @@ void SVC::OutputDebugString(VAddr address, s32 len) {
 }
 
 /// Get resource limit
-ResultCode SVC::GetResourceLimit(Handle* resource_limit, Handle process_handle) {
+Result SVC::GetResourceLimit(Handle* resource_limit, Handle process_handle) {
     LOG_TRACE(Kernel_SVC, "called process=0x{:08X}", process_handle);
 
     std::shared_ptr<Process> current_process = kernel.GetCurrentProcess();
@@ -1096,8 +1095,8 @@ ResultCode SVC::GetResourceLimit(Handle* resource_limit, Handle process_handle) 
 }
 
 /// Get resource limit current values
-ResultCode SVC::GetResourceLimitCurrentValues(VAddr values, Handle resource_limit_handle,
-                                              VAddr names, u32 name_count) {
+Result SVC::GetResourceLimitCurrentValues(VAddr values, Handle resource_limit_handle, VAddr names,
+                                          u32 name_count) {
     LOG_TRACE(Kernel_SVC, "called resource_limit={:08X}, names={:08X}, name_count={}",
               resource_limit_handle, names, name_count);
 
@@ -1115,8 +1114,8 @@ ResultCode SVC::GetResourceLimitCurrentValues(VAddr values, Handle resource_limi
 }
 
 /// Get resource limit max values
-ResultCode SVC::GetResourceLimitLimitValues(VAddr values, Handle resource_limit_handle, VAddr names,
-                                            u32 name_count) {
+Result SVC::GetResourceLimitLimitValues(VAddr values, Handle resource_limit_handle, VAddr names,
+                                        u32 name_count) {
     LOG_TRACE(Kernel_SVC, "called resource_limit={:08X}, names={:08X}, name_count={}",
               resource_limit_handle, names, name_count);
 
@@ -1134,8 +1133,8 @@ ResultCode SVC::GetResourceLimitLimitValues(VAddr values, Handle resource_limit_
     return RESULT_SUCCESS;
 }
 
-ResultCode SVC::SetResourceLimitLimitValues(Handle res_limit, VAddr names, VAddr resource_list,
-                                            u32 name_count) {
+Result SVC::SetResourceLimitLimitValues(Handle res_limit, VAddr names, VAddr resource_list,
+                                        u32 name_count) {
     LOG_TRACE(Kernel_SVC, "called resource_limit={:08X}, names={:08X}, name_count={}", res_limit,
               names, name_count);
 
@@ -1162,8 +1161,8 @@ ResultCode SVC::SetResourceLimitLimitValues(Handle res_limit, VAddr names, VAddr
 }
 
 /// Creates a new thread
-ResultCode SVC::CreateThread(Handle* out_handle, u32 entry_point, u32 arg, VAddr stack_top,
-                             u32 priority, s32 processor_id) {
+Result SVC::CreateThread(Handle* out_handle, u32 entry_point, u32 arg, VAddr stack_top,
+                         u32 priority, s32 processor_id) {
     R_UNLESS(priority <= ThreadPrioLowest, ERR_OUT_OF_RANGE);
 
     const auto current_process = kernel.GetCurrentProcess();
@@ -1202,8 +1201,8 @@ ResultCode SVC::CreateThread(Handle* out_handle, u32 entry_point, u32 arg, VAddr
 
     // Update thread count in resource limit.
     if (!resource_limit->Reserve(ResourceLimitType::Thread, 1)) {
-        return ResultCode(ErrCodes::OutOfThreads, ErrorModule::OS, ErrorSummary::OutOfResource,
-                          ErrorLevel::Status);
+        return Result(ErrCodes::OutOfThreads, ErrorModule::OS, ErrorSummary::OutOfResource,
+                      ErrorLevel::Status);
     }
 
     // Create thread.
@@ -1234,7 +1233,7 @@ void SVC::ExitThread() {
 }
 
 /// Gets the priority for the specified thread
-ResultCode SVC::GetThreadPriority(u32* priority, Handle handle) {
+Result SVC::GetThreadPriority(u32* priority, Handle handle) {
     const std::shared_ptr<Thread> thread =
         kernel.GetCurrentProcess()->handle_table.Get<Thread>(handle);
     R_UNLESS(thread, ERR_INVALID_HANDLE);
@@ -1244,7 +1243,7 @@ ResultCode SVC::GetThreadPriority(u32* priority, Handle handle) {
 }
 
 /// Sets the priority for the specified thread
-ResultCode SVC::SetThreadPriority(Handle handle, u32 priority) {
+Result SVC::SetThreadPriority(Handle handle, u32 priority) {
     R_UNLESS(priority <= ThreadPrioLowest, ERR_OUT_OF_RANGE);
 
     const auto thread = kernel.GetCurrentProcess()->handle_table.Get<Thread>(handle);
@@ -1269,13 +1268,13 @@ ResultCode SVC::SetThreadPriority(Handle handle, u32 priority) {
 }
 
 /// Create a mutex
-ResultCode SVC::CreateMutex(Handle* out_handle, u32 initial_locked) {
+Result SVC::CreateMutex(Handle* out_handle, u32 initial_locked) {
     // Update mutex count in resource limit.
     const auto current_process = kernel.GetCurrentProcess();
     const auto& resource_limit = current_process->resource_limit;
     if (!resource_limit->Reserve(ResourceLimitType::Mutex, 1)) {
-        return ResultCode(ErrCodes::OutOfMutexes, ErrorModule::OS, ErrorSummary::OutOfResource,
-                          ErrorLevel::Status);
+        return Result(ErrCodes::OutOfMutexes, ErrorModule::OS, ErrorSummary::OutOfResource,
+                      ErrorLevel::Status);
     }
 
     // Create mutex.
@@ -1286,7 +1285,7 @@ ResultCode SVC::CreateMutex(Handle* out_handle, u32 initial_locked) {
 }
 
 /// Release a mutex
-ResultCode SVC::ReleaseMutex(Handle handle) {
+Result SVC::ReleaseMutex(Handle handle) {
     LOG_TRACE(Kernel_SVC, "called handle=0x{:08X}", handle);
 
     std::shared_ptr<Mutex> mutex = kernel.GetCurrentProcess()->handle_table.Get<Mutex>(handle);
@@ -1296,7 +1295,7 @@ ResultCode SVC::ReleaseMutex(Handle handle) {
 }
 
 /// Get the ID of the specified process
-ResultCode SVC::GetProcessId(u32* process_id, Handle process_handle) {
+Result SVC::GetProcessId(u32* process_id, Handle process_handle) {
     LOG_TRACE(Kernel_SVC, "called process=0x{:08X}", process_handle);
 
     const std::shared_ptr<Process> process =
@@ -1308,7 +1307,7 @@ ResultCode SVC::GetProcessId(u32* process_id, Handle process_handle) {
 }
 
 /// Get the ID of the process that owns the specified thread
-ResultCode SVC::GetProcessIdOfThread(u32* process_id, Handle thread_handle) {
+Result SVC::GetProcessIdOfThread(u32* process_id, Handle thread_handle) {
     LOG_TRACE(Kernel_SVC, "called thread=0x{:08X}", thread_handle);
 
     const std::shared_ptr<Thread> thread =
@@ -1323,7 +1322,7 @@ ResultCode SVC::GetProcessIdOfThread(u32* process_id, Handle thread_handle) {
 }
 
 /// Get the ID for the specified thread.
-ResultCode SVC::GetThreadId(u32* thread_id, Handle handle) {
+Result SVC::GetThreadId(u32* thread_id, Handle handle) {
     LOG_TRACE(Kernel_SVC, "called thread=0x{:08X}", handle);
 
     const std::shared_ptr<Thread> thread =
@@ -1335,13 +1334,13 @@ ResultCode SVC::GetThreadId(u32* thread_id, Handle handle) {
 }
 
 /// Creates a semaphore
-ResultCode SVC::CreateSemaphore(Handle* out_handle, s32 initial_count, s32 max_count) {
+Result SVC::CreateSemaphore(Handle* out_handle, s32 initial_count, s32 max_count) {
     // Update semaphore count in resource limit.
     const auto current_process = kernel.GetCurrentProcess();
     const auto& resource_limit = current_process->resource_limit;
     if (!resource_limit->Reserve(ResourceLimitType::Semaphore, 1)) {
-        return ResultCode(ErrCodes::OutOfSemaphores, ErrorModule::OS, ErrorSummary::OutOfResource,
-                          ErrorLevel::Status);
+        return Result(ErrCodes::OutOfSemaphores, ErrorModule::OS, ErrorSummary::OutOfResource,
+                      ErrorLevel::Status);
     }
 
     // Create semaphore
@@ -1353,7 +1352,7 @@ ResultCode SVC::CreateSemaphore(Handle* out_handle, s32 initial_count, s32 max_c
 }
 
 /// Releases a certain number of slots in a semaphore
-ResultCode SVC::ReleaseSemaphore(s32* count, Handle handle, s32 release_count) {
+Result SVC::ReleaseSemaphore(s32* count, Handle handle, s32 release_count) {
     LOG_TRACE(Kernel_SVC, "called release_count={}, handle=0x{:08X}", release_count, handle);
 
     std::shared_ptr<Semaphore> semaphore =
@@ -1364,7 +1363,7 @@ ResultCode SVC::ReleaseSemaphore(s32* count, Handle handle, s32 release_count) {
 }
 
 /// Sets the kernel state
-ResultCode SVC::KernelSetState(u32 kernel_state, u32 varg1, u32 varg2) {
+Result SVC::KernelSetState(u32 kernel_state, u32 varg1, u32 varg2) {
     switch (static_cast<KernelState>(kernel_state)) {
     // This triggers a hardware reboot on real console, since this doesn't make sense
     // on emulator, we shutdown instead.
@@ -1379,8 +1378,8 @@ ResultCode SVC::KernelSetState(u32 kernel_state, u32 varg1, u32 varg2) {
 }
 
 /// Query process memory
-ResultCode SVC::QueryProcessMemory(MemoryInfo* memory_info, PageInfo* page_info,
-                                   Handle process_handle, u32 addr) {
+Result SVC::QueryProcessMemory(MemoryInfo* memory_info, PageInfo* page_info, Handle process_handle,
+                               u32 addr) {
     std::shared_ptr<Process> process =
         kernel.GetCurrentProcess()->handle_table.Get<Process>(process_handle);
     R_UNLESS(process, ERR_INVALID_HANDLE);
@@ -1416,18 +1415,18 @@ ResultCode SVC::QueryProcessMemory(MemoryInfo* memory_info, PageInfo* page_info,
 }
 
 /// Query memory
-ResultCode SVC::QueryMemory(MemoryInfo* memory_info, PageInfo* page_info, u32 addr) {
+Result SVC::QueryMemory(MemoryInfo* memory_info, PageInfo* page_info, u32 addr) {
     return QueryProcessMemory(memory_info, page_info, CurrentProcess, addr);
 }
 
 /// Create an event
-ResultCode SVC::CreateEvent(Handle* out_handle, u32 reset_type) {
+Result SVC::CreateEvent(Handle* out_handle, u32 reset_type) {
     // Update event count in resource limit.
     const auto current_process = kernel.GetCurrentProcess();
     const auto& resource_limit = current_process->resource_limit;
     if (!resource_limit->Reserve(ResourceLimitType::Event, 1)) {
-        return ResultCode(ErrCodes::OutOfEvents, ErrorModule::OS, ErrorSummary::OutOfResource,
-                          ErrorLevel::Status);
+        return Result(ErrCodes::OutOfEvents, ErrorModule::OS, ErrorSummary::OutOfResource,
+                      ErrorLevel::Status);
     }
 
     // Create event.
@@ -1438,12 +1437,12 @@ ResultCode SVC::CreateEvent(Handle* out_handle, u32 reset_type) {
 }
 
 /// Duplicates a kernel handle
-ResultCode SVC::DuplicateHandle(Handle* out, Handle handle) {
+Result SVC::DuplicateHandle(Handle* out, Handle handle) {
     return kernel.GetCurrentProcess()->handle_table.Duplicate(out, handle);
 }
 
 /// Signals an event
-ResultCode SVC::SignalEvent(Handle handle) {
+Result SVC::SignalEvent(Handle handle) {
     LOG_TRACE(Kernel_SVC, "called event=0x{:08X}", handle);
 
     std::shared_ptr<Event> evt = kernel.GetCurrentProcess()->handle_table.Get<Event>(handle);
@@ -1454,7 +1453,7 @@ ResultCode SVC::SignalEvent(Handle handle) {
 }
 
 /// Clears an event
-ResultCode SVC::ClearEvent(Handle handle) {
+Result SVC::ClearEvent(Handle handle) {
     LOG_TRACE(Kernel_SVC, "called event=0x{:08X}", handle);
 
     std::shared_ptr<Event> evt = kernel.GetCurrentProcess()->handle_table.Get<Event>(handle);
@@ -1465,13 +1464,13 @@ ResultCode SVC::ClearEvent(Handle handle) {
 }
 
 /// Creates a timer
-ResultCode SVC::CreateTimer(Handle* out_handle, u32 reset_type) {
+Result SVC::CreateTimer(Handle* out_handle, u32 reset_type) {
     // Update timer count in resource limit.
     const auto current_process = kernel.GetCurrentProcess();
     const auto& resource_limit = current_process->resource_limit;
     if (!resource_limit->Reserve(ResourceLimitType::Timer, 1)) {
-        return ResultCode(ErrCodes::OutOfTimers, ErrorModule::OS, ErrorSummary::OutOfResource,
-                          ErrorLevel::Status);
+        return Result(ErrCodes::OutOfTimers, ErrorModule::OS, ErrorSummary::OutOfResource,
+                      ErrorLevel::Status);
     }
 
     // Create timer.
@@ -1482,7 +1481,7 @@ ResultCode SVC::CreateTimer(Handle* out_handle, u32 reset_type) {
 }
 
 /// Clears a timer
-ResultCode SVC::ClearTimer(Handle handle) {
+Result SVC::ClearTimer(Handle handle) {
     LOG_TRACE(Kernel_SVC, "called timer=0x{:08X}", handle);
 
     std::shared_ptr<Timer> timer = kernel.GetCurrentProcess()->handle_table.Get<Timer>(handle);
@@ -1493,7 +1492,7 @@ ResultCode SVC::ClearTimer(Handle handle) {
 }
 
 /// Starts a timer
-ResultCode SVC::SetTimer(Handle handle, s64 initial, s64 interval) {
+Result SVC::SetTimer(Handle handle, s64 initial, s64 interval) {
     LOG_TRACE(Kernel_SVC, "called timer=0x{:08X}", handle);
 
     R_UNLESS(initial >= 0 && interval >= 0, ERR_OUT_OF_RANGE_KERNEL);
@@ -1507,7 +1506,7 @@ ResultCode SVC::SetTimer(Handle handle, s64 initial, s64 interval) {
 }
 
 /// Cancels a timer
-ResultCode SVC::CancelTimer(Handle handle) {
+Result SVC::CancelTimer(Handle handle) {
     LOG_TRACE(Kernel_SVC, "called timer=0x{:08X}", handle);
 
     std::shared_ptr<Timer> timer = kernel.GetCurrentProcess()->handle_table.Get<Timer>(handle);
@@ -1549,7 +1548,7 @@ s64 SVC::GetSystemTick() {
 }
 
 // Returns information of the specified handle
-ResultCode SVC::GetHandleInfo(s64* out, Handle handle, u32 type) {
+Result SVC::GetHandleInfo(s64* out, Handle handle, u32 type) {
     std::shared_ptr<Object> object = kernel.GetCurrentProcess()->handle_table.GetGeneric(handle);
     R_UNLESS(object, ERR_INVALID_HANDLE);
 
@@ -1581,8 +1580,8 @@ ResultCode SVC::GetHandleInfo(s64* out, Handle handle, u32 type) {
 }
 
 /// Creates a memory block at the specified address with the specified permissions and size
-ResultCode SVC::CreateMemoryBlock(Handle* out_handle, u32 addr, u32 size, u32 my_permission,
-                                  u32 other_permission) {
+Result SVC::CreateMemoryBlock(Handle* out_handle, u32 addr, u32 size, u32 my_permission,
+                              u32 other_permission) {
     R_UNLESS(size % Memory::CITRA_PAGE_SIZE == 0, ERR_MISALIGNED_SIZE);
 
     std::shared_ptr<SharedMemory> shared_memory = nullptr;
@@ -1618,8 +1617,8 @@ ResultCode SVC::CreateMemoryBlock(Handle* out_handle, u32 addr, u32 size, u32 my
     const auto current_process = kernel.GetCurrentProcess();
     const auto& resource_limit = current_process->resource_limit;
     if (!resource_limit->Reserve(ResourceLimitType::SharedMemory, 1)) {
-        return ResultCode(ErrCodes::OutOfSharedMems, ErrorModule::OS, ErrorSummary::OutOfResource,
-                          ErrorLevel::Status);
+        return Result(ErrCodes::OutOfSharedMems, ErrorModule::OS, ErrorSummary::OutOfResource,
+                      ErrorLevel::Status);
     }
 
     // When trying to create a memory block with address = 0,
@@ -1638,8 +1637,8 @@ ResultCode SVC::CreateMemoryBlock(Handle* out_handle, u32 addr, u32 size, u32 my
     return current_process->handle_table.Create(out_handle, std::move(shared_memory));
 }
 
-ResultCode SVC::CreatePort(Handle* server_port, Handle* client_port, VAddr name_address,
-                           u32 max_sessions) {
+Result SVC::CreatePort(Handle* server_port, Handle* client_port, VAddr name_address,
+                       u32 max_sessions) {
     // TODO(Subv): Implement named ports.
     ASSERT_MSG(name_address == 0, "Named ports are currently unimplemented");
     LOG_TRACE(Kernel_SVC, "called max_sessions={}", max_sessions);
@@ -1653,7 +1652,7 @@ ResultCode SVC::CreatePort(Handle* server_port, Handle* client_port, VAddr name_
     return current_process->handle_table.Create(server_port, std::move(server));
 }
 
-ResultCode SVC::CreateSessionToPort(Handle* out_client_session, Handle client_port_handle) {
+Result SVC::CreateSessionToPort(Handle* out_client_session, Handle client_port_handle) {
     std::shared_ptr<Process> current_process = kernel.GetCurrentProcess();
     std::shared_ptr<ClientPort> client_port =
         current_process->handle_table.Get<ClientPort>(client_port_handle);
@@ -1665,7 +1664,7 @@ ResultCode SVC::CreateSessionToPort(Handle* out_client_session, Handle client_po
     return current_process->handle_table.Create(out_client_session, std::move(session));
 }
 
-ResultCode SVC::CreateSession(Handle* server_session, Handle* client_session) {
+Result SVC::CreateSession(Handle* server_session, Handle* client_session) {
     auto [server, client] = kernel.CreateSessionPair();
     LOG_TRACE(Kernel_SVC, "called");
 
@@ -1675,7 +1674,7 @@ ResultCode SVC::CreateSession(Handle* server_session, Handle* client_session) {
     return current_process->handle_table.Create(client_session, std::move(client));
 }
 
-ResultCode SVC::AcceptSession(Handle* out_server_session, Handle server_port_handle) {
+Result SVC::AcceptSession(Handle* out_server_session, Handle server_port_handle) {
     std::shared_ptr<Process> current_process = kernel.GetCurrentProcess();
     std::shared_ptr<ServerPort> server_port =
         current_process->handle_table.Get<ServerPort>(server_port_handle);
@@ -1697,7 +1696,7 @@ static void CopyStringPart(char* out, const char* in, size_t offset, size_t max_
     }
 }
 
-ResultCode SVC::GetSystemInfo(s64* out, u32 type, s32 param) {
+Result SVC::GetSystemInfo(s64* out, u32 type, s32 param) {
     LOG_TRACE(Kernel_SVC, "called type={} param={}", type, param);
 
     switch ((SystemInfoType)type) {
@@ -1795,7 +1794,7 @@ ResultCode SVC::GetSystemInfo(s64* out, u32 type, s32 param) {
     return RESULT_SUCCESS;
 }
 
-ResultCode SVC::GetProcessInfo(s64* out, Handle process_handle, u32 type) {
+Result SVC::GetProcessInfo(s64* out, Handle process_handle, u32 type) {
     LOG_TRACE(Kernel_SVC, "called process=0x{:08X} type={}", process_handle, type);
 
     std::shared_ptr<Process> process =
@@ -1868,7 +1867,7 @@ ResultCode SVC::GetProcessInfo(s64* out, Handle process_handle, u32 type) {
     return RESULT_SUCCESS;
 }
 
-ResultCode SVC::GetThreadInfo(s64* out, Handle thread_handle, u32 type) {
+Result SVC::GetThreadInfo(s64* out, Handle thread_handle, u32 type) {
     LOG_TRACE(Kernel_SVC, "called thread=0x{:08X} type={}", thread_handle, type);
 
     std::shared_ptr<Thread> thread =
@@ -1887,8 +1886,8 @@ ResultCode SVC::GetThreadInfo(s64* out, Handle thread_handle, u32 type) {
     return RESULT_SUCCESS;
 }
 
-ResultCode SVC::GetProcessList(s32* process_count, VAddr out_process_array,
-                               s32 out_process_array_count) {
+Result SVC::GetProcessList(s32* process_count, VAddr out_process_array,
+                           s32 out_process_array_count) {
     R_UNLESS(memory.IsValidVirtualAddress(*kernel.GetCurrentProcess(), out_process_array),
              ERR_INVALID_POINTER);
 
@@ -1905,12 +1904,12 @@ ResultCode SVC::GetProcessList(s32* process_count, VAddr out_process_array,
     return RESULT_SUCCESS;
 }
 
-ResultCode SVC::InvalidateInstructionCacheRange(u32 addr, u32 size) {
+Result SVC::InvalidateInstructionCacheRange(u32 addr, u32 size) {
     system.GetRunningCore().InvalidateCacheRange(addr, size);
     return RESULT_SUCCESS;
 }
 
-ResultCode SVC::InvalidateEntireInstructionCache() {
+Result SVC::InvalidateEntireInstructionCache() {
     system.GetRunningCore().ClearInstructionCache();
     return RESULT_SUCCESS;
 }
@@ -1926,8 +1925,8 @@ u32 SVC::ConvertVaToPa(u32 addr) {
            Memory::FCRAM_PADDR;
 }
 
-ResultCode SVC::MapProcessMemoryEx(Handle dst_process_handle, u32 dst_address,
-                                   Handle src_process_handle, u32 src_address, u32 size) {
+Result SVC::MapProcessMemoryEx(Handle dst_process_handle, u32 dst_address,
+                               Handle src_process_handle, u32 src_address, u32 size) {
     std::shared_ptr<Process> dst_process =
         kernel.GetCurrentProcess()->handle_table.Get<Process>(dst_process_handle);
     std::shared_ptr<Process> src_process =
@@ -1963,7 +1962,7 @@ ResultCode SVC::MapProcessMemoryEx(Handle dst_process_handle, u32 dst_address,
     return RESULT_SUCCESS;
 }
 
-ResultCode SVC::UnmapProcessMemoryEx(Handle process, u32 dst_address, u32 size) {
+Result SVC::UnmapProcessMemoryEx(Handle process, u32 dst_address, u32 size) {
     std::shared_ptr<Process> dst_process =
         kernel.GetCurrentProcess()->handle_table.Get<Process>(process);
     R_UNLESS(dst_process, ERR_INVALID_HANDLE);
@@ -1983,7 +1982,7 @@ ResultCode SVC::UnmapProcessMemoryEx(Handle process, u32 dst_address, u32 size) 
     return RESULT_SUCCESS;
 }
 
-ResultCode SVC::ControlProcess(Handle process_handle, u32 process_OP, u32 varg2, u32 varg3) {
+Result SVC::ControlProcess(Handle process_handle, u32 process_OP, u32 varg2, u32 varg3) {
     std::shared_ptr<Process> process =
         kernel.GetCurrentProcess()->handle_table.Get<Process>(process_handle);
     R_UNLESS(process, ERR_INVALID_HANDLE);

--- a/src/core/hle/kernel/svc_wrapper.h
+++ b/src/core/hle/kernel/svc_wrapper.h
@@ -281,21 +281,21 @@ private:
     };
 
     template <typename SVCT>
-    struct WrapPass<SVCT, ResultCode /*empty for T, Ts...*/> {
+    struct WrapPass<SVCT, Result /*empty for T, Ts...*/> {
         // Call function R(Context::svc)(Us...) and transfer the return value to registers
         template <typename... Us>
         static void Call(Context& context, SVCT svc, Us... u) {
-            static_assert(std::is_same_v<SVCT, ResultCode (Context::*)(Us...)>);
-            if constexpr (std::is_void_v<ResultCode>) {
+            static_assert(std::is_same_v<SVCT, Result (Context::*)(Us...)>);
+            if constexpr (std::is_void_v<Result>) {
                 (context.*svc)(u...);
             } else {
-                ResultCode r = (context.*svc)(u...);
+                Result r = (context.*svc)(u...);
                 if (r.IsError()) {
                     LOG_ERROR(Kernel_SVC, "level={} summary={} module={} description={}",
                               r.level.ExtractValue(r.raw), r.summary.ExtractValue(r.raw),
                               r.module.ExtractValue(r.raw), r.description.ExtractValue(r.raw));
                 }
-                SetParam<INDEX_RETURN, ResultCode, ResultCode, Us...>(context, r);
+                SetParam<INDEX_RETURN, Result, Result, Us...>(context, r);
             }
         }
     };

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -344,8 +344,8 @@ ResultVal<std::shared_ptr<Thread>> KernelSystem::CreateThread(
     if (!memory.IsValidVirtualAddress(*owner_process, entry_point)) {
         LOG_ERROR(Kernel_SVC, "(name={}): invalid entry {:08x}", name, entry_point);
         // TODO: Verify error
-        return ResultCode(ErrorDescription::InvalidAddress, ErrorModule::Kernel,
-                          ErrorSummary::InvalidArgument, ErrorLevel::Permanent);
+        return Result(ErrorDescription::InvalidAddress, ErrorModule::Kernel,
+                      ErrorSummary::InvalidArgument, ErrorLevel::Permanent);
     }
 
     auto thread = std::make_shared<Thread>(*this, processor_id);
@@ -445,7 +445,7 @@ void ThreadManager::Reschedule() {
     SwitchContext(next);
 }
 
-void Thread::SetWaitSynchronizationResult(ResultCode result) {
+void Thread::SetWaitSynchronizationResult(Result result) {
     context.cpu_registers[0] = result.raw;
 }
 

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -332,12 +332,12 @@ ResultVal<std::shared_ptr<Thread>> KernelSystem::CreateThread(
     // Check if priority is in ranged. Lowest priority -> highest priority id.
     if (priority > ThreadPrioLowest) {
         LOG_ERROR(Kernel_SVC, "Invalid thread priority: {}", priority);
-        return ERR_OUT_OF_RANGE;
+        return ResultOutOfRange;
     }
 
     if (processor_id > ThreadProcessorIdMax) {
         LOG_ERROR(Kernel_SVC, "Invalid processor id: {}", processor_id);
-        return ERR_OUT_OF_RANGE_KERNEL;
+        return ResultOutOfRangeKernel;
     }
 
     // TODO(yuriks): Other checks, returning 0xD9001BEA

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -243,7 +243,7 @@ public:
      * Sets the result after the thread awakens (from either WaitSynchronization SVC)
      * @param result Value to set to the returned result
      */
-    void SetWaitSynchronizationResult(ResultCode result);
+    void SetWaitSynchronizationResult(Result result);
 
     /**
      * Sets the output parameter value after the thread awakens (from WaitSynchronizationN SVC only)

--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -83,8 +83,8 @@ ResultVal<VAddr> VMManager::MapBackingMemoryToBase(VAddr base, u32 region_size, 
     // Do not try to allocate the block if there are no available addresses within the desired
     // region.
     if (vma_handle == vma_map.end() || target + size > base + region_size) {
-        return ResultCode(ErrorDescription::OutOfMemory, ErrorModule::Kernel,
-                          ErrorSummary::OutOfResource, ErrorLevel::Permanent);
+        return Result(ErrorDescription::OutOfMemory, ErrorModule::Kernel,
+                      ErrorSummary::OutOfResource, ErrorLevel::Permanent);
     }
 
     auto result = MapBackingMemory(target, memory, size, state);
@@ -114,9 +114,9 @@ ResultVal<VMManager::VMAHandle> VMManager::MapBackingMemory(VAddr target, Memory
     return MergeAdjacent(vma_handle);
 }
 
-ResultCode VMManager::ChangeMemoryState(VAddr target, u32 size, MemoryState expected_state,
-                                        VMAPermission expected_perms, MemoryState new_state,
-                                        VMAPermission new_perms) {
+Result VMManager::ChangeMemoryState(VAddr target, u32 size, MemoryState expected_state,
+                                    VMAPermission expected_perms, MemoryState new_state,
+                                    VMAPermission new_perms) {
     if (is_locked) {
         return RESULT_SUCCESS;
     }
@@ -168,7 +168,7 @@ VMManager::VMAIter VMManager::Unmap(VMAIter vma_handle) {
     return MergeAdjacent(vma_handle);
 }
 
-ResultCode VMManager::UnmapRange(VAddr target, u32 size) {
+Result VMManager::UnmapRange(VAddr target, u32 size) {
     ASSERT(!is_locked);
 
     CASCADE_RESULT(VMAIter vma, CarveVMARange(target, size));
@@ -197,7 +197,7 @@ VMManager::VMAHandle VMManager::Reprotect(VMAHandle vma_handle, VMAPermission ne
     return MergeAdjacent(iter);
 }
 
-ResultCode VMManager::ReprotectRange(VAddr target, u32 size, VMAPermission new_perms) {
+Result VMManager::ReprotectRange(VAddr target, u32 size, VMAPermission new_perms) {
     ASSERT(!is_locked);
 
     CASCADE_RESULT(VMAIter vma, CarveVMARange(target, size));

--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -118,7 +118,7 @@ Result VMManager::ChangeMemoryState(VAddr target, u32 size, MemoryState expected
                                     VMAPermission expected_perms, MemoryState new_state,
                                     VMAPermission new_perms) {
     if (is_locked) {
-        return RESULT_SUCCESS;
+        return ResultSuccess;
     }
 
     VAddr target_end = target + size;
@@ -126,16 +126,16 @@ Result VMManager::ChangeMemoryState(VAddr target, u32 size, MemoryState expected
     VMAIter i_end = vma_map.lower_bound(target_end);
 
     if (begin_vma == vma_map.end())
-        return ERR_INVALID_ADDRESS;
+        return ResultInvalidAddress;
 
     for (auto i = begin_vma; i != i_end; ++i) {
         auto& vma = i->second;
         if (vma.meminfo_state != expected_state) {
-            return ERR_INVALID_ADDRESS_STATE;
+            return ResultInvalidAddressState;
         }
         u32 perms = static_cast<u32>(expected_perms);
         if ((static_cast<u32>(vma.permissions) & perms) != perms) {
-            return ERR_INVALID_ADDRESS_STATE;
+            return ResultInvalidAddressState;
         }
     }
 
@@ -151,7 +151,7 @@ Result VMManager::ChangeMemoryState(VAddr target, u32 size, MemoryState expected
         vma = std::next(MergeAdjacent(vma));
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 VMManager::VMAIter VMManager::Unmap(VMAIter vma_handle) {
@@ -182,7 +182,7 @@ Result VMManager::UnmapRange(VAddr target, u32 size) {
     }
 
     ASSERT(FindVMA(target)->second.size >= size);
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 VMManager::VMAHandle VMManager::Reprotect(VMAHandle vma_handle, VMAPermission new_perms) {
@@ -210,7 +210,7 @@ Result VMManager::ReprotectRange(VAddr target, u32 size, VMAPermission new_perms
         vma = std::next(StripIterConstness(Reprotect(vma, new_perms)));
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 void VMManager::LogLayout(Common::Log::Level log_level) const {
@@ -242,13 +242,13 @@ ResultVal<VMManager::VMAIter> VMManager::CarveVMA(VAddr base, u32 size) {
     VMAIter vma_handle = StripIterConstness(FindVMA(base));
     if (vma_handle == vma_map.end()) {
         // Target address is outside the range managed by the kernel
-        return ERR_INVALID_ADDRESS;
+        return ResultInvalidAddress;
     }
 
     const VirtualMemoryArea& vma = vma_handle->second;
     if (vma.type != VMAType::Free) {
         // Region is already allocated
-        return ERR_INVALID_ADDRESS_STATE;
+        return ResultInvalidAddressState;
     }
 
     const VAddr start_in_vma = base - vma.base;
@@ -256,7 +256,7 @@ ResultVal<VMManager::VMAIter> VMManager::CarveVMA(VAddr base, u32 size) {
 
     if (end_in_vma > vma.size) {
         // Requested allocation doesn't fit inside VMA
-        return ERR_INVALID_ADDRESS_STATE;
+        return ResultInvalidAddressState;
     }
 
     if (end_in_vma != vma.size) {
@@ -284,7 +284,7 @@ ResultVal<VMManager::VMAIter> VMManager::CarveVMARange(VAddr target, u32 size) {
     const VMAIter i_end = vma_map.lower_bound(target_end);
     if (std::any_of(begin_vma, i_end,
                     [](const auto& entry) { return entry.second.type == VMAType::Free; })) {
-        return ERR_INVALID_ADDRESS_STATE;
+        return ResultInvalidAddressState;
     }
 
     if (target != begin_vma->second.base) {
@@ -367,7 +367,7 @@ ResultVal<std::vector<std::pair<MemoryRef, u32>>> VMManager::GetBackingBlocksFor
         auto vma = FindVMA(interval_target);
         if (vma->second.type != VMAType::BackingMemory) {
             LOG_ERROR(Kernel, "Trying to use already freed memory");
-            return ERR_INVALID_ADDRESS_STATE;
+            return ResultInvalidAddressState;
         }
 
         VAddr interval_end = std::min(address + size, vma->second.base + vma->second.size);

--- a/src/core/hle/kernel/vm_manager.h
+++ b/src/core/hle/kernel/vm_manager.h
@@ -165,18 +165,18 @@ public:
      * @param new_state New MemoryState for the range.
      * @param new_perms New VMAPermission for the range.
      */
-    ResultCode ChangeMemoryState(VAddr target, u32 size, MemoryState expected_state,
-                                 VMAPermission expected_perms, MemoryState new_state,
-                                 VMAPermission new_perms);
+    Result ChangeMemoryState(VAddr target, u32 size, MemoryState expected_state,
+                             VMAPermission expected_perms, MemoryState new_state,
+                             VMAPermission new_perms);
 
     /// Unmaps a range of addresses, splitting VMAs as necessary.
-    ResultCode UnmapRange(VAddr target, u32 size);
+    Result UnmapRange(VAddr target, u32 size);
 
     /// Changes the permissions of the given VMA.
     VMAHandle Reprotect(VMAHandle vma, VMAPermission new_perms);
 
     /// Changes the permissions of a range of addresses, splitting VMAs as necessary.
-    ResultCode ReprotectRange(VAddr target, u32 size, VMAPermission new_perms);
+    Result ReprotectRange(VAddr target, u32 size, VMAPermission new_perms);
 
     /// Dumps the address space layout to the log, for debugging
     void LogLayout(Common::Log::Level log_level) const;

--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -245,7 +245,7 @@ constexpr bool operator!=(const Result& a, const Result& b) {
 // Convenience functions for creating some common kinds of errors:
 
 /// The default success `Result`.
-constexpr Result RESULT_SUCCESS(0);
+constexpr Result ResultSuccess(0);
 
 /// Might be returned instead of a dummy success for unimplemented APIs.
 constexpr Result UnimplementedFunction(ErrorModule module) {
@@ -259,7 +259,7 @@ constexpr Result UnimplementedFunction(ErrorModule module) {
  * @note This should only be used when a particular error code
  *       is not known yet.
  */
-constexpr Result RESULT_UNKNOWN(UINT32_MAX);
+constexpr Result ResultUnknown(std::numeric_limits<u32>::max());
 
 /**
  * This is an optional value type. It holds a `Result` and, if that code is ResultSuccess, it
@@ -318,7 +318,7 @@ public:
     }
 
     [[nodiscard]] constexpr Result Code() const {
-        return expected.has_value() ? RESULT_SUCCESS : expected.error();
+        return expected.has_value() ? ResultSuccess : expected.error();
     }
 
     [[nodiscard]] constexpr bool Succeeded() const {
@@ -430,7 +430,7 @@ private:
     }
 
 /// Evaluates a boolean expression, and succeeds if that expression is true.
-#define R_SUCCEED_IF(expr) R_UNLESS(!(expr), RESULT_SUCCESS)
+#define R_SUCCEED_IF(expr) R_UNLESS(!(expr), ResultSuccess)
 
 /// Evaluates a boolean expression, and asserts if that expression is false.
 #define R_ASSERT(expr) ASSERT(R_SUCCEEDED(expr))

--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -400,15 +400,6 @@ private:
         return CONCAT2(check_result_L, __LINE__).Code();                                           \
     target = std::move(*CONCAT2(check_result_L, __LINE__))
 
-/**
- * Analogous to CASCADE_RESULT, but for a bare Result. The code will be propagated if
- * non-success, or discarded otherwise.
- */
-#define CASCADE_CODE(source)                                                                       \
-    auto CONCAT2(check_result_L, __LINE__) = source;                                               \
-    if (CONCAT2(check_result_L, __LINE__).IsError())                                               \
-        return CONCAT2(check_result_L, __LINE__);
-
 #define R_SUCCEEDED(res) (static_cast<Result>(res).IsSuccess())
 #define R_FAILED(res) (static_cast<Result>(res).IsError())
 

--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -408,3 +408,29 @@ private:
     auto CONCAT2(check_result_L, __LINE__) = source;                                               \
     if (CONCAT2(check_result_L, __LINE__).IsError())                                               \
         return CONCAT2(check_result_L, __LINE__);
+
+#define R_SUCCEEDED(res) (static_cast<ResultCode>(res).IsSuccess())
+#define R_FAILED(res) (static_cast<ResultCode>(res).IsError())
+
+/// Evaluates a boolean expression, and returns a result unless that expression is true.
+#define R_UNLESS(expr, res)                                                                        \
+    {                                                                                              \
+        if (!(expr)) {                                                                             \
+            return (res);                                                                          \
+        }                                                                                          \
+    }
+
+/// Evaluates an expression that returns a result, and returns the result if it would fail.
+#define R_TRY(res_expr)                                                                            \
+    {                                                                                              \
+        const auto _tmp_r_try_rc = (res_expr);                                                     \
+        if (R_FAILED(_tmp_r_try_rc)) {                                                             \
+            return (_tmp_r_try_rc);                                                                \
+        }                                                                                          \
+    }
+
+/// Evaluates a boolean expression, and succeeds if that expression is true.
+#define R_SUCCEED_IF(expr) R_UNLESS(!(expr), RESULT_SUCCESS)
+
+/// Evaluates a boolean expression, and asserts if that expression is false.
+#define R_ASSERT(expr) ASSERT(R_SUCCEEDED(expr))

--- a/src/core/hle/service/ac/ac.cpp
+++ b/src/core/hle/service/ac/ac.cpp
@@ -28,7 +28,7 @@ void Module::Interface::CreateDefaultConfig(Kernel::HLERequestContext& ctx) {
     std::memcpy(buffer.data(), &ac->default_config, buffer.size());
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushStaticBuffer(std::move(buffer), 0);
 
     LOG_WARNING(Service_AC, "(STUBBED) called");
@@ -48,7 +48,7 @@ void Module::Interface::ConnectAsync(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_AC, "(STUBBED) called");
 }
@@ -58,7 +58,7 @@ void Module::Interface::GetConnectResult(Kernel::HLERequestContext& ctx) {
     rp.Skip(2, false); // ProcessId descriptor
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void Module::Interface::CloseAsync(Kernel::HLERequestContext& ctx) {
@@ -79,7 +79,7 @@ void Module::Interface::CloseAsync(Kernel::HLERequestContext& ctx) {
     ac->ac_connected = false;
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void Module::Interface::GetCloseResult(Kernel::HLERequestContext& ctx) {
@@ -87,7 +87,7 @@ void Module::Interface::GetCloseResult(Kernel::HLERequestContext& ctx) {
     rp.Skip(2, false); // ProcessId descriptor
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_AC, "(STUBBED) called");
 }
@@ -102,7 +102,7 @@ void Module::Interface::GetWifiStatus(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u32>(static_cast<u32>(can_reach_internet ? (Settings::values.is_new_3ds
                                                             ? WifiStatus::STATUS_CONNECTED_N3DS
                                                             : WifiStatus::STATUS_CONNECTED_O3DS)
@@ -114,7 +114,7 @@ void Module::Interface::GetInfraPriority(Kernel::HLERequestContext& ctx) {
     [[maybe_unused]] const std::vector<u8>& ac_config = rp.PopStaticBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u32>(0); // Infra Priority, default 0
 
     LOG_WARNING(Service_AC, "(STUBBED) called");
@@ -131,7 +131,7 @@ void Module::Interface::SetRequestEulaVersion(Kernel::HLERequestContext& ctx) {
     // TODO(Subv): Copy over the input ACConfig to the stored ACConfig.
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushStaticBuffer(std::move(ac_config), 0);
 
     LOG_WARNING(Service_AC, "(STUBBED) called, major={}, minor={}", major, minor);
@@ -147,7 +147,7 @@ void Module::Interface::RegisterDisconnectEvent(Kernel::HLERequestContext& ctx) 
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_AC, "(STUBBED) called");
 }
@@ -157,7 +157,7 @@ void Module::Interface::GetConnectingProxyEnable(Kernel::HLERequestContext& ctx)
     constexpr bool proxy_enabled = false;
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(proxy_enabled);
 
     LOG_WARNING(Service_AC, "(STUBBED) called");
@@ -170,7 +170,7 @@ void Module::Interface::IsConnected(Kernel::HLERequestContext& ctx) {
     u32 unk_param = rp.Pop<u32>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(ac->ac_connected);
 
     LOG_WARNING(Service_AC, "(STUBBED) called unk=0x{:08X} descriptor=0x{:08X} param=0x{:08X}", unk,
@@ -186,7 +186,7 @@ void Module::Interface::SetClientVersion(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service_AC, "(STUBBED) called, version: 0x{:08X}", version);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 Module::Interface::Interface(std::shared_ptr<Module> ac, const char* name, u32 max_session)

--- a/src/core/hle/service/act/act.cpp
+++ b/src/core/hle/service/act/act.cpp
@@ -28,7 +28,7 @@ void Module::Interface::Initialize(Kernel::HLERequestContext& ctx) {
               sdk_version, shared_memory_size, caller_pid);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void Module::Interface::GetAccountDataBlock(Kernel::HLERequestContext& ctx) {
@@ -42,7 +42,7 @@ void Module::Interface::GetAccountDataBlock(Kernel::HLERequestContext& ctx) {
               size, block_id);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void InstallInterfaces(Core::System& system) {

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -105,7 +105,7 @@ Result CIAFile::WriteTicket() {
     // TODO: Write out .tik files to nand?
 
     install_state = CIAInstallState::TicketLoaded;
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result CIAFile::WriteTitleMetadata() {
@@ -138,7 +138,7 @@ Result CIAFile::WriteTitleMetadata() {
     if (tmd.Save(tmd_path) != Loader::ResultStatus::Success) {
         LOG_ERROR(Service_AM, "Failed to install title metadata file from CIA.");
         // TODO: Correct result code.
-        return FileSys::ERROR_FILE_NOT_FOUND;
+        return FileSys::ResultFileNotFound;
     }
 
     // Create any other .app folders which may not exist yet
@@ -158,7 +158,7 @@ Result CIAFile::WriteTitleMetadata() {
         if (!file.IsOpen()) {
             LOG_ERROR(Service_AM, "Could not open output file '{}' for content {}.", path, i);
             // TODO: Correct error code.
-            return FileSys::ERROR_FILE_NOT_FOUND;
+            return FileSys::ResultFileNotFound;
         }
     }
 
@@ -173,7 +173,7 @@ Result CIAFile::WriteTitleMetadata() {
         } else {
             LOG_ERROR(Service_AM, "Could not read title key from ticket for encrypted CIA.");
             // TODO: Correct error code.
-            return FileSys::ERROR_FILE_NOT_FOUND;
+            return FileSys::ResultFileNotFound;
         }
     } else {
         LOG_INFO(Service_AM,
@@ -182,7 +182,7 @@ Result CIAFile::WriteTitleMetadata() {
 
     install_state = CIAInstallState::TMDLoaded;
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 ResultVal<std::size_t> CIAFile::WriteContentData(u64 offset, std::size_t length, const u8* buffer) {
@@ -772,7 +772,7 @@ void Module::Interface::GetNumPrograms(Kernel::HLERequestContext& ctx) {
     u32 media_type = rp.Pop<u8>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u32>(static_cast<u32>(am->am_title_list[media_type].size()));
 }
 
@@ -836,7 +836,7 @@ void Module::Interface::FindDLCContentInfos(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 4);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(content_requested_in);
     rb.PushMappedBuffer(content_info_out);
 }
@@ -889,7 +889,7 @@ void Module::Interface::ListDLCContentInfos(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(copied);
     rb.PushMappedBuffer(content_info_out);
 }
@@ -902,7 +902,7 @@ void Module::Interface::DeleteContents(Kernel::HLERequestContext& ctx) {
     auto& content_ids_in = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(content_ids_in);
     LOG_WARNING(Service_AM, "(STUBBED) media_type={}, title_id=0x{:016x}, content_count={}",
                 media_type, title_id, content_count);
@@ -929,7 +929,7 @@ void Module::Interface::GetProgramList(Kernel::HLERequestContext& ctx) {
     title_ids_output.Write(am->am_title_list[media_type].data(), 0, copied * sizeof(u64));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(copied);
     rb.PushMappedBuffer(title_ids_output);
 }
@@ -958,7 +958,7 @@ Result GetTitleInfoFromList(std::span<const u64> title_id_list, Service::FS::Med
         write_offset += sizeof(TitleInfo);
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 void Module::Interface::GetProgramInfos(Kernel::HLERequestContext& ctx) {
@@ -1007,7 +1007,7 @@ void Module::Interface::DeleteUserProgram(Kernel::HLERequestContext& ctx) {
     }
     bool success = FileUtil::DeleteDirRecursively(path);
     am->ScanForAllTitles();
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     if (!success)
         LOG_ERROR(Service_AM, "FileUtil::DeleteDirRecursively unexpectedly failed");
 }
@@ -1033,7 +1033,7 @@ void Module::Interface::GetProductCode(Kernel::HLERequestContext& ctx) {
         FileSys::NCCHContainer ncch(path);
         ncch.Load();
         std::memcpy(&product_code.code, &ncch.ncch_header.product_code, 0x10);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.PushRaw(product_code);
     }
 }
@@ -1049,7 +1049,7 @@ void Module::Interface::GetDLCTitleInfos(Kernel::HLERequestContext& ctx) {
     std::vector<u64> title_id_list(title_count);
     title_id_list_buffer.Read(title_id_list.data(), 0, title_count * sizeof(u64));
 
-    Result result = RESULT_SUCCESS;
+    Result result = ResultSuccess;
 
     // Validate that DLC TIDs were passed in
     for (u32 i = 0; i < title_count; i++) {
@@ -1082,7 +1082,7 @@ void Module::Interface::GetPatchTitleInfos(Kernel::HLERequestContext& ctx) {
     std::vector<u64> title_id_list(title_count);
     title_id_list_buffer.Read(title_id_list.data(), 0, title_count * sizeof(u64));
 
-    Result result = RESULT_SUCCESS;
+    Result result = ResultSuccess;
 
     // Validate that update TIDs were passed in
     for (u32 i = 0; i < title_count; i++) {
@@ -1123,7 +1123,7 @@ void Module::Interface::ListDataTitleTicketInfos(Kernel::HLERequestContext& ctx)
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(ticket_count);
     rb.PushMappedBuffer(ticket_info_out);
 
@@ -1148,7 +1148,7 @@ void Module::Interface::GetDLCContentInfoCount(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS); // No error
+    rb.Push(ResultSuccess); // No error
 
     std::string tmd_path = GetTitleMetadataPath(media_type, title_id);
 
@@ -1167,7 +1167,7 @@ void Module::Interface::DeleteTicket(Kernel::HLERequestContext& ctx) {
     u64 title_id = rp.Pop<u64>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     LOG_WARNING(Service_AM, "(STUBBED) called title_id=0x{:016x}", title_id);
 }
 
@@ -1180,7 +1180,7 @@ void Module::Interface::GetNumTickets(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(ticket_count);
     LOG_WARNING(Service_AM, "(STUBBED) called ticket_count=0x{:08x}", ticket_count);
 }
@@ -1201,7 +1201,7 @@ void Module::Interface::GetTicketList(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(tickets_written);
     rb.PushMappedBuffer(ticket_tids_out);
     LOG_WARNING(Service_AM, "(STUBBED) ticket_list_count=0x{:08x}, ticket_index=0x{:08x}",
@@ -1215,7 +1215,7 @@ void Module::Interface::NeedsCleanup(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "(STUBBED) media_type=0x{:02x}", media_type);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<bool>(false);
 }
 
@@ -1226,7 +1226,7 @@ void Module::Interface::DoCleanup(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "(STUBBED) called, media_type={:#02x}", media_type);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void Module::Interface::QueryAvailableTitleDatabase(Kernel::HLERequestContext& ctx) {
@@ -1234,7 +1234,7 @@ void Module::Interface::QueryAvailableTitleDatabase(Kernel::HLERequestContext& c
     u8 media_type = rp.Pop<u8>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS); // No error
+    rb.Push(ResultSuccess); // No error
     rb.Push(true);
 
     LOG_WARNING(Service_AM, "(STUBBED) media_type={}", media_type);
@@ -1246,7 +1246,7 @@ void Module::Interface::GetPersonalizedTicketInfoList(Kernel::HLERequestContext&
     [[maybe_unused]] auto& buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS); // No error
+    rb.Push(ResultSuccess); // No error
     rb.Push(0);
 
     LOG_WARNING(Service_AM, "(STUBBED) called, ticket_count={}", ticket_count);
@@ -1258,7 +1258,7 @@ void Module::Interface::GetNumImportTitleContextsFiltered(Kernel::HLERequestCont
     u8 filter = rp.Pop<u8>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS); // No error
+    rb.Push(ResultSuccess); // No error
     rb.Push(0);
 
     LOG_WARNING(Service_AM, "(STUBBED) called, media_type={}, filter={}", media_type, filter);
@@ -1272,7 +1272,7 @@ void Module::Interface::GetImportTitleContextListFiltered(Kernel::HLERequestCont
     auto& buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
-    rb.Push(RESULT_SUCCESS); // No error
+    rb.Push(ResultSuccess); // No error
     rb.Push(0);
     rb.PushMappedBuffer(buffer);
 
@@ -1290,7 +1290,7 @@ void Module::Interface::CheckContentRights(Kernel::HLERequestContext& ctx) {
         FileUtil::Exists(GetTitleContentPath(Service::FS::MediaType::SDMC, tid, content_index));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS); // No error
+    rb.Push(ResultSuccess); // No error
     rb.Push(has_rights);
 
     LOG_WARNING(Service_AM, "(STUBBED) tid={:016x}, content_index={}", tid, content_index);
@@ -1306,7 +1306,7 @@ void Module::Interface::CheckContentRightsIgnorePlatform(Kernel::HLERequestConte
         FileUtil::Exists(GetTitleContentPath(Service::FS::MediaType::SDMC, tid, content_index));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS); // No error
+    rb.Push(ResultSuccess); // No error
     rb.Push(has_rights);
 
     LOG_WARNING(Service_AM, "(STUBBED) tid={:016x}, content_index={}", tid, content_index);
@@ -1332,7 +1332,7 @@ void Module::Interface::BeginImportProgram(Kernel::HLERequestContext& ctx) {
     am->cia_installing = true;
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS); // No error
+    rb.Push(ResultSuccess); // No error
     rb.PushCopyObjects(file->Connect());
 
     LOG_WARNING(Service_AM, "(STUBBED) media_type={}", media_type);
@@ -1359,7 +1359,7 @@ void Module::Interface::BeginImportProgramTemporarily(Kernel::HLERequestContext&
     am->cia_installing = true;
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS); // No error
+    rb.Push(ResultSuccess); // No error
     rb.PushCopyObjects(file->Connect());
 
     LOG_WARNING(Service_AM, "(STUBBED)");
@@ -1373,7 +1373,7 @@ void Module::Interface::EndImportProgram(Kernel::HLERequestContext& ctx) {
 
     am->cia_installing = false;
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void Module::Interface::EndImportProgramWithoutCommit(Kernel::HLERequestContext& ctx) {
@@ -1386,7 +1386,7 @@ void Module::Interface::EndImportProgramWithoutCommit(Kernel::HLERequestContext&
 
     am->cia_installing = false;
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void Module::Interface::CommitImportPrograms(Kernel::HLERequestContext& ctx) {
@@ -1401,7 +1401,7 @@ void Module::Interface::CommitImportPrograms(Kernel::HLERequestContext& ctx) {
     am->ScanForAllTitles();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(buffer);
 }
 
@@ -1444,14 +1444,14 @@ ResultVal<std::unique_ptr<AMFileWrapper>> GetFileFromSession(
 
     if (file_session->parent == nullptr) {
         LOG_WARNING(Service_AM, "Invalid file handle!");
-        return Kernel::ERR_INVALID_HANDLE;
+        return Kernel::ResultInvalidHandle;
     }
 
     std::shared_ptr<Kernel::ServerSession> server =
         Kernel::SharedFrom(file_session->parent->server);
     if (server == nullptr) {
         LOG_WARNING(Service_AM, "File handle ServerSession disconnected!");
-        return Kernel::ERR_SESSION_CLOSED_BY_REMOTE;
+        return Kernel::ResultSessionClosed;
     }
 
     if (server->hle_handler != nullptr) {
@@ -1467,13 +1467,13 @@ ResultVal<std::unique_ptr<AMFileWrapper>> GetFileFromSession(
         }
 
         LOG_ERROR(Service_AM, "Failed to cast handle to FSFile!");
-        return Kernel::ERR_INVALID_HANDLE;
+        return Kernel::ResultInvalidHandle;
     }
 
     // Probably the best bet if someone is LLEing the fs service is to just have them LLE AM
     // while they're at it, so not implemented.
     LOG_ERROR(Service_AM, "Given file handle does not have an HLE handler!");
-    return Kernel::ERR_NOT_IMPLEMENTED;
+    return Kernel::ResultNotImplemented;
 }
 
 void Module::Interface::GetProgramInfoFromCia(Kernel::HLERequestContext& ctx) {
@@ -1509,7 +1509,7 @@ void Module::Interface::GetProgramInfoFromCia(Kernel::HLERequestContext& ctx) {
     title_info.type = tmd.GetTitleType();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(8, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushRaw<TitleInfo>(title_info);
 }
 
@@ -1553,7 +1553,7 @@ void Module::Interface::GetSystemMenuDataFromCia(Kernel::HLERequestContext& ctx)
     output_buffer.Write(temp.data(), 0, temp.size());
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(output_buffer);
 }
 
@@ -1580,7 +1580,7 @@ void Module::Interface::GetDependencyListFromCia(Kernel::HLERequestContext& ctx)
     std::memcpy(buffer.data(), container.GetDependencies().data(), buffer.size());
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushStaticBuffer(std::move(buffer), 0);
 }
 
@@ -1604,7 +1604,7 @@ void Module::Interface::GetTransferSizeFromCia(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(container.GetMetadataOffset());
 }
 
@@ -1628,7 +1628,7 @@ void Module::Interface::GetCoreVersionFromCia(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(container.GetCoreVersion());
 }
 
@@ -1656,7 +1656,7 @@ void Module::Interface::GetRequiredSizeFromCia(Kernel::HLERequestContext& ctx) {
     // on some mediatypes. Since this is more of a required install size we'll report
     // what Citra needs, but it would be good to be more accurate here.
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(container.GetTitleMetadata().GetContentSizeByIndex(FileSys::TMDContentIndex::Main));
 }
 
@@ -1672,7 +1672,7 @@ Result UninstallProgram(const FS::MediaType media_type, const u64 title_id) {
         return {ErrorDescription::NotFound, ErrorModule::AM, ErrorSummary::InvalidState,
                 ErrorLevel::Permanent};
     }
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 void Module::Interface::DeleteProgram(Kernel::HLERequestContext& ctx) {
@@ -1693,7 +1693,7 @@ void Module::Interface::GetSystemUpdaterMutex(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushCopyObjects(am->system_updater_mutex);
 }
 
@@ -1718,7 +1718,7 @@ void Module::Interface::GetMetaSizeFromCia(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(container.GetMetadataSize());
 }
 
@@ -1761,7 +1761,7 @@ void Module::Interface::GetMetaDataFromCia(Kernel::HLERequestContext& ctx) {
 
     output_buffer.Write(temp.data(), 0, output_size);
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(output_buffer);
 }
 
@@ -1773,7 +1773,7 @@ void Module::Interface::BeginImportTicket(Kernel::HLERequestContext& ctx) {
                                                     FileSys::Path{});
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS); // No error
+    rb.Push(ResultSuccess); // No error
     rb.PushCopyObjects(file->Connect());
 
     LOG_WARNING(Service_AM, "(STUBBED) called");
@@ -1784,7 +1784,7 @@ void Module::Interface::EndImportTicket(Kernel::HLERequestContext& ctx) {
     [[maybe_unused]] const auto ticket = rp.PopObject<Kernel::ClientSession>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_AM, "(STUBBED) called");
 }

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -84,8 +84,8 @@ public:
     ~CIAFile();
 
     ResultVal<std::size_t> Read(u64 offset, std::size_t length, u8* buffer) const override;
-    ResultCode WriteTicket();
-    ResultCode WriteTitleMetadata();
+    Result WriteTicket();
+    Result WriteTitleMetadata();
     ResultVal<std::size_t> WriteContentData(u64 offset, std::size_t length, const u8* buffer);
     ResultVal<std::size_t> Write(u64 offset, std::size_t length, bool flush,
                                  const u8* buffer) override;
@@ -203,7 +203,7 @@ std::string GetMediaTitlePath(Service::FS::MediaType media_type);
  * @param title_id the title ID to uninstall
  * @return result of the uninstall operation
  */
-ResultCode UninstallProgram(const FS::MediaType media_type, const u64 title_id);
+Result UninstallProgram(const FS::MediaType media_type, const u64 title_id);
 
 class Module final {
 public:

--- a/src/core/hle/service/apt/applet_manager.cpp
+++ b/src/core/hle/service/apt/applet_manager.cpp
@@ -271,7 +271,7 @@ Result AppletManager::SendParameter(const MessageParameter& parameter) {
     }
 
     CancelAndSendParameter(parameter);
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 ResultVal<MessageParameter> AppletManager::GlanceParameter(AppletId app_id) {
@@ -406,7 +406,7 @@ Result AppletManager::Enable(AppletAttributes attributes) {
         delayed_parameter.reset();
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result AppletManager::Finalize(AppletId app_id) {
@@ -430,7 +430,7 @@ Result AppletManager::Finalize(AppletId app_id) {
         active_slot = GetAppletSlotFromPos(AppletPos::System);
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 u32 AppletManager::CountRegisteredApplet() {
@@ -480,7 +480,7 @@ Result AppletManager::SendNotification(Notification notification) {
         if (slot_data->registered) {
             slot_data->notification = notification;
             slot_data->notification_event->Signal();
-            return RESULT_SUCCESS;
+            return ResultSuccess;
         }
     }
 
@@ -519,14 +519,14 @@ Result AppletManager::PrepareToStartLibraryApplet(AppletId applet_id) {
     auto process =
         NS::LaunchTitle(FS::MediaType::NAND, GetTitleIdForApplet(applet_id, cfg->GetRegionValue()));
     if (process) {
-        return RESULT_SUCCESS;
+        return ResultSuccess;
     }
 
     // If we weren't able to load the native applet title, try to fallback to an HLE implementation.
     auto applet = HLE::Applets::Applet::Get(applet_id);
     if (applet) {
         LOG_WARNING(Service_APT, "applet has already been started id={:03X}", applet_id);
-        return RESULT_SUCCESS;
+        return ResultSuccess;
     } else {
         auto parent = GetAppletSlotId(last_library_launcher_slot);
         LOG_DEBUG(Service_APT, "Creating HLE applet {:03X} with parent {:03X}", applet_id, parent);
@@ -547,14 +547,14 @@ Result AppletManager::PreloadLibraryApplet(AppletId applet_id) {
     auto process =
         NS::LaunchTitle(FS::MediaType::NAND, GetTitleIdForApplet(applet_id, cfg->GetRegionValue()));
     if (process) {
-        return RESULT_SUCCESS;
+        return ResultSuccess;
     }
 
     // If we weren't able to load the native applet title, try to fallback to an HLE implementation.
     auto applet = HLE::Applets::Applet::Get(applet_id);
     if (applet) {
         LOG_WARNING(Service_APT, "applet has already been started id={:08X}", applet_id);
-        return RESULT_SUCCESS;
+        return ResultSuccess;
     } else {
         auto parent = GetAppletSlotId(last_library_launcher_slot);
         LOG_DEBUG(Service_APT, "Creating HLE applet {:03X} with parent {:03X}", applet_id, parent);
@@ -565,7 +565,7 @@ Result AppletManager::PreloadLibraryApplet(AppletId applet_id) {
 Result AppletManager::FinishPreloadingLibraryApplet(AppletId applet_id) {
     // TODO(Subv): This function should fail depending on the applet preparation state.
     GetAppletSlot(AppletSlot::LibraryApplet)->loaded = true;
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result AppletManager::StartLibraryApplet(AppletId applet_id, std::shared_ptr<Kernel::Object> object,
@@ -584,7 +584,7 @@ Result AppletManager::StartLibraryApplet(AppletId applet_id, std::shared_ptr<Ker
         return send_res;
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result AppletManager::PrepareToCloseLibraryApplet(bool not_pause, bool exiting, bool jump_home) {
@@ -602,7 +602,7 @@ Result AppletManager::PrepareToCloseLibraryApplet(bool not_pause, bool exiting, 
     else
         library_applet_closing_command = SignalType::WakeupByExit;
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result AppletManager::CloseLibraryApplet(std::shared_ptr<Kernel::Object> object,
@@ -628,7 +628,7 @@ Result AppletManager::CloseLibraryApplet(std::shared_ptr<Kernel::Object> object,
         SendParameter(param);
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result AppletManager::CancelLibraryApplet(bool app_exiting) {
@@ -679,7 +679,7 @@ Result AppletManager::SendDspSleep(AppletId from_applet_id,
         });
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result AppletManager::SendDspWakeUp(AppletId from_applet_id,
@@ -712,7 +712,7 @@ Result AppletManager::SendDspWakeUp(AppletId from_applet_id,
         }
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result AppletManager::PrepareToStartSystemApplet(AppletId applet_id) {
@@ -724,7 +724,7 @@ Result AppletManager::PrepareToStartSystemApplet(AppletId applet_id) {
     }
 
     last_system_launcher_slot = active_slot;
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result AppletManager::StartSystemApplet(AppletId applet_id, std::shared_ptr<Kernel::Object> object,
@@ -766,7 +766,7 @@ Result AppletManager::StartSystemApplet(AppletId applet_id, std::shared_ptr<Kern
         .buffer = buffer,
     });
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result AppletManager::PrepareToCloseSystemApplet() {
@@ -775,7 +775,7 @@ Result AppletManager::PrepareToCloseSystemApplet() {
                 ErrorLevel::Status};
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result AppletManager::CloseSystemApplet(std::shared_ptr<Kernel::Object> object,
@@ -803,7 +803,7 @@ Result AppletManager::CloseSystemApplet(std::shared_ptr<Kernel::Object> object,
     }
 
     // TODO: Terminate the running applet title
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result AppletManager::OrderToCloseSystemApplet() {
@@ -840,7 +840,7 @@ Result AppletManager::OrderToCloseSystemApplet() {
         .signal = SignalType::WakeupByCancel,
     });
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result AppletManager::PrepareToJumpToHomeMenu() {
@@ -857,7 +857,7 @@ Result AppletManager::PrepareToJumpToHomeMenu() {
         EnsureHomeMenuLoaded();
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result AppletManager::JumpToHomeMenu(std::shared_ptr<Kernel::Object> object,
@@ -907,7 +907,7 @@ Result AppletManager::JumpToHomeMenu(std::shared_ptr<Kernel::Object> object,
         }
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result AppletManager::PrepareToLeaveHomeMenu() {
@@ -921,7 +921,7 @@ Result AppletManager::PrepareToLeaveHomeMenu() {
                 ErrorLevel::Status};
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result AppletManager::LeaveHomeMenu(std::shared_ptr<Kernel::Object> object,
@@ -936,7 +936,7 @@ Result AppletManager::LeaveHomeMenu(std::shared_ptr<Kernel::Object> object,
         .buffer = buffer,
     });
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result AppletManager::OrderToCloseApplication() {
@@ -961,7 +961,7 @@ Result AppletManager::OrderToCloseApplication() {
         .signal = SignalType::WakeupByCancel,
     });
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result AppletManager::PrepareToCloseApplication(bool return_to_sys) {
@@ -1012,7 +1012,7 @@ Result AppletManager::PrepareToCloseApplication(bool return_to_sys) {
         // EnsureHomeMenuLoaded();
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result AppletManager::CloseApplication(std::shared_ptr<Kernel::Object> object,
@@ -1041,7 +1041,7 @@ Result AppletManager::CloseApplication(std::shared_ptr<Kernel::Object> object,
     }
 
     // TODO: Terminate the application process.
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 ResultVal<AppletManager::AppletManInfo> AppletManager::GetAppletManInfo(
@@ -1176,7 +1176,7 @@ Result AppletManager::PrepareToDoApplicationJump(u64 title_id, FS::MediaType med
     // Note: The real console uses the Home Menu to perform the application jump, therefore the menu
     // needs to be running. The real APT module starts the Home Menu here if it's not already
     // running, we don't have to do this. See `EnsureHomeMenuLoaded` for launching the Home Menu.
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result AppletManager::DoApplicationJump(const DeliverArg& arg) {
@@ -1208,7 +1208,7 @@ Result AppletManager::DoApplicationJump(const DeliverArg& arg) {
         });
 
         // TODO: APT terminates the application here, usually it will exit itself properly though.
-        return RESULT_SUCCESS;
+        return ResultSuccess;
     } else {
         // Otherwise, work around the missing home menu by launching the title directly.
 
@@ -1223,12 +1223,12 @@ Result AppletManager::DoApplicationJump(const DeliverArg& arg) {
             LOG_CRITICAL(Service_APT, "Failed to launch title during application jump, exiting.");
             system.RequestShutdown();
         }
-        return RESULT_SUCCESS;
+        return ResultSuccess;
         */
 
         NS::RebootToTitle(system, app_jump_parameters.next_media_type,
                           app_jump_parameters.next_title_id);
-        return RESULT_SUCCESS;
+        return ResultSuccess;
     }
 }
 
@@ -1255,7 +1255,7 @@ Result AppletManager::PrepareToStartApplication(u64 title_id, FS::MediaType medi
 
     capture_buffer_info.reset();
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result AppletManager::StartApplication(const std::vector<u8>& parameter,
@@ -1291,7 +1291,7 @@ Result AppletManager::StartApplication(const std::vector<u8>& parameter,
         return WakeupApplication(nullptr, {});
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result AppletManager::WakeupApplication(std::shared_ptr<Kernel::Object> object,
@@ -1307,7 +1307,7 @@ Result AppletManager::WakeupApplication(std::shared_ptr<Kernel::Object> object,
         .buffer = buffer,
     });
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result AppletManager::CancelApplication() {
@@ -1326,7 +1326,7 @@ Result AppletManager::CancelApplication() {
         .signal = SignalType::WakeupByCancel,
     });
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 void AppletManager::SendApplicationParameterAfterRegistration(const MessageParameter& parameter) {

--- a/src/core/hle/service/apt/applet_manager.h
+++ b/src/core/hle/service/apt/applet_manager.h
@@ -264,7 +264,7 @@ public:
      */
     void CancelAndSendParameter(const MessageParameter& parameter);
 
-    ResultCode SendParameter(const MessageParameter& parameter);
+    Result SendParameter(const MessageParameter& parameter);
     ResultVal<MessageParameter> GlanceParameter(AppletId app_id);
     ResultVal<MessageParameter> ReceiveParameter(AppletId app_id);
     bool CancelParameter(bool check_sender, AppletId sender_appid, bool check_receiver,
@@ -283,51 +283,48 @@ public:
     };
     ResultVal<InitializeResult> Initialize(AppletId app_id, AppletAttributes attributes);
 
-    ResultCode Enable(AppletAttributes attributes);
-    ResultCode Finalize(AppletId app_id);
+    Result Enable(AppletAttributes attributes);
+    Result Finalize(AppletId app_id);
     u32 CountRegisteredApplet();
     bool IsRegistered(AppletId app_id);
     ResultVal<AppletAttributes> GetAttribute(AppletId app_id);
 
     ResultVal<Notification> InquireNotification(AppletId app_id);
-    ResultCode SendNotification(Notification notification);
+    Result SendNotification(Notification notification);
     void SendNotificationToAll(Notification notification);
 
-    ResultCode PrepareToStartLibraryApplet(AppletId applet_id);
-    ResultCode PreloadLibraryApplet(AppletId applet_id);
-    ResultCode FinishPreloadingLibraryApplet(AppletId applet_id);
-    ResultCode StartLibraryApplet(AppletId applet_id, std::shared_ptr<Kernel::Object> object,
-                                  const std::vector<u8>& buffer);
-    ResultCode PrepareToCloseLibraryApplet(bool not_pause, bool exiting, bool jump_home);
-    ResultCode CloseLibraryApplet(std::shared_ptr<Kernel::Object> object,
-                                  const std::vector<u8>& buffer);
-    ResultCode CancelLibraryApplet(bool app_exiting);
-
-    ResultCode SendDspSleep(AppletId from_applet_id, std::shared_ptr<Kernel::Object> object);
-    ResultCode SendDspWakeUp(AppletId from_applet_id, std::shared_ptr<Kernel::Object> object);
-
-    ResultCode PrepareToStartSystemApplet(AppletId applet_id);
-    ResultCode StartSystemApplet(AppletId applet_id, std::shared_ptr<Kernel::Object> object,
-                                 const std::vector<u8>& buffer);
-    ResultCode PrepareToCloseSystemApplet();
-    ResultCode CloseSystemApplet(std::shared_ptr<Kernel::Object> object,
-                                 const std::vector<u8>& buffer);
-    ResultCode OrderToCloseSystemApplet();
-
-    ResultCode PrepareToJumpToHomeMenu();
-    ResultCode JumpToHomeMenu(std::shared_ptr<Kernel::Object> object,
+    Result PrepareToStartLibraryApplet(AppletId applet_id);
+    Result PreloadLibraryApplet(AppletId applet_id);
+    Result FinishPreloadingLibraryApplet(AppletId applet_id);
+    Result StartLibraryApplet(AppletId applet_id, std::shared_ptr<Kernel::Object> object,
                               const std::vector<u8>& buffer);
-    ResultCode PrepareToLeaveHomeMenu();
-    ResultCode LeaveHomeMenu(std::shared_ptr<Kernel::Object> object, const std::vector<u8>& buffer);
+    Result PrepareToCloseLibraryApplet(bool not_pause, bool exiting, bool jump_home);
+    Result CloseLibraryApplet(std::shared_ptr<Kernel::Object> object,
+                              const std::vector<u8>& buffer);
+    Result CancelLibraryApplet(bool app_exiting);
 
-    ResultCode OrderToCloseApplication();
-    ResultCode PrepareToCloseApplication(bool return_to_sys);
-    ResultCode CloseApplication(std::shared_ptr<Kernel::Object> object,
-                                const std::vector<u8>& buffer);
+    Result SendDspSleep(AppletId from_applet_id, std::shared_ptr<Kernel::Object> object);
+    Result SendDspWakeUp(AppletId from_applet_id, std::shared_ptr<Kernel::Object> object);
 
-    ResultCode PrepareToDoApplicationJump(u64 title_id, FS::MediaType media_type,
-                                          ApplicationJumpFlags flags);
-    ResultCode DoApplicationJump(const DeliverArg& arg);
+    Result PrepareToStartSystemApplet(AppletId applet_id);
+    Result StartSystemApplet(AppletId applet_id, std::shared_ptr<Kernel::Object> object,
+                             const std::vector<u8>& buffer);
+    Result PrepareToCloseSystemApplet();
+    Result CloseSystemApplet(std::shared_ptr<Kernel::Object> object, const std::vector<u8>& buffer);
+    Result OrderToCloseSystemApplet();
+
+    Result PrepareToJumpToHomeMenu();
+    Result JumpToHomeMenu(std::shared_ptr<Kernel::Object> object, const std::vector<u8>& buffer);
+    Result PrepareToLeaveHomeMenu();
+    Result LeaveHomeMenu(std::shared_ptr<Kernel::Object> object, const std::vector<u8>& buffer);
+
+    Result OrderToCloseApplication();
+    Result PrepareToCloseApplication(bool return_to_sys);
+    Result CloseApplication(std::shared_ptr<Kernel::Object> object, const std::vector<u8>& buffer);
+
+    Result PrepareToDoApplicationJump(u64 title_id, FS::MediaType media_type,
+                                      ApplicationJumpFlags flags);
+    Result DoApplicationJump(const DeliverArg& arg);
 
     boost::optional<DeliverArg> ReceiveDeliverArg() {
         auto arg = deliver_arg;
@@ -369,12 +366,11 @@ public:
         std::memcpy(&capture_buffer_info.get(), buffer.data(), sizeof(CaptureBufferInfo));
     }
 
-    ResultCode PrepareToStartApplication(u64 title_id, FS::MediaType media_type);
-    ResultCode StartApplication(const std::vector<u8>& parameter, const std::vector<u8>& hmac,
-                                bool paused);
-    ResultCode WakeupApplication(std::shared_ptr<Kernel::Object> object,
-                                 const std::vector<u8>& buffer);
-    ResultCode CancelApplication();
+    Result PrepareToStartApplication(u64 title_id, FS::MediaType media_type);
+    Result StartApplication(const std::vector<u8>& parameter, const std::vector<u8>& hmac,
+                            bool paused);
+    Result WakeupApplication(std::shared_ptr<Kernel::Object> object, const std::vector<u8>& buffer);
+    Result CancelApplication();
 
     struct AppletManInfo {
         AppletPos active_applet_pos;

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -70,7 +70,7 @@ void Module::NSInterface::SetWirelessRebootInfo(Kernel::HLERequestContext& ctx) 
     apt->wireless_reboot_info = std::move(buffer);
 
     auto rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_APT, "called size={}", size);
 }
@@ -83,7 +83,7 @@ void Module::NSInterface::ShutdownAsync(Kernel::HLERequestContext& ctx) {
     apt->system.RequestShutdown();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void Module::NSInterface::RebootSystem(Kernel::HLERequestContext& ctx) {
@@ -107,7 +107,7 @@ void Module::NSInterface::RebootSystem(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void Module::NSInterface::RebootSystemClean(Kernel::HLERequestContext& ctx) {
@@ -118,7 +118,7 @@ void Module::NSInterface::RebootSystemClean(Kernel::HLERequestContext& ctx) {
     apt->system.RequestReset();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void Module::APTInterface::Initialize(Kernel::HLERequestContext& ctx) {
@@ -134,7 +134,7 @@ void Module::APTInterface::Initialize(Kernel::HLERequestContext& ctx) {
         rb.Push(result.Code());
     } else {
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 3);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.PushCopyObjects(result->notification_event, result->parameter_event);
     }
 }
@@ -314,7 +314,7 @@ void Module::APTInterface::GetSharedFont(Kernel::HLERequestContext& ctx) {
         apt->shared_font_relocated = true;
     }
 
-    rb.Push(RESULT_SUCCESS); // No error
+    rb.Push(ResultSuccess); // No error
     // Since the SharedMemory interface doesn't provide the address at which the memory was
     // allocated, the real APT service calculates this address by scanning the entire address space
     // (using svcQueryMemory) and searches for an allocation of the same size as the Shared Font.
@@ -329,7 +329,7 @@ void Module::APTInterface::GetWirelessRebootInfo(Kernel::HLERequestContext& ctx)
     LOG_WARNING(Service_APT, "called size={:08X}", size);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushStaticBuffer(apt->wireless_reboot_info, 0);
 }
 
@@ -338,7 +338,7 @@ void Module::APTInterface::NotifyToWait(Kernel::HLERequestContext& ctx) {
     const auto app_id = rp.Pop<u32>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS); // No error
+    rb.Push(ResultSuccess); // No error
 
     LOG_WARNING(Service_APT, "(STUBBED) app_id={}", app_id);
 }
@@ -359,7 +359,7 @@ void Module::APTInterface::GetLockHandle(Kernel::HLERequestContext& ctx) {
         rb.Push(result.Code());
     } else {
         IPC::RequestBuilder rb = rp.MakeBuilder(3, 2);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.PushRaw(result->corrected_attributes);
         rb.Push<u32>(result->state);
         rb.PushCopyObjects(result->lock);
@@ -398,7 +398,7 @@ void Module::APTInterface::GetAppletManInfo(Kernel::HLERequestContext& ctx) {
         rb.Push(info.Code());
     } else {
         IPC::RequestBuilder rb = rp.MakeBuilder(5, 0);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.PushEnum(info->active_applet_pos);
         rb.PushEnum(info->requested_applet_id);
         rb.PushEnum(info->home_menu_applet_id);
@@ -412,7 +412,7 @@ void Module::APTInterface::CountRegisteredApplet(Kernel::HLERequestContext& ctx)
     LOG_DEBUG(Service_APT, "called");
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(apt->applet_manager->CountRegisteredApplet());
 }
 
@@ -421,7 +421,7 @@ void Module::APTInterface::IsRegistered(Kernel::HLERequestContext& ctx) {
     const auto app_id = rp.PopEnum<AppletId>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS); // No error
+    rb.Push(ResultSuccess); // No error
     rb.Push(apt->applet_manager->IsRegistered(app_id));
 
     LOG_DEBUG(Service_APT, "called app_id={:#010X}", app_id);
@@ -439,7 +439,7 @@ void Module::APTInterface::GetAttribute(Kernel::HLERequestContext& ctx) {
         rb.Push(applet_attr.Code());
     } else {
         IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.Push(applet_attr.Unwrap().raw);
     }
 }
@@ -456,7 +456,7 @@ void Module::APTInterface::InquireNotification(Kernel::HLERequestContext& ctx) {
         rb.Push(notification.Code());
     } else {
         IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.Push(static_cast<u32>(notification.Unwrap()));
     }
 }
@@ -502,7 +502,7 @@ void Module::APTInterface::ReceiveParameter(Kernel::HLERequestContext& ctx) {
             buffer_size); // APT always push a buffer with the maximum size
 
         IPC::RequestBuilder rb = rp.MakeBuilder(4, 4);
-        rb.Push(RESULT_SUCCESS); // No error
+        rb.Push(ResultSuccess); // No error
         rb.PushEnum(next_parameter->sender_id);
         rb.PushEnum(next_parameter->signal); // Signal type
         rb.Push(size);                       // Parameter buffer size
@@ -528,7 +528,7 @@ void Module::APTInterface::GlanceParameter(Kernel::HLERequestContext& ctx) {
             buffer_size); // APT always push a buffer with the maximum size
 
         IPC::RequestBuilder rb = rp.MakeBuilder(4, 4);
-        rb.Push(RESULT_SUCCESS); // No error
+        rb.Push(ResultSuccess); // No error
         rb.PushEnum(next_parameter->sender_id);
         rb.PushEnum(next_parameter->signal); // Signal type
         rb.Push(size);                       // Parameter buffer size
@@ -550,7 +550,7 @@ void Module::APTInterface::CancelParameter(Kernel::HLERequestContext& ctx) {
         check_sender, sender_appid, check_receiver, receiver_appid);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS); // No error
+    rb.Push(ResultSuccess); // No error
     rb.Push(apt->applet_manager->CancelParameter(check_sender, sender_appid, check_receiver,
                                                  receiver_appid));
 }
@@ -592,7 +592,7 @@ void Module::APTInterface::GetProgramIdOnApplicationJump(Kernel::HLERequestConte
     const auto parameters = apt->applet_manager->GetApplicationJumpParameters();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(7, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u64>(parameters.current_title_id);
     rb.Push(static_cast<u8>(parameters.current_media_type));
     rb.Push<u64>(parameters.next_title_id);
@@ -611,7 +611,7 @@ void Module::APTInterface::SendDeliverArg(Kernel::HLERequestContext& ctx) {
     apt->applet_manager->SetDeliverArg(DeliverArg{param, hmac});
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void Module::APTInterface::ReceiveDeliverArg(Kernel::HLERequestContext& ctx) {
@@ -626,7 +626,7 @@ void Module::APTInterface::ReceiveDeliverArg(Kernel::HLERequestContext& ctx) {
     arg.hmac.resize(std::min<std::size_t>(hmac_size, 0x20));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(4, 4);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(arg.source_program_id);
     rb.Push<u8>(1);
     rb.PushStaticBuffer(std::move(arg.param), 0);
@@ -702,8 +702,8 @@ void Module::APTInterface::AppletUtility(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
-    rb.Push(RESULT_SUCCESS); // No error
-    rb.Push(RESULT_SUCCESS); // Utility function result
+    rb.Push(ResultSuccess); // No error
+    rb.Push(ResultSuccess); // Utility function result
     rb.PushStaticBuffer(out, 0);
 }
 
@@ -720,7 +720,7 @@ void Module::APTInterface::SetAppCpuTimeLimit(Kernel::HLERequestContext& ctx) {
     apt->cpu_percent = value;
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS); // No error
+    rb.Push(ResultSuccess); // No error
 }
 
 void Module::APTInterface::GetAppCpuTimeLimit(Kernel::HLERequestContext& ctx) {
@@ -733,7 +733,7 @@ void Module::APTInterface::GetAppCpuTimeLimit(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS); // No error
+    rb.Push(ResultSuccess); // No error
     rb.Push(apt->cpu_percent);
 }
 
@@ -944,7 +944,7 @@ void Module::APTInterface::ReplySleepQuery(Kernel::HLERequestContext& ctx) {
                 from_app_id, reply_value);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void Module::APTInterface::ReplySleepNotificationComplete(Kernel::HLERequestContext& ctx) {
@@ -954,7 +954,7 @@ void Module::APTInterface::ReplySleepNotificationComplete(Kernel::HLERequestCont
     LOG_WARNING(Service_APT, "(STUBBED) called, from_app_id={:08X}", from_app_id);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void Module::APTInterface::PrepareToJumpToHomeMenu(Kernel::HLERequestContext& ctx) {
@@ -1010,7 +1010,7 @@ void Module::APTInterface::LoadSysMenuArg(Kernel::HLERequestContext& ctx) {
     std::copy_n(apt->sys_menu_arg_buffer.cbegin(), size, buffer.begin());
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushStaticBuffer(std::move(buffer), 0);
 }
 
@@ -1025,7 +1025,7 @@ void Module::APTInterface::StoreSysMenuArg(Kernel::HLERequestContext& ctx) {
     std::copy_n(buffer.cbegin(), size, apt->sys_menu_arg_buffer.begin());
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void Module::APTInterface::SendCaptureBufferInfo(Kernel::HLERequestContext& ctx) {
@@ -1038,7 +1038,7 @@ void Module::APTInterface::SendCaptureBufferInfo(Kernel::HLERequestContext& ctx)
     apt->applet_manager->SendCaptureBufferInfo(buffer);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void Module::APTInterface::ReceiveCaptureBufferInfo(Kernel::HLERequestContext& ctx) {
@@ -1052,7 +1052,7 @@ void Module::APTInterface::ReceiveCaptureBufferInfo(Kernel::HLERequestContext& c
     screen_capture_buffer.resize(size);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(real_size);
     rb.PushStaticBuffer(std::move(screen_capture_buffer), 0);
 }
@@ -1068,7 +1068,7 @@ void Module::APTInterface::GetCaptureInfo(Kernel::HLERequestContext& ctx) {
     screen_capture_buffer.resize(size);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(real_size);
     rb.PushStaticBuffer(std::move(screen_capture_buffer), 0);
 }
@@ -1085,7 +1085,7 @@ void Module::APTInterface::Unknown54(Kernel::HLERequestContext& ctx) {
         rb.Push(media_type.Code());
     } else {
         IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.PushEnum(media_type.Unwrap());
     }
 }
@@ -1099,7 +1099,7 @@ void Module::APTInterface::SetScreenCapturePostPermission(Kernel::HLERequestCont
     apt->screen_capture_post_permission = static_cast<ScreencapPostPermission>(permission & 0xF);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS); // No error
+    rb.Push(ResultSuccess); // No error
 }
 
 void Module::APTInterface::GetScreenCapturePostPermission(Kernel::HLERequestContext& ctx) {
@@ -1108,7 +1108,7 @@ void Module::APTInterface::GetScreenCapturePostPermission(Kernel::HLERequestCont
     LOG_DEBUG(Service_APT, "called");
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS); // No error
+    rb.Push(ResultSuccess); // No error
     rb.Push(static_cast<u32>(apt->screen_capture_post_permission));
 }
 
@@ -1131,7 +1131,7 @@ void Module::APTInterface::GetProgramId(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_APT, "called process_id={}", process_id);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     auto fs_user =
         Core::System::GetInstance().ServiceManager().GetService<Service::FS::FS_USER>("fs:USER");
@@ -1161,7 +1161,7 @@ void Module::APTInterface::GetProgramInfo(Kernel::HLERequestContext& ctx) {
 
         // TODO: Proper error code
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-        rb.Push(RESULT_UNKNOWN);
+        rb.Push(ResultUnknown);
         return;
     }
 
@@ -1171,7 +1171,7 @@ void Module::APTInterface::GetProgramInfo(Kernel::HLERequestContext& ctx) {
 
         // TODO: Proper error code
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-        rb.Push(RESULT_UNKNOWN);
+        rb.Push(ResultUnknown);
         return;
     }
 
@@ -1181,12 +1181,12 @@ void Module::APTInterface::GetProgramInfo(Kernel::HLERequestContext& ctx) {
 
         // TODO: Proper error code
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-        rb.Push(RESULT_UNKNOWN);
+        rb.Push(ResultUnknown);
         return;
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(static_cast<u8>(memory_mode.first.value()));
     rb.Push(core_version.first.value());
 }
@@ -1203,7 +1203,7 @@ void Module::APTInterface::GetAppletInfo(Kernel::HLERequestContext& ctx) {
         rb.Push(info.Code());
     } else {
         IPC::RequestBuilder rb = rp.MakeBuilder(7, 0);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.Push(info->title_id);
         rb.Push(static_cast<u8>(info->media_type));
         rb.Push(info->registered);
@@ -1248,7 +1248,7 @@ void Module::APTInterface::GetStartupArgument(Kernel::HLERequestContext& ctx) {
     param.resize(std::min(parameter_size, max_parameter_size));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(exists);
     rb.PushStaticBuffer(std::move(param), 0);
 }
@@ -1292,7 +1292,7 @@ void Module::APTInterface::Wrap(Kernel::HLERequestContext& ctx) {
     output.Write(cipher.data(), nonce_size, cipher.size());
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 4);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     // Unmap buffer
     rb.PushMappedBuffer(input);
     rb.PushMappedBuffer(output);
@@ -1338,7 +1338,7 @@ void Module::APTInterface::Unwrap(Kernel::HLERequestContext& ctx) {
         output.Write(nonce.data(), nonce_offset, nonce_size);
         output.Write(pdata.data() + nonce_offset, nonce_offset + nonce_size,
                      pdata.size() - nonce_offset);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
     } else {
         LOG_ERROR(Service_APT, "Failed to decrypt data");
         rb.Push(Result(static_cast<ErrorDescription>(1), ErrorModule::PS,
@@ -1366,7 +1366,7 @@ void Module::APTInterface::Reboot(Kernel::HLERequestContext& ctx) {
     NS::RebootToTitle(apt->system, media_type, title_id);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void Module::APTInterface::HardwareResetAsync(Kernel::HLERequestContext& ctx) {
@@ -1377,7 +1377,7 @@ void Module::APTInterface::HardwareResetAsync(Kernel::HLERequestContext& ctx) {
     apt->system.RequestReset();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void Module::APTInterface::GetTargetPlatform(Kernel::HLERequestContext& ctx) {
@@ -1386,7 +1386,7 @@ void Module::APTInterface::GetTargetPlatform(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_APT, "called");
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushEnum(apt->applet_manager->GetTargetPlatform());
 }
 
@@ -1405,7 +1405,7 @@ void Module::APTInterface::GetApplicationRunningMode(Kernel::HLERequestContext& 
     LOG_DEBUG(Service_APT, "called");
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushEnum(apt->applet_manager->GetApplicationRunningMode());
 }
 
@@ -1425,7 +1425,7 @@ void Module::APTInterface::IsStandardMemoryLayout(Kernel::HLERequestContext& ctx
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(is_standard);
 }
 
@@ -1439,7 +1439,7 @@ void Module::APTInterface::IsTitleAllowed(Kernel::HLERequestContext& ctx) {
 
     // We allow all titles to be launched, so this function is a no-op
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(true);
 }
 

--- a/src/core/hle/service/apt/apt.cpp
+++ b/src/core/hle/service/apt/apt.cpp
@@ -564,7 +564,7 @@ void Module::APTInterface::PrepareToDoApplicationJump(Kernel::HLERequestContext&
     LOG_INFO(Service_APT, "called title_id={:016X}, media_type={:#01X}, flags={:#08X}", title_id,
              media_type, flags);
 
-    ResultCode result = apt->applet_manager->PrepareToDoApplicationJump(
+    Result result = apt->applet_manager->PrepareToDoApplicationJump(
         title_id, static_cast<FS::MediaType>(media_type), flags);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
@@ -767,8 +767,8 @@ void Module::APTInterface::PrepareToStartNewestHomeMenu(Kernel::HLERequestContex
 
     // This command must return an error when called, otherwise the Home Menu will try to reboot the
     // system.
-    rb.Push(ResultCode(ErrorDescription::AlreadyExists, ErrorModule::Applet,
-                       ErrorSummary::InvalidState, ErrorLevel::Status));
+    rb.Push(Result(ErrorDescription::AlreadyExists, ErrorModule::Applet, ErrorSummary::InvalidState,
+                   ErrorLevel::Status));
 }
 
 void Module::APTInterface::PreloadLibraryApplet(Kernel::HLERequestContext& ctx) {
@@ -1341,8 +1341,8 @@ void Module::APTInterface::Unwrap(Kernel::HLERequestContext& ctx) {
         rb.Push(RESULT_SUCCESS);
     } else {
         LOG_ERROR(Service_APT, "Failed to decrypt data");
-        rb.Push(ResultCode(static_cast<ErrorDescription>(1), ErrorModule::PS,
-                           ErrorSummary::WrongArgument, ErrorLevel::Status));
+        rb.Push(Result(static_cast<ErrorDescription>(1), ErrorModule::PS,
+                       ErrorSummary::WrongArgument, ErrorLevel::Status));
     }
 
     // Unmap buffer

--- a/src/core/hle/service/boss/boss.cpp
+++ b/src/core/hle/service/boss/boss.cpp
@@ -43,7 +43,7 @@ std::shared_ptr<OnlineService> Module::Interface::GetSessionService(
         // TODO: Error code for uninitialized session.
         IPC::RequestParser rp(ctx);
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-        rb.Push(RESULT_UNKNOWN);
+        rb.Push(ResultUnknown);
         return nullptr;
     }
     return session_data->online_service;
@@ -80,7 +80,7 @@ void Module::Interface::SetStorageInfo(Kernel::HLERequestContext& ctx) {
     const u8 extdata_type = rp.Pop<u8>(); /// 0 = NAND, 1 = SD
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_BOSS,
                 "(STUBBED) extdata_id={:#018x}, boss_size={:#010x}, extdata_type={:#04x}",
@@ -91,7 +91,7 @@ void Module::Interface::UnregisterStorage(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_BOSS, "(STUBBED) called");
 }
@@ -100,7 +100,7 @@ void Module::Interface::GetStorageInfo(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u32>(0);
 
     LOG_WARNING(Service_BOSS, "(STUBBED) called");
@@ -112,7 +112,7 @@ void Module::Interface::RegisterPrivateRootCa(Kernel::HLERequestContext& ctx) {
     auto& buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(buffer);
 
     LOG_WARNING(Service_BOSS, "(STUBBED)");
@@ -126,7 +126,7 @@ void Module::Interface::RegisterPrivateClientCert(Kernel::HLERequestContext& ctx
     auto& buffer2 = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 4);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(buffer1);
     rb.PushMappedBuffer(buffer2);
 
@@ -138,7 +138,7 @@ void Module::Interface::GetNewArrivalFlag(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u8>(boss->new_arrival_flag);
 
     LOG_WARNING(Service_BOSS, "(STUBBED) new_arrival_flag={}", boss->new_arrival_flag);
@@ -149,7 +149,7 @@ void Module::Interface::RegisterNewArrivalEvent(Kernel::HLERequestContext& ctx) 
     [[maybe_unused]] const auto event = rp.PopObject<Kernel::Event>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_BOSS, "(STUBBED)");
 }
@@ -159,7 +159,7 @@ void Module::Interface::SetOptoutFlag(Kernel::HLERequestContext& ctx) {
     boss->output_flag = rp.Pop<u8>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_BOSS, "output_flag={}", boss->output_flag);
 }
@@ -168,7 +168,7 @@ void Module::Interface::GetOptoutFlag(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u8>(boss->output_flag);
 
     LOG_WARNING(Service_BOSS, "output_flag={}", boss->output_flag);
@@ -188,7 +188,7 @@ void Module::Interface::RegisterTask(Kernel::HLERequestContext& ctx) {
     online_service->RegisterTask(size, buffer);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(buffer);
 
     LOG_DEBUG(Service_BOSS, "called, size={:#010x}, unk_param2={:#04x}, unk_param3={:#04x}", size,
@@ -221,7 +221,7 @@ void Module::Interface::ReconfigureTask(Kernel::HLERequestContext& ctx) {
     auto& buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(buffer);
 
     LOG_WARNING(Service_BOSS, "(STUBBED) size={:#010x}, unk_param2={:#04x}", size, unk_param2);
@@ -237,7 +237,7 @@ void Module::Interface::GetTaskIdList(Kernel::HLERequestContext& ctx) {
     online_service->GetTaskIdList();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_BOSS, "called");
 }
@@ -248,7 +248,7 @@ void Module::Interface::GetStepIdList(Kernel::HLERequestContext& ctx) {
     auto& buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(buffer);
 
     LOG_WARNING(Service_BOSS, "(STUBBED) size={:#010x}", size);
@@ -269,7 +269,7 @@ void Module::Interface::GetNsDataIdList(Kernel::HLERequestContext& ctx) {
     const u16 entries_count = online_service->GetNsDataIdList(filter, max_entries, buffer);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u16>(entries_count); /// Actual number of output entries
     rb.Push<u16>(0);             /// Last word-index copied to output in the internal NsDataId list.
     rb.PushMappedBuffer(buffer);
@@ -295,7 +295,7 @@ void Module::Interface::GetNsDataIdList1(Kernel::HLERequestContext& ctx) {
     const u16 entries_count = online_service->GetNsDataIdList(filter, max_entries, buffer);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u16>(entries_count); /// Actual number of output entries
     rb.Push<u16>(0);             /// Last word-index copied to output in the internal NsDataId list.
     rb.PushMappedBuffer(buffer);
@@ -321,7 +321,7 @@ void Module::Interface::GetNsDataIdList2(Kernel::HLERequestContext& ctx) {
     const u16 entries_count = online_service->GetNsDataIdList(filter, max_entries, buffer);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u16>(entries_count); /// Actual number of output entries
     rb.Push<u16>(0);             /// Last word-index copied to output in the internal NsDataId list.
     rb.PushMappedBuffer(buffer);
@@ -347,7 +347,7 @@ void Module::Interface::GetNsDataIdList3(Kernel::HLERequestContext& ctx) {
     const u16 entries_count = online_service->GetNsDataIdList(filter, max_entries, buffer);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u16>(entries_count); /// Actual number of output entries
     rb.Push<u16>(0);             /// Last word-index copied to output in the internal NsDataId list.
     rb.PushMappedBuffer(buffer);
@@ -383,7 +383,7 @@ void Module::Interface::SendPropertyHandle(Kernel::HLERequestContext& ctx) {
     [[maybe_unused]] const std::shared_ptr<Kernel::Object> object = rp.PopGenericObject();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_BOSS, "(STUBBED) property_id={:#06x}", property_id);
 }
@@ -415,7 +415,7 @@ void Module::Interface::UpdateTaskInterval(Kernel::HLERequestContext& ctx) {
     auto& buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(buffer);
 
     LOG_WARNING(Service_BOSS, "(STUBBED) size={:#010x}, unk_param2={:#06x}", size, unk_param2);
@@ -431,7 +431,7 @@ void Module::Interface::UpdateTaskCount(Kernel::HLERequestContext& ctx) {
     buffer.Read(task_id.data(), 0, size);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(buffer);
 
     LOG_WARNING(Service_BOSS, "(STUBBED) size={:#010x}, unk_param2={:#010x}, task_id={}", size,
@@ -444,7 +444,7 @@ void Module::Interface::GetTaskInterval(Kernel::HLERequestContext& ctx) {
     auto& buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u32>(0); // stub 0 ( 32bit value)
     rb.PushMappedBuffer(buffer);
 
@@ -460,7 +460,7 @@ void Module::Interface::GetTaskCount(Kernel::HLERequestContext& ctx) {
     buffer.Read(task_id.data(), 0, size);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u32>(0); // stub 0 ( 32bit value)
     rb.PushMappedBuffer(buffer);
 
@@ -477,7 +477,7 @@ void Module::Interface::GetTaskServiceStatus(Kernel::HLERequestContext& ctx) {
     constexpr u8 task_service_status = 1;
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u8>(task_service_status);
     rb.PushMappedBuffer(buffer);
 
@@ -490,7 +490,7 @@ void Module::Interface::StartTask(Kernel::HLERequestContext& ctx) {
     auto& buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(buffer);
 
     LOG_WARNING(Service_BOSS, "(STUBBED) size={:#010x}", size);
@@ -502,7 +502,7 @@ void Module::Interface::StartTaskImmediate(Kernel::HLERequestContext& ctx) {
     auto& buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(buffer);
 
     LOG_WARNING(Service_BOSS, "(STUBBED) size={:#010x}", size);
@@ -514,7 +514,7 @@ void Module::Interface::CancelTask(Kernel::HLERequestContext& ctx) {
     auto& buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(buffer);
 
     LOG_WARNING(Service_BOSS, "(STUBBED) size={:#010x}", size);
@@ -524,7 +524,7 @@ void Module::Interface::GetTaskFinishHandle(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushCopyObjects<Kernel::Event>(boss->task_finish_event);
 
     LOG_WARNING(Service_BOSS, "(STUBBED) called");
@@ -537,7 +537,7 @@ void Module::Interface::GetTaskState(Kernel::HLERequestContext& ctx) {
     auto& buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(4, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u8>(0);  /// TaskStatus
     rb.Push<u32>(0); /// Current state value for task PropertyID 0x4
     rb.Push<u8>(0);  /// unknown, usually 0
@@ -552,7 +552,7 @@ void Module::Interface::GetTaskResult(Kernel::HLERequestContext& ctx) {
     auto& buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(4, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u8>(0);  // stub 0 (8 bit value)
     rb.Push<u32>(0); // stub 0 (32 bit value)
     rb.Push<u8>(0);  // stub 0 (8 bit value)
@@ -567,7 +567,7 @@ void Module::Interface::GetTaskCommErrorCode(Kernel::HLERequestContext& ctx) {
     auto& buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(4, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u32>(0); // stub 0 (32 bit value)
     rb.Push<u32>(0); // stub 0 (32 bit value)
     rb.Push<u8>(0);  // stub 0 (8 bit value)
@@ -584,7 +584,7 @@ void Module::Interface::GetTaskStatus(Kernel::HLERequestContext& ctx) {
     auto& buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u8>(0); // stub 0 (8 bit value)
     rb.PushMappedBuffer(buffer);
 
@@ -599,7 +599,7 @@ void Module::Interface::GetTaskError(Kernel::HLERequestContext& ctx) {
     auto& buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u8>(0); // stub 0 (8 bit value)
     rb.PushMappedBuffer(buffer);
 
@@ -613,7 +613,7 @@ void Module::Interface::GetTaskInfo(Kernel::HLERequestContext& ctx) {
     auto& buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(buffer);
 
     LOG_WARNING(Service_BOSS, "(STUBBED) size={:#010x}, unk_param2={:#04x}", size, unk_param2);
@@ -624,7 +624,7 @@ void Module::Interface::DeleteNsData(Kernel::HLERequestContext& ctx) {
     const u32 ns_data_id = rp.Pop<u32>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_BOSS, "(STUBBED) ns_data_id={:#010x}", ns_data_id);
 }
@@ -684,7 +684,7 @@ void Module::Interface::SetNsDataAdditionalInfo(Kernel::HLERequestContext& ctx) 
     const u32 unk_param2 = rp.Pop<u32>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_BOSS, "(STUBBED) unk_param1={:#010x}, unk_param2={:#010x}", unk_param1,
                 unk_param2);
@@ -695,7 +695,7 @@ void Module::Interface::GetNsDataAdditionalInfo(Kernel::HLERequestContext& ctx) 
     const u32 unk_param1 = rp.Pop<u32>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u32>(0); // stub 0 (32bit value)
 
     LOG_WARNING(Service_BOSS, "(STUBBED) unk_param1={:#010x}", unk_param1);
@@ -707,7 +707,7 @@ void Module::Interface::SetNsDataNewFlag(Kernel::HLERequestContext& ctx) {
     boss->ns_data_new_flag = rp.Pop<u8>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_BOSS, "(STUBBED) unk_param1={:#010x}, ns_data_new_flag={:#04x}", unk_param1,
                 boss->ns_data_new_flag);
@@ -718,7 +718,7 @@ void Module::Interface::GetNsDataNewFlag(Kernel::HLERequestContext& ctx) {
     const u32 unk_param1 = rp.Pop<u32>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u8>(boss->ns_data_new_flag);
 
     LOG_WARNING(Service_BOSS, "(STUBBED) unk_param1={:#010x}, ns_data_new_flag={:#04x}", unk_param1,
@@ -738,12 +738,12 @@ void Module::Interface::GetNsDataLastUpdate(Kernel::HLERequestContext& ctx) {
     if (!entry.has_value()) {
         // TODO: Proper error code.
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-        rb.Push(RESULT_UNKNOWN);
+        rb.Push(ResultUnknown);
         return;
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u32>(0);
     rb.Push<u32>(entry->header.download_date); // return the download date from the ns data
 
@@ -755,7 +755,7 @@ void Module::Interface::GetErrorCode(Kernel::HLERequestContext& ctx) {
     const u8 input = rp.Pop<u8>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u32>(0); /// output value
 
     LOG_WARNING(Service_BOSS, "(STUBBED) input={:#010x}", input);
@@ -770,7 +770,7 @@ void Module::Interface::RegisterStorageEntry(Kernel::HLERequestContext& ctx) {
     const u8 unk_param5 = rp.Pop<u8>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_BOSS,
                 "(STUBBED)  unk_param1={:#010x}, unk_param2={:#010x}, unk_param3={:#010x}, "
@@ -782,7 +782,7 @@ void Module::Interface::GetStorageEntryInfo(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u32>(0); // stub 0 (32bit value)
     rb.Push<u16>(0); // stub 0 (16bit value)
 
@@ -797,7 +797,7 @@ void Module::Interface::SetStorageOption(Kernel::HLERequestContext& ctx) {
     const u16 unk_param4 = rp.Pop<u16>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_BOSS,
                 "(STUBBED)  unk_param1={:#04x}, unk_param2={:#010x}, "
@@ -809,7 +809,7 @@ void Module::Interface::GetStorageOption(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(5, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u32>(0); // stub 0 (32bit value)
     rb.Push<u8>(0);  // stub 0 (8bit value)
     rb.Push<u16>(0); // stub 0 (16bit value)
@@ -824,7 +824,7 @@ void Module::Interface::StartBgImmediate(Kernel::HLERequestContext& ctx) {
     auto& buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(buffer);
 
     LOG_WARNING(Service_BOSS, "(STUBBED) size={:#010x}", size);
@@ -836,7 +836,7 @@ void Module::Interface::GetTaskProperty0(Kernel::HLERequestContext& ctx) {
     auto& buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u8>(0); /// current state of PropertyID 0x0 stub 0 (8bit value)
     rb.PushMappedBuffer(buffer);
 
@@ -851,7 +851,7 @@ void Module::Interface::RegisterImmediateTask(Kernel::HLERequestContext& ctx) {
     auto& buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(buffer);
 
     LOG_WARNING(Service_BOSS, "(STUBBED) size={:#010x}, unk_param2={:#04x}, unk_param3={:#04x}",
@@ -866,7 +866,7 @@ void Module::Interface::SetTaskQuery(Kernel::HLERequestContext& ctx) {
     auto& buffer2 = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 4);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(buffer1);
     rb.PushMappedBuffer(buffer2);
 
@@ -882,7 +882,7 @@ void Module::Interface::GetTaskQuery(Kernel::HLERequestContext& ctx) {
     auto& buffer2 = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 4);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(buffer1);
     rb.PushMappedBuffer(buffer2);
 
@@ -896,7 +896,7 @@ void Module::Interface::InitializeSessionPrivileged(Kernel::HLERequestContext& c
     rp.PopPID();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_BOSS, "(STUBBED) programID={:#018x}", programID);
 }
@@ -906,7 +906,7 @@ void Module::Interface::GetAppNewFlag(Kernel::HLERequestContext& ctx) {
     const u64 programID = rp.Pop<u64>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u8>(0); // 0 = nothing new, 1 = new content
 
     LOG_WARNING(Service_BOSS, "(STUBBED) programID={:#018x}", programID);
@@ -922,7 +922,7 @@ void Module::Interface::GetNsDataIdListPrivileged(Kernel::HLERequestContext& ctx
     auto& buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u16>(0); /// Actual number of output entries
     rb.Push<u16>(0); /// Last word-index copied to output in the internal NsDataId list.
     rb.PushMappedBuffer(buffer);
@@ -943,7 +943,7 @@ void Module::Interface::GetNsDataIdListPrivileged1(Kernel::HLERequestContext& ct
     auto& buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u16>(0); /// Actual number of output entries
     rb.Push<u16>(0); /// Last word-index copied to output in the internal NsDataId list.
     rb.PushMappedBuffer(buffer);
@@ -961,7 +961,7 @@ void Module::Interface::SendPropertyPrivileged(Kernel::HLERequestContext& ctx) {
     auto& buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(buffer);
 
     LOG_WARNING(Service_BOSS, "(STUBBED) property_id={:#06x}, size={:#010x}", property_id, size);
@@ -973,7 +973,7 @@ void Module::Interface::DeleteNsDataPrivileged(Kernel::HLERequestContext& ctx) {
     const u32 ns_data_id = rp.Pop<u32>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_BOSS, "(STUBBED) programID={:#018x}, ns_data_id={:#010x}", programID,
                 ns_data_id);
@@ -988,7 +988,7 @@ void Module::Interface::GetNsDataHeaderInfoPrivileged(Kernel::HLERequestContext&
     auto& buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(buffer);
 
     LOG_WARNING(Service_BOSS,
@@ -1005,7 +1005,7 @@ void Module::Interface::ReadNsDataPrivileged(Kernel::HLERequestContext& ctx) {
     auto& buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u32>(size); /// Should be actual read size
     rb.Push<u32>(0);    /// unknown
     rb.PushMappedBuffer(buffer);
@@ -1022,7 +1022,7 @@ void Module::Interface::SetNsDataNewFlagPrivileged(Kernel::HLERequestContext& ct
     boss->ns_data_new_flag_privileged = rp.Pop<u8>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(
         Service_BOSS,
@@ -1036,7 +1036,7 @@ void Module::Interface::GetNsDataNewFlagPrivileged(Kernel::HLERequestContext& ct
     const u32 unk_param1 = rp.Pop<u32>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u8>(boss->ns_data_new_flag_privileged);
 
     LOG_WARNING(

--- a/src/core/hle/service/boss/online_service.cpp
+++ b/src/core/hle/service/boss/online_service.cpp
@@ -38,7 +38,7 @@ void BossTaskProperties::serialize(Archive& ar, const unsigned int) {
 }
 SERIALIZE_IMPL(BossTaskProperties)
 
-ResultCode OnlineService::InitializeSession(u64 init_program_id) {
+Result OnlineService::InitializeSession(u64 init_program_id) {
     // The BOSS service uses three databases:
     // BOSS_A: Archive? A list of program ids and some properties that are keyed on program
     // BOSS_SS: Saved Strings? Includes the url and the other string properties, and also some other
@@ -150,7 +150,7 @@ void OnlineService::RegisterTask(const u32 size, Kernel::MappedBuffer& buffer) {
     current_props = BossTaskProperties();
 }
 
-ResultCode OnlineService::UnregisterTask(const u32 size, Kernel::MappedBuffer& buffer) {
+Result OnlineService::UnregisterTask(const u32 size, Kernel::MappedBuffer& buffer) {
     if (size > TASK_ID_SIZE) {
         LOG_WARNING(Service_BOSS, "TaskId cannot be longer than 8");
         // TODO: Proper error code.
@@ -334,7 +334,7 @@ std::optional<NsDataEntry> OnlineService::GetNsDataEntryFromId(const u32 ns_data
     return *entry_iter;
 }
 
-ResultCode OnlineService::GetNsDataHeaderInfo(const u32 ns_data_id, const NsDataHeaderInfoType type,
+Result OnlineService::GetNsDataHeaderInfo(const u32 ns_data_id, const NsDataHeaderInfoType type,
                                               const u32 size, Kernel::MappedBuffer& buffer) {
     const auto entry = GetNsDataEntryFromId(ns_data_id);
     if (!entry.has_value()) {
@@ -452,7 +452,7 @@ struct overload : Ts... {
 template <class... Ts>
 overload(Ts...) -> overload<Ts...>;
 
-ResultCode OnlineService::SendProperty(const u16 id, const u32 size, Kernel::MappedBuffer& buffer) {
+Result OnlineService::SendProperty(const u16 id, const u32 size, Kernel::MappedBuffer& buffer) {
     const auto property_id = static_cast<PropertyID>(id);
     if (!current_props.properties.contains(property_id)) {
         LOG_ERROR(Service_BOSS, "Unknown property with ID {:#06x} and size {}", property_id, size);
@@ -492,8 +492,7 @@ ResultCode OnlineService::SendProperty(const u16 id, const u32 size, Kernel::Map
     return RESULT_SUCCESS;
 }
 
-ResultCode OnlineService::ReceiveProperty(const u16 id, const u32 size,
-                                          Kernel::MappedBuffer& buffer) {
+Result OnlineService::ReceiveProperty(const u16 id, const u32 size, Kernel::MappedBuffer& buffer) {
     const auto property_id = static_cast<PropertyID>(id);
     if (!current_props.properties.contains(property_id)) {
         LOG_ERROR(Service_BOSS, "Unknown property with ID {:#06x} and size {}", property_id, size);

--- a/src/core/hle/service/boss/online_service.cpp
+++ b/src/core/hle/service/boss/online_service.cpp
@@ -65,7 +65,7 @@ Result OnlineService::InitializeSession(u64 init_program_id) {
     std::unique_ptr<FileSys::ArchiveBackend> boss_system_save_data_archive;
     if (archive_result.Succeeded()) {
         boss_system_save_data_archive = std::move(archive_result).Unwrap();
-    } else if (archive_result.Code() == FileSys::ERROR_NOT_FOUND) {
+    } else if (archive_result.Code() == FileSys::ResultNotFound) {
         // If the archive didn't exist, create the files inside
         systemsavedata_factory.Format(archive_path, FileSys::ArchiveFormatInfo(), 0);
 
@@ -74,13 +74,13 @@ Result OnlineService::InitializeSession(u64 init_program_id) {
         if (!create_archive_result.Succeeded()) {
             LOG_ERROR(Service_BOSS, "Could not open BOSS savedata");
             // TODO: Proper error code.
-            return RESULT_UNKNOWN;
+            return ResultUnknown;
         }
         boss_system_save_data_archive = std::move(create_archive_result).Unwrap();
     } else {
         LOG_ERROR(Service_BOSS, "Could not open BOSS savedata");
         // TODO: Proper error code.
-        return RESULT_UNKNOWN;
+        return ResultUnknown;
     }
 
     FileSys::Mode open_mode = {};
@@ -94,7 +94,7 @@ Result OnlineService::InitializeSession(u64 init_program_id) {
         boss_system_save_data_archive->OpenFile(FileSys::Path("/BOSS_SS.db"), open_mode);
     if (!boss_sv_result.Succeeded() || !boss_ss_result.Succeeded()) {
         LOG_ERROR(Service_BOSS, "Could not open BOSS database.");
-        return RESULT_SUCCESS;
+        return ResultSuccess;
     }
 
     auto boss_sv = std::move(boss_sv_result).Unwrap();
@@ -103,7 +103,7 @@ Result OnlineService::InitializeSession(u64 init_program_id) {
           ((boss_sv->GetSize() - BOSS_SAVE_HEADER_SIZE) % BOSS_S_ENTRY_SIZE) == 0 &&
           boss_sv->GetSize() == boss_ss->GetSize())) {
         LOG_ERROR(Service_BOSS, "BOSS database has incorrect size.");
-        return RESULT_SUCCESS;
+        return ResultSuccess;
     }
 
     // Read the files if they already exist
@@ -135,7 +135,7 @@ Result OnlineService::InitializeSession(u64 init_program_id) {
         current_props = BossTaskProperties();
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 void OnlineService::RegisterTask(const u32 size, Kernel::MappedBuffer& buffer) {
@@ -154,7 +154,7 @@ Result OnlineService::UnregisterTask(const u32 size, Kernel::MappedBuffer& buffe
     if (size > TASK_ID_SIZE) {
         LOG_WARNING(Service_BOSS, "TaskId cannot be longer than 8");
         // TODO: Proper error code.
-        return RESULT_UNKNOWN;
+        return ResultUnknown;
     }
 
     std::string task_id(size, 0);
@@ -162,10 +162,10 @@ Result OnlineService::UnregisterTask(const u32 size, Kernel::MappedBuffer& buffe
     if (task_id_list.erase(task_id) == 0) {
         LOG_WARNING(Service_BOSS, "TaskId not in list");
         // TODO: Proper error code.
-        return RESULT_UNKNOWN;
+        return ResultUnknown;
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 void OnlineService::GetTaskIdList() {
@@ -340,7 +340,7 @@ Result OnlineService::GetNsDataHeaderInfo(const u32 ns_data_id, const NsDataHead
     if (!entry.has_value()) {
         LOG_WARNING(Service_BOSS, "Failed to find NsData entry for ID {:#010X}", ns_data_id);
         // TODO: Proper error code.
-        return RESULT_UNKNOWN;
+        return ResultUnknown;
     }
 
     static constexpr std::array EXPECTED_NS_DATA_HEADER_INFO_SIZES = {
@@ -355,31 +355,31 @@ Result OnlineService::GetNsDataHeaderInfo(const u32 ns_data_id, const NsDataHead
     if (size != EXPECTED_NS_DATA_HEADER_INFO_SIZES[static_cast<u8>(type)]) {
         LOG_WARNING(Service_BOSS, "Invalid size {} for type {}", size, type);
         // TODO: Proper error code.
-        return RESULT_UNKNOWN;
+        return ResultUnknown;
     }
 
     switch (type) {
     case NsDataHeaderInfoType::ProgramId:
         buffer.Write(&entry->header.program_id, 0, size);
-        return RESULT_SUCCESS;
+        return ResultSuccess;
     case NsDataHeaderInfoType::Unknown: {
         // TODO: Figure out what this is. Stubbed to zero for now.
         const u32 zero = 0;
         buffer.Write(&zero, 0, size);
-        return RESULT_SUCCESS;
+        return ResultSuccess;
     }
     case NsDataHeaderInfoType::Datatype:
         buffer.Write(&entry->header.datatype, 0, size);
-        return RESULT_SUCCESS;
+        return ResultSuccess;
     case NsDataHeaderInfoType::PayloadSize:
         buffer.Write(&entry->header.payload_size, 0, size);
-        return RESULT_SUCCESS;
+        return ResultSuccess;
     case NsDataHeaderInfoType::NsDataId:
         buffer.Write(&entry->header.ns_data_id, 0, size);
-        return RESULT_SUCCESS;
+        return ResultSuccess;
     case NsDataHeaderInfoType::Version:
         buffer.Write(&entry->header.version, 0, size);
-        return RESULT_SUCCESS;
+        return ResultSuccess;
     case NsDataHeaderInfoType::Everything: {
         const NsDataHeaderInfo info = {
             .program_id = entry->header.program_id,
@@ -389,12 +389,12 @@ Result OnlineService::GetNsDataHeaderInfo(const u32 ns_data_id, const NsDataHead
             .version = entry->header.version,
         };
         buffer.Write(&info, 0, size);
-        return RESULT_SUCCESS;
+        return ResultSuccess;
     }
     default:
         LOG_WARNING(Service_BOSS, "Unknown header info type {}", type);
         // TODO: Proper error code.
-        return RESULT_UNKNOWN;
+        return ResultUnknown;
     }
 }
 
@@ -404,7 +404,7 @@ ResultVal<size_t> OnlineService::ReadNsData(const u32 ns_data_id, const u64 offs
     if (!entry.has_value()) {
         LOG_WARNING(Service_BOSS, "Failed to find NsData entry for ID {:#010X}", ns_data_id);
         // TODO: Proper error code.
-        return RESULT_UNKNOWN;
+        return ResultUnknown;
     }
 
     if (entry->header.payload_size < size + offset) {
@@ -413,13 +413,13 @@ ResultVal<size_t> OnlineService::ReadNsData(const u32 ns_data_id, const u64 offs
                     "length is {:#010X}",
                     size, offset, static_cast<u32>(entry->header.payload_size));
         // TODO: Proper error code.
-        return RESULT_UNKNOWN;
+        return ResultUnknown;
     }
 
     auto boss_archive = OpenBossExtData();
     if (!boss_archive) {
         // TODO: Proper error code.
-        return RESULT_UNKNOWN;
+        return ResultUnknown;
     }
 
     FileSys::Path file_path = fmt::format("/{}", entry->filename);
@@ -429,7 +429,7 @@ ResultVal<size_t> OnlineService::ReadNsData(const u32 ns_data_id, const u64 offs
     if (!file_result.Succeeded()) {
         LOG_WARNING(Service_BOSS, "Failed to open SpotPass extdata file '{}'.", entry->filename);
         // TODO: Proper error code.
-        return RESULT_UNKNOWN;
+        return ResultUnknown;
     }
 
     auto file = std::move(file_result).Unwrap();
@@ -438,7 +438,7 @@ ResultVal<size_t> OnlineService::ReadNsData(const u32 ns_data_id, const u64 offs
     if (!read_result.Succeeded()) {
         LOG_WARNING(Service_BOSS, "Failed to read SpotPass extdata file '{}'.", entry->filename);
         // TODO: Proper error code.
-        return RESULT_UNKNOWN;
+        return ResultUnknown;
     }
 
     buffer.Write(ns_data_array.data(), 0, size);
@@ -457,7 +457,7 @@ Result OnlineService::SendProperty(const u16 id, const u32 size, Kernel::MappedB
     if (!current_props.properties.contains(property_id)) {
         LOG_ERROR(Service_BOSS, "Unknown property with ID {:#06x} and size {}", property_id, size);
         // TODO: Proper error code.
-        return RESULT_UNKNOWN;
+        return ResultUnknown;
     }
 
     auto& prop = current_props.properties[property_id];
@@ -489,7 +489,7 @@ Result OnlineService::SendProperty(const u16 id, const u32 size, Kernel::MappedB
                         [&](std::vector<u32>& cur_prop) { read_vector(cur_prop); }},
                prop);
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result OnlineService::ReceiveProperty(const u16 id, const u32 size, Kernel::MappedBuffer& buffer) {
@@ -497,7 +497,7 @@ Result OnlineService::ReceiveProperty(const u16 id, const u32 size, Kernel::Mapp
     if (!current_props.properties.contains(property_id)) {
         LOG_ERROR(Service_BOSS, "Unknown property with ID {:#06x} and size {}", property_id, size);
         // TODO: Proper error code.
-        return RESULT_UNKNOWN;
+        return ResultUnknown;
     }
 
     auto write_pod = [&]<typename T>(T& cur_prop) {
@@ -525,7 +525,7 @@ Result OnlineService::ReceiveProperty(const u16 id, const u32 size, Kernel::Mapp
                         [&](std::vector<u32>& cur_prop) { write_vector(cur_prop); }},
                prop);
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 } // namespace Service::BOSS

--- a/src/core/hle/service/boss/online_service.cpp
+++ b/src/core/hle/service/boss/online_service.cpp
@@ -335,7 +335,7 @@ std::optional<NsDataEntry> OnlineService::GetNsDataEntryFromId(const u32 ns_data
 }
 
 Result OnlineService::GetNsDataHeaderInfo(const u32 ns_data_id, const NsDataHeaderInfoType type,
-                                              const u32 size, Kernel::MappedBuffer& buffer) {
+                                          const u32 size, Kernel::MappedBuffer& buffer) {
     const auto entry = GetNsDataEntryFromId(ns_data_id);
     if (!entry.has_value()) {
         LOG_WARNING(Service_BOSS, "Failed to find NsData entry for ID {:#010X}", ns_data_id);

--- a/src/core/hle/service/boss/online_service.h
+++ b/src/core/hle/service/boss/online_service.h
@@ -161,18 +161,18 @@ class OnlineService final {
 public:
     explicit OnlineService(u64 program_id_, u64 extdata_id_);
 
-    ResultCode InitializeSession(u64 init_program_id);
+    Result InitializeSession(u64 init_program_id);
     void RegisterTask(const u32 size, Kernel::MappedBuffer& buffer);
-    ResultCode UnregisterTask(const u32 size, Kernel::MappedBuffer& buffer);
+    Result UnregisterTask(const u32 size, Kernel::MappedBuffer& buffer);
     void GetTaskIdList();
     u16 GetNsDataIdList(const u32 filter, const u32 max_entries, Kernel::MappedBuffer& buffer);
     std::optional<NsDataEntry> GetNsDataEntryFromId(const u32 ns_data_id);
-    ResultCode GetNsDataHeaderInfo(const u32 ns_data_id, const NsDataHeaderInfoType type,
+    Result GetNsDataHeaderInfo(const u32 ns_data_id, const NsDataHeaderInfoType type,
                                    const u32 size, Kernel::MappedBuffer& buffer);
     ResultVal<size_t> ReadNsData(const u32 ns_data_id, const u64 offset, const u32 size,
                                  Kernel::MappedBuffer& buffer);
-    ResultCode SendProperty(const u16 id, const u32 size, Kernel::MappedBuffer& buffer);
-    ResultCode ReceiveProperty(const u16 id, const u32 size, Kernel::MappedBuffer& buffer);
+    Result SendProperty(const u16 id, const u32 size, Kernel::MappedBuffer& buffer);
+    Result ReceiveProperty(const u16 id, const u32 size, Kernel::MappedBuffer& buffer);
 
 private:
     std::unique_ptr<FileSys::ArchiveBackend> OpenBossExtData();

--- a/src/core/hle/service/boss/online_service.h
+++ b/src/core/hle/service/boss/online_service.h
@@ -168,7 +168,7 @@ public:
     u16 GetNsDataIdList(const u32 filter, const u32 max_entries, Kernel::MappedBuffer& buffer);
     std::optional<NsDataEntry> GetNsDataEntryFromId(const u32 ns_data_id);
     Result GetNsDataHeaderInfo(const u32 ns_data_id, const NsDataHeaderInfoType type,
-                                   const u32 size, Kernel::MappedBuffer& buffer);
+                               const u32 size, Kernel::MappedBuffer& buffer);
     ResultVal<size_t> ReadNsData(const u32 ns_data_id, const u64 offset, const u32 size,
                                  Kernel::MappedBuffer& buffer);
     Result SendProperty(const u16 id, const u32 size, Kernel::MappedBuffer& buffer);

--- a/src/core/hle/service/cam/cam.cpp
+++ b/src/core/hle/service/cam/cam.cpp
@@ -278,7 +278,7 @@ void Module::Interface::StartCapture(Kernel::HLERequestContext& ctx) {
                 LOG_WARNING(Service_CAM, "port {} already started", i);
             }
         }
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
     } else {
         LOG_ERROR(Service_CAM, "invalid port_select={}", port_select.m_val);
         rb.Push(ERROR_INVALID_ENUM_VALUE);
@@ -303,7 +303,7 @@ void Module::Interface::StopCapture(Kernel::HLERequestContext& ctx) {
                 LOG_WARNING(Service_CAM, "port {} already stopped", i);
             }
         }
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
     } else {
         LOG_ERROR(Service_CAM, "invalid port_select={}", port_select.m_val);
         rb.Push(ERROR_INVALID_ENUM_VALUE);
@@ -324,7 +324,7 @@ void Module::Interface::IsBusy(Kernel::HLERequestContext& ctx) {
         for (int i : port_select) {
             is_busy &= cam->ports[i].is_busy;
         }
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.Push(is_busy);
     } else {
         LOG_ERROR(Service_CAM, "invalid port_select={}", port_select.m_val);
@@ -340,7 +340,7 @@ void Module::Interface::ClearBuffer(Kernel::HLERequestContext& ctx) {
     const PortSet port_select(rp.Pop<u8>());
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_CAM, "(STUBBED) called, port_select={}", port_select.m_val);
 }
@@ -352,7 +352,7 @@ void Module::Interface::GetVsyncInterruptEvent(Kernel::HLERequestContext& ctx) {
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
     if (port_select.IsSingle()) {
         int port = *port_select.begin();
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.PushCopyObjects(cam->ports[port].vsync_interrupt_event);
     } else {
         LOG_ERROR(Service_CAM, "invalid port_select={}", port_select.m_val);
@@ -370,7 +370,7 @@ void Module::Interface::GetBufferErrorInterruptEvent(Kernel::HLERequestContext& 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
     if (port_select.IsSingle()) {
         int port = *port_select.begin();
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.PushCopyObjects(cam->ports[port].buffer_error_interrupt_event);
     } else {
         LOG_ERROR(Service_CAM, "invalid port_select={}", port_select.m_val);
@@ -405,7 +405,7 @@ void Module::Interface::SetReceiving(Kernel::HLERequestContext& ctx) {
             port.is_pending_receiving = true;
         }
 
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.PushCopyObjects(port.completion_event);
     } else {
         LOG_ERROR(Service_CAM, "invalid port_select={}", port_select.m_val);
@@ -425,7 +425,7 @@ void Module::Interface::IsFinishedReceiving(Kernel::HLERequestContext& ctx) {
     if (port_select.IsSingle()) {
         int port = *port_select.begin();
         bool is_busy = cam->ports[port].is_receiving || cam->ports[port].is_pending_receiving;
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.Push(!is_busy);
     } else {
         LOG_ERROR(Service_CAM, "invalid port_select={}", port_select.m_val);
@@ -448,7 +448,7 @@ void Module::Interface::SetTransferLines(Kernel::HLERequestContext& ctx) {
         for (int i : port_select) {
             cam->ports[i].transfer_bytes = transfer_lines * width * 2;
         }
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
     } else {
         LOG_ERROR(Service_CAM, "invalid port_select={}", port_select.m_val);
         rb.Push(ERROR_INVALID_ENUM_VALUE);
@@ -476,7 +476,7 @@ void Module::Interface::GetMaxLines(Kernel::HLERequestContext& ctx) {
         if (lines > height) {
             lines = height;
         }
-        Result result = RESULT_SUCCESS;
+        Result result = ResultSuccess;
         while (height % lines != 0 || (lines * width * 2 % MIN_TRANSFER_UNIT != 0)) {
             --lines;
             if (lines == 0) {
@@ -503,7 +503,7 @@ void Module::Interface::SetTransferBytes(Kernel::HLERequestContext& ctx) {
         for (int i : port_select) {
             cam->ports[i].transfer_bytes = transfer_bytes;
         }
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
     } else {
         LOG_ERROR(Service_CAM, "invalid port_select={}", port_select.m_val);
         rb.Push(ERROR_INVALID_ENUM_VALUE);
@@ -520,7 +520,7 @@ void Module::Interface::GetTransferBytes(Kernel::HLERequestContext& ctx) {
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
     if (port_select.IsSingle()) {
         int port = *port_select.begin();
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.Push(cam->ports[port].transfer_bytes);
     } else {
         LOG_ERROR(Service_CAM, "invalid port_select={}", port_select.m_val);
@@ -551,7 +551,7 @@ void Module::Interface::GetMaxBytes(Kernel::HLERequestContext& ctx) {
             bytes -= MIN_TRANSFER_UNIT;
         }
 
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.Push(bytes);
     }
 
@@ -568,7 +568,7 @@ void Module::Interface::SetTrimming(Kernel::HLERequestContext& ctx) {
         for (int i : port_select) {
             cam->ports[i].is_trimming = trim;
         }
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
     } else {
         LOG_ERROR(Service_CAM, "invalid port_select={}", port_select.m_val);
         rb.Push(ERROR_INVALID_ENUM_VALUE);
@@ -584,7 +584,7 @@ void Module::Interface::IsTrimming(Kernel::HLERequestContext& ctx) {
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
     if (port_select.IsSingle()) {
         int port = *port_select.begin();
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.Push(cam->ports[port].is_trimming);
     } else {
         LOG_ERROR(Service_CAM, "invalid port_select={}", port_select.m_val);
@@ -611,7 +611,7 @@ void Module::Interface::SetTrimmingParams(Kernel::HLERequestContext& ctx) {
             cam->ports[i].x1 = x1;
             cam->ports[i].y1 = y1;
         }
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
     } else {
         LOG_ERROR(Service_CAM, "invalid port_select={}", port_select.m_val);
         rb.Push(ERROR_INVALID_ENUM_VALUE);
@@ -628,7 +628,7 @@ void Module::Interface::GetTrimmingParams(Kernel::HLERequestContext& ctx) {
     IPC::RequestBuilder rb = rp.MakeBuilder(5, 0);
     if (port_select.IsSingle()) {
         int port = *port_select.begin();
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.Push(cam->ports[port].x0);
         rb.Push(cam->ports[port].y0);
         rb.Push(cam->ports[port].x1);
@@ -658,7 +658,7 @@ void Module::Interface::SetTrimmingParamsCenter(Kernel::HLERequestContext& ctx) 
             cam->ports[i].x1 = cam->ports[i].x0 + trim_w;
             cam->ports[i].y1 = cam->ports[i].y0 + trim_h;
         }
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
     } else {
         LOG_ERROR(Service_CAM, "invalid port_select={}", port_select.m_val);
         rb.Push(ERROR_INVALID_ENUM_VALUE);
@@ -684,7 +684,7 @@ void Module::Interface::Activate(Kernel::HLERequestContext& ctx) {
                 cam->ports[i].is_active = false;
                 cam->system.CoreTiming().UnscheduleEvent(cam->vsync_interrupt_event_callback, i);
             }
-            rb.Push(RESULT_SUCCESS);
+            rb.Push(ResultSuccess);
         } else if (camera_select[0] && camera_select[1]) {
             LOG_ERROR(Service_CAM, "camera 0 and 1 can't be both activated");
             rb.Push(ERROR_INVALID_ENUM_VALUE);
@@ -698,7 +698,7 @@ void Module::Interface::Activate(Kernel::HLERequestContext& ctx) {
             if (camera_select[2]) {
                 cam->ActivatePort(1, 2);
             }
-            rb.Push(RESULT_SUCCESS);
+            rb.Push(ResultSuccess);
         }
     } else {
         LOG_ERROR(Service_CAM, "invalid camera_select={}", camera_select.m_val);
@@ -724,7 +724,7 @@ void Module::Interface::SwitchContext(Kernel::HLERequestContext& ctx) {
             cam->cameras[camera].impl->SetFormat(context_config.format);
             cam->cameras[camera].impl->SetResolution(context_config.resolution);
         }
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
     } else {
         LOG_ERROR(Service_CAM, "invalid camera_select={}, context_select={}", camera_select.m_val,
                   context_select.m_val);
@@ -751,7 +751,7 @@ void Module::Interface::FlipImage(Kernel::HLERequestContext& ctx) {
                 }
             }
         }
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
     } else {
         LOG_ERROR(Service_CAM, "invalid camera_select={}, context_select={}", camera_select.m_val,
                   context_select.m_val);
@@ -784,7 +784,7 @@ void Module::Interface::SetDetailSize(Kernel::HLERequestContext& ctx) {
                 }
             }
         }
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
     } else {
         LOG_ERROR(Service_CAM, "invalid camera_select={}, context_select={}", camera_select.m_val,
                   context_select.m_val);
@@ -814,7 +814,7 @@ void Module::Interface::SetSize(Kernel::HLERequestContext& ctx) {
                 }
             }
         }
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
     } else {
         LOG_ERROR(Service_CAM, "invalid camera_select={}, context_select={}", camera_select.m_val,
                   context_select.m_val);
@@ -836,7 +836,7 @@ void Module::Interface::SetFrameRate(Kernel::HLERequestContext& ctx) {
             cam->cameras[camera].frame_rate = frame_rate;
             cam->cameras[camera].impl->SetFrameRate(frame_rate);
         }
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
     } else {
         LOG_ERROR(Service_CAM, "invalid camera_select={}", camera_select.m_val);
         rb.Push(ERROR_INVALID_ENUM_VALUE);
@@ -862,7 +862,7 @@ void Module::Interface::SetEffect(Kernel::HLERequestContext& ctx) {
                 }
             }
         }
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
     } else {
         LOG_ERROR(Service_CAM, "invalid camera_select={}, context_select={}", camera_select.m_val,
                   context_select.m_val);
@@ -889,7 +889,7 @@ void Module::Interface::SetOutputFormat(Kernel::HLERequestContext& ctx) {
                 }
             }
         }
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
     } else {
         LOG_ERROR(Service_CAM, "invalid camera_select={}, context_select={}", camera_select.m_val,
                   context_select.m_val);
@@ -906,7 +906,7 @@ void Module::Interface::SynchronizeVsyncTiming(Kernel::HLERequestContext& ctx) {
     const u8 camera_select2 = rp.Pop<u8>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_CAM, "(STUBBED) called, camera_select1={}, camera_select2={}",
                 camera_select1, camera_select2);
@@ -925,7 +925,7 @@ void Module::Interface::GetLatestVsyncTiming(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     const std::size_t port_id = port_select.m_val == 1 ? 0 : 1;
     std::vector<u8> out(count * sizeof(s64_le));
@@ -961,7 +961,7 @@ void Module::Interface::GetStereoCameraCalibrationData(Kernel::HLERequestContext
     data.imageWidth = 640;
     data.imageHeight = 480;
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushRaw(data);
 
     LOG_TRACE(Service_CAM, "called");
@@ -974,7 +974,7 @@ void Module::Interface::SetPackageParameterWithoutContext(Kernel::HLERequestCont
     rp.PopRaw(package);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_CAM, "(STUBBED) called");
 }
@@ -999,7 +999,7 @@ Result Module::SetPackageParameter(const PackageParameterType& package) {
                 }
             }
         }
-        return RESULT_SUCCESS;
+        return ResultSuccess;
     } else {
         LOG_ERROR(Service_CAM, "invalid camera_select={}, context_select={}", package.camera_select,
                   package.context_select);
@@ -1040,7 +1040,7 @@ void Module::Interface::SetPackageParameterWithContextDetail(Kernel::HLERequestC
 void Module::Interface::GetSuitableY2rStandardCoefficient(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u32>(0);
 
     LOG_WARNING(Service_CAM, "(STUBBED) called");
@@ -1051,7 +1051,7 @@ void Module::Interface::PlayShutterSound(Kernel::HLERequestContext& ctx) {
     u8 sound_id = rp.Pop<u8>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_CAM, "(STUBBED) called, sound_id={}", sound_id);
 }
@@ -1081,7 +1081,7 @@ void Module::Interface::DriverInitialize(Kernel::HLERequestContext& ctx) {
 
     cam->initialized = true;
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_CAM, "called");
 }
@@ -1099,7 +1099,7 @@ void Module::Interface::DriverFinalize(Kernel::HLERequestContext& ctx) {
 
     cam->initialized = false;
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_CAM, "called");
 }

--- a/src/core/hle/service/cam/cam.cpp
+++ b/src/core/hle/service/cam/cam.cpp
@@ -77,10 +77,10 @@ constexpr std::array<int, 13> LATENCY_BY_FRAME_RATE{{
     33,  // Rate_30_To_10
 }};
 
-const ResultCode ERROR_INVALID_ENUM_VALUE(ErrorDescription::InvalidEnumValue, ErrorModule::CAM,
-                                          ErrorSummary::InvalidArgument, ErrorLevel::Usage);
-const ResultCode ERROR_OUT_OF_RANGE(ErrorDescription::OutOfRange, ErrorModule::CAM,
-                                    ErrorSummary::InvalidArgument, ErrorLevel::Usage);
+const Result ERROR_INVALID_ENUM_VALUE(ErrorDescription::InvalidEnumValue, ErrorModule::CAM,
+                                      ErrorSummary::InvalidArgument, ErrorLevel::Usage);
+const Result ERROR_OUT_OF_RANGE(ErrorDescription::OutOfRange, ErrorModule::CAM,
+                                ErrorSummary::InvalidArgument, ErrorLevel::Usage);
 
 void Module::PortConfig::Clear() {
     completion_event->Clear();
@@ -476,7 +476,7 @@ void Module::Interface::GetMaxLines(Kernel::HLERequestContext& ctx) {
         if (lines > height) {
             lines = height;
         }
-        ResultCode result = RESULT_SUCCESS;
+        Result result = RESULT_SUCCESS;
         while (height % lines != 0 || (lines * width * 2 % MIN_TRANSFER_UNIT != 0)) {
             --lines;
             if (lines == 0) {
@@ -980,7 +980,7 @@ void Module::Interface::SetPackageParameterWithoutContext(Kernel::HLERequestCont
 }
 
 template <typename PackageParameterType>
-ResultCode Module::SetPackageParameter(const PackageParameterType& package) {
+Result Module::SetPackageParameter(const PackageParameterType& package) {
     const CameraSet camera_select(package.camera_select);
     const ContextSet context_select(package.context_select);
 
@@ -1018,7 +1018,7 @@ void Module::Interface::SetPackageParameterWithContext(Kernel::HLERequestContext
     rp.PopRaw(package);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    ResultCode result = cam->SetPackageParameter(package);
+    Result result = cam->SetPackageParameter(package);
     rb.Push(result);
 
     LOG_DEBUG(Service_CAM, "called");
@@ -1031,7 +1031,7 @@ void Module::Interface::SetPackageParameterWithContextDetail(Kernel::HLERequestC
     rp.PopRaw(package);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    ResultCode result = cam->SetPackageParameter(package);
+    Result result = cam->SetPackageParameter(package);
     rb.Push(result);
 
     LOG_DEBUG(Service_CAM, "called");

--- a/src/core/hle/service/cam/cam.h
+++ b/src/core/hle/service/cam/cam.h
@@ -166,7 +166,7 @@ public:
          *      1: u8 selected port
          *  Outputs:
          *      0: 0x00010040
-         *      1: ResultCode
+         *      1: Result
          */
         void StartCapture(Kernel::HLERequestContext& ctx);
 
@@ -177,7 +177,7 @@ public:
          *      1: u8 selected port
          *  Outputs:
          *      0: 0x00020040
-         *      1: ResultCode
+         *      1: Result
          */
         void StopCapture(Kernel::HLERequestContext& ctx);
 
@@ -188,7 +188,7 @@ public:
          *      1: u8 selected port
          *  Outputs:
          *      0: 0x00030080
-         *      1: ResultCode
+         *      1: Result
          *      2: 0 if not capturing, 1 if capturing
          */
         void IsBusy(Kernel::HLERequestContext& ctx);
@@ -200,7 +200,7 @@ public:
          *      1: u8 selected port
          *  Outputs:
          *      0: 0x00040040
-         *      2: ResultCode
+         *      2: Result
          */
         void ClearBuffer(Kernel::HLERequestContext& ctx);
 
@@ -211,7 +211,7 @@ public:
          *      1: u8 selected port
          *  Outputs:
          *      0: 0x00050042
-         *      1: ResultCode
+         *      1: Result
          *      2: Descriptor: Handle
          *      3: Event handle
          */
@@ -224,7 +224,7 @@ public:
          *      1: u8 selected port
          *  Outputs:
          *      0: 0x00060042
-         *      1: ResultCode
+         *      1: Result
          *      2: Descriptor: Handle
          *      3: Event handle
          */
@@ -244,7 +244,7 @@ public:
          *      6: Handle to destination process
          *  Outputs:
          *      0: 0x00070042
-         *      1: ResultCode
+         *      1: Result
          *      2: Descriptor: Handle
          *      3: Handle to event signalled when transfer finishes
          */
@@ -257,7 +257,7 @@ public:
          *      1: u8 selected port
          *  Outputs:
          *      0: 0x00080080
-         *      1: ResultCode
+         *      1: Result
          *      2: 0 if not finished, 1 if finished
          */
         void IsFinishedReceiving(Kernel::HLERequestContext& ctx);
@@ -272,7 +272,7 @@ public:
          *      4: u16 Height
          *  Outputs:
          *      0: 0x00090040
-         *      1: ResultCode
+         *      1: Result
          * @todo figure out how the "buffer" actually works.
          */
         void SetTransferLines(Kernel::HLERequestContext& ctx);
@@ -285,7 +285,7 @@ public:
          *      2: u16 Height
          *  Outputs:
          *      0: 0x000A0080
-         *      1: ResultCode
+         *      1: Result
          *      2: Maximum number of lines that fit in the buffer
          * @todo figure out how the "buffer" actually works.
          */
@@ -301,7 +301,7 @@ public:
          *      4: u16 Height
          *  Outputs:
          *      0: 0x000B0040
-         *      1: ResultCode
+         *      1: Result
          * @todo figure out how the "buffer" actually works.
          */
         void SetTransferBytes(Kernel::HLERequestContext& ctx);
@@ -313,7 +313,7 @@ public:
          *      1: u8 selected port
          *  Outputs:
          *      0: 0x000C0080
-         *      1: ResultCode
+         *      1: Result
          *      2: The number of bytes the buffer contains
          * @todo figure out how the "buffer" actually works.
          */
@@ -327,7 +327,7 @@ public:
          *      2: u16 Height
          *  Outputs:
          *      0: 0x000D0080
-         *      1: ResultCode
+         *      1: Result
          *      2: Maximum number of bytes that fit in the buffer
          * @todo figure out how the "buffer" actually works.
          */
@@ -341,7 +341,7 @@ public:
          *      2: u8 bool Enable trimming if true
          *  Outputs:
          *      0: 0x000E0040
-         *      1: ResultCode
+         *      1: Result
          */
         void SetTrimming(Kernel::HLERequestContext& ctx);
 
@@ -352,7 +352,7 @@ public:
          *      1: u8 selected port
          *  Outputs:
          *      0: 0x000F0080
-         *      1: ResultCode
+         *      1: Result
          *      2: u8 bool Enable trimming if true
          */
         void IsTrimming(Kernel::HLERequestContext& ctx);
@@ -368,7 +368,7 @@ public:
          *      5: y end (exclusive)
          *  Outputs:
          *      0: 0x00100040
-         *      1: ResultCode
+         *      1: Result
          */
         void SetTrimmingParams(Kernel::HLERequestContext& ctx);
 
@@ -380,7 +380,7 @@ public:
          *
          *  Outputs:
          *      0: 0x00110140
-         *      1: ResultCode
+         *      1: Result
          *      2: x start
          *      3: y start
          *      4: x end (exclusive)
@@ -400,7 +400,7 @@ public:
          *      5: s16 Camera height
          *  Outputs:
          *      0: 0x00120040
-         *      1: ResultCode
+         *      1: Result
          */
         void SetTrimmingParamsCenter(Kernel::HLERequestContext& ctx);
 
@@ -411,7 +411,7 @@ public:
          *      1: u8 selected camera
          *  Outputs:
          *      0: 0x00130040
-         *      1: ResultCode
+         *      1: Result
          */
         void Activate(Kernel::HLERequestContext& ctx);
 
@@ -423,7 +423,7 @@ public:
          *      2: u8 selected context
          *  Outputs:
          *      0: 0x00140040
-         *      1: ResultCode
+         *      1: Result
          */
         void SwitchContext(Kernel::HLERequestContext& ctx);
 
@@ -436,7 +436,7 @@ public:
          *      3: u8 selected context
          *  Outputs:
          *      0: 0x001D0040
-         *      1: ResultCode
+         *      1: Result
          */
         void FlipImage(Kernel::HLERequestContext& ctx);
 
@@ -455,7 +455,7 @@ public:
          *      8: u8 selected context
          *  Outputs:
          *      0: 0x001E0040
-         *      1: ResultCode
+         *      1: Result
          */
         void SetDetailSize(Kernel::HLERequestContext& ctx);
 
@@ -468,7 +468,7 @@ public:
          *      3: u8 selected context
          *  Outputs:
          *      0: 0x001F0040
-         *      1: ResultCode
+         *      1: Result
          */
         void SetSize(Kernel::HLERequestContext& ctx);
 
@@ -480,7 +480,7 @@ public:
          *      2: u8 Camera framerate (`FrameRate` enum)
          *  Outputs:
          *      0: 0x00200040
-         *      1: ResultCode
+         *      1: Result
          */
         void SetFrameRate(Kernel::HLERequestContext& ctx);
 
@@ -493,7 +493,7 @@ public:
          *      3: u8 selected context
          *  Outputs:
          *      0: 0x00220040
-         *      1: ResultCode
+         *      1: Result
          */
         void SetEffect(Kernel::HLERequestContext& ctx);
 
@@ -506,7 +506,7 @@ public:
          *      3: u8 selected context
          *  Outputs:
          *      0: 0x00250040
-         *      1: ResultCode
+         *      1: Result
          */
         void SetOutputFormat(Kernel::HLERequestContext& ctx);
 
@@ -518,7 +518,7 @@ public:
          *      2: u8 selected camera 2
          *  Outputs:
          *      0: 0x00280040
-         *      1: ResultCode
+         *      1: Result
          */
         void SynchronizeVsyncTiming(Kernel::HLERequestContext& ctx);
 
@@ -532,7 +532,7 @@ public:
          *      65: s64* TimingsOutput
          *  Outputs:
          *      0: 0x002A0042
-         *      1: ResultCode
+         *      1: Result
          *      2-3: Output static buffer
          */
         void GetLatestVsyncTiming(Kernel::HLERequestContext& ctx);
@@ -545,7 +545,7 @@ public:
          *      0: 0x002B0000
          *  Outputs:
          *      0: 0x002B0440
-         *      1: ResultCode
+         *      1: Result
          *      2-17: `StereoCameraCalibrationData` structure with calibration values
          */
         void GetStereoCameraCalibrationData(Kernel::HLERequestContext& ctx);
@@ -559,7 +559,7 @@ public:
          *      8-11: unused
          *  Outputs:
          *      0: 0x00330040
-         *      1: ResultCode
+         *      1: Result
          */
         void SetPackageParameterWithoutContext(Kernel::HLERequestContext& ctx);
 
@@ -572,7 +572,7 @@ public:
          *      3-5: unused
          *  Outputs:
          *      0: 0x00340040
-         *      1: ResultCode
+         *      1: Result
          */
         void SetPackageParameterWithContext(Kernel::HLERequestContext& ctx);
 
@@ -585,7 +585,7 @@ public:
          *      5-7: unused
          *  Outputs:
          *      0: 0x00350040
-         *      1: ResultCode
+         *      1: Result
          */
         void SetPackageParameterWithContextDetail(Kernel::HLERequestContext& ctx);
 
@@ -595,7 +595,7 @@ public:
          *      0: 0x00360000
          *  Outputs:
          *      0: 0x00360080
-         *      1: ResultCode
+         *      1: Result
          *      2: ?
          */
         void GetSuitableY2rStandardCoefficient(Kernel::HLERequestContext& ctx);
@@ -607,7 +607,7 @@ public:
          *      1: u8 Sound ID
          *  Outputs:
          *      0: 0x00380040
-         *      1: ResultCode
+         *      1: Result
          */
         void PlayShutterSound(Kernel::HLERequestContext& ctx);
 
@@ -617,7 +617,7 @@ public:
          *      0: 0x00390000
          *  Outputs:
          *      0: 0x00390040
-         *      1: ResultCode
+         *      1: Result
          */
         void DriverInitialize(Kernel::HLERequestContext& ctx);
 
@@ -627,7 +627,7 @@ public:
          *      0: 0x003A0000
          *  Outputs:
          *      0: 0x003A0040
-         *      1: ResultCode
+         *      1: Result
          */
         void DriverFinalize(Kernel::HLERequestContext& ctx);
 
@@ -653,7 +653,7 @@ private:
     void ActivatePort(int port_id, int camera_id);
 
     template <typename PackageParameterType>
-    ResultCode SetPackageParameter(const PackageParameterType& package);
+    Result SetPackageParameter(const PackageParameterType& package);
 
     struct ContextConfig {
         Flip flip{Flip::None};

--- a/src/core/hle/service/cam/y2r_u.cpp
+++ b/src/core/hle/service/cam/y2r_u.cpp
@@ -37,10 +37,10 @@ constexpr std::array<CoefficientSet, 4> standard_coefficients{{
     {{0x12A, 0x1CA, 0x88, 0x36, 0x21C, -0x1F04, 0x99C, -0x2421}},  // ITU_Rec709_Scaling
 }};
 
-ResultCode ConversionConfiguration::SetInputLineWidth(u16 width) {
+Result ConversionConfiguration::SetInputLineWidth(u16 width) {
     if (width == 0 || width > 1024 || width % 8 != 0) {
-        return ResultCode(ErrorDescription::OutOfRange, ErrorModule::CAM,
-                          ErrorSummary::InvalidArgument, ErrorLevel::Usage); // 0xE0E053FD
+        return Result(ErrorDescription::OutOfRange, ErrorModule::CAM, ErrorSummary::InvalidArgument,
+                      ErrorLevel::Usage); // 0xE0E053FD
     }
 
     // Note: The hardware uses the register value 0 to represent a width of 1024, so for a width of
@@ -50,10 +50,10 @@ ResultCode ConversionConfiguration::SetInputLineWidth(u16 width) {
     return RESULT_SUCCESS;
 }
 
-ResultCode ConversionConfiguration::SetInputLines(u16 lines) {
+Result ConversionConfiguration::SetInputLines(u16 lines) {
     if (lines == 0 || lines > 1024) {
-        return ResultCode(ErrorDescription::OutOfRange, ErrorModule::CAM,
-                          ErrorSummary::InvalidArgument, ErrorLevel::Usage); // 0xE0E053FD
+        return Result(ErrorDescription::OutOfRange, ErrorModule::CAM, ErrorSummary::InvalidArgument,
+                      ErrorLevel::Usage); // 0xE0E053FD
     }
 
     // Note: In what appears to be a bug, the `camera` module does not set the hardware register at
@@ -65,12 +65,11 @@ ResultCode ConversionConfiguration::SetInputLines(u16 lines) {
     return RESULT_SUCCESS;
 }
 
-ResultCode ConversionConfiguration::SetStandardCoefficient(
-    StandardCoefficient standard_coefficient) {
+Result ConversionConfiguration::SetStandardCoefficient(StandardCoefficient standard_coefficient) {
     const auto index = static_cast<std::size_t>(standard_coefficient);
     if (index >= standard_coefficients.size()) {
-        return ResultCode(ErrorDescription::InvalidEnumValue, ErrorModule::CAM,
-                          ErrorSummary::InvalidArgument, ErrorLevel::Usage); // 0xE0E053ED
+        return Result(ErrorDescription::InvalidEnumValue, ErrorModule::CAM,
+                      ErrorSummary::InvalidArgument, ErrorLevel::Usage); // 0xE0E053ED
     }
 
     std::memcpy(coefficients.data(), standard_coefficients[index].data(), sizeof(coefficients));
@@ -466,8 +465,8 @@ void Y2R_U::GetStandardCoefficient(Kernel::HLERequestContext& ctx) {
         LOG_DEBUG(Service_Y2R, "called standard_coefficient={} ", index);
     } else {
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-        rb.Push(ResultCode(ErrorDescription::InvalidEnumValue, ErrorModule::CAM,
-                           ErrorSummary::InvalidArgument, ErrorLevel::Usage));
+        rb.Push(Result(ErrorDescription::InvalidEnumValue, ErrorModule::CAM,
+                       ErrorSummary::InvalidArgument, ErrorLevel::Usage));
 
         LOG_ERROR(Service_Y2R, "called standard_coefficient={}  The argument is invalid!", index);
     }
@@ -559,7 +558,7 @@ void Y2R_U::SetPackageParameter(Kernel::HLERequestContext& ctx) {
     conversion.rotation = params.rotation;
     conversion.block_alignment = params.block_alignment;
 
-    ResultCode result = conversion.SetInputLineWidth(params.input_line_width);
+    Result result = conversion.SetInputLineWidth(params.input_line_width);
 
     if (result.IsError())
         goto cleanup;

--- a/src/core/hle/service/cam/y2r_u.cpp
+++ b/src/core/hle/service/cam/y2r_u.cpp
@@ -47,7 +47,7 @@ Result ConversionConfiguration::SetInputLineWidth(u16 width) {
     // 1024 the `camera` module would set the value 0 here, but we don't need to emulate this
     // internal detail.
     this->input_line_width = width;
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result ConversionConfiguration::SetInputLines(u16 lines) {
@@ -62,7 +62,7 @@ Result ConversionConfiguration::SetInputLines(u16 lines) {
     if (lines != 1024) {
         this->input_lines = lines;
     }
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result ConversionConfiguration::SetStandardCoefficient(StandardCoefficient standard_coefficient) {
@@ -73,7 +73,7 @@ Result ConversionConfiguration::SetStandardCoefficient(StandardCoefficient stand
     }
 
     std::memcpy(coefficients.data(), standard_coefficients[index].data(), sizeof(coefficients));
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 void Y2R_U::SetInputFormat(Kernel::HLERequestContext& ctx) {
@@ -82,7 +82,7 @@ void Y2R_U::SetInputFormat(Kernel::HLERequestContext& ctx) {
     conversion.input_format = rp.PopEnum<InputFormat>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_Y2R, "called input_format={}", conversion.input_format);
 }
@@ -91,7 +91,7 @@ void Y2R_U::GetInputFormat(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushEnum(conversion.input_format);
 
     LOG_DEBUG(Service_Y2R, "called input_format={}", conversion.input_format);
@@ -103,7 +103,7 @@ void Y2R_U::SetOutputFormat(Kernel::HLERequestContext& ctx) {
     conversion.output_format = rp.PopEnum<OutputFormat>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_Y2R, "called output_format={}", conversion.output_format);
 }
@@ -112,7 +112,7 @@ void Y2R_U::GetOutputFormat(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushEnum(conversion.output_format);
 
     LOG_DEBUG(Service_Y2R, "called output_format={}", conversion.output_format);
@@ -124,7 +124,7 @@ void Y2R_U::SetRotation(Kernel::HLERequestContext& ctx) {
     conversion.rotation = rp.PopEnum<Rotation>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_Y2R, "called rotation={}", conversion.rotation);
 }
@@ -133,7 +133,7 @@ void Y2R_U::GetRotation(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushEnum(conversion.rotation);
 
     LOG_DEBUG(Service_Y2R, "called rotation={}", conversion.rotation);
@@ -145,7 +145,7 @@ void Y2R_U::SetBlockAlignment(Kernel::HLERequestContext& ctx) {
     conversion.block_alignment = rp.PopEnum<BlockAlignment>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_Y2R, "called block_alignment={}", conversion.block_alignment);
 }
@@ -154,7 +154,7 @@ void Y2R_U::GetBlockAlignment(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushEnum(conversion.block_alignment);
 
     LOG_DEBUG(Service_Y2R, "called block_alignment={}", conversion.block_alignment);
@@ -166,7 +166,7 @@ void Y2R_U::SetSpacialDithering(Kernel::HLERequestContext& ctx) {
     spacial_dithering_enabled = rp.Pop<bool>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_Y2R, "(STUBBED) called");
 }
@@ -175,7 +175,7 @@ void Y2R_U::GetSpacialDithering(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(spacial_dithering_enabled);
 
     LOG_DEBUG(Service_Y2R, "(STUBBED) called");
@@ -186,7 +186,7 @@ void Y2R_U::SetTemporalDithering(Kernel::HLERequestContext& ctx) {
     temporal_dithering_enabled = rp.Pop<bool>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_Y2R, "(STUBBED) called");
 }
@@ -195,7 +195,7 @@ void Y2R_U::GetTemporalDithering(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(temporal_dithering_enabled);
 
     LOG_DEBUG(Service_Y2R, "(STUBBED) called");
@@ -206,7 +206,7 @@ void Y2R_U::SetTransferEndInterrupt(Kernel::HLERequestContext& ctx) {
     transfer_end_interrupt_enabled = rp.Pop<bool>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_Y2R, "(STUBBED) called");
 }
@@ -215,7 +215,7 @@ void Y2R_U::GetTransferEndInterrupt(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(transfer_end_interrupt_enabled);
 
     LOG_DEBUG(Service_Y2R, "(STUBBED) called");
@@ -225,7 +225,7 @@ void Y2R_U::GetTransferEndEvent(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushCopyObjects(completion_event);
 
     LOG_DEBUG(Service_Y2R, "called");
@@ -241,7 +241,7 @@ void Y2R_U::SetSendingY(Kernel::HLERequestContext& ctx) {
     // TODO (wwylele): pass process handle to y2r engine or convert VAddr to PAddr
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_Y2R,
               "called image_size=0x{:08X}, transfer_unit={}, transfer_stride={}, "
@@ -260,7 +260,7 @@ void Y2R_U::SetSendingU(Kernel::HLERequestContext& ctx) {
     // TODO (wwylele): pass the process handle to y2r engine or convert VAddr to PAddr
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_Y2R,
               "called image_size=0x{:08X}, transfer_unit={}, transfer_stride={}, "
@@ -280,7 +280,7 @@ void Y2R_U::SetSendingV(Kernel::HLERequestContext& ctx) {
     // TODO (wwylele): pass the process handle to y2r engine or convert VAddr to PAddr
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_Y2R,
               "called image_size=0x{:08X}, transfer_unit={}, transfer_stride={}, "
@@ -300,7 +300,7 @@ void Y2R_U::SetSendingYUYV(Kernel::HLERequestContext& ctx) {
     // TODO (wwylele): pass the process handle to y2r engine or convert VAddr to PAddr
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_Y2R,
               "called image_size=0x{:08X}, transfer_unit={}, transfer_stride={}, "
@@ -313,7 +313,7 @@ void Y2R_U::IsFinishedSendingYuv(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u8>(1);
 
     LOG_DEBUG(Service_Y2R, "(STUBBED) called");
@@ -323,7 +323,7 @@ void Y2R_U::IsFinishedSendingY(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u8>(1);
 
     LOG_DEBUG(Service_Y2R, "(STUBBED) called");
@@ -333,7 +333,7 @@ void Y2R_U::IsFinishedSendingU(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u8>(1);
 
     LOG_DEBUG(Service_Y2R, "(STUBBED) called");
@@ -343,7 +343,7 @@ void Y2R_U::IsFinishedSendingV(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u8>(1);
 
     LOG_DEBUG(Service_Y2R, "(STUBBED) called");
@@ -360,7 +360,7 @@ void Y2R_U::SetReceiving(Kernel::HLERequestContext& ctx) {
     // TODO (wwylele): pass the process handle to y2r engine or convert VAddr to PAddr
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_Y2R,
               "called image_size=0x{:08X}, transfer_unit={}, transfer_stride={}, "
@@ -373,7 +373,7 @@ void Y2R_U::IsFinishedReceiving(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u8>(1);
 
     LOG_DEBUG(Service_Y2R, "(STUBBED) called");
@@ -393,7 +393,7 @@ void Y2R_U::GetInputLineWidth(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(conversion.input_line_width);
 
     LOG_DEBUG(Service_Y2R, "called input_line_width={}", conversion.input_line_width);
@@ -413,7 +413,7 @@ void Y2R_U::GetInputLines(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(static_cast<u32>(conversion.input_lines));
 
     LOG_DEBUG(Service_Y2R, "called input_lines={}", conversion.input_lines);
@@ -425,7 +425,7 @@ void Y2R_U::SetCoefficient(Kernel::HLERequestContext& ctx) {
     rp.PopRaw<CoefficientSet>(conversion.coefficients);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_Y2R, "called coefficients=[{:X}, {:X}, {:X}, {:X}, {:X}, {:X}, {:X}, {:X}]",
               conversion.coefficients[0], conversion.coefficients[1], conversion.coefficients[2],
@@ -437,7 +437,7 @@ void Y2R_U::GetCoefficient(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(5, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushRaw(conversion.coefficients);
 
     LOG_DEBUG(Service_Y2R, "called");
@@ -459,7 +459,7 @@ void Y2R_U::GetStandardCoefficient(Kernel::HLERequestContext& ctx) {
 
     if (index < standard_coefficients.size()) {
         IPC::RequestBuilder rb = rp.MakeBuilder(5, 0);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.PushRaw(standard_coefficients[index]);
 
         LOG_DEBUG(Service_Y2R, "called standard_coefficient={} ", index);
@@ -477,7 +477,7 @@ void Y2R_U::SetAlpha(Kernel::HLERequestContext& ctx) {
     conversion.alpha = rp.Pop<u32>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_Y2R, "called alpha={}", conversion.alpha);
 }
@@ -486,7 +486,7 @@ void Y2R_U::GetAlpha(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(conversion.alpha);
 
     LOG_DEBUG(Service_Y2R, "called alpha={}", conversion.alpha);
@@ -496,7 +496,7 @@ void Y2R_U::SetDitheringWeightParams(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
     rp.PopRaw(dithering_weight_params);
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_Y2R, "called");
 }
@@ -505,7 +505,7 @@ void Y2R_U::GetDitheringWeightParams(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(9, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushRaw(dithering_weight_params);
 
     LOG_DEBUG(Service_Y2R, "called");
@@ -525,7 +525,7 @@ void Y2R_U::StartConversion(Kernel::HLERequestContext& ctx) {
     completion_event->Signal();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_Y2R, "called");
 }
@@ -534,7 +534,7 @@ void Y2R_U::StopConversion(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_Y2R, "called");
 }
@@ -543,7 +543,7 @@ void Y2R_U::IsBusyConversion(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u8>(0); // StartConversion always finishes immediately
 
     LOG_DEBUG(Service_Y2R, "called");
@@ -592,7 +592,7 @@ void Y2R_U::PingProcess(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u8>(0);
 
     LOG_DEBUG(Service_Y2R, "(STUBBED) called");
@@ -620,7 +620,7 @@ void Y2R_U::DriverInitialize(Kernel::HLERequestContext& ctx) {
 
     completion_event->Clear();
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_Y2R, "called");
 }
@@ -629,7 +629,7 @@ void Y2R_U::DriverFinalize(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_Y2R, "called");
 }
@@ -638,7 +638,7 @@ void Y2R_U::GetPackageParameter(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(4, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushRaw(conversion);
 
     LOG_DEBUG(Service_Y2R, "called");

--- a/src/core/hle/service/cam/y2r_u.h
+++ b/src/core/hle/service/cam/y2r_u.h
@@ -120,9 +120,9 @@ struct ConversionConfiguration {
     /// Output parameters for the conversion results
     ConversionBuffer dst;
 
-    ResultCode SetInputLineWidth(u16 width);
-    ResultCode SetInputLines(u16 lines);
-    ResultCode SetStandardCoefficient(StandardCoefficient standard_coefficient);
+    Result SetInputLineWidth(u16 width);
+    Result SetInputLines(u16 lines);
+    Result SetStandardCoefficient(StandardCoefficient standard_coefficient);
 
 private:
     template <class Archive>

--- a/src/core/hle/service/cecd/cecd.cpp
+++ b/src/core/hle/service/cecd/cecd.cpp
@@ -76,7 +76,7 @@ void Module::Interface::Open(Kernel::HLERequestContext& ctx) {
         if (dir_result.Failed()) {
             if (open_mode.create) {
                 cecd->cecd_system_save_data_archive->CreateDirectory(path);
-                rb.Push(RESULT_SUCCESS);
+                rb.Push(ResultSuccess);
             } else {
                 LOG_DEBUG(Service_CECD, "Failed to open directory: {}", path.AsString());
                 rb.Push(Result(ErrorDescription::NoData, ErrorModule::CEC, ErrorSummary::NotFound,
@@ -93,7 +93,7 @@ void Module::Interface::Open(Kernel::HLERequestContext& ctx) {
 
             LOG_DEBUG(Service_CECD, "Number of entries found: {}", entry_count);
 
-            rb.Push(RESULT_SUCCESS);
+            rb.Push(ResultSuccess);
             rb.Push<u32>(entry_count); // Entry count
             directory->Close();
         }
@@ -108,7 +108,7 @@ void Module::Interface::Open(Kernel::HLERequestContext& ctx) {
             rb.Push<u32>(0); // No file size
         } else {
             session_data->file = std::move(file_result).Unwrap();
-            rb.Push(RESULT_SUCCESS);
+            rb.Push(ResultSuccess);
             rb.Push<u32>(static_cast<u32>(session_data->file->GetSize())); // Return file size
         }
 
@@ -163,7 +163,7 @@ void Module::Interface::Read(Kernel::HLERequestContext& ctx) {
         write_buffer.Write(buffer.data(), 0, write_buffer_size);
         session_data->file->Close();
 
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.Push<u32>(bytes_read);
     }
     rb.PushMappedBuffer(write_buffer);
@@ -225,7 +225,7 @@ void Module::Interface::ReadMessage(Kernel::HLERequestContext& ctx) {
                   msg_header.sender_id, msg_header.sender_id2, msg_header.send_count,
                   msg_header.forward_count, msg_header.user_data);
 
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.Push<u32>(bytes_read);
     } else {
         rb.Push(Result(ErrorDescription::NoData, ErrorModule::CEC, ErrorSummary::NotFound,
@@ -317,7 +317,7 @@ void Module::Interface::ReadMessageWithHMAC(Kernel::HLERequestContext& ctx) {
         else
             LOG_DEBUG(Service_CECD, "Verification failed");
 
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.Push<u32>(bytes_read);
     } else {
         rb.Push(Result(ErrorDescription::NoData, ErrorModule::CEC, ErrorSummary::NotFound,
@@ -376,7 +376,7 @@ void Module::Interface::Write(Kernel::HLERequestContext& ctx) {
             session_data->file->Write(0, buffer.size(), true, buffer.data()).Unwrap());
         session_data->file->Close();
 
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
     }
     rb.PushMappedBuffer(read_buffer);
 
@@ -438,7 +438,7 @@ void Module::Interface::WriteMessage(Kernel::HLERequestContext& ctx) {
             static_cast<u32>(message->Write(0, buffer_size, true, buffer.data()).Unwrap());
         message->Close();
 
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
     } else {
         rb.Push(Result(ErrorDescription::NoData, ErrorModule::CEC, ErrorSummary::NotFound,
                        ErrorLevel::Status));
@@ -525,7 +525,7 @@ void Module::Interface::WriteMessageWithHMAC(Kernel::HLERequestContext& ctx) {
             static_cast<u32>(message->Write(0, buffer_size, true, buffer.data()).Unwrap());
         message->Close();
 
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
     } else {
         rb.Push(Result(ErrorDescription::NoData, ErrorModule::CEC, ErrorSummary::NotFound,
                        ErrorLevel::Status));
@@ -613,7 +613,7 @@ void Module::Interface::SetData(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(read_buffer);
 
     LOG_DEBUG(Service_CECD, "called, ncch_program_id={:#010x}, buffer_size={:#x}, option={:#x}",
@@ -651,7 +651,7 @@ void Module::Interface::ReadData(Kernel::HLERequestContext& ctx) {
     dest_buffer.Write(buffer.data(), 0,
                       std::min(static_cast<size_t>(dest_buffer_size), buffer.size()));
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(param_buffer);
     rb.PushMappedBuffer(dest_buffer);
 
@@ -665,7 +665,7 @@ void Module::Interface::Start(Kernel::HLERequestContext& ctx) {
     const CecCommand command = rp.PopEnum<CecCommand>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_CECD, "(STUBBED) called, command={}", cecd->GetCecCommandAsString(command));
 }
@@ -675,7 +675,7 @@ void Module::Interface::Stop(Kernel::HLERequestContext& ctx) {
     const CecCommand command = rp.PopEnum<CecCommand>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_CECD, "(STUBBED) called, command={}", cecd->GetCecCommandAsString(command));
 }
@@ -687,7 +687,7 @@ void Module::Interface::GetCecInfoBuffer(Kernel::HLERequestContext& ctx) {
     auto& buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(buffer);
 
     LOG_DEBUG(Service_CECD, "called, buffer_size={}, possible_info_type={}", buffer_size,
@@ -698,7 +698,7 @@ void Module::Interface::GetCecdState(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushEnum(CecdState::NdmStatusIdle);
 
     LOG_WARNING(Service_CECD, "(STUBBED) called");
@@ -708,7 +708,7 @@ void Module::Interface::GetCecInfoEventHandle(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushCopyObjects(cecd->cecinfo_event);
 
     LOG_WARNING(Service_CECD, "(STUBBED) called");
@@ -718,7 +718,7 @@ void Module::Interface::GetChangeStateEventHandle(Kernel::HLERequestContext& ctx
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushCopyObjects(cecd->change_state_event);
 
     LOG_WARNING(Service_CECD, "(STUBBED) called");
@@ -768,7 +768,7 @@ void Module::Interface::OpenAndWrite(Kernel::HLERequestContext& ctx) {
                 static_cast<u32>(file->Write(0, buffer.size(), true, buffer.data()).Unwrap());
             file->Close();
 
-            rb.Push(RESULT_SUCCESS);
+            rb.Push(ResultSuccess);
         } else {
             rb.Push(Result(ErrorDescription::NoData, ErrorModule::CEC, ErrorSummary::NotFound,
                            ErrorLevel::Status));
@@ -819,7 +819,7 @@ void Module::Interface::OpenAndRead(Kernel::HLERequestContext& ctx) {
             write_buffer.Write(buffer.data(), 0, buffer_size);
             file->Close();
 
-            rb.Push(RESULT_SUCCESS);
+            rb.Push(ResultSuccess);
             rb.Push<u32>(bytes_read);
         } else {
             rb.Push(Result(ErrorDescription::NoData, ErrorModule::CEC, ErrorSummary::NotFound,
@@ -1404,7 +1404,7 @@ Module::Module(Core::System& system) : system(system) {
     auto archive_result = systemsavedata_factory.Open(archive_path, 0);
 
     // If the archive didn't exist, create the files inside
-    if (archive_result.Code() != FileSys::ERROR_NOT_FOUND) {
+    if (archive_result.Code() != FileSys::ResultNotFound) {
         ASSERT_MSG(archive_result.Succeeded(), "Could not open the CECD SystemSaveData archive!");
         cecd_system_save_data_archive = std::move(archive_result).Unwrap();
     } else {

--- a/src/core/hle/service/cecd/cecd.cpp
+++ b/src/core/hle/service/cecd/cecd.cpp
@@ -842,7 +842,7 @@ void Module::Interface::GetCecInfoEventHandleSys(Kernel::HLERequestContext& ctx)
     rp.PopPID();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushCopyObjects(cecd->cecinfosys_event);
 
     LOG_WARNING(Service_CECD, "(STUBBED) called");

--- a/src/core/hle/service/cecd/cecd.cpp
+++ b/src/core/hle/service/cecd/cecd.cpp
@@ -79,8 +79,8 @@ void Module::Interface::Open(Kernel::HLERequestContext& ctx) {
                 rb.Push(RESULT_SUCCESS);
             } else {
                 LOG_DEBUG(Service_CECD, "Failed to open directory: {}", path.AsString());
-                rb.Push(ResultCode(ErrorDescription::NoData, ErrorModule::CEC,
-                                   ErrorSummary::NotFound, ErrorLevel::Status));
+                rb.Push(Result(ErrorDescription::NoData, ErrorModule::CEC, ErrorSummary::NotFound,
+                               ErrorLevel::Status));
             }
             rb.Push<u32>(0); // Zero entries
         } else {
@@ -103,8 +103,8 @@ void Module::Interface::Open(Kernel::HLERequestContext& ctx) {
         auto file_result = cecd->cecd_system_save_data_archive->OpenFile(path, mode);
         if (file_result.Failed()) {
             LOG_DEBUG(Service_CECD, "Failed to open file: {}", path.AsString());
-            rb.Push(ResultCode(ErrorDescription::NoData, ErrorModule::CEC, ErrorSummary::NotFound,
-                               ErrorLevel::Status));
+            rb.Push(Result(ErrorDescription::NoData, ErrorModule::CEC, ErrorSummary::NotFound,
+                           ErrorLevel::Status));
             rb.Push<u32>(0); // No file size
         } else {
             session_data->file = std::move(file_result).Unwrap();
@@ -151,8 +151,8 @@ void Module::Interface::Read(Kernel::HLERequestContext& ctx) {
     case CecDataPathType::MboxDir:
     case CecDataPathType::InboxDir:
     case CecDataPathType::OutboxDir:
-        rb.Push(ResultCode(ErrorDescription::NotAuthorized, ErrorModule::CEC,
-                           ErrorSummary::NotFound, ErrorLevel::Status));
+        rb.Push(Result(ErrorDescription::NotAuthorized, ErrorModule::CEC, ErrorSummary::NotFound,
+                       ErrorLevel::Status));
         rb.Push<u32>(0); // No bytes read
         break;
     default: // If not directory, then it is a file
@@ -228,8 +228,8 @@ void Module::Interface::ReadMessage(Kernel::HLERequestContext& ctx) {
         rb.Push(RESULT_SUCCESS);
         rb.Push<u32>(bytes_read);
     } else {
-        rb.Push(ResultCode(ErrorDescription::NoData, ErrorModule::CEC, ErrorSummary::NotFound,
-                           ErrorLevel::Status));
+        rb.Push(Result(ErrorDescription::NoData, ErrorModule::CEC, ErrorSummary::NotFound,
+                       ErrorLevel::Status));
         rb.Push<u32>(0); // zero bytes read
     }
     rb.PushMappedBuffer(message_id_buffer);
@@ -320,8 +320,8 @@ void Module::Interface::ReadMessageWithHMAC(Kernel::HLERequestContext& ctx) {
         rb.Push(RESULT_SUCCESS);
         rb.Push<u32>(bytes_read);
     } else {
-        rb.Push(ResultCode(ErrorDescription::NoData, ErrorModule::CEC, ErrorSummary::NotFound,
-                           ErrorLevel::Status));
+        rb.Push(Result(ErrorDescription::NoData, ErrorModule::CEC, ErrorSummary::NotFound,
+                       ErrorLevel::Status));
         rb.Push<u32>(0); // zero bytes read
     }
 
@@ -356,8 +356,8 @@ void Module::Interface::Write(Kernel::HLERequestContext& ctx) {
     case CecDataPathType::MboxDir:
     case CecDataPathType::InboxDir:
     case CecDataPathType::OutboxDir:
-        rb.Push(ResultCode(ErrorDescription::NotAuthorized, ErrorModule::CEC,
-                           ErrorSummary::NotFound, ErrorLevel::Status));
+        rb.Push(Result(ErrorDescription::NotAuthorized, ErrorModule::CEC, ErrorSummary::NotFound,
+                       ErrorLevel::Status));
         break;
     default: // If not directory, then it is a file
         std::vector<u8> buffer(read_buffer_size);
@@ -440,8 +440,8 @@ void Module::Interface::WriteMessage(Kernel::HLERequestContext& ctx) {
 
         rb.Push(RESULT_SUCCESS);
     } else {
-        rb.Push(ResultCode(ErrorDescription::NoData, ErrorModule::CEC, ErrorSummary::NotFound,
-                           ErrorLevel::Status));
+        rb.Push(Result(ErrorDescription::NoData, ErrorModule::CEC, ErrorSummary::NotFound,
+                       ErrorLevel::Status));
     }
 
     rb.PushMappedBuffer(read_buffer);
@@ -527,8 +527,8 @@ void Module::Interface::WriteMessageWithHMAC(Kernel::HLERequestContext& ctx) {
 
         rb.Push(RESULT_SUCCESS);
     } else {
-        rb.Push(ResultCode(ErrorDescription::NoData, ErrorModule::CEC, ErrorSummary::NotFound,
-                           ErrorLevel::Status));
+        rb.Push(Result(ErrorDescription::NoData, ErrorModule::CEC, ErrorSummary::NotFound,
+                       ErrorLevel::Status));
     }
 
     rb.PushMappedBuffer(read_buffer);
@@ -745,8 +745,8 @@ void Module::Interface::OpenAndWrite(Kernel::HLERequestContext& ctx) {
     case CecDataPathType::MboxDir:
     case CecDataPathType::InboxDir:
     case CecDataPathType::OutboxDir:
-        rb.Push(ResultCode(ErrorDescription::NotAuthorized, ErrorModule::CEC,
-                           ErrorSummary::NotFound, ErrorLevel::Status));
+        rb.Push(Result(ErrorDescription::NotAuthorized, ErrorModule::CEC, ErrorSummary::NotFound,
+                       ErrorLevel::Status));
         break;
     default: // If not directory, then it is a file
         auto file_result = cecd->cecd_system_save_data_archive->OpenFile(path, mode);
@@ -770,8 +770,8 @@ void Module::Interface::OpenAndWrite(Kernel::HLERequestContext& ctx) {
 
             rb.Push(RESULT_SUCCESS);
         } else {
-            rb.Push(ResultCode(ErrorDescription::NoData, ErrorModule::CEC, ErrorSummary::NotFound,
-                               ErrorLevel::Status));
+            rb.Push(Result(ErrorDescription::NoData, ErrorModule::CEC, ErrorSummary::NotFound,
+                           ErrorLevel::Status));
         }
     }
     rb.PushMappedBuffer(read_buffer);
@@ -804,8 +804,8 @@ void Module::Interface::OpenAndRead(Kernel::HLERequestContext& ctx) {
     case CecDataPathType::MboxDir:
     case CecDataPathType::InboxDir:
     case CecDataPathType::OutboxDir:
-        rb.Push(ResultCode(ErrorDescription::NotAuthorized, ErrorModule::CEC,
-                           ErrorSummary::NotFound, ErrorLevel::Status));
+        rb.Push(Result(ErrorDescription::NotAuthorized, ErrorModule::CEC, ErrorSummary::NotFound,
+                       ErrorLevel::Status));
         rb.Push<u32>(0); // No entries read
         break;
     default: // If not directory, then it is a file
@@ -822,8 +822,8 @@ void Module::Interface::OpenAndRead(Kernel::HLERequestContext& ctx) {
             rb.Push(RESULT_SUCCESS);
             rb.Push<u32>(bytes_read);
         } else {
-            rb.Push(ResultCode(ErrorDescription::NoData, ErrorModule::CEC, ErrorSummary::NotFound,
-                               ErrorLevel::Status));
+            rb.Push(Result(ErrorDescription::NoData, ErrorModule::CEC, ErrorSummary::NotFound,
+                           ErrorLevel::Status));
             rb.Push<u32>(0); // No bytes read
         }
     }

--- a/src/core/hle/service/cecd/cecd.h
+++ b/src/core/hle/service/cecd/cecd.h
@@ -500,7 +500,7 @@ public:
          *  Inputs:
          *      0: Header Code[0x000E0000]
          *  Outputs:
-         *      1: ResultCode
+         *      1: Result
          *      2: CecdState
          */
         void GetCecdState(Kernel::HLERequestContext& ctx);
@@ -510,7 +510,7 @@ public:
          *  Inputs:
          *      0: Header Code[0x000F0000]
          *  Outputs:
-         *      1: ResultCode
+         *      1: Result
          *      3: Event Handle
          */
         void GetCecInfoEventHandle(Kernel::HLERequestContext& ctx);
@@ -520,7 +520,7 @@ public:
          *  Inputs:
          *      0: Header Code[0x00100000]
          *  Outputs:
-         *      1: ResultCode
+         *      1: Result
          *      3: Event Handle
          */
         void GetChangeStateEventHandle(Kernel::HLERequestContext& ctx);
@@ -593,7 +593,7 @@ public:
          *  Inputs:
          *      0: Header Code[0x40020002]
          *  Outputs:
-         *      1: ResultCode
+         *      1: Result
          *      3: Event Handle
          */
         void GetCecInfoEventHandleSys(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/cfg/cfg.h
+++ b/src/core/hle/service/cfg/cfg.h
@@ -389,9 +389,9 @@ private:
      * @param size The size of the block we want to read
      * @param accesss_flag The requested block must have this access flag set
      * @param output A pointer where we will write the read data
-     * @returns ResultCode indicating the result of the operation, 0 on success
+     * @returns Result indicating the result of the operation, 0 on success
      */
-    ResultCode GetConfigBlock(u32 block_id, u32 size, AccessFlag accesss_flag, void* output);
+    Result GetConfigBlock(u32 block_id, u32 size, AccessFlag accesss_flag, void* output);
 
     /**
      * Reads data from input and writes to a block with the specified id and flag
@@ -402,9 +402,9 @@ private:
      * @param size The size of the block we want to write
      * @param accesss_flag The target block must have this access flag set
      * @param input A pointer where we will read data and write to Config savegame buffer
-     * @returns ResultCode indicating the result of the operation, 0 on success
+     * @returns Result indicating the result of the operation, 0 on success
      */
-    ResultCode SetConfigBlock(u32 block_id, u32 size, AccessFlag accesss_flag, const void* input);
+    Result SetConfigBlock(u32 block_id, u32 size, AccessFlag accesss_flag, const void* input);
 
     /**
      * Creates a block with the specified id and writes the input data to the cfg savegame buffer in
@@ -414,28 +414,27 @@ private:
      * @param size The size of the block we want to create
      * @param accesss_flags The access flags of the new block
      * @param data A pointer containing the data we will write to the new block
-     * @returns ResultCode indicating the result of the operation, 0 on success
+     * @returns Result indicating the result of the operation, 0 on success
      */
-    ResultCode CreateConfigBlock(u32 block_id, u16 size, AccessFlag accesss_flags,
-                                 const void* data);
+    Result CreateConfigBlock(u32 block_id, u16 size, AccessFlag accesss_flags, const void* data);
 
     /**
      * Deletes the config savegame file from the filesystem, the buffer in memory is not affected
-     * @returns ResultCode indicating the result of the operation, 0 on success
+     * @returns Result indicating the result of the operation, 0 on success
      */
-    ResultCode DeleteConfigNANDSaveFile();
+    Result DeleteConfigNANDSaveFile();
 
     /**
      * Re-creates the config savegame file in memory and the filesystem with the default blocks
-     * @returns ResultCode indicating the result of the operation, 0 on success
+     * @returns Result indicating the result of the operation, 0 on success
      */
-    ResultCode FormatConfig();
+    Result FormatConfig();
 
     /**
      * Open the config savegame file and load it to the memory buffer
-     * @returns ResultCode indicating the result of the operation, 0 on success
+     * @returns Result indicating the result of the operation, 0 on success
      */
-    ResultCode LoadConfigNANDSaveFile();
+    Result LoadConfigNANDSaveFile();
 
     /**
      * Loads MCU specific data
@@ -538,7 +537,7 @@ public:
      * @param random_number the random_number to set
      * @param console_id the console id to set
      */
-    ResultCode SetConsoleUniqueId(u32 random_number, u64 console_id);
+    Result SetConsoleUniqueId(u32 random_number, u64 console_id);
 
     /**
      * Gets the console unique id from config savegame.
@@ -572,9 +571,9 @@ public:
 
     /**
      * Writes the config savegame memory buffer to the config savegame file in the filesystem
-     * @returns ResultCode indicating the result of the operation, 0 on success
+     * @returns Result indicating the result of the operation, 0 on success
      */
-    ResultCode UpdateConfigNANDSavegame();
+    Result UpdateConfigNANDSavegame();
 
     /**
      * Saves MCU specific data

--- a/src/core/hle/service/csnd/csnd_snd.cpp
+++ b/src/core/hle/service/csnd/csnd_snd.cpp
@@ -208,7 +208,7 @@ void CSND_SND::Initialize(Kernel::HLERequestContext& ctx) {
                         .Unwrap();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 3);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushCopyObjects(mutex, shared_memory);
 
     LOG_WARNING(Service_CSND,
@@ -228,7 +228,7 @@ void CSND_SND::Shutdown(Kernel::HLERequestContext& ctx) {
         shared_memory = nullptr;
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_CSND, "(STUBBED) called");
 }
@@ -394,7 +394,7 @@ void CSND_SND::ExecuteCommands(Kernel::HLERequestContext& ctx) {
 
     *shared_memory->GetPointer(addr + offsetof(Type0Command, finished)) = 1;
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void CSND_SND::AcquireSoundChannels(Kernel::HLERequestContext& ctx) {
@@ -405,7 +405,7 @@ void CSND_SND::AcquireSoundChannels(Kernel::HLERequestContext& ctx) {
     acquired_channel_mask = 0xFFFFFF00;
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(acquired_channel_mask);
 
     LOG_WARNING(Service_CSND, "(STUBBED) called");
@@ -417,7 +417,7 @@ void CSND_SND::ReleaseSoundChannels(Kernel::HLERequestContext& ctx) {
     acquired_channel_mask = 0;
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_CSND, "(STUBBED) called");
 }
@@ -433,7 +433,7 @@ void CSND_SND::AcquireCapUnit(Kernel::HLERequestContext& ctx) {
         rb.Skip(1, false);
         return;
     }
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     if (capture_units[0]) {
         capture_units[1] = true;
@@ -453,7 +453,7 @@ void CSND_SND::ReleaseCapUnit(Kernel::HLERequestContext& ctx) {
     capture_units[index] = false;
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_CSND, "(STUBBED) called, capture_unit_index={}", index);
 }
@@ -465,7 +465,7 @@ void CSND_SND::FlushDataCache(Kernel::HLERequestContext& ctx) {
     const auto process = rp.PopObject<Kernel::Process>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_TRACE(Service_CSND, "(STUBBED) called address=0x{:08X}, size=0x{:08X}, process={}", address,
               size, process->process_id);
@@ -478,7 +478,7 @@ void CSND_SND::StoreDataCache(Kernel::HLERequestContext& ctx) {
     const auto process = rp.PopObject<Kernel::Process>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_TRACE(Service_CSND, "(STUBBED) called address=0x{:08X}, size=0x{:08X}, process={}", address,
               size, process->process_id);
@@ -491,7 +491,7 @@ void CSND_SND::InvalidateDataCache(Kernel::HLERequestContext& ctx) {
     const auto process = rp.PopObject<Kernel::Process>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_TRACE(Service_CSND, "(STUBBED) called address=0x{:08X}, size=0x{:08X}, process={}", address,
               size, process->process_id);
@@ -501,7 +501,7 @@ void CSND_SND::Reset(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_CSND, "(STUBBED) called");
 }

--- a/src/core/hle/service/csnd/csnd_snd.cpp
+++ b/src/core/hle/service/csnd/csnd_snd.cpp
@@ -240,8 +240,8 @@ void CSND_SND::ExecuteCommands(Kernel::HLERequestContext& ctx) {
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     if (!shared_memory) {
-        rb.Push(ResultCode(ErrorDescription::InvalidResultValue, ErrorModule::CSND,
-                           ErrorSummary::InvalidState, ErrorLevel::Status));
+        rb.Push(Result(ErrorDescription::InvalidResultValue, ErrorModule::CSND,
+                       ErrorSummary::InvalidState, ErrorLevel::Status));
         LOG_ERROR(Service_CSND, "called, shared memory not allocated");
         return;
     }
@@ -428,8 +428,8 @@ void CSND_SND::AcquireCapUnit(Kernel::HLERequestContext& ctx) {
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
     if (capture_units[0] && capture_units[1]) {
         LOG_WARNING(Service_CSND, "No more capture units available");
-        rb.Push(ResultCode(ErrorDescription::InvalidResultValue, ErrorModule::CSND,
-                           ErrorSummary::OutOfResource, ErrorLevel::Status));
+        rb.Push(Result(ErrorDescription::InvalidResultValue, ErrorModule::CSND,
+                       ErrorSummary::OutOfResource, ErrorLevel::Status));
         rb.Skip(1, false);
         return;
     }

--- a/src/core/hle/service/dlp/dlp_srvr.cpp
+++ b/src/core/hle/service/dlp/dlp_srvr.cpp
@@ -18,7 +18,7 @@ void DLP_SRVR::IsChild(Kernel::HLERequestContext& ctx) {
     rp.Skip(1, false);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(false);
 
     LOG_WARNING(Service_DLP, "(STUBBED) called");

--- a/src/core/hle/service/dsp/dsp_dsp.cpp
+++ b/src/core/hle/service/dsp/dsp_dsp.cpp
@@ -250,8 +250,8 @@ void DSP_DSP::RegisterInterruptEvents(Kernel::HLERequestContext& ctx) {
                      "Ran out of space to register interrupts (Attempted to register "
                      "interrupt={}, channel={}, event={})",
                      interrupt, channel, event->GetName());
-            rb.Push(ResultCode(ErrorDescription::InvalidResultValue, ErrorModule::DSP,
-                               ErrorSummary::OutOfResource, ErrorLevel::Status));
+            rb.Push(Result(ErrorDescription::InvalidResultValue, ErrorModule::DSP,
+                           ErrorSummary::OutOfResource, ErrorLevel::Status));
             return;
         } else {
             GetInterruptEvent(type, pipe) = event;

--- a/src/core/hle/service/dsp/dsp_dsp.cpp
+++ b/src/core/hle/service/dsp/dsp_dsp.cpp
@@ -28,7 +28,7 @@ void DSP_DSP::RecvData(Kernel::HLERequestContext& ctx) {
     const u32 register_number = rp.Pop<u32>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(system.DSP().RecvData(register_number));
 
     LOG_DEBUG(Service_DSP, "register_number={}", register_number);
@@ -39,7 +39,7 @@ void DSP_DSP::RecvDataIsReady(Kernel::HLERequestContext& ctx) {
     const u32 register_number = rp.Pop<u32>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(system.DSP().RecvDataIsReady(register_number));
 
     LOG_DEBUG(Service_DSP, "register_number={}", register_number);
@@ -52,7 +52,7 @@ void DSP_DSP::SetSemaphore(Kernel::HLERequestContext& ctx) {
     system.DSP().SetSemaphore(semaphore_value);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_INFO(Service_DSP, "called, semaphore_value={:04X}", semaphore_value);
 }
@@ -62,7 +62,7 @@ void DSP_DSP::ConvertProcessAddressFromDspDram(Kernel::HLERequestContext& ctx) {
     const u32 address = rp.Pop<u32>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     // TODO(merry): There is a per-region offset missing in this calculation (that seems to be
     // always zero).
@@ -103,7 +103,7 @@ void DSP_DSP::WriteProcessPipe(Kernel::HLERequestContext& ctx) {
     system.DSP().PipeWrite(pipe, buffer);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_DSP, "channel={}, size=0x{:X}, buffer_size={:X}", channel, size,
               buffer.size());
@@ -125,7 +125,7 @@ void DSP_DSP::ReadPipe(Kernel::HLERequestContext& ctx) {
         UNREACHABLE(); // No more data is in pipe. Hardware hangs in this case; Should never happen.
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushStaticBuffer(std::move(pipe_buffer), 0);
 
     LOG_DEBUG(Service_DSP, "channel={}, peer={}, size=0x{:04X}, pipe_readable_size=0x{:04X}",
@@ -141,7 +141,7 @@ void DSP_DSP::GetPipeReadableSize(Kernel::HLERequestContext& ctx) {
     const u16 pipe_readable_size = static_cast<u16>(system.DSP().GetPipeReadableSize(pipe));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u16>(pipe_readable_size);
 
     LOG_DEBUG(Service_DSP, "channel={}, peer={}, return pipe_readable_size=0x{:04X}", channel, peer,
@@ -163,7 +163,7 @@ void DSP_DSP::ReadPipeIfPossible(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u16>(static_cast<u16>(pipe_buffer.size()));
     rb.PushStaticBuffer(std::move(pipe_buffer), 0);
 
@@ -179,7 +179,7 @@ void DSP_DSP::LoadComponent(Kernel::HLERequestContext& ctx) {
     auto& buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(true);
     rb.PushMappedBuffer(buffer);
 
@@ -198,7 +198,7 @@ void DSP_DSP::UnloadComponent(Kernel::HLERequestContext& ctx) {
     system.DSP().UnloadComponent();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_INFO(Service_DSP, "(STUBBED)");
 }
@@ -210,7 +210,7 @@ void DSP_DSP::FlushDataCache(Kernel::HLERequestContext& ctx) {
     const auto process = rp.PopObject<Kernel::Process>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_TRACE(Service_DSP, "called address=0x{:08X}, size=0x{:X}, process={}", address, size,
               process->process_id);
@@ -223,7 +223,7 @@ void DSP_DSP::InvalidateDataCache(Kernel::HLERequestContext& ctx) {
     const auto process = rp.PopObject<Kernel::Process>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_TRACE(Service_DSP, "called address=0x{:08X}, size=0x{:X}, process={}", address, size,
               process->process_id);
@@ -262,14 +262,14 @@ void DSP_DSP::RegisterInterruptEvents(Kernel::HLERequestContext& ctx) {
         GetInterruptEvent(type, pipe) = nullptr;
         LOG_INFO(Service_DSP, "Unregistered interrupt={}, channel={}", interrupt, channel);
     }
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void DSP_DSP::GetSemaphoreEventHandle(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushCopyObjects(semaphore_event);
 
     LOG_WARNING(Service_DSP, "(STUBBED) called");
@@ -280,7 +280,7 @@ void DSP_DSP::SetSemaphoreMask(Kernel::HLERequestContext& ctx) {
     preset_semaphore = rp.Pop<u16>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_DSP, "(STUBBED) called mask=0x{:04X}", preset_semaphore);
 }
@@ -289,7 +289,7 @@ void DSP_DSP::GetHeadphoneStatus(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(false); /// u8, 0 = not inserted, 1 = inserted
 
     LOG_DEBUG(Service_DSP, "called");
@@ -300,7 +300,7 @@ void DSP_DSP::ForceHeadphoneOut(Kernel::HLERequestContext& ctx) {
     const u8 force = rp.Pop<u8>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_DSP, "(STUBBED) called, force={}", force);
 }

--- a/src/core/hle/service/err/err_f.cpp
+++ b/src/core/hle/service/err/err_f.cpp
@@ -155,7 +155,7 @@ static void LogGenericInfo(const ErrInfo::ErrInfoCommon& errinfo_common) {
                  errinfo_common.app_title_id_low);
     LOG_CRITICAL(Service_ERR, "ADR: 0x{:08X}", errinfo_common.pc_address);
 
-    ResultCode result_code{errinfo_common.result_code};
+    Result result_code{errinfo_common.result_code};
     LOG_CRITICAL(Service_ERR, "RSL: 0x{:08X}", result_code.raw);
     LOG_CRITICAL(Service_ERR, "  Level: {}", static_cast<u32>(result_code.level.Value()));
     LOG_CRITICAL(Service_ERR, "  Summary: {}", static_cast<u32>(result_code.summary.Value()));

--- a/src/core/hle/service/err/err_f.cpp
+++ b/src/core/hle/service/err/err_f.cpp
@@ -244,7 +244,7 @@ void ERR_F::ThrowFatalError(Kernel::HLERequestContext& ctx) {
     } // switch FatalErrType
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 ERR_F::ERR_F(Core::System& system) : ServiceFramework("err:f", 1), system(system) {

--- a/src/core/hle/service/frd/frd.cpp
+++ b/src/core/hle/service/frd/frd.cpp
@@ -35,7 +35,7 @@ void Module::Interface::GetMyPresence(Kernel::HLERequestContext& ctx) {
     std::memcpy(buffer.data(), &frd->my_presence, buffer.size());
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushStaticBuffer(std::move(buffer), 0);
 
     LOG_WARNING(Service_FRD, "(STUBBED) called");
@@ -49,7 +49,7 @@ void Module::Interface::GetFriendKeyList(Kernel::HLERequestContext& ctx) {
     std::vector<u8> buffer(sizeof(FriendKey) * frd_count, 0);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u32>(0); // 0 friends
     rb.PushStaticBuffer(std::move(buffer), 0);
 
@@ -65,7 +65,7 @@ void Module::Interface::GetFriendProfile(Kernel::HLERequestContext& ctx) {
     std::vector<u8> buffer(sizeof(Profile) * count, 0);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushStaticBuffer(std::move(buffer), 0);
 
     LOG_WARNING(Service_FRD, "(STUBBED) called, count={}", count);
@@ -80,7 +80,7 @@ void Module::Interface::GetFriendAttributeFlags(Kernel::HLERequestContext& ctx) 
     // TODO:(mailwl) figure out AttributeFlag size and zero all buffer. Assume 1 byte
     std::vector<u8> buffer(1 * count, 0);
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushStaticBuffer(std::move(buffer), 0);
 
     LOG_WARNING(Service_FRD, "(STUBBED) called, count={}", count);
@@ -89,7 +89,7 @@ void Module::Interface::GetFriendAttributeFlags(Kernel::HLERequestContext& ctx) 
 void Module::Interface::GetMyFriendKey(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
     IPC::RequestBuilder rb = rp.MakeBuilder(5, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushRaw(frd->my_friend_key);
 
     LOG_WARNING(Service_FRD, "(STUBBED) called");
@@ -105,7 +105,7 @@ void Module::Interface::GetMyScreenName(Kernel::HLERequestContext& ctx) {
     ScreenName screen_name{};
     std::memcpy(screen_name.name.data(), username.data(), username.length() * sizeof(char16_t));
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushRaw(screen_name);
     rb.Push(0);
 
@@ -118,7 +118,7 @@ void Module::Interface::GetMyComment(Kernel::HLERequestContext& ctx) {
 
     constexpr Comment comment{.name = {u'H', u'e', u'y', '!'}};
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushRaw<Comment>(comment);
     rb.Push(0);
 
@@ -133,7 +133,7 @@ void Module::Interface::GetMyMii(Kernel::HLERequestContext& ctx) {
     Mii::ChecksummedMiiData mii{};
     mii.SetMiiData(mii_data);
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushRaw<Mii::ChecksummedMiiData>(mii);
 
     LOG_WARNING(Service_FRD, "(STUBBED) called");
@@ -145,7 +145,7 @@ void Module::Interface::GetMyProfile(Kernel::HLERequestContext& ctx) {
 
     constexpr Profile profile{.region = 1, .country = 1, .area = 1, .language = 1, .platform = 1};
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushRaw<Profile>(profile);
 
     LOG_WARNING(Service_FRD, "(STUBBED) called");
@@ -157,7 +157,7 @@ void Module::Interface::GetMyFavoriteGame(Kernel::HLERequestContext& ctx) {
 
     constexpr Game game{.title_id = 0x0004000E00030700, .version = 1};
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushRaw<Game>(game);
 
     LOG_WARNING(Service_FRD, "(STUBBED) called");
@@ -169,7 +169,7 @@ void Module::Interface::GetMyPlayingGame(Kernel::HLERequestContext& ctx) {
 
     constexpr Game game{.title_id = 0x0004000E00030700, .version = 1};
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushRaw<Game>(game);
 
     LOG_WARNING(Service_FRD, "(STUBBED) called");
@@ -183,7 +183,7 @@ void Module::Interface::GetMyPreference(Kernel::HLERequestContext& ctx) {
     constexpr u32 show_game = 1;
     constexpr u32 show_history = 0;
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u32>(is_public);
     rb.Push<u32>(show_game);
     rb.Push<u32>(show_history);
@@ -218,7 +218,7 @@ void Module::Interface::UnscrambleLocalFriendCode(Kernel::HLERequestContext& ctx
 
     LOG_WARNING(Service_FRD, "(STUBBED) called");
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushStaticBuffer(std::move(unscrambled_friend_codes), 0);
 }
 
@@ -228,7 +228,7 @@ void Module::Interface::SetClientSdkVersion(Kernel::HLERequestContext& ctx) {
     rp.PopPID();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_FRD, "(STUBBED) called, version: 0x{:08X}", version);
 }
@@ -237,7 +237,7 @@ void Module::Interface::IsOnline(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(frd->logged_in);
 
     LOG_WARNING(Service_FRD, "(STUBBED) called");
@@ -248,7 +248,7 @@ void Module::Interface::HasLoggedIn(Kernel::HLERequestContext& ctx) {
 
     IPC::RequestParser rp(ctx);
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(frd->logged_in);
 }
 
@@ -270,7 +270,7 @@ void Module::Interface::Login(Kernel::HLERequestContext& ctx) {
     frd->system.CoreTiming().ScheduleEvent(msToCycles(login_delay_ms), frd->login_delay_event);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void Module::Interface::GetLastResponseResult(Kernel::HLERequestContext& ctx) {
@@ -278,7 +278,7 @@ void Module::Interface::GetLastResponseResult(Kernel::HLERequestContext& ctx) {
 
     IPC::RequestParser rp(ctx);
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 Module::Module(Core::System& system) : system(system){};

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -52,7 +52,7 @@ ResultVal<ArchiveHandle> ArchiveManager::OpenArchive(ArchiveIdCode id_code,
 
     auto itr = id_code_map.find(id_code);
     if (itr == id_code_map.end()) {
-        return FileSys::ERROR_NOT_FOUND;
+        return FileSys::ResultNotFound;
     }
 
     CASCADE_RESULT(std::unique_ptr<ArchiveBackend> res,
@@ -68,9 +68,9 @@ ResultVal<ArchiveHandle> ArchiveManager::OpenArchive(ArchiveIdCode id_code,
 
 Result ArchiveManager::CloseArchive(ArchiveHandle handle) {
     if (handle_map.erase(handle) == 0)
-        return FileSys::ERR_INVALID_ARCHIVE_HANDLE;
+        return FileSys::ResultInvalidArchiveHandle;
     else
-        return RESULT_SUCCESS;
+        return ResultSuccess;
 }
 
 // TODO(yuriks): This might be what the fs:REG service is for. See the Register/Unregister calls in
@@ -85,7 +85,7 @@ Result ArchiveManager::RegisterArchiveType(std::unique_ptr<FileSys::ArchiveFacto
     auto& archive = result.first->second;
     LOG_DEBUG(Service_FS, "Registered archive {} with id code 0x{:08X}", archive->GetName(),
               id_code);
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 std::pair<ResultVal<std::shared_ptr<File>>, std::chrono::nanoseconds>
@@ -93,7 +93,7 @@ ArchiveManager::OpenFileFromArchive(ArchiveHandle archive_handle, const FileSys:
                                     const FileSys::Mode mode) {
     ArchiveBackend* archive = GetArchive(archive_handle);
     if (archive == nullptr) {
-        return std::make_pair(FileSys::ERR_INVALID_ARCHIVE_HANDLE, std::chrono::nanoseconds{0});
+        return std::make_pair(FileSys::ResultInvalidArchiveHandle, std::chrono::nanoseconds{0});
     }
 
     const std::chrono::nanoseconds open_timeout_ns{archive->GetOpenDelayNs()};
@@ -110,7 +110,7 @@ Result ArchiveManager::DeleteFileFromArchive(ArchiveHandle archive_handle,
                                              const FileSys::Path& path) {
     ArchiveBackend* archive = GetArchive(archive_handle);
     if (archive == nullptr)
-        return FileSys::ERR_INVALID_ARCHIVE_HANDLE;
+        return FileSys::ResultInvalidArchiveHandle;
 
     return archive->DeleteFile(path);
 }
@@ -122,7 +122,7 @@ Result ArchiveManager::RenameFileBetweenArchives(ArchiveHandle src_archive_handl
     ArchiveBackend* src_archive = GetArchive(src_archive_handle);
     ArchiveBackend* dest_archive = GetArchive(dest_archive_handle);
     if (src_archive == nullptr || dest_archive == nullptr)
-        return FileSys::ERR_INVALID_ARCHIVE_HANDLE;
+        return FileSys::ResultInvalidArchiveHandle;
 
     if (src_archive == dest_archive) {
         return src_archive->RenameFile(src_path, dest_path);
@@ -136,7 +136,7 @@ Result ArchiveManager::DeleteDirectoryFromArchive(ArchiveHandle archive_handle,
                                                   const FileSys::Path& path) {
     ArchiveBackend* archive = GetArchive(archive_handle);
     if (archive == nullptr)
-        return FileSys::ERR_INVALID_ARCHIVE_HANDLE;
+        return FileSys::ResultInvalidArchiveHandle;
 
     return archive->DeleteDirectory(path);
 }
@@ -145,7 +145,7 @@ Result ArchiveManager::DeleteDirectoryRecursivelyFromArchive(ArchiveHandle archi
                                                              const FileSys::Path& path) {
     ArchiveBackend* archive = GetArchive(archive_handle);
     if (archive == nullptr)
-        return FileSys::ERR_INVALID_ARCHIVE_HANDLE;
+        return FileSys::ResultInvalidArchiveHandle;
 
     return archive->DeleteDirectoryRecursively(path);
 }
@@ -154,7 +154,7 @@ Result ArchiveManager::CreateFileInArchive(ArchiveHandle archive_handle, const F
                                            u64 file_size) {
     ArchiveBackend* archive = GetArchive(archive_handle);
     if (archive == nullptr)
-        return FileSys::ERR_INVALID_ARCHIVE_HANDLE;
+        return FileSys::ResultInvalidArchiveHandle;
 
     return archive->CreateFile(path, file_size);
 }
@@ -163,7 +163,7 @@ Result ArchiveManager::CreateDirectoryFromArchive(ArchiveHandle archive_handle,
                                                   const FileSys::Path& path) {
     ArchiveBackend* archive = GetArchive(archive_handle);
     if (archive == nullptr)
-        return FileSys::ERR_INVALID_ARCHIVE_HANDLE;
+        return FileSys::ResultInvalidArchiveHandle;
 
     return archive->CreateDirectory(path);
 }
@@ -175,7 +175,7 @@ Result ArchiveManager::RenameDirectoryBetweenArchives(ArchiveHandle src_archive_
     ArchiveBackend* src_archive = GetArchive(src_archive_handle);
     ArchiveBackend* dest_archive = GetArchive(dest_archive_handle);
     if (src_archive == nullptr || dest_archive == nullptr)
-        return FileSys::ERR_INVALID_ARCHIVE_HANDLE;
+        return FileSys::ResultInvalidArchiveHandle;
 
     if (src_archive == dest_archive) {
         return src_archive->RenameDirectory(src_path, dest_path);
@@ -189,7 +189,7 @@ ResultVal<std::shared_ptr<Directory>> ArchiveManager::OpenDirectoryFromArchive(
     ArchiveHandle archive_handle, const FileSys::Path& path) {
     ArchiveBackend* archive = GetArchive(archive_handle);
     if (archive == nullptr) {
-        return FileSys::ERR_INVALID_ARCHIVE_HANDLE;
+        return FileSys::ResultInvalidArchiveHandle;
     }
 
     auto backend = archive->OpenDirectory(path);
@@ -203,7 +203,7 @@ ResultVal<std::shared_ptr<Directory>> ArchiveManager::OpenDirectoryFromArchive(
 ResultVal<u64> ArchiveManager::GetFreeBytesInArchive(ArchiveHandle archive_handle) {
     const ArchiveBackend* archive = GetArchive(archive_handle);
     if (archive == nullptr) {
-        return FileSys::ERR_INVALID_ARCHIVE_HANDLE;
+        return FileSys::ResultInvalidArchiveHandle;
     }
     return archive->GetFreeBytes();
 }
@@ -252,7 +252,7 @@ Result ArchiveManager::CreateExtSaveData(MediaType media_type, u32 high, u32 low
     }
 
     ext_savedata->WriteIcon(path, smdh_icon);
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result ArchiveManager::DeleteExtSaveData(MediaType media_type, u32 high, u32 low) {
@@ -267,7 +267,7 @@ Result ArchiveManager::DeleteExtSaveData(MediaType media_type, u32 high, u32 low
         media_type_directory = FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir);
     } else {
         LOG_ERROR(Service_FS, "Unsupported media type {}", media_type);
-        return Result(-1); // TODO(Subv): Find the right error code
+        return ResultUnknown; // TODO(Subv): Find the right error code
     }
 
     // Delete all directories (/user, /boss) and the icon file.
@@ -275,8 +275,8 @@ Result ArchiveManager::DeleteExtSaveData(MediaType media_type, u32 high, u32 low
         FileSys::GetExtDataContainerPath(media_type_directory, media_type == MediaType::NAND);
     std::string extsavedata_path = FileSys::GetExtSaveDataPath(base_path, path);
     if (FileUtil::Exists(extsavedata_path) && !FileUtil::DeleteDirRecursively(extsavedata_path))
-        return Result(-1); // TODO(Subv): Find the right error code
-    return RESULT_SUCCESS;
+        return ResultUnknown; // TODO(Subv): Find the right error code
+    return ResultSuccess;
 }
 
 Result ArchiveManager::DeleteSystemSaveData(u32 high, u32 low) {
@@ -287,10 +287,10 @@ Result ArchiveManager::DeleteSystemSaveData(u32 high, u32 low) {
     const std::string base_path = FileSys::GetSystemSaveDataContainerPath(nand_directory);
     const std::string systemsavedata_path = FileSys::GetSystemSaveDataPath(base_path, path);
     if (!FileUtil::DeleteDirRecursively(systemsavedata_path)) {
-        return Result(-1); // TODO(Subv): Find the right error code
+        return ResultUnknown; // TODO(Subv): Find the right error code
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result ArchiveManager::CreateSystemSaveData(u32 high, u32 low) {
@@ -301,10 +301,10 @@ Result ArchiveManager::CreateSystemSaveData(u32 high, u32 low) {
     const std::string base_path = FileSys::GetSystemSaveDataContainerPath(nand_directory);
     const std::string systemsavedata_path = FileSys::GetSystemSaveDataPath(base_path, path);
     if (!FileUtil::CreateFullPath(systemsavedata_path)) {
-        return Result(-1); // TODO(Subv): Find the right error code
+        return ResultUnknown; // TODO(Subv): Find the right error code
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 ResultVal<ArchiveResource> ArchiveManager::GetArchiveResource(MediaType media_type) const {

--- a/src/core/hle/service/fs/archive.cpp
+++ b/src/core/hle/service/fs/archive.cpp
@@ -66,7 +66,7 @@ ResultVal<ArchiveHandle> ArchiveManager::OpenArchive(ArchiveIdCode id_code,
     return next_handle++;
 }
 
-ResultCode ArchiveManager::CloseArchive(ArchiveHandle handle) {
+Result ArchiveManager::CloseArchive(ArchiveHandle handle) {
     if (handle_map.erase(handle) == 0)
         return FileSys::ERR_INVALID_ARCHIVE_HANDLE;
     else
@@ -75,8 +75,8 @@ ResultCode ArchiveManager::CloseArchive(ArchiveHandle handle) {
 
 // TODO(yuriks): This might be what the fs:REG service is for. See the Register/Unregister calls in
 // http://3dbrew.org/wiki/Filesystem_services#ProgramRegistry_service_.22fs:REG.22
-ResultCode ArchiveManager::RegisterArchiveType(std::unique_ptr<FileSys::ArchiveFactory>&& factory,
-                                               ArchiveIdCode id_code) {
+Result ArchiveManager::RegisterArchiveType(std::unique_ptr<FileSys::ArchiveFactory>&& factory,
+                                           ArchiveIdCode id_code) {
     auto result = id_code_map.emplace(id_code, std::move(factory));
 
     bool inserted = result.second;
@@ -106,8 +106,8 @@ ArchiveManager::OpenFileFromArchive(ArchiveHandle archive_handle, const FileSys:
     return std::make_pair(std::move(file), open_timeout_ns);
 }
 
-ResultCode ArchiveManager::DeleteFileFromArchive(ArchiveHandle archive_handle,
-                                                 const FileSys::Path& path) {
+Result ArchiveManager::DeleteFileFromArchive(ArchiveHandle archive_handle,
+                                             const FileSys::Path& path) {
     ArchiveBackend* archive = GetArchive(archive_handle);
     if (archive == nullptr)
         return FileSys::ERR_INVALID_ARCHIVE_HANDLE;
@@ -115,10 +115,10 @@ ResultCode ArchiveManager::DeleteFileFromArchive(ArchiveHandle archive_handle,
     return archive->DeleteFile(path);
 }
 
-ResultCode ArchiveManager::RenameFileBetweenArchives(ArchiveHandle src_archive_handle,
-                                                     const FileSys::Path& src_path,
-                                                     ArchiveHandle dest_archive_handle,
-                                                     const FileSys::Path& dest_path) {
+Result ArchiveManager::RenameFileBetweenArchives(ArchiveHandle src_archive_handle,
+                                                 const FileSys::Path& src_path,
+                                                 ArchiveHandle dest_archive_handle,
+                                                 const FileSys::Path& dest_path) {
     ArchiveBackend* src_archive = GetArchive(src_archive_handle);
     ArchiveBackend* dest_archive = GetArchive(dest_archive_handle);
     if (src_archive == nullptr || dest_archive == nullptr)
@@ -132,8 +132,8 @@ ResultCode ArchiveManager::RenameFileBetweenArchives(ArchiveHandle src_archive_h
     }
 }
 
-ResultCode ArchiveManager::DeleteDirectoryFromArchive(ArchiveHandle archive_handle,
-                                                      const FileSys::Path& path) {
+Result ArchiveManager::DeleteDirectoryFromArchive(ArchiveHandle archive_handle,
+                                                  const FileSys::Path& path) {
     ArchiveBackend* archive = GetArchive(archive_handle);
     if (archive == nullptr)
         return FileSys::ERR_INVALID_ARCHIVE_HANDLE;
@@ -141,8 +141,8 @@ ResultCode ArchiveManager::DeleteDirectoryFromArchive(ArchiveHandle archive_hand
     return archive->DeleteDirectory(path);
 }
 
-ResultCode ArchiveManager::DeleteDirectoryRecursivelyFromArchive(ArchiveHandle archive_handle,
-                                                                 const FileSys::Path& path) {
+Result ArchiveManager::DeleteDirectoryRecursivelyFromArchive(ArchiveHandle archive_handle,
+                                                             const FileSys::Path& path) {
     ArchiveBackend* archive = GetArchive(archive_handle);
     if (archive == nullptr)
         return FileSys::ERR_INVALID_ARCHIVE_HANDLE;
@@ -150,8 +150,8 @@ ResultCode ArchiveManager::DeleteDirectoryRecursivelyFromArchive(ArchiveHandle a
     return archive->DeleteDirectoryRecursively(path);
 }
 
-ResultCode ArchiveManager::CreateFileInArchive(ArchiveHandle archive_handle,
-                                               const FileSys::Path& path, u64 file_size) {
+Result ArchiveManager::CreateFileInArchive(ArchiveHandle archive_handle, const FileSys::Path& path,
+                                           u64 file_size) {
     ArchiveBackend* archive = GetArchive(archive_handle);
     if (archive == nullptr)
         return FileSys::ERR_INVALID_ARCHIVE_HANDLE;
@@ -159,8 +159,8 @@ ResultCode ArchiveManager::CreateFileInArchive(ArchiveHandle archive_handle,
     return archive->CreateFile(path, file_size);
 }
 
-ResultCode ArchiveManager::CreateDirectoryFromArchive(ArchiveHandle archive_handle,
-                                                      const FileSys::Path& path) {
+Result ArchiveManager::CreateDirectoryFromArchive(ArchiveHandle archive_handle,
+                                                  const FileSys::Path& path) {
     ArchiveBackend* archive = GetArchive(archive_handle);
     if (archive == nullptr)
         return FileSys::ERR_INVALID_ARCHIVE_HANDLE;
@@ -168,10 +168,10 @@ ResultCode ArchiveManager::CreateDirectoryFromArchive(ArchiveHandle archive_hand
     return archive->CreateDirectory(path);
 }
 
-ResultCode ArchiveManager::RenameDirectoryBetweenArchives(ArchiveHandle src_archive_handle,
-                                                          const FileSys::Path& src_path,
-                                                          ArchiveHandle dest_archive_handle,
-                                                          const FileSys::Path& dest_path) {
+Result ArchiveManager::RenameDirectoryBetweenArchives(ArchiveHandle src_archive_handle,
+                                                      const FileSys::Path& src_path,
+                                                      ArchiveHandle dest_archive_handle,
+                                                      const FileSys::Path& dest_path) {
     ArchiveBackend* src_archive = GetArchive(src_archive_handle);
     ArchiveBackend* dest_archive = GetArchive(dest_archive_handle);
     if (src_archive == nullptr || dest_archive == nullptr)
@@ -208,9 +208,9 @@ ResultVal<u64> ArchiveManager::GetFreeBytesInArchive(ArchiveHandle archive_handl
     return archive->GetFreeBytes();
 }
 
-ResultCode ArchiveManager::FormatArchive(ArchiveIdCode id_code,
-                                         const FileSys::ArchiveFormatInfo& format_info,
-                                         const FileSys::Path& path, u64 program_id) {
+Result ArchiveManager::FormatArchive(ArchiveIdCode id_code,
+                                     const FileSys::ArchiveFormatInfo& format_info,
+                                     const FileSys::Path& path, u64 program_id) {
     auto archive_itr = id_code_map.find(id_code);
     if (archive_itr == id_code_map.end()) {
         return UnimplementedFunction(ErrorModule::FS); // TODO(Subv): Find the right error
@@ -229,10 +229,10 @@ ResultVal<FileSys::ArchiveFormatInfo> ArchiveManager::GetArchiveFormatInfo(
     return archive->second->GetFormatInfo(archive_path, program_id);
 }
 
-ResultCode ArchiveManager::CreateExtSaveData(MediaType media_type, u32 high, u32 low,
-                                             std::span<const u8> smdh_icon,
-                                             const FileSys::ArchiveFormatInfo& format_info,
-                                             u64 program_id) {
+Result ArchiveManager::CreateExtSaveData(MediaType media_type, u32 high, u32 low,
+                                         std::span<const u8> smdh_icon,
+                                         const FileSys::ArchiveFormatInfo& format_info,
+                                         u64 program_id) {
     // Construct the binary path to the archive first
     FileSys::Path path =
         FileSys::ConstructExtDataBinaryPath(static_cast<u32>(media_type), high, low);
@@ -246,7 +246,7 @@ ResultCode ArchiveManager::CreateExtSaveData(MediaType media_type, u32 high, u32
 
     auto ext_savedata = static_cast<FileSys::ArchiveFactory_ExtSaveData*>(archive->second.get());
 
-    ResultCode result = ext_savedata->Format(path, format_info, program_id);
+    Result result = ext_savedata->Format(path, format_info, program_id);
     if (result.IsError()) {
         return result;
     }
@@ -255,7 +255,7 @@ ResultCode ArchiveManager::CreateExtSaveData(MediaType media_type, u32 high, u32
     return RESULT_SUCCESS;
 }
 
-ResultCode ArchiveManager::DeleteExtSaveData(MediaType media_type, u32 high, u32 low) {
+Result ArchiveManager::DeleteExtSaveData(MediaType media_type, u32 high, u32 low) {
     // Construct the binary path to the archive first
     FileSys::Path path =
         FileSys::ConstructExtDataBinaryPath(static_cast<u32>(media_type), high, low);
@@ -267,7 +267,7 @@ ResultCode ArchiveManager::DeleteExtSaveData(MediaType media_type, u32 high, u32
         media_type_directory = FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir);
     } else {
         LOG_ERROR(Service_FS, "Unsupported media type {}", media_type);
-        return ResultCode(-1); // TODO(Subv): Find the right error code
+        return Result(-1); // TODO(Subv): Find the right error code
     }
 
     // Delete all directories (/user, /boss) and the icon file.
@@ -275,11 +275,11 @@ ResultCode ArchiveManager::DeleteExtSaveData(MediaType media_type, u32 high, u32
         FileSys::GetExtDataContainerPath(media_type_directory, media_type == MediaType::NAND);
     std::string extsavedata_path = FileSys::GetExtSaveDataPath(base_path, path);
     if (FileUtil::Exists(extsavedata_path) && !FileUtil::DeleteDirRecursively(extsavedata_path))
-        return ResultCode(-1); // TODO(Subv): Find the right error code
+        return Result(-1); // TODO(Subv): Find the right error code
     return RESULT_SUCCESS;
 }
 
-ResultCode ArchiveManager::DeleteSystemSaveData(u32 high, u32 low) {
+Result ArchiveManager::DeleteSystemSaveData(u32 high, u32 low) {
     // Construct the binary path to the archive first
     const FileSys::Path path = FileSys::ConstructSystemSaveDataBinaryPath(high, low);
 
@@ -287,13 +287,13 @@ ResultCode ArchiveManager::DeleteSystemSaveData(u32 high, u32 low) {
     const std::string base_path = FileSys::GetSystemSaveDataContainerPath(nand_directory);
     const std::string systemsavedata_path = FileSys::GetSystemSaveDataPath(base_path, path);
     if (!FileUtil::DeleteDirRecursively(systemsavedata_path)) {
-        return ResultCode(-1); // TODO(Subv): Find the right error code
+        return Result(-1); // TODO(Subv): Find the right error code
     }
 
     return RESULT_SUCCESS;
 }
 
-ResultCode ArchiveManager::CreateSystemSaveData(u32 high, u32 low) {
+Result ArchiveManager::CreateSystemSaveData(u32 high, u32 low) {
     // Construct the binary path to the archive first
     const FileSys::Path path = FileSys::ConstructSystemSaveDataBinaryPath(high, low);
 
@@ -301,7 +301,7 @@ ResultCode ArchiveManager::CreateSystemSaveData(u32 high, u32 low) {
     const std::string base_path = FileSys::GetSystemSaveDataContainerPath(nand_directory);
     const std::string systemsavedata_path = FileSys::GetSystemSaveDataPath(base_path, path);
     if (!FileUtil::CreateFullPath(systemsavedata_path)) {
-        return ResultCode(-1); // TODO(Subv): Find the right error code
+        return Result(-1); // TODO(Subv): Find the right error code
     }
 
     return RESULT_SUCCESS;

--- a/src/core/hle/service/fs/archive.h
+++ b/src/core/hle/service/fs/archive.h
@@ -88,7 +88,7 @@ public:
      * Closes an archive
      * @param handle Handle to the archive to close
      */
-    ResultCode CloseArchive(ArchiveHandle handle);
+    Result CloseArchive(ArchiveHandle handle);
 
     /**
      * Open a File from an Archive
@@ -106,7 +106,7 @@ public:
      * @param path Path to the File inside of the Archive
      * @return Whether deletion succeeded
      */
-    ResultCode DeleteFileFromArchive(ArchiveHandle archive_handle, const FileSys::Path& path);
+    Result DeleteFileFromArchive(ArchiveHandle archive_handle, const FileSys::Path& path);
 
     /**
      * Rename a File between two Archives
@@ -116,10 +116,10 @@ public:
      * @param dest_path Path to the File inside of the destination Archive
      * @return Whether rename succeeded
      */
-    ResultCode RenameFileBetweenArchives(ArchiveHandle src_archive_handle,
-                                         const FileSys::Path& src_path,
-                                         ArchiveHandle dest_archive_handle,
-                                         const FileSys::Path& dest_path);
+    Result RenameFileBetweenArchives(ArchiveHandle src_archive_handle,
+                                     const FileSys::Path& src_path,
+                                     ArchiveHandle dest_archive_handle,
+                                     const FileSys::Path& dest_path);
 
     /**
      * Delete a Directory from an Archive
@@ -127,7 +127,7 @@ public:
      * @param path Path to the Directory inside of the Archive
      * @return Whether deletion succeeded
      */
-    ResultCode DeleteDirectoryFromArchive(ArchiveHandle archive_handle, const FileSys::Path& path);
+    Result DeleteDirectoryFromArchive(ArchiveHandle archive_handle, const FileSys::Path& path);
 
     /**
      * Delete a Directory and anything under it from an Archive
@@ -135,8 +135,8 @@ public:
      * @param path Path to the Directory inside of the Archive
      * @return Whether deletion succeeded
      */
-    ResultCode DeleteDirectoryRecursivelyFromArchive(ArchiveHandle archive_handle,
-                                                     const FileSys::Path& path);
+    Result DeleteDirectoryRecursivelyFromArchive(ArchiveHandle archive_handle,
+                                                 const FileSys::Path& path);
 
     /**
      * Create a File in an Archive
@@ -145,8 +145,8 @@ public:
      * @param file_size The size of the new file, filled with zeroes
      * @return File creation result code
      */
-    ResultCode CreateFileInArchive(ArchiveHandle archive_handle, const FileSys::Path& path,
-                                   u64 file_size);
+    Result CreateFileInArchive(ArchiveHandle archive_handle, const FileSys::Path& path,
+                               u64 file_size);
 
     /**
      * Create a Directory from an Archive
@@ -154,7 +154,7 @@ public:
      * @param path Path to the Directory inside of the Archive
      * @return Whether creation of directory succeeded
      */
-    ResultCode CreateDirectoryFromArchive(ArchiveHandle archive_handle, const FileSys::Path& path);
+    Result CreateDirectoryFromArchive(ArchiveHandle archive_handle, const FileSys::Path& path);
 
     /**
      * Rename a Directory between two Archives
@@ -164,10 +164,10 @@ public:
      * @param dest_path Path to the Directory inside of the destination Archive
      * @return Whether rename succeeded
      */
-    ResultCode RenameDirectoryBetweenArchives(ArchiveHandle src_archive_handle,
-                                              const FileSys::Path& src_path,
-                                              ArchiveHandle dest_archive_handle,
-                                              const FileSys::Path& dest_path);
+    Result RenameDirectoryBetweenArchives(ArchiveHandle src_archive_handle,
+                                          const FileSys::Path& src_path,
+                                          ArchiveHandle dest_archive_handle,
+                                          const FileSys::Path& dest_path);
 
     /**
      * Open a Directory from an Archive
@@ -192,10 +192,10 @@ public:
      * @param format_info Format information about the new archive
      * @param path The path to the archive, if relevant.
      * @param program_id the program ID of the client that requests the operation
-     * @return ResultCode 0 on success or the corresponding code on error
+     * @return Result 0 on success or the corresponding code on error
      */
-    ResultCode FormatArchive(ArchiveIdCode id_code, const FileSys::ArchiveFormatInfo& format_info,
-                             const FileSys::Path& path, u64 program_id);
+    Result FormatArchive(ArchiveIdCode id_code, const FileSys::ArchiveFormatInfo& format_info,
+                         const FileSys::Path& path, u64 program_id);
 
     /**
      * Retrieves the format info about the archive of the specified type and path.
@@ -217,36 +217,35 @@ public:
      * @param smdh_icon the SMDH icon for this ExtSaveData
      * @param format_info Format information about the new archive
      * @param program_id the program ID of the client that requests the operation
-     * @return ResultCode 0 on success or the corresponding code on error
+     * @return Result 0 on success or the corresponding code on error
      */
-    ResultCode CreateExtSaveData(MediaType media_type, u32 high, u32 low,
-                                 std::span<const u8> smdh_icon,
-                                 const FileSys::ArchiveFormatInfo& format_info, u64 program_id);
+    Result CreateExtSaveData(MediaType media_type, u32 high, u32 low, std::span<const u8> smdh_icon,
+                             const FileSys::ArchiveFormatInfo& format_info, u64 program_id);
 
     /**
      * Deletes the SharedExtSaveData archive for the specified extdata ID
      * @param media_type The media type of the archive to delete (NAND / SDMC)
      * @param high The high word of the extdata id to delete
      * @param low The low word of the extdata id to delete
-     * @return ResultCode 0 on success or the corresponding code on error
+     * @return Result 0 on success or the corresponding code on error
      */
-    ResultCode DeleteExtSaveData(MediaType media_type, u32 high, u32 low);
+    Result DeleteExtSaveData(MediaType media_type, u32 high, u32 low);
 
     /**
      * Deletes the SystemSaveData archive folder for the specified save data id
      * @param high The high word of the SystemSaveData archive to delete
      * @param low The low word of the SystemSaveData archive to delete
-     * @return ResultCode 0 on success or the corresponding code on error
+     * @return Result 0 on success or the corresponding code on error
      */
-    ResultCode DeleteSystemSaveData(u32 high, u32 low);
+    Result DeleteSystemSaveData(u32 high, u32 low);
 
     /**
      * Creates the SystemSaveData archive folder for the specified save data id
      * @param high The high word of the SystemSaveData archive to create
      * @param low The low word of the SystemSaveData archive to create
-     * @return ResultCode 0 on success or the corresponding code on error
+     * @return Result 0 on success or the corresponding code on error
      */
-    ResultCode CreateSystemSaveData(u32 high, u32 low);
+    Result CreateSystemSaveData(u32 high, u32 low);
 
     /**
      * Returns capacity and free space information about the given media type.
@@ -266,8 +265,8 @@ private:
      * @param factory File system backend interface to the archive
      * @param id_code Id code used to access this type of archive
      */
-    ResultCode RegisterArchiveType(std::unique_ptr<FileSys::ArchiveFactory>&& factory,
-                                   ArchiveIdCode id_code);
+    Result RegisterArchiveType(std::unique_ptr<FileSys::ArchiveFactory>&& factory,
+                               ArchiveIdCode id_code);
 
     /// Register all archive types
     void RegisterArchiveTypes();

--- a/src/core/hle/service/fs/directory.cpp
+++ b/src/core/hle/service/fs/directory.cpp
@@ -51,7 +51,7 @@ void Directory::Read(Kernel::HLERequestContext& ctx) {
     buffer.Write(entries.data(), 0, read * sizeof(FileSys::Entry));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(read);
     rb.PushMappedBuffer(buffer);
 }
@@ -62,7 +62,7 @@ void Directory::Close(Kernel::HLERequestContext& ctx) {
     backend->Close();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 } // namespace Service::FS

--- a/src/core/hle/service/fs/file.cpp
+++ b/src/core/hle/service/fs/file.cpp
@@ -86,7 +86,7 @@ void File::Read(Kernel::HLERequestContext& ctx) {
             rb.Push<u32>(0);
         } else {
             buffer.Write(*data, 0, *read);
-            rb.Push(RESULT_SUCCESS);
+            rb.Push(ResultSuccess);
             rb.Push<u32>(static_cast<u32>(*read));
         }
         rb.PushMappedBuffer(buffer);
@@ -130,7 +130,7 @@ void File::Read(Kernel::HLERequestContext& ctx) {
                 async_data->ret = read.Code();
                 async_data->read_size = 0;
             } else {
-                async_data->ret = RESULT_SUCCESS;
+                async_data->ret = ResultSuccess;
                 async_data->read_size = *read;
             }
 
@@ -157,7 +157,7 @@ void File::Read(Kernel::HLERequestContext& ctx) {
                 rb.Push<u32>(0);
             } else {
                 async_data->buffer->Write(*async_data->data, 0, async_data->read_size);
-                rb.Push(RESULT_SUCCESS);
+                rb.Push(ResultSuccess);
                 rb.Push<u32>(static_cast<u32>(async_data->read_size));
             }
             rb.PushMappedBuffer(*async_data->buffer);
@@ -180,7 +180,7 @@ void File::Write(Kernel::HLERequestContext& ctx) {
 
     // Subfiles can not be written to
     if (file->subfile) {
-        rb.Push(FileSys::ERROR_UNSUPPORTED_OPEN_FLAGS);
+        rb.Push(FileSys::ResultUnsupportedOpenFlags);
         rb.Push<u32>(0);
         rb.PushMappedBuffer(buffer);
         return;
@@ -197,7 +197,7 @@ void File::Write(Kernel::HLERequestContext& ctx) {
         rb.Push(written.Code());
         rb.Push<u32>(0);
     } else {
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.Push<u32>(static_cast<u32>(*written));
     }
     rb.PushMappedBuffer(buffer);
@@ -209,7 +209,7 @@ void File::GetSize(Kernel::HLERequestContext& ctx) {
     const FileSessionSlot* file = GetSessionData(ctx.Session());
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u64>(file->size);
 }
 
@@ -223,13 +223,13 @@ void File::SetSize(Kernel::HLERequestContext& ctx) {
 
     // SetSize can not be called on subfiles.
     if (file->subfile) {
-        rb.Push(FileSys::ERROR_UNSUPPORTED_OPEN_FLAGS);
+        rb.Push(FileSys::ResultUnsupportedOpenFlags);
         return;
     }
 
     file->size = size;
     backend->SetSize(size);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void File::Close(Kernel::HLERequestContext& ctx) {
@@ -242,7 +242,7 @@ void File::Close(Kernel::HLERequestContext& ctx) {
 
     backend->Close();
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void File::Flush(Kernel::HLERequestContext& ctx) {
@@ -254,12 +254,12 @@ void File::Flush(Kernel::HLERequestContext& ctx) {
 
     // Subfiles can not be flushed.
     if (file->subfile) {
-        rb.Push(FileSys::ERROR_UNSUPPORTED_OPEN_FLAGS);
+        rb.Push(FileSys::ResultUnsupportedOpenFlags);
         return;
     }
 
     backend->Flush();
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void File::SetPriority(Kernel::HLERequestContext& ctx) {
@@ -269,7 +269,7 @@ void File::SetPriority(Kernel::HLERequestContext& ctx) {
     file->priority = rp.Pop<u32>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void File::GetPriority(Kernel::HLERequestContext& ctx) {
@@ -277,7 +277,7 @@ void File::GetPriority(Kernel::HLERequestContext& ctx) {
     const FileSessionSlot* file = GetSessionData(ctx.Session());
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(file->priority);
 }
 
@@ -298,7 +298,7 @@ void File::OpenLinkFile(Kernel::HLERequestContext& ctx) {
     slot->size = backend->GetSize();
     slot->subfile = false;
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMoveObjects(client);
 }
 
@@ -313,21 +313,21 @@ void File::OpenSubFile(Kernel::HLERequestContext& ctx) {
 
     if (original_file->subfile) {
         // OpenSubFile can not be called on a file which is already as subfile
-        rb.Push(FileSys::ERROR_UNSUPPORTED_OPEN_FLAGS);
+        rb.Push(FileSys::ResultUnsupportedOpenFlags);
         return;
     }
 
     if (offset < 0 || size < 0) {
-        rb.Push(FileSys::ERR_WRITE_BEYOND_END);
+        rb.Push(FileSys::ResultWriteBeyondEnd);
         return;
     }
 
     std::size_t end = offset + size;
 
-    // TODO(Subv): Check for overflow and return ERR_WRITE_BEYOND_END
+    // TODO(Subv): Check for overflow and return ResultWriteBeyondEnd
 
     if (end > original_file->size) {
-        rb.Push(FileSys::ERR_WRITE_BEYOND_END);
+        rb.Push(FileSys::ResultWriteBeyondEnd);
         return;
     }
 
@@ -342,7 +342,7 @@ void File::OpenSubFile(Kernel::HLERequestContext& ctx) {
     slot->size = size;
     slot->subfile = true;
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMoveObjects(client);
 }
 

--- a/src/core/hle/service/fs/file.cpp
+++ b/src/core/hle/service/fs/file.cpp
@@ -104,7 +104,7 @@ void File::Read(Kernel::HLERequestContext& ctx) {
         bool cache_ready;
 
         // Output
-        ResultCode ret{0};
+        Result ret{0};
         Kernel::MappedBuffer* buffer;
         std::unique_ptr<u8*> data;
         size_t read_size;

--- a/src/core/hle/service/fs/fs_user.cpp
+++ b/src/core/hle/service/fs/fs_user.cpp
@@ -43,7 +43,7 @@ void FS_USER::Initialize(Kernel::HLERequestContext& ctx) {
     slot->program_id = system.Kernel().GetProcessById(pid)->codeset->program_id;
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void FS_USER::OpenFile(Kernel::HLERequestContext& ctx) {
@@ -349,7 +349,7 @@ void FS_USER::ControlArchive(Kernel::HLERequestContext& ctx) {
                 archive_handle, action, input_size, output_size);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void FS_USER::CloseArchive(Kernel::HLERequestContext& ctx) {
@@ -363,14 +363,14 @@ void FS_USER::CloseArchive(Kernel::HLERequestContext& ctx) {
 void FS_USER::IsSdmcDetected(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(Settings::values.use_virtual_sd.GetValue());
 }
 
 void FS_USER::IsSdmcWriteable(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     // If the SD isn't enabled, it can't be writeable...else, stubbed true
     rb.Push(Settings::values.use_virtual_sd.GetValue());
     LOG_DEBUG(Service_FS, " (STUBBED)");
@@ -398,7 +398,7 @@ void FS_USER::FormatSaveData(Kernel::HLERequestContext& ctx) {
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     if (archive_id != FS::ArchiveIdCode::SaveData) {
         LOG_ERROR(Service_FS, "tried to format an archive different than SaveData, {}", archive_id);
-        rb.Push(FileSys::ERROR_INVALID_PATH);
+        rb.Push(FileSys::ResultInvalidPath);
         return;
     }
 
@@ -471,7 +471,7 @@ void FS_USER::GetSdmcArchiveResource(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(5, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushRaw(*resource);
 }
 
@@ -488,7 +488,7 @@ void FS_USER::GetNandArchiveResource(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(5, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushRaw(*resource);
 }
 
@@ -544,7 +544,7 @@ void FS_USER::DeleteExtSaveData(Kernel::HLERequestContext& ctx) {
 void FS_USER::CardSlotIsInserted(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(false);
     LOG_WARNING(Service_FS, "(STUBBED) called");
 }
@@ -614,7 +614,7 @@ void FS_USER::InitializeWithSdkVersion(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service_FS, "(STUBBED) called, version: 0x{:08X}", version);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void FS_USER::SetPriority(Kernel::HLERequestContext& ctx) {
@@ -623,7 +623,7 @@ void FS_USER::SetPriority(Kernel::HLERequestContext& ctx) {
     priority = rp.Pop<u32>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_FS, "called priority=0x{:X}", priority);
 }
@@ -636,7 +636,7 @@ void FS_USER::GetPriority(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(priority);
 
     LOG_DEBUG(Service_FS, "called priority=0x{:X}", priority);
@@ -656,7 +656,7 @@ void FS_USER::GetArchiveResource(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(5, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushRaw(*resource);
 }
 
@@ -704,7 +704,7 @@ void FS_USER::GetProductInfo(Kernel::HLERequestContext& ctx) {
         return;
     }
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushRaw<ProductInfo>(product_info.value());
 }
 
@@ -737,7 +737,7 @@ void FS_USER::GetProgramLaunchInfo(Kernel::HLERequestContext& ctx) {
         program_info.media_type = MediaType::SDMC;
     }
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushRaw<ProgramInfo>(program_info);
 }
 
@@ -801,7 +801,7 @@ void FS_USER::GetSpecialContentIndex(Kernel::HLERequestContext& ctx) {
 
     if (index.Succeeded()) {
         IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.Push(index.Unwrap());
     } else {
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
@@ -812,7 +812,7 @@ void FS_USER::GetSpecialContentIndex(Kernel::HLERequestContext& ctx) {
 void FS_USER::GetNumSeeds(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u32>(FileSys::GetSeedCount());
 }
 
@@ -822,7 +822,7 @@ void FS_USER::AddSeed(Kernel::HLERequestContext& ctx) {
     FileSys::Seed::Data seed{rp.PopRaw<FileSys::Seed::Data>()};
     FileSys::AddSeed({title_id, seed, {}});
     IPC::RequestBuilder rb{rp.MakeBuilder(1, 0)};
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void FS_USER::ObsoletedSetSaveDataSecureValue(Kernel::HLERequestContext& ctx) {
@@ -841,7 +841,7 @@ void FS_USER::ObsoletedSetSaveDataSecureValue(Kernel::HLERequestContext& ctx) {
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void FS_USER::ObsoletedGetSaveDataSecureValue(Kernel::HLERequestContext& ctx) {
@@ -857,7 +857,7 @@ void FS_USER::ObsoletedGetSaveDataSecureValue(Kernel::HLERequestContext& ctx) {
 
     IPC::RequestBuilder rb = rp.MakeBuilder(4, 0);
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     // TODO: Implement Secure Value Lookup & Generation
 
@@ -877,7 +877,7 @@ void FS_USER::SetThisSaveDataSecureValue(Kernel::HLERequestContext& ctx) {
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void FS_USER::GetThisSaveDataSecureValue(Kernel::HLERequestContext& ctx) {
@@ -888,7 +888,7 @@ void FS_USER::GetThisSaveDataSecureValue(Kernel::HLERequestContext& ctx) {
 
     IPC::RequestBuilder rb = rp.MakeBuilder(5, 0);
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     // TODO: Implement Secure Value Lookup & Generation
 
@@ -913,7 +913,7 @@ void FS_USER::SetSaveDataSecureValue(Kernel::HLERequestContext& ctx) {
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void FS_USER::GetSaveDataSecureValue(Kernel::HLERequestContext& ctx) {
@@ -926,7 +926,7 @@ void FS_USER::GetSaveDataSecureValue(Kernel::HLERequestContext& ctx) {
 
     IPC::RequestBuilder rb = rp.MakeBuilder(5, 0);
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     // TODO: Implement Secure Value Lookup & Generation
 
@@ -966,7 +966,7 @@ ResultVal<u16> FS_USER::GetSpecialContentIndexFromGameCard(u64 title_id, Special
     if (type > SpecialContentType::DLPChild) {
         // Maybe type 4 is New 3DS update/partition 6 but this needs more research
         // TODO(B3N30): Find correct result code
-        return Result(-1);
+        return ResultUnknown;
     }
 
     switch (type) {
@@ -985,7 +985,7 @@ ResultVal<u16> FS_USER::GetSpecialContentIndexFromTMD(MediaType media_type, u64 
                                                       SpecialContentType type) {
     if (type > SpecialContentType::DLPChild) {
         // TODO(B3N30): Find correct result code
-        return Result(-1);
+        return ResultUnknown;
     }
 
     std::string tmd_path = AM::GetTitleMetadataPath(media_type, title_id);
@@ -993,7 +993,7 @@ ResultVal<u16> FS_USER::GetSpecialContentIndexFromTMD(MediaType media_type, u64 
     FileSys::TitleMetadata tmd;
     if (tmd.Load(tmd_path) != Loader::ResultStatus::Success || type == SpecialContentType::Update) {
         // TODO(B3N30): Find correct result code
-        return Result(-1);
+        return ResultUnknown;
     }
 
     // TODO(B3N30): Does real 3DS check if content exists in TMD?
@@ -1007,7 +1007,7 @@ ResultVal<u16> FS_USER::GetSpecialContentIndexFromTMD(MediaType media_type, u64 
         ASSERT(false);
     }
 
-    return Result(-1);
+    return ResultUnknown;
 }
 
 FS_USER::FS_USER(Core::System& system)

--- a/src/core/hle/service/fs/fs_user.cpp
+++ b/src/core/hle/service/fs/fs_user.cpp
@@ -699,8 +699,8 @@ void FS_USER::GetProductInfo(Kernel::HLERequestContext& ctx) {
 
     const auto product_info = GetProductInfo(process_id);
     if (!product_info.has_value()) {
-        rb.Push(ResultCode(FileSys::ErrCodes::ArchiveNotMounted, ErrorModule::FS,
-                           ErrorSummary::NotFound, ErrorLevel::Status));
+        rb.Push(Result(FileSys::ErrCodes::ArchiveNotMounted, ErrorModule::FS,
+                       ErrorSummary::NotFound, ErrorLevel::Status));
         return;
     }
 
@@ -966,7 +966,7 @@ ResultVal<u16> FS_USER::GetSpecialContentIndexFromGameCard(u64 title_id, Special
     if (type > SpecialContentType::DLPChild) {
         // Maybe type 4 is New 3DS update/partition 6 but this needs more research
         // TODO(B3N30): Find correct result code
-        return ResultCode(-1);
+        return Result(-1);
     }
 
     switch (type) {
@@ -985,7 +985,7 @@ ResultVal<u16> FS_USER::GetSpecialContentIndexFromTMD(MediaType media_type, u64 
                                                       SpecialContentType type) {
     if (type > SpecialContentType::DLPChild) {
         // TODO(B3N30): Find correct result code
-        return ResultCode(-1);
+        return Result(-1);
     }
 
     std::string tmd_path = AM::GetTitleMetadataPath(media_type, title_id);
@@ -993,7 +993,7 @@ ResultVal<u16> FS_USER::GetSpecialContentIndexFromTMD(MediaType media_type, u64 
     FileSys::TitleMetadata tmd;
     if (tmd.Load(tmd_path) != Loader::ResultStatus::Success || type == SpecialContentType::Update) {
         // TODO(B3N30): Find correct result code
-        return ResultCode(-1);
+        return Result(-1);
     }
 
     // TODO(B3N30): Does real 3DS check if content exists in TMD?
@@ -1007,7 +1007,7 @@ ResultVal<u16> FS_USER::GetSpecialContentIndexFromTMD(MediaType media_type, u64 
         ASSERT(false);
     }
 
-    return ResultCode(-1);
+    return Result(-1);
 }
 
 FS_USER::FS_USER(Core::System& system)

--- a/src/core/hle/service/fs/fs_user.h
+++ b/src/core/hle/service/fs/fs_user.h
@@ -72,8 +72,8 @@ public:
         if (info != program_info_map.end()) {
             return info->second;
         } else {
-            return ResultCode(FileSys::ErrCodes::ArchiveNotMounted, ErrorModule::FS,
-                              ErrorSummary::NotFound, ErrorLevel::Status);
+            return Result(FileSys::ErrCodes::ArchiveNotMounted, ErrorModule::FS,
+                          ErrorSummary::NotFound, ErrorLevel::Status);
         }
     }
 

--- a/src/core/hle/service/gsp/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp/gsp_gpu.cpp
@@ -37,15 +37,15 @@ enum {
 };
 }
 
-constexpr Result RESULT_FIRST_INITIALIZATION(ErrCodes::FirstInitialization, ErrorModule::GX,
-                                             ErrorSummary::Success, ErrorLevel::Success);
-constexpr Result ERR_REGS_OUTOFRANGE_OR_MISALIGNED(ErrCodes::OutofRangeOrMisalignedAddress,
-                                                   ErrorModule::GX, ErrorSummary::InvalidArgument,
-                                                   ErrorLevel::Usage); // 0xE0E02A01
-constexpr Result ERR_REGS_MISALIGNED(ErrorDescription::MisalignedSize, ErrorModule::GX,
-                                     ErrorSummary::InvalidArgument,
-                                     ErrorLevel::Usage); // 0xE0E02BF2
-constexpr Result ERR_REGS_INVALID_SIZE(ErrorDescription::InvalidSize, ErrorModule::GX,
+constexpr Result ResultFirstInitialization(ErrCodes::FirstInitialization, ErrorModule::GX,
+                                           ErrorSummary::Success, ErrorLevel::Success);
+constexpr Result ResultRegsOutOfRangeOrMisaligned(ErrCodes::OutofRangeOrMisalignedAddress,
+                                                  ErrorModule::GX, ErrorSummary::InvalidArgument,
+                                                  ErrorLevel::Usage); // 0xE0E02A01
+constexpr Result ResultRegsMisaligned(ErrorDescription::MisalignedSize, ErrorModule::GX,
+                                      ErrorSummary::InvalidArgument,
+                                      ErrorLevel::Usage); // 0xE0E02BF2
+constexpr Result ResultRegsInvalidSize(ErrorDescription::InvalidSize, ErrorModule::GX,
                                        ErrorSummary::InvalidArgument,
                                        ErrorLevel::Usage); // 0xE0E02BEC
 
@@ -93,7 +93,7 @@ void GSP_GPU::ClientDisconnected(std::shared_ptr<Kernel::ServerSession> server_s
  * @param base_address The address of the first register in the sequence
  * @param size_in_bytes The number of registers to update (size of data)
  * @param data A vector containing the source data
- * @return RESULT_SUCCESS if the parameters are valid, error code otherwise
+ * @return ResultSuccess if the parameters are valid, error code otherwise
  */
 static Result WriteHWRegs(u32 base_address, u32 size_in_bytes, std::span<const u8> data,
                               VideoCore::GPU& gpu) {
@@ -104,17 +104,17 @@ static Result WriteHWRegs(u32 base_address, u32 size_in_bytes, std::span<const u
         LOG_ERROR(Service_GSP,
                   "Write address was out of range or misaligned! (address=0x{:08x}, size=0x{:08x})",
                   base_address, size_in_bytes);
-        return ERR_REGS_OUTOFRANGE_OR_MISALIGNED;
+        return ResultRegsOutOfRangeOrMisaligned;
     }
 
     if (size_in_bytes > max_size_in_bytes) {
         LOG_ERROR(Service_GSP, "Out of range size 0x{:08x}", size_in_bytes);
-        return ERR_REGS_INVALID_SIZE;
+        return ResultRegsInvalidSize;
     }
 
     if (size_in_bytes & 3) {
         LOG_ERROR(Service_GSP, "Misaligned size 0x{:08x}", size_in_bytes);
-        return ERR_REGS_MISALIGNED;
+        return ResultRegsMisaligned;
     }
 
     std::size_t offset = 0;
@@ -128,7 +128,7 @@ static Result WriteHWRegs(u32 base_address, u32 size_in_bytes, std::span<const u
         base_address += 4;
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 /**
@@ -139,7 +139,7 @@ static Result WriteHWRegs(u32 base_address, u32 size_in_bytes, std::span<const u
  * @param size_in_bytes The number of registers to update (size of data)
  * @param data    A vector containing the data to write
  * @param masks   A vector containing the masks
- * @return RESULT_SUCCESS if the parameters are valid, error code otherwise
+ * @return ResultSuccess if the parameters are valid, error code otherwise
  */
 static Result WriteHWRegsWithMask(u32 base_address, u32 size_in_bytes, std::span<const u8> data,
                                       std::span<const u8> masks, VideoCore::GPU& gpu) {
@@ -150,17 +150,17 @@ static Result WriteHWRegsWithMask(u32 base_address, u32 size_in_bytes, std::span
         LOG_ERROR(Service_GSP,
                   "Write address was out of range or misaligned! (address=0x{:08x}, size=0x{:08x})",
                   base_address, size_in_bytes);
-        return ERR_REGS_OUTOFRANGE_OR_MISALIGNED;
+        return ResultRegsOutOfRangeOrMisaligned;
     }
 
     if (size_in_bytes > max_size_in_bytes) {
         LOG_ERROR(Service_GSP, "Out of range size 0x{:08x}", size_in_bytes);
-        return ERR_REGS_INVALID_SIZE;
+        return ResultRegsInvalidSize;
     }
 
     if (size_in_bytes & 3) {
         LOG_ERROR(Service_GSP, "Misaligned size 0x{:08x}", size_in_bytes);
-        return ERR_REGS_MISALIGNED;
+        return ResultRegsMisaligned;
     }
 
     std::size_t offset = 0;
@@ -181,7 +181,7 @@ static Result WriteHWRegsWithMask(u32 base_address, u32 size_in_bytes, std::span
         base_address += 4;
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 void GSP_GPU::WriteHWRegs(Kernel::HLERequestContext& ctx) {
@@ -215,7 +215,7 @@ void GSP_GPU::ReadHWRegs(Kernel::HLERequestContext& ctx) {
 
     if ((reg_addr % 4) != 0 || reg_addr >= 0x420000) {
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-        rb.Push(ERR_REGS_OUTOFRANGE_OR_MISALIGNED);
+        rb.Push(ResultRegsOutOfRangeOrMisaligned);
         LOG_ERROR(Service_GSP, "Invalid address 0x{:08x}", reg_addr);
         return;
     }
@@ -223,7 +223,7 @@ void GSP_GPU::ReadHWRegs(Kernel::HLERequestContext& ctx) {
     // Size should be word-aligned
     if ((size % 4) != 0) {
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-        rb.Push(ERR_REGS_MISALIGNED);
+        rb.Push(ResultRegsMisaligned);
         LOG_ERROR(Service_GSP, "Invalid size 0x{:08x}", size);
         return;
     }
@@ -235,7 +235,7 @@ void GSP_GPU::ReadHWRegs(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushStaticBuffer(std::move(buffer), 0);
 }
 
@@ -247,7 +247,7 @@ void GSP_GPU::SetBufferSwap(Kernel::HLERequestContext& ctx) {
     system.GPU().SetBufferSwap(screen_id, fb_info);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void GSP_GPU::FlushDataCache(Kernel::HLERequestContext& ctx) {
@@ -259,7 +259,7 @@ void GSP_GPU::FlushDataCache(Kernel::HLERequestContext& ctx) {
     // TODO(purpasmart96): Verify return header on HW
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_TRACE(Service_GSP, "(STUBBED) called address=0x{:08X}, size=0x{:08X}, process={}", address,
               size, process->process_id);
@@ -274,7 +274,7 @@ void GSP_GPU::InvalidateDataCache(Kernel::HLERequestContext& ctx) {
     // TODO(purpasmart96): Verify return header on HW
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_TRACE(Service_GSP, "(STUBBED) called address=0x{:08X}, size=0x{:08X}, process={}", address,
               size, process->process_id);
@@ -285,7 +285,7 @@ void GSP_GPU::SetAxiConfigQoSMode(Kernel::HLERequestContext& ctx) {
     u32 mode = rp.Pop<u32>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_GSP, "(STUBBED) called mode=0x{:08X}", mode);
 }
@@ -308,9 +308,9 @@ void GSP_GPU::RegisterInterruptRelayQueue(Kernel::HLERequestContext& ctx) {
     if (first_initialization) {
         // This specific code is required for a successful initialization, rather than 0
         first_initialization = false;
-        rb.Push(RESULT_FIRST_INITIALIZATION);
+        rb.Push(ResultFirstInitialization);
     } else {
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
     }
 
     rb.Push(session_data->thread_id);
@@ -327,7 +327,7 @@ void GSP_GPU::UnregisterInterruptRelayQueue(Kernel::HLERequestContext& ctx) {
     session_data->registered = false;
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_GSP, "called");
 }
@@ -402,7 +402,7 @@ void GSP_GPU::SetLcdForceBlack(Kernel::HLERequestContext& ctx) {
     system.GPU().SetColorFill(data);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void GSP_GPU::TriggerCmdReqQueue(Kernel::HLERequestContext& ctx) {
@@ -422,7 +422,7 @@ void GSP_GPU::TriggerCmdReqQueue(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void GSP_GPU::ImportDisplayCaptureInfo(Kernel::HLERequestContext& ctx) {
@@ -461,7 +461,7 @@ void GSP_GPU::ImportDisplayCaptureInfo(Kernel::HLERequestContext& ctx) {
     bottom_entry.stride = bottom_screen->framebuffer_info[bottom_screen->index].stride;
 
     IPC::RequestBuilder rb = rp.MakeBuilder(9, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushRaw(top_entry);
     rb.PushRaw(bottom_entry);
 
@@ -536,7 +536,7 @@ void GSP_GPU::SaveVramSysArea(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void GSP_GPU::RestoreVramSysArea(Kernel::HLERequestContext& ctx) {
@@ -553,10 +553,10 @@ void GSP_GPU::RestoreVramSysArea(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
-ResultCode GSP_GPU::AcquireGpuRight(const Kernel::HLERequestContext& ctx,
+Result GSP_GPU::AcquireGpuRight(const Kernel::HLERequestContext& ctx,
                                     const std::shared_ptr<Kernel::Process>& process, u32 flag,
                                     bool blocking) {
     const auto session_data = GetSessionData(ctx.Session());
@@ -579,7 +579,7 @@ ResultCode GSP_GPU::AcquireGpuRight(const Kernel::HLERequestContext& ctx,
     }
 
     active_thread_id = session_data->thread_id;
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 void GSP_GPU::TryAcquireRight(Kernel::HLERequestContext& ctx) {
@@ -616,7 +616,7 @@ void GSP_GPU::ReleaseRight(Kernel::HLERequestContext& ctx) {
     ReleaseRight(session_data);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_GSP, "called");
 }
@@ -629,7 +629,7 @@ void GSP_GPU::StoreDataCache(Kernel::HLERequestContext& ctx) {
     auto process = rp.PopObject<Kernel::Process>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_TRACE(Service_GSP, "(STUBBED) called address=0x{:08X}, size=0x{:08X}, process={}", address,
               size, process->process_id);
@@ -643,7 +643,7 @@ void GSP_GPU::SetLedForceOff(Kernel::HLERequestContext& ctx) {
     system.Kernel().GetSharedPageHandler().Set3DLed(state);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     LOG_DEBUG(Service_GSP, "(STUBBED) called");
 }
 

--- a/src/core/hle/service/gsp/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp/gsp_gpu.cpp
@@ -37,18 +37,17 @@ enum {
 };
 }
 
-constexpr ResultCode RESULT_FIRST_INITIALIZATION(ErrCodes::FirstInitialization, ErrorModule::GX,
-                                                 ErrorSummary::Success, ErrorLevel::Success);
-constexpr ResultCode ERR_REGS_OUTOFRANGE_OR_MISALIGNED(ErrCodes::OutofRangeOrMisalignedAddress,
-                                                       ErrorModule::GX,
-                                                       ErrorSummary::InvalidArgument,
-                                                       ErrorLevel::Usage); // 0xE0E02A01
-constexpr ResultCode ERR_REGS_MISALIGNED(ErrorDescription::MisalignedSize, ErrorModule::GX,
-                                         ErrorSummary::InvalidArgument,
-                                         ErrorLevel::Usage); // 0xE0E02BF2
-constexpr ResultCode ERR_REGS_INVALID_SIZE(ErrorDescription::InvalidSize, ErrorModule::GX,
-                                           ErrorSummary::InvalidArgument,
-                                           ErrorLevel::Usage); // 0xE0E02BEC
+constexpr Result RESULT_FIRST_INITIALIZATION(ErrCodes::FirstInitialization, ErrorModule::GX,
+                                             ErrorSummary::Success, ErrorLevel::Success);
+constexpr Result ERR_REGS_OUTOFRANGE_OR_MISALIGNED(ErrCodes::OutofRangeOrMisalignedAddress,
+                                                   ErrorModule::GX, ErrorSummary::InvalidArgument,
+                                                   ErrorLevel::Usage); // 0xE0E02A01
+constexpr Result ERR_REGS_MISALIGNED(ErrorDescription::MisalignedSize, ErrorModule::GX,
+                                     ErrorSummary::InvalidArgument,
+                                     ErrorLevel::Usage); // 0xE0E02BF2
+constexpr Result ERR_REGS_INVALID_SIZE(ErrorDescription::InvalidSize, ErrorModule::GX,
+                                       ErrorSummary::InvalidArgument,
+                                       ErrorLevel::Usage); // 0xE0E02BEC
 
 u32 GSP_GPU::GetUnusedThreadId() const {
     for (u32 id = 0; id < MaxGSPThreads; ++id) {
@@ -96,7 +95,7 @@ void GSP_GPU::ClientDisconnected(std::shared_ptr<Kernel::ServerSession> server_s
  * @param data A vector containing the source data
  * @return RESULT_SUCCESS if the parameters are valid, error code otherwise
  */
-static ResultCode WriteHWRegs(u32 base_address, u32 size_in_bytes, std::span<const u8> data,
+static Result WriteHWRegs(u32 base_address, u32 size_in_bytes, std::span<const u8> data,
                               VideoCore::GPU& gpu) {
     // This magic number is verified to be done by the gsp module
     const u32 max_size_in_bytes = 0x80;
@@ -142,7 +141,7 @@ static ResultCode WriteHWRegs(u32 base_address, u32 size_in_bytes, std::span<con
  * @param masks   A vector containing the masks
  * @return RESULT_SUCCESS if the parameters are valid, error code otherwise
  */
-static ResultCode WriteHWRegsWithMask(u32 base_address, u32 size_in_bytes, std::span<const u8> data,
+static Result WriteHWRegsWithMask(u32 base_address, u32 size_in_bytes, std::span<const u8> data,
                                       std::span<const u8> masks, VideoCore::GPU& gpu) {
     // This magic number is verified to be done by the gsp module
     const u32 max_size_in_bytes = 0x80;

--- a/src/core/hle/service/gsp/gsp_gpu.cpp
+++ b/src/core/hle/service/gsp/gsp_gpu.cpp
@@ -96,7 +96,7 @@ void GSP_GPU::ClientDisconnected(std::shared_ptr<Kernel::ServerSession> server_s
  * @return ResultSuccess if the parameters are valid, error code otherwise
  */
 static Result WriteHWRegs(u32 base_address, u32 size_in_bytes, std::span<const u8> data,
-                              VideoCore::GPU& gpu) {
+                          VideoCore::GPU& gpu) {
     // This magic number is verified to be done by the gsp module
     const u32 max_size_in_bytes = 0x80;
 
@@ -142,7 +142,7 @@ static Result WriteHWRegs(u32 base_address, u32 size_in_bytes, std::span<const u
  * @return ResultSuccess if the parameters are valid, error code otherwise
  */
 static Result WriteHWRegsWithMask(u32 base_address, u32 size_in_bytes, std::span<const u8> data,
-                                      std::span<const u8> masks, VideoCore::GPU& gpu) {
+                                  std::span<const u8> masks, VideoCore::GPU& gpu) {
     // This magic number is verified to be done by the gsp module
     const u32 max_size_in_bytes = 0x80;
 
@@ -557,8 +557,8 @@ void GSP_GPU::RestoreVramSysArea(Kernel::HLERequestContext& ctx) {
 }
 
 Result GSP_GPU::AcquireGpuRight(const Kernel::HLERequestContext& ctx,
-                                    const std::shared_ptr<Kernel::Process>& process, u32 flag,
-                                    bool blocking) {
+                                const std::shared_ptr<Kernel::Process>& process, u32 flag,
+                                bool blocking) {
     const auto session_data = GetSessionData(ctx.Session());
 
     LOG_DEBUG(Service_GSP, "called flag={:08X} process={} thread_id={}", flag, process->process_id,
@@ -653,7 +653,7 @@ void GSP_GPU::SetInternalPriorities(Kernel::HLERequestContext& ctx) {
     const auto priority_with_rights = rp.Pop<u32>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_GSP, "(STUBBED) called priority={:#02X}, priority_with_rights={:#02X}",
               priority, priority_with_rights);

--- a/src/core/hle/service/gsp/gsp_gpu.h
+++ b/src/core/hle/service/gsp/gsp_gpu.h
@@ -366,9 +366,9 @@ private:
 
     std::unique_ptr<Kernel::SessionRequestHandler::SessionDataBase> MakeSessionData() override;
 
-    ResultCode AcquireGpuRight(const Kernel::HLERequestContext& ctx,
-                               const std::shared_ptr<Kernel::Process>& process, u32 flag,
-                               bool blocking);
+    Result AcquireGpuRight(const Kernel::HLERequestContext& ctx,
+                           const std::shared_ptr<Kernel::Process>& process, u32 flag,
+                           bool blocking);
 
     Core::System& system;
 

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -308,7 +308,7 @@ void Module::UpdateGyroscopeCallback(std::uintptr_t user_data, s64 cycles_late) 
 void Module::Interface::GetIPCHandles(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 7);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushCopyObjects(hid->shared_mem, hid->event_pad_or_touch_1, hid->event_pad_or_touch_2,
                        hid->event_accelerometer, hid->event_gyroscope, hid->event_debug_pad);
 }
@@ -325,7 +325,7 @@ void Module::Interface::EnableAccelerometer(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_HID, "called");
 }
@@ -341,7 +341,7 @@ void Module::Interface::DisableAccelerometer(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_HID, "called");
 }
@@ -357,7 +357,7 @@ void Module::Interface::EnableGyroscopeLow(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_HID, "called");
 }
@@ -373,7 +373,7 @@ void Module::Interface::DisableGyroscopeLow(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_HID, "called");
 }
@@ -382,7 +382,7 @@ void Module::Interface::GetGyroscopeLowRawToDpsCoefficient(Kernel::HLERequestCon
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(gyroscope_coef);
 }
 
@@ -390,7 +390,7 @@ void Module::Interface::GetGyroscopeLowCalibrateParam(Kernel::HLERequestContext&
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(6, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     const s16 param_unit = 6700; // an approximate value taken from hw
     GyroscopeCalibrateParam param = {
@@ -409,7 +409,7 @@ void Module::Interface::GetSoundVolume(Kernel::HLERequestContext& ctx) {
     const u8 volume = static_cast<u8>(0x3F * Settings::values.volume.GetValue());
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(volume);
 }
 

--- a/src/core/hle/service/http/http_c.cpp
+++ b/src/core/hle/service/http/http_c.cpp
@@ -334,7 +334,7 @@ void HTTP_C::Initialize(Kernel::HLERequestContext& ctx) {
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     // This returns 0xd8a0a046 if no network connection is available.
     // Just assume we are always connected.
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void HTTP_C::InitializeConnectionSession(Kernel::HLERequestContext& ctx) {
@@ -369,7 +369,7 @@ void HTTP_C::InitializeConnectionSession(Kernel::HLERequestContext& ctx) {
     session_data->current_http_context = context_handle;
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void HTTP_C::BeginRequest(Kernel::HLERequestContext& ctx) {
@@ -404,7 +404,7 @@ void HTTP_C::BeginRequest(Kernel::HLERequestContext& ctx) {
     http_context.current_copied_data = 0;
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void HTTP_C::BeginRequestAsync(Kernel::HLERequestContext& ctx) {
@@ -439,7 +439,7 @@ void HTTP_C::BeginRequestAsync(Kernel::HLERequestContext& ctx) {
     http_context.current_copied_data = 0;
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void HTTP_C::ReceiveData(Kernel::HLERequestContext& ctx) {
@@ -462,7 +462,7 @@ void HTTP_C::ReceiveDataImpl(Kernel::HLERequestContext& ctx, bool timeout) {
         Kernel::MappedBuffer* buffer;
         bool is_complete;
         // Output
-        Result async_res = RESULT_SUCCESS;
+        Result async_res = ResultSuccess;
     };
     std::shared_ptr<AsyncData> async_data = std::make_shared<AsyncData>();
     async_data->timeout = timeout;
@@ -502,7 +502,7 @@ void HTTP_C::ReceiveDataImpl(Kernel::HLERequestContext& ctx, bool timeout) {
         [this, async_data](Kernel::HLERequestContext& ctx) {
             IPC::RequestBuilder rb(ctx, static_cast<u16>(ctx.CommandHeader().command_id.Value()), 1,
                                    0);
-            if (async_data->async_res != RESULT_SUCCESS) {
+            if (async_data->async_res != ResultSuccess) {
                 rb.Push(async_data->async_res);
                 return;
             }
@@ -516,7 +516,7 @@ void HTTP_C::ReceiveDataImpl(Kernel::HLERequestContext& ctx, bool timeout) {
                                               http_context.current_copied_data,
                                           0, remaining_data);
                 http_context.current_copied_data += remaining_data;
-                rb.Push(RESULT_SUCCESS);
+                rb.Push(ResultSuccess);
             } else {
                 async_data->buffer->Write(http_context.response.body.data() +
                                               http_context.current_copied_data,
@@ -537,7 +537,7 @@ void HTTP_C::SetProxyDefault(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service_HTTP, "(STUBBED) called, handle={}", context_handle);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void HTTP_C::CreateContext(Kernel::HLERequestContext& ctx) {
@@ -602,7 +602,7 @@ void HTTP_C::CreateContext(Kernel::HLERequestContext& ctx) {
     session_data->num_http_contexts++;
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u32>(context_counter);
     rb.PushMappedBuffer(buffer);
 }
@@ -626,7 +626,7 @@ void HTTP_C::CloseContext(Kernel::HLERequestContext& ctx) {
     if (itr == contexts.end()) {
         // The real HTTP module just silently fails in this case.
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         LOG_ERROR(Service_HTTP, "called, context {} not found", context_handle);
         return;
     }
@@ -639,7 +639,7 @@ void HTTP_C::CloseContext(Kernel::HLERequestContext& ctx) {
     session_data->num_http_contexts--;
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void HTTP_C::CancelConnection(Kernel::HLERequestContext& ctx) {
@@ -656,7 +656,7 @@ void HTTP_C::CancelConnection(Kernel::HLERequestContext& ctx) {
     [[maybe_unused]] Context& http_context = GetContext(context_handle);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void HTTP_C::AddRequestHeader(Kernel::HLERequestContext& ctx) {
@@ -696,7 +696,7 @@ void HTTP_C::AddRequestHeader(Kernel::HLERequestContext& ctx) {
     http_context.headers.emplace_back(name, value);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(value_buffer);
 }
 
@@ -737,7 +737,7 @@ void HTTP_C::AddPostDataAscii(Kernel::HLERequestContext& ctx) {
     http_context.post_data.emplace(name, value);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(value_buffer);
 }
 
@@ -770,7 +770,7 @@ void HTTP_C::AddPostDataRaw(Kernel::HLERequestContext& ctx) {
     buffer.Read(http_context.post_data_raw.data(), 0, buffer.GetSize());
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(buffer);
 }
 
@@ -836,7 +836,7 @@ void HTTP_C::GetResponseHeader(Kernel::HLERequestContext& ctx) {
 
             IPC::RequestBuilder rb(ctx, static_cast<u16>(ctx.CommandHeader().command_id.Value()), 2,
                                    2);
-            rb.Push(RESULT_SUCCESS);
+            rb.Push(ResultSuccess);
             rb.Push(copied_size);
             rb.PushMappedBuffer(*async_data->value_buffer);
         });
@@ -859,7 +859,7 @@ void HTTP_C::GetResponseStatusCodeImpl(Kernel::HLERequestContext& ctx, bool time
         bool timeout;
         u64 timeout_nanos = 0;
         // Output
-        Result async_res = RESULT_SUCCESS;
+        Result async_res = ResultSuccess;
     };
     std::shared_ptr<AsyncData> async_data = std::make_shared<AsyncData>();
 
@@ -896,7 +896,7 @@ void HTTP_C::GetResponseStatusCodeImpl(Kernel::HLERequestContext& ctx, bool time
             return 0;
         },
         [this, async_data](Kernel::HLERequestContext& ctx) {
-            if (async_data->async_res != RESULT_SUCCESS) {
+            if (async_data->async_res != ResultSuccess) {
                 IPC::RequestBuilder rb(
                     ctx, static_cast<u16>(ctx.CommandHeader().command_id.Value()), 1, 0);
                 rb.Push(async_data->async_res);
@@ -910,7 +910,7 @@ void HTTP_C::GetResponseStatusCodeImpl(Kernel::HLERequestContext& ctx, bool time
 
             IPC::RequestBuilder rb(ctx, static_cast<u16>(ctx.CommandHeader().command_id.Value()), 2,
                                    0);
-            rb.Push(RESULT_SUCCESS);
+            rb.Push(ResultSuccess);
             rb.Push(response_code);
         });
 }
@@ -924,7 +924,7 @@ void HTTP_C::AddTrustedRootCA(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service_HTTP, "(STUBBED) called, handle={}", context_handle);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(root_ca_data);
 }
 
@@ -937,7 +937,7 @@ void HTTP_C::AddDefaultCert(Kernel::HLERequestContext& ctx) {
                 certificate_id);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void HTTP_C::SetDefaultClientCert(Kernel::HLERequestContext& ctx) {
@@ -963,7 +963,7 @@ void HTTP_C::SetDefaultClientCert(Kernel::HLERequestContext& ctx) {
     http_context.clcert_data = &GetClCertA();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void HTTP_C::SetClientCertContext(Kernel::HLERequestContext& ctx) {
@@ -1007,7 +1007,7 @@ void HTTP_C::SetClientCertContext(Kernel::HLERequestContext& ctx) {
 
     http_context.ssl_config.client_cert_ctx = cert_context_itr->second;
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void HTTP_C::GetSSLError(Kernel::HLERequestContext& ctx) {
@@ -1020,7 +1020,7 @@ void HTTP_C::GetSSLError(Kernel::HLERequestContext& ctx) {
     [[maybe_unused]] Context& http_context = GetContext(context_handle);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     // Since we create the actual http/ssl context only when the request is submitted we can't check
     // for SSL Errors here. Just submit no error.
     rb.Push<u32>(0);
@@ -1034,7 +1034,7 @@ void HTTP_C::SetSSLOpt(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service_HTTP, "(STUBBED) called, context_handle={}, opts={}", context_handle, opts);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void HTTP_C::OpenClientCertContext(Kernel::HLERequestContext& ctx) {
@@ -1049,7 +1049,7 @@ void HTTP_C::OpenClientCertContext(Kernel::HLERequestContext& ctx) {
     auto* session_data = GetSessionData(ctx.Session());
     ASSERT(session_data);
 
-    Result result(RESULT_SUCCESS);
+    Result result(ResultSuccess);
 
     if (!session_data->initialized) {
         LOG_ERROR(Service_HTTP, "Command called without Initialize");
@@ -1126,7 +1126,7 @@ void HTTP_C::OpenDefaultClientCertContext(Kernel::HLERequestContext& ctx) {
 
     if (it != client_certs.end()) {
         IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.Push<u32>(it->first);
 
         LOG_DEBUG(Service_HTTP, "called, with an already loaded cert_id={}", cert_id);
@@ -1141,7 +1141,7 @@ void HTTP_C::OpenDefaultClientCertContext(Kernel::HLERequestContext& ctx) {
     ++session_data->num_client_certs;
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u32>(client_certs_counter);
 }
 
@@ -1158,7 +1158,7 @@ void HTTP_C::CloseClientCertContext(Kernel::HLERequestContext& ctx) {
         LOG_ERROR(Service_HTTP, "Command called with a unkown client cert handle {}", cert_handle);
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
         // This just return success without doing anything
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         return;
     }
 
@@ -1166,7 +1166,7 @@ void HTTP_C::CloseClientCertContext(Kernel::HLERequestContext& ctx) {
         LOG_ERROR(Service_HTTP, "called from another main session");
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
         // This just return success without doing anything
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         return;
     }
 
@@ -1174,7 +1174,7 @@ void HTTP_C::CloseClientCertContext(Kernel::HLERequestContext& ctx) {
     session_data->num_client_certs--;
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void HTTP_C::SetKeepAlive(Kernel::HLERequestContext& ctx) {
@@ -1185,7 +1185,7 @@ void HTTP_C::SetKeepAlive(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service_HTTP, "(STUBBED) called, handle={}, option={}", context_handle, option);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void HTTP_C::Finalize(Kernel::HLERequestContext& ctx) {
@@ -1194,7 +1194,7 @@ void HTTP_C::Finalize(Kernel::HLERequestContext& ctx) {
     shared_memory = nullptr;
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_HTTP, "(STUBBED) called");
 }
@@ -1230,7 +1230,7 @@ void HTTP_C::GetDownloadSizeState(Kernel::HLERequestContext& ctx) {
               content_length);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(static_cast<u32>(http_context.current_copied_data));
     rb.Push(content_length);
 }

--- a/src/core/hle/service/http/http_c.cpp
+++ b/src/core/hle/service/http/http_c.cpp
@@ -45,25 +45,25 @@ enum {
 };
 }
 
-const ResultCode ERROR_STATE_ERROR = // 0xD8A0A066
-    ResultCode(ErrCodes::SessionStateError, ErrorModule::HTTP, ErrorSummary::InvalidState,
-               ErrorLevel::Permanent);
-const ResultCode ERROR_NOT_IMPLEMENTED = // 0xD960A3F4
-    ResultCode(ErrCodes::NotImplemented, ErrorModule::HTTP, ErrorSummary::Internal,
-               ErrorLevel::Permanent);
-const ResultCode ERROR_TOO_MANY_CLIENT_CERTS = // 0xD8A0A0CB
-    ResultCode(ErrCodes::TooManyClientCerts, ErrorModule::HTTP, ErrorSummary::InvalidState,
-               ErrorLevel::Permanent);
-const ResultCode ERROR_HEADER_NOT_FOUND = ResultCode(
-    ErrCodes::HeaderNotFound, ErrorModule::HTTP, ErrorSummary::InvalidState, ErrorLevel::Permanent);
-const ResultCode ERROR_BUFFER_SMALL = ResultCode(ErrCodes::BufferTooSmall, ErrorModule::HTTP,
-                                                 ErrorSummary::WouldBlock, ErrorLevel::Permanent);
-const ResultCode ERROR_WRONG_CERT_ID = // 0xD8E0B839
-    ResultCode(57, ErrorModule::SSL, ErrorSummary::InvalidArgument, ErrorLevel::Permanent);
-const ResultCode ERROR_WRONG_CERT_HANDLE = // 0xD8A0A0C9
-    ResultCode(201, ErrorModule::HTTP, ErrorSummary::InvalidState, ErrorLevel::Permanent);
-const ResultCode ERROR_CERT_ALREADY_SET = // 0xD8A0A03D
-    ResultCode(61, ErrorModule::HTTP, ErrorSummary::InvalidState, ErrorLevel::Permanent);
+const Result ERROR_STATE_ERROR = // 0xD8A0A066
+    Result(ErrCodes::SessionStateError, ErrorModule::HTTP, ErrorSummary::InvalidState,
+           ErrorLevel::Permanent);
+const Result ERROR_NOT_IMPLEMENTED = // 0xD960A3F4
+    Result(ErrCodes::NotImplemented, ErrorModule::HTTP, ErrorSummary::Internal,
+           ErrorLevel::Permanent);
+const Result ERROR_TOO_MANY_CLIENT_CERTS = // 0xD8A0A0CB
+    Result(ErrCodes::TooManyClientCerts, ErrorModule::HTTP, ErrorSummary::InvalidState,
+           ErrorLevel::Permanent);
+const Result ERROR_HEADER_NOT_FOUND = Result(ErrCodes::HeaderNotFound, ErrorModule::HTTP,
+                                             ErrorSummary::InvalidState, ErrorLevel::Permanent);
+const Result ERROR_BUFFER_SMALL = Result(ErrCodes::BufferTooSmall, ErrorModule::HTTP,
+                                         ErrorSummary::WouldBlock, ErrorLevel::Permanent);
+const Result ERROR_WRONG_CERT_ID = // 0xD8E0B839
+    Result(57, ErrorModule::SSL, ErrorSummary::InvalidArgument, ErrorLevel::Permanent);
+const Result ERROR_WRONG_CERT_HANDLE = // 0xD8A0A0C9
+    Result(201, ErrorModule::HTTP, ErrorSummary::InvalidState, ErrorLevel::Permanent);
+const Result ERROR_CERT_ALREADY_SET = // 0xD8A0A03D
+    Result(61, ErrorModule::HTTP, ErrorSummary::InvalidState, ErrorLevel::Permanent);
 
 // Splits URL into its components. Example: https://citra-emu.org:443/index.html
 // is_https: true; host: citra-emu.org; port: 443; path: /index.html
@@ -358,8 +358,8 @@ void HTTP_C::InitializeConnectionSession(Kernel::HLERequestContext& ctx) {
     auto itr = contexts.find(context_handle);
     if (itr == contexts.end()) {
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-        rb.Push(ResultCode(ErrCodes::ContextNotFound, ErrorModule::HTTP, ErrorSummary::InvalidState,
-                           ErrorLevel::Permanent));
+        rb.Push(Result(ErrCodes::ContextNotFound, ErrorModule::HTTP, ErrorSummary::InvalidState,
+                       ErrorLevel::Permanent));
         return;
     }
 
@@ -462,7 +462,7 @@ void HTTP_C::ReceiveDataImpl(Kernel::HLERequestContext& ctx, bool timeout) {
         Kernel::MappedBuffer* buffer;
         bool is_complete;
         // Output
-        ResultCode async_res = RESULT_SUCCESS;
+        Result async_res = RESULT_SUCCESS;
     };
     std::shared_ptr<AsyncData> async_data = std::make_shared<AsyncData>();
     async_data->timeout = timeout;
@@ -490,8 +490,8 @@ void HTTP_C::ReceiveDataImpl(Kernel::HLERequestContext& ctx, bool timeout) {
                     std::chrono::nanoseconds(async_data->timeout_nanos));
                 if (wait_res == std::future_status::timeout) {
                     async_data->async_res =
-                        ResultCode(105, ErrorModule::HTTP, ErrorSummary::NothingHappened,
-                                   ErrorLevel::Permanent);
+                        Result(105, ErrorModule::HTTP, ErrorSummary::NothingHappened,
+                               ErrorLevel::Permanent);
                 }
             } else {
                 http_context.request_future.wait();
@@ -562,8 +562,8 @@ void HTTP_C::CreateContext(Kernel::HLERequestContext& ctx) {
         LOG_ERROR(Service_HTTP, "Command called with a bound context");
 
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-        rb.Push(ResultCode(ErrorDescription::NotImplemented, ErrorModule::HTTP,
-                           ErrorSummary::Internal, ErrorLevel::Permanent));
+        rb.Push(Result(ErrorDescription::NotImplemented, ErrorModule::HTTP, ErrorSummary::Internal,
+                       ErrorLevel::Permanent));
         rb.PushMappedBuffer(buffer);
         return;
     }
@@ -574,8 +574,8 @@ void HTTP_C::CreateContext(Kernel::HLERequestContext& ctx) {
         LOG_ERROR(Service_HTTP, "Tried to open too many HTTP contexts");
 
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-        rb.Push(ResultCode(ErrCodes::TooManyContexts, ErrorModule::HTTP, ErrorSummary::InvalidState,
-                           ErrorLevel::Permanent));
+        rb.Push(Result(ErrCodes::TooManyContexts, ErrorModule::HTTP, ErrorSummary::InvalidState,
+                       ErrorLevel::Permanent));
         rb.PushMappedBuffer(buffer);
         return;
     }
@@ -584,8 +584,8 @@ void HTTP_C::CreateContext(Kernel::HLERequestContext& ctx) {
         LOG_ERROR(Service_HTTP, "invalid request method={}", method);
 
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-        rb.Push(ResultCode(ErrCodes::InvalidRequestMethod, ErrorModule::HTTP,
-                           ErrorSummary::InvalidState, ErrorLevel::Permanent));
+        rb.Push(Result(ErrCodes::InvalidRequestMethod, ErrorModule::HTTP,
+                       ErrorSummary::InvalidState, ErrorLevel::Permanent));
         rb.PushMappedBuffer(buffer);
         return;
     }
@@ -687,8 +687,8 @@ void HTTP_C::AddRequestHeader(Kernel::HLERequestContext& ctx) {
         LOG_ERROR(Service_HTTP,
                   "Tried to add a request header on a context that has already been started.");
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-        rb.Push(ResultCode(ErrCodes::InvalidRequestState, ErrorModule::HTTP,
-                           ErrorSummary::InvalidState, ErrorLevel::Permanent));
+        rb.Push(Result(ErrCodes::InvalidRequestState, ErrorModule::HTTP, ErrorSummary::InvalidState,
+                       ErrorLevel::Permanent));
         rb.PushMappedBuffer(value_buffer);
         return;
     }
@@ -728,8 +728,8 @@ void HTTP_C::AddPostDataAscii(Kernel::HLERequestContext& ctx) {
         LOG_ERROR(Service_HTTP,
                   "Tried to add post data on a context that has already been started.");
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-        rb.Push(ResultCode(ErrCodes::InvalidRequestState, ErrorModule::HTTP,
-                           ErrorSummary::InvalidState, ErrorLevel::Permanent));
+        rb.Push(Result(ErrCodes::InvalidRequestState, ErrorModule::HTTP, ErrorSummary::InvalidState,
+                       ErrorLevel::Permanent));
         rb.PushMappedBuffer(value_buffer);
         return;
     }
@@ -760,8 +760,8 @@ void HTTP_C::AddPostDataRaw(Kernel::HLERequestContext& ctx) {
         LOG_ERROR(Service_HTTP,
                   "Tried to add post data on a context that has already been started.");
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-        rb.Push(ResultCode(ErrCodes::InvalidRequestState, ErrorModule::HTTP,
-                           ErrorSummary::InvalidState, ErrorLevel::Permanent));
+        rb.Push(Result(ErrCodes::InvalidRequestState, ErrorModule::HTTP, ErrorSummary::InvalidState,
+                       ErrorLevel::Permanent));
         rb.PushMappedBuffer(buffer);
         return;
     }
@@ -859,7 +859,7 @@ void HTTP_C::GetResponseStatusCodeImpl(Kernel::HLERequestContext& ctx, bool time
         bool timeout;
         u64 timeout_nanos = 0;
         // Output
-        ResultCode async_res = RESULT_SUCCESS;
+        Result async_res = RESULT_SUCCESS;
     };
     std::shared_ptr<AsyncData> async_data = std::make_shared<AsyncData>();
 
@@ -887,8 +887,8 @@ void HTTP_C::GetResponseStatusCodeImpl(Kernel::HLERequestContext& ctx, bool time
                 if (wait_res == std::future_status::timeout) {
                     LOG_DEBUG(Service_HTTP, "Status code: {}", "timeout");
                     async_data->async_res =
-                        ResultCode(105, ErrorModule::HTTP, ErrorSummary::NothingHappened,
-                                   ErrorLevel::Permanent);
+                        Result(105, ErrorModule::HTTP, ErrorSummary::NothingHappened,
+                               ErrorLevel::Permanent);
                 }
             } else {
                 http_context.request_future.wait();
@@ -1000,8 +1000,8 @@ void HTTP_C::SetClientCertContext(Kernel::HLERequestContext& ctx) {
         LOG_ERROR(Service_HTTP,
                   "Tried to set a client cert on a context that has already been started.");
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-        rb.Push(ResultCode(ErrCodes::InvalidRequestState, ErrorModule::HTTP,
-                           ErrorSummary::InvalidState, ErrorLevel::Permanent));
+        rb.Push(Result(ErrCodes::InvalidRequestState, ErrorModule::HTTP, ErrorSummary::InvalidState,
+                       ErrorLevel::Permanent));
         return;
     }
 
@@ -1049,7 +1049,7 @@ void HTTP_C::OpenClientCertContext(Kernel::HLERequestContext& ctx) {
     auto* session_data = GetSessionData(ctx.Session());
     ASSERT(session_data);
 
-    ResultCode result(RESULT_SUCCESS);
+    Result result(RESULT_SUCCESS);
 
     if (!session_data->initialized) {
         LOG_ERROR(Service_HTTP, "Command called without Initialize");
@@ -1114,7 +1114,7 @@ void HTTP_C::OpenDefaultClientCertContext(Kernel::HLERequestContext& ctx) {
     if (!ClCertA.init) {
         LOG_ERROR(Service_HTTP, "called but ClCertA is missing");
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-        rb.Push(static_cast<ResultCode>(-1));
+        rb.Push(static_cast<Result>(-1));
         return;
     }
 
@@ -1262,8 +1262,8 @@ bool HTTP_C::PerformStateChecks(Kernel::HLERequestContext& ctx, IPC::RequestPars
         LOG_ERROR(Service_HTTP, "Tried to make a request without a bound context");
 
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-        rb.Push(ResultCode(ErrorDescription::NotImplemented, ErrorModule::HTTP,
-                           ErrorSummary::Internal, ErrorLevel::Permanent));
+        rb.Push(Result(ErrorDescription::NotImplemented, ErrorModule::HTTP, ErrorSummary::Internal,
+                       ErrorLevel::Permanent));
         return false;
     }
 

--- a/src/core/hle/service/ir/ir_rst.cpp
+++ b/src/core/hle/service/ir/ir_rst.cpp
@@ -130,7 +130,7 @@ void IR_RST::UpdateCallback(std::uintptr_t user_data, s64 cycles_late) {
 void IR_RST::GetHandles(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 3);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMoveObjects(shared_memory, update_event);
 }
 
@@ -147,7 +147,7 @@ void IR_RST::Initialize(Kernel::HLERequestContext& ctx) {
     system.CoreTiming().ScheduleEvent(msToCycles(update_period), update_callback_id);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_IR, "called. update_period={}, raw_c_stick={}", update_period, raw_c_stick);
 }
@@ -159,7 +159,7 @@ void IR_RST::Shutdown(Kernel::HLERequestContext& ctx) {
     UnloadInputDevices();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     LOG_DEBUG(Service_IR, "called");
 }
 

--- a/src/core/hle/service/ir/ir_user.cpp
+++ b/src/core/hle/service/ir/ir_user.cpp
@@ -293,7 +293,7 @@ void IR_USER::InitializeIrNopShared(Kernel::HLERequestContext& ctx) {
     shared_memory_init.initialized = 1;
     std::memcpy(shared_memory->GetPointer(), &shared_memory_init, sizeof(SharedMemoryHeader));
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_INFO(Service_IR,
              "called, shared_buff_size={}, recv_buff_size={}, "
@@ -325,7 +325,7 @@ void IR_USER::RequireConnection(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_INFO(Service_IR, "called, device_id = {}", device_id);
 }
@@ -333,7 +333,7 @@ void IR_USER::RequireConnection(Kernel::HLERequestContext& ctx) {
 void IR_USER::GetReceiveEvent(Kernel::HLERequestContext& ctx) {
     IPC::RequestBuilder rb(ctx, 0x0A, 1, 2);
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushCopyObjects(receive_event);
 
     LOG_INFO(Service_IR, "called");
@@ -342,7 +342,7 @@ void IR_USER::GetReceiveEvent(Kernel::HLERequestContext& ctx) {
 void IR_USER::GetSendEvent(Kernel::HLERequestContext& ctx) {
     IPC::RequestBuilder rb(ctx, 0x0B, 1, 2);
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushCopyObjects(send_event);
 
     LOG_INFO(Service_IR, "called");
@@ -360,7 +360,7 @@ void IR_USER::Disconnect(Kernel::HLERequestContext& ctx) {
     shared_memory_ptr[offsetof(SharedMemoryHeader, connected)] = 0;
 
     IPC::RequestBuilder rb(ctx, 0x09, 1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_INFO(Service_IR, "called");
 }
@@ -368,7 +368,7 @@ void IR_USER::Disconnect(Kernel::HLERequestContext& ctx) {
 void IR_USER::GetConnectionStatusEvent(Kernel::HLERequestContext& ctx) {
     IPC::RequestBuilder rb(ctx, 0x0C, 1, 2);
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushCopyObjects(conn_status_event);
 
     LOG_INFO(Service_IR, "called");
@@ -384,7 +384,7 @@ void IR_USER::FinalizeIrNop(Kernel::HLERequestContext& ctx) {
     receive_buffer = nullptr;
 
     IPC::RequestBuilder rb(ctx, 0x02, 1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_INFO(Service_IR, "called");
 }
@@ -399,7 +399,7 @@ void IR_USER::SendIrNop(Kernel::HLERequestContext& ctx) {
     if (connected_device) {
         extra_hid->OnReceive(buffer);
         send_event->Signal();
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
     } else {
         LOG_ERROR(Service_IR, "not connected");
         rb.Push(Result(static_cast<ErrorDescription>(13), ErrorModule::IR,
@@ -416,7 +416,7 @@ void IR_USER::ReleaseReceivedData(Kernel::HLERequestContext& ctx) {
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
 
     if (receive_buffer->Release(count)) {
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
     } else {
         LOG_ERROR(Service_IR, "failed to release {} packets", count);
         rb.Push(Result(ErrorDescription::NoData, ErrorModule::IR, ErrorSummary::NotFound,

--- a/src/core/hle/service/ir/ir_user.cpp
+++ b/src/core/hle/service/ir/ir_user.cpp
@@ -402,8 +402,8 @@ void IR_USER::SendIrNop(Kernel::HLERequestContext& ctx) {
         rb.Push(RESULT_SUCCESS);
     } else {
         LOG_ERROR(Service_IR, "not connected");
-        rb.Push(ResultCode(static_cast<ErrorDescription>(13), ErrorModule::IR,
-                           ErrorSummary::InvalidState, ErrorLevel::Status));
+        rb.Push(Result(static_cast<ErrorDescription>(13), ErrorModule::IR,
+                       ErrorSummary::InvalidState, ErrorLevel::Status));
     }
 
     LOG_TRACE(Service_IR, "called, data={}", fmt::format("{:02x}", fmt::join(buffer, " ")));
@@ -419,8 +419,8 @@ void IR_USER::ReleaseReceivedData(Kernel::HLERequestContext& ctx) {
         rb.Push(RESULT_SUCCESS);
     } else {
         LOG_ERROR(Service_IR, "failed to release {} packets", count);
-        rb.Push(ResultCode(ErrorDescription::NoData, ErrorModule::IR, ErrorSummary::NotFound,
-                           ErrorLevel::Status));
+        rb.Push(Result(ErrorDescription::NoData, ErrorModule::IR, ErrorSummary::NotFound,
+                       ErrorLevel::Status));
     }
 
     LOG_TRACE(Service_IR, "called, count={}", count);

--- a/src/core/hle/service/ldr_ro/cro_helper.cpp
+++ b/src/core/hle/service/ldr_ro/cro_helper.cpp
@@ -88,7 +88,7 @@ Result CROHelper::ApplyRelocation(VAddr target_address, RelocationType relocatio
     default:
         return CROFormatError(0x22);
     }
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result CROHelper::ClearRelocation(VAddr target_address, RelocationType relocation_type) {
@@ -111,7 +111,7 @@ Result CROHelper::ClearRelocation(VAddr target_address, RelocationType relocatio
     default:
         return CROFormatError(0x22);
     }
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result CROHelper::ApplyRelocationBatch(VAddr batch, u32 symbol_address, bool reset) {
@@ -146,7 +146,7 @@ Result CROHelper::ApplyRelocationBatch(VAddr batch, u32 symbol_address, bool res
     system.Memory().ReadBlock(process, batch, &relocation, sizeof(RelocationEntry));
     relocation.is_batch_resolved = reset ? 0 : 1;
     system.Memory().WriteBlock(process, batch, &relocation, sizeof(RelocationEntry));
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 VAddr CROHelper::FindExportNamedSymbol(const std::string& name) const {
@@ -269,7 +269,7 @@ Result CROHelper::RebaseHeader(u32 cro_size) {
             return error;
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 ResultVal<VAddr> CROHelper::RebaseSegmentTable(u32 cro_size, VAddr data_segment_address,
@@ -323,7 +323,7 @@ Result CROHelper::RebaseExportNamedSymbolTable() {
 
         SetEntry(system.Memory(), i, entry);
     }
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result CROHelper::VerifyExportTreeTable() const {
@@ -336,7 +336,7 @@ Result CROHelper::VerifyExportTreeTable() const {
             return CROFormatError(0x11);
         }
     }
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result CROHelper::RebaseImportModuleTable() {
@@ -382,7 +382,7 @@ Result CROHelper::RebaseImportModuleTable() {
 
         SetEntry(system.Memory(), i, entry);
     }
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result CROHelper::RebaseImportNamedSymbolTable() {
@@ -416,7 +416,7 @@ Result CROHelper::RebaseImportNamedSymbolTable() {
 
         SetEntry(system.Memory(), i, entry);
     }
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result CROHelper::RebaseImportIndexedSymbolTable() {
@@ -440,7 +440,7 @@ Result CROHelper::RebaseImportIndexedSymbolTable() {
 
         SetEntry(system.Memory(), i, entry);
     }
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result CROHelper::RebaseImportAnonymousSymbolTable() {
@@ -464,7 +464,7 @@ Result CROHelper::RebaseImportAnonymousSymbolTable() {
 
         SetEntry(system.Memory(), i, entry);
     }
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 VAddr CROHelper::GetOnUnresolvedAddress() {
@@ -508,7 +508,7 @@ Result CROHelper::ResetExternalRelocations() {
         batch_begin = relocation.is_batch_end != 0;
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result CROHelper::ClearExternalRelocations() {
@@ -540,7 +540,7 @@ Result CROHelper::ClearExternalRelocations() {
         batch_begin = relocation.is_batch_end != 0;
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result CROHelper::ApplyStaticAnonymousSymbolToCRS(VAddr crs_address) {
@@ -572,7 +572,7 @@ Result CROHelper::ApplyStaticAnonymousSymbolToCRS(VAddr crs_address) {
             return result;
         }
     }
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result CROHelper::ApplyInternalRelocations(u32 old_data_segment_address) {
@@ -613,7 +613,7 @@ Result CROHelper::ApplyInternalRelocations(u32 old_data_segment_address) {
             return result;
         }
     }
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result CROHelper::ClearInternalRelocations() {
@@ -633,7 +633,7 @@ Result CROHelper::ClearInternalRelocations() {
             return result;
         }
     }
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 void CROHelper::UnrebaseImportAnonymousSymbolTable() {
@@ -786,7 +786,7 @@ Result CROHelper::ApplyImportNamedSymbol(VAddr crs_address) {
             }
         }
     }
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result CROHelper::ResetImportNamedSymbol() {
@@ -807,7 +807,7 @@ Result CROHelper::ResetImportNamedSymbol() {
             return result;
         }
     }
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result CROHelper::ResetImportIndexedSymbol() {
@@ -828,7 +828,7 @@ Result CROHelper::ResetImportIndexedSymbol() {
             return result;
         }
     }
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result CROHelper::ResetImportAnonymousSymbol() {
@@ -849,7 +849,7 @@ Result CROHelper::ResetImportAnonymousSymbol() {
             return result;
         }
     }
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result CROHelper::ApplyModuleImport(VAddr crs_address) {
@@ -905,7 +905,7 @@ Result CROHelper::ApplyModuleImport(VAddr crs_address) {
             return result;
         }
     }
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result CROHelper::ApplyExportNamedSymbol(CROHelper target) {
@@ -935,7 +935,7 @@ Result CROHelper::ApplyExportNamedSymbol(CROHelper target) {
             }
         }
     }
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result CROHelper::ResetExportNamedSymbol(CROHelper target) {
@@ -967,7 +967,7 @@ Result CROHelper::ResetExportNamedSymbol(CROHelper target) {
             }
         }
     }
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result CROHelper::ApplyModuleExport(CROHelper target) {
@@ -1013,7 +1013,7 @@ Result CROHelper::ApplyModuleExport(CROHelper target) {
         }
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result CROHelper::ResetModuleExport(CROHelper target) {
@@ -1057,7 +1057,7 @@ Result CROHelper::ResetModuleExport(CROHelper target) {
         }
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result CROHelper::ApplyExitRelocations(VAddr crs_address) {
@@ -1099,7 +1099,7 @@ Result CROHelper::ApplyExitRelocations(VAddr crs_address) {
             }
         }
     }
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 /**
@@ -1109,14 +1109,14 @@ Result CROHelper::ApplyExitRelocations(VAddr crs_address) {
  * whole string (table) is terminated properly, despite that it is not actually one string.
  * @param address the virtual address of the string (table)
  * @param size the size of the string (table), including the terminating 0
- * @returns Result RESULT_SUCCESS if the size matches, otherwise error code.
+ * @returns Result ResultSuccess if the size matches, otherwise error code.
  */
 static Result VerifyStringTableLength(Memory::MemorySystem& memory, VAddr address, u32 size) {
     if (size != 0) {
         if (memory.Read8(address + size - 1) != 0)
             return CROFormatError(0x0B);
     }
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result CROHelper::Rebase(VAddr crs_address, u32 cro_size, VAddr data_segment_addresss,
@@ -1225,7 +1225,7 @@ Result CROHelper::Rebase(VAddr crs_address, u32 cro_size, VAddr data_segment_add
         }
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 void CROHelper::Unrebase(bool is_crs) {
@@ -1248,11 +1248,11 @@ void CROHelper::Unrebase(bool is_crs) {
 
 Result CROHelper::VerifyHash(u32 cro_size, VAddr crr) const {
     // TODO(wwylele): actually verify the hash
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result CROHelper::Link(VAddr crs_address, bool link_on_load_bug_fix) {
-    Result result = RESULT_SUCCESS;
+    Result result = ResultSuccess;
 
     {
         VAddr data_segment_address = 0;
@@ -1322,7 +1322,7 @@ Result CROHelper::Link(VAddr crs_address, bool link_on_load_bug_fix) {
         return result;
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result CROHelper::Unlink(VAddr crs_address) {
@@ -1367,7 +1367,7 @@ Result CROHelper::Unlink(VAddr crs_address) {
         return result;
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result CROHelper::ClearRelocations() {
@@ -1382,7 +1382,7 @@ Result CROHelper::ClearRelocations() {
         LOG_ERROR(Service_LDR, "Error clearing internal relocations {:08X}", result.raw);
         return result;
     }
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 void CROHelper::InitCRS() {

--- a/src/core/hle/service/ldr_ro/cro_helper.cpp
+++ b/src/core/hle/service/ldr_ro/cro_helper.cpp
@@ -12,13 +12,13 @@
 
 namespace Service::LDR {
 
-static const ResultCode ERROR_BUFFER_TOO_SMALL = // 0xE0E12C1F
-    ResultCode(static_cast<ErrorDescription>(31), ErrorModule::RO, ErrorSummary::InvalidArgument,
-               ErrorLevel::Usage);
+static const Result ERROR_BUFFER_TOO_SMALL = // 0xE0E12C1F
+    Result(static_cast<ErrorDescription>(31), ErrorModule::RO, ErrorSummary::InvalidArgument,
+           ErrorLevel::Usage);
 
-static constexpr ResultCode CROFormatError(u32 description) {
-    return ResultCode(static_cast<ErrorDescription>(description), ErrorModule::RO,
-                      ErrorSummary::WrongArgument, ErrorLevel::Permanent);
+static constexpr Result CROFormatError(u32 description) {
+    return Result(static_cast<ErrorDescription>(description), ErrorModule::RO,
+                  ErrorSummary::WrongArgument, ErrorLevel::Permanent);
 }
 
 const std::array<int, 17> CROHelper::ENTRY_SIZE{{
@@ -63,8 +63,8 @@ VAddr CROHelper::SegmentTagToAddress(SegmentTag segment_tag) const {
     return entry.offset + segment_tag.offset_into_segment;
 }
 
-ResultCode CROHelper::ApplyRelocation(VAddr target_address, RelocationType relocation_type,
-                                      u32 addend, u32 symbol_address, u32 target_future_address) {
+Result CROHelper::ApplyRelocation(VAddr target_address, RelocationType relocation_type, u32 addend,
+                                  u32 symbol_address, u32 target_future_address) {
 
     switch (relocation_type) {
     case RelocationType::Nothing:
@@ -91,7 +91,7 @@ ResultCode CROHelper::ApplyRelocation(VAddr target_address, RelocationType reloc
     return RESULT_SUCCESS;
 }
 
-ResultCode CROHelper::ClearRelocation(VAddr target_address, RelocationType relocation_type) {
+Result CROHelper::ClearRelocation(VAddr target_address, RelocationType relocation_type) {
     switch (relocation_type) {
     case RelocationType::Nothing:
         break;
@@ -114,7 +114,7 @@ ResultCode CROHelper::ClearRelocation(VAddr target_address, RelocationType reloc
     return RESULT_SUCCESS;
 }
 
-ResultCode CROHelper::ApplyRelocationBatch(VAddr batch, u32 symbol_address, bool reset) {
+Result CROHelper::ApplyRelocationBatch(VAddr batch, u32 symbol_address, bool reset) {
     if (symbol_address == 0 && !reset)
         return CROFormatError(0x10);
 
@@ -129,8 +129,8 @@ ResultCode CROHelper::ApplyRelocationBatch(VAddr batch, u32 symbol_address, bool
             return CROFormatError(0x12);
         }
 
-        ResultCode result = ApplyRelocation(relocation_target, relocation.type, relocation.addend,
-                                            symbol_address, relocation_target);
+        Result result = ApplyRelocation(relocation_target, relocation.type, relocation.addend,
+                                        symbol_address, relocation_target);
         if (result.IsError()) {
             LOG_ERROR(Service_LDR, "Error applying relocation {:08X}", result.raw);
             return result;
@@ -195,8 +195,8 @@ VAddr CROHelper::FindExportNamedSymbol(const std::string& name) const {
     return SegmentTagToAddress(symbol_entry.symbol_position);
 }
 
-ResultCode CROHelper::RebaseHeader(u32 cro_size) {
-    ResultCode error = CROFormatError(0x11);
+Result CROHelper::RebaseHeader(u32 cro_size) {
+    Result error = CROFormatError(0x11);
 
     // verifies magic
     if (GetField(Magic) != MAGIC_CRO0)
@@ -304,7 +304,7 @@ ResultVal<VAddr> CROHelper::RebaseSegmentTable(u32 cro_size, VAddr data_segment_
     return prev_data_segment + module_address;
 }
 
-ResultCode CROHelper::RebaseExportNamedSymbolTable() {
+Result CROHelper::RebaseExportNamedSymbolTable() {
     VAddr export_strings_offset = GetField(ExportStringsOffset);
     VAddr export_strings_end = export_strings_offset + GetField(ExportStringsSize);
 
@@ -326,7 +326,7 @@ ResultCode CROHelper::RebaseExportNamedSymbolTable() {
     return RESULT_SUCCESS;
 }
 
-ResultCode CROHelper::VerifyExportTreeTable() const {
+Result CROHelper::VerifyExportTreeTable() const {
     u32 tree_num = GetField(ExportTreeNum);
     for (u32 i = 0; i < tree_num; ++i) {
         ExportTreeEntry entry;
@@ -339,7 +339,7 @@ ResultCode CROHelper::VerifyExportTreeTable() const {
     return RESULT_SUCCESS;
 }
 
-ResultCode CROHelper::RebaseImportModuleTable() {
+Result CROHelper::RebaseImportModuleTable() {
     VAddr import_strings_offset = GetField(ImportStringsOffset);
     VAddr import_strings_end = import_strings_offset + GetField(ImportStringsSize);
     VAddr import_indexed_symbol_table_offset = GetField(ImportIndexedSymbolTableOffset);
@@ -385,7 +385,7 @@ ResultCode CROHelper::RebaseImportModuleTable() {
     return RESULT_SUCCESS;
 }
 
-ResultCode CROHelper::RebaseImportNamedSymbolTable() {
+Result CROHelper::RebaseImportNamedSymbolTable() {
     VAddr import_strings_offset = GetField(ImportStringsOffset);
     VAddr import_strings_end = import_strings_offset + GetField(ImportStringsSize);
     VAddr external_relocation_table_offset = GetField(ExternalRelocationTableOffset);
@@ -419,7 +419,7 @@ ResultCode CROHelper::RebaseImportNamedSymbolTable() {
     return RESULT_SUCCESS;
 }
 
-ResultCode CROHelper::RebaseImportIndexedSymbolTable() {
+Result CROHelper::RebaseImportIndexedSymbolTable() {
     VAddr external_relocation_table_offset = GetField(ExternalRelocationTableOffset);
     VAddr external_relocation_table_end =
         external_relocation_table_offset +
@@ -443,7 +443,7 @@ ResultCode CROHelper::RebaseImportIndexedSymbolTable() {
     return RESULT_SUCCESS;
 }
 
-ResultCode CROHelper::RebaseImportAnonymousSymbolTable() {
+Result CROHelper::RebaseImportAnonymousSymbolTable() {
     VAddr external_relocation_table_offset = GetField(ExternalRelocationTableOffset);
     VAddr external_relocation_table_end =
         external_relocation_table_offset +
@@ -471,7 +471,7 @@ VAddr CROHelper::GetOnUnresolvedAddress() {
     return SegmentTagToAddress(SegmentTag(GetField(OnUnresolvedSegmentTag)));
 }
 
-ResultCode CROHelper::ResetExternalRelocations() {
+Result CROHelper::ResetExternalRelocations() {
     u32 unresolved_symbol = GetOnUnresolvedAddress();
     u32 external_relocation_num = GetField(ExternalRelocationNum);
     ExternalRelocationEntry relocation;
@@ -491,8 +491,8 @@ ResultCode CROHelper::ResetExternalRelocations() {
             return CROFormatError(0x12);
         }
 
-        ResultCode result = ApplyRelocation(relocation_target, relocation.type, relocation.addend,
-                                            unresolved_symbol, relocation_target);
+        Result result = ApplyRelocation(relocation_target, relocation.type, relocation.addend,
+                                        unresolved_symbol, relocation_target);
         if (result.IsError()) {
             LOG_ERROR(Service_LDR, "Error applying relocation {:08X}", result.raw);
             return result;
@@ -511,7 +511,7 @@ ResultCode CROHelper::ResetExternalRelocations() {
     return RESULT_SUCCESS;
 }
 
-ResultCode CROHelper::ClearExternalRelocations() {
+Result CROHelper::ClearExternalRelocations() {
     u32 external_relocation_num = GetField(ExternalRelocationNum);
     ExternalRelocationEntry relocation;
 
@@ -524,7 +524,7 @@ ResultCode CROHelper::ClearExternalRelocations() {
             return CROFormatError(0x12);
         }
 
-        ResultCode result = ClearRelocation(relocation_target, relocation.type);
+        Result result = ClearRelocation(relocation_target, relocation.type);
         if (result.IsError()) {
             LOG_ERROR(Service_LDR, "Error clearing relocation {:08X}", result.raw);
             return result;
@@ -543,7 +543,7 @@ ResultCode CROHelper::ClearExternalRelocations() {
     return RESULT_SUCCESS;
 }
 
-ResultCode CROHelper::ApplyStaticAnonymousSymbolToCRS(VAddr crs_address) {
+Result CROHelper::ApplyStaticAnonymousSymbolToCRS(VAddr crs_address) {
     VAddr static_relocation_table_offset = GetField(StaticRelocationTableOffset);
     VAddr static_relocation_table_end =
         static_relocation_table_offset +
@@ -566,7 +566,7 @@ ResultCode CROHelper::ApplyStaticAnonymousSymbolToCRS(VAddr crs_address) {
         u32 symbol_address = SegmentTagToAddress(entry.symbol_position);
         LOG_TRACE(Service_LDR, "CRO \"{}\" exports 0x{:08X} to the static module", ModuleName(),
                   symbol_address);
-        ResultCode result = crs.ApplyRelocationBatch(batch_address, symbol_address);
+        Result result = crs.ApplyRelocationBatch(batch_address, symbol_address);
         if (result.IsError()) {
             LOG_ERROR(Service_LDR, "Error applying relocation batch {:08X}", result.raw);
             return result;
@@ -575,7 +575,7 @@ ResultCode CROHelper::ApplyStaticAnonymousSymbolToCRS(VAddr crs_address) {
     return RESULT_SUCCESS;
 }
 
-ResultCode CROHelper::ApplyInternalRelocations(u32 old_data_segment_address) {
+Result CROHelper::ApplyInternalRelocations(u32 old_data_segment_address) {
     u32 segment_num = GetField(SegmentNum);
     u32 internal_relocation_num = GetField(InternalRelocationNum);
     for (u32 i = 0; i < internal_relocation_num; ++i) {
@@ -606,8 +606,8 @@ ResultCode CROHelper::ApplyInternalRelocations(u32 old_data_segment_address) {
         GetEntry(system.Memory(), relocation.symbol_segment, symbol_segment);
         LOG_TRACE(Service_LDR, "Internally relocates 0x{:08X} with 0x{:08X}", target_address,
                   symbol_segment.offset);
-        ResultCode result = ApplyRelocation(target_address, relocation.type, relocation.addend,
-                                            symbol_segment.offset, target_addressB);
+        Result result = ApplyRelocation(target_address, relocation.type, relocation.addend,
+                                        symbol_segment.offset, target_addressB);
         if (result.IsError()) {
             LOG_ERROR(Service_LDR, "Error applying relocation {:08X}", result.raw);
             return result;
@@ -616,7 +616,7 @@ ResultCode CROHelper::ApplyInternalRelocations(u32 old_data_segment_address) {
     return RESULT_SUCCESS;
 }
 
-ResultCode CROHelper::ClearInternalRelocations() {
+Result CROHelper::ClearInternalRelocations() {
     u32 internal_relocation_num = GetField(InternalRelocationNum);
     for (u32 i = 0; i < internal_relocation_num; ++i) {
         InternalRelocationEntry relocation;
@@ -627,7 +627,7 @@ ResultCode CROHelper::ClearInternalRelocations() {
             return CROFormatError(0x15);
         }
 
-        ResultCode result = ClearRelocation(target_address, relocation.type);
+        Result result = ClearRelocation(target_address, relocation.type);
         if (result.IsError()) {
             LOG_ERROR(Service_LDR, "Error clearing relocation {:08X}", result.raw);
             return result;
@@ -747,7 +747,7 @@ void CROHelper::UnrebaseHeader() {
     }
 }
 
-ResultCode CROHelper::ApplyImportNamedSymbol(VAddr crs_address) {
+Result CROHelper::ApplyImportNamedSymbol(VAddr crs_address) {
     u32 import_strings_size = GetField(ImportStringsSize);
     u32 symbol_import_num = GetField(ImportNamedSymbolNum);
     for (u32 i = 0; i < symbol_import_num; ++i) {
@@ -759,7 +759,7 @@ ResultCode CROHelper::ApplyImportNamedSymbol(VAddr crs_address) {
                                   sizeof(ExternalRelocationEntry));
 
         if (!relocation_entry.is_batch_resolved) {
-            ResultCode result = ForEachAutoLinkCRO(
+            Result result = ForEachAutoLinkCRO(
                 process, system, crs_address, [&](CROHelper source) -> ResultVal<bool> {
                     std::string symbol_name =
                         system.Memory().ReadCString(entry.name_offset, import_strings_size);
@@ -769,7 +769,7 @@ ResultCode CROHelper::ApplyImportNamedSymbol(VAddr crs_address) {
                         LOG_TRACE(Service_LDR, "CRO \"{}\" imports \"{}\" from \"{}\"",
                                   ModuleName(), symbol_name, source.ModuleName());
 
-                        ResultCode result = ApplyRelocationBatch(relocation_addr, symbol_address);
+                        Result result = ApplyRelocationBatch(relocation_addr, symbol_address);
                         if (result.IsError()) {
                             LOG_ERROR(Service_LDR, "Error applying relocation batch {:08X}",
                                       result.raw);
@@ -789,7 +789,7 @@ ResultCode CROHelper::ApplyImportNamedSymbol(VAddr crs_address) {
     return RESULT_SUCCESS;
 }
 
-ResultCode CROHelper::ResetImportNamedSymbol() {
+Result CROHelper::ResetImportNamedSymbol() {
     u32 unresolved_symbol = GetOnUnresolvedAddress();
 
     u32 symbol_import_num = GetField(ImportNamedSymbolNum);
@@ -801,7 +801,7 @@ ResultCode CROHelper::ResetImportNamedSymbol() {
         system.Memory().ReadBlock(process, relocation_addr, &relocation_entry,
                                   sizeof(ExternalRelocationEntry));
 
-        ResultCode result = ApplyRelocationBatch(relocation_addr, unresolved_symbol, true);
+        Result result = ApplyRelocationBatch(relocation_addr, unresolved_symbol, true);
         if (result.IsError()) {
             LOG_ERROR(Service_LDR, "Error reseting relocation batch {:08X}", result.raw);
             return result;
@@ -810,7 +810,7 @@ ResultCode CROHelper::ResetImportNamedSymbol() {
     return RESULT_SUCCESS;
 }
 
-ResultCode CROHelper::ResetImportIndexedSymbol() {
+Result CROHelper::ResetImportIndexedSymbol() {
     u32 unresolved_symbol = GetOnUnresolvedAddress();
 
     u32 import_num = GetField(ImportIndexedSymbolNum);
@@ -822,7 +822,7 @@ ResultCode CROHelper::ResetImportIndexedSymbol() {
         system.Memory().ReadBlock(process, relocation_addr, &relocation_entry,
                                   sizeof(ExternalRelocationEntry));
 
-        ResultCode result = ApplyRelocationBatch(relocation_addr, unresolved_symbol, true);
+        Result result = ApplyRelocationBatch(relocation_addr, unresolved_symbol, true);
         if (result.IsError()) {
             LOG_ERROR(Service_LDR, "Error reseting relocation batch {:08X}", result.raw);
             return result;
@@ -831,7 +831,7 @@ ResultCode CROHelper::ResetImportIndexedSymbol() {
     return RESULT_SUCCESS;
 }
 
-ResultCode CROHelper::ResetImportAnonymousSymbol() {
+Result CROHelper::ResetImportAnonymousSymbol() {
     u32 unresolved_symbol = GetOnUnresolvedAddress();
 
     u32 import_num = GetField(ImportAnonymousSymbolNum);
@@ -843,7 +843,7 @@ ResultCode CROHelper::ResetImportAnonymousSymbol() {
         system.Memory().ReadBlock(process, relocation_addr, &relocation_entry,
                                   sizeof(ExternalRelocationEntry));
 
-        ResultCode result = ApplyRelocationBatch(relocation_addr, unresolved_symbol, true);
+        Result result = ApplyRelocationBatch(relocation_addr, unresolved_symbol, true);
         if (result.IsError()) {
             LOG_ERROR(Service_LDR, "Error reseting relocation batch {:08X}", result.raw);
             return result;
@@ -852,7 +852,7 @@ ResultCode CROHelper::ResetImportAnonymousSymbol() {
     return RESULT_SUCCESS;
 }
 
-ResultCode CROHelper::ApplyModuleImport(VAddr crs_address) {
+Result CROHelper::ApplyModuleImport(VAddr crs_address) {
     u32 import_strings_size = GetField(ImportStringsSize);
 
     u32 import_module_num = GetField(ImportModuleNum);
@@ -862,7 +862,7 @@ ResultCode CROHelper::ApplyModuleImport(VAddr crs_address) {
         std::string want_cro_name =
             system.Memory().ReadCString(entry.name_offset, import_strings_size);
 
-        ResultCode result = ForEachAutoLinkCRO(
+        Result result = ForEachAutoLinkCRO(
             process, system, crs_address, [&](CROHelper source) -> ResultVal<bool> {
                 if (want_cro_name == source.ModuleName()) {
                     LOG_INFO(Service_LDR, "CRO \"{}\" imports {} indexed symbols from \"{}\"",
@@ -874,7 +874,7 @@ ResultCode CROHelper::ApplyModuleImport(VAddr crs_address) {
                         source.GetEntry(system.Memory(), im.index, ex);
                         u32 symbol_address = source.SegmentTagToAddress(ex.symbol_position);
                         LOG_TRACE(Service_LDR, "    Imports 0x{:08X}", symbol_address);
-                        ResultCode result =
+                        Result result =
                             ApplyRelocationBatch(im.relocation_batch_offset, symbol_address);
                         if (result.IsError()) {
                             LOG_ERROR(Service_LDR, "Error applying relocation batch {:08X}",
@@ -889,7 +889,7 @@ ResultCode CROHelper::ApplyModuleImport(VAddr crs_address) {
                         entry.GetImportAnonymousSymbolEntry(process, system.Memory(), j, im);
                         u32 symbol_address = source.SegmentTagToAddress(im.symbol_position);
                         LOG_TRACE(Service_LDR, "    Imports 0x{:08X}", symbol_address);
-                        ResultCode result =
+                        Result result =
                             ApplyRelocationBatch(im.relocation_batch_offset, symbol_address);
                         if (result.IsError()) {
                             LOG_ERROR(Service_LDR, "Error applying relocation batch {:08X}",
@@ -908,7 +908,7 @@ ResultCode CROHelper::ApplyModuleImport(VAddr crs_address) {
     return RESULT_SUCCESS;
 }
 
-ResultCode CROHelper::ApplyExportNamedSymbol(CROHelper target) {
+Result CROHelper::ApplyExportNamedSymbol(CROHelper target) {
     LOG_DEBUG(Service_LDR, "CRO \"{}\" exports named symbols to \"{}\"", ModuleName(),
               target.ModuleName());
     u32 target_import_strings_size = target.GetField(ImportStringsSize);
@@ -927,7 +927,7 @@ ResultCode CROHelper::ApplyExportNamedSymbol(CROHelper target) {
             u32 symbol_address = FindExportNamedSymbol(symbol_name);
             if (symbol_address != 0) {
                 LOG_TRACE(Service_LDR, "    exports symbol \"{}\"", symbol_name);
-                ResultCode result = target.ApplyRelocationBatch(relocation_addr, symbol_address);
+                Result result = target.ApplyRelocationBatch(relocation_addr, symbol_address);
                 if (result.IsError()) {
                     LOG_ERROR(Service_LDR, "Error applying relocation batch {:08X}", result.raw);
                     return result;
@@ -938,7 +938,7 @@ ResultCode CROHelper::ApplyExportNamedSymbol(CROHelper target) {
     return RESULT_SUCCESS;
 }
 
-ResultCode CROHelper::ResetExportNamedSymbol(CROHelper target) {
+Result CROHelper::ResetExportNamedSymbol(CROHelper target) {
     LOG_DEBUG(Service_LDR, "CRO \"{}\" unexports named symbols to \"{}\"", ModuleName(),
               target.ModuleName());
     u32 unresolved_symbol = target.GetOnUnresolvedAddress();
@@ -958,7 +958,7 @@ ResultCode CROHelper::ResetExportNamedSymbol(CROHelper target) {
             u32 symbol_address = FindExportNamedSymbol(symbol_name);
             if (symbol_address != 0) {
                 LOG_TRACE(Service_LDR, "    unexports symbol \"{}\"", symbol_name);
-                ResultCode result =
+                Result result =
                     target.ApplyRelocationBatch(relocation_addr, unresolved_symbol, true);
                 if (result.IsError()) {
                     LOG_ERROR(Service_LDR, "Error applying relocation batch {:08X}", result.raw);
@@ -970,7 +970,7 @@ ResultCode CROHelper::ResetExportNamedSymbol(CROHelper target) {
     return RESULT_SUCCESS;
 }
 
-ResultCode CROHelper::ApplyModuleExport(CROHelper target) {
+Result CROHelper::ApplyModuleExport(CROHelper target) {
     std::string module_name = ModuleName();
     u32 target_import_string_size = target.GetField(ImportStringsSize);
     u32 target_import_module_num = target.GetField(ImportModuleNum);
@@ -991,8 +991,7 @@ ResultCode CROHelper::ApplyModuleExport(CROHelper target) {
             GetEntry(system.Memory(), im.index, ex);
             u32 symbol_address = SegmentTagToAddress(ex.symbol_position);
             LOG_TRACE(Service_LDR, "    exports symbol 0x{:08X}", symbol_address);
-            ResultCode result =
-                target.ApplyRelocationBatch(im.relocation_batch_offset, symbol_address);
+            Result result = target.ApplyRelocationBatch(im.relocation_batch_offset, symbol_address);
             if (result.IsError()) {
                 LOG_ERROR(Service_LDR, "Error applying relocation batch {:08X}", result.raw);
                 return result;
@@ -1006,8 +1005,7 @@ ResultCode CROHelper::ApplyModuleExport(CROHelper target) {
             entry.GetImportAnonymousSymbolEntry(process, system.Memory(), j, im);
             u32 symbol_address = SegmentTagToAddress(im.symbol_position);
             LOG_TRACE(Service_LDR, "    exports symbol 0x{:08X}", symbol_address);
-            ResultCode result =
-                target.ApplyRelocationBatch(im.relocation_batch_offset, symbol_address);
+            Result result = target.ApplyRelocationBatch(im.relocation_batch_offset, symbol_address);
             if (result.IsError()) {
                 LOG_ERROR(Service_LDR, "Error applying relocation batch {:08X}", result.raw);
                 return result;
@@ -1018,7 +1016,7 @@ ResultCode CROHelper::ApplyModuleExport(CROHelper target) {
     return RESULT_SUCCESS;
 }
 
-ResultCode CROHelper::ResetModuleExport(CROHelper target) {
+Result CROHelper::ResetModuleExport(CROHelper target) {
     u32 unresolved_symbol = target.GetOnUnresolvedAddress();
 
     std::string module_name = ModuleName();
@@ -1037,7 +1035,7 @@ ResultCode CROHelper::ResetModuleExport(CROHelper target) {
         for (u32 j = 0; j < entry.import_indexed_symbol_num; ++j) {
             ImportIndexedSymbolEntry im;
             entry.GetImportIndexedSymbolEntry(process, system.Memory(), j, im);
-            ResultCode result =
+            Result result =
                 target.ApplyRelocationBatch(im.relocation_batch_offset, unresolved_symbol, true);
             if (result.IsError()) {
                 LOG_ERROR(Service_LDR, "Error applying relocation batch {:08X}", result.raw);
@@ -1050,7 +1048,7 @@ ResultCode CROHelper::ResetModuleExport(CROHelper target) {
         for (u32 j = 0; j < entry.import_anonymous_symbol_num; ++j) {
             ImportAnonymousSymbolEntry im;
             entry.GetImportAnonymousSymbolEntry(process, system.Memory(), j, im);
-            ResultCode result =
+            Result result =
                 target.ApplyRelocationBatch(im.relocation_batch_offset, unresolved_symbol, true);
             if (result.IsError()) {
                 LOG_ERROR(Service_LDR, "Error applying relocation batch {:08X}", result.raw);
@@ -1062,7 +1060,7 @@ ResultCode CROHelper::ResetModuleExport(CROHelper target) {
     return RESULT_SUCCESS;
 }
 
-ResultCode CROHelper::ApplyExitRelocations(VAddr crs_address) {
+Result CROHelper::ApplyExitRelocations(VAddr crs_address) {
     u32 import_strings_size = GetField(ImportStringsSize);
     u32 symbol_import_num = GetField(ImportNamedSymbolNum);
     for (u32 i = 0; i < symbol_import_num; ++i) {
@@ -1075,7 +1073,7 @@ ResultCode CROHelper::ApplyExitRelocations(VAddr crs_address) {
 
         if (system.Memory().ReadCString(entry.name_offset, import_strings_size) ==
             "__aeabi_atexit") {
-            ResultCode result = ForEachAutoLinkCRO(
+            Result result = ForEachAutoLinkCRO(
                 process, system, crs_address, [&](CROHelper source) -> ResultVal<bool> {
                     u32 symbol_address = source.FindExportNamedSymbol("nnroAeabiAtexit_");
 
@@ -1083,7 +1081,7 @@ ResultCode CROHelper::ApplyExitRelocations(VAddr crs_address) {
                         LOG_DEBUG(Service_LDR, "CRO \"{}\" import exit function from \"{}\"",
                                   ModuleName(), source.ModuleName());
 
-                        ResultCode result = ApplyRelocationBatch(relocation_addr, symbol_address);
+                        Result result = ApplyRelocationBatch(relocation_addr, symbol_address);
                         if (result.IsError()) {
                             LOG_ERROR(Service_LDR, "Error applying relocation batch {:08X}",
                                       result.raw);
@@ -1111,9 +1109,9 @@ ResultCode CROHelper::ApplyExitRelocations(VAddr crs_address) {
  * whole string (table) is terminated properly, despite that it is not actually one string.
  * @param address the virtual address of the string (table)
  * @param size the size of the string (table), including the terminating 0
- * @returns ResultCode RESULT_SUCCESS if the size matches, otherwise error code.
+ * @returns Result RESULT_SUCCESS if the size matches, otherwise error code.
  */
-static ResultCode VerifyStringTableLength(Memory::MemorySystem& memory, VAddr address, u32 size) {
+static Result VerifyStringTableLength(Memory::MemorySystem& memory, VAddr address, u32 size) {
     if (size != 0) {
         if (memory.Read8(address + size - 1) != 0)
             return CROFormatError(0x0B);
@@ -1121,11 +1119,11 @@ static ResultCode VerifyStringTableLength(Memory::MemorySystem& memory, VAddr ad
     return RESULT_SUCCESS;
 }
 
-ResultCode CROHelper::Rebase(VAddr crs_address, u32 cro_size, VAddr data_segment_addresss,
-                             u32 data_segment_size, VAddr bss_segment_address, u32 bss_segment_size,
-                             bool is_crs) {
+Result CROHelper::Rebase(VAddr crs_address, u32 cro_size, VAddr data_segment_addresss,
+                         u32 data_segment_size, VAddr bss_segment_address, u32 bss_segment_size,
+                         bool is_crs) {
 
-    ResultCode result = RebaseHeader(cro_size);
+    Result result = RebaseHeader(cro_size);
     if (result.IsError()) {
         LOG_ERROR(Service_LDR, "Error rebasing header {:08X}", result.raw);
         return result;
@@ -1248,13 +1246,13 @@ void CROHelper::Unrebase(bool is_crs) {
     UnrebaseHeader();
 }
 
-ResultCode CROHelper::VerifyHash(u32 cro_size, VAddr crr) const {
+Result CROHelper::VerifyHash(u32 cro_size, VAddr crr) const {
     // TODO(wwylele): actually verify the hash
     return RESULT_SUCCESS;
 }
 
-ResultCode CROHelper::Link(VAddr crs_address, bool link_on_load_bug_fix) {
-    ResultCode result = RESULT_SUCCESS;
+Result CROHelper::Link(VAddr crs_address, bool link_on_load_bug_fix) {
+    Result result = RESULT_SUCCESS;
 
     {
         VAddr data_segment_address = 0;
@@ -1309,7 +1307,7 @@ ResultCode CROHelper::Link(VAddr crs_address, bool link_on_load_bug_fix) {
     // Exports symbols to other modules
     result = ForEachAutoLinkCRO(process, system, crs_address,
                                 [this](CROHelper target) -> ResultVal<bool> {
-                                    ResultCode result = ApplyExportNamedSymbol(target);
+                                    Result result = ApplyExportNamedSymbol(target);
                                     if (result.IsError())
                                         return result;
 
@@ -1327,10 +1325,10 @@ ResultCode CROHelper::Link(VAddr crs_address, bool link_on_load_bug_fix) {
     return RESULT_SUCCESS;
 }
 
-ResultCode CROHelper::Unlink(VAddr crs_address) {
+Result CROHelper::Unlink(VAddr crs_address) {
 
     // Resets all imported named symbols
-    ResultCode result = ResetImportNamedSymbol();
+    Result result = ResetImportNamedSymbol();
     if (result.IsError()) {
         LOG_ERROR(Service_LDR, "Error resetting symbol import {:08X}", result.raw);
         return result;
@@ -1354,7 +1352,7 @@ ResultCode CROHelper::Unlink(VAddr crs_address) {
     // Note: the RO service seems only searching in auto-link modules
     result = ForEachAutoLinkCRO(process, system, crs_address,
                                 [this](CROHelper target) -> ResultVal<bool> {
-                                    ResultCode result = ResetExportNamedSymbol(target);
+                                    Result result = ResetExportNamedSymbol(target);
                                     if (result.IsError())
                                         return result;
 
@@ -1372,8 +1370,8 @@ ResultCode CROHelper::Unlink(VAddr crs_address) {
     return RESULT_SUCCESS;
 }
 
-ResultCode CROHelper::ClearRelocations() {
-    ResultCode result = ClearExternalRelocations();
+Result CROHelper::ClearRelocations() {
+    Result result = ClearExternalRelocations();
     if (result.IsError()) {
         LOG_ERROR(Service_LDR, "Error clearing external relocations {:08X}", result.raw);
         return result;

--- a/src/core/hle/service/ldr_ro/cro_helper.h
+++ b/src/core/hle/service/ldr_ro/cro_helper.h
@@ -51,11 +51,11 @@ public:
      * @param bss_segment_address the buffer address for .bss segment
      * @param bss_segment_size the buffer size for .bss segment
      * @param is_crs true if the module itself is the static module
-     * @returns ResultCode RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result RESULT_SUCCESS on success, otherwise error code.
      */
-    ResultCode Rebase(VAddr crs_address, u32 cro_size, VAddr data_segment_address,
-                      u32 data_segment_size, VAddr bss_segment_address, u32 bss_segment_size,
-                      bool is_crs);
+    Result Rebase(VAddr crs_address, u32 cro_size, VAddr data_segment_address,
+                  u32 data_segment_size, VAddr bss_segment_address, u32 bss_segment_size,
+                  bool is_crs);
 
     /**
      * Unrebases the module.
@@ -67,30 +67,30 @@ public:
      * Verifies module hash by CRR.
      * @param cro_size the size of the CRO
      * @param crr the virtual address of the CRR
-     * @returns ResultCode RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result RESULT_SUCCESS on success, otherwise error code.
      */
-    ResultCode VerifyHash(u32 cro_size, VAddr crr) const;
+    Result VerifyHash(u32 cro_size, VAddr crr) const;
 
     /**
      * Links this module with all registered auto-link module.
      * @param crs_address the virtual address of the static module
      * @param link_on_load_bug_fix true if links when loading and fixes the bug
-     * @returns ResultCode RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result RESULT_SUCCESS on success, otherwise error code.
      */
-    ResultCode Link(VAddr crs_address, bool link_on_load_bug_fix);
+    Result Link(VAddr crs_address, bool link_on_load_bug_fix);
 
     /**
      * Unlinks this module with other modules.
      * @param crs_address the virtual address of the static module
-     * @returns ResultCode RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result RESULT_SUCCESS on success, otherwise error code.
      */
-    ResultCode Unlink(VAddr crs_address);
+    Result Unlink(VAddr crs_address);
 
     /**
      * Clears all relocations to zero.
-     * @returns ResultCode RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result RESULT_SUCCESS on success, otherwise error code.
      */
-    ResultCode ClearRelocations();
+    Result ClearRelocations();
 
     /// Initialize this module as the static module (CRS)
     void InitCRS();
@@ -465,13 +465,13 @@ private:
      *        CROHelper and returns ResultVal<bool>. It should return true to continue the
      * iteration,
      *        false to stop the iteration, or an error code (which will also stop the iteration).
-     * @returns ResultCode indicating the result of the operation, RESULT_SUCCESS if all iteration
+     * @returns Result indicating the result of the operation, RESULT_SUCCESS if all iteration
      * success,
      *         otherwise error code of the last iteration.
      */
     template <typename FunctionObject>
-    static ResultCode ForEachAutoLinkCRO(Kernel::Process& process, Core::System& system,
-                                         VAddr crs_address, FunctionObject func) {
+    static Result ForEachAutoLinkCRO(Kernel::Process& process, Core::System& system,
+                                     VAddr crs_address, FunctionObject func) {
         VAddr current = crs_address;
         while (current != 0) {
             CROHelper cro(current, process, system);
@@ -491,18 +491,18 @@ private:
      * @param symbol_address the symbol address to be relocated with
      * @param target_future_address the future address of the target.
      *        Usually equals to target_address, but will be different for a target in .data segment
-     * @returns ResultCode RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result RESULT_SUCCESS on success, otherwise error code.
      */
-    ResultCode ApplyRelocation(VAddr target_address, RelocationType relocation_type, u32 addend,
-                               u32 symbol_address, u32 target_future_address);
+    Result ApplyRelocation(VAddr target_address, RelocationType relocation_type, u32 addend,
+                           u32 symbol_address, u32 target_future_address);
 
     /**
      * Clears a relocation to zero
      * @param target_address where to apply the relocation
      * @param relocation_type the type of the relocation
-     * @returns ResultCode RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result RESULT_SUCCESS on success, otherwise error code.
      */
-    ResultCode ClearRelocation(VAddr target_address, RelocationType relocation_type);
+    Result ClearRelocation(VAddr target_address, RelocationType relocation_type);
 
     /**
      * Applies or resets a batch of relocations
@@ -510,9 +510,9 @@ private:
      * @param symbol_address the symbol address to be relocated with
      * @param reset false to set the batch to resolved state, true to reset the batch to unresolved
      * state
-     * @returns ResultCode RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result RESULT_SUCCESS on success, otherwise error code.
      */
-    ResultCode ApplyRelocationBatch(VAddr batch, u32 symbol_address, bool reset = false);
+    Result ApplyRelocationBatch(VAddr batch, u32 symbol_address, bool reset = false);
 
     /**
      * Finds an exported named symbol in this module.
@@ -524,10 +524,10 @@ private:
     /**
      * Rebases offsets in module header according to module address.
      * @param cro_size the size of the CRO file
-     * @returns ResultCode RESULT_SUCCESS if all offsets are verified as valid, otherwise error
+     * @returns Result RESULT_SUCCESS if all offsets are verified as valid, otherwise error
      * code.
      */
-    ResultCode RebaseHeader(u32 cro_size);
+    Result RebaseHeader(u32 cro_size);
 
     /**
      * Rebases offsets in segment table according to module address.
@@ -544,45 +544,45 @@ private:
 
     /**
      * Rebases offsets in exported named symbol table according to module address.
-     * @returns ResultCode RESULT_SUCCESS if all offsets are verified as valid, otherwise error
+     * @returns Result RESULT_SUCCESS if all offsets are verified as valid, otherwise error
      * code.
      */
-    ResultCode RebaseExportNamedSymbolTable();
+    Result RebaseExportNamedSymbolTable();
 
     /**
      * Verifies indices in export tree table.
-     * @returns ResultCode RESULT_SUCCESS if all indices are verified as valid, otherwise error
+     * @returns Result RESULT_SUCCESS if all indices are verified as valid, otherwise error
      * code.
      */
-    ResultCode VerifyExportTreeTable() const;
+    Result VerifyExportTreeTable() const;
 
     /**
      * Rebases offsets in exported module table according to module address.
-     * @returns ResultCode RESULT_SUCCESS if all offsets are verified as valid, otherwise error
+     * @returns Result RESULT_SUCCESS if all offsets are verified as valid, otherwise error
      * code.
      */
-    ResultCode RebaseImportModuleTable();
+    Result RebaseImportModuleTable();
 
     /**
      * Rebases offsets in imported named symbol table according to module address.
-     * @returns ResultCode RESULT_SUCCESS if all offsets are verified as valid, otherwise error
+     * @returns Result RESULT_SUCCESS if all offsets are verified as valid, otherwise error
      * code.
      */
-    ResultCode RebaseImportNamedSymbolTable();
+    Result RebaseImportNamedSymbolTable();
 
     /**
      * Rebases offsets in imported indexed symbol table according to module address.
-     * @returns ResultCode RESULT_SUCCESS if all offsets are verified as valid, otherwise error
+     * @returns Result RESULT_SUCCESS if all offsets are verified as valid, otherwise error
      * code.
      */
-    ResultCode RebaseImportIndexedSymbolTable();
+    Result RebaseImportIndexedSymbolTable();
 
     /**
      * Rebases offsets in imported anonymous symbol table according to module address.
-     * @returns ResultCode RESULT_SUCCESS if all offsets are verified as valid, otherwise error
+     * @returns Result RESULT_SUCCESS if all offsets are verified as valid, otherwise error
      * code.
      */
-    ResultCode RebaseImportAnonymousSymbolTable();
+    Result RebaseImportAnonymousSymbolTable();
 
     /**
      * Gets the address of OnUnresolved function in this module.
@@ -593,35 +593,35 @@ private:
 
     /**
      * Resets all external relocations to unresolved state.
-     * @returns ResultCode RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result RESULT_SUCCESS on success, otherwise error code.
      */
-    ResultCode ResetExternalRelocations();
+    Result ResetExternalRelocations();
 
     /**
      * Clears all external relocations to zero.
-     * @returns ResultCode RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result RESULT_SUCCESS on success, otherwise error code.
      */
-    ResultCode ClearExternalRelocations();
+    Result ClearExternalRelocations();
 
     /**
      * Applies all static anonymous symbol to the static module.
      * @param crs_address the virtual address of the static module
-     * @returns ResultCode RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result RESULT_SUCCESS on success, otherwise error code.
      */
-    ResultCode ApplyStaticAnonymousSymbolToCRS(VAddr crs_address);
+    Result ApplyStaticAnonymousSymbolToCRS(VAddr crs_address);
 
     /**
      * Applies all internal relocations to the module itself.
      * @param old_data_segment_address the virtual address of data segment in CRO buffer
-     * @returns ResultCode RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result RESULT_SUCCESS on success, otherwise error code.
      */
-    ResultCode ApplyInternalRelocations(u32 old_data_segment_address);
+    Result ApplyInternalRelocations(u32 old_data_segment_address);
 
     /**
      * Clears all internal relocations to zero.
-     * @returns ResultCode RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result RESULT_SUCCESS on success, otherwise error code.
      */
-    ResultCode ClearInternalRelocations();
+    Result ClearInternalRelocations();
 
     /// Unrebases offsets in imported anonymous symbol table
     void UnrebaseImportAnonymousSymbolTable();
@@ -648,71 +648,71 @@ private:
      * Looks up all imported named symbols of this module in all registered auto-link modules, and
      * resolves them if found.
      * @param crs_address the virtual address of the static module
-     * @returns ResultCode RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result RESULT_SUCCESS on success, otherwise error code.
      */
-    ResultCode ApplyImportNamedSymbol(VAddr crs_address);
+    Result ApplyImportNamedSymbol(VAddr crs_address);
 
     /**
      * Resets all imported named symbols of this module to unresolved state.
-     * @returns ResultCode RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result RESULT_SUCCESS on success, otherwise error code.
      */
-    ResultCode ResetImportNamedSymbol();
+    Result ResetImportNamedSymbol();
 
     /**
      * Resets all imported indexed symbols of this module to unresolved state.
-     * @returns ResultCode RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result RESULT_SUCCESS on success, otherwise error code.
      */
-    ResultCode ResetImportIndexedSymbol();
+    Result ResetImportIndexedSymbol();
 
     /**
      * Resets all imported anonymous symbols of this module to unresolved state.
-     * @returns ResultCode RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result RESULT_SUCCESS on success, otherwise error code.
      */
-    ResultCode ResetImportAnonymousSymbol();
+    Result ResetImportAnonymousSymbol();
 
     /**
      * Finds registered auto-link modules that this module imports, and resolves indexed and
      * anonymous symbols exported by them.
      * @param crs_address the virtual address of the static module
-     * @returns ResultCode RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result RESULT_SUCCESS on success, otherwise error code.
      */
-    ResultCode ApplyModuleImport(VAddr crs_address);
+    Result ApplyModuleImport(VAddr crs_address);
 
     /**
      * Resolves target module's imported named symbols that exported by this module.
      * @param target the module to resolve.
-     * @returns ResultCode RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result RESULT_SUCCESS on success, otherwise error code.
      */
-    ResultCode ApplyExportNamedSymbol(CROHelper target);
+    Result ApplyExportNamedSymbol(CROHelper target);
 
     /**
      * Resets target's named symbols imported from this module to unresolved state.
      * @param target the module to reset.
-     * @returns ResultCode RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result RESULT_SUCCESS on success, otherwise error code.
      */
-    ResultCode ResetExportNamedSymbol(CROHelper target);
+    Result ResetExportNamedSymbol(CROHelper target);
 
     /**
      * Resolves imported indexed and anonymous symbols in the target module which imports this
      * module.
      * @param target the module to resolve.
-     * @returns ResultCode RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result RESULT_SUCCESS on success, otherwise error code.
      */
-    ResultCode ApplyModuleExport(CROHelper target);
+    Result ApplyModuleExport(CROHelper target);
 
     /**
      * Resets target's indexed and anonymous symbol imported from this module to unresolved state.
      * @param target the module to reset.
-     * @returns ResultCode RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result RESULT_SUCCESS on success, otherwise error code.
      */
-    ResultCode ResetModuleExport(CROHelper target);
+    Result ResetModuleExport(CROHelper target);
 
     /**
      * Resolves the exit function in this module
      * @param crs_address the virtual address of the static module.
-     * @returns ResultCode RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result RESULT_SUCCESS on success, otherwise error code.
      */
-    ResultCode ApplyExitRelocations(VAddr crs_address);
+    Result ApplyExitRelocations(VAddr crs_address);
 };
 
 } // namespace Service::LDR

--- a/src/core/hle/service/ldr_ro/cro_helper.h
+++ b/src/core/hle/service/ldr_ro/cro_helper.h
@@ -51,7 +51,7 @@ public:
      * @param bss_segment_address the buffer address for .bss segment
      * @param bss_segment_size the buffer size for .bss segment
      * @param is_crs true if the module itself is the static module
-     * @returns Result RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result ResultSuccess on success, otherwise error code.
      */
     Result Rebase(VAddr crs_address, u32 cro_size, VAddr data_segment_address,
                   u32 data_segment_size, VAddr bss_segment_address, u32 bss_segment_size,
@@ -67,7 +67,7 @@ public:
      * Verifies module hash by CRR.
      * @param cro_size the size of the CRO
      * @param crr the virtual address of the CRR
-     * @returns Result RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result ResultSuccess on success, otherwise error code.
      */
     Result VerifyHash(u32 cro_size, VAddr crr) const;
 
@@ -75,20 +75,20 @@ public:
      * Links this module with all registered auto-link module.
      * @param crs_address the virtual address of the static module
      * @param link_on_load_bug_fix true if links when loading and fixes the bug
-     * @returns Result RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result ResultSuccess on success, otherwise error code.
      */
     Result Link(VAddr crs_address, bool link_on_load_bug_fix);
 
     /**
      * Unlinks this module with other modules.
      * @param crs_address the virtual address of the static module
-     * @returns Result RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result ResultSuccess on success, otherwise error code.
      */
     Result Unlink(VAddr crs_address);
 
     /**
      * Clears all relocations to zero.
-     * @returns Result RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result ResultSuccess on success, otherwise error code.
      */
     Result ClearRelocations();
 
@@ -465,7 +465,7 @@ private:
      *        CROHelper and returns ResultVal<bool>. It should return true to continue the
      * iteration,
      *        false to stop the iteration, or an error code (which will also stop the iteration).
-     * @returns Result indicating the result of the operation, RESULT_SUCCESS if all iteration
+     * @returns Result indicating the result of the operation, ResultSuccess if all iteration
      * success,
      *         otherwise error code of the last iteration.
      */
@@ -480,7 +480,7 @@ private:
                 break;
             current = cro.NextModule();
         }
-        return RESULT_SUCCESS;
+        return ResultSuccess;
     }
 
     /**
@@ -491,7 +491,7 @@ private:
      * @param symbol_address the symbol address to be relocated with
      * @param target_future_address the future address of the target.
      *        Usually equals to target_address, but will be different for a target in .data segment
-     * @returns Result RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result ResultSuccess on success, otherwise error code.
      */
     Result ApplyRelocation(VAddr target_address, RelocationType relocation_type, u32 addend,
                            u32 symbol_address, u32 target_future_address);
@@ -500,7 +500,7 @@ private:
      * Clears a relocation to zero
      * @param target_address where to apply the relocation
      * @param relocation_type the type of the relocation
-     * @returns Result RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result ResultSuccess on success, otherwise error code.
      */
     Result ClearRelocation(VAddr target_address, RelocationType relocation_type);
 
@@ -510,7 +510,7 @@ private:
      * @param symbol_address the symbol address to be relocated with
      * @param reset false to set the batch to resolved state, true to reset the batch to unresolved
      * state
-     * @returns Result RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result ResultSuccess on success, otherwise error code.
      */
     Result ApplyRelocationBatch(VAddr batch, u32 symbol_address, bool reset = false);
 
@@ -524,7 +524,7 @@ private:
     /**
      * Rebases offsets in module header according to module address.
      * @param cro_size the size of the CRO file
-     * @returns Result RESULT_SUCCESS if all offsets are verified as valid, otherwise error
+     * @returns Result ResultSuccess if all offsets are verified as valid, otherwise error
      * code.
      */
     Result RebaseHeader(u32 cro_size);
@@ -544,42 +544,42 @@ private:
 
     /**
      * Rebases offsets in exported named symbol table according to module address.
-     * @returns Result RESULT_SUCCESS if all offsets are verified as valid, otherwise error
+     * @returns Result ResultSuccess if all offsets are verified as valid, otherwise error
      * code.
      */
     Result RebaseExportNamedSymbolTable();
 
     /**
      * Verifies indices in export tree table.
-     * @returns Result RESULT_SUCCESS if all indices are verified as valid, otherwise error
+     * @returns Result ResultSuccess if all indices are verified as valid, otherwise error
      * code.
      */
     Result VerifyExportTreeTable() const;
 
     /**
      * Rebases offsets in exported module table according to module address.
-     * @returns Result RESULT_SUCCESS if all offsets are verified as valid, otherwise error
+     * @returns Result ResultSuccess if all offsets are verified as valid, otherwise error
      * code.
      */
     Result RebaseImportModuleTable();
 
     /**
      * Rebases offsets in imported named symbol table according to module address.
-     * @returns Result RESULT_SUCCESS if all offsets are verified as valid, otherwise error
+     * @returns Result ResultSuccess if all offsets are verified as valid, otherwise error
      * code.
      */
     Result RebaseImportNamedSymbolTable();
 
     /**
      * Rebases offsets in imported indexed symbol table according to module address.
-     * @returns Result RESULT_SUCCESS if all offsets are verified as valid, otherwise error
+     * @returns Result ResultSuccess if all offsets are verified as valid, otherwise error
      * code.
      */
     Result RebaseImportIndexedSymbolTable();
 
     /**
      * Rebases offsets in imported anonymous symbol table according to module address.
-     * @returns Result RESULT_SUCCESS if all offsets are verified as valid, otherwise error
+     * @returns Result ResultSuccess if all offsets are verified as valid, otherwise error
      * code.
      */
     Result RebaseImportAnonymousSymbolTable();
@@ -593,33 +593,33 @@ private:
 
     /**
      * Resets all external relocations to unresolved state.
-     * @returns Result RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result ResultSuccess on success, otherwise error code.
      */
     Result ResetExternalRelocations();
 
     /**
      * Clears all external relocations to zero.
-     * @returns Result RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result ResultSuccess on success, otherwise error code.
      */
     Result ClearExternalRelocations();
 
     /**
      * Applies all static anonymous symbol to the static module.
      * @param crs_address the virtual address of the static module
-     * @returns Result RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result ResultSuccess on success, otherwise error code.
      */
     Result ApplyStaticAnonymousSymbolToCRS(VAddr crs_address);
 
     /**
      * Applies all internal relocations to the module itself.
      * @param old_data_segment_address the virtual address of data segment in CRO buffer
-     * @returns Result RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result ResultSuccess on success, otherwise error code.
      */
     Result ApplyInternalRelocations(u32 old_data_segment_address);
 
     /**
      * Clears all internal relocations to zero.
-     * @returns Result RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result ResultSuccess on success, otherwise error code.
      */
     Result ClearInternalRelocations();
 
@@ -648,25 +648,25 @@ private:
      * Looks up all imported named symbols of this module in all registered auto-link modules, and
      * resolves them if found.
      * @param crs_address the virtual address of the static module
-     * @returns Result RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result ResultSuccess on success, otherwise error code.
      */
     Result ApplyImportNamedSymbol(VAddr crs_address);
 
     /**
      * Resets all imported named symbols of this module to unresolved state.
-     * @returns Result RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result ResultSuccess on success, otherwise error code.
      */
     Result ResetImportNamedSymbol();
 
     /**
      * Resets all imported indexed symbols of this module to unresolved state.
-     * @returns Result RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result ResultSuccess on success, otherwise error code.
      */
     Result ResetImportIndexedSymbol();
 
     /**
      * Resets all imported anonymous symbols of this module to unresolved state.
-     * @returns Result RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result ResultSuccess on success, otherwise error code.
      */
     Result ResetImportAnonymousSymbol();
 
@@ -674,21 +674,21 @@ private:
      * Finds registered auto-link modules that this module imports, and resolves indexed and
      * anonymous symbols exported by them.
      * @param crs_address the virtual address of the static module
-     * @returns Result RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result ResultSuccess on success, otherwise error code.
      */
     Result ApplyModuleImport(VAddr crs_address);
 
     /**
      * Resolves target module's imported named symbols that exported by this module.
      * @param target the module to resolve.
-     * @returns Result RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result ResultSuccess on success, otherwise error code.
      */
     Result ApplyExportNamedSymbol(CROHelper target);
 
     /**
      * Resets target's named symbols imported from this module to unresolved state.
      * @param target the module to reset.
-     * @returns Result RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result ResultSuccess on success, otherwise error code.
      */
     Result ResetExportNamedSymbol(CROHelper target);
 
@@ -696,21 +696,21 @@ private:
      * Resolves imported indexed and anonymous symbols in the target module which imports this
      * module.
      * @param target the module to resolve.
-     * @returns Result RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result ResultSuccess on success, otherwise error code.
      */
     Result ApplyModuleExport(CROHelper target);
 
     /**
      * Resets target's indexed and anonymous symbol imported from this module to unresolved state.
      * @param target the module to reset.
-     * @returns Result RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result ResultSuccess on success, otherwise error code.
      */
     Result ResetModuleExport(CROHelper target);
 
     /**
      * Resolves the exit function in this module
      * @param crs_address the virtual address of the static module.
-     * @returns Result RESULT_SUCCESS on success, otherwise error code.
+     * @returns Result ResultSuccess on success, otherwise error code.
      */
     Result ApplyExitRelocations(VAddr crs_address);
 };

--- a/src/core/hle/service/ldr_ro/ldr_ro.cpp
+++ b/src/core/hle/service/ldr_ro/ldr_ro.cpp
@@ -118,7 +118,7 @@ void RO::Initialize(Kernel::HLERequestContext& ctx) {
         return;
     }
 
-    Result result = RESULT_SUCCESS;
+    Result result = ResultSuccess;
 
     result = process->Map(crs_address, crs_buffer_ptr, crs_size, Kernel::VMAPermission::Read, true);
     if (result.IsError()) {
@@ -139,7 +139,7 @@ void RO::Initialize(Kernel::HLERequestContext& ctx) {
 
     slot->loaded_crs = crs_address;
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void RO::LoadCRR(Kernel::HLERequestContext& ctx) {
@@ -149,7 +149,7 @@ void RO::LoadCRR(Kernel::HLERequestContext& ctx) {
     auto process = rp.PopObject<Kernel::Process>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_LDR, "(STUBBED) called, crr_buffer_ptr=0x{:08X}, crr_size=0x{:08X}",
                 crr_buffer_ptr, crr_size);
@@ -161,7 +161,7 @@ void RO::UnloadCRR(Kernel::HLERequestContext& ctx) {
     auto process = rp.PopObject<Kernel::Process>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_LDR, "(STUBBED) called, crr_buffer_ptr=0x{:08X}", crr_buffer_ptr);
 }
@@ -251,7 +251,7 @@ void RO::LoadCRO(Kernel::HLERequestContext& ctx, bool link_on_load_bug_fix) {
         return;
     }
 
-    Result result = RESULT_SUCCESS;
+    Result result = ResultSuccess;
 
     result = process->Map(cro_address, cro_buffer_ptr, cro_size, Kernel::VMAPermission::Read, true);
     if (result.IsError()) {
@@ -330,7 +330,7 @@ void RO::LoadCRO(Kernel::HLERequestContext& ctx, bool link_on_load_bug_fix) {
     LOG_INFO(Service_LDR, "CRO \"{}\" loaded at 0x{:08X}, fixed_end=0x{:08X}", cro.ModuleName(),
              cro_address, cro_address + fix_size);
 
-    rb.Push(RESULT_SUCCESS, fix_size);
+    rb.Push(ResultSuccess, fix_size);
 }
 
 void RO::UnloadCRO(Kernel::HLERequestContext& ctx) {
@@ -502,7 +502,7 @@ void RO::Shutdown(Kernel::HLERequestContext& ctx) {
     CROHelper crs(slot->loaded_crs, *process, system);
     crs.Unrebase(true);
 
-    Result result = RESULT_SUCCESS;
+    Result result = ResultSuccess;
 
     result = process->Unmap(slot->loaded_crs, crs_buffer_ptr, crs.GetFileSize(),
                             Kernel::VMAPermission::ReadWrite, true);

--- a/src/core/hle/service/ldr_ro/ldr_ro.cpp
+++ b/src/core/hle/service/ldr_ro/ldr_ro.cpp
@@ -19,30 +19,30 @@ SERIALIZE_EXPORT_IMPL(Service::LDR::ClientSlot)
 
 namespace Service::LDR {
 
-static const ResultCode ERROR_ALREADY_INITIALIZED = // 0xD9612FF9
-    ResultCode(ErrorDescription::AlreadyInitialized, ErrorModule::RO, ErrorSummary::Internal,
-               ErrorLevel::Permanent);
-static const ResultCode ERROR_NOT_INITIALIZED = // 0xD9612FF8
-    ResultCode(ErrorDescription::NotInitialized, ErrorModule::RO, ErrorSummary::Internal,
-               ErrorLevel::Permanent);
-static const ResultCode ERROR_BUFFER_TOO_SMALL = // 0xE0E12C1F
-    ResultCode(static_cast<ErrorDescription>(31), ErrorModule::RO, ErrorSummary::InvalidArgument,
-               ErrorLevel::Usage);
-static const ResultCode ERROR_MISALIGNED_ADDRESS = // 0xD9012FF1
-    ResultCode(ErrorDescription::MisalignedAddress, ErrorModule::RO, ErrorSummary::WrongArgument,
-               ErrorLevel::Permanent);
-static const ResultCode ERROR_MISALIGNED_SIZE = // 0xD9012FF2
-    ResultCode(ErrorDescription::MisalignedSize, ErrorModule::RO, ErrorSummary::WrongArgument,
-               ErrorLevel::Permanent);
-static const ResultCode ERROR_ILLEGAL_ADDRESS = // 0xE1612C0F
-    ResultCode(static_cast<ErrorDescription>(15), ErrorModule::RO, ErrorSummary::Internal,
-               ErrorLevel::Usage);
-static const ResultCode ERROR_INVALID_MEMORY_STATE = // 0xD8A12C08
-    ResultCode(static_cast<ErrorDescription>(8), ErrorModule::RO, ErrorSummary::InvalidState,
-               ErrorLevel::Permanent);
-static const ResultCode ERROR_NOT_LOADED = // 0xD8A12C0D
-    ResultCode(static_cast<ErrorDescription>(13), ErrorModule::RO, ErrorSummary::InvalidState,
-               ErrorLevel::Permanent);
+static const Result ERROR_ALREADY_INITIALIZED = // 0xD9612FF9
+    Result(ErrorDescription::AlreadyInitialized, ErrorModule::RO, ErrorSummary::Internal,
+           ErrorLevel::Permanent);
+static const Result ERROR_NOT_INITIALIZED = // 0xD9612FF8
+    Result(ErrorDescription::NotInitialized, ErrorModule::RO, ErrorSummary::Internal,
+           ErrorLevel::Permanent);
+static const Result ERROR_BUFFER_TOO_SMALL = // 0xE0E12C1F
+    Result(static_cast<ErrorDescription>(31), ErrorModule::RO, ErrorSummary::InvalidArgument,
+           ErrorLevel::Usage);
+static const Result ERROR_MISALIGNED_ADDRESS = // 0xD9012FF1
+    Result(ErrorDescription::MisalignedAddress, ErrorModule::RO, ErrorSummary::WrongArgument,
+           ErrorLevel::Permanent);
+static const Result ERROR_MISALIGNED_SIZE = // 0xD9012FF2
+    Result(ErrorDescription::MisalignedSize, ErrorModule::RO, ErrorSummary::WrongArgument,
+           ErrorLevel::Permanent);
+static const Result ERROR_ILLEGAL_ADDRESS = // 0xE1612C0F
+    Result(static_cast<ErrorDescription>(15), ErrorModule::RO, ErrorSummary::Internal,
+           ErrorLevel::Usage);
+static const Result ERROR_INVALID_MEMORY_STATE = // 0xD8A12C08
+    Result(static_cast<ErrorDescription>(8), ErrorModule::RO, ErrorSummary::InvalidState,
+           ErrorLevel::Permanent);
+static const Result ERROR_NOT_LOADED = // 0xD8A12C0D
+    Result(static_cast<ErrorDescription>(13), ErrorModule::RO, ErrorSummary::InvalidState,
+           ErrorLevel::Permanent);
 
 static bool VerifyBufferState(Kernel::Process& process, VAddr buffer_ptr, u32 size) {
     auto vma = process.vm_manager.FindVMA(buffer_ptr);
@@ -118,7 +118,7 @@ void RO::Initialize(Kernel::HLERequestContext& ctx) {
         return;
     }
 
-    ResultCode result = RESULT_SUCCESS;
+    Result result = RESULT_SUCCESS;
 
     result = process->Map(crs_address, crs_buffer_ptr, crs_size, Kernel::VMAPermission::Read, true);
     if (result.IsError()) {
@@ -245,13 +245,13 @@ void RO::LoadCRO(Kernel::HLERequestContext& ctx, bool link_on_load_bug_fix) {
 
     if (zero) {
         LOG_ERROR(Service_LDR, "Zero is not zero {}", zero);
-        rb.Push(ResultCode(static_cast<ErrorDescription>(29), ErrorModule::RO,
-                           ErrorSummary::Internal, ErrorLevel::Usage));
+        rb.Push(Result(static_cast<ErrorDescription>(29), ErrorModule::RO, ErrorSummary::Internal,
+                       ErrorLevel::Usage));
         rb.Push<u32>(0);
         return;
     }
 
-    ResultCode result = RESULT_SUCCESS;
+    Result result = RESULT_SUCCESS;
 
     result = process->Map(cro_address, cro_buffer_ptr, cro_size, Kernel::VMAPermission::Read, true);
     if (result.IsError()) {
@@ -372,7 +372,7 @@ void RO::UnloadCRO(Kernel::HLERequestContext& ctx) {
 
     cro.Unregister(slot->loaded_crs);
 
-    ResultCode result = cro.Unlink(slot->loaded_crs);
+    Result result = cro.Unlink(slot->loaded_crs);
     if (result.IsError()) {
         LOG_ERROR(Service_LDR, "Error unlinking CRO {:08X}", result.raw);
         rb.Push(result);
@@ -435,7 +435,7 @@ void RO::LinkCRO(Kernel::HLERequestContext& ctx) {
 
     LOG_INFO(Service_LDR, "Linking CRO \"{}\"", cro.ModuleName());
 
-    ResultCode result = cro.Link(slot->loaded_crs, false);
+    Result result = cro.Link(slot->loaded_crs, false);
     if (result.IsError()) {
         LOG_ERROR(Service_LDR, "Error linking CRO {:08X}", result.raw);
     }
@@ -475,7 +475,7 @@ void RO::UnlinkCRO(Kernel::HLERequestContext& ctx) {
 
     LOG_INFO(Service_LDR, "Unlinking CRO \"{}\"", cro.ModuleName());
 
-    ResultCode result = cro.Unlink(slot->loaded_crs);
+    Result result = cro.Unlink(slot->loaded_crs);
     if (result.IsError()) {
         LOG_ERROR(Service_LDR, "Error unlinking CRO {:08X}", result.raw);
     }
@@ -502,7 +502,7 @@ void RO::Shutdown(Kernel::HLERequestContext& ctx) {
     CROHelper crs(slot->loaded_crs, *process, system);
     crs.Unrebase(true);
 
-    ResultCode result = RESULT_SUCCESS;
+    Result result = RESULT_SUCCESS;
 
     result = process->Unmap(slot->loaded_crs, crs_buffer_ptr, crs.GetFileSize(),
                             Kernel::VMAPermission::ReadWrite, true);

--- a/src/core/hle/service/mic/mic_u.cpp
+++ b/src/core/hle/service/mic/mic_u.cpp
@@ -157,7 +157,7 @@ struct MIC_U::Impl {
         }
 
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
 
         LOG_TRACE(Service_MIC, "called, size=0x{:X}", size);
     }
@@ -166,7 +166,7 @@ struct MIC_U::Impl {
         IPC::RequestParser rp(ctx);
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
         shared_memory = nullptr;
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         LOG_TRACE(Service_MIC, "called");
     }
 
@@ -230,7 +230,7 @@ struct MIC_U::Impl {
         timing.ScheduleEvent(GetBufferUpdatePeriod(state.sample_rate), buffer_write_event);
 
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         LOG_TRACE(Service_MIC,
                   "called, encoding={}, sample_rate={}, "
                   "audio_buffer_offset={}, audio_buffer_size={}, audio_buffer_loop={}",
@@ -246,7 +246,7 @@ struct MIC_U::Impl {
         }
 
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         LOG_TRACE(Service_MIC, "sample_rate={}", sample_rate);
     }
 
@@ -254,7 +254,7 @@ struct MIC_U::Impl {
         IPC::RequestParser rp(ctx);
 
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         timing.RemoveEvent(buffer_write_event);
         if (mic) {
             mic->StopSampling();
@@ -267,7 +267,7 @@ struct MIC_U::Impl {
         IPC::RequestParser rp(ctx);
 
         IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         bool is_sampling = mic && mic->IsSampling();
         rb.Push<bool>(is_sampling);
         LOG_TRACE(Service_MIC, "IsSampling: {}", is_sampling);
@@ -277,7 +277,7 @@ struct MIC_U::Impl {
         IPC::RequestParser rp(ctx);
 
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.PushCopyObjects(buffer_full_event);
         LOG_WARNING(Service_MIC, "(STUBBED) called");
     }
@@ -288,7 +288,7 @@ struct MIC_U::Impl {
         state.gain = gain;
 
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         LOG_TRACE(Service_MIC, "gain={}", gain);
     }
 
@@ -296,7 +296,7 @@ struct MIC_U::Impl {
         IPC::RequestParser rp(ctx);
 
         IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.Push<u8>(state.gain);
         LOG_TRACE(Service_MIC, "gain={}", state.gain);
     }
@@ -307,7 +307,7 @@ struct MIC_U::Impl {
         state.power = power;
 
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         LOG_TRACE(Service_MIC, "mic_power={}", power);
     }
 
@@ -315,7 +315,7 @@ struct MIC_U::Impl {
         IPC::RequestParser rp(ctx);
 
         IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.Push<u8>(state.power);
         LOG_TRACE(Service_MIC, "called");
     }
@@ -326,7 +326,7 @@ struct MIC_U::Impl {
         const Kernel::MappedBuffer& buffer = rp.PopMappedBuffer();
 
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.PushMappedBuffer(buffer);
         LOG_WARNING(Service_MIC, "(STUBBED) called, size=0x{:X}, buffer=0x{:08X}", size,
                     buffer.GetId());
@@ -337,7 +337,7 @@ struct MIC_U::Impl {
         clamp = rp.Pop<bool>();
 
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         LOG_WARNING(Service_MIC, "(STUBBED) called, clamp={}", clamp);
     }
 
@@ -345,7 +345,7 @@ struct MIC_U::Impl {
         IPC::RequestParser rp(ctx);
 
         IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.Push<bool>(clamp);
         LOG_WARNING(Service_MIC, "(STUBBED) called");
     }
@@ -355,7 +355,7 @@ struct MIC_U::Impl {
         allow_shell_closed = rp.Pop<bool>();
 
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         LOG_WARNING(Service_MIC, "(STUBBED) called, allow_shell_closed={}", allow_shell_closed);
     }
 
@@ -365,7 +365,7 @@ struct MIC_U::Impl {
         LOG_WARNING(Service_MIC, "(STUBBED) called, version: 0x{:08X}", version);
 
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
     }
 
     void CreateMic() {

--- a/src/core/hle/service/ndm/ndm_u.cpp
+++ b/src/core/hle/service/ndm/ndm_u.cpp
@@ -17,7 +17,7 @@ void NDM_U::EnterExclusiveState(Kernel::HLERequestContext& ctx) {
     rp.PopPID();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     LOG_WARNING(Service_NDM, "(STUBBED) exclusive_state=0x{:08X}", exclusive_state);
 }
 
@@ -26,14 +26,14 @@ void NDM_U::LeaveExclusiveState(Kernel::HLERequestContext& ctx) {
     rp.PopPID();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     LOG_WARNING(Service_NDM, "(STUBBED)");
 }
 
 void NDM_U::QueryExclusiveMode(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushEnum(exclusive_state);
     LOG_WARNING(Service_NDM, "(STUBBED)");
 }
@@ -44,7 +44,7 @@ void NDM_U::LockState(Kernel::HLERequestContext& ctx) {
     daemon_lock_enabled = true;
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     LOG_WARNING(Service_NDM, "(STUBBED)");
 }
 
@@ -54,7 +54,7 @@ void NDM_U::UnlockState(Kernel::HLERequestContext& ctx) {
     daemon_lock_enabled = false;
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     LOG_WARNING(Service_NDM, "(STUBBED)");
 }
 
@@ -70,7 +70,7 @@ void NDM_U::SuspendDaemons(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     LOG_WARNING(Service_NDM, "(STUBBED) bit_mask=0x{:08X}", bit_mask);
 }
 
@@ -85,7 +85,7 @@ void NDM_U::ResumeDaemons(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     LOG_WARNING(Service_NDM, "(STUBBED) bit_mask=0x{:08X}", bit_mask);
 }
 
@@ -94,14 +94,14 @@ void NDM_U::SuspendScheduler(Kernel::HLERequestContext& ctx) {
     bool perform_in_background = rp.Pop<bool>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     LOG_WARNING(Service_NDM, "(STUBBED) perform_in_background={}", perform_in_background);
 }
 
 void NDM_U::ResumeScheduler(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     LOG_WARNING(Service_NDM, "(STUBBED)");
 }
 
@@ -110,7 +110,7 @@ void NDM_U::QueryStatus(Kernel::HLERequestContext& ctx) {
     u8 daemon = rp.Pop<u8>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushEnum(daemon_status.at(daemon));
     LOG_WARNING(Service_NDM, "(STUBBED) daemon=0x{:02X}", daemon);
 }
@@ -120,7 +120,7 @@ void NDM_U::GetDaemonDisableCount(Kernel::HLERequestContext& ctx) {
     u8 daemon = rp.Pop<u8>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u32>(0); // current process disable count
     rb.Push<u32>(0); // total disable count
     LOG_WARNING(Service_NDM, "(STUBBED) daemon=0x{:02X}", daemon);
@@ -130,7 +130,7 @@ void NDM_U::GetSchedulerDisableCount(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u32>(0); // current process disable count
     rb.Push<u32>(0); // total disable count
     LOG_WARNING(Service_NDM, "(STUBBED)");
@@ -141,14 +141,14 @@ void NDM_U::SetScanInterval(Kernel::HLERequestContext& ctx) {
     scan_interval = rp.Pop<u32>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     LOG_WARNING(Service_NDM, "(STUBBED) scan_interval=0x{:08X}", scan_interval);
 }
 
 void NDM_U::GetScanInterval(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(scan_interval);
     LOG_WARNING(Service_NDM, "(STUBBED)");
 }
@@ -158,14 +158,14 @@ void NDM_U::SetRetryInterval(Kernel::HLERequestContext& ctx) {
     retry_interval = rp.Pop<u32>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     LOG_WARNING(Service_NDM, "(STUBBED) retry_interval=0x{:08X}", retry_interval);
 }
 
 void NDM_U::GetRetryInterval(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(retry_interval);
     LOG_WARNING(Service_NDM, "(STUBBED)");
 }
@@ -182,7 +182,7 @@ void NDM_U::OverrideDefaultDaemons(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     LOG_WARNING(Service_NDM, "(STUBBED) bit_mask=0x{:08X}", bit_mask);
 }
 
@@ -191,14 +191,14 @@ void NDM_U::ResetDefaultDaemons(Kernel::HLERequestContext& ctx) {
     default_daemon_bit_mask = DaemonMask::Default;
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     LOG_WARNING(Service_NDM, "(STUBBED)");
 }
 
 void NDM_U::GetDefaultDaemons(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushEnum(default_daemon_bit_mask);
     LOG_WARNING(Service_NDM, "(STUBBED)");
 }
@@ -206,7 +206,7 @@ void NDM_U::GetDefaultDaemons(Kernel::HLERequestContext& ctx) {
 void NDM_U::ClearHalfAwakeMacFilter(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     LOG_WARNING(Service_NDM, "(STUBBED)");
 }
 

--- a/src/core/hle/service/news/news_s.cpp
+++ b/src/core/hle/service/news/news_s.cpp
@@ -24,7 +24,7 @@ void NEWS_S::GetTotalNotifications(Kernel::HLERequestContext& ctx) {
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u32>(0);
 }
 
@@ -40,7 +40,7 @@ void NEWS_S::GetNewsDBHeader(Kernel::HLERequestContext& ctx) {
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u32>(size);
 }
 

--- a/src/core/hle/service/nfc/nfc.cpp
+++ b/src/core/hle/service/nfc/nfc.cpp
@@ -34,7 +34,7 @@ void Module::Interface::Initialize(Kernel::HLERequestContext& ctx) {
         return;
     }
 
-    ResultCode result = RESULT_SUCCESS;
+    Result result = RESULT_SUCCESS;
     switch (communication_mode) {
     case CommunicationMode::Ntag:
     case CommunicationMode::Amiibo:
@@ -68,7 +68,7 @@ void Module::Interface::Finalize(Kernel::HLERequestContext& ctx) {
         return;
     }
 
-    ResultCode result = RESULT_SUCCESS;
+    Result result = RESULT_SUCCESS;
     switch (communication_mode) {
     case CommunicationMode::Ntag:
     case CommunicationMode::Amiibo:
@@ -129,7 +129,7 @@ void Module::Interface::StartDetection(Kernel::HLERequestContext& ctx) {
 
     LOG_INFO(Service_NFC, "called, in_val={:04x}", in_val);
 
-    ResultCode result = RESULT_SUCCESS;
+    Result result = RESULT_SUCCESS;
     switch (nfc->nfc_mode) {
     case CommunicationMode::Ntag:
     case CommunicationMode::Amiibo:
@@ -150,7 +150,7 @@ void Module::Interface::StopDetection(Kernel::HLERequestContext& ctx) {
 
     LOG_INFO(Service_NFC, "called");
 
-    ResultCode result = RESULT_SUCCESS;
+    Result result = RESULT_SUCCESS;
     switch (nfc->nfc_mode) {
     case CommunicationMode::Ntag:
     case CommunicationMode::Amiibo:
@@ -175,7 +175,7 @@ void Module::Interface::Mount(Kernel::HLERequestContext& ctx) {
 
     nfc->device->RescheduleTagRemoveEvent();
 
-    ResultCode result = RESULT_SUCCESS;
+    Result result = RESULT_SUCCESS;
     switch (nfc->nfc_mode) {
     case CommunicationMode::Ntag:
         result = nfc->device->Mount();
@@ -197,7 +197,7 @@ void Module::Interface::Unmount(Kernel::HLERequestContext& ctx) {
 
     LOG_INFO(Service_NFC, "called");
 
-    ResultCode result = RESULT_SUCCESS;
+    Result result = RESULT_SUCCESS;
     switch (nfc->nfc_mode) {
     case CommunicationMode::Ntag:
     case CommunicationMode::Amiibo:
@@ -217,7 +217,7 @@ void Module::Interface::Flush(Kernel::HLERequestContext& ctx) {
 
     LOG_INFO(Service_NFC, "called");
 
-    ResultCode result = RESULT_SUCCESS;
+    Result result = RESULT_SUCCESS;
     switch (nfc->nfc_mode) {
     case CommunicationMode::Ntag:
         LOG_ERROR(Service_NFC, "CommunicationMode  {} not implemented", nfc->nfc_mode);
@@ -514,7 +514,7 @@ void Module::Interface::MountRom(Kernel::HLERequestContext& ctx) {
 
     LOG_INFO(Service_NFC, "called");
 
-    ResultCode result = RESULT_SUCCESS;
+    Result result = RESULT_SUCCESS;
     switch (nfc->nfc_mode) {
     case CommunicationMode::Ntag:
         result = nfc->device->PartiallyMount();

--- a/src/core/hle/service/nfc/nfc.cpp
+++ b/src/core/hle/service/nfc/nfc.cpp
@@ -34,7 +34,7 @@ void Module::Interface::Initialize(Kernel::HLERequestContext& ctx) {
         return;
     }
 
-    Result result = RESULT_SUCCESS;
+    Result result = ResultSuccess;
     switch (communication_mode) {
     case CommunicationMode::Ntag:
     case CommunicationMode::Amiibo:
@@ -68,7 +68,7 @@ void Module::Interface::Finalize(Kernel::HLERequestContext& ctx) {
         return;
     }
 
-    Result result = RESULT_SUCCESS;
+    Result result = ResultSuccess;
     switch (communication_mode) {
     case CommunicationMode::Ntag:
     case CommunicationMode::Amiibo:
@@ -97,7 +97,7 @@ void Module::Interface::Connect(Kernel::HLERequestContext& ctx) {
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     if (nfc->nfc_mode == CommunicationMode::TrainTag) {
         LOG_ERROR(Service_NFC, "CommunicationMode  {} not implemented", nfc->nfc_mode);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         return;
     }
 
@@ -114,7 +114,7 @@ void Module::Interface::Disconnect(Kernel::HLERequestContext& ctx) {
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
     if (nfc->nfc_mode == CommunicationMode::TrainTag) {
         LOG_ERROR(Service_NFC, "CommunicationMode  {} not implemented", nfc->nfc_mode);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         return;
     }
 
@@ -129,7 +129,7 @@ void Module::Interface::StartDetection(Kernel::HLERequestContext& ctx) {
 
     LOG_INFO(Service_NFC, "called, in_val={:04x}", in_val);
 
-    Result result = RESULT_SUCCESS;
+    Result result = ResultSuccess;
     switch (nfc->nfc_mode) {
     case CommunicationMode::Ntag:
     case CommunicationMode::Amiibo:
@@ -150,7 +150,7 @@ void Module::Interface::StopDetection(Kernel::HLERequestContext& ctx) {
 
     LOG_INFO(Service_NFC, "called");
 
-    Result result = RESULT_SUCCESS;
+    Result result = ResultSuccess;
     switch (nfc->nfc_mode) {
     case CommunicationMode::Ntag:
     case CommunicationMode::Amiibo:
@@ -175,7 +175,7 @@ void Module::Interface::Mount(Kernel::HLERequestContext& ctx) {
 
     nfc->device->RescheduleTagRemoveEvent();
 
-    Result result = RESULT_SUCCESS;
+    Result result = ResultSuccess;
     switch (nfc->nfc_mode) {
     case CommunicationMode::Ntag:
         result = nfc->device->Mount();
@@ -197,7 +197,7 @@ void Module::Interface::Unmount(Kernel::HLERequestContext& ctx) {
 
     LOG_INFO(Service_NFC, "called");
 
-    Result result = RESULT_SUCCESS;
+    Result result = ResultSuccess;
     switch (nfc->nfc_mode) {
     case CommunicationMode::Ntag:
     case CommunicationMode::Amiibo:
@@ -217,7 +217,7 @@ void Module::Interface::Flush(Kernel::HLERequestContext& ctx) {
 
     LOG_INFO(Service_NFC, "called");
 
-    Result result = RESULT_SUCCESS;
+    Result result = ResultSuccess;
     switch (nfc->nfc_mode) {
     case CommunicationMode::Ntag:
         LOG_ERROR(Service_NFC, "CommunicationMode  {} not implemented", nfc->nfc_mode);
@@ -247,7 +247,7 @@ void Module::Interface::GetActivateEvent(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushCopyObjects(nfc->device->GetActivateEvent());
 }
 
@@ -264,7 +264,7 @@ void Module::Interface::GetDeactivateEvent(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushCopyObjects(nfc->device->GetDeactivateEvent());
 }
 
@@ -281,7 +281,7 @@ void Module::Interface::GetStatus(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushEnum(state);
 }
 
@@ -293,7 +293,7 @@ void Module::Interface::GetTargetConnectionStatus(Kernel::HLERequestContext& ctx
     if (nfc->nfc_mode == CommunicationMode::TrainTag) {
         LOG_ERROR(Service_NFC, "CommunicationMode  {} not implemented", nfc->nfc_mode);
         IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.PushEnum(CommunicationState::Idle);
         return;
     }
@@ -315,7 +315,7 @@ void Module::Interface::GetTagInfo2(Kernel::HLERequestContext& ctx) {
     if (nfc->nfc_mode == CommunicationMode::TrainTag) {
         LOG_ERROR(Service_NFC, "CommunicationMode  {} not implemented", nfc->nfc_mode);
         IPC::RequestBuilder rb = rp.MakeBuilder(25, 0);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.PushRaw<TagInfo2>({});
         return;
     }
@@ -337,7 +337,7 @@ void Module::Interface::GetTagInfo(Kernel::HLERequestContext& ctx) {
     if (nfc->nfc_mode == CommunicationMode::TrainTag) {
         LOG_ERROR(Service_NFC, "CommunicationMode  {} not implemented", nfc->nfc_mode);
         IPC::RequestBuilder rb = rp.MakeBuilder(12, 0);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.PushRaw<TagInfo>({});
         return;
     }
@@ -353,7 +353,7 @@ void Module::Interface::GetConnectResult(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(0);
     LOG_WARNING(Service_NFC, "(STUBBED) called");
 }
@@ -505,7 +505,7 @@ void Module::Interface::InitializeCreateInfo(Kernel::HLERequestContext& ctx) {
     InitialStruct empty{};
 
     IPC::RequestBuilder rb = rp.MakeBuilder(16, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushRaw<InitialStruct>(empty);
 }
 
@@ -514,7 +514,7 @@ void Module::Interface::MountRom(Kernel::HLERequestContext& ctx) {
 
     LOG_INFO(Service_NFC, "called");
 
-    Result result = RESULT_SUCCESS;
+    Result result = ResultSuccess;
     switch (nfc->nfc_mode) {
     case CommunicationMode::Ntag:
         result = nfc->device->PartiallyMount();
@@ -599,7 +599,7 @@ void Module::Interface::GetEmptyRegisterInfo(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(43, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushRaw<RegisterInfo>({});
 }
 

--- a/src/core/hle/service/nfc/nfc_device.cpp
+++ b/src/core/hle/service/nfc/nfc_device.cpp
@@ -166,7 +166,7 @@ void NfcDevice::Finalize() {
     is_initalized = false;
 }
 
-ResultCode NfcDevice::StartCommunication() {
+Result NfcDevice::StartCommunication() {
     const auto connection_result = CheckConnectionState();
     if (connection_result.IsError()) {
         return connection_result;
@@ -184,7 +184,7 @@ ResultCode NfcDevice::StartCommunication() {
     return RESULT_SUCCESS;
 }
 
-ResultCode NfcDevice::StopCommunication() {
+Result NfcDevice::StopCommunication() {
     const auto connection_result = CheckConnectionState();
     if (connection_result.IsError()) {
         return connection_result;
@@ -204,7 +204,7 @@ ResultCode NfcDevice::StopCommunication() {
     return RESULT_SUCCESS;
 }
 
-ResultCode NfcDevice::StartDetection(TagProtocol allowed_protocol) {
+Result NfcDevice::StartDetection(TagProtocol allowed_protocol) {
     const auto connection_result = CheckConnectionState();
     if (connection_result.IsError()) {
         return connection_result;
@@ -230,7 +230,7 @@ ResultCode NfcDevice::StartDetection(TagProtocol allowed_protocol) {
     return RESULT_SUCCESS;
 }
 
-ResultCode NfcDevice::StopDetection() {
+Result NfcDevice::StopDetection() {
     const auto connection_result = CheckConnectionState();
     if (connection_result.IsError()) {
         return connection_result;
@@ -257,7 +257,7 @@ ResultCode NfcDevice::StopDetection() {
     return ResultInvalidOperation;
 }
 
-ResultCode NfcDevice::Flush() {
+Result NfcDevice::Flush() {
     if (device_state != DeviceState::TagMounted) {
         LOG_ERROR(Service_NFC, "Wrong device state {}", device_state);
         const auto connection_result = CheckConnectionState();
@@ -327,7 +327,7 @@ ResultCode NfcDevice::Flush() {
     return RESULT_SUCCESS;
 }
 
-ResultCode NfcDevice::Mount() {
+Result NfcDevice::Mount() {
     if (device_state != DeviceState::TagFound) {
         LOG_ERROR(Service_NFC, "Wrong device state {}", device_state);
         const auto connection_result = CheckConnectionState();
@@ -357,7 +357,7 @@ ResultCode NfcDevice::Mount() {
     return RESULT_SUCCESS;
 }
 
-ResultCode NfcDevice::MountAmiibo() {
+Result NfcDevice::MountAmiibo() {
     TagInfo tag_info{};
     const auto result = GetTagInfo(tag_info);
 
@@ -372,7 +372,7 @@ ResultCode NfcDevice::MountAmiibo() {
     return Mount();
 }
 
-ResultCode NfcDevice::PartiallyMount() {
+Result NfcDevice::PartiallyMount() {
     if (device_state != DeviceState::TagFound) {
         LOG_ERROR(Service_NFC, "Wrong device state {}", device_state);
         const auto connection_result = CheckConnectionState();
@@ -402,7 +402,7 @@ ResultCode NfcDevice::PartiallyMount() {
     return RESULT_SUCCESS;
 }
 
-ResultCode NfcDevice::PartiallyMountAmiibo() {
+Result NfcDevice::PartiallyMountAmiibo() {
     TagInfo tag_info{};
     const auto result = GetTagInfo(tag_info);
 
@@ -416,7 +416,7 @@ ResultCode NfcDevice::PartiallyMountAmiibo() {
 
     return PartiallyMount();
 }
-ResultCode NfcDevice::ResetTagScanState() {
+Result NfcDevice::ResetTagScanState() {
     if (device_state != DeviceState::TagMounted &&
         device_state != DeviceState::TagPartiallyMounted) {
         LOG_ERROR(Service_NFC, "Wrong device state {}", device_state);
@@ -433,7 +433,7 @@ ResultCode NfcDevice::ResetTagScanState() {
     return RESULT_SUCCESS;
 }
 
-ResultCode NfcDevice::GetTagInfo2(TagInfo2& tag_info) const {
+Result NfcDevice::GetTagInfo2(TagInfo2& tag_info) const {
     tag_info = {
         .uuid_length = static_cast<u16>(encrypted_tag.file.uuid.uid.size()),
         .tag_type = PackedTagType::Type2,
@@ -446,7 +446,7 @@ ResultCode NfcDevice::GetTagInfo2(TagInfo2& tag_info) const {
     return RESULT_SUCCESS;
 }
 
-ResultCode NfcDevice::GetTagInfo(TagInfo& tag_info) const {
+Result NfcDevice::GetTagInfo(TagInfo& tag_info) const {
     if (device_state != DeviceState::TagFound && device_state != DeviceState::TagMounted &&
         device_state != DeviceState::TagPartiallyMounted) {
         LOG_ERROR(Service_NFC, "Wrong device state {}", device_state);
@@ -468,7 +468,7 @@ ResultCode NfcDevice::GetTagInfo(TagInfo& tag_info) const {
     return RESULT_SUCCESS;
 }
 
-ResultCode NfcDevice::GetCommonInfo(CommonInfo& common_info) const {
+Result NfcDevice::GetCommonInfo(CommonInfo& common_info) const {
     if (device_state != DeviceState::TagMounted) {
         LOG_ERROR(Service_NFC, "Wrong device state {}", device_state);
         const auto connection_result = CheckConnectionState();
@@ -497,7 +497,7 @@ ResultCode NfcDevice::GetCommonInfo(CommonInfo& common_info) const {
     return RESULT_SUCCESS;
 }
 
-ResultCode NfcDevice::GetModelInfo(ModelInfo& model_info) const {
+Result NfcDevice::GetModelInfo(ModelInfo& model_info) const {
     if (device_state != DeviceState::TagMounted &&
         device_state != DeviceState::TagPartiallyMounted) {
         LOG_ERROR(Service_NFC, "Wrong device state {}", device_state);
@@ -520,7 +520,7 @@ ResultCode NfcDevice::GetModelInfo(ModelInfo& model_info) const {
     return RESULT_SUCCESS;
 }
 
-ResultCode NfcDevice::GetRegisterInfo(RegisterInfo& register_info) const {
+Result NfcDevice::GetRegisterInfo(RegisterInfo& register_info) const {
     if (device_state != DeviceState::TagMounted) {
         LOG_ERROR(Service_NFC, "Wrong device state {}", device_state);
         const auto connection_result = CheckConnectionState();
@@ -548,7 +548,7 @@ ResultCode NfcDevice::GetRegisterInfo(RegisterInfo& register_info) const {
     return RESULT_SUCCESS;
 }
 
-ResultCode NfcDevice::GetAdminInfo(AdminInfo& admin_info) const {
+Result NfcDevice::GetAdminInfo(AdminInfo& admin_info) const {
     if (device_state != DeviceState::TagMounted) {
         LOG_ERROR(Service_NFC, "Wrong device state {}", device_state);
         const auto connection_result = CheckConnectionState();
@@ -607,7 +607,7 @@ ResultCode NfcDevice::GetAdminInfo(AdminInfo& admin_info) const {
     return RESULT_SUCCESS;
 }
 
-ResultCode NfcDevice::DeleteRegisterInfo() {
+Result NfcDevice::DeleteRegisterInfo() {
     // This is a hack to get around a HW issue
     if (device_state == DeviceState::TagFound) {
         Mount();
@@ -645,7 +645,7 @@ ResultCode NfcDevice::DeleteRegisterInfo() {
     return Flush();
 }
 
-ResultCode NfcDevice::SetRegisterInfoPrivate(const RegisterInfoPrivate& register_info) {
+Result NfcDevice::SetRegisterInfoPrivate(const RegisterInfoPrivate& register_info) {
     if (device_state != DeviceState::TagMounted) {
         LOG_ERROR(Service_NFC, "Wrong device state {}", device_state);
         const auto connection_result = CheckConnectionState();
@@ -677,7 +677,7 @@ ResultCode NfcDevice::SetRegisterInfoPrivate(const RegisterInfoPrivate& register
     return Flush();
 }
 
-ResultCode NfcDevice::RestoreAmiibo() {
+Result NfcDevice::RestoreAmiibo() {
     if (device_state != DeviceState::TagMounted) {
         LOG_ERROR(Service_NFC, "Wrong device state {}", device_state);
         const auto connection_result = CheckConnectionState();
@@ -692,22 +692,22 @@ ResultCode NfcDevice::RestoreAmiibo() {
     return RESULT_SUCCESS;
 }
 
-ResultCode NfcDevice::Format() {
-    auto ResultCode = DeleteApplicationArea();
-    auto ResultCode2 = DeleteRegisterInfo();
+Result NfcDevice::Format() {
+    auto Result = DeleteApplicationArea();
+    auto Result2 = DeleteRegisterInfo();
 
-    if (ResultCode.IsError()) {
-        return ResultCode;
+    if (Result.IsError()) {
+        return Result;
     }
 
-    if (ResultCode2.IsError()) {
-        return ResultCode2;
+    if (Result2.IsError()) {
+        return Result2;
     }
 
     return RESULT_SUCCESS;
 }
 
-ResultCode NfcDevice::OpenApplicationArea(u32 access_id) {
+Result NfcDevice::OpenApplicationArea(u32 access_id) {
     if (device_state != DeviceState::TagMounted) {
         LOG_ERROR(Service_NFC, "Wrong device state {}", device_state);
         const auto connection_result = CheckConnectionState();
@@ -732,7 +732,7 @@ ResultCode NfcDevice::OpenApplicationArea(u32 access_id) {
     return RESULT_SUCCESS;
 }
 
-ResultCode NfcDevice::GetApplicationAreaId(u32& application_area_id) const {
+Result NfcDevice::GetApplicationAreaId(u32& application_area_id) const {
     application_area_id = {};
 
     if (device_state != DeviceState::TagMounted) {
@@ -754,7 +754,7 @@ ResultCode NfcDevice::GetApplicationAreaId(u32& application_area_id) const {
     return RESULT_SUCCESS;
 }
 
-ResultCode NfcDevice::GetApplicationArea(std::vector<u8>& data) const {
+Result NfcDevice::GetApplicationArea(std::vector<u8>& data) const {
     if (device_state != DeviceState::TagMounted) {
         LOG_ERROR(Service_NFC, "Wrong device state {}", device_state);
         const auto connection_result = CheckConnectionState();
@@ -783,7 +783,7 @@ ResultCode NfcDevice::GetApplicationArea(std::vector<u8>& data) const {
     return RESULT_SUCCESS;
 }
 
-ResultCode NfcDevice::SetApplicationArea(std::span<const u8> data) {
+Result NfcDevice::SetApplicationArea(std::span<const u8> data) {
     if (device_state != DeviceState::TagMounted) {
         LOG_ERROR(Service_NFC, "Wrong device state {}", device_state);
         const auto connection_result = CheckConnectionState();
@@ -831,7 +831,7 @@ ResultCode NfcDevice::SetApplicationArea(std::span<const u8> data) {
     return RESULT_SUCCESS;
 }
 
-ResultCode NfcDevice::CreateApplicationArea(u32 access_id, std::span<const u8> data) {
+Result NfcDevice::CreateApplicationArea(u32 access_id, std::span<const u8> data) {
     if (device_state != DeviceState::TagMounted) {
         LOG_ERROR(Service_NFC, "Wrong device state {}", device_state);
         const auto connection_result = CheckConnectionState();
@@ -849,7 +849,7 @@ ResultCode NfcDevice::CreateApplicationArea(u32 access_id, std::span<const u8> d
     return RecreateApplicationArea(access_id, data);
 }
 
-ResultCode NfcDevice::RecreateApplicationArea(u32 access_id, std::span<const u8> data) {
+Result NfcDevice::RecreateApplicationArea(u32 access_id, std::span<const u8> data) {
     if (device_state != DeviceState::TagMounted) {
         LOG_ERROR(Service_NFC, "Wrong device state {}", device_state);
         const auto connection_result = CheckConnectionState();
@@ -900,7 +900,7 @@ ResultCode NfcDevice::RecreateApplicationArea(u32 access_id, std::span<const u8>
     return Flush();
 }
 
-ResultCode NfcDevice::DeleteApplicationArea() {
+Result NfcDevice::DeleteApplicationArea() {
     // This is a hack to get around a HW issue
     if (device_state == DeviceState::TagFound) {
         Mount();
@@ -943,7 +943,7 @@ ResultCode NfcDevice::DeleteApplicationArea() {
     return Flush();
 }
 
-ResultCode NfcDevice::ApplicationAreaExist(bool& has_application_area) {
+Result NfcDevice::ApplicationAreaExist(bool& has_application_area) {
     if (device_state != DeviceState::TagMounted) {
         LOG_ERROR(Service_NFC, "Wrong device state {}", device_state);
         const auto connection_result = CheckConnectionState();
@@ -966,7 +966,7 @@ DeviceState NfcDevice::GetCurrentState() const {
     return device_state;
 }
 
-ResultCode NfcDevice::GetCommunicationStatus(CommunicationState& status) const {
+Result NfcDevice::GetCommunicationStatus(CommunicationState& status) const {
     if (communication_state == CommunicationState::Idle ||
         communication_state == CommunicationState::SearchingForAdapter) {
         status = communication_state;
@@ -982,7 +982,7 @@ ResultCode NfcDevice::GetCommunicationStatus(CommunicationState& status) const {
     return ResultInvalidOperation;
 }
 
-ResultCode NfcDevice::CheckConnectionState() const {
+Result NfcDevice::CheckConnectionState() const {
     if (connection_state == ConnectionState::Lost) {
         return ResultSleep;
     }

--- a/src/core/hle/service/nfc/nfc_device.cpp
+++ b/src/core/hle/service/nfc/nfc_device.cpp
@@ -181,7 +181,7 @@ Result NfcDevice::StartCommunication() {
 
     // This is a hack. This mode needs to change when the tag reader has completed the initalization
     communication_state = CommunicationState::Initialized;
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result NfcDevice::StopCommunication() {
@@ -201,7 +201,7 @@ Result NfcDevice::StopCommunication() {
 
     device_state = DeviceState::Initialized;
     communication_state = CommunicationState::Idle;
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result NfcDevice::StartDetection(TagProtocol allowed_protocol) {
@@ -227,7 +227,7 @@ Result NfcDevice::StartDetection(TagProtocol allowed_protocol) {
         LoadAmiibo(amiibo_filename);
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result NfcDevice::StopDetection() {
@@ -250,7 +250,7 @@ Result NfcDevice::StopDetection() {
         // TODO: Stop console search mode here
         device_state = DeviceState::Initialized;
         connection_state = ConnectionState::Success;
-        return RESULT_SUCCESS;
+        return ResultSuccess;
     }
 
     LOG_ERROR(Service_NFC, "Wrong device state {}", device_state);
@@ -282,7 +282,7 @@ Result NfcDevice::Flush() {
 
     if (is_write_protected) {
         LOG_ERROR(Service_NFC, "No keys available skipping write request");
-        return RESULT_SUCCESS;
+        return ResultSuccess;
     }
 
     if (!is_plain_amiibo) {
@@ -324,7 +324,7 @@ Result NfcDevice::Flush() {
 
     is_data_moddified = false;
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result NfcDevice::Mount() {
@@ -345,7 +345,7 @@ Result NfcDevice::Mount() {
     // The loaded amiibo is not encrypted
     if (is_plain_amiibo) {
         device_state = DeviceState::TagMounted;
-        return RESULT_SUCCESS;
+        return ResultSuccess;
     }
 
     if (!AmiiboCrypto::DecodeAmiibo(encrypted_tag.file, tag.file)) {
@@ -354,7 +354,7 @@ Result NfcDevice::Mount() {
     }
 
     device_state = DeviceState::TagMounted;
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result NfcDevice::MountAmiibo() {
@@ -390,7 +390,7 @@ Result NfcDevice::PartiallyMount() {
     // The loaded amiibo is not encrypted
     if (is_plain_amiibo) {
         device_state = DeviceState::TagPartiallyMounted;
-        return RESULT_SUCCESS;
+        return ResultSuccess;
     }
 
     if (!AmiiboCrypto::DecodeAmiibo(encrypted_tag.file, tag.file)) {
@@ -399,7 +399,7 @@ Result NfcDevice::PartiallyMount() {
     }
 
     device_state = DeviceState::TagPartiallyMounted;
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result NfcDevice::PartiallyMountAmiibo() {
@@ -430,7 +430,7 @@ Result NfcDevice::ResetTagScanState() {
     device_state = DeviceState::TagFound;
     is_app_area_open = false;
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result NfcDevice::GetTagInfo2(TagInfo2& tag_info) const {
@@ -443,7 +443,7 @@ Result NfcDevice::GetTagInfo2(TagInfo2& tag_info) const {
         .extra_data2 = {}, // Used on non amiibo tags
     };
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result NfcDevice::GetTagInfo(TagInfo& tag_info) const {
@@ -465,7 +465,7 @@ Result NfcDevice::GetTagInfo(TagInfo& tag_info) const {
         .extra_data = {}, // Used on non amiibo tags
     };
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result NfcDevice::GetCommonInfo(CommonInfo& common_info) const {
@@ -494,7 +494,7 @@ Result NfcDevice::GetCommonInfo(CommonInfo& common_info) const {
         .application_area_size = sizeof(ApplicationArea),
     };
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result NfcDevice::GetModelInfo(ModelInfo& model_info) const {
@@ -517,7 +517,7 @@ Result NfcDevice::GetModelInfo(ModelInfo& model_info) const {
         .amiibo_type = model_info_data.amiibo_type,
     };
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result NfcDevice::GetRegisterInfo(RegisterInfo& register_info) const {
@@ -545,7 +545,7 @@ Result NfcDevice::GetRegisterInfo(RegisterInfo& register_info) const {
         .creation_date = settings.init_date.GetWriteDate(),
     };
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result NfcDevice::GetAdminInfo(AdminInfo& admin_info) const {
@@ -604,7 +604,7 @@ Result NfcDevice::GetAdminInfo(AdminInfo& admin_info) const {
         .app_area_version = app_area_version,
     };
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result NfcDevice::DeleteRegisterInfo() {
@@ -689,7 +689,7 @@ Result NfcDevice::RestoreAmiibo() {
 
     // TODO: Load amiibo from backup on system
     LOG_ERROR(Service_NFC, "Not Implemented");
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result NfcDevice::Format() {
@@ -704,7 +704,7 @@ Result NfcDevice::Format() {
         return Result2;
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result NfcDevice::OpenApplicationArea(u32 access_id) {
@@ -729,7 +729,7 @@ Result NfcDevice::OpenApplicationArea(u32 access_id) {
 
     is_app_area_open = true;
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result NfcDevice::GetApplicationAreaId(u32& application_area_id) const {
@@ -751,7 +751,7 @@ Result NfcDevice::GetApplicationAreaId(u32& application_area_id) const {
 
     application_area_id = tag.file.application_area_id;
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result NfcDevice::GetApplicationArea(std::vector<u8>& data) const {
@@ -780,7 +780,7 @@ Result NfcDevice::GetApplicationArea(std::vector<u8>& data) const {
 
     memcpy(data.data(), tag.file.application_area.data(), data.size());
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result NfcDevice::SetApplicationArea(std::span<const u8> data) {
@@ -828,7 +828,7 @@ Result NfcDevice::SetApplicationArea(std::span<const u8> data) {
 
     is_data_moddified = true;
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result NfcDevice::CreateApplicationArea(u32 access_id, std::span<const u8> data) {
@@ -955,7 +955,7 @@ Result NfcDevice::ApplicationAreaExist(bool& has_application_area) {
 
     has_application_area = tag.file.settings.settings.appdata_initialized.Value() != 0;
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 constexpr u32 NfcDevice::GetApplicationAreaSize() const {
@@ -970,13 +970,13 @@ Result NfcDevice::GetCommunicationStatus(CommunicationState& status) const {
     if (communication_state == CommunicationState::Idle ||
         communication_state == CommunicationState::SearchingForAdapter) {
         status = communication_state;
-        return RESULT_SUCCESS;
+        return ResultSuccess;
     }
 
     if (communication_state == CommunicationState::Initialized ||
         communication_state == CommunicationState::Active) {
         status = CommunicationState::Initialized;
-        return RESULT_SUCCESS;
+        return ResultSuccess;
     }
 
     return ResultInvalidOperation;
@@ -991,7 +991,7 @@ Result NfcDevice::CheckConnectionState() const {
         return ResultWifiOff;
     }
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 void NfcDevice::SetAmiiboName(AmiiboSettings& settings, const AmiiboName& amiibo_name) {

--- a/src/core/hle/service/nfc/nfc_device.h
+++ b/src/core/hle/service/nfc/nfc_device.h
@@ -31,42 +31,42 @@ public:
     void Initialize();
     void Finalize();
 
-    ResultCode StartCommunication();
-    ResultCode StopCommunication();
-    ResultCode StartDetection(TagProtocol allowed_protocol);
-    ResultCode StopDetection();
-    ResultCode Mount();
-    ResultCode MountAmiibo();
-    ResultCode PartiallyMount();
-    ResultCode PartiallyMountAmiibo();
-    ResultCode ResetTagScanState();
-    ResultCode Flush();
+    Result StartCommunication();
+    Result StopCommunication();
+    Result StartDetection(TagProtocol allowed_protocol);
+    Result StopDetection();
+    Result Mount();
+    Result MountAmiibo();
+    Result PartiallyMount();
+    Result PartiallyMountAmiibo();
+    Result ResetTagScanState();
+    Result Flush();
 
-    ResultCode GetTagInfo2(TagInfo2& tag_info) const;
-    ResultCode GetTagInfo(TagInfo& tag_info) const;
-    ResultCode GetCommonInfo(CommonInfo& common_info) const;
-    ResultCode GetModelInfo(ModelInfo& model_info) const;
-    ResultCode GetRegisterInfo(RegisterInfo& register_info) const;
-    ResultCode GetAdminInfo(AdminInfo& admin_info) const;
+    Result GetTagInfo2(TagInfo2& tag_info) const;
+    Result GetTagInfo(TagInfo& tag_info) const;
+    Result GetCommonInfo(CommonInfo& common_info) const;
+    Result GetModelInfo(ModelInfo& model_info) const;
+    Result GetRegisterInfo(RegisterInfo& register_info) const;
+    Result GetAdminInfo(AdminInfo& admin_info) const;
 
-    ResultCode DeleteRegisterInfo();
-    ResultCode SetRegisterInfoPrivate(const RegisterInfoPrivate& register_info);
-    ResultCode RestoreAmiibo();
-    ResultCode Format();
+    Result DeleteRegisterInfo();
+    Result SetRegisterInfoPrivate(const RegisterInfoPrivate& register_info);
+    Result RestoreAmiibo();
+    Result Format();
 
-    ResultCode OpenApplicationArea(u32 access_id);
-    ResultCode GetApplicationAreaId(u32& application_area_id) const;
-    ResultCode GetApplicationArea(std::vector<u8>& data) const;
-    ResultCode SetApplicationArea(std::span<const u8> data);
-    ResultCode CreateApplicationArea(u32 access_id, std::span<const u8> data);
-    ResultCode RecreateApplicationArea(u32 access_id, std::span<const u8> data);
-    ResultCode DeleteApplicationArea();
-    ResultCode ApplicationAreaExist(bool& has_application_area);
+    Result OpenApplicationArea(u32 access_id);
+    Result GetApplicationAreaId(u32& application_area_id) const;
+    Result GetApplicationArea(std::vector<u8>& data) const;
+    Result SetApplicationArea(std::span<const u8> data);
+    Result CreateApplicationArea(u32 access_id, std::span<const u8> data);
+    Result RecreateApplicationArea(u32 access_id, std::span<const u8> data);
+    Result DeleteApplicationArea();
+    Result ApplicationAreaExist(bool& has_application_area);
 
     constexpr u32 GetApplicationAreaSize() const;
     DeviceState GetCurrentState() const;
-    ResultCode GetCommunicationStatus(CommunicationState& status) const;
-    ResultCode CheckConnectionState() const;
+    Result GetCommunicationStatus(CommunicationState& status) const;
+    Result CheckConnectionState() const;
 
     std::shared_ptr<Kernel::Event> GetActivateEvent() const;
     std::shared_ptr<Kernel::Event> GetDeactivateEvent() const;

--- a/src/core/hle/service/nfc/nfc_results.h
+++ b/src/core/hle/service/nfc/nfc_results.h
@@ -43,29 +43,29 @@ enum {
 };
 } // namespace ErrCodes
 
-constexpr ResultCode ResultInvalidArgumentValue(ErrCodes::InvalidArgumentValue, ErrorModule::NFC,
-                                                ErrorSummary::InvalidArgument, ErrorLevel::Status);
-constexpr ResultCode ResultInvalidArgument(ErrCodes::InvalidArgument, ErrorModule::NFC,
-                                           ErrorSummary::InvalidArgument, ErrorLevel::Status);
-constexpr ResultCode ResultInvalidOperation(ErrCodes::InvalidOperation, ErrorModule::NFC,
-                                            ErrorSummary::InvalidState, ErrorLevel::Status);
-constexpr ResultCode ResultNotSupported(ErrCodes::NotSupported, ErrorModule::NFC,
+constexpr Result ResultInvalidArgumentValue(ErrCodes::InvalidArgumentValue, ErrorModule::NFC,
+                                            ErrorSummary::InvalidArgument, ErrorLevel::Status);
+constexpr Result ResultInvalidArgument(ErrCodes::InvalidArgument, ErrorModule::NFC,
+                                       ErrorSummary::InvalidArgument, ErrorLevel::Status);
+constexpr Result ResultInvalidOperation(ErrCodes::InvalidOperation, ErrorModule::NFC,
                                         ErrorSummary::InvalidState, ErrorLevel::Status);
-constexpr ResultCode ResultNeedFormat(ErrCodes::NeedFormat, ErrorModule::NFC,
+constexpr Result ResultNotSupported(ErrCodes::NotSupported, ErrorModule::NFC,
+                                    ErrorSummary::InvalidState, ErrorLevel::Status);
+constexpr Result ResultNeedFormat(ErrCodes::NeedFormat, ErrorModule::NFC,
+                                  ErrorSummary::InvalidState, ErrorLevel::Status);
+constexpr Result ResultOperationFailed(ErrCodes::OperationFailed, ErrorModule::NFC,
+                                       ErrorSummary::InvalidState, ErrorLevel::Status);
+constexpr Result ResultNeedCreate(ErrCodes::NeedCreate, ErrorModule::NFC,
+                                  ErrorSummary::InvalidState, ErrorLevel::Status);
+constexpr Result ResultNeedRegister(ErrCodes::NeedRegister, ErrorModule::NFC,
+                                    ErrorSummary::InvalidState, ErrorLevel::Status);
+constexpr Result ResultAlreadyCreated(ErrCodes::AlreadyCreated, ErrorModule::NFC,
                                       ErrorSummary::InvalidState, ErrorLevel::Status);
-constexpr ResultCode ResultOperationFailed(ErrCodes::OperationFailed, ErrorModule::NFC,
-                                           ErrorSummary::InvalidState, ErrorLevel::Status);
-constexpr ResultCode ResultNeedCreate(ErrCodes::NeedCreate, ErrorModule::NFC,
-                                      ErrorSummary::InvalidState, ErrorLevel::Status);
-constexpr ResultCode ResultNeedRegister(ErrCodes::NeedRegister, ErrorModule::NFC,
+constexpr Result ResultAccessIdMisMatch(ErrCodes::AccessIdMisMatch, ErrorModule::NFC,
                                         ErrorSummary::InvalidState, ErrorLevel::Status);
-constexpr ResultCode ResultAlreadyCreated(ErrCodes::AlreadyCreated, ErrorModule::NFC,
-                                          ErrorSummary::InvalidState, ErrorLevel::Status);
-constexpr ResultCode ResultAccessIdMisMatch(ErrCodes::AccessIdMisMatch, ErrorModule::NFC,
-                                            ErrorSummary::InvalidState, ErrorLevel::Status);
-constexpr ResultCode ResultSleep(ErrCodes::Sleep, ErrorModule::NFC, ErrorSummary::InvalidState,
-                                 ErrorLevel::Status);
-constexpr ResultCode ResultWifiOff(ErrCodes::WifiOff, ErrorModule::NFC, ErrorSummary::InvalidState,
-                                   ErrorLevel::Status);
+constexpr Result ResultSleep(ErrCodes::Sleep, ErrorModule::NFC, ErrorSummary::InvalidState,
+                             ErrorLevel::Status);
+constexpr Result ResultWifiOff(ErrCodes::WifiOff, ErrorModule::NFC, ErrorSummary::InvalidState,
+                               ErrorLevel::Status);
 
 } // namespace Service::NFC

--- a/src/core/hle/service/nim/nim_u.cpp
+++ b/src/core/hle/service/nim/nim_u.cpp
@@ -190,7 +190,7 @@ void NIM_U::StartNetworkUpdate(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called");
 }
@@ -202,7 +202,7 @@ void NIM_U::GetProgress(Kernel::HLERequestContext& ctx) {
     std::memset(&progress, 0, sizeof(progress));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(13, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushRaw(progress);
     rb.Push(0);
     rb.Push(0);
@@ -214,7 +214,7 @@ void NIM_U::Cancel(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called");
 }
@@ -223,7 +223,7 @@ void NIM_U::CommitSystemTitles(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called");
 }
@@ -232,7 +232,7 @@ void NIM_U::GetBackgroundEventForMenu(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushCopyObjects(nim_system_update_event_for_menu);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called");
@@ -242,7 +242,7 @@ void NIM_U::GetBackgroundEventForNews(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushCopyObjects(nim_system_update_event_for_news);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called");
@@ -252,7 +252,7 @@ void NIM_U::FormatSaveData(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called");
 }
@@ -261,7 +261,7 @@ void NIM_U::GetCustomerSupportCode(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(0); // Customer support code
 
     LOG_WARNING(Service_NIM, "(STUBBED) called");
@@ -271,7 +271,7 @@ void NIM_U::IsCommittableAllSystemTitles(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(false);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called");
@@ -284,7 +284,7 @@ void NIM_U::GetBackgroundProgress(Kernel::HLERequestContext& ctx) {
     std::memset(&progress, 0, sizeof(progress));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(13, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushRaw(progress);
     rb.Push(0);
     rb.Push(0);
@@ -299,7 +299,7 @@ void NIM_U::GetSavedHash(Kernel::HLERequestContext& ctx) {
     std::memset(&hash, 0, sizeof(hash));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(10, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushRaw(hash);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called");
@@ -325,7 +325,7 @@ void NIM_U::IsRegistered(Kernel::HLERequestContext& ctx) {
     const u64 title_id = rp.Pop<u64>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(false);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called title_id={:016X}", title_id);
@@ -353,7 +353,7 @@ void NIM_U::GetTaskInfos(Kernel::HLERequestContext& ctx) {
     auto& task_infos_buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(0);
     rb.PushMappedBuffer(task_infos_buffer);
 
@@ -365,7 +365,7 @@ void NIM_U::DeleteUnmanagedContexts(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called");
 }
@@ -377,7 +377,7 @@ void NIM_U::UpdateAutoTitleDownloadTasksAsync(Kernel::HLERequestContext& ctx) {
     nim_async_completion_event->Signal();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushCopyObjects(nim_async_completion_event);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called");
@@ -390,7 +390,7 @@ void NIM_U::StartPendingAutoTitleDownloadTasksAsync(Kernel::HLERequestContext& c
     nim_async_completion_event->Signal();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushCopyObjects(nim_async_completion_event);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called");
@@ -400,8 +400,8 @@ void NIM_U::GetAsyncResult(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 0);
-    rb.Push(RESULT_SUCCESS);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
+    rb.Push(ResultSuccess);
     rb.Push(0);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called");
@@ -411,7 +411,7 @@ void NIM_U::CancelAsyncCall(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called");
 }
@@ -420,7 +420,7 @@ void NIM_U::IsPendingAutoTitleDownloadTasks(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(false);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called");
@@ -430,7 +430,7 @@ void NIM_U::GetNumAutoTitleDownloadTasks(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(0);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called");
@@ -443,7 +443,7 @@ void NIM_U::GetAutoTitleDownloadTaskInfos(Kernel::HLERequestContext& ctx) {
     auto& task_infos_buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(0);
     rb.PushMappedBuffer(task_infos_buffer);
 
@@ -457,7 +457,7 @@ void NIM_U::CancelAutoTitleDownloadTask(Kernel::HLERequestContext& ctx) {
     const u64 task_id = rp.Pop<u64>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called task_id={:016X}", task_id);
 }
@@ -468,7 +468,7 @@ void NIM_U::SetAutoDbgDat(Kernel::HLERequestContext& ctx) {
     auto& auto_dbg_dat_buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(auto_dbg_dat_buffer);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called auto_dbg_dat_buffer=0x{:08X}",
@@ -481,7 +481,7 @@ void NIM_U::GetAutoDbgDat(Kernel::HLERequestContext& ctx) {
     auto& auto_dbg_dat_buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(auto_dbg_dat_buffer);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called auto_dbg_dat_buffer=0x{:08X}",
@@ -495,7 +495,7 @@ void NIM_U::SetDbgTasks(Kernel::HLERequestContext& ctx) {
     auto& task_infos_buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(task_infos_buffer);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called max_task_infos={:08X}, task_infos_buffer=0x{:08X}",
@@ -509,7 +509,7 @@ void NIM_U::GetDbgTasks(Kernel::HLERequestContext& ctx) {
     auto& task_infos_buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(0);
     rb.PushMappedBuffer(task_infos_buffer);
 
@@ -521,7 +521,7 @@ void NIM_U::DeleteDbgData(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called");
 }
@@ -533,7 +533,7 @@ void NIM_U::SetTslXml(Kernel::HLERequestContext& ctx) {
     auto& xml_buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(xml_buffer);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called buffer_size={:08X}, xml_buffer=0x{:08X}",
@@ -544,7 +544,7 @@ void NIM_U::GetTslXmlSize(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u64>(0);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called");
@@ -557,7 +557,7 @@ void NIM_U::GetTslXml(Kernel::HLERequestContext& ctx) {
     auto& xml_buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(xml_buffer);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called buffer_capacity={:08X}, xml_buffer=0x{:08X}",
@@ -568,7 +568,7 @@ void NIM_U::DeleteTslXml(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called");
 }
@@ -580,7 +580,7 @@ void NIM_U::SetDtlXml(Kernel::HLERequestContext& ctx) {
     auto& xml_buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(xml_buffer);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called buffer_size={:08X}, xml_buffer=0x{:08X}",
@@ -591,7 +591,7 @@ void NIM_U::GetDtlXmlSize(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u64>(0);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called");
@@ -604,7 +604,7 @@ void NIM_U::GetDtlXml(Kernel::HLERequestContext& ctx) {
     auto& xml_buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(xml_buffer);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called buffer_capacity={:08X}, xml_buffer=0x{:08X}",
@@ -615,8 +615,8 @@ void NIM_U::UpdateAccountStatus(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 0);
-    rb.Push(RESULT_SUCCESS);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
+    rb.Push(ResultSuccess);
     rb.Push(0);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called");
@@ -628,7 +628,7 @@ void NIM_U::StartTitleDownload(Kernel::HLERequestContext& ctx) {
     const auto& download_config = rp.PopRaw<TitleDownloadConfig>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called title_id={:016X}", download_config.title_id);
 }
@@ -637,7 +637,7 @@ void NIM_U::StopTitleDownload(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called");
 }
@@ -649,7 +649,7 @@ void NIM_U::GetTitleDownloadProgress(Kernel::HLERequestContext& ctx) {
     std::memset(&progress, 0, sizeof(progress));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(9, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushRaw(progress);
     rb.Push(0);
     rb.Push(0);
@@ -669,7 +669,7 @@ void NIM_U::RegisterTask(Kernel::HLERequestContext& ctx) {
     const auto& developer_name = rp.PopStaticBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     const auto title_name_end = std::find(title_name.begin(), title_name.end(), u'\0');
     const auto title_name_utf8 =
@@ -690,8 +690,8 @@ void NIM_U::IsSystemUpdateAvailable(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(4, 0);
-    rb.Push(RESULT_SUCCESS);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
+    rb.Push(ResultSuccess);
     rb.Push(0);
     rb.Push(false);
 
@@ -702,7 +702,7 @@ void NIM_U::Unknown2B(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called");
 }
@@ -711,8 +711,8 @@ void NIM_U::UpdateTickets(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 0);
-    rb.Push(RESULT_SUCCESS);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
+    rb.Push(ResultSuccess);
     rb.Push(0);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called");
@@ -728,7 +728,7 @@ void NIM_U::DownloadTitleSeedAsync(Kernel::HLERequestContext& ctx) {
     nim_async_completion_event->Signal();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushCopyObjects(nim_async_completion_event);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called title_id={:016X}, country_code={:04X}", title_id,
@@ -742,7 +742,7 @@ void NIM_U::DownloadMissingTitleSeedsAsync(Kernel::HLERequestContext& ctx) {
     nim_async_completion_event->Signal();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushCopyObjects(nim_async_completion_event);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called");

--- a/src/core/hle/service/nim/nim_u.cpp
+++ b/src/core/hle/service/nim/nim_u.cpp
@@ -312,8 +312,8 @@ void NIM_U::UnregisterTask(Kernel::HLERequestContext& ctx) {
     const u32 process_id = rp.PopPID();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(ResultCode(ErrorDescription::NotFound, ErrorModule::NIM, ErrorSummary::NotFound,
-                       ErrorLevel::Status));
+    rb.Push(Result(ErrorDescription::NotFound, ErrorModule::NIM, ErrorSummary::NotFound,
+                   ErrorLevel::Status));
 
     LOG_WARNING(Service_NIM, "(STUBBED) called title_id={:016X}, process_id={:08X}", title_id,
                 process_id);
@@ -339,8 +339,8 @@ void NIM_U::FindTaskInfo(Kernel::HLERequestContext& ctx) {
     std::vector<u8> buffer(0x120, 0);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(ResultCode(ErrorDescription::NotFound, ErrorModule::NIM, ErrorSummary::NotFound,
-                       ErrorLevel::Status));
+    rb.Push(Result(ErrorDescription::NotFound, ErrorModule::NIM, ErrorSummary::NotFound,
+                   ErrorLevel::Status));
     rb.PushStaticBuffer(std::move(buffer), 0);
 
     LOG_WARNING(Service_NIM, "(STUBBED) called title_id={:016X}", title_id);

--- a/src/core/hle/service/nwm/nwm_uds.cpp
+++ b/src/core/hle/service/nwm/nwm_uds.cpp
@@ -576,7 +576,7 @@ void NWM_UDS::Shutdown(Kernel::HLERequestContext& ctx) {
     recv_buffer_memory.reset();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     LOG_DEBUG(Service_NWM, "called");
 }
 
@@ -636,7 +636,7 @@ void NWM_UDS::RecvBeaconBroadcastData(Kernel::HLERequestContext& ctx) {
     out_buffer.Write(&data_reply_header, 0, sizeof(BeaconDataReplyHeader));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(out_buffer);
 
     LOG_DEBUG(Service_NWM,
@@ -707,7 +707,7 @@ void NWM_UDS::GetConnectionStatus(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
     IPC::RequestBuilder rb = rp.MakeBuilder(13, 0);
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     {
         std::scoped_lock lock(connection_status_mutex);
         rb.PushRaw(connection_status);
@@ -747,7 +747,7 @@ void NWM_UDS::GetNodeInformation(Kernel::HLERequestContext& ctx) {
         }
 
         IPC::RequestBuilder rb = rp.MakeBuilder(11, 0);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.PushRaw<NodeInfo>(*itr);
     }
     LOG_DEBUG(Service_NWM, "called");
@@ -800,7 +800,7 @@ void NWM_UDS::Bind(Kernel::HLERequestContext& ctx) {
     channel_data[data_channel] = {bind_node_id, data_channel, network_node_id, event};
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushCopyObjects(event);
 }
 
@@ -829,7 +829,7 @@ void NWM_UDS::Unbind(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(5, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(bind_node_id);
     // TODO(B3N30): Find out what the other return values are
     rb.Push<u32>(0);
@@ -901,7 +901,7 @@ Result NWM_UDS::BeginHostingNetwork(std::span<const u8> network_info_buffer,
     system.CoreTiming().ScheduleEvent(msToCycles(DefaultBeaconInterval * MillisecondsPerTU),
                                       beacon_broadcast_event, 0);
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 void NWM_UDS::BeginHostingNetwork(Kernel::HLERequestContext& ctx) {
@@ -965,7 +965,7 @@ void NWM_UDS::EjectClient(Kernel::HLERequestContext& ctx) {
     }
 
     // This function always returns success if the status is valid.
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     using Network::WifiPacket;
     Network::MacAddress dest_address = Network::BroadcastMac;
@@ -996,7 +996,7 @@ void NWM_UDS::UpdateNetworkAttribute(Kernel::HLERequestContext& ctx) {
     rp.Skip(2, false);
     LOG_WARNING(Service_NWM, "stubbed");
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void NWM_UDS::DestroyNetwork(Kernel::HLERequestContext& ctx) {
@@ -1032,7 +1032,7 @@ void NWM_UDS::DestroyNetwork(Kernel::HLERequestContext& ctx) {
     }
     channel_data.clear();
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     LOG_DEBUG(Service_NWM, "called");
 }
@@ -1078,7 +1078,7 @@ void NWM_UDS::DisconnectNetwork(Kernel::HLERequestContext& ctx) {
     }
     channel_data.clear();
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     LOG_DEBUG(Service_NWM, "called");
 }
 
@@ -1157,7 +1157,7 @@ void NWM_UDS::SendTo(Kernel::HLERequestContext& ctx) {
 
     SendPacket(packet);
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void NWM_UDS::PullPacket(Kernel::HLERequestContext& ctx) {
@@ -1195,7 +1195,7 @@ void NWM_UDS::PullPacket(Kernel::HLERequestContext& ctx) {
     if (channel->second.received_packets.empty()) {
         std::vector<u8> output_buffer(buff_size);
         IPC::RequestBuilder rb = rp.MakeBuilder(3, 2);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.Push<u32>(0);
         rb.Push<u16>(0);
         rb.PushStaticBuffer(std::move(output_buffer), 0);
@@ -1221,7 +1221,7 @@ void NWM_UDS::PullPacket(Kernel::HLERequestContext& ctx) {
     std::memcpy(output_buffer.data(),
                 next_packet.data() + sizeof(LLCHeader) + sizeof(SecureDataHeader), data_size);
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u32>(data_size);
     rb.Push<u16>(secure_data.src_node_id);
     rb.PushStaticBuffer(std::move(output_buffer), 0);
@@ -1238,7 +1238,7 @@ void NWM_UDS::GetChannel(Kernel::HLERequestContext& ctx) {
 
     u8 channel = is_connected ? network_channel : 0;
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(channel);
 
     LOG_DEBUG(Service_NWM, "called");
@@ -1252,7 +1252,7 @@ public:
                 Kernel::ThreadWakeupReason reason) {
         // TODO(B3N30): Add error handling for host full and timeout
         IPC::RequestBuilder rb(ctx, command_id, 1, 0);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         LOG_DEBUG(Service_NWM, "connection sequence finished");
     }
 
@@ -1339,7 +1339,7 @@ void NWM_UDS::SetApplicationData(Kernel::HLERequestContext& ctx) {
     network_info.application_data_size = static_cast<u8>(size);
     std::memcpy(network_info.application_data.data(), application_data.data(), size);
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void NWM_UDS::GetApplicationData(Kernel::HLERequestContext& ctx) {
@@ -1348,7 +1348,7 @@ void NWM_UDS::GetApplicationData(Kernel::HLERequestContext& ctx) {
     u8 appdata_size = network_info.application_data_size;
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     if (input_size < appdata_size) {
         rb.Push(0);
@@ -1420,7 +1420,7 @@ void NWM_UDS::DecryptBeaconData(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 
     std::vector<u8> output_buffer(sizeof(NodeInfo) * UDSMaxNodes);
     std::memcpy(output_buffer.data(), nodes.data(), sizeof(NodeInfo) * nodes.size());

--- a/src/core/hle/service/nwm/nwm_uds.h
+++ b/src/core/hle/service/nwm/nwm_uds.h
@@ -449,8 +449,7 @@ private:
         u32 sharedmem_size, const NodeInfo& node, u16 version,
         std::shared_ptr<Kernel::SharedMemory> sharedmem);
 
-    ResultCode BeginHostingNetwork(std::span<const u8> network_info_buffer,
-                                   std::vector<u8> passphrase);
+    Result BeginHostingNetwork(std::span<const u8> network_info_buffer, std::vector<u8> passphrase);
 
     void ConnectToNetwork(Kernel::HLERequestContext& ctx, u16 command_id,
                           std::span<const u8> network_info_buffer, u8 connection_type,

--- a/src/core/hle/service/plgldr/plgldr.cpp
+++ b/src/core/hle/service/plgldr/plgldr.cpp
@@ -160,7 +160,7 @@ void PLG_LDR::IsEnabled(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(plgldr_context.is_enabled);
 }
 
@@ -174,7 +174,7 @@ void PLG_LDR::SetEnabled(Kernel::HLERequestContext& ctx) {
         Settings::values.plugin_loader_enabled.SetValue(enabled);
     }
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push((can_change) ? RESULT_SUCCESS : Kernel::ERR_NOT_AUTHORIZED);
+    rb.Push((can_change) ? ResultSuccess : Kernel::ResultNotAuthorized);
 }
 
 void PLG_LDR::SetLoadSettings(Kernel::HLERequestContext& ctx) {
@@ -198,7 +198,7 @@ void PLG_LDR::SetLoadSettings(Kernel::HLERequestContext& ctx) {
         std::min(sizeof(PluginLoaderContext::PluginLoadParameters::config), config.GetSize()));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void PLG_LDR::DisplayErrorMessage(Kernel::HLERequestContext& ctx) {
@@ -220,14 +220,14 @@ void PLG_LDR::DisplayErrorMessage(Kernel::HLERequestContext& ctx) {
               std::string(title_data.data()), std::string(desc_data.data()));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void PLG_LDR::GetPLGLDRVersion(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(plgldr_version.raw);
 }
 
@@ -239,7 +239,7 @@ void PLG_LDR::GetArbiter(Kernel::HLERequestContext& ctx) {
     // signal the plgldr service thread when a event is ready. Instead we just send
     // an error and the 3GX plugin will take care of it.
     // (We never send any events anyways)
-    rb.Push(Kernel::ERR_NOT_IMPLEMENTED);
+    rb.Push(Kernel::ResultNotImplemented);
 }
 
 void PLG_LDR::GetPluginPath(Kernel::HLERequestContext& ctx) {
@@ -260,7 +260,7 @@ void PLG_LDR::GetPluginPath(Kernel::HLERequestContext& ctx) {
     path.Write(plugin_path.c_str(), 0, std::min(path.GetSize(), plugin_path.length() + 1));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(path);
 }
 

--- a/src/core/hle/service/plgldr/plgldr.cpp
+++ b/src/core/hle/service/plgldr/plgldr.cpp
@@ -130,21 +130,22 @@ void PLG_LDR::OnProcessExit(Kernel::Process& process, Kernel::KernelSystem& kern
 }
 
 ResultVal<Kernel::Handle> PLG_LDR::GetMemoryChangedHandle(Kernel::KernelSystem& kernel) {
-    if (plgldr_context.memory_changed_handle)
+    if (plgldr_context.memory_changed_handle) {
         return plgldr_context.memory_changed_handle;
+    }
 
     std::shared_ptr<Kernel::Event> evt = kernel.CreateEvent(
         Kernel::ResetType::OneShot,
         fmt::format("event-{:08x}", Core::System::GetInstance().GetRunningCore().GetReg(14)));
-    CASCADE_RESULT(plgldr_context.memory_changed_handle,
-                   kernel.GetCurrentProcess()->handle_table.Create(std::move(evt)));
-
+    R_TRY(kernel.GetCurrentProcess()->handle_table.Create(
+        std::addressof(plgldr_context.memory_changed_handle), std::move(evt)));
     return plgldr_context.memory_changed_handle;
 }
 
 void PLG_LDR::OnMemoryChanged(Kernel::Process& process, Kernel::KernelSystem& kernel) {
-    if (!plgldr_context.plugin_loaded || !plgldr_context.memory_changed_handle)
+    if (!plgldr_context.plugin_loaded || !plgldr_context.memory_changed_handle) {
         return;
+    }
 
     std::shared_ptr<Kernel::Event> evt =
         kernel.GetCurrentProcess()->handle_table.Get<Kernel::Event>(

--- a/src/core/hle/service/ps/ps_ps.cpp
+++ b/src/core/hle/service/ps/ps_ps.cpp
@@ -141,7 +141,7 @@ void PS_PS::EncryptDecryptAes(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(5, 4);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushRaw(new_iv);
     rb.PushMappedBuffer(source);
     rb.PushMappedBuffer(destination);
@@ -157,7 +157,7 @@ void PS_PS::GenerateRandomBytes(Kernel::HLERequestContext& ctx) {
     buffer.Write(out_data.data(), 0, size);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(buffer);
 }
 

--- a/src/core/hle/service/ps/ps_ps.cpp
+++ b/src/core/hle/service/ps/ps_ps.cpp
@@ -77,8 +77,8 @@ void PS_PS::EncryptDecryptAes(Kernel::HLERequestContext& ctx) {
     if (algorithm == AlgorithmType::CCM_Encrypt || algorithm == AlgorithmType::CCM_Decrypt) {
         // AES-CCM is not supported with this function
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 4);
-        rb.Push(ResultCode(ErrorDescription::InvalidSection, ErrorModule::PS,
-                           ErrorSummary::WrongArgument, ErrorLevel::Status));
+        rb.Push(Result(ErrorDescription::InvalidSection, ErrorModule::PS,
+                       ErrorSummary::WrongArgument, ErrorLevel::Status));
         rb.PushMappedBuffer(source);
         rb.PushMappedBuffer(destination);
         return;

--- a/src/core/hle/service/ptm/ptm.cpp
+++ b/src/core/hle/service/ptm/ptm.cpp
@@ -30,7 +30,7 @@ void Module::Interface::GetAdapterState(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(ptm->battery_is_charging);
 
     LOG_WARNING(Service_PTM, "(STUBBED) called");
@@ -40,7 +40,7 @@ void Module::Interface::GetShellState(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(ptm->shell_open);
 }
 
@@ -48,7 +48,7 @@ void Module::Interface::GetBatteryLevel(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(static_cast<u32>(ChargeLevels::CompletelyFull)); // Set to a completely full battery
 
     LOG_WARNING(Service_PTM, "(STUBBED) called");
@@ -58,7 +58,7 @@ void Module::Interface::GetBatteryChargeState(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(ptm->battery_is_charging);
 
     LOG_WARNING(Service_PTM, "(STUBBED) called");
@@ -68,7 +68,7 @@ void Module::Interface::GetPedometerState(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(ptm->pedometer_is_counting);
 
     LOG_WARNING(Service_PTM, "(STUBBED) called");
@@ -90,7 +90,7 @@ void Module::Interface::GetStepHistory(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(buffer);
 
     LOG_WARNING(Service_PTM, "(STUBBED) called, from time(raw): 0x{:x}, for {} hours", start_time,
@@ -101,7 +101,7 @@ void Module::Interface::GetTotalStepCount(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push<u32>(0);
 
     LOG_WARNING(Service_PTM, "(STUBBED) called");
@@ -111,7 +111,7 @@ void Module::Interface::GetSoftwareClosedFlag(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(false);
 
     LOG_WARNING(Service_PTM, "(STUBBED) called");
@@ -120,7 +120,7 @@ void Module::Interface::GetSoftwareClosedFlag(Kernel::HLERequestContext& ctx) {
 void CheckNew3DS(IPC::RequestBuilder& rb) {
     const bool is_new_3ds = Settings::values.is_new_3ds.GetValue();
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(is_new_3ds);
 
     LOG_DEBUG(Service_PTM, "called isNew3DS = 0x{:08x}", static_cast<u32>(is_new_3ds));
@@ -140,7 +140,7 @@ void Module::Interface::GetSystemTime(Kernel::HLERequestContext& ctx) {
     const u64 console_time = share_page.GetSystemTimeSince2000();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(console_time);
 }
 
@@ -155,7 +155,7 @@ static void WriteGameCoinData(GameCoin gamecoin_data) {
 
     FileSys::Path gamecoin_path("/gamecoin.dat");
     // If the archive didn't exist, create the files inside
-    if (archive_result.Code() == FileSys::ERR_NOT_FORMATTED) {
+    if (archive_result.Code() == FileSys::ResultNotFormatted) {
         // Format the archive to create the directories
         extdata_archive_factory.Format(archive_path, FileSys::ArchiveFormatInfo(), 0);
         // Open it again to get a valid archive now that the folder exists
@@ -216,7 +216,7 @@ Module::Module() {
     const FileSys::Path archive_path(ptm_shared_extdata_id);
     const auto archive_result = extdata_archive_factory.Open(archive_path, 0);
     // If the archive didn't exist, write the default game coin file
-    if (archive_result.Code() == FileSys::ERR_NOT_FORMATTED) {
+    if (archive_result.Code() == FileSys::ResultNotFormatted) {
         WriteGameCoinData(default_game_coin);
     }
 }

--- a/src/core/hle/service/qtm/qtm_s.cpp
+++ b/src/core/hle/service/qtm/qtm_s.cpp
@@ -16,7 +16,7 @@ void QTM_S::GetHeadtrackingInfo(Kernel::HLERequestContext& ctx) {
 
     std::array<u8, 0x40> data{};
     IPC::RequestBuilder rb = rp.MakeBuilder(17, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushRaw<std::array<u8, 0x40>>(data);
 
     LOG_DEBUG(Service, "(STUBBED) called");

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -131,7 +131,7 @@ ServiceFrameworkBase::~ServiceFrameworkBase() = default;
 
 void ServiceFrameworkBase::InstallAsService(SM::ServiceManager& service_manager) {
     std::shared_ptr<Kernel::ServerPort> port;
-    R_ASSERT(service_manager.RegisterService(port, service_name, max_sessions));
+    R_ASSERT(service_manager.RegisterService(std::addressof(port), service_name, max_sessions));
     port->SetHleHandler(shared_from_this());
 }
 

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -130,7 +130,8 @@ ServiceFrameworkBase::ServiceFrameworkBase(const char* service_name, u32 max_ses
 ServiceFrameworkBase::~ServiceFrameworkBase() = default;
 
 void ServiceFrameworkBase::InstallAsService(SM::ServiceManager& service_manager) {
-    auto port = service_manager.RegisterService(service_name, max_sessions).Unwrap();
+    std::shared_ptr<Kernel::ServerPort> port;
+    R_ASSERT(service_manager.RegisterService(port, service_name, max_sessions));
     port->SetHleHandler(shared_from_this());
 }
 

--- a/src/core/hle/service/sm/sm.cpp
+++ b/src/core/hle/service/sm/sm.cpp
@@ -12,7 +12,7 @@
 
 namespace Service::SM {
 
-static ResultCode ValidateServiceName(const std::string& name) {
+static Result ValidateServiceName(const std::string& name) {
     R_UNLESS(name.size() > 0 && name.size() <= 8, ERR_INVALID_NAME_SIZE);
     R_UNLESS(name.find('\0') == std::string::npos, ERR_NAME_CONTAINS_NUL);
     return RESULT_SUCCESS;
@@ -28,8 +28,8 @@ void ServiceManager::InstallInterfaces(Core::System& system) {
     system.ServiceManager().srv_interface = srv;
 }
 
-ResultCode ServiceManager::RegisterService(std::shared_ptr<Kernel::ServerPort>& server_port,
-                                           std::string name, u32 max_sessions) {
+Result ServiceManager::RegisterService(std::shared_ptr<Kernel::ServerPort>& server_port,
+                                       std::string name, u32 max_sessions) {
     R_TRY(ValidateServiceName(name));
     R_UNLESS(registered_services.find(name) == registered_services.end(), ERR_ALREADY_REGISTERED);
 
@@ -41,8 +41,8 @@ ResultCode ServiceManager::RegisterService(std::shared_ptr<Kernel::ServerPort>& 
     return RESULT_SUCCESS;
 }
 
-ResultCode ServiceManager::GetServicePort(std::shared_ptr<Kernel::ClientPort>& out_port,
-                                          const std::string& name) {
+Result ServiceManager::GetServicePort(std::shared_ptr<Kernel::ClientPort>& out_port,
+                                      const std::string& name) {
     R_TRY(ValidateServiceName(name));
 
     auto it = registered_services.find(name);
@@ -52,8 +52,8 @@ ResultCode ServiceManager::GetServicePort(std::shared_ptr<Kernel::ClientPort>& o
     return RESULT_SUCCESS;
 }
 
-ResultCode ServiceManager::ConnectToService(std::shared_ptr<Kernel::ClientSession>& session,
-                                            const std::string& name) {
+Result ServiceManager::ConnectToService(std::shared_ptr<Kernel::ClientSession>& session,
+                                        const std::string& name) {
     std::shared_ptr<Kernel::ClientPort> client_port;
     R_TRY(GetServicePort(client_port, name));
     return client_port->Connect(session);

--- a/src/core/hle/service/sm/sm.cpp
+++ b/src/core/hle/service/sm/sm.cpp
@@ -13,9 +13,9 @@
 namespace Service::SM {
 
 static Result ValidateServiceName(const std::string& name) {
-    R_UNLESS(name.size() > 0 && name.size() <= 8, ERR_INVALID_NAME_SIZE);
-    R_UNLESS(name.find('\0') == std::string::npos, ERR_NAME_CONTAINS_NUL);
-    return RESULT_SUCCESS;
+    R_UNLESS(name.size() > 0 && name.size() <= 8, ResultInvalidNameSize);
+    R_UNLESS(name.find('\0') == std::string::npos, ResultNameContainsNul);
+    return ResultSuccess;
 }
 
 ServiceManager::ServiceManager(Core::System& system) : system(system) {}
@@ -31,14 +31,14 @@ void ServiceManager::InstallInterfaces(Core::System& system) {
 Result ServiceManager::RegisterService(std::shared_ptr<Kernel::ServerPort>& server_port,
                                        std::string name, u32 max_sessions) {
     R_TRY(ValidateServiceName(name));
-    R_UNLESS(registered_services.find(name) == registered_services.end(), ERR_ALREADY_REGISTERED);
+    R_UNLESS(registered_services.find(name) == registered_services.end(), ResultAlreadyRegistered);
 
     std::shared_ptr<Kernel::ClientPort> client_port;
     std::tie(server_port, client_port) = system.Kernel().CreatePortPair(max_sessions, name);
     registered_services_inverse.emplace(client_port->GetObjectId(), name);
     registered_services.emplace(std::move(name), std::move(client_port));
 
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result ServiceManager::GetServicePort(std::shared_ptr<Kernel::ClientPort>& out_port,
@@ -46,10 +46,10 @@ Result ServiceManager::GetServicePort(std::shared_ptr<Kernel::ClientPort>& out_p
     R_TRY(ValidateServiceName(name));
 
     auto it = registered_services.find(name);
-    R_UNLESS(it != registered_services.end(), ERR_SERVICE_NOT_REGISTERED);
+    R_UNLESS(it != registered_services.end(), ResultServiceNotRegistered);
 
     out_port = it->second;
-    return RESULT_SUCCESS;
+    return ResultSuccess;
 }
 
 Result ServiceManager::ConnectToService(std::shared_ptr<Kernel::ClientSession>& session,

--- a/src/core/hle/service/sm/sm.h
+++ b/src/core/hle/service/sm/sm.h
@@ -51,10 +51,12 @@ public:
 
     explicit ServiceManager(Core::System& system);
 
-    ResultVal<std::shared_ptr<Kernel::ServerPort>> RegisterService(std::string name,
-                                                                   unsigned int max_sessions);
-    ResultVal<std::shared_ptr<Kernel::ClientPort>> GetServicePort(const std::string& name);
-    ResultVal<std::shared_ptr<Kernel::ClientSession>> ConnectToService(const std::string& name);
+    ResultCode RegisterService(std::shared_ptr<Kernel::ServerPort>& out_port, std::string name,
+                               u32 max_sessions);
+    ResultCode GetServicePort(std::shared_ptr<Kernel::ClientPort>& out_port,
+                              const std::string& name);
+    ResultCode ConnectToService(std::shared_ptr<Kernel::ClientSession>& out_session,
+                                const std::string& name);
     // For IPC Recorder
     std::string GetServiceNameByPortId(u32 port) const;
 

--- a/src/core/hle/service/sm/sm.h
+++ b/src/core/hle/service/sm/sm.h
@@ -31,19 +31,19 @@ namespace Service::SM {
 
 class SRV;
 
-constexpr ResultCode ERR_SERVICE_NOT_REGISTERED(1, ErrorModule::SRV, ErrorSummary::WouldBlock,
-                                                ErrorLevel::Temporary); // 0xD0406401
-constexpr ResultCode ERR_MAX_CONNECTIONS_REACHED(2, ErrorModule::SRV, ErrorSummary::WouldBlock,
-                                                 ErrorLevel::Temporary); // 0xD0406402
-constexpr ResultCode ERR_INVALID_NAME_SIZE(5, ErrorModule::SRV, ErrorSummary::WrongArgument,
-                                           ErrorLevel::Permanent); // 0xD9006405
-constexpr ResultCode ERR_ACCESS_DENIED(6, ErrorModule::SRV, ErrorSummary::InvalidArgument,
-                                       ErrorLevel::Permanent); // 0xD8E06406
-constexpr ResultCode ERR_NAME_CONTAINS_NUL(7, ErrorModule::SRV, ErrorSummary::WrongArgument,
-                                           ErrorLevel::Permanent); // 0xD9006407
-constexpr ResultCode ERR_ALREADY_REGISTERED(ErrorDescription::AlreadyExists, ErrorModule::OS,
-                                            ErrorSummary::WrongArgument,
-                                            ErrorLevel::Permanent); // 0xD9001BFC
+constexpr Result ERR_SERVICE_NOT_REGISTERED(1, ErrorModule::SRV, ErrorSummary::WouldBlock,
+                                            ErrorLevel::Temporary); // 0xD0406401
+constexpr Result ERR_MAX_CONNECTIONS_REACHED(2, ErrorModule::SRV, ErrorSummary::WouldBlock,
+                                             ErrorLevel::Temporary); // 0xD0406402
+constexpr Result ERR_INVALID_NAME_SIZE(5, ErrorModule::SRV, ErrorSummary::WrongArgument,
+                                       ErrorLevel::Permanent); // 0xD9006405
+constexpr Result ERR_ACCESS_DENIED(6, ErrorModule::SRV, ErrorSummary::InvalidArgument,
+                                   ErrorLevel::Permanent); // 0xD8E06406
+constexpr Result ERR_NAME_CONTAINS_NUL(7, ErrorModule::SRV, ErrorSummary::WrongArgument,
+                                       ErrorLevel::Permanent); // 0xD9006407
+constexpr Result ERR_ALREADY_REGISTERED(ErrorDescription::AlreadyExists, ErrorModule::OS,
+                                        ErrorSummary::WrongArgument,
+                                        ErrorLevel::Permanent); // 0xD9001BFC
 
 class ServiceManager {
 public:
@@ -51,12 +51,11 @@ public:
 
     explicit ServiceManager(Core::System& system);
 
-    ResultCode RegisterService(std::shared_ptr<Kernel::ServerPort>& out_port, std::string name,
-                               u32 max_sessions);
-    ResultCode GetServicePort(std::shared_ptr<Kernel::ClientPort>& out_port,
-                              const std::string& name);
-    ResultCode ConnectToService(std::shared_ptr<Kernel::ClientSession>& out_session,
-                                const std::string& name);
+    Result RegisterService(std::shared_ptr<Kernel::ServerPort>& out_port, std::string name,
+                           u32 max_sessions);
+    Result GetServicePort(std::shared_ptr<Kernel::ClientPort>& out_port, const std::string& name);
+    Result ConnectToService(std::shared_ptr<Kernel::ClientSession>& out_session,
+                            const std::string& name);
     // For IPC Recorder
     std::string GetServiceNameByPortId(u32 port) const;
 

--- a/src/core/hle/service/sm/sm.h
+++ b/src/core/hle/service/sm/sm.h
@@ -51,10 +51,11 @@ public:
 
     explicit ServiceManager(Core::System& system);
 
-    Result RegisterService(std::shared_ptr<Kernel::ServerPort>& out_port, std::string name,
+    Result RegisterService(std::shared_ptr<Kernel::ServerPort>* out_server_port, std::string name,
                            u32 max_sessions);
-    Result GetServicePort(std::shared_ptr<Kernel::ClientPort>& out_port, const std::string& name);
-    Result ConnectToService(std::shared_ptr<Kernel::ClientSession>& out_session,
+    Result GetServicePort(std::shared_ptr<Kernel::ClientPort>* out_client_port,
+                          const std::string& name);
+    Result ConnectToService(std::shared_ptr<Kernel::ClientSession>* out_client_session,
                             const std::string& name);
     // For IPC Recorder
     std::string GetServiceNameByPortId(u32 port) const;

--- a/src/core/hle/service/sm/sm.h
+++ b/src/core/hle/service/sm/sm.h
@@ -31,19 +31,19 @@ namespace Service::SM {
 
 class SRV;
 
-constexpr Result ERR_SERVICE_NOT_REGISTERED(1, ErrorModule::SRV, ErrorSummary::WouldBlock,
+constexpr Result ResultServiceNotRegistered(1, ErrorModule::SRV, ErrorSummary::WouldBlock,
                                             ErrorLevel::Temporary); // 0xD0406401
-constexpr Result ERR_MAX_CONNECTIONS_REACHED(2, ErrorModule::SRV, ErrorSummary::WouldBlock,
+constexpr Result ResultMaxConnectionsReached(2, ErrorModule::SRV, ErrorSummary::WouldBlock,
                                              ErrorLevel::Temporary); // 0xD0406402
-constexpr Result ERR_INVALID_NAME_SIZE(5, ErrorModule::SRV, ErrorSummary::WrongArgument,
+constexpr Result ResultInvalidNameSize(5, ErrorModule::SRV, ErrorSummary::WrongArgument,
                                        ErrorLevel::Permanent); // 0xD9006405
-constexpr Result ERR_ACCESS_DENIED(6, ErrorModule::SRV, ErrorSummary::InvalidArgument,
-                                   ErrorLevel::Permanent); // 0xD8E06406
-constexpr Result ERR_NAME_CONTAINS_NUL(7, ErrorModule::SRV, ErrorSummary::WrongArgument,
+constexpr Result ResultAccessDenied(6, ErrorModule::SRV, ErrorSummary::InvalidArgument,
+                                    ErrorLevel::Permanent); // 0xD8E06406
+constexpr Result ResultNameContainsNul(7, ErrorModule::SRV, ErrorSummary::WrongArgument,
                                        ErrorLevel::Permanent); // 0xD9006407
-constexpr Result ERR_ALREADY_REGISTERED(ErrorDescription::AlreadyExists, ErrorModule::OS,
-                                        ErrorSummary::WrongArgument,
-                                        ErrorLevel::Permanent); // 0xD9001BFC
+constexpr Result ResultAlreadyRegistered(ErrorDescription::AlreadyExists, ErrorModule::OS,
+                                         ErrorSummary::WrongArgument,
+                                         ErrorLevel::Permanent); // 0xD9001BFC
 
 class ServiceManager {
 public:

--- a/src/core/hle/service/sm/srv.cpp
+++ b/src/core/hle/service/sm/srv.cpp
@@ -53,13 +53,13 @@ void SRV::RegisterClient(Kernel::HLERequestContext& ctx) {
     const auto pid_descriptor = rp.Pop<u32>();
     if (pid_descriptor != IPC::CallingPidDesc()) {
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-        rb.Push(IPC::ERR_INVALID_BUFFER_DESCRIPTOR);
+        rb.Push(IPC::ResultInvalidBufferDescriptor);
         return;
     }
     const auto caller_pid = rp.Pop<u32>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     LOG_WARNING(Service_SRV, "(STUBBED) called. Caller PID={}", caller_pid);
 }
 
@@ -80,7 +80,7 @@ void SRV::EnableNotification(Kernel::HLERequestContext& ctx) {
         system.Kernel().CreateSemaphore(0, MAX_PENDING_NOTIFICATIONS, "SRV:Notification").Unwrap();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushCopyObjects(notification_semaphore);
     LOG_WARNING(Service_SRV, "(STUBBED) called");
 }
@@ -104,8 +104,8 @@ public:
             IPC::RequestBuilder rb(ctx, 0x5, 1, 2);
             rb.Push(result);
             rb.PushMoveObjects(std::move(session));
-        } else if (result == Kernel::ERR_MAX_CONNECTIONS_REACHED) {
-            LOG_ERROR(Service_SRV, "called service={} -> ERR_MAX_CONNECTIONS_REACHED", name);
+        } else if (result == Kernel::ResultMaxConnectionsReached) {
+            LOG_ERROR(Service_SRV, "called service={} -> ResultMaxConnectionsReached", name);
             UNREACHABLE();
         } else {
             LOG_ERROR(Service_SRV, "called service={} -> error 0x{:08X}", name, result.raw);
@@ -149,8 +149,8 @@ void SRV::GetServiceHandle(Kernel::HLERequestContext& ctx) {
 
     if (name_len > Service::kMaxPortSize) {
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-        rb.Push(ERR_INVALID_NAME_SIZE);
-        LOG_ERROR(Service_SRV, "called name_len=0x{:X} -> ERR_INVALID_NAME_SIZE", name_len);
+        rb.Push(ResultInvalidNameSize);
+        LOG_ERROR(Service_SRV, "called name_len=0x{:X} -> ResultInvalidNameSize", name_len);
         return;
     }
     std::string name(name_buf.data(), name_len);
@@ -162,7 +162,7 @@ void SRV::GetServiceHandle(Kernel::HLERequestContext& ctx) {
     std::shared_ptr<Kernel::ClientPort> client_port;
     auto result = system.ServiceManager().GetServicePort(client_port, name);
     if (result.IsError()) {
-        if (wait_until_available && result == ERR_SERVICE_NOT_REGISTERED) {
+        if (wait_until_available && result == ResultServiceNotRegistered) {
             LOG_INFO(Service_SRV, "called service={} delayed", name);
             std::shared_ptr<Kernel::Event> get_service_handle_event =
                 ctx.SleepClientThread("GetServiceHandle", std::chrono::nanoseconds(-1), get_handle);
@@ -183,8 +183,8 @@ void SRV::GetServiceHandle(Kernel::HLERequestContext& ctx) {
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
         rb.Push(result);
         rb.PushMoveObjects(std::move(session));
-    } else if (result == Kernel::ERR_MAX_CONNECTIONS_REACHED && wait_until_available) {
-        LOG_WARNING(Service_SRV, "called service={} -> ERR_MAX_CONNECTIONS_REACHED", name);
+    } else if (result == Kernel::ResultMaxConnectionsReached && wait_until_available) {
+        LOG_WARNING(Service_SRV, "called service={} -> ResultMaxConnectionsReached", name);
         // TODO(Subv): Put the caller guest thread to sleep until this port becomes available again.
         UNIMPLEMENTED_MSG("Unimplemented wait until port {} is available.", name);
     } else {
@@ -208,7 +208,7 @@ void SRV::Subscribe(Kernel::HLERequestContext& ctx) {
     u32 notification_id = rp.Pop<u32>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     LOG_WARNING(Service_SRV, "(STUBBED) called, notification_id=0x{:X}", notification_id);
 }
 
@@ -226,7 +226,7 @@ void SRV::Unsubscribe(Kernel::HLERequestContext& ctx) {
     u32 notification_id = rp.Pop<u32>();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     LOG_WARNING(Service_SRV, "(STUBBED) called, notification_id=0x{:X}", notification_id);
 }
 
@@ -256,7 +256,7 @@ void SRV::PublishToSubscriber(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void SRV::RegisterService(Kernel::HLERequestContext& ctx) {
@@ -285,7 +285,7 @@ void SRV::RegisterService(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMoveObjects(std::move(port));
 }
 

--- a/src/core/hle/service/sm/srv.cpp
+++ b/src/core/hle/service/sm/srv.cpp
@@ -45,7 +45,7 @@ constexpr int MAX_PENDING_NOTIFICATIONS = 16;
  *      1: ProcessId Header (must be 0x20)
  *  Outputs:
  *      0: 0x00010040
- *      1: ResultCode
+ *      1: Result
  */
 void SRV::RegisterClient(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
@@ -69,7 +69,7 @@ void SRV::RegisterClient(Kernel::HLERequestContext& ctx) {
  *      0: 0x00020000
  *  Outputs:
  *      0: 0x00020042
- *      1: ResultCode
+ *      1: Result
  *      2: Translation descriptor: 0x20
  *      3: Handle to semaphore signaled on process notification
  */
@@ -136,7 +136,7 @@ private:
  *      3: Name length
  *      4: Flags (bit0: if not set, return port-handle if session-handle unavailable)
  *  Outputs:
- *      1: ResultCode
+ *      1: Result
  *      3: Service handle
  */
 void SRV::GetServiceHandle(Kernel::HLERequestContext& ctx) {
@@ -201,7 +201,7 @@ void SRV::GetServiceHandle(Kernel::HLERequestContext& ctx) {
  *      1: Notification ID
  *  Outputs:
  *      0: 0x00090040
- *      1: ResultCode
+ *      1: Result
  */
 void SRV::Subscribe(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
@@ -219,7 +219,7 @@ void SRV::Subscribe(Kernel::HLERequestContext& ctx) {
  *      1: Notification ID
  *  Outputs:
  *      0: 0x000A0040
- *      1: ResultCode
+ *      1: Result
  */
 void SRV::Unsubscribe(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
@@ -238,7 +238,7 @@ void SRV::Unsubscribe(Kernel::HLERequestContext& ctx) {
  *      2: Flags (bit0: only fire if not fired, bit1: report errors)
  *  Outputs:
  *      0: 0x000C0040
- *      1: ResultCode
+ *      1: Result
  */
 void SRV::PublishToSubscriber(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);

--- a/src/core/hle/service/sm/srv.cpp
+++ b/src/core/hle/service/sm/srv.cpp
@@ -95,10 +95,10 @@ public:
                 Kernel::ThreadWakeupReason reason) {
         LOG_ERROR(Service_SRV, "called service={} wakeup", name);
         std::shared_ptr<Kernel::ClientPort> client_port;
-        R_ASSERT(system.ServiceManager().GetServicePort(client_port, name));
+        R_ASSERT(system.ServiceManager().GetServicePort(std::addressof(client_port), name));
 
         std::shared_ptr<Kernel::ClientSession> session;
-        auto result = client_port->Connect(session);
+        auto result = client_port->Connect(std::addressof(session));
         if (result.IsSuccess()) {
             LOG_DEBUG(Service_SRV, "called service={} -> session={}", name, session->GetObjectId());
             IPC::RequestBuilder rb(ctx, 0x5, 1, 2);
@@ -160,7 +160,7 @@ void SRV::GetServiceHandle(Kernel::HLERequestContext& ctx) {
     auto get_handle = std::make_shared<ThreadCallback>(system, name);
 
     std::shared_ptr<Kernel::ClientPort> client_port;
-    auto result = system.ServiceManager().GetServicePort(client_port, name);
+    auto result = system.ServiceManager().GetServicePort(std::addressof(client_port), name);
     if (result.IsError()) {
         if (wait_until_available && result == ResultServiceNotRegistered) {
             LOG_INFO(Service_SRV, "called service={} delayed", name);
@@ -177,7 +177,7 @@ void SRV::GetServiceHandle(Kernel::HLERequestContext& ctx) {
     }
 
     std::shared_ptr<Kernel::ClientSession> session;
-    result = client_port->Connect(session);
+    result = client_port->Connect(std::addressof(session));
     if (result.IsSuccess()) {
         LOG_DEBUG(Service_SRV, "called service={} -> session={}", name, session->GetObjectId());
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
@@ -269,7 +269,7 @@ void SRV::RegisterService(Kernel::HLERequestContext& ctx) {
     std::string name(name_buf.data(), std::min(name_len, name_buf.size()));
 
     std::shared_ptr<Kernel::ServerPort> port;
-    auto result = system.ServiceManager().RegisterService(port, name, max_sessions);
+    auto result = system.ServiceManager().RegisterService(std::addressof(port), name, max_sessions);
 
     if (result.IsError()) {
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);

--- a/src/core/hle/service/soc/soc_u.cpp
+++ b/src/core/hle/service/soc/soc_u.cpp
@@ -428,21 +428,21 @@ std::optional<std::reference_wrapper<SocketHolder>> SOC_U::GetSocketHolder(u32 c
     if (initialized_processes.find(process_id) == initialized_processes.end()) {
         LOG_DEBUG(Service_SOC, "Process not initialized: pid={}", process_id);
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-        rb.Push(ERR_NOT_INITIALIZED);
+        rb.Push(ResultNotInitialized);
         return std::nullopt;
     }
     auto fd_info = created_sockets.find(ctr_socket_fd);
     if (fd_info == created_sockets.end()) {
         LOG_DEBUG(Service_SOC, "Invalid socket: pid={}, fd={}", process_id, ctr_socket_fd);
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-        rb.Push(ERR_INVALID_SOCKET_DESCRIPTOR);
+        rb.Push(ResultInvalidSocketDescriptor);
         return std::nullopt;
     }
     if (fd_info->second.ownerProcess != process_id && !fd_info->second.isGlobal) {
         LOG_DEBUG(Service_SOC, "Invalid process owner: pid={}, fd={}, owner_pid={}", process_id,
                   ctr_socket_fd, fd_info->second.ownerProcess);
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-        rb.Push(ERR_WRONG_PROCESS);
+        rb.Push(ResultWrongProcess);
         return std::nullopt;
     }
     return std::ref(fd_info->second);
@@ -820,7 +820,7 @@ void SOC_U::Socket(Kernel::HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_SOC, "called, pid={}, ret={}", pid, static_cast<s32>(ret));
 
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(static_cast<s32>(ret));
 }
 
@@ -851,7 +851,7 @@ void SOC_U::Bind(Kernel::HLERequestContext& ctx) {
               static_cast<s32>(ret));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(ret);
 }
 
@@ -874,7 +874,7 @@ void SOC_U::Fcntl(Kernel::HLERequestContext& ctx) {
                   static_cast<s32>(posix_ret));
 
         IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ResultSuccess);
         rb.Push(posix_ret);
     });
 
@@ -911,7 +911,7 @@ void SOC_U::Listen(Kernel::HLERequestContext& ctx) {
               static_cast<s32>(ret));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(ret);
 }
 
@@ -1029,7 +1029,7 @@ void SOC_U::SockAtMark(Kernel::HLERequestContext& ctx) {
              static_cast<s32>(ret));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(ret);
 }
 
@@ -1043,7 +1043,7 @@ void SOC_U::GetHostId(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(host_id);
 }
 
@@ -1068,7 +1068,7 @@ void SOC_U::Close(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_SOC, "pid={}, fd={}, ret={}", pid, socket_handle, static_cast<s32>(ret));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(ret);
 }
 
@@ -1133,7 +1133,7 @@ void SOC_U::SendToOther(Kernel::HLERequestContext& ctx) {
     LOG_SEND_RECV(Service_SOC, "called, fd={}, ret={}", socket_handle, static_cast<s32>(ret));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(ret);
 }
 
@@ -1202,7 +1202,7 @@ void SOC_U::SendToSingle(Kernel::HLERequestContext& ctx) {
     LOG_SEND_RECV(Service_SOC, "called, fd={}, ret={}", socket_handle, static_cast<s32>(ret));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(ret);
 }
 
@@ -1335,7 +1335,7 @@ void SOC_U::RecvFromOther(Kernel::HLERequestContext& ctx) {
                           static_cast<s32>(async_data->ret));
 
             IPC::RequestBuilder rb(ctx, 0x07, 2, 4);
-            rb.Push(RESULT_SUCCESS);
+            rb.Push(ResultSuccess);
             rb.Push(async_data->ret);
             rb.PushStaticBuffer(std::move(async_data->addr_buff), 0);
             rb.PushMappedBuffer(*async_data->buffer);
@@ -1456,7 +1456,7 @@ void SOC_U::RecvFrom(Kernel::HLERequestContext& ctx) {
                           static_cast<s32>(async_data->ret));
 
             IPC::RequestBuilder rb(ctx, 0x08, 3, 4);
-            rb.Push(RESULT_SUCCESS);
+            rb.Push(ResultSuccess);
             rb.Push(async_data->ret);
             rb.Push(total_received);
             rb.PushStaticBuffer(std::move(async_data->output_buff), 0);
@@ -1532,7 +1532,7 @@ void SOC_U::Poll(Kernel::HLERequestContext& ctx) {
 
             IPC::RequestBuilder rb(ctx, static_cast<u16>(ctx.CommandHeader().command_id.Value()), 2,
                                    2);
-            rb.Push(RESULT_SUCCESS);
+            rb.Push(ResultSuccess);
             rb.Push(async_data->ret);
             rb.PushStaticBuffer(std::move(output_fds), 0);
 
@@ -1574,7 +1574,7 @@ void SOC_U::GetSockName(Kernel::HLERequestContext& ctx) {
               static_cast<s32>(ret));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(ret);
     rb.PushStaticBuffer(std::move(dest_addr_buff), 0);
 }
@@ -1604,7 +1604,7 @@ void SOC_U::Shutdown(Kernel::HLERequestContext& ctx) {
               static_cast<s32>(ret));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(ret);
 }
 
@@ -1716,7 +1716,7 @@ void SOC_U::GetPeerName(Kernel::HLERequestContext& ctx) {
               static_cast<s32>(result));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(result);
     rb.PushStaticBuffer(std::move(dest_addr_buff), 0);
 }
@@ -1787,7 +1787,7 @@ void SOC_U::InitializeSockets(Kernel::HLERequestContext& ctx) {
     if (initialized_processes.find(pid) == initialized_processes.end()) {
         initialized_processes.insert(pid);
     } else {
-        res = ERR_ALREADY_INITIALIZED;
+        res = ResultAlreadyInitialized;
     }
 
     LOG_DEBUG(Service_SOC, "called, pid={}, res={:#08X}", pid, res.raw);
@@ -1806,7 +1806,7 @@ void SOC_U::ShutdownSockets(Kernel::HLERequestContext& ctx) {
     if (initialized_processes.find(pid) == initialized_processes.end()) {
         LOG_DEBUG(Service_SOC, "Process not initialized: pid={}", pid);
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-        rb.Push(ERR_NOT_INITIALIZED);
+        rb.Push(ResultNotInitialized);
         return;
     }
 
@@ -1816,7 +1816,7 @@ void SOC_U::ShutdownSockets(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_SOC, "called, pid={}", pid);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void SOC_U::GetSockOpt(Kernel::HLERequestContext& ctx) {
@@ -1863,7 +1863,7 @@ void SOC_U::GetSockOpt(Kernel::HLERequestContext& ctx) {
               static_cast<s32>(err));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(err);
     rb.Push(static_cast<u32>(optval.size()));
     rb.PushStaticBuffer(std::move(optval), 0);
@@ -1910,7 +1910,7 @@ void SOC_U::SetSockOpt(Kernel::HLERequestContext& ctx) {
               static_cast<s32>(err));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(err);
 }
 
@@ -1963,7 +1963,7 @@ void SOC_U::GetNetworkOpt(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(err);
     rb.Push(static_cast<u32>(opt_len));
     rb.PushStaticBuffer(std::move(opt_data), 0);
@@ -2026,7 +2026,7 @@ void SOC_U::GetAddrInfoImpl(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(3, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(ret);
     rb.Push(count);
     rb.PushStaticBuffer(std::move(out_buff), 0);
@@ -2055,7 +2055,7 @@ void SOC_U::GetNameInfoImpl(Kernel::HLERequestContext& ctx) {
     }
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 4);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(ret);
     rb.PushStaticBuffer(std::move(host), 0);
     rb.PushStaticBuffer(std::move(serv), 1);
@@ -2102,7 +2102,7 @@ void SOC_U::CloseSockets(Kernel::HLERequestContext& ctx) {
     if (initialized_processes.find(pid) == initialized_processes.end()) {
         LOG_DEBUG(Service_SOC, "Process not initialized: pid={}", pid);
         IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-        rb.Push(ERR_NOT_INITIALIZED);
+        rb.Push(ResultNotInitialized);
         return;
     }
 

--- a/src/core/hle/service/soc/soc_u.cpp
+++ b/src/core/hle/service/soc/soc_u.cpp
@@ -985,7 +985,7 @@ void SOC_U::Accept(Kernel::HLERequestContext& ctx) {
                       static_cast<s32>(async_data->ret));
 
             IPC::RequestBuilder rb(ctx, 0x04, 2, 2);
-            rb.Push(RESULT_SUCCESS);
+            rb.Push(ResultSuccess);
             rb.Push(async_data->ret);
             rb.PushStaticBuffer(std::move(ctr_addr_buf), 0);
         });
@@ -1649,7 +1649,7 @@ void SOC_U::GetHostByAddr(Kernel::HLERequestContext& ctx) {
         ::gethostbyaddr(reinterpret_cast<char*>(&platform_addr), sizeof(platform_addr), type);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     s32 ret;
     if (!result) {
         rb.Push(ret = TranslateError(GET_ERRNO));
@@ -1670,7 +1670,7 @@ void SOC_U::GetHostByName(Kernel::HLERequestContext& ctx) {
     struct hostent* result = ::gethostbyname(reinterpret_cast<char*>(host_name.data()));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     s32 ret;
     if (!result) {
         rb.Push(ret = TranslateError(GET_ERRNO));
@@ -1772,7 +1772,7 @@ void SOC_U::Connect(Kernel::HLERequestContext& ctx) {
                       async_data->socket_handle, static_cast<s32>(async_data->ret));
 
             IPC::RequestBuilder rb(ctx, 0x06, 2, 0);
-            rb.Push(RESULT_SUCCESS);
+            rb.Push(ResultSuccess);
             rb.Push(async_data->ret);
         });
 }
@@ -1783,7 +1783,7 @@ void SOC_U::InitializeSockets(Kernel::HLERequestContext& ctx) {
     const u32 pid = rp.PopPID();
     [[maybe_unused]] auto shared_memory = rp.PopObject<Kernel::SharedMemory>();
 
-    ResultCode res = RESULT_SUCCESS;
+    ResultCode res = ResultSuccess;
     if (initialized_processes.find(pid) == initialized_processes.end()) {
         initialized_processes.insert(pid);
     } else {
@@ -2091,7 +2091,7 @@ void SOC_U::SendToMultiple(Kernel::HLERequestContext& ctx) {
               static_cast<s32>(ret));
 
     IPC::RequestBuilder rb = rp.MakeBuilder(2, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.Push(ret);
 }
 
@@ -2111,7 +2111,7 @@ void SOC_U::CloseSockets(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_SOC, "called, pid={}", pid);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void SOC_U::AddGlobalSocket(Kernel::HLERequestContext& ctx) {
@@ -2133,7 +2133,7 @@ void SOC_U::AddGlobalSocket(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_SOC, "called, pid={}, fd={}", pid, socket_handle);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 SOC_U::SOC_U() : ServiceFramework("soc:U", 18) {

--- a/src/core/hle/service/soc/soc_u.cpp
+++ b/src/core/hle/service/soc/soc_u.cpp
@@ -1783,7 +1783,7 @@ void SOC_U::InitializeSockets(Kernel::HLERequestContext& ctx) {
     const u32 pid = rp.PopPID();
     [[maybe_unused]] auto shared_memory = rp.PopObject<Kernel::SharedMemory>();
 
-    ResultCode res = ResultSuccess;
+    Result res = ResultSuccess;
     if (initialized_processes.find(pid) == initialized_processes.end()) {
         initialized_processes.insert(pid);
     } else {

--- a/src/core/hle/service/soc/soc_u.h
+++ b/src/core/hle/service/soc/soc_u.h
@@ -61,13 +61,13 @@ public:
     std::optional<InterfaceInfo> GetDefaultInterfaceInfo();
 
 private:
-    static constexpr Result ERR_WRONG_PROCESS =
+    static constexpr Result ResultWrongProcess =
         Result(4, ErrorModule::SOC, ErrorSummary::InvalidState, ErrorLevel::Status);
-    static constexpr Result ERR_NOT_INITIALIZED =
+    static constexpr Result ResultNotInitialized =
         Result(6, ErrorModule::SOC, ErrorSummary::InvalidArgument, ErrorLevel::Permanent);
-    static constexpr Result ERR_INVALID_SOCKET_DESCRIPTOR =
+    static constexpr Result ResultInvalidSocketDescriptor =
         Result(7, ErrorModule::SOC, ErrorSummary::InvalidArgument, ErrorLevel::Permanent);
-    static constexpr Result ERR_ALREADY_INITIALIZED =
+    static constexpr Result ResultAlreadyInitialized =
         Result(11, ErrorModule::SOC, ErrorSummary::InvalidState, ErrorLevel::Status);
 
     static constexpr u32 SOC_ERR_INAVLID_ENUM_VALUE = 0xFFFF8025;

--- a/src/core/hle/service/soc/soc_u.h
+++ b/src/core/hle/service/soc/soc_u.h
@@ -61,14 +61,14 @@ public:
     std::optional<InterfaceInfo> GetDefaultInterfaceInfo();
 
 private:
-    static constexpr ResultCode ERR_WRONG_PROCESS =
-        ResultCode(4, ErrorModule::SOC, ErrorSummary::InvalidState, ErrorLevel::Status);
-    static constexpr ResultCode ERR_NOT_INITIALIZED =
-        ResultCode(6, ErrorModule::SOC, ErrorSummary::InvalidArgument, ErrorLevel::Permanent);
-    static constexpr ResultCode ERR_INVALID_SOCKET_DESCRIPTOR =
-        ResultCode(7, ErrorModule::SOC, ErrorSummary::InvalidArgument, ErrorLevel::Permanent);
-    static constexpr ResultCode ERR_ALREADY_INITIALIZED =
-        ResultCode(11, ErrorModule::SOC, ErrorSummary::InvalidState, ErrorLevel::Status);
+    static constexpr Result ERR_WRONG_PROCESS =
+        Result(4, ErrorModule::SOC, ErrorSummary::InvalidState, ErrorLevel::Status);
+    static constexpr Result ERR_NOT_INITIALIZED =
+        Result(6, ErrorModule::SOC, ErrorSummary::InvalidArgument, ErrorLevel::Permanent);
+    static constexpr Result ERR_INVALID_SOCKET_DESCRIPTOR =
+        Result(7, ErrorModule::SOC, ErrorSummary::InvalidArgument, ErrorLevel::Permanent);
+    static constexpr Result ERR_ALREADY_INITIALIZED =
+        Result(11, ErrorModule::SOC, ErrorSummary::InvalidState, ErrorLevel::Status);
 
     static constexpr u32 SOC_ERR_INAVLID_ENUM_VALUE = 0xFFFF8025;
 

--- a/src/core/hle/service/ssl/ssl_c.cpp
+++ b/src/core/hle/service/ssl/ssl_c.cpp
@@ -19,7 +19,7 @@ void SSL_C::Initialize(Kernel::HLERequestContext& ctx) {
 
     // Stub, return success
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 0);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
 }
 
 void SSL_C::GenerateRandomData(Kernel::HLERequestContext& ctx) {
@@ -32,7 +32,7 @@ void SSL_C::GenerateRandomData(Kernel::HLERequestContext& ctx) {
     buffer.Write(out_data.data(), 0, size);
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
-    rb.Push(RESULT_SUCCESS);
+    rb.Push(ResultSuccess);
     rb.PushMappedBuffer(buffer);
 }
 

--- a/src/tests/core/hle/kernel/hle_ipc.cpp
+++ b/src/tests/core/hle/kernel/hle_ipc.cpp
@@ -59,7 +59,8 @@ TEST_CASE("HLERequestContext::PopulateFromIncomingCommandBuffer", "[core][kernel
 
     SECTION("translates move handles") {
         auto a = MakeObject(kernel);
-        Handle a_handle = process->handle_table.Create(a).Unwrap();
+        Handle a_handle;
+        process->handle_table.Create(std::addressof(a_handle), a);
         const u32_le input[]{
             IPC::MakeHeader(0, 0, 2),
             IPC::MoveHandleDesc(1),
@@ -75,7 +76,8 @@ TEST_CASE("HLERequestContext::PopulateFromIncomingCommandBuffer", "[core][kernel
 
     SECTION("translates copy handles") {
         auto a = MakeObject(kernel);
-        Handle a_handle = process->handle_table.Create(a).Unwrap();
+        Handle a_handle;
+        process->handle_table.Create(std::addressof(a_handle), a);
         const u32_le input[]{
             IPC::MakeHeader(0, 0, 2),
             IPC::CopyHandleDesc(1),
@@ -93,13 +95,17 @@ TEST_CASE("HLERequestContext::PopulateFromIncomingCommandBuffer", "[core][kernel
         auto a = MakeObject(kernel);
         auto b = MakeObject(kernel);
         auto c = MakeObject(kernel);
+        Handle a_handle, b_handle, c_handle;
+        process->handle_table.Create(std::addressof(a_handle), a);
+        process->handle_table.Create(std::addressof(b_handle), b);
+        process->handle_table.Create(std::addressof(c_handle), c);
         const u32_le input[]{
             IPC::MakeHeader(0, 0, 5),
             IPC::MoveHandleDesc(2),
-            process->handle_table.Create(a).Unwrap(),
-            process->handle_table.Create(b).Unwrap(),
+            a_handle,
+            b_handle,
             IPC::MoveHandleDesc(1),
-            process->handle_table.Create(c).Unwrap(),
+            c_handle,
         };
 
         context.PopulateFromIncomingCommandBuffer(input, process);
@@ -209,12 +215,14 @@ TEST_CASE("HLERequestContext::PopulateFromIncomingCommandBuffer", "[core][kernel
         REQUIRE(result.Code() == RESULT_SUCCESS);
 
         auto a = MakeObject(kernel);
+        Handle a_handle;
+        process->handle_table.Create(std::addressof(a_handle), a);
         const u32_le input[]{
             IPC::MakeHeader(0, 2, 8),
             0x12345678,
             0xABCDEF00,
             IPC::MoveHandleDesc(1),
-            process->handle_table.Create(a).Unwrap(),
+            a_handle,
             IPC::CallingPidDesc(),
             0,
             IPC::StaticBufferDesc(buffer_static.GetSize(), 0),

--- a/src/tests/core/hle/kernel/hle_ipc.cpp
+++ b/src/tests/core/hle/kernel/hle_ipc.cpp
@@ -125,7 +125,7 @@ TEST_CASE("HLERequestContext::PopulateFromIncomingCommandBuffer", "[core][kernel
 
         auto result = context.PopulateFromIncomingCommandBuffer(input, process);
 
-        REQUIRE(result == RESULT_SUCCESS);
+        REQUIRE(result == ResultSuccess);
         auto* output = context.CommandBuffer();
         REQUIRE(context.GetIncomingHandle(output[2]) == nullptr);
     }
@@ -150,7 +150,7 @@ TEST_CASE("HLERequestContext::PopulateFromIncomingCommandBuffer", "[core][kernel
         VAddr target_address = 0x10000000;
         auto result = process->vm_manager.MapBackingMemory(
             target_address, buffer, static_cast<u32>(buffer.GetSize()), MemoryState::Private);
-        REQUIRE(result.Code() == RESULT_SUCCESS);
+        REQUIRE(result.Code() == ResultSuccess);
 
         const u32_le input[]{
             IPC::MakeHeader(0, 0, 2),
@@ -163,7 +163,7 @@ TEST_CASE("HLERequestContext::PopulateFromIncomingCommandBuffer", "[core][kernel
         CHECK(context.GetStaticBuffer(0) == mem->Vector());
 
         REQUIRE(process->vm_manager.UnmapRange(
-                    target_address, static_cast<u32>(buffer.GetSize())) == RESULT_SUCCESS);
+                    target_address, static_cast<u32>(buffer.GetSize())) == ResultSuccess);
     }
 
     SECTION("translates MappedBuffer descriptors") {
@@ -174,7 +174,7 @@ TEST_CASE("HLERequestContext::PopulateFromIncomingCommandBuffer", "[core][kernel
         VAddr target_address = 0x10000000;
         auto result = process->vm_manager.MapBackingMemory(
             target_address, buffer, static_cast<u32>(buffer.GetSize()), MemoryState::Private);
-        REQUIRE(result.Code() == RESULT_SUCCESS);
+        REQUIRE(result.Code() == ResultSuccess);
 
         const u32_le input[]{
             IPC::MakeHeader(0, 0, 2),
@@ -190,7 +190,7 @@ TEST_CASE("HLERequestContext::PopulateFromIncomingCommandBuffer", "[core][kernel
         CHECK(other_buffer == mem->Vector());
 
         REQUIRE(process->vm_manager.UnmapRange(
-                    target_address, static_cast<u32>(buffer.GetSize())) == RESULT_SUCCESS);
+                    target_address, static_cast<u32>(buffer.GetSize())) == ResultSuccess);
     }
 
     SECTION("translates mixed params") {
@@ -206,13 +206,13 @@ TEST_CASE("HLERequestContext::PopulateFromIncomingCommandBuffer", "[core][kernel
         auto result = process->vm_manager.MapBackingMemory(
             target_address_static, buffer_static, static_cast<u32>(buffer_static.GetSize()),
             MemoryState::Private);
-        REQUIRE(result.Code() == RESULT_SUCCESS);
+        REQUIRE(result.Code() == ResultSuccess);
 
         VAddr target_address_mapped = 0x20000000;
         result = process->vm_manager.MapBackingMemory(target_address_mapped, buffer_mapped,
                                                       static_cast<u32>(buffer_mapped.GetSize()),
                                                       MemoryState::Private);
-        REQUIRE(result.Code() == RESULT_SUCCESS);
+        REQUIRE(result.Code() == ResultSuccess);
 
         auto a = MakeObject(kernel);
         Handle a_handle;
@@ -245,10 +245,10 @@ TEST_CASE("HLERequestContext::PopulateFromIncomingCommandBuffer", "[core][kernel
 
         REQUIRE(process->vm_manager.UnmapRange(target_address_static,
                                                static_cast<u32>(buffer_static.GetSize())) ==
-                RESULT_SUCCESS);
+                ResultSuccess);
         REQUIRE(process->vm_manager.UnmapRange(target_address_mapped,
                                                static_cast<u32>(buffer_mapped.GetSize())) ==
-                RESULT_SUCCESS);
+                ResultSuccess);
     }
 }
 
@@ -309,7 +309,7 @@ TEST_CASE("HLERequestContext::WriteToOutgoingCommandBuffer", "[core][kernel]") {
 
         auto result = context.WriteToOutgoingCommandBuffer(output, *process);
 
-        REQUIRE(result == RESULT_SUCCESS);
+        REQUIRE(result == ResultSuccess);
         REQUIRE(output[2] == 0);
     }
 
@@ -344,7 +344,7 @@ TEST_CASE("HLERequestContext::WriteToOutgoingCommandBuffer", "[core][kernel]") {
         auto result = process->vm_manager.MapBackingMemory(
             target_address, output_buffer, static_cast<u32>(output_buffer.GetSize()),
             MemoryState::Private);
-        REQUIRE(result.Code() == RESULT_SUCCESS);
+        REQUIRE(result.Code() == ResultSuccess);
 
         input[0] = IPC::MakeHeader(0, 0, 2);
         input[1] = IPC::StaticBufferDesc(input_buffer.size(), 0);
@@ -362,7 +362,7 @@ TEST_CASE("HLERequestContext::WriteToOutgoingCommandBuffer", "[core][kernel]") {
 
         CHECK(output_mem->Vector() == input_buffer);
         REQUIRE(process->vm_manager.UnmapRange(
-                    target_address, static_cast<u32>(output_buffer.GetSize())) == RESULT_SUCCESS);
+                    target_address, static_cast<u32>(output_buffer.GetSize())) == ResultSuccess);
     }
 
     SECTION("translates StaticBuffer descriptors") {
@@ -376,7 +376,7 @@ TEST_CASE("HLERequestContext::WriteToOutgoingCommandBuffer", "[core][kernel]") {
         auto result = process->vm_manager.MapBackingMemory(
             target_address, output_buffer, static_cast<u32>(output_buffer.GetSize()),
             MemoryState::Private);
-        REQUIRE(result.Code() == RESULT_SUCCESS);
+        REQUIRE(result.Code() == ResultSuccess);
 
         const u32_le input_cmdbuff[]{
             IPC::MakeHeader(0, 0, 2),
@@ -398,7 +398,7 @@ TEST_CASE("HLERequestContext::WriteToOutgoingCommandBuffer", "[core][kernel]") {
         CHECK(output[2] == target_address);
         CHECK(output_mem->Vector() == input_buffer);
         REQUIRE(process->vm_manager.UnmapRange(
-                    target_address, static_cast<u32>(output_buffer.GetSize())) == RESULT_SUCCESS);
+                    target_address, static_cast<u32>(output_buffer.GetSize())) == ResultSuccess);
     }
 }
 


### PR DESCRIPTION
The line count may seem huge but its only 3 major changes:

* Switch to using mesosphere style macros in the kernel for error checking. This de-nests a lot of code, simplifies error handling and is likely closer to the style nintendo actually uses in real kernel. This also means we have to get rid of ResultVal in some places, however this does make code simpler in most cases.

* Rename ResultCode to plain Result and make result constants PascalCase. SDK symbols from various games do reveal that nintendo names this type as Result and not ResultCode.

For reviewing purposes you can only view the first commit, if everything was translated correctly. The other two are simply find-replace.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/7242)
<!-- Reviewable:end -->
