### PR TITLE
[SettingsFragmentPresenter.kt] correct RESOLUTION_FACTOR key/default

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -687,8 +687,8 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     1,
                     10,
                     "x",
-                    IntSetting.GRAPHICS_API.key,
-                    IntSetting.GRAPHICS_API.defaultValue.toFloat()
+                    IntSetting.RESOLUTION_FACTOR.key,
+                    IntSetting.RESOLUTION_FACTOR.defaultValue.toFloat()
                 )
             )
             add(


### PR DESCRIPTION
Currently, the RESOLUTION_FACTOR preference is being set with the GRAPHICS_API key and default. Therefore, it will set/retrieve the wrong values

This revision updates the RESOLUTION_FACTOR preference to use the RESOLUTION_FACTOR key and default value. As a result, RESOLUTION_FACTOR and GRAPHICS_API should store and return the correct (separate) values.

**Testing:**
I caught this in my fork (CitraVR)., which uses distinct defaults for RESOLUTION_FACTOR and GRAPHICS_API. To test this change, I verified:
- RESOLUTION_FACTOR preference contains the expected default value in settings
- setting the RESOLUTION_FACTOR preference does not change the value of the GRAPHICS_API preference.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/7392)
<!-- Reviewable:end -->
