### PR TITLE
Add regex filter to debug log

### DIFF
--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -244,12 +244,14 @@ void Config::ReadValues() {
 
     // Miscellaneous
     ReadSetting("Miscellaneous", Settings::values.log_filter);
+    ReadSetting("Miscellaneous", Settings::values.log_regex_filter);
 
     // Apply the log_filter setting as the logger has already been initialized
     // and doesn't pick up the filter on its own.
     Common::Log::Filter filter;
     filter.ParseFilterString(Settings::values.log_filter.GetValue());
     Common::Log::SetGlobalFilter(filter);
+    Common::Log::SetRegexFilter(Settings::values.log_regex_filter.GetValue());
 
     // Debugging
     Settings::values.record_frame_times =

--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -306,12 +306,14 @@ void Config::ReadValues() {
 
     // Miscellaneous
     ReadSetting("Miscellaneous", Settings::values.log_filter);
+    ReadSetting("Miscellaneous", Settings::values.log_regex_filter);
 
     // Apply the log_filter setting as the logger has already been initialized
     // and doesn't pick up the filter on its own.
     Common::Log::Filter filter;
     filter.ParseFilterString(Settings::values.log_filter.GetValue());
     Common::Log::SetGlobalFilter(filter);
+    Common::Log::SetRegexFilter(Settings::values.log_regex_filter.GetValue());
 
     // Debugging
     Settings::values.record_frame_times =

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -531,6 +531,7 @@ void Config::ReadMiscellaneousValues() {
     qt_config->beginGroup(QStringLiteral("Miscellaneous"));
 
     ReadBasicSetting(Settings::values.log_filter);
+    ReadBasicSetting(Settings::values.log_regex_filter);
     ReadBasicSetting(Settings::values.enable_gamemode);
 
     qt_config->endGroup();
@@ -1054,6 +1055,7 @@ void Config::SaveMiscellaneousValues() {
     qt_config->beginGroup(QStringLiteral("Miscellaneous"));
 
     WriteBasicSetting(Settings::values.log_filter);
+    WriteBasicSetting(Settings::values.log_regex_filter);
     WriteBasicSetting(Settings::values.enable_gamemode);
 
     qt_config->endGroup();

--- a/src/citra_qt/configuration/configure_debug.cpp
+++ b/src/citra_qt/configuration/configure_debug.cpp
@@ -97,6 +97,8 @@ void ConfigureDebug::SetConfiguration() {
     ui->toggle_console->setEnabled(!is_powered_on);
     ui->toggle_console->setChecked(UISettings::values.show_console.GetValue());
     ui->log_filter_edit->setText(QString::fromStdString(Settings::values.log_filter.GetValue()));
+    ui->log_regex_filter_edit->setText(
+        QString::fromStdString(Settings::values.log_regex_filter.GetValue()));
     ui->toggle_cpu_jit->setChecked(Settings::values.use_cpu_jit.GetValue());
     ui->delay_start_for_lle_modules->setChecked(
         Settings::values.delay_start_for_lle_modules.GetValue());
@@ -126,10 +128,12 @@ void ConfigureDebug::ApplyConfiguration() {
     Settings::values.gdbstub_port = ui->gdbport_spinbox->value();
     UISettings::values.show_console = ui->toggle_console->isChecked();
     Settings::values.log_filter = ui->log_filter_edit->text().toStdString();
+    Settings::values.log_regex_filter = ui->log_regex_filter_edit->text().toStdString();
     Debugger::ToggleConsole();
     Common::Log::Filter filter;
     filter.ParseFilterString(Settings::values.log_filter.GetValue());
     Common::Log::SetGlobalFilter(filter);
+    Common::Log::SetRegexFilter(Settings::values.log_regex_filter.GetValue());
     Settings::values.use_cpu_jit = ui->toggle_cpu_jit->isChecked();
     Settings::values.delay_start_for_lle_modules = ui->delay_start_for_lle_modules->isChecked();
     Settings::values.renderer_debug = ui->toggle_renderer_debug->isChecked();

--- a/src/citra_qt/configuration/configure_debug.ui
+++ b/src/citra_qt/configuration/configure_debug.ui
@@ -86,6 +86,20 @@
        </layout>
       </item>
       <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>Regex Log Filter</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="log_regex_filter_edit"/>
+        </item>
+       </layout>
+      </item>
+      <item>
        <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
          <widget class="QCheckBox" name="toggle_console">

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <chrono>
+#include <boost/regex.hpp>
 
 #include <fmt/format.h>
 
@@ -234,6 +235,19 @@ public:
         filter = f;
     }
 
+    bool SetRegexFilter(const std::string& regex) {
+        if (regex.empty()) {
+            regex_filter = boost::regex();
+            return true;
+        }
+        regex_filter = boost::regex(regex, boost::regex_constants::no_except);
+        if (regex_filter.status() != 0) {
+            regex_filter = boost::regex();
+            return false;
+        }
+        return true;
+    }
+
     void SetColorConsoleBackendEnabled(bool enabled) {
         color_console_backend.SetEnabled(enabled);
     }
@@ -243,8 +257,13 @@ public:
         if (!filter.CheckMessage(log_class, log_level)) {
             return;
         }
-        message_queue.EmplaceWait(
-            CreateEntry(log_class, log_level, filename, line_num, function, std::move(message)));
+        Entry new_entry =
+            CreateEntry(log_class, log_level, filename, line_num, function, std::move(message));
+        if (!regex_filter.empty() &&
+            !boost::regex_search(FormatLogMessage(new_entry), regex_filter)) {
+            return;
+        }
+        message_queue.EmplaceWait(new_entry);
     }
 
 private:
@@ -406,6 +425,7 @@ private:
     static inline std::unique_ptr<Impl, decltype(&Deleter)> instance{nullptr, Deleter};
 
     Filter filter;
+    boost::regex regex_filter;
     DebuggerBackend debugger_backend{};
     ColorConsoleBackend color_console_backend{};
     FileBackend file_backend;
@@ -444,6 +464,10 @@ void DisableLoggingInTests() {
 
 void SetGlobalFilter(const Filter& filter) {
     Impl::Instance().SetGlobalFilter(filter);
+}
+
+bool SetRegexFilter(const std::string& regex) {
+    return Impl::Instance().SetRegexFilter(regex);
 }
 
 void SetColorConsoleBackendEnabled(bool enabled) {

--- a/src/common/logging/backend.h
+++ b/src/common/logging/backend.h
@@ -27,7 +27,8 @@ void DisableLoggingInTests();
 void SetGlobalFilter(const Filter& filter);
 
 /**
- * Only allow messages that match the specified regex. The regex is matched against the final log text.
+ * Only allow messages that match the specified regex. The regex is matched against the final log
+ * text.
  */
 bool SetRegexFilter(const std::string& regex);
 

--- a/src/common/logging/backend.h
+++ b/src/common/logging/backend.h
@@ -26,5 +26,10 @@ void DisableLoggingInTests();
  */
 void SetGlobalFilter(const Filter& filter);
 
+/**
+ * Only allow messages that match the specified regex. The regex is matched against the final log text.
+ */
+bool SetRegexFilter(const std::string& regex);
+
 void SetColorConsoleBackendEnabled(bool enabled);
 } // namespace Common::Log

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -542,6 +542,7 @@ struct Values {
 
     // Miscellaneous
     Setting<std::string> log_filter{"*:Info", "log_filter"};
+    Setting<std::string> log_regex_filter{"", "log_regex_filter"};
 
     // Video Dumping
     std::string output_format;


### PR DESCRIPTION
Adds a regex filter to the log. Only those messages that have the regex pattern in them will be logged and the rest will be discarded. Useful in some cases where using the global filter is not enough. (For example, to differentiate debug logs in the same class.)

Leaving the regex filter field empty will disable any regex filtering.

![image](https://github.com/citra-emu/citra/assets/10946643/070eb006-2eae-4f6d-bbc9-9a0cf894c4b3)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/7403)
<!-- Reviewable:end -->
