### PR TITLE
service: Stub mcu::HWC

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -327,6 +327,10 @@ add_library(citra_core STATIC
     hle/service/ldr_ro/cro_helper.h
     hle/service/ldr_ro/ldr_ro.cpp
     hle/service/ldr_ro/ldr_ro.h
+    hle/service/mcu/mcu_hwc.cpp
+    hle/service/mcu/mcu_hwc.h
+    hle/service/mcu/mcu.cpp
+    hle/service/mcu/mcu.h
     hle/service/mic/mic_u.cpp
     hle/service/mic/mic_u.h
     hle/service/mvd/mvd.cpp

--- a/src/core/hle/service/mcu/mcu.cpp
+++ b/src/core/hle/service/mcu/mcu.cpp
@@ -1,0 +1,16 @@
+// Copyright 2024 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/core.h"
+#include "core/hle/service/mcu/mcu.h"
+#include "core/hle/service/mcu/mcu_hwc.h"
+
+namespace Service::MCU {
+
+void InstallInterfaces(Core::System& system) {
+    auto& service_manager = system.ServiceManager();
+    std::make_shared<HWC>()->InstallAsService(service_manager);
+}
+
+} // namespace Service::MCU

--- a/src/core/hle/service/mcu/mcu.h
+++ b/src/core/hle/service/mcu/mcu.h
@@ -1,0 +1,15 @@
+// Copyright 2024 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+namespace Core {
+class System;
+}
+
+namespace Service::MCU {
+
+void InstallInterfaces(Core::System& system);
+
+} // namespace Service::MCU

--- a/src/core/hle/service/mcu/mcu_hwc.cpp
+++ b/src/core/hle/service/mcu/mcu_hwc.cpp
@@ -1,0 +1,36 @@
+// Copyright 2024 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "common/archives.h"
+#include "core/hle/service/mcu/mcu_hwc.h"
+
+SERIALIZE_EXPORT_IMPL(Service::MCU::HWC)
+
+namespace Service::MCU {
+
+HWC::HWC() : ServiceFramework("mcu::HWC", 1) {
+    static const FunctionInfo functions[] = {
+        // clang-format off
+        {0x0001, nullptr, "ReadRegister"},
+        {0x0002, nullptr, "WriteRegister"},
+        {0x0003, nullptr, "GetInfoRegisters"},
+        {0x0004, nullptr, "GetBatteryVoltage"},
+        {0x0005, nullptr, "GetBatteryLevel"},
+        {0x0006, nullptr, "SetPowerLEDPattern"},
+        {0x0007, nullptr, "SetWifiLEDState"},
+        {0x0008, nullptr, "SetCameraLEDPattern"},
+        {0x0009, nullptr, "Set3DLEDState"},
+        {0x000A, nullptr, "SetInfoLEDPattern"},
+        {0x000B, nullptr, "GetSoundVolume"},
+        {0x000C, nullptr, "SetTopScreenFlicker"},
+        {0x000D, nullptr, "SetBottomScreenFlicker"},
+        {0x000F, nullptr, "GetRtcTime"},
+        {0x0010, nullptr, "GetMcuFwVerHigh"},
+        {0x0011, nullptr, "GetMcuFwVerLow"},
+        // clang-format on
+    };
+    RegisterHandlers(functions);
+}
+
+} // namespace Service::MCU

--- a/src/core/hle/service/mcu/mcu_hwc.h
+++ b/src/core/hle/service/mcu/mcu_hwc.h
@@ -1,0 +1,21 @@
+// Copyright 2024 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service::MCU {
+
+class HWC final : public ServiceFramework<HWC> {
+public:
+    explicit HWC();
+
+private:
+    SERVICE_SERIALIZATION_SIMPLE
+};
+
+} // namespace Service::MCU
+
+BOOST_CLASS_EXPORT_KEY(Service::MCU::HWC)

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -35,6 +35,7 @@
 #include "core/hle/service/http/http_c.h"
 #include "core/hle/service/ir/ir.h"
 #include "core/hle/service/ldr_ro/ldr_ro.h"
+#include "core/hle/service/mcu/mcu.h"
 #include "core/hle/service/mic/mic_u.h"
 #include "core/hle/service/mvd/mvd.h"
 #include "core/hle/service/ndm/ndm_u.h"
@@ -101,7 +102,7 @@ const std::array<ServiceModuleInfo, 41> service_module_map{
      {"CDC", 0x00040130'00001802, nullptr},
      {"GPIO", 0x00040130'00001B02, nullptr},
      {"I2C", 0x00040130'00001E02, nullptr},
-     {"MCU", 0x00040130'00001F02, nullptr},
+     {"MCU", 0x00040130'00001F02, MCU::InstallInterfaces},
      {"MP", 0x00040130'00002A02, nullptr},
      {"PDN", 0x00040130'00002102, nullptr},
      {"SPI", 0x00040130'00002302, nullptr}}};


### PR DESCRIPTION
Allows CTRAging to work on Citra. I'm not sure how it used it work in the past, but the app was stuck waiting for the service handle to become available.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/citra-emu/citra/7428)
<!-- Reviewable:end -->
