### PR TITLE
video_core: Use source3 when GPU_PREVIOUS is used in first stage

### DIFF
--- a/src/video_core/rasterizer_accelerated.cpp
+++ b/src/video_core/rasterizer_accelerated.cpp
@@ -846,7 +846,7 @@ void RasterizerAccelerated::SyncTextureBorderColor(int tex_index) {
 }
 
 void RasterizerAccelerated::SyncClipPlane() {
-    const bool enable_clip1 = regs.rasterizer.clip_enable != 0;
+    const u32 enable_clip1 = regs.rasterizer.clip_enable != 0;
     const auto raw_clip_coef = regs.rasterizer.GetClipCoef();
     const Common::Vec4f new_clip_coef = {raw_clip_coef.x.ToFloat32(), raw_clip_coef.y.ToFloat32(),
                                          raw_clip_coef.z.ToFloat32(), raw_clip_coef.w.ToFloat32()};

--- a/src/video_core/renderer_software/sw_rasterizer.cpp
+++ b/src/video_core/renderer_software/sw_rasterizer.cpp
@@ -695,7 +695,7 @@ Common::Vec4<u8> RasterizerSoftware::WriteTevConfig(
      * with some basic arithmetic. Alpha combiners can be configured separately but work
      * analogously.
      **/
-    Common::Vec4<u8> combiner_output = primary_color;
+    Common::Vec4<u8> combiner_output = {0, 0, 0, 0};
     Common::Vec4<u8> combiner_buffer = {0, 0, 0, 0};
     Common::Vec4<u8> next_combiner_buffer =
         Common::MakeVec(regs.texturing.tev_combiner_buffer_color.r.Value(),
@@ -746,9 +746,15 @@ Common::Vec4<u8> RasterizerSoftware::WriteTevConfig(
          *       combiner_output.rgb(), but instead store it in a temporary variable until
          *       alpha combining has been done.
          **/
+        const auto source1 = tev_stage_index == 0 && tev_stage.color_source1 == Source::Previous
+                                 ? tev_stage.color_source3.Value()
+                                 : tev_stage.color_source1.Value();
+        const auto source2 = tev_stage_index == 0 && tev_stage.color_source2 == Source::Previous
+                                 ? tev_stage.color_source3.Value()
+                                 : tev_stage.color_source2.Value();
         const std::array<Common::Vec3<u8>, 3> color_result = {
-            GetColorModifier(tev_stage.color_modifier1, get_source(tev_stage.color_source1)),
-            GetColorModifier(tev_stage.color_modifier2, get_source(tev_stage.color_source2)),
+            GetColorModifier(tev_stage.color_modifier1, get_source(source1)),
+            GetColorModifier(tev_stage.color_modifier2, get_source(source2)),
             GetColorModifier(tev_stage.color_modifier3, get_source(tev_stage.color_source3)),
         };
         const Common::Vec3<u8> color_output = ColorCombine(tev_stage.color_op, color_result);

--- a/src/video_core/shader/generator/glsl_fs_shader_gen.h
+++ b/src/video_core/shader/generator/glsl_fs_shader_gen.h
@@ -41,8 +41,8 @@ private:
     /// Writes the code to emulate PICA min/max blending factors
     void WriteBlending();
 
-    /// Writes the specified TEV stage source component(s)
-    void AppendSource(Pica::TexturingRegs::TevStageConfig::Source source, u32 tev_index);
+    /// Returns the specified TEV stage source component(s)
+    std::string GetSource(Pica::TexturingRegs::TevStageConfig::Source source, u32 tev_index);
 
     /// Writes the color components to use for the specified TEV stage color modifier
     void AppendColorModifier(Pica::TexturingRegs::TevStageConfig::ColorModifier modifier,

--- a/src/video_core/shader/generator/shader_uniforms.h
+++ b/src/video_core/shader/generator/shader_uniforms.h
@@ -86,7 +86,7 @@ struct PicaUniformsData {
 };
 
 struct VSUniformData {
-    bool enable_clip1;
+    u32 enable_clip1;
     alignas(16) Common::Vec4f clip_coef;
 };
 static_assert(sizeof(VSUniformData) == 32,

--- a/src/video_core/shader/generator/spv_fs_shader_gen.h
+++ b/src/video_core/shader/generator/spv_fs_shader_gen.h
@@ -99,13 +99,13 @@ private:
     /// Lookups the lighting LUT at the provided lut_index
     [[nodiscard]] Id LookupLightingLUT(Id lut_index, Id index, Id delta);
 
-    /// Writes the specified TEV stage source component(s)
-    [[nodiscard]] Id AppendSource(Pica::TexturingRegs::TevStageConfig::Source source, s32 index);
+    /// Returns the specified TEV stage source component(s)
+    [[nodiscard]] Id GetSource(Pica::TexturingRegs::TevStageConfig::Source source, s32 index);
 
     /// Writes the color components to use for the specified TEV stage color modifier
     [[nodiscard]] Id AppendColorModifier(
         Pica::TexturingRegs::TevStageConfig::ColorModifier modifier,
-        Pica::TexturingRegs::TevStageConfig::Source source, s32 index);
+        Pica::TexturingRegs::TevStageConfig::Source source, s32 tev_index);
 
     /// Writes the alpha component to use for the specified TEV stage alpha modifier
     [[nodiscard]] Id AppendAlphaModifier(
@@ -272,7 +272,7 @@ private:
     Id secondary_fragment_color{};
     Id combiner_buffer{};
     Id next_combiner_buffer{};
-    Id last_tex_env_out{};
+    Id combiner_output{};
 
     Id color_results_1{};
     Id color_results_2{};


### PR DESCRIPTION
Silly me to assume PICA is a sane GPU that would follow OpenGL ES spec :P

Fantasy Life places the color of each box in const_color[0], but strangely it never uses it in the first stage. The aforementioned stage is configured as follows. It uses GPU_PREVIOUS as the first source and simply passes that to the next stage. The vertex color of the draw is vec4(1.f) so all the boxes appear white.

```
color_results_1 = combiner_output.xyz;
color_results_2 = const_color[0].xyz;
color_results_3 = const_color[0].xyz;
color_output_0 = clamp(color_results_1, vec3(0.0), vec3(1.0));
```

After testing this particular configuration however I noticed something else happened on hardware: the source1 value was replaced with whatever was in source3. This happens to source2 as well, when the combiner is op for example GPU_MODULATE. I'm pretty sure this is some undefined behavior of the GPU we are hitting here, and it certainly doesn't follow the ES spec. Though given how weird this rule is, I'm hesitant to say it's fully correct but it matches with my hardware observations.

Alongside fixing Fantasy Life it also fully fixes the Kirby Blowout Blast grey sky. While the previous attempt mostly fixed the sky, it still remained grey when looking at it from larger angles. Now it matches with hardware fully.

Citra (master) | Citra (PR)
-|-
![Fantasy Life™_01 02 24_17 50 33 512](https://github.com/citra-emu/citra/assets/47210458/78e273c8-524e-4e00-a076-c065309fdc2f) | ![Fantasy Life™_01 02 24_16 25 16 444](https://github.com/citra-emu/citra/assets/47210458/f3ce9340-481b-49d3-a416-ca49c252bb19)
![Kirby's Blowout Blast_01 02 24_17 50 52 93](https://github.com/citra-emu/citra/assets/47210458/218640ea-3824-486c-97d4-c6adb60c1d15) | ![Kirby's Blowout Blast_01 02 24_17 51 43 283](https://github.com/citra-emu/citra/assets/47210458/74d07e06-1085-49a8-b366-d56297001d85)

Fixes:
https://github.com/citra-emu/citra/issues/3654

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/7411)
<!-- Reviewable:end -->
