### PR TITLE
gamemode: Fix compile issues

### DIFF
--- a/externals/gamemode/CMakeLists.txt
+++ b/externals/gamemode/CMakeLists.txt
@@ -5,7 +5,5 @@ project(gamemode LANGUAGES CXX C)
 
 add_library(gamemode include/gamemode_client.h)
 
-target_link_libraries(gamemode PRIVATE common)
-
 target_include_directories(gamemode PUBLIC include)
 set_target_properties(gamemode PROPERTIES LINKER_LANGUAGE C)


### PR DESCRIPTION
The Linux build fails to compile because gamemode will try to link against `common` when it's not needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/7276)
<!-- Reviewable:end -->
