### PR TITLE
kernel: Release thread resource limit in Thread::Stop

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -449,6 +449,12 @@ System::ResultStatus System::Init(Frontend::EmuWindow& emu_window,
     gpu->SetInterruptHandler(
         [gsp](Service::GSP::InterruptId interrupt_id) { gsp->SignalInterrupt(interrupt_id); });
 
+    auto plg_ldr = Service::PLGLDR::GetService(*this);
+    if (plg_ldr) {
+        plg_ldr->SetEnabled(Settings::values.plugin_loader_enabled.GetValue());
+        plg_ldr->SetAllowGameChangeState(Settings::values.allow_plugin_loader.GetValue());
+    }
+
     LOG_DEBUG(Core, "Initialized OK");
 
     is_powered_on = true;

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -60,12 +60,7 @@ void Thread::Acquire(Thread* thread) {
 Thread::Thread(KernelSystem& kernel, u32 core_id)
     : WaitObject(kernel), core_id(core_id), thread_manager(kernel.GetThreadManager(core_id)) {}
 
-Thread::~Thread() {
-    auto process = owner_process.lock();
-    if (process) {
-        process->resource_limit->Release(ResourceLimitType::Thread, 1);
-    }
-}
+Thread::~Thread() = default;
 
 Thread* ThreadManager::GetCurrentThread() const {
     return current_thread.get();
@@ -101,6 +96,7 @@ void Thread::Stop() {
         ((tls_address - Memory::TLS_AREA_VADDR) % Memory::CITRA_PAGE_SIZE) / Memory::TLS_ENTRY_SIZE;
     if (auto process = owner_process.lock()) {
         process->tls_slots[tls_page].reset(tls_slot);
+        process->resource_limit->Release(ResourceLimitType::Thread, 1);
     }
 }
 

--- a/src/core/hle/service/plgldr/plgldr.cpp
+++ b/src/core/hle/service/plgldr/plgldr.cpp
@@ -26,12 +26,10 @@
 #include "common/settings.h"
 #include "core/core.h"
 #include "core/file_sys/plugin_3gx.h"
-#include "core/hle/ipc.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/event.h"
 #include "core/hle/kernel/handle_table.h"
 #include "core/hle/kernel/kernel.h"
-#include "core/hle/kernel/shared_memory.h"
 #include "core/hle/service/plgldr/plgldr.h"
 #include "core/loader/loader.h"
 
@@ -290,12 +288,7 @@ void PLG_LDR::GetPluginPath(Kernel::HLERequestContext& ctx) {
 }
 
 std::shared_ptr<PLG_LDR> GetService(Core::System& system) {
-    if (!system.KernelRunning())
-        return nullptr;
-    auto it = system.Kernel().named_ports.find("plg:ldr");
-    if (it != system.Kernel().named_ports.end())
-        return std::static_pointer_cast<PLG_LDR>(it->second->GetServerPort()->hle_handler);
-    return nullptr;
+    return system.ServiceManager().GetService<PLG_LDR>("plg:ldr");
 }
 
 void InstallInterfaces(Core::System& system) {

--- a/src/core/hle/service/plgldr/plgldr.cpp
+++ b/src/core/hle/service/plgldr/plgldr.cpp
@@ -288,6 +288,9 @@ void PLG_LDR::GetPluginPath(Kernel::HLERequestContext& ctx) {
 }
 
 std::shared_ptr<PLG_LDR> GetService(Core::System& system) {
+    if (!system.IsPoweredOn()) {
+        return nullptr;
+    }
     return system.ServiceManager().GetService<PLG_LDR>("plg:ldr");
 }
 

--- a/src/core/hle/service/plgldr/plgldr.cpp
+++ b/src/core/hle/service/plgldr/plgldr.cpp
@@ -288,10 +288,12 @@ void PLG_LDR::GetPluginPath(Kernel::HLERequestContext& ctx) {
 }
 
 std::shared_ptr<PLG_LDR> GetService(Core::System& system) {
-    if (!system.IsPoweredOn()) {
+    if (!system.KernelRunning())
         return nullptr;
-    }
-    return system.ServiceManager().GetService<PLG_LDR>("plg:ldr");
+    auto it = system.Kernel().named_ports.find("plg:ldr");
+    if (it != system.Kernel().named_ports.end())
+        return std::static_pointer_cast<PLG_LDR>(it->second->GetServerPort()->hle_handler);
+    return nullptr;
 }
 
 void InstallInterfaces(Core::System& system) {


### PR DESCRIPTION
Fixes https://github.com/citra-emu/citra/issues/7315

When the thread destruction occurs in the process destructor, owner_process is nullptr so the limit isn't released properly. Also fixed a problem with the PLGLDR service, being always enabled and crashing the home menu if a default 3gx plugin was around. https://github.com/citra-emu/citra/pull/7317 fixes the crash though and allows 3GX plugins to work on the home menu

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/7318)
<!-- Reviewable:end -->
