### PR TITLE
cecd: Fixup GetCecInfoBuffer params order

### DIFF
--- a/src/core/hle/service/cecd/cecd.cpp
+++ b/src/core/hle/service/cecd/cecd.cpp
@@ -682,16 +682,16 @@ void Module::Interface::Stop(Kernel::HLERequestContext& ctx) {
 
 void Module::Interface::GetCecInfoBuffer(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
-    const u32 buffer_size = rp.Pop<u32>();
     const u32 possible_info_type = rp.Pop<u32>();
+    const u32 buffer_size = rp.Pop<u32>();
     auto& buffer = rp.PopMappedBuffer();
 
     IPC::RequestBuilder rb = rp.MakeBuilder(1, 2);
     rb.Push(ResultSuccess);
     rb.PushMappedBuffer(buffer);
 
-    LOG_DEBUG(Service_CECD, "called, buffer_size={}, possible_info_type={}", buffer_size,
-              possible_info_type);
+    LOG_DEBUG(Service_CECD, "called, possible_info_type={}, buffer_size={}", possible_info_type,
+              buffer_size);
 }
 
 void Module::Interface::GetCecdState(Kernel::HLERequestContext& ctx) {


### PR DESCRIPTION
While I was looking at the NEWS sysmodule, I noticed the params order for this command were backwards: the info type is the first param, followed by the buffer size.

This is accurate to my reverse engineered code for the NEWS sysmodule.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/7361)
<!-- Reviewable:end -->
