### PR TITLE
general: Fixes for Tales of the Abyss

### DIFF
--- a/src/video_core/pica/geometry_pipeline.cpp
+++ b/src/video_core/pica/geometry_pipeline.cpp
@@ -337,7 +337,6 @@ void GeometryPipeline::Reconfigure() {
     // The following assumes that when geometry shader is in use, the shader unit 3 is configured as
     // a geometry shader unit.
     // TODO: what happens if this is not true?
-    ASSERT(regs.pipeline.gs_unit_exclusive_configuration == 1);
     ASSERT(regs.gs.shader_mode == ShaderRegs::ShaderMode::GS);
     ASSERT(regs.pipeline.use_gs == PipelineRegs::UseGS::Yes);
 

--- a/src/video_core/pica/pica_core.cpp
+++ b/src/video_core/pica/pica_core.cpp
@@ -35,7 +35,7 @@ PicaCore::PicaCore(Memory::MemorySystem& memory_, std::shared_ptr<DebugContext> 
                                                                                    gs_unit,
                                                                                    gs_setup},
       shader_engine{CreateEngine(Settings::values.use_shader_jit.GetValue())} {
-    SetFramebufferDefaults();
+    InitializeRegs();
 
     const auto submit_vertex = [this](const AttributeBuffer& buffer) {
         const auto add_triangle = [this](const OutputVertex& v0, const OutputVertex& v1,
@@ -54,7 +54,7 @@ PicaCore::PicaCore(Memory::MemorySystem& memory_, std::shared_ptr<DebugContext> 
 
 PicaCore::~PicaCore() = default;
 
-void PicaCore::SetFramebufferDefaults() {
+void PicaCore::InitializeRegs() {
     auto& framebuffer_top = regs.framebuffer_config[0];
     auto& framebuffer_sub = regs.framebuffer_config[1];
 
@@ -77,6 +77,9 @@ void PicaCore::SetFramebufferDefaults() {
     framebuffer_sub.stride = 3 * 240;
     framebuffer_sub.color_format.Assign(PixelFormat::RGB8);
     framebuffer_sub.active_fb = 0;
+
+    // Tales of Abyss expects this register to have the following default value.
+    regs.internal.gs.input_buffer_config = 0xa0000001;
 }
 
 void PicaCore::BindRasterizer(VideoCore::RasterizerInterface* rasterizer) {

--- a/src/video_core/pica/pica_core.cpp
+++ b/src/video_core/pica/pica_core.cpp
@@ -254,6 +254,13 @@ void PicaCore::WriteInternalReg(u32 id, u32 value, u32 mask) {
         break;
     }
 
+    case PICA_REG_INDEX(vs.output_mask):
+        if (!regs.internal.pipeline.gs_unit_exclusive_configuration &&
+            regs.internal.pipeline.use_gs == PipelineRegs::UseGS::No) {
+            regs.internal.gs.output_mask.Assign(value);
+        }
+        break;
+
     case PICA_REG_INDEX(vs.bool_uniforms):
         vs_setup.WriteUniformBoolReg(regs.internal.vs.bool_uniforms.Value());
         if (!regs.internal.pipeline.gs_unit_exclusive_configuration &&

--- a/src/video_core/pica/pica_core.cpp
+++ b/src/video_core/pica/pica_core.cpp
@@ -78,8 +78,10 @@ void PicaCore::InitializeRegs() {
     framebuffer_sub.color_format.Assign(PixelFormat::RGB8);
     framebuffer_sub.active_fb = 0;
 
-    // Tales of Abyss expects this register to have the following default value.
-    regs.internal.gs.input_buffer_config = 0xa0000001;
+    // Tales of Abyss expects this register to have the following default values.
+    auto& gs = regs.internal.gs;
+    gs.max_input_attribute_index.Assign(1);
+    gs.shader_mode.Assign(ShaderRegs::ShaderMode::VS);
 }
 
 void PicaCore::BindRasterizer(VideoCore::RasterizerInterface* rasterizer) {

--- a/src/video_core/pica/pica_core.h
+++ b/src/video_core/pica/pica_core.h
@@ -39,7 +39,7 @@ public:
     void ProcessCmdList(PAddr list, u32 size);
 
 private:
-    void SetFramebufferDefaults();
+    void InitializeRegs();
 
     void WriteInternalReg(u32 id, u32 value, u32 mask);
 

--- a/src/video_core/pica/regs_shader.h
+++ b/src/video_core/pica/regs_shader.h
@@ -35,7 +35,7 @@ struct ShaderRegs {
 
     union {
         // Number of input attributes to shader unit - 1
-        u32 raw{0xa0000001};
+        u32 input_buffer_config;
         BitField<0, 4, u32> max_input_attribute_index;
         BitField<8, 8, u32> input_to_uniform;
         BitField<24, 8, ShaderMode> shader_mode;

--- a/src/video_core/pica/regs_shader.h
+++ b/src/video_core/pica/regs_shader.h
@@ -35,6 +35,7 @@ struct ShaderRegs {
 
     union {
         // Number of input attributes to shader unit - 1
+        u32 raw{0xa0000001};
         BitField<0, 4, u32> max_input_attribute_index;
         BitField<8, 8, u32> input_to_uniform;
         BitField<24, 8, ShaderMode> shader_mode;

--- a/src/video_core/rasterizer_cache/texture_codec.h
+++ b/src/video_core/rasterizer_cache/texture_codec.h
@@ -341,8 +341,8 @@ static constexpr void MortonCopy(u32 width, u32 height, u32 start_offset, u32 en
  */
 template <bool decode, PixelFormat format, bool converted = false>
 static constexpr void LinearCopy(std::span<u8> src_buffer, std::span<u8> dst_buffer) {
-    const std::size_t src_size = src_buffer.size();
-    const std::size_t dst_size = dst_buffer.size();
+    std::size_t src_size = src_buffer.size();
+    std::size_t dst_size = dst_buffer.size();
 
     if constexpr (converted) {
         constexpr u32 encoded_bytes_per_pixel = GetFormatBpp(format) / 8;
@@ -351,6 +351,9 @@ static constexpr void LinearCopy(std::span<u8> src_buffer, std::span<u8> dst_buf
             decode ? encoded_bytes_per_pixel : decoded_bytes_per_pixel;
         constexpr u32 dst_bytes_per_pixel =
             decode ? decoded_bytes_per_pixel : encoded_bytes_per_pixel;
+
+        src_size = Common::AlignDown(src_size, src_bytes_per_pixel);
+        dst_size = Common::AlignDown(dst_size, dst_bytes_per_pixel);
 
         for (std::size_t src_index = 0, dst_index = 0; src_index < src_size && dst_index < dst_size;
              src_index += src_bytes_per_pixel, dst_index += dst_bytes_per_pixel) {


### PR DESCRIPTION
The following are a bunch of minor fixes, mainly to geometry shaders, that fix the TOA crashing in the tutorial battle to make the game playable. The particles emitted are also correctly rendered.

* The game does not enable GS exclusive mode at any point, which triggers the first assertion in geometry_pipeline. The assertion has been removed as there is no evidence that this disallows geometry shader execution. I have hw-tested this as well and geometry tests work correctly without it as well.

* The game does not initialize GPUREG_GSH_OUTMAP_MASK nor GPUREG_GSH_INPUTBUFFER_CONFIG. After testing, the former is propagated from VS writes under the same conditions as uniforms, while the latter is not progated (and wouldn't make sense either as it has a flag that enabled/disables gs). The game expects it to have the default value of 0xa0000001 (found by reading the register directly). I initially suspected that it was set by the HOME menu, as it submits a huge command list on boot to initialize every register, but it doesn't write to the lower part either so it really seems like a hardware set default.

* When launching the game from the HOME menu, it would crash when trying to download an RGB8 image because dst_size was not 3-byte aligned (was 1 byte more than needed). Aligning down the size resolves the crashing.

It might be hard to see but the particles are also rendering correctly now, as shown in the following screenshot.

![TALES OF THE ABYSS_24 01 24_05 02 26 325](https://github.com/citra-emu/citra/assets/47210458/627c539d-3758-43ef-8d07-3d3b611b3b62)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/7381)
<!-- Reviewable:end -->
