### PR TITLE
shader_unit: Intialize temporaries on shader invocation

### DIFF
--- a/src/video_core/pica/shader_unit.cpp
+++ b/src/video_core/pica/shader_unit.cpp
@@ -9,7 +9,10 @@
 
 namespace Pica {
 
-ShaderUnit::ShaderUnit(GeometryEmitter* emitter) : emitter_ptr{emitter} {}
+ShaderUnit::ShaderUnit(GeometryEmitter* emitter) : emitter_ptr{emitter} {
+    const Common::Vec4<f24> temp_vec{f24::Zero(), f24::Zero(), f24::Zero(), f24::One()};
+    temporary.fill(temp_vec);
+}
 
 ShaderUnit::~ShaderUnit() = default;
 


### PR DESCRIPTION
This has been done in the hardware renderer for quite some time, but not in the software path. Hero Bank reads r15.w without setting it first and expects it to be set to 1 to properly show the textboxes.

Due to this there was a slight difference in behavior between the implementations. Hardware renderer would display the textboxes correctly, but wouldn't show the text as that is rendered using a geometry shader with the software path. Software shaders wouldn't display anything on the other hand, as the resulting geometry would end up off-screen, due to the missing intialization

On console the game likely relies on vertex shader register preservation. Though, in contrast to geometry shaders that exclusively use the software path, vertex register preservation when combined with hardware shaders is almost impossible to do. To my knowledge no games rely on that behavior either, this case seems more like a bug in the game's code than anything.

Still I plan on implementing the shader scheduler in the near future as snes9x [relies](https://github.com/citra-emu/citra/issues/2460) on the register preservation when switching the fourth unit from vertex to geometry mode

Citra (master Hardware) | Citra (master Software) | Citra (PR Both)
-|-|-
![bad_hw](https://github.com/citra-emu/citra/assets/47210458/432d237b-4218-46ca-9286-eeef0b2c9fc6) | ![bad_sw](https://github.com/citra-emu/citra/assets/47210458/6b0d1b8a-aa99-4d28-aa46-59e183791325) | ![good_both](https://github.com/citra-emu/citra/assets/47210458/d13c8132-7560-40ac-b66f-9f3a4db24805)

Fixes
https://github.com/citra-emu/citra/issues/3357

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/7366)
<!-- Reviewable:end -->
