### PR TITLE
apt: Cleanup slot data when a process exits

### DIFF
--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -22,6 +22,7 @@
 #include "core/hle/kernel/resource_limit.h"
 #include "core/hle/kernel/thread.h"
 #include "core/hle/kernel/vm_manager.h"
+#include "core/hle/service/apt/apt.h"
 #include "core/hle/service/plgldr/plgldr.h"
 #include "core/loader/loader.h"
 #include "core/memory.h"
@@ -264,6 +265,12 @@ void Process::Exit() {
     auto plgldr = Service::PLGLDR::GetService(Core::System::GetInstance());
     if (plgldr) {
         plgldr->OnProcessExit(*this, kernel);
+    }
+
+    auto apt = Service::APT::GetModule(Core::System::GetInstance());
+    if (apt) {
+        auto applet_manager = apt->GetAppletManager();
+        applet_manager->OnProcessExit(*this);
     }
 }
 

--- a/src/core/hle/service/apt/applet_manager.h
+++ b/src/core/hle/service/apt/applet_manager.h
@@ -262,6 +262,8 @@ public:
 
     void ReloadInputDevices();
 
+    void OnProcessExit(Kernel::Process& process);
+
     /**
      * Clears any existing parameter and places a new one. This function is currently only used by
      * HLE Applets and should be likely removed in the future
@@ -507,6 +509,8 @@ private:
     AppletSlot GetAppletSlotFromId(AppletId id);
     AppletSlot GetAppletSlotFromAttributes(AppletAttributes attributes);
     AppletSlot GetAppletSlotFromPos(AppletPos pos);
+
+    AppletSlotData* GetAppletSlotDataFromTitleId(const u64 title_id);
 
     /// Checks if the Application slot has already been registered and sends the parameter to it,
     /// otherwise it queues for sending when the application registers itself with APT::Enable.


### PR DESCRIPTION
When launching a system applet in Old 3DS mode, the Home Menu process exits without finalizing on APT. Clear slot data accordingly with an `OnProcessExit` function, called when a process exits.

This allows Old 3DS mode to exit a system applet back to the Home Menu without hanging in the transition, due to APT falsely thinking that the Home Menu is running.

This also removes the previous workaround for other system applets that didn't finalize correctly, and it was being cleared once `StartSystemApplet` was called.