### PR TITLE
core: Do not update framebuffer layout on android

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -629,7 +629,9 @@ void System::ApplySettings() {
     GDBStub::ToggleServer(Settings::values.use_gdbstub.GetValue());
 
     if (gpu) {
+#ifndef ANDROID
         gpu->Renderer().UpdateCurrentFramebufferLayout();
+#endif
         auto& settings = gpu->Renderer().Settings();
         settings.bg_color_update_requested = true;
         settings.shader_update_requested = true;


### PR DESCRIPTION
Fixes another regression from https://github.com/citra-emu/citra/pull/7272/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/7330)
<!-- Reviewable:end -->
