### PR TITLE
glsl_shader_gen: Increase z=0 epsillon

### DIFF
--- a/src/video_core/shader/generator/glsl_shader_gen.cpp
+++ b/src/video_core/shader/generator/glsl_shader_gen.cpp
@@ -40,7 +40,7 @@ layout (binding = 1, std140) uniform vs_data {
     vec4 clip_coef;
 };
 
-const vec2 EPSILON_Z = vec2(0.00000001f, -1.00001f);
+const vec2 EPSILON_Z = vec2(0.000001f, -1.00001f);
 
 vec4 SanitizeVertex(vec4 vtx_pos) {
     float ndc_z = vtx_pos.z / vtx_pos.w;


### PR DESCRIPTION
Pokemon Ultra Sun/Moon render a white fade animation on console, though that doesn't show up on Citra. Looking at renderdoc this is again a clipping issue, where the kind-of fullscreen pass the game does is getting discarded. The vertex shader computes the dot product between vec4(0.0, 0.0, 1.00098, 1.00098) and vec4(0.0, 0.0, -1.0, 1.0) which should be zero but it ends up a very tiny positive number. In the shader interpreter the result is the same but -1.0 is -0.9999754 etc.

I'm not sure where this inaccuracy comes from, or if renderdoc is not showing the full number for whatever reason. Either way increasing the epsilon value works around this and it most likely fine. Any value higher than this though is probably pushing it. Given the amount of games with such issues I'm wondering about alternative methods of managing precision inside shaders :/

Citra (master) | Citra (PR)
-|-
<video src="https://github.com/citra-emu/citra/assets/47210458/bbbfb3eb-680a-445e-b998-060e3a2f6307.mp4"> | <video src="https://github.com/citra-emu/citra/assets/47210458/59b138c8-2b84-47a8-a8f2-92040c238e5b">

Fixes:
https://github.com/citra-emu/citra/issues/3931

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/7408)
<!-- Reviewable:end -->
