### PR TITLE
Add HOST_TICK and BUILD_PLATFORM to svcGetSystemInfo CITRA_INFORMATION type

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -272,6 +272,7 @@ enum class SystemInfoCitraInformation {
     HOST_TICK = 1,         // Tick reference from the host in ns, unaffected by lag or cpu speed.
     BUILD_NAME = 10,       // (ie: Nightly, Canary).
     BUILD_VERSION = 11,    // Build version.
+    BUILD_PLATFORM = 12,   // Build platform, see SystemInfoCitraPlatform.
     BUILD_DATE_PART1 = 20, // Build date first 7 characters.
     BUILD_DATE_PART2 = 21, // Build date next 7 characters.
     BUILD_DATE_PART3 = 22, // Build date next 7 characters.
@@ -280,6 +281,17 @@ enum class SystemInfoCitraInformation {
     BUILD_GIT_BRANCH_PART2 = 31,      // Git branch last 7 characters.
     BUILD_GIT_DESCRIPTION_PART1 = 40, // Git description (commit) first 7 characters.
     BUILD_GIT_DESCRIPTION_PART2 = 41, // Git description (commit) last 7 characters.
+};
+
+/**
+ * Current officially supported platforms.
+ */
+enum class SystemInfoCitraPlatform {
+    PLATFORM_UNKNOWN = 0,
+    PLATFORM_WINDOWS = 1,
+    PLATFORM_LINUX = 2,
+    PLATFORM_APPLE = 3,
+    PLATFORM_ANDROID = 4,
 };
 
 /**
@@ -1743,9 +1755,9 @@ Result SVC::GetSystemInfo(s64* out, u32 type, s32 param) {
             *out = 1;
             break;
         case SystemInfoCitraInformation::HOST_TICK:
-            *out = (s64)std::chrono::duration_cast<std::chrono::nanoseconds>(
-                       std::chrono::steady_clock::now().time_since_epoch())
-                       .count();
+            *out = static_cast<s64>(std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                        std::chrono::steady_clock::now().time_since_epoch())
+                                        .count());
             break;
         case SystemInfoCitraInformation::BUILD_NAME:
             CopyStringPart(reinterpret_cast<char*>(out), Common::g_build_name, 0, sizeof(s64));
@@ -1753,6 +1765,20 @@ Result SVC::GetSystemInfo(s64* out, u32 type, s32 param) {
         case SystemInfoCitraInformation::BUILD_VERSION:
             CopyStringPart(reinterpret_cast<char*>(out), Common::g_build_version, 0, sizeof(s64));
             break;
+        case SystemInfoCitraInformation::BUILD_PLATFORM: {
+#if defined(_WIN32)
+            *out = static_cast<s64>(SystemInfoCitraPlatform::PLATFORM_WINDOWS);
+#elif defined(ANDROID)
+            *out = static_cast<s64>(SystemInfoCitraPlatform::PLATFORM_ANDROID);
+#elif defined(__linux__)
+            *out = static_cast<s64>(SystemInfoCitraPlatform::PLATFORM_LINUX);
+#elif defined(__APPLE__)
+            *out = static_cast<s64>(SystemInfoCitraPlatform::PLATFORM_APPLE);
+#else
+            *out = static_cast<s64>(SystemInfoCitraPlatform::PLATFORM_UNKNOWN);
+#endif
+            break;
+        }
         case SystemInfoCitraInformation::BUILD_DATE_PART1:
             CopyStringPart(reinterpret_cast<char*>(out), Common::g_build_date,
                            (sizeof(s64) - 1) * 0, sizeof(s64));

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <fmt/format.h>
 #include "common/archives.h"
 #include "common/logging/log.h"
@@ -268,6 +269,7 @@ enum class SystemInfoMemUsageRegion {
  */
 enum class SystemInfoCitraInformation {
     IS_CITRA = 0,          // Always set the output to 1, signaling the app is running on Citra.
+    HOST_TICK = 1,         // Tick reference from the host in ns, unaffected by lag or cpu speed.
     BUILD_NAME = 10,       // (ie: Nightly, Canary).
     BUILD_VERSION = 11,    // Build version.
     BUILD_DATE_PART1 = 20, // Build date first 7 characters.
@@ -1739,6 +1741,11 @@ Result SVC::GetSystemInfo(s64* out, u32 type, s32 param) {
         switch ((SystemInfoCitraInformation)param) {
         case SystemInfoCitraInformation::IS_CITRA:
             *out = 1;
+            break;
+        case SystemInfoCitraInformation::HOST_TICK:
+            *out = (s64)std::chrono::duration_cast<std::chrono::nanoseconds>(
+                       std::chrono::steady_clock::now().time_since_epoch())
+                       .count();
             break;
         case SystemInfoCitraInformation::BUILD_NAME:
             CopyStringPart(reinterpret_cast<char*>(out), Common::g_build_name, 0, sizeof(s64));


### PR DESCRIPTION
Adds a way for the emulated application to know the time reference of the host. This is useful for homebrew applications to detect if the emulator is lagging or has changed the emulated CPU speed, by comparing it with the system tick.

Adds information regarding the current build platform.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/7388)
<!-- Reviewable:end -->
