### PR TITLE
pica_core: Propagate vertex uniforms to geometry setup when not in exclusive mode

### DIFF
--- a/src/video_core/pica/pica_core.cpp
+++ b/src/video_core/pica/pica_core.cpp
@@ -256,6 +256,10 @@ void PicaCore::WriteInternalReg(u32 id, u32 value, u32 mask) {
 
     case PICA_REG_INDEX(vs.bool_uniforms):
         vs_setup.WriteUniformBoolReg(regs.internal.vs.bool_uniforms.Value());
+        if (!regs.internal.pipeline.gs_unit_exclusive_configuration &&
+            regs.internal.pipeline.use_gs == PipelineRegs::UseGS::No) {
+            gs_setup.WriteUniformBoolReg(regs.internal.vs.bool_uniforms.Value());
+        }
         break;
 
     case PICA_REG_INDEX(vs.int_uniforms[0]):
@@ -264,6 +268,10 @@ void PicaCore::WriteInternalReg(u32 id, u32 value, u32 mask) {
     case PICA_REG_INDEX(vs.int_uniforms[3]): {
         const u32 index = (id - PICA_REG_INDEX(vs.int_uniforms[0]));
         vs_setup.WriteUniformIntReg(index, regs.internal.vs.GetIntUniform(index));
+        if (!regs.internal.pipeline.gs_unit_exclusive_configuration &&
+            regs.internal.pipeline.use_gs == PipelineRegs::UseGS::No) {
+            gs_setup.WriteUniformIntReg(index, regs.internal.vs.GetIntUniform(index));
+        }
         break;
     }
 
@@ -275,7 +283,11 @@ void PicaCore::WriteInternalReg(u32 id, u32 value, u32 mask) {
     case PICA_REG_INDEX(vs.uniform_setup.set_value[5]):
     case PICA_REG_INDEX(vs.uniform_setup.set_value[6]):
     case PICA_REG_INDEX(vs.uniform_setup.set_value[7]): {
-        vs_setup.WriteUniformFloatReg(regs.internal.vs, value);
+        const auto index = vs_setup.WriteUniformFloatReg(regs.internal.vs, value);
+        if (!regs.internal.pipeline.gs_unit_exclusive_configuration &&
+            regs.internal.pipeline.use_gs == PipelineRegs::UseGS::No && index) {
+            gs_setup.uniforms.f[index.value()] = vs_setup.uniforms.f[index.value()];
+        }
         break;
     }
 

--- a/src/video_core/pica/shader_setup.cpp
+++ b/src/video_core/pica/shader_setup.cpp
@@ -27,21 +27,23 @@ void ShaderSetup::WriteUniformIntReg(u32 index, const Common::Vec4<u8> values) {
     uniforms.i[index] = values;
 }
 
-void ShaderSetup::WriteUniformFloatReg(ShaderRegs& config, u32 value) {
+std::optional<u32> ShaderSetup::WriteUniformFloatReg(ShaderRegs& config, u32 value) {
     auto& uniform_setup = config.uniform_setup;
     const bool is_float32 = uniform_setup.IsFloat32();
     if (!uniform_queue.Push(value, is_float32)) {
-        return;
+        return std::nullopt;
     }
 
     const auto uniform = uniform_queue.Get(is_float32);
     if (uniform_setup.index >= uniforms.f.size()) {
         LOG_ERROR(HW_GPU, "Invalid float uniform index {}", uniform_setup.index.Value());
-        return;
+        return std::nullopt;
     }
 
-    uniforms.f[uniform_setup.index] = uniform;
-    uniform_setup.index.Assign(uniform_setup.index + 1);
+    const u32 index = uniform_setup.index.Value();
+    uniforms.f[index] = uniform;
+    uniform_setup.index.Assign(index + 1);
+    return index;
 }
 
 u64 ShaderSetup::GetProgramCodeHash() {

--- a/src/video_core/pica/shader_setup.h
+++ b/src/video_core/pica/shader_setup.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <optional>
 #include "common/vector_math.h"
 #include "video_core/pica/packed_attribute.h"
 #include "video_core/pica_types.h"
@@ -58,7 +59,7 @@ public:
 
     void WriteUniformIntReg(u32 index, const Common::Vec4<u8> values);
 
-    void WriteUniformFloatReg(ShaderRegs& config, u32 value);
+    std::optional<u32> WriteUniformFloatReg(ShaderRegs& config, u32 value);
 
     u64 GetProgramCodeHash();
 


### PR DESCRIPTION
Luigi's Mansion Dark Moon, uses a fixed primitive geometry shader to render the rain particles in the first mansion. The geometry shader itself runs correctly, but it tried to multiply the final position with a matrix that was zero. After a bit of experimentation and examining the command lists, I noticed it wasn't initializing these specific geometry shader uniforms during the draw (or at all since the start of the game), but it was doing that for the appropriate vertex uniforms.

The game also seems to enable the gs exclusive configuration switch at specific points it wants to modify geometry uniforms and then disables it again, hinting that it relies on this propagation taking place. The behavior also logically makes sense, uniforms are common state between shader units so it wouldn't be a reach to make it possible to also share them with geometry unit.

Haven't tested this on hardware yet but given it fixes such a specific issue I'm pretty confident it is correct. Regardless I make a hardware test for this before merging the PR for verification purposes. Fixes both missing rain and suction effect

Citra (master) | Citra (PR)
-|-
![Luigi's Mansion Dark Moon_20 01 24_03 00 11 797](https://github.com/citra-emu/citra/assets/47210458/2088a6b0-9f2b-4564-912e-3bd2d51914d5) | ![Luigi's Mansion Dark Moon_20 01 24_03 01 12 524](https://github.com/citra-emu/citra/assets/47210458/91056b62-ed2e-44d3-8b4f-981974494de4)

Fixes
https://github.com/citra-emu/citra/issues/6226
https://github.com/citra-emu/citra/issues/5058

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/7367)
<!-- Reviewable:end -->
