### PR TITLE
glsl_shader_fs_gen: Apply shadow before ambient light

### DIFF
--- a/src/video_core/renderer_software/sw_lighting.cpp
+++ b/src/video_core/renderer_software/sw_lighting.cpp
@@ -285,19 +285,20 @@ std::pair<Common::Vec4<u8>, Common::Vec4<u8>> ComputeFragmentsColors(
             }
         }
 
-        auto diffuse =
-            (light_config.diffuse.ToVec3f() * dot_product + light_config.ambient.ToVec3f()) *
-            dist_atten * spot_atten;
-        auto specular = (specular_0 + specular_1) * clamp_highlights * dist_atten * spot_atten;
+        const bool shadow_primary_enable =
+            lighting.config0.shadow_primary && !lighting.IsShadowDisabled(num);
+        const bool shadow_secondary_enable =
+            lighting.config0.shadow_secondary && !lighting.IsShadowDisabled(num);
+        const auto shadow_primary =
+            shadow_primary_enable ? shadow.xyz() : Common::MakeVec(1.f, 1.f, 1.f);
+        const auto shadow_secondary =
+            shadow_secondary_enable ? shadow.xyz() : Common::MakeVec(1.f, 1.f, 1.f);
 
-        if (!lighting.IsShadowDisabled(num)) {
-            if (lighting.config0.shadow_primary) {
-                diffuse = diffuse * shadow.xyz();
-            }
-            if (lighting.config0.shadow_secondary) {
-                specular = specular * shadow.xyz();
-            }
-        }
+        const auto diffuse = (light_config.diffuse.ToVec3f() * dot_product * shadow_primary +
+                              light_config.ambient.ToVec3f()) *
+                             dist_atten * spot_atten;
+        const auto specular = (specular_0 + specular_1) * clamp_highlights * dist_atten *
+                              spot_atten * shadow_secondary;
 
         diffuse_sum += Common::MakeVec(diffuse, 0.0f);
         specular_sum += Common::MakeVec(specular, 0.0f);

--- a/src/video_core/shader/generator/glsl_fs_shader_gen.cpp
+++ b/src/video_core/shader/generator/glsl_fs_shader_gen.cpp
@@ -810,8 +810,8 @@ void FragmentModule::WriteLighting() {
 
         // Compute primary fragment color (diffuse lighting) function
         out += fmt::format(
-            "diffuse_sum.rgb += (({}.diffuse * dot_product) + {}.ambient) * {} * {}{};\n",
-            light_src, light_src, dist_atten, spot_atten, shadow_primary);
+            "diffuse_sum.rgb += (({}.diffuse * dot_product{}) + {}.ambient) * {} * {};\n",
+            light_src, shadow_primary, light_src, dist_atten, spot_atten);
 
         // Compute secondary fragment color (specular lighting) function
         out += fmt::format("specular_sum.rgb += ({} + {}) * clamp_highlights * {} * {}{};\n",


### PR DESCRIPTION
Captain Toad Treasure Tracker has an issue where the shadow intensity is too high which makes everything much darker compared to console. Looking at the generated fragment shader as noted in https://github.com/citra-emu/citra/issues/3920 the game samples the shadow texture from the lighting unit, compared to most other games that do it from TEV.

The resulting values from shadow buffer were all zero which made the light very dark. After tinkering a bit, it seems that shadow must be applied before the light ambient factor is taken into account, otherwise the shadow completely erases its contribution to the final pixel light. The game also has a relatively high ambience value so it seems like it's trying to offset the shadow darkness. This makes the shadows looks correct and match hardware very well.


Citra (master) | Citra (PR) | 3DS
-|-|-
![Captain Toad Treasure Tracker_31 01 24_00 28 40 622](https://github.com/citra-emu/citra/assets/47210458/7eb440b6-cb5f-4995-a174-661676327542) | ![Captain Toad Treasure Tracker_31 01 24_00 27 16 007](https://github.com/citra-emu/citra/assets/47210458/14640b5e-f163-45a7-9b1a-d27a8adca2f3) | ![2024-01-30_23-25-00 318_top](https://github.com/citra-emu/citra/assets/47210458/2be74c52-e383-48d8-8e7b-807de92f4349)



Fixes:
https://github.com/citra-emu/citra/issues/3920

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/7404)
<!-- Reviewable:end -->
