### PR TITLE
glsl_shader_gen: Remove invariant qualifier

### DIFF
--- a/src/video_core/rasterizer_cache/rasterizer_cache.h
+++ b/src/video_core/rasterizer_cache/rasterizer_cache.h
@@ -67,6 +67,16 @@ RasterizerCache<T>::RasterizerCache(Memory::MemorySystem& memory_,
                                            .wrap_s = TextureConfig::WrapMode::ClampToBorder,
                                            .wrap_t = TextureConfig::WrapMode::ClampToBorder,
                                        }));
+
+    auto& null_surface = slot_surfaces[NULL_SURFACE_ID];
+    runtime.ClearTexture(null_surface, {
+                                           .texture_level = 0,
+                                           .texture_rect = null_surface.GetScaledRect(),
+                                           .value =
+                                               {
+                                                   .color = {0.f, 0.f, 0.f, 0.f},
+                                               },
+                                       });
 }
 
 template <class T>

--- a/src/video_core/shader/generator/glsl_shader_gen.cpp
+++ b/src/video_core/shader/generator/glsl_shader_gen.cpp
@@ -63,7 +63,13 @@ static std::string GetVertexInterfaceDeclaration(bool is_output, bool use_clip_p
     if (is_output && separable_shader) {
         // gl_PerVertex redeclaration is required for separate shader object
         out += "out gl_PerVertex {\n";
+        // Apple Silicon GPU drivers optimize more aggressively, which can create
+        // too much variance and cause visual artifacting in games like Pokemon.
+#ifdef __APPLE__
+        out += "    invariant vec4 gl_Position;\n";
+#else
         out += "    vec4 gl_Position;\n";
+#endif
         if (use_clip_planes) {
             out += "    float gl_ClipDistance[2];\n";
         }

--- a/src/video_core/shader/generator/glsl_shader_gen.cpp
+++ b/src/video_core/shader/generator/glsl_shader_gen.cpp
@@ -63,7 +63,7 @@ static std::string GetVertexInterfaceDeclaration(bool is_output, bool use_clip_p
     if (is_output && separable_shader) {
         // gl_PerVertex redeclaration is required for separate shader object
         out += "out gl_PerVertex {\n";
-        out += "    invariant vec4 gl_Position;\n";
+        out += "    vec4 gl_Position;\n";
         if (use_clip_planes) {
             out += "    float gl_ClipDistance[2];\n";
         }


### PR DESCRIPTION
Seems to be the cause of the depth glitches in RADV. Also made sure the null surface is cleared to transparent as RADV also exhibited the black squares in the player's face

Citra (master) | Citra (PR)
-|-
![Pokémon Y_21 01 24_12 29 27 775](https://github.com/citra-emu/citra/assets/47210458/0ba9db52-b2a6-495f-ac3a-cf6e01fbdfa2) | ![Pokémon Y_21 01 24_12 28 36 403](https://github.com/citra-emu/citra/assets/47210458/1efb7f19-b6a5-46bd-9050-1ebc03f41c80)

Fixes:
https://github.com/citra-emu/citra/issues/7197

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/7376)
<!-- Reviewable:end -->
